### PR TITLE
Utf8ToWideCharParser: Fix memory leak in case of error

### DIFF
--- a/src/host/utf8ToWideCharParser.cpp
+++ b/src/host/utf8ToWideCharParser.cpp
@@ -505,5 +505,5 @@ void Utf8ToWideCharParser::_Reset()
 {
     _currentState = _State::Ready;
     _bytesStored = 0;
-    _convertedWideChars.release();
+    _convertedWideChars.reset(nullptr);
 }


### PR DESCRIPTION
## Summary of the Pull Request
std::unique_ptr.release() releases ownership and does not destroy an object.
Fix this issue by using reset(nullptr)

## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments
_Reset() is used only in the two places:
- in case of `_currentState == _State::Error` 
- when some exception has occured during parsing or converting