### PR TITLE
Add a ControlKeyStates wrapper class

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -1213,7 +1213,7 @@ namespace winrt::TerminalApp::implementation
         {
             if (focusedTabIndex >= _tabs.size())
             {
-                focusedTabIndex = _tabs.size() - 1;
+                focusedTabIndex = static_cast<int>(_tabs.size()) - 1;
             }
 
             if (focusedTabIndex < 0)

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -624,9 +624,9 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         if (bindings)
         {
             KeyChord chord(
-                WI_IsAnyFlagSet(modifiers, CTRL_PRESSED),
-                WI_IsAnyFlagSet(modifiers, ALT_PRESSED),
-                WI_IsFlagSet(modifiers, SHIFT_PRESSED),
+                modifiers.IsCtrlPressed(),
+                modifiers.IsAltPressed(),
+                modifiers.IsShiftPressed(),
                 vkey);
             handled = bindings.TryKeyChord(chord);
         }
@@ -1413,8 +1413,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     //   find out which modifiers (ctrl, alt, shift) are pressed in events that
     //   don't necessarily include that state.
     // Return Value:
-    // - The combined ControlKeyState flags as a bitfield.
-    DWORD TermControl::_GetPressedModifierKeys() const
+    // - The Microsoft::Terminal::Core::ControlKeyStates representing the modifier key states.
+    ControlKeyStates TermControl::_GetPressedModifierKeys() const
     {
         CoreWindow window = CoreWindow::GetForCurrentThread();
         // DONT USE
@@ -1428,24 +1428,28 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         struct KeyModifier
         {
             VirtualKey vkey;
-            DWORD flag;
+            ControlKeyStates flags;
         };
 
         constexpr std::array<KeyModifier, 5> modifiers{ {
-            { VirtualKey::RightMenu, RIGHT_ALT_PRESSED },
-            { VirtualKey::LeftMenu, LEFT_ALT_PRESSED },
-            { VirtualKey::RightControl, RIGHT_CTRL_PRESSED },
-            { VirtualKey::LeftControl, LEFT_CTRL_PRESSED },
-            { VirtualKey::Shift, SHIFT_PRESSED },
+            { VirtualKey::RightMenu, ControlKeyStates::RightAltPressed },
+            { VirtualKey::LeftMenu, ControlKeyStates::LeftAltPressed },
+            { VirtualKey::RightControl, ControlKeyStates::RightCtrlPressed },
+            { VirtualKey::LeftControl, ControlKeyStates::LeftCtrlPressed },
+            { VirtualKey::Shift, ControlKeyStates::ShiftPressed },
         } };
 
-        DWORD flags = 0;
+        ControlKeyStates flags;
 
         for (const auto& mod : modifiers)
         {
             const auto state = window.GetKeyState(mod.vkey);
             const auto isDown = WI_IsFlagSet(state, CoreVirtualKeyStates::Down);
-            flags |= isDown ? mod.flag : 0;
+
+            if (isDown)
+            {
+                flags |= mod.flags;
+            }
         }
 
         return flags;

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -110,7 +110,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _ApplyUISettings();
         void _InitializeBackgroundBrush();
         void _BackgroundColorChanged(const uint32_t color);
-        void _ApplyConnectionSettings();
         void _InitializeTerminal();
         void _UpdateFont();
         void _KeyDownHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e);

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -140,7 +140,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _ScrollbarUpdater(Windows::UI::Xaml::Controls::Primitives::ScrollBar scrollbar, const int viewTop, const int viewHeight, const int bufferSize);
         static Windows::UI::Xaml::Thickness _ParseThicknessFromPadding(const hstring padding);
 
-        DWORD _GetPressedModifierKeys() const;
+        ::Microsoft::Terminal::Core::ControlKeyStates _GetPressedModifierKeys() const;
 
         const COORD _GetTerminalPosition(winrt::Windows::Foundation::Point cursorPosition);
     };

