### PR TITLE
Correctly process composite characters in Terminal

### DIFF
--- a/src/cascadia/TerminalConnection/ConhostConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConhostConnection.cpp
@@ -168,7 +168,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
     DWORD ConhostConnection::_OutputThread()
     {
         UTF8OutPipeReader pipeReader{ _outPipe.get() };
-        std::string_view strView{};
+        std::wstring_view strView{};
 
         // process the data of the output pipe in a loop
         while (true)
@@ -192,7 +192,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             }
 
             // Convert buffer to hstring
-            auto hstr{ winrt::to_hstring(strView) };
+            winrt::hstring hstr{ strView };
 
             // Pass the output to our registered event handlers
             _outputHandlers(hstr);

--- a/src/types/UTF8OutPipeReader.cpp
+++ b/src/types/UTF8OutPipeReader.cpp
@@ -3,8 +3,6 @@
 
 #include "precomp.h"
 #include "inc/Utf8OutPipeReader.hpp"
-#include <type_traits>
-#include <utility>
 
 UTF8OutPipeReader::UTF8OutPipeReader(HANDLE outPipe) :
     _outPipe{ outPipe }
@@ -14,9 +12,10 @@ UTF8OutPipeReader::UTF8OutPipeReader(HANDLE outPipe) :
 // Method Description:
 //   Populates a string_view with *complete* UTF-8 codepoints read from the pipe.
 //   If it receives an incomplete codepoint, it will cache it until it can be completed.
+//   Furthermore it populates only complete composite characters.
 //   Note: This method trusts that the other end will, in fact, send complete codepoints.
 // Arguments:
-//   - strView: on return, populated with successfully-read codepoints.
+//   - utf8StrView: on return, populated with successfully-read codepoints.
 // Return Value:
 //   An HRESULT indicating whether the read was successful. For the purposes of this
 //   method, a closed pipe is considered a successful (but false!) read. All other errors
@@ -24,48 +23,69 @@ UTF8OutPipeReader::UTF8OutPipeReader(HANDLE outPipe) :
 //   S_OK for a successful read
 //   S_FALSE for a read on a closed pipe
 //   E_* (anything) for a failed read
-[[nodiscard]] HRESULT UTF8OutPipeReader::Read(_Out_ std::string_view& strView)
+[[nodiscard]] HRESULT UTF8OutPipeReader::Read(_Out_ std::string_view& utf8StrView)
 {
     DWORD dwRead{};
     bool fSuccess{};
+    bool fBufferFull{};
 
     // in case of early escaping
-    *_buffer = 0;
-    strView = std::string_view{ reinterpret_cast<char*>(_buffer), 0 };
+    utf8StrView = std::string_view{ reinterpret_cast<char*>(_buffer), 0 };
 
     // copy UTF-8 code units that were remaining from the previously read chunk (if any)
+    if (_dwNonCombiningLen != 0)
+    {
+        std::move(_utf8NonCombining, _utf8NonCombining + _dwNonCombiningLen, _buffer);
+    }
+
     if (_dwPartialsLen != 0)
     {
-        std::move(_utf8Partials, _utf8Partials + _dwPartialsLen, _buffer);
+        std::move(_utf8Partials, _utf8Partials + _dwPartialsLen, _buffer + _dwNonCombiningLen);
     }
 
     // try to read data
-    fSuccess = !!ReadFile(_outPipe, &_buffer[_dwPartialsLen], std::extent<decltype(_buffer)>::value - _dwPartialsLen, &dwRead, nullptr);
-
-    dwRead += _dwPartialsLen;
-    _dwPartialsLen = 0;
+    fSuccess = !!ReadFile(_outPipe, &_buffer[_dwNonCombiningLen + _dwPartialsLen], std::extent<decltype(_buffer)>::value - _dwNonCombiningLen - _dwPartialsLen, &dwRead, nullptr);
 
     if (!fSuccess) // reading failed (we must check this first, because dwRead will also be 0.)
     {
         auto lastError = GetLastError();
-        if (lastError == ERROR_BROKEN_PIPE)
+
+        // This is a serous reading error.
+        if (lastError != ERROR_BROKEN_PIPE)
         {
-            // This is a successful, but detectable, exit.
-            // There is a chance that we put some partials into the buffer. Since
-            // the pipe has closed, they're just invalid now. They're not worth
-            // reporting.
+            return HRESULT_FROM_WIN32(lastError);
+        }
+
+        // This is a successful, but detectable, exit.
+        // There is a chance that we put some partials into the buffer. Since
+        // the pipe has closed, they're just invalid now. They're not worth
+        // reporting.
+        if (_dwNonCombiningLen == 0)
+        {
+            _dwPartialsLen = 0;
             return S_FALSE;
         }
 
-        return HRESULT_FROM_WIN32(lastError);
+        // At that point we ignore partials and leave only the cached last character.
+        dwRead += _dwNonCombiningLen;
     }
+    else
+    {
+        dwRead += _dwNonCombiningLen + _dwPartialsLen;
+    }
+
+    _dwPartialsLen = 0;
+    _dwNonCombiningLen = 0;
 
     if (dwRead == 0) // quit if no data has been read and no cached data was left over
     {
         return S_OK;
     }
 
-    const BYTE* const endPtr{ _buffer + dwRead };
+    fBufferFull = (std::extent<decltype(_buffer)>::value == dwRead);
+
+    // Cache UTF-8 partials from the end of the chunk read, if any
+    const BYTE* endPtr{ _buffer + dwRead };
     const BYTE* backIter{ endPtr - 1 };
     // If the last byte in the buffer was a byte belonging to a UTF-8 multi-byte character
     if ((*backIter & _Utf8BitMasks::MaskAsciiByte) > _Utf8BitMasks::IsAsciiByte)
@@ -92,7 +112,141 @@ UTF8OutPipeReader::UTF8OutPipeReader(HANDLE outPipe) :
         }
     }
 
