### PR TITLE
Amends user-docs procedure

### DIFF
--- a/doc/user-docs/index.md
+++ b/doc/user-docs/index.md
@@ -36,12 +36,14 @@ default shell is displayed (default shortcut `Ctrl+Shift+1`).
 
 ## Running a Different Shell
 
-Note: The following text assumes you have WSL installed.
+Note: This section assumes you already have _Windows Subsystem for Linux_ (WSL) installed.
 
-To choose a different shell (e.g. `cmd.exe` or WSL `bash`) then
+Windows Terminal uses PowerShell as its default shell. You can also use Windows Terminal to launch other shells, such as `cmd.exe` or WSL's `bash`:
 
-1. Select the `down` button next to the `+` in the tab bar
-2. Choose your new shell from the list (more on how to extend the list in the config section)
+1. In the tab bar, click the `⌵` button to view the available shells.
+2. Choose your shell from the dropdown list. The new shell session will open in a new tab.
+
+To customize the shell list, see the _Configuring Windows Terminal_ section below.
 
 ## Starting a new PowerShell tab with admin privilege
 

--- a/doc/user-docs/index.md
+++ b/doc/user-docs/index.md
@@ -36,7 +36,7 @@ default shell is displayed (default shortcut `Ctrl+Shift+1`).
 
 ## Running a Different Shell
 
-Note: This section assumes you already have _Windows Subsystem for Linux_ (WSL) installed.
+Note: This section assumes you already have _Windows Subsystem for Linux_ (WSL) installed. For more information, see [the installation guide](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
 
 Windows Terminal uses PowerShell as its default shell. You can also use Windows Terminal to launch other shells, such as `cmd.exe` or WSL's `bash`:
 


### PR DESCRIPTION
Amends docs procedure for `Running a Different Shell`:
* Adds an overview sentence.
* Adds some light rephrasing.
* Proposes using the countersink arrow `⌵` to depict the `down` GUI element.
