### PR TITLE
Multi-Click Selection: Triple-Click Settings + Viewport Selection

### DIFF
--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -60,9 +60,9 @@ static constexpr std::string_view ImageStretchModeUniform{ "uniform" };
 static constexpr std::string_view ImageStretchModeUniformTofill{ "uniformToFill" };
 
 // Possible values for Triple Click Selection Mode
-static constexpr std::wstring_view SelectionModeDisabled{ L"disabled" };
-static constexpr std::wstring_view SelectionModeLine{ L"line" };
-static constexpr std::wstring_view SelectionModeViewport{ L"viewport" };
+static constexpr std::wstring_view TripleClickSelectionModeDisabled{ L"disabled" };
+static constexpr std::wstring_view TripleClickSelectionModeLine{ L"line" };
+static constexpr std::wstring_view TripleClickSelectionModeViewport{ L"viewport" };
 
 Profile::Profile() :
     Profile(Utils::CreateGuid())
@@ -82,7 +82,7 @@ Profile::Profile(const winrt::guid& guid) :
     _cursorColor{ DEFAULT_CURSOR_COLOR },
     _cursorShape{ CursorStyle::Bar },
     _cursorHeight{ DEFAULT_CURSOR_HEIGHT },
-    _tripleClickSelectionMode{ SelectionMode::Line },
+    _tripleClickSelectionMode{ TripleClickSelectionMode::Line },
 
     _commandline{ L"cmd.exe" },
     _startingDirectory{},
@@ -257,7 +257,7 @@ Json::Value Profile::ToJson() const
         root[JsonKey(CursorHeightKey)] = _cursorHeight;
     }
     root[JsonKey(CursorShapeKey)] = winrt::to_string(_SerializeCursorStyle(_cursorShape));
-    root[JsonKey(TripleClickSelectionModeKey)] = winrt::to_string(_SerializeSelectionMode(_tripleClickSelectionMode));
+    root[JsonKey(TripleClickSelectionModeKey)] = winrt::to_string(_SerializeTripleClickSelectionMode(_tripleClickSelectionMode));
 
     ///// Control Settings /////
     root[JsonKey(CommandlineKey)] = winrt::to_string(_commandline);
@@ -380,7 +380,7 @@ Profile Profile::FromJson(const Json::Value& json)
     }
     if (auto tripleClickSelectionMode{ json[JsonKey(TripleClickSelectionModeKey)] })
     {
-        result._tripleClickSelectionMode = _ParseSelectionMode(GetWstringFromJson(tripleClickSelectionMode));
+        result._tripleClickSelectionMode = _ParseTripleClickSelectionMode(GetWstringFromJson(tripleClickSelectionMode));
     }
 
     // Control Settings
@@ -687,29 +687,43 @@ std::wstring_view Profile::_SerializeCursorStyle(const CursorStyle cursorShape)
     }
 }
 
-winrt::Microsoft::Terminal::Settings::SelectionMode Profile::_ParseSelectionMode(const std::wstring& selectionModeString)
+// Method Description:
+// - Helper function for converting a user-specified triple click selection mode to the corresponding
+//   TripleClickSelectionMode enum value
+// Arguments:
+// - selectionModeString: The string value from the settings file to parse
+// Return Value:
+// - The corresponding enum value which maps to the string provided by the user
+winrt::Microsoft::Terminal::Settings::TripleClickSelectionMode Profile::_ParseTripleClickSelectionMode(const std::wstring& selectionModeString)
 {
-    if (selectionModeString == SelectionModeDisabled)
+    if (selectionModeString == TripleClickSelectionModeDisabled)
     {
-        return SelectionMode::Disabled;
+        return winrt::Microsoft::Terminal::Settings::TripleClickSelectionMode::Disabled;
     }
-    else if (selectionModeString == SelectionModeViewport)
+    else if (selectionModeString == TripleClickSelectionModeViewport)
     {
-        return SelectionMode::VisibleViewport;
+        return winrt::Microsoft::Terminal::Settings::TripleClickSelectionMode::VisibleViewport;
     }
-    return SelectionMode::Line;
+    return winrt::Microsoft::Terminal::Settings::TripleClickSelectionMode::Line;
 }
 
