### PR TITLE
Fix the ut_app build for VS 16.2, 16.3

### DIFF
--- a/src/cascadia/TerminalApp/FixVisualStudioBug.targets
+++ b/src/cascadia/TerminalApp/FixVisualStudioBug.targets
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    This is a terrible, terrible rule. There exists a bug in Visual Studio 2019 16.2 and 16.3 previews
+    where ResolveAssemblyReferences will try and fail to parse a .lib when it produces a .winmd.
+    To fix that, we have to _temporarily_ replace the %(Implementation) on any winmd-producing
+    static library references with the empty string so as to make ResolveAssemblyReferences
+    not try to read it.
+
+    Upstream problem report:
+    https://developercommunity.visualstudio.com/content/problem/629524/static-library-reference-causes-there-was-a-proble.html
+  -->
+  <Target Name="_RemoveTerminalAppLibImplementationFromReference" BeforeTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <_TerminalAppLibProjectReference Include="@(_ResolvedProjectReferencePaths)" Condition="'%(Filename)' == 'TerminalApp'" />
+      <_ResolvedProjectReferencePaths Remove="@(_TerminalAppLibProjectReference)" />
+      <_ResolvedProjectReferencePaths Include="@(_TerminalAppLibProjectReference)">
+        <Implementation />
+      </_ResolvedProjectReferencePaths>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_RestoreTerminalAppLibImplementationFromReference" AfterTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <_ResolvedProjectReferencePaths Remove="@(_TerminalAppLibProjectReference)" />
+      <_ResolvedProjectReferencePaths Include="@(_TerminalAppLibProjectReference)" />
+    </ItemGroup>
+  </Target>
+  <!-- End "terrible, terrible rule" -->
+</Project>

--- a/src/cascadia/TerminalApp/TerminalApp.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalApp.vcxproj
@@ -109,32 +109,8 @@
 
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.post.props" />
 
-  <!--
-    This is a terrible, terrible rule. There exists a bug in Visual Studio 2019 16.2 and 16.3 previews
-    where ResolveAssemblyReferences will try and fail to parse a .lib when it produces a .winmd.
-    To fix that, we have to _temporarily_ replace the %(Implementation) on any winmd-producing
-    static library references with the empty string so as to make ResolveAssemblyReferences
-    not try to read it.
-
-    Upstream problem report:
-    https://developercommunity.visualstudio.com/content/problem/629524/static-library-reference-causes-there-was-a-proble.html
-  -->
-  <Target Name="_RemoveTerminalAppLibImplementationFromReference" BeforeTargets="ResolveAssemblyReferences">
-    <ItemGroup>
-      <_TerminalAppLibProjectReference Include="@(_ResolvedProjectReferencePaths)" Condition="'%(Filename)' == 'TerminalApp'" />
-      <_ResolvedProjectReferencePaths Remove="@(_TerminalAppLibProjectReference)" />
-      <_ResolvedProjectReferencePaths Include="@(_TerminalAppLibProjectReference)">
-        <Implementation />
-      </_ResolvedProjectReferencePaths>
-    </ItemGroup>
-  </Target>
-
-  <Target Name="_RestoreTerminalAppLibImplementationFromReference" AfterTargets="ResolveAssemblyReferences">
-    <ItemGroup>
-      <_ResolvedProjectReferencePaths Remove="@(_TerminalAppLibProjectReference)" />
-      <_ResolvedProjectReferencePaths Include="@(_TerminalAppLibProjectReference)" />
-    </ItemGroup>
-  </Target>
-  <!-- End "terrible, terrible rule" -->
+  <!-- Import this set of targets that fixes a VS bug that manifests when using
+  the TerminalAppLib project -->
+  <Import Project="FixVisualStudioBug.targets" />
 
 </Project>

--- a/src/cascadia/ut_app/TerminalApp.UnitTests.vcxproj
+++ b/src/cascadia/ut_app/TerminalApp.UnitTests.vcxproj
@@ -122,4 +122,8 @@
     </PostBuildEvent>
   </ItemDefinitionGroup>
 
+  <!-- Import this set of targets that fixes a VS bug that manifests when using
+  the TerminalAppLib project -->
+  <Import Project="../TerminalApp/FixVisualStudioBug.targets" />
+
 </Project>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
  Move the hack from TerminalApp.vcxproj to a .targets file to be used by the  ut_app project too.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

This might need to go into #2294 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #2143
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
