### PR TITLE
Set utf-8 for the entire project

### DIFF
--- a/src/common.build.pre.props
+++ b/src/common.build.pre.props
@@ -73,7 +73,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
-      <AdditionalOptions>/std:c++17 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/std:c++17 /utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
         <PreprocessorDefinitions>EXTERNAL_BUILD;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/host/ut_host/ClipboardTests.cpp
+++ b/src/host/ut_host/ClipboardTests.cpp
@@ -19,7 +19,6 @@
 #include "..\..\interactivity\inc\VtApiRedirection.hpp"
 #endif
 
-#include "UnicodeLiteral.hpp"
 #include "../../inc/consoletaeftemplates.hpp"
 
 using namespace WEX::Common;

--- a/src/host/ut_host/UnicodeLiteral.hpp
+++ b/src/host/ut_host/UnicodeLiteral.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#define REMOTE_STRING L"ñremote ìnpipe:pipe=foo,server=barî\t"
+#define REMOTE_STRING L"‚Äìremote ‚Äúnpipe:pipe=foo,server=bar‚Äù\t"
 #define EXPECTED_REMOTE_STRING L"-remote \"npipe:pipe=foo,server=bar\""

--- a/src/host/ut_host/UnicodeLiteral.hpp
+++ b/src/host/ut_host/UnicodeLiteral.hpp
@@ -1,5 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-#define REMOTE_STRING L"–remote “npipe:pipe=foo,server=bar”\t"
-#define EXPECTED_REMOTE_STRING L"-remote \"npipe:pipe=foo,server=bar\""


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

There were a few issues when we first opened the project related to building in other locales because we weren't using UTF-8.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
#458 
#549
I will close those because this supersedes them.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes assorted build issues for people who are fortunate enough to live in places that aren't 'MURICA.
* [x] CLA not signed but I work at Microsoft so I've already signed away my life.
* [x] Tests should still pass. I'll let the CI tell me.
* [x] Doesn't require docs.
* [x] Hi, it's me. It's my project. You all live in my world.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
I set the /utf-8 flag globally in the pre props file per the commentary in #458. I also converted the one complaining file `UnicodeLiterals.hpp` to UTF-8 without a BOM to get it to stop complaining.

I have a personal vendetta against BOMs so I'm wholesale rejecting the idea of #549. Microsoft was wrong to BOM. If I had a time machine, I would go egg the person on the .NET team at Microsoft who decided to BOM everything a long time ago and keep going back in time to egg them repeatedly until I felt satisfaction for the pain they've caused me in my life because Microsoft UTF-8 stuff is BOM'd.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- I built it and it's fine.
- The CI will build it and it will hopefully be fine.
- I built it in Windows with true Razzle and it's fine.
