### PR TITLE
Use wstring_view for constants instead of wstring

### DIFF
--- a/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
@@ -18,12 +18,12 @@ using namespace winrt::Windows::Storage;
 using namespace winrt::Windows::Storage::Streams;
 using namespace ::Microsoft::Console;
 
-static const std::wstring FILENAME { L"profiles.json" };
-static const std::wstring SETTINGS_FOLDER_NAME{ L"\\Microsoft\\Windows Terminal\\" };
+static constexpr std::wstring_view FILENAME { L"profiles.json" };
+static constexpr std::wstring_view SETTINGS_FOLDER_NAME{ L"\\Microsoft\\Windows Terminal\\" };
 
-static const std::wstring PROFILES_KEY{ L"profiles" };
-static const std::wstring KEYBINDINGS_KEY{ L"keybindings" };
-static const std::wstring SCHEMES_KEY{ L"schemes" };
+static constexpr std::wstring_view PROFILES_KEY{ L"profiles" };
+static constexpr std::wstring_view KEYBINDINGS_KEY{ L"keybindings" };
+static constexpr std::wstring_view SCHEMES_KEY{ L"schemes" };
 
 // Method Description:
 // - Creates a CascadiaSettings from whatever's saved on disk, or instantiates

--- a/src/cascadia/TerminalApp/ColorScheme.cpp
+++ b/src/cascadia/TerminalApp/ColorScheme.cpp
@@ -12,10 +12,10 @@ using namespace winrt::Microsoft::Terminal::TerminalControl;
 using namespace winrt::TerminalApp;
 using namespace winrt::Windows::Data::Json;
 
