### PR TITLE
Remove static analysis builds because they're running out of disk space.

### DIFF
--- a/build/pipelines/ci.yml
+++ b/build/pipelines/ci.yml
@@ -19,9 +19,11 @@ pr:
 name: 0.0.$(Date:yyMM).$(Date:dd)$(Rev:rr)
 
 jobs:
-  - template: ./templates/build-console-audit-job.yml
-    parameters:
-      platform: x64
+# This is disabled because the build agents were running out of disk space. 
+# We're pursuing that in the background, but the spice must flow in the meantime.
+#  - template: ./templates/build-console-audit-job.yml
+#    parameters:
+#      platform: x64
 
   - template: ./templates/build-console-ci.yml
     parameters:


### PR DESCRIPTION
@DHowett-MSFT has a thread with the relevant people trying to sort this whole thing out.

But in the meantime, the static analysis builds are low value and are blocking actual work from happening.

So I commented them out for now.