### PR TITLE
- [Sample - MiniTerm] Changed callable process in ProcessFactory from…

### DIFF
--- a/samples/ConPTY/MiniTerm/MiniTerm/Processes/ProcessFactory.cs
+++ b/samples/ConPTY/MiniTerm/MiniTerm/Processes/ProcessFactory.cs
@@ -18,7 +18,7 @@ namespace MiniTerm
         internal static Process Start(string command, IntPtr attributes, IntPtr hPC)
         {
             var startupInfo = ConfigureProcessThread(hPC, attributes);
-            var processInfo = RunProcess(ref startupInfo, "cmd.exe");
+            var processInfo = RunProcess(ref startupInfo, command);
             return new Process(startupInfo, processInfo);
         }
 


### PR DESCRIPTION
… static cmd.exe to command argument as intended originally

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Changed from "cmd.exe" to command argument in ProcessFactory StartFunction.
Seems to be a bug since this way only cmd.exe can be used in the example.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
Don't think so

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Nothing else changed

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Simple recalled the shell from VS 19 and see that example is still working fine