### PR TITLE
#1708 - Feature Request - Keyboard zoom-level adjustment

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -507,6 +507,8 @@ namespace winrt::TerminalApp::implementation
         bindings.NewTab([this]() { _OpenNewTab(std::nullopt); });
         bindings.CloseTab([this]() { _CloseFocusedTab(); });
         bindings.NewTabWithProfile([this](const auto index) { _OpenNewTab({ index }); });
+        bindings.IncreaseZoom([this]() { _IncreaseZoom(); });
+        bindings.DecreaseZoom([this]() { _DecreaseZoom(); });
         bindings.ScrollUp([this]() { _Scroll(-1); });
         bindings.ScrollDown([this]() { _Scroll(1); });
         bindings.NextTab([this]() { _SelectNextTab(true); });
@@ -993,6 +995,22 @@ namespace winrt::TerminalApp::implementation
         int focusedTabIndex = _GetFocusedTabIndex();
         std::shared_ptr<Tab> focusedTab{ _tabs[focusedTabIndex] };
         _RemoveTabViewItem(focusedTab->GetTabViewItem());
+    }
+
+    // Method Description:
+    // - Increase font zoom by 1. Behaves like pressing CTRL and turing the mouse wheel 1 step up.
+    void App::_IncreaseZoom()
+    {
+        const auto control = _GetFocusedControl();
+        control.KeyboardZoomHandler(1);
+    }
+
+    // Method Description:
+    // - Decrease font zoom by 1. Behaves like pressing CTRL and turing the mouse wheel 1 step down.
+    void App::_DecreaseZoom()
+    {
+        const auto control = _GetFocusedControl();
+        control.KeyboardZoomHandler(-1);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/App.h
+++ b/src/cascadia/TerminalApp/App.h
@@ -111,6 +111,8 @@ namespace winrt::TerminalApp::implementation
         void _SetFocusedTabIndex(int tabIndex);
         int _GetFocusedTabIndex() const;
 
+        void _IncreaseZoom();
+        void _DecreaseZoom();
         void _Scroll(int delta);
         void _CopyText(const bool trimTrailingWhitespace);
         void _PasteText();

--- a/src/cascadia/TerminalApp/AppKeyBindings.cpp
+++ b/src/cascadia/TerminalApp/AppKeyBindings.cpp
@@ -100,6 +100,12 @@ namespace winrt::TerminalApp::implementation
             _CloseTabHandlers();
             return true;
 
+        case ShortcutAction::IncreaseZoom:
+            _IncreaseZoomHandlers();
+            return true;
+        case ShortcutAction::DecreaseZoom:
+            _DecreaseZoomHandlers();
+            return true;
         case ShortcutAction::ScrollUp:
             _ScrollUpHandlers();
             return true;
@@ -229,6 +235,8 @@ namespace winrt::TerminalApp::implementation
     DEFINE_EVENT(AppKeyBindings, SplitHorizontal,   _SplitHorizontalHandlers,   TerminalApp::SplitHorizontalEventArgs);
     DEFINE_EVENT(AppKeyBindings, IncreaseFontSize,  _IncreaseFontSizeHandlers,  TerminalApp::IncreaseFontSizeEventArgs);
     DEFINE_EVENT(AppKeyBindings, DecreaseFontSize,  _DecreaseFontSizeHandlers,  TerminalApp::DecreaseFontSizeEventArgs);
+    DEFINE_EVENT(AppKeyBindings, IncreaseZoom,      _IncreaseZoomHandlers,      TerminalApp::IncreaseZoomEventArgs);
+    DEFINE_EVENT(AppKeyBindings, DecreaseZoom,      _DecreaseZoomHandlers,      TerminalApp::DecreaseZoomEventArgs);
     DEFINE_EVENT(AppKeyBindings, ScrollUp,          _ScrollUpHandlers,          TerminalApp::ScrollUpEventArgs);
     DEFINE_EVENT(AppKeyBindings, ScrollDown,        _ScrollDownHandlers,        TerminalApp::ScrollDownEventArgs);
     DEFINE_EVENT(AppKeyBindings, ScrollUpPage,      _ScrollUpPageHandlers,      TerminalApp::ScrollUpPageEventArgs);

--- a/src/cascadia/TerminalApp/AppKeyBindings.h
+++ b/src/cascadia/TerminalApp/AppKeyBindings.h
@@ -54,6 +54,8 @@ namespace winrt::TerminalApp::implementation
         DECLARE_EVENT(SplitHorizontal,   _SplitHorizontalHandlers,   TerminalApp::SplitHorizontalEventArgs);
         DECLARE_EVENT(IncreaseFontSize,  _IncreaseFontSizeHandlers,  TerminalApp::IncreaseFontSizeEventArgs);
         DECLARE_EVENT(DecreaseFontSize,  _DecreaseFontSizeHandlers,  TerminalApp::DecreaseFontSizeEventArgs);
+        DECLARE_EVENT(IncreaseZoom,      _IncreaseZoomHandlers,      TerminalApp::IncreaseZoomEventArgs);
+        DECLARE_EVENT(DecreaseZoom,      _DecreaseZoomHandlers,      TerminalApp::DecreaseZoomEventArgs);
         DECLARE_EVENT(ScrollUp,          _ScrollUpHandlers,          TerminalApp::ScrollUpEventArgs);
         DECLARE_EVENT(ScrollDown,        _ScrollDownHandlers,        TerminalApp::ScrollDownEventArgs);
         DECLARE_EVENT(ScrollUpPage,      _ScrollUpPageHandlers,      TerminalApp::ScrollUpPageEventArgs);

--- a/src/cascadia/TerminalApp/AppKeyBindings.idl
+++ b/src/cascadia/TerminalApp/AppKeyBindings.idl
@@ -36,6 +36,8 @@ namespace TerminalApp
         SwitchToTab8,
         IncreaseFontSize,
         DecreaseFontSize,
+        IncreaseZoom,
+        DecreaseZoom,
         ScrollUp,
         ScrollDown,
         ScrollUpPage,
@@ -57,6 +59,8 @@ namespace TerminalApp
     delegate void SwitchToTabEventArgs(Int32 profileIndex);
     delegate void IncreaseFontSizeEventArgs();
     delegate void DecreaseFontSizeEventArgs();
+    delegate void IncreaseZoomEventArgs();
+    delegate void DecreaseZoomEventArgs();
     delegate void ScrollUpEventArgs();
     delegate void ScrollDownEventArgs();
     delegate void ScrollUpPageEventArgs();
@@ -85,6 +89,8 @@ namespace TerminalApp
         event SplitHorizontalEventArgs SplitHorizontal;
         event IncreaseFontSizeEventArgs IncreaseFontSize;
         event DecreaseFontSizeEventArgs DecreaseFontSize;
+        event IncreaseZoomEventArgs IncreaseZoom;
+        event DecreaseZoomEventArgs DecreaseZoom;
         event ScrollUpEventArgs ScrollUp;
         event ScrollDownEventArgs ScrollDown;
         event ScrollUpPageEventArgs ScrollUpPage;

--- a/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
@@ -34,6 +34,8 @@ static constexpr std::string_view NextTabKey{ "nextTab" };
 static constexpr std::string_view PrevTabKey{ "prevTab" };
 static constexpr std::string_view IncreaseFontSizeKey{ "increaseFontSize" };
 static constexpr std::string_view DecreaseFontSizeKey{ "decreaseFontSize" };
+static constexpr std::string_view IncreaseZoomKey{ "increaseZoom" };
+static constexpr std::string_view DecreaseZoomKey{ "decreaseZoom" };
 static constexpr std::string_view ScrollupKey{ "scrollUp" };
 static constexpr std::string_view ScrolldownKey{ "scrollDown" };
 static constexpr std::string_view ScrolluppageKey{ "scrollUpPage" };
@@ -80,6 +82,8 @@ static const std::map<std::string_view, ShortcutAction, std::less<>> commandName
     { PrevTabKey, ShortcutAction::PrevTab },
     { IncreaseFontSizeKey, ShortcutAction::IncreaseFontSize },
     { DecreaseFontSizeKey, ShortcutAction::DecreaseFontSize },
+    { IncreaseZoomKey, ShortcutAction::IncreaseZoom },
+    { DecreaseZoomKey, ShortcutAction::DecreaseZoom },
     { ScrollupKey, ShortcutAction::ScrollUp },
     { ScrolldownKey, ShortcutAction::ScrollDown },
     { ScrolluppageKey, ShortcutAction::ScrollUpPage },

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -310,10 +310,10 @@ void CascadiaSettings::_CreateDefaultKeybindings()
 
     keyBindings.SetKeyBinding(ShortcutAction::IncreaseZoom,
                               KeyChord{ KeyModifiers::Ctrl,
-                                        VK_ADD});
+                                        VK_ADD | VK_OEM_PLUS });
     keyBindings.SetKeyBinding(ShortcutAction::DecreaseZoom,
                               KeyChord{ KeyModifiers::Ctrl,
-                                        VK_SUBTRACT });
+                                        VK_SUBTRACT | VK_OEM_MINUS });
     keyBindings.SetKeyBinding(ShortcutAction::ScrollUp,
                               KeyChord{ KeyModifiers::Ctrl | KeyModifiers::Shift,
                                         VK_UP });

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -308,6 +308,12 @@ void CascadiaSettings::_CreateDefaultKeybindings()
                               KeyChord{ KeyModifiers::Ctrl | KeyModifiers::Shift,
                                         static_cast<int>('9') });
 
