### PR TITLE
Fix acrylic brush flash/fade on new tab creation.

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -223,7 +223,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                 acrylic.BackgroundSource(Media::AcrylicBackgroundSource::HostBackdrop);
             }
 
-            // Initialize background color so we don't get a
+            // see GH#1082: Initialize background color so we don't get a
             // fade/flash when _BackgroundColorChanged is called
             uint32_t color = _settings.DefaultBackground();
             winrt::Windows::UI::Color bgColor{};

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -202,8 +202,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     //       enabled and no background image is present.
     // - Avoids image flickering and acrylic brush redraw if settings are changed
     //   but the appropriate brush is still in place.
-    // - Does not apply background color; _BackgroundColorChanged must be called
-    //   to do so.
+    // - Does not apply background color outside of acrylic mode;
+    //   _BackgroundColorChanged must be called to do so.
     // Arguments:
     // - <none>
     // Return Value:
@@ -222,6 +222,18 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                 acrylic = Media::AcrylicBrush{};
                 acrylic.BackgroundSource(Media::AcrylicBackgroundSource::HostBackdrop);
             }
+
+            // Initialize background color so we don't get a
+            // fade/flash when _BackgroundColorChanged is called
+            uint32_t color = _settings.DefaultBackground();
+            winrt::Windows::UI::Color bgColor{};
+            bgColor.R = GetRValue(color);
+            bgColor.G = GetGValue(color);
+            bgColor.B = GetBValue(color);
+            bgColor.A = 255;
+
+            acrylic.FallbackColor(bgColor);
+            acrylic.TintColor(bgColor);
 
             // Apply brush settings
             acrylic.TintOpacity(_settings.TintOpacity());


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fixes #1082 -- #853's fix of the acrylic background's flash/fade on _any_ settings change managed to cause a flash/fade on new tab creation.  This change removed both flash/fades.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1082
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1082

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

#853 split background brush initialization from background color changes; due to the brush being constructed with a default color and then the color being initialized later, new tabs were getting the flash/fade that accompanies a re-focused fluent-style acrylic background.  This PR initializes the acrylic color at brush initialization to avoid the problem.