### PR TITLE
inbox: Synchronize the font between WDDMCon and the SCREEN_INFORMATION

### DIFF
--- a/src/interactivity/onecore/ConsoleInputThread.cpp
+++ b/src/interactivity/onecore/ConsoleInputThread.cpp
@@ -53,6 +53,8 @@ DWORD WINAPI ConsoleInputThreadProcOneCore(LPVOID /*lpParam*/)
 
                 if (NT_SUCCESS(Status))
                 {
+                    globals.getConsoleInformation().GetActiveOutputBuffer().RefreshFontWithRenderer();
+
                     globals.ntstatusConsoleInputInitStatus = Status;
                     globals.hConsoleInputInitEvent.SetEvent();
 

--- a/src/renderer/wddmcon/WddmConRenderer.cpp
+++ b/src/renderer/wddmcon/WddmConRenderer.cpp
@@ -339,19 +339,9 @@ HRESULT WddmConEngine::UpdateDrawingBrushes(COLORREF const /*colorForeground*/,
 }
 
 [[nodiscard]]
-HRESULT WddmConEngine::UpdateFont(const FontInfoDesired& /*pfiFontInfoDesired*/, FontInfo& fiFontInfo) noexcept
+HRESULT WddmConEngine::UpdateFont(const FontInfoDesired& fiFontInfoDesired, FontInfo& fiFontInfo) noexcept
 {
-    COORD coordSize = {0};
-    LOG_IF_FAILED(GetFontSize(&coordSize));
-
-    fiFontInfo.SetFromEngine(fiFontInfo.GetFaceName(),
-                             fiFontInfo.GetFamily(),
-                             fiFontInfo.GetWeight(),
-                             fiFontInfo.IsTrueTypeFont(),
-                             coordSize,
-                             coordSize);
-
-    return S_OK;
+    return GetProposedFont(fiFontInfoDesired, fiFontInfo, USER_DEFAULT_SCREEN_DPI);
 }
 
 [[nodiscard]]
@@ -374,10 +364,20 @@ HRESULT WddmConEngine::UpdateViewport(const SMALL_RECT /*srNewViewport*/) noexce
 }
 
 [[nodiscard]]
-HRESULT WddmConEngine::GetProposedFont(const FontInfoDesired& /*pfiFontInfoDesired*/,
-                                       FontInfo& /*pfiFontInfo*/,
+HRESULT WddmConEngine::GetProposedFont(const FontInfoDesired& /*fiFontInfoDesired*/,
+                                       FontInfo& fiFontInfo,
                                        int const /*iDpi*/) noexcept
 {
+    COORD coordSize = { 0 };
+    LOG_IF_FAILED(GetFontSize(&coordSize));
+
+    fiFontInfo.SetFromEngine(fiFontInfo.GetFaceName(),
+        fiFontInfo.GetFamily(),
+        fiFontInfo.GetWeight(),
+        fiFontInfo.IsTrueTypeFont(),
+        coordSize,
+        coordSize);
+
     return S_OK;
 }
 


### PR DESCRIPTION
Synchronize the font between the WDDMCon Renderer and the SCREEN_INFORMATION when the OneCore Interactivity library starts up. #21717424

Retrieved from rs_onecore_dep_acioss ccca0315e7db34c09f5fcd9dfabae666ede1687b

Fixes #958.