### PR TITLE
Add a keybinding for ClosePane

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -493,6 +493,7 @@ namespace winrt::TerminalApp::implementation
         bindings.NewTab([this]() { _OpenNewTab(std::nullopt); });
         bindings.DuplicateTab([this]() { _DuplicateTabViewItem(); });
         bindings.CloseTab([this]() { _CloseFocusedTab(); });
+        bindings.ClosePane([this]() { _CloseFocusedPane(); });
         bindings.NewTabWithProfile([this](const auto index) { _OpenNewTab({ index }); });
         bindings.ScrollUp([this]() { _Scroll(-1); });
         bindings.ScrollDown([this]() { _Scroll(1); });
@@ -984,6 +985,17 @@ namespace winrt::TerminalApp::implementation
         int focusedTabIndex = _GetFocusedTabIndex();
         std::shared_ptr<Tab> focusedTab{ _tabs[focusedTabIndex] };
         _RemoveTabViewItem(focusedTab->GetTabViewItem());
+    }
+
+    // Method Description:
+    // - Close the currently focused pane. If the pane is the last pane in the
+    //   tab, the tab will also be closed. This will happen when we handle the
+    //   tab's Closed event.
+    void App::_CloseFocusedPane()
+    {
+        int focusedTabIndex = _GetFocusedTabIndex();
+        std::shared_ptr<Tab> focusedTab{ _tabs[focusedTabIndex] };
+        focusedTab->ClosePane();
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/App.h
+++ b/src/cascadia/TerminalApp/App.h
@@ -105,6 +105,7 @@ namespace winrt::TerminalApp::implementation
         void _OpenNewTab(std::optional<int> profileIndex);
         void _DuplicateTabViewItem();
         void _CloseFocusedTab();
+        void _CloseFocusedPane();
         void _SelectNextTab(const bool bMoveRight);
         void _SelectTab(const int tabIndex);
 

--- a/src/cascadia/TerminalApp/AppKeyBindings.cpp
+++ b/src/cascadia/TerminalApp/AppKeyBindings.cpp
@@ -102,6 +102,9 @@ namespace winrt::TerminalApp::implementation
         case ShortcutAction::CloseTab:
             _CloseTabHandlers();
             return true;
+        case ShortcutAction::ClosePane:
+            _ClosePaneHandlers();
+            return true;
 
         case ShortcutAction::ScrollUp:
             _ScrollUpHandlers();
@@ -249,6 +252,7 @@ namespace winrt::TerminalApp::implementation
     DEFINE_EVENT(AppKeyBindings, NewWindow,         _NewWindowHandlers,         TerminalApp::NewWindowEventArgs);
     DEFINE_EVENT(AppKeyBindings, CloseWindow,       _CloseWindowHandlers,       TerminalApp::CloseWindowEventArgs);
     DEFINE_EVENT(AppKeyBindings, CloseTab,          _CloseTabHandlers,          TerminalApp::CloseTabEventArgs);
+    DEFINE_EVENT(AppKeyBindings, ClosePane,         _ClosePaneHandlers,         TerminalApp::ClosePaneEventArgs);
     DEFINE_EVENT(AppKeyBindings, SwitchToTab,       _SwitchToTabHandlers,       TerminalApp::SwitchToTabEventArgs);
     DEFINE_EVENT(AppKeyBindings, NextTab,           _NextTabHandlers,           TerminalApp::NextTabEventArgs);
     DEFINE_EVENT(AppKeyBindings, PrevTab,           _PrevTabHandlers,           TerminalApp::PrevTabEventArgs);

--- a/src/cascadia/TerminalApp/AppKeyBindings.h
+++ b/src/cascadia/TerminalApp/AppKeyBindings.h
@@ -48,6 +48,7 @@ namespace winrt::TerminalApp::implementation
         DECLARE_EVENT(NewWindow,         _NewWindowHandlers,         TerminalApp::NewWindowEventArgs);
         DECLARE_EVENT(CloseWindow,       _CloseWindowHandlers,       TerminalApp::CloseWindowEventArgs);
         DECLARE_EVENT(CloseTab,          _CloseTabHandlers,          TerminalApp::CloseTabEventArgs);
+        DECLARE_EVENT(ClosePane,         _ClosePaneHandlers,         TerminalApp::ClosePaneEventArgs);
         DECLARE_EVENT(SwitchToTab,       _SwitchToTabHandlers,       TerminalApp::SwitchToTabEventArgs);
         DECLARE_EVENT(NextTab,           _NextTabHandlers,           TerminalApp::NextTabEventArgs);
         DECLARE_EVENT(PrevTab,           _PrevTabHandlers,           TerminalApp::PrevTabEventArgs);

--- a/src/cascadia/TerminalApp/AppKeyBindings.idl
+++ b/src/cascadia/TerminalApp/AppKeyBindings.idl
@@ -30,6 +30,7 @@ namespace TerminalApp
         NewWindow,
         CloseWindow,
         CloseTab,
+        ClosePane,
         NextTab,
         PrevTab,
         SplitVertical,
@@ -68,6 +69,7 @@ namespace TerminalApp
     delegate void NewWindowEventArgs();
     delegate void CloseWindowEventArgs();
     delegate void CloseTabEventArgs();
+    delegate void ClosePaneEventArgs();
     delegate void NextTabEventArgs();
     delegate void PrevTabEventArgs();
     delegate void SplitVerticalEventArgs();
@@ -98,6 +100,7 @@ namespace TerminalApp
         event NewWindowEventArgs NewWindow;
         event CloseWindowEventArgs CloseWindow;
         event CloseTabEventArgs CloseTab;
+        event ClosePaneEventArgs ClosePane;
         event SwitchToTabEventArgs SwitchToTab;
         event NextTabEventArgs NextTab;
         event PrevTabEventArgs PrevTab;

--- a/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
@@ -30,6 +30,7 @@ static constexpr std::string_view NewTabWithProfile8Key{ "newTabProfile8" };
 static constexpr std::string_view NewWindowKey{ "newWindow" };
 static constexpr std::string_view CloseWindowKey{ "closeWindow" };
 static constexpr std::string_view CloseTabKey{ "closeTab" };
+static constexpr std::string_view ClosePaneKey{ "closePane" };
 static constexpr std::string_view SwitchtoTabKey{ "switchToTab" };
 static constexpr std::string_view NextTabKey{ "nextTab" };
 static constexpr std::string_view PrevTabKey{ "prevTab" };
@@ -86,6 +87,7 @@ static const std::map<std::string_view, ShortcutAction, std::less<>> commandName
     { NewWindowKey, ShortcutAction::NewWindow },
     { CloseWindowKey, ShortcutAction::CloseWindow },
     { CloseTabKey, ShortcutAction::CloseTab },
+    { ClosePaneKey, ShortcutAction::ClosePane },
     { NextTabKey, ShortcutAction::NextTab },
     { PrevTabKey, ShortcutAction::PrevTab },
     { IncreaseFontSizeKey, ShortcutAction::IncreaseFontSize },

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -287,8 +287,8 @@ void CascadiaSettings::_CreateDefaultKeybindings()
                               KeyChord{ KeyModifiers::Ctrl | KeyModifiers::Shift,
                                         static_cast<int>('D') });
 
