### PR TITLE
Selection Code Cleanup and Double Click Delimiter Runs

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -45,7 +45,7 @@ Terminal::Terminal() :
     _snapOnInput{ true },
     _boxSelection{ false },
     _selectionActive{ false },
-    _allowSingleCharSelection{ false },
+    _allowSingleCharSelection{ true },
     _copyOnSelect{ false },
     _selectionAnchor{ 0, 0 },
     _endSelectionPosition{ 0, 0 }

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -220,7 +220,7 @@ private:
     const SHORT _ExpandWideGlyphSelectionRight(const SHORT xPos, const SHORT yPos) const;
     const COORD _ExpandDoubleClickSelectionLeft(const COORD position) const;
     const COORD _ExpandDoubleClickSelectionRight(const COORD position) const;
-    const int _GetDelimiterClass(std::wstring_view cellChar) const;
+    const UINT _GetDelimiterClass(const WCHAR cellChar) const noexcept;
     const COORD _ConvertToBufferCell(const COORD viewportPos) const;
     const bool _IsSingleCellSelection() const noexcept;
     std::tuple<COORD, COORD> _PreprocessSelectionCoords() const;

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -166,6 +166,12 @@ private:
         Word,
         Line
     };
+    enum DelimiterClass
+    {
+        ControlChar,
+        DelimiterChar,
+        RegularChar
+    };
     COORD _selectionAnchor;
     COORD _endSelectionPosition;
     bool _boxSelection;
@@ -220,7 +226,7 @@ private:
     const SHORT _ExpandWideGlyphSelectionRight(const SHORT xPos, const SHORT yPos) const;
     const COORD _ExpandDoubleClickSelectionLeft(const COORD position) const;
     const COORD _ExpandDoubleClickSelectionRight(const COORD position) const;
-    const UINT _GetDelimiterClass(const WCHAR cellChar) const noexcept;
+    const DelimiterClass _GetDelimiterClass(const std::wstring_view cellChar) const noexcept;
     const COORD _ConvertToBufferCell(const COORD viewportPos) const;
     const bool _IsSingleCellSelection() const noexcept;
     std::tuple<COORD, COORD> _PreprocessSelectionCoords() const;

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -160,13 +160,13 @@ private:
     bool _snapOnInput;
 
 #pragma region Text Selection
-    enum SelectionExpansionMode
+    enum class SelectionExpansionMode
     {
         Cell,
         Word,
         Line
     };
