### PR TITLE
#1363 - Campbell color scheme should change the foreground color from #F2F2F2 to #CCCCCC

### DIFF
--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -37,7 +37,7 @@ CascadiaSettings::~CascadiaSettings()
 ColorScheme _CreateCampbellScheme()
 {
     ColorScheme campbellScheme{ L"Campbell",
-                                RGB(242, 242, 242),
+                                RGB(204, 204, 204),
                                 RGB(12, 12, 12) };
     auto& campbellTable = campbellScheme.GetTable();
     auto campbellSpan = gsl::span<COLORREF>(&campbellTable[0], gsl::narrow<ptrdiff_t>(COLOR_TABLE_SIZE));


### PR DESCRIPTION
Changed the foreground color from #F2F2F2 to #CCCCCC.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
I changed where foreground is set in CascadiaSettings.cpp, from #F2F2F2 : RGB(242, 242, 242) to #CCCCCC : RGB(204, 204, 204).

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1363
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests ~~added/passed~~ N/A
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1363

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
As detailed in the bug, this slightly reduces the brightness of the default/foreground color of the Campbell color scheme from BrightWhite to White. This then allows the use of ESC sequence codes to add an intensity bit to make White display as BrightWhite. Without this change, using ESC[1m would keep the display color the same.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
This was tested by manipulating the profiles.json to find the correct values to use. The code change was not tested outside this commit because it is a direct replacement of hard coded data, so there are no behavioral changes which should need to be evaluated separately.
