### PR TITLE
Change ParseNext function in UTF16 parser to never yield invalid data…

### DIFF
--- a/src/buffer/out/OutputCellIterator.cpp
+++ b/src/buffer/out/OutputCellIterator.cpp
@@ -411,7 +411,7 @@ OutputCellView OutputCellIterator::s_GenerateView(const std::wstring_view view,
                                                   const TextAttribute attr,
                                                   const TextAttributeBehavior behavior)
 {
-    auto glyph = Utf16Parser::ParseNext(view);
+    const auto glyph = Utf16Parser::ParseNext(view);
     DbcsAttribute dbcsAttr;
     if (IsGlyphFullWidth(glyph))
     {

--- a/src/buffer/out/OutputCellIterator.cpp
+++ b/src/buffer/out/OutputCellIterator.cpp
@@ -411,9 +411,9 @@ OutputCellView OutputCellIterator::s_GenerateView(const std::wstring_view view,
                                                   const TextAttribute attr,
                                                   const TextAttributeBehavior behavior)
 {
-    const auto glyph = Utf16Parser::ParseNext(view);
+    auto glyph = Utf16Parser::ParseNext(view);
     DbcsAttribute dbcsAttr;
-    if (!glyph.empty() && IsGlyphFullWidth(glyph))
+    if (IsGlyphFullWidth(glyph))
     {
         dbcsAttr.SetLeading();
     }

--- a/src/host/ut_host/Utf16ParserTests.cpp
+++ b/src/host/ut_host/Utf16ParserTests.cpp
@@ -86,4 +86,127 @@ class Utf16ParserTests
             VERIFY_ARE_EQUAL(result.at(0).at(i), SunglassesEmoji.at(i));
         }
     }
+
+    const std::wstring_view Replacement{ &UNICODE_REPLACEMENT, 1 };
+
+    TEST_METHOD(ParseNextLeadOnly)
+    {
+        std::wstring wstr{ SunglassesEmoji.at(0)};
+
+        const auto expected = Replacement;
+        const auto actual = Utf16Parser::ParseNext(wstr);
+
+        VERIFY_ARE_EQUAL(expected, actual);
+    }
+
+    TEST_METHOD(ParseNextTrailOnly)
+    {
+        std::wstring wstr{ SunglassesEmoji.at(1) };
+
+        const auto expected = Replacement;
+        const auto actual = Utf16Parser::ParseNext(wstr);
+
+        VERIFY_ARE_EQUAL(expected, actual);
+    }
+
+    TEST_METHOD(ParseNextSingleOnly)
+    {
+        std::wstring wstr{ CyrillicChar.at(0) };
+
+        const auto expected = std::wstring_view{ CyrillicChar.data(), CyrillicChar.size() };
+        const auto actual = Utf16Parser::ParseNext(wstr);
+
+        VERIFY_ARE_EQUAL(expected, actual);
+    }
+
+    TEST_METHOD(ParseNextLeadLead)
+    {
+        std::wstring wstr{ SunglassesEmoji.at(0) };
+        wstr += SunglassesEmoji.at(0);
+
+        const auto expected = Replacement;
+        const auto actual = Utf16Parser::ParseNext(wstr);
+
+        VERIFY_ARE_EQUAL(expected, actual);
+    }
+
+    TEST_METHOD(ParseNextLeadTrail)
+    {
+        std::wstring wstr{ SunglassesEmoji.at(0) };
+        wstr += SunglassesEmoji.at(1);
+
+        const auto expected = std::wstring_view{ SunglassesEmoji.data(), SunglassesEmoji.size() };
+        const auto actual = Utf16Parser::ParseNext(wstr);
+
+        VERIFY_ARE_EQUAL(expected, actual);
+    }
+
+    TEST_METHOD(ParseNextTrailTrail)
+    {
+        std::wstring wstr{ SunglassesEmoji.at(1) };
+        wstr += SunglassesEmoji.at(1);
+
+        const auto expected = Replacement;
+        const auto actual = Utf16Parser::ParseNext(wstr);
+
+        VERIFY_ARE_EQUAL(expected, actual);
+    }
+
+    TEST_METHOD(ParseNextLeadSingle)
+    {
+        std::wstring wstr{ SunglassesEmoji.at(0) };
+        wstr += LatinChar.at(0);
+
+        const auto expected = std::wstring_view{ LatinChar.data(), LatinChar.size() };
+        const auto actual = Utf16Parser::ParseNext(wstr);
+
+        VERIFY_ARE_EQUAL(expected, actual);
+    }
+
+    TEST_METHOD(ParseNextTrailSingle)
+    {
+        std::wstring wstr{ SunglassesEmoji.at(1) };
+        wstr += LatinChar.at(0);
+
+        const auto expected = std::wstring_view{ LatinChar.data(), LatinChar.size() };
+        const auto actual = Utf16Parser::ParseNext(wstr);
+
+        VERIFY_ARE_EQUAL(expected, actual);
+    }
+
+    TEST_METHOD(ParseNextLeadLeadTrail)
+    {
+        std::wstring wstr{ SunglassesEmoji.at(0) };
+        wstr += SunglassesEmoji.at(0);
+        wstr += SunglassesEmoji.at(1);
+
+        const auto expected = std::wstring_view{ SunglassesEmoji.data(), SunglassesEmoji.size() };
+        const auto actual = Utf16Parser::ParseNext(wstr);
+
+        VERIFY_ARE_EQUAL(expected, actual);
+    }
+
+    TEST_METHOD(ParseNextTrailLeadTrail)
+    {
+        std::wstring wstr{ SunglassesEmoji.at(1) };
+        wstr += SunglassesEmoji.at(0);
+        wstr += SunglassesEmoji.at(1);
+
+        const auto expected = std::wstring_view{ SunglassesEmoji.data(), SunglassesEmoji.size() };
+        const auto actual = Utf16Parser::ParseNext(wstr);
+
+        VERIFY_ARE_EQUAL(expected, actual);
+    }
+
+    TEST_METHOD(ParseNextSingleLeadTrail)
+    {
+        std::wstring wstr{ GaelicChar.at(0) };
+        wstr += SunglassesEmoji.at(0);
+        wstr += SunglassesEmoji.at(1);
+
+        const auto expected = std::wstring_view{ GaelicChar.data(), GaelicChar.size() };
+        const auto actual = Utf16Parser::ParseNext(wstr);
+
+        VERIFY_ARE_EQUAL(expected, actual);
+    }
 };

