### PR TITLE
Roll up WindowsTerminal's subprojects into packaging outputs

### DIFF
--- a/src/cascadia/TerminalApp/TerminalApp.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalApp.vcxproj
@@ -103,4 +103,32 @@
 
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.post.props" />
 
+  <!--
+    This is a terrible, terrible rule. There exists a bug in Visual Studio 2019 16.2 and 16.3 previews
+    where ResolveAssemblyReferences will try and fail to parse a .lib when it produces a .winmd.
+    To fix that, we have to _temporarily_ replace the %(Implementation) on any winmd-producing
+    static library references with the empty string so as to make ResolveAssemblyReferences
+    not try to read it.
+
+    Upstream problem report:
+    https://developercommunity.visualstudio.com/content/problem/629524/static-library-reference-causes-there-was-a-proble.html
+  -->
+  <Target Name="_RemoveTerminalAppLibImplementationFromReference" BeforeTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <_TerminalAppLibProjectReference Include="@(_ResolvedProjectReferencePaths)" Condition="'%(Filename)' == 'TerminalApp'" />
+      <_ResolvedProjectReferencePaths Remove="@(_TerminalAppLibProjectReference)" />
+      <_ResolvedProjectReferencePaths Include="@(_TerminalAppLibProjectReference)">
+        <Implementation />
+      </_ResolvedProjectReferencePaths>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_RestoreTerminalAppLibImplementationFromReference" AfterTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <_ResolvedProjectReferencePaths Remove="@(_TerminalAppLibProjectReference)" />
+      <_ResolvedProjectReferencePaths Include="@(_TerminalAppLibProjectReference)" />
+    </ItemGroup>
+  </Target>
+  <!-- End "terrible, terrible rule" -->
+
 </Project>

--- a/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
+++ b/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
@@ -155,4 +155,31 @@
   <Import Project="..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.190521.3\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.190521.3\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   <Import Project="..\..\..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.0.0-preview6.2\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets" Condition="Exists('..\..\..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.0.0-preview6.2\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets')" />
   <Import Project="..\..\..\packages\Microsoft.VCRTForwarders.140.1.0.0-rc\build\native\Microsoft.VCRTForwarders.140.targets" Condition="Exists('..\..\..\packages\Microsoft.VCRTForwarders.140.1.0.0-rc\build\native\Microsoft.VCRTForwarders.140.targets')" />
+
+  <!-- Override GetPackagingOutputs to roll up all our dependencies.
+       This ensures that when the WAP packaging project asks what files go into
+       the package, we tell it.
+       This is a heavily stripped version of the one in Microsoft.*.AppxPackage.targets.
+  -->
+  <PropertyGroup>
+    <_ContinueOnError Condition="'$(BuildingProject)' == 'true'">true</_ContinueOnError>
+    <_ContinueOnError Condition="'$(BuildingProject)' != 'true'">false</_ContinueOnError>
+  </PropertyGroup>
+  <Target Name="GetPackagingOutputs" Returns="@(PackagingOutputs)">
+    <MSBuild
+      Projects="@(ProjectReferenceWithConfiguration)"
+      Targets="GetPackagingOutputs"
+      BuildInParallel="$(BuildInParallel)"
+      Properties="%(ProjectReferenceWithConfiguration.SetConfiguration); %(ProjectReferenceWithConfiguration.SetPlatform)"
+      Condition="'@(ProjectReferenceWithConfiguration)' != ''
+                 and '%(ProjectReferenceWithConfiguration.BuildReference)' == 'true'
+                 and '%(ProjectReferenceWithConfiguration.ReferenceOutputAssembly)' == 'true'"
+      ContinueOnError="$(_ContinueOnError)">
+      <Output TaskParameter="TargetOutputs" ItemName="_PackagingOutputsFromOtherProjects"/>
+    </MSBuild>
+
+    <ItemGroup>
+      <PackagingOutputs Include="@(_PackagingOutputsFromOtherProjects)" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
This may be a targeted fix that obviates the need for #2002 without going all the way to #1995.