### PR TITLE
Fix crash when closing last tab

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -866,7 +866,7 @@ namespace winrt::TerminalApp::implementation
             // We go to the tab on the right if we are on the 0th tab, or the one on the left otherwise.
             if (removingTabIndex == _GetFocusedTabIndex())
             {
-                _tabView.SelectedIndex(removingTabIndex > 0 ? removingTabIndex - 1 : 1);
+                _tabView.SelectedIndex((removingTabIndex > 0) ? removingTabIndex - 1 : 1);
             }
             _tabView.Items().RemoveAt(removingTabIndex);
 

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -846,7 +846,7 @@ namespace winrt::TerminalApp::implementation
     // - tabViewItem: the TabViewItem in the TabView that is being removed.
     void App::_RemoveTabViewItem(const IInspectable& tabViewItem)
     {
-        uint32_t removingTabIndex;
+        uint32_t removingTabIndex = 0;
         WINRT_ASSERT(_tabView.Items().IndexOf(tabViewItem, removingTabIndex));
 
         if (_tabs.size() == 1)

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -869,8 +869,6 @@ namespace winrt::TerminalApp::implementation
                 _tabView.SelectedIndex((removingTabIndex > 0) ? removingTabIndex - 1 : 1);
             }
             _tabView.Items().RemoveAt(removingTabIndex);
-            // Ensure tabs and focus are in sync (see PR 737)
-            _tabView.SelectedIndex((removingTabIndex > 0) ? removingTabIndex - 1 : 0);
 
             // Removing the tab from the collection will destroy its control and disconnect its connection.
             _tabs.erase(_tabs.begin() + removingTabIndex);

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -869,6 +869,8 @@ namespace winrt::TerminalApp::implementation
                 _tabView.SelectedIndex((removingTabIndex > 0) ? removingTabIndex - 1 : 1);
             }
             _tabView.Items().RemoveAt(removingTabIndex);
+            // Ensure tabs and focus are in sync (see PR 737)
+            _tabView.SelectedIndex((removingTabIndex > 0) ? removingTabIndex - 1 : 0);
 
             // Removing the tab from the collection will destroy its control and disconnect its connection.
             _tabs.erase(_tabs.begin() + removingTabIndex);

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -846,27 +846,27 @@ namespace winrt::TerminalApp::implementation
     // - tabViewItem: the TabViewItem in the TabView that is being removed.
     void App::_RemoveTabViewItem(const IInspectable& tabViewItem)
     {
-		uint32_t removingTabIndex;
-		_tabView.Items().IndexOf(tabViewItem, removingTabIndex);
+        uint32_t removingTabIndex;
+        _tabView.Items().IndexOf(tabViewItem, removingTabIndex);
 
         if (_tabs.size() == 1)
         {
-			// To close the window here, we need to close the hosting window.
+            // To close the window here, we need to close the hosting window.
             _lastTabClosedHandlers();
         }
-		else
-		{
-			// If we are closing the tab we are on, flee to an adjacent tab first!
-			// We go to the tab on the right if we are on the 0th tab, or the one on the left otherwise.
-			if (removingTabIndex == _GetFocusedTabIndex())
-			{
-				_tabView.SelectedIndex(removingTabIndex > 0 ? removingTabIndex - 1 : 1);
-			}
-			_tabView.Items().RemoveAt(removingTabIndex);
-		}
+        else
+        {
+            // If we are closing the tab we are on, flee to an adjacent tab first!
+            // We go to the tab on the right if we are on the 0th tab, or the one on the left otherwise.
+            if (removingTabIndex == _GetFocusedTabIndex())
+            {
+                _tabView.SelectedIndex(removingTabIndex > 0 ? removingTabIndex - 1 : 1);
+            }
+            _tabView.Items().RemoveAt(removingTabIndex);
+        }
 
-		// Removing the tab from the collection will destroy its control and disconnect its connection.
-		_tabs.erase(_tabs.begin() + removingTabIndex);
+        // Removing the tab from the collection will destroy its control and disconnect its connection.
+        _tabs.erase(_tabs.begin() + removingTabIndex);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -846,16 +846,22 @@ namespace winrt::TerminalApp::implementation
     // - tabViewItem: the TabViewItem in the TabView that is being removed.
     void App::_RemoveTabViewItem(const IInspectable& tabViewItem)
     {
-        uint32_t removingTabIndex = 0;
-        WINRT_ASSERT(_tabView.Items().IndexOf(tabViewItem, removingTabIndex));
-
         if (_tabs.size() == 1)
         {
+            _tabView.Items().RemoveAt(0);
+            _tabView = nullptr;
+
+            // Removing the tab from the collection will destroy its control and disconnect its connection.
+            _tabs.clear();
+
             // To close the window here, we need to close the hosting window.
             _lastTabClosedHandlers();
         }
         else
         {
+            uint32_t removingTabIndex = 0;
+            WINRT_ASSERT(_tabView.Items().IndexOf(tabViewItem, removingTabIndex));
+
             // If we are closing the tab we are on, flee to an adjacent tab first!
             // We go to the tab on the right if we are on the 0th tab, or the one on the left otherwise.
             if (removingTabIndex == _GetFocusedTabIndex())
@@ -863,10 +869,10 @@ namespace winrt::TerminalApp::implementation
                 _tabView.SelectedIndex(removingTabIndex > 0 ? removingTabIndex - 1 : 1);
             }
             _tabView.Items().RemoveAt(removingTabIndex);
-        }
 
-        // Removing the tab from the collection will destroy its control and disconnect its connection.
-        _tabs.erase(_tabs.begin() + removingTabIndex);
+            // Removing the tab from the collection will destroy its control and disconnect its connection.
+            _tabs.erase(_tabs.begin() + removingTabIndex);
+        }
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -847,7 +847,7 @@ namespace winrt::TerminalApp::implementation
     void App::_RemoveTabViewItem(const IInspectable& tabViewItem)
     {
         uint32_t removingTabIndex;
-        _tabView.Items().IndexOf(tabViewItem, removingTabIndex);
+        WINRT_ASSERT(_tabView.Items().IndexOf(tabViewItem, removingTabIndex));
 
         if (_tabs.size() == 1)
         {


### PR DESCRIPTION
## Summary of the Pull Request
This commit fixes crashes that happen when the last tab is being closed.

## References
None.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments
Commit bc69d1a99a8921b5088c035096e659b9e0a1d50e adds code that closes
the window when the last tab is being closed, but code that should only
be executed when closing one of multiple open tabs continues to be
executed.  This leads to App::_RemoveTabViewItem trying to call
TabView::SelectedIndex(1) when there is only 1 tab remaining in the
TabView, resulting in an argument exception.