### PR TITLE
Amend Color array to typed values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,7 +271,7 @@ MSG*.bin
 # python
 *.pyc
 
-**Generated Files/
+**/Generated Files/
 **/Merged/*
 **/Unmerged/*
 profiles.json

--- a/src/cascadia/TerminalApp/ColorScheme.cpp
+++ b/src/cascadia/TerminalApp/ColorScheme.cpp
@@ -19,22 +19,22 @@ static const std::wstring BACKGROUND_KEY{ L"background" };
 static const std::int16_t TABLE_SIZE = 16;
 static const std::wstring TABLE_COLORS[TABLE_SIZE] =
 {
-	L"black",
-	L"red",
-	L"green",
-	L"yellow",
-	L"blue",
-	L"purple",
-	L"cyan",
-	L"white",
-	L"brightBlack",
-	L"brightRed",
-	L"brightGreen",
-	L"brightYellow",
-	L"brightBlue",
-	L"brightPurple",
-	L"brightCyan",
-	L"brightWhite"
+    L"black",
+    L"red",
+    L"green",
+    L"yellow",
+    L"blue",
+    L"purple",
+    L"cyan",
+    L"white",
+    L"brightBlack",
+    L"brightRed",
+    L"brightGreen",
+    L"brightYellow",
+    L"brightBlue",
+    L"brightPurple",
+    L"brightCyan",
+    L"brightWhite"
 };
 
 ColorScheme::ColorScheme() :
@@ -96,14 +96,14 @@ JsonObject ColorScheme::ToJson() const
     jsonObject.Insert(FOREGROUND_KEY, fg);
     jsonObject.Insert(BACKGROUND_KEY, bg);
  
-	for (int i = 0; i < TABLE_SIZE; i++)
-	{
-		auto current = TABLE_COLORS[i];
-		auto& color = _table[i];
-		auto s = JsonValue::CreateStringValue(Utils::ColorToHexString(color));
-				
-		jsonObject.Insert(current, s);
-	}
+    for (int i = 0; i < TABLE_SIZE; i++)
+    {
+        auto current = TABLE_COLORS[i];
+        auto& color = _table[i];
+        auto s = JsonValue::CreateStringValue(Utils::ColorToHexString(color));
+
+        jsonObject.Insert(current, s);
+    }
 
     return jsonObject;
 }
@@ -135,34 +135,34 @@ ColorScheme ColorScheme::FromJson(winrt::Windows::Data::Json::JsonObject json)
         result._defaultBackground = color;
     }
 
-	//Legacy Deserialization. Leave in place to allow forward compatibility
-	if (json.HasKey(TABLE_KEY))
-	{
-		const auto table = json.GetNamedArray(TABLE_KEY);
-		int i = 0;
+    //Legacy Deserialization. Leave in place to allow forward compatibility
+    if (json.HasKey(TABLE_KEY))
+    {
+        const auto table = json.GetNamedArray(TABLE_KEY);
+        int i = 0;
 
-		for (auto v : table)
-		{
-			if (v.ValueType() == JsonValueType::String)
-			{
-				auto str = v.GetString();
-				auto color = Utils::ColorFromHexString(str.c_str());
-				result._table[i] = color;
-			}
-			i++;
-		}
-	}
+        for (auto v : table)
+        {
+            if (v.ValueType() == JsonValueType::String)
+            {
+                auto str = v.GetString();
+                auto color = Utils::ColorFromHexString(str.c_str());
+                result._table[i] = color;
+            }
+            i++;
+        }
+    }
 
-	for (int i = 0; i < TABLE_SIZE; i++)
-	{
-		auto current = TABLE_COLORS[i];
-		if (json.HasKey(current))
-		{
-			const auto str = json.GetNamedString(current);
-			const auto color = Utils::ColorFromHexString(str.c_str());
-			result._table[i] = color;
-		}
-	}
+    for (int i = 0; i < TABLE_SIZE; i++)
+    {
+        auto current = TABLE_COLORS[i];
+        if (json.HasKey(current))
+        {
+            const auto str = json.GetNamedString(current);
+            const auto color = Utils::ColorFromHexString(str.c_str());
+            result._table[i] = color;
+        }
+    }
 
     return result;
 }

--- a/src/cascadia/TerminalApp/ColorScheme.cpp
+++ b/src/cascadia/TerminalApp/ColorScheme.cpp
@@ -134,6 +134,25 @@ ColorScheme ColorScheme::FromJson(winrt::Windows::Data::Json::JsonObject json)
         const auto color = Utils::ColorFromHexString(bgString.c_str());
         result._defaultBackground = color;
     }
+
+	//Legacy Deserialization. Leave in place to allow forward compatibility
+	if (json.HasKey(TABLE_KEY))
+	{
+		const auto table = json.GetNamedArray(TABLE_KEY);
+		int i = 0;
+
+		for (auto v : table)
+		{
+			if (v.ValueType() == JsonValueType::String)
+			{
+				auto str = v.GetString();
+				auto color = Utils::ColorFromHexString(str.c_str());
+				result._table[i] = color;
+			}
+			i++;
+		}
+	}
+
 	for (int i = 0; i < TABLE_SIZE; i++)
 	{
 		auto current = TABLE_COLORS[i];

--- a/src/cascadia/TerminalApp/ColorScheme.cpp
+++ b/src/cascadia/TerminalApp/ColorScheme.cpp
@@ -16,6 +16,26 @@ static const std::wstring NAME_KEY{ L"name" };
 static const std::wstring TABLE_KEY{ L"colors" };
 static const std::wstring FOREGROUND_KEY{ L"foreground" };
 static const std::wstring BACKGROUND_KEY{ L"background" };
+static const std::int16_t TABLE_SIZE = 16;
+static const std::wstring TABLE_COLORS[TABLE_SIZE] =
+{
+	L"black",
+	L"red",
+	L"green",
+	L"yellow",
+	L"blue",
+	L"purple",
+	L"cyan",
+	L"white",
+	L"brightBlack",
+	L"brightRed",
+	L"brightGreen",
+	L"brightYellow",
+	L"brightBlue",
+	L"brightPurple",
+	L"brightCyan",
+	L"brightWhite"
+};
 
 ColorScheme::ColorScheme() :
     _schemeName{ L"" },
@@ -71,17 +91,19 @@ JsonObject ColorScheme::ToJson() const
     auto fg = JsonValue::CreateStringValue(Utils::ColorToHexString(_defaultForeground));
     auto bg = JsonValue::CreateStringValue(Utils::ColorToHexString(_defaultBackground));
     auto name = JsonValue::CreateStringValue(_schemeName);
-    JsonArray tableArray{};
-    for (auto& color : _table)
-    {
-        auto s = Utils::ColorToHexString(color);
-        tableArray.Append(JsonValue::CreateStringValue(s));
-    }
 
     jsonObject.Insert(NAME_KEY, name);
     jsonObject.Insert(FOREGROUND_KEY, fg);
     jsonObject.Insert(BACKGROUND_KEY, bg);
-    jsonObject.Insert(TABLE_KEY, tableArray);
+ 
+	for (int i = 0; i < TABLE_SIZE; i++)
+	{
+		auto current = TABLE_COLORS[i];
+		auto color = _table[i];
+		auto s = JsonValue::CreateStringValue(Utils::ColorToHexString(color));
+				
+		jsonObject.Insert(current, s);
+	}
 
     return jsonObject;
 }
@@ -112,22 +134,16 @@ ColorScheme ColorScheme::FromJson(winrt::Windows::Data::Json::JsonObject json)
         const auto color = Utils::ColorFromHexString(bgString.c_str());
         result._defaultBackground = color;
     }
-    if (json.HasKey(TABLE_KEY))
-    {
-        const auto table = json.GetNamedArray(TABLE_KEY);
-        int i = 0;
-
-        for (auto v : table)
-        {
-            if (v.ValueType() == JsonValueType::String)
-            {
-                auto str = v.GetString();
-                auto color = Utils::ColorFromHexString(str.c_str());
-                result._table[i] = color;
-            }
-            i++;
-        }
-    }
+	for (int i = 0; i < TABLE_SIZE; i++)
+	{
+		auto current = TABLE_COLORS[i];
+		if (json.HasKey(current))
+		{
+			const auto str = json.GetNamedString(current);
+			const auto color = Utils::ColorFromHexString(str.c_str());
+			result._table[i] = color;
+		}
+	}
 
     return result;
 }

--- a/src/cascadia/TerminalApp/ColorScheme.cpp
+++ b/src/cascadia/TerminalApp/ColorScheme.cpp
@@ -16,8 +16,7 @@ static const std::wstring NAME_KEY{ L"name" };
 static const std::wstring TABLE_KEY{ L"colors" };
 static const std::wstring FOREGROUND_KEY{ L"foreground" };
 static const std::wstring BACKGROUND_KEY{ L"background" };
-static const std::int16_t TABLE_SIZE = 16;
-static const std::wstring TABLE_COLORS[TABLE_SIZE] =
+static const std::array<std::wstring, 16> TABLE_COLORS =
 {
     L"black",
     L"red",
@@ -96,13 +95,14 @@ JsonObject ColorScheme::ToJson() const
     jsonObject.Insert(FOREGROUND_KEY, fg);
     jsonObject.Insert(BACKGROUND_KEY, bg);
  
-    for (int i = 0; i < TABLE_SIZE; i++)
+    int i = 0;
+    for (const auto& current : TABLE_COLORS)
     {
-        auto current = TABLE_COLORS[i];
         auto& color = _table[i];
         auto s = JsonValue::CreateStringValue(Utils::ColorToHexString(color));
 
         jsonObject.Insert(current, s);
+        i++;
     }
 
     return jsonObject;
@@ -153,15 +153,16 @@ ColorScheme ColorScheme::FromJson(winrt::Windows::Data::Json::JsonObject json)
         }
     }
 
-    for (int i = 0; i < TABLE_SIZE; i++)
+    int i = 0;
+    for (const auto& current : TABLE_COLORS)
     {
-        auto current = TABLE_COLORS[i];
         if (json.HasKey(current))
         {
             const auto str = json.GetNamedString(current);
             const auto color = Utils::ColorFromHexString(str.c_str());
             result._table[i] = color;
         }
+        i++;
     }
 
     return result;

--- a/src/cascadia/TerminalApp/ColorScheme.cpp
+++ b/src/cascadia/TerminalApp/ColorScheme.cpp
@@ -99,7 +99,7 @@ JsonObject ColorScheme::ToJson() const
 	for (int i = 0; i < TABLE_SIZE; i++)
 	{
 		auto current = TABLE_COLORS[i];
-		auto color = _table[i];
+		auto& color = _table[i];
 		auto s = JsonValue::CreateStringValue(Utils::ColorToHexString(color));
 				
 		jsonObject.Insert(current, s);

--- a/src/cascadia/TerminalApp/ColorScheme.cpp
+++ b/src/cascadia/TerminalApp/ColorScheme.cpp
@@ -98,7 +98,7 @@ JsonObject ColorScheme::ToJson() const
     int i = 0;
     for (const auto& current : TABLE_COLORS)
     {
-        auto& color = _table[i];
+        auto& color = _table.at(i);
         auto s = JsonValue::CreateStringValue(Utils::ColorToHexString(color));
 
         jsonObject.Insert(current, s);
@@ -147,7 +147,7 @@ ColorScheme ColorScheme::FromJson(winrt::Windows::Data::Json::JsonObject json)
             {
                 auto str = v.GetString();
                 auto color = Utils::ColorFromHexString(str.c_str());
-                result._table[i] = color;
+                result._table.at(i) = color;
             }
             i++;
         }
@@ -160,7 +160,7 @@ ColorScheme ColorScheme::FromJson(winrt::Windows::Data::Json::JsonObject json)
         {
             const auto str = json.GetNamedString(current);
             const auto color = Utils::ColorFromHexString(str.c_str());
-            result._table[i] = color;
+            result._table.at(i) = color;
         }
         i++;
     }


### PR DESCRIPTION
microsoft/Terminal#711

Refactoring the terminal `color` array to a list of typed values to remove confusion as to what the values represent.