### PR TITLE
Roll up dependencies through TerminalApp so the package is right

### DIFF
--- a/build/pipelines/templates/build-console-steps.yml
+++ b/build/pipelines/templates/build-console-steps.yml
@@ -46,6 +46,14 @@ steps:
     clean: true
     maximumCpuCount: true
 
+- task: PowerShell@2
+  displayName: 'Check MSIX for common regressions'
+  inputs:
+    targetType: inline
+    script: |
+      $Package = Get-ChildItem -Recurse -Filter "CascadiaPackage_*.msix"
+      .\build\scripts\Test-WindowsTerminalPackage.ps1 -Verbose -Path $Package.FullName
+
 - task: VSTest@2
   displayName: 'Run Unit Tests'
   inputs:

--- a/build/scripts/Test-WindowsTerminalPackage.ps1
+++ b/build/scripts/Test-WindowsTerminalPackage.ps1
@@ -1,0 +1,79 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$true, ValueFromPipeline=$true,
+      HelpMessage="Path to the .appx/.msix to validate")]
+    [string]
+    $Path,
+
+    [Parameter(HelpMessage="Path to Windows Kit")]
+    [ValidateScript({Test-Path $_ -Type Leaf})]
+    [string]
+    $WindowsKitPath = "C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0"
+)
+
+$ErrorActionPreference = "Stop"
+
+If ($null -Eq (Get-Item $WindowsKitPath -EA:SilentlyContinue)) {
+    Write-Error "Could not find a windows SDK at at `"$WindowsKitPath`".`nMake sure that WindowsKitPath points to a valid SDK."
+    Exit 1
+}
+
+$makeAppx = "$WindowsKitPath\x86\MakeAppx.exe"
+$makePri = "$WindowsKitPath\x86\MakePri.exe"
+
+Function Expand-ApplicationPackage {
+    Param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [string]
+        $Path
+    )
+
+    $sentinelFile = New-TemporaryFile
+    $directory = New-Item -Type Directory "$($sentinelFile.FullName)_Package"
+    Remove-Item $sentinelFile -Force -EA:Ignore
+
+    & $makeAppx unpack /p $Path /d $directory /nv /o
+
+    If ($LastExitCode -Ne 0) {
+        Throw "Failed to expand AppX"
+    }
+
+    $directory
+}
+
+Write-Verbose "Expanding $Path"
+$AppxPackageRoot = Expand-ApplicationPackage $Path
+$AppxPackageRootPath = $AppxPackageRoot.FullName
+
+Write-Verbose "Expanded to $AppxPackageRootPath"
+
+Try {
+    & $makePri dump /if "$AppxPackageRootPath\resources.pri" /of "$AppxPackageRootPath\resources.pri.xml" /o
+    If ($LastExitCode -Ne 0) {
+        Throw "Failed to dump PRI"
+    }
+
+    $Manifest = [xml](Get-Content "$AppxPackageRootPath\AppxManifest.xml")
+    $PRIFile = [xml](Get-Content "$AppxPackageRootPath\resources.pri.xml")
+
+    ### Check the activatable class entries for a few DLLs we need.
+    $inProcServers = $Manifest.Package.Extensions.Extension.InProcessServer.Path
+    $RequiredInProcServers = ("TerminalApp.dll", "TerminalControl.dll", "TerminalConnection.dll")
+
+    Write-Verbose "InProc Servers: $inProcServers"
+
+    ForEach ($req in $RequiredInProcServers) {
+        If ($req -NotIn $inProcServers) {
+            Throw "Failed to find $req in InProcServer list $inProcServers"
+        }
+    }
+
+    ### Check that we have an App.xbf (which is a proxy for our resources having been merged)
+    $resourceXpath = '/PriInfo/ResourceMap/ResourceMapSubtree[@name="Files"]/NamedResource[@name="App.xbf"]'
+    $AppXbf = $PRIFile.SelectSingleNode($resourceXpath)
+    If ($null -eq $AppXbf) {
+        Throw "Failed to find App.xbf (TerminalApp project) in resources.pri"
+    }
+} Finally {
+    Remove-Item -Recurse -Force $AppxPackageRootPath
+}

--- a/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
+++ b/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
@@ -260,24 +260,6 @@
     <PRIResource Include="Resources\en-US\Resources.resw" />
   </ItemGroup>
   <Import Project="$(OpenConsoleDir)src\wap-common.build.post.props" />
