### PR TITLE
Disable the AppContainer bit on our C++/WinRT binaries

### DIFF
--- a/src/cppwinrt.build.pre.props
+++ b/src/cppwinrt.build.pre.props
@@ -128,6 +128,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>WindowsApp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AppContainer>false</AppContainer>
     </Link>
   </ItemDefinitionGroup>
 


### PR DESCRIPTION
Having the AppContainer bit enabled makes us fail the Windows App
Certification Kit test required to submit to the store.

## References

## PR Checklist
* [x] Closes #1652
* [x] CLA signed.
* [x] I've discussed this with core contributors already.

## Validation

Manual, local WACK.