### PR TITLE
Fix the WAP packaging project

### DIFF
--- a/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
+++ b/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
@@ -22,6 +22,7 @@
   <PropertyGroup>
     <ProjectGuid>CA5CAD1A-224A-4171-B13A-F16E576FDD12</ProjectGuid>
     <EntryPointProjectUniqueName>..\WindowsTerminal\WindowsTerminal.vcxproj</EntryPointProjectUniqueName>
+    <DebuggerType>NativeOnly</DebuggerType>
   </PropertyGroup>
   <PropertyGroup Condition="!Exists('CascadiaPackage_TemporaryKey.pfx')">
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
@@ -310,4 +311,25 @@
       </_FilteredNonWapProjProjectOutput>
     </ItemGroup>
   </Target>
+
+  <!-- Move all the PRI files that would be packaged into the appx into _PriFile so that
+       GenerateProjectPriFile catches them. This requires us to move payload collection
+       up before GenerateProjectPriFile, when it is typically _after_ it (because the
+       DesktopBridge project type is built to only prepare the payload during appx manifest
+       generation.
+
+       Since PRI file generation is _before_ manifest generation (for possibly obvious or
+       important reasons), that doesn't work for us.
+  -->
+  <PropertyGroup>
+    <_GenerateProjectPriFileDependsOn>OpenConsoleLiftDesktopBridgePriFiles;$(_GenerateProjectPriFileDependsOn)</_GenerateProjectPriFileDependsOn>
+  </PropertyGroup>
+  <Target Name="OpenConsoleLiftDesktopBridgePriFiles" DependsOnTargets="_ConvertItems">
+    <ItemGroup>
+      <_PriFile Include="@(_NonWapProjProjectOutput)" Condition="'%(Extension)' == '.pri'" />
+      <!-- Remove all other .pri files from the appx payload. -->
+      <AppxPackagePayload Remove="@(AppxPackagePayload)" Condition="'%(Extension)' == '.pri'" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
+++ b/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
@@ -261,12 +261,11 @@
   </ItemGroup>
   <Import Project="$(OpenConsoleDir)src\wap-common.build.post.props" />
   <!--
-    This exists to work around Microsoft/microsoft-ui-xaml#494.
-    https://github.com/Microsoft/microsoft-ui-xaml/issues/494
+    Microsoft.UI.Xaml contains some <Content> resource files that need to be included in our package.
+    For some reason, they're not rolled up through dependent projects; if they were, their paths would
+    be wrong.
 
-    Because the MUX nuget package hardcodes a requirement that the consuming project
-    be of type 'UAP', its resources are included in packaging and dependency resolution
-    by default. Inject them here.
+    WAP Packaging projects don't actually support nuget package references, so we added one manually.
 
     This does mean that version changes to Microsoft.UI.Xaml must be manually reflected
     here.
@@ -277,17 +276,6 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\packages\Microsoft.UI.Xaml.2.2.190611001-prerelease\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.UI.Xaml.2.2.190611001-prerelease\build\native\Microsoft.UI.Xaml.targets'))" />
-  </Target>
-  <PropertyGroup>
-    <WapProjBeforeGenerateAppxManifestDependsOn>
-      $(WapProjBeforeGenerateAppxManifestDependsOn);
-      _ConsoleInjectMUXWinmdIntoReferences;
-    </WapProjBeforeGenerateAppxManifestDependsOn>
-  </PropertyGroup>
-  <Target Name="_ConsoleInjectMUXWinmdIntoReferences">
-    <ItemGroup>
-      <_WinmdFilesFromReferences Include="@(Reference)" Condition="'%(Reference.Filename)' == 'Microsoft.UI.Xaml' and '%(Reference.Extension)' == '.winmd'" />
-    </ItemGroup>
   </Target>
   <!-- End workaround -->
   <ItemGroup>

--- a/src/cascadia/TerminalApp/MinMaxCloseControl.cpp
+++ b/src/cascadia/TerminalApp/MinMaxCloseControl.cpp
@@ -13,8 +13,7 @@ namespace winrt::TerminalApp::implementation
 {
     MinMaxCloseControl::MinMaxCloseControl()
     {
-        const winrt::Windows::Foundation::Uri resourceLocator{ L"ms-appx:///MinMaxCloseControl.xaml" };
-        winrt::Windows::UI::Xaml::Application::LoadComponent(*this, resourceLocator, winrt::Windows::UI::Xaml::Controls::Primitives::ComponentResourceLocation::Nested);
+        InitializeComponent();
     }
 
     uint64_t MinMaxCloseControl::ParentWindowHandle() const

--- a/src/cascadia/TerminalApp/TerminalApp.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalApp.vcxproj
@@ -172,4 +172,25 @@
     <Error Condition="!Exists('..\..\..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.0.0-preview6.2\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.0.0-preview6.2\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets'))" />
   </Target>
   <Import Project="..\..\..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.0.0-preview6.2\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets" Condition="Exists('..\..\..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.0.0-preview6.2\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets')" />
+
+  <!--
+    By default, the PRI file will contain resource paths beginning with the
+    project name. Since we enabled XBF embedding, this *also* includes App.xbf.
+    Well, App.xbf is hardcoded by the framework to be found at the resource ROOT.
+    To make that happen, we have to disable the prepending of the project name
+    to the App xaml files.
+  -->
+  <PropertyGroup>
+    <_GenerateProjectPriFileDependsOn>OpenConsolePlaceAppXbfAtRootOfResourceTree;$(_GenerateProjectPriFileDependsOn)</_GenerateProjectPriFileDependsOn>
+  </PropertyGroup>
+  <Target Name="OpenConsolePlaceAppXbfAtRootOfResourceTree" DependsOnTargets="GetPackagingOutputs">
+    <ItemGroup>
+      <!-- Stomp all "SourceProject" values for all incoming dependencies to flatten the package. -->
+      <_RelocatedAppXamlData Include="@(PackagingOutputs)" Condition="'%(Filename)' == 'App' and ('%(Extension)' == '.xaml' or '%(Extension)' == '.xbf')" />
+      <PackagingOutputs Remove="@(_RelocatedAppXamlData)" />
+      <PackagingOutputs Include="@(_RelocatedAppXamlData)">
+        <TargetPath>%(Filename)%(Extension)</TargetPath>
+      </PackagingOutputs>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/cascadia/TerminalApp/TerminalApp.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalApp.vcxproj
@@ -185,7 +185,6 @@
   </PropertyGroup>
   <Target Name="OpenConsolePlaceAppXbfAtRootOfResourceTree" DependsOnTargets="GetPackagingOutputs">
     <ItemGroup>
-      <!-- Stomp all "SourceProject" values for all incoming dependencies to flatten the package. -->
       <_RelocatedAppXamlData Include="@(PackagingOutputs)" Condition="'%(Filename)' == 'App' and ('%(Extension)' == '.xaml' or '%(Extension)' == '.xbf')" />
       <PackagingOutputs Remove="@(_RelocatedAppXamlData)" />
       <PackagingOutputs Include="@(_RelocatedAppXamlData)">

--- a/src/cascadia/TerminalApp/TerminalApp.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalApp.vcxproj
@@ -15,6 +15,12 @@
     <ProjectGuid>{CA5CAD1A-44BD-4AC7-AC72-F16E576FDD12}</ProjectGuid>
     <ProjectName>TerminalApp</ProjectName>
     <RootNamespace>TerminalApp</RootNamespace>
+    <!--
+      This is an override that, puzzlingly, _forces XBF (XAML binary) embedding_.
+      We have to do this to overcome a layout issue in the WAP packaging project.
+      When we do this, the XBF ends up in resources.pri.
+    -->
+    <DisableEmbeddedXbf>false</DisableEmbeddedXbf>
   </PropertyGroup>
   <!-- ========================= XAML files ======================== -->
   <ItemGroup>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -13,10 +13,7 @@ namespace winrt::TerminalApp::implementation
 {
     TerminalPage::TerminalPage()
     {
-        // The generated code will by default attempt to load from ms-appx://TerminalApp/TerminalPage.xaml.
-        // We'll force it to load from the root of the appx instead.
-        const winrt::Windows::Foundation::Uri resourceLocator{ L"ms-appx:///TerminalPage.xaml" };
-        winrt::Windows::UI::Xaml::Application::LoadComponent(*this, resourceLocator, winrt::Windows::UI::Xaml::Controls::Primitives::ComponentResourceLocation::Nested);
+        InitializeComponent();
     }
 
     // Method Description:

--- a/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
+++ b/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
@@ -92,15 +92,6 @@
     </NativeReferenceFile>
 
     <!--
-      The reason why this is needed for ARM64 is unknown,
-      If not added, the centenial package will fail to include the XamlHost dll.
-    -->
-    <NativeReferenceFile Include="$(OpenConsoleDir)$(Platform)\$(Configuration)\TerminalApp\Microsoft.Toolkit.Win32.UI.XamlHost.dll" Condition="'$(Platform)'=='ARM64'">
-      <DeploymentContent>true</DeploymentContent>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </NativeReferenceFile>
-
-    <!--
       the packaging project wont recurse through our dependencies, you have to
       make sure that if you add a cppwinrt dependency to any of these projects,
       you also update all the consumers


### PR DESCRIPTION
This commits fixes the centennial package by:
* Forcing XBF (XAML binary format) files to be embedded in project
  PRI files.
* Moving package content generation to before PRI generation
* Collecting all of the package's PRI files to merge into resources.pri
* Fixing the hardcoded resource paths to reflect the new reality.

It also includes a magic value that fixes the bug where the project is
autodetected as a Mixed (CLR + Native) project.

Fixes #1816.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1816
* [x] CLA signed
* [x] Tests added/passed/na?
* [x] Requires documentation to be updated/na?
* [x] I've discussed this with core contributors already.