### PR TITLE
ColorTool: Proofread the helper text, update Build.bat

### DIFF
--- a/src/tools/ColorTool/ColorTool/Program.cs
+++ b/src/tools/ColorTool/ColorTool/Program.cs
@@ -32,50 +32,18 @@ namespace ColorTool
                 string arg = args[i];
                 switch (arg)
                 {
-                    case "-c":
-                    case "--current":
-                        ColorTable.PrintTable();
-                        return;
-                    case "-e":
-                    case "--errors":
-                        reportErrors = true;
-                        break;
-                    case "-q":
-                    case "--quiet":
-                        quietMode = true;
-                        break;
-                    case "-d":
-                    case "--defaults":
-                        setDefaults = true;
-                        setProperties = false;
-                        break;
-                    case "-b":
-                    case "--both":
-                        setDefaults = true;
-                        setProperties = true;
-                        break;
                     case "-?":
                     case "--help":
                         Usage();
                         return;
-                    case "-v":
-                    case "--version":
-                        Version();
+                    case "-c":
+                    case "--current":
+                        ColorTable.PrintTable();
                         return;
                     case "-l":
                     case "--location":
                         SchemeManager.PrintSchemesDirectory();
                         return;
-                    case "-x":
-                    case "--xterm":
-                        setUnixStyle = true;
-                        setProperties = true;
-                        break;
-                    case "-t":
-                    case "--terminal":
-                        setTerminalStyle = true;
-                        setProperties = true;
-                        break;
                     case "-o":
                     case "--output":
                         if (i + 1 < args.Length)
@@ -91,6 +59,38 @@ namespace ColorTool
                     case "--schemes":
                         SchemeManager.PrintSchemes();
                         return;
+                    case "-v":
+                    case "--version":
+                        Version();
+                        return;
+                    case "-e":
+                    case "--errors":
+                        reportErrors     = true;
+                        break;
+                    case "-q":
+                    case "--quiet":
+                        quietMode        = true;
+                        break;
+                    case "-d":
+                    case "--defaults":
+                        setDefaults      = true;
+                        setProperties    = false;
+                        break;
+                    case "-b":
+                    case "--both":
+                        setDefaults      = true;
+                        setProperties    = true;
+                        break;
+                    case "-x":
+                    case "--xterm":
+                        setUnixStyle     = true;
+                        setProperties    = true;
+                        break;
+                    case "-t":
+                    case "--terminal":
+                        setTerminalStyle = true;
+                        setProperties    = true;
+                        break;
                     default:
                         break;
                 }
@@ -127,7 +127,7 @@ namespace ColorTool
         {
             var assembly = System.Reflection.Assembly.GetExecutingAssembly();
             var info = System.Diagnostics.FileVersionInfo.GetVersionInfo(assembly.Location);
-            Console.WriteLine($"colortool v{info.FileVersion}");
+            Console.WriteLine($"ColorTool v{info.FileVersion}");
         }
 
         /// <summary>

--- a/src/tools/ColorTool/ColorTool/Resources.resx
+++ b/src/tools/ColorTool/ColorTool/Resources.resx
@@ -139,30 +139,47 @@
   </data>
   <data name="Usage" xml:space="preserve">
     <value>Usage:
-    colortool.exe [options] &lt;schemename&gt;
+    ColorTool.exe &lt;Function&gt;
+    ColorTool.exe [Options] &lt;Scheme name&gt;
+
 ColorTool is a utility for helping to set the color palette of the Windows Console.
 By default, applies the colors in the specified .itermcolors, .json or .ini file to the current console window.
 This does NOT save the properties automatically. For that, you'll need to open the properties sheet and hit "Ok".
 Included should be a `schemes/` directory with a selection of schemes of both formats for examples.
 Feel free to add your own preferred scheme to that directory.
-Arguments:
-    &lt;schemename&gt;: The name of a color scheme. ct will try to first load it as an .ini file color scheme
-                  If that fails, it will look for it as a .json file color scheme
-                  If that fails, it will look for it as an .itermcolors file color scheme.
-Options:
+
+Parameters:
+    &lt;Function&gt;   : One and only one of the switches listed in the "Functions" section below.
+    &lt;Scheme name&gt;: The name of a color scheme. ColorTool will try to first load it as an .ini file color scheme
+                   If that fails, it will look for it as a .json file color scheme
+                   If that fails, it will look for it as an .itermcolors file color scheme.
+                   Must be the last parameter passed to ColorTool.
+    [Option]     : One or more of the switches listed in the "Options" section below. Must appear before scheme
+                   name.
+
+Functions:
+    You may specify only one of the following switches each time you invoke ColorTool. Any additional switches
+    before or after the first one of them will be ignored.
+ 
     -?, --help     : Display this help message
     -c, --current  : Print the color table for the currently applied scheme