-std::wstring_view Profile::_SerializeSelectionMode(const winrt::Microsoft::Terminal::Settings::SelectionMode selectionMode)
+// Method Description:
+// - Helper function for converting a TripleClickSelectionMode to its corresponding string
+//   value.
+// Arguments:
+// - selectionMode: The enum value to convert to a string.
+// Return Value:
+// - The string value for the given TripleClickSelectionMode
+std::wstring_view Profile::_SerializeTripleClickSelectionMode(const winrt::Microsoft::Terminal::Settings::TripleClickSelectionMode selectionMode)
 {
     switch (selectionMode)
     {
-    case SelectionMode::Disabled:
-        return SelectionModeDisabled;
-    case SelectionMode::VisibleViewport:
-        return SelectionModeViewport;
-    case SelectionMode::Line:
+    case winrt::Microsoft::Terminal::Settings::TripleClickSelectionMode::Disabled:
+        return TripleClickSelectionModeDisabled;
+    case winrt::Microsoft::Terminal::Settings::TripleClickSelectionMode::VisibleViewport:
+        return TripleClickSelectionModeViewport;
+    case winrt::Microsoft::Terminal::Settings::TripleClickSelectionMode::Line:
     default:
-        return SelectionModeLine;
+        return TripleClickSelectionModeLine;
     }
 }

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -61,8 +61,8 @@ private:
     static std::string_view SerializeImageStretchMode(const winrt::Windows::UI::Xaml::Media::Stretch imageStretchMode);
     static winrt::Microsoft::Terminal::Settings::CursorStyle _ParseCursorShape(const std::wstring& cursorShapeString);
     static std::wstring_view _SerializeCursorStyle(const winrt::Microsoft::Terminal::Settings::CursorStyle cursorShape);
-    static winrt::Microsoft::Terminal::Settings::SelectionMode _ParseSelectionMode(const std::wstring& selectionModeString);
-    static std::wstring_view _SerializeSelectionMode(const winrt::Microsoft::Terminal::Settings::SelectionMode selectionMode);
+    static winrt::Microsoft::Terminal::Settings::TripleClickSelectionMode _ParseTripleClickSelectionMode(const std::wstring& selectionModeString);
+    static std::wstring_view _SerializeTripleClickSelectionMode(const winrt::Microsoft::Terminal::Settings::TripleClickSelectionMode selectionMode);
 
     GUID _guid;
     std::wstring _name;
@@ -78,7 +78,7 @@ private:
     uint32_t _cursorColor;
     uint32_t _cursorHeight;
     winrt::Microsoft::Terminal::Settings::CursorStyle _cursorShape;
-    winrt::Microsoft::Terminal::Settings::SelectionMode _tripleClickSelectionMode;
+    winrt::Microsoft::Terminal::Settings::TripleClickSelectionMode _tripleClickSelectionMode;
 
     std::wstring _commandline;
     std::wstring _fontFace;

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -61,6 +61,8 @@ private:
     static std::string_view SerializeImageStretchMode(const winrt::Windows::UI::Xaml::Media::Stretch imageStretchMode);
     static winrt::Microsoft::Terminal::Settings::CursorStyle _ParseCursorShape(const std::wstring& cursorShapeString);
     static std::wstring_view _SerializeCursorStyle(const winrt::Microsoft::Terminal::Settings::CursorStyle cursorShape);
+    static winrt::Microsoft::Terminal::Settings::SelectionMode _ParseSelectionMode(const std::wstring& selectionModeString);
+    static std::wstring_view _SerializeSelectionMode(const winrt::Microsoft::Terminal::Settings::SelectionMode selectionMode);
 
     GUID _guid;
     std::wstring _name;
@@ -76,6 +78,7 @@ private:
     uint32_t _cursorColor;
     uint32_t _cursorHeight;
     winrt::Microsoft::Terminal::Settings::CursorStyle _cursorShape;
