### PR TITLE
Add non-acrylic opacity

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -756,6 +756,7 @@ namespace winrt::TerminalApp::implementation
 
                 tab->SetFocused(true);
                 _titleChangeHandlers(GetTitle());
+                _opacityChangeHandlers(_settings->FindProfile(tab->GetProfile())->GetOpacity());
             }
             CATCH_LOG();
         }
@@ -817,6 +818,27 @@ namespace winrt::TerminalApp::implementation
             }
         }
         return { L"Windows Terminal" };
+    }
+
+    // Method Description:
+    // - Gets the opacity of the currently focused terminal control. If there
+    //   isn't a control selected for any reason, returns 1
+    // Arguments:
+    // - <none>
+    // Return Value:
+    // - the opacity of the focused control if there is one, else 1
+    double App::GetOpacity()
+    {
+        auto selectedIndex = _tabView.SelectedIndex();
+        if (selectedIndex >= 0)
+        {
+            try
+            {
+                return _settings->FindProfile(_tabs.at(selectedIndex)->GetProfile())->GetOpacity();
+            }
+            CATCH_LOG();
+        }
+        return 1;
     }
 
     // Method Description:
@@ -891,5 +913,6 @@ namespace winrt::TerminalApp::implementation
     // -------------------------------- WinRT Events ---------------------------------
     // Winrt events need a method for adding a callback to the event and removing the callback.
     // These macros will define them both for you.
-    DEFINE_EVENT(App, TitleChanged, _titleChangeHandlers, TerminalControl::TitleChangedEventArgs);
+    DEFINE_EVENT(App, TitleChanged,   _titleChangeHandlers,   TerminalControl::TitleChangedEventArgs);
+    DEFINE_EVENT(App, OpacityChanged, _opacityChangeHandlers, TerminalApp::OpacityChangedEventArgs);
 }

--- a/src/cascadia/TerminalApp/App.h
+++ b/src/cascadia/TerminalApp/App.h
@@ -41,9 +41,11 @@ namespace winrt::TerminalApp::implementation
         ~App();
 
         hstring GetTitle();
+        double GetOpacity();
 
         // -------------------------------- WinRT Events ---------------------------------
-        DECLARE_EVENT(TitleChanged, _titleChangeHandlers, winrt::Microsoft::Terminal::TerminalControl::TitleChangedEventArgs);
+        DECLARE_EVENT(TitleChanged,   _titleChangeHandlers,   winrt::Microsoft::Terminal::TerminalControl::TitleChangedEventArgs);
+        DECLARE_EVENT(OpacityChanged, _opacityChangeHandlers, TerminalApp::OpacityChangedEventArgs);
 
     private:
         App(Windows::UI::Xaml::Markup::IXamlMetadataProvider const& parentProvider);

