### PR TITLE
Eat all tab keypresses no matter what.

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -535,6 +535,14 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             }
         }
 
+        // Manually prevent keyboard navigation with tab. We want to send tab to
+        // the terminal, and we don't want to be able to escape focus of the
+        // control with tab.
+        if (e.OriginalKey() == VirtualKey::Tab)
+        {
+            handled = true;
+        }
+
         e.Handled(handled);
     }
 


### PR DESCRIPTION
## Summary of the Pull Request
Fix #744, by making sure the TermControl always handles Tab keypresses. This will break keyboard navigation with tab, but considering that the shell almost _always_ wants tab as a character, this makes more sense. We should probably introduce another keybinding to manually get the focus out of the control, but that can be a follow-up.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #744
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] N/A Tests added/passed
* [x] N/A Requires documentation to be updated
* [x] I've discussed this with myself in the long hours waiting to fall asleep
