### PR TITLE
Refactor TextBuffer::GenHTML

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -8,7 +8,6 @@
 
 #include "../types/inc/utils.hpp"
 #include "../types/inc/convert.hpp"
-#include <regex>
 
 #pragma hdrstop
 

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1050,9 +1050,9 @@ std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPo
         // First we have to add some standard
         // HTML boiler plate required for CF_HTML
         // as part of the HTML Clipboard format
-        const std::string HtmlHeader =
+        const std::string htmlHeader =
             "<!DOCTYPE><HTML><HEAD><TITLE>" + htmlTitle + "</TITLE></HEAD><BODY>";
-        htmlBuilder << HtmlHeader;
+        htmlBuilder << htmlHeader;
 
         htmlBuilder << "<!--StartFragment -->";
 
@@ -1184,7 +1184,7 @@ std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPo
         // these values are byte offsets from start of clipboard
         const size_t htmlStartPos = ClipboardHeaderSize;
         const size_t htmlEndPos = ClipboardHeaderSize + htmlBuilder.tellp();
-        const size_t fragStartPos = ClipboardHeaderSize + HtmlHeader.length();
+        const size_t fragStartPos = ClipboardHeaderSize + htmlHeader.length();
         const size_t fragEndPos = htmlEndPos - HtmlFooter.length();
 
         // header required by HTML 0.9 format

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1038,9 +1038,10 @@ const TextBuffer::TextAndColor TextBuffer::GetTextForClipboard(const bool lineSe
 // - rows - the text and color data we will format & encapsulate
 // - fontHeightPoints - the unscaled font height
 // - fontFaceName - the name of the font used
+// - htmlTitle - value used in title tag of html header. Used to name the application
 // Return Value:
 // - string containing the generated HTML
-std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPoints, const PCWCHAR fontFaceName)
+std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPoints, const PCWCHAR fontFaceName, const std::string htmlTitle)
 {
     try
     {
@@ -1049,8 +1050,8 @@ std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPo
         // First we have to add some standard
         // HTML boiler plate required for CF_HTML
         // as part of the HTML Clipboard format
-        constexpr std::string_view HtmlHeader =
-            "<!DOCTYPE><HTML><HEAD><TITLE>Windows Terminal</TITLE></HEAD><BODY>";
+        const std::string HtmlHeader =
+            "<!DOCTYPE><HTML><HEAD><TITLE>" + htmlTitle + "</TITLE></HEAD><BODY>";
         htmlBuilder << HtmlHeader;
 
         htmlBuilder << "<!--StartFragment -->";
@@ -1091,7 +1092,7 @@ std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPo
         }
 
         // copy text and info color from buffer
-        bool hasWroteAnyText = false;
+        bool hasWrittenAnyText = false;
         std::optional<COLORREF> fgColor = std::nullopt;
         std::optional<COLORREF> bkColor = std::nullopt;
         for (UINT row = 0; row < rows.text.size(); row++)
@@ -1139,7 +1140,7 @@ std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPo
                 {
                     writeAccumulatedChars(false);
 
-                    if (hasWroteAnyText)
+                    if (hasWrittenAnyText)
                     {
                         htmlBuilder << "</SPAN>";
                     }
@@ -1154,7 +1155,7 @@ std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPo
                     htmlBuilder << "\">";
                 }
 
-                hasWroteAnyText = true;
+                hasWrittenAnyText = true;
 
                 if (isLastCharInRow)
                 {
@@ -1164,7 +1165,7 @@ std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPo
             }
         }
 
