### PR TITLE
Implement #1949 Background Image Align (as one setting)

### DIFF
--- a/doc/cascadia/SettingsSchema.md
+++ b/doc/cascadia/SettingsSchema.md
@@ -35,6 +35,10 @@ Properties listed below are specific to each unique profile.
 | `startingDirectory` | _Required_ | String | `%USERPROFILE%` | The directory the shell starts in when it is loaded. |
 | `useAcrylic` | _Required_ | Boolean | `false` | When set to `true`, the window will have an acrylic background. When set to `false`, the window will have a plain, untextured background. |
 | `background` | Optional | String | | Sets the background color of the profile. Overrides `background` set in color scheme if `colorscheme` is set. Uses hex color format: `"#rrggbb"`. |
+| `backgroundImage` | Optional | String | | Sets the file location of the Image to draw over the window background. |
+| `backgroundImageAlignment` | Optional | String | `center` | Sets how the background image aligns to the boundaries of the window. Possible values: `"center"`, `"left"`, `"top"`, `"right"`, `"bottom"`, `"topLeft"`, `"topRight"`, `"bottomLeft"`, `"bottomRight"` |
+| `backgroundImageOpacity` | Optional | Number | `1.0` | Sets the transparency of the background image. Accepts floating point values from 0-1. |
+| `backgroundImageStretchMode` | Optional | String | `uniformToFill` | Sets how the background image is resized to fill the window. Possible values: `"none"`, `"fill"`, `"uniform"`, `"uniformToFill"` |
 | `colorTable` | Optional | Array[String] | | Array of colors used in the profile if `colorscheme` is not set. Colors use hex color format: `"#rrggbb"`. Ordering is as follows: `[black, red, green, yellow, blue, magenta, cyan, white, bright black, bright red, bright green, bright yellow, bright blue, bright magenta, bright cyan, bright white]` |
 | `cursorHeight` | Optional | Integer | | Sets the percentage height of the cursor starting from the bottom. Only works when `cursorShape` is set to `"vintage"`. Accepts values from 25-100. |
 | `foreground` | Optional | String | | Sets the foreground color of the profile. Overrides `foreground` set in color scheme if `colorscheme` is set. Uses hex color format: `"#rrggbb"`. |

--- a/doc/user-docs/UsingJsonSettings.md
+++ b/doc/user-docs/UsingJsonSettings.md
@@ -110,7 +110,7 @@ The schema name can then be referenced in one or more profiles.
 ```json
     "backgroundImage": "ms-appdata:///Roaming/openlogo.jpg",
     "backgroundImageOpacity": 0.3,
-    "backgroundImageStretchMode":  "Fill",
+    "backgroundImageStretchMode":  "fill",
 ```
 5. Make sure that `useAcrylic` is `false`.
 6. Save the file.

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -40,7 +40,7 @@ static constexpr std::string_view StartingDirectoryKey{ "startingDirectory" };
 static constexpr std::string_view IconKey{ "icon" };
 static constexpr std::string_view BackgroundImageKey{ "backgroundImage" };
 static constexpr std::string_view BackgroundImageOpacityKey{ "backgroundImageOpacity" };
-static constexpr std::string_view BackgroundimageStretchModeKey{ "backgroundImageStretchMode" };
+static constexpr std::string_view BackgroundImageStretchModeKey{ "backgroundImageStretchMode" };
 static constexpr std::string_view BackgroundImageAlignmentKey{ "backgroundImageAlignment" };
 
 // Possible values for Scrollbar state
@@ -316,7 +316,7 @@ Json::Value Profile::ToJson() const
 
     if (_backgroundImageStretchMode)
     {
-        root[JsonKey(BackgroundimageStretchModeKey)] = SerializeImageStretchMode(_backgroundImageStretchMode.value()).data();
+        root[JsonKey(BackgroundImageStretchModeKey)] = SerializeImageStretchMode(_backgroundImageStretchMode.value()).data();
     }
 
     if (_backgroundImageAlignment)
@@ -456,7 +456,7 @@ Profile Profile::FromJson(const Json::Value& json)
     {
         result._backgroundImageOpacity = backgroundImageOpacity.asFloat();
     }
