### PR TITLE
Bugfix: vertical selection out of bounds

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -192,7 +192,7 @@ private:
 #pragma region TextSelection
     // These methods are defined in TerminalSelection.cpp
     std::vector<SMALL_RECT> _GetSelectionRects() const;
-    const SHORT _ExpandWideGlyphSelectionLeft(const SHORT xPos, const SHORT yPos) const noexcept;
-    const SHORT _ExpandWideGlyphSelectionRight(const SHORT xPos, const SHORT yPos) const noexcept;
+    const SHORT _ExpandWideGlyphSelectionLeft(const SHORT xPos, const SHORT yPos) const;
+    const SHORT _ExpandWideGlyphSelectionRight(const SHORT xPos, const SHORT yPos) const;
 #pragma endregion
 };

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -37,8 +37,8 @@ std::vector<SMALL_RECT> Terminal::_GetSelectionRects() const
     // Here, we want the "left"most coordinate to be the one "higher" on the screen. The other gets the dubious honor of
     // being the "lower."
     const auto& [higherCoord, lowerCoord] = bufferSize.CompareInBounds(selectionAnchorWithOffset, endSelectionPositionWithOffset) <= 0 ?
-                                               std::make_tuple(selectionAnchorWithOffset, endSelectionPositionWithOffset) :
-                                               std::make_tuple(endSelectionPositionWithOffset, selectionAnchorWithOffset);
+                                                std::make_tuple(selectionAnchorWithOffset, endSelectionPositionWithOffset) :
+                                                std::make_tuple(endSelectionPositionWithOffset, selectionAnchorWithOffset);
 
     selectionArea.reserve(lowerCoord.Y - higherCoord.Y + 1);
     for (auto row = higherCoord.Y; row <= lowerCoord.Y; row++)

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -27,6 +27,10 @@ std::vector<SMALL_RECT> Terminal::_GetSelectionRects() const
     THROW_IF_FAILED(ShortAdd(_selectionAnchor.Y, _selectionAnchor_YOffset, &selectionAnchorWithOffset.Y));
     THROW_IF_FAILED(ShortAdd(_endSelectionPosition.Y, _endSelectionPosition_YOffset, &endSelectionPositionWithOffset.Y));
 
+    // clamp Y values to be within mutable viewport bounds
+    selectionAnchorWithOffset.Y = std::clamp(selectionAnchorWithOffset.Y, static_cast<SHORT>(0), _mutableViewport.BottomInclusive());
+    endSelectionPositionWithOffset.Y = std::clamp(endSelectionPositionWithOffset.Y, static_cast<SHORT>(0), _mutableViewport.BottomInclusive());
+
     // clamp X values to be within buffer bounds
     const auto bufferWidth = _buffer->GetSize().RightInclusive();
     selectionAnchorWithOffset.X = std::clamp(_selectionAnchor.X, static_cast<SHORT>(0), bufferWidth);
@@ -73,7 +77,7 @@ std::vector<SMALL_RECT> Terminal::_GetSelectionRects() const
 // - position: the (x,y) coordinate on the visible viewport
 // Return Value:
 // - updated x position to encapsulate the wide glyph
-const SHORT Terminal::_ExpandWideGlyphSelectionLeft(const SHORT xPos, const SHORT yPos) const noexcept
+const SHORT Terminal::_ExpandWideGlyphSelectionLeft(const SHORT xPos, const SHORT yPos) const
 {
     // don't change the value if at/outside the boundary
     if (xPos <= 0 || xPos >= _buffer->GetSize().RightInclusive())
@@ -98,7 +102,7 @@ const SHORT Terminal::_ExpandWideGlyphSelectionLeft(const SHORT xPos, const SHOR
 // - position: the (x,y) coordinate on the visible viewport
 // Return Value:
 // - updated x position to encapsulate the wide glyph
-const SHORT Terminal::_ExpandWideGlyphSelectionRight(const SHORT xPos, const SHORT yPos) const noexcept
+const SHORT Terminal::_ExpandWideGlyphSelectionRight(const SHORT xPos, const SHORT yPos) const
 {
     // don't change the value if at/outside the boundary
     if (xPos <= 0 || xPos >= _buffer->GetSize().RightInclusive())

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -27,7 +27,7 @@ std::vector<SMALL_RECT> Terminal::_GetSelectionRects() const
     THROW_IF_FAILED(ShortAdd(_selectionAnchor.Y, _selectionAnchor_YOffset, &selectionAnchorWithOffset.Y));
     THROW_IF_FAILED(ShortAdd(_endSelectionPosition.Y, _endSelectionPosition_YOffset, &endSelectionPositionWithOffset.Y));
 
-    // clamp Y values to be within mutable viewport bounds
+    // clamp Y values to be within mutable viewport height
     selectionAnchorWithOffset.Y = std::clamp(selectionAnchorWithOffset.Y, static_cast<SHORT>(0), _mutableViewport.BottomInclusive());
     endSelectionPositionWithOffset.Y = std::clamp(endSelectionPositionWithOffset.Y, static_cast<SHORT>(0), _mutableViewport.BottomInclusive());
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This was a side effect of #905. But applies the same logic #1254. We were trying to get buffer data at a location that doesn't exist for the buffer. Removed the `noexcept`s from the expand selection functions.

The fix is simple enough. Just clamp the Y value of the selection to be between 0 and the mutable viewport's height. I tried using the Viewport's Clamp method but we're doing some weird transforms so I found that it's just easiest to do it manually (and slightly differently).

As an extra benefit, now if you're all the way at the top of the buffer and you try making a selection past the top, the x-value still updates as you move. The same thing applies to the bottom when you're at the bottom of the buffer.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1312 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- create a selection expanding past the top of the window
- do same selection as above but right-click to copy (this tests extracting the data from the buffer is still done properly)
- do both tests above, but for the bottom (this wasn't an issue before, and shouldn't be one now)
- repeat mentioned tests when you create a scrollable region and you are NOT at the boundaries

NOTE: for that last one, the selection should actually expand to outside of the viewport. That's actually intended as we need that for #1247 . 
