### PR TITLE
Check null pointer before fclose

### DIFF
--- a/src/terminal/parser/ft_fuzzwrapper/main.cpp
+++ b/src/terminal/parser/ft_fuzzwrapper/main.cpp
@@ -70,7 +70,9 @@ int __cdecl wmain(int argc, wchar_t* argv[])
             fGotChar = GetChar(&wch);
         }
 
-        fclose(hFile);
+        if (hFile != NULL) {
+            fclose(hFile);
+        }
         wprintf(L"Done.\r\n");
     }
 

--- a/src/terminal/parser/ft_fuzzwrapper/main.cpp
+++ b/src/terminal/parser/ft_fuzzwrapper/main.cpp
@@ -70,7 +70,8 @@ int __cdecl wmain(int argc, wchar_t* argv[])
             fGotChar = GetChar(&wch);
         }
 
-        if (hFile != NULL) {
+        if (hFile != NULL)
+        {
             fclose(hFile);
         }
         wprintf(L"Done.\r\n");

--- a/src/terminal/parser/ft_fuzzwrapper/main.cpp
+++ b/src/terminal/parser/ft_fuzzwrapper/main.cpp
@@ -70,7 +70,7 @@ int __cdecl wmain(int argc, wchar_t* argv[])
             fGotChar = GetChar(&wch);
         }
 
-        if (hFile != NULL)
+        if (hFile)
         {
             fclose(hFile);
         }


### PR DESCRIPTION
Check null pointer before fclose because fclose(NULL) will lead to undefined behavior (CWE-476: NULL Pointer Dereference)