### PR TITLE
Don't always send an uppercase letter for Alt+key

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -230,9 +230,9 @@ bool Terminal::SendKeyEvent(const WORD vkey,
         // MapVirtualKey will give us the capitalized version of the char.
         // However, if shift isn't pressed, we want to send the lowercase version.
         // (See GH#637)
-        if (!shiftPressed && (ch >= L'A' && ch <= L'Z'))
+        if (!shiftPressed)
         {
-            ch += 0x20;
+            ch = towlower(ch);
         }
     }
 

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -223,7 +223,18 @@ bool Terminal::SendKeyEvent(const WORD vkey,
     // KeyEvent.
     // DON'T manually handle Alt+Space - the system will use this to bring up
     // the system menu for restore, min/maximimize, size, move, close
-    wchar_t ch = altPressed && vkey != VK_SPACE ? static_cast<wchar_t>(LOWORD(MapVirtualKey(vkey, MAPVK_VK_TO_CHAR))) : UNICODE_NULL;
+    wchar_t ch = UNICODE_NULL;
+    if (altPressed && vkey != VK_SPACE)
+    {
+        ch = static_cast<wchar_t>(LOWORD(MapVirtualKey(vkey, MAPVK_VK_TO_CHAR)));
+        // MapVirtualKey will give us the capitalized version of the char.
+        // However, if shift isn't pressed, we want to send the lowercase version.
+        // (See GH#637)
+        if (!shiftPressed && (ch >= L'A' && ch <= L'Z'))
+        {
+            ch += 0x20;
+        }
+    }
 
     // Manually handle Ctrl+H. Ctrl+H should be handled as Backspace. To do this
     // correctly, the keyEvents's char needs to be set to Backspace.

--- a/src/cascadia/UnitTests_TerminalCore/InputTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/InputTest.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "precomp.h"
+#include <WexTestClass.h>
+
+#include "../cascadia/TerminalCore/Terminal.hpp"
+#include "../renderer/inc/DummyRenderTarget.hpp"
+#include "consoletaeftemplates.hpp"
+
+using namespace WEX::Logging;
+using namespace WEX::TestExecution;
+
+using namespace Microsoft::Terminal::Core;
+using namespace Microsoft::Console::Render;
+
+namespace TerminalCoreUnitTests
+{
+    class InputTest
+    {
+        TEST_CLASS(InputTest);
+        TEST_CLASS_SETUP(ClassSetup)
+        {
+            DummyRenderTarget emptyRT;
+            term.Create({ 100, 100 }, 0, emptyRT);
+            auto inputFn = std::bind(&InputTest::_VerifyExpectedInput, this, std::placeholders::_1);
+            term.SetWriteInputCallback(inputFn);
+            return true;
+        };
+
+        TEST_METHOD(AltShiftKey);
+        TEST_METHOD(AltSpace);
+
+        void _VerifyExpectedInput(std::wstring& actualInput)
+        {
+            VERIFY_ARE_EQUAL(expectedinput.size(), actualInput.size());
+            VERIFY_ARE_EQUAL(expectedinput, actualInput);
+        };
+
+        Terminal term{};
+        std::wstring expectedinput{};
+    };
+
+    void InputTest::AltShiftKey()
+    {
+        // Tests GH:637
+
+        // Verify that Alt+a generates a lowercase a on the input
+        expectedinput = L"\x1b""a";
+        VERIFY_IS_TRUE(term.SendKeyEvent(L'A', false, true, false));
+
+        // Verify that Alt+shift+a generates a uppercase a on the input
+        expectedinput = L"\x1b""A";
+        VERIFY_IS_TRUE(term.SendKeyEvent(L'A', false, true, true));
+    }
+
+    void InputTest::AltSpace()
+    {
+        // Make sure we don't handle Alt+Space. The system will use this to
+        // bring up the system menu for restore, min/maximimize, size, move,
+        // close
+        VERIFY_IS_FALSE(term.SendKeyEvent(L' ', false, true, false));
+    }
+}

--- a/src/cascadia/UnitTests_TerminalCore/InputTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/InputTest.cpp
@@ -46,11 +46,13 @@ namespace TerminalCoreUnitTests
         // Tests GH:637
 
         // Verify that Alt+a generates a lowercase a on the input
-        expectedinput = L"\x1b""a";
+        expectedinput = L"\x1b"
+                        "a";
         VERIFY_IS_TRUE(term.SendKeyEvent(L'A', false, true, false));
 
         // Verify that Alt+shift+a generates a uppercase a on the input
-        expectedinput = L"\x1b""A";
+        expectedinput = L"\x1b"
+                        "A";
         VERIFY_IS_TRUE(term.SendKeyEvent(L'A', false, true, true));
     }
 

--- a/src/cascadia/UnitTests_TerminalCore/UnitTests.vcxproj
+++ b/src/cascadia/UnitTests_TerminalCore/UnitTests.vcxproj
@@ -5,6 +5,7 @@
   <ItemGroup>
     <ClCompile Include="ScreenSizeLimitsTest.cpp" />
     <ClCompile Include="SelectionTest.cpp" />
+    <ClCompile Include="InputTest.cpp" />
     <ClCompile Include="precomp.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

MapVirtualKey will give us the capitalized version of the char.
However, if shift isn't pressed, we want to send the lowercase version.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #637 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
I added a test for this case.
