### PR TITLE
Accessibility: Refactor IRenderData with IUiaData

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1393,7 +1393,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     //    and get text to appear on separate lines.
     bool TermControl::CopySelectionToClipboard(bool trimTrailingWhitespace)
     {
-        if (_terminal != nullptr && _terminal->IsAreaSelected())
+        if (_terminal != nullptr && _terminal->IsSelectionActive())
         {
             // extract text from buffer
             const auto copiedData = _terminal->RetrieveSelectedTextFromBuffer(trimTrailingWhitespace);

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -347,7 +347,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         return winrt::make<winrt::Microsoft::Terminal::TerminalControl::implementation::TermControlAutomationPeer>(*this);
     }
 
-    ::Microsoft::Console::Render::IRenderData* TermControl::GetRenderData() const
+    ::Microsoft::Console::Types::IUiaData* TermControl::GetUiaData() const
     {
         return _terminal.get();
     }

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -54,7 +54,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         ~TermControl();
 
         Windows::UI::Xaml::Automation::Peers::AutomationPeer OnCreateAutomationPeer();
-        ::Microsoft::Console::Render::IRenderData* GetRenderData() const;
+        ::Microsoft::Console::Types::IUiaData* GetUiaData() const;
 
         static Windows::Foundation::Point GetProposedDimensions(Microsoft::Terminal::Settings::IControlSettings const& settings, const uint32_t dpi);
 

--- a/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
+++ b/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
@@ -29,7 +29,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 {
     TermControlAutomationPeer::TermControlAutomationPeer(winrt::Microsoft::Terminal::TerminalControl::implementation::TermControl const& owner) :
         TermControlAutomationPeerT<TermControlAutomationPeer>(owner), // pass owner to FrameworkElementAutomationPeer
-        _uiaProvider{ owner.GetRenderData(), nullptr, std::bind(&TermControlAutomationPeer::GetBoundingRectWrapped, this) } {};
+        _uiaProvider{ owner.GetUiaData(), nullptr, std::bind(&TermControlAutomationPeer::GetBoundingRectWrapped, this) } {};
 
     winrt::hstring TermControlAutomationPeer::GetClassNameCore() const
     {

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -88,7 +88,7 @@ public:
     int GetScrollOffset() override;
 #pragma endregion
 
-#pragma region IBaseData (base to IRenderData and IUiaData)
+#pragma region IBaseData(base to IRenderData and IUiaData)
     Microsoft::Console::Types::Viewport GetViewport() noexcept override;
     const TextBuffer& GetTextBuffer() noexcept override;
     const FontInfo& GetFontInfo() noexcept override;

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -116,7 +116,7 @@ public:
 
 #pragma region IUiaData
     std::vector<Microsoft::Console::Types::Viewport> GetSelectionRects() noexcept override;
-    bool IsAreaSelected() const override;
+    const bool IsSelectionActive() const noexcept;
     void ClearSelection() override;
     void SelectNewRegion(const COORD coordStart, const COORD coordEnd) override;
 
@@ -146,7 +146,6 @@ public:
 
 #pragma region TextSelection
     // These methods are defined in TerminalSelection.cpp
-    const bool IsSelectionActive() const noexcept;
     void DoubleClickSelection(const COORD position);
     void TripleClickSelection(const COORD position);
     void SetSelectionAnchor(const COORD position);

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -11,6 +11,7 @@
 #include "../../terminal/input/terminalInput.hpp"
 
 #include "../../types/inc/Viewport.hpp"
+#include "../../types/IUiaData.h"
 #include "../../cascadia/terminalcore/ITerminalApi.hpp"
 #include "../../cascadia/terminalcore/ITerminalInput.hpp"
 
@@ -30,7 +31,8 @@ namespace Microsoft::Terminal::Core
 class Microsoft::Terminal::Core::Terminal final :
     public Microsoft::Terminal::Core::ITerminalApi,
     public Microsoft::Terminal::Core::ITerminalInput,
-    public Microsoft::Console::Render::IRenderData
+    public Microsoft::Console::Render::IRenderData,
+    public Microsoft::Console::Types::IUiaData
 {
 public:
     Terminal();
@@ -86,11 +88,17 @@ public:
     int GetScrollOffset() override;
 #pragma endregion
 
-#pragma region IRenderData
-    // These methods are defined in TerminalRenderData.cpp
+#pragma region IBaseData (base to IRenderData and IUiaData)
     Microsoft::Console::Types::Viewport GetViewport() noexcept override;
     const TextBuffer& GetTextBuffer() noexcept override;
     const FontInfo& GetFontInfo() noexcept override;
+
+    void LockConsole() noexcept override;
+    void UnlockConsole() noexcept override;
+#pragma endregion
+
+#pragma region IRenderData
+    // These methods are defined in TerminalRenderData.cpp
     const TextAttribute GetDefaultBrushColors() noexcept override;
     const COLORREF GetForegroundColor(const TextAttribute& attr) const noexcept override;
     const COLORREF GetBackgroundColor(const TextAttribute& attr) const noexcept override;
@@ -104,6 +112,9 @@ public:
     bool IsCursorDoubleWidth() const noexcept override;
     const std::vector<Microsoft::Console::Render::RenderOverlay> GetOverlays() const noexcept override;
     const bool IsGridLineDrawingAllowed() noexcept override;
+#pragma endregion
+
+#pragma region IUiaData
     std::vector<Microsoft::Console::Types::Viewport> GetSelectionRects() noexcept override;
     bool IsAreaSelected() const override;
     void ClearSelection() override;
@@ -118,13 +129,11 @@ public:
                           _Outptr_result_maybenull_ ITextRangeProvider** ppRetVal,
                           unsigned int _start,
                           unsigned int _end,
-                          std::function<unsigned int(IRenderData*, const COORD)> _coordToEndpoint,
-                          std::function<COORD(IRenderData*, const unsigned int)> _endpointToCoord,
+                          std::function<unsigned int(IUiaData*, const COORD)> _coordToEndpoint,
+                          std::function<COORD(IUiaData*, const unsigned int)> _endpointToCoord,
                           std::function<IFACEMETHODIMP(ITextRangeProvider**)> Clone) override;
 
     const std::wstring GetConsoleTitle() const noexcept override;
-    void LockConsole() noexcept override;
-    void UnlockConsole() noexcept override;
 #pragma endregion
 
     void SetWriteInputCallback(std::function<void(std::wstring&)> pfn) noexcept;

--- a/src/cascadia/TerminalCore/terminalrenderdata.cpp
+++ b/src/cascadia/TerminalCore/terminalrenderdata.cpp
@@ -117,11 +117,6 @@ std::vector<Microsoft::Console::Types::Viewport> Terminal::GetSelectionRects() n
     return result;
 }
 
-bool Terminal::IsAreaSelected() const
-{
-    return _selectionActive;
-}
-
 void Terminal::SelectNewRegion(const COORD coordStart, const COORD coordEnd)
 {
     SetSelectionAnchor(coordStart);

--- a/src/cascadia/TerminalCore/terminalrenderdata.cpp
+++ b/src/cascadia/TerminalCore/terminalrenderdata.cpp
@@ -137,8 +137,8 @@ HRESULT Terminal::SearchForText(_In_ BSTR /*text*/,
                                 _Outptr_result_maybenull_ ITextRangeProvider** /*ppRetVal*/,
                                 unsigned int /*_start*/,
                                 unsigned int /*_end*/,
-                                std::function<unsigned int(IRenderData*, const COORD)> /*_coordToEndpoint*/,
-                                std::function<COORD(IRenderData*, const unsigned int)> /*_endpointToCoord*/,
+                                std::function<unsigned int(IUiaData*, const COORD)> /*_coordToEndpoint*/,
+                                std::function<COORD(IUiaData*, const unsigned int)> /*_endpointToCoord*/,
                                 std::function<IFACEMETHODIMP(ITextRangeProvider**)> /*Clone*/)
 {
     return E_NOTIMPL;

--- a/src/host/renderData.cpp
+++ b/src/host/renderData.cpp
@@ -343,7 +343,7 @@ const COLORREF RenderData::GetBackgroundColor(const TextAttribute& attr) const n
 // - <none>
 // Return Value:
 // - True if the selection variables contain valid selection data. False otherwise.
-bool RenderData::IsAreaSelected() const
+const bool RenderData::IsSelectionActive() const
 {
     return Selection::Instance().IsAreaSelected();
 }

--- a/src/host/renderData.cpp
+++ b/src/host/renderData.cpp
@@ -7,8 +7,8 @@
 
 #include "dbcs.h"
 #include "handle.h"
-
 #include "..\interactivity\inc\ServiceLocator.hpp"
+
 #include "search.h"
 #include "..\types\UiaTextRange.hpp"
 
@@ -16,6 +16,8 @@
 
 using namespace Microsoft::Console::Types;
 using Microsoft::Console::Interactivity::ServiceLocator;
+
+#pragma region IBaseData
 // Routine Description:
 // - Retrieves the viewport that applies over the data available in the GetTextBuffer() call
 // Return Value:
@@ -47,6 +49,48 @@ const FontInfo& RenderData::GetFontInfo() noexcept
     return gci.GetActiveOutputBuffer().GetCurrentFont();
 }
 
+// Method Description:
+// - Retrieves one rectangle per line describing the area of the viewport
+//   that should be highlighted in some way to represent a user-interactive selection
+// Return Value:
+// - Vector of Viewports describing the area selected
+std::vector<Viewport> RenderData::GetSelectionRects() noexcept
+{
+    std::vector<Viewport> result;
+
+    try
+    {
+        for (const auto& select : Selection::Instance().GetSelectionRects())
+        {
+            result.emplace_back(Viewport::FromInclusive(select));
+        }
+    }
+    CATCH_LOG();
+
+    return result;
+}
+
+// Method Description:
+// - Lock the console for reading the contents of the buffer. Ensures that the
+//      contents of the console won't be changed in the middle of a paint
+//      operation.
+//   Callers should make sure to also call RenderData::UnlockConsole once
+//      they're done with any querying they need to do.
+void RenderData::LockConsole() noexcept
+{
+    ::LockConsole();
+}
+
+// Method Description:
+// - Unlocks the console after a call to RenderData::LockConsole.
+void RenderData::UnlockConsole() noexcept
+{
+    ::UnlockConsole();
+}
+
+#pragma endregion
+
+#pragma region IRenderData
 // Routine Description:
 // - Retrieves the brush colors that should be used in absence of any other color data from
 //   cells in the text buffer.
@@ -227,115 +271,6 @@ bool RenderData::IsCursorDoubleWidth() const noexcept
     return gci.GetActiveOutputBuffer().CursorIsDoubleWidth();
 }
 
-// Method Description:
-// - Retrieves one rectangle per line describing the area of the viewport
-//   that should be highlighted in some way to represent a user-interactive selection
-// Return Value:
-// - Vector of Viewports describing the area selected
-std::vector<Viewport> RenderData::GetSelectionRects() noexcept
-{
-    std::vector<Viewport> result;
-
-    try
-    {
-        for (const auto& select : Selection::Instance().GetSelectionRects())
-        {
-            result.emplace_back(Viewport::FromInclusive(select));
-        }
-    }
-    CATCH_LOG();
-
-    return result;
-}
-
-// Routine Description:
-// - Determines whether the selection area is empty.
-// Arguments:
-// - <none>
-// Return Value:
-// - True if the selection variables contain valid selection data. False otherwise.
-bool RenderData::IsAreaSelected() const
-{
-    return Selection::Instance().IsAreaSelected();
-}
-
-// Routine Description:
-// - If a selection exists, clears it and restores the state.
-//   Will also unblock a blocked write if one exists.
-// Arguments:
-// - <none> (Uses global state)
-// Return Value:
-// - <none>
-void RenderData::ClearSelection()
-{
-    Selection::Instance().ClearSelection();
-}
-
-// Routine Description:
-// - Resets the current selection and selects a new region from the start to end coordinates
-// Arguments:
-// - coordStart - Position to start selection area from
-// - coordEnd - Position to select up to
-// Return Value:
-// - <none>
-void RenderData::SelectNewRegion(const COORD coordStart, const COORD coordEnd)
-{
-    Selection::Instance().SelectNewRegion(coordStart, coordEnd);
-}
-
-// TODO GitHub #605: Search functionality
-// For now, just adding it here to make UiaTextRange easier to create (Accessibility)
-// We should actually abstract this out better once Windows Terminal has Search
-HRESULT RenderData::SearchForText(_In_ BSTR text,
-                                  _In_ BOOL searchBackward,
-                                  _In_ BOOL ignoreCase,
-                                  _Outptr_result_maybenull_ ITextRangeProvider** ppRetVal,
-                                  unsigned int _start,
-                                  unsigned int _end,
-                                  std::function<unsigned int(IRenderData*, const COORD)> _coordToEndpoint,
-                                  std::function<COORD(IRenderData*, const unsigned int)> _endpointToCoord,
-                                  std::function<IFACEMETHODIMP(ITextRangeProvider**)> Clone)
-{
-    typedef unsigned int Endpoint;
-
-    const std::wstring wstr{ text, SysStringLen(text) };
-    const auto sensitivity = ignoreCase ? Search::Sensitivity::CaseInsensitive : Search::Sensitivity::CaseSensitive;
-
-    auto searchDirection = Search::Direction::Forward;
-    Endpoint searchAnchor = _start;
-    if (searchBackward)
-    {
-        searchDirection = Search::Direction::Backward;
-        searchAnchor = _end;
-    }
-
-    CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
-    THROW_HR_IF(E_POINTER, !gci.HasActiveOutputBuffer());
-    const auto& screenInfo = gci.GetActiveOutputBuffer().GetActiveBuffer();
-
-    Search searcher{ screenInfo, wstr, searchDirection, sensitivity, _endpointToCoord(this, searchAnchor) };
-
-    HRESULT hr = S_OK;
-    if (searcher.FindNext())
-    {
-        const auto foundLocation = searcher.GetFoundLocation();
-        const Endpoint start = _coordToEndpoint(this, foundLocation.first);
-        const Endpoint end = _coordToEndpoint(this, foundLocation.second);
-        // make sure what was found is within the bounds of the current range
-        if ((searchDirection == Search::Direction::Forward && end < _end) ||
-            (searchDirection == Search::Direction::Backward && start > _start))
-        {
-            hr = Clone(ppRetVal);
-            if (SUCCEEDED(hr))
-            {
-                UiaTextRange& range = static_cast<UiaTextRange&>(**ppRetVal);
-                range.SetRangeValues(start, end, false);
-            }
-        }
-    }
-    return hr;
-}
-
 // Routine Description:
 // - Checks the user preference as to whether grid line drawing is allowed around the edges of each cell.
 // - This is for backwards compatibility with old behaviors in the legacy console.
@@ -399,21 +334,94 @@ const COLORREF RenderData::GetBackgroundColor(const TextAttribute& attr) const n
     const CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     return gci.LookupBackgroundColor(attr);
 }
+#pragma endregion
 
-// Method Description:
-// - Lock the console for reading the contents of the buffer. Ensures that the
-//      contents of the console won't be changed in the middle of a paint
-//      operation.
-//   Callers should make sure to also call RenderData::UnlockConsole once
-//      they're done with any querying they need to do.
-void RenderData::LockConsole() noexcept
+#pragma region IUiaData
+// Routine Description:
+// - Determines whether the selection area is empty.
+// Arguments:
+// - <none>
+// Return Value:
+// - True if the selection variables contain valid selection data. False otherwise.
+bool RenderData::IsAreaSelected() const
 {
-    ::LockConsole();
+    return Selection::Instance().IsAreaSelected();
 }
 
-// Method Description:
-// - Unlocks the console after a call to RenderData::LockConsole.
-void RenderData::UnlockConsole() noexcept
+// Routine Description:
+// - If a selection exists, clears it and restores the state.
+//   Will also unblock a blocked write if one exists.
+// Arguments:
+// - <none> (Uses global state)
+// Return Value:
+// - <none>
+void RenderData::ClearSelection()
 {
-    ::UnlockConsole();
+    Selection::Instance().ClearSelection();
 }
+
+// Routine Description:
+// - Resets the current selection and selects a new region from the start to end coordinates
+// Arguments:
+// - coordStart - Position to start selection area from
+// - coordEnd - Position to select up to
+// Return Value:
+// - <none>
+void RenderData::SelectNewRegion(const COORD coordStart, const COORD coordEnd)
+{
+    Selection::Instance().SelectNewRegion(coordStart, coordEnd);
+}
+
+// TODO GitHub #605: Search functionality
+// For now, just adding it here to make UiaTextRange easier to create (Accessibility)
+// We should actually abstract this out better once Windows Terminal has Search
+HRESULT RenderData::SearchForText(_In_ BSTR text,
+                               _In_ BOOL searchBackward,
+                               _In_ BOOL ignoreCase,
+                               _Outptr_result_maybenull_ ITextRangeProvider** ppRetVal,
+                               unsigned int _start,
+                               unsigned int _end,
+                               std::function<unsigned int(IUiaData*, const COORD)> _coordToEndpoint,
+                               std::function<COORD(IUiaData*, const unsigned int)> _endpointToCoord,
+                               std::function<IFACEMETHODIMP(ITextRangeProvider**)> Clone)
+{
+    typedef unsigned int Endpoint;
+
+    const std::wstring wstr{ text, SysStringLen(text) };
+    const auto sensitivity = ignoreCase ? Search::Sensitivity::CaseInsensitive : Search::Sensitivity::CaseSensitive;
+
+    auto searchDirection = Search::Direction::Forward;
+    Endpoint searchAnchor = _start;
+    if (searchBackward)
+    {
+        searchDirection = Search::Direction::Backward;
+        searchAnchor = _end;
+    }
+
+    CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
+    THROW_HR_IF(E_POINTER, !gci.HasActiveOutputBuffer());
+    const auto& screenInfo = gci.GetActiveOutputBuffer().GetActiveBuffer();
+
+    Search searcher{ screenInfo, wstr, searchDirection, sensitivity, _endpointToCoord(this, searchAnchor) };
+
+    HRESULT hr = S_OK;
+    if (searcher.FindNext())
+    {
+        const auto foundLocation = searcher.GetFoundLocation();
+        const Endpoint start = _coordToEndpoint(this, foundLocation.first);
+        const Endpoint end = _coordToEndpoint(this, foundLocation.second);
+        // make sure what was found is within the bounds of the current range
+        if ((searchDirection == Search::Direction::Forward && end < _end) ||
+            (searchDirection == Search::Direction::Backward && start > _start))
+        {
+            hr = Clone(ppRetVal);
+            if (SUCCEEDED(hr))
+            {
+                UiaTextRange& range = static_cast<UiaTextRange&>(**ppRetVal);
+                range.SetRangeValues(start, end, false);
+            }
+        }
+    }
+    return hr;
+}
+#pragma endregion

--- a/src/host/renderData.cpp
+++ b/src/host/renderData.cpp
@@ -376,14 +376,14 @@ void RenderData::SelectNewRegion(const COORD coordStart, const COORD coordEnd)
 // For now, just adding it here to make UiaTextRange easier to create (Accessibility)
 // We should actually abstract this out better once Windows Terminal has Search
 HRESULT RenderData::SearchForText(_In_ BSTR text,
-                               _In_ BOOL searchBackward,
-                               _In_ BOOL ignoreCase,
-                               _Outptr_result_maybenull_ ITextRangeProvider** ppRetVal,
-                               unsigned int _start,
-                               unsigned int _end,
-                               std::function<unsigned int(IUiaData*, const COORD)> _coordToEndpoint,
-                               std::function<COORD(IUiaData*, const unsigned int)> _endpointToCoord,
-                               std::function<IFACEMETHODIMP(ITextRangeProvider**)> Clone)
+                                  _In_ BOOL searchBackward,
+                                  _In_ BOOL ignoreCase,
+                                  _Outptr_result_maybenull_ ITextRangeProvider** ppRetVal,
+                                  unsigned int _start,
+                                  unsigned int _end,
+                                  std::function<unsigned int(IUiaData*, const COORD)> _coordToEndpoint,
+                                  std::function<COORD(IUiaData*, const unsigned int)> _endpointToCoord,
+                                  std::function<IFACEMETHODIMP(ITextRangeProvider**)> Clone)
 {
     typedef unsigned int Endpoint;
 

--- a/src/host/renderData.hpp
+++ b/src/host/renderData.hpp
@@ -56,7 +56,7 @@ public:
 #pragma endregion
 
 #pragma region IUiaData
-    bool IsAreaSelected() const override;
+    const bool IsSelectionActive() const override;
     void ClearSelection() override;
     void SelectNewRegion(const COORD coordStart, const COORD coordEnd) override;
 

--- a/src/host/renderData.hpp
+++ b/src/host/renderData.hpp
@@ -15,13 +15,25 @@ Author(s):
 #pragma once
 
 #include "..\renderer\inc\IRenderData.hpp"
+#include "..\types\IUiaData.h"
 
-class RenderData final : public Microsoft::Console::Render::IRenderData
+class RenderData final :
+    public Microsoft::Console::Render::IRenderData,
+    public Microsoft::Console::Types::IUiaData
 {
 public:
+#pragma region BaseData
     Microsoft::Console::Types::Viewport GetViewport() noexcept override;
     const TextBuffer& GetTextBuffer() noexcept override;
     const FontInfo& GetFontInfo() noexcept override;
+
+    std::vector<Microsoft::Console::Types::Viewport> GetSelectionRects() noexcept override;
+
+    void LockConsole() noexcept override;
+    void UnlockConsole() noexcept override;
+#pragma endregion
+
+#pragma region IRenderData
     const TextAttribute GetDefaultBrushColors() noexcept override;
 
     const COLORREF GetForegroundColor(const TextAttribute& attr) const noexcept override;
@@ -40,7 +52,10 @@ public:
 
     const bool IsGridLineDrawingAllowed() noexcept override;
 
-    std::vector<Microsoft::Console::Types::Viewport> GetSelectionRects() noexcept override;
+    const std::wstring GetConsoleTitle() const noexcept override;
+#pragma endregion
+
+#pragma region IUiaData
     bool IsAreaSelected() const override;
     void ClearSelection() override;
     void SelectNewRegion(const COORD coordStart, const COORD coordEnd) override;
@@ -54,12 +69,8 @@ public:
                           _Outptr_result_maybenull_ ITextRangeProvider** ppRetVal,
                           unsigned int _start,
                           unsigned int _end,
-                          std::function<unsigned int(IRenderData*, const COORD)> _coordToEndpoint,
-                          std::function<COORD(IRenderData*, const unsigned int)> _endpointToCoord,
+                          std::function<unsigned int(IUiaData*, const COORD)> _coordToEndpoint,
+                          std::function<COORD(IUiaData*, const unsigned int)> _endpointToCoord,
                           std::function<IFACEMETHODIMP(ITextRangeProvider**)> Clone);
-
-    const std::wstring GetConsoleTitle() const noexcept override;
-
-    void LockConsole() noexcept override;
-    void UnlockConsole() noexcept override;
+#pragma endregion
 };

