### PR TITLE
Stop crash on window snap by preventing torn device resources state 

### DIFF
--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -692,10 +692,9 @@ void DxEngine::_InvalidOr(RECT rc) noexcept
         {
             // OK, we're going to play a dangerous game here for the sake of optimizing resize
             // First, set up a complete clear of all device resources if something goes terribly wrong.
-            auto resetDeviceResourcesOnFailure = wil::scope_exit([&]
-                {
-                    _ReleaseDeviceResources();
-                });
+            auto resetDeviceResourcesOnFailure = wil::scope_exit([&] {
+                _ReleaseDeviceResources();
+            });
 
             // Now let go of a few of the device resources that get in the way of resizing buffers in the swap chain
             _dxgiSurface.Reset();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adjusts the logic inside the DX renderer's resize operations to not leave some device resources null and not others when a resize operation fails.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1572
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [x] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. 

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
You can see the verbose diagnostics that led to this conclusion in https://github.com/microsoft/terminal/issues/1572#issuecomment-507469309

This should resolve the crash, though it might not resolve the underlying issue of why the resizing is failing. But we should have more diagnostic information available when running under the debugger with the wil macros applied.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Ran the build with the patched and snapped it all over the place on my multiple monitors at varying speeds. 
- Turned on the 4k monitor and snapped to/from that one as well to see if a DPI transition gave it a problem.