### PR TITLE
Multi-Click Selection: Double-Click Settings

### DIFF
--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -77,7 +77,7 @@ Profile::Profile(const winrt::guid& guid) :
     _cursorColor{ DEFAULT_CURSOR_COLOR },
     _cursorShape{ CursorStyle::Bar },
     _cursorHeight{ DEFAULT_CURSOR_HEIGHT },
-    _doubleClickDelimiters{ L" /\\" },
+    _doubleClickDelimiters{ L" ./\\()\"'-:,.;<>~!@#$%^&*|+=[]{}~?" },
 
     _commandline{ L"cmd.exe" },
     _startingDirectory{},

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -77,7 +77,7 @@ Profile::Profile(const winrt::guid& guid) :
     _cursorColor{ DEFAULT_CURSOR_COLOR },
     _cursorShape{ CursorStyle::Bar },
     _cursorHeight{ DEFAULT_CURSOR_HEIGHT },
-    _doubleClickDelimiters{ L" ./\\()\"'-:,.;<>~!@#$%^&*|+=[]{}~?" },
+    _doubleClickDelimiters{ DEFAULT_DOUBLE_CLICK_DELIMITERS },
 
     _commandline{ L"cmd.exe" },
     _startingDirectory{},

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -26,6 +26,7 @@ static constexpr std::string_view SnapOnInputKey{ "snapOnInput" };
 static constexpr std::string_view CursorColorKey{ "cursorColor" };
 static constexpr std::string_view CursorShapeKey{ "cursorShape" };
 static constexpr std::string_view CursorHeightKey{ "cursorHeight" };
+static constexpr std::string_view DoubleClickDelimitersKey{ "doubleClickDelimiters" };
 
 static constexpr std::string_view CommandlineKey{ "commandline" };
 static constexpr std::string_view FontFaceKey{ "fontFace" };
@@ -76,6 +77,7 @@ Profile::Profile(const winrt::guid& guid) :
     _cursorColor{ DEFAULT_CURSOR_COLOR },
     _cursorShape{ CursorStyle::Bar },
     _cursorHeight{ DEFAULT_CURSOR_HEIGHT },
+    _doubleClickDelimiters{ L" /\\" },
 
     _commandline{ L"cmd.exe" },
     _startingDirectory{},
@@ -200,6 +202,11 @@ TerminalSettings Profile::CreateTerminalSettings(const std::vector<ColorScheme>&
         terminalSettings.BackgroundImageStretchMode(_backgroundImageStretchMode.value());
     }
 
+    if (!_doubleClickDelimiters.empty())
+    {
+        terminalSettings.DoubleClickDelimiters(winrt::to_hstring(_doubleClickDelimiters.c_str()));
+    }
+
     return terminalSettings;
 }
 
@@ -249,6 +256,7 @@ Json::Value Profile::ToJson() const
         root[JsonKey(CursorHeightKey)] = _cursorHeight;
     }
     root[JsonKey(CursorShapeKey)] = winrt::to_string(_SerializeCursorStyle(_cursorShape));
+    root[JsonKey(DoubleClickDelimitersKey)] = winrt::to_string(_doubleClickDelimiters);
 
     ///// Control Settings /////
     root[JsonKey(CommandlineKey)] = winrt::to_string(_commandline);
@@ -369,6 +377,10 @@ Profile Profile::FromJson(const Json::Value& json)
     {
         result._cursorShape = _ParseCursorShape(GetWstringFromJson(cursorShape));
     }
+    if (auto doubleClickDelimiters{ json[JsonKey(DoubleClickDelimitersKey)] })
+    {
+        result._doubleClickDelimiters = GetWstringFromJson(doubleClickDelimiters);
+    }
 
     // Control Settings
     if (auto commandline{ json[JsonKey(CommandlineKey)] })