-    enum DelimiterClass
+    enum class DelimiterClass
     {
         ControlChar,
         DelimiterChar,
@@ -221,13 +221,13 @@ private:
 
 #pragma region TextSelection
     // These methods are defined in TerminalSelection.cpp
-    std::vector<SMALL_RECT> _GetSelectionRects() const;
-    const SHORT _ExpandWideGlyphSelectionLeft(const SHORT xPos, const SHORT yPos) const;
-    const SHORT _ExpandWideGlyphSelectionRight(const SHORT xPos, const SHORT yPos) const;
-    const COORD _ExpandDoubleClickSelectionLeft(const COORD position) const;
-    const COORD _ExpandDoubleClickSelectionRight(const COORD position) const;
-    const DelimiterClass _GetDelimiterClass(const std::wstring_view cellChar) const noexcept;
-    const COORD _ConvertToBufferCell(const COORD viewportPos) const;
+    std::vector<SMALL_RECT> _GetSelectionRects() const noexcept;
+    SHORT _ExpandWideGlyphSelectionLeft(const SHORT xPos, const SHORT yPos) const;
+    SHORT _ExpandWideGlyphSelectionRight(const SHORT xPos, const SHORT yPos) const;
+    COORD _ExpandDoubleClickSelectionLeft(const COORD position) const;
+    COORD _ExpandDoubleClickSelectionRight(const COORD position) const;
+    DelimiterClass _GetDelimiterClass(const std::wstring_view cellChar) const noexcept;
+    COORD _ConvertToBufferCell(const COORD viewportPos) const;
     const bool _IsSingleCellSelection() const noexcept;
     std::tuple<COORD, COORD> _PreprocessSelectionCoords() const;
     SMALL_RECT _GetSelectionRow(const SHORT row, const COORD higherCoord, const COORD lowerCoord) const;

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -220,9 +220,9 @@ private:
     const SHORT _ExpandWideGlyphSelectionRight(const SHORT xPos, const SHORT yPos) const;
     const COORD _ExpandDoubleClickSelectionLeft(const COORD position) const;
     const COORD _ExpandDoubleClickSelectionRight(const COORD position) const;
-    const bool _isWordDelimiter(std::wstring_view cellChar) const;
+    const int _GetDelimiterClass(std::wstring_view cellChar) const;
     const COORD _ConvertToBufferCell(const COORD viewportPos) const;
-    const bool _isSingleCellSelection() const noexcept;
+    const bool _IsSingleCellSelection() const noexcept;
     std::tuple<COORD, COORD> _PreprocessSelectionCoords() const;
     SMALL_RECT _GetSelectionRow(const SHORT row, const COORD higherCoord, const COORD lowerCoord) const;
     void _ExpandSelectionRow(SMALL_RECT& selectionRow) const;

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -172,8 +172,7 @@ private:
     bool _selectionActive;
     bool _allowSingleCharSelection;
     bool _copyOnSelect;
-    SHORT _selectionAnchor_YOffset;
-    SHORT _endSelectionPosition_YOffset;
+    SHORT _selectionVerticalOffset;
     std::wstring _wordDelimiters;
     SelectionExpansionMode _multiClickSelectionMode;
 #pragma endregion
@@ -219,10 +218,13 @@ private:
     std::vector<SMALL_RECT> _GetSelectionRects() const;
     const SHORT _ExpandWideGlyphSelectionLeft(const SHORT xPos, const SHORT yPos) const;
     const SHORT _ExpandWideGlyphSelectionRight(const SHORT xPos, const SHORT yPos) const;
-    COORD _ExpandDoubleClickSelectionLeft(const COORD position) const;
-    COORD _ExpandDoubleClickSelectionRight(const COORD position) const;
+    const COORD _ExpandDoubleClickSelectionLeft(const COORD position) const;
+    const COORD _ExpandDoubleClickSelectionRight(const COORD position) const;
     const bool _isWordDelimiter(std::wstring_view cellChar) const;
     const COORD _ConvertToBufferCell(const COORD viewportPos) const;
     const bool _isSingleCellSelection() const noexcept;
+    std::tuple<COORD, COORD> _PreprocessSelectionCoords() const;
+    SMALL_RECT _GetSelectionRow(const SHORT row, const COORD higherCoord, const COORD lowerCoord) const;
+    void _ExpandSelectionRow(SMALL_RECT& selectionRow) const;
 #pragma endregion
 };

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -19,77 +19,116 @@ std::vector<SMALL_RECT> Terminal::_GetSelectionRects() const
         return selectionArea;
     }
 