-    if (auto backgroundImageStretchMode{ json[JsonKey(BackgroundimageStretchModeKey)] })
+    if (auto backgroundImageStretchMode{ json[JsonKey(BackgroundImageStretchModeKey)] })
     {
         result._backgroundImageStretchMode = ParseImageStretchMode(backgroundImageStretchMode.asString());
     }

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -41,6 +41,7 @@ static constexpr std::string_view IconKey{ "icon" };
 static constexpr std::string_view BackgroundImageKey{ "backgroundImage" };
 static constexpr std::string_view BackgroundImageOpacityKey{ "backgroundImageOpacity" };
 static constexpr std::string_view BackgroundimageStretchModeKey{ "backgroundImageStretchMode" };
+static constexpr std::string_view BackgroundImageAlignmentKey{ "backgroundImageAlignment" };
 
 // Possible values for Scrollbar state
 static constexpr std::wstring_view AlwaysVisible{ L"visible" };
@@ -58,6 +59,17 @@ static constexpr std::string_view ImageStretchModeNone{ "none" };
 static constexpr std::string_view ImageStretchModeFill{ "fill" };
 static constexpr std::string_view ImageStretchModeUniform{ "uniform" };
 static constexpr std::string_view ImageStretchModeUniformTofill{ "uniformToFill" };
+
+// Possible values for Image Alignment
+static constexpr std::string_view ImageAlignmentCenter{ "center" };
+static constexpr std::string_view ImageAlignmentLeft{ "left" };
+static constexpr std::string_view ImageAlignmentTop{ "top" };
+static constexpr std::string_view ImageAlignmentRight{ "right" };
+static constexpr std::string_view ImageAlignmentBottom{ "bottom" };
+static constexpr std::string_view ImageAlignmentTopLeft{ "topLeft" };
+static constexpr std::string_view ImageAlignmentTopRight{ "topRight" };
+static constexpr std::string_view ImageAlignmentBottomLeft{ "bottomLeft" };
+static constexpr std::string_view ImageAlignmentBottomRight{ "bottomRight" };
 
 Profile::Profile() :
     Profile(Utils::CreateGuid())
@@ -91,7 +103,8 @@ Profile::Profile(const winrt::guid& guid) :
     _icon{},
     _backgroundImage{},
     _backgroundImageOpacity{},
-    _backgroundImageStretchMode{}
+    _backgroundImageStretchMode{},
+    _backgroundImageAlignment{}
 {
 }
 
@@ -202,6 +215,14 @@ TerminalSettings Profile::CreateTerminalSettings(const std::vector<ColorScheme>&
         terminalSettings.BackgroundImageStretchMode(_backgroundImageStretchMode.value());
     }
 
+    if (_backgroundImageAlignment)
+    {
+        const auto imageHorizontalAlignment = std::get<winrt::Windows::UI::Xaml::HorizontalAlignment>(_backgroundImageAlignment.value());
+        const auto imageVerticalAlignment = std::get<winrt::Windows::UI::Xaml::VerticalAlignment>(_backgroundImageAlignment.value());
+        terminalSettings.BackgroundImageHorizontalAlignment(imageHorizontalAlignment);
+        terminalSettings.BackgroundImageVerticalAlignment(imageVerticalAlignment);
+    }
+
     return terminalSettings;
 }
 
@@ -296,6 +317,11 @@ Json::Value Profile::ToJson() const
     if (_backgroundImageStretchMode)
     {
         root[JsonKey(BackgroundimageStretchModeKey)] = SerializeImageStretchMode(_backgroundImageStretchMode.value()).data();
+    }
+
+    if (_backgroundImageAlignment)
+    {
+        root[JsonKey(BackgroundImageAlignmentKey)] = SerializeImageAlignment(_backgroundImageAlignment.value()).data();
     }
 
     return root;
