### PR TITLE
Fix a couple of the DEC Special Graphics characters

### DIFF
--- a/src/terminal/adapter/terminalOutput.cpp
+++ b/src/terminal/adapter/terminalOutput.cpp
@@ -84,7 +84,7 @@ const wchar_t TerminalOutput::s_rgDECSpecialGraphicsTranslations[s_uiNumDisplayC
     L'\x5d',
     L'\x5e',
     L'\u0020', // L'\x5f',   -> Blank
-    L'\u25C6', // L'\x60',   -> Diamond
+    L'\u2666', // L'\x60',   -> Diamond (more commonly U+25C6, but U+2666 renders better for us)
     L'\u2592', // L'\x61',   -> Checkerboard
     L'\u2409', // L'\x62',   -> HT, SYMBOL FOR HORIZONTAL TABULATION
     L'\u240c', // L'\x63',   -> FF, SYMBOL FOR FORM FEED

--- a/src/terminal/adapter/terminalOutput.cpp
+++ b/src/terminal/adapter/terminalOutput.cpp
@@ -98,12 +98,12 @@ const wchar_t TerminalOutput::s_rgDECSpecialGraphicsTranslations[s_uiNumDisplayC
     L'\u2510', // L'\x6b',   -> Upper-right corner
     L'\u250c', // L'\x6c',   -> Upper-left corner
     L'\u2514', // L'\x6d',   -> Lower-left corner
-    L'\u253C', // L'\x6e',   -> crossing lines
-    L'\u23ba', // L'\x6f',   -> HORIZONTAL SCAN LINE-3
-    L'\u23bb', // L'\x70',   -> HORIZONTAL SCAN LINE-3
-    L'\u2500', // L'\x71',   -> HORIZONTAL SCAN LINE-5
-    L'\u23bc', // L'\x72',   -> HORIZONTAL SCAN LINE-7
-    L'\u23bd', // L'\x73',   -> HORIZONTAL SCAN LINE-7
+    L'\u253C', // L'\x6e',   -> Crossing lines
+    L'\u23ba', // L'\x6f',   -> Horizontal line - Scan 1
+    L'\u23bb', // L'\x70',   -> Horizontal line - Scan 3
+    L'\u2500', // L'\x71',   -> Horizontal line - Scan 5
+    L'\u23bc', // L'\x72',   -> Horizontal line - Scan 7
+    L'\u23bd', // L'\x73',   -> Horizontal line - Scan 9
     L'\u251c', // L'\x74',   -> Left "T"
     L'\u2524', // L'\x75',   -> Right "T"
     L'\u2534', // L'\x76',   -> Bottom "T"

--- a/src/terminal/adapter/terminalOutput.cpp
+++ b/src/terminal/adapter/terminalOutput.cpp
@@ -90,15 +90,15 @@ const wchar_t TerminalOutput::s_rgDECSpecialGraphicsTranslations[s_uiNumDisplayC
     L'\u240c', // L'\x63',   -> FF, SYMBOL FOR FORM FEED
     L'\u240d', // L'\x64',   -> CR, SYMBOL FOR CARRIAGE RETURN
     L'\u240a', // L'\x65',   -> LF, SYMBOL FOR LINE FEED
-    L'\u00B0', // L'\x66',   -> Degree symbol
-    L'\u00B1', // L'\x67',   -> Plus/minus
+    L'\u00b0', // L'\x66',   -> Degree symbol
+    L'\u00b1', // L'\x67',   -> Plus/minus
     L'\u2424', // L'\x68',   -> NL, SYMBOL FOR NEWLINE
     L'\u240b', // L'\x69',   -> VT, SYMBOL FOR VERTICAL TABULATION
     L'\u2518', // L'\x6a',   -> Lower-right corner
     L'\u2510', // L'\x6b',   -> Upper-right corner
     L'\u250c', // L'\x6c',   -> Upper-left corner
     L'\u2514', // L'\x6d',   -> Lower-left corner
-    L'\u253C', // L'\x6e',   -> Crossing lines
+    L'\u253c', // L'\x6e',   -> Crossing lines
     L'\u23ba', // L'\x6f',   -> Horizontal line - Scan 1
     L'\u23bb', // L'\x70',   -> Horizontal line - Scan 3
     L'\u2500', // L'\x71',   -> Horizontal line - Scan 5
@@ -111,10 +111,10 @@ const wchar_t TerminalOutput::s_rgDECSpecialGraphicsTranslations[s_uiNumDisplayC
     L'\u2502', // L'\x78',   -> | Vertical bar
     L'\u2264', // L'\x79',   -> Less than or equal to
     L'\u2265', // L'\x7a',   -> Greater than or equal to
-    L'\u03C0', // L'\x7b',   -> Pi
+    L'\u03c0', // L'\x7b',   -> Pi
     L'\u2260', // L'\x7c',   -> Not equal to
-    L'\u00A3', // L'\x7d',   -> UK pound sign
-    L'\u00B7', // L'\x7e',   -> Centered dot
+    L'\u00a3', // L'\x7d',   -> UK pound sign
+    L'\u00b7', // L'\x7e',   -> Centered dot
     L'\x7f' // L'\x7f',   -> DEL
 };
 

--- a/src/terminal/adapter/terminalOutput.cpp
+++ b/src/terminal/adapter/terminalOutput.cpp
@@ -83,7 +83,7 @@ const wchar_t TerminalOutput::s_rgDECSpecialGraphicsTranslations[s_uiNumDisplayC
     L'\x5c',
     L'\x5d',
     L'\x5e',
-    L'\x5f',
+    L'\u0020', // L'\x5f',   -> Blank
     L'\u25C6', // L'\x60',   -> Diamond
     L'\u2592', // L'\x61',   -> Checkerboard
     L'\u2409', // L'\x62',   -> HT, SYMBOL FOR HORIZONTAL TABULATION
@@ -157,7 +157,7 @@ wchar_t TerminalOutput::TranslateKey(const wchar_t wch) const
 {
     wchar_t wchFound = wch;
     if (_wchCurrentCharset == DispatchTypes::VTCharacterSets::USASCII ||
-        wch < '\x60' || wch > '\x7f') // filter out the region we know is unchanged
+        wch < '\x5f' || wch > '\x7f') // filter out the region we know is unchanged
     {
         ; // do nothing, these are the same as default.
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Corrects the 0x5f code point in the DEC Special Graphics character set, which is meant to map to a blank glyph rather than an underscore. and updates the 0x60 code point to map to a "black diamond suite" glyph, rather than the "black diamond" glyph, since the latter currently renders as a double width character.

## PR Checklist
* [x] Closes #2049 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #2049

## Detailed Description of the Pull Request / Additional comments

The was mostly a matter of updating the `s_rgDECSpecialGraphicsTranslations` table in the `TerminalOutput` class, but also required a change in the `TranslateKey` method, to make sure the 0x5f code point was included in the range of translatable characters.

I've also made a few cosmetic changes to the source, fixing the comments on the translation table to match the DEC documentation (a couple of them were not quite right), and tidying up the case of the hex values in the table, so they're all consistently lowercase now.

The latter changes have been committed separately, so they're easy enough to revert if there are any objections to including them in this PR.

## Validation Steps Performed

I've tested manually with [Vttest's](https://invisible-island.net/vttest/) _Test of character sets_, making sure the two code points are mapped as expected, and the diamond glyph doesn't break the layout by being too wide.