-static const std::wstring NAME_KEY{ L"name" };
-static const std::wstring TABLE_KEY{ L"colors" };
-static const std::wstring FOREGROUND_KEY{ L"foreground" };
-static const std::wstring BACKGROUND_KEY{ L"background" };
+static constexpr std::wstring_view NAME_KEY{ L"name" };
+static constexpr std::wstring_view TABLE_KEY{ L"colors" };
+static constexpr std::wstring_view FOREGROUND_KEY{ L"foreground" };
+static constexpr std::wstring_view BACKGROUND_KEY{ L"background" };
 static const std::array<std::wstring, 16> TABLE_COLORS =
 {
     L"black",

--- a/src/cascadia/TerminalApp/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.cpp
@@ -13,18 +13,18 @@ using namespace winrt::Windows::Data::Json;
 using namespace winrt::Windows::UI::Xaml;
 using namespace ::Microsoft::Console;
 
-static const std::wstring DEFAULTPROFILE_KEY{ L"defaultProfile" };
-static const std::wstring ALWAYS_SHOW_TABS_KEY{ L"alwaysShowTabs" };
-static const std::wstring INITIALROWS_KEY{ L"initialRows" };
-static const std::wstring INITIALCOLS_KEY{ L"initialCols" };
-static const std::wstring SHOW_TITLE_IN_TITLEBAR_KEY{ L"showTerminalTitleInTitlebar" };
-static const std::wstring REQUESTED_THEME_KEY{ L"requestedTheme" };
+static constexpr std::wstring_view DEFAULTPROFILE_KEY{ L"defaultProfile" };
+static constexpr std::wstring_view ALWAYS_SHOW_TABS_KEY{ L"alwaysShowTabs" };
+static constexpr std::wstring_view INITIALROWS_KEY{ L"initialRows" };
+static constexpr std::wstring_view INITIALCOLS_KEY{ L"initialCols" };
+static constexpr std::wstring_view SHOW_TITLE_IN_TITLEBAR_KEY{ L"showTerminalTitleInTitlebar" };
+static constexpr std::wstring_view REQUESTED_THEME_KEY{ L"requestedTheme" };
 
-static const std::wstring SHOW_TABS_IN_TITLEBAR_KEY{ L"experimental_showTabsInTitlebar" };
+static constexpr std::wstring_view SHOW_TABS_IN_TITLEBAR_KEY{ L"experimental_showTabsInTitlebar" };
 
-static const std::wstring LIGHT_THEME_VALUE{ L"light" };
-static const std::wstring DARK_THEME_VALUE{ L"dark" };
-static const std::wstring SYSTEM_THEME_VALUE{ L"system" };
+static constexpr std::wstring_view LIGHT_THEME_VALUE{ L"light" };
+static constexpr std::wstring_view DARK_THEME_VALUE{ L"dark" };
+static constexpr std::wstring_view SYSTEM_THEME_VALUE{ L"system" };
 
 GlobalAppSettings::GlobalAppSettings() :
     _keybindings{},
@@ -242,7 +242,7 @@ ElementTheme GlobalAppSettings::_ParseTheme(const std::wstring& themeString) noe
 // - theme: The enum value to convert to a string.
 // Return Value:
 // - The string value for the given CursorStyle
-std::wstring GlobalAppSettings::_SerializeTheme(const ElementTheme theme) noexcept
+std::wstring_view GlobalAppSettings::_SerializeTheme(const ElementTheme theme) noexcept
 {
     switch (theme)
     {

--- a/src/cascadia/TerminalApp/GlobalAppSettings.h
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.h
@@ -72,6 +72,6 @@ private:
     winrt::Windows::UI::Xaml::ElementTheme _requestedTheme;
 
     static winrt::Windows::UI::Xaml::ElementTheme _ParseTheme(const std::wstring& themeString) noexcept;
-    static std::wstring _SerializeTheme(const winrt::Windows::UI::Xaml::ElementTheme theme) noexcept;
+    static std::wstring_view _SerializeTheme(const winrt::Windows::UI::Xaml::ElementTheme theme) noexcept;
 
 };

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -13,40 +13,40 @@ using namespace winrt::Windows::Data::Json;
 using namespace ::Microsoft::Console;
 
 
-static const std::wstring NAME_KEY{ L"name" };
-static const std::wstring GUID_KEY{ L"guid" };
-static const std::wstring COLORSCHEME_KEY{ L"colorscheme" };
+static constexpr std::wstring_view NAME_KEY{ L"name" };
+static constexpr std::wstring_view GUID_KEY{ L"guid" };
+static constexpr std::wstring_view COLORSCHEME_KEY{ L"colorscheme" };
 
-static const std::wstring FOREGROUND_KEY{ L"foreground" };
-static const std::wstring BACKGROUND_KEY{ L"background" };
-static const std::wstring COLORTABLE_KEY{ L"colorTable" };
-static const std::wstring HISTORYSIZE_KEY{ L"historySize" };
-static const std::wstring SNAPONINPUT_KEY{ L"snapOnInput" };
-static const std::wstring CURSORCOLOR_KEY{ L"cursorColor" };
-static const std::wstring CURSORSHAPE_KEY{ L"cursorShape" };
-static const std::wstring CURSORHEIGHT_KEY{ L"cursorHeight" };
+static constexpr std::wstring_view FOREGROUND_KEY{ L"foreground" };
+static constexpr std::wstring_view BACKGROUND_KEY{ L"background" };
+static constexpr std::wstring_view COLORTABLE_KEY{ L"colorTable" };
+static constexpr std::wstring_view HISTORYSIZE_KEY{ L"historySize" };
+static constexpr std::wstring_view SNAPONINPUT_KEY{ L"snapOnInput" };
+static constexpr std::wstring_view CURSORCOLOR_KEY{ L"cursorColor" };
+static constexpr std::wstring_view CURSORSHAPE_KEY{ L"cursorShape" };
+static constexpr std::wstring_view CURSORHEIGHT_KEY{ L"cursorHeight" };
 
-static const std::wstring COMMANDLINE_KEY{ L"commandline" };
-static const std::wstring FONTFACE_KEY{ L"fontFace" };
-static const std::wstring FONTSIZE_KEY{ L"fontSize" };
-static const std::wstring ACRYLICTRANSPARENCY_KEY{ L"acrylicOpacity" };
-static const std::wstring USEACRYLIC_KEY{ L"useAcrylic" };
-static const std::wstring SCROLLBARSTATE_KEY{ L"scrollbarState" };
-static const std::wstring CLOSEONEXIT_KEY{ L"closeOnExit" };
-static const std::wstring PADDING_KEY{ L"padding" };
-static const std::wstring STARTINGDIRECTORY_KEY{ L"startingDirectory" };
-static const std::wstring ICON_KEY{ L"icon" };
+static constexpr std::wstring_view COMMANDLINE_KEY{ L"commandline" };
+static constexpr std::wstring_view FONTFACE_KEY{ L"fontFace" };
+static constexpr std::wstring_view FONTSIZE_KEY{ L"fontSize" };
+static constexpr std::wstring_view ACRYLICTRANSPARENCY_KEY{ L"acrylicOpacity" };
+static constexpr std::wstring_view USEACRYLIC_KEY{ L"useAcrylic" };
+static constexpr std::wstring_view SCROLLBARSTATE_KEY{ L"scrollbarState" };
+static constexpr std::wstring_view CLOSEONEXIT_KEY{ L"closeOnExit" };
+static constexpr std::wstring_view PADDING_KEY{ L"padding" };
+static constexpr std::wstring_view STARTINGDIRECTORY_KEY{ L"startingDirectory" };
+static constexpr std::wstring_view ICON_KEY{ L"icon" };
 
 // Possible values for Scrollbar state
-static const std::wstring ALWAYS_VISIBLE{ L"visible" };
-static const std::wstring ALWAYS_HIDE{ L"hidden" };
+static constexpr std::wstring_view ALWAYS_VISIBLE{ L"visible" };
+static constexpr std::wstring_view ALWAYS_HIDE{ L"hidden" };
 
 // Possible values for Cursor Shape
-static const std::wstring CURSORSHAPE_VINTAGE{ L"vintage" };
-static const std::wstring CURSORSHAPE_BAR{ L"bar" };
-static const std::wstring CURSORSHAPE_UNDERSCORE{ L"underscore" };
-static const std::wstring CURSORSHAPE_FILLEDBOX{ L"filledBox" };
-static const std::wstring CURSORSHAPE_EMPTYBOX{ L"emptyBox" };
+static constexpr std::wstring_view CURSORSHAPE_VINTAGE{ L"vintage" };
+static constexpr std::wstring_view CURSORSHAPE_BAR{ L"bar" };
+static constexpr std::wstring_view CURSORSHAPE_UNDERSCORE{ L"underscore" };
+static constexpr std::wstring_view CURSORSHAPE_FILLEDBOX{ L"filledBox" };
+static constexpr std::wstring_view CURSORSHAPE_EMPTYBOX{ L"emptyBox" };
 
 Profile::Profile() :
     Profile(Utils::CreateGuid())
@@ -582,7 +582,7 @@ CursorStyle Profile::_ParseCursorShape(const std::wstring& cursorShapeString)
 // - cursorShape: The enum value to convert to a string.
 // Return Value:
 // - The string value for the given CursorStyle
-std::wstring Profile::_SerializeCursorStyle(const CursorStyle cursorShape)
+std::wstring_view Profile::_SerializeCursorStyle(const CursorStyle cursorShape)
 {
     switch (cursorShape)
     {

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -59,7 +59,7 @@ private:
 
     static winrt::Microsoft::Terminal::Settings::ScrollbarState ParseScrollbarState(const std::wstring& scrollbarState);
     static winrt::Microsoft::Terminal::Settings::CursorStyle _ParseCursorShape(const std::wstring& cursorShapeString);
-    static std::wstring _SerializeCursorStyle(const winrt::Microsoft::Terminal::Settings::CursorStyle cursorShape);
+    static std::wstring_view _SerializeCursorStyle(const winrt::Microsoft::Terminal::Settings::CursorStyle cursorShape);
 
     GUID _guid;
     std::wstring _name;

--- a/src/host/ConsoleArguments.cpp
+++ b/src/host/ConsoleArguments.cpp
@@ -7,19 +7,19 @@
 #include <shellapi.h>
 using namespace Microsoft::Console::Utils;
 
-const std::wstring ConsoleArguments::VT_MODE_ARG = L"--vtmode";
-const std::wstring ConsoleArguments::HEADLESS_ARG = L"--headless";
-const std::wstring ConsoleArguments::SERVER_HANDLE_ARG = L"--server";
-const std::wstring ConsoleArguments::SIGNAL_HANDLE_ARG = L"--signal";
-const std::wstring ConsoleArguments::HANDLE_PREFIX = L"0x";
-const std::wstring ConsoleArguments::CLIENT_COMMANDLINE_ARG = L"--";
-const std::wstring ConsoleArguments::FORCE_V1_ARG = L"-ForceV1";
-const std::wstring ConsoleArguments::FILEPATH_LEADER_PREFIX = L"\\??\\";
-const std::wstring ConsoleArguments::WIDTH_ARG = L"--width";
-const std::wstring ConsoleArguments::HEIGHT_ARG = L"--height";
-const std::wstring ConsoleArguments::INHERIT_CURSOR_ARG = L"--inheritcursor";
-const std::wstring ConsoleArguments::FEATURE_ARG = L"--feature";
-const std::wstring ConsoleArguments::FEATURE_PTY_ARG = L"pty";
+const std::wstring_view ConsoleArguments::VT_MODE_ARG = L"--vtmode";
+const std::wstring_view ConsoleArguments::HEADLESS_ARG = L"--headless";
+const std::wstring_view ConsoleArguments::SERVER_HANDLE_ARG = L"--server";
+const std::wstring_view ConsoleArguments::SIGNAL_HANDLE_ARG = L"--signal";
+const std::wstring_view ConsoleArguments::HANDLE_PREFIX = L"0x";
+const std::wstring_view ConsoleArguments::CLIENT_COMMANDLINE_ARG = L"--";
+const std::wstring_view ConsoleArguments::FORCE_V1_ARG = L"-ForceV1";
+const std::wstring_view ConsoleArguments::FILEPATH_LEADER_PREFIX = L"\\??\\";
+const std::wstring_view ConsoleArguments::WIDTH_ARG = L"--width";
+const std::wstring_view ConsoleArguments::HEIGHT_ARG = L"--height";
+const std::wstring_view ConsoleArguments::INHERIT_CURSOR_ARG = L"--inheritcursor";
+const std::wstring_view ConsoleArguments::FEATURE_ARG = L"--feature";
+const std::wstring_view ConsoleArguments::FEATURE_PTY_ARG = L"pty";
 
 ConsoleArguments::ConsoleArguments(const std::wstring& commandline,
                                    const HANDLE hStdIn,

--- a/src/host/ConsoleArguments.hpp
+++ b/src/host/ConsoleArguments.hpp
@@ -55,19 +55,19 @@ public:
 
     void SetExpectedSize(COORD dimensions) noexcept;
 
-    static const std::wstring VT_MODE_ARG;
-    static const std::wstring HEADLESS_ARG;
-    static const std::wstring SERVER_HANDLE_ARG;
-    static const std::wstring SIGNAL_HANDLE_ARG;
-    static const std::wstring HANDLE_PREFIX;
-    static const std::wstring CLIENT_COMMANDLINE_ARG;
-    static const std::wstring FORCE_V1_ARG;
-    static const std::wstring FILEPATH_LEADER_PREFIX;
-    static const std::wstring WIDTH_ARG;
-    static const std::wstring HEIGHT_ARG;
-    static const std::wstring INHERIT_CURSOR_ARG;
-    static const std::wstring FEATURE_ARG;
-    static const std::wstring FEATURE_PTY_ARG;
+    static const std::wstring_view VT_MODE_ARG;
+    static const std::wstring_view HEADLESS_ARG;
+    static const std::wstring_view SERVER_HANDLE_ARG;
+    static const std::wstring_view SIGNAL_HANDLE_ARG;
+    static const std::wstring_view HANDLE_PREFIX;
+    static const std::wstring_view CLIENT_COMMANDLINE_ARG;
+    static const std::wstring_view FORCE_V1_ARG;
+    static const std::wstring_view FILEPATH_LEADER_PREFIX;
+    static const std::wstring_view WIDTH_ARG;
+    static const std::wstring_view HEIGHT_ARG;
+    static const std::wstring_view INHERIT_CURSOR_ARG;
+    static const std::wstring_view FEATURE_ARG;
+    static const std::wstring_view FEATURE_PTY_ARG;
 
 private:
 #ifdef UNIT_TESTING

--- a/src/host/ut_host/CodepointWidthDetectorTests.cpp
+++ b/src/host/ut_host/CodepointWidthDetectorTests.cpp
@@ -10,9 +10,9 @@
 
 using namespace WEX::Logging;
 
-static const std::wstring emoji = L"\xD83E\xDD22"; // U+1F922 nauseated face
+static constexpr std::wstring_view emoji = L"\xD83E\xDD22"; // U+1F922 nauseated face
 
-static const std::wstring ambiguous = L"\x414"; // U+0414 cyrillic capital de
+static constexpr std::wstring_view ambiguous = L"\x414"; // U+0414 cyrillic capital de
 
 // codepoint and utf16 encoded string
 static const std::vector<std::tuple<unsigned int, std::wstring, CodepointWidth>> testData =


### PR DESCRIPTION
Instead of creating const static wstring objects which call malloc in the constructor, use wstring_view instead which just wraps the constant.

## Summary of the Pull Request

Simple code refactoring.

## References

## PR Checklist
* [ ] Closes no bug
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
