### PR TITLE
Captured pointer for SwapChainPanel and ScrollBar separately

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -674,7 +674,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // - sender: not used
     // - args: event data
     void TermControl::_PointerPressedHandler(Windows::Foundation::IInspectable const& sender,
-                                         Input::PointerRoutedEventArgs const& args)
+                                             Input::PointerRoutedEventArgs const& args)
     {
         _CapturePointer(sender, args);
 
@@ -745,7 +745,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // - sender: not used
     // - args: event data
     void TermControl::_PointerMovedHandler(Windows::Foundation::IInspectable const& /*sender*/,
-                                         Input::PointerRoutedEventArgs const& args)
+                                           Input::PointerRoutedEventArgs const& args)
     {
         const auto ptr = args.Pointer();
         const auto point = args.GetCurrentPoint(_root);

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -477,6 +477,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         _scrollBar.Value(0);
         _scrollBar.ViewportSize(bufferHeight);
         _scrollBar.ValueChanged({ this, &TermControl::_ScrollbarChangeHandler });
+        _scrollBar.PointerPressed({ this, &TermControl::_CapturePointer });
+        _scrollBar.PointerReleased({ this, &TermControl::_ReleasePointer });
 
         // Apply settings for scrollbar
         if (_settings.ScrollState() == ScrollbarState::Visible)
@@ -499,9 +501,9 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         }
 
         _root.PointerWheelChanged({ this, &TermControl::_MouseWheelHandler });
-        _root.PointerPressed({ this, &TermControl::_MouseClickHandler });
-        _root.PointerMoved({ this, &TermControl::_MouseMovedHandler });
-        _root.PointerReleased({ this, &TermControl::_PointerReleasedHandler });
+        _swapChainPanel.PointerPressed({ this, &TermControl::_PointerPressedHandler });
+        _swapChainPanel.PointerMoved({ this, &TermControl::_PointerMovedHandler });
+        _swapChainPanel.PointerReleased({ this, &TermControl::_PointerReleasedHandler });
 
         localPointerToThread->EnablePainting();
 
@@ -671,9 +673,11 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // Arguments:
     // - sender: not used
     // - args: event data
-    void TermControl::_MouseClickHandler(Windows::Foundation::IInspectable const& /*sender*/,
+    void TermControl::_PointerPressedHandler(Windows::Foundation::IInspectable const& sender,
                                          Input::PointerRoutedEventArgs const& args)
     {
+        _CapturePointer(sender, args);
+
         const auto ptr = args.Pointer();
         const auto point = args.GetCurrentPoint(_root);
 
@@ -740,7 +744,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // Arguments:
     // - sender: not used
     // - args: event data
-    void TermControl::_MouseMovedHandler(Windows::Foundation::IInspectable const& /*sender*/,
+    void TermControl::_PointerMovedHandler(Windows::Foundation::IInspectable const& /*sender*/,
                                          Input::PointerRoutedEventArgs const& args)
     {
         const auto ptr = args.Pointer();
@@ -801,9 +805,11 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // - args: event data
     // Return Value:
     // - <none>
-    void TermControl::_PointerReleasedHandler(Windows::Foundation::IInspectable const& /*sender*/,
+    void TermControl::_PointerReleasedHandler(Windows::Foundation::IInspectable const& sender,
                                               Input::PointerRoutedEventArgs const& args)
     {
+        _ReleasePointer(sender, args);
+
         const auto ptr = args.Pointer();
 
         if (ptr.PointerDeviceType() == Windows::Devices::Input::PointerDeviceType::Touch)
@@ -947,6 +953,30 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             //      itself - it was initiated by the mouse wheel, or the scrollbar.
             this->ScrollViewport(static_cast<int>(newValue));
         }
+    }
+
+    // Method Description:
+    // - captures the pointer so that none of the other XAML elements respond to pointer events
+    // Arguments:
+    // - sender: XAML element that is interacting with pointer
+    // - args: pointer data (i.e.: mouse, touch)
+    void TermControl::_CapturePointer(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& args)
+    {
+        IUIElement uielem;
+        sender.as(uielem);
+        uielem.CapturePointer(args.Pointer());
+    }
+
+    // Method Description:
+    // - releases the captured pointer because we're done responding to XAML pointer events
+    // Arguments:
+    // - sender: XAML element that is interacting with pointer
+    // - args: pointer data (i.e.: mouse, touch)
+    void TermControl::_ReleasePointer(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& args)
+    {
+        IUIElement uielem;
+        sender.as(uielem);
+        uielem.ReleasePointerCapture(args.Pointer());
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -478,7 +478,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         _scrollBar.ViewportSize(bufferHeight);
         _scrollBar.ValueChanged({ this, &TermControl::_ScrollbarChangeHandler });
         _scrollBar.PointerPressed({ this, &TermControl::_CapturePointer });
-        _scrollBar.PointerReleased({ this, &TermControl::_ReleasePointer });
+        _scrollBar.PointerReleased({ this, &TermControl::_ReleasePointerCapture });
 
         // Apply settings for scrollbar
         if (_settings.ScrollState() == ScrollbarState::Visible)

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -119,8 +119,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _PointerReleasedHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
         void _MouseWheelHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
         void _ScrollbarChangeHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Controls::Primitives::RangeBaseValueChangedEventArgs const& e);
-        void _CapturePointer(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
-        void _ReleasePointer(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
         void _GotFocusHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
         void _LostFocusHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
 
@@ -135,6 +133,9 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _MouseScrollHandler(const double delta);
         void _MouseZoomHandler(const double delta);
         void _MouseTransparencyHandler(const double delta);
+
+        bool _CapturePointer(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
+        bool _ReleasePointerCapture(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
 
         void _ScrollbarUpdater(Windows::UI::Xaml::Controls::Primitives::ScrollBar scrollbar, const int viewTop, const int viewHeight, const int bufferSize);
         static Windows::UI::Xaml::Thickness _ParseThicknessFromPadding(const hstring padding);

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -114,11 +114,13 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _UpdateFont();
         void _KeyDownHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e);
         void _CharacterHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::CharacterReceivedRoutedEventArgs const& e);
-        void _MouseClickHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
-        void _MouseMovedHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
+        void _PointerPressedHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
+        void _PointerMovedHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
         void _PointerReleasedHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
         void _MouseWheelHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
         void _ScrollbarChangeHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Controls::Primitives::RangeBaseValueChangedEventArgs const& e);
+        void _CapturePointer(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
+        void _ReleasePointer(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
         void _GotFocusHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
         void _LostFocusHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- capturing the SwapChainPanel and ScrollBar separately:
  - it used to be that the root would take pointer events. So both the scroll bar AND the terminal would respond to a mouse drag on the scroll bar. Yuck!
- Renamed MouseClickHandler and MouseMovedHandler to more generic names (since they handle touch events too).

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
So, this fixes #950, but also doesn't. The reason #950 crashes is because the copy is waaaaaay too big. This will make it so that you can't make the selection that unreasonably big anymore. That said, there's still other ways to make massive copy selections so I think there's two relevant issues here:
- #1246 Copy large selection --> crash
- #1247 While selecting, dragging mouse over top/bottom border scrolls.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #950
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [x] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. 