+    winrt::Microsoft::Terminal::Settings::SelectionMode _tripleClickSelectionMode;
 
     std::wstring _commandline;
     std::wstring _fontFace;

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -133,8 +133,19 @@ void Terminal::UpdateSettings(winrt::Microsoft::Terminal::Settings::ICoreSetting
 
     _snapOnInput = settings.SnapOnInput();
 
-    // TODO: import tripleClickSelection setting from Settings
-    _tripleClickMode = TripleClickSelectionMode::Line;
+    switch (settings.TripleClickSelectionMode())
+    {
+    case winrt::Microsoft::Terminal::Settings::SelectionMode::Disabled:
+        _tripleClickMode = TripleClickSelectionMode::Disabled;
+        break;
+    case winrt::Microsoft::Terminal::Settings::SelectionMode::VisibleViewport:
+        _tripleClickMode = TripleClickSelectionMode::VisibleViewport;
+        break;
+    case winrt::Microsoft::Terminal::Settings::SelectionMode::Line:
+    default:
+        _tripleClickMode = TripleClickSelectionMode::Line;
+        break;
+    }
 
     // TODO:MSFT:21327402 - if HistorySize has changed, resize the buffer so we
     // have a smaller scrollback. We should do this carefully - if the new buffer

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -133,19 +133,7 @@ void Terminal::UpdateSettings(winrt::Microsoft::Terminal::Settings::ICoreSetting
 
     _snapOnInput = settings.SnapOnInput();
 
-    switch (settings.TripleClickSelectionMode())
-    {
-    case winrt::Microsoft::Terminal::Settings::SelectionMode::Disabled:
-        _tripleClickMode = TripleClickSelectionMode::Disabled;
-        break;
-    case winrt::Microsoft::Terminal::Settings::SelectionMode::VisibleViewport:
-        _tripleClickMode = TripleClickSelectionMode::VisibleViewport;
-        break;
-    case winrt::Microsoft::Terminal::Settings::SelectionMode::Line:
-    default:
-        _tripleClickMode = TripleClickSelectionMode::Line;
-        break;
-    }
+    _tripleClickMode = settings.TripleClickSelectionMode();
 
     // TODO:MSFT:21327402 - if HistorySize has changed, resize the buffer so we
     // have a smaller scrollback. We should do this carefully - if the new buffer

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -20,6 +20,7 @@
 namespace winrt::Microsoft::Terminal::Settings
 {
     struct ICoreSettings;
+    enum class TripleClickSelectionMode;
 }
 
 namespace Microsoft::Terminal::Core
@@ -145,19 +146,13 @@ private:
     bool _snapOnInput;
 
     // Text Selection
-    enum TripleClickSelectionMode
-    {
-        Disabled = 0,
-        Line,
-        VisibleViewport
-    };
     COORD _selectionAnchor;
     COORD _endSelectionPosition;
     bool _boxSelection;
     bool _selectionActive;
     SHORT _selectionAnchor_YOffset;
     SHORT _endSelectionPosition_YOffset;
-    TripleClickSelectionMode _tripleClickMode;
+    winrt::Microsoft::Terminal::Settings::TripleClickSelectionMode _tripleClickMode;
     void _ExpandDoubleClickSelectionLeft(const COORD position);
     void _ExpandDoubleClickSelectionRight(const COORD position);
     const bool _DoubleClickDelimiterCheck(std::wstring_view cellChar) const;

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -145,15 +145,24 @@ private:
     bool _snapOnInput;
 
     // Text Selection
+    enum TripleClickSelectionMode
+    {
+        Disabled = 0,
+        Line,
+        VisibleViewport
+    };
     COORD _selectionAnchor;
     COORD _endSelectionPosition;
     bool _boxSelection;
     bool _selectionActive;
     SHORT _selectionAnchor_YOffset;
     SHORT _endSelectionPosition_YOffset;
+    TripleClickSelectionMode _tripleClickMode;
     void _ExpandDoubleClickSelectionLeft(const COORD position);
     void _ExpandDoubleClickSelectionRight(const COORD position);
     const bool _DoubleClickDelimiterCheck(std::wstring_view cellChar) const;
+    void _SelectRow(const COORD position);
+    void _SelectViewport();
     const COORD _ConvertToBufferCell(const COORD viewportPos) const;
 
     std::shared_mutex _readWriteLock;

--- a/src/cascadia/TerminalSettings/ICoreSettings.idl
+++ b/src/cascadia/TerminalSettings/ICoreSettings.idl
@@ -12,7 +12,7 @@ namespace Microsoft.Terminal.Settings
         EmptyBox
     };
 
-    enum SelectionMode
+    enum TripleClickSelectionMode
     {
         Disabled,
         Line,
@@ -34,7 +34,7 @@ namespace Microsoft.Terminal.Settings
         UInt32 CursorColor;
         CursorStyle CursorShape;
         UInt32 CursorHeight;
-        SelectionMode TripleClickSelectionMode;
+        TripleClickSelectionMode TripleClickSelectionMode;
     };
 
 }

