### PR TITLE
Update badge to link to Pipelines build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Welcome\! This repository contains the source code for:
 
 Project|Build Status
 ---|---
-Terminal|![](https://dev.azure.com/ms/Terminal/_apis/build/status/Terminal%20CI?branchName=master)
+Terminal|[![Build Status](https://dev.azure.com/ms/Terminal/_apis/build/status/Terminal%20CI?branchName=master)](https://dev.azure.com/ms/Terminal/_build/latest?definitionId=136&branchName=master)
 ColorTool|![](https://microsoft.visualstudio.com/_apis/public/build/definitions/c93e867a-8815-43c1-92c4-e7dd5404f1e1/17023/badge)
 
 # Terminal & Console Overview


### PR DESCRIPTION
This commit updates the build status badge of Terminal on `README.md`
to a link to its Azure Pipelines build status page.

The badges on `README.md` were links to the badge images themselves.
I do not know the location of the build status page of ColorTools, so
that badge is not updated.

Signed-off-by: Fred Miller <fghzxm@outlook.com>