### PR TITLE
Implement background image over acrylic or solid color

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -99,7 +99,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         _root = root;
         _acrylicLayer = container;
-        _backgroundImageLayer = backgroundImageLayer;
+        _bgImageLayer = backgroundImageLayer;
 
         _swapChainPanel = swapChainPanel;
         _controlRoot.Content(_root);
@@ -268,7 +268,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
             // Check if the existing brush is an image brush, and if not
             // construct a new one
-            auto brush = _backgroundImageLayer.Background().try_as<Media::ImageBrush>();
+            auto brush = _bgImageLayer.Background().try_as<Media::ImageBrush>();
 
             if (brush == nullptr)
             {
@@ -297,14 +297,14 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             brush.Opacity(_settings.BackgroundImageOpacity());
 
             // Apply brush if it isn't already there
-            if (_backgroundImageLayer.Background() != brush)
+            if (_bgImageLayer.Background() != brush)
             {
-                _backgroundImageLayer.Background(brush);
+                _bgImageLayer.Background(brush);
             }
         }
         else
         {
-            _backgroundImageLayer.Background(nullptr);
+            _bgImageLayer.Background(nullptr);
         }
 
         if (!_settings.UseAcrylic())

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -99,7 +99,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         root.Children().Append(container);
 
         _root = root;
-        _acrylicLayer = container;
         _bgImageLayer = bgImageLayer;
 
         _swapChainPanel = swapChainPanel;
@@ -217,12 +216,13 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         {
             // See if we've already got an acrylic background brush
             // to avoid the flicker when setting up a new one
-            auto acrylic = _acrylicLayer.Background().try_as<Media::AcrylicBrush>();
+            auto acrylic = _root.Background().try_as<Media::AcrylicBrush>();
 
             // Instantiate a brush if there's not already one there
             if (acrylic == nullptr)
             {
                 acrylic = Media::AcrylicBrush{};
+                acrylic.BackgroundSource(Media::AcrylicBackgroundSource::HostBackdrop);
             }
 
             // see GH#1082: Initialize background color so we don't get a
@@ -238,25 +238,18 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             acrylic.TintColor(bgColor);
 
             // Apply brush settings
-            if (_settings.BackgroundImage().empty())
-            {
-                acrylic.BackgroundSource(Media::AcrylicBackgroundSource::HostBackdrop);
-            }
-            else
-            {
-                acrylic.BackgroundSource(Media::AcrylicBackgroundSource::Backdrop);
-            }
             acrylic.TintOpacity(_settings.TintOpacity());
 
             // Apply brush to control if it's not already there
-            if (_acrylicLayer.Background() != acrylic)
+            if (_root.Background() != acrylic)
             {
-                _acrylicLayer.Background(acrylic);
+                _root.Background(acrylic);
             }
         }
         else
         {
-            _acrylicLayer.Background(nullptr);
+            Media::SolidColorBrush solidColor{};
+            _root.Background(solidColor);
         }
 
         if (!_settings.BackgroundImage().empty())
@@ -292,16 +285,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             _bgImageLayer.Source(nullptr);
         }
 
-        if (!_settings.UseAcrylic())
-        {
-            Media::SolidColorBrush solidColor{};
-            _root.Background(solidColor);
-        }
-        else
-        {
-            _root.Background(nullptr);
-        }
-
     }
 
     // Method Description:
