### PR TITLE
CreateFile with the right flags

### DIFF
--- a/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
@@ -236,7 +236,7 @@ void CascadiaSettings::_WriteSettings(const std::string_view content)
 {
     auto pathToSettingsFile{ CascadiaSettings::GetSettingsPath() };
 
-    auto hOut = CreateFileW(pathToSettingsFile.c_str(), GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    auto hOut = CreateFileW(pathToSettingsFile.c_str(), GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
     if (hOut == INVALID_HANDLE_VALUE)
     {
         THROW_LAST_ERROR();
@@ -257,7 +257,7 @@ void CascadiaSettings::_WriteSettings(const std::string_view content)
 std::optional<std::string> CascadiaSettings::_ReadSettings()
 {
     auto pathToSettingsFile{ CascadiaSettings::GetSettingsPath() };
-    const auto hFile = CreateFileW(pathToSettingsFile.c_str(), GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    const auto hFile = CreateFileW(pathToSettingsFile.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     if (hFile == INVALID_HANDLE_VALUE)
     {
         // If the file doesn't exist, that's fine. Just log the error and return


### PR DESCRIPTION
We need `FILE_SHARE_READ | FILE_SHARE_WRITE` on _both_ calls to `CreateFile`, so that we can properly watch the file for reloads.

Without these, when the file reloaded, we'd fail to open the file, think that it's because the file doesn't exist, create the default settings, and then we'd blow away the user's settings.

Fixes #1325