+    -v, --version  : Display the version number
+    -l, --location : Displays the full path to the schemes directory
+    -s, --schemes  : Displays all available schemes
+    -o, --output &lt;filename&gt; : output the current color table to a file in .ini format
+
+Options:
+    You may use these switches before a scheme name.
+
     -q, --quiet    : Don't print the color table after applying
     -e, --errors   : Report scheme parsing errors on the console
     -d, --defaults : Apply the scheme to only the defaults in the registry
+                     By default, the scheme would be applied to the current console instead.
     -b, --both     : Apply the scheme to both the current console and the defaults.
+                     By default, the scheme would be applied to the current console only.
     -x, --xterm    : Set the colors using VT sequences. Used for setting the colors in WSL.
                      Only works in Windows versions &gt;= 17048.
     -t, --terminal : Output the colors in JSON format for copying into a Windows Terminal settings file.
-    -s, --schemes  : Displays all available schemes
-    -l, --location : Displays the full path to the schemes directory
-    -v, --version  : Display the version number
-    -o, --output &lt;filename&gt; : output the current color table to a file (in .ini format)
 
 Available importers:
   {0}</value>

--- a/src/tools/ColorTool/README.md
+++ b/src/tools/ColorTool/README.md
@@ -1,54 +1,77 @@
-# ColorTool 
+# ColorTool
 
 ColorTool makes it easy to change the Windows console to your desired scheme. Includes support for iTerm themes!
 
-```
+```plain
 Usage:
-    colortool.exe [options] <schemename>
+    ColorTool.exe <Function>
+    ColorTool.exe [Options] <Scheme name>
+
 ColorTool is a utility for helping to set the color palette of the Windows Console.
-By default, applies the colors in the specified .itermcolors or .ini file to the current console window.
+By default, applies the colors in the specified .itermcolors, .json or .ini file to the current console window.
 This does NOT save the properties automatically. For that, you'll need to open the properties sheet and hit "Ok".
 Included should be a `schemes/` directory with a selection of schemes of both formats for examples.
 Feel free to add your own preferred scheme to that directory.
-Arguments:
-    <schemename>: The name of a color scheme. ct will try to first load it as an .itermcolors color scheme.
-                  If that fails, it will look for it as an .ini file color scheme.
-Options:
+
+Parameters:
+    <Function>   : One and only one of the switches listed in the "Functions" section below.
+    <Scheme name>: The name of a color scheme. ColorTool will try to first load it as an .ini file color scheme
+                   If that fails, it will look for it as a .json file color scheme
+                   If that fails, it will look for it as an .itermcolors file color scheme.
+                   Must be the last parameter passed to ColorTool.
+    [Option]     : One or more of the switches listed in the "Options" section below. Must appear before scheme
+                   name.
+
+Functions:
+    You may specify only one of the following switches each time you invoke ColorTool. Any additional switches
+    before or after the first one of them will be ignored.
+
     -?, --help     : Display this help message
     -c, --current  : Print the color table for the currently applied scheme
-    -q, --quiet    : Don't print the color table after applying
-    -d, --defaults : Apply the scheme to only the defaults in the registry
-    -b, --both     : Apply the scheme to both the current console and the defaults.
-    -s, --schemes  : Display all available schemes
     -v, --version  : Display the version number
