### PR TITLE
Change "Summary"->"Description" in the Feature Request Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Feature_Request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.md
@@ -20,7 +20,7 @@ I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
 All good? Then proceed!
 -->
 
-# Summary of the new feature/enhancement
+# Description of the new feature/enhancement
 
 <!-- 
 A clear and concise description of what the problem is that the new feature would solve.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

When I'm scrolling through emails, Outlook usually clips the preview of the message after the first few words. Both the PR template and the Feature Request template start with the words "Summary of the ", so both look basically the same in my inbox. PRs are way more interesting to read, so I'd love a way to be able to tell the difference immediately.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #showerthoughts
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] I've discussed this with core contributors already.

