### PR TITLE
Stop Roaming settings

### DIFF
--- a/src/cascadia/TerminalApp/CascadiaSettings.h
+++ b/src/cascadia/TerminalApp/CascadiaSettings.h
@@ -65,7 +65,6 @@ private:
     static void _WriteSettings(const std::string_view content);
     static std::optional<std::string> _ReadSettings();
 
-    static std::wstring _GetRoamingSettingsPath();
     static bool _isPowerShellCoreInstalledInPath(const std::wstring_view programFileEnv, std::filesystem::path& cmdline);
     static bool _isPowerShellCoreInstalled(std::filesystem::path& cmdline);
     static void _AppendWslProfiles(std::vector<TerminalApp::Profile>& profileStorage);

--- a/src/cascadia/TerminalApp/CascadiaSettings.h
+++ b/src/cascadia/TerminalApp/CascadiaSettings.h
@@ -47,7 +47,7 @@ public:
     Json::Value ToJson() const;
     static std::unique_ptr<CascadiaSettings> FromJson(const Json::Value& json);
 
-    static std::wstring GetSettingsPath();
+    static std::wstring GetSettingsPath(const bool useRoamingPath = false);
 
     const Profile* FindProfile(GUID profileGuid) const noexcept;
 

--- a/src/cascadia/TerminalApp/CascadiaSettings.h
+++ b/src/cascadia/TerminalApp/CascadiaSettings.h
@@ -65,6 +65,7 @@ private:
     static void _WriteSettings(const std::string_view content);
     static std::optional<std::string> _ReadSettings();
 
+    static std::wstring _GetRoamingSettingsPath();
     static bool _isPowerShellCoreInstalledInPath(const std::wstring_view programFileEnv, std::filesystem::path& cmdline);
     static bool _isPowerShellCoreInstalled(std::filesystem::path& cmdline);
     static void _AppendWslProfiles(std::vector<TerminalApp::Profile>& profileStorage);

--- a/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
@@ -262,13 +262,45 @@ void CascadiaSettings::_WriteSettings(const std::string_view content)
 std::optional<std::string> CascadiaSettings::_ReadSettings()
 {
     auto pathToSettingsFile{ CascadiaSettings::GetSettingsPath() };
-    const auto hFile = CreateFileW(pathToSettingsFile.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    auto hFile = CreateFileW(pathToSettingsFile.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     if (hFile == INVALID_HANDLE_VALUE)
     {
-        // If the file doesn't exist, that's fine. Just log the error and return
-        //      nullopt - we'll create the defaults.
-        LOG_LAST_ERROR();
-        return std::nullopt;
+        // GH#1770 - Now that we're _not_ roaming our settings, do a quick check
+        // to see if there's a file in the Roaming App data folder. If there is
+        // a file there, but not in the LocalAppData, it's likely the user is
+        // upgrading from a version of the terminal from before this change.
+        // We'll try moving the file from the Roaming app data folder to the
+        // local appdata folder.
+
+        auto pathToRoamingSettingsFile{ CascadiaSettings::_GetRoamingSettingsPath() };
+        const auto hRoamingFile = CreateFileW(pathToRoamingSettingsFile.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+        if (hRoamingFile != INVALID_HANDLE_VALUE)
+        {
+            // Close the file handle, move it, and re-open the file in its new location.
+            CloseHandle(hRoamingFile);
+            const bool fSuccess = MoveFile(pathToRoamingSettingsFile.c_str(), pathToSettingsFile.c_str());
+            if (!fSuccess)
+            {
+                THROW_LAST_ERROR();
+            }
+
+            hFile = CreateFileW(pathToSettingsFile.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+            if (hFile == INVALID_HANDLE_VALUE)
+            {
+                // This was unexpected - We just moved the file, we should be
+                // able to open it. Throw the error so we can get some
+                // information here.
+                THROW_LAST_ERROR();
+            }
+        }
+        else
+        {
+            // If the roaming file didn't exist, and the local file doesn't exist,
+            //      that's fine. Just log the error and return nullopt - we'll
+            //      create the defaults.
+            LOG_LAST_ERROR();
+            return std::nullopt;
+        }
     }
 
     // fileSize is in bytes
@@ -289,14 +321,49 @@ std::optional<std::string> CascadiaSettings::_ReadSettings()
 
 // function Description:
 // - Returns the full path to the settings file, either within the application
-//   package, or in its unpackaged location.
+//   package, or in its unpackaged location. This path is under the "Local
+//   AppData" folder, so it _doesn't_ roam to other machines.
+// - If the application is unpackaged,
+//   the file will end up under e.g. C:\Users\admin\AppData\Local\Microsoft\Windows Terminal\profiles.json
+// Arguments:
+// - <none>
+// Return Value:
+// - the full path to the settings file
+std::wstring CascadiaSettings::GetSettingsPath()
+{
+    wil::unique_cotaskmem_string localAppDataFolder;
+    // KF_FLAG_FORCE_APP_DATA_REDIRECTION, when engaged, causes SHGet... to return
+    // the new AppModel paths (Packages/xxx/RoamingState, etc.) for standard path requests.
+    // Using this flag allows us to avoid Windows.Storage.ApplicationData completely.
+    if (FAILED(SHGetKnownFolderPath(FOLDERID_LocalAppData, KF_FLAG_FORCE_APP_DATA_REDIRECTION, 0, &localAppDataFolder)))
+    {
+        THROW_LAST_ERROR();
+    }
+
+    std::filesystem::path parentDirectoryForSettingsFile{ localAppDataFolder.get() };
+
+    if (!_IsPackaged())
+    {
+        parentDirectoryForSettingsFile /= UnpackagedSettingsFolderName;
+    }
+
+    // Create the directory if it doesn't exist
+    std::filesystem::create_directories(parentDirectoryForSettingsFile);
+
+    return parentDirectoryForSettingsFile / SettingsFilename;
+}
+
+// Function Description:
+// - Returns the full path to the settings file, either within the application
+//   package, or in its unpackaged location. This is the old Roaming app data
+//   location.
 // - If the application is unpackaged,
 //   the file will end up under e.g. C:\Users\admin\AppData\Roaming\Microsoft\Windows Terminal\profiles.json
 // Arguments:
 // - <none>
 // Return Value:
 // - the full path to the settings file
-std::wstring CascadiaSettings::GetSettingsPath()
+std::wstring CascadiaSettings::_GetRoamingSettingsPath()
 {
     wil::unique_cotaskmem_string roamingAppDataFolder;
     // KF_FLAG_FORCE_APP_DATA_REDIRECTION, when engaged, causes SHGet... to return


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

We'll no longer use RoamingState as our app data folder. Instead we'll use the LocalState folder. This will prevent settings from automatically roaming. 

We'll also `MoveFile` existing settings from RoamingState to LocalState, if we find it in RoamingState, but not LocalState.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1770
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [?] Requires documentation to be updated
* [x] I've discussed this with core contributors already. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* No profiles.json -> generates a new one in LocalState
* Profile in LocalState, not Roaming -> Nothing happens, loads normally.
* Profile in RoamingState, not Local -> File moves to Local, loads normally.
* profile in _both_ -> File in Roaming is ignored, only uses Local, loads normally.