+    auto [higherCoord, lowerCoord] = _PreprocessSelectionCoords();
+
+    SHORT selectionRectSize;
+    THROW_IF_FAILED(ShortSub(lowerCoord.Y, higherCoord.Y, &selectionRectSize));
+    THROW_IF_FAILED(ShortAdd(selectionRectSize, 1, &selectionRectSize));
+    selectionArea.reserve(selectionRectSize);
+    for (auto row = higherCoord.Y; row <= lowerCoord.Y; row++)
+    {
+        SMALL_RECT selectionRow = _GetSelectionRow(row, higherCoord, lowerCoord);
+        _ExpandSelectionRow(selectionRow);
+        selectionArea.emplace_back(selectionRow);
+    }
+    return selectionArea;
+}
+
+// Method Description:
+// - convert selection anchors to proper coordinates for rendering
+// Arguments:
+// - None
+// Return Value:
+// - tuple.first: the higher coordinate (or leftmost)
+// - tuple.second: the lower coordinate (or rightmost)
+std::tuple<COORD, COORD> Terminal::_PreprocessSelectionCoords() const
+{
     // create these new anchors for comparison and rendering
     COORD selectionAnchorWithOffset{ _selectionAnchor };
     COORD endSelectionPositionWithOffset{ _endSelectionPosition };
 
     // Add anchor offset here to update properly on new buffer output
-    THROW_IF_FAILED(ShortAdd(selectionAnchorWithOffset.Y, _selectionAnchor_YOffset, &selectionAnchorWithOffset.Y));
-    THROW_IF_FAILED(ShortAdd(endSelectionPositionWithOffset.Y, _endSelectionPosition_YOffset, &endSelectionPositionWithOffset.Y));
+    THROW_IF_FAILED(ShortAdd(selectionAnchorWithOffset.Y, _selectionVerticalOffset, &selectionAnchorWithOffset.Y));
+    THROW_IF_FAILED(ShortAdd(endSelectionPositionWithOffset.Y, _selectionVerticalOffset, &endSelectionPositionWithOffset.Y));
 
-    // clamp Y values to be within mutable viewport bounds
-    selectionAnchorWithOffset.Y = std::clamp(selectionAnchorWithOffset.Y, static_cast<SHORT>(0), _mutableViewport.BottomInclusive());
-    endSelectionPositionWithOffset.Y = std::clamp(endSelectionPositionWithOffset.Y, static_cast<SHORT>(0), _mutableViewport.BottomInclusive());
-
-    // clamp X values to be within buffer bounds
+    // clamp anchors to be within buffer bounds
     const auto bufferSize = _buffer->GetSize();
-    selectionAnchorWithOffset.X = std::clamp(_selectionAnchor.X, bufferSize.Left(), bufferSize.RightInclusive());
-    endSelectionPositionWithOffset.X = std::clamp(_endSelectionPosition.X, bufferSize.Left(), bufferSize.RightInclusive());
+    bufferSize.Clamp(selectionAnchorWithOffset);
+    bufferSize.Clamp(endSelectionPositionWithOffset);
 
     // NOTE: (0,0) is top-left so vertical comparison is inverted
-    const COORD& higherCoord = (selectionAnchorWithOffset.Y <= endSelectionPositionWithOffset.Y) ?
-                                   selectionAnchorWithOffset :
-                                   endSelectionPositionWithOffset;
-    const COORD& lowerCoord = (selectionAnchorWithOffset.Y > endSelectionPositionWithOffset.Y) ?
-                                  selectionAnchorWithOffset :
-                                  endSelectionPositionWithOffset;
+    // CompareInBounds returns whether A is to the left of (rv<0), equal to (rv==0), or to the right of (rv>0) B.
+    // Here, we want the "left"most coordinate to be the one "higher" on the screen. The other gets the dubious honor of
+    // being the "lower."
+    return bufferSize.CompareInBounds(selectionAnchorWithOffset, endSelectionPositionWithOffset) <= 0 ?
+               std::make_tuple(selectionAnchorWithOffset, endSelectionPositionWithOffset) :
+               std::make_tuple(endSelectionPositionWithOffset, selectionAnchorWithOffset);
+}
 
-    selectionArea.reserve(lowerCoord.Y - higherCoord.Y + 1);
-    for (auto row = higherCoord.Y; row <= lowerCoord.Y; row++)
+// Method Description:
+// - convert selection anchors to proper coordinates for rendering
+// Arguments:
+// - row: the buffer y-value under observation
+// - higherCoord: the higher coordinate (or leftmost)
+// - lowerCoord: the lower coordinate (or rightmost)
+// Return Value:
+// - tuple.first: the coordinate the higher coordinate (or leftmost)
+// - tuple.second: the lower coordinate (or rightmost)
+SMALL_RECT Terminal::_GetSelectionRow(const SHORT row, const COORD higherCoord, const COORD lowerCoord) const
+{
+    SMALL_RECT selectionRow;
+
+    selectionRow.Top = row;
+    selectionRow.Bottom = row;
+
+    if (_boxSelection || higherCoord.Y == lowerCoord.Y)
     {
-        SMALL_RECT selectionRow;
+        selectionRow.Left = std::min(higherCoord.X, lowerCoord.X);
+        selectionRow.Right = std::max(higherCoord.X, lowerCoord.X);
+    }
+    else
+    {
+        selectionRow.Left = (row == higherCoord.Y) ? higherCoord.X : 0;
+        selectionRow.Right = (row == lowerCoord.Y) ? lowerCoord.X : _buffer->GetSize().RightInclusive();
+    }
 
-        selectionRow.Top = row;
-        selectionRow.Bottom = row;
+    return selectionRow;
+}
 
