### PR TITLE
inc: add include for `functional`

### DIFF
--- a/src/inc/LibraryIncludes.h
+++ b/src/inc/LibraryIncludes.h
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <atomic>
 #include <deque>
+#include <functional>
 #include <list>
 #include <memory>
 #include <map>


### PR DESCRIPTION
The use of `std::function` requires `functional` to be included.  This
prevented building with the VS 14.20 toolset.