-    // give back a view of the part of the buffer that contains complete code points only
-    strView = std::string_view{ reinterpret_cast<char*>(_buffer), dwRead };
+    // Composite characters are expected only from external sources like files. Thus, split composite
+    //  characters may only appear if a big amount of data fills the buffer at once. This is only
+    //  situation where we cache the last character, too.
+    // This caching must not be applied to keyboard input because it would lead to an delay of one
+    //  key stroke between input and output.
+    if (fBufferFull)
+    {
+        endPtr = _buffer + dwRead;
+        backIter = endPtr - 1;
+        // Check up to 4 last bytes for the begin of the last complete character
+        for (DWORD dwSequenceLen{ 1UL }, stop{ dwRead < 5UL ? dwRead : 5UL }; dwSequenceLen < stop; ++dwSequenceLen, --backIter)
+        {
+            // If either an ASCII byte or a Lead Byte is found
+            if ((*backIter & _Utf8BitMasks::MaskAsciiByte) == _Utf8BitMasks::IsAsciiByte || (*backIter & _Utf8BitMasks::MaskContinuationByte) > _Utf8BitMasks::IsContinuationByte)
+            {
+                // If the character is either of the Combining Diacritical Marks then don't cache it
+                if (dwSequenceLen == 2)
+                {
+                    if (std::memcmp(backIter, _combiningMarks.diacriticalBasic.first, dwSequenceLen) >= 0 && std::memcmp(backIter, _combiningMarks.diacriticalBasic.last, dwSequenceLen) <= 0)
+                    {
+                        break;
+                    }
+                }
+                else if (dwSequenceLen == 3)
+                {
+                    if ((std::memcmp(backIter, _combiningMarks.diacriticalExtended.first, dwSequenceLen) >= 0 && std::memcmp(_combiningMarks.diacriticalExtended.last, backIter, dwSequenceLen) <= 0) ||
+                        (std::memcmp(backIter, _combiningMarks.diacriticalSupplement.first, dwSequenceLen) >= 0 && std::memcmp(backIter, _combiningMarks.diacriticalSupplement.last, dwSequenceLen) <= 0) ||
+                        (std::memcmp(backIter, _combiningMarks.diacriticalForSymbols.first, dwSequenceLen) >= 0 && std::memcmp(backIter, _combiningMarks.diacriticalForSymbols.last, dwSequenceLen) <= 0) ||
+                        (std::memcmp(backIter, _combiningMarks.halfMarks.first, dwSequenceLen) >= 0 && std::memcmp(backIter, _combiningMarks.halfMarks.last, dwSequenceLen) <= 0))
+                    {
+                        break;
+                    }
+                }
+
+                // otherwise cache it
+                std::move(backIter, endPtr, _utf8NonCombining);
+                dwRead -= dwSequenceLen;
+                _dwNonCombiningLen = dwSequenceLen;
+                break;
+            }
+        }
+    }
+
+    // populate a view of the part of the buffer that contains only complete code points and complete composite characters
+    utf8StrView = std::string_view{ reinterpret_cast<char*>(_buffer), dwRead };
+    return S_OK;
+}
+
+// Method Description:
+//   Populates a wstring_view with *complete* UTF-16 codepoints read and converted from the pipe.
+//   Calls the Read() overload for UTF-8, and _UTF8ToUtf16Precomposed() for the converson to UTF-16.
+//   Note: This method trusts that the other end will, in fact, send complete codepoints.
+// Arguments:
+//   - utf16StrView: on return, populated with successfully-read and converted codepoints.
+// Return Value:
+//   An HRESULT indicating whether both read and conversion were successful. For the purposes of this
+//   method, a closed pipe is considered a successful (but false!) read. All other errors
+//   are translated into an appropriate status code.
+//   S_OK for a successful read and conversion
+//   S_FALSE for a read on a closed pipe
+//   E_* (anything) for a failed read or conversion
+[[nodiscard]] HRESULT UTF8OutPipeReader::Read(_Out_ std::wstring_view& utf16StrView)
+{
+    std::string_view utf8StrView{};
+    utf16StrView = std::wstring_view{ _precomposedBuffer.get(), 0 };
+    HRESULT hr{ Read(utf8StrView) };
+    RETURN_HR_IF(hr, hr != S_OK);
+    return _UTF8ToUtf16Precomposed(utf8StrView, utf16StrView);
+}
+
+// Method Description:
+// - Takes a UTF-8 string,
+//   allocates memory for the conversions,
+//   performs the conversion to UTF-16,
+//   converts base + combining characters to the canonical precomposed equivalents,
+//   and populates the UTF-16 result as wide string.
+//   Note: This routine trusts that the caller passed complete codepoints and
+//         complete composite characters (if any).
+// Arguments:
+// - utf8StrView - Taken view of characters of UTF-8 source text.
+// - utf16StrView - Populated view of characters of UTF-16 target text.
+// Return Value:
+//   S_OK for a successful conversion
+//   E_* (anything) for a bad allocation or a failed conversion
+[[nodiscard]] HRESULT UTF8OutPipeReader::_UTF8ToUtf16Precomposed(_In_ const std::string_view utf8StrView, _Out_ std::wstring_view& utf16StrView)
+{
+    if (utf8StrView.empty())
+    {
+        utf16StrView = std::wstring_view{ _precomposedBuffer.get(), 0 };
+        return S_OK;
+    }
+
+    int utf8Size{};
+    size_t utf16Size{};
+
+    // The length must not exceed the maximum value of an int because both MultiByteToWideChar and FoldStringW use int to represent the size.
+    RETURN_IF_FAILED(SizeTToInt(utf8StrView.length(), &utf8Size));
+
+    // Convert UTF-8 to UTF-16.
+    int convertedSize = MultiByteToWideChar(static_cast<UINT>(CP_UTF8), 0UL, utf8StrView.data(), utf8Size, nullptr, 0);
+    RETURN_LAST_ERROR_IF(0 == convertedSize);
+    RETURN_IF_FAILED(IntToSizeT(convertedSize, &utf16Size));
+    if (_convertedCapacity < utf16Size)
+    {
+        _convertedBuffer.reset(new (std::nothrow) wchar_t[utf16Size]);
+        if (nullptr == _convertedBuffer.get())
+        {
+            _convertedCapacity = 0;
+            return E_OUTOFMEMORY;
+        }
+
+        _convertedCapacity = utf16Size;
+    }
+
+    RETURN_LAST_ERROR_IF(0 == MultiByteToWideChar(static_cast<UINT>(CP_UTF8), 0UL, utf8StrView.data(), utf8Size, _convertedBuffer.get(), convertedSize));
+
+    // Convert each base + combining characters to the canonical precomposed equivalent.
+    // TODO: Should we pass MAP_FOLDCZONE rather than MAP_PRECOMPOSED to address compatibility characters, too?
+    int precomposedSize{ FoldStringW(static_cast<DWORD>(MAP_PRECOMPOSED), _convertedBuffer.get(), convertedSize, nullptr, 0) };
+    RETURN_LAST_ERROR_IF(0 == precomposedSize);
+    RETURN_IF_FAILED(IntToSizeT(precomposedSize, &utf16Size));
+    if (_precomposedCapacity < utf16Size)
+    {
+        _precomposedBuffer.reset(new (std::nothrow) wchar_t[utf16Size]);
+        if (nullptr == _precomposedBuffer.get())
+        {
+            _precomposedCapacity = 0;
+            return E_OUTOFMEMORY;
+        }
+
+        _precomposedCapacity = utf16Size;
+    }
+
+    RETURN_LAST_ERROR_IF(0 == FoldStringW(static_cast<DWORD>(MAP_PRECOMPOSED), _convertedBuffer.get(), convertedSize, _precomposedBuffer.get(), precomposedSize));
+
+    utf16StrView = std::wstring_view{ _precomposedBuffer.get(), utf16Size };
     return S_OK;
 }

