### PR TITLE
Fixed Ctrl+Alt shortcuts conflicting with AltGr

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -164,6 +164,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         static Windows::UI::Xaml::Thickness _ParseThicknessFromPadding(const hstring padding);
 
         ::Microsoft::Terminal::Core::ControlKeyStates _GetPressedModifierKeys() const;
+        void _HandleVoidKeyEvent();
+        bool _TrySendKeyEvent(WORD vkey, ::Microsoft::Terminal::Core::ControlKeyStates modifiers);
 
         const COORD _GetTerminalPosition(winrt::Windows::Foundation::Point cursorPosition);
         const unsigned int _NumberOfClicks(winrt::Windows::Foundation::Point clickPos, Timestamp clickTime);

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -210,18 +210,6 @@ bool Terminal::SendKeyEvent(const WORD vkey, const ControlKeyStates states)
         _NotifyScrollEvent();
     }
 
-    // AltGr key combinations don't always contain any meaningful,
-    // pretranslated unicode character during WM_KEYDOWN.
-    // E.g. on a German keyboard AltGr+Q should result in a "@" character,
-    // but actually results in "Q" with Alt and Ctrl modifier states.
-    // By returning false though, we can abort handling this WM_KEYDOWN
-    // event and let the WM_CHAR handler kick in, which will be
-    // provided with an appropriate unicode character.
-    if (states.IsAltGrPressed())
-    {
-        return false;
-    }
-
     // Alt key sequences _require_ the char to be in the keyevent. If alt is
     // pressed, manually get the character that's being typed, and put it in the
     // KeyEvent.


### PR DESCRIPTION
## Summary of the Pull Request

This moves the detection of AltGr keypresses in front of the shortcut handling.
This allows one to have Ctrl+Alt shortcuts, while simultaneously being able to use the AltGr key for special characters.

## References

This fixes a regression in v0.3.2142.0, which automatically creates `Ctrl+Alt+[0-9]` shortcuts for switching between tabs. These conflicted with the detection of the AltGr key. in `SendKeyEvent()`.
Refixes #521.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #521, Closes #2254
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments

This PR has the flaw that it doesn't allow one to define AltGr shortcuts anymore.
Considering that it's probably more important to get a fix out of the door quickly I personally see this as a minor flaw though. VS Code has the same "flaw" for instance and doesn't allow AltGr combinations either.
We could fix it more correctly later on, by modifying the `IKeyBindings` interface and `KeyChord` class.

## Validation Steps Performed

* Enter AltGr-characters on my german keyboard and ensuring they appear in my shell.
* Ensure that `Ctrl+Alt+[0-9]` shortcuts simultaneously work.