### PR TITLE
Move implementation of padding to DxRenderer

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -86,6 +86,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         FontInfoDesired _desiredFont;
         FontInfo _actualFont;
+        RECT _charGridPadding;
 
         std::optional<int> _lastScrollOffset;
 
@@ -139,11 +140,11 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         bool _ReleasePointerCapture(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
 
         void _ScrollbarUpdater(Windows::UI::Xaml::Controls::Primitives::ScrollBar scrollbar, const int viewTop, const int viewHeight, const int bufferSize);
-        static Windows::UI::Xaml::Thickness _ParseThicknessFromPadding(const hstring padding);
+        static RECT _ParsePadding(const hstring padding);
 
         Settings::KeyModifiers _GetPressedModifierKeys() const;
 
-        const COORD _GetTerminalPosition(winrt::Windows::Foundation::Point cursorPosition);
+        const COORD _GetTerminalPosition(winrt::Windows::Foundation::Point cursorPosition, bool clampToViewport = true);
     };
 }
 

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1273,7 +1273,7 @@ float DxEngine::GetScaling() const noexcept
 {
     SMALL_RECT r;
     r.Top = (SHORT)(floor((_invalidRect.top - _charGridPadding.top) / _glyphCell.cy));
-    r.Left = (SHORT)(floor((_invalidRect.left- _charGridPadding.left) / _glyphCell.cx));
+    r.Left = (SHORT)(floor((_invalidRect.left - _charGridPadding.left) / _glyphCell.cx));
     r.Bottom = (SHORT)(floor((_invalidRect.bottom - _charGridPadding.bottom) / _glyphCell.cy));
     r.Right = (SHORT)(floor((_invalidRect.right - _charGridPadding.right) / _glyphCell.cx));
 

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -42,6 +42,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT SetHwnd(const HWND hwnd) noexcept;
 
         [[nodiscard]] HRESULT SetWindowSize(const SIZE pixels) noexcept;
+        [[nodiscard]] HRESULT SetCharGridPadding(const RECT pixels) noexcept;
 
         void SetCallback(std::function<void()> pfn);
 
@@ -107,6 +108,7 @@ namespace Microsoft::Console::Render
 
         HWND _hwndTarget;
         SIZE _sizeTarget;
+        RECT _charGridPadding;
         int _dpi;
         float _scale;
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Moved padding from `TermControl` to `DxRenderer`. It solves problems with handling pointer input at padded area, since now this is the same control as the text is (#1367). Since this removes padding from `_root` element, scrollbar now sticks to the right edge (#1365).

It allows the renderer to draw on that area, which can be now somehow used. Specifically, it prevents potential effects from being cut on the char grid edge, when there is still some space for them (like selection outlining, which I would like).

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #1367, #1365
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- I implemented this only on `DxRendere` since padding is only used there.
- It removes support for floating-point padding, but playing with floating-point pixel dimensions in such cases seems only to cause trouble.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Set padding, click or select both inside and outside padding, change padding at rutime.