### PR TITLE
Automatic builds on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,20 @@
+image: Visual Studio 2017
+
+# Enable build_script below
+build: Script
+
+build_script:
+  - git submodule update --init --recursive
+  - nuget restore OpenConsole.sln
+  - msbuild OpenConsole.sln /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  - dir
+
+deploy:
+  release: terminal-v$(appveyor_build_version)
+  provider: GitHub
+  auth_token:
+    secure: SKpt/2S61XnJOaA6+Pg5+/g9WOAV1OzQiQmUtRTfieSadyc355HCkVG5vPJ1OEBT
+  artifact: /.*\.nupkg/
+  #on:
+  #  branch: master                 # release from master branch only
+  #  APPVEYOR_REPO_TAG: true        # deploy on tag push only


### PR DESCRIPTION
Hi all,

I'm having a look at building Terminal automatically on each tag or merged PR, so I could follow along and try things out without necessarily installing the build infrastructure.

- https://ci.appveyor.com/project/mottosso/terminal

The script works well so far, except it fails after about 8 minutes due to some issue I couldn't find mentioned in the issue section or in code.

```
  LINK : fatal error LNK1104: cannot open file 'atls.lib' [C:\projects\terminal\src\interactivity\win32\ut_interactivity_win32\Interactivity.Win32.UnitTests.vcxproj]
```

- [Full report](https://ci.appveyor.com/project/mottosso/terminal/builds/24458487?fullLog=true)

I suspect AppVeyor doesn't provide the necessary libraries from Windows 1903, in which case my next question would be whether there was anything I could install or add to AppVeyor during build so as to make it pass?

I found this for 1803, and figured maybe applying those lessons for 1903 would work here?

- https://github.com/appveyor/ci/issues/1984

> PS: Before merging, don't forget to update the GitHub personal access token.