### PR TITLE
Avoid passing commands through with the shift modifier

### DIFF
--- a/src/host/input.cpp
+++ b/src/host/input.cpp
@@ -111,6 +111,7 @@ void HandleGenericKeyEvent(_In_ KeyEvent keyEvent, const bool generateBreak)
 
     if (keyEvent.IsCtrlPressed() &&
         !keyEvent.IsAltPressed() &&
+        !keyEvent.IsShiftPressed() &&
         keyEvent.IsKeyDown())
     {
         // check for ctrl-c, if in line input mode.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This change would enable keybinds like Ctrl+Shift+C or Ctrl+Shift+V  to work, as they would be captured inadvertently, and sent as their respective escape sequences.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
#2000 
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed

## Validation Steps Performed
Built Terminal on separate instance of Azure Pipelines, then validated that functionality (Ctrl+Shift+V/Ctrl+Shift+C) work as intended (which is, that they properly copy and paste)
