### PR TITLE
Update manifest to correct 1903 version, unref param fix

### DIFF
--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -173,7 +173,7 @@ LRESULT IslandWindow::MessageHandler(UINT const message, WPARAM const wparam, LP
 // Arguments:
 // - width: the new width of the window _in pixels_
 // - height: the new height of the window _in pixels_
-void IslandWindow::OnResize(const UINT width, const UINT height)
+void IslandWindow::OnResize(const UINT /*width*/, const UINT /*height*/)
 {
     OnSize();
 }

--- a/src/cascadia/WindowsTerminal/WindowsTerminal.manifest
+++ b/src/cascadia/WindowsTerminal/WindowsTerminal.manifest
@@ -2,7 +2,10 @@
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-      <maxversiontested Id="10.0.18295.0"/>
+        <!-- Windows 10 1903 -->
+        <!-- See https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/xaml-islands -->
+        <maxversiontested Id="10.0.18362.0"/>
+        <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
     </application>
   </compatibility>
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
While messing around with building with VS2019/14.2/etc, I noticed that the version we're using in the compatibility manifest doesn't match guidance for XAML Islands. This puts the version information from the public guidance into the manifest and leaves a link back to the page where I got this idea from.

I also found an unreferenced paramter thing that I'm fixing up qucik.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] I've discussed this with myself.

