### PR TITLE
Fix The conhost command line is not properly escaped

### DIFF
--- a/src/host/ConsoleArguments.cpp
+++ b/src/host/ConsoleArguments.cpp
@@ -21,13 +21,13 @@ const std::wstring_view ConsoleArguments::INHERIT_CURSOR_ARG = L"--inheritcursor
 const std::wstring_view ConsoleArguments::FEATURE_ARG = L"--feature";
 const std::wstring_view ConsoleArguments::FEATURE_PTY_ARG = L"pty";
 
-std::wstring escape_argument(std::wstring_view ac)
+std::wstring EscapeArgument(std::wstring_view ac)
 {
     if (ac.empty())
     {
         return L"\"\"";
     }
-    bool hasspace = false;
+    bool hasSpace = false;
     auto n = ac.size();
     for (auto c : ac)
     {
@@ -39,13 +39,13 @@ std::wstring escape_argument(std::wstring_view ac)
             break;
         case ' ':
         case '\t':
-            hasspace = true;
+            hasSpace = true;
             break;
         default:
             break;
         }
     }
-    if (hasspace)
+    if (hasSpace)
     {
         n += 2;
     }
@@ -54,7 +54,7 @@ std::wstring escape_argument(std::wstring_view ac)
         return std::wstring{ ac };
     }
     std::wstring buf;
-    if (hasspace)
+    if (hasSpace)
     {
         buf.push_back(L'"');
     }
@@ -83,7 +83,7 @@ std::wstring escape_argument(std::wstring_view ac)
             break;
         }
     }
-    if (hasspace)
+    if (hasSpace)
     {
         for (; slashes > 0; slashes--)
         {
@@ -345,7 +345,7 @@ void ConsoleArguments::s_ConsumeArg(_Inout_ std::vector<std::wstring>& args, _In
     size_t j = 0;
     for (j = index; j < args.size(); j++)
     {
-        _clientCommandline += escape_argument(args[j]); // escape commandline
+        _clientCommandline += EscapeArgument(args[j]); // escape commandline
         if (j + 1 < args.size())
         {
             _clientCommandline += L" ";

--- a/src/host/ConsoleArguments.cpp
+++ b/src/host/ConsoleArguments.cpp
@@ -21,6 +21,79 @@ const std::wstring_view ConsoleArguments::INHERIT_CURSOR_ARG = L"--inheritcursor
 const std::wstring_view ConsoleArguments::FEATURE_ARG = L"--feature";
 const std::wstring_view ConsoleArguments::FEATURE_PTY_ARG = L"pty";
 
+std::wstring escape_argument(std::wstring_view ac)
+{
+    if (ac.empty())
+    {
+        return L"\"\"";
+    }
+    bool hasspace = false;
+    auto n = ac.size();
+    for (auto c : ac)
+    {
+        switch (c)
+        {
+        case L'"':
+        case L'\\':
+            n++;
+            break;
+        case ' ':
+        case '\t':
+            hasspace = true;
+            break;
+        default:
+            break;
+        }
+    }
+    if (hasspace)
+    {
+        n += 2;
+    }
+    if (n == ac.size())
+    {
+        return std::wstring{ ac };
+    }
+    std::wstring buf;
+    if (hasspace)
+    {
+        buf.push_back(L'"');
+    }
+    size_t slashes = 0;
+    for (auto c : ac)
+    {
+        switch (c)
+        {
+        case L'\\':
+            slashes++;
+            buf.push_back(L'\\');
+            break;
+        case L'"':
+        {
+            for (; slashes > 0; slashes--)
+            {
+                buf.push_back(L'\\');
+            }
+            buf.push_back(L'\\');
+            buf.push_back(c);
+        }
+        break;
+        default:
+            slashes = 0;
+            buf.push_back(c);
+            break;
+        }
+    }
+    if (hasspace)
+    {
+        for (; slashes > 0; slashes--)
+        {
+            buf.push_back(L'\\');
+        }
+        buf.push_back(L'"');
+    }
+    return buf;
+}
+
 ConsoleArguments::ConsoleArguments(const std::wstring& commandline,
                                    const HANDLE hStdIn,
                                    const HANDLE hStdOut) :
@@ -272,7 +345,7 @@ void ConsoleArguments::s_ConsumeArg(_Inout_ std::vector<std::wstring>& args, _In
     size_t j = 0;
     for (j = index; j < args.size(); j++)
     {
-        _clientCommandline += args[j];
+        _clientCommandline += escape_argument(args[j]); // escape commandline
         if (j + 1 < args.size())
         {
             _clientCommandline += L" ";

--- a/src/host/ut_host/ConsoleArgumentsTests.cpp
+++ b/src/host/ut_host/ConsoleArgumentsTests.cpp
@@ -90,7 +90,7 @@ void ConsoleArgumentsTests::ArgSplittingTests()
                    INVALID_HANDLE_VALUE,
                    INVALID_HANDLE_VALUE,
                    ConsoleArguments(commandline,
-                                    L"this is the commandline", // clientCommandLine
+                                    L"\"this is the commandline\"", // clientCommandLine
                                     INVALID_HANDLE_VALUE,
                                     INVALID_HANDLE_VALUE,
                                     L"", // vtMode
@@ -110,7 +110,7 @@ void ConsoleArgumentsTests::ArgSplittingTests()
                    INVALID_HANDLE_VALUE,
                    INVALID_HANDLE_VALUE,
                    ConsoleArguments(commandline,
-                                    L"--vtmode bar this is the commandline", // clientCommandLine
+                                    L"\"--vtmode bar this is the commandline\"", // clientCommandLine
                                     INVALID_HANDLE_VALUE,
                                     INVALID_HANDLE_VALUE,
                                     L"", // vtMode

--- a/src/host/ut_host/ConsoleArgumentsTests.cpp
+++ b/src/host/ut_host/ConsoleArgumentsTests.cpp
@@ -223,6 +223,26 @@ void ConsoleArgumentsTests::ArgSplittingTests()
                                     0, // signalHandle
                                     false), // inheritCursor
                    true); // successful parse?
+
+    commandline = L"conhost.exe this is the commandline";
+    ArgTestsRunner(L"#9 commandline no quotes",
+                   commandline,
+                   INVALID_HANDLE_VALUE,
+                   INVALID_HANDLE_VALUE,
+                   ConsoleArguments(commandline,
+                                    L"this is the commandline", // clientCommandLine
+                                    INVALID_HANDLE_VALUE,
+                                    INVALID_HANDLE_VALUE,
+                                    L"", // vtMode
+                                    0, // width
+                                    0, // height
+                                    false, // forceV1
+                                    false, // headless
+                                    true, // createServerHandle
+                                    0, // serverHandle
+                                    0, // signalHandle
+                                    false), // inheritCursor
+                   true); // successful parse?
 }
 
 void ConsoleArgumentsTests::ClientCommandlineTests()


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR is used to fix conhost when the process is started, and the command line is not properly escaped causing an error. For details, please see Issues: #1090 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1090
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
