### PR TITLE
Blink the cursor

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -883,7 +883,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // - sender: not used
     // - e: not used
     void TermControl::_BlinkCursor(Windows::Foundation::IInspectable const& /* sender */,
-        Windows::Foundation::IInspectable const& /* e */)
+                                   Windows::Foundation::IInspectable const& /* e */)
     {
         _terminal->SetCursorVisible(!_terminal->IsCursorVisible());
     }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -7,6 +7,7 @@
 #include <DefaultSettings.h>
 #include <unicode.hpp>
 #include <Utf16Parser.hpp>
+#include <WinUser.h>
 #include "..\..\types\inc\GlyphWidth.hpp"
 
 using namespace ::Microsoft::Console::Types;
@@ -412,11 +413,22 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         _terminal->SetScrollPositionChangedCallback(pfnScrollPositionChanged);
 
         // Set up blinking cursor
-        _cursorTimer.Interval(std::chrono::milliseconds(500));
-        auto registrationtoken = _cursorTimer.Tick({ this, &TermControl::_BlinkCursor });
+        int blinkTime = GetCaretBlinkTime();
+        if (blinkTime != INFINITE)
+        {
+            // Create a timer
+            _cursorTimer = std::make_optional(DispatcherTimer());
+            _cursorTimer.value().Interval(std::chrono::milliseconds(blinkTime));
+            auto registrationtoken = _cursorTimer.value().Tick({ this, &TermControl::_BlinkCursor });
 
-        _controlRoot.GotFocus({ this, &TermControl::_GotFocusHandler });
-        _controlRoot.LostFocus({ this, &TermControl::_LostFocusHandler });
+            _controlRoot.GotFocus({ this, &TermControl::_GotFocusHandler });
+            _controlRoot.LostFocus({ this, &TermControl::_LostFocusHandler });
+        }
+        else
+        {
+            // The user has disabled cursor blinking
+            _cursorTimer = std::nullopt;
+        }
 
         // Focus the control here. If we do it up above (in _Create_), then the
         //      focus won't actually get passed to us. I believe this is because
@@ -517,10 +529,13 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                                               WI_IsFlagSet(modifiers, KeyModifiers::Alt),
                                               WI_IsFlagSet(modifiers, KeyModifiers::Shift));
 
-            // Manually show the cursor when a key is pressed. Restarting
-            // the timer prevents flickering.
-            _terminal->SetCursorVisible(true);
-            _cursorTimer.Start();
+            if (_cursorTimer.has_value())
+            {
+                // Manually show the cursor when a key is pressed. Restarting
+                // the timer prevents flickering.
+                _terminal->SetCursorVisible(true);
+                _cursorTimer.value().Start();
+            }
         }
 
         e.Handled(handled);
@@ -816,17 +831,23 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // - Event handler for the GotFocus event. This is used to start
     //   blinking the cursor when the window is focused.
     void TermControl::_GotFocusHandler(Windows::Foundation::IInspectable const& /* sender */,
-                                       RoutedEventArgs const& /* args */) {
-        _cursorTimer.Start();
+                                       RoutedEventArgs const& /* args */)
+    {
+        if (_cursorTimer.has_value())
+            _cursorTimer.value().Start();
     }
 
     // Method Description:
     // - Event handler for the LostFocus event. This is used to hide
     //   and stop blinking the cursor when the window loses focus.
     void TermControl::_LostFocusHandler(Windows::Foundation::IInspectable const& /* sender */,
-                                        RoutedEventArgs const& /* args */) {
-        _cursorTimer.Stop();
-        _terminal->SetCursorVisible(false);
+                                        RoutedEventArgs const& /* args */)
+    {
+        if (_cursorTimer.has_value())
+        {
+            _cursorTimer.value().Stop();
+            _terminal->SetCursorVisible(false);
+        }
     }
 
     void TermControl::_SendInputToConnection(const std::wstring& wstr)

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -36,7 +36,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         _desiredFont{ DEFAULT_FONT_FACE.c_str(), 0, 10, { 0, DEFAULT_FONT_SIZE }, CP_UTF8 },
         _actualFont{ DEFAULT_FONT_FACE.c_str(), 0, 10, { 0, DEFAULT_FONT_SIZE }, CP_UTF8, false },
         _touchAnchor{ std::nullopt },
-        _leadingSurrogate{}
+        _leadingSurrogate{},
+        _cursorTimer{}
     {
         _Create();
     }
@@ -411,28 +412,11 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         _terminal->SetScrollPositionChangedCallback(pfnScrollPositionChanged);
 
         // Set up blinking cursor
