### PR TITLE
Only update the icon of a tab it the icon actually _changed_

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -689,10 +689,7 @@ namespace winrt::TerminalApp::implementation
             const auto* const matchingProfile = _settings->FindProfile(lastFocusedProfile);
             if (matchingProfile)
             {
-                std::wstring path{ matchingProfile->GetIconPath() };
-                const auto envExpandedPath{ wil::ExpandEnvironmentStringsW<std::wstring>(path.data()) };
-                winrt::hstring iconPath{ envExpandedPath };
-                tab->UpdateIcon(iconPath);
+                tab->UpdateIcon(matchingProfile->GetExpandedIconPath());
             }
             else
             {
@@ -930,10 +927,7 @@ namespace winrt::TerminalApp::implementation
         // Set this profile's tab to the icon the user specified
         if (profile != nullptr && profile->HasIcon())
         {
-            std::wstring path{ profile->GetIconPath() };
-            const auto envExpandedPath{ wil::ExpandEnvironmentStringsW<std::wstring>(path.data()) };
-            winrt::hstring iconPath{ envExpandedPath };
-            newTab->UpdateIcon(iconPath);
+            newTab->UpdateIcon(profile->GetExpandedIconPath());
         }
 
         tabViewItem.PointerPressed({ this, &App::_OnTabClick });
@@ -1259,9 +1253,7 @@ namespace winrt::TerminalApp::implementation
         {
             try
             {
-                std::wstring path{ profile.GetIconPath() };
-                const auto envExpandedPath{ wil::ExpandEnvironmentStringsW<std::wstring>(path.data()) };
-                winrt::hstring iconPath{ envExpandedPath };
+                winrt::hstring iconPath{ profile.GetExpandedIconPath() };
                 winrt::Windows::Foundation::Uri iconUri{ iconPath };
                 Controls::BitmapIconSource iconSource;
                 // Make sure to set this to false, so we keep the RGB data of the

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -1250,20 +1250,7 @@ namespace winrt::TerminalApp::implementation
     // - an IconElement for the profile's icon, if it has one.
     Controls::IconElement App::_GetIconFromProfile(const Profile& profile)
     {
-        if (profile.HasIcon())
-        {
-            try
-            {
-                winrt::hstring iconPath{ profile.GetExpandedIconPath() };
-                return GetColoredIcon(iconPath);
-            }
-            CATCH_LOG();
-            return { nullptr };
-        }
-        else
-        {
-            return { nullptr };
-        }
+        return profile.HasIcon() ? GetColoredIcon(profile.GetExpandedIconPath()) : Controls::IconElement{ nullptr };
     }
 
     winrt::Microsoft::Terminal::TerminalControl::TermControl App::_GetFocusedControl()

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -7,6 +7,7 @@
 
 #include "App.g.cpp"
 #include "TerminalPage.h"
+#include "Utils.h"
 
 using namespace winrt::Windows::ApplicationModel::DataTransfer;
 using namespace winrt::Windows::UI::Xaml;
@@ -1254,16 +1255,7 @@ namespace winrt::TerminalApp::implementation
             try
             {
                 winrt::hstring iconPath{ profile.GetExpandedIconPath() };
-                winrt::Windows::Foundation::Uri iconUri{ iconPath };
-                Controls::BitmapIconSource iconSource;
-                // Make sure to set this to false, so we keep the RGB data of the
-                // image. Otherwise, the icon will be white for all the
-                // non-transparent pixels in the image.
-                iconSource.ShowAsMonochrome(false);
-                iconSource.UriSource(iconUri);
-                Controls::IconSourceElement elem;
-                elem.IconSource(iconSource);
-                return elem;
+                return GetColoredIcon(iconPath);
             }
             CATCH_LOG();
             return { nullptr };

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -568,14 +568,19 @@ void Profile::SetIconPath(std::wstring_view path)
 }
 
 // Method Description:
-// - Returns this profile's icon path, if one is set. Otherwise returns the empty string.
+// - Returns this profile's icon path, if one is set. Otherwise returns the
+//   empty string. This method will expand any environment variables in the
+//   path, if there are any.
 // Return Value:
 // - this profile's icon path, if one is set. Otherwise returns the empty string.
-std::wstring_view Profile::GetIconPath() const noexcept
+winrt::hstring Profile::GetExpandedIconPath() const
 {
-    return HasIcon() ?
-               std::wstring_view{ _icon.value().c_str(), _icon.value().size() } :
-               std::wstring_view{ L"", 0 };
+    if (!HasIcon())
+    {
+        return { L"" };
+    }
+    winrt::hstring envExpandedPath{ wil::ExpandEnvironmentStringsW<std::wstring>(_icon.value().data()) };
+    return envExpandedPath;
 }
 
 // Method Description:

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -55,7 +55,7 @@ public:
     void SetConnectionType(GUID connectionType) noexcept;
 
     bool HasIcon() const noexcept;
-    std::wstring_view GetIconPath() const noexcept;
+    winrt::hstring GetExpandedIconPath() const;
     void SetIconPath(std::wstring_view path);
 
     bool GetCloseOnExit() const noexcept;

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -142,6 +142,39 @@ void Tab::UpdateFocus()
     _rootPane->UpdateFocus();
 }
 
+void Tab::UpdateIcon(const winrt::hstring iconPath)
+{
+    // Don't reload our icon if it hasn't changed.
+    if (iconPath == _lastIconPath)
+    {
+        return;
+    }
+
+    _lastIconPath = iconPath;
+
+    _tabViewItem.Dispatcher().RunAsync(CoreDispatcherPriority::Normal, [this]() {
+        Controls::IconSourceElement elem{};
+
+        if (!_lastIconPath.empty())
+        {
+            try
+            {
+                winrt::Windows::Foundation::Uri iconUri{ _lastIconPath };
+                Controls::BitmapIconSource iconSource;
+                // Make sure to set this to false, so we keep the RGB data of the
+                // image. Otherwise, the icon will be white for all the
+                // non-transparent pixels in the image.
+                iconSource.ShowAsMonochrome(false);
+                iconSource.UriSource(iconUri);
+                elem.IconSource(iconSource);
+            }
+            CATCH_LOG();
+        }
+
+        _tabViewItem.Icon(elem);
+    });
+}
+
 // Method Description:
 // - Gets the title string of the last focused terminal control in our tree.
 //   Returns the empty string if there is no such control.

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.h"
 #include "Tab.h"
+#include "Utils.h"
 
 using namespace winrt::Windows::UI::Xaml;
 using namespace winrt::Windows::UI::Core;
@@ -153,25 +154,7 @@ void Tab::UpdateIcon(const winrt::hstring iconPath)
     _lastIconPath = iconPath;
 
     _tabViewItem.Dispatcher().RunAsync(CoreDispatcherPriority::Normal, [this]() {
-        Controls::IconSourceElement elem{};
-
-        if (!_lastIconPath.empty())
-        {
-            try
-            {
-                winrt::Windows::Foundation::Uri iconUri{ _lastIconPath };
-                Controls::BitmapIconSource iconSource;
-                // Make sure to set this to false, so we keep the RGB data of the
-                // image. Otherwise, the icon will be white for all the
-                // non-transparent pixels in the image.
-                iconSource.ShowAsMonochrome(false);
-                iconSource.UriSource(iconUri);
-                elem.IconSource(iconSource);
-            }
-            CATCH_LOG();
-        }
-
-        _tabViewItem.Icon(elem);
+        _tabViewItem.Icon(GetColoredIcon(_lastIconPath));
     });
 }
 

