### PR TITLE
VT sequence support for EraseInLine, EraseInDisplay, DeleteCharacter and InsertCharacter

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -558,6 +558,7 @@ bool TextBuffer::IncrementCircularBuffer()
 
 //Routine Description:
 // - Retrieves the position of the last non-space character on the final line of the text buffer.
+// - By default, we search the entire buffer to find the last non-space character
 //Arguments:
 // - <none>
 //Return Value:
@@ -569,6 +570,8 @@ COORD TextBuffer::GetLastNonSpaceCharacter() const
 
 //Routine Description:
 // - Retrieves the position of the last non-space character in the given viewport
+// - This is basically an optimized version of GetLastNonSpaceCharacter(), and can be called when
+// - we know the last character is within the given viewport (so we don't need to check the entire buffer)
 //Arguments:
 // - The viewport
 //Return value:

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -564,16 +564,28 @@ bool TextBuffer::IncrementCircularBuffer()
 // - Coordinate position in screen coordinates (offset coordinates, not array index coordinates).
 COORD TextBuffer::GetLastNonSpaceCharacter() const
 {
-    COORD coordEndOfText;
-    // Always search the whole buffer, by starting at the bottom.
-    coordEndOfText.Y = GetSize().BottomInclusive();
+    return GetLastNonSpaceCharacter(GetSize());
+}
+
+//Routine Description:
+// - Retrieves the position of the last non-space character in the given viewport
+//Arguments:
+// - The viewport
+//Return value:
+// - Coordinate position (relative to the text buffer)
+COORD TextBuffer::GetLastNonSpaceCharacter(const Microsoft::Console::Types::Viewport viewport) const
+{
+    COORD coordEndOfText = { 0 };
+    // Search the given viewport by starting at the bottom.
+    coordEndOfText.Y = viewport.BottomInclusive();
 
     const ROW* pCurrRow = &GetRowByOffset(coordEndOfText.Y);
     // The X position of the end of the valid text is the Right draw boundary (which is one beyond the final valid character)
     coordEndOfText.X = static_cast<short>(pCurrRow->GetCharRow().MeasureRight()) - 1;
 
     // If the X coordinate turns out to be -1, the row was empty, we need to search backwards for the real end of text.
-    bool fDoBackUp = (coordEndOfText.X < 0 && coordEndOfText.Y > 0); // this row is empty, and we're not at the top
+    const auto viewportTop = viewport.Top();
+    bool fDoBackUp = (coordEndOfText.X < 0 && coordEndOfText.Y > viewportTop); // this row is empty, and we're not at the top
     while (fDoBackUp)
     {
         coordEndOfText.Y--;
@@ -581,7 +593,7 @@ COORD TextBuffer::GetLastNonSpaceCharacter() const
         // We need to back up to the previous row if this line is empty, AND there are more rows
 
         coordEndOfText.X = static_cast<short>(pCurrRow->GetCharRow().MeasureRight()) - 1;
-        fDoBackUp = (coordEndOfText.X < 0 && coordEndOfText.Y > 0);
+        fDoBackUp = (coordEndOfText.X < 0 && coordEndOfText.Y > viewportTop);
     }
 
     // don't allow negative results

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -105,6 +105,7 @@ public:
     bool IncrementCircularBuffer();
 
     COORD GetLastNonSpaceCharacter() const;
+    COORD GetLastNonSpaceCharacter(const Microsoft::Console::Types::Viewport viewport) const;
 
     Cursor& GetCursor();
     const Cursor& GetCursor() const;

--- a/src/cascadia/TerminalCore/ITerminalApi.hpp
+++ b/src/cascadia/TerminalCore/ITerminalApi.hpp
@@ -24,7 +24,10 @@ namespace Microsoft::Terminal::Core
         virtual bool SetCursorPosition(short x, short y) = 0;
         virtual COORD GetCursorPosition() = 0;
 
+        virtual bool DeleteCharacter(const unsigned int uiCount) = 0;
         virtual bool EraseCharacters(const unsigned int numChars) = 0;
+        virtual bool EraseInLine(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) = 0;
+        virtual bool EraseInDisplay(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) = 0;
 
         virtual bool SetWindowTitle(std::wstring_view title) = 0;
 

--- a/src/cascadia/TerminalCore/ITerminalApi.hpp
+++ b/src/cascadia/TerminalCore/ITerminalApi.hpp
@@ -25,6 +25,7 @@ namespace Microsoft::Terminal::Core
         virtual COORD GetCursorPosition() = 0;
 
         virtual bool DeleteCharacter(const unsigned int uiCount) = 0;
+        virtual bool InsertCharacter(const unsigned int uiCount) = 0;
         virtual bool EraseCharacters(const unsigned int numChars) = 0;
         virtual bool EraseInLine(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) = 0;
         virtual bool EraseInDisplay(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) = 0;

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -68,8 +68,8 @@ public:
     COORD GetCursorPosition() override;
     bool DeleteCharacter(const unsigned int uiCount) override;
     bool EraseCharacters(const unsigned int numChars) override;
-    bool EraseInLine(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType);
-    bool EraseInDisplay(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType);
+    bool EraseInLine(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) override;
+    bool EraseInDisplay(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) override;
     bool SetWindowTitle(std::wstring_view title) override;
     bool SetColorTableEntry(const size_t tableIndex, const COLORREF dwColor) override;
     bool SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) override;

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -67,6 +67,7 @@ public:
     bool SetCursorPosition(short x, short y) override;
     COORD GetCursorPosition() override;
     bool DeleteCharacter(const unsigned int uiCount) override;