--- a/src/types/ut_types/UTF8OutPipeReaderTests.cpp
+++ b/src/types/ut_types/UTF8OutPipeReaderTests.cpp
@@ -34,16 +34,16 @@ class UTF8OutPipeReaderTests
         //  represent the bytes of the base + combining characters. The digits 1 to 4 represent the four
         //  bytes of the 'Hwair' letter. The vertical bar represents the buffer boundary. The horizontal
         //  bars represent the expected boundaries of populated UTF-8 chunks.
-        // Test  1: [more points] . . P a b c 1 2 3 4-Q|R S T U V W X Y Z . .-.
-        // Test  2: [more points] . . P Q a b c-1 2 3 4|R S T U V W X Y Z . .-.
-        // Test  3: [more points] . . P Q R a b c-1 2 3|4 S T U V W X Y Z . .-.
-        // Test  4: [more points] . . P Q R S a b c-1 2|3 4 T U V W X Y Z . .-.
-        // Test  5: [more points] . . P Q R S T a b c-1|2 3 4 U V W X Y Z . .-.
-        // Test  6: [more points] . . P Q R S T U a b c+1 2 3 4 V W X Y Z . .-.
-        // Test  7: [more points] . . P Q R S T U V-a b|c 1 2 3 4 W X Y Z . .-.
-        // Test  8: [more points] . . P Q R S T U V W-a|b c 1 2 3 4 X Y Z . .-.
-        // Test  9: [more points] . . P Q R S T U V W-X|a b c 1 2 3 4 Y Z . .-.
-        // Test 10: [more points] . . P Q R S T U V W-X|Y a b c 1 2 3 4 Z . .-.
+        // Test  1: [more points] . . P a b c 1 2 3 4-Q|R S T U V W X Y Z . . .
+        // Test  2: [more points] . . P Q a b c-1 2 3 4|R S T U V W X Y Z . . .
+        // Test  3: [more points] . . P Q R a b c-1 2 3|4 S T U V W X Y Z . . .
+        // Test  4: [more points] . . P Q R S a b c-1 2|3 4 T U V W X Y Z . . .
+        // Test  5: [more points] . . P Q R S T a b c-1|2 3 4 U V W X Y Z . . .
+        // Test  6: [more points] . . P Q R S T U a b c+1 2 3 4 V W X Y Z . . .
+        // Test  7: [more points] . . P Q R S T U V-a b|c 1 2 3 4 W X Y Z . . .
+        // Test  8: [more points] . . P Q R S T U V W-a|b c 1 2 3 4 X Y Z . . .
+        // Test  9: [more points] . . P Q R S T U V W-X|a b c 1 2 3 4 Y Z . . .
+        // Test 10: [more points] . . P Q R S T U V W-X|Y a b c 1 2 3 4 Z . . .
         //
         // At the beginning of a test the whole string is converted into a std::wstring containing the
         //  UTF-16 target for reference.