--- a/src/cascadia/TerminalApp/Tab.h
+++ b/src/cascadia/TerminalApp/Tab.h
@@ -23,6 +23,8 @@ public:
     void AddHorizontalSplit(const GUID& profile, winrt::Microsoft::Terminal::TerminalControl::TermControl& control);
 
     void UpdateFocus();
+    void UpdateIcon(const winrt::hstring iconPath);
+
     void ResizeContent(const winrt::Windows::Foundation::Size& newSize);
     void ResizePane(const winrt::TerminalApp::Direction& direction);
     void NavigateFocus(const winrt::TerminalApp::Direction& direction);
@@ -37,6 +39,7 @@ public:
 
 private:
     std::shared_ptr<Pane> _rootPane{ nullptr };
+    winrt::hstring _lastIconPath{};
 
     bool _focused{ false };
     winrt::Microsoft::UI::Xaml::Controls::TabViewItem _tabViewItem{ nullptr };

--- a/src/cascadia/TerminalApp/Utils.cpp
+++ b/src/cascadia/TerminalApp/Utils.cpp
@@ -28,18 +28,21 @@ std::wstring GetWstringFromJson(const Json::Value& json)
 winrt::Windows::UI::Xaml::Controls::IconElement GetColoredIcon(const winrt::hstring& path)
 {
     winrt::Windows::UI::Xaml::Controls::IconSourceElement elem{};
-    try
+    if (!path.empty())
     {
-        winrt::Windows::Foundation::Uri iconUri{ path };
-        winrt::Windows::UI::Xaml::Controls::BitmapIconSource iconSource;
-        // Make sure to set this to false, so we keep the RGB data of the
-        // image. Otherwise, the icon will be white for all the
-        // non-transparent pixels in the image.
-        iconSource.ShowAsMonochrome(false);
-        iconSource.UriSource(iconUri);
-        elem.IconSource(iconSource);
+        try
+        {
+            winrt::Windows::Foundation::Uri iconUri{ path };
+            winrt::Windows::UI::Xaml::Controls::BitmapIconSource iconSource;
+            // Make sure to set this to false, so we keep the RGB data of the
+            // image. Otherwise, the icon will be white for all the
+            // non-transparent pixels in the image.
+            iconSource.ShowAsMonochrome(false);
+            iconSource.UriSource(iconUri);
+            elem.IconSource(iconSource);
+        }
+        CATCH_LOG();
     }
-    CATCH_LOG();
 
     return elem;
 }

