### PR TITLE
add support for the -Prerelease VS locations

### DIFF
--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -51,7 +51,9 @@ function Import-LocalModule
 function Set-MsbuildDevEnvironment
 {
     [CmdletBinding()]
-    param()
+    param(
+        [switch]$Prerelease
+    )
 
     $ErrorActionPreference = 'Stop'
 
@@ -59,7 +61,7 @@ function Set-MsbuildDevEnvironment
 
     Write-Verbose 'Searching for VC++ instances'
     $vsinfo = `
-        Get-VSSetupInstance  -All `
+        Get-VSSetupInstance  -All -Prerelease:$Prerelease `
         | Select-VSSetupInstance `
             -Latest -Product * `
             -Require 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64'


### PR DESCRIPTION
take advantage of the switch parameter on the Cmdlet Get-VSSetupInstance from the vssetup module.

Get-VSSetupInstance  -All -Prerelease