+    -l, --location : Displays the full path to the schemes directory
+    -s, --schemes  : Displays all available schemes
+    -o, --output <filename> : output the current color table to a file in .ini format
+
+Options:
+    You may use these switches before a scheme name.
+
+    -q, --quiet    : Don't print the color table after applying
+    -e, --errors   : Report scheme parsing errors on the console
+    -d, --defaults : Apply the scheme to only the defaults in the registry
+                     By default, the scheme would be applied to the current console instead.
+    -b, --both     : Apply the scheme to both the current console and the defaults.
+                     By default, the scheme would be applied to the current console only.
+    -x, --xterm    : Set the colors using VT sequences. Used for setting the colors in WSL.
+                     Only works in Windows versions >= 17048.
+    -t, --terminal : Output the colors in JSON format for copying into a Windows Terminal settings file.
 ```
 
 ## Included Schemes
 
-  Included are two important color schemes in .ini file format - `cmd-legacy` and `campbell`.
+Included are two important color schemes in .ini file format: `cmd-legacy` and `campbell`.
 
-  * `cmd-legacy` is the legacy color scheme of the Windows Console, before July 2017
-    
-  * `campbell` is the new default scheme used by the Windows Console Host, as of the Fall Creator's Update.
+* `cmd-legacy` is the legacy color scheme of the Windows Console, before July 2017
+* `campbell` is the new default scheme used by the Windows Console Host, as of the Fall Creator's Update.
 
-  There are a few other schemes in that directory in both .ini format and .itermcolors. 
+There are a few other schemes in that directory in both .ini format and .itermcolors.
 
 ## Adding Schemes
 
-  You can also add color schemes to the colortool easily. Take any existing scheme in `.itermcolors` format, and paste it in the `schemes/` directory. Or just cd into a directory containing `*.itermcolors` files before running the colortool.
+You can also add color schemes to the ColorTool easily. Take any existing scheme in `.itermcolors` format, and paste it in the `schemes/` directory. Or just cd into a directory containing `*.itermcolors` files before running the ColorTool.
 
-  I recommend the excellent [iTerm2-Color-Schemes](https://github.com/mbadolato/iTerm2-Color-Schemes) repo, which has TONS of schemes to choose from, and previews.
-  
-  You can also easily visually edit `.itermcolors` color schemes using [terminal.sexy](https://terminal.sexy). Use the **Import** and **Export** tabs with `iTerm2` as the format.
+I recommend the excellent [iTerm2-Color-Schemes](https://github.com/mbadolato/iTerm2-Color-Schemes) repo, which has TONS of schemes to choose from, and previews.
 
-## Installing 
+You can also easily visually edit `.itermcolors` color schemes using [terminal.sexy](https://terminal.sexy). Use the **Import** and **Export** tabs with `iTerm2` as the format.
 
-Just [download the latest colortool release](https://github.com/microsoft/terminal/releases/tag/1904.29002) and extract the zip file. 
+## Installing
+
+Just [download the latest ColorTool release](https://github.com/microsoft/terminal/releases/tag/1904.29002) and extract the zip file.
 
 ## Building
 
-  Either build with Visual Studio, or use the included `build.bat` from the command line to try and auto-detect your msbuild version.
+Either build with Visual Studio, or use the included `build.bat` from the command line to try and auto-detect your MSBuild version.
 
 ## Contributing
 
-  This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/src/tools/ColorTool/build.bat
+++ b/src/tools/ColorTool/build.bat
@@ -6,48 +6,39 @@ for /f "usebackq tokens=*" %%f in (`where.exe msbuild.exe 2^>nul`) do (
     set MSBUILD="%%~ff"
     goto :FOUND_MSBUILD
 )
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\msbuild.exe" (
-    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\msbuild.exe"
+set AppFiles=%ProgramFiles(x86)%
+if NOT %PROCESSOR_ARCHITECTURE%==AMD64 set AppFiles=%ProgramFiles%
+set MSBUILD="%AppFiles%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe"
+if exist %MSBUILD% (
     goto :FOUND_MSBUILD
 )
-if exist "%ProgramFiles%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\msbuild.exe" (
-    set MSBUILD="%ProgramFiles%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\msbuild.exe"
+set MSBUILD="%AppFiles%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\msbuild.exe"
+if exist %MSBUILD% (
     goto :FOUND_MSBUILD
 )
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\msbuild.exe" (
-    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\msbuild.exe"
+set MSBUILD="%AppFiles%\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\msbuild.exe"
+if exist %MSBUILD% (
     goto :FOUND_MSBUILD
 )
-if exist "%ProgramFiles%\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\msbuild.exe" (
-    set MSBUILD="%ProgramFiles%\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\msbuild.exe"
+set MSBUILD="%AppFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe"
+if exist %MSBUILD% (
     goto :FOUND_MSBUILD
 )
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe" (
-    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe"
+set MSBUILD="%AppFiles%\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\MSBuild.exe"
+if exist %MSBUILD% (
     goto :FOUND_MSBUILD
 )
-if exist "%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe" (
-    set MSBUILD="%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe"
+set MSBUILD="%AppFiles%\MSBuild\14.0\bin\msbuild.exe"
+if exist %MSBUILD% (
     goto :FOUND_MSBUILD
 )
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\MSBuild.exe" (
-    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\MSBuild.exe"
-    goto :FOUND_MSBUILD
-)
-if exist "%ProgramFiles(x86)%\MSBuild\14.0\bin" (
-    set MSBUILD="%ProgramFiles(x86)%\MSBuild\14.0\bin\msbuild.exe"
-    goto :FOUND_MSBUILD
-)
-if exist "%ProgramFiles%\MSBuild\14.0\bin" (
-    set MSBUILD="%ProgramFiles%\MSBuild\14.0\bin\msbuild.exe"
-    goto :FOUND_MSBUILD
-)
+echo "MSBuild was not found. Make sure it is installed and included in the search path."
+goto :EXIT
 
-if %MSBUILD%==() (
-    echo "I couldn't find MSBuild on your PC. Make sure it's installed somewhere, and if it's not in the above if statements (in build.bat), add it."
-    goto :EXIT
-)
 :FOUND_MSBUILD
+echo MSBuild was found at %MSBUILD%
+echo.
+
 set _MSBUILD_TARGET=Build
 set _MSBUILD_CONFIG=Debug
 
@@ -63,17 +54,17 @@ shift
 goto :ARGS_LOOP
 
 :POST_ARGS_LOOP
-%MSBUILD% %~dp0ColorTool.sln /t:%_MSBUILD_TARGET% /m /nr:true /p:Configuration=%_MSBUILD_CONFIG%
+%MSBUILD% %~dp0ColorTool.sln /t:%_MSBUILD_TARGET% /m /nr:true /p:Configuration=%_MSBUILD_CONFIG% /p:OutputPath=.\bin\%_MSBUILD_CONFIG%\
 
 if (%ERRORLEVEL%) == (0) (
     echo.
     echo Created exe in:
-    echo    %~dp0ColorTool\bin\%_MSBUILD_CONFIG%\colortool.exe
+    echo    %~dp0ColorTool\bin\%_MSBUILD_CONFIG%\ColorTool.exe
     echo.
     echo Copying exe to root of project...
-    copy %~dp0ColorTool\bin\%_MSBUILD_CONFIG%\colortool.exe %~dp0colortool.exe
-    echo Done.
+    copy %~dp0ColorTool\bin\%_MSBUILD_CONFIG%\colortool.exe %~dp0ColorTool.exe
     echo.
 )
 
 :EXIT
+Pause


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

1. ColorTool: Proofread and improve the help text supplied to the user
2. ColorTool: Update `build.bat` for Visual Studio 2019 and newer versions of MSBuild

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

None

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] ~~Closes #xxx~~
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. ~~Issue number where the discussion took place: #xxx~~

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Hi.

This PR is exclusively related to the **`ColorTool.exe`**.

This is my first PR to the source code of a computer program, so I'm a little afraid I've done something wrong. Visual Studio surreptitiously made a large number of "noise" changes to the source code. I tried to upload only the relevant changes, so as to reduce the diff cross-section. I hope I didn't break anything in the process.

First, my changes to `build.bat`:

1. `Build.bat` now looks for Visual Studio 2019 too.
2. `Build.bat` now ensures that the linker places ColorTool.exe into `\debug` or `\release` folders, not `\debug\net471` or `\release\net471`.
3. `Build.bat` is now smarter in its search. It determines the operating system's CPU architecture before deciding whether to search in "Program Files (x86)" or "Program Files".

Second, my changes to the help text displayed to the user:

1. The help text now makes it clear that some switches cannot be used with certain others.
2. Some typos are fixed. e.g. "ct" to "ColorTool" (it took me two hours to figure this one out!) and "schemename" to "scheme name".

I've made a minor change to the order of `switch (arg)` in Program.cs too, to ensure that the terminating switches are analyzed first. This way, there will be fewer surprises if the user supplies malformed input. But feel free to reject this one.

### Unresolved issues

`Build.bat` is inherently faulty. On a pristine computer, a user cannot just install the latest version of Microsoft Build Tool and run `build.bat` to build ColorTool. The reason is the absence of certain NuGet packages. Either NuGet or Visual Studio must download the dependencies first.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Since the changes to the code are minor, I don't know what test I can possibly devise, other than compiling it and seeing that it works.