### PR TITLE
connection: start up the output thread _only after_ all the pipes are up

### DIFF
--- a/src/cascadia/TerminalConnection/ConhostConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConhostConnection.cpp
@@ -81,17 +81,6 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             extraEnvVars.emplace(L"WT_SESSION", pwszGuid);
         }
 
-        // Create our own output handling thread
-        // Each connection needs to make sure to drain the output from its backing host.
-        _hOutputThread.reset(CreateThread(nullptr,
-                                          0,
-                                          StaticOutputThreadProc,
-                                          this,
-                                          0,
-                                          nullptr));
-
-        THROW_LAST_ERROR_IF_NULL(_hOutputThread);
-
         STARTUPINFO si = { 0 };
         si.cb = sizeof(STARTUPINFOW);
 
@@ -118,6 +107,18 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
                          0,
                          si,
                          extraEnvVars));
+
+        // Create our own output handling thread
+        // This must be done after the pipes are populated.
+        // Each connection needs to make sure to drain the output from its backing host.
+        _hOutputThread.reset(CreateThread(nullptr,
+                                          0,
+                                          StaticOutputThreadProc,
+                                          this,
+                                          0,
+                                          nullptr));
+
+        THROW_LAST_ERROR_IF_NULL(_hOutputThread);
 
         _connected = true;
     }


### PR DESCRIPTION
Fixes #2527