### PR TITLE
allow DX rendering engine to run on windows 7

### DIFF
--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -135,6 +135,7 @@ CustomTextLayout::CustomTextLayout(IDWriteFactory1* const factory,
         RETURN_IF_FAILED(_analyzer->AnalyzeNumberSubstitution(this, 0, textLength, this));
 
         // Perform our custom font fallback analyzer that mimics the pattern of the real analyzers.
+        // Fallback routines are not available below Windows 8.1, so just skip them and let a replacement character happen.
         if (IsWindows8Point1OrGreater())
         {
             RETURN_IF_FAILED(_AnalyzeFontFallback(this, 0, textLength));

--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -7,6 +7,7 @@
 
 #include <wrl.h>
 #include <wrl/client.h>
+#include <VersionHelpers.h>
 
 using namespace Microsoft::Console::Render;
 
@@ -19,10 +20,10 @@ using namespace Microsoft::Console::Render;
 // - font - The DirectWrite font face to use while calculating layout (by default, will fallback if necessary)
 // - clusters - From the backing buffer, the text to be displayed clustered by the columns it should consume.
 // - width - The count of pixels available per column (the expected pixel width of every column)
-CustomTextLayout::CustomTextLayout(IDWriteFactory2* const factory,
+CustomTextLayout::CustomTextLayout(IDWriteFactory1* const factory,
                                    IDWriteTextAnalyzer1* const analyzer,
-                                   IDWriteTextFormat2* const format,
-                                   IDWriteFontFace5* const font,
+                                   IDWriteTextFormat* const format,
+                                   IDWriteFontFace1* const font,
                                    std::basic_string_view<Cluster> const clusters,
                                    size_t const width) :
     _factory{ factory },
@@ -134,7 +135,10 @@ CustomTextLayout::CustomTextLayout(IDWriteFactory2* const factory,
         RETURN_IF_FAILED(_analyzer->AnalyzeNumberSubstitution(this, 0, textLength, this));
 
         // Perform our custom font fallback analyzer that mimics the pattern of the real analyzers.
-        RETURN_IF_FAILED(_AnalyzeFontFallback(this, 0, textLength));
+        if (IsWindows8Point1OrGreater())
+        {
+            RETURN_IF_FAILED(_AnalyzeFontFallback(this, 0, textLength));
+        }
 
         // Ensure that a font face is attached to every run
         for (auto& run : _runs)

--- a/src/renderer/dx/CustomTextLayout.h
+++ b/src/renderer/dx/CustomTextLayout.h
@@ -19,10 +19,10 @@ namespace Microsoft::Console::Render
     public:
         // Based on the Windows 7 SDK sample at https://github.com/pauldotknopf/WindowsSDK7-Samples/tree/master/multimedia/DirectWrite/CustomLayout
 
-        CustomTextLayout(IDWriteFactory2* const factory,
+        CustomTextLayout(IDWriteFactory1* const factory,
                          IDWriteTextAnalyzer1* const analyzer,
-                         IDWriteTextFormat2* const format,
-                         IDWriteFontFace5* const font,
+                         IDWriteTextFormat* const format,
+                         IDWriteFontFace1* const font,
                          const std::basic_string_view<::Microsoft::Console::Render::Cluster> clusters,
                          size_t const width);
 
@@ -90,7 +90,7 @@ namespace Microsoft::Console::Render
             UINT8 bidiLevel;
             bool isNumberSubstituted;
             bool isSideways;
-            ::Microsoft::WRL::ComPtr<IDWriteFontFace5> fontFace;
+            ::Microsoft::WRL::ComPtr<IDWriteFontFace1> fontFace;
             FLOAT fontScale;
 
             inline bool ContainsTextPosition(UINT32 desiredTextPosition) const
@@ -135,16 +135,16 @@ namespace Microsoft::Console::Render
         [[nodiscard]] static UINT32 _EstimateGlyphCount(const UINT32 textLength) noexcept;
 
     private:
-        const ::Microsoft::WRL::ComPtr<IDWriteFactory2> _factory;
+        const ::Microsoft::WRL::ComPtr<IDWriteFactory1> _factory;
 
         // DirectWrite analyzer
         const ::Microsoft::WRL::ComPtr<IDWriteTextAnalyzer1> _analyzer;
 
         // DirectWrite text format
-        const ::Microsoft::WRL::ComPtr<IDWriteTextFormat2> _format;
+        const ::Microsoft::WRL::ComPtr<IDWriteTextFormat> _format;
 
         // DirectWrite font face
-        const ::Microsoft::WRL::ComPtr<IDWriteFontFace5> _font;
+        const ::Microsoft::WRL::ComPtr<IDWriteFontFace1> _font;
 
         // The text we're analyzing and processing into a layout
         std::wstring _text;

--- a/src/renderer/dx/CustomTextRenderer.cpp
+++ b/src/renderer/dx/CustomTextRenderer.cpp
@@ -260,6 +260,7 @@ void CustomTextRenderer::_FillRectangle(void* clientDrawingContext,
     // Now go onto drawing the text.
 
     // First check if we want a color font and try to extract color emoji first.
+    // Color emoji are only available on Windows 10+
     if (WI_IsFlagSet(drawingContext->options, D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT) && IsWindows10OrGreater())
     {
         ::Microsoft::WRL::ComPtr<ID2D1DeviceContext4> d2dContext4;

--- a/src/renderer/dx/CustomTextRenderer.cpp
+++ b/src/renderer/dx/CustomTextRenderer.cpp
@@ -264,7 +264,7 @@ void CustomTextRenderer::_FillRectangle(void* clientDrawingContext,
     if (WI_IsFlagSet(drawingContext->options, D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT) && IsWindows10OrGreater())
     {
         ::Microsoft::WRL::ComPtr<ID2D1DeviceContext4> d2dContext4;
-        RETURN_IF_FAILED(drawingContext->renderTarget->QueryInterface(d2dContext4.GetAddressOf()));
+        RETURN_IF_FAILED(d2dContext.As(&d2dContext4));
 
         ::Microsoft::WRL::ComPtr<IDWriteFactory4> dwriteFactory4;
         RETURN_IF_FAILED(drawingContext->dwriteFactory->QueryInterface(dwriteFactory4.GetAddressOf()));

--- a/src/renderer/dx/CustomTextRenderer.cpp
+++ b/src/renderer/dx/CustomTextRenderer.cpp
@@ -238,7 +238,7 @@ void CustomTextRenderer::_FillRectangle(void* clientDrawingContext,
     // Then make a copy for the baseline origin (which is part way down the left side of the text, not the top or bottom).
     // We'll use this baseline Origin for drawing the actual text.
     D2D1_POINT_2F baselineOrigin = origin;
-    baselineOrigin.y += drawingContext->baseline;
+    baselineOrigin.y += drawingContext->spacing.baseline;
 
     ::Microsoft::WRL::ComPtr<ID2D1DeviceContext> d2dContext;
     RETURN_IF_FAILED(drawingContext->renderTarget->QueryInterface(d2dContext.GetAddressOf()));

--- a/src/renderer/dx/CustomTextRenderer.cpp
+++ b/src/renderer/dx/CustomTextRenderer.cpp
@@ -7,6 +7,7 @@
 
 #include <wrl.h>
 #include <wrl/client.h>
+#include <VersionHelpers.h>
 
 using namespace Microsoft::Console::Render;
 
@@ -237,10 +238,10 @@ void CustomTextRenderer::_FillRectangle(void* clientDrawingContext,
     // Then make a copy for the baseline origin (which is part way down the left side of the text, not the top or bottom).
     // We'll use this baseline Origin for drawing the actual text.
     D2D1_POINT_2F baselineOrigin = origin;
-    baselineOrigin.y += drawingContext->spacing.baseline;
+    baselineOrigin.y += drawingContext->baseline;
 
-    ::Microsoft::WRL::ComPtr<ID2D1DeviceContext4> d2dContext4;
-    RETURN_IF_FAILED(drawingContext->renderTarget->QueryInterface(d2dContext4.GetAddressOf()));
+    ::Microsoft::WRL::ComPtr<ID2D1DeviceContext> d2dContext;
+    RETURN_IF_FAILED(drawingContext->renderTarget->QueryInterface(d2dContext.GetAddressOf()));
 
     // Draw the background
     D2D1_RECT_F rect;
@@ -254,13 +255,16 @@ void CustomTextRenderer::_FillRectangle(void* clientDrawingContext,
         rect.right += glyphRun->glyphAdvances[i];
     }
 
-    d2dContext4->FillRectangle(rect, drawingContext->backgroundBrush);
+    d2dContext->FillRectangle(rect, drawingContext->backgroundBrush);
 
     // Now go onto drawing the text.
 
     // First check if we want a color font and try to extract color emoji first.
-    if (WI_IsFlagSet(drawingContext->options, D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT))
+    if (WI_IsFlagSet(drawingContext->options, D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT) && IsWindows10OrGreater())
     {
+        ::Microsoft::WRL::ComPtr<ID2D1DeviceContext4> d2dContext4;
+        RETURN_IF_FAILED(drawingContext->renderTarget->QueryInterface(d2dContext4.GetAddressOf()));
+
         ::Microsoft::WRL::ComPtr<IDWriteFactory4> dwriteFactory4;
         RETURN_IF_FAILED(drawingContext->dwriteFactory->QueryInterface(dwriteFactory4.GetAddressOf()));
 
@@ -409,11 +413,11 @@ void CustomTextRenderer::_FillRectangle(void* clientDrawingContext,
                                                              _In_ const DWRITE_GLYPH_RUN_DESCRIPTION* glyphRunDescription,
                                                              ID2D1Brush* brush)
 {
-    ::Microsoft::WRL::ComPtr<ID2D1DeviceContext4> d2dContext4;
-    RETURN_IF_FAILED(clientDrawingContext->renderTarget->QueryInterface(d2dContext4.GetAddressOf()));
+    ::Microsoft::WRL::ComPtr<ID2D1DeviceContext> d2dContext;
+    RETURN_IF_FAILED(clientDrawingContext->renderTarget->QueryInterface(d2dContext.GetAddressOf()));
 
     // Using the context is the easiest/default way of drawing.
-    d2dContext4->DrawGlyphRun(baselineOrigin, glyphRun, glyphRunDescription, brush, measuringMode);
+    d2dContext->DrawGlyphRun(baselineOrigin, glyphRun, glyphRunDescription, brush, measuringMode);
 
     // However, we could probably add options here and switch out to one of these other drawing methods (making it
     // conditional based on the IUnknown* clientDrawingEffect or on some other switches and try these out instead:

--- a/src/renderer/dx/CustomTextRenderer.h
+++ b/src/renderer/dx/CustomTextRenderer.h
@@ -13,9 +13,7 @@ namespace Microsoft::Console::Render
                        ID2D1Brush* foregroundBrush,
                        ID2D1Brush* backgroundBrush,
                        IDWriteFactory* dwriteFactory,
-                       const DWRITE_LINE_SPACING_METHOD spacingMethod,
-                       const float spacing,
-                       const float baseline,
+                       const DWRITE_LINE_SPACING spacing,
                        const D2D_SIZE_F cellSize,
                        const D2D1_DRAW_TEXT_OPTIONS options = D2D1_DRAW_TEXT_OPTIONS_NONE)
         {
@@ -23,9 +21,7 @@ namespace Microsoft::Console::Render
             this->foregroundBrush = foregroundBrush;
             this->backgroundBrush = backgroundBrush;
             this->dwriteFactory = dwriteFactory;
-            this->spacingMethod = spacingMethod;
             this->spacing = spacing;
-            this->baseline = baseline;
             this->cellSize = cellSize;
             this->options = options;
         }
@@ -34,9 +30,7 @@ namespace Microsoft::Console::Render
         ID2D1Brush* foregroundBrush;
         ID2D1Brush* backgroundBrush;
         IDWriteFactory* dwriteFactory;
-        DWRITE_LINE_SPACING_METHOD spacingMethod;
-        float spacing;
-        float baseline;
+        DWRITE_LINE_SPACING spacing;
         D2D_SIZE_F cellSize;
         D2D1_DRAW_TEXT_OPTIONS options;
     };

--- a/src/renderer/dx/CustomTextRenderer.h
+++ b/src/renderer/dx/CustomTextRenderer.h
@@ -13,7 +13,9 @@ namespace Microsoft::Console::Render
                        ID2D1Brush* foregroundBrush,
                        ID2D1Brush* backgroundBrush,
                        IDWriteFactory* dwriteFactory,
-                       const DWRITE_LINE_SPACING spacing,
+                       const DWRITE_LINE_SPACING_METHOD spacingMethod,
+                       const float spacing,
+                       const float baseline,
                        const D2D_SIZE_F cellSize,
                        const D2D1_DRAW_TEXT_OPTIONS options = D2D1_DRAW_TEXT_OPTIONS_NONE)
         {
@@ -21,7 +23,9 @@ namespace Microsoft::Console::Render
             this->foregroundBrush = foregroundBrush;
             this->backgroundBrush = backgroundBrush;
             this->dwriteFactory = dwriteFactory;
+            this->spacingMethod = spacingMethod;
             this->spacing = spacing;
+            this->baseline = baseline;
             this->cellSize = cellSize;
             this->options = options;
         }
@@ -30,7 +34,9 @@ namespace Microsoft::Console::Render
         ID2D1Brush* foregroundBrush;
         ID2D1Brush* backgroundBrush;
         IDWriteFactory* dwriteFactory;
-        DWRITE_LINE_SPACING spacing;
+        DWRITE_LINE_SPACING_METHOD spacingMethod;
+        float spacing;
+        float baseline;
         D2D_SIZE_F cellSize;
         D2D1_DRAW_TEXT_OPTIONS options;
     };

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -144,9 +144,9 @@ namespace Microsoft::Console::Render
 
         // Device-Independent Resources
         ::Microsoft::WRL::ComPtr<ID2D1Factory> _d2dFactory;
-        ::Microsoft::WRL::ComPtr<IDWriteFactory2> _dwriteFactory;
-        ::Microsoft::WRL::ComPtr<IDWriteTextFormat2> _dwriteTextFormat;
-        ::Microsoft::WRL::ComPtr<IDWriteFontFace5> _dwriteFontFace;
+        ::Microsoft::WRL::ComPtr<IDWriteFactory1> _dwriteFactory;
+        ::Microsoft::WRL::ComPtr<IDWriteTextFormat> _dwriteTextFormat;
+        ::Microsoft::WRL::ComPtr<IDWriteFontFace1> _dwriteFontFace;
         ::Microsoft::WRL::ComPtr<IDWriteTextAnalyzer1> _dwriteTextAnalyzer;
         ::Microsoft::WRL::ComPtr<CustomTextRenderer> _customRenderer;
 
@@ -178,7 +178,7 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT _EnableDisplayAccess(const bool outputEnabled) noexcept;
 
-        [[nodiscard]] ::Microsoft::WRL::ComPtr<IDWriteFontFace5> _FindFontFace(const std::wstring& familyName,
+        [[nodiscard]] ::Microsoft::WRL::ComPtr<IDWriteFontFace1> _FindFontFace(const std::wstring& familyName,
                                                                                DWRITE_FONT_WEIGHT weight,
                                                                                DWRITE_FONT_STRETCH stretch,
                                                                                DWRITE_FONT_STYLE style) const;
@@ -186,9 +186,9 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT _GetProposedFont(const FontInfoDesired& desired,
                                                FontInfo& actual,
                                                const int dpi,
-                                               ::Microsoft::WRL::ComPtr<IDWriteTextFormat2>& textFormat,
+                                               ::Microsoft::WRL::ComPtr<IDWriteTextFormat>& textFormat,
                                                ::Microsoft::WRL::ComPtr<IDWriteTextAnalyzer1>& textAnalyzer,
-                                               ::Microsoft::WRL::ComPtr<IDWriteFontFace5>& fontFace) const noexcept;
+                                               ::Microsoft::WRL::ComPtr<IDWriteFontFace1>& fontFace) const noexcept;
 
         [[nodiscard]] COORD _GetFontSize() const noexcept;
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR allows the DirectX rendering engine to run on windows 7.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Certain DirectX features are unavailable on windows 7. The important ones as they are used in the DX renderer are color font rendering and fallback font support. Color fonts did not exist at all on windows 7 so running basic glyphrun rendering should work just fine.

Fallback font support was not exposed to the user in windows 7, making dealing with them difficult. Rather than try to get some workarounds to properly enable it I have opted to just conditionally disable the support on windows 7.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
I ran these patches both on windows 10 and windows 7 with an in-progress WPF control. The relevant features turned themselves on and off correctly based on the version of the operating system being run on.

### Comparison screenshots

#### Windows 7
![win7](https://user-images.githubusercontent.com/8010244/59541803-d37f3780-8eb7-11e9-907a-c1e2558eaa55.png)

#### Windows 10
![win10](https://user-images.githubusercontent.com/8010244/59541810-df6af980-8eb7-11e9-9e16-6eec13e6abfd.png)
