### PR TITLE
Fix a bug where Terminal may crash or hang at shutdown

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -46,10 +46,8 @@ namespace winrt::TerminalApp::implementation
         // cause you to chase down the rabbit hole of "why is App not
         // registered?" when it definitely is.
 
-        // See GH#1339. This is a workaround for MSFT:22116519
-        // We need this to prevent an occasional crash on teardown
-        AddRef();
-        m_inner.as<::IUnknown>()->Release();
+        // Initialize will become protected or be deleted when GH#1339 (workaround for MSFT:22116519) are fixed.
+        Initialize();
     }
 
     void App::Initialize()

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -52,6 +52,16 @@ namespace winrt::TerminalApp::implementation
         m_inner.as<::IUnknown>()->Release();
     }
 
+    void App::Initialize()
+    {
+        if (this->outer())
+        {
+            this->outer()->AddRef();
+        }
+
+        _windowsXamlManager = winrt::Windows::UI::Xaml::Hosting::WindowsXamlManager::InitializeForCurrentThread();
+    }
+
     // Method Description:
     // - Build the UI for the terminal app. Before this method is called, it
     //   should not be assumed that the TerminalApp is usable. The Settings

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -50,16 +50,6 @@ namespace winrt::TerminalApp::implementation
         Initialize();
     }
 
-    void App::Initialize()
-    {
-        if (this->outer())
-        {
-            this->outer()->AddRef();
-        }
-
-        _windowsXamlManager = winrt::Windows::UI::Xaml::Hosting::WindowsXamlManager::InitializeForCurrentThread();
-    }
-
     // Method Description:
     // - Build the UI for the terminal app. Before this method is called, it
     //   should not be assumed that the TerminalApp is usable. The Settings

--- a/src/cascadia/TerminalApp/App.h
+++ b/src/cascadia/TerminalApp/App.h
@@ -15,6 +15,7 @@
 #include <winrt/Microsoft.UI.Xaml.Controls.Primitives.h>
 #include <winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>
 
+#include <winrt/Windows.UI.Xaml.Hosting.h>
 #include <winrt/Windows.ApplicationModel.DataTransfer.h>
 
 namespace winrt::TerminalApp::implementation
@@ -23,6 +24,8 @@ namespace winrt::TerminalApp::implementation
     {
     public:
         App();
+
+        void Initialize();
 
         Windows::UI::Xaml::UIElement GetRoot() noexcept;
         Windows::UI::Xaml::UIElement GetTabs() noexcept;
@@ -139,6 +142,9 @@ namespace winrt::TerminalApp::implementation
         void _PasteFromClipboardHandler(const IInspectable& sender, const Microsoft::Terminal::TerminalControl::PasteFromClipboardEventArgs& eventArgs);
 
         static void _SetAcceleratorForMenuItem(Windows::UI::Xaml::Controls::MenuFlyoutItem& menuItem, const winrt::Microsoft::Terminal::Settings::KeyChord& keyChord);
+
+        bool _bIsClosed = false;
+        winrt::Windows::UI::Xaml::Hosting::WindowsXamlManager _windowsXamlManager{ nullptr };
     };
 }
 

--- a/src/cascadia/TerminalApp/App.h
+++ b/src/cascadia/TerminalApp/App.h
@@ -15,7 +15,6 @@
 #include <winrt/Microsoft.UI.Xaml.Controls.Primitives.h>
 #include <winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>
 
-#include <winrt/Windows.UI.Xaml.Hosting.h>
 #include <winrt/Windows.ApplicationModel.DataTransfer.h>
 
 namespace winrt::TerminalApp::implementation
@@ -140,9 +139,6 @@ namespace winrt::TerminalApp::implementation
         void _PasteFromClipboardHandler(const IInspectable& sender, const Microsoft::Terminal::TerminalControl::PasteFromClipboardEventArgs& eventArgs);
 
         static void _SetAcceleratorForMenuItem(Windows::UI::Xaml::Controls::MenuFlyoutItem& menuItem, const winrt::Microsoft::Terminal::Settings::KeyChord& keyChord);
-
-        bool _bIsClosed = false;
-        winrt::Windows::UI::Xaml::Hosting::WindowsXamlManager _windowsXamlManager{ nullptr };
     };
 }
 

--- a/src/cascadia/TerminalApp/App.h
+++ b/src/cascadia/TerminalApp/App.h
@@ -25,8 +25,6 @@ namespace winrt::TerminalApp::implementation
     public:
         App();
 