-        if (hasWroteAnyText)
+        if (hasWrittenAnyText)
         {
             // last opened span wasn't closed in loop above, so close it now
             htmlBuilder << "</SPAN>";

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1059,8 +1059,7 @@ std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPo
         // apply global style in div element
         {
             htmlBuilder << "<DIV STYLE=\"";
-            htmlBuilder << "display:inline-block";
-            htmlBuilder << "width:400px;";
+            htmlBuilder << "display:inline-block;";
             htmlBuilder << "white-space:pre;";
 
             // fixme: this is only walkaround for filling background after last char of row.

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1041,7 +1041,7 @@ const TextBuffer::TextAndColor TextBuffer::GetTextForClipboard(const bool lineSe
 // - htmlTitle - value used in title tag of html header. Used to name the application
 // Return Value:
 // - string containing the generated HTML
-std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPoints, const PCWCHAR fontFaceName, const std::string htmlTitle)
+std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPoints, const PCWCHAR fontFaceName, const std::string& htmlTitle)
 {
     try
     {
@@ -1070,9 +1070,10 @@ std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPo
             htmlBuilder << Utils::ColorToHexString(globalBgColor);
             htmlBuilder << ";";
 
-            htmlBuilder << "font-family:'";
+            htmlBuilder << "font-family:";
             if (fontFaceName[0] != '\0')
             {
+                htmlBuilder << "'";
                 htmlBuilder << ConvertToA(CP_UTF8, fontFaceName);
                 htmlBuilder << "',";
             }
@@ -1203,6 +1204,6 @@ std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPo
     catch (...)
     {
         LOG_HR(wil::ResultFromCaughtException());
-        return "";
+        return {};
     }
 }

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -6,10 +6,13 @@
 #include "textBuffer.hpp"
 #include "CharRow.hpp"
 
+#include "../types/inc/utils.hpp"
 #include "../types/inc/convert.hpp"
+#include <regex>
 
 #pragma hdrstop
 
+using namespace Microsoft::Console;
 using namespace Microsoft::Console::Types;
 
 // Routine Description:
@@ -1033,238 +1036,172 @@ const TextBuffer::TextAndColor TextBuffer::GetTextForClipboard(const bool lineSe
 // - Generates a CF_HTML compliant structure based on the passed in text and color data
 // Arguments:
 // - rows - the text and color data we will format & encapsulate
-// - iFontHeightPoints - the unscaled font height
+// - fontHeightPoints - the unscaled font height
 // - fontFaceName - the name of the font used
 // Return Value:
 // - string containing the generated HTML
-std::string TextBuffer::GenHTML(const TextAndColor& rows, const int iFontHeightPoints, const PCWCHAR fontFaceName)
+std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPoints, const PCWCHAR fontFaceName)
 {
-    std::string szClipboard; // we will build the data going back in this string buffer
-
     try
     {
-        std::string const szHtmlClipFormat =
-            "Version:0.9\r\n"
-            "StartHTML:%010d\r\n"
-            "EndHTML:%010d\r\n"
-            "StartFragment:%010d\r\n"
-            "EndFragment:%010d\r\n"
-            "StartSelection:%010d\r\n"
-            "EndSelection:%010d\r\n";
+        std::ostringstream htmlBuilder;
 
-        // measure clip header
-        size_t const cbHeader = 157; // when formats are expanded, there will be 157 bytes in the header.
-
-        std::string const szHtmlHeader =
-            "<!DOCTYPE><HTML><HEAD><TITLE>Windows Console Host</TITLE></HEAD><BODY>";
-        size_t const cbHtmlHeader = szHtmlHeader.size();
-
-        std::string const szHtmlFragStart = "<!--StartFragment -->";
-        std::string const szHtmlFragEnd = "<!--EndFragment -->";
-        std::string const szHtmlFooter = "</BODY></HTML>";
-        size_t const cbHtmlFooter = szHtmlFooter.size();
-
-        std::string const szDivOuterBackgroundPattern = R"X(<DIV STYLE="background-color:#%02x%02x%02x;white-space:pre;">)X";
-
-        size_t const cbDivOuter = 55;
-        std::string szDivOuter;
-        szDivOuter.reserve(cbDivOuter);
-
-        std::string const szSpanFontSizePattern = R"X(<SPAN STYLE="font-size: %dpt">)X";
-
-        size_t const cbSpanFontSize = 28 + (iFontHeightPoints / 10) + 1;
-
-        std::string szSpanFontSize;
-        szSpanFontSize.resize(cbSpanFontSize + 1); // reserve space for null after string for sprintf
-        sprintf_s(szSpanFontSize.data(), cbSpanFontSize + 1, szSpanFontSizePattern.data(), iFontHeightPoints);
-        szSpanFontSize.resize(cbSpanFontSize); //chop off null at end
-
-        std::string const szSpanStartPattern = R"X(<SPAN STYLE="color:#%02x%02x%02x;background-color:#%02x%02x%02x">)X";
-
-        size_t const cbSpanStart = 53; // when format is expanded, there will be 53 bytes per color pattern.
-        std::string szSpanStart;
-        szSpanStart.resize(cbSpanStart + 1); // +1 for null terminator
-
-        std::string const szSpanStartFontPattern = R"X(<SPAN STYLE="font-family: '%s', monospace">)X";
-        size_t const cbSpanStartFontPattern = 41;
-
-        std::string const szSpanStartFontConstant = R"X(<SPAN STYLE="font-family: monospace">)X";
-        size_t const cbSpanStartFontConstant = 37;
-
-        std::string szSpanStartFont;
-        size_t cbSpanStartFont;
-        bool fDeleteSpanStartFont = false;
-
-        std::wstring const wszFontFaceName = fontFaceName;
-        size_t const cchFontFaceName = wszFontFaceName.size();
-        if (cchFontFaceName > 0)
-        {
-            // measure and create buffer to convert face name to UTF8
-            int const cbNeeded = WideCharToMultiByte(CP_UTF8, 0, wszFontFaceName.data(), static_cast<int>(cchFontFaceName), nullptr, 0, nullptr, nullptr);
-            std::string szBuffer;
-            szBuffer.resize(cbNeeded);
-
-            // do conversion
-            WideCharToMultiByte(CP_UTF8, 0, wszFontFaceName.data(), static_cast<int>(cchFontFaceName), szBuffer.data(), cbNeeded, nullptr, nullptr);
-
-            // format converted font name into pattern
-            std::string const szFinalFontPattern = R"X(<SPAN STYLE="font-family: ')X" + szBuffer + R"X(', monospace\">)X";
-            size_t const cbBytesNeeded = szFinalFontPattern.length();
-
-            fDeleteSpanStartFont = true;
-            szSpanStartFont = szFinalFontPattern;
-            cbSpanStartFont = cbBytesNeeded;
-        }
-        else
-        {
-            szSpanStartFont = szSpanStartFontConstant;
-            cbSpanStartFont = cbSpanStartFontConstant;
-        }
-
-        std::string const szSpanEnd = "</SPAN>";
-        std::string const szDivEnd = "</DIV>";
-
-        // Start building the HTML formated string to return
-        // First we have to add the required header and then
-        // some standard HTML boiler plate required for CF_HTML
+        // First we have to add some standard
+        // HTML boiler plate required for CF_HTML
         // as part of the HTML Clipboard format
-        szClipboard.append(cbHeader, 'H'); // reserve space for a header we fill in later
-        szClipboard.append(szHtmlHeader);
-        szClipboard.append(szHtmlFragStart);
+        constexpr std::string_view HtmlHeader =
+            "<!DOCTYPE><HTML><HEAD><TITLE>Windows Terminal</TITLE></HEAD><BODY>";
+        htmlBuilder << HtmlHeader;
 
-        COLORREF iBgColor = rows.BkAttr.at(0).at(0);
+        htmlBuilder << "<!--StartFragment -->";
 
-        szDivOuter.resize(cbDivOuter + 1);
-        sprintf_s(szDivOuter.data(), cbDivOuter + 1, szDivOuterBackgroundPattern.data(), GetRValue(iBgColor), GetGValue(iBgColor), GetBValue(iBgColor));
-        szDivOuter.resize(cbDivOuter);
-        szClipboard.append(szDivOuter);
-
-        // copy font face start
-        szClipboard.append(szSpanStartFont);
-
-        // copy font size start
-        szClipboard.append(szSpanFontSize);
-
-        bool bColorFound = false;
-
-        // copy all text into the final clipboard data handle. There should be no nulls between rows of
-        // characters, but there should be a \0 at the end.
-        COLORREF const Blackness = RGB(0x00, 0x00, 0x00);
-        for (UINT iRow = 0; iRow < rows.text.size(); iRow++)
+        // apply global style in div element
         {
-            size_t cbStartOffset = 0;
-            size_t cchCharsToPrint = 0;
+            htmlBuilder << "<DIV STYLE=\"";
+            htmlBuilder << "display:inline-block";
+            htmlBuilder << "width:400px;";
+            htmlBuilder << "white-space:pre;";
 
-            COLORREF fgColor = Blackness;
-            COLORREF bkColor = Blackness;
+            // fixme: this is only walkaround for filling background after last char of row.
+            // It is based on first char of first row, not the actual char at correct position.
+            htmlBuilder << "background-color:";
+            const COLORREF globalBgColor = rows.BkAttr.at(0).at(0);
+            htmlBuilder << Utils::ColorToHexString(globalBgColor);
+            htmlBuilder << ";";
 
-            for (UINT iCol = 0; iCol < rows.text.at(iRow).length(); iCol++)
+            htmlBuilder << "font-family:'";
+            if (fontFaceName[0] != '\0')
             {
-                bool fColorDelta = false;
+                htmlBuilder << ConvertToA(CP_UTF8, fontFaceName);
+                htmlBuilder << "',";
+            }
+            // even with different font, add monospace as fallback
+            htmlBuilder << "monospace;";
 
-                if (!bColorFound)
-                {
-                    fgColor = rows.FgAttr.at(iRow).at(iCol);
-                    bkColor = rows.BkAttr.at(iRow).at(iCol);
-                    bColorFound = true;
-                    fColorDelta = true;
-                }
-                else if ((rows.FgAttr.at(iRow).at(iCol) != fgColor) || (rows.BkAttr.at(iRow).at(iCol) != bkColor))
-                {
-                    fgColor = rows.FgAttr.at(iRow).at(iCol);
-                    bkColor = rows.BkAttr.at(iRow).at(iCol);
-                    fColorDelta = true;
-                }
+            htmlBuilder << "font-size:";
+            htmlBuilder << fontHeightPoints;
+            htmlBuilder << "pt;";
 
-                if (fColorDelta)
-                {
-                    if (cchCharsToPrint > 0)
-                    {
-                        // write accumulated characters to stream ....
-                        std::string TempBuff;
-                        int const cbTempCharsNeeded = WideCharToMultiByte(CP_UTF8, 0, rows.text[iRow].data() + cbStartOffset, static_cast<int>(cchCharsToPrint), nullptr, 0, nullptr, nullptr);
-                        TempBuff.resize(cbTempCharsNeeded);
-                        WideCharToMultiByte(CP_UTF8, 0, rows.text[iRow].data() + cbStartOffset, static_cast<int>(cchCharsToPrint), TempBuff.data(), cbTempCharsNeeded, nullptr, nullptr);
-                        szClipboard.append(TempBuff);
-                        cbStartOffset += cchCharsToPrint;
-                        cchCharsToPrint = 0;
+            // note: MS Word doesn't support padding (in this way at least)
+            htmlBuilder << "padding:";
+            htmlBuilder << 4; // todo: customizable padding
+            htmlBuilder << "px;";
 
-                        // close previous span
-                        szClipboard += szSpanEnd;
-                    }
+            htmlBuilder << "\">";
+        }
 
-                    // start new span
+        // copy text and info color from buffer
+        bool hasWroteAnyText = false;
+        std::optional<COLORREF> fgColor = std::nullopt;
+        std::optional<COLORREF> bkColor = std::nullopt;
+        for (UINT row = 0; row < rows.text.size(); row++)
+        {
+            size_t startOffset = 0;
 
-                    // format with color then copy formatted string
-                    szSpanStart.resize(cbSpanStart + 1); // add room for null
-                    sprintf_s(szSpanStart.data(), cbSpanStart + 1, szSpanStartPattern.data(), GetRValue(fgColor), GetGValue(fgColor), GetBValue(fgColor), GetRValue(bkColor), GetGValue(bkColor), GetBValue(bkColor));
-                    szSpanStart.resize(cbSpanStart); // chop null from sprintf
-                    szClipboard.append(szSpanStart);
-                }
-
-                // accumulate 1 character
-                cchCharsToPrint++;
+            if (row != 0)
+            {
+                htmlBuilder << "<BR>";
             }
 
-            PCWCHAR pwchAccumulateStart = rows.text.at(iRow).data() + cbStartOffset;
+            for (UINT col = 0; col < rows.text[row].length(); col++)
+            {
+                // do not include \r nor \n as they don't have attributes
+                // and are not HTML friendly. For line break use '<BR>' instead.
+                bool isLastCharInRow =
+                    col == rows.text[row].length() - 1 ||
+                    rows.text[row][col + 1] == '\r' ||
+                    rows.text[row][col + 1] == '\n';
 
-            // write accumulated characters to stream
-            std::string CharsConverted;
-            int cbCharsConverted = WideCharToMultiByte(CP_UTF8, 0, pwchAccumulateStart, static_cast<int>(cchCharsToPrint), nullptr, 0, nullptr, nullptr);
-            CharsConverted.resize(cbCharsConverted);
-            WideCharToMultiByte(CP_UTF8, 0, pwchAccumulateStart, static_cast<int>(cchCharsToPrint), CharsConverted.data(), cbCharsConverted, nullptr, nullptr);
-            szClipboard.append(CharsConverted);
+                bool colorChanged = false;
+                if (!fgColor.has_value() || rows.FgAttr[row][col] != fgColor.value())
+                {
+                    fgColor = rows.FgAttr[row][col];
+                    colorChanged = true;
+                }
+
+                if (!bkColor.has_value() || rows.BkAttr[row][col] != bkColor.value())
+                {
+                    bkColor = rows.BkAttr[row][col];
+                    colorChanged = true;
+                }
+
+                const auto writeAccumulatedChars = [&](bool includeCurrent) {
+                    if (col > startOffset)
+                    {
+                        // note: this should be escaped (for '<', '>', and '&'),
+                        // however MS Word doesn't appear to support HTML entities
+                        htmlBuilder << ConvertToA(CP_UTF8, std::wstring_view(rows.text[row].data() + startOffset, col - startOffset + includeCurrent));
+                        startOffset = col;
+                    }
+                };
+
+                if (colorChanged)
+                {
+                    writeAccumulatedChars(false);
+
+                    if (hasWroteAnyText)
+                    {
+                        htmlBuilder << "</SPAN>";
+                    }
+
+                    htmlBuilder << "<SPAN STYLE=\"";
+                    htmlBuilder << "color:";
+                    htmlBuilder << Utils::ColorToHexString(fgColor.value());
+                    htmlBuilder << ";";
+                    htmlBuilder << "background-color:";
+                    htmlBuilder << Utils::ColorToHexString(bkColor.value());
+                    htmlBuilder << ";";
+                    htmlBuilder << "\">";
+                }
+
+                hasWroteAnyText = true;
+
+                if (isLastCharInRow)
+                {
+                    writeAccumulatedChars(true);
+                    break;
+                }
+            }
         }
 
-        if (bColorFound)
+        if (hasWroteAnyText)
         {
-            // copy end span
-            szClipboard.append(szSpanEnd);
+            // last opened span wasn't closed in loop above, so close it now
+            htmlBuilder << "</SPAN>";
         }
 
-        // after we have copied all text we must wrap up
-        // with a standard set of HTML boilerplate required
-        // by CF_HTML
+        htmlBuilder << "</DIV>";
 
-        // copy end font size span
-        szClipboard.append(szSpanEnd);
+        htmlBuilder << "<!--EndFragment -->";
 
-        // copy end font face span
-        szClipboard.append(szSpanEnd);
+        constexpr std::string_view HtmlFooter = "</BODY></HTML>";
+        htmlBuilder << HtmlFooter;
 
-        // copy end background color span
-        szClipboard.append(szDivEnd);
+        // once filled with values, there will be exactly 157 bytes in the clipboard header
+        constexpr size_t ClipboardHeaderSize = 157;
 
-        // copy HTML end fragment
-        szClipboard.append(szHtmlFragEnd);
+        // these values are byte offsets from start of clipboard
+        const size_t htmlStartPos = ClipboardHeaderSize;
+        const size_t htmlEndPos = ClipboardHeaderSize + htmlBuilder.tellp();
+        const size_t fragStartPos = ClipboardHeaderSize + HtmlHeader.length();
+        const size_t fragEndPos = htmlEndPos - HtmlFooter.length();
 
-        // copy HTML footer
-        szClipboard.append(szHtmlFooter);
+        // header required by HTML 0.9 format
+        std::ostringstream clipHeaderBuilder;
+        clipHeaderBuilder << "Version:0.9\r\n";
+        clipHeaderBuilder << std::setfill('0');
+        clipHeaderBuilder << "StartHTML:" << std::setw(10) << htmlStartPos << "\r\n";
+        clipHeaderBuilder << "EndHTML:" << std::setw(10) << htmlEndPos << "\r\n";
+        clipHeaderBuilder << "StartFragment:" << std::setw(10) << fragStartPos << "\r\n";
+        clipHeaderBuilder << "EndFragment:" << std::setw(10) << fragEndPos << "\r\n";
+        clipHeaderBuilder << "StartSelection:" << std::setw(10) << fragStartPos << "\r\n";
+        clipHeaderBuilder << "EndSelection:" << std::setw(10) << fragEndPos << "\r\n";
 
-        // null terminate the clipboard data
-        szClipboard += '\0';
-
-        // we are done generating formating & building HTML for the selection
-        // prepare the header text with the byte counts now that we know them
-        size_t const cbHtmlStart = cbHeader; // bytecount to start of HTML context
-        size_t const cbHtmlEnd = szClipboard.size() - 1; // don't count the null at the end
-        size_t const cbFragStart = cbHeader + cbHtmlHeader; // bytecount to start of selection fragment
-        size_t const cbFragEnd = cbHtmlEnd - cbHtmlFooter;
-
-        // push the values into the required HTML 0.9 header format
-        std::string szHtmlClipHeaderFinal;
-        szHtmlClipHeaderFinal.resize(cbHeader + 1); // add room for a null
-        sprintf_s(szHtmlClipHeaderFinal.data(), cbHeader + 1, szHtmlClipFormat.data(), cbHtmlStart, cbHtmlEnd, cbFragStart, cbFragEnd, cbFragStart, cbFragEnd);
-        szHtmlClipHeaderFinal.resize(cbHeader); // chop off the null
-
-        // overwrite the reserved space with the actual header & offsets we calculated
-        szClipboard.replace(0, cbHeader, szHtmlClipHeaderFinal.data());
+        return clipHeaderBuilder.str() + htmlBuilder.str();
     }
     catch (...)
     {
         LOG_HR(wil::ResultFromCaughtException());
-        szClipboard.clear(); // dont return a partial html fragment...
+        return "";
     }
-
-    return szClipboard;
 }

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -145,8 +145,9 @@ public:
                                            std::function<COLORREF(TextAttribute&)> GetBackgroundColor) const;
 
     static std::string GenHTML(const TextAndColor& rows,
-                               const int iFontHeightPoints,
-                               const PCWCHAR fontFaceName);
+                               const int fontHeightPoints,
+                               const PCWCHAR fontFaceName,
+                               const std::string htmlTitle);
 
 private:
     std::deque<ROW> _storage;

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -147,7 +147,7 @@ public:
     static std::string GenHTML(const TextAndColor& rows,
                                const int fontHeightPoints,
                                const PCWCHAR fontFaceName,
-                               const std::string htmlTitle);
+                               const std::string& htmlTitle);
 
 private:
     std::deque<ROW> _storage;

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1194,8 +1194,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         }
 
         // convert text to HTML format
