### PR TITLE
Clean up Pane

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -1493,8 +1493,7 @@ namespace winrt::TerminalApp::implementation
         const int focusedTabIndex = _GetFocusedTabIndex();
         auto focusedTab = _tabs[focusedTabIndex];
 
-        const auto canSplit = splitType == Pane::SplitState::Horizontal ? focusedTab->CanAddHorizontalSplit() :
-                                                                          focusedTab->CanAddVerticalSplit();
+        const auto canSplit = focusedTab->CanAddSplit(splitType);
 
         if (!canSplit)
         {
@@ -1506,8 +1505,7 @@ namespace winrt::TerminalApp::implementation
         // Hookup our event handlers to the new terminal
         _RegisterTerminalEvents(newControl, focusedTab);
 
-        return splitType == Pane::SplitState::Horizontal ? focusedTab->AddHorizontalSplit(realGuid, newControl) :
-                                                           focusedTab->AddVerticalSplit(realGuid, newControl);
+        focusedTab->AddSplit(splitType, realGuid, newControl);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -1493,7 +1493,7 @@ namespace winrt::TerminalApp::implementation
         const int focusedTabIndex = _GetFocusedTabIndex();
         auto focusedTab = _tabs[focusedTabIndex];
 
-        const auto canSplit = focusedTab->CanAddSplit(splitType);
+        const auto canSplit = focusedTab->CanSplitPane(splitType);
 
         if (!canSplit)
         {
@@ -1505,7 +1505,7 @@ namespace winrt::TerminalApp::implementation
         // Hookup our event handlers to the new terminal
         _RegisterTerminalEvents(newControl, focusedTab);
 
-        focusedTab->AddSplit(splitType, realGuid, newControl);
+        focusedTab->SplitPane(splitType, realGuid, newControl);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -778,110 +778,57 @@ void Pane::_ApplySplitDefinitions()
 }
 
 // Method Description:
-// - Determines whether the pane can be split vertically
+// - Determines whether the pane can be split
 // Arguments:
 // - splitType: what type of split we want to create.
 // Return Value:
-// - True if the pane can be split vertically. False otherwise.
-bool Pane::CanSplitVertical()
+// - True if the pane can be split. False otherwise.
+bool Pane::CanSplit(SplitState splitType)
 {
     if (!_IsLeaf())
     {
         if (_firstChild->_HasFocusedChild())
         {
-            return _firstChild->CanSplitVertical();
+            return _firstChild->CanSplit(splitType);
         }
         else if (_secondChild->_HasFocusedChild())
         {
-            return _secondChild->CanSplitVertical();
+            return _secondChild->CanSplit(splitType);
         }
 
         return false;
     }
 
-    return _CanSplit(SplitState::Vertical);
+    return _CanSplit(splitType);
 }
 
 // Method Description:
-// - Vertically split the focused pane in our tree of panes, and place the given
+// - Split the focused pane in our tree of panes, and place the given
 //   TermControl into the newly created pane. If we're the focused pane, then
 //   we'll create two new children, and place them side-by-side in our Grid.
-// Arguments:
-// - profile: The profile GUID to associate with the newly created pane.
-// - control: A TermControl to use in the new pane.
-// Return Value:
-// - <none>
-void Pane::SplitVertical(const GUID& profile, const TermControl& control)
-{
-    // If we're not the leaf, recurse into our children to split them.
-    if (!_IsLeaf())
-    {
-        if (_firstChild->_HasFocusedChild())
-        {
-            _firstChild->SplitVertical(profile, control);
-        }
-        else if (_secondChild->_HasFocusedChild())
-        {
-            _secondChild->SplitVertical(profile, control);
-        }
-
-        return;
-    }
-
-    _Split(SplitState::Vertical, profile, control);
-}
-
-// Method Description:
-// - Determines whether the pane can be split horizontally
 // Arguments:
 // - splitType: what type of split we want to create.
-// Return Value:
-// - True if the pane can be split horizontally. False otherwise.
-bool Pane::CanSplitHorizontal()
-{
-    if (!_IsLeaf())
-    {
-        if (_firstChild->_HasFocusedChild())
-        {
-            return _firstChild->CanSplitHorizontal();
-        }
-        else if (_secondChild->_HasFocusedChild())
-        {
-            return _secondChild->CanSplitHorizontal();
-        }
-
-        return false;
-    }
-
-    return _CanSplit(SplitState::Horizontal);
-}
-
-// Method Description:
-// - Horizontally split the focused pane in our tree of panes, and place the given
-//   TermControl into the newly created pane. If we're the focused pane, then
-//   we'll create two new children, and place them side-by-side in our Grid.
-// Arguments:
 // - profile: The profile GUID to associate with the newly created pane.
 // - control: A TermControl to use in the new pane.
 // Return Value:
 // - <none>
-void Pane::SplitHorizontal(const GUID& profile, const TermControl& control)
+void Pane::Split(SplitState splitType, const GUID& profile, const TermControl& control)
 {
     if (!_IsLeaf())
     {
         if (_firstChild->_HasFocusedChild())
         {
-            _firstChild->SplitHorizontal(profile, control);
+            _firstChild->Split(splitType, profile, control);
         }
         else if (_secondChild->_HasFocusedChild())
         {
-            _secondChild->SplitHorizontal(profile, control);
+            _secondChild->Split(splitType, profile, control);
         }
 
         return;
     }
 
-    _Split(SplitState::Horizontal, profile, control);
+    _Split(splitType, profile, control);
 }
 
 // Method Description:

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -839,8 +839,6 @@ void Pane::Split(SplitState splitType, const GUID& profile, const TermControl& c
 // - True if the pane can be split. False otherwise.
 bool Pane::_CanSplit(SplitState splitType)
 {
-    const bool changeWidth = _splitState == SplitState::Vertical;
-
     const Size actualSize{ gsl::narrow_cast<float>(_root.ActualWidth()),
                            gsl::narrow_cast<float>(_root.ActualHeight()) };
 

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -49,11 +49,8 @@ public:
     bool ResizePane(const winrt::TerminalApp::Direction& direction);
     bool NavigateFocus(const winrt::TerminalApp::Direction& direction);
 
-    bool CanSplitHorizontal();
-    void SplitHorizontal(const GUID& profile, const winrt::Microsoft::Terminal::TerminalControl::TermControl& control);
-
-    bool CanSplitVertical();
-    void SplitVertical(const GUID& profile, const winrt::Microsoft::Terminal::TerminalControl::TermControl& control);
+    bool CanSplit(SplitState splitType);
+    void Split(SplitState splitType, const GUID& profile, const winrt::Microsoft::Terminal::TerminalControl::TermControl& control);
 
     void Close();
 

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -209,7 +209,7 @@ void Tab::Scroll(const int delta)
 // - splitType: The type of split we want to create.
 // Return Value:
 // - True if the focused pane can be split. False otherwise.
-bool Tab::CanAddSplit(Pane::SplitState splitType)
+bool Tab::CanSplitPane(Pane::SplitState splitType)
 {
     return _rootPane->CanSplit(splitType);
 }
@@ -223,7 +223,7 @@ bool Tab::CanAddSplit(Pane::SplitState splitType)
 // - control: A TermControl to use in the new pane.
 // Return Value:
 // - <none>
-void Tab::AddSplit(Pane::SplitState splitType, const GUID& profile, TermControl& control)
+void Tab::SplitPane(Pane::SplitState splitType, const GUID& profile, TermControl& control)
 {
     _rootPane->Split(splitType, profile, control);
 }

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -204,47 +204,28 @@ void Tab::Scroll(const int delta)
 }
 
 // Method Description:
-// - Determines whether the focused pane has sufficient space to be split vertically.
+// - Determines whether the focused pane has sufficient space to be split.
+// Arguments:
+// - splitType: The type of split we want to create.
 // Return Value:
-// - True if the focused pane can be split horizontally. False otherwise.
-bool Tab::CanAddVerticalSplit()
+// - True if the focused pane can be split. False otherwise.
+bool Tab::CanAddSplit(Pane::SplitState splitType)
 {
-    return _rootPane->CanSplitVertical();
+    return _rootPane->CanSplit(splitType);
 }
 
 // Method Description:
-// - Vertically split the focused pane in our tree of panes, and place the
+// - Split the focused pane in our tree of panes, and place the
 //   given TermControl into the newly created pane.
 // Arguments:
+// - splitType: The type of split we want to create.
 // - profile: The profile GUID to associate with the newly created pane.
 // - control: A TermControl to use in the new pane.
 // Return Value:
 // - <none>
-void Tab::AddVerticalSplit(const GUID& profile, TermControl& control)
+void Tab::AddSplit(Pane::SplitState splitType, const GUID& profile, TermControl& control)
 {
-    _rootPane->SplitVertical(profile, control);
-}
-
-// Method Description:
-// - Determines whether the focused pane has sufficient space to be split horizontally.
-// Return Value:
-// - True if the focused pane can be split horizontally. False otherwise.
-bool Tab::CanAddHorizontalSplit()
-{
-    return _rootPane->CanSplitHorizontal();
-}
-
-// Method Description:
-// - Horizontally split the focused pane in our tree of panes, and place the
-//   given TermControl into the newly created pane.
-// Arguments:
-// - profile: The profile GUID to associate with the newly created pane.
-// - control: A TermControl to use in the new pane.
-// Return Value:
-// - <none>
-void Tab::AddHorizontalSplit(const GUID& profile, TermControl& control)
-{
-    _rootPane->SplitHorizontal(profile, control);
+    _rootPane->Split(splitType, profile, control);
 }
 
 // Method Description:

--- a/src/cascadia/TerminalApp/Tab.h
+++ b/src/cascadia/TerminalApp/Tab.h
@@ -19,10 +19,8 @@ public:
     void SetFocused(const bool focused);
 
     void Scroll(const int delta);
-    bool CanAddVerticalSplit();
-    void AddVerticalSplit(const GUID& profile, winrt::Microsoft::Terminal::TerminalControl::TermControl& control);
-    bool CanAddHorizontalSplit();
-    void AddHorizontalSplit(const GUID& profile, winrt::Microsoft::Terminal::TerminalControl::TermControl& control);
+    bool CanAddSplit(Pane::SplitState splitType);
+    void AddSplit(Pane::SplitState splitType, const GUID& profile, winrt::Microsoft::Terminal::TerminalControl::TermControl& control);
 
     void UpdateFocus();
     void UpdateIcon(const winrt::hstring iconPath);

--- a/src/cascadia/TerminalApp/Tab.h
+++ b/src/cascadia/TerminalApp/Tab.h
@@ -19,8 +19,9 @@ public:
     void SetFocused(const bool focused);
 
     void Scroll(const int delta);
-    bool CanAddSplit(Pane::SplitState splitType);
-    void AddSplit(Pane::SplitState splitType, const GUID& profile, winrt::Microsoft::Terminal::TerminalControl::TermControl& control);
+
+    bool CanSplitPane(Pane::SplitState splitType);
+    void SplitPane(Pane::SplitState splitType, const GUID& profile, winrt::Microsoft::Terminal::TerminalControl::TermControl& control);
 
     void UpdateFocus();
     void UpdateIcon(const winrt::hstring iconPath);


### PR DESCRIPTION
Cleanup of Pane.cpp based on conversations in #2450

## Summary of the Pull Request

* Merging of all `Split{Horizontal,Vertical}` methods into a single method that accepts  `Pane::SplitState`
* Rename `Tab::(Can)AddSplit` to `(Can)SplitPane` to keep the verb/noun usage consistent with Pane.cpp
 * Cleanup of a few other Pane methods, mostly removing unnecessarily nested `else` statements where the `if` always returns

Each change has been committed separately to make them easier to rebase out if you're not happy with them, but feel free to squash them when merging.

## References

#2450

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx (not directly related to an issue)
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed (N/A - there are no tests for Pane.cpp)
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #2450

## Detailed Description of the Pull Request / Additional comments

All covered by the "Summary" above.

## Validation Steps Performed

Simple usage of the terminal, and hammering the split feature to ensure it still works (including the previously fixed crash fixed by #2450)