### PR TITLE
fixed on build error xcopy on localized machines

### DIFF
--- a/src/cppwinrt.build.post.props
+++ b/src/cppwinrt.build.post.props
@@ -26,15 +26,15 @@
     <PostBuildEvent Condition="'$(Platform)'!='Win32'">
       <Command>
         echo OutDir=$(OutDir)
-        (echo f | xcopy /y &quot;$(OutDir)$(ProjectName).dll&quot; &quot;$(OpenConsoleDir)$(Platform)\$(Configuration)\$(ProjectName).dll*&quot; )
-        (echo f | xcopy /y &quot;$(OutDir)$(ProjectName).pdb&quot; &quot;$(OpenConsoleDir)$(Platform)\$(Configuration)\$(ProjectName).pdb*&quot; )
+        (xcopy /Y &quot;$(OutDir)$(ProjectName).dll&quot; &quot;$(OpenConsoleDir)$(Platform)\$(Configuration)\$(ProjectName).dll*&quot; )
+        (xcopy /Y &quot;$(OutDir)$(ProjectName).pdb&quot; &quot;$(OpenConsoleDir)$(Platform)\$(Configuration)\$(ProjectName).pdb*&quot; )
       </Command>
     </PostBuildEvent>
     <PostBuildEvent Condition="'$(Platform)'=='Win32'">
       <Command>
         echo OutDir=$(OutDir)
-        (echo f | xcopy /y &quot;$(OutDir)$(ProjectName).dll&quot; &quot;$(OpenConsoleDir)$(Configuration)\$(ProjectName).dll*&quot; )
-        (echo f | xcopy /y &quot;$(OutDir)$(ProjectName).pdb&quot; &quot;$(OpenConsoleDir)$(Configuration)\$(ProjectName).pdb*&quot; )
+        (xcopy /Y &quot;$(OutDir)$(ProjectName).dll&quot; &quot;$(OpenConsoleDir)$(Configuration)\$(ProjectName).dll*&quot; )
+        (xcopy /Y &quot;$(OutDir)$(ProjectName).pdb&quot; &quot;$(OpenConsoleDir)$(Configuration)\$(ProjectName).pdb*&quot; )
       </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>

--- a/src/cppwinrt.build.post.props
+++ b/src/cppwinrt.build.post.props
@@ -26,15 +26,15 @@
     <PostBuildEvent Condition="'$(Platform)'!='Win32'">
       <Command>
         echo OutDir=$(OutDir)
-        (echo f | xcopy /y &quot;$(OutDir)$(ProjectName).dll&quot; &quot;$(OpenConsoleDir)$(Platform)\$(Configuration)\$(ProjectName).dll&quot; )
-        (echo f | xcopy /y &quot;$(OutDir)$(ProjectName).pdb&quot; &quot;$(OpenConsoleDir)$(Platform)\$(Configuration)\$(ProjectName).pdb&quot; )
+        (echo f | xcopy /y &quot;$(OutDir)$(ProjectName).dll&quot; &quot;$(OpenConsoleDir)$(Platform)\$(Configuration)\$(ProjectName).dll*&quot; )
+        (echo f | xcopy /y &quot;$(OutDir)$(ProjectName).pdb&quot; &quot;$(OpenConsoleDir)$(Platform)\$(Configuration)\$(ProjectName).pdb*&quot; )
       </Command>
     </PostBuildEvent>
     <PostBuildEvent Condition="'$(Platform)'=='Win32'">
       <Command>
         echo OutDir=$(OutDir)
-        (echo f | xcopy /y &quot;$(OutDir)$(ProjectName).dll&quot; &quot;$(OpenConsoleDir)$(Configuration)\$(ProjectName).dll&quot; )
-        (echo f | xcopy /y &quot;$(OutDir)$(ProjectName).pdb&quot; &quot;$(OpenConsoleDir)$(Configuration)\$(ProjectName).pdb&quot; )
+        (echo f | xcopy /y &quot;$(OutDir)$(ProjectName).dll&quot; &quot;$(OpenConsoleDir)$(Configuration)\$(ProjectName).dll*&quot; )
+        (echo f | xcopy /y &quot;$(OutDir)$(ProjectName).pdb&quot; &quot;$(OpenConsoleDir)$(Configuration)\$(ProjectName).pdb*&quot; )
       </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>


### PR DESCRIPTION
echo ( f | xcopy ) will not work, can get around with putting an '*' at the end, xcopy will treat then as file. This solutions builds 
fine on DE German machine.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #507 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