--- a/src/interactivity/win32/windowUiaProvider.cpp
+++ b/src/interactivity/win32/windowUiaProvider.cpp
@@ -5,6 +5,7 @@
 #include "windowUiaProvider.hpp"
 #include "../types/ScreenInfoUiaProvider.h"
 
+#include "../types/IUiaData.h"
 #include "../host/renderData.hpp"
 #include "../inc/ServiceLocator.hpp"
 
@@ -35,9 +36,9 @@ WindowUiaProvider* WindowUiaProvider::Create(IConsoleWindow* baseWindow)
 
         Globals& g = ServiceLocator::LocateGlobals();
         CONSOLE_INFORMATION& gci = g.getConsoleInformation();
-        Microsoft::Console::Render::IRenderData* renderData = &gci.renderData;
+        IUiaData* uiaData = &gci.renderData;
 
-        pScreenInfoProvider = new Microsoft::Console::Types::ScreenInfoUiaProvider(renderData, pWindowProvider);
+        pScreenInfoProvider = new Microsoft::Console::Types::ScreenInfoUiaProvider(uiaData, pWindowProvider);
         pWindowProvider->_pScreenInfoProvider = pScreenInfoProvider;
 
         // TODO GitHub #1914: Re-attach Tracing to UIA Tree

--- a/src/renderer/inc/IRenderData.hpp
+++ b/src/renderer/inc/IRenderData.hpp
@@ -16,11 +16,9 @@ Author(s):
 
 #include "../../host/conimeinfo.h"
 #include "../../buffer/out/TextAttribute.hpp"
