### PR TITLE
Specify the NuGet packages folder

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -11,4 +11,7 @@
     <!--<add key="TAEF - internal" value="https://microsoft.pkgs.visualstudio.com/DefaultCollection/_packaging/Taef/nuget/v3/index.json" />
     <add key="OpenConsole - Internal" value="https://microsoft.pkgs.visualstudio.com/_packaging/OpenConsole/nuget/v3/index.json" />-->
   </packageSources>
+  <config>
+	<add key="repositorypath" value=".\packages" />
+  </config>
 </configuration>


### PR DESCRIPTION
Projects are looking for the packages under the path './packages', so we need to specify the path in Project config, in case it is restored by the User/Computer config.