### PR TITLE
Make the RIS command clear the display and scrollback correctly

### DIFF
--- a/src/host/ut_host/ViewportTests.cpp
+++ b/src/host/ut_host/ViewportTests.cpp
@@ -1044,18 +1044,8 @@ class ViewportTests
         const auto original = Viewport::FromInclusive(srOriginal);
         const auto remove = original;
 
-        std::vector<Viewport> expected;
-        expected.emplace_back(Viewport::FromDimensions(original.Origin(), { 0, 0 }));
-
         const auto actual = Viewport::Subtract(original, remove);
 
-        VERIFY_ARE_EQUAL(expected.size(), actual.size(), L"Same number of viewports in expected and actual");
-        Log::Comment(L"Now validate that each viewport has the expected area.");
-        for (size_t i = 0; i < expected.size(); i++)
-        {
-            const auto& exp = expected.at(i);
-            const auto& act = actual.at(i);
-            VERIFY_ARE_EQUAL(exp, act);
-        }
+        VERIFY_ARE_EQUAL(0, actual.size(), L"There should be no viewports returned");
     }
 };

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1601,17 +1601,17 @@ bool AdaptDispatch::SoftReset()
 // True if handled successfully. False otherwise.
 bool AdaptDispatch::HardReset()
 {
+    // Sets the SGR state to normal.
+    bool fSuccess = SoftReset();
+
     // Clears the screen - Needs to be done in two operations.
-    bool fSuccess = _EraseScrollback();
     if (fSuccess)
     {
         fSuccess = EraseInDisplay(DispatchTypes::EraseType::All);
     }
-
-    // Sets the SGR state to normal.
     if (fSuccess)
     {
-        fSuccess = SoftReset();
+        fSuccess = _EraseScrollback();
     }
 
     // Cursor to 1,1 - the Soft Reset guarantees this is absolute

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -3426,30 +3426,33 @@ public:
         // The cursor will be moved to the same relative location in the new viewport with origin @ 0, 0
         const COORD coordRelativeCursor = { _testGetSet->_coordCursorPos.X - _testGetSet->_srViewport.Left,
                                             _testGetSet->_coordCursorPos.Y - _testGetSet->_srViewport.Top };
-
-        // Cursor to 1,1
-        _testGetSet->_coordExpectedCursorPos = { 0, 0 };
-        _testGetSet->_fSetConsoleCursorPositionResult = true;
-        _testGetSet->_fPrivateSetLegacyAttributesResult = true;
-        _testGetSet->_fPrivateSetDefaultAttributesResult = true;
-        _testGetSet->_fPrivateBoldTextResult = true;
-        _testGetSet->_fExpectedForeground = true;
-        _testGetSet->_fExpectedBackground = true;
-        _testGetSet->_fExpectedMeta = true;
-        _testGetSet->_fExpectedIsBold = false;
-        _testGetSet->_expectedShowCursor = true;
-        _testGetSet->_privateShowCursorResult = true;
         const COORD coordExpectedCursorPos = { 0, 0 };
 
-        // We're expecting _SetDefaultColorHelper to call
-        //      PrivateSetLegacyAttributes with 0 as the wAttr param.
-        _testGetSet->_wExpectedAttribute = 0;
+        auto prepExpectedParameters = [&]() {
+            // Cursor to 1,1
+            _testGetSet->_coordExpectedCursorPos = { 0, 0 };
+            _testGetSet->_fSetConsoleCursorPositionResult = true;
+            _testGetSet->_fPrivateSetLegacyAttributesResult = true;
+            _testGetSet->_fPrivateSetDefaultAttributesResult = true;
+            _testGetSet->_fPrivateBoldTextResult = true;
+            _testGetSet->_fExpectedForeground = true;
+            _testGetSet->_fExpectedBackground = true;
+            _testGetSet->_fExpectedMeta = true;
+            _testGetSet->_fExpectedIsBold = false;
+            _testGetSet->_expectedShowCursor = true;
+            _testGetSet->_privateShowCursorResult = true;
 
-        // Prepare the results of SoftReset api calls
-        _testGetSet->_fPrivateSetCursorKeysModeResult = true;
-        _testGetSet->_fPrivateSetKeypadModeResult = true;
-        _testGetSet->_fGetConsoleScreenBufferInfoExResult = true;
-        _testGetSet->_fPrivateSetScrollingRegionResult = true;
+            // We're expecting _SetDefaultColorHelper to call
+            //      PrivateSetLegacyAttributes with 0 as the wAttr param.
+            _testGetSet->_wExpectedAttribute = 0;
+
+            // Prepare the results of SoftReset api calls
+            _testGetSet->_fPrivateSetCursorKeysModeResult = true;
+            _testGetSet->_fPrivateSetKeypadModeResult = true;
+            _testGetSet->_fGetConsoleScreenBufferInfoExResult = true;
+            _testGetSet->_fPrivateSetScrollingRegionResult = true;
+        };
+        prepExpectedParameters();
 
         VERIFY_IS_TRUE(_pDispatch->HardReset());
         VERIFY_ARE_EQUAL(_testGetSet->_coordCursorPos, coordExpectedCursorPos);
@@ -3457,18 +3460,21 @@ public:
 
         Log::Comment(L"Test 2: Gracefully fail when getting console information fails.");
         _testGetSet->PrepData();
+        prepExpectedParameters();
         _testGetSet->_fGetConsoleScreenBufferInfoExResult = false;
 
         VERIFY_IS_FALSE(_pDispatch->HardReset());
 
         Log::Comment(L"Test 3: Gracefully fail when filling the rectangle fails.");
         _testGetSet->PrepData();
+        prepExpectedParameters();
         _testGetSet->_fFillConsoleOutputCharacterWResult = false;
 
         VERIFY_IS_FALSE(_pDispatch->HardReset());
 
         Log::Comment(L"Test 4: Gracefully fail when setting the window fails.");
         _testGetSet->PrepData();
+        prepExpectedParameters();
         _testGetSet->_fSetConsoleWindowInfoResult = false;
 
         VERIFY_IS_FALSE(_pDispatch->HardReset());


### PR DESCRIPTION
## Summary of the Pull Request

When the scrollback buffer is empty, the RIS escape sequence (Reset to Initial State) will fail to clear the screen, or reset any of the state. And when there is something in the scrollback, it doesn't get cleared completely, and the screen may get filled with the wrong background color (it should use the default color, but it actually uses the previously active background color). This PR attempts to fix those issues.

## PR Checklist
* [x] Closes #2307
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #2307

## Detailed Description of the Pull Request / Additional comments

The initial failure is caused by the `SCREEN_INFORMATION::WriteRect` method [throwing an exception](https://github.com/microsoft/terminal/blob/7abcc35fdf7d98bc98016cda8f4b90398c65692e/src/host/screenInfo.cpp#L2608-L2609) when passed an empty viewport. And the reason it's passed an empty viewport is because that's what the `Viewport::Subtract` method returns [when the result of the subtraction is nothing](https://github.com/microsoft/terminal/blob/9b92986b49bed8cc41fde4d6ef080921c41e6d9e/src/types/viewport.cpp#L995-L998). The PR fixes the problem by making the `Viewport::Subtract` method actually return nothing in that situation. 

This is a change in the defined behavior that also required the associated viewport tests to be updated. However, it does seem a sensible change, since the `Subtract` method never returns empty viewports under any other circumstances. And [the only place the method seems to be used](https://github.com/microsoft/terminal/blob/9b92986b49bed8cc41fde4d6ef080921c41e6d9e/src/host/output.cpp#L469-L476) is in the `ScrollRegion` implementation, where the previous behavior is guaranteed to throw an exception.

The other issues are fixed simply by changing the order in which things are reset in the `AdaptDispatch::HardReset` method. The call to `SoftReset` needed to be made first, so that the SGR attributes would be reset before the screen was cleared, thus making sure that the default background color would be used. And the screen needed to be cleared before the scrollback was erased, otherwise the last view of the screen would be retained in the scrollback buffer.

These changes also required existing adapter tests to be updated, but not because of a change in the expected behaviour. It's just that certain tests relied on the `SoftReset` happening later in the order, so weren't expecting it to be called if say the scrollback erase had failed. It doesn't seem like the tests were deliberately trying to verify that the SoftReset _hadn't_ been called.

## Validation Steps Performed

In addition to the updates to existing tests, this PR also add a new screen buffer test which verifies the display and scrollback are correctly cleared under the conditions that were previously failing.