### PR TITLE
Add support for short hex color codes like #CCC (#2639)

### DIFF
--- a/src/cascadia/ut_app/JsonTests.cpp
+++ b/src/cascadia/ut_app/JsonTests.cpp
@@ -79,7 +79,7 @@ namespace TerminalAppUnitTests
                                           "\"name\" : \"Campbell\","
                                           "\"purple\" : \"#881798\","
                                           "\"red\" : \"#C50F1F\","
-                                          "\"white\" : \"#CCCCCC\","
+                                          "\"white\" : \"#CCC\","
                                           "\"yellow\" : \"#C19C00\""
                                           "}" };
 

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -93,7 +93,6 @@ COLORREF Utils::ColorFromHexString(const std::string str)
 {
     THROW_HR_IF(E_INVALIDARG, str.size() != 7 && str.size() != 4);
     THROW_HR_IF(E_INVALIDARG, str[0] != '#');
-    
 
     std::string rStr;
     std::string gStr;
@@ -104,11 +103,12 @@ COLORREF Utils::ColorFromHexString(const std::string str)
         rStr = std::string(2, str[1]);
         gStr = std::string(2, str[2]);
         bStr = std::string(2, str[3]);
-    } else
+    }
+    else
     {
-        rStr = std::string( &str[1],2);
-        gStr = std::string( &str[3],2);
-        bStr = std::string( &str[5],2);
+        rStr = std::string(&str[1], 2);
+        gStr = std::string(&str[3], 2);
+        bStr = std::string(&str[5], 2);
     }
 
     BYTE r = static_cast<BYTE>(std::stoul(rStr, nullptr, 16));

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -83,7 +83,7 @@ std::string Utils::ColorToHexString(const COLORREF color)
 }
 
 // Function Description:
-// - Parses a color from a string. The string should be in the format "#RRGGBB"
+// - Parses a color from a string. The string should be in the format "#RRGGBB" or "#RGB"
 // Arguments:
 // - str: a string representation of the COLORREF to parse
 // Return Value:
@@ -91,12 +91,25 @@ std::string Utils::ColorToHexString(const COLORREF color)
 //      the correct format, throws E_INVALIDARG
 COLORREF Utils::ColorFromHexString(const std::string str)
 {
-    THROW_HR_IF(E_INVALIDARG, str.size() < 7 || str.size() >= 8);
+    THROW_HR_IF(E_INVALIDARG, str.size() != 7 && str.size() != 4);
     THROW_HR_IF(E_INVALIDARG, str[0] != '#');
+    
 
-    std::string rStr{ &str[1], 2 };
-    std::string gStr{ &str[3], 2 };
-    std::string bStr{ &str[5], 2 };
+    std::string rStr;
+    std::string gStr;
+    std::string bStr;
+
+    if (str.size() == 4)
+    {
+        rStr = std::string(2, str[1]);
+        gStr = std::string(2, str[2]);
+        bStr = std::string(2, str[3]);
+    } else
+    {
+        rStr = std::string( &str[1],2);
+        gStr = std::string( &str[3],2);
+        bStr = std::string( &str[5],2);
+    }
 
     BYTE r = static_cast<BYTE>(std::stoul(rStr, nullptr, 16));
     BYTE g = static_cast<BYTE>(std::stoul(gStr, nullptr, 16));


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This adds a few lines to support shorthand color hex codes like `#ABC`. They are treated as equivalent of `#AABBCC`
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
N/A
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #2639
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [x] Doesn't require documentation to be updated as far as I understand
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #2639

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The PR is only a few lines of code so should be self-explanatory.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
I've changed `src/cascadia/ut_app/JsonTests.cpp` thanks to the fact that Cascadia actually has a white color that can be expressed this way. The new test passes on my machine.

I thought that change might be a better idea than adding a new test to https://github.com/microsoft/terminal/blob/master/src/types/ut_types/UtilsTests.cpp as discussed originally, if only for the reason of simplicity. I'll be happy to write an explicit test if that seems like a better idea to maintainers.