### PR TITLE
fix: replaced outdated url

### DIFF
--- a/src/tools/ColorTool/schemes/deuteranopia.itermcolors
+++ b/src/tools/ColorTool/schemes/deuteranopia.itermcolors
@@ -31,7 +31,7 @@
 	have been altered from a conventional red and green to values that will instead show a more 
 	noticeable difference, since red and green are most frequently used in the Console for
 	'success' or 'error'. This scheme was designed using a tool called Color Oracle which can 
-	be found here: http://colororacle.cartography.ch/
+	be found here: https://colororacle.org/
 -->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">


### PR DESCRIPTION
http://colororacle.cartography.ch/ moved to https://colororacle.org/

The old link is no longer accessible and this screenshot of the old link [(source)](https://sur.ly/i/colororacle.cartography.ch/) shows that this seems to be the new location:
![image](https://user-images.githubusercontent.com/29959150/57311082-4217eb00-70eb-11e9-8e7d-f17c042bb4f0.png)

Only comments are affected by this change.