-#include "../../types/inc/viewport.hpp"
+#include "../../types/IBaseData.h"
 
-class TextBuffer;
 class Cursor;
-struct ITextRangeProvider;
 
 namespace Microsoft::Console::Render
 {
@@ -39,13 +37,10 @@ namespace Microsoft::Console::Render
         const Microsoft::Console::Types::Viewport region;
     };
 
-    class IRenderData
+    class IRenderData : public Microsoft::Console::Types::IBaseData
     {
     public:
         virtual ~IRenderData() = 0;
-        virtual Microsoft::Console::Types::Viewport GetViewport() noexcept = 0;
-        virtual const TextBuffer& GetTextBuffer() noexcept = 0;
-        virtual const FontInfo& GetFontInfo() noexcept = 0;
         virtual const TextAttribute GetDefaultBrushColors() noexcept = 0;
 
         virtual const COLORREF GetForegroundColor(const TextAttribute& attr) const noexcept = 0;
@@ -63,30 +58,7 @@ namespace Microsoft::Console::Render
         virtual const std::vector<RenderOverlay> GetOverlays() const noexcept = 0;
 
         virtual const bool IsGridLineDrawingAllowed() noexcept = 0;
-
-        // TODO GitHub #1992: Move some of these functions to IAccessibilityData (or IUiaData)
-        virtual std::vector<Microsoft::Console::Types::Viewport> GetSelectionRects() noexcept = 0;
-        virtual bool IsAreaSelected() const = 0;
-        virtual void ClearSelection() = 0;
-        virtual void SelectNewRegion(const COORD coordStart, const COORD coordEnd) = 0;
-
-        // TODO GitHub #605: Search functionality
-        // For now, just adding it here to make UiaTextRange easier to create (Accessibility)
-        // We should actually abstract this out better once Windows Terminal has Search
-        virtual HRESULT SearchForText(_In_ BSTR text,
-                                      _In_ BOOL searchBackward,
-                                      _In_ BOOL ignoreCase,
-                                      _Outptr_result_maybenull_ ITextRangeProvider** ppRetVal,
-                                      unsigned int _start,
-                                      unsigned int _end,
-                                      std::function<unsigned int(IRenderData*, const COORD)> _coordToEndpoint,
-                                      std::function<COORD(IRenderData*, const unsigned int)> _endpointToCoord,
-                                      std::function<IFACEMETHODIMP(ITextRangeProvider**)> Clone) = 0;
-
         virtual const std::wstring GetConsoleTitle() const noexcept = 0;
-
-        virtual void LockConsole() noexcept = 0;
-        virtual void UnlockConsole() noexcept = 0;
     };
 
     // See docs/virtual-dtors.md for an explanation of why this is weird.

