### PR TITLE
Add the keybinding for panes back

### DIFF
--- a/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
@@ -47,6 +47,8 @@ static constexpr std::string_view SwitchToTab6Key{ "switchToTab6" };
 static constexpr std::string_view SwitchToTab7Key{ "switchToTab7" };
 static constexpr std::string_view SwitchToTab8Key{ "switchToTab8" };
 static constexpr std::string_view OpenSettingsKey{ "openSettings" };
+static constexpr std::string_view SplitHorizontalKey{ "splitHorizontal" };
+static constexpr std::string_view SplitVerticalKey{ "splitVertical" };
 
 // Specifically use a map here over an unordered_map. We want to be able to
 // iterate over these entries in-order when we're serializing the keybindings.
@@ -89,6 +91,8 @@ static const std::map<std::string_view, ShortcutAction, std::less<>> commandName
     { SwitchToTab6Key, ShortcutAction::SwitchToTab6 },
     { SwitchToTab7Key, ShortcutAction::SwitchToTab7 },
     { SwitchToTab8Key, ShortcutAction::SwitchToTab8 },
+    { SplitHorizontalKey, ShortcutAction::SplitHorizontal },
+    { SplitVerticalKey, ShortcutAction::SplitVertical },
 };
 
 // Function Description:


### PR DESCRIPTION
Related to #825, #1000.

The actual keybinding serialization for splitting new panes got lost in a bad merge. This adds it back.


