### PR TITLE
bugfix for saving profiles.json during runtime

### DIFF
--- a/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
@@ -238,7 +238,7 @@ void CascadiaSettings::_SaveAsPackagedApp(const winrt::hstring content)
 
     dw.WriteString(content);
 
-    FileIO::WriteBufferAsync(file, dw.DetachBuffer()).get();
+    FileIO::WriteBufferAsync(file, dw.DetachBuffer());
 }
 
 // Method Description:


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Remove unnecessary call at the end of _SaveAsPackagedApp which is called by SaveAll() and could be called to edit profiles.json from the runtime.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
- [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The `_SaveAsPackagedApp` function was broken. When attempting to call `_settings->SaveAll()` from App.cpp, the app hangs indefinitely. I'm unsure why this fixes it, but I propose that we remove the unnecessary .get() method call from the end of line 241. This prevents lockups from calling CascadiaSettings::SaveAll() at runtime, which would be necessary to make profile creation more dynamic and UI-driven.