### PR TITLE
Reflect new AppNameDev in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Secondly, try pressing <kbd>Ctrl</kbd> + <kbd>T</kbd>. The tabs are hidden when 
 
 ## I tried running WindowsTerminal.exe and it crashes!
 
-* Don't try to run it unpackaged. Make sure to build & deploy `CascadiaPackage` from Visual Studio, and run the Windows Terminal (Preview) app.
+* Don't try to run it unpackaged. Make sure to build & deploy `CascadiaPackage` from Visual Studio, and run the Windows Terminal (Dev Build) app.
 * Make sure you're on the right version of Windows. You'll need to be on Insider's builds, or wait for the 1903 release, as the Windows Terminal **REQUIRES** features from the latest Windows release.
 
 # Getting Started


### PR DESCRIPTION
due to #558, app that is built from source will be named "Windows Terminal (Dev Build)” instead of "Windows Terminal (Preview)”