### PR TITLE
Support any number of leading zeros in VT parameter values

### DIFF
--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -450,11 +450,15 @@ void StateMachine::_ActionParam(const wchar_t wch)
                 // multiply existing values by 10 to make space in the 1s digit
                 *_pusActiveParam *= 10;
 
-                // mark that we've now stored another digit.
-                _iParamAccumulatePos++;
-
                 // store the digit in the 1s place.
                 *_pusActiveParam += usDigit;
+
+                // if the total is zero, it must be a leading zero digit, so we don't count it.
+                if (*_pusActiveParam != 0)
+                {
+                    // otherwise mark that we've now stored another digit.
+                    _iParamAccumulatePos++;
+                }
 
                 if (*_pusActiveParam > SHORT_MAX)
                 {
@@ -530,11 +534,15 @@ void StateMachine::_ActionOscParam(const wchar_t wch)
         // multiply existing values by 10 to make space in the 1s digit
         _sOscParam *= 10;
 
-        // mark that we've now stored another digit.
-        _iParamAccumulatePos++;
-
         // store the digit in the 1s place.
         _sOscParam += usDigit;
+
+        // if the total is zero, it must be a leading zero digit, so we don't count it.
+        if (_sOscParam != 0)
+        {
+            // otherwise mark that we've now stored another digit.
+            _iParamAccumulatePos++;
+        }
 
         if (_sOscParam > SHORT_MAX)
         {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Adds support for any number of leading zeros in the parameter values of VT escape sequences. Tested manually, with [Vttest](https://invisible-island.net/vttest/), and with unit tests.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #358
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #358

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

In the `StateMachine::_ActionParam` and `StateMachine::_ActionOscParam` methods, the parser would treat any parameter number with more than 5 digits as being the maximum value. This PR add checks which prevent leading zeros from contributing to that count, so the 5 digit limit now only applies to _significant_ digits.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

* I've tested in the WSL bash shell with escape sequences containing many leading zeros, e.g.: 
  `printf "\033[0000000032mGREEN?\033[m\n"`.
* I've confirmed that the leading zeros test in [Vttest](https://invisible-island.net/vttest/) now works (the last screen in the _Test of cursor movements_).
* I've added a couple of unit tests in `Microsoft::Console::VirtualTerminal::OutputEngineTest` for both the CSI and OSC sequences.