-        if (_boxSelection || higherCoord.Y == lowerCoord.Y)
+// Method Description:
+// - Expand the selection row according to selection mode and wide glyphs
+// - this is particularly useful for box selections (ALT + selection)
+// Arguments:
+// - selectionRow: the selection row to be expanded
+// Return Value:
+// - modifies selectionRow's Left and Right values to expand properly
+void Terminal::_ExpandSelectionRow(SMALL_RECT& selectionRow) const
+{
+    const auto row = selectionRow.Top;
+
+    // expand selection for Double/Triple Click
+    if (_multiClickSelectionMode == SelectionExpansionMode::Word)
+    {
+        const auto cellChar = _buffer->GetCellDataAt({ _selectionAnchor.X, row })->Chars();
+        if (_isSingleCellSelection() && _isWordDelimiter(cellChar))
         {
-            selectionRow.Left = std::min(higherCoord.X, lowerCoord.X);
-            selectionRow.Right = std::max(higherCoord.X, lowerCoord.X);
+            // only highlight the cell if you double click a delimiter
         }
         else
         {
-            selectionRow.Left = (row == higherCoord.Y) ? higherCoord.X : 0;
-            selectionRow.Right = (row == lowerCoord.Y) ? lowerCoord.X : bufferSize.RightInclusive();
+            selectionRow.Left = _ExpandDoubleClickSelectionLeft({ selectionRow.Left, row }).X;
+            selectionRow.Right = _ExpandDoubleClickSelectionRight({ selectionRow.Right, row }).X;
         }
-
-        // expand selection for Double/Triple Click
-        if (_multiClickSelectionMode == SelectionExpansionMode::Word)
-        {
-            const auto cellChar = _buffer->GetCellDataAt(selectionAnchorWithOffset)->Chars();
-            if (_isSingleCellSelection() && _isWordDelimiter(cellChar))
-            {
-                // only highlight the cell if you double click a delimiter
-            }
-            else
-            {
-                selectionRow.Left = _ExpandDoubleClickSelectionLeft({ selectionRow.Left, row }).X;
-                selectionRow.Right = _ExpandDoubleClickSelectionRight({ selectionRow.Right, row }).X;
-            }
-        }
-        else if (_multiClickSelectionMode == SelectionExpansionMode::Line)
-        {
-            selectionRow.Left = 0;
-            selectionRow.Right = bufferSize.RightInclusive();
-        }
-
-        // expand selection for Wide Glyphs
-        selectionRow.Left = _ExpandWideGlyphSelectionLeft(selectionRow.Left, row);
-        selectionRow.Right = _ExpandWideGlyphSelectionRight(selectionRow.Right, row);
-
-        selectionArea.emplace_back(selectionRow);
     }
-    return selectionArea;
+    else if (_multiClickSelectionMode == SelectionExpansionMode::Line)
+    {
+        selectionRow.Left = 0;
+        selectionRow.Right = _buffer->GetSize().RightInclusive();
+    }
+
+    // expand selection for Wide Glyphs
+    selectionRow.Left = _ExpandWideGlyphSelectionLeft(selectionRow.Left, row);
+    selectionRow.Right = _ExpandWideGlyphSelectionRight(selectionRow.Right, row);
 }
 
 // Method Description:
@@ -195,13 +234,12 @@ void Terminal::DoubleClickSelection(const COORD position)
     // set selection anchor to one right of that spot
     _selectionAnchor = _ExpandDoubleClickSelectionLeft(positionWithOffsets);
     THROW_IF_FAILED(ShortSub(_selectionAnchor.Y, gsl::narrow<SHORT>(_ViewStartIndex()), &_selectionAnchor.Y));
-    _selectionAnchor_YOffset = gsl::narrow<SHORT>(_ViewStartIndex());
+    _selectionVerticalOffset = gsl::narrow<SHORT>(_ViewStartIndex());
 
     // scan rightwards until delimiter is found and
     // set endSelectionPosition to one left of that spot
     _endSelectionPosition = _ExpandDoubleClickSelectionRight(positionWithOffsets);
     THROW_IF_FAILED(ShortSub(_endSelectionPosition.Y, gsl::narrow<SHORT>(_ViewStartIndex()), &_endSelectionPosition.Y));
-    _endSelectionPosition_YOffset = gsl::narrow<SHORT>(_ViewStartIndex());
 
     _selectionActive = true;
     _multiClickSelectionMode = SelectionExpansionMode::Word;
@@ -232,7 +270,7 @@ void Terminal::SetSelectionAnchor(const COORD position)
 
     // copy value of ViewStartIndex to support scrolling
     // and update on new buffer output (used in _GetSelectionRects())
-    _selectionAnchor_YOffset = gsl::narrow<SHORT>(_ViewStartIndex());
+    _selectionVerticalOffset = gsl::narrow<SHORT>(_ViewStartIndex());
 
     _selectionActive = true;
     _allowSingleCharSelection = (_copyOnSelect) ? false : true;
@@ -255,7 +293,7 @@ void Terminal::SetEndSelectionPosition(const COORD position)
 
     // copy value of ViewStartIndex to support scrolling
     // and update on new buffer output (used in _GetSelectionRects())