+    bool InsertCharacter(const unsigned int uiCount) override;
     bool EraseCharacters(const unsigned int numChars) override;
     bool EraseInLine(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) override;
     bool EraseInDisplay(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) override;

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -66,7 +66,10 @@ public:
     bool ReverseText(bool reversed) override;
     bool SetCursorPosition(short x, short y) override;
     COORD GetCursorPosition() override;
+    bool DeleteCharacter(const unsigned int uiCount) override;
     bool EraseCharacters(const unsigned int numChars) override;
+    bool EraseInLine(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType);
+    bool EraseInDisplay(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType);
     bool SetWindowTitle(std::wstring_view title) override;
     bool SetColorTableEntry(const size_t tableIndex, const COLORREF dwColor) override;
     bool SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) override;

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -239,7 +239,7 @@ bool Terminal::EraseInDisplay(const DispatchTypes::EraseType eraseType)
         _buffer->ScrollRows(scrollFromPos.Y, _mutableViewport.Height(), -scrollFromPos.Y);
 
         // Since we only did a rotation, the text that was in the scrollback is now _below_ where we are going to move the viewport
-        // and we have to make sure we erase that text 
+        // and we have to make sure we erase that text
         auto eraseIter = OutputCellIterator(L' ', _buffer->GetCurrentAttributes(), _mutableViewport.RightInclusive());
         auto eraseStart = _mutableViewport.Height();
         auto eraseEnd = _buffer->GetLastNonSpaceCharacter(_mutableViewport).Y;

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -188,6 +188,7 @@ bool Terminal::InsertCharacter(const unsigned int uiCount)
     // NOTE: the code below is _extremely_ similar to DeleteCharacter
     // We will want to use this same logic and implement a helper function instead
     // that does the 'move a region from here to there' operation
+    // TODO: Github issue #2163
     SHORT dist;
     if (!SUCCEEDED(UIntToShort(uiCount, &dist)))
     {
@@ -334,9 +335,9 @@ bool Terminal::EraseInDisplay(const DispatchTypes::EraseType eraseType)
 
         // Since we only did a rotation, the text that was in the scrollback is now _below_ where we are going to move the viewport
         // and we have to make sure we erase that text
-        auto eraseIter = OutputCellIterator(UNICODE_SPACE, _buffer->GetCurrentAttributes(), _mutableViewport.RightInclusive());
         auto eraseStart = _mutableViewport.Height();
         auto eraseEnd = _buffer->GetLastNonSpaceCharacter(_mutableViewport).Y;
+        auto eraseIter = OutputCellIterator(UNICODE_SPACE, _buffer->GetCurrentAttributes(), _mutableViewport.RightInclusive() * (eraseEnd - eraseStart + 1));
         for (SHORT i = eraseStart; i <= eraseEnd; i++)
         {
             COORD erasePos{ 0, i };

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -126,7 +126,6 @@ bool TerminalDispatch::DeleteCharacter(const unsigned int uiCount)
     return _terminalApi.DeleteCharacter(uiCount);
 }
 
-
 // Method Description:
 // - Moves the viewport and erases text from the buffer depending on the eraseType
 // Arguments:

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -47,6 +47,13 @@ bool TerminalDispatch::CursorForward(const unsigned int uiDistance)
     return _terminalApi.SetCursorPosition(newCursorPos.X, newCursorPos.Y);
 }
 
+bool TerminalDispatch::CursorUp(const unsigned int uiDistance)
+{
+    const auto cursorPos = _terminalApi.GetCursorPosition();
+    const COORD newCursorPos{ cursorPos.X, cursorPos.Y + gsl::narrow<short>(uiDistance) };
+    return _terminalApi.SetCursorPosition(newCursorPos.X, newCursorPos.Y);
+}
+
 bool TerminalDispatch::EraseCharacters(const unsigned int uiNumChars)
 {
     return _terminalApi.EraseCharacters(uiNumChars);
@@ -98,9 +105,35 @@ bool TerminalDispatch::SetDefaultBackground(const DWORD dwColor)
 }
 
 // Method Description:
