### PR TITLE
Prevent a crash on resizing too small caused by the Titlebar

### DIFF
--- a/src/cascadia/TerminalApp/TitlebarControl.cpp
+++ b/src/cascadia/TerminalApp/TitlebarControl.cpp
@@ -35,13 +35,19 @@ namespace winrt::TerminalApp::implementation
         ContentRoot().Children().Append(content);
     }
 
-    void TitlebarControl::Root_SizeChanged(const IInspectable& sender, Windows::UI::Xaml::SizeChangedEventArgs const& e)
+    void TitlebarControl::Root_SizeChanged(const IInspectable& sender,
+                                           const Windows::UI::Xaml::SizeChangedEventArgs& e)
     {
         const auto windowWidth = ActualWidth();
         const auto minMaxCloseWidth = MinMaxCloseControl().ActualWidth();
         const auto dragBarMinWidth = DragBar().MinWidth();
         const auto maxWidth = windowWidth - minMaxCloseWidth - dragBarMinWidth;
-        ContentRoot().MaxWidth(maxWidth);
+        // Only set our MaxWidth if it's greater than 0. Setting it to a
+        // negative value will cause a crash.
+        if (maxWidth >= 0)
+        {
+            ContentRoot().MaxWidth(maxWidth);
+        }
     }
 
     void TitlebarControl::_OnMaximizeOrRestore(byte flag)


### PR DESCRIPTION


<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
  Only set the MaxWidth of the TitlebarControl's Content when the value is
  positive. Any smaller will crash the app.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #2045
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [n/a] Tests added/passed
* [x] I've discussed this with core contributors already. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Opened the terminal with this fix and just went wild on the resize