### PR TITLE
Added support for DECSCUSR sequences

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -920,6 +920,10 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     void TermControl::_BlinkCursor(Windows::Foundation::IInspectable const& /* sender */,
                                    Windows::Foundation::IInspectable const& /* e */)
     {
+        if (!_terminal->IsCursorBlinkingAllowed() && _terminal->IsCursorVisible())
+        {
+            return;
+        }
         _terminal->SetCursorVisible(!_terminal->IsCursorVisible());
     }
 

--- a/src/cascadia/TerminalCore/ITerminalApi.hpp
+++ b/src/cascadia/TerminalCore/ITerminalApi.hpp
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-
 #pragma once
+
+#include "../../terminal/adapter/DispatchTypes.hpp"
+
 namespace Microsoft::Terminal::Core
 {
     class ITerminalApi
@@ -27,5 +29,7 @@ namespace Microsoft::Terminal::Core
         virtual bool SetWindowTitle(std::wstring_view title) = 0;
 
         virtual bool SetColorTableEntry(const size_t tableIndex, const DWORD dwColor) = 0;
+
+        virtual bool SetCursorStyle(const Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) = 0;
     };
 }

--- a/src/cascadia/TerminalCore/ITerminalApi.hpp
+++ b/src/cascadia/TerminalCore/ITerminalApi.hpp
@@ -30,6 +30,6 @@ namespace Microsoft::Terminal::Core
 
         virtual bool SetColorTableEntry(const size_t tableIndex, const DWORD dwColor) = 0;
 
-        virtual bool SetCursorStyle(const Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) = 0;
+        virtual bool SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) = 0;
     };
 }

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -606,8 +606,8 @@ void Terminal::SetCursorVisible(const bool isVisible) noexcept
     cursor.SetIsVisible(isVisible);
 }
 
-bool Terminal::IsCursorBlinkingAllowed() noexcept
+bool Terminal::IsCursorBlinkingAllowed() const noexcept
 {
-    auto& cursor = _buffer->GetCursor();
+    const auto& cursor = _buffer->GetCursor();
     return cursor.IsBlinkingAllowed();
 }

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -605,3 +605,9 @@ void Terminal::SetCursorVisible(const bool isVisible) noexcept
     auto& cursor = _buffer->GetCursor();
     cursor.SetIsVisible(isVisible);
 }
+
+bool Terminal::IsCursorBlinkingAllowed() noexcept
+{
+    auto& cursor = _buffer->GetCursor();
+    return cursor.IsBlinkingAllowed();
+}

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -71,7 +71,7 @@ public:
     bool EraseCharacters(const unsigned int numChars) override;
     bool SetWindowTitle(std::wstring_view title) override;
     bool SetColorTableEntry(const size_t tableIndex, const DWORD dwColor) override;
-    bool SetCursorStyle(const Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) override;
+    bool SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) override;
     #pragma endregion
 
     #pragma region ITerminalInput
@@ -115,7 +115,7 @@ public:
     void SetScrollPositionChangedCallback(std::function<void(const int, const int, const int)> pfn) noexcept;
 
     void SetCursorVisible(const bool isVisible) noexcept;
-    bool IsCursorBlinkingAllowed() noexcept;
+    bool IsCursorBlinkingAllowed() const noexcept;
 
     #pragma region TextSelection
     const bool IsSelectionActive() const noexcept;

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -71,6 +71,7 @@ public:
     bool EraseCharacters(const unsigned int numChars) override;
     bool SetWindowTitle(std::wstring_view title) override;
     bool SetColorTableEntry(const size_t tableIndex, const DWORD dwColor) override;
+    bool SetCursorStyle(const Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) override;
     #pragma endregion
 
     #pragma region ITerminalInput
@@ -114,6 +115,7 @@ public:
     void SetScrollPositionChangedCallback(std::function<void(const int, const int, const int)> pfn) noexcept;
 
     void SetCursorVisible(const bool isVisible) noexcept;
+    bool IsCursorBlinkingAllowed() noexcept;
 
     #pragma region TextSelection
     const bool IsSelectionActive() const noexcept;

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -170,6 +170,12 @@ bool Terminal::SetColorTableEntry(const size_t tableIndex, const DWORD dwColor)
     return true;
 }
 
