### PR TITLE
Bugfix: ESC didn't clear selection (except CMD)

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -501,7 +501,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         if (!handled)
         {
             _terminal->ClearSelection();
-            _renderer->TriggerSelection();
             // If the terminal translated the key, mark the event as handled.
             // This will prevent the system from trying to get the character out
             // of it and sending us a CharacterRecieved event.
@@ -961,7 +960,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         const auto copiedData = _terminal->RetrieveSelectedTextFromBuffer(trimTrailingWhitespace);
 
         _terminal->ClearSelection();
-        _renderer->TriggerSelection();
 
         // send data up for clipboard
         _clipboardCopyHandlers(copiedData);

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -501,6 +501,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         if (!handled)
         {
             _terminal->ClearSelection();
+            _renderer->TriggerSelection();
             // If the terminal translated the key, mark the event as handled.
             // This will prevent the system from trying to get the character out
             // of it and sending us a CharacterRecieved event.

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -560,6 +560,8 @@ void Terminal::ClearSelection() noexcept
     _endSelectionPosition = {0, 0};
     _selectionAnchor_YOffset = 0;
     _endSelectionPosition_YOffset = 0;
+
+    _buffer->GetRenderTarget().TriggerSelection();
 }
 
 // Method Description:


### PR DESCRIPTION
Text selection is now removed when ESC is passed as input. Still unclear as to why selection did get cleared in CMD but not in any of the other options. The line `_terminal->ClearSelection()` was still called but, for whatever reason, the renderer didn't update. @miniksa Any thoughts on that? Just curious.