@@ -470,6 +482,11 @@ void Profile::SetDefaultForeground(COLORREF defaultForeground) noexcept
 void Profile::SetDefaultBackground(COLORREF defaultBackground) noexcept
 {
     _defaultBackground = defaultBackground;
+}
+
+void Profile::SetDoubleClickDelimiters(std::wstring delimiters) noexcept
+{
+    _doubleClickDelimiters = delimiters;
 }
 
 bool Profile::HasIcon() const noexcept

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -46,6 +46,7 @@ public:
     void SetUseAcrylic(bool useAcrylic) noexcept;
     void SetDefaultForeground(COLORREF defaultForeground) noexcept;
     void SetDefaultBackground(COLORREF defaultBackground) noexcept;
+    void SetDoubleClickDelimiters(std::wstring delimiters) noexcept;
 
     bool HasIcon() const noexcept;
     std::wstring_view GetIconPath() const noexcept;
@@ -76,6 +77,7 @@ private:
     uint32_t _cursorColor;
     uint32_t _cursorHeight;
     winrt::Microsoft::Terminal::Settings::CursorStyle _cursorShape;
+    std::wstring _doubleClickDelimiters;
 
     std::wstring _commandline;
     std::wstring _fontFace;

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -133,6 +133,8 @@ void Terminal::UpdateSettings(winrt::Microsoft::Terminal::Settings::ICoreSetting
 
     _snapOnInput = settings.SnapOnInput();
 
+    _doubleClickDelimiters = settings.DoubleClickDelimiters();
+
     // TODO:MSFT:21327402 - if HistorySize has changed, resize the buffer so we
     // have a smaller scrollback. We should do this carefully - if the new buffer
     // size is smaller than where the mutable viewport currently is, we'll want
@@ -597,21 +599,7 @@ void Terminal::_ExpandDoubleClickSelectionRight(const COORD position)
 // - true if cell data contains the delimiter.
 const bool Terminal::_DoubleClickDelimiterCheck(std::wstring_view cellChar) const
 {
-    // TODO GitHub #988: hook up delimiters to Settings
-    const std::wstring_view delimiters[] = {
-        L" ",
-        L"/",
-        L"\\"
-    };
-
-    for (const auto delimiter : delimiters)
-    {
-        if (cellChar == delimiter)
-        {
-            return true;
-        }
-    }
-    return false;
+    return _doubleClickDelimiters.find(cellChar) != std::wstring_view::npos;
 }
 
 // Method Description:

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -151,6 +151,7 @@ private:
     bool _selectionActive;
     SHORT _selectionAnchor_YOffset;
     SHORT _endSelectionPosition_YOffset;
+    std::wstring_view _doubleClickDelimiters;
     void _ExpandDoubleClickSelectionLeft(const COORD position);
     void _ExpandDoubleClickSelectionRight(const COORD position);
     const bool _DoubleClickDelimiterCheck(std::wstring_view cellChar) const;

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -151,7 +151,7 @@ private:
     bool _selectionActive;
     SHORT _selectionAnchor_YOffset;
     SHORT _endSelectionPosition_YOffset;
-    std::wstring_view _doubleClickDelimiters;
+    std::wstring _doubleClickDelimiters;
     void _ExpandDoubleClickSelectionLeft(const COORD position);
     void _ExpandDoubleClickSelectionRight(const COORD position);
     const bool _DoubleClickDelimiterCheck(std::wstring_view cellChar) const;

--- a/src/cascadia/TerminalSettings/ICoreSettings.idl
+++ b/src/cascadia/TerminalSettings/ICoreSettings.idl
@@ -27,6 +27,8 @@ namespace Microsoft.Terminal.Settings
         UInt32 CursorColor;
         CursorStyle CursorShape;
         UInt32 CursorHeight;
+
+        String DoubleClickDelimiters;
     };
 
 }

--- a/src/cascadia/TerminalSettings/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettings/TerminalSettings.cpp
@@ -20,6 +20,7 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         _cursorColor{ DEFAULT_CURSOR_COLOR },
         _cursorShape{ CursorStyle::Vintage },
         _cursorHeight{ DEFAULT_CURSOR_HEIGHT },
