### PR TITLE
Azure connector only shows up if available

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -1462,6 +1462,12 @@ namespace winrt::TerminalApp::implementation
         const auto* const profile = _settings->FindProfile(profileGuid);
         TerminalConnection::ITerminalConnection connection{ nullptr };
 
+        GUID connectionType{ 0 };
+        if (profile->HasConnectionType())
+        {
+            connectionType = profile->GetConnectionType();
+        }
+
         if (profile->HasConnectionType() && profile->GetConnectionType() == AzureConnectionType && TerminalConnection::AzureConnection::IsAzureConnectionAvailable())
         {
             connection = TerminalConnection::AzureConnection(settings.InitialRows(), settings.InitialCols());

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -1461,20 +1461,12 @@ namespace winrt::TerminalApp::implementation
     {
         const auto* const profile = _settings->FindProfile(profileGuid);
         TerminalConnection::ITerminalConnection connection{ nullptr };
-        // The Azure connection has a boost dependency, and boost does not support ARM64
-        // so we make sure that we do not try to compile the Azure connection code if we are in ARM64 (we would get build errors otherwise)
-        GUID connectionType{ 0 };
-        if (profile->HasConnectionType())
-        {
-            connectionType = profile->GetConnectionType();
-        }
-#ifndef _M_ARM64
-        if (connectionType == AzureConnectionType)
+
+        if (profile->HasConnectionType() && profile->GetConnectionType() == AzureConnectionType && TerminalConnection::AzureConnection::IsAzureConnectionAvailable())
         {
             connection = TerminalConnection::AzureConnection(settings.InitialRows(), settings.InitialCols());
         }
         else
-#endif
         {
             connection = TerminalConnection::ConhostConnection(settings.Commandline(), settings.StartingDirectory(), settings.InitialRows(), settings.InitialCols(), winrt::guid());
         }

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -9,6 +9,7 @@
 #include "CascadiaSettings.h"
 #include "../../types/inc/utils.hpp"
 #include "../../inc/DefaultSettings.h"
+#include "winrt/Microsoft.Terminal.TerminalConnection.h"
 
 using namespace winrt::Microsoft::Terminal::Settings;
 using namespace ::TerminalApp;
@@ -239,19 +240,6 @@ void CascadiaSettings::_CreateDefaultProfiles()
     powershellProfile.SetDefaultBackground(POWERSHELL_BLUE);
     powershellProfile.SetUseAcrylic(false);
 
-    // The Azure connection has a boost dependency, and boost does not support ARM64
-    // so we don't create a default profile for the Azure cloud shell if we're in ARM64
-#ifndef _M_ARM64
-    auto azureCloudShellProfile{ _CreateDefaultProfile(L"Azure Cloud Shell") };
-    azureCloudShellProfile.SetCommandline(L"Azure");
-    azureCloudShellProfile.SetStartingDirectory(DEFAULT_STARTING_DIRECTORY);
-    azureCloudShellProfile.SetColorScheme({ L"Solarized Dark" });
-    azureCloudShellProfile.SetAcrylicOpacity(0.85);
-    azureCloudShellProfile.SetUseAcrylic(true);
-    azureCloudShellProfile.SetCloseOnExit(false);
-    azureCloudShellProfile.SetConnectionType(AzureConnectionType);
-#endif
-
     // If the user has installed PowerShell Core, we add PowerShell Core as a default.
     // PowerShell Core default folder is "%PROGRAMFILES%\PowerShell\[Version]\".
     std::filesystem::path psCoreCmdline{};
@@ -274,9 +262,20 @@ void CascadiaSettings::_CreateDefaultProfiles()
 
     _profiles.emplace_back(powershellProfile);
     _profiles.emplace_back(cmdProfile);
-#ifndef _M_ARM64
-    _profiles.emplace_back(azureCloudShellProfile);
-#endif
+
+    if (winrt::Microsoft::Terminal::TerminalConnection::AzureConnection::IsAzureConnectionAvailable())
+    {
+        auto azureCloudShellProfile{ _CreateDefaultProfile(L"Azure Cloud Shell") };
+        azureCloudShellProfile.SetCommandline(L"Azure");
+        azureCloudShellProfile.SetStartingDirectory(DEFAULT_STARTING_DIRECTORY);
+        azureCloudShellProfile.SetColorScheme({ L"Vintage" });
+        azureCloudShellProfile.SetAcrylicOpacity(0.6);
+        azureCloudShellProfile.SetUseAcrylic(true);
+        azureCloudShellProfile.SetCloseOnExit(false);
+        azureCloudShellProfile.SetConnectionType(AzureConnectionType);
+        _profiles.emplace_back(azureCloudShellProfile);
+    }
+
     try
     {
         _AppendWslProfiles(_profiles);

--- a/src/cascadia/TerminalConnection/AzureConnection-ARM64.cpp
+++ b/src/cascadia/TerminalConnection/AzureConnection-ARM64.cpp
@@ -1,0 +1,47 @@
+#include "pch.h"
+#include "AzureConnection-ARM64.h"
+#include "AzureConnection.g.cpp"
+
+namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
+{
+    bool AzureConnection::IsAzureConnectionAvailable()
+    {
+        return false;
+    }
+    AzureConnection::AzureConnection(uint32_t rows, uint32_t columns)
+    {
+        throw hresult_not_implemented();
+    }
+    winrt::event_token AzureConnection::TerminalOutput(Microsoft::Terminal::TerminalConnection::TerminalOutputEventArgs const& handler)
+    {
+        throw hresult_not_implemented();
+    }
+    void AzureConnection::TerminalOutput(winrt::event_token const& token)
+    {
+        throw hresult_not_implemented();
+    }
+    winrt::event_token AzureConnection::TerminalDisconnected(Microsoft::Terminal::TerminalConnection::TerminalDisconnectedEventArgs const& handler)
+    {
+        throw hresult_not_implemented();
+    }
+    void AzureConnection::TerminalDisconnected(winrt::event_token const& token)
+    {
+        throw hresult_not_implemented();
+    }
+    void AzureConnection::Start()
+    {
+        throw hresult_not_implemented();
+    }
+    void AzureConnection::WriteInput(hstring const& data)
+    {
+        throw hresult_not_implemented();
+    }
+    void AzureConnection::Resize(uint32_t rows, uint32_t columns)
+    {
+        throw hresult_not_implemented();
+    }
+    void AzureConnection::Close()
+    {
+        throw hresult_not_implemented();
+    }
+}

--- a/src/cascadia/TerminalConnection/AzureConnection-ARM64.cpp
+++ b/src/cascadia/TerminalConnection/AzureConnection-ARM64.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 #include "pch.h"
 #include "AzureConnection-ARM64.h"
 #include "AzureConnection.g.cpp"

--- a/src/cascadia/TerminalConnection/AzureConnection-ARM64.h
+++ b/src/cascadia/TerminalConnection/AzureConnection-ARM64.h
@@ -1,5 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 #pragma once
 #include "AzureConnection.g.h"
+#include "pch.h"
 
 namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 {

--- a/src/cascadia/TerminalConnection/AzureConnection-ARM64.h
+++ b/src/cascadia/TerminalConnection/AzureConnection-ARM64.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "AzureConnection.g.h"
+
+namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
+{
+    struct AzureConnection : AzureConnectionT<AzureConnection>
+    {
+        AzureConnection() = default;
+
+        AzureConnection(uint32_t rows, uint32_t columns);
+        static bool IsAzureConnectionAvailable();
+        winrt::event_token TerminalOutput(Microsoft::Terminal::TerminalConnection::TerminalOutputEventArgs const& handler);
+        void TerminalOutput(winrt::event_token const& token);
+        winrt::event_token TerminalDisconnected(Microsoft::Terminal::TerminalConnection::TerminalDisconnectedEventArgs const& handler);
+        void TerminalDisconnected(winrt::event_token const& token);
+        void Start();
+        void WriteInput(hstring const& data);
+        void Resize(uint32_t rows, uint32_t columns);
+        void Close();
+    };
+}
+namespace winrt::Microsoft::Terminal::TerminalConnection::factory_implementation
+{
+    struct AzureConnection : AzureConnectionT<AzureConnection, implementation::AzureConnection>
+    {
+    };
+}

--- a/src/cascadia/TerminalConnection/AzureConnection.cpp
+++ b/src/cascadia/TerminalConnection/AzureConnection.cpp
@@ -26,6 +26,9 @@ using namespace winrt::Windows::Security::Credentials;
 namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 {
     // This file only builds for non-ARM64 so we don't need to check that here
+    // This function exists because the clientID only gets added by the release pipelines
+    // and is not available on local builds, so we want to be able to make sure we don't
+    // try to make an Azure connection if its a local build
     bool AzureConnection::IsAzureConnectionAvailable()
     {
         return (AzureClientID != L"0");

--- a/src/cascadia/TerminalConnection/AzureConnection.cpp
+++ b/src/cascadia/TerminalConnection/AzureConnection.cpp
@@ -25,6 +25,12 @@ using namespace winrt::Windows::Security::Credentials;
 
 namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 {
+    // This file only builds for non-ARM64 so we don't need to check that here
+    bool AzureConnection::IsAzureConnectionAvailable()
+    {
+        return (AzureClientID != L"0");
+    }
+
     AzureConnection::AzureConnection(const uint32_t initialRows, const uint32_t initialCols) :
         _initialRows{ initialRows },
         _initialCols{ initialCols }

--- a/src/cascadia/TerminalConnection/AzureConnection.h
+++ b/src/cascadia/TerminalConnection/AzureConnection.h
@@ -15,6 +15,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 {
     struct AzureConnection : AzureConnectionT<AzureConnection>
     {
+        static bool IsAzureConnectionAvailable();
         AzureConnection(const uint32_t rows, const uint32_t cols);
 
         winrt::event_token TerminalOutput(TerminalConnection::TerminalOutputEventArgs const& handler);

--- a/src/cascadia/TerminalConnection/AzureConnection.idl
+++ b/src/cascadia/TerminalConnection/AzureConnection.idl
@@ -8,7 +8,8 @@ namespace Microsoft.Terminal.TerminalConnection
     [default_interface] runtimeclass AzureConnection : ITerminalConnection
     {
         static Boolean IsAzureConnectionAvailable();
-		AzureConnection(UInt32 rows, UInt32 columns);
+
+	 AzureConnection(UInt32 rows, UInt32 columns);
     };
 
 }

--- a/src/cascadia/TerminalConnection/AzureConnection.idl
+++ b/src/cascadia/TerminalConnection/AzureConnection.idl
@@ -7,7 +7,8 @@ namespace Microsoft.Terminal.TerminalConnection
 {
     [default_interface] runtimeclass AzureConnection : ITerminalConnection
     {
-        AzureConnection(UInt32 rows, UInt32 columns);
+        static Boolean IsAzureConnectionAvailable();
+		AzureConnection(UInt32 rows, UInt32 columns);
     };
 
 }

--- a/src/cascadia/TerminalConnection/AzureConnection.idl
+++ b/src/cascadia/TerminalConnection/AzureConnection.idl
@@ -9,7 +9,7 @@ namespace Microsoft.Terminal.TerminalConnection
     {
         static Boolean IsAzureConnectionAvailable();
 
-	AzureConnection(UInt32 rows, UInt32 columns);
+        AzureConnection(UInt32 rows, UInt32 columns);
     };
 
 }

--- a/src/cascadia/TerminalConnection/AzureConnection.idl
+++ b/src/cascadia/TerminalConnection/AzureConnection.idl
@@ -9,7 +9,7 @@ namespace Microsoft.Terminal.TerminalConnection
     {
         static Boolean IsAzureConnectionAvailable();
 
-	 AzureConnection(UInt32 rows, UInt32 columns);
+	AzureConnection(UInt32 rows, UInt32 columns);
     };
 
 }

--- a/src/cascadia/TerminalConnection/TerminalConnection.vcxproj
+++ b/src/cascadia/TerminalConnection/TerminalConnection.vcxproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <ClInclude Include="AzureClientID.h" Condition="'$(Platform)'!='ARM64'" />
     <ClInclude Include="AzureConnection.h" Condition="'$(Platform)'!='ARM64'" />
+    <ClInclude Include="AzureConnection-ARM64.h" Condition="'$(Platform)'=='ARM64'" />
     <ClInclude Include="AzureConnectionStrings.h" Condition="'$(Platform)'!='ARM64'" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="ConhostConnection.h">
@@ -35,6 +36,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AzureConnection.cpp" Condition="'$(Platform)'!='ARM64'" />
+    <ClCompile Include="AzureConnection-ARM64.cpp" Condition="'$(Platform)'=='ARM64'" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
@@ -50,7 +52,7 @@
     <Midl Include="ITerminalConnection.idl" />
     <Midl Include="ConhostConnection.idl" />
     <Midl Include="EchoConnection.idl" />
-    <Midl Include="AzureConnection.idl" Condition="'$(Platform)'!='ARM64'" />
+    <Midl Include="AzureConnection.idl" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -337,11 +337,9 @@ bool Terminal::EraseInDisplay(const DispatchTypes::EraseType eraseType)
         // and we have to make sure we erase that text
         auto eraseStart = _mutableViewport.Height();
         auto eraseEnd = _buffer->GetLastNonSpaceCharacter(_mutableViewport).Y;
-        auto eraseIter = OutputCellIterator(UNICODE_SPACE, _buffer->GetCurrentAttributes(), _mutableViewport.RightInclusive() * (eraseEnd - eraseStart + 1));
         for (SHORT i = eraseStart; i <= eraseEnd; i++)
         {
-            COORD erasePos{ 0, i };
-            _buffer->Write(eraseIter, erasePos);
+            _buffer->GetRowByOffset(i).Reset(_buffer->GetCurrentAttributes());
         }
 
         // Reset the scroll offset now because there's nothing for the user to 'scroll' to

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -337,9 +337,11 @@ bool Terminal::EraseInDisplay(const DispatchTypes::EraseType eraseType)
         // and we have to make sure we erase that text
         auto eraseStart = _mutableViewport.Height();
         auto eraseEnd = _buffer->GetLastNonSpaceCharacter(_mutableViewport).Y;
+        auto eraseIter = OutputCellIterator(UNICODE_SPACE, _buffer->GetCurrentAttributes(), _mutableViewport.RightInclusive() * (eraseEnd - eraseStart + 1));
         for (SHORT i = eraseStart; i <= eraseEnd; i++)
         {
-            _buffer->GetRowByOffset(i).Reset(_buffer->GetCurrentAttributes());
+            COORD erasePos{ 0, i };
+            _buffer->Write(eraseIter, erasePos);
         }
 
         // Reset the scroll offset now because there's nothing for the user to 'scroll' to


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The Azure connection profile will not show up as an option anymore if the user is on an ARM64 build or if they're on a local build (and so they do not have the required clientID). 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #2170 
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