@@ -325,7 +308,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
             if (_settings.UseAcrylic())
             {
-                if (auto acrylic = _acrylicLayer.Background().try_as<Media::AcrylicBrush>())
+                if (auto acrylic = _root.Background().try_as<Media::AcrylicBrush>())
                 {
                     acrylic.FallbackColor(bgColor);
                     acrylic.TintColor(bgColor);
@@ -872,7 +855,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         {
             try
             {
-                auto acrylicBrush = _acrylicLayer.Background().as<Media::AcrylicBrush>();
+                auto acrylicBrush = _root.Background().as<Media::AcrylicBrush>();
                 acrylicBrush.TintOpacity(acrylicBrush.TintOpacity() + effectiveDelta);
             }
             CATCH_LOG();

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -93,7 +93,14 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         Controls::Grid::SetColumn(swapChainPanel, 0);
         Controls::Grid::SetColumn(_scrollBar, 1);
 
-        _root = container;
+        Controls::Grid root{}, backgroundImageLayer{};
+        backgroundImageLayer.Children().Append(container);
+        root.Children().Append(backgroundImageLayer);
+
+        _root = root;
+        _acrylicLayer = container;
+        _backgroundImageLayer = backgroundImageLayer;
+
         _swapChainPanel = swapChainPanel;
         _controlRoot.Content(_root);
 
@@ -213,13 +220,12 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         {
             // See if we've already got an acrylic background brush
             // to avoid the flicker when setting up a new one
-            auto acrylic = _root.Background().try_as<Media::AcrylicBrush>();
+            auto acrylic = _acrylicLayer.Background().try_as<Media::AcrylicBrush>();
 
             // Instantiate a brush if there's not already one there
             if (acrylic == nullptr)
             {
                 acrylic = Media::AcrylicBrush{};
-                acrylic.BackgroundSource(Media::AcrylicBackgroundSource::HostBackdrop);
             }
 
             // see GH#1082: Initialize background color so we don't get a
@@ -235,21 +241,34 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             acrylic.TintColor(bgColor);
 
             // Apply brush settings
+            if (_settings.BackgroundImage().empty())
+            {
+                acrylic.BackgroundSource(Media::AcrylicBackgroundSource::HostBackdrop);
+            }
+            else
+            {
+                acrylic.BackgroundSource(Media::AcrylicBackgroundSource::Backdrop);
+            }
             acrylic.TintOpacity(_settings.TintOpacity());
 
             // Apply brush to control if it's not already there
-            if (_root.Background() != acrylic)
+            if (_acrylicLayer.Background() != acrylic)
             {
-                _root.Background(acrylic);
+                _acrylicLayer.Background(acrylic);
             }
         }
-        else if (!_settings.BackgroundImage().empty())
+        else
+        {
+            _acrylicLayer.Background(nullptr);
+        }
+
+        if (!_settings.BackgroundImage().empty())
         {
             Windows::Foundation::Uri imageUri{ _settings.BackgroundImage() };
 
             // Check if the existing brush is an image brush, and if not
             // construct a new one
-            auto brush = _root.Background().try_as<Media::ImageBrush>();
+            auto brush = _backgroundImageLayer.Background().try_as<Media::ImageBrush>();
 
             if (brush == nullptr)
             {
@@ -278,16 +297,26 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             brush.Opacity(_settings.BackgroundImageOpacity());
 
             // Apply brush if it isn't already there
-            if (_root.Background() != brush)
+            if (_backgroundImageLayer.Background() != brush)
             {
-                _root.Background(brush);
+                _backgroundImageLayer.Background(brush);
             }
         }
         else
         {
+            _backgroundImageLayer.Background(nullptr);
+        }
+
+        if (!_settings.UseAcrylic())
+        {
             Media::SolidColorBrush solidColor{};
             _root.Background(solidColor);
         }
+        else
+        {
+            _root.Background(nullptr);
+        }
+
     }
 
     // Method Description:
@@ -311,7 +340,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
             if (_settings.UseAcrylic())
             {
-                if (auto acrylic = _root.Background().try_as<Media::AcrylicBrush>())
+                if (auto acrylic = _acrylicLayer.Background().try_as<Media::AcrylicBrush>())
                 {
                     acrylic.FallbackColor(bgColor);
                     acrylic.TintColor(bgColor);
@@ -327,6 +356,10 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                 // This currently applies no changes to the image background
                 // brush itself.
 
+                if (auto solidColor = _root.Background().try_as<Media::SolidColorBrush>())
+                {
+                    solidColor.Color(bgColor);
+                }
                 // Set the default background as transparent to prevent the
                 // DX layer from overwriting the background image
                 _settings.DefaultBackground(ARGB(0, R, G, B));
@@ -857,7 +890,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         {
             try
             {
-                auto acrylicBrush = _root.Background().as<Media::AcrylicBrush>();
+                auto acrylicBrush = _acrylicLayer.Background().as<Media::AcrylicBrush>();
                 acrylicBrush.TintOpacity(acrylicBrush.TintOpacity() + effectiveDelta);
             }
             CATCH_LOG();

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -278,13 +278,11 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             // Apply stretch and opacity settings
             _bgImageLayer.Stretch(_settings.BackgroundImageStretchMode());
             _bgImageLayer.Opacity(_settings.BackgroundImageOpacity());
-
         }
         else
         {
             _bgImageLayer.Source(nullptr);
         }
-
     }
 
     // Method Description:
@@ -306,38 +304,19 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             bgColor.B = B;
             bgColor.A = 255;
 
-            if (_settings.UseAcrylic())
+            if (auto acrylic = _root.Background().try_as<Media::AcrylicBrush>())
             {
-                if (auto acrylic = _root.Background().try_as<Media::AcrylicBrush>())
-                {
-                    acrylic.FallbackColor(bgColor);
-                    acrylic.TintColor(bgColor);
-                }
+                acrylic.FallbackColor(bgColor);
+                acrylic.TintColor(bgColor);
+            }
+            else if (auto solidColor = _root.Background().try_as<Media::SolidColorBrush>())
+            {
+                solidColor.Color(bgColor);
+            }
 
-                // If we're acrylic, we want to make sure that the default BG color
-                // is transparent, so we can see the acrylic effect on text with the
-                // default BG color.
-                _settings.DefaultBackground(ARGB(0, R, G, B));
-            }
-            else if (!_settings.BackgroundImage().empty())
-            {
-                if (auto solidColor = _root.Background().try_as<Media::SolidColorBrush>())
-                {
-                    solidColor.Color(bgColor);
-                }
-                // Set the default background as transparent to prevent the
-                // DX layer from overwriting the background image
-                _settings.DefaultBackground(ARGB(0, R, G, B));
-            }
-            else
-            {
-                if (auto solidColor = _root.Background().try_as<Media::SolidColorBrush>())
-                {
-                    solidColor.Color(bgColor);
-                }
-
-                _settings.DefaultBackground(RGB(R, G, B));
-            }
+            // Set the default background as transparent to prevent the
+            // DX layer from overwriting the background image or acrylic effect
+            _settings.DefaultBackground(ARGB(0, R, G, B));
         });
     }
 

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -69,7 +69,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         bool _initializedTerminal;
 
         Windows::UI::Xaml::Controls::UserControl _controlRoot;