-        void Initialize();
-
         Windows::UI::Xaml::UIElement GetRoot() noexcept;
         Windows::UI::Xaml::UIElement GetTabs() noexcept;
 

--- a/src/cascadia/TerminalApp/App.idl
+++ b/src/cascadia/TerminalApp/App.idl
@@ -9,6 +9,8 @@ namespace TerminalApp
     {
         App();
 
+        void Initialize();
+
         // For your own sanity, it's better to do setup outside the ctor.
         // If you do any setup in the ctor that ends up throwing an exception,
         // then it might look like TermApp just failed to activate, which will

--- a/src/cascadia/TerminalApp/pch.h
+++ b/src/cascadia/TerminalApp/pch.h
@@ -35,6 +35,7 @@
 #include <winrt/Windows.ui.xaml.media.h>
 #include <winrt/Windows.ui.xaml.input.h>
 #include <winrt/Windows.UI.Xaml.Hosting.h>
+#include <winrt/Microsoft.Toolkit.Win32.UI.XamlHost.h>
 
 #include <windows.ui.xaml.media.dxinterop.h>
 

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -41,6 +41,7 @@ AppHost::AppHost() noexcept :
 
 AppHost::~AppHost()
 {
+    // destruction order is important for proper teardown here
     _window = nullptr;
     _app.Close();
     _app = nullptr;

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -41,7 +41,9 @@ AppHost::AppHost() noexcept :
 
 AppHost::~AppHost()
 {
+    _window = nullptr;
     _app.Close();
+    _app = nullptr;
 }
 
 // Method Description:
@@ -57,7 +59,6 @@ AppHost::~AppHost()
 // - <none>
 void AppHost::Initialize()
 {
-    _app.Initialize();
     _window->Initialize();
     const auto handle = _window->GetHandle();
     _app.Create(reinterpret_cast<uint64_t>(handle));

--- a/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
+++ b/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
@@ -90,10 +90,16 @@
       <DeploymentContent>true</DeploymentContent>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </NativeReferenceFile>
-    <NativeReferenceFile Include="$(OpenConsoleDir)$(Platform)\$(Configuration)\TerminalApp\Microsoft.Toolkit.Win32.UI.XamlHost.dll">
+
+    <!--
+      The reason why this is needed for ARM64 is unknown,
+      If not added, the centenial package will fail to include the XamlHost dll.
+    -->
+    <NativeReferenceFile Include="$(OpenConsoleDir)$(Platform)\$(Configuration)\TerminalApp\Microsoft.Toolkit.Win32.UI.XamlHost.dll" Condition="'$(Platform)'=='ARM64'">
       <DeploymentContent>true</DeploymentContent>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </NativeReferenceFile>
+
     <!--
       the packaging project wont recurse through our dependencies, you have to
       make sure that if you add a cppwinrt dependency to any of these projects,

--- a/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
+++ b/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
@@ -90,6 +90,10 @@
       <DeploymentContent>true</DeploymentContent>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </NativeReferenceFile>
+    <NativeReferenceFile Include="$(OpenConsoleDir)$(Platform)\$(Configuration)\TerminalApp\Microsoft.Toolkit.Win32.UI.XamlHost.dll">
+      <DeploymentContent>true</DeploymentContent>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </NativeReferenceFile>
     <!--
       the packaging project wont recurse through our dependencies, you have to
       make sure that if you add a cppwinrt dependency to any of these projects,

--- a/src/cascadia/WindowsTerminal/pch.h
+++ b/src/cascadia/WindowsTerminal/pch.h
@@ -41,7 +41,6 @@ Abstract:
 #include <winrt/Windows.system.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.UI.Xaml.Hosting.h>
-#include <winrt/Microsoft.Toolkit.Win32.UI.XamlHost.h>
 #include <windows.ui.xaml.hosting.desktopwindowxamlsource.h>
 
 // Additional headers for various xaml features. We need:


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fix issue [1380](https://github.com/microsoft/terminal/issues/1380)
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
[1380](https://github.com/microsoft/terminal/issues/1380)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #1380
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The order of destruction is incorrect:
Construction: 1. XamlApp, 2. XamlIsland
Destruction: 1. XamlApp, 2. XamlIsland, it should be 1. Xamlsland, 2. XamlApp

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually debugged that the Xaml core is de-initialized correctly.
