### PR TITLE
Add a dev manifest, which will be used by default

### DIFF
--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -19,13 +19,16 @@ jobs:
   - template: ./templates/build-console-int.yml
     parameters:
       platform: x64
+      additionalBuildArguments: /p:WindowsTerminalReleaseBuild=true
 
   - template: ./templates/build-console-int.yml
     parameters:
       platform: x86
+      additionalBuildArguments: /p:WindowsTerminalReleaseBuild=true
 
   - template: ./templates/build-console-int.yml
     parameters:
       platform: arm64
+      additionalBuildArguments: /p:WindowsTerminalReleaseBuild=true
 
   - template: ./templates/release-sign-and-bundle.yml

--- a/build/pipelines/templates/build-console-int.yml
+++ b/build/pipelines/templates/build-console-int.yml
@@ -27,4 +27,4 @@ jobs:
 
   - template: build-console-steps.yml
     parameters:
-      additionalBuildArguments: '/p:XesUseOneStoreVersioning=true;XesBaseYearForStoreVersion=$(baseYearForVersioning)'
+      additionalBuildArguments: "/p:XesUseOneStoreVersioning=true;XesBaseYearForStoreVersion=$(baseYearForVersioning) ${{ parameters.additionalBuildArguments }}"

--- a/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
+++ b/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
@@ -44,7 +44,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AppxManifest Include="Package.appxmanifest">
+    <AppxManifest Include="Package.appxmanifest" Condition="'$(WindowsTerminalReleaseBuild)'=='true'">
+      <SubType>Designer</SubType>
+    </AppxManifest>
+    <AppxManifest Include="Package-Dev.appxmanifest" Condition="'$(WindowsTerminalReleaseBuild)'!='true'">
       <SubType>Designer</SubType>
     </AppxManifest>
   </ItemGroup>

--- a/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
+  xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap mp rescap">
+
+  <Identity
+    Name="WindowsTerminalDev"
+    Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
+    Version="1.0.0.0" />
+
+  <Properties>
+    <DisplayName>ms-resource:AppNameDev</DisplayName>
+    <PublisherDisplayName>A Lone Developer</PublisherDisplayName>
+    <Logo>Images\StoreLogo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.18362.0" MaxVersionTested="10.0.18362.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="x-generate"/>
+  </Resources>
+
+  <Applications>
+    <Application Id="App"
+      Executable="$targetnametoken$.exe"
+      EntryPoint="$targetentrypoint$">
+      <uap:VisualElements
+        DisplayName="ms-resource:AppNameDev"
+        Description="ms-resource:AppDescriptionDev"
+        BackgroundColor="transparent"
+        Square150x150Logo="Images\Square150x150Logo.png"
+        Square44x44Logo="Images\Square44x44Logo.png">
+        <uap:DefaultTile
+          Wide310x150Logo="Images\Wide310x150Logo.png" 
+          Square71x71Logo="Images\SmallTile.png"
+          Square310x310Logo="Images\LargeTile.png"/>
+        <uap:SplashScreen Image="Images\SplashScreen.png"/>
+      </uap:VisualElements>
+
+      <Extensions>
+        <uap3:Extension Category="windows.appExecutionAlias" Executable="WindowsTerminal.exe" EntryPoint="Windows.FullTrustApplication">
+          <uap3:AppExecutionAlias>
+            <desktop:ExecutionAlias Alias="wtd.exe" />
+          </uap3:AppExecutionAlias>
+        </uap3:Extension>
+      </Extensions>
+
+    </Application>
+  </Applications>
+
+  <Capabilities>
+    <Capability Name="internetClient" />
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+</Package>

--- a/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
@@ -12,7 +12,7 @@
   <Identity
     Name="WindowsTerminalDev"
     Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
-    Version="1.0.0.0" />
+    Version="0.0.1.0" />
 
   <Properties>
     <DisplayName>ms-resource:AppNameDev</DisplayName>

--- a/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
@@ -118,9 +118,15 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppDescription" xml:space="preserve">
-    <value>Codename Cascadia</value>
+    <value>The New Windows Terminal</value>
   </data>
   <data name="AppName" xml:space="preserve">
     <value>Windows Terminal (Preview)</value>
+  </data>
+  <data name="AppDescriptionDev" xml:space="preserve">
+    <value>The Windows Terminal, but Unofficial</value>
+  </data>
+  <data name="AppNameDev" xml:space="preserve">
+    <value>Windows Terminal (Dev Build)</value>
   </data>
 </root>


### PR DESCRIPTION
To produce a package named `Microsoft.WindowsTerminal`, you must build with
`/p:WindowsTerminalReleaseBuild=true`.

Fixes #556.