### PR TITLE
Accounting padding when calculating the initial window size

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1282,7 +1282,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             width += scrollbarSize;
         }
 
-        double height =rows * fFontHeight;
+        double height = rows * fFontHeight;
         auto thickness = _ParseThicknessFromPadding(settings.Padding());
         width += thickness.Left + thickness.Right;
         height += thickness.Top + thickness.Bottom;

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1281,10 +1281,75 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         {
             width += scrollbarSize;
         }
+        float height = gsl::narrow<float>(rows * fFontHeight);
 
-        const float height = gsl::narrow<float>(rows * fFontHeight);
-
+        // Reserve space for padding
+        uint8_t paddingPropIndex;
+        const auto paddingArr = _ParsePadding(settings.Padding(), paddingPropIndex);
+        switch (paddingPropIndex)
+        {
+            case 1:
+                width += paddingArr[0] * 2;
+                height += paddingArr[0] * 2;
+                break;
+            case 2:
+                width += paddingArr[0] * 2;
+                height += paddingArr[1] * 2;
+            // No case for paddingPropIndex = 3, since it's not a norm to provide just Left, Top & Right padding values leaving out Bottom
+            case 4:
+                width += paddingArr[0] + paddingArr[2];
+                height += paddingArr[1] + paddingArr[3];
+            default:
+                break;
+        }
+        
         return { width, height };
+    }
+
+    // Method Description:
+    // - Parse the given padding props to an array.
+    // Arguments:
+    // - padding: 2D padding values
+    //      Single Double value provides uniform padding
+    //      Two Double values provide isometric horizontal & vertical padding
+    //      Four Double values provide independent padding for 4 sides of the bounding rectangle
+    // - paddingPropIndex:
+    // Return Value:
+    // - std::array<double, 4> object
+    std::array<double, 4> TermControl::_ParsePadding(const hstring padding, uint8_t& paddingPropIndex)
+    {
+        const wchar_t singleCharDelim = L',';
+        std::wstringstream tokenStream(padding.c_str());
+        std::wstring token;
+        paddingPropIndex = 0;
+        std::array<double, 4> paddingArr = {};
+        size_t* idx = nullptr;
+
+        // Get padding values till we run out of delimiter separated values in the stream
+        //  or we hit max number of allowable values (= 4) for the bounding rectangle
+        // Non-numeral values detected will default to 0
+        // std::getline will not throw exception unless flags are set on the wstringstream
+        // std::stod will throw invalid_argument expection if the input is an invalid double value
+        // std::stod will throw out_of_range expection if the input value is more than DBL_MAX
+        try
+        {
+            for (; std::getline(tokenStream, token, singleCharDelim) && (paddingPropIndex < paddingArr.size()); paddingPropIndex++)
+            {
+                // std::stod internall calls wcstod which handles whitespace prefix (which is ignored)
+                //  & stops the scan when first char outside the range of radix is encountered
+                // We'll be permissive till the extent that stod function allows us to be by default
+                // Ex. a value like 100.3#535w2 will be read as 100.3, but ;df25 will fail
+                paddingArr[paddingPropIndex] = std::stod(token, idx);
+            }
+        }
+        catch (...)
+        {
+            // If something goes wrong, even if due to a single bad padding value, we'll reset the index & return default 0 padding
+            paddingPropIndex = 0;
+            LOG_CAUGHT_EXCEPTION();
+        }
+
+        return paddingArr;
     }
 
     // Method Description:
