### PR TITLE
Lowercase GH org name in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "dep/gsl"]
 	path = dep/gsl
-	url = https://github.com/Microsoft/gsl
+	url = https://github.com/microsoft/gsl
 [submodule "dep/wil"]
 	path = dep/wil
-	url = https://github.com/Microsoft/wil
+	url = https://github.com/microsoft/wil


### PR DESCRIPTION
The `Microsoft` org has been renamed to `microsoft`. While casing isn't an issue with GitHub, just correcting it in case some implementations are case-sensitive.