### PR TITLE
Fix signatures of some callback functions

### DIFF
--- a/src/cascadia/TerminalConnection/ConhostConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConhostConnection.cpp
@@ -80,7 +80,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         _outputThreadId = (DWORD)-1;
         _hOutputThread = CreateThread(nullptr,
                                       0,
-                                      (LPTHREAD_START_ROUTINE)StaticOutputThreadProc,
+                                      StaticOutputThreadProc,
                                       this,
                                       0,
                                       &_outputThreadId);

--- a/src/cascadia/TerminalConnection/ConhostConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConhostConnection.cpp
@@ -131,7 +131,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         CloseHandle(_piConhost.hProcess);
     }
 
-    DWORD ConhostConnection::StaticOutputThreadProc(LPVOID lpParameter)
+    DWORD WINAPI ConhostConnection::StaticOutputThreadProc(LPVOID lpParameter)
     {
         ConhostConnection* const pInstance = (ConhostConnection*)lpParameter;
         return pInstance->_OutputThread();

--- a/src/cascadia/TerminalConnection/ConhostConnection.h
+++ b/src/cascadia/TerminalConnection/ConhostConnection.h
@@ -39,7 +39,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         PROCESS_INFORMATION _piConhost;
         bool _closing;
 
-        static DWORD StaticOutputThreadProc(LPVOID lpParameter);
+        static DWORD WINAPI StaticOutputThreadProc(LPVOID lpParameter);
         DWORD _OutputThread();
     };
 }

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -60,7 +60,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         _outputThreadId = (DWORD)-1;
         _hOutputThread = CreateThread(nullptr,
                                       0,
-                                      (LPTHREAD_START_ROUTINE)StaticOutputThreadProc,
+                                      StaticOutputThreadProc,
                                       this,
                                       0,
                                       &_outputThreadId);

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -222,7 +222,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
     }
 
 
-    DWORD ConptyConnection::StaticOutputThreadProc(LPVOID lpParameter)
+    DWORD WINAPI ConptyConnection::StaticOutputThreadProc(LPVOID lpParameter)
     {
         ConptyConnection* const pInstance = (ConptyConnection*)lpParameter;
         return pInstance->_OutputThread();

--- a/src/cascadia/TerminalConnection/ConptyConnection.h
+++ b/src/cascadia/TerminalConnection/ConptyConnection.h
@@ -39,7 +39,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         HANDLE _hOutputThread;
         PROCESS_INFORMATION _piClient;
 
-        static DWORD StaticOutputThreadProc(LPVOID lpParameter);
+        static DWORD WINAPI StaticOutputThreadProc(LPVOID lpParameter);
         void _CreatePseudoConsole();
         DWORD _OutputThread();
     };

--- a/src/host/CursorBlinker.cpp
+++ b/src/host/CursorBlinker.cpp
@@ -129,7 +129,7 @@ DoScroll:
     Scrolling::s_ScrollIfNecessary(ScreenInfo);
 }
 
