### PR TITLE
Enable DECCOLM support via a private mode escape sequence

### DIFF
--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -992,8 +992,7 @@ void ScreenBufferTests::VtResizeDECCOLM()
     const auto setDECCOLM = L"\x1b[?3h";
     const auto resetDECCOLM = L"\x1b[?3l";
 
-    auto getRelativeCursorPosition = [&]()
-    {
+    auto getRelativeCursorPosition = [&]() {
         return si.GetTextBuffer().GetCursor().GetPosition() - si.GetViewport().Origin();
     };
 
@@ -1031,8 +1030,9 @@ void ScreenBufferTests::VtResizeDECCOLM()
     initialViewHeight = newViewHeight;
     initialViewWidth = newViewWidth;
 
-    Log::Comment(L"Once DECCOLM is allowed, "
-        L"setting it should change the width to 132 columns "
+    Log::Comment(
+        L"Once DECCOLM is allowed, setting it "
+        L"should change the width to 132 columns "
         L"and reset the margins and cursor position");
     stateMachine.ProcessString(allowDECCOLM);
     stateMachine.ProcessString(setDECCOLM);
@@ -1084,8 +1084,9 @@ void ScreenBufferTests::VtResizeDECCOLM()
     initialViewHeight = newViewHeight;
     initialViewWidth = newViewWidth;
 
-    Log::Comment(L"Once DECCOLM is allowed again, "
-        L"resetting it should change the width to 80 columns "
+    Log::Comment(
+        L"Once DECCOLM is allowed again, resetting it "
+        L"should change the width to 80 columns "
         L"and reset the margins and cursor position");
     stateMachine.ProcessString(allowDECCOLM);
     stateMachine.ProcessString(resetDECCOLM);

--- a/src/terminal/adapter/DispatchTypes.hpp
+++ b/src/terminal/adapter/DispatchTypes.hpp
@@ -77,6 +77,7 @@ namespace Microsoft::Console::VirtualTerminal::DispatchTypes
         DECCOLM_SetNumberOfColumns = 3,
         ATT610_StartCursorBlink = 12,
         DECTCEM_TextCursorEnableMode = 25,
+        XTERM_EnableDECCOLMSupport = 40,
         VT200_MOUSE_MODE = 1000,
         BUTTTON_EVENT_MOUSE_MODE = 1002,
         ANY_EVENT_MOUSE_MODE = 1003,

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -58,6 +58,7 @@ public:
     virtual bool ForwardTab(const SHORT sNumTabs) = 0; // CHT
     virtual bool BackwardsTab(const SHORT sNumTabs) = 0; // CBT
     virtual bool TabClear(const SHORT sClearType) = 0; // TBC
+    virtual bool EnableDECCOLMSupport(const bool fEnabled) = 0; // ?40
     virtual bool EnableVT200MouseMode(const bool fEnabled) = 0; // ?1000
     virtual bool EnableUTF8ExtendedMouseMode(const bool fEnabled) = 0; // ?1005
     virtual bool EnableSGRExtendedMouseMode(const bool fEnabled) = 0; // ?1006

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -85,6 +85,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool DesignateCharset(const wchar_t wchCharset) override; // DesignateCharset
         bool SoftReset() override; // DECSTR
         bool HardReset() override; // RIS
+        bool EnableDECCOLMSupport(const bool fEnabled) override; // ?40
         bool EnableVT200MouseMode(const bool fEnabled) override; // ?1000
         bool EnableUTF8ExtendedMouseMode(const bool fEnabled) override; // ?1005
         bool EnableSGRExtendedMouseMode(const bool fEnabled) override; // ?1006
@@ -149,7 +150,7 @@ namespace Microsoft::Console::VirtualTerminal
         COORD _coordSavedCursor;
         SMALL_RECT _srScrollMargins;
 
-        bool _fIsSetColumnsEnabled;
+        bool _fIsDECCOLMAllowed;
 
         bool _fChangedForeground;
         bool _fChangedBackground;

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -55,6 +55,7 @@ public:
     bool ForwardTab(const SHORT /*sNumTabs*/) override { return false; } // CHT
     bool BackwardsTab(const SHORT /*sNumTabs*/) override { return false; } // CBT
     bool TabClear(const SHORT /*sClearType*/) override { return false; } // TBC
+    bool EnableDECCOLMSupport(const bool /*fEnabled*/) override { return false; } // ?40
     bool EnableVT200MouseMode(const bool /*fEnabled*/) override { return false; } // ?1000
     bool EnableUTF8ExtendedMouseMode(const bool /*fEnabled*/) override { return false; } // ?1005
     bool EnableSGRExtendedMouseMode(const bool /*fEnabled*/) override { return false; } // ?1006

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -641,6 +641,7 @@ public:
         _fIsAltBuffer{ false },
         _fCursorKeysMode{ false },
         _fCursorBlinking{ true },
+        _fIsDECCOLMAllowed{ false },
         _uiWindowWidth{ 80 }
     {
         memset(_rgOptions, s_uiGraphicsCleared, sizeof(_rgOptions));
@@ -807,6 +808,9 @@ public:
         case DispatchTypes::PrivateModeParams::DECTCEM_TextCursorEnableMode:
             fSuccess = CursorVisibility(fEnable);
             break;
+        case DispatchTypes::PrivateModeParams::XTERM_EnableDECCOLMSupport:
+            fSuccess = EnableDECCOLMSupport(fEnable);
+            break;
         case DispatchTypes::PrivateModeParams::ASB_AlternateScreenBuffer:
             fSuccess = fEnable ? UseAlternateScreenBuffer() : UseMainScreenBuffer();
             break;
@@ -860,6 +864,12 @@ public:
         return true;
     }
 
+    bool EnableDECCOLMSupport(const bool fEnabled) override
+    {
+        _fIsDECCOLMAllowed = fEnabled;
+        return true;
+    }
+
     bool UseAlternateScreenBuffer() override
     {
         _fIsAltBuffer = true;
@@ -899,6 +909,7 @@ public:
     bool _fIsAltBuffer;
     bool _fCursorKeysMode;
     bool _fCursorBlinking;
+    bool _fIsDECCOLMAllowed;
     unsigned int _uiWindowWidth;
 
     static const size_t s_cMaxOptions = 16;
@@ -1261,6 +1272,24 @@ class StateMachineExternalTest final
         VERIFY_IS_FALSE(pDispatch->_fIsAltBuffer);
         mach.ProcessString(L"\x1b[?1049l", 8);
         VERIFY_IS_FALSE(pDispatch->_fIsAltBuffer);
+
+        pDispatch->ClearState();
+    }
+
+    TEST_METHOD(TestEnableDECCOLMSupport)
+    {
+        StatefulDispatch* pDispatch = new StatefulDispatch;
+        VERIFY_IS_NOT_NULL(pDispatch);
+        StateMachine mach(new OutputStateMachineEngine(pDispatch));
+
+        mach.ProcessString(L"\x1b[?40h");
+        VERIFY_IS_TRUE(pDispatch->_fIsDECCOLMAllowed);
+
+        pDispatch->ClearState();
+        pDispatch->_fIsDECCOLMAllowed = true;
+
+        mach.ProcessString(L"\x1b[?40l");
+        VERIFY_IS_FALSE(pDispatch->_fIsDECCOLMAllowed);
 
         pDispatch->ClearState();
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

While the [DECCOLM](https://vt100.net/docs/vt100-ug/chapter3.html#DECCOLM) escape sequence is technically implemented, it's disabled by a flag that is not user-accessible. This PR adds support for an escape sequence (XTerm's private mode 40) which essentially enables that flag, so users can turn on DECCOLM support in an XTerm-compatible way. Tested manually, with [Vttest](https://invisible-island.net/vttest/), and with unit tests.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #171
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [x] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #171

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

My initial plan was to build this on top of the existing `_fIsSetColumnsEnabled` flag, but after further investigation that proved not to be practical. In order to be compatible with XTerm, the flag needs to be checked in the `_DoDECCOLMHelper` method rather than in `SetColumns`, since it needs to prevent all facets of the DECCOLM operation taking effect - not just the column sizing.

And in the future, if the `SetColumns` method is also going to be used to support the DECSCPP escape sequence, that will need a flag of its own - it's not controlled by the same option as DECCOLMN.

For those reasons, I've removed the existing `_fIsSetColumnsEnabled` flag and added a new `_fIsDECCOLMAllowed` flag which is checked in the `_DoDECCOLMHelper` method. I've then added a `EnableDECCOLMSupport` method to toggle that flag, and added a case in `_PrivateModeParamsHelper` to call that method in response to the private mode 40 sequence.

While I did mention my initial plans on issue #171, I never actually got feedback from core contributors, so I completely understand if this PR is rejected in favour of a different approach. I'm just offering it as one possible solution.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

I've added an output engine unit test which validates that the private mode escape sequences trigger the `EnableDECCOLMSupport` call, and some screen buffer unit tests which check that the DECCOLM sequence does take effect when allowed, and doesn't do anything when disallowed.

I've also done a fair amount of manual testing, and run several of the [Vttest](https://invisible-island.net/vttest/) suites which toggle between 80 and 132 column modes, and which now work (at least in terms of column width) where previously they didn't. 