### PR TITLE
AZ: Introduce a "credential version" to force old credentials to be deleted

### DIFF
--- a/src/cascadia/TerminalConnection/AzureConnectionStrings.h
+++ b/src/cascadia/TerminalConnection/AzureConnectionStrings.h
@@ -26,5 +26,6 @@ const auto tokensRemoved = L"Tokens removed!\r\n";
 const auto exitStr = L"Exit.\r\n";
 const auto authString = L"Authenticated.\r\n";
 const auto internetOrServerIssue = L"Could not connect to Azure. You may not have internet or the server might be down.\r\n";
+const auto oldCredentialsFlushedMessage = L"Authentication parameters changed. You'll need to log in again.\r\n";
 
 const auto ithTenant = L"Tenant %d: %s (%s)\r\n";


### PR DESCRIPTION
When we change the client ID, we're going to need to force people to log
in again.

We can do that either by:

1. Trying to log in and refresh the user's token and failing (displaying
   a cryptic message like "you aren't on the internet, please get on the
   internet"), **OR** by...
2. Getting out ahead of it, detecting when we would have failed for client
   ID (and other) reasons, and _not trying at all._

This is option 2.