### PR TITLE
Guard try_query calls with a null check on the pointer we're QI-ing...

### DIFF
--- a/src/tsf/ConsoleTSF.h
+++ b/src/tsf/ConsoleTSF.h
@@ -148,10 +148,13 @@ public:
         if (!fSet && _cCompositions)
         {
             // Close (terminate) any open compositions when losing the input focus.
-            wil::com_ptr_nothrow<ITfContextOwnerCompositionServices> spCompositionServices(_spITfInputContext.try_query<ITfContextOwnerCompositionServices>());
-            if (spCompositionServices)
+            if (_spITfInputContext)
             {
-                spCompositionServices->TerminateComposition(NULL);
+                wil::com_ptr_nothrow<ITfContextOwnerCompositionServices> spCompositionServices(_spITfInputContext.try_query<ITfContextOwnerCompositionServices>());
+                if (spCompositionServices)
+                {
+                    spCompositionServices->TerminateComposition(NULL);
+                }
             }
         }
     }


### PR DESCRIPTION
…from as even wil::com_ptr_nothrow can still inadvertantly throw an 'access violation exception' when null pointer deref-ing (WIL won't check if it's null before attempting, CComQIPtr apparently didn't care.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1037
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [x] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1037

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

This failed inside internal stress gates in scenarios where the TSF couldn't be stood up. The `Uninitialize` method gets called and attempts to QI things while unregistering and tearing down. The old `CComQIPtr` apparently tolerated QI-ing a null into something as a null without an issue. the `wil::com_ptr_nothrow` apparently blindly dereferences the given pointer and "throws" an access violation.

Theoretically, this might be something to upstream to https://github.com/microsoft/wil... but we need to fix the gate failure ASAP.
