### PR TITLE
Improve Accessibility Reliability

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -342,9 +342,15 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
     Windows::UI::Xaml::Automation::Peers::AutomationPeer TermControl::OnCreateAutomationPeer()
     {
-        // create a custom automation peer with this code pattern:
-        // (https://docs.microsoft.com/en-us/windows/uwp/design/accessibility/custom-automation-peers)
-        return winrt::make<winrt::Microsoft::Terminal::TerminalControl::implementation::TermControlAutomationPeer>(*this);
+        Windows::UI::Xaml::Automation::Peers::AutomationPeer autoPeer = nullptr;
+        try
+        {
+            // create a custom automation peer with this code pattern:
+            // (https://docs.microsoft.com/en-us/windows/uwp/design/accessibility/custom-automation-peers)
+            autoPeer = winrt::make<winrt::Microsoft::Terminal::TerminalControl::implementation::TermControlAutomationPeer>(*this);
+        }
+        CATCH_LOG();
+        return autoPeer;
     }
 
     ::Microsoft::Console::Types::IUiaData* TermControl::GetUiaData() const

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -342,7 +342,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
     Windows::UI::Xaml::Automation::Peers::AutomationPeer TermControl::OnCreateAutomationPeer()
     {
-        Windows::UI::Xaml::Automation::Peers::AutomationPeer autoPeer = nullptr;
+        Windows::UI::Xaml::Automation::Peers::AutomationPeer autoPeer{ nullptr };
         try
         {
             // create a custom automation peer with this code pattern:

--- a/src/cascadia/WindowsTerminal/BaseWindow.h
+++ b/src/cascadia/WindowsTerminal/BaseWindow.h
@@ -56,13 +56,24 @@ public:
             return HandleDpiChange(_window.get(), wparam, lparam);
         }
 
+        // TODO GitHub #2447: Properly attach WindowUiaProvider for signaling model
+        /*
         case WM_GETOBJECT:
         {
             return HandleGetObject(_window.get(), wparam, lparam);
         }
+        */
 
         case WM_DESTROY:
         {
+            // TODO GitHub #2447: Properly attach WindowUiaProvider for signaling model
+            /*
+            // signal to uia that they can disconnect our uia provider
+            if (_pUiaProvider)
+            {
+                UiaReturnRawElementProvider(hWnd, 0, 0, NULL);
+            }
+            */
             PostQuitMessage(0);
             return 0;
         }

--- a/src/cascadia/WindowsTerminal/BaseWindow.h
+++ b/src/cascadia/WindowsTerminal/BaseWindow.h
@@ -56,8 +56,8 @@ public:
             return HandleDpiChange(_window.get(), wparam, lparam);
         }
 
-        // TODO GitHub #2447: Properly attach WindowUiaProvider for signaling model
-        /*
+            // TODO GitHub #2447: Properly attach WindowUiaProvider for signaling model
+            /*
         case WM_GETOBJECT:
         {
             return HandleGetObject(_window.get(), wparam, lparam);

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -161,6 +161,16 @@ void IslandWindow::OnSize(const UINT width, const UINT height)
     {
         if (_interopWindowHandle != nullptr)
         {
+            // TODO GitHub #2447: Properly attach WindowUiaProvider for signaling model
+            /*
+                // set the text area to have focus for accessibility consumers
+                if (_pUiaProvider)
+                {
+                    LOG_IF_FAILED(_pUiaProvider->SetTextAreaFocus());
+                }
+                break;
+            */
+
             // send focus to the child window
             SetFocus(_interopWindowHandle);
             return 0; // eat the message

--- a/src/cascadia/WindowsTerminal/IslandWindow.h
+++ b/src/cascadia/WindowsTerminal/IslandWindow.h
@@ -36,7 +36,7 @@ public:
     void UpdateTheme(const winrt::Windows::UI::Xaml::ElementTheme& requestedTheme);
 
 #pragma region IUiaWindow
-    void ChangeViewport(const SMALL_RECT NewWindow)
+    void ChangeViewport(const SMALL_RECT /*NewWindow*/)
     {
         // TODO GitHub #1352: Hook up ScreenInfoUiaProvider to WindowUiaProvider
         // Relevant comment from zadjii-msft:


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Remove WindowUiaProvider entry points
Make TerminalAutomationPeer not crash the app if creation failed.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes nothing
* [x] CLA signed.
* [x] ~Tests added/passed~
* [x] ~Requires documentation to be updated~
* [x] I'm a core contributor

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
WindowUiaProvider was something I thought we needed. We still need it for signaling (maybe). But it sometimes can crash because it's not hooked up properly at all. For now, I removed all entry points. After the signaling model gets added for #2447, I'll decide if we actually need to remove it.

Also surrounded the TerminalControlAutomationPeer with a try/catch. If we don't have everything we need to create the AutomationPeer yet, we'll just catch it and move forward.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
