### PR TITLE
Bugfix: Copy data should persist after Windows Terminal Closes

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -1546,6 +1546,7 @@ namespace winrt::TerminalApp::implementation
             }
 
             Clipboard::SetContent(dataPack);
+            Clipboard::Flush();
         });
     }
 


### PR DESCRIPTION
## Summary of the Pull Request
Turns out, you need to call `Clipboard::Flush()`. This is apparently a very common issue with the UWP Clipboard ([link](https://stackoverflow.com/questions/31781019/clipboard-content-of-closed-windows-universal-app)).

## PR Checklist
* [x] Closes #1644 
* [x] CLA signed
* [x] ~Tests added/passed~
* [x] ~Requires documentation to be updated~
* [x] I am a core contributor

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
N/A

## Validation Steps Performed
Manual test of repro defined in bug report.