@@ -433,6 +459,10 @@ Profile Profile::FromJson(const Json::Value& json)
     if (auto backgroundImageStretchMode{ json[JsonKey(BackgroundimageStretchModeKey)] })
     {
         result._backgroundImageStretchMode = ParseImageStretchMode(backgroundImageStretchMode.asString());
+    }
+    if (auto backgroundImageAlignment{ json[JsonKey(BackgroundImageAlignmentKey)] })
+    {
+        result._backgroundImageAlignment = ParseImageAlignment(backgroundImageAlignment.asString());
     }
 
     return result;
@@ -653,6 +683,114 @@ std::string_view Profile::SerializeImageStretchMode(const winrt::Windows::UI::Xa
     default:
     case winrt::Windows::UI::Xaml::Media::Stretch::UniformToFill:
         return ImageStretchModeUniformTofill;
+    }
+}
+
+// Method Description:
+// - Helper function for converting a user-specified image horizontal and vertical
+//   alignment to the appropriate enum values tuple
+// Arguments:
+// - The value from the profiles.json file
+// Return Value:
+// - The corresponding enum values tuple which maps to the string provided by the user
+std::tuple<winrt::Windows::UI::Xaml::HorizontalAlignment, winrt::Windows::UI::Xaml::VerticalAlignment> Profile::ParseImageAlignment(const std::string_view imageAlignment)
+{
+    if (imageAlignment == ImageAlignmentTopLeft)
+    {
+        return std::make_tuple(winrt::Windows::UI::Xaml::HorizontalAlignment::Left,
+                               winrt::Windows::UI::Xaml::VerticalAlignment::Top);
+    }
+    else if (imageAlignment == ImageAlignmentBottomLeft)
+    {
+        return std::make_tuple(winrt::Windows::UI::Xaml::HorizontalAlignment::Left,
+                               winrt::Windows::UI::Xaml::VerticalAlignment::Bottom);
+    }
+    else if (imageAlignment == ImageAlignmentLeft)
+    {
+        return std::make_tuple(winrt::Windows::UI::Xaml::HorizontalAlignment::Left,
+                               winrt::Windows::UI::Xaml::VerticalAlignment::Center);
+    }
+    else if (imageAlignment == ImageAlignmentTopRight)
+    {
+        return std::make_tuple(winrt::Windows::UI::Xaml::HorizontalAlignment::Right,
+                               winrt::Windows::UI::Xaml::VerticalAlignment::Top);
+    }
+    else if (imageAlignment == ImageAlignmentBottomRight)
+    {
+        return std::make_tuple(winrt::Windows::UI::Xaml::HorizontalAlignment::Right,
+                               winrt::Windows::UI::Xaml::VerticalAlignment::Bottom);
+    }
+    else if (imageAlignment == ImageAlignmentRight)
+    {
+        return std::make_tuple(winrt::Windows::UI::Xaml::HorizontalAlignment::Right,
+                               winrt::Windows::UI::Xaml::VerticalAlignment::Center);
+    }
+    else if (imageAlignment == ImageAlignmentTop)
+    {
+        return std::make_tuple(winrt::Windows::UI::Xaml::HorizontalAlignment::Center,
+                               winrt::Windows::UI::Xaml::VerticalAlignment::Top);
+    }
+    else if (imageAlignment == ImageAlignmentBottom)
+    {
+        return std::make_tuple(winrt::Windows::UI::Xaml::HorizontalAlignment::Center,
+                               winrt::Windows::UI::Xaml::VerticalAlignment::Bottom);
+    }
+    else // Fall through to default alignment
+    {
+        return std::make_tuple(winrt::Windows::UI::Xaml::HorizontalAlignment::Center,
+                               winrt::Windows::UI::Xaml::VerticalAlignment::Center);
+    }
+}
+
+// Method Description:
+// - Helper function for converting the HorizontalAlignment+VerticalAlignment tuple
+//   to the correct string value.
+// Arguments:
+// - imageAlignment: The enum values tuple to convert to a string.
+// Return Value:
+// - The string value for the given ImageAlignment
+std::string_view Profile::SerializeImageAlignment(const std::tuple<winrt::Windows::UI::Xaml::HorizontalAlignment, winrt::Windows::UI::Xaml::VerticalAlignment> imageAlignment)
+{
+    const auto imageHorizontalAlignment = std::get<winrt::Windows::UI::Xaml::HorizontalAlignment>(imageAlignment);
+    const auto imageVerticalAlignment = std::get<winrt::Windows::UI::Xaml::VerticalAlignment>(imageAlignment);
+    switch (imageHorizontalAlignment)
+    {
+    case winrt::Windows::UI::Xaml::HorizontalAlignment::Left:
+        switch (imageVerticalAlignment)
+        {
+        case winrt::Windows::UI::Xaml::VerticalAlignment::Top:
+            return ImageAlignmentTopLeft;
+        case winrt::Windows::UI::Xaml::VerticalAlignment::Bottom:
+            return ImageAlignmentBottomLeft;
+        default:
+        case winrt::Windows::UI::Xaml::VerticalAlignment::Center:
+            return ImageAlignmentLeft;
+        }
+
+    case winrt::Windows::UI::Xaml::HorizontalAlignment::Right:
+        switch (imageVerticalAlignment)
+        {
+        case winrt::Windows::UI::Xaml::VerticalAlignment::Top:
+            return ImageAlignmentTopRight;
+        case winrt::Windows::UI::Xaml::VerticalAlignment::Bottom:
+            return ImageAlignmentBottomRight;
+        default:
+        case winrt::Windows::UI::Xaml::VerticalAlignment::Center:
+            return ImageAlignmentRight;
+        }
+
+    default:
+    case winrt::Windows::UI::Xaml::HorizontalAlignment::Center:
+        switch (imageVerticalAlignment)
+        {
+        case winrt::Windows::UI::Xaml::VerticalAlignment::Top:
+            return ImageAlignmentTop;
+        case winrt::Windows::UI::Xaml::VerticalAlignment::Bottom:
+            return ImageAlignmentBottom;
+        default:
+        case winrt::Windows::UI::Xaml::VerticalAlignment::Center:
+            return ImageAlignmentCenter;
+        }
     }
 }
 

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -62,6 +62,8 @@ private:
     static winrt::Microsoft::Terminal::Settings::ScrollbarState ParseScrollbarState(const std::wstring& scrollbarState);
     static winrt::Windows::UI::Xaml::Media::Stretch ParseImageStretchMode(const std::string_view imageStretchMode);
     static std::string_view SerializeImageStretchMode(const winrt::Windows::UI::Xaml::Media::Stretch imageStretchMode);
