### PR TITLE
Switch away from Windows.Storage.ApplicationData

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -569,18 +569,14 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     void App::_RegisterSettingsChange()
     {
-        // Make sure this hstring has a stack-local reference. If we don't it
-        // might get cleaned up before we parse the path.
-        const auto localPathCopy = CascadiaSettings::GetSettingsPath();
-
-        // Getting the containing folder.
-        std::filesystem::path fileParser = localPathCopy.c_str();
-        const auto folder = fileParser.parent_path();
+        // Get the containing folder.
+        std::filesystem::path settingsPath{ CascadiaSettings::GetSettingsPath() };
+        const auto folder = settingsPath.parent_path();
 
         _reader.create(folder.c_str(),
                        false,
                        wil::FolderChangeEvents::All,
-                       [this](wil::FolderChangeEvent event, PCWSTR fileModified) {
+                       [this, settingsPath](wil::FolderChangeEvent event, PCWSTR fileModified) {
                            // We want file modifications, AND when files are renamed to be
                            // profiles.json. This second case will oftentimes happen with text
                            // editors, who will write a temp file, then rename it to be the
@@ -591,13 +587,11 @@ namespace winrt::TerminalApp::implementation
                                return;
                            }
 
-                           const auto localPathCopy = CascadiaSettings::GetSettingsPath();
-                           std::filesystem::path settingsParser = localPathCopy.c_str();
-                           std::filesystem::path modifiedParser = fileModified;
+                           std::filesystem::path modifiedFilePath = fileModified;
 
                            // Getting basename (filename.ext)
-                           const auto settingsBasename = settingsParser.filename();
-                           const auto modifiedBasename = modifiedParser.filename();
+                           const auto settingsBasename = settingsPath.filename();
+                           const auto modifiedBasename = modifiedFilePath.filename();
 
                            if (settingsBasename == modifiedBasename)
                            {

--- a/src/cascadia/TerminalApp/CascadiaSettings.h
+++ b/src/cascadia/TerminalApp/CascadiaSettings.h
@@ -45,7 +45,7 @@ public:
     Json::Value ToJson() const;
     static std::unique_ptr<CascadiaSettings> FromJson(const Json::Value& json);
 
-    static winrt::hstring GetSettingsPath();
+    static std::wstring GetSettingsPath();
 
     const Profile* FindProfile(GUID profileGuid) const noexcept;
 
@@ -60,12 +60,9 @@ private:
     void _CreateDefaultProfiles();
 
     static bool _IsPackaged();
-    static void _SaveAsPackagedApp(const std::string& content);
-    static void _SaveAsUnpackagedApp(const std::string& content);
-    static std::wstring _GetFullPathToUnpackagedSettingsFile();
-    static winrt::hstring _GetPackagedSettingsPath();
-    static std::optional<std::string> _LoadAsPackagedApp();
-    static std::optional<std::string> _LoadAsUnpackagedApp();
+    static void _WriteSettings(const std::string_view content);
+    static std::optional<std::string> _ReadSettings();
+
     static bool _isPowerShellCoreInstalledInPath(const std::wstring_view programFileEnv, std::filesystem::path& cmdline);
     static bool _isPowerShellCoreInstalled(std::filesystem::path& cmdline);
     static void _AppendWslProfiles(std::vector<TerminalApp::Profile>& profileStorage);

--- a/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
@@ -12,13 +12,10 @@
 using namespace ::TerminalApp;
 using namespace winrt::Microsoft::Terminal::TerminalControl;
 using namespace winrt::TerminalApp;
-using namespace winrt::Windows::Data::Json;
-using namespace winrt::Windows::Storage;
-using namespace winrt::Windows::Storage::Streams;
 using namespace ::Microsoft::Console;
 
-static constexpr std::wstring_view FILENAME{ L"profiles.json" };
-static constexpr std::wstring_view SETTINGS_FOLDER_NAME{ L"\\Microsoft\\Windows Terminal\\" };
+static constexpr std::wstring_view SettingsFilename{ L"profiles.json" };
+static constexpr std::wstring_view UnpackagedSettingsFolderName{ L"Microsoft\\Windows Terminal\\" };
 
 static constexpr std::string_view ProfilesKey{ "profiles" };
 static constexpr std::string_view KeybindingsKey{ "keybindings" };
@@ -41,9 +38,7 @@ static constexpr std::string_view Utf8Bom{ u8"\uFEFF" };
 std::unique_ptr<CascadiaSettings> CascadiaSettings::LoadAll(const bool saveOnLoad)
 {
     std::unique_ptr<CascadiaSettings> resultPtr;
-    std::optional<std::string> fileData = _IsPackaged() ?
-                                              _LoadAsPackagedApp() :
-                                              _LoadAsUnpackagedApp();
+    std::optional<std::string> fileData = _ReadSettings();
 
     const bool foundFile = fileData.has_value();
     if (foundFile)
@@ -110,14 +105,7 @@ void CascadiaSettings::SaveAll() const
     wbuilder.settings_["indentation"] = "    ";
     const auto serializedString = Json::writeString(wbuilder, json);
 
-    if (_IsPackaged())
-    {
-        _SaveAsPackagedApp(serializedString);
-    }
-    else
-    {
-        _SaveAsUnpackagedApp(serializedString);
-    }
+    _WriteSettings(serializedString);
 }
 
 // Method Description:
@@ -222,9 +210,8 @@ std::unique_ptr<CascadiaSettings> CascadiaSettings::FromJson(const Json::Value& 
 }
 
 // Function Description:
-// - Returns true if we're running in a packaged context. If we are, then we
-//      have to use the Windows.Storage API's to save/load our files. If we're
-//      not, then we won't be able to use those API's.
+// - Returns true if we're running in a packaged context.
+//   If we are, we want to change our settings path slightly.
 // Arguments:
 // - <none>
 // Return Value:
@@ -237,37 +224,6 @@ bool CascadiaSettings::_IsPackaged()
 }
 
 // Method Description:
-// - Writes the given content to our settings file as UTF-8 encoded using the Windows.Storage
-//      APIS's. This will only work within the context of an application with
-//      package identity, so make sure to call _IsPackaged before calling this method.
-//   Will overwrite any existing content in the file.
-// Arguments:
-// - content: the given string of content to write to the file.
-// Return Value:
-// - <none>
-void CascadiaSettings::_SaveAsPackagedApp(const std::string& content)
-{
-    auto curr = ApplicationData::Current();
-    auto folder = curr.RoamingFolder();
-
-    auto file_async = folder.CreateFileAsync(FILENAME,
-                                             CreationCollisionOption::ReplaceExisting);
-
-    auto file = file_async.get();
-
-    DataWriter dw = DataWriter();
-    const char* firstChar = content.c_str();
-    const char* lastChar = firstChar + content.size();
-
-    const uint8_t* firstByte = reinterpret_cast<const uint8_t*>(firstChar);
-    const uint8_t* lastByte = reinterpret_cast<const uint8_t*>(lastChar);
-    winrt::array_view<const uint8_t> bytes{ firstByte, lastByte };
-    dw.WriteBytes(bytes);
-
-    FileIO::WriteBufferAsync(file, dw.DetachBuffer()).get();
-}
-
-// Method Description:
 // - Writes the given content in UTF-8 to our settings file using the Win32 APIS's.
 //   Will overwrite any existing content in the file.
 // Arguments:
@@ -276,82 +232,21 @@ void CascadiaSettings::_SaveAsPackagedApp(const std::string& content)
 // - <none>
 //   This can throw an exception if we fail to open the file for writing, or we
 //      fail to write the file
-void CascadiaSettings::_SaveAsUnpackagedApp(const std::string& content)
+void CascadiaSettings::_WriteSettings(const std::string_view content)
 {
-    // Get path to output file
-    // In this scenario, the settings file will end up under e.g. C:\Users\admin\AppData\Roaming\Microsoft\Windows Terminal\profiles.json
-    std::wstring pathToSettingsFile = CascadiaSettings::_GetFullPathToUnpackagedSettingsFile();
+    auto pathToSettingsFile{ CascadiaSettings::GetSettingsPath() };
 
     auto hOut = CreateFileW(pathToSettingsFile.c_str(), GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
     if (hOut == INVALID_HANDLE_VALUE)
     {
         THROW_LAST_ERROR();
     }
-    THROW_LAST_ERROR_IF(!WriteFile(hOut, content.c_str(), gsl::narrow<DWORD>(content.length()), 0, 0));
+    THROW_LAST_ERROR_IF(!WriteFile(hOut, content.data(), gsl::narrow<DWORD>(content.size()), 0, 0));
     CloseHandle(hOut);
 }
 
 // Method Description:
-// - Computes the path to the settings file if the app is run unpackaged.
-//   Will create any intermediate directories if they don't exist.
-//   The file will end up under e.g. C:\Users\admin\AppData\Roaming\Microsoft\Windows Terminal\profiles.json
-// Arguments:
-// - <none>
-// Return Value:
-// - A string containing the path to the unpackaged settings file
-//   This can throw an exception if it fails to get the roaming app data folder.
-std::wstring CascadiaSettings::_GetFullPathToUnpackagedSettingsFile()
-{
-    wil::unique_cotaskmem_string roamingAppDataFolder;
-    if (FAILED(SHGetKnownFolderPath(FOLDERID_RoamingAppData, 0, 0, &roamingAppDataFolder)))
-    {
-        THROW_LAST_ERROR();
-    }
-
-    std::wstring parentDirectoryForSettingsFile(roamingAppDataFolder.get());
-    parentDirectoryForSettingsFile.append(SETTINGS_FOLDER_NAME);
-
-    // Create the directory if it doesn't exist
-    wil::CreateDirectoryDeep(parentDirectoryForSettingsFile.c_str());
-
-    std::wstring pathToSettingsFile(parentDirectoryForSettingsFile);
-    pathToSettingsFile.append(FILENAME);
-
-    return pathToSettingsFile;
-}
-
-// Method Description:
-// - Reads the content of our settings file using the Windows.Storage
-//      APIS's. This will only work within the context of an application with
-//      package identity, so make sure to call _IsPackaged before calling this method.
-// Arguments:
-// - <none>
-// Return Value:
-// - an optional with the content of the file if we were able to open it,
-//      otherwise the optional will be empty
-std::optional<std::string> CascadiaSettings::_LoadAsPackagedApp()
-{
-    auto curr = ApplicationData::Current();
-    auto folder = curr.RoamingFolder();
-    auto file_async = folder.TryGetItemAsync(FILENAME);
-    auto file = file_async.get();
-
-    if (file == nullptr)
-    {
-        return std::nullopt;
-    }
-    const auto storageFile = file.as<StorageFile>();
-
-    // settings file is UTF-8 without BOM
-    auto buffer = FileIO::ReadBufferAsync(storageFile).get();
-    auto bufferData = buffer.data();
-    std::vector<uint8_t> bytes{ bufferData, bufferData + buffer.Length() };
-    std::string resultString{ bytes.begin(), bytes.end() };
-    return { resultString };
-}
-
-// Method Description:
-// - Reads the content in UTF-8 enconding of our settings file using the Win32 APIs
+// - Reads the content in UTF-8 encoding of our settings file using the Win32 APIs
 // Arguments:
 // - <none>
 // Return Value:
@@ -359,9 +254,9 @@ std::optional<std::string> CascadiaSettings::_LoadAsPackagedApp()
 //      otherwise the optional will be empty.
 //   If the file exists, but we fail to read it, this can throw an exception
 //      from reading the file
-std::optional<std::string> CascadiaSettings::_LoadAsUnpackagedApp()
+std::optional<std::string> CascadiaSettings::_ReadSettings()
 {
-    std::wstring pathToSettingsFile = CascadiaSettings::_GetFullPathToUnpackagedSettingsFile();
+    auto pathToSettingsFile{ CascadiaSettings::GetSettingsPath() };
     const auto hFile = CreateFileW(pathToSettingsFile.c_str(), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     if (hFile == INVALID_HANDLE_VALUE)
     {
@@ -390,27 +285,32 @@ std::optional<std::string> CascadiaSettings::_LoadAsUnpackagedApp()
 // function Description:
 // - Returns the full path to the settings file, either within the application
 //   package, or in its unpackaged location.
+// - If the application is unpackaged,
+//   the file will end up under e.g. C:\Users\admin\AppData\Roaming\Microsoft\Windows Terminal\profiles.json
 // Arguments:
 // - <none>
 // Return Value:
 // - the full path to the settings file
-winrt::hstring CascadiaSettings::GetSettingsPath()
+std::wstring CascadiaSettings::GetSettingsPath()
 {
-    return _IsPackaged() ? CascadiaSettings::_GetPackagedSettingsPath() :
-                           winrt::hstring{ CascadiaSettings::_GetFullPathToUnpackagedSettingsFile() };
-}
+    wil::unique_cotaskmem_string roamingAppDataFolder;
+    // KF_FLAG_FORCE_APP_DATA_REDIRECTION, when engaged, causes SHGet... to return
+    // the new AppModel paths (Packages/xxx/RoamingState, etc.) for standard path requests.
+    // Using this flag allows us to avoid Windows.Storage.ApplicationData completely.
+    if (FAILED(SHGetKnownFolderPath(FOLDERID_RoamingAppData, KF_FLAG_FORCE_APP_DATA_REDIRECTION, 0, &roamingAppDataFolder)))
+    {
+        THROW_LAST_ERROR();
+    }
 
-// Function Description:
-// - Get the full path to settings file in its packaged location.
-// Arguments:
-// - <none>
-// Return Value:
-// - the full path to the packaged settings file.
-winrt::hstring CascadiaSettings::_GetPackagedSettingsPath()
-{
-    const auto curr = ApplicationData::Current();
-    const auto folder = curr.RoamingFolder();
-    const auto file_async = folder.TryGetItemAsync(FILENAME);
-    const auto file = file_async.get();
-    return file.Path();
+    std::filesystem::path parentDirectoryForSettingsFile{ roamingAppDataFolder.get() };
+
+    if (!_IsPackaged())
+    {
+        parentDirectoryForSettingsFile /= UnpackagedSettingsFolderName;
+    }
+
+    // Create the directory if it doesn't exist
+    std::filesystem::create_directories(parentDirectoryForSettingsFile);
+
+    return parentDirectoryForSettingsFile / SettingsFilename;
 }

--- a/src/cascadia/TerminalApp/pch.h
+++ b/src/cascadia/TerminalApp/pch.h
@@ -38,8 +38,6 @@
 #include <windows.ui.xaml.media.dxinterop.h>
 
 #include <winrt/Windows.System.h>
-#include <winrt/Windows.Storage.h>
-#include <winrt/Windows.Storage.Streams.h>
 
 // Including TraceLogging essentials for the binary
 #include <TraceLoggingProvider.h>


### PR DESCRIPTION
This commit drops all of the special packaged app code in
CascadiaSettingsSerialization. It can all be replaced with passing
KF_FLAG_FORCE_APP_DATA_REDIRECTION to SHGetKnownFolderPath, which will
automatically handle the different paths used in packaged context.

We'll still store profiles.json under %APPDATA%\Microsoft\Windows
Terminal in an unpackaged context.

I've also taken the liberty of fixing a settings reload crash. Using the
Application storage APIs would cause us to throw an exception when
profiles.json was deleted, which it absolutely was for certain editors
that do an atomic replace.

Because we're not using W.S.A any more, this cuts down our load time
significantly and fixes all of our known STA/MTA-on-startup issues.

Fixes #1102, #1292.

## PR Checklist
* [x] Closes #1102, #1292
* [x] CLA signed
* [x] Tests: manual
* [x] I've discussed this with core contributors already.