### PR TITLE
Fix build errors in VS2019 and Build Tools v142

### DIFF
--- a/src/inc/LibraryIncludes.h
+++ b/src/inc/LibraryIncludes.h
@@ -40,6 +40,7 @@
 #include <sstream>
 #include <iomanip>
 #include <filesystem>
+#include <functional>
 
 // WIL
 


### PR DESCRIPTION
Without this, building in VS2019 results in multiple function is not a member of std errors. This fixes that. 😃 

EDIT: Important to mention I'm using VS2019 16.0.3 and build tools v. 142.