### PR TITLE
Fix #670: Terminal selects a char when bringing window to foreground

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -544,20 +544,20 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     void TermControl::_MouseClickHandler(Windows::Foundation::IInspectable const& /*sender*/,
                                          Input::PointerRoutedEventArgs const& args)
     {
-        // Ignore mouse events while the terminal does not have focus. 
-        // This prevents the user from selecting and copying text if they 
-        // click inside the current tab to refocus the terminal window. 
-        if (!_focused) 
-        {
-            args.Handled(true);
-            return;
-        }
-
         const auto ptr = args.Pointer();
         const auto point = args.GetCurrentPoint(_root);
 
         if (ptr.PointerDeviceType() == Windows::Devices::Input::PointerDeviceType::Mouse)
         {
+            // Ignore mouse events while the terminal does not have focus. 
+            // This prevents the user from selecting and copying text if they 
+            // click inside the current tab to refocus the terminal window. 
+            if (!_focused)
+            {
+                args.Handled(true);
+                return;
+            }
+
             const auto modifiers = args.KeyModifiers();
             const auto altEnabled = WI_IsFlagSet(modifiers, VirtualKeyModifiers::Menu);
             const auto shiftEnabled = WI_IsFlagSet(modifiers, VirtualKeyModifiers::Shift);

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -547,7 +547,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         // Ignore mouse events while the terminal does not have focus. 
         // This prevents the user from selecting and copying text if they 
         // click inside the current tab to refocus the terminal window. 
-        if (!_focused) {
+        if (!_focused) 
+        {
             args.Handled(true);
             return;
         }

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -75,6 +75,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         std::unique_ptr<::Microsoft::Console::Render::DxEngine> _renderEngine;
 
         Settings::IControlSettings _settings;
+        bool _focused;
         bool _closing;
 
         FontInfoDesired _desiredFont;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This fix prevents text from being selected when the user clicks within the active terminal to re-focus the window. This brings the new terminal's behavior inline with the original powershell and cmd terminals. 

Fixes #670 

I tested this fix's behavior manually, but did ensure all unit tests are passing. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The proposed changes may be a naive way of fixing the issue. I simply added a bool called _focused to the TermControl class which is set and unset during the respective GotFocus and LostFocus events. That bool is then checked whenever a new MouseClick event is encountered. If _focused is false during the MouseClick event, the MouseClick event handler immediately returns instead of handling the event normally. 

I did try to fix this issue using the GettingFocus event, but I could not find a way to stop the MouseClick event from the GettingFocus event handler. I am pretty new to UWP events, so I am more than happy to revise this fix if a better method exists. 

