### PR TITLE
Use a ComPtr to avoid leaking font.

### DIFF
--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -822,7 +822,7 @@ HRESULT STDMETHODCALLTYPE CustomTextLayout::_AnalyzeFontFallback(IDWriteTextAnal
         while (textLength > 0)
         {
             UINT32 mappedLength = 0;
-            IDWriteFont* mappedFont = nullptr;
+            ::Microsoft::WRL::ComPtr<IDWriteFont> mappedFont;
             FLOAT scale = 0.0f;
 
             fallback->MapCharacters(source,
@@ -837,7 +837,7 @@ HRESULT STDMETHODCALLTYPE CustomTextLayout::_AnalyzeFontFallback(IDWriteTextAnal
                                     &mappedFont,
                                     &scale);
 
-            RETURN_IF_FAILED(_SetMappedFont(textPosition, mappedLength, mappedFont, scale));
+            RETURN_IF_FAILED(_SetMappedFont(textPosition, mappedLength, mappedFont.Get(), scale));
 
             textPosition += mappedLength;
             textLength -= mappedLength;
@@ -860,7 +860,7 @@ HRESULT STDMETHODCALLTYPE CustomTextLayout::_AnalyzeFontFallback(IDWriteTextAnal
 [[nodiscard]]
 HRESULT STDMETHODCALLTYPE CustomTextLayout::_SetMappedFont(UINT32 textPosition,
                                                            UINT32 textLength,
-                                                           IDWriteFont* const font,
+                                                           _In_ IDWriteFont* const font,
                                                            FLOAT const scale)
 {
     try


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Every screen update was causing memory usage to grow, seemingly unbounded. This appears to be due to a failure to decrement the reference count on a COM object.
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #768 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The main allocation stack was:

|Commit   Stack | Size (MB)|
|-- | --|
[Root] | 3.609
ntdll.dll!RtlUserThreadStart | 3.609
kernel32.dll!BaseThreadInitThunk | 3.609
TerminalControl.dll!Microsoft::Console::Render::RenderThread::s_ThreadProc | 3.609
TerminalControl.dll!Microsoft::Console::Render::Renderer::PaintFrame | 3.609
TerminalControl.dll!Microsoft::Console::Render::Renderer::_PaintFrameForEngine | 3.609
TerminalControl.dll!Microsoft::Console::Render::Renderer::_PaintBufferOutput | 3.609
TerminalControl.dll!Microsoft::Console::Render::Renderer::_PaintBufferOutputHelper | 3.609
TerminalControl.dll!Microsoft::Console::Render::DxEngine::PaintBufferLine | 3.609
TerminalControl.dll!Microsoft::Console::Render::CustomTextLayout::_AnalyzeRuns | 3.609
\|-   TerminalControl.dll!Microsoft::Console::Render::CustomTextLayout::_AnalyzeFontFallback | 3.133
\|      DWrite.dll!DWriteFontFallback::MapCharacters | 3.133

DWriteFontFallback::MapCharacters was allocating a new IDWriteFont, but the COM object was never being released after it was used. Switching from a raw pointer to a ComPtr makes the leak no longer occur when, e.g., just scrolling up and down.