+    keyBindings.SetKeyBinding(ShortcutAction::IncreaseZoom,
+                              KeyChord{ KeyModifiers::Ctrl,
+                                        VK_ADD});
+    keyBindings.SetKeyBinding(ShortcutAction::DecreaseZoom,
+                              KeyChord{ KeyModifiers::Ctrl,
+                                        VK_SUBTRACT });
     keyBindings.SetKeyBinding(ShortcutAction::ScrollUp,
                               KeyChord{ KeyModifiers::Ctrl | KeyModifiers::Shift,
                                         VK_UP });

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1277,6 +1277,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         return viewPort.Height();
     }
 
+    // Method Description:
+    // - Sets a incremented or decremented fontsize as value to the current tab.
     void TermControl::KeyboardZoomHandler(int zoom)
     {
         try

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1277,6 +1277,23 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         return viewPort.Height();
     }
 
+    void TermControl::KeyboardZoomHandler(int zoom)
+    {
+        try
+        {
+            const auto newSize = std::max(gsl::narrow<short>(_desiredFont.GetEngineSize().Y + zoom), static_cast<short>(1));
+            const auto* fontFace = _settings.FontFace().c_str();
+
+            _actualFont = { fontFace, 0, 10, { 0, newSize }, CP_UTF8, false };
+            _desiredFont = { _actualFont };
+
+            _UpdateFont();
+            auto lock = _terminal->LockForWriting();
+            _DoResize(_swapChainPanel.ActualWidth(), _swapChainPanel.ActualHeight());
+        }
+        CATCH_LOG();
+    }
+
     // Function Description:
     // - Determines how much space (in pixels) an app would need to reserve to
     //   create a control with the settings stored in the settings param. This

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -50,6 +50,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         int GetScrollOffset();
         int GetViewHeight() const;
 
+        void KeyboardZoomHandler(int zoom);
+
         void SwapChainChanged();
         ~TermControl();
 

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -40,6 +40,8 @@ namespace Microsoft.Terminal.TerminalControl
         void KeyboardScrollViewport(Int32 viewTop);
         Int32 GetScrollOffset();
         Int32 GetViewHeight();
+
+        void KeyboardZoomHandler(Int32 zoom);
         event ScrollPositionChangedEventArgs ScrollPositionChanged;
     }
 }


### PR DESCRIPTION
Added keybinding option for increasing and decreasing the font size in a terminal

## Summary of the Pull Request

Added implementation to allow users to increase and decrease the font size in a terminal.
This feature behaves like the user would turn the mouse-wheel one step up/down.
## References

## PR Checklist
* [x] Closes #1708
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests <del>added/passed</del> N/A
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1708

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

A simple implementation for the functionality to 'zoom' in/out with CTRL pressed and using the wheel on the mouse was made. 
Therefore I added the needed implementations for this, which can be seen in the diff to the master.

## Validation Steps Performed
* Open Terminal
* Press CTRL + '+' -> Font size increases
* Press CTRL + '-' -> Font size decreases