-// - For now, this is a hacky backspace
-// - TODO: GitHub #1883
-bool TerminalDispatch::EraseInLine(const DispatchTypes::EraseType)
+// - Erases characters in the buffer depending on the erase type
+// Arguments:
+// - eraseType: the erase type (from beginning, to end, or all)
+// Return Value:
+// True if handled successfully. False otherwise.
+bool TerminalDispatch::EraseInLine(const DispatchTypes::EraseType eraseType)
 {
-    return _terminalApi.EraseCharacters(1);
+    return _terminalApi.EraseInLine(eraseType);
+}
+
+// Method Description:
+// - Deletes uiCount number of characters starting from where the cursor is currently
+// Arguments:
+// - uiCount, the number of characters to delete
+// Return Value:
+// True if handled successfully. False otherwise.
+bool TerminalDispatch::DeleteCharacter(const unsigned int uiCount)
+{
+    return _terminalApi.DeleteCharacter(uiCount);
+}
+
+
+// Method Description:
+// - Moves the viewport and erases text from the buffer depending on the eraseType
+// Arguments:
+// - eraseType: the desired erase type
+// Return Value:
+// True if handled successfully. False otherwise
+bool TerminalDispatch::EraseInDisplay(const DispatchTypes::EraseType eraseType)
+{
+    return _terminalApi.EraseInDisplay(eraseType);
 }

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -47,6 +47,13 @@ bool TerminalDispatch::CursorForward(const unsigned int uiDistance)
     return _terminalApi.SetCursorPosition(newCursorPos.X, newCursorPos.Y);
 }
 
+bool TerminalDispatch::CursorBackward(const unsigned int uiDistance)
+{
+    const auto cursorPos = _terminalApi.GetCursorPosition();
+    const COORD newCursorPos{ cursorPos.X - gsl::narrow<short>(uiDistance), cursorPos.Y };
+    return _terminalApi.SetCursorPosition(newCursorPos.X, newCursorPos.Y);
+}
+
 bool TerminalDispatch::CursorUp(const unsigned int uiDistance)
 {
     const auto cursorPos = _terminalApi.GetCursorPosition();
@@ -124,6 +131,17 @@ bool TerminalDispatch::EraseInLine(const DispatchTypes::EraseType eraseType)
 bool TerminalDispatch::DeleteCharacter(const unsigned int uiCount)
 {
     return _terminalApi.DeleteCharacter(uiCount);
+}
+
+// Method Description:
+// - Adds uiCount number of spaces starting from where the cursor is currently
+// Arguments:
+// - uiCount, the number of spaces to add
+// Return Value:
+// True if handled successfully, false otherwise
+bool TerminalDispatch::InsertCharacter(const unsigned int uiCount)
+{
+    return _terminalApi.InsertCharacter(uiCount);
 }
 
 // Method Description:

--- a/src/cascadia/TerminalCore/TerminalDispatch.hpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.hpp
@@ -20,6 +20,7 @@ public:
                                 const unsigned int uiColumn) override; // CUP
 
     bool CursorForward(const unsigned int uiDistance) override;
+    bool CursorBackward(const unsigned int uiDistance) override;
     bool CursorUp(const unsigned int uiDistance) override;
 
     bool EraseCharacters(const unsigned int uiNumChars) override;
@@ -32,6 +33,7 @@ public:
     bool SetDefaultBackground(const DWORD dwColor) override;
     bool EraseInLine(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) override; // ED
     bool DeleteCharacter(const unsigned int uiCount) override;
+    bool InsertCharacter(const unsigned int uiCount) override;
     bool EraseInDisplay(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) override;
 
 private:

--- a/src/cascadia/TerminalCore/TerminalDispatch.hpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.hpp
@@ -20,6 +20,7 @@ public:
                                 const unsigned int uiColumn) override; // CUP
 
     bool CursorForward(const unsigned int uiDistance) override;
+    bool CursorUp(const unsigned int uiDistance) override;
 
     bool EraseCharacters(const unsigned int uiNumChars) override;
     bool SetWindowTitle(std::wstring_view title) override;
@@ -29,7 +30,9 @@ public:
 
     bool SetDefaultForeground(const DWORD dwColor) override;
     bool SetDefaultBackground(const DWORD dwColor) override;
-    bool EraseInLine(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType /* eraseType*/) override; // ED
+    bool EraseInLine(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) override; // ED
+    bool DeleteCharacter(const unsigned int uiCount) override;
+    bool EraseInDisplay(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) override;
 
 private:
     ::Microsoft::Terminal::Core::ITerminalApi& _terminalApi;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Implemented the following VT sequences:

- EraseInLine
- EraseInDisplay
- DeleteCharacter
- InsertCharacter

(Minor: implemented CursorUp and CursorBackward in TerminalDispatch with existing APIs)

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
Related to #1883 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Without these VT sequences, non-Conhost connections behave strangely (since they do not go through conpty for VT parsing). 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Compared behaviour with putty/other terminals and imitated them