### PR TITLE
Implement copy and paste for keyboard shortcuts

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -428,6 +428,8 @@ namespace winrt::TerminalApp::implementation
         bindings.ScrollDownPage([this]() { _ScrollPage(1); });
         bindings.SwitchToTab([this](const auto index) { _SelectTab({ index }); });
         bindings.OpenSettings([this]() { _OpenSettings(); });
+        bindings.CopyText([this]() { _CopyText(true);  });
+        bindings.PasteText([this]() { _PasteText();  });
     }
 
     // Method Description:
@@ -873,6 +875,19 @@ namespace winrt::TerminalApp::implementation
 
         const auto control = focusedTab->GetTerminalControl();
         control.CopySelectionToClipboard(trimTrailingWhitespace);
+    }
+
+    // Method Description:
+    // - Paste text from the Windows Clipboard to the focused terminal
+    // Arguments:
+    // - <none>
+    void App::_PasteText()
+    {
+        const int focusedTabIndex = _GetFocusedTabIndex();
+        std::shared_ptr<Tab> focusedTab{ _tabs[focusedTabIndex] };
+
+        const auto control = focusedTab->GetTerminalControl();
+        control.PasteTextFromClipboard();
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/App.h
+++ b/src/cascadia/TerminalApp/App.h
@@ -103,6 +103,7 @@ namespace winrt::TerminalApp::implementation
 
         void _Scroll(int delta);
         void _CopyText(const bool trimTrailingWhitespace);
+        void _PasteText();
         // Todo: add more event implementations here
         // MSFT:20641986: Add keybindings for New Window
         void _ScrollPage(int delta);

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -32,7 +32,7 @@ static constexpr std::wstring_view ACRYLICTRANSPARENCY_KEY{ L"acrylicOpacity" };
 static constexpr std::wstring_view USEACRYLIC_KEY{ L"useAcrylic" };
 static constexpr std::wstring_view SCROLLBARSTATE_KEY{ L"scrollbarState" };
 static constexpr std::wstring_view CLOSEONEXIT_KEY{ L"closeOnExit" };
-static constexpr std::wstring_view STRIPLINEFEEDSONPASTE_KEY{ L"stripLineFeedsOnPaste" };
+static constexpr std::wstring_view CONVERTPASTELINEENDINGS_KEY{ L"convertPasteLineEndings" };
 static constexpr std::wstring_view PADDING_KEY{ L"padding" };
 static constexpr std::wstring_view STARTINGDIRECTORY_KEY{ L"startingDirectory" };
 static constexpr std::wstring_view ICON_KEY{ L"icon" };
@@ -84,7 +84,7 @@ Profile::Profile(const winrt::guid& guid):
     _useAcrylic{ false },
     _scrollbarState{ },
     _closeOnExit{ true },
-    _stripLineFeedsOnPaste{ },
+    _convertPasteLineEndings{ },
     _padding{ DEFAULT_PADDING },
     _icon{ },
     _backgroundImage{ },
@@ -150,9 +150,9 @@ TerminalSettings Profile::CreateTerminalSettings(const std::vector<ColorScheme>&
     terminalSettings.UseAcrylic(_useAcrylic);
     terminalSettings.CloseOnExit(_closeOnExit);
 
-    if (_stripLineFeedsOnPaste)
+    if (_convertPasteLineEndings)
     {
-        terminalSettings.StripLineFeedsOnPaste(_stripLineFeedsOnPaste.value());
+        terminalSettings.ConvertPasteLineEndings(_convertPasteLineEndings.value());
     }
 
     terminalSettings.TintOpacity(_acrylicTransparency);
@@ -296,10 +296,10 @@ JsonObject Profile::ToJson() const
     jsonObject.Insert(CLOSEONEXIT_KEY, closeOnExit);
     jsonObject.Insert(PADDING_KEY, padding);
 
-    if (_stripLineFeedsOnPaste)
+    if (_convertPasteLineEndings)
     {
-        const auto stripLineFeedsOnPaste = JsonValue::CreateBooleanValue(_stripLineFeedsOnPaste.value());
-        jsonObject.Insert(STRIPLINEFEEDSONPASTE_KEY, stripLineFeedsOnPaste);
+        const auto convertPasteLineEndings = JsonValue::CreateBooleanValue(_convertPasteLineEndings.value());
+        jsonObject.Insert(CONVERTPASTELINEENDINGS_KEY, convertPasteLineEndings);
     }
 
     if (_scrollbarState)
@@ -448,9 +448,9 @@ Profile Profile::FromJson(winrt::Windows::Data::Json::JsonObject json)
     {
         result._closeOnExit = json.GetNamedBoolean(CLOSEONEXIT_KEY);
     }
-    if (json.HasKey(STRIPLINEFEEDSONPASTE_KEY))
+    if (json.HasKey(CONVERTPASTELINEENDINGS_KEY))
     {
-        result._stripLineFeedsOnPaste = json.GetNamedBoolean(STRIPLINEFEEDSONPASTE_KEY);
+        result._convertPasteLineEndings = json.GetNamedBoolean(CONVERTPASTELINEENDINGS_KEY);
     }
     if (json.HasKey(PADDING_KEY))
     {

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -32,6 +32,7 @@ static constexpr std::wstring_view ACRYLICTRANSPARENCY_KEY{ L"acrylicOpacity" };
 static constexpr std::wstring_view USEACRYLIC_KEY{ L"useAcrylic" };
 static constexpr std::wstring_view SCROLLBARSTATE_KEY{ L"scrollbarState" };
 static constexpr std::wstring_view CLOSEONEXIT_KEY{ L"closeOnExit" };
+static constexpr std::wstring_view STRIPLINEFEEDSONPASTE_KEY{ L"stripLineFeedsOnPaste" };
 static constexpr std::wstring_view PADDING_KEY{ L"padding" };
 static constexpr std::wstring_view STARTINGDIRECTORY_KEY{ L"startingDirectory" };
 static constexpr std::wstring_view ICON_KEY{ L"icon" };
@@ -83,6 +84,7 @@ Profile::Profile(const winrt::guid& guid):
     _useAcrylic{ false },
     _scrollbarState{ },
     _closeOnExit{ true },
+    _stripLineFeedsOnPaste{ },
     _padding{ DEFAULT_PADDING },
     _icon{ },
     _backgroundImage{ },
@@ -147,6 +149,12 @@ TerminalSettings Profile::CreateTerminalSettings(const std::vector<ColorScheme>&
     // Fill in the remaining properties from the profile
     terminalSettings.UseAcrylic(_useAcrylic);
     terminalSettings.CloseOnExit(_closeOnExit);
+
+    if (_stripLineFeedsOnPaste)
+    {
+        terminalSettings.StripLineFeedsOnPaste(_stripLineFeedsOnPaste.value());
+    }
+
     terminalSettings.TintOpacity(_acrylicTransparency);
 
     terminalSettings.FontFace(_fontFace);
@@ -287,6 +295,12 @@ JsonObject Profile::ToJson() const
     jsonObject.Insert(USEACRYLIC_KEY, useAcrylic);
     jsonObject.Insert(CLOSEONEXIT_KEY, closeOnExit);
     jsonObject.Insert(PADDING_KEY, padding);
+
+    if (_stripLineFeedsOnPaste)
+    {
+        const auto stripLineFeedsOnPaste = JsonValue::CreateBooleanValue(_stripLineFeedsOnPaste.value());
+        jsonObject.Insert(STRIPLINEFEEDSONPASTE_KEY, stripLineFeedsOnPaste);
+    }
 
     if (_scrollbarState)
     {
@@ -433,6 +447,10 @@ Profile Profile::FromJson(winrt::Windows::Data::Json::JsonObject json)
     if (json.HasKey(CLOSEONEXIT_KEY))
     {
         result._closeOnExit = json.GetNamedBoolean(CLOSEONEXIT_KEY);
+    }
+    if (json.HasKey(STRIPLINEFEEDSONPASTE_KEY))
+    {
+        result._stripLineFeedsOnPaste = json.GetNamedBoolean(STRIPLINEFEEDSONPASTE_KEY);
     }
     if (json.HasKey(PADDING_KEY))
     {

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -92,7 +92,7 @@ private:
 
     std::optional<std::wstring> _scrollbarState;
     bool _closeOnExit;
-    std::optional<bool> _stripLineFeedsOnPaste;
+    std::optional<bool> _convertPasteLineEndings;
     std::wstring _padding;
 
     std::optional<std::wstring> _icon;

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -92,6 +92,7 @@ private:
 
     std::optional<std::wstring> _scrollbarState;
     bool _closeOnExit;
+    std::optional<bool> _stripLineFeedsOnPaste;
     std::wstring _padding;
 
     std::optional<std::wstring> _icon;

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -981,9 +981,9 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     //   appropriate terminal settings
     void TermControl::_SendPastedTextToConnection(const std::wstring& wstr)
     {
-        // Check settings to see if we should be stripping
-        // out line feeds
-        if (_settings.StripLineFeedsOnPaste())
+        // Check settings to see if we should be converting line
+        // endings
+        if (_settings.ConvertPasteLineEndings())
         {
             std::wstring stripped(wstr);
 
@@ -991,7 +991,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
             // Lament that the stl string does not have
             // a search/replace method
-            while ((pos = stripped.find(L'\r', pos)) != std::wstring::npos)
+            while ((pos = stripped.find(L'\r\n', pos)) != std::wstring::npos)
             {
                 stripped.replace(pos, 1, L"");
             }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1185,6 +1185,10 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         _clipboardCopyHandlers(copiedData);
     }
 
+    // Method Description:
+    // - Initiate a paste operation.
+    // Arguments:
+    // - <none>
     void TermControl::PasteTextFromClipboard()
     {
         // attach TermControl::_SendInputToConnection() as the clipboardDataHandler.

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -40,6 +40,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         hstring Title();
         void CopySelectionToClipboard(bool trimTrailingWhitespace);
+        void PasteTextFromClipboard();
         void Close();
 
         void ScrollViewport(int viewTop);
@@ -112,6 +113,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         void _BlinkCursor(Windows::Foundation::IInspectable const& sender, Windows::Foundation::IInspectable const& e);
         void _SendInputToConnection(const std::wstring& wstr);
+        void _SendPastedTextToConnection(const std::wstring& wstr);
         void _SwapChainSizeChanged(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::SizeChangedEventArgs const& e);
         void _SwapChainScaleChanged(Windows::UI::Xaml::Controls::SwapChainPanel const& sender, Windows::Foundation::IInspectable const& args);
         void _DoResize(const double newWidth, const double newHeight);

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -32,7 +32,7 @@ namespace Microsoft.Terminal.TerminalControl
 
         String Title { get; };
         void CopySelectionToClipboard(Boolean trimTrailingWhitespace);
-		void PasteTextFromClipboard();
+        void PasteTextFromClipboard();
         void Close();
 
         void ScrollViewport(Int32 viewTop);

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -32,6 +32,7 @@ namespace Microsoft.Terminal.TerminalControl
 
         String Title { get; };
         void CopySelectionToClipboard(Boolean trimTrailingWhitespace);
+		void PasteTextFromClipboard();
         void Close();
 
         void ScrollViewport(Int32 viewTop);

--- a/src/cascadia/TerminalSettings/IControlSettings.idl
+++ b/src/cascadia/TerminalSettings/IControlSettings.idl
@@ -21,6 +21,7 @@ namespace Microsoft.Terminal.Settings
     {
         Boolean UseAcrylic;
         Boolean CloseOnExit;
+		Boolean StripLineFeedsOnPaste;
         Double TintOpacity;
         ScrollbarState ScrollState; 
 

--- a/src/cascadia/TerminalSettings/IControlSettings.idl
+++ b/src/cascadia/TerminalSettings/IControlSettings.idl
@@ -21,7 +21,7 @@ namespace Microsoft.Terminal.Settings
     {
         Boolean UseAcrylic;
         Boolean CloseOnExit;
-        Boolean StripLineFeedsOnPaste;
+        Boolean ConvertPasteLineEndings;
         Double TintOpacity;
         ScrollbarState ScrollState; 
 

--- a/src/cascadia/TerminalSettings/IControlSettings.idl
+++ b/src/cascadia/TerminalSettings/IControlSettings.idl
@@ -21,7 +21,7 @@ namespace Microsoft.Terminal.Settings
     {
         Boolean UseAcrylic;
         Boolean CloseOnExit;
-		Boolean StripLineFeedsOnPaste;
+        Boolean StripLineFeedsOnPaste;
         Double TintOpacity;
         ScrollbarState ScrollState; 
 

--- a/src/cascadia/TerminalSettings/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettings/TerminalSettings.cpp
@@ -22,6 +22,7 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         _cursorHeight{ DEFAULT_CURSOR_HEIGHT },
         _useAcrylic{ false },
         _closeOnExit{ true },
+        _stripLineFeedsOnPaste{ false },
         _tintOpacity{ 0.5 },
         _padding{ DEFAULT_PADDING },
         _fontFace{ DEFAULT_FONT_FACE },
@@ -154,6 +155,16 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
     void TerminalSettings::CloseOnExit(bool value)
     {
         _closeOnExit = value;
+    }
+
+    bool TerminalSettings::StripLineFeedsOnPaste()
+    {
+        return _stripLineFeedsOnPaste;
+    }
+
+    void TerminalSettings::StripLineFeedsOnPaste(bool value)
+    {
+        _stripLineFeedsOnPaste = value;
     }
 
     double TerminalSettings::TintOpacity()

--- a/src/cascadia/TerminalSettings/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettings/TerminalSettings.cpp
@@ -22,7 +22,7 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         _cursorHeight{ DEFAULT_CURSOR_HEIGHT },
         _useAcrylic{ false },
         _closeOnExit{ true },
-        _stripLineFeedsOnPaste{ false },
+        _convertPasteLineEndings{ false },
         _tintOpacity{ 0.5 },
         _padding{ DEFAULT_PADDING },
         _fontFace{ DEFAULT_FONT_FACE },
@@ -157,14 +157,14 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         _closeOnExit = value;
     }
 
-    bool TerminalSettings::StripLineFeedsOnPaste()
+    bool TerminalSettings::ConvertPasteLineEndings()
     {
-        return _stripLineFeedsOnPaste;
+        return _convertPasteLineEndings;
     }
 
-    void TerminalSettings::StripLineFeedsOnPaste(bool value)
+    void TerminalSettings::ConvertPasteLineEndings(bool value)
     {
-        _stripLineFeedsOnPaste = value;
+        _convertPasteLineEndings = value;
     }
 
     double TerminalSettings::TintOpacity()

--- a/src/cascadia/TerminalSettings/terminalsettings.h
+++ b/src/cascadia/TerminalSettings/terminalsettings.h
@@ -51,6 +51,8 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         void UseAcrylic(bool value);
         bool CloseOnExit();
         void CloseOnExit(bool value);
+        bool StripLineFeedsOnPaste();
+        void StripLineFeedsOnPaste(bool value);
         double TintOpacity();
         void TintOpacity(double value);
         hstring Padding();
@@ -97,6 +99,7 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
 
         bool _useAcrylic;
         bool _closeOnExit;
+        bool _stripLineFeedsOnPaste;
         double _tintOpacity;
         hstring _fontFace;
         int32_t _fontSize;

--- a/src/cascadia/TerminalSettings/terminalsettings.h
+++ b/src/cascadia/TerminalSettings/terminalsettings.h
@@ -51,8 +51,8 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         void UseAcrylic(bool value);
         bool CloseOnExit();
         void CloseOnExit(bool value);
-        bool StripLineFeedsOnPaste();
-        void StripLineFeedsOnPaste(bool value);
+        bool ConvertPasteLineEndings();
+        void ConvertPasteLineEndings(bool value);
         double TintOpacity();
         void TintOpacity(double value);
         hstring Padding();
@@ -99,7 +99,7 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
 
         bool _useAcrylic;
         bool _closeOnExit;
-        bool _stripLineFeedsOnPaste;
+        bool _convertPasteLineEndings;
         double _tintOpacity;
         hstring _fontFace;
         int32_t _fontSize;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Attaches copy/paste functionality to their keyboard shortcuts and adds an option to improve interaction between "Windows-space" clipboards and "Linux-space" Terminals.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

#968

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #968
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #968 

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

This connects the (mostly) pre-existing copy/paste mechanics to the keyboard shortcut mechanics, and adds a new option which makes multi-line pasting in WSL actually _usable_.

The new option, *convertPasteLineEndings* does what it says -- replacing Windows-space CRLF pairs with Unix-space LFs in text pasted to the console.  This option applies to both the keyboard-shortcut paste and the right-click paste.  Without this most multiline text pasted into Terminal will be "double-spaced" due to the Windows-style CRLF pairs.  Furthermore, any multiline text copied from Terminal (in trim whitespace mode) generates CRLF pairs, which guarantees double-spacing when copying from a WSL Terminal session.

Changes:

- Added TermControl::PasteTextFromClipboard which does what it says on the tin.  Refactored the paste code from the right-click handling in TermControl here.
- Added App::_PasteText, functioning in parallel to the pre-existing App::_CopyText
- Added TermControl::_SendPastedTextToConnection which adds a pre-processing layer on top of _SendInputToConnection to allow line-ending conversion
- Added connections from keybindings to copy/paste functionality in App::_HookupKeyBindings
- Various code in Profile/TerminalSettings to support the new option "convertPasteLineEndings" (optional, defaults to false)

Other notes:

- This PR interprets the keybinding "copy" as a copy trimming trailing whitespace (the operation performed by a right-click with a selection active).  It may be appropriate to add a keybinding for a whitespace-preserving copy (which is now done as a shift-right-click with a selection active).
- Windows -> Unix line-ending conversion is pretty much unavoidable for Terminal to interact happily with WSL.  TextBuffer::GetTextForClipboard inserts CRLF pairs into copied text, and while this could be changed to (optionally) generate LFs instead of CRLFs, this doesn't seem to be sufficient since (e.g.) Notepad also happily generates CRLF pairs.
- The architecture for the copy/paste functionality is... odd, at least to my mind.  This PR follows the existing mechanisms as closely as possible (the additional paste functions closely mirror the existing copy functions), but stuff like App::_CreateNewTabFromSettings filling out the event handlers as opposed to TermControl probably deserves an eyeball, as the only knowledge not available to TermControl during this process is which DependencyObject the Dispatcher for the copy/paste operations should come from (and I'm not sure this particularly matters).