### PR TITLE
Fix display of the "low ASCII" glyphs in PC code pages

### DIFF
--- a/src/host/_stream.cpp
+++ b/src/host/_stream.cpp
@@ -516,7 +516,7 @@ using Microsoft::Console::VirtualTerminal::StateMachine;
                         WORD CharType;
 
                         GetStringTypeW(CT_CTYPE1, &RealUnicodeChar, 1, &CharType);
-                        if (CharType == C1_CNTRL)
+                        if (WI_IsFlagSet(CharType, C1_CNTRL))
                         {
                             ConvertOutputToUnicode(gci.OutputCP,
                                                    (LPSTR)&RealUnicodeChar,

--- a/src/host/_stream.cpp
+++ b/src/host/_stream.cpp
@@ -511,26 +511,29 @@ using Microsoft::Console::VirtualTerminal::StateMachine;
                     }
                     else
                     {
-                        // As a special favor to incompetent apps that attempt to display control chars,
-                        // convert to corresponding OEM Glyph Chars
-                        WORD CharType;
-
-                        GetStringTypeW(CT_CTYPE1, &RealUnicodeChar, 1, &CharType);
-                        if (WI_IsFlagSet(CharType, C1_CNTRL))
-                        {
-                            ConvertOutputToUnicode(gci.OutputCP,
-                                                   (LPSTR)&RealUnicodeChar,
-                                                   1,
-                                                   LocalBufPtr,
-                                                   1);
-                        }
-                        else if (Char == UNICODE_NULL)
+                        if (Char == UNICODE_NULL)
                         {
                             *LocalBufPtr = UNICODE_SPACE;
                         }
                         else
                         {
-                            *LocalBufPtr = Char;
+                            // As a special favor to incompetent apps that attempt to display control chars,
+                            // convert to corresponding OEM Glyph Chars
+                            WORD CharType;
+
+                            GetStringTypeW(CT_CTYPE1, &RealUnicodeChar, 1, &CharType);
+                            if (WI_IsFlagSet(CharType, C1_CNTRL))
+                            {
+                                ConvertOutputToUnicode(gci.OutputCP,
+                                                       (LPSTR)&RealUnicodeChar,
+                                                       1,
+                                                       LocalBufPtr,
+                                                       1);
+                            }
+                            else
+                            {
+                                *LocalBufPtr = Char;
+                            }
                         }
 
                         LocalBufPtr++;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

In the legacy console, it used to be possible to write out characters from the C0 range of a PC code page (e.g. CP437), and get the actual glyphs defined for those code points (at least those that weren't processed as control codes). In the v2 console this stopped working so you'd get an FFFD replacement glyph (�) for those characters instead. This PR fixes the issue so the correct glyphs are displayed again.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #166
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #166

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

There was already code in place to achieve this in the `WriteCharsLegacy` method. It used the `GetStringTypeW` method to determine the character type of the value being output, and if it was a `C1_CNTRL` character it performed the appropriate mapping. The problem was that the test of the character type flag was done as a direct comparision, when it should have been a bit test, so the condition was never met.

With this condition fixed, the code also needed to be reordered slightly to handle the null character. That had a special-case mapping to space, which was previously performed after the control test, but since a null character now successfully matches `C1_CNTRL`, it no longer falls through to that special case. To address that, I've had to move the null check above the control test.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

I've tested this manually, by trying to output all the characters in the affected range (ASCII values 0 to 31, and 127, excluding the actual control codes 8,9,10 and 13). In all cases they now match the output that the legacy console produced.

Note that this only applies to PC code pages that have glyphs defined for the C0 range, so it won't work with the UTF-8 code page, but that was to be expected - the legacy console behaved the same way.

Also, note that this only works when the `ENABLE_PROCESSED_OUTPUT` console mode is set. That seems wrong to me (I'd expect the glyphs to work in both cases), but that's the way the legacy console behaved as well, so if that's a bug it's a separate issue.

I haven't added any unit tests, because I expect the behaviour of some of these characters to change over time (as support is added for more control codes), which could then cause the tests to fail. But if that's not a concern, I could probably add something to the ScreenBufferTests (perhaps with a comment warning that the tests might be expected to fail in the future).