### PR TITLE
Allow file modifications to quiet down before reloading settings

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -595,9 +595,22 @@ namespace winrt::TerminalApp::implementation
 
                            if (settingsBasename == modifiedBasename)
                            {
-                               this->_ReloadSettings();
+                               this->_DispatchReloadSettings();
                            }
                        });
+    }
+
+    // Method Description:
+    // - Dispatches a settings reload with debounce.
+    fire_and_forget App::_DispatchReloadSettings()
+    {
+        static constexpr auto FileActivityQuiesceTime{ std::chrono::milliseconds(50) };
+        if (!_settingsReloadQueued.exchange(true))
+        {
+            co_await winrt::resume_after(FileActivityQuiesceTime);
+            _ReloadSettings();
+            _settingsReloadQueued.store(false);
+        }
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -602,6 +602,8 @@ namespace winrt::TerminalApp::implementation
 
     // Method Description:
     // - Dispatches a settings reload with debounce.
+    //   Text editors implement Save in a bunch of different ways, so
+    //   this stops us from reloading too many times or too quickly.
     fire_and_forget App::_DispatchReloadSettings()
     {
         static constexpr auto FileActivityQuiesceTime{ std::chrono::milliseconds(50) };

--- a/src/cascadia/TerminalApp/App.h
+++ b/src/cascadia/TerminalApp/App.h
@@ -69,6 +69,8 @@ namespace winrt::TerminalApp::implementation
 
         wil::unique_folder_change_reader_nothrow _reader;
 
+        std::atomic<bool> _settingsReloadQueued{ false };
+
         void _Create();
         void _CreateNewTabFlyout();
 
@@ -85,6 +87,7 @@ namespace winrt::TerminalApp::implementation
         void _HookupKeyBindings(TerminalApp::AppKeyBindings bindings) noexcept;
 
         void _RegisterSettingsChange();
+        fire_and_forget _DispatchReloadSettings();
         void _ReloadSettings();
 
         void _SettingsButtonOnClick(const IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& eventArgs);


### PR DESCRIPTION
This commit introduces a 50ms debounce so that we stop flapping around while text editors are making directory changes.
Fixes #1329.

### Tested

* Write from VSCode (hold down <kbd>Ctrl+S</kbd>, go mad with power)
* Write from vim
* Write invalid settings
* Run multiple terminals simultaneously and do the above.