### PR TITLE
Add Vintage color scheme to defaults; fixes #1781

### DIFF
--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -49,6 +49,35 @@ ColorScheme _CreateCampbellScheme()
 
 // clang-format off
 
+ColorScheme _CreateVintageScheme()
+{
+    // as per https://github.com/microsoft/terminal/issues/1781
+    ColorScheme vintageScheme { L"Vintage",
+                                RGB(192, 192, 192),
+                                RGB(  0,   0,   0) };
+    auto& vintageTable = vintageScheme.GetTable();
+    auto vintageSpan = gsl::span<COLORREF>(&vintageTable[0], gsl::narrow<ptrdiff_t>(COLOR_TABLE_SIZE));
+    vintageTable[0]  = RGB(  0,   0,   0); // black
+    vintageTable[1]  = RGB(128,   0,   0); // dark red
+    vintageTable[2]  = RGB(  0, 128,   0); // dark green
+    vintageTable[3]  = RGB(128, 128,   0); // dark yellow
+    vintageTable[4]  = RGB(  0,   0, 128); // dark blue
+    vintageTable[5]  = RGB(128,   0, 128); // dark magenta
+    vintageTable[6]  = RGB(  0, 128, 128); // dark cyan
+    vintageTable[7]  = RGB(192, 192, 192); // gray
+    vintageTable[8]  = RGB(128, 128, 128); // dark gray
+    vintageTable[9]  = RGB(255,   0,   0); // red
+    vintageTable[10] = RGB(  0, 255,   0); // green
+    vintageTable[11] = RGB(255, 255,   0); // yellow
+    vintageTable[12] = RGB(  0,   0, 255); // blue
+    vintageTable[13] = RGB(255,   0, 255); // magenta
+    vintageTable[14] = RGB(  0, 255, 255); // cyan
+    vintageTable[15] = RGB(255, 255, 255); // white
+    Utils::SetColorTableAlpha(vintageSpan, 0xff);
+
+    return vintageScheme;
+}
+
 ColorScheme _CreateOneHalfDarkScheme()
 {
     // First 8 dark colors per: https://github.com/sonph/onehalf/blob/master/putty/onehalf-dark.reg
@@ -179,6 +208,7 @@ ColorScheme _CreateSolarizedLightScheme()
 void CascadiaSettings::_CreateDefaultSchemes()
 {
     _globals.GetColorSchemes().emplace_back(_CreateCampbellScheme());
+    _globals.GetColorSchemes().emplace_back(_CreateVintageScheme());
     _globals.GetColorSchemes().emplace_back(_CreateOneHalfDarkScheme());
     _globals.GetColorSchemes().emplace_back(_CreateOneHalfLightScheme());
     _globals.GetColorSchemes().emplace_back(_CreateSolarizedDarkScheme());


### PR DESCRIPTION
This change adds the "Classic" color scheme to the ones in [the default `profiles.json` settings file](https://github.com/microsoft/terminal/blob/122f0de382542de14d79babad92699d916057783/doc/user-docs/UsingJsonSettings.md), with the colors suggested by @ocalvo in issue #1781. I named it "Vintage" per @DHowett-MSFT's suggestion.

### PR Checklist
* [x] Closes #1781
* [x] CLA signed - N/A; I work for Microsoft
* [ ] Tests added/passed - N/A; see discussion below
* [x] Requires documentation to be updated - N/A; no doc update required
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.

### Validation Steps Performed
All manual tests. I didn't feel it was necessary to add any automated tests because the only ones that would make sense would be ones to check that other default color schemes aren't regressed, and we don't have any tests for default settings today (presumably because they change too often!).
- Deleted `profiles.json`, started Terminal.
- Verified that the output "Vintage" color scheme existed in the newly created `profiles.json` file.
- Verified that "Vintage" diffed equal to the "Classic" scheme in the issue, apart from the name and the addition of  "background" and "foreground" colors, which I made equal to the "black" and "white" ones respectively.
- Verified that I could set a profile to use Vintage and that the colors changed accordingly.