--- a/src/cascadia/TerminalCore/ControlKeyStates.hpp
+++ b/src/cascadia/TerminalCore/ControlKeyStates.hpp
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+namespace Microsoft::Terminal::Core
+{
+    class ControlKeyStates;
+}
+
+constexpr Microsoft::Terminal::Core::ControlKeyStates operator|(Microsoft::Terminal::Core::ControlKeyStates lhs, Microsoft::Terminal::Core::ControlKeyStates rhs) noexcept;
+
+// This class is functionally equivalent to PowerShell's System.Management.Automation.Host.ControlKeyStates enum:
+//   https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.host.controlkeystates
+// It's flagging values are compatible to those used by the NT console subsystem (<um/wincon.h>),
+// as these are being used throughout older parts of this project.
+class Microsoft::Terminal::Core::ControlKeyStates
+{
+    struct StaticValue
+    {
+        DWORD v;
+    };
+
+public:
+    static constexpr StaticValue RightAltPressed{ RIGHT_ALT_PRESSED };
+    static constexpr StaticValue LeftAltPressed{ LEFT_ALT_PRESSED };
+    static constexpr StaticValue RightCtrlPressed{ RIGHT_CTRL_PRESSED };
+    static constexpr StaticValue LeftCtrlPressed{ LEFT_CTRL_PRESSED };
+    static constexpr StaticValue ShiftPressed{ SHIFT_PRESSED };
+    static constexpr StaticValue NumlockOn{ NUMLOCK_ON };
+    static constexpr StaticValue ScrolllockOn{ SCROLLLOCK_ON };
+    static constexpr StaticValue CapslockOn{ CAPSLOCK_ON };
+    static constexpr StaticValue EnhancedKey{ ENHANCED_KEY };
+
+    constexpr ControlKeyStates() noexcept :
+        _value(0) {}
+
+    constexpr ControlKeyStates(StaticValue value) noexcept :
+        _value(value.v) {}
+
+    explicit constexpr ControlKeyStates(DWORD value) noexcept :
+        _value(value) {}
+
+    ControlKeyStates& operator|=(ControlKeyStates rhs) noexcept
+    {
+        _value |= rhs.Value();
+        return *this;
+    }
+
+    constexpr DWORD Value() const noexcept
+    {
+        return _value;
+    }
+
+    constexpr bool IsShiftPressed() const noexcept
+    {
+        return IsAnyFlagSet(ShiftPressed);
+    }
+
+    constexpr bool IsAltPressed() const noexcept
+    {
+        return IsAnyFlagSet(RightAltPressed | LeftAltPressed);
+    }
+
+    constexpr bool IsCtrlPressed() const noexcept
+    {
+        return IsAnyFlagSet(RightCtrlPressed | LeftCtrlPressed);
+    }
+
+    constexpr bool IsAltGrPressed() const noexcept
+    {
+        return AreAllFlagsSet(RightAltPressed | LeftCtrlPressed);
+    }
+
+    constexpr bool IsModifierPressed() const noexcept
+    {
+        return IsAnyFlagSet(RightAltPressed | LeftAltPressed | RightCtrlPressed | LeftCtrlPressed | ShiftPressed);
+    }
+
+private:
+    constexpr bool AreAllFlagsSet(ControlKeyStates mask) const noexcept
+    {
+        return (Value() & mask.Value()) == mask.Value();
+    }
+
+    constexpr bool IsAnyFlagSet(ControlKeyStates mask) const noexcept
+    {
+        return (Value() & mask.Value()) != 0;
+    }
+
+    DWORD _value;
+};
+
+constexpr Microsoft::Terminal::Core::ControlKeyStates operator|(Microsoft::Terminal::Core::ControlKeyStates lhs, Microsoft::Terminal::Core::ControlKeyStates rhs) noexcept
+{
+    return Microsoft::Terminal::Core::ControlKeyStates{ lhs.Value() | rhs.Value() };
+}
+
+constexpr Microsoft::Terminal::Core::ControlKeyStates operator&(Microsoft::Terminal::Core::ControlKeyStates lhs, Microsoft::Terminal::Core::ControlKeyStates rhs) noexcept
+{
+    return Microsoft::Terminal::Core::ControlKeyStates{ lhs.Value() & rhs.Value() };
+}
+
+constexpr bool operator==(Microsoft::Terminal::Core::ControlKeyStates lhs, Microsoft::Terminal::Core::ControlKeyStates rhs) noexcept
+{
+    return lhs.Value() == rhs.Value();
+}
+
+constexpr bool operator!=(Microsoft::Terminal::Core::ControlKeyStates lhs, Microsoft::Terminal::Core::ControlKeyStates rhs) noexcept
+{
+    return lhs.Value() != rhs.Value();
+}

