### PR TITLE
ci: Restore Taef.TestAdapter before build to run tests in CI

### DIFF
--- a/build/.nuget/packages.config
+++ b/build/.nuget/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Taef.TestAdapter" version="10.30.180808002" />
+</packages>

--- a/build/config/NuGet.config
+++ b/build/config/NuGet.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <add key="TAEF Internal" value="https://microsoft.pkgs.visualstudio.com/_packaging/Taef/nuget/v3/index.json" />
+    </packageSources>
+    <config>
+        <add key="repositorypath" value="..\..\packages" />
+    </config>
+</configuration>

--- a/build/pipelines/templates/build-console-steps.yml
+++ b/build/pipelines/templates/build-console-steps.yml
@@ -25,6 +25,16 @@ steps:
     restoreSolution: OpenConsole.sln
     restoreDirectory: '$(Build.SourcesDirectory)\packages'
 
+- task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+  displayName: 'NuGet restore packages for CI'
+  inputs:
+    command: restore
+    restoreSolution: build/.nuget/packages.config
+    feedsToUse: config
+    externalFeedCredentials: 'TAEF NuGet Feed'
+    nugetConfigPath: build/config/NuGet.config
+    restoreDirectory: '$(Build.SourcesDirectory)/packages'
+
 - task: VSBuild@1
   displayName: 'Build solution **\OpenConsole.sln'
   inputs:


### PR DESCRIPTION
This requires an additional service connection on the Azure Devops instance running our builds. That has been done.

**OPEN DISCUSSION**: We may want to mark this task optional so it doesn't fail the build when external folks set up their own AzDO instances?

Fixes #775.