### PR TITLE
Use operator*() for known non-empty optionals

### DIFF
--- a/src/buffer/out/UnicodeStorage.cpp
+++ b/src/buffer/out/UnicodeStorage.cpp
@@ -66,7 +66,7 @@ void UnicodeStorage::Remap(const std::map<SHORT, SHORT>& rowMap, const std::opti
             const auto oldColId = oldCoord.X;
 
             // If the column index is at/beyond the row width, don't bother copying it to the new map.
-            if (oldColId >= width.value())
+            if (oldColId >= *width)
             {
                 continue;
             }

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -867,7 +867,7 @@ void TextBuffer::_RefreshRowIDs(std::optional<SHORT> newRowWidth)
         if (newRowWidth.has_value())
         {
             // Realloc in the X direction
-            THROW_IF_FAILED(it.Resize(newRowWidth.value()));
+            THROW_IF_FAILED(it.Resize(*newRowWidth));
         }
     }
 

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -510,7 +510,7 @@ namespace winrt::TerminalApp::implementation
 
         if (profileIndex)
         {
-            const auto realIndex = profileIndex.value();
+            const auto realIndex = *profileIndex;
             const auto profiles = _settings->GetProfiles();
 
             // If we don't have that many profiles, then do nothing.

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -303,7 +303,7 @@ const Profile* CascadiaSettings::FindProfile(GUID profileGuid) const noexcept
 // - <none>
 TerminalSettings CascadiaSettings::MakeSettings(std::optional<GUID> profileGuidArg) const
 {
-    GUID profileGuid = profileGuidArg ? profileGuidArg.value() : _globals.GetDefaultProfile();
+    GUID profileGuid = profileGuidArg.value_or(_globals.GetDefaultProfile());
     const Profile* const profile = FindProfile(profileGuid);
     if (profile == nullptr)
     {

--- a/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
@@ -45,7 +45,7 @@ std::unique_ptr<CascadiaSettings> CascadiaSettings::LoadAll(const bool saveOnLoa
     const bool foundFile = fileData.has_value();
     if (foundFile)
     {
-        const auto actualData = fileData.value();
+        const auto actualData = *fileData;
 
         JsonValue root{ nullptr };
         bool parsedSuccessfully = JsonValue::TryParse(actualData, root);

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -142,13 +142,13 @@ TerminalSettings Profile::CreateTerminalSettings(const std::vector<ColorScheme>&
 
     if (_startingDirectory)
     {
-        const auto evaluatedDirectory = Profile::EvaluateStartingDirectory(_startingDirectory.value());
+        const auto evaluatedDirectory = Profile::EvaluateStartingDirectory(*_startingDirectory);
         terminalSettings.StartingDirectory(winrt::to_hstring(evaluatedDirectory.c_str()));
     }
 
     if (_schemeName)
     {
-        const ColorScheme* const matchingScheme = _FindScheme(schemes, _schemeName.value());
+        const ColorScheme* const matchingScheme = _FindScheme(schemes, *_schemeName);
         if (matchingScheme)
         {
             matchingScheme->ApplyScheme(terminalSettings);
@@ -156,16 +156,16 @@ TerminalSettings Profile::CreateTerminalSettings(const std::vector<ColorScheme>&
     }
     if (_defaultForeground)
     {
-        terminalSettings.DefaultForeground(_defaultForeground.value());
+        terminalSettings.DefaultForeground(*_defaultForeground);
     }
     if (_defaultBackground)
     {
-        terminalSettings.DefaultBackground(_defaultBackground.value());
+        terminalSettings.DefaultBackground(*_defaultBackground);
     }
 
     if (_scrollbarState)
     {
-        ScrollbarState result = ParseScrollbarState(_scrollbarState.value());
+        ScrollbarState result = ParseScrollbarState(*_scrollbarState);
         terminalSettings.ScrollState(result);
     }
 
@@ -203,7 +203,7 @@ JsonObject Profile::ToJson() const
 
     if (_startingDirectory)
     {
-        const auto startingDirectory = JsonValue::CreateStringValue(_startingDirectory.value());
+        const auto startingDirectory = JsonValue::CreateStringValue(*_startingDirectory);
         jsonObject.Insert(STARTINGDIRECTORY_KEY, startingDirectory);
     }
 
@@ -213,17 +213,17 @@ JsonObject Profile::ToJson() const
     // Core Settings
     if (_defaultForeground)
     {
-        const auto defaultForeground = JsonValue::CreateStringValue(Utils::ColorToHexString(_defaultForeground.value()));
+        const auto defaultForeground = JsonValue::CreateStringValue(Utils::ColorToHexString(*_defaultForeground));
         jsonObject.Insert(FOREGROUND_KEY, defaultForeground);
     }
     if (_defaultBackground)
     {
-        const auto defaultBackground = JsonValue::CreateStringValue(Utils::ColorToHexString(_defaultBackground.value()));
+        const auto defaultBackground = JsonValue::CreateStringValue(Utils::ColorToHexString(*_defaultBackground));
         jsonObject.Insert(BACKGROUND_KEY, defaultBackground);
     }
     if (_schemeName)
     {
-        const auto scheme = JsonValue::CreateStringValue(_schemeName.value());
+        const auto scheme = JsonValue::CreateStringValue(*_schemeName);
         jsonObject.Insert(COLORSCHEME_KEY, scheme);
     }
     else
@@ -266,7 +266,7 @@ JsonObject Profile::ToJson() const
 
     if (_icon)
     {
-        const auto icon = JsonValue::CreateStringValue(_icon.value());
+        const auto icon = JsonValue::CreateStringValue(*_icon);
         jsonObject.Insert(ICON_KEY, icon);
     }
 
@@ -464,7 +464,7 @@ bool Profile::HasIcon() const noexcept
 std::wstring_view Profile::GetIconPath() const noexcept
 {
     return HasIcon() ?
-           std::wstring_view{ _icon.value().c_str(), _icon.value().size() } :
+           std::wstring_view{ *_icon } :
            std::wstring_view{ L"", 0 };
 }
 

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -260,7 +260,7 @@ JsonObject Profile::ToJson() const
 
     if (_scrollbarState)
     {
-        const auto scrollbarState = JsonValue::CreateStringValue(_scrollbarState.value());
+        const auto scrollbarState = JsonValue::CreateStringValue(*_scrollbarState);
         jsonObject.Insert(SCROLLBARSTATE_KEY, scrollbarState);
     }
 

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -445,7 +445,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             {
                 // we already were storing a leading surrogate but we got another one. Go ahead and send the
                 // saved surrogate piece and save the new one
-                auto hstr = to_hstring(_leadingSurrogate.value());
+                auto hstr = to_hstring(*_leadingSurrogate);
                 _connection.WriteInput(hstr);
             }
             // save the leading portion of a surrogate pair so that they can be sent at the same time
@@ -455,7 +455,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         {
             std::wstring wstr;
             wstr.reserve(2);
-            wstr.push_back(_leadingSurrogate.value());
+            wstr.push_back(*_leadingSurrogate);
             wstr.push_back(ch);
             _leadingSurrogate.reset();
 
@@ -612,7 +612,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         {
             const auto contactRect = point.Properties().ContactRect();
             winrt::Windows::Foundation::Point newTouchPoint{ contactRect.X, contactRect.Y };
-            const auto anchor = _touchAnchor.value();
+            const auto anchor = *_touchAnchor;
 
             // Get the difference between the point we've dragged to and the start of the touch.
             const float fontHeight = float(_actualFont.GetSize().Y);
@@ -785,7 +785,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             //      last scroll event we raised.
             // Regardless, we're going to ignore this message, because the
             //      terminal is already in the scroll position it wants.
-            const auto ourLastOffset = _lastScrollOffset.value();
+            const auto ourLastOffset = *_lastScrollOffset;
             if (newValue == ourLastOffset)
             {
                 _lastScrollOffset = std::nullopt;

--- a/src/host/alias.cpp
+++ b/src/host/alias.cpp
@@ -147,9 +147,9 @@ HRESULT GetConsoleAliasWImplHelper(const std::wstring_view source,
     // Ensure output variables are initialized
     writtenOrNeeded = 0;
 
-    if (target.has_value() && target.value().size() > 0)
+    if (target.has_value() && target->size() > 0)
     {
-        target.value().at(0) = UNICODE_NULL;
+        target->at(0) = UNICODE_NULL;
     }
 
     std::wstring exeNameString(exeName);
@@ -178,9 +178,9 @@ HRESULT GetConsoleAliasWImplHelper(const std::wstring_view source,
     if (target.has_value())
     {
         // if the user didn't give us enough space, return with insufficient buffer code early.
-        RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER), gsl::narrow<size_t>(target.value().size()) < neededSize);
+        RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER), gsl::narrow<size_t>(target->size()) < neededSize);
 
-        RETURN_IF_FAILED(StringCchCopyNW(target.value().data(), target.value().size(), targetString.data(), targetSize));
+        RETURN_IF_FAILED(StringCchCopyNW(target->data(), target->size(), targetString.data(), targetSize));
     }
 
     return S_OK;
@@ -455,14 +455,14 @@ HRESULT GetConsoleAliasesWImplHelper(const std::wstring_view exeName,
     // Ensure output variables are initialized.
     writtenOrNeeded = 0;
 
-    if (aliasBuffer.has_value() && aliasBuffer.value().size() > 0)
+    if (aliasBuffer.has_value() && aliasBuffer->size() > 0)
     {
-        aliasBuffer.value().at(0) = UNICODE_NULL;
+        aliasBuffer->at(0) = UNICODE_NULL;
     }
 
     std::wstring exeNameString(exeName);
 
-    LPWSTR AliasesBufferPtrW = aliasBuffer.has_value() ? aliasBuffer.value().data() : nullptr;
+    LPWSTR AliasesBufferPtrW = aliasBuffer.has_value() ? aliasBuffer->data() : nullptr;
     size_t cchTotalLength = 0; // accumulate the characters we need/have copied as we walk the list
 
     // Each of the alises will be made up of the source, a seperator, the target, then a null character.
@@ -495,10 +495,10 @@ HRESULT GetConsoleAliasesWImplHelper(const std::wstring_view exeName,
                 size_t cchNewTotal;
                 RETURN_IF_FAILED(SizeTAdd(cchTotalLength, cchNeeded, &cchNewTotal));
 
-                RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_BUFFER_OVERFLOW), cchNewTotal > gsl::narrow<size_t>(aliasBuffer.value().size()));
+                RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_BUFFER_OVERFLOW), cchNewTotal > gsl::narrow<size_t>(aliasBuffer->size()));
 
                 size_t cchAliasBufferRemaining;
-                RETURN_IF_FAILED(SizeTSub(aliasBuffer.value().size(), cchTotalLength, &cchAliasBufferRemaining));
+                RETURN_IF_FAILED(SizeTSub(aliasBuffer->size(), cchTotalLength, &cchAliasBufferRemaining));
 
                 RETURN_IF_FAILED(StringCchCopyNW(AliasesBufferPtrW, cchAliasBufferRemaining, pair.first.data(), cchSource));
                 RETURN_IF_FAILED(SizeTSub(cchAliasBufferRemaining, cchSource, &cchAliasBufferRemaining));
@@ -708,12 +708,12 @@ HRESULT GetConsoleAliasExesWImplHelper(std::optional<gsl::span<wchar_t>> aliasEx
 {
     // Ensure output variables are initialized.
     writtenOrNeeded = 0;
-    if (aliasExesBuffer.has_value() && aliasExesBuffer.value().size() > 0)
+    if (aliasExesBuffer.has_value() && aliasExesBuffer->size() > 0)
     {
-        aliasExesBuffer.value().at(0) = UNICODE_NULL;
+        aliasExesBuffer->at(0) = UNICODE_NULL;
     }
 
-    LPWSTR AliasExesBufferPtrW = aliasExesBuffer.has_value() ? aliasExesBuffer.value().data() : nullptr;
+    LPWSTR AliasExesBufferPtrW = aliasExesBuffer.has_value() ? aliasExesBuffer->data() : nullptr;
     size_t cchTotalLength = 0; // accumulate the characters we need/have copied as we walk the list
 
     size_t const cchNull = 1;
@@ -734,10 +734,10 @@ HRESULT GetConsoleAliasExesWImplHelper(std::optional<gsl::span<wchar_t>> aliasEx
             // Error out early if there is a problem.
             size_t cchNewTotal;
             RETURN_IF_FAILED(SizeTAdd(cchTotalLength, cchNeeded, &cchNewTotal));
-            RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_BUFFER_OVERFLOW), cchNewTotal > gsl::narrow<size_t>(aliasExesBuffer.value().size()));
+            RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_BUFFER_OVERFLOW), cchNewTotal > gsl::narrow<size_t>(aliasExesBuffer->size()));
 
             size_t cchRemaining;
-            RETURN_IF_FAILED(SizeTSub(aliasExesBuffer.value().size(), cchTotalLength, &cchRemaining));
+            RETURN_IF_FAILED(SizeTSub(aliasExesBuffer->size(), cchTotalLength, &cchRemaining));
 
             RETURN_IF_FAILED(StringCchCopyNW(AliasExesBufferPtrW, cchRemaining, pair.first.data(), cchExe));
             AliasExesBufferPtrW += cchNeeded;

--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -1732,9 +1732,9 @@ HRESULT GetConsoleTitleWImplHelper(std::optional<gsl::span<wchar_t>> title,
         written = 0;
         needed = 0;
 
-        if (title.has_value() && title.value().size() > 0)
+        if (title.has_value() && title->size() > 0)
         {
-            title.value().at(0) = ANSI_NULL;
+            title->at(0) = ANSI_NULL;
         }
 
         // Get the appropriate title and length depending on the mode.
@@ -1758,13 +1758,13 @@ HRESULT GetConsoleTitleWImplHelper(std::optional<gsl::span<wchar_t>> title,
         // If we have a pointer to receive the data, then copy it out.
         if (title.has_value())
         {
-            HRESULT const hr = StringCchCopyNW(title.value().data(), title.value().size(), pwszTitle, cchTitleLength);
+            HRESULT const hr = StringCchCopyNW(title->data(), title->size(), pwszTitle, cchTitleLength);
 
             // Insufficient buffer is allowed. If we return a partial string, that's still OK by historical/compat standards.
             // Just say how much we managed to return.
             if (SUCCEEDED(hr) || STRSAFE_E_INSUFFICIENT_BUFFER == hr)
             {
-                written = std::min(gsl::narrow<size_t>(title.value().size()), cchTitleLength);
+                written = std::min(gsl::narrow<size_t>(title->size()), cchTitleLength);
             }
         }
         return S_OK;

--- a/src/host/history.cpp
+++ b/src/host/history.cpp
@@ -397,7 +397,7 @@ CommandHistory* CommandHistory::s_Allocate(const std::wstring_view appName, cons
         BestCandidate->_processHandle = processHandle;
         WI_SetFlag(BestCandidate->Flags, CLE_ALLOCATED);
 
-        return &s_historyLists.emplace_front(BestCandidate.value());
+        return &s_historyLists.emplace_front(*BestCandidate);
     }
 
     return nullptr;

--- a/src/host/ut_host/ApiRoutinesTests.cpp
+++ b/src/host/ut_host/ApiRoutinesTests.cpp
@@ -490,7 +490,7 @@ class ApiRoutinesTests
         while (it)
         {
             if (backgroundArea.IsInBounds(it._pos) ||
-                (clip.has_value() && !clip.value().IsInBounds(it._pos)))
+                (clip.has_value() && !clip->IsInBounds(it._pos)))
             {
                 auto cellInfo = gci.AsCharInfo(*it);
                 VERIFY_ARE_EQUAL(background, cellInfo);
@@ -555,7 +555,7 @@ class ApiRoutinesTests
             // If there is a clip rectangle...
             else
             {
-                const auto unboxedClip = clip.value();
+                const auto unboxedClip = *clip;
 
                 if (unboxedClip.IsInBounds(it._pos))
                 {
@@ -637,7 +637,7 @@ class ApiRoutinesTests
             clipRectDimensions.X /= 2;
 
             clipViewport = Viewport::FromDimensions({ 0, 0 }, clipRectDimensions);
-            clipRectangle = clipViewport.value().ToInclusive();
+            clipRectangle = clipViewport->ToInclusive();
         }
 
         // Scroll everything up and backfill with red As.
@@ -661,7 +661,7 @@ class ApiRoutinesTests
             clipRectDimensions.Y /= 2;
             
             clipViewport = Viewport::FromDimensions({ 0, 0 }, clipRectDimensions);
-            clipRectangle = clipViewport.value().ToInclusive();
+            clipRectangle = clipViewport->ToInclusive();
         }
 
         Log::Comment(L"Fill screen with green Zs. Scroll all left by two, backfilling with red As. Confirm every cell.");
@@ -695,7 +695,7 @@ class ApiRoutinesTests
         {
             // Clip out the left most and top most column.
             clipViewport = Viewport::FromDimensions({ 1, 1 }, { 4, 4 });
-            clipRectangle = clipViewport.value().ToInclusive();
+            clipRectangle = clipViewport->ToInclusive();
         }
         VERIFY_SUCCEEDED(_pApiRoutines->ScrollConsoleScreenBufferWImpl(si, scroll, destination, clipRectangle, fill.Char.UnicodeChar, fill.Attributes));
         ValidateScreen(si, background, fill, destination, clipViewport);
@@ -711,7 +711,7 @@ class ApiRoutinesTests
         {
             // Clip out the bottom most and right most column
             clipViewport = Viewport::FromDimensions({ 0, 0 }, { 4, 4 });
-            clipRectangle = clipViewport.value().ToInclusive();
+            clipRectangle = clipViewport->ToInclusive();
         }
         VERIFY_SUCCEEDED(_pApiRoutines->ScrollConsoleScreenBufferWImpl(si, scroll, destination, clipRectangle, fill.Char.UnicodeChar, fill.Attributes));
         ValidateScreen(si, background, fill, destination, clipViewport);
@@ -730,7 +730,7 @@ class ApiRoutinesTests
             clipRectDimensions.X /= 2;
 
             clipViewport = Viewport::FromDimensions({ 0, 0 }, clipRectDimensions);
-            clipRectangle = clipViewport.value().ToInclusive();
+            clipRectangle = clipViewport->ToInclusive();
         }
         VERIFY_SUCCEEDED(_pApiRoutines->ScrollConsoleScreenBufferWImpl(si, scroll, destination, clipRectangle, fill.Char.UnicodeChar, fill.Attributes));
         ValidateScreen(si, background, fill, destination, clipViewport);
@@ -756,7 +756,7 @@ class ApiRoutinesTests
             // If we're doing clipping here, we're going to clip the scrolled area (after Bs are filled onto field of Zs)
             // to only the 3rd and 4th columns of the pattern.
             clipViewport = Viewport::FromDimensions({ 2, 0 }, { 2, 5 });
-            clipRectangle = clipViewport.value().ToInclusive();
+            clipRectangle = clipViewport->ToInclusive();
         }
 
         Log::Comment(L"Scroll a small portion of the screen in an overlapping fashion.");

--- a/src/inc/conpty-universal.h
+++ b/src/inc/conpty-universal.h
@@ -140,7 +140,7 @@ HRESULT CreateConPty(const std::wstring& cmdline,
         return hr;
     }
 
-    LPCWSTR lpCurrentDirectory = startingDirectory.has_value() ? startingDirectory.value().c_str() : nullptr;
+    LPCWSTR lpCurrentDirectory = startingDirectory.has_value() ? startingDirectory->c_str() : nullptr;
 
     bool fSuccess = !!CreateProcessW(
         nullptr,


### PR DESCRIPTION
This commit changes uses of std::optional::value() to operator*() and
operator->() for optionals known to contain values.

optional::value() throws while operator*() and operator->() do not.
Using the latters should help generating more efficient code at no
maintainability cost.

Signed-off-by: Fred Miller <fghzxm@outlook.com>