### PR TITLE
"Color scheme" is two words

### DIFF
--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -15,7 +15,7 @@ using namespace ::Microsoft::Console;
 
 static constexpr std::wstring_view NAME_KEY{ L"name" };
 static constexpr std::wstring_view GUID_KEY{ L"guid" };
-static constexpr std::wstring_view COLORSCHEME_KEY{ L"colorscheme" };
+static constexpr std::wstring_view COLORSCHEME_KEY{ L"colorScheme" };
 
 static constexpr std::wstring_view FOREGROUND_KEY{ L"foreground" };
 static constexpr std::wstring_view BACKGROUND_KEY{ L"background" };
@@ -113,7 +113,7 @@ const ColorScheme* _FindScheme(const std::vector<ColorScheme>& schemes,
 
 // Method Description:
 // - Create a TerminalSettings from this object. Apply our settings, as well as
-//      any colors from our colorscheme, if we have one.
+//      any colors from our color scheme, if we have one.
 // Arguments:
 // - schemes: a list of schemes to look for our color scheme in, if we have one.
 // Return Value:

--- a/src/tools/ColorTool/ColorTool/ColorScheme.cs
+++ b/src/tools/ColorTool/ColorTool/ColorScheme.cs
@@ -10,7 +10,7 @@ using System.Linq;
 namespace ColorTool
 {
     /// <summary>
-    /// Represents a colorscheme that can be applied to a console.
+    /// Represents a color scheme that can be applied to a console.
     /// </summary>
     public class ColorScheme
     {

--- a/src/tools/ColorTool/ColorTool/ColorTable.cs
+++ b/src/tools/ColorTool/ColorTool/ColorTable.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 namespace ColorTool
 {
     /// <summary>
-    /// Displays the color table that demonstrates the current colorscheme.
+    /// Displays the color table that demonstrates the current color scheme.
     /// </summary>
     static class ColorTable
     {

--- a/src/tools/ColorTool/ColorTool/ConsoleAttributes.cs
+++ b/src/tools/ColorTool/ColorTool/ConsoleAttributes.cs
@@ -6,7 +6,7 @@
 namespace ColorTool
 {
     /// <summary>
-    /// Keeps track of the color table indices for the background/foreground in a colorscheme.
+    /// Keeps track of the color table indices for the background/foreground in a color scheme.
     /// </summary>
     public readonly struct ConsoleAttributes
     {

--- a/src/tools/ColorTool/ColorTool/Program.cs
+++ b/src/tools/ColorTool/ColorTool/Program.cs
@@ -125,7 +125,7 @@ namespace ColorTool
         }
 
         /// <summary>
-        /// Returns an enumerable of consoles that we want to apply the colorscheme to.
+        /// Returns an enumerable of consoles that we want to apply the color scheme to.
         /// The contents of this enumerable depends on the user's provided command line flags.
         /// </summary>
         private static IEnumerable<IConsoleTarget> GetConsoleTargets()


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Change the profile key to `colorScheme` (from `colorscheme`), to be consistent with other configuration options.
Update some comments in ColorTool to match.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
This will likely break some existing profiles that use the old key.