+    static std::tuple<winrt::Windows::UI::Xaml::HorizontalAlignment, winrt::Windows::UI::Xaml::VerticalAlignment> ParseImageAlignment(const std::string_view imageAlignment);
+    static std::string_view SerializeImageAlignment(const std::tuple<winrt::Windows::UI::Xaml::HorizontalAlignment, winrt::Windows::UI::Xaml::VerticalAlignment> imageAlignment);
     static winrt::Microsoft::Terminal::Settings::CursorStyle _ParseCursorShape(const std::wstring& cursorShapeString);
     static std::wstring_view _SerializeCursorStyle(const winrt::Microsoft::Terminal::Settings::CursorStyle cursorShape);
 
@@ -91,6 +93,7 @@ private:
     std::optional<std::wstring> _backgroundImage;
     std::optional<double> _backgroundImageOpacity;
     std::optional<winrt::Windows::UI::Xaml::Media::Stretch> _backgroundImageStretchMode;
+    std::optional<std::tuple<winrt::Windows::UI::Xaml::HorizontalAlignment, winrt::Windows::UI::Xaml::VerticalAlignment>> _backgroundImageAlignment;
 
     std::optional<std::wstring> _scrollbarState;
     bool _closeOnExit;

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -272,13 +272,13 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                 // internet.
                 Media::Imaging::BitmapImage image(imageUri);
                 _bgImageLayer.Source(image);
-                _bgImageLayer.HorizontalAlignment(HorizontalAlignment::Center);
-                _bgImageLayer.VerticalAlignment(VerticalAlignment::Center);
             }
 
-            // Apply stretch and opacity settings
+            // Apply stretch, opacity and alignment settings
             _bgImageLayer.Stretch(_settings.BackgroundImageStretchMode());
             _bgImageLayer.Opacity(_settings.BackgroundImageOpacity());
