### PR TITLE
Allow the mapping of OEM keys ({}|\<>/_-=+) in key bindings

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -1396,12 +1396,40 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Method Description:
+    // - Handles the special case of providing a text override for the UI shortcut due to VK_OEM issue.
+    //      Looks at the flags from the KeyChord modifiers and provides a concatenated string value of all
+    //      in the same order that XAML would put them as well.
+    // Return Value:
+    // - a WinRT hstring representation of the key modifiers for the shortcut
+    //NOTE: This needs to be localized with https://github.com/microsoft/terminal/issues/794 if XAML framework issue not resolved before then
+    static std::wstring _FormatOverrideShortcutText(Settings::KeyModifiers modifiers)
+    {
+        std::wstring buffer{ L"" };
+
+        if (WI_IsFlagSet(modifiers, Settings::KeyModifiers::Ctrl))
+        {
+            buffer += L"Ctrl+";
+        }
+        if (WI_IsFlagSet(modifiers, Settings::KeyModifiers::Shift))
+        {
+            buffer += L"Shift+";
+        }
+        if (WI_IsFlagSet(modifiers, Settings::KeyModifiers::Alt))
+        {
+            buffer += L"Alt+";
+        }
+
+        return buffer;
+    }
+
+    // Method Description:
     // - Takes a MenuFlyoutItem and a corresponding KeyChord value and creates the accelerator for UI display.
     //   Takes into account a special case for an error condition for a comma
     // Arguments:
     // - MenuFlyoutItem that will be displayed, and a KeyChord to map an accelerator
     void App::_SetAcceleratorForMenuItem(Windows::UI::Xaml::Controls::MenuFlyoutItem& menuItem, const winrt::Microsoft::Terminal::Settings::KeyChord& keyChord)
     {
+#ifdef DEP_MICROSOFT_UI_XAML_708_FIXED
         // work around https://github.com/microsoft/microsoft-ui-xaml/issues/708 in case of VK_OEM_COMMA
         if (keyChord.Vkey() != VK_OEM_COMMA)
         {
@@ -1421,10 +1449,15 @@ namespace winrt::TerminalApp::implementation
             menuItem.KeyboardAccelerators().Append(menuShortcut);
         }
         else // we've got a comma, so need to just use the alternate method
+#endif
         {
             // extract the modifier and key to a nice format
-            auto overrideString = AppKeyBindings::FormatOverrideShortcutText(keyChord.Modifiers());
-            menuItem.KeyboardAcceleratorTextOverride(overrideString + L" ,");
+            auto overrideString = _FormatOverrideShortcutText(keyChord.Modifiers());
+            auto mappedCh = MapVirtualKeyW(keyChord.Vkey(), MAPVK_VK_TO_CHAR);
+            if (mappedCh != 0)
+            {
+                menuItem.KeyboardAcceleratorTextOverride(overrideString + gsl::narrow_cast<wchar_t>(mappedCh));
+            }
         }
     }
 

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -1400,7 +1400,7 @@ namespace winrt::TerminalApp::implementation
     //      Looks at the flags from the KeyChord modifiers and provides a concatenated string value of all
     //      in the same order that XAML would put them as well.
     // Return Value:
-    // - a WinRT hstring representation of the key modifiers for the shortcut
+    // - a string representation of the key modifiers for the shortcut
     //NOTE: This needs to be localized with https://github.com/microsoft/terminal/issues/794 if XAML framework issue not resolved before then
     static std::wstring _FormatOverrideShortcutText(Settings::KeyModifiers modifiers)
     {

--- a/src/cascadia/TerminalApp/AppKeyBindings.cpp
+++ b/src/cascadia/TerminalApp/AppKeyBindings.cpp
@@ -215,33 +215,6 @@ namespace winrt::TerminalApp::implementation
         return keyModifiers;
     }
 
