### PR TITLE
When the titlebar is clicked, dismiss the new tab flyout

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -1462,6 +1462,23 @@ namespace winrt::TerminalApp::implementation
         return connection;
     }
 
+    // Method Description:
+    // - Used to tell the app that the titlebar has been clicked. The App won't
+    //   actually recieve any clicks in the titlebar area, so this is a helper
+    //   to clue the app in that a click has happened. The App will use this as
+    //   a indicator that it needs to dismiss any open flyouts.
+    // Arguments:
+    // - <none>
+    // Return Value:
+    // - <none>
+    void App::TitlebarClicked()
+    {
+        if (_newTabButton && _newTabButton.Flyout())
+        {
+            _newTabButton.Flyout().Hide();
+        }
+    }
+
     // -------------------------------- WinRT Events ---------------------------------
     // Winrt events need a method for adding a callback to the event and removing the callback.
     // These macros will define them both for you.

--- a/src/cascadia/TerminalApp/App.h
+++ b/src/cascadia/TerminalApp/App.h
@@ -37,6 +37,7 @@ namespace winrt::TerminalApp::implementation
         ~App() = default;
 
         hstring GetTitle();
+        void TitlebarClicked();
 
         // -------------------------------- WinRT Events ---------------------------------
         DECLARE_EVENT(TitleChanged, _titleChangeHandlers, winrt::Microsoft::Terminal::TerminalControl::TitleChangedEventArgs);

--- a/src/cascadia/TerminalApp/App.idl
+++ b/src/cascadia/TerminalApp/App.idl
@@ -30,5 +30,7 @@ namespace TerminalApp
         event Windows.Foundation.TypedEventHandler<App, Windows.UI.Xaml.ElementTheme> RequestedThemeChanged;
 
         String GetTitle();
+
+        void TitlebarClicked();
     }
 }

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -68,6 +68,11 @@ void AppHost::Initialize()
         // This has to be done _before_ App::Create, as the app might set the
         // content in Create.
         _app.SetTitleBarContent({ this, &AppHost::_UpdateTitleBarContent });
+
+        // Add an event handler to plumb clicks in the titlebar area down to the
+        // application layer.
+        auto pNcWindow = static_cast<NonClientIslandWindow*>(_window.get());
+        pNcWindow->DragRegionClicked([this]() { _app.TitlebarClicked(); });
     }
     _app.RequestedThemeChanged({ this, &AppHost::_UpdateTheme });
 

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -68,12 +68,12 @@ void AppHost::Initialize()
         // This has to be done _before_ App::Create, as the app might set the
         // content in Create.
         _app.SetTitleBarContent({ this, &AppHost::_UpdateTitleBarContent });
-
-        // Add an event handler to plumb clicks in the titlebar area down to the
-        // application layer.
-        auto pNcWindow = static_cast<NonClientIslandWindow*>(_window.get());
-        pNcWindow->DragRegionClicked([this]() { _app.TitlebarClicked(); });
     }
+
+    // Add an event handler to plumb clicks in the titlebar area down to the
+    // application layer.
+    _window->DragRegionClicked([this]() { _app.TitlebarClicked(); });
+
     _app.RequestedThemeChanged({ this, &AppHost::_UpdateTheme });
 
     _app.Create();

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -166,6 +166,21 @@ void IslandWindow::OnSize(const UINT width, const UINT height)
             return 0; // eat the message
         }
     }
+
+    case WM_NCLBUTTONDOWN:
+    case WM_NCLBUTTONUP:
+    case WM_NCMBUTTONDOWN:
+    case WM_NCMBUTTONUP:
+    case WM_NCRBUTTONDOWN:
+    case WM_NCRBUTTONUP:
+    case WM_NCXBUTTONDOWN:
+    case WM_NCXBUTTONUP:
+    {
+        // If we clicked in the titlebar, raise an event so the app host can
+        // dispatch an appropriate event.
+        _DragRegionClickedHandlers();
+        break;
+    }
     case WM_MENUCHAR:
     {
         // GH#891: return this LRESULT here to prevent the app from making a
@@ -258,3 +273,5 @@ void IslandWindow::UpdateTheme(const winrt::Windows::UI::Xaml::ElementTheme& req
     // drawing ourselves to match the new theme
     ::InvalidateRect(_window.get(), nullptr, false);
 }
+
+DEFINE_EVENT(IslandWindow, DragRegionClicked, _DragRegionClickedHandlers, winrt::delegate<>);

--- a/src/cascadia/WindowsTerminal/IslandWindow.h
+++ b/src/cascadia/WindowsTerminal/IslandWindow.h
@@ -7,6 +7,7 @@
 #include "WindowUiaProvider.hpp"
 #include <winrt/Microsoft.Terminal.TerminalControl.h>
 #include <winrt/TerminalApp.h>
+#include "../../cascadia/inc/cppwinrt_utils.h"
 
 class IslandWindow :
     public BaseWindow<IslandWindow>,
@@ -65,6 +66,8 @@ public:
     };
 
 #pragma endregion
