### PR TITLE
Add TERM_PROGRAM[_VERSION] env vars, partial fix #1040

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -1137,6 +1137,23 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Method Description:
+    // - Gets the package version.
+    // Arguments:
+    // - <none>
+    // Return Value:
+    // - the package version string in the form major.minor.build.revision
+    hstring App::GetPackageVersion()
+    {
+        const auto package = winrt::Windows::ApplicationModel::Package::Current();
+        const auto version = package.Id().Version();
+
+        std::wstringstream versionTextStream;
+        versionTextStream << version.Major << L"." << version.Minor << L"." << version.Build << L"." << version.Revision;
+        winrt::hstring versionText{ versionTextStream.str() };
+        return versionText;
+    }
+
+    // Method Description:
     // - Gets the title of the currently focused terminal control. If there
     //   isn't a control selected for any reason, returns "Windows Terminal"
     // Arguments:
@@ -1213,7 +1230,7 @@ namespace winrt::TerminalApp::implementation
         {
             if (focusedTabIndex >= _tabs.size())
             {
-                focusedTabIndex = _tabs.size() - 1;
+                focusedTabIndex = gsl::narrow<int>(_tabs.size()) - 1;
             }
 
             if (focusedTabIndex < 0)

--- a/src/cascadia/TerminalApp/App.h
+++ b/src/cascadia/TerminalApp/App.h
@@ -39,6 +39,7 @@ namespace winrt::TerminalApp::implementation
 
         ~App();
 
+        hstring GetPackageVersion();
         hstring GetTitle();
 
         // -------------------------------- WinRT Events ---------------------------------

--- a/src/cascadia/TerminalApp/App.idl
+++ b/src/cascadia/TerminalApp/App.idl
@@ -30,6 +30,7 @@ namespace TerminalApp
         event Microsoft.Terminal.TerminalControl.TitleChangedEventArgs TitleChanged;
         event LastTabClosedEventArgs LastTabClosed;
 
+        String GetPackageVersion();
         String GetTitle();
     }
 }

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -85,6 +85,17 @@ void AppHost::AppTitleChanged(winrt::hstring newTitle)
 }
 
 // Method Description:
+// - Gets the package version.
+// Arguments:
+// - <none>
+// Return Value:
+// - the package version in the form major.minor.build.revision
+winrt::hstring AppHost::GetPackageVersion()
+{
+    return _app.GetPackageVersion();
+}
+
+// Method Description:
 // - Called when no tab is remaining to close the window.
 // Arguments:
 // - <none>

--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -17,6 +17,7 @@ public:
     void AppTitleChanged(winrt::hstring newTitle);
     void LastTabClosed();
     void Initialize();
+    winrt::hstring GetPackageVersion();
 
 private:
     bool _useNonClientArea;

--- a/src/cascadia/WindowsTerminal/main.cpp
+++ b/src/cascadia/WindowsTerminal/main.cpp
@@ -5,6 +5,7 @@
 #include "AppHost.h"
 
 using namespace winrt;
+using namespace Windows::ApplicationModel;
 using namespace Windows::UI;
 using namespace Windows::UI::Composition;
 using namespace Windows::UI::Xaml::Hosting;
@@ -19,6 +20,12 @@ int __stdcall wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int)
     // Terminal App. This MUST BE constructed before the Xaml manager as TermApp
     // provides an implementation of Windows.UI.Xaml.Application.
     AppHost host;
+
+    // Create TERM_PROGRAM / TERM_PROGRAM_VERSION environment variables so that each conhost process inherits it.
+    // Shells, shell scripts and console applications can use this information about the hosting environment to
+    // determine how to configure their console environment.
+    SetEnvironmentVariable(L"TERM_PROGRAM", L"WindowsTerminal");
+    SetEnvironmentVariable(L"TERM_PROGRAM_VERSION", host.GetPackageVersion().c_str());
 
     // !!! LOAD BEARING !!!
     // This is _magic_. Do the initial loading of our settings *BEFORE* we


### PR DESCRIPTION
Fix potential loss of data warning, size_t to int.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Create the following environment variables for every conhost app spawned:
```
TERM_PROGRAM                   WindowsTerminal
TERM_PROGRAM_VERSION           0.0.1.0
```
This allows shell, shell scripts, PowerShell modules and console applications to determine if they need to tweak the console environment.  For example, in the `posh-git` module we actually mess with low-level console mode settings for old versions of PowerShell.

https://github.com/dahlbyk/posh-git/blob/a64e5e073f6ce4dcd01394965bf0bbc91a0e3016/src/ConsoleMode.ps1#L3-L4

Even for an old version (v5) of Windows PowerShell, if it's running in Windows Terminal, we probably do not need to call `SetConsoleMode()` to set the `ENABLE_VIRTUAL_TERMINAL_PROCESSING` flag. I'd like to change that test above to also not mess with the console mode if `$env:TERM_PROGRAM` is defined.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
Partially addresses #1040

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [x] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
I "think" the right place to set these env vars is early on in the WindowsTerminal `main()` entry point.  I wasn't able to access the package version number directly from that project.  So I expose it from the `TerminalApp` project's `App` class.  That is then in turn exposed by the WindowsTerminal `AppHost` class.  I'm completely open to a better way to get the package version.  Or if the env vars should be set in another project - like the headless conhost.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Start WindowsTerminal and checked for the existence of these two env vars in powershell.exe, pwsh.exe and cmd.exe.