### PR TITLE
Fix the terminal snapping across DPI boundaries strangely.

### DIFF
--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -623,6 +623,12 @@ RECT NonClientIslandWindow::GetMaxWindowRectInPixels(const RECT* const prcSugges
             break;
         }
     }
+    case WM_DPICHANGED:
+    {
+        auto lprcNewScale = reinterpret_cast<RECT*>(lParam);
+        OnSize(RECT_WIDTH(lprcNewScale), RECT_HEIGHT(lprcNewScale));
+        break;
+    }
     }
 
     return IslandWindow::MessageHandler(message, wParam, lParam);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

When we snap across a DPI boundary, we'll get the DPI changed message _after_ the resize message. So when we try to calculate the new terminal position, we'll use the _old_ DPI to calculate the size. When snapping to a lower DPI, this means the terminal will be smaller, with "padding" all around the actual app. 

Instead, when we get a new DPI, force us to update out UI layout for the new DPI.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #2057
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [N/A] Tests added/passed

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Snapped the terminal a bunch back and forth on my monitors.

Checked this works fine for `showTabsInTitlebar: false`.

Tried snapping into corners from high to low back to high DPI
