### PR TITLE
When we reload a profile, always use the same GUID for it

### DIFF
--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -357,7 +357,10 @@ Profile Profile::FromJson(const Json::Value& json)
     }
     else
     {
-        result._guid = Utils::CreateGuid();
+        // Always use the name to generate the temporary GUID. That way, across
+        // reloads, we'll generate the same static GUID.
+        const std::wstring_view name = result._name;
+        result._guid = Utils::CreateV5Uuid(RUNTIME_GENERATED_PROFILE_NAMESPACE_GUID, gsl::as_bytes(gsl::make_span(name)));
 
         TraceLoggingWrite(
             g_hTerminalAppProvider,

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -16,6 +16,10 @@ Author(s):
 #pragma once
 #include "ColorScheme.h"
 
+// GUID used for generating GUIDs at runtime, for profiles that did not have a
+// GUID specified manually.
+constexpr GUID RUNTIME_GENERATED_PROFILE_NAMESPACE_GUID = { 0xf65ddb7e, 0x706b, 0x4499, { 0x8a, 0x50, 0x40, 0x31, 0x3c, 0xaf, 0x51, 0x0a } };
+
 namespace TerminalApp
 {
     class Profile;


### PR DESCRIPTION


<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
  This ensures that settings reload works for profiles w/o GUIDs.

  After #2475, we no longer persist the auto-generated GUID for a profile. This means that when settings get reloaded, the profiles without GUIDs will get re-created, and the existing tabs with those profiles will no longer be associated with a profile. That's really bad, and can cause explosions. 

  This will ensure that we always generate the same GUID for a profile that didn't have one, preventing explosions.

  If a person has two profiles with the same name and NO guid, then we'll generate the same GUID for both, then cull the second one when we validate that there should be no duplicate profiles.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
#2475 caused this regression.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Don't really have an issue for this one
* [x] I work here
* [ ] This should have tests, but much of this is changing in #2515 anyways
* [x] Doesn't require documentation to be updated 
* [x] @DHowett-MSFT caught this in the testing for v0.4

