### PR TITLE
Show name on startmenu tile

### DIFF
--- a/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
@@ -41,7 +41,8 @@
         <uap:DefaultTile
           Wide310x150Logo="Images\Wide310x150Logo.png" 
           Square71x71Logo="Images\SmallTile.png"
-          Square310x310Logo="Images\LargeTile.png">
+          Square310x310Logo="Images\LargeTile.png"
+          ShortName="Terminal (Dev)">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo"/>
             <uap:ShowOn Tile="wide310x150Logo"/>

--- a/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
@@ -42,7 +42,7 @@
           Wide310x150Logo="Images\Wide310x150Logo.png" 
           Square71x71Logo="Images\SmallTile.png"
           Square310x310Logo="Images\LargeTile.png"
-          ShortName="Terminal (Dev)">
+          ShortName="ms-resource:AppShortNameDev">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo"/>
             <uap:ShowOn Tile="wide310x150Logo"/>

--- a/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
@@ -41,7 +41,13 @@
         <uap:DefaultTile
           Wide310x150Logo="Images\Wide310x150Logo.png" 
           Square71x71Logo="Images\SmallTile.png"
-          Square310x310Logo="Images\LargeTile.png"/>
+          Square310x310Logo="Images\LargeTile.png">
+          <uap:ShowNameOnTiles>
+            <uap:ShowOn Tile="square150x150Logo"/>
+            <uap:ShowOn Tile="wide310x150Logo"/>
+            <uap:ShowOn Tile="square310x310Logo"/>
+          </uap:ShowNameOnTiles>
+        </uap:DefaultTile>
         <uap:SplashScreen Image="Images\SplashScreen.png"/>
       </uap:VisualElements>
 

--- a/src/cascadia/CascadiaPackage/Package.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package.appxmanifest
@@ -41,7 +41,8 @@
         <uap:DefaultTile
           Wide310x150Logo="Images\Wide310x150Logo.png" 
           Square71x71Logo="Images\SmallTile.png"
-          Square310x310Logo="Images\LargeTile.png">
+          Square310x310Logo="Images\LargeTile.png"
+          ShortName="Terminal">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo"/>
             <uap:ShowOn Tile="wide310x150Logo"/>

--- a/src/cascadia/CascadiaPackage/Package.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package.appxmanifest
@@ -41,7 +41,13 @@
         <uap:DefaultTile
           Wide310x150Logo="Images\Wide310x150Logo.png" 
           Square71x71Logo="Images\SmallTile.png"
-          Square310x310Logo="Images\LargeTile.png"/>
+          Square310x310Logo="Images\LargeTile.png">
+          <uap:ShowNameOnTiles>
+            <uap:ShowOn Tile="square150x150Logo"/>
+            <uap:ShowOn Tile="wide310x150Logo"/>
+            <uap:ShowOn Tile="square310x310Logo"/>
+          </uap:ShowNameOnTiles>
+        </uap:DefaultTile>
         <uap:SplashScreen Image="Images\SplashScreen.png"/>
       </uap:VisualElements>
 

--- a/src/cascadia/CascadiaPackage/Package.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package.appxmanifest
@@ -42,7 +42,7 @@
           Wide310x150Logo="Images\Wide310x150Logo.png" 
           Square71x71Logo="Images\SmallTile.png"
           Square310x310Logo="Images\LargeTile.png"
-          ShortName="Terminal">
+          ShortName="ms-resource:AppShortName">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo"/>
             <uap:ShowOn Tile="wide310x150Logo"/>

--- a/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
@@ -154,6 +154,6 @@
     <value>Terminal</value>
   </data>
   <data name="AppShortNameDev" xml:space="preserve">
-    <value>Terminal Dev</value>
+    <value>Terminal (Dev)</value>
   </data>
 </root>

--- a/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
@@ -150,4 +150,10 @@
   <data name="VersionLabelText" xml:space="preserve">
     <value>Version:</value>
   </data>
+  <data name="AppShortName" xml:space="preserve">
+    <value>Terminal</value>
+  </data>
+  <data name="AppShortNameDev" xml:space="preserve">
+    <value>Terminal Dev</value>
+  </data>
 </root>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1244
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Note that the word "Windows Terminal" is way too long for a medium size tile, and thus will be truncated by Windows. I choose "Terminal" as the short name for tiles, but I can revert that if you prefer to leave the app name as it is.

Example of a truncated tile:
![](https://i.imgur.com/0rJhuWw.png)

Current implementation 
![](https://i.imgur.com/wliLUnk.png)
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
