### PR TITLE
Add some ETL around profile, control and connection creation

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -103,6 +103,14 @@ namespace winrt::TerminalApp::implementation
         _tabContent.SizeChanged({ this, &App::_OnContentSizeChanged });
 
         _ApplyTheme(_settings->GlobalSettings().GetRequestedTheme());
+
+        TraceLoggingWrite(
+            g_hTerminalAppProvider,
+            "AppCreated",
+            TraceLoggingDescription("Event emitted when the application is started"),
+            TraceLoggingBool(_settings->GlobalSettings().GetShowTabsInTitlebar(), "TabsInTitlebar"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/App.h
+++ b/src/cascadia/TerminalApp/App.h
@@ -34,7 +34,7 @@ namespace winrt::TerminalApp::implementation
         Windows::Foundation::Point GetLaunchDimensions(uint32_t dpi);
         bool GetShowTabsInTitlebar();
 
-        ~App();
+        ~App() = default;
 
         hstring GetTitle();
 

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -353,6 +353,13 @@ Profile Profile::FromJson(const Json::Value& json)
     else
     {
         result._guid = Utils::CreateGuid();
+
+        TraceLoggingWrite(
+            g_hTerminalAppProvider,
+            "SynthesizedGuidForProfile",
+            TraceLoggingDescription("Event emitted when a profile is deserialized without a GUID"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
     }
 
     // Core Settings

--- a/src/cascadia/TerminalApp/TerminalApp.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalApp.vcxproj
@@ -99,6 +99,10 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>User32.lib;WindowsApp.lib;shell32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+
+      <!-- TerminalAppLib contains a DllMain that we need to force the use of. -->
+      <AdditionalOptions Condition="'$(Platform)'=='Win32'">/INCLUDE:_DllMain@12</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Platform)'!='Win32'">/INCLUDE:DllMain</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(OpenConsoleDir)src\common.build.post.props" />

--- a/src/cascadia/TerminalApp/init.cpp
+++ b/src/cascadia/TerminalApp/init.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation
+// Licensed under the MIT license.
+
+#include "pch.h"
+
+// Note: Generate GUID using TlgGuid.exe tool
+TRACELOGGING_DEFINE_PROVIDER(
+    g_hTerminalAppProvider,
+    "Microsoft.Windows.Terminal.App",
+    // {24a1622f-7da7-5c77-3303-d850bd1ab2ed}
+    (0x24a1622f, 0x7da7, 0x5c77, 0x33, 0x03, 0xd8, 0x50, 0xbd, 0x1a, 0xb2, 0xed),
+    TraceLoggingOptionMicrosoftTelemetry());
+
+BOOL WINAPI DllMain(HINSTANCE hInstDll, DWORD reason, LPVOID /*reserved*/)
+{
+    switch (reason)
+    {
+    case DLL_PROCESS_ATTACH:
+        DisableThreadLibraryCalls(hInstDll);
+        TraceLoggingRegister(g_hTerminalAppProvider);
+        break;
+    case DLL_PROCESS_DETACH:
+        if (g_hTerminalAppProvider)
+        {
+            TraceLoggingUnregister(g_hTerminalAppProvider);
+        }
+        break;
+    }
+
+    return TRUE;
+}

--- a/src/cascadia/TerminalApp/lib/TerminalAppLib.vcxproj
+++ b/src/cascadia/TerminalApp/lib/TerminalAppLib.vcxproj
@@ -77,6 +77,7 @@
 
   <!-- ========================= Cpp Files ======================== -->
   <ItemGroup>
+    <ClCompile Include="../init.cpp" />
     <ClCompile Include="../MinMaxCloseControl.cpp">
       <DependentUpon>../MinMaxCloseControl.xaml</DependentUpon>
     </ClCompile>

--- a/src/cascadia/TerminalApp/lib/pch.h
+++ b/src/cascadia/TerminalApp/lib/pch.h
@@ -45,7 +45,7 @@
 // Including TraceLogging essentials for the binary
 #include <TraceLoggingProvider.h>
 #include <winmeta.h>
-TRACELOGGING_DECLARE_PROVIDER(g_hTerminalWin32Provider);
+TRACELOGGING_DECLARE_PROVIDER(g_hTerminalAppProvider);
 #include <telemetry\ProjectTelemetry.h>
 #include <TraceLoggingActivity.h>
 

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -185,15 +185,20 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         _BackgroundColorChanged(bg);
 
         // Apply padding as swapChainPanel's margin
-        auto thickness = _ParseThicknessFromPadding(_settings.Padding());
-        _swapChainPanel.Margin(thickness);
+        auto newMargin = _ParseThicknessFromPadding(_settings.Padding());
+        auto existingMargin = _swapChainPanel.Margin();
+        _swapChainPanel.Margin(newMargin);
 
-        if (thickness.Bottom != 0 || thickness.Top != 0 || thickness.Left != 0 || thickness.Right != 0)
+        if (newMargin != existingMargin && newMargin != Thickness{ 0 })
         {
             TraceLoggingWrite(g_hTerminalControlProvider,
                               "NonzeroPaddingApplied",
                               TraceLoggingDescription("An event emitted when a control has padding applied to it"),
-                              TraceLoggingWideString(_settings.Padding().c_str(), "Padding", "The user-specified padding value"),
+                              TraceLoggingStruct(4, "Padding"),
+                              TraceLoggingFloat64(newMargin.Left, "Left"),
+                              TraceLoggingFloat64(newMargin.Top, "Top"),
+                              TraceLoggingFloat64(newMargin.Right, "Right"),
+                              TraceLoggingFloat64(newMargin.Bottom, "Bottom"),
                               TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
                               TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -188,6 +188,16 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         auto thickness = _ParseThicknessFromPadding(_settings.Padding());
         _swapChainPanel.Margin(thickness);
 
+        if (thickness.Bottom != 0 || thickness.Top != 0 || thickness.Left != 0 || thickness.Right != 0)
+        {
+            TraceLoggingWrite(g_hTerminalControlProvider,
+                              "NonzeroPaddingApplied",
+                              TraceLoggingDescription("An event emitted when a control has padding applied to it"),
+                              TraceLoggingWideString(_settings.Padding().c_str(), "Padding", "The user-specified padding value"),
+                              TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+                              TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
+        }
+
         // Initialize our font information.
         const auto* fontFace = _settings.FontFace().c_str();
         const short fontHeight = gsl::narrow<short>(_settings.FontSize());

--- a/src/cascadia/TerminalControl/TerminalControl.vcxproj
+++ b/src/cascadia/TerminalControl/TerminalControl.vcxproj
@@ -25,6 +25,7 @@
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="init.cpp" />
     <ClCompile Include="TermControl.cpp">
       <DependentUpon>TermControl.idl</DependentUpon>
     </ClCompile>

--- a/src/cascadia/TerminalControl/init.cpp
+++ b/src/cascadia/TerminalControl/init.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation
+// Licensed under the MIT license.
+
+#include "pch.h"
+
+// Note: Generate GUID using TlgGuid.exe tool
+TRACELOGGING_DEFINE_PROVIDER(
+    g_hTerminalControlProvider,
+    "Microsoft.Windows.Terminal.Control",
+    // {28c82e50-57af-5a86-c25b-e39cd990032b}
+    (0x28c82e50, 0x57af, 0x5a86, 0xc2, 0x5b, 0xe3, 0x9c, 0xd9, 0x90, 0x03, 0x2b),
+    TraceLoggingOptionMicrosoftTelemetry());
+
+BOOL WINAPI DllMain(HINSTANCE hInstDll, DWORD reason, LPVOID /*reserved*/)
+{
+    switch (reason)
+    {
+    case DLL_PROCESS_ATTACH:
+        DisableThreadLibraryCalls(hInstDll);
+        TraceLoggingRegister(g_hTerminalControlProvider);
+        break;
+    case DLL_PROCESS_DETACH:
+        if (g_hTerminalControlProvider)
+        {
+            TraceLoggingUnregister(g_hTerminalControlProvider);
+        }
+        break;
+    }
+
+    return TRUE;
+}

--- a/src/cascadia/TerminalControl/pch.h
+++ b/src/cascadia/TerminalControl/pch.h
@@ -30,3 +30,7 @@
 #include <winrt/Windows.ui.xaml.input.h>
 
 #include <windows.ui.xaml.media.dxinterop.h>
+
+#include <TraceLoggingProvider.h>
+TRACELOGGING_DECLARE_PROVIDER(g_hTerminalControlProvider);
+#include <telemetry/ProjectTelemetry.h>


### PR DESCRIPTION
## Summary of the Pull Request
This pull request adds some logging around profile and tab creation. We'd like to learn what default settings people are using so that we can inform discussions like #1417.

## PR Checklist
* [x] I've discussed this with core contributors already.

## Validation Steps Performed
Looked at the generated ETL.