+            _bgImageLayer.HorizontalAlignment(_settings.BackgroundImageHorizontalAlignment());
+            _bgImageLayer.VerticalAlignment(_settings.BackgroundImageVerticalAlignment());
         }
         else
         {

--- a/src/cascadia/TerminalSettings/IControlSettings.idl
+++ b/src/cascadia/TerminalSettings/IControlSettings.idl
@@ -37,5 +37,7 @@ namespace Microsoft.Terminal.Settings
         String BackgroundImage;
         Double BackgroundImageOpacity;
         Windows.UI.Xaml.Media.Stretch BackgroundImageStretchMode;
+        Windows.UI.Xaml.HorizontalAlignment BackgroundImageHorizontalAlignment;
+        Windows.UI.Xaml.VerticalAlignment BackgroundImageVerticalAlignment;
     };
 }

--- a/src/cascadia/TerminalSettings/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettings/TerminalSettings.cpp
@@ -30,6 +30,8 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         _backgroundImage{},
         _backgroundImageOpacity{ 1.0 },
         _backgroundImageStretchMode{ winrt::Windows::UI::Xaml::Media::Stretch::UniformToFill },
+        _backgroundImageHorizontalAlignment{ winrt::Windows::UI::Xaml::HorizontalAlignment::Center },
+        _backgroundImageVerticalAlignment{ winrt::Windows::UI::Xaml::VerticalAlignment::Center },
         _keyBindings{ nullptr },
         _scrollbarState{ ScrollbarState::Visible }
     {
@@ -234,6 +236,26 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
     void TerminalSettings::BackgroundImageStretchMode(winrt::Windows::UI::Xaml::Media::Stretch value)
     {
         _backgroundImageStretchMode = value;
+    }
+
+    winrt::Windows::UI::Xaml::HorizontalAlignment TerminalSettings::BackgroundImageHorizontalAlignment()
+    {
+        return _backgroundImageHorizontalAlignment;
+    }
+
+    void TerminalSettings::BackgroundImageHorizontalAlignment(winrt::Windows::UI::Xaml::HorizontalAlignment value)
+    {
+        _backgroundImageHorizontalAlignment = value;
+    }
+
+    winrt::Windows::UI::Xaml::VerticalAlignment TerminalSettings::BackgroundImageVerticalAlignment()
+    {
+        return _backgroundImageVerticalAlignment;
+    }
+
+    void TerminalSettings::BackgroundImageVerticalAlignment(winrt::Windows::UI::Xaml::VerticalAlignment value)
+    {
+        _backgroundImageVerticalAlignment = value;
     }
 
     Settings::IKeyBindings TerminalSettings::KeyBindings()

--- a/src/cascadia/TerminalSettings/terminalsettings.h
+++ b/src/cascadia/TerminalSettings/terminalsettings.h
@@ -69,6 +69,10 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         void BackgroundImageOpacity(double value);
         winrt::Windows::UI::Xaml::Media::Stretch BackgroundImageStretchMode();
         void BackgroundImageStretchMode(winrt::Windows::UI::Xaml::Media::Stretch value);
+        winrt::Windows::UI::Xaml::HorizontalAlignment BackgroundImageHorizontalAlignment();
+        void BackgroundImageHorizontalAlignment(winrt::Windows::UI::Xaml::HorizontalAlignment value);
+        winrt::Windows::UI::Xaml::VerticalAlignment BackgroundImageVerticalAlignment();
+        void BackgroundImageVerticalAlignment(winrt::Windows::UI::Xaml::VerticalAlignment value);
 
         winrt::Microsoft::Terminal::Settings::IKeyBindings KeyBindings();
         void KeyBindings(winrt::Microsoft::Terminal::Settings::IKeyBindings const& value);
@@ -107,6 +111,8 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         hstring _backgroundImage;
         double _backgroundImageOpacity;
         winrt::Windows::UI::Xaml::Media::Stretch _backgroundImageStretchMode;
+        winrt::Windows::UI::Xaml::HorizontalAlignment _backgroundImageHorizontalAlignment;
+        winrt::Windows::UI::Xaml::VerticalAlignment _backgroundImageVerticalAlignment;
         hstring _commandline;
         hstring _startingDir;
         hstring _envVars;


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Implement #1949: `profiles.json` has been given a setting for background images labeled as shown below, with the following valid values. This allows background images to be anchored to different corners/sides of the console to fit that background image's intended use-case and focus.

```json
"backgroundImageAlignment": "center" | "left" | "top" | "right" | "bottom"
                   | "topLeft" | "topRight" | "bottomLeft" | "bottomRight"
```

When `left`, `top`, `right`, or `bottom` is specified, the other axis is implied to be centered, as that is the default behavior. I went in favor of labeling the default value as `center` instead of `none` as "none" does not clearly list the alignment behavior.

### Alternative Setting

The branch [dev/trigger/background-image-align-two-settings](https://github.com/trigger-segfault/terminal/tree/dev/trigger/background-image-align-two-settings) implements the exact same functionality, but by splitting the `profiles.json` setting into separate horizontal and vertical settings. I am happy to submit it as a PR if the two-setting approach is preferred.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

There seems to be no other issues or pull requests relevant to background image alignment.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #1949
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [X] Tests ~~added~~/passed
* [X] Requires documentation to be updated <sup>([SettingsSchema.md](https://github.com/microsoft/terminal/blob/master/doc/cascadia/SettingsSchema.md), [UsingJsonSettings.md](https://github.com/microsoft/terminal/blob/master/doc/user-docs/UsingJsonSettings.md) (optional))</sup>
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1949

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The `Profile` class defines methods for parsing and serializing the combined `HorizontalAlignment` and `VerticalAlignment` enums to and from JSON. An `std::tuple<HorizontalAlignment, VerticalAlignment>` field `_backgroundImageAlignment` has been added  for storing the profile setting in one place, as it logically makes sense that both alignments to be in use together.

`TerminalSettings` and `IControlSettings` have been given `BackgroundImageHorizontalAlignment` and `BackgroundImageVerticalAlignment` properties. The combination of `std::tuple<HorizontalAlignment, VerticalAlignment>` is gone once we leave the `Profile` class. Combining the two enums is only relevant to how they are stored in `profiles.json`. `TerminalSettings` defines the default values of both alignment properties as `Center`.

The `TermControl` class changes the image setup in `TermControl::_InitializeBackgroundBrush()` to assign the `_bgImageLayer`'s (background image control's) alignments to that of the specified alignment settings. The alignments assignments have also been moved from within the image source assignment block, to the bottom of the *additional* images settings definitions (`Stretch` and `Opacity`).

### Additional Fixes

The line below for the constant definition has a lowercase `i` at the beginning of the word *"image"*. The `i` has been capitalized to follow proper UpperCamelCase. The two references to this `BackgroundImageStretchModeKey` constant have been updated to reflect the new name.

https://github.com/microsoft/terminal/blob/fad7638bb39d5c5107431605a1adf50010f8646a/src/cascadia/TerminalApp/Profile.cpp#L43

*(This change was performed in its own commit, so it can be reverted if needed.)*

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

* [X] Test and observe all 9 possible alignment values, invalid input, and not specifying the setting at all.
  * [X] For each image stretch mode.
  * [X] For when a background image is defined or not.
  * [X] Confirm alignment names match up.
* [X] For each alignment value, confirm they are re-serialized correctly when opening Windows Terminal.
* [X] Confirm default setting results in a centered background image.
* [X] Test and observe if alignment settings are properly applied when first opening the Windows Terminal or opening a new profile tab.

## Preview Example Alignments

Below are examples of the alignments `bottom` (Left) and `bottomRight` (Right) in use.

<p align="center"><img alt="Preview Figure A (Left) and Figure B (Right)" src="https://i.imgur.com/4g0bs5E.png"></p>

*Figure A (Left) shows the use of `bottom` alignment with `uniformToFill` stretch mode. The waves will always be at the bottom and stay centered horizontally. Figure B (Right) shows the use of `bottomRight` alignment with `none` stretch mode. The image will always remain in the bottom right corner and remain the same size.*