@@ -1299,36 +1364,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // - Windows::UI::Xaml::Thickness object
     Windows::UI::Xaml::Thickness TermControl::_ParseThicknessFromPadding(const hstring padding)
     {
-        const wchar_t singleCharDelim = L',';
-        std::wstringstream tokenStream(padding.c_str());
-        std::wstring token;
-        uint8_t paddingPropIndex = 0;
-        std::array<double, 4> thicknessArr = {};
-        size_t* idx = nullptr;
-
-        // Get padding values till we run out of delimiter separated values in the stream
-        //  or we hit max number of allowable values (= 4) for the bounding rectangle
-        // Non-numeral values detected will default to 0
-        // std::getline will not throw exception unless flags are set on the wstringstream
-        // std::stod will throw invalid_argument expection if the input is an invalid double value
-        // std::stod will throw out_of_range expection if the input value is more than DBL_MAX
-        try
-        {
-            for (; std::getline(tokenStream, token, singleCharDelim) && (paddingPropIndex < thicknessArr.size()); paddingPropIndex++)
-            {
-                // std::stod internall calls wcstod which handles whitespace prefix (which is ignored)
-                //  & stops the scan when first char outside the range of radix is encountered
-                // We'll be permissive till the extent that stod function allows us to be by default
-                // Ex. a value like 100.3#535w2 will be read as 100.3, but ;df25 will fail
-                thicknessArr[paddingPropIndex] = std::stod(token, idx);
-            }
-        }
-        catch (...)
-        {
-            // If something goes wrong, even if due to a single bad padding value, we'll reset the index & return default 0 padding
-            paddingPropIndex = 0;
-            LOG_CAUGHT_EXCEPTION();
-        }
+        uint8_t paddingPropIndex;
+        const auto thicknessArr = _ParsePadding(padding, paddingPropIndex);
 
         switch (paddingPropIndex)
         {

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1288,17 +1288,17 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         switch (paddingArr.size())
         {
             case 1:
-                width += paddingArr[0] * 2;
-                height += paddingArr[0] * 2;
+                width += paddingArr.at(0) * 2;
+                height += paddingArr.at(0) * 2;
                 break;
             case 2:
-                width += paddingArr[0] * 2;
-                height += paddingArr[1] * 2;
+                width += paddingArr.at(0) * 2;
+                height += paddingArr.at(1) * 2;
                 break;
             // No case for 3 padding values, since it's not a norm to provide just Left, Top & Right padding values leaving out Bottom
             case 4:
-                width += paddingArr[0] + paddingArr[2];
-                height += paddingArr[1] + paddingArr[3];
+                width += paddingArr.at(0) + paddingArr.at(2);
+                height += paddingArr.at(1) + paddingArr.at(3);
                 break;
             default:
                 break;
@@ -1323,8 +1323,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         const wchar_t singleCharDelim = L',';
         std::wstringstream tokenStream(padding.c_str());
         std::wstring token;
-        std::vector<double> paddingArr = {};
-        size_t* idx = nullptr;
+        std::vector<double> paddingArr;
 
         // Get padding values till we run out of delimiter separated values in the stream
         //  or we hit max number of allowable values (= 4) for the bounding rectangle
@@ -1340,7 +1339,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                 //  & stops the scan when first char outside the range of radix is encountered
                 // We'll be permissive till the extent that stod function allows us to be by default
                 // Ex. a value like 100.3#535w2 will be read as 100.3, but ;df25 will fail
-                paddingArr.push_back(std::stod(token, idx));
+                paddingArr.push_back(std::stod(token));
             }
         }
         catch (...)

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1294,10 +1294,12 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             case 2:
                 width += paddingArr[0] * 2;
                 height += paddingArr[1] * 2;
+                break;
             // No case for 3 padding values, since it's not a norm to provide just Left, Top & Right padding values leaving out Bottom
             case 4:
                 width += paddingArr[0] + paddingArr[2];
                 height += paddingArr[1] + paddingArr[3];
+                break;
             default:
                 break;
         }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1294,7 +1294,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             case 2:
                 width += paddingArr[0] * 2;
                 height += paddingArr[1] * 2;
-            // No case for paddingPropIndex = 3, since it's not a norm to provide just Left, Top & Right padding values leaving out Bottom
+            // No case for 3 padding values, since it's not a norm to provide just Left, Top & Right padding values leaving out Bottom
             case 4:
                 width += paddingArr[0] + paddingArr[2];
                 height += paddingArr[1] + paddingArr[3];