--- a/src/cascadia/TerminalCore/ITerminalInput.hpp
+++ b/src/cascadia/TerminalCore/ITerminalInput.hpp
@@ -2,6 +2,9 @@
 // Licensed under the MIT license.
 
 #pragma once
+
+#include "ControlKeyStates.hpp"
+
 namespace Microsoft::Terminal::Core
 {
     class ITerminalInput
@@ -9,7 +12,7 @@ namespace Microsoft::Terminal::Core
     public:
         virtual ~ITerminalInput() {}
 
-        virtual bool SendKeyEvent(const WORD vkey, const DWORD modifiers) = 0;
+        virtual bool SendKeyEvent(const WORD vkey, const ControlKeyStates states) = 0;
 
         // void SendMouseEvent(uint row, uint col, KeyModifiers modifiers);
         [[nodiscard]] virtual HRESULT UserResize(const COORD size) noexcept = 0;

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -195,11 +195,11 @@ void Terminal::Write(std::wstring_view stringView)
 //   real character out of the event.
 // Arguments:
 // - vkey: The vkey of the key pressed.
-// - modifiers: The current ControlKeyState flags.
+// - states: The Microsoft::Terminal::Core::ControlKeyStates representing the modifier key states.
 // Return Value:
 // - true if we translated the key event, and it should not be processed any further.
 // - false if we did not translate the key, and it should be processed into a character.
-bool Terminal::SendKeyEvent(const WORD vkey, const DWORD modifiers)
+bool Terminal::SendKeyEvent(const WORD vkey, const ControlKeyStates states)
 {
     if (_snapOnInput && _scrollOffset != 0)
     {
@@ -208,8 +208,6 @@ bool Terminal::SendKeyEvent(const WORD vkey, const DWORD modifiers)
         _NotifyScrollEvent();
     }
 
-    KeyEvent keyEv{ true, 0, vkey, 0, UNICODE_NULL, modifiers };
-
     // AltGr key combinations don't always contain any meaningful,
     // pretranslated unicode character during WM_KEYDOWN.
     // E.g. on a German keyboard AltGr+Q should result in a "@" character,
@@ -217,14 +215,10 @@ bool Terminal::SendKeyEvent(const WORD vkey, const DWORD modifiers)
     // By returning false though, we can abort handling this WM_KEYDOWN
     // event and let the WM_CHAR handler kick in, which will be
     // provided with an appropriate unicode character.
-    if (keyEv.IsAltGrPressed())
+    if (states.IsAltGrPressed())
     {
         return false;
     }
-
-    const auto ctrlPressed = keyEv.IsCtrlPressed();
-    const auto altPressed = keyEv.IsAltPressed();
-    const auto shiftPressed = keyEv.IsShiftPressed();
 
     // Alt key sequences _require_ the char to be in the keyevent. If alt is
     // pressed, manually get the character that's being typed, and put it in the
@@ -232,35 +226,39 @@ bool Terminal::SendKeyEvent(const WORD vkey, const DWORD modifiers)
     // DON'T manually handle Alt+Space - the system will use this to bring up
     // the system menu for restore, min/maximimize, size, move, close
     wchar_t ch = UNICODE_NULL;
-    if (altPressed && vkey != VK_SPACE)
+    if (states.IsAltPressed() && vkey != VK_SPACE)
     {
         ch = static_cast<wchar_t>(LOWORD(MapVirtualKey(vkey, MAPVK_VK_TO_CHAR)));
         // MapVirtualKey will give us the capitalized version of the char.
         // However, if shift isn't pressed, we want to send the lowercase version.
         // (See GH#637)
-        if (!shiftPressed)
+        if (!states.IsShiftPressed())
         {
             ch = towlower(ch);
         }
     }
 
-    // Manually handle Ctrl+H. Ctrl+H should be handled as Backspace. To do this
-    // correctly, the keyEvents's char needs to be set to Backspace.
-    // 0x48 is the VKEY for 'H', which isn't named
-    if (ctrlPressed && vkey == 0x48)
+    if (states.IsCtrlPressed())
     {
-        ch = UNICODE_BACKSPACE;
+        switch (vkey)
+        {
+        case 0x48:
+            // Manually handle Ctrl+H. Ctrl+H should be handled as Backspace. To do this
+            // correctly, the keyEvents's char needs to be set to Backspace.
+            // 0x48 is the VKEY for 'H', which isn't named
+            ch = UNICODE_BACKSPACE;
+            break;
+        case VK_SPACE:
+            // Manually handle Ctrl+Space here. The terminalInput translator requires
+            // the char to be set to Space for space handling to work correctly.
+            ch = UNICODE_SPACE;
+            break;
+        }
     }
-    // Manually handle Ctrl+Space here. The terminalInput translator requires
-    // the char to be set to Space for space handling to work correctly.
-    if (ctrlPressed && vkey == VK_SPACE)
-    {
-        ch = UNICODE_SPACE;
-    }
-
-    keyEv.SetCharData(ch);
 
     const bool manuallyHandled = ch != UNICODE_NULL;
+
+    KeyEvent keyEv{ true, 0, vkey, 0, ch, states.Value() };
     const bool translated = _terminalInput->HandleKey(&keyEv);
 
     return translated && manuallyHandled;

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -76,7 +76,7 @@ public:
 
 #pragma region ITerminalInput
     // These methods are defined in Terminal.cpp
-    bool SendKeyEvent(const WORD vkey, const DWORD modifiers) override;
+    bool SendKeyEvent(const WORD vkey, const Microsoft::Terminal::Core::ControlKeyStates states) override;
     [[nodiscard]] HRESULT UserResize(const COORD viewportSize) noexcept override;
     void UserScrollViewport(const int viewTop) override;
     int GetScrollOffset() override;

--- a/src/cascadia/TerminalCore/terminalcore-common.vcxproj
+++ b/src/cascadia/TerminalCore/terminalcore-common.vcxproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ClInclude Include="..\ControlKeyStates.hpp" />
     <ClInclude Include="..\TerminalDispatch.hpp" />
     <ClInclude Include="..\ITerminalApi.hpp" />
     <ClInclude Include="..\pch.h" />

--- a/src/cascadia/UnitTests_TerminalCore/InputTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/InputTest.cpp
@@ -48,12 +48,12 @@ namespace TerminalCoreUnitTests
         // Verify that Alt+a generates a lowercase a on the input
         expectedinput = L"\x1b"
                         "a";
-        VERIFY_IS_TRUE(term.SendKeyEvent(L'A', LEFT_ALT_PRESSED));
+        VERIFY_IS_TRUE(term.SendKeyEvent(L'A', ControlKeyStates::LeftAltPressed));
 
         // Verify that Alt+shift+a generates a uppercase a on the input
         expectedinput = L"\x1b"
                         "A";
-        VERIFY_IS_TRUE(term.SendKeyEvent(L'A', LEFT_ALT_PRESSED | SHIFT_PRESSED));
+        VERIFY_IS_TRUE(term.SendKeyEvent(L'A', ControlKeyStates::LeftAltPressed | ControlKeyStates::ShiftPressed));
     }
 
     void InputTest::AltSpace()
@@ -61,6 +61,6 @@ namespace TerminalCoreUnitTests
         // Make sure we don't handle Alt+Space. The system will use this to
         // bring up the system menu for restore, min/maximimize, size, move,
         // close
-        VERIFY_IS_FALSE(term.SendKeyEvent(L' ', LEFT_ALT_PRESSED));
+        VERIFY_IS_FALSE(term.SendKeyEvent(L' ', ControlKeyStates::LeftAltPressed));
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

As a continuation to #1436 this PR adds a `Microsoft::Terminal::Core::ControlKeyStates` class which will act as a safe wrapper for the ControlKeyState enum, found in the NT console subsystem (`<um/wincon.h>`) and used throughout the older parts of this project.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [x] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1436

## Detailed Description of the Pull Request / Additional comments

Feel free to reject, modify, adopt or otherwise use this code in any way or form.
If you have comments I'll try my best of integrating them.
The `ControlKeyStates` class I wrote is as good as I was able to think of one for now which is compatible to the rest of the code base.
I think it should replace the `KeyModifiers` enum, but I'm a total C# noob and was afraid of doing so (my total C# experience is about 10h or so and I haven't even touched IDLs yet lol).

## Validation Steps Performed

As with #1436 I tested all possible Alt/Ctrl/Shift/AltGr combinations on my german keyboard using PowerShell and wsl.
Only AltGr+E (= €) on PowerShell failed to work, but I strongly assume that this is due to the ReadLine module or similar, as it works with wsl.