### PR TITLE
Added fontSize and acrylicOpacity changing tip

### DIFF
--- a/doc/user-docs/index.md
+++ b/doc/user-docs/index.md
@@ -85,4 +85,6 @@ The list of valid settings can be found in the [Profiles.json Documentation](../
 
     (ref https://twitter.com/r_keith_hill/status/1142871145852440576)
 
-2. Please add more Tips and Tricks
+2. Terminal `fontSize` can be changed by holding `Ctrl` and scrolling with mouse.
+3. Terminal `acrylicOpacity` can be changed by holding `Ctrl+Shift` and scrolling with mouse given `useAcrylic` is set to `true` in profiles.json.
+4. Please add more Tips and Tricks

--- a/doc/user-docs/index.md
+++ b/doc/user-docs/index.md
@@ -85,6 +85,6 @@ The list of valid settings can be found in the [Profiles.json Documentation](../
 
     (ref https://twitter.com/r_keith_hill/status/1142871145852440576)
 
-2. Terminal `fontSize` can be changed by holding `Ctrl` and scrolling with mouse.
-3. Terminal `acrylicOpacity` can be changed by holding `Ctrl+Shift` and scrolling with mouse given `useAcrylic` is set to `true` in profiles.json.
+2. Terminal zoom can be changed by holding `Ctrl` and scrolling with mouse.
+3. If `useAcrylic` is enabled in profiles.json, background opacity can be changed by holding `Ctrl+Shift` and scrolling with mouse.
 4. Please add more Tips and Tricks


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Added Terminal tip about changing the font size and acrylic opacity using keyboard shortcuts.
`Ctrl`+mouse scroll to change font size
`Ctrl+Shift` + mouse scroll to change acrylic opacity  given `useAcrylic` is set to `true` in profiles.json.


