### PR TITLE
fix couple of null pointer dereferences

### DIFF
--- a/src/propsheet/OptionsPage.cpp
+++ b/src/propsheet/OptionsPage.cpp
@@ -239,29 +239,32 @@ INT_PTR WINAPI SettingsDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lPara
         else
         {
             const PSHNOTIFY * const pshn = (LPPSHNOTIFY)lParam;
-            switch (pshn->hdr.code) {
-                case PSN_APPLY:
-                    /*
-                     * Write out the state values and exit.
-                     */
-                    EndDlgPage(hDlg, !pshn->lParam);
-                    return TRUE;
+            if (lParam) 
+            {
+                switch (pshn->hdr.code) {
+                    case PSN_APPLY:
+                        /*
+                         * Write out the state values and exit.
+                         */
+                        EndDlgPage(hDlg, !pshn->lParam);
+                        return TRUE;
 
-                case PSN_SETACTIVE:
-                    ToggleV2OptionsControls(hDlg);
-                    return 0;
+                    case PSN_SETACTIVE:
+                        ToggleV2OptionsControls(hDlg);
+                        return 0;
 
-                case PSN_KILLACTIVE:
-                    /*
-                     * Fake the dialog proc into thinking the edit control just
-                     * lost focus so it'll update properly
-                     */
-                    Item = GetDlgCtrlID(GetFocus());
-                    if (Item)
-                    {
-                        SendMessage(hDlg, WM_COMMAND, MAKELONG(Item, EN_KILLFOCUS), 0);
-                    }
-                    return TRUE;
+                    case PSN_KILLACTIVE:
+                        /*
+                         * Fake the dialog proc into thinking the edit control just
+                         * lost focus so it'll update properly
+                         */
+                        Item = GetDlgCtrlID(GetFocus());
+                        if (Item)
+                        {
+                            SendMessage(hDlg, WM_COMMAND, MAKELONG(Item, EN_KILLFOCUS), 0);
+                        }
+                        return TRUE;
+                }
             }
         }
 

--- a/src/propsheet/TerminalPage.cpp
+++ b/src/propsheet/TerminalPage.cpp
@@ -375,20 +375,23 @@ INT_PTR WINAPI TerminalDlgProc(const HWND hDlg, const UINT wMsg, const WPARAM wP
             else
             {
                 const PSHNOTIFY * const pshn = (LPPSHNOTIFY)lParam;
-                switch (pshn->hdr.code) {
-                    case PSN_APPLY:
-                        EndDlgPage(hDlg, !pshn->lParam);
-                        return TRUE;
-                    case PSN_KILLACTIVE:
-                    {
-                        // Fake the dialog proc into thinking the edit control just
-                        // lost focus so it'll update properly
-                        int item = GetDlgCtrlID(GetFocus());
-                        if (item)
+                if (lParam) 
+                {
+                    switch (pshn->hdr.code) {
+                        case PSN_APPLY:
+                            EndDlgPage(hDlg, !pshn->lParam);
+                            return TRUE;
+                        case PSN_KILLACTIVE:
                         {
-                            SendMessage(hDlg, WM_COMMAND, MAKELONG(item, EN_KILLFOCUS), 0);
+                            // Fake the dialog proc into thinking the edit control just
+                            // lost focus so it'll update properly
+                            int item = GetDlgCtrlID(GetFocus());
+                            if (item)
+                            {
+                                SendMessage(hDlg, WM_COMMAND, MAKELONG(item, EN_KILLFOCUS), 0);
+                            }
+                            return TRUE;
                         }
-                        return TRUE;
                     }
                 }
 


### PR DESCRIPTION
found by cppcheck

[src/propsheet/OptionsPage.cpp:216] -> [src/propsheet/OptionsPage.cpp:242]: (warning) Either the condition 'lParam' is redundant or there is possible null pointer dereference: pshn.
[src/propsheet/TerminalPage.cpp:352] -> [src/propsheet/TerminalPage.cpp:378]: (warning) Either the condition 'lParam' is redundant or there is possible null pointer dereference: pshn.
