### PR TITLE
Fix #1045 - Allow `tools\razzle & nuget restore` to work with NuGet 5 and later

### DIFF
--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -53,7 +53,7 @@ if not defined MSBUILD (
     goto :EXIT
 )
 
-set PATH=%PATH%"%MSBUILD%\..";
+set PATH=%PATH%%MSBUILD%\..;
 
 if "%PROCESSOR_ARCHITECTURE%" == "AMD64" (
     set ARCH=x64


### PR DESCRIPTION
This PR fixes issue #1045, in which if you had NuGet 5 on your PATH prior to running `tools\razzle.cmd`, then `tools\razzle.cmd & nuget restore` would fail with an "Illegal characters on path" error in NuGet.

## Detailed description of the pull request

Since version 5.0.2, NuGet has used the PATH environment variable to find MSBuild.exe before looking in other file paths. See NuGet change https://github.com/NuGet/NuGet.Client/commit/21f2b07f2c2e84afd6602c6743d356dae8880c0c (https://github.com/NuGet/NuGet.Client/pull/2687 ).

Unfortunately, in PR https://github.com/microsoft/terminal/pull/606 , `tools\razzle.cmd` was changed to add the MSBuild.exe folder path in _quotes_ to the PATH environment variable. Windows itself is fine with this (you can type `msbuild` and MSBuild runs), but some tools are not, including NuGet itself, so you would get errors like this:

```
D:\GitHub\metathinker\console> path
PATH=[snip snip];"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe\..";

D:\GitHub\metathinker\console> where nuget
C:\ProgramData\chocolatey\bin\nuget.exe
D:\GitHub\metathinker\console\dep\nuget\nuget.exe

D:\GitHub\metathinker\console> nuget restore OpenConsole.sln
Illegal characters in path.
```

`razzle.cmd` runs NuGet itself, but does so before adding the MSBuild folder to the PATH, so it was not affected by this problem.

This change fixes the issue by dequotifying the PATH, so that if you already had a newer version of NuGet on your PATH before running `tools\razzle.cmd`, that version will continue to work should you need to run `nuget restore` again (such as after a `git clean -dx`).

## PR checklist
* [x] Closes #1045
* [x] CLA signed - I'm a Microsoft employee so I don't need to sign
* [ ] Tests added/passed - not sure any tests are applicable?
* [x] Requires documentation to be updated - N/A; documentation doesn't need updating
* [ ] I've discussed this with core contributors already

## References
Nothing else relevant.