### PR TITLE
Add explicit "validation steps" to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,3 +14,6 @@
 
 <!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
 ## Detailed Description of the Pull Request / Additional comments
+
+<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
+## Validation Steps Performed


### PR DESCRIPTION
While filling out PR templates, I've realized that I am making a strong effort to list my validation steps at the bottom in the "details and other comments" block. I feel like it would be good to make it explicit that we would like to see justification of how changes have been validated for functionality.