--- a/src/types/IBaseData.h
+++ b/src/types/IBaseData.h
@@ -1,0 +1,39 @@
+/*++
+Copyright (c) Microsoft Corporation
+Licensed under the MIT license.
+
+Module Name:
+- IUiaData.hpp
+
+Abstract:
+- This serves as the interface defining all information needed for the UI Automation Tree and the Renderer
+
+Author(s):
+- Carlos Zamora (CaZamor) Aug-2019
+--*/
+
+#pragma once
+
+#include "inc/viewport.hpp"
+
+class TextBuffer;
+
+namespace Microsoft::Console::Types
+{
+    class IBaseData
+    {
+    public:
+        virtual ~IBaseData() = 0;
+        virtual Microsoft::Console::Types::Viewport GetViewport() noexcept = 0;
+        virtual const TextBuffer& GetTextBuffer() noexcept = 0;
+        virtual const FontInfo& GetFontInfo() noexcept = 0;
+
+        virtual std::vector<Microsoft::Console::Types::Viewport> GetSelectionRects() noexcept = 0;
+
+        virtual void LockConsole() noexcept = 0;
+        virtual void UnlockConsole() noexcept = 0;
+    };
+
+    // See docs/virtual-dtors.md for an explanation of why this is weird.
+    inline IBaseData::~IBaseData() {}
+}

--- a/src/types/IUiaData.h
+++ b/src/types/IUiaData.h
@@ -1,0 +1,48 @@
+/*++
+Copyright (c) Microsoft Corporation
+Licensed under the MIT license.
+
+Module Name:
+- IUiaData.hpp
+
+Abstract:
+- This serves as the interface defining all information needed for the UI Automation Tree
+
+Author(s):
+- Carlos Zamora (CaZamor) Aug-2019
+--*/
+
+#pragma once
+
+#include "IBaseData.h"
+
+struct ITextRangeProvider;
+
+namespace Microsoft::Console::Types
+{
+    class IUiaData : public IBaseData
+    {
+    public:
+        virtual ~IUiaData() = 0;
+        // TODO GitHub #1992: Move some of these functions to IAccessibilityData (or IUiaData)
+        virtual bool IsAreaSelected() const = 0;
+        virtual void ClearSelection() = 0;
+        virtual void SelectNewRegion(const COORD coordStart, const COORD coordEnd) = 0;
+
+        // TODO GitHub #605: Search functionality
+        // For now, just adding it here to make UiaTextRange easier to create (Accessibility)
+        // We should actually abstract this out better once Windows Terminal has Search
+        virtual HRESULT SearchForText(_In_ BSTR text,
+                                      _In_ BOOL searchBackward,
+                                      _In_ BOOL ignoreCase,
+                                      _Outptr_result_maybenull_ ITextRangeProvider** ppRetVal,
+                                      unsigned int _start,
+                                      unsigned int _end,
+                                      std::function<unsigned int(IUiaData*, const COORD)> _coordToEndpoint,
+                                      std::function<COORD(IUiaData*, const unsigned int)> _endpointToCoord,
+                                      std::function<IFACEMETHODIMP(ITextRangeProvider**)> Clone) = 0;
+    };
+
+    // See docs/virtual-dtors.md for an explanation of why this is weird.
+    inline IUiaData::~IUiaData() {}
+}

