### PR TITLE
Bugfix: padding offsets selection

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1209,8 +1209,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         };
         
         const auto fontSize = _actualFont.GetSize();
-        WI_ASSERT(fontSize.X != 0);
-        WI_ASSERT(fontSize.Y != 0);
+        FAIL_FAST_IF(fontSize.X == 0);
+        FAIL_FAST_IF(fontSize.Y == 0);
         
         // Normalize to terminal coordinates by using font size
         terminalPosition.X /= fontSize.X;

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1201,14 +1201,18 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // - the corresponding viewport terminal position for the given Point parameter
     const COORD TermControl::_GetTerminalPosition(winrt::Windows::Foundation::Point cursorPosition)
     {
-        COORD terminalPosition = {};
-        
         // Exclude padding from cursor position calculation
-        THROW_IF_FAILED(ShortSub(cursorPosition.X, static_cast<SHORT>(_root.Padding().Left), &terminalPosition.X));
-        THROW_IF_FAILED(ShortSub(cursorPosition.Y, static_cast<SHORT>(_root.Padding().Top), &terminalPosition.Y));
+        COORD terminalPosition =
+        {
+            static_cast<SHORT>(cursorPosition.X - _root.Padding().Left),
+            static_cast<SHORT>(cursorPosition.Y - _root.Padding().Top)
+        };
+        
+        const auto fontSize = _actualFont.GetSize();
+        WI_ASSERT(fontSize.X != 0);
+        WI_ASSERT(fontSize.Y != 0);
         
         // Normalize to terminal coordinates by using font size
-        const auto fontSize = _actualFont.GetSize();
         terminalPosition.X /= fontSize.X;
         terminalPosition.Y /= fontSize.Y;
 

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -560,8 +560,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                 const auto fontSize = _actualFont.GetSize();
 
                 const COORD terminalPosition = {
-                    static_cast<SHORT>(cursorPosition.X / fontSize.X),
-                    static_cast<SHORT>(cursorPosition.Y / fontSize.Y)
+                    static_cast<SHORT>((cursorPosition.X - _root.Padding().Left) / fontSize.X),
+                    static_cast<SHORT>((cursorPosition.Y - _root.Padding().Top) / fontSize.Y)
                 };
 
                 // save location before rendering
@@ -622,8 +622,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                 const auto fontSize = _actualFont.GetSize();
 
                 const COORD terminalPosition = {
-                    static_cast<SHORT>(cursorPosition.X / fontSize.X),
-                    static_cast<SHORT>(cursorPosition.Y / fontSize.Y)
+                    static_cast<SHORT>((cursorPosition.X - _root.Padding().Left) / fontSize.X),
+                    static_cast<SHORT>((cursorPosition.Y - _root.Padding().Top) / fontSize.Y)
                 };
 
                 // save location (for rendering) + render

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -123,6 +123,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         Settings::KeyModifiers _GetPressedModifierKeys() const;
 
+        const COORD _GetTerminalPosition(winrt::Windows::Foundation::Point cursorPosition);
     };
 }
 

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -454,7 +454,7 @@ const bool Terminal::IsSelectionActive() const noexcept
 // Method Description:
 // - Record the position of the beginning of a selection
 // Arguments:
-// - position: the (x,y) coordinate on the visible viewport
+// - position: the (x,y) coordinate on the visible viewport (including padding)
 void Terminal::SetSelectionAnchor(const COORD position)
 {
     _selectionAnchor = position;
@@ -473,7 +473,7 @@ void Terminal::SetSelectionAnchor(const COORD position)
 // Method Description:
 // - Record the position of the end of a selection
 // Arguments:
-// - position: the (x,y) coordinate on the visible viewport
+// - position: the (x,y) coordinate on the visible viewport (including padding)
 void Terminal::SetEndSelectionPosition(const COORD position)
 {
     _endSelectionPosition = position;

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -454,7 +454,7 @@ const bool Terminal::IsSelectionActive() const noexcept
 // Method Description:
 // - Record the position of the beginning of a selection
 // Arguments:
-// - position: the (x,y) coordinate on the visible viewport (including padding)
+// - position: the (x,y) coordinate on the visible viewport
 void Terminal::SetSelectionAnchor(const COORD position)
 {
     _selectionAnchor = position;
@@ -473,7 +473,7 @@ void Terminal::SetSelectionAnchor(const COORD position)
 // Method Description:
 // - Record the position of the end of a selection
 // Arguments:
-// - position: the (x,y) coordinate on the visible viewport (including padding)
+// - position: the (x,y) coordinate on the visible viewport
 void Terminal::SetEndSelectionPosition(const COORD position)
 {
     _endSelectionPosition = position;


### PR DESCRIPTION
## Summary of the Pull Request
Padding used to offset selection. 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #660
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [x] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. (I am a core contributor)

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Created `_GetTerminalPosition()` to encompass some of this logic and prevent this kind of stuff from happening again. Also, just nice to wrap everything up into a function call. 

To the team: this was already somewhat reviewed back before we went on GitHub. So if you have a deja vu feeling, that's why.