-        const auto htmlData = TextBuffer::GenHTML(bufferData, _actualFont.GetUnscaledSize().Y, _actualFont.GetFaceName());
-
+        const auto htmlData = TextBuffer::GenHTML(bufferData, _actualFont.GetUnscaledSize().Y, _actualFont.GetFaceName(), "Windows Terminal");
+        
         _terminal->ClearSelection();
 
         // send data up for clipboard

--- a/src/interactivity/win32/Clipboard.cpp
+++ b/src/interactivity/win32/Clipboard.cpp
@@ -277,7 +277,7 @@ void Clipboard::CopyTextToSystemClipboard(const TextBuffer::TextAndColor& rows, 
     {
         const auto& fontData = ServiceLocator::LocateGlobals().getConsoleInformation().GetActiveOutputBuffer().GetCurrentFont();
         int const iFontHeightPoints = fontData.GetUnscaledSize().Y * 72 / ServiceLocator::LocateGlobals().dpi;
-        std::string HTMLToPlaceOnClip = TextBuffer::GenHTML(rows, iFontHeightPoints, fontData.GetFaceName());
+        std::string HTMLToPlaceOnClip = TextBuffer::GenHTML(rows, iFontHeightPoints, fontData.GetFaceName(), "Windows Console Host");
         const size_t cbNeededHTML = HTMLToPlaceOnClip.size();
         if (cbNeededHTML)
         {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Modernizes style of code in `TextBuffer::GenHTML` and significantly simplifies structure of produced HTML. There is sill scope for improvement (customization in particular) but that's another story.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #1846
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Changed `string` to `ostringstream` for string building.
- Changed 'sprintf_s` to c++ stream formatting.
- Changed `\r\n` to `<BR>` in produced HTML.
- Used already implemented function for UTF16->UTF8 conversion.
- Now there is flat and minimalised list of `<span>`s with fg and bg color.
Previous structure was.. weird. Each row was child span of previous row and there were empty spans with black color attributes in place of `\r\n` at end of the row. And all of this seemed unintended.
- HTML text was unescaped, and it still is, becouse Word doesn't work with HTML entities, like `&lt;`. But it seems to accept the invalid HTML with `>` from prompts. So if there is no text like `<someTextThatNowBecomesATag>`, it should work.

Problems/questions:
- So what to do with HTML escaping?
- Is `try` still needed?
- Bg color past last character in row is incorrect (actually it looks correct most of time as it doesn't change. But run e.g. `mc` to see it). Neither I and the function's author seemed to know how to fix this, becouse they (me at least) don't quite feel like HTML.
- The width of pasted text is infinite but it should be either terminal's size or copied text's size. And it again looks like HTML thing.
- If selection doesn't start at first character, this fact is ignored (the text is pasted as if it was the first character). No good, right?

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->

