### PR TITLE
Add Powershell command to get OS version

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -35,7 +35,7 @@ Please use this form and describe your issue, concisely but precisely, with as m
 # Environment
 
 ```none
-Windows build number: [run "ver" at a command prompt]
+Windows build number: [run `[Environment]::OSVersion` for powershell, or `ver` for cmd]
 Windows Terminal version (if applicable):
 
 Any other software?


### PR DESCRIPTION
As `ver` doesn't work in default shell.

## Summary of the Pull Request

GitHub issues currently have instructions to run `ver` which doesn't work in Windows default shell. This PR adds Powershell instructions and keeps the cmd instructions too.

## References
No issues. Could create one if you want.

## PR Checklist
* [x] CLA signed. 
* [x] Tests added/passed
* [ ] Requires documentation to be updated (N/A, as this is documentation)
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. 

## Validation Steps Performed
Follow instructions. Note they work now in the default shell now rather than producing an error.