### PR TITLE
add exclusion directories to PR builds, not just rolling builds.

### DIFF
--- a/build/pipelines/ci.yml
+++ b/build/pipelines/ci.yml
@@ -13,6 +13,11 @@ pr:
   branches:
     include:
       - master
+  paths:
+    exclude:
+      - doc/*
+      - samples/*
+      - tools/*
 
 #     0.0.yyMM.dd##
 #     0.0.1904.0900


### PR DESCRIPTION
Changing docs is still causing a full 30 minute PR build. This should stop it by copying the exclusion pattern for directories down from the rolling build to the PR build too.