### PR TITLE
WIP: Expose current TextAttributes from the underlying console API.

### DIFF
--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -1651,7 +1651,7 @@ void DoSrvSetCursorColor(SCREEN_INFORMATION& screenInfo,
 // - pwAttributes - Pointer to space that will receive color attributes data
 // Return Value:
 // - STATUS_SUCCESS if we succeeded or STATUS_INVALID_PARAMETER for bad params (nullptr).
-[[nodiscard]] NTSTATUS DoSrvPrivateGetConsoleScreenBufferAttributes(_In_ const SCREEN_INFORMATION& screenInfo, _Out_ WORD* const pwAttributes)
+[[nodiscard]] NTSTATUS DoSrvPrivateGetConsoleScreenBufferLegacyAttributes(_In_ const SCREEN_INFORMATION& screenInfo, _Out_ WORD* const pwAttributes)
 {
     NTSTATUS Status = STATUS_SUCCESS;
 
@@ -1667,6 +1667,12 @@ void DoSrvSetCursorColor(SCREEN_INFORMATION& screenInfo,
 
     return Status;
 }
+
+void DoSrvPrivateGetConsoleScreenBufferAttributes(_In_ const SCREEN_INFORMATION& screenInfo, TextAttribute& attributes)
+{
+    attributes = screenInfo.GetActiveBuffer().GetAttributes();
+}
+
 
 // Routine Description:
 // - A private API call for forcing the renderer to repaint the screen. If the

--- a/src/host/getset.h
+++ b/src/host/getset.h
@@ -16,6 +16,7 @@ Revision History:
 
 #pragma once
 #include "../inc/conattrs.hpp"
+#include "../buffer/out/TextAttribute.hpp"
 class SCREEN_INFORMATION;
 
 void DoSrvPrivateSetLegacyAttributes(SCREEN_INFORMATION& screenInfo,
@@ -67,8 +68,9 @@ void DoSrvSetCursorStyle(SCREEN_INFORMATION& screenInfo,
 void DoSrvSetCursorColor(SCREEN_INFORMATION& screenInfo,
                          const COLORREF cursorColor);
 
-[[nodiscard]] NTSTATUS DoSrvPrivateGetConsoleScreenBufferAttributes(const SCREEN_INFORMATION& screenInfo,
-                                                                    _Out_ WORD* const pwAttributes);
+[[nodiscard]] NTSTATUS DoSrvPrivateGetConsoleScreenBufferLegacyAttributes(const SCREEN_INFORMATION& screenInfo,
+                                                                          _Out_ WORD* const pwAttributes);
+void DoSrvPrivateGetConsoleScreenBufferAttributes(_In_ const SCREEN_INFORMATION& screenInfo, TextAttribute& attributes);
 
 void DoSrvPrivateRefreshWindow(const SCREEN_INFORMATION& screenInfo);
 

--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -629,9 +629,21 @@ BOOL ConhostInternalGetSet::SetCursorStyle(const CursorType cursorType)
 // - pwAttributes - Pointer to space to receive color attributes data
 // Return Value:
 // - TRUE if successful. FALSE otherwise.
-BOOL ConhostInternalGetSet::PrivateGetConsoleScreenBufferAttributes(_Out_ WORD* const pwAttributes)
+BOOL ConhostInternalGetSet::PrivateGetConsoleScreenBufferLegacyAttributes(_Out_ WORD* const pwAttributes)
 {
-    return NT_SUCCESS(DoSrvPrivateGetConsoleScreenBufferAttributes(_io.GetActiveOutputBuffer(), pwAttributes));
+    return NT_SUCCESS(DoSrvPrivateGetConsoleScreenBufferLegacyAttributes(_io.GetActiveOutputBuffer(), pwAttributes));
+}
+
+// Routine Description:
+// - Retrieves the default color attributes information for the active screen buffer.
+// - This function is used to optimize SGR calls in lieu of calling GetConsoleScreenBufferInfoEx.
+// Arguments:
+// - pAttributes - Pointer to space to receive color attributes data
+// Return Value:
+// - TRUE if successful. FALSE otherwise.
+void ConhostInternalGetSet::PrivateGetConsoleScreenBufferAttributes(_Out_ TextAttribute& attributes)
+{
+    DoSrvPrivateGetConsoleScreenBufferAttributes(_io.GetActiveOutputBuffer(), attributes);
 }
 
 // Routine Description:

--- a/src/host/outputStream.hpp
+++ b/src/host/outputStream.hpp
@@ -132,7 +132,8 @@ public:
     BOOL PrivateEnableAlternateScroll(const bool fEnabled) override;
     BOOL PrivateEraseAll() override;
 
-    BOOL PrivateGetConsoleScreenBufferAttributes(_Out_ WORD* const pwAttributes) override;
+    BOOL PrivateGetConsoleScreenBufferLegacyAttributes(_Out_ WORD* const pwAttributes) override;
+    void PrivateGetConsoleScreenBufferAttributes(_Out_ TextAttribute& attributes) override;
 
     BOOL PrivatePrependConsoleInput(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& events,
                                     _Out_ size_t& eventsWritten) override;

--- a/src/terminal/adapter/adaptDispatchGraphics.cpp
+++ b/src/terminal/adapter/adaptDispatchGraphics.cpp
@@ -400,7 +400,7 @@ bool AdaptDispatch::SetGraphicsRendition(_In_reads_(cOptions) const DispatchType
     // because it has to fill the Largest Window Size by asking the OS and wastes time memcpying colors and other data
     // we do not need to resolve this Set Graphics Rendition request.
     WORD attr;
-    bool fSuccess = !!_conApi->PrivateGetConsoleScreenBufferAttributes(&attr);
+    bool fSuccess = !!_conApi->PrivateGetConsoleScreenBufferLegacyAttributes(&attr);
 
     if (fSuccess)
     {

--- a/src/terminal/adapter/conGetSet.hpp
+++ b/src/terminal/adapter/conGetSet.hpp
@@ -17,6 +17,7 @@ Author(s):
 
 #include "..\..\types\inc\IInputEvent.hpp"
 #include "..\..\inc\conattrs.hpp"
+#include "..\..\buffer\out\TextAttribute.hpp"
 
 #include <deque>
 #include <memory>
@@ -87,7 +88,8 @@ namespace Microsoft::Console::VirtualTerminal
         virtual BOOL PrivateEraseAll() = 0;
         virtual BOOL SetCursorStyle(const CursorType cursorType) = 0;
         virtual BOOL SetCursorColor(const COLORREF cursorColor) = 0;
-        virtual BOOL PrivateGetConsoleScreenBufferAttributes(_Out_ WORD* const pwAttributes) = 0;
+        virtual BOOL PrivateGetConsoleScreenBufferLegacyAttributes(_Out_ WORD* const pwAttributes) = 0;
+        virtual void PrivateGetConsoleScreenBufferAttributes(_Out_ TextAttribute& attributes) = 0;
         virtual BOOL PrivatePrependConsoleInput(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& events,
                                                 _Out_ size_t& eventsWritten) = 0;
         virtual BOOL PrivateWriteConsoleControlInput(_In_ KeyEvent key) = 0;

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -689,16 +689,24 @@ public:
         return _fSetCursorColorResult;
     }
 
-    BOOL PrivateGetConsoleScreenBufferAttributes(_Out_ WORD* const pwAttributes) override
+    BOOL PrivateGetConsoleScreenBufferLegacyAttributes(_Out_ WORD* const pwAttributes) override
     {
-        Log::Comment(L"PrivateGetConsoleScreenBufferAttributes MOCK returning data...");
+        Log::Comment(L"PrivateGetConsoleScreenBufferLegacyAttributes MOCK returning data...");
 
-        if (pwAttributes != nullptr && _fPrivateGetConsoleScreenBufferAttributesResult)
+        if (pwAttributes != nullptr && _fPrivateGetConsoleScreenBufferLegacyAttributesResult)
         {
             *pwAttributes = _wAttribute;
         }
 
-        return _fPrivateGetConsoleScreenBufferAttributesResult;
+        return _fPrivateGetConsoleScreenBufferLegacyAttributesResult;
+    }
+
+    void PrivateGetConsoleScreenBufferAttributes(_Out_ TextAttribute& attributes) override
+    {
+        Log::Comment(L"PrivateGetConsoleScreenBufferAttributes MOCK returning data...");
+
+        // TODO
+        attributes = TextAttribute();
     }
 
     BOOL PrivateRefreshWindow() override
@@ -871,7 +879,7 @@ public:
         _fPrivateWriteConsoleControlInputResult = TRUE;
         _fScrollConsoleScreenBufferWResult = TRUE;
         _fSetConsoleWindowInfoResult = TRUE;
-        _fPrivateGetConsoleScreenBufferAttributesResult = TRUE;
+        _fPrivateGetConsoleScreenBufferLegacyAttributesResult = TRUE;
         _fMoveToBottomResult = true;
 
         _PrepCharsBuffer(wch, wAttr);
@@ -1394,7 +1402,7 @@ public:
     BOOL _fSetConsoleXtermTextAttributeResult = false;
     BOOL _fSetConsoleRGBTextAttributeResult = false;
     BOOL _fPrivateSetLegacyAttributesResult = false;
-    BOOL _fPrivateGetConsoleScreenBufferAttributesResult = false;
+    BOOL _fPrivateGetConsoleScreenBufferLegacyAttributesResult = false;
     BOOL _fSetCursorStyleResult = false;
     CursorType _ExpectedCursorStyle;
     BOOL _fSetCursorColorResult = false;
@@ -2505,7 +2513,7 @@ public:
         Log::Comment(L"Test 2: Gracefully fail when getting buffer information fails.");
 
         _testGetSet->PrepData();
-        _testGetSet->_fPrivateGetConsoleScreenBufferAttributesResult = FALSE;
+        _testGetSet->_fPrivateGetConsoleScreenBufferLegacyAttributesResult = FALSE;
 
         VERIFY_IS_FALSE(_pDispatch->SetGraphicsRendition(rgOptions, cOptions));
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This is not a polished PR that is ready to merge; it demonstrates a
direction for which I need to get buy-off from the team before pursuing
further.

I'm currently working on implementing the XTPUSHSGR/XTPOPSGR control
sequences (WIP PR [here](https://github.com/microsoft/terminal/pull/1978), which requires saving a [stack of] text
attributes, and not just the legacy attributes, but full RGB colors,
etc.

My first instinct was to implement the "business logic" (the stack) in
the `AdaptDispatch` layer, but that will require getting the [full] text
attributes from the underlying console API. This is not a *terribly*
"invasive" change, but it is exposing new stuff at a layer boundary.

Put another way, this means pound-including the
"../buffer/out/TextAttribute.hpp" header in a few places outside of
"buffer/out", and is that okay, or does that header need to be kept
private and isolated?

So there are a few ways this could go:

1. You folks might say "ugh, no!", and:
   1. I could push (haha) the business logic of pushing and popping text
      attributes down another layer (so `AdaptDispatch` just forwards on
      the [PushGraphicsRendition](https://github.com/microsoft/terminal/blob/0af275b9cb68da14f38f05b2cdcbb35da99cb17c/src/terminal/adapter/adaptDispatchGraphics.cpp#L452) call to the lower layer, OR
   2. You suggest a different, cleaner way of exposing the text
      attributes.

OR

2. Maybe you think this general direction is fine, but maybe you have
   some particular requests that I do certain things differently (I
   totally understand being picky about stuff that cuts across API
   layers).

What do you think?

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

Related: PR #1978
Related: Issue #1796

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

*none*