### PR TITLE
az: Don't fail when a tenant doesn't have a knowable name

### DIFF
--- a/src/cascadia/TerminalConnection/AzureConnection.cpp
+++ b/src/cascadia/TerminalConnection/AzureConnection.cpp
@@ -273,7 +273,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
     }
 
     // Method description:
-    // - This method returns a tenant's ID and display name (if one if available).
+    // - This method returns a tenant's ID and display name (if one is available).
     //   If there is no display name, a placeholder is returned in its stead.
     // Arguments:
     // - tenant - the unparsed tenant

--- a/src/cascadia/TerminalConnection/AzureConnectionStrings.h
+++ b/src/cascadia/TerminalConnection/AzureConnectionStrings.h
@@ -27,4 +27,5 @@ const auto exitStr = L"Exit.\r\n";
 const auto authString = L"Authenticated.\r\n";
 const auto internetOrServerIssue = L"Could not connect to Azure. You may not have internet or the server might be down.\r\n";
 
+const auto unknownTenantName = L"<unknown tenant name>";
 const auto ithTenant = L"Tenant %d: %s (%s)\r\n";


### PR DESCRIPTION
On occasion, in certain delegated access scenarios, we'll fail to read
the name of one or more of the user's Azure tenants. We would summarily
explode (because we're being strict about our incoming JSON, and we
didn't know that this was possible.)

Now we'll substitute in an alternate name and present the ID.

Fixes #2249.