### PR TITLE
Enable C++/WinRT Optimizations for local component builds

### DIFF
--- a/src/cascadia/Microsoft.UI.Xaml.Markup/XamlApplication.cpp
+++ b/src/cascadia/Microsoft.UI.Xaml.Markup/XamlApplication.cpp
@@ -5,6 +5,8 @@
 
 #include "XamlApplication.h"
 
+#include "XamlApplication.g.cpp"
+
 namespace xaml = ::winrt::Windows::UI::Xaml;
 
 extern "C" {

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -7,6 +7,8 @@
 #include <filesystem>
 #include <winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>
 
+#include "App.g.cpp"
+
 using namespace winrt::Windows::ApplicationModel::DataTransfer;
 using namespace winrt::Windows::UI::Xaml;
 using namespace winrt::Windows::UI::Core;

--- a/src/cascadia/TerminalApp/AppKeyBindings.cpp
+++ b/src/cascadia/TerminalApp/AppKeyBindings.cpp
@@ -5,6 +5,8 @@
 #include "AppKeyBindings.h"
 #include "KeyChordSerialization.h"
 
+#include "AppKeyBindings.g.cpp"
+
 using namespace winrt::Microsoft::Terminal;
 using namespace winrt::TerminalApp;
 using namespace winrt::Windows::Data::Json;

--- a/src/cascadia/TerminalConnection/ConhostConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConhostConnection.cpp
@@ -11,6 +11,8 @@
 #define STARTF_USESTDHANDLES       0x00000100
 #endif
 
+#include "ConhostConnection.g.cpp"
+
 #include <conpty-universal.h>
 #include "../../types/inc/Utils.hpp"
 

--- a/src/cascadia/TerminalConnection/EchoConnection.cpp
+++ b/src/cascadia/TerminalConnection/EchoConnection.cpp
@@ -5,6 +5,8 @@
 #include "EchoConnection.h"
 #include <sstream>
 
+#include "EchoConnection.g.cpp"
+
 namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 {
     EchoConnection::EchoConnection()

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -10,6 +10,8 @@
 #include <WinUser.h>
 #include "..\..\types\inc\GlyphWidth.hpp"
 
+#include "TermControl.g.cpp"
+
 using namespace ::Microsoft::Console::Types;
 using namespace ::Microsoft::Terminal::Core;
 using namespace winrt::Windows::UI::Xaml;

--- a/src/cascadia/TerminalSettings/KeyChord.cpp
+++ b/src/cascadia/TerminalSettings/KeyChord.cpp
@@ -4,6 +4,8 @@
 #include "pch.h"
 #include "KeyChord.h"
 
+#include "KeyChord.g.cpp"
+
 namespace winrt::Microsoft::Terminal::Settings::implementation
 {
     KeyChord::KeyChord(bool ctrl, bool alt, bool shift, int32_t vkey) :

--- a/src/cascadia/TerminalSettings/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettings/TerminalSettings.cpp
@@ -5,6 +5,8 @@
 #include "TerminalSettings.h"
 #include <DefaultSettings.h>
 
+#include "TerminalSettings.g.cpp"
+
 namespace winrt::Microsoft::Terminal::Settings::implementation
 {
     TerminalSettings::TerminalSettings() :

--- a/src/cppwinrt.build.pre.props
+++ b/src/cppwinrt.build.pre.props
@@ -11,6 +11,7 @@
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.17763.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <CppWinRTEnabled>true</CppWinRTEnabled>
+    <CppWinRTOptimized>true</CppWinRTOptimized>
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>


### PR DESCRIPTION
Doing this speeds up local builds and makes module.g.cpp a lot simpler.
There's also some goodness around instantiating components that are local to your DLL not going through RoGetActivationFactory.

## PR Checklist
* [x] Closes #945
* [x] CLA signed
* [x] Tests added/passed/not applicable
* [x] Documentation updated or not applicable
* [x] I've discussed this with core contributors already.
