### PR TITLE
Convert copy to move

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1024,9 +1024,9 @@ const TextBuffer::TextAndColor TextBuffer::GetTextForClipboard(const bool lineSe
             }
         }
 
-        data.text.emplace_back(selectionText);
-        data.FgAttr.emplace_back(selectionFgAttr);
-        data.BkAttr.emplace_back(selectionBkAttr);
+        data.text.emplace_back(std::move(selectionText));
+        data.FgAttr.emplace_back(std::move(selectionFgAttr));
+        data.BkAttr.emplace_back(std::move(selectionBkAttr));
     }
 
     return data;


### PR DESCRIPTION
I believe there are bunches of unnecessary copies in the codebase that can be converted into moves.  Is there any idea how we can find and fix them?