### PR TITLE
Change some default keybindings

### DIFF
--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -277,11 +277,9 @@ void CascadiaSettings::_CreateDefaultProfiles()
 void CascadiaSettings::_CreateDefaultKeybindings()
 {
     AppKeyBindings keyBindings = _globals.GetKeybindings();
-    // Set up spme basic default keybindings
-    // TODO:MSFT:20700157 read our settings from some source, and configure
-    //      keychord,action pairings from that file
+    // Set up some basic default keybindings
     keyBindings.SetKeyBinding(ShortcutAction::NewTab,
-                              KeyChord{ KeyModifiers::Ctrl,
+                              KeyChord{ KeyModifiers::Ctrl | KeyModifiers::Shift,
                                         static_cast<int>('T') });
     keyBindings.SetKeyBinding(ShortcutAction::DuplicateTab,
                               KeyChord{ KeyModifiers::Ctrl | KeyModifiers::Shift,
@@ -354,31 +352,31 @@ void CascadiaSettings::_CreateDefaultKeybindings()
                               KeyChord{ KeyModifiers::Ctrl | KeyModifiers::Shift,
                                         VK_PRIOR });
     keyBindings.SetKeyBinding(ShortcutAction::SwitchToTab0,
-                              KeyChord{ KeyModifiers::Alt,
+                              KeyChord{ KeyModifiers::Alt | KeyModifiers::Ctrl,
                                         static_cast<int>('1') });
     keyBindings.SetKeyBinding(ShortcutAction::SwitchToTab1,
-                              KeyChord{ KeyModifiers::Alt,
+                              KeyChord{ KeyModifiers::Alt | KeyModifiers::Ctrl,
                                         static_cast<int>('2') });
     keyBindings.SetKeyBinding(ShortcutAction::SwitchToTab2,
-                              KeyChord{ KeyModifiers::Alt,
+                              KeyChord{ KeyModifiers::Alt | KeyModifiers::Ctrl,
                                         static_cast<int>('3') });
     keyBindings.SetKeyBinding(ShortcutAction::SwitchToTab3,
-                              KeyChord{ KeyModifiers::Alt,
+                              KeyChord{ KeyModifiers::Alt | KeyModifiers::Ctrl,
                                         static_cast<int>('4') });
     keyBindings.SetKeyBinding(ShortcutAction::SwitchToTab4,
-                              KeyChord{ KeyModifiers::Alt,
+                              KeyChord{ KeyModifiers::Alt | KeyModifiers::Ctrl,
                                         static_cast<int>('5') });
     keyBindings.SetKeyBinding(ShortcutAction::SwitchToTab5,
-                              KeyChord{ KeyModifiers::Alt,
+                              KeyChord{ KeyModifiers::Alt | KeyModifiers::Ctrl,
                                         static_cast<int>('6') });
     keyBindings.SetKeyBinding(ShortcutAction::SwitchToTab6,
-                              KeyChord{ KeyModifiers::Alt,
+                              KeyChord{ KeyModifiers::Alt | KeyModifiers::Ctrl,
                                         static_cast<int>('7') });
     keyBindings.SetKeyBinding(ShortcutAction::SwitchToTab7,
-                              KeyChord{ KeyModifiers::Alt,
+                              KeyChord{ KeyModifiers::Alt | KeyModifiers::Ctrl,
                                         static_cast<int>('8') });
     keyBindings.SetKeyBinding(ShortcutAction::SwitchToTab8,
-                              KeyChord{ KeyModifiers::Alt,
+                              KeyChord{ KeyModifiers::Alt | KeyModifiers::Ctrl,
                                         static_cast<int>('9') });
 }
 


### PR DESCRIPTION
  Closes #1417.

  Changes New Tab to Ctrl+Shift+t (from Ctrl+t)
  Changes SwitchToTabN to Ctrl+Alt+&lt;number> (from Alt+&lt;number>)

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
This is from discussion in #1417
#2012 Changes "Close Window" by removing it by default, and adding ClosePane on Ctrl+Shift+W

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1417
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed - Oh I guess I might be able to test this now...
* [N/A] Requires documentation to be updated
* [x] I've discussed this with core contributors already. 