### PR TITLE
Changes link to go to latest ColorTool release

### DIFF
--- a/src/tools/ColorTool/README.md
+++ b/src/tools/ColorTool/README.md
@@ -43,7 +43,7 @@ Options:
 
 ## Installing 
 
-Just [download the latest colortool release](https://github.com/Microsoft/console/releases) and extract the zip file. 
+Just [download the latest colortool release](https://github.com/microsoft/terminal/releases/tag/1904.29002) and extract the zip file. 
 
 ## Building
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Since ColorTool shares the same Release page as Windows Terminal, it is more difficult to navigate to it. So whenever ColorTool is updated with a new release, we will update the link to the latest release. The link I changed to is the latest available from April 2019. @zadjii-msft and @miniksa please review. This also came up in https://github.com/microsoft/terminal/issues/2025.
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes https://github.com/microsoft/terminal/issues/2025
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed N/A
* [x] Requires documentation to be updated - This is a doc update.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
N/A
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Link works in updated README