--- a/src/host/ut_host/Utf16ParserTests.cpp
+++ b/src/host/ut_host/Utf16ParserTests.cpp
@@ -91,7 +91,7 @@ class Utf16ParserTests
 
     TEST_METHOD(ParseNextLeadOnly)
     {
-        std::wstring wstr{ SunglassesEmoji.at(0)};
+        std::wstring wstr{ SunglassesEmoji.at(0) };
 
         const auto expected = Replacement;
         const auto actual = Utf16Parser::ParseNext(wstr);

--- a/src/inc/consoletaeftemplates.hpp
+++ b/src/inc/consoletaeftemplates.hpp
@@ -543,4 +543,38 @@ namespace WEX::TestExecution
         }
     };
 
+
+    template<>
+    class VerifyOutputTraits < std::wstring_view >
+    {
+    public:
+        static WEX::Common::NoThrowString ToString(const std::wstring_view& view)
+        {
+            return WEX::Common::NoThrowString(view.data(), gsl::narrow<int>(view.size()));
+        }
+    };
+
+    template<>
+    class VerifyCompareTraits < std::wstring_view, std::wstring_view >
+    {
+    public:
+        static bool AreEqual(const std::wstring_view& expected, const std::wstring_view& actual)
+        {
+            return expected == actual;
+        }
+
+        static bool AreSame(const std::wstring_view& expected, const std::wstring_view& actual)
+        {
+            return expected.data() == actual.data();
+        }
+
+        static bool IsLessThan(const std::wstring_view&, const std::wstring_view&) = delete;
+
+        static bool IsGreaterThan(const std::wstring_view&, const std::wstring_view&) = delete;
+
+        static bool IsNull(const std::wstring_view& object)
+        {
+            return object.size() == 0;
+        }
+    };
 }

--- a/src/types/Utf16Parser.cpp
+++ b/src/types/Utf16Parser.cpp
@@ -4,6 +4,7 @@
 #include "precomp.h"
 
 #include "inc/Utf16Parser.hpp"
+#include "unicode.hpp"
 
 // Routine Description:
 // - Finds the next single collection for the codepoint out of the given UTF-16 string information.
