### PR TITLE
Exclude Windows Terminal sources and some other files from git2git

### DIFF
--- a/consolegit2gitfilters.json
+++ b/consolegit2gitfilters.json
@@ -12,7 +12,8 @@
     "/ipch/",
     "/dep/",
     "/.vs/",
-    "/build/"
+    "/build/",
+    "/src/cascadia/"
   ],
   "SuffixFilters": [
     ".dbb",

--- a/consolegit2gitfilters.json
+++ b/consolegit2gitfilters.json
@@ -13,7 +13,9 @@
     "/dep/",
     "/.vs/",
     "/build/",
-    "/src/cascadia/"
+    "/src/cascadia/",
+    "/.nuget/",
+    "/.github/"
   ],
   "SuffixFilters": [
     ".dbb",


### PR DESCRIPTION
This will remove Windows Terminal sources from any replications driven by git2git.