+// Method Description:
+// - Sets the cursor style to the given style.
+// Arguments:
+// - cursorStyle: the style to be set for the cursor
+// Return Value:
+// - true iff we successfully set the cursor style
 bool Terminal::SetCursorStyle(const DispatchTypes::CursorStyle cursorStyle)
 {
     CursorType finalCursorType = CursorType::Legacy;

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -178,40 +178,44 @@ bool Terminal::SetColorTableEntry(const size_t tableIndex, const DWORD dwColor)
 // - true iff we successfully set the cursor style
 bool Terminal::SetCursorStyle(const DispatchTypes::CursorStyle cursorStyle)
 {
-    CursorType finalCursorType = CursorType::Legacy;
-    bool shouldBlink = false;
+    CursorType finalCursorType;
+    bool fShouldBlink;
 
     switch (cursorStyle)
     {
-    case DispatchTypes::CursorStyle::BlinkingBlock:
     case DispatchTypes::CursorStyle::BlinkingBlockDefault:
+        [[fallthrough]];
+    case DispatchTypes::CursorStyle::BlinkingBlock:
         finalCursorType = CursorType::FullBox;
-        shouldBlink = true;
+        fShouldBlink = true;
         break;
     case DispatchTypes::CursorStyle::SteadyBlock:
         finalCursorType = CursorType::FullBox;
-        shouldBlink = false;
+        fShouldBlink = false;
         break;
     case DispatchTypes::CursorStyle::BlinkingUnderline:
         finalCursorType = CursorType::Underscore;
-        shouldBlink = true;
+        fShouldBlink = true;
         break;
     case DispatchTypes::CursorStyle::SteadyUnderline:
         finalCursorType = CursorType::Underscore;
-        shouldBlink = false;
+        fShouldBlink = false;
         break;
     case DispatchTypes::CursorStyle::BlinkingBar:
         finalCursorType = CursorType::VerticalBar;
-        shouldBlink = true;
+        fShouldBlink = true;
         break;
     case DispatchTypes::CursorStyle::SteadyBar:
         finalCursorType = CursorType::VerticalBar;
-        shouldBlink = false;
+        fShouldBlink = false;
         break;
+    default:
+        finalCursorType = CursorType::Legacy;
+        fShouldBlink = false;
     }
 
     _buffer->GetCursor().SetType(finalCursorType);
-    _buffer->GetCursor().SetBlinkingAllowed(shouldBlink);
+    _buffer->GetCursor().SetBlinkingAllowed(fShouldBlink);
 
     return true;
 }

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -172,8 +172,8 @@ bool Terminal::SetColorTableEntry(const size_t tableIndex, const DWORD dwColor)
 
 bool Terminal::SetCursorStyle(const DispatchTypes::CursorStyle cursorStyle)
 {
-    CursorType finalCursorType;
-    bool shouldBlink;
+    CursorType finalCursorType = CursorType::Legacy;
+    bool shouldBlink = false;
 
     switch (cursorStyle)
     {
@@ -202,8 +202,6 @@ bool Terminal::SetCursorStyle(const DispatchTypes::CursorStyle cursorStyle)
         finalCursorType = CursorType::VerticalBar;
         shouldBlink = false;
         break;
-    default:
-        return false;
     }
 
     _buffer->GetCursor().SetType(finalCursorType);

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -169,3 +169,45 @@ bool Terminal::SetColorTableEntry(const size_t tableIndex, const DWORD dwColor)
     _buffer->GetRenderTarget().TriggerRedrawAll();
     return true;
 }
+
+bool Terminal::SetCursorStyle(const DispatchTypes::CursorStyle cursorStyle)
+{
+    CursorType finalCursorType;
+    bool shouldBlink;
+
+    switch (cursorStyle)
+    {
+    case DispatchTypes::CursorStyle::BlinkingBlock:
+    case DispatchTypes::CursorStyle::BlinkingBlockDefault:
+        finalCursorType = CursorType::FullBox;
+        shouldBlink = true;
+        break;
+    case DispatchTypes::CursorStyle::SteadyBlock:
+        finalCursorType = CursorType::FullBox;
+        shouldBlink = false;
+        break;
+    case DispatchTypes::CursorStyle::BlinkingUnderline:
+        finalCursorType = CursorType::Underscore;
+        shouldBlink = true;
+        break;
+    case DispatchTypes::CursorStyle::SteadyUnderline:
+        finalCursorType = CursorType::Underscore;
+        shouldBlink = false;
+        break;
+    case DispatchTypes::CursorStyle::BlinkingBar:
+        finalCursorType = CursorType::VerticalBar;
+        shouldBlink = true;
+        break;
+    case DispatchTypes::CursorStyle::SteadyBar:
+        finalCursorType = CursorType::VerticalBar;
+        shouldBlink = false;
+        break;
+    default:
+        return false;
+    }
+
+    _buffer->GetCursor().SetType(finalCursorType);
+    _buffer->GetCursor().SetBlinkingAllowed(shouldBlink);
+
+    return true;
+}

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -70,3 +70,8 @@ bool TerminalDispatch::SetColorTableEntry(const size_t tableIndex,
 {
     return _terminalApi.SetColorTableEntry(tableIndex, dwColor);
 }
+
+bool TerminalDispatch::SetCursorStyle(const DispatchTypes::CursorStyle cursorStyle)
+{
+    return _terminalApi.SetCursorStyle(cursorStyle);
+}

--- a/src/cascadia/TerminalCore/TerminalDispatch.hpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.hpp
@@ -25,6 +25,7 @@ public:
     bool SetWindowTitle(std::wstring_view title) override;
 
     bool SetColorTableEntry(const size_t tableIndex, const DWORD dwColor) override;
+    bool SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) override;
 
 private:
     ::Microsoft::Terminal::Core::ITerminalApi& _terminalApi;


### PR DESCRIPTION
## Summary
Fixes #601

Added support for changing the cursor style via the [DECSCUSR](https://vt100.net/docs/vt510-rm/DECSCUSR.html) sequences. Higher values (e.g. `\x1b[\x37 q`) fall back to the legacy cursor.

Tested manually by invoking `wsl` and using `echo` commands (e.g. `echo -e -n "\x1b[\x32 q"`). 

## PR Checklist
* [x] Closes #601 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #601 

## Detailed Description of the Pull Request / Additional comments
Implemented the `SetCursorStyle()` method for `TerminalDispatch` and `TerminalApi`. Also, had to implement logic in `TermControl.cpp` to stop cursor blink when `cursor->IsBlinkingAllowed()` is `false`.