--- a/src/cascadia/TerminalSettings/ICoreSettings.idl
+++ b/src/cascadia/TerminalSettings/ICoreSettings.idl
@@ -12,6 +12,13 @@ namespace Microsoft.Terminal.Settings
         EmptyBox
     };
 
+    enum SelectionMode
+    {
+        Disabled,
+        Line,
+        VisibleViewport
+    };
+
     interface ICoreSettings
     {
         UInt32 DefaultForeground;
@@ -27,6 +34,7 @@ namespace Microsoft.Terminal.Settings
         UInt32 CursorColor;
         CursorStyle CursorShape;
         UInt32 CursorHeight;
+        SelectionMode TripleClickSelectionMode;
     };
 
 }

--- a/src/cascadia/TerminalSettings/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettings/TerminalSettings.cpp
@@ -20,6 +20,7 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         _cursorColor{ DEFAULT_CURSOR_COLOR },
         _cursorShape{ CursorStyle::Vintage },
         _cursorHeight{ DEFAULT_CURSOR_HEIGHT },
+        _tripleClickSelectionMode{ Settings::SelectionMode::Line },
         _useAcrylic{ false },
         _closeOnExit{ true },
         _tintOpacity{ 0.5 },
@@ -133,6 +134,16 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
     void TerminalSettings::CursorHeight(uint32_t value)
     {
         _cursorHeight = value;
+    }
+
+    Settings::SelectionMode TerminalSettings::TripleClickSelectionMode() const noexcept
+    {
+        return _tripleClickSelectionMode;
+    }
+
+    void TerminalSettings::TripleClickSelectionMode(winrt::Microsoft::Terminal::Settings::SelectionMode const& value) noexcept
+    {
+        _tripleClickSelectionMode = value;
     }
 
     bool TerminalSettings::UseAcrylic()

--- a/src/cascadia/TerminalSettings/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettings/TerminalSettings.cpp
@@ -20,7 +20,7 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         _cursorColor{ DEFAULT_CURSOR_COLOR },
         _cursorShape{ CursorStyle::Vintage },
         _cursorHeight{ DEFAULT_CURSOR_HEIGHT },
-        _tripleClickSelectionMode{ Settings::SelectionMode::Line },
+        _tripleClickSelectionMode{ Settings::TripleClickSelectionMode::Line },
         _useAcrylic{ false },
         _closeOnExit{ true },
         _tintOpacity{ 0.5 },
@@ -136,12 +136,12 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         _cursorHeight = value;
     }
 
-    Settings::SelectionMode TerminalSettings::TripleClickSelectionMode() const noexcept
+    Settings::TripleClickSelectionMode TerminalSettings::TripleClickSelectionMode() const noexcept
     {
         return _tripleClickSelectionMode;
     }
 
-    void TerminalSettings::TripleClickSelectionMode(winrt::Microsoft::Terminal::Settings::SelectionMode const& value) noexcept
+    void TerminalSettings::TripleClickSelectionMode(winrt::Microsoft::Terminal::Settings::TripleClickSelectionMode const& value) noexcept
     {
         _tripleClickSelectionMode = value;
     }

--- a/src/cascadia/TerminalSettings/terminalsettings.h
+++ b/src/cascadia/TerminalSettings/terminalsettings.h
@@ -45,6 +45,8 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         void CursorShape(winrt::Microsoft::Terminal::Settings::CursorStyle const& value) noexcept;
         uint32_t CursorHeight();
         void CursorHeight(uint32_t value);
+        Settings::SelectionMode TripleClickSelectionMode() const noexcept;
+        void TripleClickSelectionMode(winrt::Microsoft::Terminal::Settings::SelectionMode const& value) noexcept;
         // ------------------------ End of Core Settings -----------------------
 
         bool UseAcrylic();
@@ -94,6 +96,7 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         uint32_t _cursorColor;
         Settings::CursorStyle _cursorShape;
         uint32_t _cursorHeight;
