### PR TITLE
Fix #936: misuse of uninitialized objects causes AppVerifier breaks on Windows Terminal startup

### DIFF
--- a/src/renderer/base/thread.cpp
+++ b/src/renderer/base/thread.cpp
@@ -12,42 +12,42 @@ using namespace Microsoft::Console::Render;
 
 RenderThread::RenderThread() :
     _pRenderer(nullptr),
-    _hThread(INVALID_HANDLE_VALUE),
-    _hEvent(INVALID_HANDLE_VALUE),
-    _hPaintCompletedEvent(INVALID_HANDLE_VALUE),
+    _hThread(nullptr),
+    _hEvent(nullptr),
+    _hPaintCompletedEvent(nullptr),
     _fKeepRunning(true),
-    _hPaintEnabledEvent(INVALID_HANDLE_VALUE)
+    _hPaintEnabledEvent(nullptr)
 {
 
 }
 
 RenderThread::~RenderThread()
 {
-    if (_hThread != INVALID_HANDLE_VALUE)
+    if (_hThread)
     {
         _fKeepRunning = false; // stop loop after final run
         SignalObjectAndWait(_hEvent, _hThread, INFINITE, FALSE); // signal final paint and wait for thread to finish.
 
         CloseHandle(_hThread);
-        _hThread = INVALID_HANDLE_VALUE;
+        _hThread = nullptr;
     }
 
-    if (_hEvent != INVALID_HANDLE_VALUE)
+    if (_hEvent)
     {
         CloseHandle(_hEvent);
-        _hEvent = INVALID_HANDLE_VALUE;
+        _hEvent = nullptr;
     }
 
-    if (_hPaintEnabledEvent != INVALID_HANDLE_VALUE)
+    if (_hPaintEnabledEvent)
     {
         CloseHandle(_hPaintEnabledEvent);
-        _hPaintEnabledEvent = INVALID_HANDLE_VALUE;
+        _hPaintEnabledEvent = nullptr;
     }
 
-    if (_hPaintCompletedEvent != INVALID_HANDLE_VALUE)
+    if (_hPaintCompletedEvent)
     {
         CloseHandle(_hPaintCompletedEvent);
-        _hPaintCompletedEvent = INVALID_HANDLE_VALUE;
+        _hPaintCompletedEvent = nullptr;
     }
 }
 


### PR DESCRIPTION
This PR makes a couple of small changes:
- In src\cascadia\TerminalControl\TermControl.cpp, the `TermControl::_InitializeTerminal()` method now initializes the `RenderThread` it creates before making any calls into the `Renderer` it also creates, as the Renderer has been given the RenderThread and expects it to be fully initialized.
- In src\renderer\base\thread.cpp, the RenderThread's members of type `HANDLE` are now initialized to NULL instead of INVALID_HANDLE_VALUE. The latter is not appropriate for these HANDLEs because they are returned from CreateThread() or CreateEvent(), which both return NULL on failure.

Using manual testing, I verified that either of these changes alone will resolve one or both of the 2 AppVerifier stops cited in the bug report.

<!-- Please review the items on the PR checklist before submitting-->
### PR Checklist
* [x] Closes #936 
 TermControl._InitializeTerminal() gives Renderer an uninitialized RenderThread then calls into Renderer. Cleanup needed?
* [x] I've discussed this with core contributors already -- See bug thread - mr
* [ ] Tests added/passed -- not sure where to put new test code? - mr