@@ -15,35 +16,41 @@
 // - A view into the string given of just the next codepoint unit.
 std::wstring_view Utf16Parser::ParseNext(std::wstring_view wstr)
 {
-    size_t pos = 0;
-    size_t length = 0;
-
-    for (auto wch : wstr)
+    for (size_t pos = 0; pos < wstr.size(); ++pos)
     {
+        const auto wch = wstr.at(pos);
+
+        // If it's a lead and followed directly by a trail, then return the pair.
+        // If it's not followed directly by the trail, go around again and seek forward.
         if (IsLeadingSurrogate(wch))
         {
-            length++;
+            // Try to find the next item... if it isn't there, we'll go around again.
+            const auto posNext = pos + 1;
+            if (posNext < wstr.size())
+            {
+                // If we found it and it's trailing, return the pair.
+                const auto wchNext = wstr.at(posNext);
+                if (IsTrailingSurrogate(wchNext))
+                {
+                    return wstr.substr(pos, 2);
+                }
+            }
+            // If we missed either if in any way, we'll fall through and go around again searching for more.
         }
+        // If it's just a trail at this point, go around again and seek forward.
         else if (IsTrailingSurrogate(wch))
         {
-            if (length != 0)
-            {
-                length++;
-                break;
-            }
-            else
-            {
-                pos++;
-            }
+            continue;
         }
+        // If it's neither lead nor trail, then it's < U+10000 and it can be returned as a single wchar_t point.
         else
         {
-            length++;
-            break;
+            return wstr.substr(pos, 1);
         }
     }
 
-    return wstr.substr(pos, length);
+    // If we get all the way through and there's nothing valid, then this is just a replacement character as it was broken/garbage.
+    return std::wstring_view{ &UNICODE_REPLACEMENT, 1 };
 }
 
 // Routine Description:


### PR DESCRIPTION
…. It will return a replacement character at that point if it was given bad data. #788

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This modifies the parser used while inserting text into the underlying data buffer to never return an empty sequence. The empty sequence is invalid as you can't insert a "nothing" into the buffer. The buffer asserted this with a fail fast crash. Now we will instead insert U+FFFD (the Unicode replacement character) � to symbolize that something was invalid and has been replaced.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #788 and internal MSFT: 20990158
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [x] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #788

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The solution here isn't perfect and isn't going to solve all of our problems. I was basically trying to stop the crash while not getting in the way of the other things coming down the pipe for the input channels.

I considered the following:
1. Remove the fail fast assertion from the buffer
  - I didn't want to do this because it really is invalid to get all the way to placing the text down into the buffer and then request a string of 0 length get inserted. I feel the fail fast is a good indication that something is terribly wrong elsewhere that should be corrected.
2. Update the UTF16 parser in order to stop returning empty strings
  - This is what I ultimately did. If it would ever return just a lead, it returns �. If it would ever return just a trail, it returns �. Otherwise it will return them as a pair if they're both there, or it will return a single valid codepoint. I am now assuming that if the parse function is being called in an Output Iterator and doesn't contain a string with all pieces of the data that are needed, that someone at a higher level messed up the data, it is in valid, and it should be repaired into replacements.
  - This then will move the philosophy up out of the buffer layer to make folks inserting into the buffer identify half a sequence (if they're sitting on a stream where this circumstance could happen... one `wchar_t` at a time) and hold onto it until the next bit arrives. This is because there can be many different routes into the buffer from many different streams/channels. So buffering it low, right near the insertion point, is bad as it might pair loose `wchar_t` across stream entrypoints.
3. Update the iterator, on creating views, to disallow/transform empty strings. 
  - I considered this solution as well, but it would have required, under some circumstances, a second parsing of the string to identify lead/trail status from outside the `Utf16Parser` class to realize when to use the � character. So I avoided the double-parse.
4. Change the cooked read classes to identify that they pulled the lead `wchar_t` from a sequence then try to pull another one.
   - I was going to attempt this, but @adiviness said that he tried it and it made all sorts of other weirdness happen with the edit line.
   - Additionally, @adiviness has an outstanding series of effort to make cooked read significantly less horrible and disgusting. I didn't want to get in the way here.
5. Change the `GetChar` method off of the input buffer queue to return a `char32_t`, a `wstring_view`, transform a standalone lead/trail, etc.
    - The `GetChar` method is used by several different accessors and API calls to retrieve information off of the input queue, transforming the Key events into straight up characters. To change this at that level would change them all.  Long-term, it is probably warranted to do so as all of those consumers likely need to become aware of handling UTF-16 surrogates before we can declare victory. But two problems.
          1. This gets in the way of @adiviness work on cooked read data
          2. This goes WAY beyond the scope of what I want to accomplish here as the immediate goal is to stop the crash, not fix the world.


I've validated this by:
1. Writing some additional tests against the Utf16Parser to simulate some of the theoretical sequences that could arrive and need to be corrected into replacement characters per a verbal discussion and whiteboarding with @adiviness.
2. Manually triggered the emoji panel and inserted a bunch of emoji. Then seeked around left and right, deleted assorted points with the backspace key, pressed enter to commit, and used the up-arrow history to recommit them to see what happened. There were no crashes. The behavior is still weird and not great... but outside the scope of no crashy crashy.