--- a/src/types/ut_types/UTF8OutPipeReaderTests.cpp
+++ b/src/types/ut_types/UTF8OutPipeReaderTests.cpp
@@ -7,9 +7,6 @@
 
 #include "..\inc\UTF8OutPipeReader.hpp"
 
-#include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.Foundation.Collections.h>
-
 using namespace WEX::Common;
 using namespace WEX::Logging;
 using namespace WEX::TestExecution;
@@ -20,71 +17,92 @@ class UTF8OutPipeReaderTests
 
     TEST_METHOD(TestUtf8MergePartials)
     {
-        // The test uses the character 'GOTHIC LETTER HWAIR' (U+10348) as an example
+        // The test uses the base character 'a' + 'COMBINING DIAERESIS' (U+0308) as an example for a composite character
+        // Their UTF-8 representation consists of three bytes:
+        //   a    b    c
+        // 0x61 0xCC 0x88
+        //
+        // And the character 'GOTHIC LETTER HWAIR' (U+10348) as an example for a UTF-8 multi-byte character
         // Its UTF-8 representation consists of four bytes:
         //   1    2    3    4
         // 0xF0 0x90 0x8D 0x88
         //
-        // For the test a std::string is filled with 4104 '.' characters to make sure it exceeds the
+        // For the test a std::string is filled with 4108 '.' characters to make sure it exceeds the
         //  buffer size of 4096 bytes in UTF8OutPipeReader.
         //
-        // This figure shows how the string is getting changed for the 7 sub-tests. The digits 1 to 4
-        //  represent the four bytes of the 'Hwair' letter. The vertical bar represents the buffer boundary.
-        // Test 1: [more points] . . S 1 2 3 4 T|U V W X Y Z . .
-        // Test 2: [more points] . . S T 1 2 3 4|U V W X Y Z . .
-        // Test 3: [more points] . . S T U 1 2 3|4 V W X Y Z . .
-        // Test 4: [more points] . . S T U V 1 2|3 4 W X Y Z . .
-        // Test 5: [more points] . . S T U V W 1|2 3 4 X Y Z . .
-        // Test 6: [more points] . . S T U V W X|1 2 3 4 Y Z . .
-        // Test 7: [more points] . . S T U V W X|Y 1 2 3 4 Z . .
+        // This figure shows how the string is getting changed for the 10 sub-tests. The letters a to c
+        //  represent the bytes of the base + combining characters. The digits 1 to 4 represent the four
+        //  bytes of the 'Hwair' letter. The vertical bar represents the buffer boundary. The horizontal
+        //  bars represent the expected boundaries of populated UTF-8 chunks.
+        // Test  1: [more points] . . P a b c 1 2 3 4-Q|R S T U V W X Y Z . .-.
+        // Test  2: [more points] . . P Q a b c-1 2 3 4|R S T U V W X Y Z . .-.
+        // Test  3: [more points] . . P Q R a b c-1 2 3|4 S T U V W X Y Z . .-.
+        // Test  4: [more points] . . P Q R S a b c-1 2|3 4 T U V W X Y Z . .-.
+        // Test  5: [more points] . . P Q R S T a b c-1|2 3 4 U V W X Y Z . .-.
+        // Test  6: [more points] . . P Q R S T U a b c+1 2 3 4 V W X Y Z . .-.
+        // Test  7: [more points] . . P Q R S T U V-a b|c 1 2 3 4 W X Y Z . .-.
+        // Test  8: [more points] . . P Q R S T U V W-a|b c 1 2 3 4 X Y Z . .-.
+        // Test  9: [more points] . . P Q R S T U V W-X|a b c 1 2 3 4 Y Z . .-.
+        // Test 10: [more points] . . P Q R S T U V W-X|Y a b c 1 2 3 4 Z . .-.
         //
-        // Tests 1, 6, and 7 prove proper ASCII handling.
-        // Test 2 leaves all four bytes of 'Hwair' in the first chunk.
-        // Test 3, 4, and 5 move the partials from the end of the first chunk to the begin of the
-        //  second chunk.
-        //
-        // At the beginning of a test the whole string is converted into a winrt::hstring for reference.
-        // During the test a second hstring is concatenated out of the chunks that we get from
-        //  UTF8OutPipeReader::Read. Each chunk is separately converted to hstring in order to make
-        //  sure it would be corrupted if we get UTF-8 partials.
-        // The test is positive if both hstrings are equal.
+        // At the beginning of a test the whole string is converted into a std::wstring containing the
+        //  UTF-16 target for reference.
+        // During the test a second wstring is concatenated out of the chunks that we get from
+        //  UTF8OutPipeReader::Read(). Each chunk is separately converted to wstring in order to
+        //  make sure it would be corrupted if we get UTF-8 partials or split composite characters.
+        // The test is positive if both wstrings are equal.
 
         const size_t bufferSize{ 4096 }; // NOTE: This has to match the buffer size in UTF8OutPipeReader!
-        std::string utf8TestString(bufferSize + 8, '.'); // create a test string with the required size
+        std::string utf8TestString(bufferSize + 12, '.'); // create a test string with the required size
 
         // Test 1:
-        //                                                           ||
-        utf8TestString.replace(bufferSize - 6, 12, "S\xF0\x90\x8D\x88TUVWXYZ");
+        //                                                                       ||
+        utf8TestString.replace(bufferSize - 9, 18, "P\x61\xCC\x88\xF0\x90\x8D\x88QRSTUVWXYZ");
         VERIFY_SUCCEEDED(RunTest(utf8TestString));
 
         // Test 2:
-        //                                                          | |
-        utf8TestString.replace(bufferSize - 6, 12, "ST\xF0\x90\x8D\x88UVWXYZ");
+        //                                                                      | |
+        utf8TestString.replace(bufferSize - 9, 18, "PQ\x61\xCC\x88\xF0\x90\x8D\x88RSTUVWXYZ");
         VERIFY_SUCCEEDED(RunTest(utf8TestString));
 
         // Test 3:
-        //                                                       |   |
-        utf8TestString.replace(bufferSize - 6, 12, "STU\xF0\x90\x8D\x88VWXYZ");
+        //                                                                   |   |
+        utf8TestString.replace(bufferSize - 9, 18, "PQR\x61\xCC\x88\xF0\x90\x8D\x88STUVWXYZ");
         VERIFY_SUCCEEDED(RunTest(utf8TestString));
 
         // Test 4:
-        //                                                    |   |
-        utf8TestString.replace(bufferSize - 6, 12, "STUV\xF0\x90\x8D\x88WXYZ");
+        //                                                                |   |
+        utf8TestString.replace(bufferSize - 9, 18, "PQRS\x61\xCC\x88\xF0\x90\x8D\x88TUVWXYZ");
         VERIFY_SUCCEEDED(RunTest(utf8TestString));
 
         // Test 5:
-        //                                                 |   |
-        utf8TestString.replace(bufferSize - 6, 12, "STUVW\xF0\x90\x8D\x88XYZ");
+        //                                                             |   |
+        utf8TestString.replace(bufferSize - 9, 18, "PQRST\x61\xCC\x88\xF0\x90\x8D\x88UVWXYZ");
         VERIFY_SUCCEEDED(RunTest(utf8TestString));
 
         // Test 6:
-        //                                               |  |
-        utf8TestString.replace(bufferSize - 6, 12, "STUVWX\xF0\x90\x8D\x88YZ");
+        //                                                          |   |
+        utf8TestString.replace(bufferSize - 9, 18, "PQRSTU\x61\xCC\x88\xF0\x90\x8D\x88VWXYZ");
         VERIFY_SUCCEEDED(RunTest(utf8TestString));
 
         // Test 7:
-        //                                               ||
-        utf8TestString.replace(bufferSize - 6, 12, "STUVWXY\xF0\x90\x8D\x88Z");
+        //                                                       |   |
+        utf8TestString.replace(bufferSize - 9, 18, "PQRSTUV\x61\xCC\x88\xF0\x90\x8D\x88WXYZ");
+        VERIFY_SUCCEEDED(RunTest(utf8TestString));
+
+        // Test 8:
+        //                                                    |   |
+        utf8TestString.replace(bufferSize - 9, 18, "PQRSTUVW\x61\xCC\x88\xF0\x90\x8D\x88XYZ");
+        VERIFY_SUCCEEDED(RunTest(utf8TestString));
+
+        // Test 9:
+        //                                                  |  |
+        utf8TestString.replace(bufferSize - 9, 18, "PQRSTUVWX\x61\xCC\x88\xF0\x90\x8D\x88YZ");
+        VERIFY_SUCCEEDED(RunTest(utf8TestString));
+
+        // Test 10:
+        //                                                  ||
+        utf8TestString.replace(bufferSize - 9, 18, "PQRSTUVWXY\x61\xCC\x88\xF0\x90\x8D\x88Z");
         VERIFY_SUCCEEDED(RunTest(utf8TestString));
     }
 
