### PR TITLE
Fix the .gitignore for /Generated Files/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,7 +271,7 @@ MSG*.bin
 # python
 *.pyc
 
-**Generated Files/
+**/Generated Files/
 **/Merged/*
 **/Unmerged/*
 profiles.json


### PR DESCRIPTION
The paths in this section of the .gitignore are not done the way I'd write them, but this one is clearly just wrong, right?