### PR TITLE
Attempt to clean up PCHs as we build to leave more Hosted Agent disk space

### DIFF
--- a/src/common.build.post.props
+++ b/src/common.build.post.props
@@ -30,7 +30,7 @@
   <PropertyGroup>
     <CAExcludePath>$(SolutionDir)\dep\;$(CAExcludePath)</CAExcludePath>
   </PropertyGroup>
-  <Target Name="CleanUpPrecompForSmallCIAgents" AfterTargets="AfterBuild">
+  <Target Name="CleanUpPrecompForSmallCIAgents" AfterTargets="AfterBuild" Condition="'$(AGENT_ID)' != ''">
     <ItemGroup>
       <FilesToClean Include="$(IntDir)\**\*.pch" />
       <FilesToClean Include="$(IntDir)\**\precomp.obj" />

--- a/src/common.build.post.props
+++ b/src/common.build.post.props
@@ -36,5 +36,6 @@
       <FilesToClean Include="$(IntDir)\**\precomp.obj" />
     </ItemGroup>
     <Delete Files="@(FilesToClean)"/>
+    <Message Text="PCH and Precomp objects have been deleted for $(ProjectName)." />
   </Target>
 </Project>

--- a/src/common.build.post.props
+++ b/src/common.build.post.props
@@ -30,4 +30,11 @@
   <PropertyGroup>
     <CAExcludePath>$(SolutionDir)\dep\;$(CAExcludePath)</CAExcludePath>
   </PropertyGroup>
+  <Target Name="CleanUpPrecompForSmallCIAgents" AfterTargets="AfterBuild">
+    <ItemGroup>
+      <FilesToClean Include="$(IntDir)\**\*.pch" />
+      <FilesToClean Include="$(IntDir)\**\precomp.obj" />
+    </ItemGroup>
+    <Delete Files="@(FilesToClean)"/>
+  </Target>
 </Project>


### PR DESCRIPTION
This cleans up PCHs on CI machines only as builds continue to attempt to mitigate the 10GB maximum scratch space limitation.


