### PR TITLE
Fix #2078 by removing the NavigateUri's from the hyperlinks

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -195,7 +195,6 @@ namespace winrt::TerminalApp::implementation
         const auto package = winrt::Windows::ApplicationModel::Package::Current();
         const auto packageName = package.DisplayName();
         const auto version = package.Id().Version();
-        Windows::UI::Xaml::Media::SolidColorBrush blueBrush{ Windows::UI::ColorHelper::FromArgb(255, 0, 115, 207) };
         winrt::Windows::UI::Xaml::Documents::Run about;
         winrt::Windows::UI::Xaml::Documents::Run gettingStarted;
         winrt::Windows::UI::Xaml::Documents::Run documentation;

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -213,9 +213,19 @@ namespace winrt::TerminalApp::implementation
         winrt::Windows::Foundation::Uri documentationUri{ documentationUriValue };
         winrt::Windows::Foundation::Uri releaseNotesUri{ releaseNotesUriValue };
 
-        gettingStartedLink.NavigateUri(gettingStartedUri);
-        documentationLink.NavigateUri(documentationUri);
-        releaseNotesLink.NavigateUri(releaseNotesUri);
+        // GH#2078: If you use a NavigateUri property here, the dialog will
+        // crash the app immediately upon opening. While we _should_ find out
+        // why this is happening, using the Click event is a good enough work
+        // around to unblock us.
+        gettingStartedLink.Click([gettingStartedUri](auto&&, auto&&) {
+            winrt::Windows::System::Launcher::LaunchUriAsync({ gettingStartedUri });
+        });
+        documentationLink.Click([documentationUri](auto&&, auto&&) {
+            winrt::Windows::System::Launcher::LaunchUriAsync({ documentationUri });
+        });
+        releaseNotesLink.Click([releaseNotesUri](auto&&, auto&&) {
+            winrt::Windows::System::Launcher::LaunchUriAsync({ releaseNotesUri });
+        });
 
         gettingStartedLink.Inlines().Append(gettingStarted);
         documentationLink.Inlines().Append(documentation);
@@ -237,10 +247,6 @@ namespace winrt::TerminalApp::implementation
         about.Text(aboutText);
 
         const auto buttonText = _resourceLoader.GetLocalizedString(L"Ok");
-
-        gettingStartedLink.Foreground(blueBrush);
-        documentationLink.Foreground(blueBrush);
-        releaseNotesLink.Foreground(blueBrush);
 
         Controls::TextBlock aboutTextBlock;
         aboutTextBlock.Inlines().Append(about);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

For some reason the NavigateUri property on the Hyperlinks in the about dialog don't work. This is a workaround for that bug. Instead of using NavigateUri, I'm just using a Click handler to do the same thing.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #2078
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [N/A] Tests added/passed