-  <!--
-    Microsoft.UI.Xaml contains some <Content> resource files that need to be included in our package.
-    For some reason, they're not rolled up through dependent projects; if they were, their paths would
-    be wrong.
-
-    WAP Packaging projects don't actually support nuget package references, so we added one manually.
-
-    This does mean that version changes to Microsoft.UI.Xaml must be manually reflected
-    here.
-  -->
-  <Import Project="..\..\..\packages\Microsoft.UI.Xaml.2.2.190611001-prerelease\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\..\..\packages\Microsoft.UI.Xaml.2.2.190611001-prerelease\build\native\Microsoft.UI.Xaml.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\Microsoft.UI.Xaml.2.2.190611001-prerelease\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.UI.Xaml.2.2.190611001-prerelease\build\native\Microsoft.UI.Xaml.targets'))" />
-  </Target>
-  <!-- End workaround -->
   <ItemGroup>
     <ProjectReference Include="..\WindowsTerminal\WindowsTerminal.vcxproj" />
     <ProjectReference Include="..\..\host\exe\Host.EXE.vcxproj" />

--- a/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
+++ b/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
@@ -74,7 +74,14 @@
   </ItemGroup>
   <!-- Dependencies -->
   <ItemGroup>
+    <!-- Even though we do have proper recursive dependencies, we want to keep some of these here
+         so that the AppX Manifest contains their activatable classes. -->
+    <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalSettings\TerminalSettings.vcxproj" />
+    <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\TerminalControl.vcxproj" />
+    <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalConnection\TerminalConnection.vcxproj" />
+
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalApp\TerminalApp.vcxproj" />
+
     <ProjectReference Include="$(OpenConsoleDir)src\types\lib\types.vcxproj" />
   </ItemGroup>
 

--- a/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
+++ b/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
@@ -74,51 +74,8 @@
   </ItemGroup>
   <!-- Dependencies -->
   <ItemGroup>
-    <!-- Manually include the .pri files from the app project as content files. -->
-    <NativeReferenceFile Include="$(OpenConsoleDir)$(Platform)\$(Configuration)\TerminalAppLib\*.pri">
-      <DeploymentContent>true</DeploymentContent>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </NativeReferenceFile>
-
-    <!-- Manually include the xbf files from the app project as content files -->
-    <NativeReferenceFile Include="$(OpenConsoleDir)$(Platform)\$(Configuration)\TerminalAppLib\*.xbf">
-      <DeploymentContent>true</DeploymentContent>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </NativeReferenceFile>
-
-    <!--
-      the packaging project wont recurse through our dependencies, you have to
-      make sure that if you add a cppwinrt dependency to any of these projects,
-      you also update all the consumers
-    -->
-    <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalSettings\TerminalSettings.vcxproj" />
-    <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\TerminalControl.vcxproj" />
-    <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalConnection\TerminalConnection.vcxproj" />
-    <!-- Don't add a ProjectReference to TerminalApp here. If you do, the
-    packaging project will find the TerminalApp.pri from both the TerminalAppLib
-    and TerminalApp project, and we only want this lib project's pri file. We'll
-    manually add a reference to the TerminalApp winmd and dll below, because we
-    still need those. -->
+    <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalApp\TerminalApp.vcxproj" />
     <ProjectReference Include="$(OpenConsoleDir)src\types\lib\types.vcxproj" />
-
-  </ItemGroup>
-
-  <PropertyGroup>
-    <!-- A small helper for paths to the compiled cppwinrt projects -->
-    <_BinRoot Condition="'$(Platform)' != 'Win32'">$(OpenConsoleDir)$(Platform)\$(Configuration)\</_BinRoot>
-    <_BinRoot Condition="'$(Platform)' == 'Win32'">$(OpenConsoleDir)$(Configuration)\</_BinRoot>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <!-- Manually reference TerminalApp, since we can't use a ProjectReference. -->
-    <Reference Include="TerminalApp">
-      <HintPath>$(_BinRoot)\TerminalApp\TerminalApp.winmd</HintPath>
-      <IsWinMDFile>true</IsWinMDFile>
-      <Private>false</Private>
-      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
-    </Reference>
-    <ReferenceCopyLocalPaths Include="$(_BinRoot)\TerminalApp\TerminalApp.dll" />
-
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
This pull request removes some of our manual cross-project reference hacks. CascadiaPackage no longer needs to import `Microsoft.UI.Xaml` directly to roll up its content, and it can get a bunch of stuff from TerminalApp (DLL only!) for free.

I've unpacked the package and verified that `resources.pri` contains TerminalApp's resources _and_ that the AppX manifest contains all of the activatable classes.