-        DispatcherTimer cursorTimer;
-        cursorTimer.Interval(std::chrono::milliseconds(500));
-        auto registrationtoken = cursorTimer.Tick({ this, &TermControl::_BlinkCursor });
+        _cursorTimer.Interval(std::chrono::milliseconds(500));
+        auto registrationtoken = _cursorTimer.Tick({ this, &TermControl::_BlinkCursor });
 
-        _controlRoot.GotFocus([cursorTimer](auto&, auto&) {
-            // Start blinking the cursor when the window is focused.
-            cursorTimer.Start();
-        });
-
-        _controlRoot.LostFocus([this, cursorTimer](auto&, auto&) {
-            // Stop blinking the cursor when the window goes out of focus,
-            // and hide it.
-            cursorTimer.Stop();
-            _terminal->SetCursorVisible(false);
-        });
-
-        _controlRoot.KeyDown([this, cursorTimer](auto&, auto&) {
-            // Manually show the cursor when a key is pressed. Restarting
-            // the timer prevents flickering.
-            _terminal->SetCursorVisible(true);
-            cursorTimer.Start();
-        });
+        _controlRoot.GotFocus({ this, &TermControl::_GotFocusHandler });
+        _controlRoot.LostFocus({ this, &TermControl::_LostFocusHandler });
 
         // Focus the control here. If we do it up above (in _Create_), then the
         //      focus won't actually get passed to us. I believe this is because
@@ -532,6 +516,11 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                                               WI_IsFlagSet(modifiers, KeyModifiers::Ctrl),
                                               WI_IsFlagSet(modifiers, KeyModifiers::Alt),
                                               WI_IsFlagSet(modifiers, KeyModifiers::Shift));
+
+            // Manually show the cursor when a key is pressed. Restarting
+            // the timer prevents flickering.
+            _terminal->SetCursorVisible(true);
+            _cursorTimer.Start();
         }
 
         e.Handled(handled);
@@ -821,6 +810,23 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             //      itself - it was initiated by the mouse wheel, or the scrollbar.
             this->ScrollViewport(static_cast<int>(newValue));
         }
+    }
+
+    // Method Description:
+    // - Event handler for the GotFocus event. This is used to start
+    //   blinking the cursor when the window is focused.
+    void TermControl::_GotFocusHandler(Windows::Foundation::IInspectable const& /* sender */,
+                                       RoutedEventArgs const& /* args */) {
+        _cursorTimer.Start();
+    }
+
+    // Method Description:
+    // - Event handler for the LostFocus event. This is used to hide
+    //   and stop blinking the cursor when the window loses focus.
+    void TermControl::_LostFocusHandler(Windows::Foundation::IInspectable const& /* sender */,
+                                        RoutedEventArgs const& /* args */) {
+        _cursorTimer.Stop();
+        _terminal->SetCursorVisible(false);
     }
 
     void TermControl::_SendInputToConnection(const std::wstring& wstr)

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -419,7 +419,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             // Create a timer
             _cursorTimer = std::make_optional(DispatcherTimer());
             _cursorTimer.value().Interval(std::chrono::milliseconds(blinkTime));
-            auto registrationtoken = _cursorTimer.value().Tick({ this, &TermControl::_BlinkCursor });
+            _cursorTimer.value().Tick({ this, &TermControl::_BlinkCursor });
 
             _controlRoot.GotFocus({ this, &TermControl::_GotFocusHandler });
             _controlRoot.LostFocus({ this, &TermControl::_LostFocusHandler });

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -102,8 +102,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _PointerReleasedHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
         void _MouseWheelHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
         void _ScrollbarChangeHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Controls::Primitives::RangeBaseValueChangedEventArgs const& e);
-        void _GotFocusHandler(Windows::Foundation::IInspectable const & sender, Windows::UI::Xaml::RoutedEventArgs const & e);
-        void _LostFocusHandler(Windows::Foundation::IInspectable const & sender, Windows::UI::Xaml::RoutedEventArgs const & e);
+        void _GotFocusHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
+        void _LostFocusHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
 
         void _BlinkCursor(Windows::Foundation::IInspectable const& sender, Windows::Foundation::IInspectable const& e);
         void _SendInputToConnection(const std::wstring& wstr);

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -84,6 +84,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         // storage location for the leading surrogate of a utf-16 surrogate pair
         std::optional<wchar_t> _leadingSurrogate;
 
+        Windows::UI::Xaml::DispatcherTimer _cursorTimer;
+
         // If this is set, then we assume we are in the middle of panning the
         //      viewport via touch input.
         std::optional<winrt::Windows::Foundation::Point> _touchAnchor;
@@ -100,6 +102,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _PointerReleasedHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
         void _MouseWheelHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
         void _ScrollbarChangeHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Controls::Primitives::RangeBaseValueChangedEventArgs const& e);