-    keyBindings.SetKeyBinding(ShortcutAction::CloseTab,
-                              KeyChord{ KeyModifiers::Ctrl,
+    keyBindings.SetKeyBinding(ShortcutAction::ClosePane,
+                              KeyChord{ KeyModifiers::Ctrl | KeyModifiers::Shift,
                                         static_cast<int>('W') });
 
     keyBindings.SetKeyBinding(ShortcutAction::CopyText,

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -309,6 +309,18 @@ void Pane::_ControlClosedHandler()
 }
 
 // Method Description:
+// - Fire our Closed event to tell our parent that we should be removed.
+// Arguments:
+// - <none>
+// Return Value:
+// - <none>
+void Pane::Close()
+{
+    // Fire our Closed event to tell our parent that we should be removed.
+    _closedHandlers();
+}
+
+// Method Description:
 // - Get the root UIElement of this pane. There may be a single TermControl as a
 //   child, or an entire tree of grids and panes as children of this element.
 // Arguments:

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -52,6 +52,8 @@ public:
     void SplitHorizontal(const GUID& profile, const winrt::Microsoft::Terminal::TerminalControl::TermControl& control);
     void SplitVertical(const GUID& profile, const winrt::Microsoft::Terminal::TerminalControl::TermControl& control);
 
+    void Close();
+
     DECLARE_EVENT(Closed, _closedHandlers, winrt::Microsoft::Terminal::TerminalControl::ConnectionClosedEventArgs);
 
 private:

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -249,4 +249,18 @@ void Tab::NavigateFocus(const winrt::TerminalApp::Direction& direction)
     _rootPane->NavigateFocus(direction);
 }
 
+// Method Description:
+// - Closes the currently focused pane in this tab. If it's the last pane in
+//   this tab, our Closed event will be fired (at a later time) for anyone
+//   registered as a handler of our close event.
+// Arguments:
+// - <none>
+// Return Value:
+// - <none>
+void Tab::ClosePane()
+{
+    auto focused = _rootPane->GetFocusedPane();
+    focused->Close();
+}
+
 DEFINE_EVENT(Tab, Closed, _closedHandlers, ConnectionClosedEventArgs);

--- a/src/cascadia/TerminalApp/Tab.h
+++ b/src/cascadia/TerminalApp/Tab.h
@@ -31,6 +31,8 @@ public:
     winrt::hstring GetFocusedTitle() const;
     void SetTabText(const winrt::hstring& text);
 
+    void ClosePane();
+
     DECLARE_EVENT(Closed, _closedHandlers, winrt::Microsoft::Terminal::TerminalControl::ConnectionClosedEventArgs);
 
 private:


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
  Closes #993
  When the last pane in a tab is closed, the tab will close.
  Bound to Ctrl+Shift+W by default. 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
See #1417 for discussion on the default keybindings. The Ctrl+W->CloseTab keybinding is being removed in favor ClosePane.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #993
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [N/A] Requires documentation to be updated
* [X] I work here
