### PR TITLE
Add link to related console-docs GH repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-Welcome\! This repository contains the source code for:
+# Welcome\! 
+#### This repository contains the source code for:
 
   - Windows Terminal
   - The Windows console host (`conhost.exe`)
   - Components shared between the two projects
   - [ColorTool](https://github.com/Microsoft/Terminal/tree/master/src/tools/ColorTool)
   - [Sample projects](https://github.com/Microsoft/Terminal/tree/master/samples) that show how to consume the Windows Console APIs
+  
+#### Other related repositories include:
+  - [Console API Documentation](https://github.com/MicrosoftDocs/Console-Docs/issues)
 
 ### Build Status
 


### PR DESCRIPTION
The console-docs repository is very related to this one. I feel it should be linked somewhere prominently in this one.