### PR TITLE
Fix `it's` versus `its` typo.

### DIFF
--- a/src/buffer/out/TextAttribute.cpp
+++ b/src/buffer/out/TextAttribute.cpp
@@ -238,8 +238,8 @@ void TextAttribute::SetDefaultBackground() noexcept
 }
 
 // Method Description:
-// - Returns true if this attribute indicates it's foreground is the "default"
-//      foreground. It's _rgbForeground will contain the actual value of the
+// - Returns true if this attribute indicates its foreground is the "default"
+//      foreground. Its _rgbForeground will contain the actual value of the
 //      default foreground. If the default colors are ever changed, this method
 //      should be used to identify attributes with the default fg value, and
 //      update them accordingly.
@@ -253,8 +253,8 @@ bool TextAttribute::ForegroundIsDefault() const noexcept
 }
 
 // Method Description:
-// - Returns true if this attribute indicates it's background is the "default"
-//      background. It's _rgbBackground will contain the actual value of the
+// - Returns true if this attribute indicates its background is the "default"
+//      background. Its _rgbBackground will contain the actual value of the
 //      default background. If the default colors are ever changed, this method
 //      should be used to identify attributes with the default bg value, and
 //      update them accordingly.

--- a/src/buffer/out/UnicodeStorage.cpp
+++ b/src/buffer/out/UnicodeStorage.cpp
@@ -32,7 +32,7 @@ void UnicodeStorage::StoreGlyph(const key_type key, const mapped_type& glyph)
 }
 
 // Routine Description:
-// - erases key and it's associated data from the storage
+// - erases key and its associated data from the storage
 // Arguments:
 // - key - the key to remove
 void UnicodeStorage::Erase(const key_type key) noexcept

--- a/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
@@ -366,7 +366,7 @@ std::optional<winrt::hstring> CascadiaSettings::_LoadAsUnpackagedApp()
 
 // function Description:
 // - Returns the full path to the settings file, either within the application
-//   package, or in it's unpackaged location.
+//   package, or in its unpackaged location.
 // Arguments:
 // - <none>
 // Return Value:
@@ -378,7 +378,7 @@ winrt::hstring CascadiaSettings::GetSettingsPath()
 }
 
 // Function Description:
-// - Get the full path to settings file in it's packaged location.
+// - Get the full path to settings file in its packaged location.
 // Arguments:
 // - <none>
 // Return Value:

--- a/src/cascadia/TerminalApp/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.cpp
@@ -228,7 +228,7 @@ ElementTheme GlobalAppSettings::_ParseTheme(const std::wstring& themeString) noe
 }
 
 // Method Description:
-// - Helper function for converting a CursorStyle to it's corresponding string
+// - Helper function for converting a CursorStyle to its corresponding string
 //   value.
 // Arguments:
 // - theme: The enum value to convert to a string.

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -572,7 +572,7 @@ CursorStyle Profile::_ParseCursorShape(const std::wstring& cursorShapeString)
 }
 
 // Method Description:
-// - Helper function for converting a CursorStyle to it's corresponding string
+// - Helper function for converting a CursorStyle to its corresponding string
 //   value.
 // Arguments:
 // - cursorShape: The enum value to convert to a string.

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -20,7 +20,7 @@ Tab::~Tab()
 {
     // When we're destructed, winrt will automatically decrement the refcount
     // of our terminalcontrol.
-    // Assuming that refcount hits 0, it'll destruct it on it's own, including
+    // Assuming that refcount hits 0, it'll destruct it on its own, including
     //      calling Close on the terminal and connection.
 }
 

--- a/src/cascadia/TerminalConnection/ConhostConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConhostConnection.cpp
@@ -76,7 +76,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         _connected = true;
 
         // Create our own output handling thread
