### PR TITLE
Prevent unwanted debug logs when calling _DoGetConsoleInput

### DIFF
--- a/src/host/directio.cpp
+++ b/src/host/directio.cpp
@@ -273,13 +273,18 @@ void EventsToUnicode(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& inEvents,
 {
     try
     {
-        RETURN_NTSTATUS(_DoGetConsoleInput(context,
-                                           outEvents,
-                                           eventsToRead,
-                                           readHandleState,
-                                           false,
-                                           true,
-                                           waiter));
+        NTSTATUS Status = _DoGetConsoleInput(context,
+                                             outEvents,
+                                             eventsToRead,
+                                             readHandleState,
+                                             false,
+                                             true,
+                                             waiter);
+        if (CONSOLE_STATUS_WAIT == Status)
+        {
+            return HRESULT_FROM_NT(Status);
+        }
+        RETURN_NTSTATUS(Status);
     }
     CATCH_RETURN();
 }
@@ -308,13 +313,18 @@ void EventsToUnicode(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& inEvents,
 {
     try
     {
-        RETURN_NTSTATUS(_DoGetConsoleInput(context,
-                                           outEvents,
-                                           eventsToRead,
-                                           readHandleState,
-                                           true,
-                                           true,
-                                           waiter));
+        NTSTATUS Status = _DoGetConsoleInput(context,
+                                             outEvents,
+                                             eventsToRead,
+                                             readHandleState,
+                                             true,
+                                             true,
+                                             waiter);
+        if (CONSOLE_STATUS_WAIT == Status)
+        {
+            return HRESULT_FROM_NT(Status);
+        }
+        RETURN_NTSTATUS(Status);
     }
     CATCH_RETURN();
 }
@@ -343,13 +353,18 @@ void EventsToUnicode(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& inEvents,
 {
     try
     {
-        RETURN_NTSTATUS(_DoGetConsoleInput(context,
-                                           outEvents,
-                                           eventsToRead,
-                                           readHandleState,
-                                           false,
-                                           false,
-                                           waiter));
+        NTSTATUS Status = _DoGetConsoleInput(context,
+                                             outEvents,
+                                             eventsToRead,
+                                             readHandleState,
+                                             false,
+                                             false,
+                                             waiter);
+        if (CONSOLE_STATUS_WAIT == Status)
+        {
+            return HRESULT_FROM_NT(Status);
+        }
+        RETURN_NTSTATUS(Status);
     }
     CATCH_RETURN();
 }
@@ -378,13 +393,18 @@ void EventsToUnicode(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& inEvents,
 {
     try
     {
-        RETURN_NTSTATUS(_DoGetConsoleInput(context,
-                                           outEvents,
-                                           eventsToRead,
-                                           readHandleState,
-                                           true,
-                                           false,
-                                           waiter));
+        NTSTATUS Status = _DoGetConsoleInput(context,
+                                             outEvents,
+                                             eventsToRead,
+                                             readHandleState,
+                                             true,
+                                             false,
+                                             waiter);
+        if (CONSOLE_STATUS_WAIT == Status)
+        {
+            return HRESULT_FROM_NT(Status);
+        }
+        RETURN_NTSTATUS(Status);
     }
     CATCH_RETURN();
 }


### PR DESCRIPTION
## Summary of the Pull Request

The `_DoGetConsoleInput` method is documented as returning `STATUS_SUCCESS` if data was found, and `CONSOLE_STATUS_WAIT` if there wasn't enough data or it needed to block. While the latter is an expected response, the fact that its high bit is set means it is treated as an error, generating many unwanted logs in the debug output window. This PR makes sure that the `CONSOLE_STATUS_WAIT` response is never logged as an error.

## PR Checklist
* [x] Closes #2075
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #2075

## Detailed Description of the Pull Request / Additional comments

The `_DoGetConsoleInput` is called from four places in the `ApiRoutines` class. In each case, the `NTSTATUS` response is returned via the `RETURN_NTSTATUS` macro, which is what currently generates the debug logs. This PR simply adds a check before the `RETURN_NTSTATUS` call to handle the `CONSOLE_STATUS_WAIT` as a special case, and return it directly (using `HRESULT_FROM_NT` to convert the `NTSTATUS` to an `HRESULT`).

I considered using the `RETURN_IF_FAILED_WITH_EXPECTED` macro for this, but it expects an `HRESULT` rather than an `NTSTATUS`, which means first converting the status with `wil::details::NtStatusToHr` to match the existing behaviour, and also converting the `CONSOLE_STATUS_WAIT` in order to compare it as an `HRESULT`. In the end it's not really simpler than an extra comparison step, doesn't seem quite as clear, and doesn't exactly match the existing behaviour.

## Validation Steps Performed

I ran the code from within the Visual Studio debugger and confirmed that it no longer generated a lot of debug logs when typing in a conhost WSL shell.