### PR TITLE
set identifying environment variable for new connections

### DIFF
--- a/src/cascadia/TerminalConnection/ConhostConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConhostConnection.cpp
@@ -29,13 +29,9 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         _startingDirectory{ startingDirectory },
         _guid{ initialGuid }
     {
-        guid zeroGuid{};
-        if (_guid == zeroGuid)
+        if (_guid == guid())
         {
-            GUID Guid;
-            THROW_IF_FAILED(CoCreateGuid(&Guid));
-
-            _guid = Guid;
+            _guid = Utils::CreateGuid();
         }
     }
 

--- a/src/cascadia/TerminalConnection/ConhostConnection.h
+++ b/src/cascadia/TerminalConnection/ConhostConnection.h
@@ -9,7 +9,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 {
     struct ConhostConnection : ConhostConnectionT<ConhostConnection>
     {
-        ConhostConnection(const hstring& cmdline, const hstring& startingDirectory, uint32_t rows, uint32_t cols);
+        ConhostConnection(const hstring& cmdline, const hstring& startingDirectory, uint32_t rows, uint32_t cols, const guid& guid);
 
         winrt::event_token TerminalOutput(TerminalConnection::TerminalOutputEventArgs const& handler);
         void TerminalOutput(winrt::event_token const& token) noexcept;
@@ -24,21 +24,21 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         winrt::event<TerminalConnection::TerminalOutputEventArgs> _outputHandlers;
         winrt::event<TerminalConnection::TerminalDisconnectedEventArgs> _disconnectHandlers;
 
-        uint32_t _initialRows;
-        uint32_t _initialCols;
-        hstring _commandline;
-        hstring _startingDirectory;
+        uint32_t _initialRows{};
+        uint32_t _initialCols{};
+        hstring _commandline{};
+        hstring _startingDirectory{};
 
-        bool _connected;
-        HANDLE _inPipe;  // The pipe for writing input to
-        HANDLE _outPipe; // The pipe for reading output from
-        HANDLE _signalPipe;
+        bool _connected{};
+        HANDLE _inPipe{ INVALID_HANDLE_VALUE };  // The pipe for writing input to
+        HANDLE _outPipe{ INVALID_HANDLE_VALUE }; // The pipe for reading output from
+        HANDLE _signalPipe{ INVALID_HANDLE_VALUE };
         //HPCON _hPC;
-        DWORD _outputThreadId;
-        HANDLE _hOutputThread;
-        PROCESS_INFORMATION _piConhost;
-        GUID _guid; // A "unique" session identifier for connected client
-        bool _closing;
+        DWORD _outputThreadId{};
+        HANDLE _hOutputThread{ INVALID_HANDLE_VALUE };
+        PROCESS_INFORMATION _piConhost{};
+        guid _guid{}; // A "unique" session identifier for connected client
+        bool _closing{};
 
         static DWORD WINAPI StaticOutputThreadProc(LPVOID lpParameter);
         DWORD _OutputThread();

--- a/src/cascadia/TerminalConnection/ConhostConnection.h
+++ b/src/cascadia/TerminalConnection/ConhostConnection.h
@@ -9,7 +9,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 {
     struct ConhostConnection : ConhostConnectionT<ConhostConnection>
     {
-        ConhostConnection(const hstring& cmdline, const hstring& startingDirectory, uint32_t rows, uint32_t cols, const guid& guid);
+        ConhostConnection(const hstring& cmdline, const hstring& startingDirectory, const uint32_t rows, const uint32_t cols, const guid& guid);
 
         winrt::event_token TerminalOutput(TerminalConnection::TerminalOutputEventArgs const& handler);
         void TerminalOutput(winrt::event_token const& token) noexcept;
@@ -19,6 +19,8 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         void WriteInput(hstring const& data);
         void Resize(uint32_t rows, uint32_t columns);
         void Close();
+
+        winrt::guid Guid() const noexcept;
 
     private:
         winrt::event<TerminalConnection::TerminalOutputEventArgs> _outputHandlers;
@@ -33,7 +35,6 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         HANDLE _inPipe{ INVALID_HANDLE_VALUE };  // The pipe for writing input to
         HANDLE _outPipe{ INVALID_HANDLE_VALUE }; // The pipe for reading output from
         HANDLE _signalPipe{ INVALID_HANDLE_VALUE };
-        //HPCON _hPC;
         DWORD _outputThreadId{};
         HANDLE _hOutputThread{ INVALID_HANDLE_VALUE };
         PROCESS_INFORMATION _piConhost{};

--- a/src/cascadia/TerminalConnection/ConhostConnection.h
+++ b/src/cascadia/TerminalConnection/ConhostConnection.h
@@ -37,6 +37,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         DWORD _outputThreadId;
         HANDLE _hOutputThread;
         PROCESS_INFORMATION _piConhost;
+        GUID _guid; // A "unique" session identifier for connected client
         bool _closing;
 
         static DWORD WINAPI StaticOutputThreadProc(LPVOID lpParameter);

--- a/src/cascadia/TerminalConnection/ConhostConnection.idl
+++ b/src/cascadia/TerminalConnection/ConhostConnection.idl
@@ -8,7 +8,7 @@ namespace Microsoft.Terminal.TerminalConnection
     [default_interface]
     runtimeclass ConhostConnection : ITerminalConnection
     {
-        ConhostConnection(String cmdline, String startingDirectory, UInt32 rows, UInt32 columns);
+        ConhostConnection(String cmdline, String startingDirectory, UInt32 rows, UInt32 columns, Guid guid);
     };
 
 }

--- a/src/cascadia/TerminalConnection/ConhostConnection.idl
+++ b/src/cascadia/TerminalConnection/ConhostConnection.idl
@@ -9,6 +9,8 @@ namespace Microsoft.Terminal.TerminalConnection
     runtimeclass ConhostConnection : ITerminalConnection
     {
         ConhostConnection(String cmdline, String startingDirectory, UInt32 rows, UInt32 columns, Guid guid);
+
+        Guid Guid { get; };
     };
 
 }

--- a/src/cascadia/TerminalConnection/TerminalConnection.vcxproj
+++ b/src/cascadia/TerminalConnection/TerminalConnection.vcxproj
@@ -52,6 +52,18 @@
 
   </ItemDefinitionGroup>
 
+  <!-- ========================= Project References ======================== -->
+  <ItemGroup>
+    <!--
+      the packaging project won't recurse through our dependencies, you have to
+      make sure that if you add a cppwinrt dependency to any of these projects,
+      you also update all the consumers
+    -->
+    <ProjectReference Include="$(OpenConsoleDir)src\types\lib\types.vcxproj">
+      <Project>{18D09A24-8240-42D6-8CB6-236EEE820263}</Project>
+    </ProjectReference>
+
+  </ItemGroup>
   <PropertyGroup>
     <!--
       DON'T REDIRECT OUR OUTPUT.

--- a/src/cascadia/TerminalConnection/pch.h
+++ b/src/cascadia/TerminalConnection/pch.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <LibraryIncludes.h>
+
 #include "winrt/Windows.Foundation.h"
 #include <Windows.h>
 #include <wil/result.h>

--- a/src/cascadia/TerminalConnection/pch.h
+++ b/src/cascadia/TerminalConnection/pch.h
@@ -9,3 +9,4 @@
 
 #include "winrt/Windows.Foundation.h"
 #include <Windows.h>
+#include <wil/result.h>

--- a/src/cascadia/TerminalConnection/pch.h
+++ b/src/cascadia/TerminalConnection/pch.h
@@ -9,6 +9,9 @@
 
 #include <LibraryIncludes.h>
 
+// Must be included before any WinRT headers.
+#include <unknwn.h>
+
 #include "winrt/Windows.Foundation.h"
 #include <Windows.h>
 #include <wil/result.h>

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -26,7 +26,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     }
 
     TermControl::TermControl(Settings::IControlSettings settings) :
-        _connection{ TerminalConnection::ConhostConnection(winrt::to_hstring("cmd.exe"), winrt::hstring(), 30, 80) },
+        _connection{ TerminalConnection::ConhostConnection(winrt::to_hstring("cmd.exe"), winrt::hstring(), 30, 80, winrt::guid()) },
         _initializedTerminal{ false },
         _root{ nullptr },
         _controlRoot{ nullptr },
@@ -221,7 +221,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     //     directory.
     void TermControl::_ApplyConnectionSettings()
     {
-        _connection = TerminalConnection::ConhostConnection(_settings.Commandline(), _settings.StartingDirectory(), 30, 80);
+        _connection = TerminalConnection::ConhostConnection(_settings.Commandline(), _settings.StartingDirectory(), 30, 80, winrt::guid());
     }
 
     TermControl::~TermControl()

--- a/src/inc/conpty-universal.h
+++ b/src/inc/conpty-universal.h
@@ -30,18 +30,161 @@
 
 const unsigned int PTY_SIGNAL_RESIZE_WINDOW = 8u;
 
-HRESULT CreateConPty(const std::wstring& cmdline,       // _In_
-                     const unsigned short w,            // _In_
-                     const unsigned short h,            // _In_
-                     HANDLE* const hInput,              // _Out_
-                     HANDLE* const hOutput,             // _Out_
-                     HANDLE* const hSignal,             // _Out_
-                     PROCESS_INFORMATION* const piPty); // _Out_
+// A case-insensitive wide-character map is used to store environment variables
+// due to documented requirements:
+//
+//      "All strings in the environment block must be sorted alphabetically by name.
+//      The sort is case-insensitive, Unicode order, without regard to locale.
+//      Because the equal sign is a separator, it must not be used in the name of
+//      an environment variable."
+//      https://docs.microsoft.com/en-us/windows/desktop/ProcThread/changing-environment-variables
+//
+struct WStringCaseInsensitiveCompare
+{
+    bool operator()(const std::wstring& lhs, const std::wstring& rhs) const
+    {
+        return (::_wcsicmp(lhs.c_str(), rhs.c_str()) < 0);
+    }
+};
+
+using EnvironmentVariableMapW = std::map<std::wstring, std::wstring, WStringCaseInsensitiveCompare>;
+
+HRESULT CreateConPty(const std::wstring& cmdline,                       // _In_
+                     const unsigned short w,                            // _In_
+                     const unsigned short h,                            // _In_
+                     HANDLE* const hInput,                              // _Out_
+                     HANDLE* const hOutput,                             // _Out_
+                     HANDLE* const hSignal,                             // _Out_
+                     PROCESS_INFORMATION* const piPty,                  // _Out_
+                     const EnvironmentVariableMapW& extraEnvVars = {}); // _In_
 
 bool SignalResizeWindow(const HANDLE hSignal,
                         const unsigned short w,
                         const unsigned short h);
 
+HRESULT UpdateEnvironmentMapW(EnvironmentVariableMapW& map);
+
+HRESULT EnvironmentMapToEnvironmentStringsW(EnvironmentVariableMapW& map, std::vector<wchar_t>& newEnvVars);
+
+// Function Description:
+// - Updates an EnvironmentVariableMapW with the current process's unicode
+//   environment variables ignoring ones already set in the provided map.
+// Arguments:
+// - map: The map to populate with the current processes's environment variables.
+// Return Value:
+// - S_OK if we succeeded, or an appropriate HRESULT for failing
+__declspec(noinline) inline
+HRESULT UpdateEnvironmentMapW(EnvironmentVariableMapW& map)
+{
+    LPWCH currentEnvVars{};
+    auto freeCurrentEnv = wil::scope_exit([&] {
+        if (currentEnvVars)
+        {
+            (void)FreeEnvironmentStringsW(currentEnvVars);
+            currentEnvVars = nullptr;
+        }
+    });
+
+    RETURN_IF_NULL_ALLOC(currentEnvVars = ::GetEnvironmentStringsW());
+
+    // Block is guaranteed to be double-NULL terminated at a minimum.
+    for (wchar_t const* lastCh{ currentEnvVars }; *lastCh != '\0';)
+    {
+        // Copy current entry into temporary map.
+        const size_t cchEntry{ ::wcslen(lastCh) };
+        const std::wstring_view entry{ lastCh, cchEntry };
+
+        // Every entry is of the form "name=value\0".
+        auto pos = entry.find_first_of(L"=", 0, 1);
+        RETURN_HR_IF(E_UNEXPECTED, pos == std::wstring::npos);
+
+        std::wstring name{ lastCh, pos };
+        std::wstring value{ lastCh + pos + 1, cchEntry - pos - 1 };
+
+        // Don't replace entries that already exist.
+        map.try_emplace(std::move(name), std::move(value));
+
+        lastCh += cchEntry + 1; // Each entry is NULL-terminated.
+    }
+
+    return S_OK;
+}
+
+// Function Description:
+// - Creates a new environment block using the provided vector as appropriate
+//   (resizing if needed) based on the provided environment variable map
+//   matching the format of GetEnvironmentStringsW.
+// Arguments:
+// - map: The map to populate the new environment block vector with.
+// - newEnvVars: The vector that will be used to create the new environment block.
+// Return Value:
+// - S_OK if we succeeded, or an appropriate HRESULT for failing
+__declspec(noinline) inline
+HRESULT EnvironmentMapToEnvironmentStringsW(EnvironmentVariableMapW& map, std::vector<wchar_t>& newEnvVars)
+{
+    // Clear environment block before use.
+    constexpr size_t cbChar{ sizeof(decltype(newEnvVars.begin())::value_type) };
+
+    if (!newEnvVars.empty())
+    {
+        ::SecureZeroMemory(newEnvVars.data(), newEnvVars.size() * cbChar);
+    }
+
+    // Resize environment block to fit map.
+    size_t cchEnv{ 2 }; // For the block's double NULL-terminator.
+    for (const auto&[name, value] : map)
+    {
+        // Final form of "name=value\0".
+        cchEnv += name.size() + 1 + value.size() + 1;
+    }
+    newEnvVars.resize(cchEnv);
+
+    // Ensure new block is wiped if we exit due to failure.
+    auto zeroNewEnv = wil::scope_exit([&] {
+        ::SecureZeroMemory(newEnvVars.data(), newEnvVars.size() * cbChar);
+    });
+
+    // Transform each map entry and copy it into the new environment block.
+    LPWCH pEnvVars{ newEnvVars.data() };
+    size_t cbRemaining{ cchEnv * cbChar };
+    for (const auto&[name, value] : map)
+    {
+        // Final form of "name=value\0" for every entry.
+        {
+            const size_t cchSrc{ name.size() };
+            const size_t cbSrc{ cchSrc * cbChar };
+            RETURN_HR_IF(E_OUTOFMEMORY, memcpy_s(pEnvVars, cbRemaining, name.c_str(), cbSrc) != 0);
+            pEnvVars += cchSrc;
+            cbRemaining -= cbSrc;
+        }
+
+        RETURN_HR_IF(E_OUTOFMEMORY, memcpy_s(pEnvVars, cbRemaining, L"=", cbChar) != 0);
+        ++pEnvVars;
+        cbRemaining -= cbChar;
+
+        {
+            const size_t cchSrc{ value.size() };
+            const size_t cbSrc{ cchSrc * cbChar };
+            RETURN_HR_IF(E_OUTOFMEMORY, memcpy_s(pEnvVars, cbRemaining, value.c_str(), cbSrc) != 0);
+            pEnvVars += cchSrc;
+            cbRemaining -= cbSrc;
+        }
+
+        RETURN_HR_IF(E_OUTOFMEMORY, memcpy_s(pEnvVars, cbRemaining, L"\0", cbChar) != 0);
+        ++pEnvVars;
+        cbRemaining -= cbChar;
+    }
+
+    // Environment block only has to be NULL-terminated, but double NULL-terminate anyway.
+    RETURN_HR_IF(E_OUTOFMEMORY, memcpy_s(pEnvVars, cbRemaining, L"\0\0", cbChar * 2) != 0);
+    cbRemaining -= cbChar * 2;
+
+    RETURN_HR_IF(E_UNEXPECTED, cbRemaining != 0);
+
+    zeroNewEnv.release(); // success; don't wipe new environment block on exit
+
+    return S_OK;
+}
 
 // Function Description:
 // - Creates a headless conhost in "pty mode" and launches the given commandline
@@ -64,6 +207,9 @@ bool SignalResizeWindow(const HANDLE hSignal,
 // - hSignal: A handle to the pipe for writing signal messages to the pty.
 // - piPty: The PROCESS_INFORMATION of the pty process. NOTE: This is *not* the
 //      PROCESS_INFORMATION of the process that's created as a result the cmdline.
+// - extraEnvVars : A map of pairs of (Name, Value) representing additional
+//      environment variable strings and values to be set in the client process
+//      environment.  May override any already present in parent process.
 // Return Value:
 // - S_OK if we succeeded, or an appropriate HRESULT for failing format the
 //      commandline or failing to launch the conhost
@@ -75,7 +221,8 @@ HRESULT CreateConPty(const std::wstring& cmdline,
                      HANDLE* const hInput,
                      HANDLE* const hOutput,
                      HANDLE* const hSignal,
-                     PROCESS_INFORMATION* const piPty)
+                     PROCESS_INFORMATION* const piPty,
+                     const EnvironmentVariableMapW& extraEnvVars = {})
 {
     // Create some anon pipes so we can pass handles down and into the console.
     // IMPORTANT NOTE:
@@ -142,14 +289,42 @@ HRESULT CreateConPty(const std::wstring& cmdline,
 
     LPCWSTR lpCurrentDirectory = startingDirectory.has_value() ? startingDirectory.value().c_str() : nullptr;
 
+    std::vector<wchar_t> newEnvVars;
+    auto zeroNewEnv = wil::scope_exit([&] {
+        ::SecureZeroMemory(newEnvVars.data(),
+                           newEnvVars.size() * sizeof(decltype(newEnvVars.begin())::value_type));
+    });
+
+    DWORD dwCreationFlags = 0;
+    if (!extraEnvVars.empty())
+    {
+        EnvironmentVariableMapW tempEnvMap{ extraEnvVars };
+        auto zeroEnvMap = wil::scope_exit([&] {
+            // Can't zero the keys, but at least we can zero the values.
+            for (auto&[name, value] : tempEnvMap)
+            {
+                ::SecureZeroMemory(value.data(), value.size() * sizeof(decltype(value.begin())::value_type));
+            }
+
+            tempEnvMap.clear();
+        });
+
+        RETURN_IF_FAILED(UpdateEnvironmentMapW(tempEnvMap));
+        RETURN_IF_FAILED(EnvironmentMapToEnvironmentStringsW(tempEnvMap, newEnvVars));
+
+        // Required when using a unicode environment block.
+        dwCreationFlags |= CREATE_UNICODE_ENVIRONMENT;
+    }
+
+    LPWCH lpEnvironment = newEnvVars.empty() ? nullptr : newEnvVars.data();
     bool fSuccess = !!CreateProcessW(
         nullptr,
         mutableCommandline.get(),
         nullptr,                    // lpProcessAttributes
         nullptr,                    // lpThreadAttributes
         true,                       // bInheritHandles
-        0,                          // dwCreationFlags
-        nullptr,                    // lpEnvironment
+        dwCreationFlags,            // dwCreationFlags
+        lpEnvironment,              // lpEnvironment
         lpCurrentDirectory,         // lpCurrentDirectory
         &si,                        // lpStartupInfo
         piPty                       // lpProcessInformation

--- a/src/inc/conpty-universal.h
+++ b/src/inc/conpty-universal.h
@@ -41,7 +41,8 @@ const unsigned int PTY_SIGNAL_RESIZE_WINDOW = 8u;
 //
 struct WStringCaseInsensitiveCompare
 {
-    bool operator()(const std::wstring& lhs, const std::wstring& rhs) const
+    [[nodiscard]]
+    bool operator()(const std::wstring& lhs, const std::wstring& rhs) const noexcept
     {
         return (::_wcsicmp(lhs.c_str(), rhs.c_str()) < 0);
     }
@@ -49,22 +50,25 @@ struct WStringCaseInsensitiveCompare
 
 using EnvironmentVariableMapW = std::map<std::wstring, std::wstring, WStringCaseInsensitiveCompare>;
 
-HRESULT CreateConPty(const std::wstring& cmdline,                       // _In_
-                     const unsigned short w,                            // _In_
-                     const unsigned short h,                            // _In_
-                     HANDLE* const hInput,                              // _Out_
-                     HANDLE* const hOutput,                             // _Out_
-                     HANDLE* const hSignal,                             // _Out_
-                     PROCESS_INFORMATION* const piPty,                  // _Out_
-                     const EnvironmentVariableMapW& extraEnvVars = {}); // _In_
+[[nodiscard]]
+HRESULT CreateConPty(const std::wstring& cmdline,
+                     const unsigned short w,
+                     const unsigned short h,
+                     HANDLE* const hInput,
+                     HANDLE* const hOutput,
+                     HANDLE* const hSignal,
+                     PROCESS_INFORMATION* const piPty,
+                     const EnvironmentVariableMapW& extraEnvVars = {}) noexcept;
 
 bool SignalResizeWindow(const HANDLE hSignal,
                         const unsigned short w,
                         const unsigned short h);
 
-HRESULT UpdateEnvironmentMapW(EnvironmentVariableMapW& map);
+[[nodiscard]]
+HRESULT UpdateEnvironmentMapW(EnvironmentVariableMapW& map) noexcept;
 
-HRESULT EnvironmentMapToEnvironmentStringsW(EnvironmentVariableMapW& map, std::vector<wchar_t>& newEnvVars);
+[[nodiscard]]
+HRESULT EnvironmentMapToEnvironmentStringsW(EnvironmentVariableMapW& map, std::vector<wchar_t>& newEnvVars) noexcept;
 
 // Function Description:
 // - Updates an EnvironmentVariableMapW with the current process's unicode
@@ -73,8 +77,9 @@ HRESULT EnvironmentMapToEnvironmentStringsW(EnvironmentVariableMapW& map, std::v
 // - map: The map to populate with the current processes's environment variables.
 // Return Value:
 // - S_OK if we succeeded, or an appropriate HRESULT for failing
+[[nodiscard]]
 __declspec(noinline) inline
-HRESULT UpdateEnvironmentMapW(EnvironmentVariableMapW& map)
+HRESULT UpdateEnvironmentMapW(EnvironmentVariableMapW& map) noexcept
 {
     LPWCH currentEnvVars{};
     auto freeCurrentEnv = wil::scope_exit([&] {
@@ -119,8 +124,9 @@ HRESULT UpdateEnvironmentMapW(EnvironmentVariableMapW& map)
 // - newEnvVars: The vector that will be used to create the new environment block.
 // Return Value:
 // - S_OK if we succeeded, or an appropriate HRESULT for failing
+[[nodiscard]]
 __declspec(noinline) inline
-HRESULT EnvironmentMapToEnvironmentStringsW(EnvironmentVariableMapW& map, std::vector<wchar_t>& newEnvVars)
+HRESULT EnvironmentMapToEnvironmentStringsW(EnvironmentVariableMapW& map, std::vector<wchar_t>& newEnvVars) noexcept
 {
     // Clear environment block before use.
     constexpr size_t cbChar{ sizeof(decltype(newEnvVars.begin())::value_type) };
@@ -213,6 +219,7 @@ HRESULT EnvironmentMapToEnvironmentStringsW(EnvironmentVariableMapW& map, std::v
 // Return Value:
 // - S_OK if we succeeded, or an appropriate HRESULT for failing format the
 //      commandline or failing to launch the conhost
+[[nodiscard]]
 __declspec(noinline) inline
 HRESULT CreateConPty(const std::wstring& cmdline,
                      std::optional<std::wstring> startingDirectory,
@@ -222,7 +229,7 @@ HRESULT CreateConPty(const std::wstring& cmdline,
                      HANDLE* const hOutput,
                      HANDLE* const hSignal,
                      PROCESS_INFORMATION* const piPty,
-                     const EnvironmentVariableMapW& extraEnvVars = {})
+                     const EnvironmentVariableMapW& extraEnvVars = {}) noexcept
 {
     // Create some anon pipes so we can pass handles down and into the console.
     // IMPORTANT NOTE:


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Set a WT_SESSION environment variable to a unique guid on every new connection to allow shell consumers to detect Windows Terminal and uniquely identify the session.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

Unknown.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #840 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [X] Requires documentation to be updated
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #840

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Set a new 'WT_SESSION' environment variable when creating new terminal connections to allow shells to detect a unique Windows Terminal session.  The value of the variable is a stringified GUID as returned by
CoCreateGuid.

How verified:
- "razzle" & vs debug build
- runut
- opencon
- testcon
- manual inspection

Uncertain about what tests to add and where; all of the existing ones passed.

I did some basic research to try to ensure that "WT_SESSION" is a "unique", non-conflicting environment variable and so shouldn't cause any problems with any existing programs.  I'm certainly open to suggestions about the name though.