### PR TITLE
Use ROW.Reset in EraseInDisplay instead of printing millions of spaces per line

### DIFF
--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -337,11 +337,9 @@ bool Terminal::EraseInDisplay(const DispatchTypes::EraseType eraseType)
         // and we have to make sure we erase that text
         auto eraseStart = _mutableViewport.Height();
         auto eraseEnd = _buffer->GetLastNonSpaceCharacter(_mutableViewport).Y;
-        auto eraseIter = OutputCellIterator(UNICODE_SPACE, _buffer->GetCurrentAttributes(), _mutableViewport.RightInclusive() * (eraseEnd - eraseStart + 1));
         for (SHORT i = eraseStart; i <= eraseEnd; i++)
         {
-            COORD erasePos{ 0, i };
-            _buffer->Write(eraseIter, erasePos);
+            _buffer->GetRowByOffset(i).Reset(_buffer->GetCurrentAttributes());
         }
 
         // Reset the scroll offset now because there's nothing for the user to 'scroll' to


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
EraseScrollback no longer hangs

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #2180 
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
