### PR TITLE
Fix win key resets scroll location

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -622,7 +622,10 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         if (_closing ||
             e.OriginalKey() == VirtualKey::Control ||
             e.OriginalKey() == VirtualKey::Shift ||
-            e.OriginalKey() == VirtualKey::Menu)
+            e.OriginalKey() == VirtualKey::Menu ||
+            e.OriginalKey() == VirtualKey::LeftWindows ||
+            e.OriginalKey() == VirtualKey::RightWindows)
+
         {
             e.Handled(true);
             return;

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -196,7 +196,7 @@ void Terminal::Write(std::wstring_view stringView)
 // - Send this particular key event to the terminal. The terminal will translate
 //   the key and the modifiers pressed into the appropriate VT sequence for that
 //   key chord. If we do translate the key, we'll return true. In that case, the
-//   event should NOT br processed any further. If we return false, the event
+//   event should NOT be processed any further. If we return false, the event
 //   was NOT translated, and we should instead use the event to try and get the
 //   real character out of the event.
 // Arguments:

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -207,13 +207,6 @@ void Terminal::Write(std::wstring_view stringView)
 // - false if we did not translate the key, and it should be processed into a character.
 bool Terminal::SendKeyEvent(const WORD vkey, const ControlKeyStates states)
 {
-    // The windows keys should not be handled at all. This must be the first to be
-    // checked to prevent automatic scrolling
-    if (vkey == VK_LWIN || vkey == VK_RWIN)
-    {
-        return true;
-    }
-
     if (_snapOnInput && _scrollOffset != 0)
     {
         auto lock = LockForWriting();

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -207,6 +207,13 @@ void Terminal::Write(std::wstring_view stringView)
 // - false if we did not translate the key, and it should be processed into a character.
 bool Terminal::SendKeyEvent(const WORD vkey, const ControlKeyStates states)
 {
+    // The windows keys should not be handled at all. This must be the first to be
+    // checked to prevent automatic scrolling
+    if (vkey == VK_LWIN || vkey == VK_RWIN)
+    {
+        return true;
+    }
+
     if (_snapOnInput && _scrollOffset != 0)
     {
         auto lock = LockForWriting();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Checking if a windows key is pressed and prevent handling at all.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #2506
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Run commands until the scroll bar appears
2. Scroll up
3. Press the windows key

The terminal should not reset the scroll location

This is my very first pull request on GitHub. Please be kind :smiley: