### PR TITLE
Flush input queue before running test. #1137

### DIFF
--- a/src/host/ft_host/API_InputTests.cpp
+++ b/src/host/ft_host/API_InputTests.cpp
@@ -55,7 +55,7 @@ class InputTests
     TEST_METHOD(TestMouseHorizWheelReadConsoleNoMouseInput);
     TEST_METHOD(TestMouseWheelReadConsoleInputQuickEdit);
     TEST_METHOD(TestMouseHorizWheelReadConsoleInputQuickEdit);
-    TEST_METHOD(RawReadUnpacksCoalsescedInputRecords);
+    TEST_METHOD(RawReadUnpacksCoalescedInputRecords);
 
     BEGIN_TEST_METHOD(TestVtInputGeneration)
         TEST_METHOD_PROPERTY(L"IsolationLevel", L"Method")
@@ -671,7 +671,7 @@ void InputTests::TestVtInputGeneration()
     VERIFY_ARE_EQUAL(rgInputRecords[2].Event.KeyEvent.uChar.UnicodeChar, L'A');
 }
 
-void InputTests::RawReadUnpacksCoalsescedInputRecords()
+void InputTests::RawReadUnpacksCoalescedInputRecords()
 {
     DWORD mode = 0;
     HANDLE hIn = GetStdInputHandle();
@@ -682,6 +682,10 @@ void InputTests::RawReadUnpacksCoalsescedInputRecords()
     GetConsoleMode(hIn, &mode);
     WI_ClearFlag(mode, ENABLE_LINE_INPUT);
     SetConsoleMode(hIn, mode);
+
+    // flush input queue before attempting to add new events and check
+    // in case any are leftover from previous tests
+    VERIFY_WIN32_BOOL_SUCCEEDED(FlushConsoleInputBuffer(hIn));
 
     INPUT_RECORD record;
     record.EventType = KEY_EVENT;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Flushes the input queue on `RawReadUnpacksCoalescedInputRecords` test to ensure that other tests cannot cause failure by leaving extraneous input records behind after they run.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1137 and internal issue MSFT: 21918618
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [x] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1137 

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

This only failed in the core operating system gate tests. This is because those tests run a subset of the complete test suite (subtracting the ones that do not make sense in a core environment). Apparently one of the tests that was skipped that normally runs prior to the `UnpacksCoalesced` test ensured that the input queue was clean enough for this test to succeed. But in the core environment, the test that ran prior left stuff behind.

To resolve this, I'm making the `Coalesced` test more resilient by cleaning out the queue prior to performing its operations.

(Also, bonus, I'm fixing the typo in the name `Coalesced`.)

This is less complicated/expensive than tracking down the tests that are leaving garbage behind, should prevent issues in the future related to ordering (since the tests run alphabetically, by default), and isn't as expensive as running the test in isolation (with its own conhost stood up for just the one test.)

Validated by running `te.exe Microsoft.Console.Host.FeatureTests.dll /name:*InputTests*` against a core operating system variant. Prior to change, this test failed. After the change, this test succeeded.

This will be automatically double-checked by the gates run after check-in.
