### PR TITLE
Apply [[nodiscard]] to functions returning error codes

### DIFF
--- a/src/cascadia/WindowsTerminal/BaseWindow.h
+++ b/src/cascadia/WindowsTerminal/BaseWindow.h
@@ -16,6 +16,7 @@ public:
         return reinterpret_cast<T *>(GetWindowLongPtr(window, GWLP_USERDATA));
     }
 
+    [[nodiscard]]
     static LRESULT __stdcall WndProc(HWND const window, UINT const message, WPARAM const wparam, LPARAM const lparam) noexcept
     {
         WINRT_ASSERT(window);
@@ -40,6 +41,7 @@ public:
         return DefWindowProc(window, message, wparam, lparam);
     }
 
+    [[nodiscard]]
     virtual LRESULT MessageHandler(UINT const message, WPARAM const wparam, LPARAM const lparam) noexcept
     {
         switch (message) {
@@ -98,6 +100,7 @@ public:
     }
 
     // DPI Change handler. on WM_DPICHANGE resize the window
+    [[nodiscard]]
     LRESULT HandleDpiChange(const HWND hWnd, const WPARAM wParam, const LPARAM lParam)
     {
         _inDpiChange = true;

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -144,6 +144,7 @@ void IslandWindow::OnSize()
     }
 }
 
