### PR TITLE
Implement DXGI guidance for variable refresh displays

### DIFF
--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -732,7 +732,11 @@ void DxEngine::_InvalidOr(RECT rc) noexcept
         {
             _dxgiSurface.Reset();
             _d2dRenderTarget.Reset();
-            _dxgiSwapChain->ResizeBuffers(2, clientSize.cx, clientSize.cy, DXGI_FORMAT_B8G8R8A8_UNORM, 0);
+
+            UINT swapChainFlags = 0;
+            WI_SetFlagIf(swapChainFlags, DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING, _allowTearing);
+
+            _dxgiSwapChain->ResizeBuffers(2, clientSize.cx, clientSize.cy, DXGI_FORMAT_B8G8R8A8_UNORM, swapChainFlags);
             RETURN_IF_FAILED(_PrepareRenderTarget());
             _displaySizePixels = clientSize;
         }

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -103,6 +103,7 @@ namespace Microsoft::Console::Render
             ForComposition
         };
 
+        bool _allowTearing;
         SwapChainMode _chainMode;
 
         HWND _hwndTarget;
@@ -163,6 +164,7 @@ namespace Microsoft::Console::Render
         ::Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> _d2dBrushBackground;
         ::Microsoft::WRL::ComPtr<IDXGISwapChain1> _dxgiSwapChain;
 
+        [[nodiscard]] HRESULT _CheckTearingSupport() noexcept;
         [[nodiscard]] HRESULT _CreateDeviceResources(const bool createSwapChain) noexcept;
 
         [[nodiscard]] HRESULT _PrepareRenderTarget() noexcept;

--- a/src/renderer/dx/precomp.h
+++ b/src/renderer/dx/precomp.h
@@ -22,6 +22,8 @@
 #include <dxgi.h>
 #include <dxgi1_2.h>
 #include <dxgi1_3.h>
+#include <dxgi1_4.h>
+#include <dxgi1_5.h>
 
 #include <d3d11.h>
 #include <d2d1.h>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Implements guidance examples from https://docs.microsoft.com/en-us/windows/desktop/direct3ddxgi/variable-refresh-rate-displays to hopefully resolve variable refresh rate display issues.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1413
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed (n/a, visual)
* [x] Requires documentation to be updated (no)
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: I am a core contributor.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Adds check during DXGI creation for tearing support
- Uses tearing check status to apply appropriate flags to swap chain creation, swap chain buffer resize, and presentation calls.
- Sets presentation sync to 0 to present immediately (per variable refresh doc). I don't remember why I had this as 1. It might become a problem. If it does, we'll conditionally change it back and forth. But reading the docs now, I think 0 is OK.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- All manual since we don't have automated visual tests:
    - I checked that everything was looking fine on a standard 1080p 60hz monitor still
    - I changed my second monitor to 150% scaling and dragged the window back and forth with a full line of text at the pwsh prompt to ensure that everything fit correctly as the display size updated and caused refreshes of buffer and scaling sizes