-void CALLBACK CursorTimerRoutineWrapper(_In_ PVOID /* lpParam */, _In_ BOOL /* TimerOrWaitFired */)
+void CALLBACK CursorTimerRoutineWrapper(_In_ PVOID /* lpParam */, _In_ BOOLEAN /* TimerOrWaitFired */)
 {
     // Suppose the following sequence of events takes place:
     //

--- a/src/host/CursorBlinker.cpp
+++ b/src/host/CursorBlinker.cpp
@@ -192,7 +192,7 @@ void CursorBlinker::SetCaretTimer()
 
         bRet = CreateTimerQueueTimer(&_hCaretBlinkTimer,
                                      _hCaretBlinkTimerQueue,
-                                     (WAITORTIMERCALLBACKFUNC)CursorTimerRoutineWrapper,
+                                     CursorTimerRoutineWrapper,
                                      this,
                                      dwEffectivePeriod,
                                      dwEffectivePeriod,

--- a/src/host/PtySignalInputThread.cpp
+++ b/src/host/PtySignalInputThread.cpp
@@ -175,7 +175,7 @@ HRESULT PtySignalInputThread::Start() noexcept
 
     hThread = CreateThread(nullptr,
                            0,
-                           (LPTHREAD_START_ROUTINE)PtySignalInputThread::StaticThreadProc,
+                           PtySignalInputThread::StaticThreadProc,
                            this,
                            0,
                            &dwThreadId);

--- a/src/host/PtySignalInputThread.cpp
+++ b/src/host/PtySignalInputThread.cpp
@@ -51,7 +51,7 @@ PtySignalInputThread::~PtySignalInputThread()
 // - lpParameter - A pointer to the PtySignalInputTHread instance that should be called.
 // Return Value:
 // - The return value of the underlying instance's _InputThread
-DWORD PtySignalInputThread::StaticThreadProc(_In_ LPVOID lpParameter)
+DWORD WINAPI PtySignalInputThread::StaticThreadProc(_In_ LPVOID lpParameter)
 {
     PtySignalInputThread* const pInstance = reinterpret_cast<PtySignalInputThread*>(lpParameter);
     return pInstance->_InputThread();

--- a/src/host/PtySignalInputThread.hpp
+++ b/src/host/PtySignalInputThread.hpp
@@ -25,7 +25,7 @@ namespace Microsoft::Console
 
         [[nodiscard]]
         HRESULT Start() noexcept;
-        static DWORD StaticThreadProc(_In_ LPVOID lpParameter);
+        static DWORD WINAPI StaticThreadProc(_In_ LPVOID lpParameter);
 
         // Prevent copying and assignment.
         PtySignalInputThread(const PtySignalInputThread&) = delete;

--- a/src/host/VtInputThread.cpp
+++ b/src/host/VtInputThread.cpp
@@ -90,7 +90,7 @@ HRESULT VtInputThread::_HandleRunInput(_In_reads_(cch) const byte* const charBuf
 // - lpParameter - A pointer to the VtInputThread instance that should be called.
 // Return Value:
 // - The return value of the underlying instance's _InputThread
-DWORD VtInputThread::StaticVtInputThreadProc(_In_ LPVOID lpParameter)
+DWORD WINAPI VtInputThread::StaticVtInputThreadProc(_In_ LPVOID lpParameter)
 {
     VtInputThread* const pInstance = reinterpret_cast<VtInputThread*>(lpParameter);
     return pInstance->_InputThread();

--- a/src/host/VtInputThread.cpp
+++ b/src/host/VtInputThread.cpp
@@ -167,7 +167,7 @@ HRESULT VtInputThread::Start()
 
     hThread = CreateThread(nullptr,
                            0,
-                           (LPTHREAD_START_ROUTINE)VtInputThread::StaticVtInputThreadProc,
+                           VtInputThread::StaticVtInputThreadProc,
                            this,
                            0,
                            &dwThreadId);

--- a/src/host/VtInputThread.hpp
+++ b/src/host/VtInputThread.hpp
@@ -26,7 +26,7 @@ namespace Microsoft::Console
 
         [[nodiscard]]
         HRESULT Start();
-        static DWORD StaticVtInputThreadProc(_In_ LPVOID lpParameter);
+        static DWORD WINAPI StaticVtInputThreadProc(_In_ LPVOID lpParameter);
         void DoReadInput(const bool throwOnFail);
 
     private:

--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -258,7 +258,7 @@ HRESULT ConsoleCreateIoThreadLegacy(_In_ HANDLE Server, const ConsoleArguments* 
     ServerInformation.InputAvailableEvent = ServiceLocator::LocateGlobals().hInputEvent.get();
     RETURN_IF_FAILED(g.pDeviceComm->SetServerInformation(&ServerInformation));
 
-    HANDLE const hThread = CreateThread(nullptr, 0, (LPTHREAD_START_ROUTINE)ConsoleIoThread, 0, 0, nullptr);
+    HANDLE const hThread = CreateThread(nullptr, 0, ConsoleIoThread, 0, 0, nullptr);
     RETURN_HR_IF(E_HANDLE, hThread == nullptr);
     LOG_IF_WIN32_BOOL_FALSE(CloseHandle(hThread)); // The thread will run on its own and close itself. Free the associated handle.
 

--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -214,7 +214,7 @@ NTSTATUS RemoveConsole(_In_ ConsoleProcessHandle* ProcessData)
     return Status;
 }
 
-DWORD ConsoleIoThread();
+DWORD ConsoleIoThread(LPVOID lpParameter);
 
 void ConsoleCheckDebug()
 {
@@ -638,7 +638,7 @@ NTSTATUS ConsoleAllocateConsole(PCONSOLE_API_CONNECTINFO p)
 // - <none>
 // Return Value:
 // - This routine never returns. The process exits when no more references or clients exist.
-DWORD ConsoleIoThread()
+DWORD ConsoleIoThread(LPVOID /*lpParameter*/)
 {
     auto& globals = ServiceLocator::LocateGlobals();
 

--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -214,7 +214,7 @@ NTSTATUS RemoveConsole(_In_ ConsoleProcessHandle* ProcessData)
     return Status;
 }
 
-DWORD ConsoleIoThread(LPVOID lpParameter);
+DWORD WINAPI ConsoleIoThread(LPVOID lpParameter);
 
 void ConsoleCheckDebug()
 {
@@ -638,7 +638,7 @@ NTSTATUS ConsoleAllocateConsole(PCONSOLE_API_CONNECTINFO p)
 // - <none>
 // Return Value:
 // - This routine never returns. The process exits when no more references or clients exist.
-DWORD ConsoleIoThread(LPVOID /*lpParameter*/)
+DWORD WINAPI ConsoleIoThread(LPVOID /*lpParameter*/)
 {
     auto& globals = ServiceLocator::LocateGlobals();
 

--- a/src/interactivity/onecore/ConsoleInputThread.cpp
+++ b/src/interactivity/onecore/ConsoleInputThread.cpp
@@ -16,7 +16,7 @@
 using namespace Microsoft::Console::Interactivity::OneCore;
 
 
-DWORD ConsoleInputThreadProcOneCore(LPVOID /*lpParam*/)
+DWORD WINAPI ConsoleInputThreadProcOneCore(LPVOID /*lpParam*/)
 {
     Globals& globals = ServiceLocator::LocateGlobals();
     ConIoSrvComm * const Server = ServiceLocator::LocateInputServices<ConIoSrvComm>();

--- a/src/interactivity/onecore/ConsoleInputThread.cpp
+++ b/src/interactivity/onecore/ConsoleInputThread.cpp
@@ -108,7 +108,7 @@ HANDLE ConsoleInputThread::Start()
 
     hThread = CreateThread(nullptr,
                            0,
-                           (LPTHREAD_START_ROUTINE)ConsoleInputThreadProcOneCore,
+                           ConsoleInputThreadProcOneCore,
                            _pConIoSrvComm,
                            0,
                            &dwThreadId);

--- a/src/interactivity/win32/ConsoleInputThread.cpp
+++ b/src/interactivity/win32/ConsoleInputThread.cpp
@@ -18,7 +18,7 @@ HANDLE ConsoleInputThread::Start()
 
     hThread = CreateThread(nullptr,
                            0,
-                           (LPTHREAD_START_ROUTINE)ConsoleInputThreadProcWin32,
+                           ConsoleInputThreadProcWin32,
                            nullptr,
                            0,
                            &dwThreadId);

--- a/src/interactivity/win32/find.cpp
+++ b/src/interactivity/win32/find.cpp
@@ -92,7 +92,7 @@ void DoFind()
         HWND const hwnd = pWindow->GetWindowHandle();
 
         ++g.uiDialogBoxCount;
-        DialogBoxParamW(g.hInstance, MAKEINTRESOURCE(ID_CONSOLE_FINDDLG), hwnd, (DLGPROC)FindDialogProc, (LPARAM) nullptr);
+        DialogBoxParamW(g.hInstance, MAKEINTRESOURCE(ID_CONSOLE_FINDDLG), hwnd, FindDialogProc, (LPARAM) nullptr);
         --g.uiDialogBoxCount;
     }
 }

--- a/src/interactivity/win32/find.cpp
+++ b/src/interactivity/win32/find.cpp
@@ -15,7 +15,7 @@
 
 #pragma hdrstop
 
-INT_PTR FindDialogProc(HWND hWnd, UINT Message, WPARAM wParam, LPARAM lParam)
+INT_PTR CALLBACK FindDialogProc(HWND hWnd, UINT Message, WPARAM wParam, LPARAM lParam)
 {
     CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     // This bool is used to track which option - up or down - was used to perform the last search. That way, the next time the

--- a/src/interactivity/win32/windowio.cpp
+++ b/src/interactivity/win32/windowio.cpp
@@ -979,7 +979,7 @@ NTSTATUS InitWindowsSubsystem(_Out_ HHOOK * phhook)
 
     // We intentionally ignore the return value of SetWindowsHookEx. There are mixed LUID cases where this call will fail but in the past this call
     // was special cased (for CSRSS) to always succeed. Thus, we ignore failure for app compat (as not having the hook isn't fatal).
-    *phhook = SetWindowsHookExW(WH_MSGFILTER, (HOOKPROC)DialogHookProc, nullptr, GetCurrentThreadId());
+    *phhook = SetWindowsHookExW(WH_MSGFILTER, DialogHookProc, nullptr, GetCurrentThreadId());
 
     SetConsoleWindowOwner(ServiceLocator::LocateConsoleWindow()->GetWindowHandle(), ProcessData);
 

--- a/src/interactivity/win32/windowio.cpp
+++ b/src/interactivity/win32/windowio.cpp
@@ -937,7 +937,7 @@ BOOL HandleMouseEvent(const SCREEN_INFORMATION& ScreenInfo,
 
 // Routine Description:
 // - This routine gets called to filter input to console dialogs so that we can do the special processing that StoreKeyInfo does.
-LRESULT DialogHookProc(int nCode, WPARAM /*wParam*/, LPARAM lParam)
+LRESULT CALLBACK DialogHookProc(int nCode, WPARAM /*wParam*/, LPARAM lParam)
 {
     MSG msg = *((PMSG)lParam);
 
@@ -995,7 +995,7 @@ NTSTATUS InitWindowsSubsystem(_Out_ HHOOK * phhook)
 // (for a window)
 // ----------------------------
 
-DWORD ConsoleInputThreadProcWin32(LPVOID /*lpParameter*/)
+DWORD WINAPI ConsoleInputThreadProcWin32(LPVOID /*lpParameter*/)
 {
     InitEnvironmentVariables();
 

--- a/src/interactivity/win32/windowio.hpp
+++ b/src/interactivity/win32/windowio.hpp
@@ -25,4 +25,4 @@ BOOL HandleMouseEvent(const SCREEN_INFORMATION& ScreenInfo,
                       const LPARAM lParam);
 
 VOID SetConsoleWindowOwner(const HWND hwnd, _Inout_opt_ ConsoleProcessHandle* pProcessData);
-DWORD ConsoleInputThreadProcWin32(LPVOID lpParameter);
+DWORD WINAPI ConsoleInputThreadProcWin32(LPVOID lpParameter);

--- a/src/propsheet/ColorControl.cpp
+++ b/src/propsheet/ColorControl.cpp
@@ -42,7 +42,7 @@ void SimpleColorDoPaint(const HWND hColor, PAINTSTRUCT& ps, const int ColorId)
 
 // Routine Description:
 // - Window proc for the color buttons
-LRESULT SimpleColorControlProc(const HWND hColor, const UINT wMsg, const WPARAM wParam, const LPARAM lParam)
+LRESULT CALLBACK SimpleColorControlProc(const HWND hColor, const UINT wMsg, const WPARAM wParam, const LPARAM lParam)
 {
     PAINTSTRUCT ps;
     int ColorId;

--- a/src/propsheet/ColorControl.h
+++ b/src/propsheet/ColorControl.h
@@ -14,5 +14,5 @@ Author(s):
 
 #pragma once
 
-LRESULT SimpleColorControlProc(HWND hColor, UINT wMsg, WPARAM wParam, LPARAM lParam);
+LRESULT CALLBACK SimpleColorControlProc(HWND hColor, UINT wMsg, WPARAM wParam, LPARAM lParam);
 void SimpleColorDoPaint(HWND hColor, PAINTSTRUCT& ps, int ColorId);

--- a/src/propsheet/ColorsPage.cpp
+++ b/src/propsheet/ColorsPage.cpp
@@ -10,7 +10,7 @@ static int iColor;
 
 // Routine Description:
 // - Window proc for the color buttons
-LRESULT ColorTableControlProc(HWND hColor, UINT wMsg, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK ColorTableControlProc(HWND hColor, UINT wMsg, WPARAM wParam, LPARAM lParam)
 {
     PAINTSTRUCT ps;
     int ColorId;

--- a/src/propsheet/ColorsPage.h
+++ b/src/propsheet/ColorsPage.h
@@ -18,4 +18,4 @@ void ToggleV2ColorControls(__in const HWND hDlg);
 INT_PTR WINAPI ColorDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam);
 void SetOpacitySlider(__in HWND hDlg);
 void PreviewOpacity(HWND hDlg, BYTE bOpacity);
-LRESULT ColorTableControlProc(HWND hColor, UINT wMsg, WPARAM wParam, LPARAM lParam);
+LRESULT CALLBACK ColorTableControlProc(HWND hColor, UINT wMsg, WPARAM wParam, LPARAM lParam);

--- a/src/propsheet/console.cpp
+++ b/src/propsheet/console.cpp
@@ -506,7 +506,7 @@ BOOL PopulatePropSheetPageArray(_Out_writes_(cPsps) PROPSHEETPAGE *pPsp, const s
         pFontPage->dwSize      = sizeof(PROPSHEETPAGE);
         pFontPage->hInstance   = ghInstance;
         pFontPage->pszTemplate = MAKEINTRESOURCE(DID_FONTDLG);
-        pFontPage->pfnDlgProc  = (DLGPROC) FontDlgProc;
+        pFontPage->pfnDlgProc  = FontDlgProc;
         pFontPage->lParam      = FONT_PAGE_INDEX;
         pOptionsPage->dwFlags      = PSP_DEFAULT;
 
@@ -660,7 +660,7 @@ void RegisterClasses(HINSTANCE hModule)
     WNDCLASS wc;
     wc.lpszClassName = TEXT("SimpleColor");
     wc.hInstance     = hModule;
-    wc.lpfnWndProc   = (WNDPROC) SimpleColorControlProc;
+    wc.lpfnWndProc   = SimpleColorControlProc;
     wc.hCursor       = LoadCursor(NULL, IDC_ARROW);
     wc.hIcon         = NULL;
     wc.lpszMenuName  = NULL;
@@ -672,7 +672,7 @@ void RegisterClasses(HINSTANCE hModule)
 
     wc.lpszClassName = TEXT("ColorTableColor");
     wc.hInstance     = hModule;
-    wc.lpfnWndProc   = (WNDPROC) ColorTableControlProc;
+    wc.lpfnWndProc   = ColorTableControlProc;
     wc.hCursor       = LoadCursor(NULL, IDC_ARROW);
     wc.hIcon         = NULL;
     wc.lpszMenuName  = NULL;
@@ -683,13 +683,13 @@ void RegisterClasses(HINSTANCE hModule)
     RegisterClass(&wc);
 
     wc.lpszClassName = TEXT("WOAWinPreview");
-    wc.lpfnWndProc   = (WNDPROC) PreviewWndProc;
+    wc.lpfnWndProc   = PreviewWndProc;
     wc.hbrBackground = (HBRUSH) (COLOR_BACKGROUND + 1);
     wc.style         = 0;
     RegisterClass(&wc);
 
     wc.lpszClassName = TEXT("WOAFontPreview");
-    wc.lpfnWndProc   = (WNDPROC) FontPreviewWndProc;
+    wc.lpfnWndProc   = FontPreviewWndProc;
     wc.hbrBackground = (HBRUSH) GetStockObject(BLACK_BRUSH);
     wc.style         = 0;
     RegisterClass(&wc);

--- a/src/propsheet/console.h
+++ b/src/propsheet/console.h
@@ -173,13 +173,13 @@ VOID SetRegistryValues(
 PCONSOLE_STATE_INFO InitStateValues(
     HWND hwnd);
 
-LRESULT FontPreviewWndProc(
+LRESULT CALLBACK FontPreviewWndProc(
     HWND hWnd,
     UINT wMsg,
     WPARAM wParam,
     LPARAM lParam);
 
-LRESULT PreviewWndProc(
+LRESULT CALLBACK PreviewWndProc(
     HWND hWnd,
     UINT wMsg,
     WPARAM wParam,

--- a/src/propsheet/fontdlg.cpp
+++ b/src/propsheet/fontdlg.cpp
@@ -979,6 +979,7 @@ Return Value:
 /* ----- Preview routines ----- */
 
 LRESULT
+CALLBACK
 FontPreviewWndProc(
     HWND hWnd,
     UINT wMessage,

--- a/src/propsheet/misc.cpp
+++ b/src/propsheet/misc.cpp
@@ -420,7 +420,7 @@ DestroyFonts(
  * Is called exactly once by GDI for each font in the system. This
  * routine is used to store the FONT_INFO structure.
  */
-int FontEnumForV2Console(ENUMLOGFONT *pelf, NEWTEXTMETRIC *pntm, int nFontType, LPARAM lParam)
+int CALLBACK FontEnumForV2Console(ENUMLOGFONT *pelf, NEWTEXTMETRIC *pntm, int nFontType, LPARAM lParam)
 {
     FAIL_FAST_IF(!(ShouldAllowAllMonoTTFonts()));
     UINT i;
@@ -546,6 +546,7 @@ int FontEnumForV2Console(ENUMLOGFONT *pelf, NEWTEXTMETRIC *pntm, int nFontType, 
  * routine is used to store the FONT_INFO structure.
  */
 int
+CALLBACK
 FontEnum(
     ENUMLOGFONT *pelf,
     NEWTEXTMETRIC *pntm,

--- a/src/propsheet/preview.cpp
+++ b/src/propsheet/preview.cpp
@@ -371,6 +371,7 @@ PreviewPaint(
 
 
 LRESULT
+CALLBACK
 PreviewWndProc(
     HWND hWnd,
     UINT wMessage,

--- a/src/tools/echokey/main.cpp
+++ b/src/tools/echokey/main.cpp
@@ -163,7 +163,7 @@ void handleWindowEvent(WINDOW_BUFFER_SIZE_RECORD windowEvent)
 
 }
 
-BOOL CtrlHandler( DWORD fdwCtrlType )
+BOOL WINAPI CtrlHandler( DWORD fdwCtrlType )
 {
     switch( fdwCtrlType )
     {

--- a/src/tools/echokey/main.cpp
+++ b/src/tools/echokey/main.cpp
@@ -239,7 +239,7 @@ int __cdecl wmain(int argc, wchar_t* argv[])
     DWORD dwInMode = 0;
     GetConsoleMode(g_hOut, &dwOutMode);
     GetConsoleMode(g_hIn, &dwInMode);
-    SetConsoleCtrlHandler( (PHANDLER_ROUTINE) CtrlHandler, TRUE );
+    SetConsoleCtrlHandler(CtrlHandler, TRUE );
     const DWORD initialInMode = dwInMode;
     const DWORD initialOutMode = dwOutMode;
 

--- a/src/tools/fontlist/main.cpp
+++ b/src/tools/fontlist/main.cpp
@@ -5,7 +5,7 @@
 #include <windowsx.h>
 #include <wil\result.h>
 
-int FontEnumForV2Console(ENUMLOGFONT *pelf, NEWTEXTMETRIC *pntm, int nFontType, LPARAM lParam);
+int CALLBACK FontEnumForV2Console(ENUMLOGFONT *pelf, NEWTEXTMETRIC *pntm, int nFontType, LPARAM lParam);
 int
 AddFont(
     ENUMLOGFONT *pelf,
@@ -56,7 +56,7 @@ SHORT TTPoints[] = {
 };
 
 
-int FontEnumForV2Console(ENUMLOGFONT *pelf, NEWTEXTMETRIC *pntm, int nFontType, LPARAM lParam)
+int CALLBACK FontEnumForV2Console(ENUMLOGFONT *pelf, NEWTEXTMETRIC *pntm, int nFontType, LPARAM lParam)
 {
     UINT i;
     LPCWSTR pwszFace = pelf->elfLogFont.lfFaceName;

--- a/src/tools/vtpipeterm/VtConsole.cpp
+++ b/src/tools/vtpipeterm/VtConsole.cpp
@@ -335,7 +335,7 @@ void VtConsole::deactivate()
     _active = false;
 }
 
-DWORD VtConsole::StaticOutputThreadProc(LPVOID lpParameter)
+DWORD WINAPI VtConsole::StaticOutputThreadProc(LPVOID lpParameter)
 {
     VtConsole* const pInstance = (VtConsole*)lpParameter;
     return pInstance->_OutputThread();

--- a/src/tools/vtpipeterm/VtConsole.cpp
+++ b/src/tools/vtpipeterm/VtConsole.cpp
@@ -149,7 +149,7 @@ void VtConsole::_spawn(const std::wstring& command)
     _dwOutputThreadId = (DWORD)-1;
     _hOutputThread = CreateThread(nullptr,
                                   0,
-                                  (LPTHREAD_START_ROUTINE)StaticOutputThreadProc,
+                                  StaticOutputThreadProc,
                                   this,
                                   0,
                                   &_dwOutputThreadId);

--- a/src/tools/vtpipeterm/VtConsole.hpp
+++ b/src/tools/vtpipeterm/VtConsole.hpp
@@ -44,7 +44,7 @@ public:
 
     void signalWindow(unsigned short sx, unsigned short sy);
 
-    static DWORD StaticOutputThreadProc(LPVOID lpParameter);
+    static DWORD WINAPI StaticOutputThreadProc(LPVOID lpParameter);
 
     bool WriteInput(std::string& seq);
 

--- a/src/tools/vtpipeterm/main.cpp
+++ b/src/tools/vtpipeterm/main.cpp
@@ -461,7 +461,7 @@ void SetupInput()
     SetConsoleMode(hIn, dwInMode);
 }
 
-DWORD InputThread(LPVOID /*lpParameter*/)
+DWORD WINAPI InputThread(LPVOID /*lpParameter*/)
 {
     // Because the input thread ends up owning the lifetime of the application,
     // Set/restore the CP here.
@@ -510,7 +510,7 @@ void CreateIOThreads()
 }
 
 
-BOOL CtrlHandler( DWORD fdwCtrlType )
+BOOL WINAPI CtrlHandler( DWORD fdwCtrlType )
 {
     switch( fdwCtrlType )
     {

--- a/src/tools/vtpipeterm/main.cpp
+++ b/src/tools/vtpipeterm/main.cpp
@@ -502,7 +502,7 @@ void CreateIOThreads()
     DWORD dwInputThreadId = (DWORD) -1;
     HANDLE hInputThread = CreateThread(nullptr,
                                         0,
-                                        (LPTHREAD_START_ROUTINE)InputThread,
+                                        InputThread,
                                         nullptr,
                                         0,
                                         &dwInputThreadId);
@@ -531,7 +531,7 @@ int __cdecl wmain(int argc, WCHAR* argv[])
 {
     // initialize random seed:
     srand((unsigned int)time(NULL));
-    SetConsoleCtrlHandler( (PHANDLER_ROUTINE) CtrlHandler, TRUE );
+    SetConsoleCtrlHandler(CtrlHandler, TRUE );
 
     hOut = GetStdHandle(STD_OUTPUT_HANDLE);
     hIn = GetStdHandle(STD_INPUT_HANDLE);


### PR DESCRIPTION
## Summary of the Pull Request
This PR fixes a bunch of callback function signatures so that they align with the signatures expected by Windows API. Most changes are from `__cdecl` to `__stdcall`, which matters on x86, but not on x64 or ARM64.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
I find it hard to believe that conhost.exe as shipped in Windows would use callback functions with incorrect calling convention. Perhaps the version that ships with Windows is compiled with `/Gz` (`__stdcall`-by-default)? But OpenConsole.sln isn't.

All of these functions were found manually, so it's likely that there are more issues like this that I didn't find. It would be great if MSVC had a warning similar to GCC's `-Wcast-function-type`.

The only one signature incompatibility I found that wasn't eliminated was with `FONTENUMPROC` (I only fixed the calling convention, which is most important anyway), since a slightly different signature is being used that is similar to [`EnumFontFamProc`](https://docs.microsoft.com/en-us/previous-versions/dd162621(v%3Dvs.85)) rather than [`EnumFontFamExProc`/`FONTENUMPROC`](https://docs.microsoft.com/en-us/previous-versions//dd162618(v=vs.85)), and a slightly more invasive change would be needed.