### PR TITLE
SVG currently doesn't work; using .jpg instead

### DIFF
--- a/doc/user-docs/UsingJsonSettings.md
+++ b/doc/user-docs/UsingJsonSettings.md
@@ -99,7 +99,7 @@ The schema name can then be referenced in one or more profiles.
 
 ### Add a custom background to the WSL Debian terminal profile
 
-1. Download the Debian SVG logo https://www.debian.org/logos/openlogo.svg
+1. Download the Debian JPG logo https://www.debian.org/logos/openlogo-100.jpg
 2. Put the image in the
  `$env:LocalAppData\Packages\Microsoft.WindowsTerminal_<randomString>\RoamingState\`
  directory (same directory as your `profiles.json` file).
@@ -108,9 +108,10 @@ The schema name can then be referenced in one or more profiles.
 3. Open your WT json properties file.
 4. Under the Debian Linux profile, add the following fields:
 ```json
-    "backgroundImage": "ms-appdata:///Roaming/openlogo.jpg",
-    "backgroundImageOpacity": 0.3,
-    "backgroundImageStretchMode":  "fill",
+    "backgroundImage": "ms-appdata:///Roaming/openlogo-100.jpg",
+    "backgroundImageOpacity": 1,
+    "backgroundImageStretchMode" : "none",
+    "backgroundImageAlignment" : "topRight",
 ```
 5. Make sure that `useAcrylic` is `false`.
 6. Save the file.


### PR DESCRIPTION
## Summary of the Pull Request
Docs show example config with with a background image
That image is listed as being .SVG
SVG currently doesn't work
Let's have the docs use .jpg instead

Since the JPG won't stretch nicely we're also going to put it in the top-right corner without any scaling

## References
We can go back to an SVG file after #2441 gets fixed

## PR Checklist
* [ ] Closes #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [X] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. 

## Detailed Description of the Pull Request / Additional comments
No additional comments

## Validation Steps Performed
I looked at it in the 'Preview' panel