### PR TITLE
fallback to software rendering

### DIFF
--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -152,18 +152,21 @@ DxEngine::~DxEngine()
         D3D_FEATURE_LEVEL_9_1,
     };
 
-    auto hardware_result = D3D11CreateDevice(NULL,
-                                             D3D_DRIVER_TYPE_HARDWARE,
-                                             NULL,
-                                             DeviceFlags,
-                                             FeatureLevels,
-                                             ARRAYSIZE(FeatureLevels),
-                                             D3D11_SDK_VERSION,
-                                             &_d3dDevice,
-                                             NULL,
-                                             &_d3dDeviceContext);
+    // Trying hardware first for maximum performance, then trying WARP (software) renderer second
+    // in case we're running inside a downlevel VM where hardware passthrough isn't enabled like
+    // for Windows 7 in a VM.
+    const auto hardwareResult = D3D11CreateDevice(NULL,
+                                                  D3D_DRIVER_TYPE_HARDWARE,
+                                                  NULL,
+                                                  DeviceFlags,
+                                                  FeatureLevels,
+                                                  ARRAYSIZE(FeatureLevels),
+                                                  D3D11_SDK_VERSION,
+                                                  &_d3dDevice,
+                                                  NULL,
+                                                  &_d3dDeviceContext);
 
-    if (FAILED(hardware_result))
+    if (FAILED(hardwareResult))
     {
         RETURN_IF_FAILED(D3D11CreateDevice(NULL,
                                            D3D_DRIVER_TYPE_WARP,

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -154,9 +154,7 @@ namespace Microsoft::Console::Render
         bool _haveDeviceResources;
         ::Microsoft::WRL::ComPtr<ID3D11Device> _d3dDevice;
         ::Microsoft::WRL::ComPtr<ID3D11DeviceContext> _d3dDeviceContext;
-        ::Microsoft::WRL::ComPtr<IDXGIAdapter1> _dxgiAdapter1;
         ::Microsoft::WRL::ComPtr<IDXGIFactory2> _dxgiFactory2;
-        ::Microsoft::WRL::ComPtr<IDXGIOutput> _dxgiOutput;
         ::Microsoft::WRL::ComPtr<IDXGISurface> _dxgiSurface;
         ::Microsoft::WRL::ComPtr<ID2D1RenderTarget> _d2dRenderTarget;
         ::Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> _d2dBrushForeground;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR enables a software rendering fallback for the DX renderer in the case that hardware acceleration fails. This is primarily useful for Hyper-V environments where hardware acceleration is not guaranteed to exist.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
This will be useful for future work to enable the DX renderer to run on windows 7 since win7 virtual machines do not/cannot have hardware acceleration unlike windows 10 machines
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA

* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The PR does two things:

- Fallback to `D3D_DRIVER_TYPE_WARP` if `D3D_DRIVER_TYPE_HARDWARE` fails.
- pass `NULL` as the adapter instead of creating the default adapter ourselves.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
I ran this as part of a larger codechange to enable win7 support. The software fallback worked correctly on win7.