### PR TITLE
Change the Feedback link to take you to github

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -300,14 +300,12 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Method Description:
-    // - Called when the feedback button is clicked. Launches the feedback hub
-    //   to the list of all feedback for the Terminal app.
+    // - Called when the feedback button is clicked. Launches github in your
+    //   default browser, navigated to the "issues" page of the Terminal repo.
     void App::_FeedbackButtonOnClick(const IInspectable&,
                                      const RoutedEventArgs&)
     {
-        // If you want this to go to the new feedback page automatically, use &newFeedback=true
-        winrt::Windows::System::Launcher::LaunchUriAsync({ L"feedback-hub://?tabid=2&appid=Microsoft.WindowsTerminal_8wekyb3d8bbwe!App" });
-
+        winrt::Windows::System::Launcher::LaunchUriAsync({ L"https://github.com/microsoft/Terminal/issues" });
     }
 
     // Method Description:


### PR DESCRIPTION
  Fixes #787.

  Considering we're just duping all feedback hub issues to github, lets cut out
  the middleman and take them straight here.