### PR TITLE
Fix interpretation of DECSTBM margin parameters

### DIFF
--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -3207,26 +3207,26 @@ public:
         _testGetSet->_fPrivateSetScrollingRegionResult = TRUE;
         VERIFY_IS_FALSE(_pDispatch->SetTopBottomScrollingMargins(srTestMargins.Top, srTestMargins.Bottom));
 
-        Log::Comment(L"Test 6: Verify Setting margins to (0, height) clears them");
+        Log::Comment(L"Test 6: Verify setting margins to (0, height) clears them");
         // First set,
         _testGetSet->_fPrivateSetScrollingRegionResult = TRUE;
         _testGetSet->_SetMarginsHelper(&srTestMargins, 2, 6);
         VERIFY_IS_TRUE(_pDispatch->SetTopBottomScrollingMargins(srTestMargins.Top, srTestMargins.Bottom));
         // Then clear
+        _testGetSet->_SetMarginsHelper(&srTestMargins, 0, sScreenHeight);
         _testGetSet->_srExpectedScrollRegion.Top = 0;
         _testGetSet->_srExpectedScrollRegion.Bottom = 0;
-        _testGetSet->_SetMarginsHelper(&srTestMargins, 0, 7);
         VERIFY_IS_TRUE(_pDispatch->SetTopBottomScrollingMargins(srTestMargins.Top, srTestMargins.Bottom));
 
-        Log::Comment(L"Test 7: Verify Setting margins to (1, height) clears them");
+        Log::Comment(L"Test 7: Verify setting margins to (1, height) clears them");
         // First set,
         _testGetSet->_fPrivateSetScrollingRegionResult = TRUE;
         _testGetSet->_SetMarginsHelper(&srTestMargins, 2, 6);
         VERIFY_IS_TRUE(_pDispatch->SetTopBottomScrollingMargins(srTestMargins.Top, srTestMargins.Bottom));
         // Then clear
+        _testGetSet->_SetMarginsHelper(&srTestMargins, 1, sScreenHeight);
         _testGetSet->_srExpectedScrollRegion.Top = 0;
         _testGetSet->_srExpectedScrollRegion.Bottom = 0;
-        _testGetSet->_SetMarginsHelper(&srTestMargins, 0, 7);
         VERIFY_IS_TRUE(_pDispatch->SetTopBottomScrollingMargins(srTestMargins.Top, srTestMargins.Bottom));
 
         Log::Comment(L"Test 8: Verify setting margins to (1, 0) clears them");

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -3173,6 +3173,7 @@ public:
         _testGetSet->_srViewport.Right = 8;
         _testGetSet->_srViewport.Bottom = 8;
         _testGetSet->_fGetConsoleScreenBufferInfoExResult = TRUE;
+        SHORT sScreenHeight = _testGetSet->_srViewport.Bottom - _testGetSet->_srViewport.Top;
 
         Log::Comment(L"Test 1: Verify having both values is valid.");
         _testGetSet->_SetMarginsHelper(&srTestMargins, 2, 6);
@@ -3227,6 +3228,35 @@ public:
         _testGetSet->_srExpectedScrollRegion.Bottom = 0;
         _testGetSet->_SetMarginsHelper(&srTestMargins, 0, 7);
         VERIFY_IS_TRUE(_pDispatch->SetTopBottomScrollingMargins(srTestMargins.Top, srTestMargins.Bottom));
+
+        Log::Comment(L"Test 8: Verify setting margins to (1, 0) clears them");
+        // First set,
+        _testGetSet->_fPrivateSetScrollingRegionResult = TRUE;
+        _testGetSet->_SetMarginsHelper(&srTestMargins, 2, 6);
+        VERIFY_IS_TRUE(_pDispatch->SetTopBottomScrollingMargins(srTestMargins.Top, srTestMargins.Bottom));
+        // Then clear
+        _testGetSet->_SetMarginsHelper(&srTestMargins, 1, 0);
+        _testGetSet->_srExpectedScrollRegion.Top = 0;
+        _testGetSet->_srExpectedScrollRegion.Bottom = 0;
+        VERIFY_IS_TRUE(_pDispatch->SetTopBottomScrollingMargins(srTestMargins.Top, srTestMargins.Bottom));
+
+        Log::Comment(L"Test 9: Verify having top and bottom margin the same is invalid.");
+
+        _testGetSet->_SetMarginsHelper(&srTestMargins, 4, 4);
+        _testGetSet->_fPrivateSetScrollingRegionResult = TRUE;
+        VERIFY_IS_FALSE(_pDispatch->SetTopBottomScrollingMargins(srTestMargins.Top, srTestMargins.Bottom));
+
+        Log::Comment(L"Test 10: Verify having top margin out of bounds is invalid.");
+
+        _testGetSet->_SetMarginsHelper(&srTestMargins, sScreenHeight + 1, sScreenHeight + 10);
+        _testGetSet->_fPrivateSetScrollingRegionResult = TRUE;
+        VERIFY_IS_FALSE(_pDispatch->SetTopBottomScrollingMargins(srTestMargins.Top, srTestMargins.Bottom));
+
+        Log::Comment(L"Test 11: Verify having bottom margin out of bounds is invalid.");
+
+        _testGetSet->_SetMarginsHelper(&srTestMargins, 1, sScreenHeight + 1);
+        _testGetSet->_fPrivateSetScrollingRegionResult = TRUE;
+        VERIFY_IS_FALSE(_pDispatch->SetTopBottomScrollingMargins(srTestMargins.Top, srTestMargins.Bottom));
     }
 
     TEST_METHOD(TabSetClearTests)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

When setting the scroll margins with the [DECSTBM](https://vt100.net/docs/vt510-rm/DECSTBM.html) escape sequence, some of the edge cases are interpreted incorrectly. If the top margin is equal to the bottom margin, or the bottom margin is greater than the screen height, the command should be ignored, but at the moment it isn't. This PR fixes those cases.

Tested manually and with additional adapter unit tests.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1849
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1849

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

This is a slight rewrite of the `AdaptDispatch::_DoSetTopBottomScrollingMargins` method which I think should be a little easier to follow.

* Step 1: Translate the default (zero) values - default top is 1, and default bottom is the screen height.
* Step 2: Check whether the values are valid, i.e. top is less than bottom, and bottom is less than or equal to the screen height.
* Step 3a: If valid, check whether the range covers the full height of the screen, in which case the margins are cleared (i.e. set to 0,0).
* Step 3b: If valid but not full screen, subtract 1 from the values to translate from the VT 1-based coordinate system to the internal 0-based coordinates.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

I've added a few more unit tests to the `ScrollMarginsTest` in _adapterTest.cpp_ to validate the specific edge cases that were previously incorrect: the top margin being equal to the bottom margin, the top margin being out of range, and the bottom margin being out of range. There was also a weird range of 1,0 which should have cleared the margins but didn't.

While adding these tests, I noticed a couple of the existing tests weren't correct. They were meant to be testing whether certain full screen ranges would clear the margins, but the expected values weren't correctly set, and the tested ranges weren't covering the full screen. So while the tests passed, they weren't actually testing what they claimed to be. This PR also includes fixes for those tests.