@@ -1306,15 +1306,16 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     }
 
     // Method Description:
-    // - Parse the given padding props to an array.
+    // - Parse the given padding props to a std::vector.
     // Arguments:
     // - padding: 2D padding values
     //      Single Double value provides uniform padding
     //      Two Double values provide isometric horizontal & vertical padding
     //      Four Double values provide independent padding for 4 sides of the bounding rectangle
-    // - paddingPropIndex:
     // Return Value:
-    // - std::array<double, 4> object
+    // - A std::vector object
+    // - If parsed successfully the vector will have the same size as the number of padding values.
+    // - If parsing failed the vector will be empty.
     std::vector<double> TermControl::_ParsePadding(const hstring padding)
     {
         const wchar_t singleCharDelim = L',';
@@ -1342,7 +1343,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         }
         catch (...)
         {
-            // If something goes wrong, even if due to a single bad padding value, we'll reset the index & return default 0 padding
+            // If something goes wrong, even if due to a single bad padding value, we'll clear the vector & return default 0 padding
             paddingArr.clear();
             LOG_CAUGHT_EXCEPTION();
         }
@@ -1368,7 +1369,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         {
             case 1: return ThicknessHelper::FromUniformLength(thicknessArr[0]);
             case 2: return ThicknessHelper::FromLengths(thicknessArr[0], thicknessArr[1], thicknessArr[0], thicknessArr[1]);
-            // No case for paddingPropIndex = 3, since it's not a norm to provide just Left, Top & Right padding values leaving out Bottom
+            // No case for 3 padding values, since it's not a norm to provide just Left, Top & Right padding values leaving out Bottom
             case 4: return ThicknessHelper::FromLengths(thicknessArr[0], thicknessArr[1], thicknessArr[2], thicknessArr[3]);
             default: return Thickness();
         }

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -123,7 +123,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _MouseTransparencyHandler(const double delta);
 
         void _ScrollbarUpdater(Windows::UI::Xaml::Controls::Primitives::ScrollBar scrollbar, const int viewTop, const int viewHeight, const int bufferSize);
-        Windows::UI::Xaml::Thickness _ParseThicknessFromPadding(const hstring padding);
+        static std::array<double, 4> _ParsePadding(const hstring padding, uint8_t& paddingPropIndex);
+        static Windows::UI::Xaml::Thickness _ParseThicknessFromPadding(const hstring padding);
 
         Settings::KeyModifiers _GetPressedModifierKeys() const;
 

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -123,7 +123,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _MouseTransparencyHandler(const double delta);
 
         void _ScrollbarUpdater(Windows::UI::Xaml::Controls::Primitives::ScrollBar scrollbar, const int viewTop, const int viewHeight, const int bufferSize);
-        static std::array<double, 4> _ParsePadding(const hstring padding, uint8_t& paddingPropIndex);
+        static std::vector<double> _ParsePadding(const hstring padding);
         static Windows::UI::Xaml::Thickness _ParseThicknessFromPadding(const hstring padding);
 
         Settings::KeyModifiers _GetPressedModifierKeys() const;

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -123,7 +123,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _MouseTransparencyHandler(const double delta);
 
         void _ScrollbarUpdater(Windows::UI::Xaml::Controls::Primitives::ScrollBar scrollbar, const int viewTop, const int viewHeight, const int bufferSize);
-        static std::vector<double> _ParsePadding(const hstring padding);
         static Windows::UI::Xaml::Thickness _ParseThicknessFromPadding(const hstring padding);
 
         Settings::KeyModifiers _GetPressedModifierKeys() const;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Accounting padding when calculating the initial window size

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1143
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Set `"padding": "100"` and observe the window becomes larger
Set `"padding": "100, 200"` and observe the window becomes larger
Set `"padding": "50, 100, 150, 200"` and observe the window becomes larger