### PR TITLE
Don't NCPAINT our window, PAINT our window

### DIFF
--- a/src/cascadia/WindowsTerminal/BaseWindow.h
+++ b/src/cascadia/WindowsTerminal/BaseWindow.h
@@ -89,6 +89,7 @@ public:
                 // do nothing.
                 break;
             }
+            break;
         }
         case CM_UPDATE_TITLE:
         {

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -53,7 +53,7 @@ void IslandWindow::MakeWindow() noexcept
     // WM_CREATE will be handled synchronously, before CreateWindow returns.
     WINRT_VERIFY(CreateWindow(wc.lpszClassName,
                               L"Windows Terminal",
-                              WS_CAPTION | WS_POPUP, // WS_OVERLAPPEDWINDOW,
+                              WS_OVERLAPPEDWINDOW,
                               CW_USEDEFAULT,
                               CW_USEDEFAULT,
                               CW_USEDEFAULT,

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -53,7 +53,7 @@ void IslandWindow::MakeWindow() noexcept
     // WM_CREATE will be handled synchronously, before CreateWindow returns.
     WINRT_VERIFY(CreateWindow(wc.lpszClassName,
                               L"Windows Terminal",
-                              WS_OVERLAPPEDWINDOW,
+                              WS_CAPTION | WS_POPUP, // WS_OVERLAPPEDWINDOW,
                               CW_USEDEFAULT,
                               CW_USEDEFAULT,
                               CW_USEDEFAULT,

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -657,7 +657,7 @@ bool NonClientIslandWindow::_HandleWindowPosChanging(WINDOWPOS* const windowPos)
         // you do this here, then a small gap will appear between the titlebar
         // and the content, until the window is moved. However, we do need to
         // keep this here _in general_ for dragging across DPI boundaries.
-        if (!_isMaximized)
+        if (_isMaximized)
         {
             THROW_IF_FAILED(_UpdateFrameMargins());
         }

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.h
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.h
@@ -54,6 +54,7 @@ private:
 
     void _HandleActivateWindow();
     bool _HandleWindowPosChanging(WINDOWPOS* const windowPos);
+    void _UpdateDragRegion();
 
     void OnDragBarSizeChanged(winrt::Windows::Foundation::IInspectable sender, winrt::Windows::UI::Xaml::SizeChangedEventArgs eventArgs);
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fixes the round corners and lack of shadow on the window introduced in #929.
![image](https://user-images.githubusercontent.com/18356694/60923472-931b9b00-a264-11e9-97a5-7b36f0dbfde2.png)

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
This introduces the problem discussed in #1897

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Touches some #1625 bits. Closes #872 
* [x] you better believe I work here
* [ ] Tests make me cry
* [x] Requires documentation to be updated - no

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

* If we handle `WM_NCPAINT`, we _don't_ get shadows. We also get the legacy rounded top window corners, because of some kernel insanity. The whole point of `DwmExtendFrameIntoClientArea` is that we can just `PAINT` the entire window, instead of trying to do `NC_PAINT` tricks. So, we need to move the entire NCPAINT we had into PAINT.
* We also need to remove the margins we were setting. If we leave a top margin, the system caption buttons will try and draw into that area. Since we don't want those, we need to make sure the top margin is 0, so they have no space to draw into. 
* I also split out the DragSizeChanged handler from OnSize. I don't know why, but having it inside OnSize would cause the xaml island content to go black when moving the window from a secondary normal DPI display back to a high DPI primary display. 
