### PR TITLE
Hot take: we set the tab title for cmd and powershell by default

### DIFF
--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -232,6 +232,7 @@ void CascadiaSettings::_CreateDefaultProfiles()
     cmdProfile.SetColorScheme({ L"Campbell" });
     cmdProfile.SetAcrylicOpacity(0.75);
     cmdProfile.SetUseAcrylic(true);
+    cmdProfile.SetTabTitle(std::optional<std::wstring>{ L"Command Prompt" });
 
     auto powershellProfile{ _CreateDefaultProfile(L"Windows PowerShell") };
     powershellProfile.SetCommandline(L"powershell.exe");
@@ -239,6 +240,7 @@ void CascadiaSettings::_CreateDefaultProfiles()
     powershellProfile.SetColorScheme({ L"Campbell" });
     powershellProfile.SetDefaultBackground(POWERSHELL_BLUE);
     powershellProfile.SetUseAcrylic(false);
+    powershellProfile.SetTabTitle(std::optional<std::wstring>{ L"Windows PowerShell" });
 
     // If the user has installed PowerShell Core, we add PowerShell Core as a default.
     // PowerShell Core default folder is "%PROGRAMFILES%\PowerShell\[Version]\".

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -498,6 +498,11 @@ void Profile::SetColorScheme(std::optional<std::wstring> schemeName) noexcept
     _schemeName = std::move(schemeName);
 }
 
+void Profile::SetTabTitle(std::optional<std::wstring> tabTitle) noexcept
+{
+    _tabTitle = std::move(tabTitle);
+}
+
 void Profile::SetAcrylicOpacity(double opacity) noexcept
 {
     _acrylicTransparency = opacity;

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -48,6 +48,7 @@ public:
     void SetCommandline(std::wstring cmdline) noexcept;
     void SetStartingDirectory(std::wstring startingDirectory) noexcept;
     void SetName(std::wstring name) noexcept;
+    void SetTabTitle(std::optional<std::wstring> tabTitle) noexcept;
     void SetUseAcrylic(bool useAcrylic) noexcept;
     void SetDefaultForeground(COLORREF defaultForeground) noexcept;
     void SetDefaultBackground(COLORREF defaultBackground) noexcept;


### PR DESCRIPTION
I'm submitting this PR to start a discussion about this. If we reach consensus against it, I'm happy to close it. I'm also liking **Plan B** the more I think on it.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
  We don't set it for WSL, Azure, or Powershell core

  **Plan B**: Add an `"initialTabTitle"` setting. With that set, we'll ignore the _first_ title conpty sets for us. If conpty sets another title, we'll blow the initial title away and continue using the title from VT. This would be more similar to how cmd and powershell use the title from a shortcut currently.


![image](https://user-images.githubusercontent.com/18356694/62713127-d41ce180-b9c1-11e9-8364-0ffe4d2078cb.png)


<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
literally every issue that mentions the length of the tab title, but #2327 was the one that broke the camel's back.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #the-endless-stream-of-complaints-about-tab-titles
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated - **Probably does**
* [ ] I have **not** discussed this with core contributors already. 

