### PR TITLE
Host our own NuGet feed for packages that we need that aren't elsewhere yet

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -5,7 +5,10 @@
         <!-- Add repositories here to the list of available repositories -->
         
         <!-- Dependencies that we must carry because they're not on public nuget feeds right now. -->
-        <add key="Static Package Dependencies" value="dep\packages" />
+        <!--<add key="Static Package Dependencies" value="dep\packages" />-->
+        
+        <!-- Use our own NuGet Feed -->
+        <add key="Windows Terminal NuGet Feed" value="https://terminalnuget.blob.core.windows.net/feed/index.json" />
         
         <!-- Internal NuGet feeds that may not be accessible outside Microsoft corporate network -->
         <!--<add key="TAEF - internal" value="https://microsoft.pkgs.visualstudio.com/DefaultCollection/_packaging/Taef/nuget/v3/index.json" />

--- a/dep/packages/README.md
+++ b/dep/packages/README.md
@@ -1,7 +1,0 @@
-These packages are redistributed inside this folder because they are not yet available on a public NuGet feed.
-
-## Microsoft.UI.XAML
-This package is a custom development build fork to help us light up tab support. It will eventually go onto the same public feed as the existing `Microsoft.UI.XAML` package that's currently available on NuGet.org
-
-## TAEF.Redist.WLK
-This package is vetted for public redistribution and release, but the TAEF team hasn't set up a public feed to consume it yet. If/when they do, we'll move to that.


### PR DESCRIPTION
We think its gross to keep giant binary blobs in our dependencies folder for nuget packages that aren't hosted properly yet.

So we get an Azure Blob Storage account and put it there using [Sleet](https://github.com/emgarten/Sleet).

This removes the package in the repo and makes NuGet get it off of our feed instead.