### PR TITLE
Typos: Incorrect use of the possessive of "it".

### DIFF
--- a/doc/cascadia/TerminalSettings-spec.md
+++ b/doc/cascadia/TerminalSettings-spec.md
@@ -34,7 +34,7 @@ This spec will outline how various terminal frontends will be able to interact w
    the need for a globals/profiles structure.
 6. The Terminal should be able to read information from a settings structure
    that's independant of how it's persisted / implemented by the Application
-7. The Component should be able to have it's own settings independent of the
+7. The Component should be able to have its own settings independent of the
    application that's embedding it, such as font size and face, scrollbar
    visibility, etc. These should be settings that are specific to the component,
    and the Terminal should logically be unaffected by these settings.
@@ -57,7 +57,7 @@ VS needs to be able to persist settings just as a simple set of global settings.
 
 When the application needs to retrieve these settings, they need to use them as a tripartite structure: frontend-component-terminal settings.
 
-Each frontend will have it's own set of settings.
+Each frontend will have its own set of settings.
 Each component implementation will also ned to have some settings that control it.
 The terminal also will have some settings specific to the terminal.
 
@@ -106,13 +106,13 @@ public interface IApplicationSettings
 }
 ```
 
-The Application can store whatever settings it wants in it's implementation of `IApplicationSettings`. When it instantiates a Terminal Component, it will pass it's `IComponentSettings` to it.
+The Application can store whatever settings it wants in its implementation of `IApplicationSettings`. When it instantiates a Terminal Component, it will pass its `IComponentSettings` to it.
 
 The component will retrieve whatever settings it wants from that object, and then pass the `TerminalSettings` to the Terminal it creates.
 
 
-The frontend will be able to get/set it's settings from the `IApplicationSettings` implementation.
-The frontend will be able to create components using the `IComponentSettings` in it's `IApplicationSettings`.
+The frontend will be able to get/set its settings from the `IApplicationSettings` implementation.
+The frontend will be able to create components using the `IComponentSettings` in its `IApplicationSettings`.
 The Component will then create the Terminal using the `TerminalSettings`.
 
 #### Project Cascadia Settings Details


### PR DESCRIPTION
Should use "its" rather than "it's".