### PR TITLE
Update bug template with crash instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -26,6 +26,8 @@ This bug tracker is monitored by Windows Terminal development team and other tec
 **Important: When reporting BSODs or security issues, DO NOT attach memory dumps, logs, or traces to Github issues**.
 Instead, send dumps/traces to secure@microsoft.com, referencing this GitHub issue.
 
+If this is an application crash, please also provide a Feedback Hub submission link so we can find your diagnostic data on the backend. Use the category "Apps > Windows Terminal (Preview)" and choose "Share My Feedback" after submission to get the link.
+
 Please use this form and describe your issue, concisely but precisely, with as much detail as possible.
 
 -->


### PR DESCRIPTION
I learned that it is easier to find crash analysis data from a Feedback Hub link than anything else. Updates the bug template to ask users with application crashes to please make a feedback hub item so we can find diagnostic data more easily.