@@ -109,10 +127,6 @@ class UTF8OutPipeReaderTests
     // Performs the sub-tests.
     HRESULT RunTest(std::string& utf8TestString)
     {
-        std::string_view strView{}; // contains the chunk that we get from UTF8OutPipeReader::Read
-        const winrt::hstring utf16Expected{ winrt::to_hstring(utf8TestString) }; // contains the whole string converted to UTF-16
-        winrt::hstring utf16Actual{}; // will be concatenated from the converted chunks
-
         wil::unique_hfile outPipe{};
         wil::unique_hfile inPipe{};
 
@@ -121,30 +135,35 @@ class UTF8OutPipeReaderTests
 
         UTF8OutPipeReader reader{ outPipe.get() };
 
-        ThreadData data{ inPipe, utf8TestString };
+        std::wstring_view utf16StrView{};
+        THROW_IF_FAILED(reader._UTF8ToUtf16Precomposed(utf8TestString, utf16StrView));
+        const std::wstring utf16Expected{ utf16StrView }; // contains the whole string converted to UTF-16
+        std::wstring utf16Actual{}; // will be concatenated from the converted chunks
 
+        ThreadData data{ inPipe, utf8TestString };
         wil::unique_handle threadHandle{ CreateThread(nullptr, 0, WritePipeThread, &data, 0, nullptr) }; // create a thread that writes to the pipe
         RETURN_HR_IF_NULL(E_FAIL, threadHandle.get());
 
-        // process the chunks that we get from UTF8OutPipeReader::Read
+        // process the chunks that we get from UTF8OutPipeReader::GetUtf16Precomposed
         while (true)
         {
-            // get a chunk of UTF-8 data
-            THROW_IF_FAILED(reader.Read(strView));
+            // get a chunk of data
+            HRESULT hr = reader.Read(utf16StrView);
+            THROW_IF_FAILED(hr);
 
-            if (strView.empty())
+            if (utf16StrView.empty() || hr == S_FALSE)
             {
-                // this is okay, no data left in the pipe
+                // this is okay, no data was left or the pipe was closed
                 break;
             }
 
-            // convert the chunk to hstring and append it to the resulting hstring
-            utf16Actual = utf16Actual + winrt::to_hstring(strView);
+            // append the chunk to the resulting wstring
+            utf16Actual += utf16StrView;
         }
 
         WaitForSingleObject(threadHandle.get(), 2000);
 
-        // the test passed if both hstrings are equal
+        // the test passed if both wstrings are equal
         if (utf16Actual == utf16Expected)
         {
             return S_OK;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Convert composite characters to their precomposed equivalents in the Windows Terminal to avoid faulty output.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

Potentially closes #2003, but I'm not familiar with emacs and thus, I only printed the content of the mentioned `re.rs` file to the Terminal in my tests.
![pws](https://user-images.githubusercontent.com/46659645/62416304-63c83600-b638-11e9-93c4-eb6721344e47.png)
![wsl](https://user-images.githubusercontent.com/46659645/62416308-72165200-b638-11e9-92d7-49f7ea85ba8f.png)  
  
  
Briefly discussed in the latest comments in #1850.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #2003 (partially)
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [X] Tests added/passed
* [ ] Requires documentation to be updated
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1850

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The `winrt::to_hstring` method has been used to convert UTF-8 to UTF-16. This method does not convert composite characters to their precomposed equivalents.
This PR extends the `UTF8OutPipeReader` class with an overload of the `Read` method that takes a reference of a `std::wsting_view` variable which receives the chunks read out of the pipe, already converted to UTF-16. The conversion makes composite characters to their precomposed equivalents.
Furthermore the class methods take care that composite characters don't get split into different chunks.

That's possibly the last thing we can do using conversions of the text data.
- We have the conversion of UTF-8 to UTF-16. This changes the encoding but leaves the codepoints the same.
- Now we have the conversion of composite characters to precomposed characters, too. This leaves the encoding UTF-16 but changes the code points.
- The updated code can only solve display problems where a precomposed character for a pair of base and combining character exists. That means, a conversion is only possible if another code point for the composite characters exists.
- It can't solve problems caused by grapheme clusters in general. E.g. combinations with a non-spacing mark where no precomposed character exists will still consist of two characters in the output. Also zero-width characters (such as the byte order mark) still take the width of a character in the output. Things like intersecting base characters with non-spacing marks is a graphical task. It can't be done using conversions of the text data anymore.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- A lot of manual tests where I used `UTF8OutPipeReader` in a separate code which displayed the chunk boudaries and the bytes that belong to them, which displayed the converted text, and the return values of the methods.
- Manual tests in the Terminal to see how it behaves using keyboard input and redirected input from files and sockets.
- I updated `UTF8OutPipeReaderTest` to address the new features, and successfully run the unit test.
