### PR TITLE
Update razzle to use vswhere (#13)

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="vswhere" version="2.6.7" />
+</packages>

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ OpenConsole.sln may be built from within Visual Studio or from the command-line 
 
 ```shell
 .\tools\razzle.cmd
-msbuild
+bcz
 ```
 
 We've provided a set of convenience scripts in the **/tools** directory to help automate the process of building and running tests.

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ git submodule update --init --recursive
 OpenConsole.sln may be built from within Visual Studio or from the command-line using MSBuild. To build from the command line:
 
 ```shell
-nuget restore OpenConsole.sln
-msbuild OpenConsole.sln
+.\tools\razzle.cmd
+msbuild
 ```
 
 We've provided a set of convenience scripts in the **/tools** directory to help automate the process of building and running tests.

--- a/tools/README.md
+++ b/tools/README.md
@@ -21,7 +21,7 @@ to similar effect.
 ## bcz
 
 `bcz` can quick be used to clean and build the project. By default, it builds
-the `%DEFAULT_CONFIGURATION%` configuration, which
+the `%DEFAULT_CONFIGURATION%` configuration, which is `Debug` if you use `razzle.cmd`.
 
  - `bcz dbg` can be used to manually build the Debug configuration.
  - `bcz rel` can be used to manually build the Release configuration.

--- a/tools/bcz.cmd
+++ b/tools/bcz.cmd
@@ -43,7 +43,7 @@ if (%_LAST_BUILD_CONF%) == (Debug) (
     echo Building Appx...
 )
 
-set _BUILD_CMDLINE=%MSBUILD% %OPENCON%\OpenConsole.sln /t:%_MSBUILD_TARGET% /m /p:Configuration=%_LAST_BUILD_CONF% /p:Platform=%ARCH% %_APPX_ARGS%
+set _BUILD_CMDLINE="%MSBUILD%" %OPENCON%\OpenConsole.sln /t:%_MSBUILD_TARGET% /m /p:Configuration=%_LAST_BUILD_CONF% /p:Platform=%ARCH% %_APPX_ARGS%
 
 echo %_BUILD_CMDLINE%
 %_BUILD_CMDLINE%

--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -28,7 +28,7 @@ for /f "usebackq delims=" %%I in (`dir /b /aD /o-N /s "%~dp0..\packages\vswhere*
 )
 
 rem Add path to MSBuild Binaries
-for /f "usebackq tokens=*" %%i in (`%VSWHERE% -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) do set MSBUILD=%%i
+for /f "usebackq tokens=*" %%i in (`%VSWHERE% -latest -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) do set MSBUILD=%%i
 
 set PATH=%PATH%"%MSBUILD%\..";
 

--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -1,5 +1,7 @@
 @echo off
 
+echo Setting up dev environment...
+
 rem Open Console build environment setup
 rem Adds msbuild to your path, and adds the open\tools directory as well
 rem This recreates what it's like to be an actual windows developer!
@@ -19,16 +21,30 @@ rem Add nuget to PATH
 set PATH=%PATH%%OPENCON%\dep\nuget;
 
 rem Run nuget restore so you can use vswhere
-nuget restore %OPENCON%
+nuget restore %OPENCON% -Verbosity quiet
 
 rem Find vswhere
 rem from https://github.com/microsoft/vs-setup-samples/blob/master/tools/vswhere.cmd
-for /f "usebackq delims=" %%I in (`dir /b /aD /o-N /s "%~dp0..\packages\vswhere*"`) do (
-    for /f "usebackq delims=" %%J in (`where /r "%%I" vswhere.exe 2^>nul`) do set VSWHERE=%%J
+for /f "usebackq delims=" %%I in (`dir /b /aD /o-N /s "%~dp0..\packages\vswhere*" 2^>nul`) do (
+    for /f "usebackq delims=" %%J in (`where /r "%%I" vswhere.exe 2^>nul`) do (
+        set VSWHERE=%%J
+    )
+)
+
+if not defined VSWHERE (
+    echo Could not find vswhere on your machine. Please set the VSWHERE variable to the location of vswhere.exe and run razzle again.
+    goto :EXIT
 )
 
 rem Add path to MSBuild Binaries
-for /f "usebackq tokens=*" %%i in (`%VSWHERE% -latest -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) do set MSBUILD=%%i
+for /f "usebackq tokens=*" %%B in (`%VSWHERE% -latest -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe 2^>nul`) do (
+    set MSBUILD=%%B
+)
+
+if not defined MSBUILD (
+    echo Could not find MsBuild on your machine. Please set the MSBUILD variable to the location of MSBuild.exe and run razzle again.
+    goto :EXIT
+)
 
 set PATH=%PATH%"%MSBUILD%\..";
 

--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -7,72 +7,6 @@ rem This recreates what it's like to be an actual windows developer!
 rem skip the setup if we're already ready.
 if not "%OpenConBuild%" == "" goto :END
 
-rem Add path to MSBuild Binaries
-set MSBUILD=()
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\msbuild.exe" (
-    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\msbuild.exe"
-    goto :FOUND_MSBUILD
-)
-if exist "%ProgramFiles%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\msbuild.exe" (
-    set MSBUILD="%ProgramFiles%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\msbuild.exe"
-    goto :FOUND_MSBUILD
-)
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\msbuild.exe" (
-    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\msbuild.exe"
-    goto :FOUND_MSBUILD
-)
-if exist "%ProgramFiles%\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\msbuild.exe" (
-    set MSBUILD="%ProgramFiles%\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\msbuild.exe"
-    goto :FOUND_MSBUILD
-)
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe" (
-    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe"
-    goto :FOUND_MSBUILD
-)
-if exist "%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe" (
-    set MSBUILD="%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe"
-    goto :FOUND_MSBUILD
-)
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" (
-    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\msbuild.exe"
-    goto :FOUND_MSBUILD
-)
-if exist "%ProgramFiles%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin" (
-    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\msbuild.exe"
-    goto :FOUND_MSBUILD
-)
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" (
-    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\msbuild.exe"
-    goto :FOUND_MSBUILD
-)
-if exist "%ProgramFiles%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin" (
-    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\msbuild.exe"
-    goto :FOUND_MSBUILD
-)
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" (
-    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe"
-    goto :FOUND_MSBUILD
-)
-if exist "%ProgramFiles%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin" (
-    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe"
-    goto :FOUND_MSBUILD
-)
-if exist "%ProgramFiles(x86)%\MSBuild\14.0\bin" (
-    set MSBUILD="%ProgramFiles(x86)%\MSBuild\14.0\bin\msbuild.exe"
-    goto :FOUND_MSBUILD
-)
-if exist "%ProgramFiles%\MSBuild\14.0\bin" (
-    set MSBUILD="%ProgramFiles%\MSBuild\14.0\bin\msbuild.exe"
-    goto :FOUND_MSBUILD
-)
-
-if %MSBUILD%==() (
-    echo "Could not find MsBuild on your machine. It may be installed somewhere else."
-    goto :EXIT
-)
-
-:FOUND_MSBUILD
-
 rem Add Opencon build scripts to path
 set PATH=%PATH%;%~dp0;
 
@@ -83,6 +17,20 @@ set OPENCON=%OPENCON_TOOLS:~0,-7%
 
 rem Add nuget to PATH
 set PATH=%PATH%%OPENCON%\dep\nuget;
+
+rem Run nuget restore so you can use vswhere
+nuget restore %OPENCON%
+
+rem Find vswhere
+rem from https://github.com/microsoft/vs-setup-samples/blob/master/tools/vswhere.cmd
+for /f "usebackq delims=" %%I in (`dir /b /aD /o-N /s "%~dp0..\packages\vswhere*"`) do (
+    for /f "usebackq delims=" %%J in (`where /r "%%I" vswhere.exe 2^>nul`) do set VSWHERE=%%J
+)
+
+rem Add path to MSBuild Binaries
+for /f "usebackq tokens=*" %%i in (`%VSWHERE% -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) do set MSBUILD=%%i
+
+set PATH=%PATH%"%MSBUILD%\..";
 
 if "%PROCESSOR_ARCHITECTURE%" == "AMD64" (
     set ARCH=x64


### PR DESCRIPTION
Instead of listing out all the locations for MSBuild, use the vswhere tool to find the location and add that directory to that path. 