### PR TITLE
Fix a crash on restore down

### DIFF
--- a/src/host/PtySignalInputThread.cpp
+++ b/src/host/PtySignalInputThread.cpp
@@ -107,10 +107,6 @@ void PtySignalInputThread::ConnectConsole() noexcept
             }
             else
             {
-                ServiceLocator::LocateGlobals().getConsoleInformation().GetVtIo()->BeginResize();
-                auto endResize = wil::scope_exit([&] {
-                    ServiceLocator::LocateGlobals().getConsoleInformation().GetVtIo()->EndResize();
-                });
                 if (DispatchCommon::s_ResizeWindow(*_pConApi, resizeMsg.sx, resizeMsg.sy))
                 {
                     DispatchCommon::s_SuppressResizeRepaint(*_pConApi);

--- a/src/host/PtySignalInputThread.cpp
+++ b/src/host/PtySignalInputThread.cpp
@@ -107,6 +107,10 @@ void PtySignalInputThread::ConnectConsole() noexcept
             }
             else
             {
+                ServiceLocator::LocateGlobals().getConsoleInformation().GetVtIo()->BeginResize();
+                auto endResize = wil::scope_exit([&] {
+                    ServiceLocator::LocateGlobals().getConsoleInformation().GetVtIo()->EndResize();
+                });
                 if (DispatchCommon::s_ResizeWindow(*_pConApi, resizeMsg.sx, resizeMsg.sy))
                 {
                     DispatchCommon::s_SuppressResizeRepaint(*_pConApi);

--- a/src/host/VtIo.cpp
+++ b/src/host/VtIo.cpp
@@ -397,3 +397,37 @@ void VtIo::_ShutdownIfNeeded()
         ServiceLocator::RundownAndExit(ERROR_BROKEN_PIPE);
     }
 }
+
+// Method Description:
+// - Tell the vt renderer to begin a resize operation. During a resize
+//   operation, the vt renderer should _not_ request to be repainted during a
+//   text buffer circling event. Any callers of this method should make sure to
+//   call EndResize to make sure the renderer returns to normal behavior.
+//   See GH#1795 for context on this method.
+// Arguments:
+// - <none>
+// Return Value:
+// - <none>
+void VtIo::BeginResize()
+{
+    if (_pVtRenderEngine)
+    {
+        _pVtRenderEngine->BeginResizeRequest();
+    }
+}
+
+// Method Description:
+// - Tell the vt renderer to end a resize operation.
+//   See BeginResize for more details.
+//   See GH#1795 for context on this method.
+// Arguments:
+// - <none>
+// Return Value:
+// - <none>
+void VtIo::EndResize()
+{
+    if (_pVtRenderEngine)
+    {
+        _pVtRenderEngine->EndResizeRequest();
+    }
+}

--- a/src/host/VtIo.hpp
+++ b/src/host/VtIo.hpp
@@ -36,6 +36,9 @@ namespace Microsoft::Console::VirtualTerminal
         void CloseInput() override;
         void CloseOutput() override;
 
+        void BeginResize();
+        void EndResize();
+
     private:
         // After CreateIoHandlers is called, these will be invalid.
         wil::unique_hfile _hInput;

--- a/src/renderer/vt/invalidate.cpp
+++ b/src/renderer/vt/invalidate.cpp
@@ -102,11 +102,19 @@ using namespace Microsoft::Console::Render;
 // - S_OK
 [[nodiscard]] HRESULT VtEngine::InvalidateCircling(_Out_ bool* const pForcePaint) noexcept
 {
-    *pForcePaint = true;
+    // If we're in the middle of a resize request, don't try to immediately start a frame.
+    if (_inResizeRequest)
+    {
+        *pForcePaint = false;
+    }
+    else
+    {
+        *pForcePaint = true;
 
-    // Keep track of the fact that we circled, we'll need to do some work on
-    //      end paint to specifically handle this.
-    _circled = true;
+        // Keep track of the fact that we circled, we'll need to do some work on
+        //      end paint to specifically handle this.
+        _circled = true;
+    }
 
     return S_OK;
 }

--- a/src/renderer/vt/state.cpp
+++ b/src/renderer/vt/state.cpp
@@ -54,6 +54,7 @@ VtEngine::VtEngine(_In_ wil::unique_hfile pipe,
     _terminalOwner{ nullptr },
     _newBottomLine{ false },
     _deferredCursorPos{ INVALID_COORDS },
+    _inResizeRequest{ false },
     _trace{}
 {
 #ifndef UNIT_TESTING
@@ -416,4 +417,32 @@ HRESULT VtEngine::RequestCursor() noexcept
     RETURN_IF_FAILED(_RequestCursor());
     RETURN_IF_FAILED(_Flush());
     return S_OK;
+}
+
+// Method Description:
+// - Tell the vt renderer to begin a resize operation. During a resize
+//   operation, the vt renderer should _not_ request to be repainted during a
+//   text buffer circling event. Any callers of this method should make sure to
+//   call EndResize to make sure the renderer returns to normal behavior.
+//   See GH#1795 for context on this method.
+// Arguments:
+// - <none>
+// Return Value:
+// - <none>
+void VtEngine::BeginResizeRequest()
+{
+    _inResizeRequest = true;
+}
+
+// Method Description:
+// - Tell the vt renderer to end a resize operation.
+//   See BeginResize for more details.
+//   See GH#1795 for context on this method.
+// Arguments:
+// - <none>
+// Return Value:
+// - <none>
+void VtEngine::EndResizeRequest()
+{
+    _inResizeRequest = false;
 }

--- a/src/renderer/vt/vtrenderer.hpp
+++ b/src/renderer/vt/vtrenderer.hpp
@@ -94,6 +94,8 @@ namespace Microsoft::Console::Render
         [[nodiscard]] virtual HRESULT WriteTerminalW(const std::wstring& str) noexcept = 0;
 
         void SetTerminalOwner(Microsoft::Console::ITerminalOwner* const terminalOwner);
+        void BeginResizeRequest();
+        void EndResizeRequest();
 
     protected:
         wil::unique_hfile _hFile;
@@ -132,6 +134,7 @@ namespace Microsoft::Console::Render
         Microsoft::Console::ITerminalOwner* _terminalOwner;
 
         Microsoft::Console::VirtualTerminal::RenderTracing _trace;
+        bool _inResizeRequest{ false };
 
         [[nodiscard]] HRESULT _Write(std::string_view const str) noexcept;
         [[nodiscard]] HRESULT _WriteFormattedString(const std::string* const pFormat, ...) noexcept;

--- a/src/terminal/adapter/InteractDispatch.cpp
+++ b/src/terminal/adapter/InteractDispatch.cpp
@@ -114,10 +114,8 @@ bool InteractDispatch::WindowManipulation(const DispatchTypes::WindowManipulatio
         }
         break;
     case DispatchTypes::WindowManipulationType::ResizeWindowInCharacters:
-        // TODO:GH#1765 This should BeginResize and EndResize, like the signal
-        // pipe does. Either that, or we should introduce a better
-        // `ResizeConpty` function to the ConGetSet interface, that specifically
-        // handles a conpty resize.
+        // TODO:GH#1765 We should introduce a better `ResizeConpty` function to
+        // the ConGetSet interface, that specifically handles a conpty resize.
         if (cParams == 2)
         {
             fSuccess = DispatchCommon::s_ResizeWindow(*_pConApi, rgusParams[1], rgusParams[0]);

--- a/src/terminal/adapter/InteractDispatch.cpp
+++ b/src/terminal/adapter/InteractDispatch.cpp
@@ -114,6 +114,10 @@ bool InteractDispatch::WindowManipulation(const DispatchTypes::WindowManipulatio
         }
         break;
     case DispatchTypes::WindowManipulationType::ResizeWindowInCharacters:
+        // TODO:GH#1765 This should BeginResize and EndResize, like the signal
+        // pipe does. Either that, or we should introduce a better
+        // `ResizeConpty` function to the ConGetSet interface, that specifically
+        // handles a conpty resize.
         if (cParams == 2)
         {
             fSuccess = DispatchCommon::s_ResizeWindow(*_pConApi, rgusParams[1], rgusParams[0]);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fixes a crash that occur when changing the buffer height. During the resize, conpty would immediately request a repaint, which would throw an exception that would cause the resize to fail halfway through, and that would make the subsequent render fail.

This change prevents the VT Renderer from immediately requesting a paint during the resize. 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

Might also be related to #1095. I can't seem to get that to repro anymore with this change.

Might be related to #1856. We should verify.

This does however make another issue more apparent. When you restore down with a COOKED_READ input line (read:cmd.exe), the terminal can crash. I have a fix for that in d34a3be, which I wasn't sure if I should include in this PR or not, because I wasn't confident that was the right fix. I'm fairly certain there's another issue floating around tracking that bug. We could either merge that commit/branch into this one, or wait and save it for a separate one. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1795 