--- a/src/cascadia/TerminalApp/Utils.cpp
+++ b/src/cascadia/TerminalApp/Utils.cpp
@@ -16,3 +16,30 @@ std::wstring GetWstringFromJson(const Json::Value& json)
 {
     return winrt::to_hstring(json.asString()).c_str();
 }
+
+// Method Description:
+// - Creates an IconElement for the given path. The icon returned is a colored
+//   icon. If we couldn't create the icon for any reason, we return an empty
+//   IconElement.
+// Arguments:
+// - path: the full, expanded path to the icon.
+// Return Value:
+// - An IconElement with its IconSource set, if possible.
+winrt::Windows::UI::Xaml::Controls::IconElement GetColoredIcon(const winrt::hstring& path)
+{
+    winrt::Windows::UI::Xaml::Controls::IconSourceElement elem{};
+    try
+    {
+        winrt::Windows::Foundation::Uri iconUri{ path };
+        winrt::Windows::UI::Xaml::Controls::BitmapIconSource iconSource;
+        // Make sure to set this to false, so we keep the RGB data of the
+        // image. Otherwise, the icon will be white for all the
+        // non-transparent pixels in the image.
+        iconSource.ShowAsMonochrome(false);
+        iconSource.UriSource(iconUri);
+        elem.IconSource(iconSource);
+    }
+    CATCH_LOG();
+
+    return elem;
+}

--- a/src/cascadia/TerminalApp/Utils.h
+++ b/src/cascadia/TerminalApp/Utils.h
@@ -28,3 +28,5 @@ inline std::string JsonKey(const std::string_view key)
 {
     return static_cast<std::string>(key);
 }
+
+winrt::Windows::UI::Xaml::Controls::IconElement GetColoredIcon(const winrt::hstring& path);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Only update the icon of a tab it the icon actually _changed_. The way we have it, we'll try and update the icon everytime focus changes, causing the tab icon to blink for a second, even when switching between two panes with the same profile.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

While I was here, I also fixed #2329, I think accidentally. But that's cool!

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist  
* [x] fixes #1333
* [x] Also tangentially fixes #2329
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed (please review #2294 so I can start checking this box)

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