--- a/src/cascadia/TerminalApp/App.idl
+++ b/src/cascadia/TerminalApp/App.idl
@@ -3,6 +3,8 @@
 
 namespace TerminalApp
 {
+    delegate void OpacityChangedEventArgs(Double opacity);
+
     [default_interface]
     runtimeclass App : Microsoft.UI.Xaml.Markup.XamlApplication
     {
@@ -24,8 +26,10 @@ namespace TerminalApp
         Boolean GetShowTabsInTitlebar();
 
         event Microsoft.Terminal.TerminalControl.TitleChangedEventArgs TitleChanged;
+        event OpacityChangedEventArgs OpacityChanged;
 
         String GetTitle();
+        Double GetOpacity();
 
         // IXamlMetadataProvider, Xaml.Application:
         // Application's composing initializer will register the composing class

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -30,6 +30,7 @@ static const std::wstring COMMANDLINE_KEY{ L"commandline" };
 static const std::wstring FONTFACE_KEY{ L"fontFace" };
 static const std::wstring FONTSIZE_KEY{ L"fontSize" };
 static const std::wstring ACRYLICTRANSPARENCY_KEY{ L"acrylicOpacity" };
+static const std::wstring OPACITY_KEY{ L"opacity" };
 static const std::wstring USEACRYLIC_KEY{ L"useAcrylic" };
 static const std::wstring SCROLLBARSTATE_KEY{ L"scrollbarState" };
 static const std::wstring CLOSEONEXIT_KEY{ L"closeOnExit" };
@@ -67,6 +68,7 @@ Profile::Profile() :
     _fontFace{ DEFAULT_FONT_FACE },
     _fontSize{ DEFAULT_FONT_SIZE },
     _acrylicTransparency{ 0.5 },
+    _opacity{ 0.75 },
     _useAcrylic{ false },
     _scrollbarState{ },
     _closeOnExit{ true },
@@ -133,6 +135,7 @@ TerminalSettings Profile::CreateTerminalSettings(const std::vector<ColorScheme>&
     terminalSettings.UseAcrylic(_useAcrylic);
     terminalSettings.CloseOnExit(_closeOnExit);
     terminalSettings.TintOpacity(_acrylicTransparency);
+    terminalSettings.Opacity(_opacity);
 
     terminalSettings.FontFace(_fontFace);
     terminalSettings.FontSize(_fontSize);
@@ -197,6 +200,7 @@ JsonObject Profile::ToJson() const
     const auto fontFace = JsonValue::CreateStringValue(_fontFace);
     const auto fontSize = JsonValue::CreateNumberValue(_fontSize);
     const auto acrylicTransparency = JsonValue::CreateNumberValue(_acrylicTransparency);
+    const auto opacity = JsonValue::CreateNumberValue(_opacity);
     const auto useAcrylic = JsonValue::CreateBooleanValue(_useAcrylic);
     const auto closeOnExit = JsonValue::CreateBooleanValue(_closeOnExit);
     const auto padding = JsonValue::CreateStringValue(_padding);
@@ -254,6 +258,7 @@ JsonObject Profile::ToJson() const
     jsonObject.Insert(FONTFACE_KEY, fontFace);
     jsonObject.Insert(FONTSIZE_KEY, fontSize);
     jsonObject.Insert(ACRYLICTRANSPARENCY_KEY, acrylicTransparency);
+    jsonObject.Insert(OPACITY_KEY, opacity);
     jsonObject.Insert(USEACRYLIC_KEY, useAcrylic);
     jsonObject.Insert(CLOSEONEXIT_KEY, closeOnExit);
     jsonObject.Insert(PADDING_KEY, padding);
@@ -377,6 +382,10 @@ Profile Profile::FromJson(winrt::Windows::Data::Json::JsonObject json)
     {
         result._acrylicTransparency = json.GetNamedNumber(ACRYLICTRANSPARENCY_KEY);
     }
+    if (json.HasKey(OPACITY_KEY))
+    {
+        result._opacity = json.GetNamedNumber(OPACITY_KEY);
+    }
     if (json.HasKey(USEACRYLIC_KEY))
     {
         result._useAcrylic = json.GetNamedBoolean(USEACRYLIC_KEY);
@@ -482,6 +491,16 @@ std::wstring_view Profile::GetName() const noexcept
 bool Profile::GetCloseOnExit() const noexcept
 {
     return _closeOnExit;
+}
+
+double Profile::GetOpacity() const noexcept
+{
+    return _opacity;
+}
+
+void Profile::SetOpacity(double opacity) noexcept
+{
+    _opacity = opacity;
 }
 
 // Method Description:

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -51,6 +51,9 @@ public:
 
     bool GetCloseOnExit() const noexcept;
 
+    double GetOpacity() const noexcept;
+    void SetOpacity(double opacity) noexcept;
+
 private:
 
     static std::wstring EvaluateStartingDirectory(const std::wstring& directory);
@@ -79,6 +82,7 @@ private:
     std::optional<std::wstring> _startingDirectory;
     int32_t _fontSize;
     double _acrylicTransparency;
+    double _opacity;
     bool _useAcrylic;
 
     std::optional<std::wstring> _scrollbarState;

--- a/src/cascadia/TerminalSettings/IControlSettings.idl
+++ b/src/cascadia/TerminalSettings/IControlSettings.idl
@@ -22,6 +22,7 @@ namespace Microsoft.Terminal.Settings
         Boolean UseAcrylic;
         Boolean CloseOnExit;
         Double TintOpacity;
+        Double Opacity;
         ScrollbarState ScrollState; 
 
         String FontFace;

--- a/src/cascadia/TerminalSettings/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettings/TerminalSettings.cpp
@@ -21,6 +21,7 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         _useAcrylic{ false },
         _closeOnExit{ true },
         _tintOpacity{ 0.5 },
+        _opacity{ 0.75 },
         _padding{ DEFAULT_PADDING },
         _fontFace{ DEFAULT_FONT_FACE },
         _fontSize{ DEFAULT_FONT_SIZE },
@@ -159,6 +160,16 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
     void TerminalSettings::TintOpacity(double value)
     {
         _tintOpacity = value;
+    }
+
+    double TerminalSettings::Opacity()
+    {
+        return _opacity;
+    }
+
+    void TerminalSettings::Opacity(double value)
+    {
+        _opacity = value;
     }
 
     hstring TerminalSettings::Padding()

--- a/src/cascadia/TerminalSettings/terminalsettings.h
+++ b/src/cascadia/TerminalSettings/terminalsettings.h
@@ -53,6 +53,8 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         void CloseOnExit(bool value);
         double TintOpacity();
         void TintOpacity(double value);
+        double Opacity();
+        void Opacity(double value);
         hstring Padding();
         void Padding(hstring value);
 
@@ -91,6 +93,7 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         bool _useAcrylic;
         bool _closeOnExit;
         double _tintOpacity;
+        double _opacity;
         hstring _fontFace;
         int32_t _fontSize;
         hstring _padding;

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -70,8 +70,10 @@ void AppHost::Initialize()
     _app.Create();
 
     _app.TitleChanged({ this, &AppHost::AppTitleChanged });
+    _app.OpacityChanged({ this, &AppHost::AppOpacityChanged });
 
     AppTitleChanged(_app.GetTitle());
+    AppOpacityChanged(_app.GetOpacity());
 
     _window->SetRootContent(_app.GetRoot());
     if (_useNonClientArea)
@@ -91,6 +93,18 @@ void AppHost::Initialize()
 void AppHost::AppTitleChanged(winrt::hstring newTitle)
 {
     _window->UpdateTitle(newTitle.c_str());
+}
+
+// Method Description:
+// - Called when the app's opacity changes. Fires off a window message so we can
+//   update the window's opacity on the main thread.
+// Arguments:
+// - newOpacity: the number to use as the new window opacity
+// Return Value:
+// - <none>
+void AppHost::AppOpacityChanged(double newOpacity)
+{
+    _window->UpdateOpacity(newOpacity);
 }
 
 // Method Description:

--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -15,6 +15,7 @@ public:
     virtual ~AppHost();
 
     void AppTitleChanged(winrt::hstring newTitle);
+    void AppOpacityChanged(double newOpacity);
 
     void Initialize();
 

--- a/src/cascadia/WindowsTerminal/BaseWindow.h
+++ b/src/cascadia/WindowsTerminal/BaseWindow.h
@@ -5,6 +5,7 @@
 
 // Custom window messages
 #define CM_UPDATE_TITLE          (WM_USER)
+#define CM_UPDATE_OPACITY        (WM_USER + 1)
 
 template <typename T>
 class BaseWindow
@@ -93,6 +94,11 @@ public:
             SetWindowTextW(_window, _title.c_str());
             break;
         }
+        case CM_UPDATE_OPACITY:
+        {
+            SetLayeredWindowAttributes(_window, 0x000000, _opacity * 0xFF, LWA_ALPHA);
+            break;
+        }
         }
 
         return DefWindowProc(_window, message, wparam, lparam);
@@ -151,6 +157,18 @@ public:
         PostMessageW(_window, CM_UPDATE_TITLE, 0, reinterpret_cast<LPARAM>(nullptr));
     };
 
+    // Method Description:
+    // - Send a message to our message loop to update the opacity of the window.
+    // Arguments:
+    // - opacity: a number in [0, 1] to use as the new opacity of the window.
+    // Return Value:
+    // - <none>
+    void UpdateOpacity(double opacity)
+    {
+        _opacity = opacity;
+        PostMessageW(_window, CM_UPDATE_OPACITY, 0, 0);
+    }
+
 protected:
     using base_type = BaseWindow<T>;
     HWND _window = nullptr;
@@ -159,6 +177,8 @@ protected:
     bool _inDpiChange = false;
 
     std::wstring _title = L"";
+
+    double _opacity;
 
     bool _minimized = false;
 };

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -107,6 +107,8 @@ void IslandWindow::Initialize()
 {
     const bool initialized = (_interopWindowHandle != nullptr);
 
+    SetWindowLong(_window, GWL_EXSTYLE, GetWindowLong(_window, GWL_EXSTYLE) | WS_EX_LAYERED);
+
     _source = DesktopWindowXamlSource{};
 
     auto interop = _source.as<IDesktopWindowXamlSourceNative>();


### PR DESCRIPTION
fix #603

Can't find a simple way to make the tab content area translucent. Ended up using layered window.

Added an option `opacity` controlling the opacity of the layered window. Preserved the option `acrylicOpacity`.

TODO:
- [ ] remove option `acrylicOpacity`, as mentioned in https://github.com/microsoft/Terminal/issues/593#issuecomment-491072359.