### PR TITLE
Fixed #1186, incorrect path was calculated when module already install…

### DIFF
--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -41,7 +41,7 @@ function Import-LocalModule
         Write-Verbose "$Name already downloaded"
         $versions = Get-ChildItem "$modules_root\$Name" | Sort-Object
 
-        Get-ChildItem -Path $versions[0] "$Name.psd1" | Import-Module
+        Get-ChildItem -Path "$modules_root\$Name\$($versions[0])\$Name.psd1" | Import-Module
     }
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

Fixes #1186 

Incorrect path was calculated when VSSetup module already downloaded locally.. It now loads correctly.
