### PR TITLE
Make opening the settings file more robust

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -445,7 +445,12 @@ namespace winrt::TerminalApp::implementation
         co_await winrt::resume_background();
 
         const auto settingsPath = CascadiaSettings::GetSettingsPath();
-        ShellExecute(nullptr, L"open", settingsPath.c_str(), nullptr, nullptr, SW_SHOW);
+
+        HINSTANCE res = ShellExecute(nullptr, nullptr, settingsPath.c_str(), nullptr, nullptr, SW_SHOW);
+        if ((INT_PTR)res <= 32)
+        {
+            ShellExecute(nullptr, nullptr, L"notepad", settingsPath.c_str(), nullptr, SW_SHOW);
+        }
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -447,7 +447,7 @@ namespace winrt::TerminalApp::implementation
         const auto settingsPath = CascadiaSettings::GetSettingsPath();
 
         HINSTANCE res = ShellExecute(nullptr, nullptr, settingsPath.c_str(), nullptr, nullptr, SW_SHOW);
-        if ((INT_PTR)res <= 32)
+        if (static_cast<int>(reinterpret_cast<uintptr_t>(res)) <= 32)
         {
             ShellExecute(nullptr, nullptr, L"notepad", settingsPath.c_str(), nullptr, SW_SHOW);
         }


### PR DESCRIPTION
This fixes two issues.

 * Opens the assigned default application regardless of its configuration.
   Gvim for example only reacts to the "edit" verb so when selected as default application won't open.
   Using nullptr results in using the first specified application.
   This fixes #1789
 * If no application is assigned for json files fall back to notepad

 See https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shellexecutea for more details
 especially why the result code checking is so horrific.

## Summary of the Pull Request

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1789 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Set a default application and make sure it opens
* Remove the default application and make sure that notepad gets opened