### PR TITLE
Fix wrong maximized window offset on non primary monitors

### DIFF
--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -611,7 +611,7 @@ bool NonClientIslandWindow::_HandleWindowPosChanging(WINDOWPOS* const windowPos)
             // Calculate the maxmized window overhang by getting the size of the window frame.
             // We use the style without WS_CAPTION otherwise the caption height is included.
             // Only remove WS_DLGFRAME since WS_CAPTION = WS_DLGFRAME | WS_BORDER,
-            // but WS_BORDER is needed as it modifies the calculation of the width of the frame. 
+            // but WS_BORDER is needed as it modifies the calculation of the width of the frame.
             const auto targetStyle = windowStyle & ~WS_DLGFRAME;
             AdjustWindowRectExForDpi(&frame, targetStyle, false, GetWindowExStyle(_window.get()), _currentDpi);
 

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -607,27 +607,19 @@ bool NonClientIslandWindow::_HandleWindowPosChanging(WINDOWPOS* const windowPos)
             ((suggestedWidth > maxWidth) ||
              (suggestedHeight > maxHeight)))
         {
-            auto offset = 0;
-            // Determine which side of the window to use for the offset
-            //  calculation. If the taskbar is on the left or top of the screen,
-            //  then the x or y coordinate of the work rect might not be 0.
-            //  Check both, and use whichever is 0.
-            if (rcMaximum.left == 0)
-            {
-                offset = windowPos->x;
-            }
-            else if (rcMaximum.top == 0)
-            {
-                offset = windowPos->y;
-            }
-            const auto offsetX = offset;
-            const auto offsetY = offset;
+            RECT frame{};
+            // Calculate the maxmized window overhang by getting the size of the window frame.
+            // We use the style without WS_CAPTION otherwise the caption height is included.
+            // Only remove WS_DLGFRAME since WS_CAPTION = WS_DLGFRAME | WS_BORDER,
+            // but WS_BORDER is needed as it modifies the calculation of the width of the frame. 
+            const auto targetStyle = windowStyle & ~WS_DLGFRAME;
+            AdjustWindowRectExForDpi(&frame, targetStyle, false, GetWindowExStyle(_window.get()), _currentDpi);
 
-            _maximizedMargins.cxRightWidth = -offset;
-            _maximizedMargins.cxLeftWidth = -offset;
-
-            _maximizedMargins.cyTopHeight = -offset;
-            _maximizedMargins.cyBottomHeight = -offset;
+            // Frame left and top will be negative
+            _maximizedMargins.cxLeftWidth = frame.left * -1;
+            _maximizedMargins.cyTopHeight = frame.top * -1;
+            _maximizedMargins.cxRightWidth = frame.right;
+            _maximizedMargins.cyBottomHeight = frame.bottom;
 
             _isMaximized = true;
             THROW_IF_FAILED(_UpdateFrameMargins());


### PR DESCRIPTION
## Summary of the Pull Request
Fixes the calculation of the margins when the non client island window is maximized on non primary monitors

## References
#1055 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1055 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments
The overhang of a maximized window is currently calculated with this:
```cpp
auto offset = 0;
if (rcMaximum.left == 0)
{
    offset = windowPos->x;
}
else if (rcMaximum.top == 0)
{
    offset = windowPos->y;
}
```

This always works on the primary monitor but on a non primary monitor, it isn't always the case that `left` or `top` can be 0. Examples are when you offset a monitor. In those cases, `offset` will be 0 and the window will be cut off.

Instead I've changed the calculation to calculate the width of the windows frame which is how much it would overhang. Admittedly, the old calculation could be kept and take into consideration the current monitor.

Also I see a lot of work on the non client window so maybe we won't even need to do this later?

## Validation Steps Performed
Manually tested on primary and non primary monitors and the same offset is given: 8 pixels on all sides at 100% scaling. Also tested with different dpi and the margins are the same as using the old method.

