### PR TITLE
Minor fixes

### DIFF
--- a/src/cascadia/TerminalConnection/ConhostConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConhostConnection.cpp
@@ -144,17 +144,17 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             return;
         }
         _closing = true;
+        _connected = false;
 
-        // TODO:
-        //      terminate the output thread
-        //      Close our handles
-        //      Close the Pseudoconsole
-        //      terminate our processes
+        // Terminate the output thread
+        _outputThreadId = 0;
+        TerminateThread(_hOutputThread, 0);
+
+        // Close our pipes and the pseudoconsole
         CloseHandle(_signalPipe);
         CloseHandle(_inPipe);
         CloseHandle(_outPipe);
 
-        TerminateThread(_hOutputThread, 0);
         TerminateProcess(_piConhost.hProcess, 0);
         CloseHandle(_piConhost.hProcess);
     }

--- a/src/cascadia/TerminalConnection/ConhostConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConhostConnection.cpp
@@ -144,6 +144,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             return;
         }
         _closing = true;
+
         // TODO:
         //      terminate the output thread
         //      Close our handles
@@ -152,8 +153,8 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         CloseHandle(_signalPipe);
         CloseHandle(_inPipe);
         CloseHandle(_outPipe);
-        // What? CreateThread is in app partition but TerminateThread isn't?
-        //TerminateThread(_hOutputThread, 0);
+
+        TerminateThread(_hOutputThread, 0);
         TerminateProcess(_piConhost.hProcess, 0);
         CloseHandle(_piConhost.hProcess);
     }

--- a/src/tools/vtpipeterm/VtConsole.cpp
+++ b/src/tools/vtpipeterm/VtConsole.cpp
@@ -345,8 +345,12 @@ DWORD VtConsole::_OutputThread()
         bool fSuccess = false;
 
         fSuccess = !!ReadFile(this->outPipe(), buffer, ARRAYSIZE(buffer), &dwRead, nullptr);
+        if (!fSuccess)
+        {
+            HRESULT hr = GetLastError();
+            exit(hr);
+        }
 
-        THROW_LAST_ERROR_IF(!fSuccess);
         if (this->_active)
         {
             _pfnReadCallback(buffer, dwRead);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

I try to fix what looked as a "FIXME" to me (under question), and a crash when using the test-app VtPipeTerm.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed **_(performed manually only)_**
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
I would like to have feedback on this commit:
```
Cascadia/TerminalConnection: Close the output thread on exit.
It seems that TerminateThread() is available in the code...
```
The following one concerns VtPipeTerm:
```
VtPipeTerm: Don't crash when closing the app.
- Gracefully handle ReadFile returning false (usually because of ERROR_BROKEN_PIPE on exit).
- Minor whitespace formatting.
```

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual tests only, by starting, interacting with, and closing the programs.