--- a/src/types/IUiaData.h
+++ b/src/types/IUiaData.h
@@ -24,8 +24,8 @@ namespace Microsoft::Console::Types
     {
     public:
         virtual ~IUiaData() = 0;
-        // TODO GitHub #1992: Move some of these functions to IAccessibilityData (or IUiaData)
-        virtual bool IsAreaSelected() const = 0;
+
+        virtual const bool IsSelectionActive() const = 0;
         virtual void ClearSelection() = 0;
         virtual void SelectNewRegion(const COORD coordStart, const COORD coordEnd) = 0;
 

--- a/src/types/ScreenInfoUiaProvider.cpp
+++ b/src/types/ScreenInfoUiaProvider.cpp
@@ -31,7 +31,7 @@ SAFEARRAY* BuildIntSafeArray(_In_reads_(length) const int* const data, const int
     return psa;
 }
 
-ScreenInfoUiaProvider::ScreenInfoUiaProvider(_In_ Microsoft::Console::Render::IRenderData* pData,
+ScreenInfoUiaProvider::ScreenInfoUiaProvider(_In_ IUiaData* pData,
                                              _In_ WindowUiaProviderBase* const pUiaParent,
                                              _In_ std::function<RECT(void)> GetBoundingRect) :
     _pUiaParent(pUiaParent),
@@ -44,7 +44,7 @@ ScreenInfoUiaProvider::ScreenInfoUiaProvider(_In_ Microsoft::Console::Render::IR
     //Tracing::s_TraceUia(nullptr, ApiCall::Constructor, nullptr);
 }
 
-ScreenInfoUiaProvider::ScreenInfoUiaProvider(_In_ Microsoft::Console::Render::IRenderData* pData,
+ScreenInfoUiaProvider::ScreenInfoUiaProvider(_In_ IUiaData* pData,
                                              _In_ WindowUiaProviderBase* const pUiaParent) :
     _pUiaParent(pUiaParent),
     _signalFiringMapping{},

--- a/src/types/ScreenInfoUiaProvider.cpp
+++ b/src/types/ScreenInfoUiaProvider.cpp
@@ -387,7 +387,7 @@ IFACEMETHODIMP ScreenInfoUiaProvider::GetSelection(_Outptr_result_maybenull_ SAF
     *ppRetVal = nullptr;
     HRESULT hr = S_OK;
 
-    if (!_pData->IsAreaSelected())
+    if (!_pData->IsSelectionActive())
     {
         // TODO GitHub #1914: Re-attach Tracing to UIA Tree
         //apiMsg.AreaSelected = false;

--- a/src/types/ScreenInfoUiaProvider.h
+++ b/src/types/ScreenInfoUiaProvider.h
@@ -23,7 +23,7 @@ Author(s):
 
 #include "precomp.h"
 #include "../buffer/out/textBuffer.hpp"
-#include "../renderer/inc/IRenderData.hpp"
+#include "IUiaData.h"
 
 namespace Microsoft::Console::Types
 {
@@ -36,12 +36,12 @@ namespace Microsoft::Console::Types
         public ITextProvider
     {
     public:
-        ScreenInfoUiaProvider(_In_ Microsoft::Console::Render::IRenderData* pData,
+        ScreenInfoUiaProvider(_In_ IUiaData* pData,
                               _In_ WindowUiaProviderBase* const pUiaParent,
                               _In_ std::function<RECT()> GetBoundingRect);
 
         // TODO GitHub 2120: pUiaParent should not be allowed to be null
-        ScreenInfoUiaProvider(_In_ Microsoft::Console::Render::IRenderData* pData,
+        ScreenInfoUiaProvider(_In_ IUiaData* pData,
                               _In_ WindowUiaProviderBase* const pUiaParent);
         virtual ~ScreenInfoUiaProvider();
 
@@ -93,7 +93,7 @@ namespace Microsoft::Console::Types
         WindowUiaProviderBase* const _pUiaParent;
 
         // weak reference to IRenderData
-        Microsoft::Console::Render::IRenderData* _pData;
+        IUiaData* _pData;
 
         // this is used to prevent the object from
         // signaling an event while it is already in the

--- a/src/types/UiaTextRange.cpp
+++ b/src/types/UiaTextRange.cpp
@@ -14,7 +14,7 @@ using namespace Microsoft::Console::Types::UiaTextRangeTracing;
 
 IdType UiaTextRange::id = 1;
 
-UiaTextRange::MoveState::MoveState(Microsoft::Console::Render::IRenderData* pData,
+UiaTextRange::MoveState::MoveState(IUiaData* pData,
                                    const UiaTextRange& range,
                                    const MovementDirection direction) :
     StartScreenInfoRow{ UiaTextRange::_endpointToScreenInfoRow(pData, range.GetStart()) },
@@ -65,7 +65,7 @@ UiaTextRange::MoveState::MoveState(const ScreenInfoRow startScreenInfoRow,
 // This is a debugging function that prints out the current
 // relationship between screen info rows, text buffer rows, and
 // endpoints.
-void UiaTextRange::_outputRowConversions(Microsoft::Console::Render::IRenderData* pData)
+void UiaTextRange::_outputRowConversions(IUiaData* pData)
 {
     try
     {
@@ -101,7 +101,7 @@ void UiaTextRange::_outputObjectState()
 }
 #endif // _DEBUG
 
-std::deque<UiaTextRange*> UiaTextRange::GetSelectionRanges(_In_ Microsoft::Console::Render::IRenderData* pData,
+std::deque<UiaTextRange*> UiaTextRange::GetSelectionRanges(_In_ IUiaData* pData,
                                                            _In_ IRawElementProviderSimple* pProvider)
 {
     std::deque<UiaTextRange*> ranges;
@@ -139,7 +139,7 @@ std::deque<UiaTextRange*> UiaTextRange::GetSelectionRanges(_In_ Microsoft::Conso
     return ranges;
 }
 
-UiaTextRange* UiaTextRange::Create(_In_ Microsoft::Console::Render::IRenderData* pData,
+UiaTextRange* UiaTextRange::Create(_In_ IUiaData* pData,
                                    _In_ IRawElementProviderSimple* const pProvider)
 {
     UiaTextRange* range = nullptr;
@@ -160,7 +160,7 @@ UiaTextRange* UiaTextRange::Create(_In_ Microsoft::Console::Render::IRenderData*
     return range;
 }
 
-UiaTextRange* UiaTextRange::Create(_In_ Microsoft::Console::Render::IRenderData* pData,
+UiaTextRange* UiaTextRange::Create(_In_ IUiaData* pData,
                                    _In_ IRawElementProviderSimple* const pProvider,
                                    const Cursor& cursor)
 {
@@ -181,7 +181,7 @@ UiaTextRange* UiaTextRange::Create(_In_ Microsoft::Console::Render::IRenderData*
     return range;
 }
 
-UiaTextRange* UiaTextRange::Create(_In_ Microsoft::Console::Render::IRenderData* pData,
+UiaTextRange* UiaTextRange::Create(_In_ IUiaData* pData,
                                    _In_ IRawElementProviderSimple* const pProvider,
                                    const Endpoint start,
                                    const Endpoint end,
@@ -208,7 +208,7 @@ UiaTextRange* UiaTextRange::Create(_In_ Microsoft::Console::Render::IRenderData*
     return range;
 }
 
-UiaTextRange* UiaTextRange::Create(_In_ Microsoft::Console::Render::IRenderData* pData,
+UiaTextRange* UiaTextRange::Create(_In_ IUiaData* pData,
                                    _In_ IRawElementProviderSimple* const pProvider,
                                    const UiaPoint point)
 {
@@ -230,7 +230,7 @@ UiaTextRange* UiaTextRange::Create(_In_ Microsoft::Console::Render::IRenderData*
 }
 
 // degenerate range constructor.
-UiaTextRange::UiaTextRange(_In_ Microsoft::Console::Render::IRenderData* pData, _In_ IRawElementProviderSimple* const pProvider) :
+UiaTextRange::UiaTextRange(_In_ IUiaData* pData, _In_ IRawElementProviderSimple* const pProvider) :
     _cRefs{ 1 },
     _pProvider{ THROW_HR_IF_NULL(E_INVALIDARG, pProvider) },
     _start{ 0 },
@@ -248,7 +248,7 @@ UiaTextRange::UiaTextRange(_In_ Microsoft::Console::Render::IRenderData* pData, 
     Tracing::s_TraceUia(nullptr, ApiCall::Constructor, &apiMsg);*/
 }
 
-UiaTextRange::UiaTextRange(_In_ Microsoft::Console::Render::IRenderData* pData,
+UiaTextRange::UiaTextRange(_In_ IUiaData* pData,
                            _In_ IRawElementProviderSimple* const pProvider,
                            const Cursor& cursor) :
     UiaTextRange(pData, pProvider)
@@ -263,7 +263,7 @@ UiaTextRange::UiaTextRange(_In_ Microsoft::Console::Render::IRenderData* pData,
 #endif
 }
 
-UiaTextRange::UiaTextRange(_In_ Microsoft::Console::Render::IRenderData* pData,
+UiaTextRange::UiaTextRange(_In_ IUiaData* pData,
                            _In_ IRawElementProviderSimple* const pProvider,
                            const Endpoint start,
                            const Endpoint end,
@@ -283,7 +283,7 @@ UiaTextRange::UiaTextRange(_In_ Microsoft::Console::Render::IRenderData* pData,
 }
 
 // returns a degenerate text range of the start of the row closest to the y value of point
-UiaTextRange::UiaTextRange(_In_ Microsoft::Console::Render::IRenderData* pData,
+UiaTextRange::UiaTextRange(_In_ IUiaData* pData,
                            _In_ IRawElementProviderSimple* const pProvider,
                            const UiaPoint point) :
     UiaTextRange(pData, pProvider)
@@ -1209,7 +1209,7 @@ IFACEMETHODIMP UiaTextRange::GetChildren(_Outptr_result_maybenull_ SAFEARRAY** p
 
 #pragma endregion
 
-const COORD UiaTextRange::_getScreenBufferCoords(Microsoft::Console::Render::IRenderData* pData)
+const COORD UiaTextRange::_getScreenBufferCoords(IUiaData* pData)
 {
     return pData->GetTextBuffer().GetSize().Dimensions();
 }
@@ -1231,7 +1231,7 @@ COORD UiaTextRange::_getScreenFontSize() const
 // - <none>
 // Return Value:
 // - The number of rows
-const unsigned int UiaTextRange::_getTotalRows(Microsoft::Console::Render::IRenderData* pData)
+const unsigned int UiaTextRange::_getTotalRows(IUiaData* pData)
 {
     return pData->GetTextBuffer().TotalRowCount();
 }
@@ -1242,7 +1242,7 @@ const unsigned int UiaTextRange::_getTotalRows(Microsoft::Console::Render::IRend
 // - <none>
 // Return Value:
 // - The row width
-const unsigned int UiaTextRange::_getRowWidth(Microsoft::Console::Render::IRenderData* pData)
+const unsigned int UiaTextRange::_getRowWidth(IUiaData* pData)
 {
     // make sure that we can't leak a 0
     return std::max(static_cast<unsigned int>(_getScreenBufferCoords(pData).X), 1u);
@@ -1254,7 +1254,7 @@ const unsigned int UiaTextRange::_getRowWidth(Microsoft::Console::Render::IRende
 // - endpoint - the endpoint to translate
 // Return Value:
 // - the column value
-const Column UiaTextRange::_endpointToColumn(Microsoft::Console::Render::IRenderData* pData, const Endpoint endpoint)
+const Column UiaTextRange::_endpointToColumn(IUiaData* pData, const Endpoint endpoint)
 {
     return endpoint % _getRowWidth(pData);
 }
@@ -1265,7 +1265,7 @@ const Column UiaTextRange::_endpointToColumn(Microsoft::Console::Render::IRender
 // - endpoint - the endpoint to convert
 // Return Value:
 // - the text buffer row value
-const TextBufferRow UiaTextRange::_endpointToTextBufferRow(Microsoft::Console::Render::IRenderData* pData,
+const TextBufferRow UiaTextRange::_endpointToTextBufferRow(IUiaData* pData,
                                                            const Endpoint endpoint)
 {
     return endpoint / _getRowWidth(pData);
@@ -1278,7 +1278,7 @@ const TextBufferRow UiaTextRange::_endpointToTextBufferRow(Microsoft::Console::R
 // - <none>
 // Return Value:
 // - The number of rows in the range.
-const unsigned int UiaTextRange::_rowCountInRange(Microsoft::Console::Render::IRenderData* pData) const
+const unsigned int UiaTextRange::_rowCountInRange(IUiaData* pData) const
 {
     if (_degenerate)
     {
@@ -1302,7 +1302,7 @@ const unsigned int UiaTextRange::_rowCountInRange(Microsoft::Console::Render::IR
 // - row - the TextBufferRow to convert
 // Return Value:
 // - the equivalent ScreenInfoRow.
-const ScreenInfoRow UiaTextRange::_textBufferRowToScreenInfoRow(Microsoft::Console::Render::IRenderData* pData,
+const ScreenInfoRow UiaTextRange::_textBufferRowToScreenInfoRow(IUiaData* pData,
                                                                 const TextBufferRow row)
 {
     const int firstRowIndex = pData->GetTextBuffer().GetFirstRowIndex();
@@ -1316,7 +1316,7 @@ const ScreenInfoRow UiaTextRange::_textBufferRowToScreenInfoRow(Microsoft::Conso
 // - row - the ScreenInfoRow to convert
 // Return Value:
 // - the equivalent ViewportRow.
-const ViewportRow UiaTextRange::_screenInfoRowToViewportRow(Microsoft::Console::Render::IRenderData* pData, const ScreenInfoRow row)
+const ViewportRow UiaTextRange::_screenInfoRowToViewportRow(IUiaData* pData, const ScreenInfoRow row)
 {
     const SMALL_RECT viewport = pData->GetViewport().ToInclusive();
     return _screenInfoRowToViewportRow(row, viewport);
@@ -1343,7 +1343,7 @@ const ViewportRow UiaTextRange::_screenInfoRowToViewportRow(const ScreenInfoRow 
 // - the non-normalized row index
 // Return Value:
 // - the normalized row index
-const Row UiaTextRange::_normalizeRow(Microsoft::Console::Render::IRenderData* pData, const Row row)
+const Row UiaTextRange::_normalizeRow(IUiaData* pData, const Row row)
 {
     const unsigned int totalRows = _getTotalRows(pData);
     return ((row + totalRows) % totalRows);
@@ -1385,7 +1385,7 @@ const unsigned int UiaTextRange::_getViewportWidth(const SMALL_RECT viewport)
 // - row - the screen info row to check
 // Return Value:
 // - true if the row is within the bounds of the viewport
-const bool UiaTextRange::_isScreenInfoRowInViewport(Microsoft::Console::Render::IRenderData* pData,
+const bool UiaTextRange::_isScreenInfoRowInViewport(IUiaData* pData,
                                                     const ScreenInfoRow row)
 {
     return _isScreenInfoRowInViewport(row, pData->GetViewport().ToInclusive());
@@ -1412,7 +1412,7 @@ const bool UiaTextRange::_isScreenInfoRowInViewport(const ScreenInfoRow row,
 // - row - the ScreenInfoRow to convert
 // Return Value:
 // - the equivalent TextBufferRow.
-const TextBufferRow UiaTextRange::_screenInfoRowToTextBufferRow(Microsoft::Console::Render::IRenderData* pData,
+const TextBufferRow UiaTextRange::_screenInfoRowToTextBufferRow(IUiaData* pData,
                                                                 const ScreenInfoRow row)
 {
     const TextBufferRow firstRowIndex = pData->GetTextBuffer().GetFirstRowIndex();
@@ -1425,7 +1425,7 @@ const TextBufferRow UiaTextRange::_screenInfoRowToTextBufferRow(Microsoft::Conso
 // - row - the TextBufferRow to convert
 // Return Value:
 // - the equivalent Endpoint, starting at the beginning of the TextBufferRow.
-const Endpoint UiaTextRange::_textBufferRowToEndpoint(Microsoft::Console::Render::IRenderData* pData, const TextBufferRow row)
+const Endpoint UiaTextRange::_textBufferRowToEndpoint(IUiaData* pData, const TextBufferRow row)
 {
     return _getRowWidth(pData) * row;
 }
@@ -1436,7 +1436,7 @@ const Endpoint UiaTextRange::_textBufferRowToEndpoint(Microsoft::Console::Render
 // - row - the ScreenInfoRow to convert
 // Return Value:
 // - the equivalent Endpoint.
-const Endpoint UiaTextRange::_screenInfoRowToEndpoint(Microsoft::Console::Render::IRenderData* pData,
+const Endpoint UiaTextRange::_screenInfoRowToEndpoint(IUiaData* pData,
                                                       const ScreenInfoRow row)
 {
     return _textBufferRowToEndpoint(pData, _screenInfoRowToTextBufferRow(pData, row));
@@ -1448,7 +1448,7 @@ const Endpoint UiaTextRange::_screenInfoRowToEndpoint(Microsoft::Console::Render
 // - endpoint - the endpoint to convert
 // Return Value:
 // - the equivalent ScreenInfoRow.
-const ScreenInfoRow UiaTextRange::_endpointToScreenInfoRow(Microsoft::Console::Render::IRenderData* pData,
+const ScreenInfoRow UiaTextRange::_endpointToScreenInfoRow(IUiaData* pData,
                                                            const Endpoint endpoint)
 {
     return _textBufferRowToScreenInfoRow(pData, _endpointToTextBufferRow(pData, endpoint));
@@ -1463,7 +1463,7 @@ const ScreenInfoRow UiaTextRange::_endpointToScreenInfoRow(Microsoft::Console::R
 // - <none>
 // Notes:
 // - alters coords. may throw an exception.
-void UiaTextRange::_addScreenInfoRowBoundaries(Microsoft::Console::Render::IRenderData* pData,
+void UiaTextRange::_addScreenInfoRowBoundaries(IUiaData* pData,
                                                const ScreenInfoRow screenInfoRow,
                                                _Inout_ std::vector<double>& coords) const
 {
@@ -1540,7 +1540,7 @@ const unsigned int UiaTextRange::_getFirstScreenInfoRowIndex()
 // - <none>
 // Return Value:
 // - the index of the last row (0-indexed) of the screen info
-const unsigned int UiaTextRange::_getLastScreenInfoRowIndex(Microsoft::Console::Render::IRenderData* pData)
+const unsigned int UiaTextRange::_getLastScreenInfoRowIndex(IUiaData* pData)
 {
     return _getTotalRows(pData) - 1;
 }
@@ -1562,7 +1562,7 @@ const Column UiaTextRange::_getFirstColumnIndex()
 // - <none>
 // Return Value:
 // - the index of the last column (0-indexed) of the screen info rows
-const Column UiaTextRange::_getLastColumnIndex(Microsoft::Console::Render::IRenderData* pData)
+const Column UiaTextRange::_getLastColumnIndex(IUiaData* pData)
 {
     return _getRowWidth(pData) - 1;
 }
@@ -1578,7 +1578,7 @@ const Column UiaTextRange::_getLastColumnIndex(Microsoft::Console::Render::IRend
 //   -1 if A < B
 //    1 if A > B
 //    0 if A == B
-const int UiaTextRange::_compareScreenCoords(Microsoft::Console::Render::IRenderData* pData,
+const int UiaTextRange::_compareScreenCoords(IUiaData* pData,
                                              const ScreenInfoRow rowA,
                                              const Column colA,
                                              const ScreenInfoRow rowB,
@@ -1627,7 +1627,7 @@ const int UiaTextRange::_compareScreenCoords(Microsoft::Console::Render::IRender
 // - pAmountMoved - the number of times that the return values are "moved"
 // Return Value:
 // - a pair of endpoints of the form <start, end>
-std::pair<Endpoint, Endpoint> UiaTextRange::_moveByCharacter(Microsoft::Console::Render::IRenderData* pData,
+std::pair<Endpoint, Endpoint> UiaTextRange::_moveByCharacter(IUiaData* pData,
                                                              const int moveCount,
                                                              const MoveState moveState,
                                                              _Out_ int* const pAmountMoved)
@@ -1642,7 +1642,7 @@ std::pair<Endpoint, Endpoint> UiaTextRange::_moveByCharacter(Microsoft::Console:
     }
 }
 
-std::pair<Endpoint, Endpoint> UiaTextRange::_moveByCharacterForward(Microsoft::Console::Render::IRenderData* pData,
+std::pair<Endpoint, Endpoint> UiaTextRange::_moveByCharacterForward(IUiaData* pData,
                                                                     const int moveCount,
                                                                     const MoveState moveState,
                                                                     _Out_ int* const pAmountMoved)
@@ -1688,7 +1688,7 @@ std::pair<Endpoint, Endpoint> UiaTextRange::_moveByCharacterForward(Microsoft::C
     return std::make_pair<Endpoint, Endpoint>(std::move(start), std::move(end));
 }
 
-std::pair<Endpoint, Endpoint> UiaTextRange::_moveByCharacterBackward(Microsoft::Console::Render::IRenderData* pData,
+std::pair<Endpoint, Endpoint> UiaTextRange::_moveByCharacterBackward(IUiaData* pData,
                                                                      const int moveCount,
                                                                      const MoveState moveState,
                                                                      _Out_ int* const pAmountMoved)
@@ -1745,7 +1745,7 @@ std::pair<Endpoint, Endpoint> UiaTextRange::_moveByCharacterBackward(Microsoft::
 // - pAmountMoved - the number of times that the return values are "moved"
 // Return Value:
 // - a pair of endpoints of the form <start, end>
-std::pair<Endpoint, Endpoint> UiaTextRange::_moveByLine(Microsoft::Console::Render::IRenderData* pData,
+std::pair<Endpoint, Endpoint> UiaTextRange::_moveByLine(IUiaData* pData,
                                                         const int moveCount,
                                                         const MoveState moveState,
                                                         _Out_ int* const pAmountMoved)
@@ -1792,7 +1792,7 @@ std::pair<Endpoint, Endpoint> UiaTextRange::_moveByLine(Microsoft::Console::Rend
 // - pAmountMoved - the number of times that the return values are "moved"
 // Return Value:
 // - a pair of endpoints of the form <start, end>
-std::pair<Endpoint, Endpoint> UiaTextRange::_moveByDocument(Microsoft::Console::Render::IRenderData* pData,
+std::pair<Endpoint, Endpoint> UiaTextRange::_moveByDocument(IUiaData* pData,
                                                             const int /*moveCount*/,
                                                             const MoveState moveState,
                                                             _Out_ int* const pAmountMoved)
@@ -1819,7 +1819,7 @@ std::pair<Endpoint, Endpoint> UiaTextRange::_moveByDocument(Microsoft::Console::
 // - pAmountMoved - the number of times that the return values are "moved"
 // Return Value:
 // - A tuple of elements of the form <start, end, degenerate>
-std::tuple<Endpoint, Endpoint, bool> UiaTextRange::_moveEndpointByUnitCharacter(Microsoft::Console::Render::IRenderData* pData,
+std::tuple<Endpoint, Endpoint, bool> UiaTextRange::_moveEndpointByUnitCharacter(IUiaData* pData,
                                                                                 const int moveCount,
                                                                                 const TextPatternRangeEndpoint endpoint,
                                                                                 const MoveState moveState,
@@ -1836,7 +1836,7 @@ std::tuple<Endpoint, Endpoint, bool> UiaTextRange::_moveEndpointByUnitCharacter(
 }
 
 std::tuple<Endpoint, Endpoint, bool>
-UiaTextRange::_moveEndpointByUnitCharacterForward(Microsoft::Console::Render::IRenderData* pData,
+UiaTextRange::_moveEndpointByUnitCharacterForward(IUiaData* pData,
                                                   const int moveCount,
                                                   const TextPatternRangeEndpoint endpoint,
                                                   const MoveState moveState,
@@ -1925,7 +1925,7 @@ UiaTextRange::_moveEndpointByUnitCharacterForward(Microsoft::Console::Render::IR
 }
 
 std::tuple<Endpoint, Endpoint, bool>
-UiaTextRange::_moveEndpointByUnitCharacterBackward(Microsoft::Console::Render::IRenderData* pData,
+UiaTextRange::_moveEndpointByUnitCharacterBackward(IUiaData* pData,
                                                    const int moveCount,
                                                    const TextPatternRangeEndpoint endpoint,
                                                    const MoveState moveState,
@@ -2025,7 +2025,7 @@ UiaTextRange::_moveEndpointByUnitCharacterBackward(Microsoft::Console::Render::I
 // - pAmountMoved - the number of times that the return values are "moved"
 // Return Value:
 // - A tuple of elements of the form <start, end, degenerate>
-std::tuple<Endpoint, Endpoint, bool> UiaTextRange::_moveEndpointByUnitLine(Microsoft::Console::Render::IRenderData* pData,
+std::tuple<Endpoint, Endpoint, bool> UiaTextRange::_moveEndpointByUnitLine(IUiaData* pData,
                                                                            const int moveCount,
                                                                            const TextPatternRangeEndpoint endpoint,
                                                                            const MoveState moveState,
@@ -2184,7 +2184,7 @@ std::tuple<Endpoint, Endpoint, bool> UiaTextRange::_moveEndpointByUnitLine(Micro
 // - pAmountMoved - the number of times that the return values are "moved"
 // Return Value:
 // - A tuple of elements of the form <start, end, degenerate>
-std::tuple<Endpoint, Endpoint, bool> UiaTextRange::_moveEndpointByUnitDocument(Microsoft::Console::Render::IRenderData* pData,
+std::tuple<Endpoint, Endpoint, bool> UiaTextRange::_moveEndpointByUnitDocument(IUiaData* pData,
                                                                                const int moveCount,
                                                                                const TextPatternRangeEndpoint endpoint,
                                                                                const MoveState moveState,
@@ -2251,12 +2251,12 @@ std::tuple<Endpoint, Endpoint, bool> UiaTextRange::_moveEndpointByUnitDocument(M
     return std::make_tuple(start, end, degenerate);
 }
 
-COORD UiaTextRange::_endpointToCoord(Microsoft::Console::Render::IRenderData* pData, const Endpoint endpoint)
+COORD UiaTextRange::_endpointToCoord(IUiaData* pData, const Endpoint endpoint)
 {
     return { gsl::narrow<short>(_endpointToColumn(pData, endpoint)), gsl::narrow<short>(_endpointToScreenInfoRow(pData, endpoint)) };
 }
 
-Endpoint UiaTextRange::_coordToEndpoint(Microsoft::Console::Render::IRenderData* pData,
+Endpoint UiaTextRange::_coordToEndpoint(IUiaData* pData,
                                         const COORD coord)
 {
     return _screenInfoRowToEndpoint(pData, coord.Y) + coord.X;

--- a/src/types/UiaTextRange.hpp
+++ b/src/types/UiaTextRange.hpp
@@ -22,7 +22,7 @@ Author(s):
 
 #include "inc/viewport.hpp"
 #include "../buffer/out/textBuffer.hpp"
-#include "../renderer/inc/IRenderData.hpp"
+#include "IUiaData.h"
 
 #include <deque>
 #include <tuple>
@@ -116,7 +116,7 @@ namespace Microsoft::Console::Types
             // direction moving
             MovementDirection Direction;
 
-            MoveState(Microsoft::Console::Render::IRenderData* pData,
+            MoveState(IUiaData* pData,
                       const UiaTextRange& range,
                       const MovementDirection direction);
 
@@ -137,26 +137,26 @@ namespace Microsoft::Console::Types
         };
 
     public:
-        static std::deque<UiaTextRange*> GetSelectionRanges(_In_ Microsoft::Console::Render::IRenderData* pData, _In_ IRawElementProviderSimple* pProvider);
+        static std::deque<UiaTextRange*> GetSelectionRanges(_In_ IUiaData* pData, _In_ IRawElementProviderSimple* pProvider);
 
         // degenerate range
-        static UiaTextRange* Create(_In_ Microsoft::Console::Render::IRenderData* pData,
+        static UiaTextRange* Create(_In_ IUiaData* pData,
                                     _In_ IRawElementProviderSimple* const pProvider);
 
         // degenerate range at cursor position
-        static UiaTextRange* Create(_In_ Microsoft::Console::Render::IRenderData* pData,
+        static UiaTextRange* Create(_In_ IUiaData* pData,
                                     _In_ IRawElementProviderSimple* const pProvider,
                                     const Cursor& cursor);
 
         // specific endpoint range
-        static UiaTextRange* Create(_In_ Microsoft::Console::Render::IRenderData* pData,
+        static UiaTextRange* Create(_In_ IUiaData* pData,
                                     _In_ IRawElementProviderSimple* const pProvider,
                                     const Endpoint start,
                                     const Endpoint end,
                                     const bool degenerate);
 
         // range from a UiaPoint
-        static UiaTextRange* Create(_In_ Microsoft::Console::Render::IRenderData* pData,
+        static UiaTextRange* Create(_In_ IUiaData* pData,
                                     _In_ IRawElementProviderSimple* const pProvider,
                                     const UiaPoint point);
 
@@ -168,7 +168,7 @@ namespace Microsoft::Console::Types
         const bool IsDegenerate() const;
 
         // TODO GitHub #605:
-        // only used for RenderData::FindText. Remove after Search added properly
+        // only used for UiaData::FindText. Remove after Search added properly
         void SetRangeValues(const Endpoint start, const Endpoint end, const bool isDegenerate);
 
         // IUnknown methods
@@ -219,10 +219,10 @@ namespace Microsoft::Console::Types
 
     protected:
 #if _DEBUG
-        void _outputRowConversions(Microsoft::Console::Render::IRenderData* pData);
+        void _outputRowConversions(IUiaData* pData);
         void _outputObjectState();
 #endif
-        Microsoft::Console::Render::IRenderData* const _pData;
+        IUiaData* const _pData;
 
         IRawElementProviderSimple* const _pProvider;
 
@@ -231,23 +231,23 @@ namespace Microsoft::Console::Types
 
     private:
         // degenerate range
-        UiaTextRange(_In_ Microsoft::Console::Render::IRenderData* pData,
+        UiaTextRange(_In_ IUiaData* pData,
                      _In_ IRawElementProviderSimple* const pProvider);
 
         // degenerate range at cursor position
-        UiaTextRange(_In_ Microsoft::Console::Render::IRenderData* pData,
+        UiaTextRange(_In_ IUiaData* pData,
                      _In_ IRawElementProviderSimple* const pProvider,
                      const Cursor& cursor);
 
         // specific endpoint range
-        UiaTextRange(_In_ Microsoft::Console::Render::IRenderData* pData,
+        UiaTextRange(_In_ IUiaData* pData,
                      _In_ IRawElementProviderSimple* const pProvider,
                      const Endpoint start,
                      const Endpoint end,
                      const bool degenerate);
 
         // range from a UiaPoint
-        UiaTextRange(_In_ Microsoft::Console::Render::IRenderData* pData,
+        UiaTextRange(_In_ IUiaData* pData,
                      _In_ IRawElementProviderSimple* const pProvider,
                      const UiaPoint point);
 
@@ -283,50 +283,50 @@ namespace Microsoft::Console::Types
         // then both endpoints will contain the same value.
         bool _degenerate;
 
-        static const COORD _getScreenBufferCoords(Microsoft::Console::Render::IRenderData* pData);
+        static const COORD _getScreenBufferCoords(IUiaData* pData);
         COORD _getScreenFontSize() const;
 
-        static const unsigned int _getTotalRows(Microsoft::Console::Render::IRenderData* pData);
-        static const unsigned int _getRowWidth(Microsoft::Console::Render::IRenderData* pData);
+        static const unsigned int _getTotalRows(IUiaData* pData);
+        static const unsigned int _getRowWidth(IUiaData* pData);
 
         static const unsigned int _getFirstScreenInfoRowIndex();
-        static const unsigned int _getLastScreenInfoRowIndex(Microsoft::Console::Render::IRenderData* pData);
+        static const unsigned int _getLastScreenInfoRowIndex(IUiaData* pData);
 
         static const Column _getFirstColumnIndex();
-        static const Column _getLastColumnIndex(Microsoft::Console::Render::IRenderData* pData);
+        static const Column _getLastColumnIndex(IUiaData* pData);
 
-        const unsigned int _rowCountInRange(Microsoft::Console::Render::IRenderData* pData) const;
+        const unsigned int _rowCountInRange(IUiaData* pData) const;
 
-        static const TextBufferRow _endpointToTextBufferRow(Microsoft::Console::Render::IRenderData* pData,
+        static const TextBufferRow _endpointToTextBufferRow(IUiaData* pData,
                                                             const Endpoint endpoint);
-        static const ScreenInfoRow _textBufferRowToScreenInfoRow(Microsoft::Console::Render::IRenderData* pData,
+        static const ScreenInfoRow _textBufferRowToScreenInfoRow(IUiaData* pData,
                                                                  const TextBufferRow row);
 
-        static const TextBufferRow _screenInfoRowToTextBufferRow(Microsoft::Console::Render::IRenderData* pData,
+        static const TextBufferRow _screenInfoRowToTextBufferRow(IUiaData* pData,
                                                                  const ScreenInfoRow row);
-        static const Endpoint _textBufferRowToEndpoint(Microsoft::Console::Render::IRenderData* pData, const TextBufferRow row);
+        static const Endpoint _textBufferRowToEndpoint(IUiaData* pData, const TextBufferRow row);
 
-        static const ScreenInfoRow _endpointToScreenInfoRow(Microsoft::Console::Render::IRenderData* pData,
+        static const ScreenInfoRow _endpointToScreenInfoRow(IUiaData* pData,
                                                             const Endpoint endpoint);
-        static const Endpoint _screenInfoRowToEndpoint(Microsoft::Console::Render::IRenderData* pData,
+        static const Endpoint _screenInfoRowToEndpoint(IUiaData* pData,
                                                        const ScreenInfoRow row);
 
-        static COORD _endpointToCoord(Microsoft::Console::Render::IRenderData* pData,
+        static COORD _endpointToCoord(IUiaData* pData,
                                       const Endpoint endpoint);
-        static Endpoint _coordToEndpoint(Microsoft::Console::Render::IRenderData* pData,
+        static Endpoint _coordToEndpoint(IUiaData* pData,
                                          const COORD coord);
 
-        static const Column _endpointToColumn(Microsoft::Console::Render::IRenderData* pData,
+        static const Column _endpointToColumn(IUiaData* pData,
                                               const Endpoint endpoint);
 
-        static const Row _normalizeRow(Microsoft::Console::Render::IRenderData* pData, const Row row);
+        static const Row _normalizeRow(IUiaData* pData, const Row row);
 
-        static const ViewportRow _screenInfoRowToViewportRow(Microsoft::Console::Render::IRenderData* pData,
+        static const ViewportRow _screenInfoRowToViewportRow(IUiaData* pData,
                                                              const ScreenInfoRow row);
         static const ViewportRow _screenInfoRowToViewportRow(const ScreenInfoRow row,
                                                              const SMALL_RECT viewport);
 
-        static const bool _isScreenInfoRowInViewport(Microsoft::Console::Render::IRenderData* pData,
+        static const bool _isScreenInfoRowInViewport(IUiaData* pData,
                                                      const ScreenInfoRow row);
         static const bool _isScreenInfoRowInViewport(const ScreenInfoRow row,
                                                      const SMALL_RECT viewport);
@@ -334,71 +334,71 @@ namespace Microsoft::Console::Types
         static const unsigned int _getViewportHeight(const SMALL_RECT viewport);
         static const unsigned int _getViewportWidth(const SMALL_RECT viewport);
 
-        void _addScreenInfoRowBoundaries(Microsoft::Console::Render::IRenderData* pData,
+        void _addScreenInfoRowBoundaries(IUiaData* pData,
                                          const ScreenInfoRow screenInfoRow,
                                          _Inout_ std::vector<double>& coords) const;
 
-        static const int _compareScreenCoords(Microsoft::Console::Render::IRenderData* pData,
+        static const int _compareScreenCoords(IUiaData* pData,
                                               const ScreenInfoRow rowA,
                                               const Column colA,
                                               const ScreenInfoRow rowB,
                                               const Column colB);
 
-        static std::pair<Endpoint, Endpoint> _moveByCharacter(Microsoft::Console::Render::IRenderData* pData,
+        static std::pair<Endpoint, Endpoint> _moveByCharacter(IUiaData* pData,
                                                               const int moveCount,
                                                               const MoveState moveState,
                                                               _Out_ int* const pAmountMoved);
 
-        static std::pair<Endpoint, Endpoint> _moveByCharacterForward(Microsoft::Console::Render::IRenderData* pData,
+        static std::pair<Endpoint, Endpoint> _moveByCharacterForward(IUiaData* pData,
                                                                      const int moveCount,
                                                                      const MoveState moveState,
                                                                      _Out_ int* const pAmountMoved);
 
-        static std::pair<Endpoint, Endpoint> _moveByCharacterBackward(Microsoft::Console::Render::IRenderData* pData,
+        static std::pair<Endpoint, Endpoint> _moveByCharacterBackward(IUiaData* pData,
                                                                       const int moveCount,
                                                                       const MoveState moveState,
                                                                       _Out_ int* const pAmountMoved);
 
-        static std::pair<Endpoint, Endpoint> _moveByLine(Microsoft::Console::Render::IRenderData* pData,
+        static std::pair<Endpoint, Endpoint> _moveByLine(IUiaData* pData,
                                                          const int moveCount,
                                                          const MoveState moveState,
                                                          _Out_ int* const pAmountMoved);
 
-        static std::pair<Endpoint, Endpoint> _moveByDocument(Microsoft::Console::Render::IRenderData* pData,
+        static std::pair<Endpoint, Endpoint> _moveByDocument(IUiaData* pData,
                                                              const int moveCount,
                                                              const MoveState moveState,
                                                              _Out_ int* const pAmountMoved);
 
         static std::tuple<Endpoint, Endpoint, bool>
-        _moveEndpointByUnitCharacter(Microsoft::Console::Render::IRenderData* pData,
+        _moveEndpointByUnitCharacter(IUiaData* pData,
                                      const int moveCount,
                                      const TextPatternRangeEndpoint endpoint,
                                      const MoveState moveState,
                                      _Out_ int* const pAmountMoved);
 
         static std::tuple<Endpoint, Endpoint, bool>
-        _moveEndpointByUnitCharacterForward(Microsoft::Console::Render::IRenderData* pData,
+        _moveEndpointByUnitCharacterForward(IUiaData* pData,
                                             const int moveCount,
                                             const TextPatternRangeEndpoint endpoint,
                                             const MoveState moveState,
                                             _Out_ int* const pAmountMoved);
 
         static std::tuple<Endpoint, Endpoint, bool>
-        _moveEndpointByUnitCharacterBackward(Microsoft::Console::Render::IRenderData* pData,
+        _moveEndpointByUnitCharacterBackward(IUiaData* pData,
                                              const int moveCount,
                                              const TextPatternRangeEndpoint endpoint,
                                              const MoveState moveState,
                                              _Out_ int* const pAmountMoved);
 
         static std::tuple<Endpoint, Endpoint, bool>
-        _moveEndpointByUnitLine(Microsoft::Console::Render::IRenderData* pData,
+        _moveEndpointByUnitLine(IUiaData* pData,
                                 const int moveCount,
                                 const TextPatternRangeEndpoint endpoint,
                                 const MoveState moveState,
                                 _Out_ int* const pAmountMoved);
 
         static std::tuple<Endpoint, Endpoint, bool>
-        _moveEndpointByUnitDocument(Microsoft::Console::Render::IRenderData* pData,
+        _moveEndpointByUnitDocument(IUiaData* pData,
                                     const int moveCount,
                                     const TextPatternRangeEndpoint endpoint,
                                     const MoveState moveState,

--- a/src/types/lib/types.vcxproj
+++ b/src/types/lib/types.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="..\WindowUiaProviderBase.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\IBaseData.h" />
     <ClInclude Include="..\IConsoleWindow.hpp" />
     <ClInclude Include="..\inc\CodepointWidthDetector.hpp" />
     <ClInclude Include="..\inc\convert.hpp" />
@@ -32,6 +33,7 @@
     <ClInclude Include="..\inc\UTF8OutPipeReader.hpp" />
     <ClInclude Include="..\inc\Viewport.hpp" />
     <ClInclude Include="..\inc\Utf16Parser.hpp" />
+    <ClInclude Include="..\IUiaData.h" />
     <ClInclude Include="..\IUiaWindow.h" />
     <ClInclude Include="..\precomp.h" />
     <ClInclude Include="..\ScreenInfoUiaProvider.h" />

--- a/src/types/lib/types.vcxproj.filters
+++ b/src/types/lib/types.vcxproj.filters
@@ -158,6 +158,12 @@
     <ClInclude Include="..\IUiaWindow.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\IUiaData.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\IBaseData.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="$(SolutionDir)tools\ConsoleTypes.natvis" />


### PR DESCRIPTION
## Summary of the Pull Request
Created the following inheritance tree:
`IBaseData`
├─ `IRenderData`
└─ `IUiaData`

This cleans up what is exposed to UiaProviders. If more things are needed in `IUiaData` that are already in `IRenderData`, just move them to `IBaseData`.

## References

## PR Checklist
* [x] Closes #1992 
* [x] CLA signed.
* [x] ~Tests added/passed~ N/A
* [x] ~Requires documentation to be updated~ N/A
* [x] I am a core contributor

## Detailed Description of the Pull Request / Additional comments
Anything specifically used for the UIA Providers is now passed through IUiaData. I added a few `pragma region`s to make the code look pretty. No functionality should actually be changed here.

New files:
- `IBaseData`
- `IUiaData`

## Validation Steps Performed
Used inspect.exe to see if the UIA Tree still appears in ConHost and WindowsTerminal. I was able to still interact with the UIA Tree so nothing broke.
