### PR TITLE
Fix VS 2019 (Toolset 142) build

### DIFF
--- a/src/inc/LibraryIncludes.h
+++ b/src/inc/LibraryIncludes.h
@@ -40,6 +40,7 @@
 #include <sstream>
 #include <iomanip>
 #include <filesystem>
+#include <functional>
 
 // WIL
 


### PR DESCRIPTION
The code used `std::function<...>` without include `<functional>` header.
Add the missing <functional> header to PCH.
* Note, `<functional>` was included by `<string>` in the STL come with VS 2017 (Toolset 141).
* The STL team restructured the code, thus now we need to include it directly.