### PR TITLE
Bugfix: crash on copying resized selection

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -514,20 +514,18 @@ std::vector<SMALL_RECT> Terminal::_GetSelectionRects() const
         return selectionArea;
     }
 
+    // create these new anchors for comparison and rendering
+    COORD selectionAnchorWithOffset;
+    COORD endSelectionPositionWithOffset;
+
     // Add anchor offset here to update properly on new buffer output
-    SHORT y1;
-    SHORT y2;
-    THROW_IF_FAILED(ShortAdd(_selectionAnchor.Y, _selectionAnchor_YOffset, &y1));
-    THROW_IF_FAILED(ShortAdd(_endSelectionPosition.Y, _endSelectionPosition_YOffset, &y2));
+    THROW_IF_FAILED(ShortAdd(_selectionAnchor.Y, _selectionAnchor_YOffset, &selectionAnchorWithOffset.Y));
+    THROW_IF_FAILED(ShortAdd(_endSelectionPosition.Y, _endSelectionPosition_YOffset, &endSelectionPositionWithOffset.Y));
 
     // clamp X values to be within buffer bounds
     const auto bufferWidth = _buffer->GetSize().RightInclusive();
-    SHORT x1 = std::clamp(_selectionAnchor.X, static_cast<SHORT>(0), bufferWidth);
-    SHORT x2 = std::clamp(_endSelectionPosition.X, static_cast<SHORT>(0), bufferWidth);
-
-    // create these new anchors for comparison and rendering
-    const COORD selectionAnchorWithOffset = { x1, y1 };
-    const COORD endSelectionPositionWithOffset = { x2, y2 };
+    selectionAnchorWithOffset.X = std::clamp(_selectionAnchor.X, static_cast<SHORT>(0), bufferWidth);
+    endSelectionPositionWithOffset.X = std::clamp(_endSelectionPosition.X, static_cast<SHORT>(0), bufferWidth);
 
     // NOTE: (0,0) is top-left so vertical comparison is inverted
     const COORD& higherCoord = (selectionAnchorWithOffset.Y <= endSelectionPositionWithOffset.Y) ?


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The selection anchors would become outside of the new size. They didn't matter for rendering the selection, but they would crash on the copy because we would actually try to read the buffer in a non-existent space.

Solution: clamp the anchors at RENDER TIME
That way, if we have the window resize again AND the anchors are valid, draw them appropriately.
I think this is better than just clearing a selection after a resize event, BUT if you disagree, I guess we can add that in pretty easily.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
#1165 specifically mentions resizing so I'll close that one. Just be aware that there is a chance #1246  could be what's happening too.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1165 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [x] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- clamp when you're extracting data from buffer
- also moved the `_buffer->GetSize().RightInclusive()` out of the for loop so I guess it's more performant? 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Maximize window
2. Create a scroll region (just do "dir" or "ls" a bunch)
3. Scroll to somewhere in the middle
4. Select top-left corner, then right-most side 3 lines down (so select 3 full lines)
5. Unmaximize window
6. Right-click to copy

Used to crash, now you should get all three lines in your clipboard.

NOTE: if you copy the same selection in a maximized state vs unmaximized state, it will be slightly different BECAUSE the right side of the buffer is now cropped.