+        Settings::SelectionMode _tripleClickSelectionMode;
 
         bool _useAcrylic;
         bool _closeOnExit;

--- a/src/cascadia/TerminalSettings/terminalsettings.h
+++ b/src/cascadia/TerminalSettings/terminalsettings.h
@@ -45,8 +45,8 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         void CursorShape(winrt::Microsoft::Terminal::Settings::CursorStyle const& value) noexcept;
         uint32_t CursorHeight();
         void CursorHeight(uint32_t value);
-        Settings::SelectionMode TripleClickSelectionMode() const noexcept;
-        void TripleClickSelectionMode(winrt::Microsoft::Terminal::Settings::SelectionMode const& value) noexcept;
+        Settings::TripleClickSelectionMode TripleClickSelectionMode() const noexcept;
+        void TripleClickSelectionMode(winrt::Microsoft::Terminal::Settings::TripleClickSelectionMode const& value) noexcept;
         // ------------------------ End of Core Settings -----------------------
 
         bool UseAcrylic();
@@ -96,7 +96,7 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         uint32_t _cursorColor;
         Settings::CursorStyle _cursorShape;
         uint32_t _cursorHeight;
-        Settings::SelectionMode _tripleClickSelectionMode;
+        Settings::TripleClickSelectionMode _tripleClickSelectionMode;
 
         bool _useAcrylic;
         bool _closeOnExit;

--- a/src/cascadia/UnitTests_TerminalCore/ScreenSizeLimitsTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ScreenSizeLimitsTest.cpp
@@ -36,6 +36,7 @@ namespace TerminalCoreUnitTests
         uint32_t CursorColor() { return COLOR_WHITE; }
         CursorStyle CursorShape() const noexcept { return CursorStyle::Vintage; }
         uint32_t CursorHeight() { return 42UL; }
+        SelectionMode TripleClickSelectionMode() { return SelectionMode::Line; }
 
         // other implemented methods
         uint32_t GetColorTableEntry(int32_t) const { return 123; }
@@ -50,6 +51,7 @@ namespace TerminalCoreUnitTests
         void CursorColor(uint32_t) {}
         void CursorShape(CursorStyle const&) noexcept {}
         void CursorHeight(uint32_t) {}
+        void TripleClickSelectionMode(SelectionMode) {}
 
         // other unimplemented methods
         void SetColorTableEntry(int32_t /* index */, uint32_t /* value */) {}

--- a/src/cascadia/UnitTests_TerminalCore/ScreenSizeLimitsTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ScreenSizeLimitsTest.cpp
@@ -36,7 +36,7 @@ namespace TerminalCoreUnitTests
         uint32_t CursorColor() { return COLOR_WHITE; }
         CursorStyle CursorShape() const noexcept { return CursorStyle::Vintage; }
         uint32_t CursorHeight() { return 42UL; }
-        SelectionMode TripleClickSelectionMode() { return SelectionMode::Line; }
+        TripleClickSelectionMode TripleClickSelectionMode() { return TripleClickSelectionMode::Line; }
 
         // other implemented methods
         uint32_t GetColorTableEntry(int32_t) const { return 123; }
@@ -51,7 +51,7 @@ namespace TerminalCoreUnitTests
         void CursorColor(uint32_t) {}
         void CursorShape(CursorStyle const&) noexcept {}
         void CursorHeight(uint32_t) {}
-        void TripleClickSelectionMode(SelectionMode) {}
+        void TripleClickSelectionMode(winrt::Microsoft::Terminal::Settings::TripleClickSelectionMode) {}
 
         // other unimplemented methods
         void SetColorTableEntry(int32_t /* index */, uint32_t /* value */) {}


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Introduces "viewport selection" which creates a selection of the entire viewport. Also, adds per-profile settings to decide whether a triple-click performs a line selection or viewport selection (disabling it is also an option).

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
Builds on #1197. Similar to #1273.
Closes #1084.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #1084 
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- TerminalSettings:
  - add property to winrt TerminalSettings
- Terminal App:
  - read/write JSON for this new property
  - default set to line selection
- TerminalCore:
  - import/use selection mode from ICoreSettings
  - perform proper action
- UnitTests_TerminalCore:
  - Added setting to `MockTermSettings`

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- modified profiles.json. Then performed triple click in an instance of that profile