### PR TITLE
Provide workaround for _GetFocusedTabIndex

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -631,6 +631,8 @@ namespace winrt::TerminalApp::implementation
 
     void App::_SetFocusedTabIndex(int tabIndex)
     {
+        // GH#1117: This is a workaround because _tabView.SelectedIndex(tabIndex)
+        //          sometimes set focus to an incorrect tab after removing some tabs
         auto tab = _tabs.at(tabIndex);
         _tabView.Dispatcher().RunAsync(CoreDispatcherPriority::Normal, [tab, this](){
             auto tabViewItem = tab->GetTabViewItem();
@@ -815,6 +817,8 @@ namespace winrt::TerminalApp::implementation
     // - the index of the currently focused tab if there is one, else -1
     int App::_GetFocusedTabIndex() const
     {
+        // GH#1117: This is a workaround because _tabView.SelectedIndex()
+        //          sometimes return incorrect result after removing some tabs
         uint32_t focusedIndex;
         _tabView.Items().IndexOf(_tabView.SelectedItem(), focusedIndex);
         return focusedIndex;

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -631,11 +631,7 @@ namespace winrt::TerminalApp::implementation
 
     void App::_SetFocusedTabIndex(int tabIndex)
     {
-        auto tab = _tabs.at(tabIndex);
-        _tabView.Dispatcher().RunAsync(CoreDispatcherPriority::Normal, [tab, this](){
-            auto tabViewItem = tab->GetTabViewItem();
-            _tabView.SelectedItem(tabViewItem);
-        });
+        _tabView.SelectedIndex(tabIndex);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -815,7 +815,9 @@ namespace winrt::TerminalApp::implementation
     // - the index of the currently focused tab if there is one, else -1
     int App::_GetFocusedTabIndex() const
     {
-        return _tabView.SelectedIndex();
+        uint32_t focusedIndex;
+        _tabView.Items().IndexOf(_tabView.SelectedItem(), focusedIndex);
+        return focusedIndex;
     }
 
     void App::_OpenSettings()

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -631,7 +631,9 @@ namespace winrt::TerminalApp::implementation
 
     void App::_SetFocusedTabIndex(int tabIndex)
     {
-        _tabView.SelectedIndex(tabIndex);
+        _tabView.Dispatcher().RunAsync(CoreDispatcherPriority::Normal, [tabIndex, this]() {
+            _tabView.SelectedIndex(tabIndex);
+        });
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -631,8 +631,10 @@ namespace winrt::TerminalApp::implementation
 
     void App::_SetFocusedTabIndex(int tabIndex)
     {
-        _tabView.Dispatcher().RunAsync(CoreDispatcherPriority::Normal, [tabIndex, this]() {
-            _tabView.SelectedIndex(tabIndex);
+        auto tab = _tabs.at(tabIndex);
+        _tabView.Dispatcher().RunAsync(CoreDispatcherPriority::Normal, [tab, this](){
+            auto tabViewItem = tab->GetTabViewItem();
+            _tabView.SelectedItem(tabViewItem);
         });
     }
 

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -820,8 +820,11 @@ namespace winrt::TerminalApp::implementation
         // GH#1117: This is a workaround because _tabView.SelectedIndex()
         //          sometimes return incorrect result after removing some tabs
         uint32_t focusedIndex;
-        _tabView.Items().IndexOf(_tabView.SelectedItem(), focusedIndex);
-        return focusedIndex;
+        if (_tabView.Items().IndexOf(_tabView.SelectedItem(), focusedIndex))
+        {
+            return focusedIndex;
+        }
+        return -1;
     }
 
     void App::_OpenSettings()


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Use tabview.SelectedIndex for setting focus tab

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1100, Closes #1039, Closes #1074
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