-    _endSelectionPosition_YOffset = gsl::narrow<SHORT>(_ViewStartIndex());
+    _selectionVerticalOffset = gsl::narrow<SHORT>(_ViewStartIndex());
 
     if (_copyOnSelect && !_isSingleCellSelection())
     {
@@ -280,8 +318,7 @@ void Terminal::ClearSelection()
     _allowSingleCharSelection = false;
     _selectionAnchor = { 0, 0 };
     _endSelectionPosition = { 0, 0 };
-    _selectionAnchor_YOffset = 0;
-    _endSelectionPosition_YOffset = 0;
+    _selectionVerticalOffset = 0;
 
     _buffer->GetRenderTarget().TriggerSelection();
 }
@@ -311,7 +348,7 @@ const TextBuffer::TextAndColor Terminal::RetrieveSelectedTextFromBuffer(bool tri
 // - position: viewport coordinate for selection
 // Return Value:
 // - updated copy of "position" to new expanded location (with vertical offset)
-COORD Terminal::_ExpandDoubleClickSelectionLeft(const COORD position) const
+const COORD Terminal::_ExpandDoubleClickSelectionLeft(const COORD position) const
 {
     COORD positionWithOffsets = position;
     const auto bufferViewport = _buffer->GetSize();
@@ -337,7 +374,7 @@ COORD Terminal::_ExpandDoubleClickSelectionLeft(const COORD position) const
 // - position: viewport coordinate for selection
 // Return Value:
 // - updated copy of "position" to new expanded location (with vertical offset)
-COORD Terminal::_ExpandDoubleClickSelectionRight(const COORD position) const
+const COORD Terminal::_ExpandDoubleClickSelectionRight(const COORD position) const
 {
     COORD positionWithOffsets = position;
     const auto bufferViewport = _buffer->GetSize();

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -11,9 +11,9 @@ using namespace Microsoft::Terminal::Core;
 // - Helper to determine the selected region of the buffer. Used for rendering.
 // Return Value:
 // - A vector of rectangles representing the regions to select, line by line. They are absolute coordinates relative to the buffer origin.
-std::vector<SMALL_RECT> Terminal::_GetSelectionRects() const
+std::vector<SMALL_RECT> Terminal::_GetSelectionRects() const noexcept
 {
-    std::vector<SMALL_RECT> result = {};
+    std::vector<SMALL_RECT> result;
 
     if (!IsSelectionActive())
     {
@@ -25,13 +25,13 @@ std::vector<SMALL_RECT> Terminal::_GetSelectionRects() const
         // NOTE: (0,0) is the top-left of the screen
         // the physically "higher" coordinate is closer to the top-left
         // the physically "lower" coordinate is closer to the bottom-right
-        auto [higherCoord, lowerCoord] = _PreprocessSelectionCoords();
+        const auto [higherCoord, lowerCoord] = _PreprocessSelectionCoords();
 
         SHORT selectionRectSize;
         THROW_IF_FAILED(ShortSub(lowerCoord.Y, higherCoord.Y, &selectionRectSize));
         THROW_IF_FAILED(ShortAdd(selectionRectSize, 1, &selectionRectSize));
 
-        std::vector<SMALL_RECT> selectionArea = {};
+        std::vector<SMALL_RECT> selectionArea;
         selectionArea.reserve(selectionRectSize);
         for (auto row = higherCoord.Y; row <= lowerCoord.Y; row++)
         {
@@ -141,7 +141,7 @@ void Terminal::_ExpandSelectionRow(SMALL_RECT& selectionRow) const
 // - position: the (x,y) coordinate on the visible viewport
 // Return Value:
 // - updated x position to encapsulate the wide glyph
-const SHORT Terminal::_ExpandWideGlyphSelectionLeft(const SHORT xPos, const SHORT yPos) const
+SHORT Terminal::_ExpandWideGlyphSelectionLeft(const SHORT xPos, const SHORT yPos) const
 {
     // don't change the value if at/outside the boundary
     const auto bufferSize = _buffer->GetSize();
@@ -167,7 +167,7 @@ const SHORT Terminal::_ExpandWideGlyphSelectionLeft(const SHORT xPos, const SHOR
 // - position: the (x,y) coordinate on the visible viewport
 // Return Value:
 // - updated x position to encapsulate the wide glyph
-const SHORT Terminal::_ExpandWideGlyphSelectionRight(const SHORT xPos, const SHORT yPos) const
+SHORT Terminal::_ExpandWideGlyphSelectionRight(const SHORT xPos, const SHORT yPos) const
 {
     // don't change the value if at/outside the boundary
     const auto bufferSize = _buffer->GetSize();
@@ -347,7 +347,7 @@ const TextBuffer::TextAndColor Terminal::RetrieveSelectedTextFromBuffer(bool tri
 // - position: buffer coordinate for selection
 // Return Value:
 // - updated copy of "position" to new expanded location (with vertical offset)
-const COORD Terminal::_ExpandDoubleClickSelectionLeft(const COORD position) const
+COORD Terminal::_ExpandDoubleClickSelectionLeft(const COORD position) const
 {
     const auto bufferViewport = _buffer->GetSize();
 
@@ -385,7 +385,7 @@ const COORD Terminal::_ExpandDoubleClickSelectionLeft(const COORD position) cons
 // - position: buffer coordinate for selection
 // Return Value:
 // - updated copy of "position" to new expanded location (with vertical offset)
-const COORD Terminal::_ExpandDoubleClickSelectionRight(const COORD position) const
+COORD Terminal::_ExpandDoubleClickSelectionRight(const COORD position) const
 {
     const auto bufferViewport = _buffer->GetSize();
 
@@ -423,7 +423,7 @@ const COORD Terminal::_ExpandDoubleClickSelectionRight(const COORD position) con
 // - cellChar: the char saved to the buffer cell under observation
 // Return Value:
 // - the delimiter class for the given char
-const Terminal::DelimiterClass Terminal::_GetDelimiterClass(const std::wstring_view cellChar) const noexcept
+Terminal::DelimiterClass Terminal::_GetDelimiterClass(const std::wstring_view cellChar) const noexcept
 {
     if (cellChar[0] <= UNICODE_SPACE)
     {
@@ -445,7 +445,7 @@ const Terminal::DelimiterClass Terminal::_GetDelimiterClass(const std::wstring_v
 // - viewportPos: a coordinate on the viewport
 // Return Value:
 // - the corresponding location on the buffer
-const COORD Terminal::_ConvertToBufferCell(const COORD viewportPos) const
+COORD Terminal::_ConvertToBufferCell(const COORD viewportPos) const
 {
     // Force position to be valid
     COORD positionWithOffsets = viewportPos;

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -361,15 +361,15 @@ COORD Terminal::_ExpandDoubleClickSelectionLeft(const COORD position) const
         return positionWithOffsets;
     }
 
-    auto cellChar = _buffer->GetTextDataAt(positionWithOffsets)->data();
-    const auto startedOnDelimiter = _GetDelimiterClass(cellChar);
-    while (positionWithOffsets.X > bufferViewport.Left() && (_GetDelimiterClass(cellChar) == startedOnDelimiter))
+    auto bufferIterator = _buffer->GetTextDataAt(positionWithOffsets);
+    const auto startedOnDelimiter = _GetDelimiterClass(*bufferIterator);
+    while (positionWithOffsets.X > bufferViewport.Left() && (_GetDelimiterClass(*bufferIterator) == startedOnDelimiter))
     {
         bufferViewport.DecrementInBounds(positionWithOffsets);
-        cellChar = _buffer->GetTextDataAt(positionWithOffsets)->data();
+        bufferIterator--;
     }
 
-    if (_GetDelimiterClass(cellChar) != startedOnDelimiter)
+    if (_GetDelimiterClass(*bufferIterator) != startedOnDelimiter)
     {
         // move off of delimiter to highlight properly
         bufferViewport.IncrementInBounds(positionWithOffsets);
@@ -399,15 +399,15 @@ COORD Terminal::_ExpandDoubleClickSelectionRight(const COORD position) const
         return positionWithOffsets;
     }
 
-    auto cellChar = _buffer->GetTextDataAt(positionWithOffsets)->data();
-    const auto startedOnDelimiter = _GetDelimiterClass(cellChar);
-    while (positionWithOffsets.X < bufferViewport.RightInclusive() && (_GetDelimiterClass(cellChar) == startedOnDelimiter))
+    auto bufferIterator = _buffer->GetTextDataAt(positionWithOffsets);
+    const auto startedOnDelimiter = _GetDelimiterClass(*bufferIterator);
+    while (positionWithOffsets.X < bufferViewport.RightInclusive() && (_GetDelimiterClass(*bufferIterator) == startedOnDelimiter))
     {
         bufferViewport.IncrementInBounds(positionWithOffsets);
-        cellChar = _buffer->GetTextDataAt(positionWithOffsets)->data();
+        bufferIterator++;
     }
 
-    if (_GetDelimiterClass(cellChar) != startedOnDelimiter)
+    if (_GetDelimiterClass(*bufferIterator) != startedOnDelimiter)
     {
         // move off of delimiter to highlight properly
         bufferViewport.DecrementInBounds(positionWithOffsets);

--- a/src/cascadia/UnitTests_TerminalCore/SelectionTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/SelectionTest.cpp
@@ -475,7 +475,7 @@ namespace TerminalCoreUnitTests
             VERIFY_ARE_EQUAL(selectionRects.size(), static_cast<size_t>(1));
 
             auto selection = term.GetViewport().ConvertToOrigin(selectionRects.at(0)).ToInclusive();
-            VERIFY_ARE_EQUAL(selection, SMALL_RECT({ 15, 10, 15, 10 }));
+            VERIFY_ARE_EQUAL(selection, SMALL_RECT({ 4, 10, 15, 10 }));
         }
 
         TEST_METHOD(DoubleClickDrag_Right)

--- a/src/cascadia/UnitTests_TerminalCore/SelectionTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/SelectionTest.cpp
@@ -96,7 +96,7 @@ namespace TerminalCoreUnitTests
 
         TEST_METHOD(OverflowTests)
         {
-            const COORD maxCoord = { SHORT_MAX, SHORT_MAX };
+            const COORD maxCoord = { SHRT_MAX, SHRT_MAX };
 
             auto ValidateSelection = [&](Terminal& term, SMALL_RECT expected) {
                 auto selectionRects = term.GetSelectionRects();
@@ -150,10 +150,10 @@ namespace TerminalCoreUnitTests
             ValidateTripleClickSelection(0, { 0, 9, 9, 9 });
 
             // Test with max scrollback
-            const SHORT expected_row = MAXSHORT - 1;
-            ValidateSingleClickSelection(MAXSHORT, { 9, expected_row, 9, expected_row });
-            ValidateDoubleClickSelection(MAXSHORT, { 0, expected_row, 9, expected_row });
-            ValidateTripleClickSelection(MAXSHORT, { 0, expected_row, 9, expected_row });
+            const SHORT expected_row = SHRT_MAX - 1;
+            ValidateSingleClickSelection(SHRT_MAX, { 9, expected_row, 9, expected_row });
+            ValidateDoubleClickSelection(SHRT_MAX, { 0, expected_row, 9, expected_row });
+            ValidateTripleClickSelection(SHRT_MAX, { 0, expected_row, 9, expected_row });
         }
 
         TEST_METHOD(SelectFromOutofBounds)

--- a/src/cascadia/UnitTests_TerminalCore/SelectionTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/SelectionTest.cpp
@@ -441,7 +441,7 @@ namespace TerminalCoreUnitTests
             VERIFY_ARE_EQUAL(selectionRects.size(), static_cast<size_t>(1));
 
             auto selection = term.GetViewport().ConvertToOrigin(selectionRects.at(0)).ToInclusive();
-            VERIFY_ARE_EQUAL(selection, SMALL_RECT({ 5, 10, 5, 10 }));
+            VERIFY_ARE_EQUAL(selection, SMALL_RECT({ 0, 10, 99, 10 }));
         }
 
         TEST_METHOD(DoubleClickDrag_Right)

--- a/src/cascadia/UnitTests_TerminalCore/SelectionTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/SelectionTest.cpp
@@ -280,11 +280,6 @@ namespace TerminalCoreUnitTests
 
         TEST_METHOD(SelectWideGlyph_Trailing)
         {
-#ifdef _X86_
-            Log::Comment(L"This test is unreliable on x86 but is fine elsewhere. Disabled on x86.");
-            Log::Result(TestResults::Skipped);
-            return;
-#else
             Terminal term;
             DummyRenderTarget emptyRT;
             term.Create({ 100, 100 }, 0, emptyRT);
@@ -310,16 +305,10 @@ namespace TerminalCoreUnitTests
 
             auto selection = term.GetViewport().ConvertToOrigin(selectionRects.at(0)).ToInclusive();
             VERIFY_ARE_EQUAL(selection, SMALL_RECT({ 4, 10, 5, 10 }));
-#endif
         }
 
         TEST_METHOD(SelectWideGlyph_Leading)
         {
-#ifdef _X86_
-            Log::Comment(L"This test is unreliable on x86 but is fine elsewhere. Disabled on x86.");
-            Log::Result(TestResults::Skipped);
-            return;
-#else
             Terminal term;
             DummyRenderTarget emptyRT;
             term.Create({ 100, 100 }, 0, emptyRT);
@@ -345,16 +334,10 @@ namespace TerminalCoreUnitTests
 
             auto selection = term.GetViewport().ConvertToOrigin(selectionRects.at(0)).ToInclusive();
             VERIFY_ARE_EQUAL(selection, SMALL_RECT({ 4, 10, 5, 10 }));
-#endif
         }
 
         TEST_METHOD(SelectWideGlyphsInBoxSelection)
         {
-#ifdef _X86_
-            Log::Comment(L"This test is unreliable on x86 but is fine elsewhere. Disabled on x86.");
-            Log::Result(TestResults::Skipped);
-            return;
-#else
             Terminal term;
             DummyRenderTarget emptyRT;
             term.Create({ 100, 100 }, 0, emptyRT);
@@ -406,7 +389,6 @@ namespace TerminalCoreUnitTests
 
                 rowValue++;
             }
-#endif
         }
 
         TEST_METHOD(DoubleClick_GeneralCase)

--- a/src/cascadia/UnitTests_TerminalCore/SelectionTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/SelectionTest.cpp
@@ -444,6 +444,40 @@ namespace TerminalCoreUnitTests
             VERIFY_ARE_EQUAL(selection, SMALL_RECT({ 0, 10, 99, 10 }));
         }
 
+        TEST_METHOD(DoubleClick_DelimiterClass)
+        {
+            Terminal term;
+            DummyRenderTarget emptyRT;
+            term.Create({ 100, 100 }, 0, emptyRT);
+
+            // set word delimiters for terminal
+            auto settings = winrt::make<MockTermSettings>(0, 100, 100);
+            term.UpdateSettings(settings);
+
+            // Insert text at position (4,10)
+            const std::wstring_view text = L"C:\\Terminal>";
+            term.SetCursorPosition(4, 10);
+            term.Write(text);
+
+            // Simulate click at (x,y) = (15,10)
+            // this is over the '>' char
+            auto clickPos = COORD{ 15, 10 };
+            term.DoubleClickSelection(clickPos);
+
+            // Simulate renderer calling TriggerSelection and acquiring selection area
+            auto selectionRects = term.GetSelectionRects();
+
+            // ---Validate selection area---
+            // "Terminal" is in class 2
+            // ">" is in class 1
+            // the white space to the right of the ">" is in class 0
+            // Double-clicking the ">" should only highlight that cell
+            VERIFY_ARE_EQUAL(selectionRects.size(), static_cast<size_t>(1));
+
+            auto selection = term.GetViewport().ConvertToOrigin(selectionRects.at(0)).ToInclusive();
+            VERIFY_ARE_EQUAL(selection, SMALL_RECT({ 15, 10, 15, 10 }));
+        }
+
         TEST_METHOD(DoubleClickDrag_Right)
         {
             Terminal term;


### PR DESCRIPTION
## Summary of the Pull Request

Just some housekeeping work on our selection. Added a few more tests and refactored some of the functionality to improve code clarity. 

Reenabled x86 tests. They work on my machine. I hope they work on CI?

Added support for double clicking delimiter runs.

Double Click Delimiter runs now operate as follows. Characters are separated into 3 classes:
- class 0: spaces and control characters
- class 1: delimiters imported from settings
- class 2: all other characters
If you double click a cell, the selection will expand until the class of the next cell differs from the preceding one.

This is slightly different than before in that the following example will only highlight the ">" char instead of the ">" and all the surrounding spaces:
```
C:\Terminal>
           ^
double click here
```

## References
N/A


## PR Checklist
* [x] Closes #1327 
* [x] Closes #2261 
* [x] Closes #2206 
* [x] CLA signed
* [x] Tests added/passed
* [x] ~Requires documentation to be updated~
* [x] I am a core contributor

## Detailed Description of the Pull Request / Additional comments
Added some testing to ensure we don't crash on out-of-bounds selection anchors.
Consolidated the vertical offset for the anchors since they're always the same.
Broke up `GetSelectionRects()` into a more clear format with several helper methods.

## Validation Steps Performed
All tests pass. I manually did some ALT+selections and regular selections w/ and w/out the scroll area and it still seems fine.