+[[nodiscard]]
 LRESULT IslandWindow::MessageHandler(UINT const message, WPARAM const wparam, LPARAM const lparam) noexcept
 {
     switch (message) {
@@ -173,7 +174,7 @@ LRESULT IslandWindow::MessageHandler(UINT const message, WPARAM const wparam, LP
 // Arguments:
 // - width: the new width of the window _in pixels_
 // - height: the new height of the window _in pixels_
-void IslandWindow::OnResize(const UINT width, const UINT height)
+void IslandWindow::OnResize(const UINT /*width*/, const UINT /*height*/)
 {
     OnSize();
 }

--- a/src/cascadia/WindowsTerminal/IslandWindow.h
+++ b/src/cascadia/WindowsTerminal/IslandWindow.h
@@ -16,6 +16,7 @@ public:
     void Close();
     virtual void OnSize();
 
+    [[nodiscard]]
     virtual LRESULT MessageHandler(UINT const message, WPARAM const wparam, LPARAM const lparam) noexcept override;
     void OnResize(const UINT width, const UINT height) override;
     void OnMinimize() override;

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -209,6 +209,7 @@ void NonClientIslandWindow::OnSize()
 // NOTE:
 // Largely taken from code on:
 // https://docs.microsoft.com/en-us/windows/desktop/dwm/customframe
+[[nodiscard]]
 LRESULT NonClientIslandWindow::HitTestNCA(POINT ptMouse) const noexcept
 {
     // Get the window rectangle.
@@ -284,6 +285,7 @@ MARGINS NonClientIslandWindow::GetFrameMargins() const noexcept
 // - <none>
 // Return Value:
 // - the HRESULT returned by DwmExtendFrameIntoClientArea.
+[[nodiscard]]
 HRESULT NonClientIslandWindow::_UpdateFrameMargins() const noexcept
 {
     // Get the size of the borders we want to use. The sides and bottom will
@@ -387,6 +389,7 @@ RECT NonClientIslandWindow::GetMaxWindowRectInPixels(const RECT * const prcSugge
 // Return Value:
 // - The return value is the result of the message processing and depends on the
 //   message sent.
+[[nodiscard]]
 LRESULT NonClientIslandWindow::MessageHandler(UINT const message,
                                               WPARAM const wParam,
                                               LPARAM const lParam) noexcept
@@ -489,7 +492,7 @@ void NonClientIslandWindow::_HandleActivateWindow()
     // _titlebarUnscaledContentHeight is set with SetNonClientHeight by the app
     // hosting us.
 
-    _UpdateFrameMargins();
+    THROW_IF_FAILED(_UpdateFrameMargins());
 }
 
 // Method Description:
@@ -633,7 +636,7 @@ bool NonClientIslandWindow::_HandleWindowPosChanging(WINDOWPOS* const windowPos)
             _maximizedMargins.cyBottomHeight = -offset;
 
             _isMaximized = true;
-            _UpdateFrameMargins();
+            THROW_IF_FAILED(_UpdateFrameMargins());
         }
     }
     else
@@ -647,7 +650,7 @@ bool NonClientIslandWindow::_HandleWindowPosChanging(WINDOWPOS* const windowPos)
         // keep this here _in general_ for dragging across DPI boundaries.
         if (!_isMaximized)
         {
-            _UpdateFrameMargins();
+            THROW_IF_FAILED(_UpdateFrameMargins());
         }
 
         _isMaximized = false;

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.h
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.h
@@ -31,6 +31,7 @@ public:
 
     virtual void OnSize() override;
 
+    [[nodiscard]]
     virtual LRESULT MessageHandler(UINT const message, WPARAM const wparam, LPARAM const lparam) noexcept override;
 
     void SetNonClientContent(winrt::Windows::UI::Xaml::UIElement content);
@@ -62,7 +63,10 @@ private:
     MARGINS _maximizedMargins;
     bool _isMaximized;
 
+    [[nodiscard]]
     LRESULT HitTestNCA(POINT ptMouse) const noexcept;
+
+    [[nodiscard]]
     HRESULT _UpdateFrameMargins() const noexcept;
 
     void _HandleActivateWindow();

--- a/src/host/ConsoleArguments.hpp
+++ b/src/host/ConsoleArguments.hpp
@@ -32,7 +32,6 @@ public:
     [[nodiscard]]
     HRESULT ParseCommandline();
 
-    bool IsUsingVtPipe() const;
     bool HasVtHandles() const;
     bool InConptyMode() const noexcept;
     bool IsHeadless() const;

--- a/src/host/VtIo.cpp
+++ b/src/host/VtIo.cpp
@@ -105,7 +105,7 @@ HRESULT VtIo::Initialize(const ConsoleArguments * const pArgs)
 //  S_OK if we initialized successfully, otherwise an appropriate HRESULT
 //      indicating failure.
 [[nodiscard]]
-HRESULT VtIo::_Initialize(const HANDLE InHandle, const HANDLE OutHandle, const std::wstring& VtMode, const HANDLE SignalHandle)
+HRESULT VtIo::_Initialize(const HANDLE InHandle, const HANDLE OutHandle, const std::wstring& VtMode, _In_opt_ const HANDLE SignalHandle)
 {
     FAIL_FAST_IF_MSG(_initialized, "Someone attempted to double-_Initialize VtIo");
 

--- a/src/host/VtIo.hpp
+++ b/src/host/VtIo.hpp
@@ -63,9 +63,7 @@ namespace Microsoft::Console::VirtualTerminal
         std::unique_ptr<Microsoft::Console::PtySignalInputThread> _pPtySignalInputThread;
 
         [[nodiscard]]
-        HRESULT _Initialize(const HANDLE InHandle, const HANDLE OutHandle, const std::wstring& VtMode);
-        [[nodiscard]]
-        HRESULT _Initialize(const HANDLE InHandle, const HANDLE OutHandle, const std::wstring& VtMode, _In_opt_ HANDLE SignalHandle);
+        HRESULT _Initialize(const HANDLE InHandle, const HANDLE OutHandle, const std::wstring& VtMode, _In_opt_ const HANDLE SignalHandle);
 
         void _ShutdownIfNeeded();
 

--- a/src/host/cmdline.h
+++ b/src/host/cmdline.h
@@ -158,7 +158,7 @@ void RedrawCommandLine(COOKED_READ_DATA& cookedReadData);
 #define WC_DELAY_EOL_WRAP        0x80
 
 // Word delimiters
-bool IsWordDelim(const WCHAR wch);
+bool IsWordDelim(const wchar_t wch);
 bool IsWordDelim(const std::wstring_view charData);
 
 [[nodiscard]]

--- a/src/host/popup.cpp
+++ b/src/host/popup.cpp
@@ -333,6 +333,7 @@ void Popup::SetUserInputFunction(UserInputFunction function) noexcept
 // - wch - on completion, the char read from the user
 // Return Value:
 // - relevant NTSTATUS
+[[nodiscard]]
 NTSTATUS Popup::_getUserInput(COOKED_READ_DATA& cookedReadData, bool& popupKey, DWORD& modifiers, wchar_t& wch) noexcept
 {
     return _userInputFunction(cookedReadData, popupKey, modifiers, wch);
@@ -346,6 +347,7 @@ NTSTATUS Popup::_getUserInput(COOKED_READ_DATA& cookedReadData, bool& popupKey, 
 // - wch - on completion, the char read from the user
 // Return Value:
 // - relevant NTSTATUS
+[[nodiscard]]
 NTSTATUS Popup::_getUserInputInternal(COOKED_READ_DATA& cookedReadData,
                                       bool& popupKey,
                                       DWORD& modifiers,

--- a/src/host/popup.h
+++ b/src/host/popup.h
@@ -66,6 +66,7 @@ protected:
     friend class CommandListPopupTests;
 #endif
 
+    [[nodiscard]]
     NTSTATUS _getUserInput(COOKED_READ_DATA& cookedReadData, bool& popupKey, DWORD& modifiers, wchar_t& wch) noexcept;
     void _DrawPrompt(const UINT id);
     virtual void _DrawContent() = 0;
@@ -81,6 +82,7 @@ private:
 
     void _DrawBorder();
 
+    [[nodiscard]]
     static NTSTATUS _getUserInputInternal(COOKED_READ_DATA& cookedReadData,
                                           bool& popupKey,
                                           DWORD& modifiers,

--- a/src/inc/test/CommonState.hpp
+++ b/src/inc/test/CommonState.hpp
@@ -222,6 +222,7 @@ public:
         textBuffer.GetCursor().SetYPosition(cRowsToFill);
     }
 
+    [[nodiscard]]
     NTSTATUS GetTextBufferInfoInitResult()
     {
         return m_ntstatusTextBufferInfo;

--- a/src/interactivity/inc/IConsoleControl.hpp
+++ b/src/interactivity/inc/IConsoleControl.hpp
@@ -21,8 +21,11 @@ namespace Microsoft::Console::Interactivity
     {
     public:
         virtual ~IConsoleControl() = 0;
+        [[nodiscard]]
         virtual NTSTATUS NotifyConsoleApplication(DWORD dwProcessId) = 0;
+        [[nodiscard]]
         virtual NTSTATUS SetForeground(HANDLE hProcess, BOOL fForeground) = 0;
+        [[nodiscard]]
         virtual NTSTATUS EndTask(HANDLE hProcessId, DWORD dwEventType, ULONG ulCtrlFlags) = 0;
 
     protected:

--- a/src/interactivity/win32/window.cpp
+++ b/src/interactivity/win32/window.cpp
@@ -1191,6 +1191,7 @@ void Window::s_ReinitializeFontsForDPIChange()
     gci.GetActiveOutputBuffer().RefreshFontWithRenderer();
 }
 
+[[nodiscard]]
 LRESULT Window::s_RegPersistWindowPos(_In_ PCWSTR const pwszTitle,
                                       const BOOL fAutoPos,
                                       const Window* const pWindow)
@@ -1257,6 +1258,7 @@ LRESULT Window::s_RegPersistWindowPos(_In_ PCWSTR const pwszTitle,
     return Status;
 }
 
+[[nodiscard]]
 LRESULT Window::s_RegPersistWindowOpacity(_In_ PCWSTR const pwszTitle, const Window* const pWindow)
 {
     HKEY hCurrentUserKey, hConsoleKey, hTitleKey;

--- a/src/interactivity/win32/window.hpp
+++ b/src/interactivity/win32/window.hpp
@@ -121,10 +121,12 @@ namespace Microsoft::Console::Interactivity::Win32
         void _UpdateSystemMetrics() const;
 
         // Wndproc
+        [[nodiscard]]
         static LRESULT CALLBACK s_ConsoleWindowProc(_In_ HWND hwnd,
                                                     _In_ UINT uMsg,
                                                     _In_ WPARAM wParam,
                                                     _In_ LPARAM lParam);
+        [[nodiscard]]
         LRESULT CALLBACK ConsoleWindowProc(_In_ HWND,
                                             _In_ UINT uMsg,
                                             _In_ WPARAM wParam,
@@ -137,6 +139,7 @@ namespace Microsoft::Console::Interactivity::Win32
         void _HandleWindowPosChanged(const LPARAM lParam);
 
         // Accessibility/UI Automation
+        [[nodiscard]]
         LRESULT _HandleGetObject(const HWND hwnd,
                                     const WPARAM wParam,
                                     const LPARAM lParam);
@@ -144,9 +147,11 @@ namespace Microsoft::Console::Interactivity::Win32
         WindowUiaProvider* _pUiaProvider = nullptr;
 
         // Dynamic Settings helpers
+        [[nodiscard]]
         static LRESULT s_RegPersistWindowPos(_In_ PCWSTR const pwszTitle,
                                                 const BOOL fAutoPos,
                                                 const Window* const pWindow);
+        [[nodiscard]]
         static LRESULT s_RegPersistWindowOpacity(_In_ PCWSTR const pwszTitle,
                                                     const Window* const pWindow);
 

--- a/src/interactivity/win32/windowproc.cpp
+++ b/src/interactivity/win32/windowproc.cpp
@@ -39,6 +39,7 @@ using namespace Microsoft::Console::Types;
 // The static and specific window procedures for this class are contained here
 #pragma region Window Procedure
 
+[[nodiscard]]
 LRESULT CALLBACK Window::s_ConsoleWindowProc(_In_ HWND hWnd, _In_ UINT Message, _In_ WPARAM wParam, _In_ LPARAM lParam)
 {
     // Save the pointer here to the specific window instance when one is created
@@ -61,6 +62,7 @@ LRESULT CALLBACK Window::s_ConsoleWindowProc(_In_ HWND hWnd, _In_ UINT Message, 
     return DefWindowProcW(hWnd, Message, wParam, lParam);
 }
 
+[[nodiscard]]
 LRESULT CALLBACK Window::ConsoleWindowProc(_In_ HWND hWnd, _In_ UINT Message, _In_ WPARAM wParam, _In_ LPARAM lParam)
 {
     Globals& g = ServiceLocator::LocateGlobals();
@@ -886,6 +888,7 @@ void Window::_HandleDrop(const WPARAM wParam) const
     }
 }
 
+[[nodiscard]]
 LRESULT Window::_HandleGetObject(const HWND hwnd, const WPARAM wParam, const LPARAM lParam)
 {
     LRESULT retVal = 0;

--- a/src/propsheet/ColorControl.cpp
+++ b/src/propsheet/ColorControl.cpp
@@ -42,6 +42,7 @@ void SimpleColorDoPaint(const HWND hColor, PAINTSTRUCT& ps, const int ColorId)
 
 // Routine Description:
 // - Window proc for the color buttons
+[[nodiscard]]
 LRESULT CALLBACK SimpleColorControlProc(const HWND hColor, const UINT wMsg, const WPARAM wParam, const LPARAM lParam)
 {
     PAINTSTRUCT ps;

--- a/src/propsheet/ColorControl.h
+++ b/src/propsheet/ColorControl.h
@@ -14,5 +14,6 @@ Author(s):
 
 #pragma once
 
+[[nodiscard]]
 LRESULT CALLBACK SimpleColorControlProc(HWND hColor, UINT wMsg, WPARAM wParam, LPARAM lParam);
 void SimpleColorDoPaint(HWND hColor, PAINTSTRUCT& ps, int ColorId);

--- a/src/propsheet/ColorsPage.cpp
+++ b/src/propsheet/ColorsPage.cpp
@@ -10,6 +10,7 @@ static int iColor;
 
 // Routine Description:
 // - Window proc for the color buttons
+[[nodiscard]]
 LRESULT CALLBACK ColorTableControlProc(HWND hColor, UINT wMsg, WPARAM wParam, LPARAM lParam)
 {
     PAINTSTRUCT ps;

--- a/src/propsheet/ColorsPage.h
+++ b/src/propsheet/ColorsPage.h
@@ -18,4 +18,5 @@ void ToggleV2ColorControls(__in const HWND hDlg);
 INT_PTR WINAPI ColorDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam);
 void SetOpacitySlider(__in HWND hDlg);
 void PreviewOpacity(HWND hDlg, BYTE bOpacity);
+[[nodiscard]]
 LRESULT CALLBACK ColorTableControlProc(HWND hColor, UINT wMsg, WPARAM wParam, LPARAM lParam);

--- a/src/propsheet/console.cpp
+++ b/src/propsheet/console.cpp
@@ -702,6 +702,7 @@ void UnregisterClasses(HINSTANCE hModule)
     UnregisterClass(TEXT("WOAFontPreview"), hModule);
 }
 
+[[nodiscard]]
 HRESULT FindFontAndUpdateState()
 {
     g_currentFontIndex = FindCreateFont(gpStateInfo->FontFamily,

--- a/src/propsheet/console.h
+++ b/src/propsheet/console.h
@@ -58,8 +58,7 @@ Revision History:
 #define IDS_TOOLTIP_OPACITY          17
 #define IDS_TOOLTIP_INTERCEPT_COPY_PASTE    18
 
-[[nodiscard]]
-NTSTATUS
+void
 MakeAltRasterFont(
     __in UINT CodePage,
     __out COORD *AltFontSize,

--- a/src/propsheet/console.h
+++ b/src/propsheet/console.h
@@ -58,6 +58,7 @@ Revision History:
 #define IDS_TOOLTIP_OPACITY          17
 #define IDS_TOOLTIP_INTERCEPT_COPY_PASTE    18
 
+[[nodiscard]]
 NTSTATUS
 MakeAltRasterFont(
     __in UINT CodePage,
@@ -66,7 +67,8 @@ MakeAltRasterFont(
     __out ULONG *AltFontIndex,
     __out_ecount(LF_FACESIZE) LPTSTR AltFaceName);
 
-NTSTATUS InitializeDbcsMisc();
+[[nodiscard]]
+NTSTATUS InitializeDbcsMisc(VOID);
 
 BYTE
 CodePageToCharSet(
@@ -104,7 +106,7 @@ GetAltFaceName(
     LPCTSTR ptszFace
     );
 
-NTSTATUS DestroyDbcsMisc();
+NTSTATUS DestroyDbcsMisc(VOID);
 
 int
 LanguageListCreate(
@@ -170,15 +172,14 @@ VOID SetRegistryValues(
     PCONSOLE_STATE_INFO StateInfo,
     DWORD dwPage);
 
-PCONSOLE_STATE_INFO InitStateValues(
-    HWND hwnd);
-
+[[nodiscard]]
 LRESULT CALLBACK FontPreviewWndProc(
     HWND hWnd,
     UINT wMsg,
     WPARAM wParam,
     LPARAM lParam);
 
+[[nodiscard]]
 LRESULT CALLBACK PreviewWndProc(
     HWND hWnd,
     UINT wMsg,
@@ -197,6 +198,7 @@ BOOL UpdateStateInfo(
 BOOL InitializeConsoleState();
 void UninitializeConsoleState();
 void UpdateApplyButton(const HWND hDlg);
+[[nodiscard]]
 HRESULT FindFontAndUpdateState();
 
 BOOL PopulatePropSheetPageArray(_Out_writes_(cPsps) PROPSHEETPAGE *pPsp, const size_t cPsps, const BOOL fRegisterCallbacks);

--- a/src/propsheet/console.h
+++ b/src/propsheet/console.h
@@ -91,7 +91,7 @@ IsAvailableTTFont(
 
 BOOL
 IsAvailableTTFontCP(
-    LPCWSTR pwszFace,
+    LPCTSTR ptszFace,
     UINT CodePage
     );
 
@@ -105,6 +105,7 @@ GetAltFaceName(
     LPCTSTR ptszFace
     );
 
+[[nodiscard]]
 NTSTATUS DestroyDbcsMisc(VOID);
 
 int
@@ -118,26 +119,6 @@ LanguageDisplay(
     HWND hDlg,
     UINT CodePage
     ) ;
-
-//
-// registry.c
-//
-NTSTATUS
-MyRegOpenKey(
-    __in_opt HANDLE hKey,
-    __in LPCWSTR lpSubKey,
-    __out PHANDLE phResult
-    );
-
-NTSTATUS
-MyRegEnumValue(
-    __in HANDLE hKey,
-    __in DWORD dwIndex,
-    __in DWORD dwValueLength,
-    __out_bcount(dwValueLength) LPWSTR lpValueName,
-    __in_range(4, 1024) DWORD dwDataLength,
-    __out_bcount(dwDataLength) LPBYTE lpData
-    );
 
 //
 // Function prototypes

--- a/src/propsheet/dbcs.cpp
+++ b/src/propsheet/dbcs.cpp
@@ -67,6 +67,7 @@ MakeAltRasterFont(
     return STATUS_SUCCESS;
 }
 
+[[nodiscard]]
 NTSTATUS
 InitializeDbcsMisc(
     VOID)
@@ -243,6 +244,7 @@ int LanguageDisplay(HWND hDlg, UINT CodePage)
 }
 
 // For a given codepage, determine what the default truetype font should be
+[[nodiscard]]
 NTSTATUS GetTTFontFaceForCodePage(const UINT uiCodePage,                  // the codepage to examine (note: not charset)
                                   _Out_writes_(cchFaceName) PWSTR pszFaceName, // where to write the facename we find
                                   const size_t cchFaceName)               // space available in pszFaceName

--- a/src/propsheet/dbcs.cpp
+++ b/src/propsheet/dbcs.cpp
@@ -23,7 +23,7 @@ Revision History:
 #include <strsafe.h>
 #pragma hdrstop
 
-NTSTATUS
+void
 MakeAltRasterFont(
     __in UINT CodePage,
     __out COORD *AltFontSize,
@@ -63,8 +63,6 @@ MakeAltRasterFont(
     *AltFontFamily = FontInfo[*AltFontIndex].Family;
 
     DBGFONTS(("MakeAltRasterFont : AltFontIndex = %ld\n", *AltFontIndex));
-
-    return STATUS_SUCCESS;
 }
 
 [[nodiscard]]

--- a/src/propsheet/dbcs.cpp
+++ b/src/propsheet/dbcs.cpp
@@ -153,6 +153,7 @@ GetAltFaceName(
     return NULL;
 }
 
+[[nodiscard]]
 NTSTATUS
 DestroyDbcsMisc(
     VOID)

--- a/src/propsheet/font.h
+++ b/src/propsheet/font.h
@@ -86,13 +86,14 @@ InitializeFonts(VOID);
 VOID
 DestroyFonts(VOID);
 
+[[nodiscard]]
 NTSTATUS
 EnumerateFonts(DWORD Flags);
 
 int
 FindCreateFont(
     __in DWORD Family,
-    __in_ecount(LF_FACESIZE) LPTSTR ptszFace,
+    __in_ecount(LF_FACESIZE) LPWSTR ptszFace,
     __in COORD Size,
     __in LONG Weight,
     __in UINT CodePage);
@@ -104,6 +105,7 @@ DoFontEnum(
     __in_ecount_opt(nTTPoints) PSHORT pTTPoints,
     __in UINT nTTPoints);
 
+[[nodiscard]]
 NTSTATUS GetTTFontFaceForCodePage(const UINT uiCodePage,
                                   _Out_writes_(cchFaceName) PWSTR pszFaceName,
                                   const size_t cchFaceName);

--- a/src/propsheet/fontdlg.cpp
+++ b/src/propsheet/fontdlg.cpp
@@ -259,8 +259,7 @@ FontDlgProc(
 
         if (g_fHostedInFileProperties || gpStateInfo->Defaults)
         {
-            // Ignore failure and drive on to fallback.
-            (void)FindFontAndUpdateState();
+            LOG_IF_FAILED(FindFontAndUpdateState());
         }
 
         // IMPORTANT NOTE: When the propsheet and conhost disagree on a font (e.g. user has switched charsets and forgot
@@ -1095,10 +1094,7 @@ FindCreateFont(
                 Size = DefaultFontSize;
             }
         } else {
-            if (!NT_SUCCESS(MakeAltRasterFont(CodePage, &AltFontSize, &AltFontFamily, &AltFontIndex, AltFaceName)))
-            {
-                goto fallback;
-            }
+            MakeAltRasterFont(CodePage, &AltFontSize, &AltFontFamily, &AltFontIndex, AltFaceName);
 
             if (pwszFace == NULL || *pwszFace == TEXT('\0')) {
                 pwszFace = AltFaceName;
@@ -1109,7 +1105,6 @@ FindCreateFont(
             }
         }
     } else {
-fallback:
         if (pwszFace == NULL || *pwszFace == TEXT('\0')) {
             pwszFace = DefaultFaceName;
         }
@@ -1303,14 +1298,11 @@ SelectCurrentSize(HWND hDlg, BOOL bLB, int FontIndex)
             BYTE  AltFontFamily;
             ULONG AltFontIndex = 0;
 
-            if (!NT_SUCCESS(MakeAltRasterFont(gpStateInfo->CodePage,
-                                              &AltFontSize,
-                                              &AltFontFamily,
-                                              &AltFontIndex,
-                                              AltFaceName)))
-            {
-                goto fallback;
-            }
+            MakeAltRasterFont(gpStateInfo->CodePage,
+                              &AltFontSize,
+                              &AltFontFamily,
+                              &AltFontIndex,
+                              AltFaceName);
 
             while (iCB > 0) {
                 iCB--;
@@ -1320,7 +1312,6 @@ SelectCurrentSize(HWND hDlg, BOOL bLB, int FontIndex)
                 }
             }
         } else {
-fallback:
             while (iCB > 0) {
                 iCB--;
                 FontIndex = lcbGETITEMDATA(hWndList, bLB, iCB);

--- a/src/propsheet/misc.cpp
+++ b/src/propsheet/misc.cpp
@@ -389,7 +389,7 @@ VOID
 InitializeFonts(
     VOID)
 {
-    EnumerateFonts(EF_DEFFACE);  // Just the Default font
+    (void)EnumerateFonts(EF_DEFFACE);  // Just the Default font
 }
 
 
@@ -838,6 +838,7 @@ void CreateSizeForAllTTFonts(__in const SHORT sSize)
     }
 }
 
+[[nodiscard]]
 NTSTATUS
 EnumerateFonts(
     DWORD Flags)

--- a/src/propsheet/misc.cpp
+++ b/src/propsheet/misc.cpp
@@ -389,7 +389,7 @@ VOID
 InitializeFonts(
     VOID)
 {
-    (void)EnumerateFonts(EF_DEFFACE);  // Just the Default font
+    LOG_IF_FAILED(EnumerateFonts(EF_DEFFACE));  // Just the Default font
 }
 
 

--- a/src/propsheet/preview.cpp
+++ b/src/propsheet/preview.cpp
@@ -369,7 +369,7 @@ PreviewPaint(
     DeleteDC(hDC);
 }
 
-
+[[nodiscard]]
 LRESULT
 CALLBACK
 PreviewWndProc(

--- a/src/propsheet/util.cpp
+++ b/src/propsheet/util.cpp
@@ -80,7 +80,7 @@ void UninitializeConsoleState()
         gpStateInfo->LinkTitle = nullptr;
     }
 
-    DestroyDbcsMisc();
+    LOG_IF_NTSTATUS_FAILED(DestroyDbcsMisc());
     UnregisterClasses(ghInstance);
 }
 

--- a/src/server/IoDispatchers.cpp
+++ b/src/server/IoDispatchers.cpp
@@ -174,8 +174,7 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleHandleConnectionRequest(_In_ PCONSOLE_API
     // ConsoleApp will be false in the AttachConsole case.
     if (Cac.ConsoleApp)
     {
-        // Failure to notify is not fatal.
-        (void)ServiceLocator::LocateConsoleControl()->NotifyConsoleApplication(dwProcessId);
+        LOG_IF_FAILED(ServiceLocator::LocateConsoleControl()->NotifyConsoleApplication(dwProcessId));
     }
 
     ServiceLocator::LocateAccessibilityNotifier()->NotifyConsoleStartApplicationEvent(dwProcessId);

--- a/src/server/IoDispatchers.cpp
+++ b/src/server/IoDispatchers.cpp
@@ -174,7 +174,8 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleHandleConnectionRequest(_In_ PCONSOLE_API
     // ConsoleApp will be false in the AttachConsole case.
     if (Cac.ConsoleApp)
     {
-        ServiceLocator::LocateConsoleControl()->NotifyConsoleApplication(dwProcessId);
+        // Failure to notify is not fatal.
+        (void)ServiceLocator::LocateConsoleControl()->NotifyConsoleApplication(dwProcessId);
     }
 
     ServiceLocator::LocateAccessibilityNotifier()->NotifyConsoleStartApplicationEvent(dwProcessId);

--- a/src/terminal/parser/ft_fuzzer/fuzzing_directed.h
+++ b/src/terminal/parser/ft_fuzzer/fuzzing_directed.h
@@ -446,6 +446,7 @@ namespace fuzz
         // AddFuzzArrayEntry function can be used to add additional fuzz map 
         // entries without removing the existing map.  Returns E_INVALIDARG in the 
         // event that the total percentages add up to more than 100%.
+        [[nodiscard]]
         __inline HRESULT SetFuzzArrayMap(
             __in_ecount(cfae) const _fuzz_array_entry<_Type1, _Type2, _Args...> *rgfae,
             __in ULONG cfae) throw()
@@ -462,6 +463,7 @@ namespace fuzz
         // Adds an additional fuzz map entry, without clearing the existing
         // fuzz map.  Returns E_INVALIDARG in the event that the total percentages
         // add up to more than 100%.
+        [[nodiscard]]
         HRESULT AddFuzzArrayEntry(
             __in unsigned int uiPercentage,
             __in std::function<_Type1* (_Type1*, _Type2&, _Args...)> pfnFuzz,
@@ -558,6 +560,7 @@ namespace fuzz
             return CallFuzzMapFunction(pfnFuzz, t1, t2, tup, variadic::gen_seq < sizeof...(_Args) > {});
         }
 
+        [[nodiscard]]
         HRESULT Init(
             __in_ecount(cfae) const _fuzz_array_entry<_Type1, _Type2, _Args...> *rgfae,
             __in ULONG cfae)
@@ -571,7 +574,7 @@ namespace fuzz
             // correctly.  The intended purpose is to catch users of this
             // codebase who have incorrectly specified fuzz maps that add up
             // to more than 100%.
-            HRESULT hr = hr = SetFuzzArrayMap(rgfae, cfae);
+            HRESULT hr = SetFuzzArrayMap(rgfae, cfae);
             if (FAILED(hr) && (m_traits & TRAIT_THROW_ON_INIT_FAILURE))
             {
                 throw CFuzzRangeException();
@@ -768,22 +771,27 @@ namespace fuzz
         // AddFuzzArrayEntry function can be used to add additional fuzz map 
         // entries without removing the existing map.  Returns E_INVALIDARG in the 
         // event that the total percentages add up to more than 100%.
+        [[nodiscard]]
         __inline HRESULT SetFuzzTypeMap(
             __in_ecount(cfte) const _fuzz_type_entry<_Type, _Args...> *rgfte,
             __in ULONG cfte) throw()
         {
             ClearFuzzTypeEntries();
-            for (ULONG i = 0; i < cfte; i++)
+
+            bool fInvalidEntry{};
+            for (ULONG i{}; i < cfte; ++i)
             {
-                AddFuzzTypeEntry(rgfte[i].uiPercentage, rgfte[i].pfnFuzz, rgfte[i].pfnDealloc);
+                // Process all entries; failure will be returned at the end.
+                fInvalidEntry |= FAILED(AddFuzzTypeEntry(rgfte[i].uiPercentage, rgfte[i].pfnFuzz, rgfte[i].pfnDealloc));
             }
 
-            return (m_iPercentageTotal >= 0) ? S_OK : E_INVALIDARG;
+            return (fInvalidEntry || (m_iPercentageTotal >= 0)) ? S_OK : E_INVALIDARG;
         }
 
         // Adds an additional fuzz map entry, without clearing the existing
         // fuzz map.  Returns E_INVALIDARG in the event that the total percentages
         // add up to more than 100%.
+        [[nodiscard]]
         HRESULT AddFuzzTypeEntry(
             __in unsigned int uiPercentage,
             __in std::function<_Type(_Type, _Args...)> pfnFuzz,


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Functions returning status codes should use [[nodiscard]] as [mentioned recently](https://github.com/microsoft/terminal/pull/897#discussion_r286205725) by @adiviness.

They should also use noexcept, but that's a much more invasive change, so this issue is just about [[nodiscard]].

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
#897 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #951
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [X] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #897 

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- applied [[nodiscard]] for all HRESULT, LRESULT, and NTSTATUS functions
- fixed IntelliSense declaration complaints leading to function not
  implemented warnings
- deleted declared but never implemented functions
- fixed unused parameter warnings

Please note I only checked for functions that had a declaration in a header file of some kind, so there might still be some functions only defined and used within .cpp files that don't have [[nodiscard]] applied.

How verified:
- bcz dbg
- opencon
- testcon
- VS2019 debug build