-        Windows::UI::Xaml::Controls::Grid _root, _acrylicLayer;
+        Windows::UI::Xaml::Controls::Grid _root;
+        Windows::UI::Xaml::Controls::Grid _acrylicLayer;
         Windows::UI::Xaml::Controls::Image _bgImageLayer;
         Windows::UI::Xaml::Controls::SwapChainPanel _swapChainPanel;
         Windows::UI::Xaml::Controls::Primitives::ScrollBar _scrollBar;

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -70,7 +70,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         Windows::UI::Xaml::Controls::UserControl _controlRoot;
         Windows::UI::Xaml::Controls::Grid _root;
-        Windows::UI::Xaml::Controls::Grid _acrylicLayer;
         Windows::UI::Xaml::Controls::Image _bgImageLayer;
         Windows::UI::Xaml::Controls::SwapChainPanel _swapChainPanel;
         Windows::UI::Xaml::Controls::Primitives::ScrollBar _scrollBar;

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -69,7 +69,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         bool _initializedTerminal;
 
         Windows::UI::Xaml::Controls::UserControl _controlRoot;
-        Windows::UI::Xaml::Controls::Grid _root;
+        Windows::UI::Xaml::Controls::Grid _root, _backgroundImageLayer, _acrylicLayer;
         Windows::UI::Xaml::Controls::SwapChainPanel _swapChainPanel;
         Windows::UI::Xaml::Controls::Primitives::ScrollBar _scrollBar;
         event_token _connectionOutputEventToken;

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -69,7 +69,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         bool _initializedTerminal;
 
         Windows::UI::Xaml::Controls::UserControl _controlRoot;
-        Windows::UI::Xaml::Controls::Grid _root, _backgroundImageLayer, _acrylicLayer;
+        Windows::UI::Xaml::Controls::Grid _root, _bgImageLayer, _acrylicLayer;
         Windows::UI::Xaml::Controls::SwapChainPanel _swapChainPanel;
         Windows::UI::Xaml::Controls::Primitives::ScrollBar _scrollBar;
         event_token _connectionOutputEventToken;

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -69,7 +69,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         bool _initializedTerminal;
 
         Windows::UI::Xaml::Controls::UserControl _controlRoot;
-        Windows::UI::Xaml::Controls::Grid _root, _bgImageLayer, _acrylicLayer;
+        Windows::UI::Xaml::Controls::Grid _root, _acrylicLayer;
+        Windows::UI::Xaml::Controls::Image _bgImageLayer;
         Windows::UI::Xaml::Controls::SwapChainPanel _swapChainPanel;
         Windows::UI::Xaml::Controls::Primitives::ScrollBar _scrollBar;
         event_token _connectionOutputEventToken;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Implement acrylic over background image. Also make backgroundImageOpacity works with respect to the profile's background color

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1075 Closes #1762
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Introduce a new root Element that holds the original container and a background image. The root element's background sits behind `_bgImageLayer` and is responsible for acrylic and solid background.
