### PR TITLE
Fix typo in ColorTool documentation

### DIFF
--- a/src/tools/ColorTool/ColorTool/Resources.resx
+++ b/src/tools/ColorTool/ColorTool/Resources.resx
@@ -162,7 +162,7 @@ Options:
     -s, --schemes  : Displays all available schemes
     -l, --location : Displays the full path to the schemes directory
     -v, --version  : Display the version number
-    -o, --output &lt;filename&gt; : output the current color table to an file (in .ini format)
+    -o, --output &lt;filename&gt; : output the current color table to a file (in .ini format)
 
 Available importers:
   {0}</value>


### PR DESCRIPTION
In the ColorTool usage section, changed "an file" to "a file" under the -o option.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
In the ColorTool usage section, changed "an file" to "a file" under the -o option. I tested it by manually building and confirming that the typo is fixed when running the application from the command line.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
I didn't see any issues or existing PRs related to this typo.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] CLA signed.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
I think the description above is as detailed as necessary. I didn't see anything in any issues or pull requests about this typo, but I figured it couldn't hurt to try to fix it. Please tell me if this is not the right way to address this problem (i.e., if I should I have opened an issue first/instead).