### PR TITLE
Fix margin boundary tests in the RI, DL, and IL escape sequences.

### DIFF
--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -1350,14 +1350,10 @@ void DoSrvPrivateAllowCursorBlinking(SCREEN_INFORMATION& screenInfo, const bool 
     }
     else
     {
-        const auto margins = screenInfo.GetAbsoluteScrollMargins().ToInclusive();
-        const auto marginsSet = margins.Bottom > margins.Top;
-        const auto oldCursorInMargins = oldCursorPosition.Y <= margins.Bottom && oldCursorPosition.Y >= margins.Top;
-
         // If we don't have margins, or the cursor is within the boundaries of the margins
         // It's important to check if the cursor is in the margins,
         //      If it's not, but the margins are set, then we don't want to scroll anything
-        if (!marginsSet || oldCursorInMargins)
+        if (screenInfo.IsCursorInMargins(oldCursorPosition))
         {
             // Cursor is at the top of the viewport
             const COORD bufferSize = screenInfo.GetBufferSize().Dimensions();
@@ -1397,20 +1393,17 @@ void DoSrvPrivateAllowCursorBlinking(SCREEN_INFORMATION& screenInfo, const bool 
 [[nodiscard]] HRESULT DoSrvMoveCursorVertically(SCREEN_INFORMATION& screenInfo, const short lines)
 {
     auto& cursor = screenInfo.GetActiveBuffer().GetTextBuffer().GetCursor();
-    const int currentCursorY = cursor.GetPosition().Y;
-    SMALL_RECT margins = screenInfo.GetAbsoluteScrollMargins().ToInclusive();
-    const auto marginsSet = margins.Bottom > margins.Top;
-    const auto cursorInMargins = currentCursorY <= margins.Bottom && currentCursorY >= margins.Top;
     COORD clampedPos = { cursor.GetPosition().X, cursor.GetPosition().Y + lines };
 
     // Make sure the cursor doesn't move outside the viewport.
     screenInfo.GetViewport().Clamp(clampedPos);
 
     // Make sure the cursor stays inside the margins, but only if it started there
-    if (marginsSet && cursorInMargins)
+    if (screenInfo.AreMarginsSet() && screenInfo.IsCursorInMargins(cursor.GetPosition()))
     {
         try
         {
+            const auto margins = screenInfo.GetAbsoluteScrollMargins().ToInclusive();
             const auto v = clampedPos.Y;
             const auto lo = margins.Top;
             const auto hi = margins.Bottom;
@@ -2038,10 +2031,7 @@ void DoSrvPrivateModifyLinesImpl(const unsigned int count, const bool insert)
     auto& screenInfo = ServiceLocator::LocateGlobals().getConsoleInformation().GetActiveOutputBuffer().GetActiveBuffer();
     auto& textBuffer = screenInfo.GetTextBuffer();
     const auto cursorPosition = textBuffer.GetCursor().GetPosition();
-    const auto margins = screenInfo.GetAbsoluteScrollMargins().ToInclusive();
-    const auto marginsSet = margins.Bottom > margins.Top;
-    const auto cursorInMargins = cursorPosition.Y <= margins.Bottom && cursorPosition.Y >= margins.Top;
-    if (!marginsSet || cursorInMargins)
+    if (screenInfo.IsCursorInMargins(cursorPosition))
     {
         const auto screenEdges = screenInfo.GetBufferSize().ToInclusive();
         // Rectangle to cut out of the existing buffer

--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -2899,6 +2899,24 @@ bool SCREEN_INFORMATION::AreMarginsSet() const noexcept
     return _scrollMargins.BottomInclusive() > _scrollMargins.Top();
 }
 
+// Routine Description:
+// - Determines whether a cursor position is within the vertical bounds of the
+//      scroll margins, or the margins aren't set.
+// Parameters:
+// - cursorPosition - The cursor position to test
+// Return value:
+// - true iff the position is in bounds.
+bool SCREEN_INFORMATION::IsCursorInMargins(const COORD cursorPosition) const noexcept
+{
+    // If the margins aren't set, then any position is considered in bounds.
+    if (!AreMarginsSet())
+    {
+        return true;
+    }
+    const auto margins = GetAbsoluteScrollMargins().ToInclusive();
+    return cursorPosition.Y <= margins.Bottom && cursorPosition.Y >= margins.Top;
+}
+
 // Method Description:
 // - Gets the region of the buffer that should be used for scrolling within the
 //      scroll margins. If the scroll margins aren't set, it returns the entire

--- a/src/host/screenInfo.hpp
+++ b/src/host/screenInfo.hpp
@@ -201,6 +201,7 @@ public:
     Microsoft::Console::Types::Viewport GetAbsoluteScrollMargins() const;
     void SetScrollMargins(const Microsoft::Console::Types::Viewport margins);
     bool AreMarginsSet() const noexcept;
+    bool IsCursorInMargins(const COORD cursorPosition) const noexcept;
     Microsoft::Console::Types::Viewport GetScrollingRegion() const noexcept;
 
     [[nodiscard]] NTSTATUS UseAlternateScreenBuffer();

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -163,6 +163,9 @@ class ScreenBufferTests
 
     TEST_METHOD(ScrollUpInMargins);
     TEST_METHOD(ScrollDownInMargins);
+    TEST_METHOD(InsertLinesInMargins);
+    TEST_METHOD(DeleteLinesInMargins);
+    TEST_METHOD(ReverseLineFeedInMargins);
 
     TEST_METHOD(SetOriginMode);
 };
@@ -3213,6 +3216,232 @@ void ScreenBufferTests::ScrollDownInMargins()
         auto iter5 = tbi.GetCellDataAt({ 0, 5 });
         VERIFY_ARE_EQUAL(L"A", iter0->Chars());
         VERIFY_ARE_EQUAL(L"\x20", iter1->Chars());
+        VERIFY_ARE_EQUAL(L"5", iter2->Chars());
+        VERIFY_ARE_EQUAL(L"6", iter3->Chars());
+        VERIFY_ARE_EQUAL(L"7", iter4->Chars());
+        VERIFY_ARE_EQUAL(L"B", iter5->Chars());
+    }
+}
+
+void ScreenBufferTests::InsertLinesInMargins()
+{
+    Log::Comment(
+        L"Does the common scrolling setup, then inserts two lines inside the "
+        L"margin boundaries, and verifies the rows have what we'd expect.");
+
+    _CommonScrollingSetup();
+    auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
+    auto& si = gci.GetActiveOutputBuffer();
+    auto& tbi = si.GetTextBuffer();
+    auto& stateMachine = si.GetStateMachine();
+    auto& cursor = si.GetTextBuffer().GetCursor();
+
+    // Move to column 5 of line 3
+    stateMachine.ProcessString(L"\x1b[3;5H");
+    // Insert 2 lines
+    stateMachine.ProcessString(L"\x1b[2L");
+
+    Log::Comment(NoThrowString().Format(
+        L"cursor=%s", VerifyOutputTraits<COORD>::ToString(cursor.GetPosition()).GetBuffer()));
+    Log::Comment(NoThrowString().Format(
+        L"viewport=%s", VerifyOutputTraits<SMALL_RECT>::ToString(si.GetViewport().ToInclusive()).GetBuffer()));
+
+    VERIFY_ARE_EQUAL(4, cursor.GetPosition().X);
+    VERIFY_ARE_EQUAL(2, cursor.GetPosition().Y);
+    {
+        auto iter0 = tbi.GetCellDataAt({ 0, 0 });
+        auto iter1 = tbi.GetCellDataAt({ 0, 1 });
+        auto iter2 = tbi.GetCellDataAt({ 0, 2 });
+        auto iter3 = tbi.GetCellDataAt({ 0, 3 });
+        auto iter4 = tbi.GetCellDataAt({ 0, 4 });
+        auto iter5 = tbi.GetCellDataAt({ 0, 5 });
+        VERIFY_ARE_EQUAL(L"A", iter0->Chars());
+        VERIFY_ARE_EQUAL(L"5", iter1->Chars());
+        VERIFY_ARE_EQUAL(L"\x20", iter2->Chars());
+        VERIFY_ARE_EQUAL(L"\x20", iter3->Chars());
+        VERIFY_ARE_EQUAL(L"6", iter4->Chars());
+        VERIFY_ARE_EQUAL(L"B", iter5->Chars());
+    }
+
+    Log::Comment(
+        L"Does the common scrolling setup, then inserts one line with no "
+        L"margins set, and verifies the rows have what we'd expect.");
+
+    _CommonScrollingSetup();
+    // Clear the scroll margins
+    stateMachine.ProcessString(L"\x1b[r");
+    // Move to column 5 of line 2
+    stateMachine.ProcessString(L"\x1b[2;5H");
+    // Insert 1 line
+    stateMachine.ProcessString(L"\x1b[L");
+
+    Log::Comment(NoThrowString().Format(
+        L"cursor=%s", VerifyOutputTraits<COORD>::ToString(cursor.GetPosition()).GetBuffer()));
+    Log::Comment(NoThrowString().Format(
+        L"viewport=%s", VerifyOutputTraits<SMALL_RECT>::ToString(si.GetViewport().ToInclusive()).GetBuffer()));
+
+    VERIFY_ARE_EQUAL(4, cursor.GetPosition().X);
+    VERIFY_ARE_EQUAL(1, cursor.GetPosition().Y);
+    {
+        auto iter0 = tbi.GetCellDataAt({ 0, 0 });
+        auto iter1 = tbi.GetCellDataAt({ 0, 1 });
+        auto iter2 = tbi.GetCellDataAt({ 0, 2 });
+        auto iter3 = tbi.GetCellDataAt({ 0, 3 });
+        auto iter4 = tbi.GetCellDataAt({ 0, 4 });
+        auto iter5 = tbi.GetCellDataAt({ 0, 5 });
+        VERIFY_ARE_EQUAL(L"A", iter0->Chars());
+        VERIFY_ARE_EQUAL(L"\x20", iter1->Chars());
+        VERIFY_ARE_EQUAL(L"5", iter2->Chars());
+        VERIFY_ARE_EQUAL(L"6", iter3->Chars());
+        VERIFY_ARE_EQUAL(L"7", iter4->Chars());
+        VERIFY_ARE_EQUAL(L"\x20", iter5->Chars());
+    }
+}
+
+void ScreenBufferTests::DeleteLinesInMargins()
+{
+    Log::Comment(
+        L"Does the common scrolling setup, then deletes two lines inside the "
+        L"margin boundaries, and verifies the rows have what we'd expect.");
+
+    _CommonScrollingSetup();
+    auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
+    auto& si = gci.GetActiveOutputBuffer();
+    auto& tbi = si.GetTextBuffer();
+    auto& stateMachine = si.GetStateMachine();
+    auto& cursor = si.GetTextBuffer().GetCursor();
+
+    // Move to column 5 of line 3
+    stateMachine.ProcessString(L"\x1b[3;5H");
+    // Delete 2 lines
+    stateMachine.ProcessString(L"\x1b[2M");
+
+    Log::Comment(NoThrowString().Format(
+        L"cursor=%s", VerifyOutputTraits<COORD>::ToString(cursor.GetPosition()).GetBuffer()));
+    Log::Comment(NoThrowString().Format(
+        L"viewport=%s", VerifyOutputTraits<SMALL_RECT>::ToString(si.GetViewport().ToInclusive()).GetBuffer()));
+
+    VERIFY_ARE_EQUAL(4, cursor.GetPosition().X);
+    VERIFY_ARE_EQUAL(2, cursor.GetPosition().Y);
+    {
+        auto iter0 = tbi.GetCellDataAt({ 0, 0 });
+        auto iter1 = tbi.GetCellDataAt({ 0, 1 });
+        auto iter2 = tbi.GetCellDataAt({ 0, 2 });
+        auto iter3 = tbi.GetCellDataAt({ 0, 3 });
+        auto iter4 = tbi.GetCellDataAt({ 0, 4 });
+        auto iter5 = tbi.GetCellDataAt({ 0, 5 });
+        VERIFY_ARE_EQUAL(L"A", iter0->Chars());
+        VERIFY_ARE_EQUAL(L"5", iter1->Chars());
+        VERIFY_ARE_EQUAL(L"\x20", iter2->Chars());
+        VERIFY_ARE_EQUAL(L"\x20", iter3->Chars());
+        VERIFY_ARE_EQUAL(L"\x20", iter4->Chars());
+        VERIFY_ARE_EQUAL(L"B", iter5->Chars());
+    }
+
+    Log::Comment(
+        L"Does the common scrolling setup, then deletes one line with no "
+        L"margins set, and verifies the rows have what we'd expect.");
+
+    _CommonScrollingSetup();
+    // Clear the scroll margins
+    stateMachine.ProcessString(L"\x1b[r");
+    // Move to column 5 of line 2
+    stateMachine.ProcessString(L"\x1b[2;5H");
+    // Delete 1 line
+    stateMachine.ProcessString(L"\x1b[M");
+
+    Log::Comment(NoThrowString().Format(
+        L"cursor=%s", VerifyOutputTraits<COORD>::ToString(cursor.GetPosition()).GetBuffer()));
+    Log::Comment(NoThrowString().Format(
+        L"viewport=%s", VerifyOutputTraits<SMALL_RECT>::ToString(si.GetViewport().ToInclusive()).GetBuffer()));
+
+    VERIFY_ARE_EQUAL(4, cursor.GetPosition().X);
+    VERIFY_ARE_EQUAL(1, cursor.GetPosition().Y);
+    {
+        auto iter0 = tbi.GetCellDataAt({ 0, 0 });
+        auto iter1 = tbi.GetCellDataAt({ 0, 1 });
+        auto iter2 = tbi.GetCellDataAt({ 0, 2 });
+        auto iter3 = tbi.GetCellDataAt({ 0, 3 });
+        auto iter4 = tbi.GetCellDataAt({ 0, 4 });
+        auto iter5 = tbi.GetCellDataAt({ 0, 5 });
+        VERIFY_ARE_EQUAL(L"A", iter0->Chars());
+        VERIFY_ARE_EQUAL(L"6", iter1->Chars());
+        VERIFY_ARE_EQUAL(L"7", iter2->Chars());
+        VERIFY_ARE_EQUAL(L"\x20", iter3->Chars());
+        VERIFY_ARE_EQUAL(L"B", iter4->Chars());
+        VERIFY_ARE_EQUAL(L"\x20", iter5->Chars());
+    }
+}
+
+void ScreenBufferTests::ReverseLineFeedInMargins()
+{
+    Log::Comment(
+        L"Does the common scrolling setup, then executes a reverse line feed "
+        L"below the top margin, and verifies the rows have what we'd expect.");
+
+    _CommonScrollingSetup();
+    auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
+    auto& si = gci.GetActiveOutputBuffer();
+    auto& tbi = si.GetTextBuffer();
+    auto& stateMachine = si.GetStateMachine();
+    auto& cursor = si.GetTextBuffer().GetCursor();
+
+    // Move to column 5 of line 2, the top margin
+    stateMachine.ProcessString(L"\x1b[2;5H");
+    // Execute a reverse line feed (RI)
+    stateMachine.ProcessString(L"\x1bM");
+
+    Log::Comment(NoThrowString().Format(
+        L"cursor=%s", VerifyOutputTraits<COORD>::ToString(cursor.GetPosition()).GetBuffer()));
+    Log::Comment(NoThrowString().Format(
+        L"viewport=%s", VerifyOutputTraits<SMALL_RECT>::ToString(si.GetViewport().ToInclusive()).GetBuffer()));
+
+    VERIFY_ARE_EQUAL(4, cursor.GetPosition().X);
+    VERIFY_ARE_EQUAL(1, cursor.GetPosition().Y);
+    {
+        auto iter0 = tbi.GetCellDataAt({ 0, 0 });
+        auto iter1 = tbi.GetCellDataAt({ 0, 1 });
+        auto iter2 = tbi.GetCellDataAt({ 0, 2 });
+        auto iter3 = tbi.GetCellDataAt({ 0, 3 });
+        auto iter4 = tbi.GetCellDataAt({ 0, 4 });
+        auto iter5 = tbi.GetCellDataAt({ 0, 5 });
+        VERIFY_ARE_EQUAL(L"A", iter0->Chars());
+        VERIFY_ARE_EQUAL(L"\x20", iter1->Chars());
+        VERIFY_ARE_EQUAL(L"5", iter2->Chars());
+        VERIFY_ARE_EQUAL(L"6", iter3->Chars());
+        VERIFY_ARE_EQUAL(L"7", iter4->Chars());
+        VERIFY_ARE_EQUAL(L"B", iter5->Chars());
+    }
+
+    Log::Comment(
+        L"Does the common scrolling setup, then executes a reverse line feed "
+        L"with the top margin at the top of the screen, and verifies the rows "
+        L"have what we'd expect.");
+
+    _CommonScrollingSetup();
+    // Set the top scroll margin to the top of the screen
+    stateMachine.ProcessString(L"\x1b[1;5r");
+    // Move to column 5 of line 1, the top of the screen
+    stateMachine.ProcessString(L"\x1b[1;5H");
+    // Execute a reverse line feed (RI)
+    stateMachine.ProcessString(L"\x1bM");
+
+    Log::Comment(NoThrowString().Format(
+        L"cursor=%s", VerifyOutputTraits<COORD>::ToString(cursor.GetPosition()).GetBuffer()));
+    Log::Comment(NoThrowString().Format(
+        L"viewport=%s", VerifyOutputTraits<SMALL_RECT>::ToString(si.GetViewport().ToInclusive()).GetBuffer()));
+
+    VERIFY_ARE_EQUAL(4, cursor.GetPosition().X);
+    VERIFY_ARE_EQUAL(0, cursor.GetPosition().Y);
+    {
+        auto iter0 = tbi.GetCellDataAt({ 0, 0 });
+        auto iter1 = tbi.GetCellDataAt({ 0, 1 });
+        auto iter2 = tbi.GetCellDataAt({ 0, 2 });
+        auto iter3 = tbi.GetCellDataAt({ 0, 3 });
+        auto iter4 = tbi.GetCellDataAt({ 0, 4 });
+        auto iter5 = tbi.GetCellDataAt({ 0, 5 });
+        VERIFY_ARE_EQUAL(L"\x20", iter0->Chars());
+        VERIFY_ARE_EQUAL(L"A", iter1->Chars());
         VERIFY_ARE_EQUAL(L"5", iter2->Chars());
         VERIFY_ARE_EQUAL(L"6", iter3->Chars());
         VERIFY_ARE_EQUAL(L"7", iter4->Chars());


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

When executing an escape sequence that might cause the viewport to scroll, a check is made to see whether the cursor position is in the bounds of the scroll margins, otherwise the scroll operation shouldn't happen. In a couple of cases (in the RI, DL, and IL escape sequence), these boundary tests were incorrect, so the scroll operation would sometimes not occur when it should have. This PR fixes those boundary tests.

Tested manually, and with the _joe_ editor which was previously failing, and with some additional screen buffer unit tests.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1366
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1366

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The one problem was the use of `Viewport::IsInBounds` method to check whether the cursor was inside the margins. That method only works on the first column of the screen, because the horizontal margins are always set to 0. So that needed to be replaced with a test that only checked the y offset against the vertical margins.

The other problem was not first checking whether the margins had actually been set. When the margins aren't set, the top and bottom boundaries are both 0, so that needs to be handled as a special case, otherwise it'll only match positions on the first line of the screen.

Having made these fixes in the `DoSrvPrivateReverseLineFeed` and `DoSrvPrivateModifyLinesImpl` methods, I thought it might also be a good idea to refactor the boundary tests into a shared method in the `SCREEN_INFORMATION` class, to try and make the code more readable. I could also then make use of that method to simplify the `DoSrvMoveCursorVertically` implementation a little.

I had initially planned to refactor the `AdjustCursorPosition` method as well, but I decided against that in the end, because the code is a lot more complicated in that case, and I didn't want to risk potential performance issues given the frequency of its use.

In any event, I've committed the refactoring as a separate step, so I can always revert that if you don't think it's a good idea.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

I've added a few screen buffer units tests that make sure the RI, DL, and IL escape sequences basically work, and also specifically check the conditions that were previously failing.

I've also run a few of my own manual tests which check various margin boundary conditions. And I've made sure that the problem with _joe_ editor that was reported in issue #1366 is now working.