### PR TITLE
Fix build warnings and namespace issues introduced by GitHub merge

### DIFF
--- a/src/interactivity/base/VtApiRedirection.cpp
+++ b/src/interactivity/base/VtApiRedirection.cpp
@@ -9,6 +9,8 @@
 
 #pragma hdrstop
 
+using namespace Microsoft::Console::Interactivity;
+
 UINT VTRedirMapVirtualKeyW(_In_ UINT uCode, _In_ UINT uMapType)
 {
     return ServiceLocator::LocateInputServices()->MapVirtualKeyW(uCode, uMapType);

--- a/src/interactivity/onecore/BgfxEngine.cpp
+++ b/src/interactivity/onecore/BgfxEngine.cpp
@@ -17,6 +17,7 @@
 #define DEFAULT_COLOR_ATTRIBUTE (0xC)
 
 using namespace Microsoft::Console::Render;
+using namespace Microsoft::Console::Interactivity;
 using namespace Microsoft::Console::Interactivity::OneCore;
 
 BgfxEngine::BgfxEngine(PVOID SharedViewBase, LONG DisplayHeight, LONG DisplayWidth, LONG FontWidth, LONG FontHeight)

--- a/src/interactivity/onecore/ConIoSrvComm.cpp
+++ b/src/interactivity/onecore/ConIoSrvComm.cpp
@@ -21,6 +21,7 @@
 extern void LockConsole();
 extern void UnlockConsole();
 
+using namespace Microsoft::Console::Render;
 using namespace Microsoft::Console::Interactivity::OneCore;
 
 ConIoSrvComm::ConIoSrvComm() :
@@ -242,7 +243,7 @@ NTSTATUS ConIoSrvComm::EnsureConnection()
 VOID ConIoSrvComm::ServiceInputPipe()
 {
     // Save off a handle to the thread that is coming in here in case it gets blocked and we need to tear down.
-    THROW_HR_IF(E_NOT_VALID_STATE, _inputPipeThreadHandle); // We can't store two of them, so it's invalid if there are two.
+    THROW_HR_IF(E_NOT_VALID_STATE, !!_inputPipeThreadHandle); // We can't store two of them, so it's invalid if there are two.
     THROW_IF_WIN32_BOOL_FALSE(DuplicateHandle(GetCurrentProcess(),
                                               GetCurrentThread(),
                                               GetCurrentProcess(),

--- a/src/interactivity/onecore/ConsoleInputThread.cpp
+++ b/src/interactivity/onecore/ConsoleInputThread.cpp
@@ -13,6 +13,7 @@
 
 #include "..\inc\ServiceLocator.hpp"
 
+using namespace Microsoft::Console::Interactivity;
 using namespace Microsoft::Console::Interactivity::OneCore;
 
 


### PR DESCRIPTION
These were introduced by:
- build warning with using wrong type in wil macro: #1105 
- namespace issues: #955 

These showed up in the official Windows build. I fixed them on that side to restore the build and now I'm bringing them back out.