+        _doubleClickDelimiters { L" /\\" },
         _useAcrylic{ false },
         _closeOnExit{ true },
         _tintOpacity{ 0.5 },
@@ -133,6 +134,16 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
     void TerminalSettings::CursorHeight(uint32_t value)
     {
         _cursorHeight = value;
+    }
+
+    hstring TerminalSettings::DoubleClickDelimiters()
+    {
+        return _doubleClickDelimiters;
+    }
+
+    void TerminalSettings::DoubleClickDelimiters(hstring const& value)
+    {
+        _doubleClickDelimiters = value;
     }
 
     bool TerminalSettings::UseAcrylic()

--- a/src/cascadia/TerminalSettings/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettings/TerminalSettings.cpp
@@ -20,7 +20,7 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         _cursorColor{ DEFAULT_CURSOR_COLOR },
         _cursorShape{ CursorStyle::Vintage },
         _cursorHeight{ DEFAULT_CURSOR_HEIGHT },
-        _doubleClickDelimiters { L" /\\" },
+        _doubleClickDelimiters{ L" /\\" },
         _useAcrylic{ false },
         _closeOnExit{ true },
         _tintOpacity{ 0.5 },

--- a/src/cascadia/TerminalSettings/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettings/TerminalSettings.cpp
@@ -20,7 +20,7 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         _cursorColor{ DEFAULT_CURSOR_COLOR },
         _cursorShape{ CursorStyle::Vintage },
         _cursorHeight{ DEFAULT_CURSOR_HEIGHT },
-        _doubleClickDelimiters{ L" /\\" },
+        _doubleClickDelimiters{ DEFAULT_DOUBLE_CLICK_DELIMITERS },
         _useAcrylic{ false },
         _closeOnExit{ true },
         _tintOpacity{ 0.5 },

--- a/src/cascadia/TerminalSettings/terminalsettings.h
+++ b/src/cascadia/TerminalSettings/terminalsettings.h
@@ -45,6 +45,8 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         void CursorShape(winrt::Microsoft::Terminal::Settings::CursorStyle const& value) noexcept;
         uint32_t CursorHeight();
         void CursorHeight(uint32_t value);
+        hstring DoubleClickDelimiters();
+        void DoubleClickDelimiters(hstring const& value);
         // ------------------------ End of Core Settings -----------------------
 
         bool UseAcrylic();
@@ -94,6 +96,7 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         uint32_t _cursorColor;
         Settings::CursorStyle _cursorShape;
         uint32_t _cursorHeight;
+        hstring _doubleClickDelimiters;
 
         bool _useAcrylic;
         bool _closeOnExit;

--- a/src/inc/DefaultSettings.h
+++ b/src/inc/DefaultSettings.h
@@ -37,3 +37,5 @@ const std::wstring DEFAULT_STARTING_DIRECTORY{ L"%USERPROFILE%" };
 
 constexpr COLORREF DEFAULT_CURSOR_COLOR = COLOR_WHITE;
 constexpr COLORREF DEFAULT_CURSOR_HEIGHT = 25;
+
+const std::wstring DEFAULT_DOUBLE_CLICK_DELIMITERS{ L" ./\\()\"'-:,.;<>~!@#$%^&*|+=[]{}~?\u2502" };


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Delimiters for double click can now be set in settings. This is on a **per profile** basis (shoutout to all the WSL users out there). 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
The first of a few additions to Multi-Click Selection (#1197).
Contributes to #988 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Doesn't close issue. Please read above.
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- TerminalSettings:
  - add property to winrt TerminalSettings
- Terminal App:
  - read/write JSON for this new property
  - default set to " /\\"
- TerminalCore:
  - import/use delimiters from ICoreSettings

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- modified profiles.json. Then performed double click in an instance of that profile
