### PR TITLE
Update README.md - Build the Code section 

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,9 @@ git submodule update --init --recursive
 OpenConsole.sln may be built from within Visual Studio or from the command-line using MSBuild. To build from the command line:
 
 ```shell
-.\tools\razzle.cmd
-bcz
+cd tools
+razzle.cmd
+bcz.cmd
 ```
 
 We've provided a set of convenience scripts as well as [README](./tools/README.md) in the **/tools** directory to help automate the process of building and running tests.

--- a/README.md
+++ b/README.md
@@ -140,12 +140,11 @@ This repository uses [git submodules](https://git-scm.com/book/en/v2/Git-Tools-S
 git submodule update --init --recursive
 ```
 
-OpenConsole.sln may be built from within Visual Studio or from the command-line using MSBuild. To build from the command line:
+OpenConsole.sln may be built from within Visual Studio or from the command-line using MSBuild. To build from the command line (`cmd.exe` should be used):
 
 ```shell
-cd tools
-razzle.cmd
-bcz.cmd
+.\tools\razzle.cmd
+bcz
 ```
 
 We've provided a set of convenience scripts as well as [README](./tools/README.md) in the **/tools** directory to help automate the process of building and running tests.

--- a/README.md
+++ b/README.md
@@ -140,7 +140,17 @@ This repository uses [git submodules](https://git-scm.com/book/en/v2/Git-Tools-S
 git submodule update --init --recursive
 ```
 
-OpenConsole.sln may be built from within Visual Studio or from the command-line using MSBuild. To build from the command line (`cmd.exe` should be used):
+OpenConsole.sln may be built from within Visual Studio or from the command-line using MSBuild. To build from the command line, find your shell below.
+
+### PowerShell
+
+```powershell
+Import-Module .\tools\OpenConsole.psm1
+Set-MsBuildDevEnvironment
+Invoke-OpenConsoleBuild
+```
+
+### CMD
 
 ```shell
 .\tools\razzle.cmd


### PR DESCRIPTION
Fix readme to show correct path of build tools

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fix `README.md` documentation in Build the Code section 
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #898
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [x] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
It might be fixed also by adding path to `bcz` in `razzle` command.
