### PR TITLE
Fix inaccurate Solarized palette

### DIFF
--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -113,12 +113,12 @@ ColorScheme _CreateOneHalfLightScheme()
 ColorScheme _CreateSolarizedDarkScheme()
 {
     ColorScheme solarizedDarkScheme { L"Solarized Dark",
-                                      RGB(253, 246, 227),
-                                      RGB(  7, 54,  66) };
+                                      RGB(131, 148, 150),
+                                      RGB(  0,  43,  54) };
     auto& solarizedDarkTable = solarizedDarkScheme.GetTable();
     auto solarizedDarkSpan = gsl::span<COLORREF>(&solarizedDarkTable[0], gsl::narrow<ptrdiff_t>(COLOR_TABLE_SIZE));
     solarizedDarkTable[0]  = RGB(  7, 54, 66);
-    solarizedDarkTable[1]  = RGB(211, 1, 2);
+    solarizedDarkTable[1]  = RGB(220, 50, 47);
     solarizedDarkTable[2]  = RGB(133, 153, 0);
     solarizedDarkTable[3]  = RGB(181, 137, 0);
     solarizedDarkTable[4]  = RGB( 38, 139, 210);
@@ -141,12 +141,12 @@ ColorScheme _CreateSolarizedDarkScheme()
 ColorScheme _CreateSolarizedLightScheme()
 {
     ColorScheme solarizedLightScheme { L"Solarized Light",
-                                       RGB(  7, 54,  66),
+                                       RGB(101, 123, 131),
                                        RGB(253, 246, 227) };
     auto& solarizedLightTable = solarizedLightScheme.GetTable();
     auto solarizedLightSpan = gsl::span<COLORREF>(&solarizedLightTable[0], gsl::narrow<ptrdiff_t>(COLOR_TABLE_SIZE));
     solarizedLightTable[0]  = RGB(  7, 54, 66);
-    solarizedLightTable[1]  = RGB(211, 1, 2);
+    solarizedLightTable[1]  = RGB(220, 50, 47);
     solarizedLightTable[2]  = RGB(133, 153, 0);
     solarizedLightTable[3]  = RGB(181, 137, 0);
     solarizedLightTable[4]  = RGB( 38, 139, 210);


### PR DESCRIPTION
## Summary of the Pull Request

Some of the colors from the Solarized schemes that ship with Windows Terminal are not aligned with the [reference Solarized palette](https://github.com/altercation/solarized#the-values).

## References

Also requires #293 for [correct rendering](https://github.com/microsoft/terminal/issues/293#issuecomment-506065103) of background/foreground colors.

## PR Checklist
* [x] Closes #1509
* [x] CLA signed.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.

## Detailed Description of the Pull Request / Additional comments

Implements the changes discussed in https://github.com/microsoft/terminal/issues/1509#issuecomment-505236830.

## Validation Steps Performed

No behavioral changes.