-        // Each console needs to make sure to drain the output from it's backing host.
+        // Each console needs to make sure to drain the output from its backing host.
         _outputThreadId = (DWORD)-1;
         _hOutputThread = CreateThread(nullptr,
                                       0,

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -133,7 +133,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         _root.Dispatcher().RunAsync(CoreDispatcherPriority::Normal,[this](){
             // Update our control settings
             _ApplyUISettings();
-            // Update the terminal core with it's new Core settings
+            // Update the terminal core with its new Core settings
             _terminal->UpdateSettings(_settings);
 
             // Refresh our font with the renderer
@@ -293,7 +293,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         _renderer->AddRenderEngine(dxEngine.get());
 
         // Set up the renderer to be used to calculate the width of a glyph,
-        //      should we be unable to figure out it's width another way.
+        //      should we be unable to figure out its width another way.
         auto pfn = std::bind(&::Microsoft::Console::Render::Renderer::IsGlyphWideByFont, _renderer.get(), std::placeholders::_1);
         SetGlyphWidthFallback(pfn);
 

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -46,7 +46,7 @@ void IslandWindow::MakeWindow() noexcept
     WINRT_ASSERT(!_window);
 
     // Create the window with the default size here - During the creation of the
-    // window, the system will give us a chance to set it's size in WM_CREATE.
+    // window, the system will give us a chance to set its size in WM_CREATE.
     // WM_CREATE will be handled synchronously, before CreateWindow returns.
     WINRT_VERIFY(CreateWindow(wc.lpszClassName,
         L"Windows Terminal",

--- a/src/cppwinrt.build.post.props
+++ b/src/cppwinrt.build.post.props
@@ -42,7 +42,7 @@
 
   <!--
     For whatever reason, GENERATEPROJECTPRIFILE is incapable of creating this
-    directory on it's own, it just assumes it exists.
+    directory on its own, it just assumes it exists.
 
     Also make the directory w/o the platform, because the x86 build in CI will
     try to place the pri files into

--- a/src/host/ConsoleArguments.cpp
+++ b/src/host/ConsoleArguments.cpp
@@ -86,7 +86,7 @@ void ConsoleArguments::s_ConsumeArg(_Inout_ std::vector<std::wstring>& args, _In
 
 // Routine Description:
 //  Given the commandline of tokens `args`, tries to find the argument at
-//      index+1, and places it's value into pSetting.
+//      index+1, and places its value into pSetting.
 //  If there aren't enough args, then returns E_INVALIDARG.
 //  If we found a value, then we take the elements at both index and index+1 out
 //      of args. We'll also decrement index, so that a caller who is using index
@@ -157,7 +157,7 @@ HRESULT ConsoleArguments::s_HandleFeatureValue(_Inout_ std::vector<std::wstring>
 // Method Description:
 // Routine Description:
 //  Given the commandline of tokens `args`, tries to find the argument at
-//      index+1, and places it's value into pSetting. See above for examples.
+//      index+1, and places its value into pSetting. See above for examples.
 //  This implementation attempts to parse a short from the argument.
 // Arguments:
 //  args: A collection of wstrings representing command-line arguments

--- a/src/host/VtIo.cpp
+++ b/src/host/VtIo.cpp
@@ -367,7 +367,7 @@ void VtIo::CloseOutput()
     // owned by the paint.
     // Instead we're releasing the Engine here. A pointer to it has already been
     // given to the Renderer, so we don't want the unique_ptr to delete it. The
-    // Renderer will own it's lifetime now.
+    // Renderer will own its lifetime now.
     _pVtRenderEngine.release();
 
     g.getConsoleInformation().GetActiveOutputBuffer().SetTerminalConnection(nullptr);

--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -724,14 +724,14 @@ void SCREEN_INFORMATION::SetViewportSize(const COORD* const pcoordSize)
 
 // Method Description:
 // - Update the origin of the buffer's viewport. You can either move the
-//      viewport with a delta relative to it's current location, or set it's
+//      viewport with a delta relative to its current location, or set its
 //      absolute origin. Either way leaves the dimensions of the viewport
 //      unchanged. Also potentially updates our "virtual bottom", the last real
 //      location of the viewport in the buffer.
-//  Also notifies the window implementation to update it's scrollbars.
+//  Also notifies the window implementation to update its scrollbars.
 // Arguments:
 // - fAbsolute: If true, coordWindowOrigin is the absolute location of the origin of the new viewport.
-//      If false, coordWindowOrigin is a delta to move the viewport relative to it's current position.
+//      If false, coordWindowOrigin is a delta to move the viewport relative to its current position.
 // - coordWindowOrigin: Either the new absolute position of the origin of the
 //      viewport, or a delta to add to the current viewport location.
 // - updateBottom: If true, update our virtual bottom position. This should be
@@ -1820,7 +1820,7 @@ void SCREEN_INFORMATION::SetCursorType(const CursorType Type, const bool setMain
 
 // Routine Description:
 // - This routine sets a flag saying whether the cursor should be displayed
-//   with it's default size or it should be modified to indicate the
+//   with its default size or it should be modified to indicate the
 //   insert/overtype mode has changed.
 // Arguments:
 // - ScreenInfo - pointer to screen info structure.
@@ -2120,7 +2120,7 @@ void SCREEN_INFORMATION::UseMainScreenBuffer()
         SCREEN_INFORMATION* psiAlt = psiMain->_psiAlternateBuffer;
         psiMain->_psiAlternateBuffer = nullptr;
         s_RemoveScreenBuffer(psiAlt); // this will also delete the alt buffer
-        // deleting the alt buffer will give the GetSet back to it's main
+        // deleting the alt buffer will give the GetSet back to its main
 
         // Tell the VT MouseInput handler that we're in the main buffer now
         gci.terminalMouseInput.UseMainScreenBuffer();
@@ -2823,7 +2823,7 @@ void SCREEN_INFORMATION::MoveToBottom()
 }
 
 // Method Description:
-// - Returns the "virtual" Viewport - the viewport with it's bottom at
+// - Returns the "virtual" Viewport - the viewport with its bottom at
 //      `_virtualBottom`. For VT operations, this is essentially the mutable
 //      section of the buffer.
 // Arguments:

--- a/src/host/settings.cpp
+++ b/src/host/settings.cpp
@@ -769,7 +769,7 @@ WORD Settings::GenerateLegacyAttributes(const TextAttribute attributes) const
     if (attributes.IsRgb())
     {
         // If the attribute doesn't have a "default" colored *ground, look up
-        //  the nearest color table value for it's *ground.
+        //  the nearest color table value for its *ground.
         const COLORREF rgbForeground = LookupForegroundColor(attributes);
         fgIndex = attributes.ForegroundIsDefault() ?
                              fgIndex :

--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -517,7 +517,7 @@ NTSTATUS ConsoleAllocateConsole(PCONSOLE_API_CONNECTINFO p)
         auto renderThread = std::make_unique<RenderThread>();
         // stash a local pointer to the thread here -
         // We're going to give ownership of the thread to the Renderer,
-        //      but the thread also need to be told who it's renderer is,
+        //      but the thread also need to be told who its renderer is,
         //      and we can't do that until the renderer is constructed.
         auto* const localPointerToThread = renderThread.get();
 
@@ -529,7 +529,7 @@ NTSTATUS ConsoleAllocateConsole(PCONSOLE_API_CONNECTINFO p)
         g.pRender->EnablePainting();
 
         // Set up the renderer to be used to calculate the width of a glyph,
-        //      should we be unable to figure out it's width another way.
+        //      should we be unable to figure out its width another way.
         auto pfn = std::bind(&Renderer::IsGlyphWideByFont, static_cast<Renderer*>(g.pRender), std::placeholders::_1);
         SetGlyphWidthFallback(pfn);
 

--- a/src/interactivity/win32/windowio.cpp
+++ b/src/interactivity/win32/windowio.cpp
@@ -622,7 +622,7 @@ BOOL HandleMouseEvent(const SCREEN_INFORMATION& ScreenInfo,
 
     // We need to try and have the virtual terminal handle the mouse's position in viewport coordinates,
     //   not in screen buffer coordinates. It expects the top left to always be 0,0
-    //   (the TerminalMouseInput object will add (1,1) to convert to VT coords on it's own.)
+    //   (the TerminalMouseInput object will add (1,1) to convert to VT coords on its own.)
     // Mouse events with shift pressed will ignore this and fall through to the default handler.
     //   This is in line with PuTTY's behavior and vim's own documentation:
     //   "The xterm handling of the mouse buttons can still be used by keeping the shift key pressed." - `:help 'mouse'`, vim.

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -352,7 +352,7 @@ void Renderer::TriggerScroll(const COORD* const pcoordDelta)
 }
 
 // Routine Description:
-// - Called when the text buffer is about to circle it's backing buffer.
+// - Called when the text buffer is about to circle its backing buffer.
 //      A renderer might want to get painted before that happens.
 // Arguments:
 // - <none>
@@ -869,7 +869,7 @@ HRESULT Renderer::_UpdateDrawingBrushes(_In_ IRenderEngine* const pEngine, const
     const WORD legacyAttributes = textAttributes.GetLegacyAttributes();
     const bool isBold = textAttributes.IsBold();
 
-    // The last color need's to be each engine's responsibility. If it's local to this function,
+    // The last color needs to be each engine's responsibility. If it's local to this function,
     //      then on the next engine we might not update the color.
     RETURN_IF_FAILED(pEngine->UpdateDrawingBrushes(rgbForeground, rgbBackground, legacyAttributes, isBold, isSettingDefaultBrushes));
 

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -791,7 +791,7 @@ HRESULT DxEngine::_CopyFrontToBack() noexcept
 
 // Routine Description:
 // - Takes queued drawing information and presents it to the screen.
-// - This is separated out so it can be done outside the lock as it's expensive
+// - This is separated out so it can be done outside the lock as it's expensive.
 // Arguments:
 // - <none>
 // Return Value:

--- a/src/renderer/inc/RenderEngineBase.hpp
+++ b/src/renderer/inc/RenderEngineBase.hpp
@@ -9,7 +9,7 @@ Abstract:
 - Implements a set of functions with common behavior across all render engines.
   For example, the behavior for setting the title. The title may change many
   times in the course of a single frame, but the RenderEngine should only
-  actually perform it's update operation if at the start of a frame, the new
+  actually perform its update operation if at the start of a frame, the new
   window title will be different then the last frames, and it should only ever
   update the title once per frame.
 

--- a/src/renderer/vt/XtermEngine.cpp
+++ b/src/renderer/vt/XtermEngine.cpp
@@ -419,7 +419,7 @@ HRESULT XtermEngine::WriteTerminalW(const std::wstring& wstr) noexcept
 [[nodiscard]]
 HRESULT XtermEngine::_DoUpdateTitle(const std::wstring& newTitle) noexcept
 {
-    // inbox telnet uses xterm-ascii as it's mode. If we're in ascii mode, don't
+    // inbox telnet uses xterm-ascii as its mode. If we're in ascii mode, don't
     //      do anything, to maintain compatibility.
     if (_fUseAsciiOnly)
     {

--- a/src/terminal/adapter/MouseInput.cpp
+++ b/src/terminal/adapter/MouseInput.cpp
@@ -107,7 +107,7 @@ bool MouseInput::s_IsButtonDown(const unsigned int uiButton)
 }
 
 // Routine Description:
-// - translates the input windows mouse message into it's equivalent X11 encoding.
+// - translates the input windows mouse message into its equivalent X11 encoding.
 // X Button Encoding:
 // |7|6|5|4|3|2|1|0|
 // | |W|H|M|C|S|B|B|
@@ -178,7 +178,7 @@ int MouseInput::s_WindowsButtonToXEncoding(const unsigned int uiButton,
 
 
 // Routine Description:
-// - translates the input windows mouse message into it's equivalent SGR encoding.
+// - translates the input windows mouse message into its equivalent SGR encoding.
 // This is nearly identical to the X encoding, with an important difference.
 //      The button is always encoded as 0, 1, 2.
 //      3 is reserved for mouse hovers with _no_ buttons pressed.

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1686,7 +1686,7 @@ bool AdaptDispatch::EnableVT200MouseMode(const bool fEnabled)
 
 //Routine Description:
 // Enable UTF-8 Extended Encoding - this changes the encoding scheme for sequences
-//      emitted by the mouse input handler. Does not enable/disable mouse mode on it's own.
+//      emitted by the mouse input handler. Does not enable/disable mouse mode on its own.
 //Arguments:
 // - fEnabled - true to enable, false to disable.
 // Return value:
@@ -1698,7 +1698,7 @@ bool AdaptDispatch::EnableUTF8ExtendedMouseMode(const bool fEnabled)
 
 //Routine Description:
 // Enable SGR Extended Encoding - this changes the encoding scheme for sequences
-//      emitted by the mouse input handler. Does not enable/disable mouse mode on it's own.
+//      emitted by the mouse input handler. Does not enable/disable mouse mode on its own.
 //Arguments:
 // - fEnabled - true to enable, false to disable.
 // Return value:

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -3358,7 +3358,7 @@ public:
 
         Log::Comment(L"Test 5: Change Foreground to Legacy Attr while BG is RGB color");
         // Unfortunately this test isn't all that good, because the adapterTest adapter isn't smart enough
-        //   to have it's own color table and translate the pre-existing RGB BG into a legacy BG.
+        //   to have its own color table and translate the pre-existing RGB BG into a legacy BG.
         // Fortunately, the ft_api:RgbColorTests IS smart enough to test that.
         rgOptions[0] = DispatchTypes::GraphicsOptions::ForegroundExtended;
         rgOptions[1] = DispatchTypes::GraphicsOptions::Xterm256Index;

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -866,7 +866,7 @@ bool InputStateMachineEngine::_GenerateKeyFromChar(const wchar_t wch,
 // Method Description:
 // - Returns true if the engine should dispatch on the last charater of a string
 //      always, even if the sequence hasn't normally dispatched.
-//   If this is false, the engine will persist it's state across calls to
+//   If this is false, the engine will persist its state across calls to
 //      ProcessString, and dispatch only at the end of the sequence.
 // Return Value:
 // - True iff we should manually dispatch on the last character of a string.

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -1277,7 +1277,7 @@ bool OutputStateMachineEngine::_GetDesignateType(const wchar_t wchIntermediate, 
 // Routine Description:
 // - Returns true if the engine should dispatch on the last charater of a string
 //      always, even if the sequence hasn't normally dispatched.
-//   If this is false, the engine will persist it's state across calls to
+//   If this is false, the engine will persist its state across calls to
 //      ProcessString, and dispatch only at the end of the sequence.
 // Return Value:
 // - True iff we should manually dispatch on the last character of a string.
@@ -1302,7 +1302,7 @@ bool OutputStateMachineEngine::DispatchControlCharsFromEscape() const
 }
 
 // Routine Description:
-// - Converts a hex character to it's equivalent integer value.
+// - Converts a hex character to its equivalent integer value.
 // Arguments:
 // - wch - Character to convert.
 // - puiValue - recieves the int value of the char

--- a/src/tools/vtpipeterm/VtConsole.cpp
+++ b/src/tools/vtpipeterm/VtConsole.cpp
@@ -145,7 +145,7 @@ void VtConsole::_spawn(const std::wstring& command)
     _connected = true;
 
     // Create our own output handling thread
-    // Each console needs to make sure to drain the output from it's backing host.
+    // Each console needs to make sure to drain the output from its backing host.
     _dwOutputThreadId = (DWORD)-1;
     _hOutputThread = CreateThread(nullptr,
                                   0,
@@ -368,7 +368,8 @@ bool VtConsole::Repaint()
 
 bool VtConsole::Resize(const unsigned short rows, const unsigned short cols)
 {
-    if (_fUseConPty) {
+    if (_fUseConPty)
+    {
         return SUCCEEDED(ResizePseudoConsole(_hPC, {(SHORT)cols, (SHORT)rows}));
     }
     else


### PR DESCRIPTION
## Summary of the Pull Request

Fix common typo `it's` ("it is") versus `its` in the code comments.

## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