-    // Method Description:
-    // - Handles the special case of providing a text override for the UI shortcut due to VK_OEM_COMMA issue.
-    //      Looks at the flags from the KeyChord modifiers and provides a concatenated string value of all
-    //      in the same order that XAML would put them as well.
-    // Return Value:
-    // - a WinRT hstring representation of the key modifiers for the shortcut
-    //NOTE: This needs to be localized with https://github.com/microsoft/terminal/issues/794 if XAML framework issue not resolved before then
-    winrt::hstring AppKeyBindings::FormatOverrideShortcutText(Settings::KeyModifiers modifiers)
-    {
-        std::wstring buffer{ L"" };
-
-        if (WI_IsFlagSet(modifiers, Settings::KeyModifiers::Ctrl))
-        {
-            buffer += L"Ctrl+";
-        }
-        if (WI_IsFlagSet(modifiers, Settings::KeyModifiers::Shift))
-        {
-            buffer += L"Shift+";
-        }
-        if (WI_IsFlagSet(modifiers, Settings::KeyModifiers::Alt))
-        {
-            buffer += L"Alt+";
-        }
-
-        return winrt::hstring{ buffer };
-    }
-
     // -------------------------------- Events ---------------------------------
     // clang-format off
     DEFINE_EVENT(AppKeyBindings, CopyText,          _CopyTextHandlers,          TerminalApp::CopyTextEventArgs);

--- a/src/cascadia/TerminalApp/AppKeyBindings.h
+++ b/src/cascadia/TerminalApp/AppKeyBindings.h
@@ -37,7 +37,6 @@ namespace winrt::TerminalApp::implementation
         Microsoft::Terminal::Settings::KeyChord GetKeyBinding(TerminalApp::ShortcutAction const& action);
 
         static Windows::System::VirtualKeyModifiers ConvertVKModifiers(winrt::Microsoft::Terminal::Settings::KeyModifiers modifiers);
-        static winrt::hstring FormatOverrideShortcutText(winrt::Microsoft::Terminal::Settings::KeyModifiers modifiers);
 
         // clang-format off
         DECLARE_EVENT(CopyText,          _CopyTextHandlers,          TerminalApp::CopyTextEventArgs);


### PR DESCRIPTION
This commit introduces support for key bindings containing keys
traditionally classified as "OEM" keys. It uses VkKeyScanW and
MapVirtualKeyW, and translates the modifiers that come out of
VkKeyScanW to key chord modifiers.

The net result of this is that you can use bindings like "ctrl+|" in
your settings. That one in particular will be reserialized (and
displayed in any menus) as "ctrl+shift+\". Admittedly, this is not
clear, but it _is_ the truest representation of the key.

This commit also moves the Xaml key chord name override generator into
App as a static function, *AND* it forces its use for all modifier
names. This will present a localization issue, which will be helped in
part by #1972. This is required to work around
microsoft/microsoft-ui-xaml#708. I've kept the original code around
guarded by a puzzling ifdef, because it absolutely has value.

Fixes #1212.

![image](https://user-images.githubusercontent.com/14316954/61683890-22489a00-accc-11e9-8fa2-88869043ac4a.png)

### Renormalization

| input | reserialized as |
|-|-|
| `"alt+="` | `"alt+plus"` | 
| `"alt+:"` | `"alt+shift+;"` | 
| `"ctrl+?"` | `"ctrl+shift+/"` | 
| `"shift+~"` | `"shift+<backtick>"`<br>_(markdown limitation)_ |
| `"alt+}"` | `"alt+shift+]"` | 
| `"ctrl+alt+<pipe>"` | `"ctrl+alt+shift+\\"` |
| `"shift+\""` | `"shift+'"` | 
| `"alt+,"` | `"alt+,"` | 
| `"ctrl+-"` | `"ctrl+-"` | 
| `"shift+."` | `"shift+."` | 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1212
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] I've discussed this with core contributors already.

## Validation Steps Performed
Manual