+
+    DECLARE_EVENT(DragRegionClicked, _DragRegionClickedHandlers, winrt::delegate<>);
 
 protected:
     void ForceResize()

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -811,5 +811,3 @@ bool NonClientIslandWindow::_HandleWindowPosChanging(WINDOWPOS* const windowPos)
     }
     return true;
 }
-
-DEFINE_EVENT(NonClientIslandWindow, DragRegionClicked, _DragRegionClickedHandlers, winrt::delegate<>);

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -263,14 +263,22 @@ void NonClientIslandWindow::_UpdateDragRegion()
 // - Hit test the frame for resizing and moving.
 // Arguments:
 // - ptMouse: the mouse point being tested, in absolute (NOT WINDOW) coordinates.
+// - titlebarIsCaption: If true, we want to treat the titlebar area as
+//   HTCAPTION, otherwise we'll return HTNOWHERE for the titlebar.
 // Return Value:
 // - one of the values from
 //  https://docs.microsoft.com/en-us/windows/desktop/inputdev/wm-nchittest#return-value
 //   corresponding to the area of the window that was hit
 // NOTE:
-// Largely taken from code on:
+// - Largely taken from code on:
 // https://docs.microsoft.com/en-us/windows/desktop/dwm/customframe
-[[nodiscard]] LRESULT NonClientIslandWindow::HitTestNCA(POINT ptMouse) const noexcept
+// NOTE[2]: Concerning `titlebarIsCaption`
+// - We want HTNOWHERE as the return value for WM_NCHITTEST, so that we can get
+//   mouse presses in the titlebar area. If we return HTCAPTION there, we won't
+//   get any mouse WMs. However, when we're handling the mouse events, we need
+//   to know if the mouse was in that are or not, so we'll return HTCAPTION in
+//   that handler, to differentiate from the rest of the window.
+[[nodiscard]] LRESULT NonClientIslandWindow::HitTestNCA(POINT ptMouse, const bool titlebarIsCaption) const noexcept
 {
     // Get the window rectangle.
     RECT rcWindow = BaseWindow::GetWindowRect();
@@ -311,10 +319,11 @@ void NonClientIslandWindow::_UpdateDragRegion()
 
     // clang-format off
     // Hit test (HTTOPLEFT, ... HTBOTTOMRIGHT)
+    const auto topHt = fOnResizeBorder ? HTTOP : (titlebarIsCaption ? HTCAPTION : HTNOWHERE);
     LRESULT hitTests[3][3] = {
-        { HTTOPLEFT,    fOnResizeBorder ? HTTOP : HTCAPTION, HTTOPRIGHT },
-        { HTLEFT,       HTNOWHERE,                           HTRIGHT },
-        { HTBOTTOMLEFT, HTBOTTOM,                            HTBOTTOMRIGHT },
+        { HTTOPLEFT,    topHt,      HTTOPRIGHT },
+        { HTLEFT,       HTNOWHERE,  HTRIGHT },
+        { HTBOTTOMLEFT, HTBOTTOM,   HTBOTTOMRIGHT },
     };
     // clang-format on
 
@@ -511,8 +520,7 @@ RECT NonClientIslandWindow::GetMaxWindowRectInPixels(const RECT* const prcSugges
         // Handle hit testing in the NCA if not handled by DwmDefWindowProc.
         if (lRet == 0)
         {
-            lRet = HitTestNCA({ GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) });
-
+            lRet = HitTestNCA({ GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) }, false);
             if (lRet != HTNOWHERE)
             {
                 return lRet;
@@ -594,9 +602,14 @@ RECT NonClientIslandWindow::GetMaxWindowRectInPixels(const RECT* const prcSugges
     {
         POINT point1 = {};
         ::GetCursorPos(&point1);
-        const auto region = HitTestNCA(point1);
+
+        const auto region = HitTestNCA(point1, true);
         if (region == HTCAPTION)
         {
+            // If we clicked in the titlebar, raise an event so the app host can
+            // dispatch an appropriate event.
+            _DragRegionClickedHandlers();
+
             const auto longParam = MAKELPARAM(point1.x, point1.y);
             ::SetActiveWindow(_window.get());
             ::PostMessage(_window.get(), WM_SYSCOMMAND, SC_MOVE | HTCAPTION, longParam);
@@ -798,3 +811,5 @@ bool NonClientIslandWindow::_HandleWindowPosChanging(WINDOWPOS* const windowPos)
     }
     return true;
 }
+
+DEFINE_EVENT(NonClientIslandWindow, DragRegionClicked, _DragRegionClickedHandlers, winrt::delegate<>);

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.h
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.h
@@ -23,6 +23,7 @@ Author(s):
 #include <dwmapi.h>
 #include <windowsx.h>
 #include <wil\resource.h>
+#include "../../cascadia/inc/cppwinrt_utils.h"
 
 class NonClientIslandWindow : public IslandWindow
 {
@@ -42,6 +43,8 @@ public:
     void SetContent(winrt::Windows::UI::Xaml::UIElement content) override;
     void SetTitlebarContent(winrt::Windows::UI::Xaml::UIElement content);
 
+    DECLARE_EVENT(DragRegionClicked, _DragRegionClickedHandlers, winrt::delegate<>);
+
 private:
     winrt::TerminalApp::TitlebarControl _titlebar{ nullptr };
     winrt::Windows::UI::Xaml::UIElement _clientContent{ nullptr };
@@ -55,7 +58,7 @@ private:
 
     RECT GetDragAreaRect() const noexcept;
 
-    [[nodiscard]] LRESULT HitTestNCA(POINT ptMouse) const noexcept;
+    [[nodiscard]] LRESULT HitTestNCA(POINT ptMouse, const bool titlebarIsCaption) const noexcept;
 
     [[nodiscard]] HRESULT _UpdateFrameMargins() const noexcept;
 

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.h
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.h
@@ -23,7 +23,6 @@ Author(s):
 #include <dwmapi.h>
 #include <windowsx.h>
 #include <wil\resource.h>
-#include "../../cascadia/inc/cppwinrt_utils.h"
 
 class NonClientIslandWindow : public IslandWindow
 {
@@ -42,8 +41,6 @@ public:
     void OnAppInitialized() override;
     void SetContent(winrt::Windows::UI::Xaml::UIElement content) override;
     void SetTitlebarContent(winrt::Windows::UI::Xaml::UIElement content);
-
-    DECLARE_EVENT(DragRegionClicked, _DragRegionClickedHandlers, winrt::delegate<>);
 
 private:
     winrt::TerminalApp::TitlebarControl _titlebar{ nullptr };

--- a/src/cascadia/inc/cppwinrt_utils.h
+++ b/src/cascadia/inc/cppwinrt_utils.h
@@ -25,7 +25,7 @@ public:                                                  \
     winrt::event_token name(args const& handler);        \
     void name(winrt::event_token const& token) noexcept; \
                                                          \
-private:                                                 \
+protected:                                               \
     winrt::event<args> eventHandler;
 
 // This is a helper macro for defining the body of events.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

* Add a method to `App` to indicate to the app that the titlebar has been clicked. We'll use this method to `Hide` the flyout.
* In `NonClientIslandWindow`, treat the titlebar as `HTNOWHERE`, so we get clicks in that area.
* In `NonClientIslandWindow`, raise an event when the titlebar area is clicked. Also do the normal `HTCAPTION` thing we were doing before.
* In `AppHost`, when it handles the event from `NonClientIslandWindow`, it'll call the method on `App` to close the flyout.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #2028
* [N/A] Tests added/passed

