### PR TITLE
Fix test runner commands - runut.cmd and friends; PowerShell Invoke-OpenConsoleTests

### DIFF
--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -187,7 +187,7 @@ function Invoke-OpenConsoleTests()
     }
     $OpenConsolePath = "$env:OpenConsoleroot\bin\$OpenConsolePlatform\$Configuration\OpenConsole.exe"
     $RunTePath = "$env:OpenConsoleRoot\tools\runte.cmd"
-    $TaefExePath = "$env:OpenConsoleRoot\packages\Taef.Redist.Wlk.10.30.180808002\build\binaries\$Platform\te.exe"
+    $TaefExePath = "$env:OpenConsoleRoot\packages\Taef.Redist.Wlk.10.38.190610001-uapadmin\build\Binaries\$Platform\te.exe"
     $BinDir = "$env:OpenConsoleRoot\bin\$OpenConsolePlatform\$Configuration"
     [xml]$TestConfig = Get-Content "$env:OpenConsoleRoot\tools\tests.xml"
 

--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -104,7 +104,7 @@ shift
 goto :ARGS_LOOP
 
 :POST_ARGS_LOOP
-set TAEF=%OPENCON%\packages\Taef.Redist.Wlk.10.30.180808002\build\binaries\%ARCH%\TE.exe
+set TAEF=%OPENCON%\packages\Taef.Redist.Wlk.10.38.190610001-uapadmin\build\Binaries\%ARCH%\TE.exe
 rem Set this envvar so setup won't repeat itself
 set OpenConBuild=true
 


### PR DESCRIPTION
### Summary of the Pull Request

As above. Previously, these helper commands to run various test cases would fail with "path not found" errors without running any tests. Now, they work again.

### Detailed Description of the Pull Request / Additional comments

The problem occurred because in commit 0905140955f5d431753739312982c1d6a42d9538 (PR #1164), we updated the version of the Taef.Redist.Wlk NuGet package for the TAEF test harness and framework. However, the helper commands hard-code the path to the TAEF executable, which because of NuGet's design includes the TAEF NuGet package version. The commands weren't updated to reflect the new TAEF version and so have been broken since then.

### PR Checklist
* [ ] Closes #xxx - no bug 
* [x] CLA signed - N/A; I work for Microsoft
* [x] Tests added/passed
* [ ] Requires documentation to be updated - N/A
* [ ] I've discussed this with core contributors already