+        void _GotFocusHandler(Windows::Foundation::IInspectable const & sender, Windows::UI::Xaml::RoutedEventArgs const & e);
+        void _LostFocusHandler(Windows::Foundation::IInspectable const & sender, Windows::UI::Xaml::RoutedEventArgs const & e);
 
         void _BlinkCursor(Windows::Foundation::IInspectable const& sender, Windows::Foundation::IInspectable const& e);
         void _SendInputToConnection(const std::wstring& wstr);

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -84,7 +84,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         // storage location for the leading surrogate of a utf-16 surrogate pair
         std::optional<wchar_t> _leadingSurrogate;
 
-        Windows::UI::Xaml::DispatcherTimer _cursorTimer;
+        std::optional<Windows::UI::Xaml::DispatcherTimer> _cursorTimer;
 
         // If this is set, then we assume we are in the middle of panning the
         //      viewport via touch input.

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -101,6 +101,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _MouseWheelHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
         void _ScrollbarChangeHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Controls::Primitives::RangeBaseValueChangedEventArgs const& e);
 
+        void _BlinkCursor(Windows::Foundation::IInspectable const& sender, Windows::Foundation::IInspectable const& e);
         void _SendInputToConnection(const std::wstring& wstr);
         void _SwapChainSizeChanged(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::SizeChangedEventArgs const& e);
         void _SwapChainScaleChanged(Windows::UI::Xaml::Controls::SwapChainPanel const& sender, Windows::Foundation::IInspectable const& args);

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -590,3 +590,13 @@ const std::wstring Terminal::RetrieveSelectedTextFromBuffer(bool trimTrailingWhi
 
     return result;
 }
+
+// Method Description:
+// - Sets the visibility of the text cursor.
+// Arguments:
+// - isVisible: whether the cursor should be visible
+void Terminal::SetCursorVisible(const bool isVisible) noexcept
+{
+    auto& cursor = _buffer->GetCursor();
+    cursor.SetIsVisible(isVisible);
+}

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -96,6 +96,7 @@ public:
     COORD GetCursorPosition() const noexcept override;
     bool IsCursorVisible() const noexcept override;
     bool IsCursorOn() const noexcept override;
+    void SetCursorVisible(const bool isVisible) noexcept;
     ULONG GetCursorHeight() const noexcept override;
     ULONG GetCursorPixelWidth() const noexcept override;
     CursorType GetCursorStyle() const noexcept override;

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -96,7 +96,6 @@ public:
     COORD GetCursorPosition() const noexcept override;
     bool IsCursorVisible() const noexcept override;
     bool IsCursorOn() const noexcept override;
-    void SetCursorVisible(const bool isVisible) noexcept;
     ULONG GetCursorHeight() const noexcept override;
     ULONG GetCursorPixelWidth() const noexcept override;
     CursorType GetCursorStyle() const noexcept override;
@@ -113,6 +112,8 @@ public:
     void SetWriteInputCallback(std::function<void(std::wstring&)> pfn) noexcept;
     void SetTitleChangedCallback(std::function<void(const std::wstring_view&)> pfn) noexcept;
     void SetScrollPositionChangedCallback(std::function<void(const int, const int, const int)> pfn) noexcept;
+
+    void SetCursorVisible(const bool isVisible) noexcept;
 
     #pragma region TextSelection
     const bool IsSelectionActive() const noexcept;

--- a/src/cascadia/TerminalCore/terminalrenderdata.cpp
+++ b/src/cascadia/TerminalCore/terminalrenderdata.cpp
@@ -70,6 +70,12 @@ bool Terminal::IsCursorOn() const noexcept
     return cursor.IsOn();
 }
 
+void Terminal::SetCursorVisible(const bool isVisible) noexcept
+{
+    auto& cursor = _buffer->GetCursor();
+    cursor.SetIsVisible(isVisible);
+}
+
 ULONG Terminal::GetCursorPixelWidth() const noexcept
 {
     return 1;

--- a/src/cascadia/TerminalCore/terminalrenderdata.cpp
+++ b/src/cascadia/TerminalCore/terminalrenderdata.cpp
@@ -70,12 +70,6 @@ bool Terminal::IsCursorOn() const noexcept
     return cursor.IsOn();
 }
 
-void Terminal::SetCursorVisible(const bool isVisible) noexcept
-{
-    auto& cursor = _buffer->GetCursor();
-    cursor.SetIsVisible(isVisible);
-}
-
 ULONG Terminal::GetCursorPixelWidth() const noexcept
 {
     return 1;


### PR DESCRIPTION
Resolves #665. Behaviour was discussed a bit there:

- When the window is not in focus, the cursor is not shown.
- When the user is typing, the cursor is constantly shown.
- Otherwise, the cursor blinks.