### PR TITLE
Switch away from OS version detection for DirectWrite things

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -25,10 +25,10 @@
     "Microsoft.VisualStudio.Component.VC.Redist.14.Latest",
     "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
     "Microsoft.VisualStudio.Component.VC.Tools.ARM64",
-    "Microsoft.VisualStudio.Component.VC.v141.x86.x64",
-    "Microsoft.VisualStudio.Component.VC.v141.ARM64",
+    "Microsoft.VisualStudio.Component.VC.v142.x86.x64",
+    "Microsoft.VisualStudio.Component.VC.v142.ARM64",
     "Microsoft.VisualStudio.ComponentGroup.UWP.VC",
-    "Microsoft.VisualStudio.ComponentGroup.UWP.VC.v141",
+    "Microsoft.VisualStudio.ComponentGroup.UWP.VC.v142",
     "Microsoft.VisualStudio.Component.UWP.VC.ARM64"
   ]
 }

--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -788,7 +788,7 @@ CustomTextLayout::CustomTextLayout(IDWriteFactory1* const factory,
         if (FAILED(_format.As(&format1)))
         {
             // If IDWriteTextFormat1 does not exist, return directly as this OS version doesn't have font fallback.
-            return S_OK;
+            return S_FALSE;
         }
         RETURN_HR_IF_NULL(E_NOINTERFACE, format1);
 

--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -787,7 +787,7 @@ CustomTextLayout::CustomTextLayout(IDWriteFactory1* const factory,
         ::Microsoft::WRL::ComPtr<IDWriteTextFormat1> format1;
         if (_format.As(&format1) != S_OK)
         {
-            // If IDWriteTextFormat1 does not exist, return directly.
+            // If IDWriteTextFormat1 does not exist, return directly as this OS version doesn't have font fallback.
             return S_OK;
         }
         RETURN_HR_IF_NULL(E_NOINTERFACE, format1);

--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -133,18 +133,9 @@ CustomTextLayout::CustomTextLayout(IDWriteFactory1* const factory,
         RETURN_IF_FAILED(_analyzer->AnalyzeBidi(this, 0, textLength, this));
         RETURN_IF_FAILED(_analyzer->AnalyzeScript(this, 0, textLength, this));
         RETURN_IF_FAILED(_analyzer->AnalyzeNumberSubstitution(this, 0, textLength, this));
-
-#ifdef EXTERNAL_BUILD
-        // Perform our custom font fallback analyzer that mimics the pattern of the real analyzers.
-        // Fallback routines are not available below Windows 8.1, so just skip them and let a replacement character happen.
-        if (IsWindows8Point1OrGreater())
-        {
-            RETURN_IF_FAILED(_AnalyzeFontFallback(this, 0, textLength));
-        }
-#else
-        // Windows build os version always > Windows 8.1
+        //
         RETURN_IF_FAILED(_AnalyzeFontFallback(this, 0, textLength));
-#endif
+        
         // Ensure that a font face is attached to every run
         for (auto& run : _runs)
         {
@@ -794,7 +785,11 @@ CustomTextLayout::CustomTextLayout(IDWriteFactory1* const factory,
     {
         // Get the font fallback first
         ::Microsoft::WRL::ComPtr<IDWriteTextFormat1> format1;
-        RETURN_IF_FAILED(_format.As(&format1));
+        if(_format.As(&format1) != S_OK)
+        {
+        	// If IDWriteTextFormat1 does not exist, return directly.
+        	return S_OK;
+        }
         RETURN_HR_IF_NULL(E_NOINTERFACE, format1);
 
         ::Microsoft::WRL::ComPtr<IDWriteFontFallback> fallback;

--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -785,7 +785,7 @@ CustomTextLayout::CustomTextLayout(IDWriteFactory1* const factory,
     {
         // Get the font fallback first
         ::Microsoft::WRL::ComPtr<IDWriteTextFormat1> format1;
-        if (_format.As(&format1) != S_OK)
+        if (FAILED(_format.As(&format1)))
         {
             // If IDWriteTextFormat1 does not exist, return directly as this OS version doesn't have font fallback.
             return S_OK;

--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -134,13 +134,17 @@ CustomTextLayout::CustomTextLayout(IDWriteFactory1* const factory,
         RETURN_IF_FAILED(_analyzer->AnalyzeScript(this, 0, textLength, this));
         RETURN_IF_FAILED(_analyzer->AnalyzeNumberSubstitution(this, 0, textLength, this));
 
+#ifdef EXTERNAL_BUILD
         // Perform our custom font fallback analyzer that mimics the pattern of the real analyzers.
         // Fallback routines are not available below Windows 8.1, so just skip them and let a replacement character happen.
         if (IsWindows8Point1OrGreater())
         {
             RETURN_IF_FAILED(_AnalyzeFontFallback(this, 0, textLength));
         }
-
+#else
+        // Windows build os version always > Windows 8.1
+        RETURN_IF_FAILED(_AnalyzeFontFallback(this, 0, textLength));
+#endif
         // Ensure that a font face is attached to every run
         for (auto& run : _runs)
         {

--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -133,7 +133,7 @@ CustomTextLayout::CustomTextLayout(IDWriteFactory1* const factory,
         RETURN_IF_FAILED(_analyzer->AnalyzeBidi(this, 0, textLength, this));
         RETURN_IF_FAILED(_analyzer->AnalyzeScript(this, 0, textLength, this));
         RETURN_IF_FAILED(_analyzer->AnalyzeNumberSubstitution(this, 0, textLength, this));
-        //
+        // Perform our custom font fallback analyzer that mimics the pattern of the real analyzers.
         RETURN_IF_FAILED(_AnalyzeFontFallback(this, 0, textLength));
 
         // Ensure that a font face is attached to every run

--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -135,7 +135,7 @@ CustomTextLayout::CustomTextLayout(IDWriteFactory1* const factory,
         RETURN_IF_FAILED(_analyzer->AnalyzeNumberSubstitution(this, 0, textLength, this));
         //
         RETURN_IF_FAILED(_AnalyzeFontFallback(this, 0, textLength));
-        
+
         // Ensure that a font face is attached to every run
         for (auto& run : _runs)
         {
@@ -785,10 +785,10 @@ CustomTextLayout::CustomTextLayout(IDWriteFactory1* const factory,
     {
         // Get the font fallback first
         ::Microsoft::WRL::ComPtr<IDWriteTextFormat1> format1;
-        if(_format.As(&format1) != S_OK)
+        if (_format.As(&format1) != S_OK)
         {
-        	// If IDWriteTextFormat1 does not exist, return directly.
-        	return S_OK;
+            // If IDWriteTextFormat1 does not exist, return directly.
+            return S_OK;
         }
         RETURN_HR_IF_NULL(E_NOINTERFACE, format1);
 

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -192,20 +192,7 @@ DxEngine::~DxEngine()
         SwapChainDesc.BufferCount = 2;
         SwapChainDesc.SampleDesc.Count = 1;
         SwapChainDesc.AlphaMode = DXGI_ALPHA_MODE_UNSPECIFIED;
-
-#ifdef EXTERNAL_BUILD
-        // DXGI_SCALING_NONE is only valid on Windows 8+
-        if (IsWindows8OrGreater())
-        {
-            SwapChainDesc.Scaling = DXGI_SCALING_NONE;
-        }
-        else
-        {
-            SwapChainDesc.Scaling = DXGI_SCALING_STRETCH;
-        }
-#else
         SwapChainDesc.Scaling = DXGI_SCALING_NONE;
-#endif
 
         switch (_chainMode)
         {
@@ -220,13 +207,23 @@ DxEngine::~DxEngine()
 
             // We can't do alpha for HWNDs. Set to ignore. It will fail otherwise.
             SwapChainDesc.AlphaMode = DXGI_ALPHA_MODE_IGNORE;
+            const auto createSwapChainResult = _dxgiFactory2->CreateSwapChainForHwnd(_d3dDevice.Get(),
+                                                                                     _hwndTarget,
+                                                                                     &SwapChainDesc,
+                                                                                     nullptr,
+                                                                                     nullptr,
+                                                                                     &_dxgiSwapChain);
+            if (FAILED(createSwapChainResult))
+            {
+                SwapChainDesc.Scaling = DXGI_SCALING_STRETCH;
+                RETURN_IF_FAILED(_dxgiFactory2->CreateSwapChainForHwnd(_d3dDevice.Get(),
+                                                                       _hwndTarget,
+                                                                       &SwapChainDesc,
+                                                                       nullptr,
+                                                                       nullptr,
+                                                                       &_dxgiSwapChain));
+            }
 
-            RETURN_IF_FAILED(_dxgiFactory2->CreateSwapChainForHwnd(_d3dDevice.Get(),
-                                                                   _hwndTarget,
-                                                                   &SwapChainDesc,
-                                                                   nullptr,
-                                                                   nullptr,
-                                                                   &_dxgiSwapChain));
             break;
         }
         case SwapChainMode::ForComposition:

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -193,6 +193,7 @@ DxEngine::~DxEngine()
         SwapChainDesc.SampleDesc.Count = 1;
         SwapChainDesc.AlphaMode = DXGI_ALPHA_MODE_UNSPECIFIED;
 
+#ifdef EXTERNAL_BUILD
         // DXGI_SCALING_NONE is only valid on Windows 8+
         if (IsWindows8OrGreater())
         {
@@ -202,6 +203,9 @@ DxEngine::~DxEngine()
         {
             SwapChainDesc.Scaling = DXGI_SCALING_STRETCH;
         }
+#else
+        SwapChainDesc.Scaling = DXGI_SCALING_NONE;
+#endif
 
         switch (_chainMode)
         {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

DX rendering only needs to detect the operating system version when EXTERNAL_BUILD is turned on. For Windows building, the target Windows is almost considered to be the latest.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] (incidentally closes #2069)
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
