### PR TITLE
Prevent "Options" propsheet from reverting cursor shape settings

### DIFF
--- a/src/propsheet/OptionsPage.cpp
+++ b/src/propsheet/OptionsPage.cpp
@@ -167,7 +167,11 @@ INT_PTR WINAPI SettingsDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lPara
         CreateAndAssociateToolTipToControl(IDD_INTERCEPT_COPY_PASTE, hDlg, IDS_TOOLTIP_INTERCEPT_COPY_PASTE);
 
         // initialize cursor radio buttons
-        if (gpStateInfo->CursorSize <= 25)
+        if (gpStateInfo->CursorType != 0)
+        {
+            Item = IDD_CURSOR_ADVANCED;
+        }
+        else if (gpStateInfo->CursorSize <= 25)
         {
             Item = IDD_CURSOR_SMALL;
         }
@@ -179,7 +183,7 @@ INT_PTR WINAPI SettingsDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lPara
         {
             Item = IDD_CURSOR_LARGE;
         }
-        CheckRadioButton(hDlg, IDD_CURSOR_SMALL, IDD_CURSOR_LARGE, Item);
+        CheckRadioButton(hDlg, IDD_CURSOR_SMALL, IDD_CURSOR_ADVANCED, Item);
 
         SetDlgItemInt(hDlg, IDD_HISTORY_SIZE, gpStateInfo->HistoryBufferSize, FALSE);
         SendDlgItemMessage(hDlg, IDD_HISTORY_SIZE, EM_LIMITTEXT, 3, 0);

--- a/src/propsheet/OptionsPage.cpp
+++ b/src/propsheet/OptionsPage.cpp
@@ -147,6 +147,9 @@ INT_PTR WINAPI SettingsDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lPara
     switch (wMsg)
     {
     case WM_INITDIALOG:
+        // Initialize the global handle to this dialog
+        g_hOptionsDlg = hDlg;
+
         CheckDlgButton(hDlg, IDD_HISTORY_NODUP, gpStateInfo->HistoryNoDup);
         CheckDlgButton(hDlg, IDD_QUICKEDIT, gpStateInfo->QuickEdit);
         CheckDlgButton(hDlg, IDD_INSERT, gpStateInfo->InsertMode);
@@ -169,6 +172,8 @@ INT_PTR WINAPI SettingsDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lPara
         // initialize cursor radio buttons
         if (gpStateInfo->CursorType != 0)
         {
+            // IDD_CURSOR_ADVANCED is used as a placeholder for when a
+            // non-legacy shape is selected.
             Item = IDD_CURSOR_ADVANCED;
         }
         else if (gpStateInfo->CursorSize <= 25)

--- a/src/propsheet/OptionsPage.cpp
+++ b/src/propsheet/OptionsPage.cpp
@@ -3,6 +3,30 @@
 
 #include "precomp.h"
 
+void InitializeCursorSize(const HWND hOptionsDlg)
+{
+    unsigned int newRadioValue = IDD_CURSOR_ADVANCED;
+    if (gpStateInfo->CursorType != 0)
+    {
+        // IDD_CURSOR_ADVANCED is used as a placeholder for when a
+        // non-legacy shape is selected.
+        newRadioValue = IDD_CURSOR_ADVANCED;
+    }
+    else if (gpStateInfo->CursorSize <= 25)
+    {
+        newRadioValue = IDD_CURSOR_SMALL;
+    }
+    else if (gpStateInfo->CursorSize <= 50)
+    {
+        newRadioValue = IDD_CURSOR_MEDIUM;
+    }
+    else
+    {
+        newRadioValue = IDD_CURSOR_LARGE;
+    }
+    CheckRadioButton(hOptionsDlg, IDD_CURSOR_SMALL, IDD_CURSOR_ADVANCED, newRadioValue);
+}
+
 bool OptionsCommandCallback(HWND hDlg, const unsigned int Item, const unsigned int Notification, HWND hControlWindow)
 {
     UINT Value;
@@ -170,25 +194,7 @@ INT_PTR WINAPI SettingsDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lPara
         CreateAndAssociateToolTipToControl(IDD_INTERCEPT_COPY_PASTE, hDlg, IDS_TOOLTIP_INTERCEPT_COPY_PASTE);
 
         // initialize cursor radio buttons
-        if (gpStateInfo->CursorType != 0)
-        {
-            // IDD_CURSOR_ADVANCED is used as a placeholder for when a
-            // non-legacy shape is selected.
-            Item = IDD_CURSOR_ADVANCED;
-        }
-        else if (gpStateInfo->CursorSize <= 25)
-        {
-            Item = IDD_CURSOR_SMALL;
-        }
-        else if (gpStateInfo->CursorSize <= 50)
-        {
-            Item = IDD_CURSOR_MEDIUM;
-        }
-        else
-        {
-            Item = IDD_CURSOR_LARGE;
-        }
-        CheckRadioButton(hDlg, IDD_CURSOR_SMALL, IDD_CURSOR_ADVANCED, Item);
+        InitializeCursorSize(hDlg);
 
         SetDlgItemInt(hDlg, IDD_HISTORY_SIZE, gpStateInfo->HistoryBufferSize, FALSE);
         SendDlgItemMessage(hDlg, IDD_HISTORY_SIZE, EM_LIMITTEXT, 3, 0);

--- a/src/propsheet/OptionsPage.h
+++ b/src/propsheet/OptionsPage.h
@@ -6,7 +6,7 @@ Module Name:
 - OptionsPage.h
 
 Abstract:
-- This module contains the definitions for console options dialog. 
+- This module contains the definitions for console options dialog.
 
 Author(s):
     Mike Griese (migrie) Oct-2016
@@ -16,3 +16,4 @@ Author(s):
 
 void ToggleV2OptionsControls(__in const HWND hDlg);
 INT_PTR WINAPI SettingsDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam);
+void InitializeCursorSize(const HWND hOptionsDlg);

--- a/src/propsheet/TerminalPage.cpp
+++ b/src/propsheet/TerminalPage.cpp
@@ -323,10 +323,41 @@ bool TerminalDlgCommand(const HWND hDlg, const WORD item, const WORD command) no
     case IDD_TERMINAL_UNDERSCORE:
     case IDD_TERMINAL_EMPTYBOX:
     case IDD_TERMINAL_SOLIDBOX:
+    {
         gpStateInfo->CursorType = item - IDD_TERMINAL_LEGACY_CURSOR;
         UpdateApplyButton(hDlg);
+
+        // See GH#1219 - When the cursor state is something other than legacy,
+        // we need to manually check the "IDD_CURSOR_ADVANCED" radio button on
+        // the Options page. This will prevent the Options page from manually
+        // resetting the cursor to legacy.
+        if (g_hOptionsDlg != INVALID_HANDLE_VALUE)
+        {
+            unsigned int newRadioValue = IDD_CURSOR_ADVANCED;
+            // Check the radio button that would be checked for the current
+            // CursorType/CursorSize
+            if (gpStateInfo->CursorType != 0)
+            {
+                newRadioValue = IDD_CURSOR_ADVANCED;
+            }
+            else if (gpStateInfo->CursorSize <= 25)
+            {
+                newRadioValue = IDD_CURSOR_SMALL;
+            }
+            else if (gpStateInfo->CursorSize <= 50)
+            {
+                newRadioValue = IDD_CURSOR_MEDIUM;
+            }
+            else
+            {
+                newRadioValue = IDD_CURSOR_LARGE;
+            }
+            CheckRadioButton(g_hOptionsDlg, IDD_CURSOR_SMALL, IDD_CURSOR_ADVANCED, newRadioValue);
+        }
+
         handled = true;
         break;
+    }
     case IDD_DISABLE_SCROLLFORWARD:
         gpStateInfo->TerminalScrolling = IsDlgButtonChecked(hDlg, IDD_DISABLE_SCROLLFORWARD);
         UpdateApplyButton(hDlg);

--- a/src/propsheet/TerminalPage.cpp
+++ b/src/propsheet/TerminalPage.cpp
@@ -3,6 +3,7 @@
 
 #include "precomp.h"
 #include "TerminalPage.h"
+#include "OptionsPage.h" // For InitializeCursorSize
 #include "ColorControl.h"
 #include <functional>
 
@@ -333,26 +334,7 @@ bool TerminalDlgCommand(const HWND hDlg, const WORD item, const WORD command) no
         // resetting the cursor to legacy.
         if (g_hOptionsDlg != INVALID_HANDLE_VALUE)
         {
-            unsigned int newRadioValue = IDD_CURSOR_ADVANCED;
-            // Check the radio button that would be checked for the current
-            // CursorType/CursorSize
-            if (gpStateInfo->CursorType != 0)
-            {
-                newRadioValue = IDD_CURSOR_ADVANCED;
-            }
-            else if (gpStateInfo->CursorSize <= 25)
-            {
-                newRadioValue = IDD_CURSOR_SMALL;
-            }
-            else if (gpStateInfo->CursorSize <= 50)
-            {
-                newRadioValue = IDD_CURSOR_MEDIUM;
-            }
-            else
-            {
-                newRadioValue = IDD_CURSOR_LARGE;
-            }
-            CheckRadioButton(g_hOptionsDlg, IDD_CURSOR_SMALL, IDD_CURSOR_ADVANCED, newRadioValue);
+            InitializeCursorSize(g_hOptionsDlg);
         }
 
         handled = true;

--- a/src/propsheet/console.rc
+++ b/src/propsheet/console.rc
@@ -42,6 +42,7 @@ BEGIN
                     WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "&Medium", IDD_CURSOR_MEDIUM, 14, 33, 84, 10,
     AUTORADIOBUTTON "&Large", IDD_CURSOR_LARGE, 14, 43, 84, 10,
+    AUTORADIOBUTTON "", IDD_CURSOR_ADVANCED, 14, 53, 0, 0,
 
     GROUPBOX        "Command History", -1, 115, 11, 120, 56, WS_GROUP
     LTEXT           "&Buffer Size:", -1, 119, 25, 78, 9

--- a/src/propsheet/console.rc
+++ b/src/propsheet/console.rc
@@ -107,6 +107,7 @@ BEGIN
                     WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "&Medium", IDD_CURSOR_MEDIUM, 14, 33, 84, 10,
     AUTORADIOBUTTON "&Large", IDD_CURSOR_LARGE, 14, 43, 84, 10,
+    AUTORADIOBUTTON "", IDD_CURSOR_ADVANCED, 14, 53, 0, 0,
 
     GROUPBOX        "Command History", -1, 115, 11, 120, 56, WS_GROUP
     LTEXT           "&Buffer Size:", -1, 119, 25, 78, 9

--- a/src/propsheet/console.rc
+++ b/src/propsheet/console.rc
@@ -42,6 +42,7 @@ BEGIN
                     WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "&Medium", IDD_CURSOR_MEDIUM, 14, 33, 84, 10,
     AUTORADIOBUTTON "&Large", IDD_CURSOR_LARGE, 14, 43, 84, 10,
+    // IDD_CURSOR_ADVANCED is a hidden control, see GH#1219
     AUTORADIOBUTTON "", IDD_CURSOR_ADVANCED, 14, 53, 0, 0,
 
     GROUPBOX        "Command History", -1, 115, 11, 120, 56, WS_GROUP
@@ -107,6 +108,7 @@ BEGIN
                     WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "&Medium", IDD_CURSOR_MEDIUM, 14, 33, 84, 10,
     AUTORADIOBUTTON "&Large", IDD_CURSOR_LARGE, 14, 43, 84, 10,
+    // IDD_CURSOR_ADVANCED is a hidden control, see GH#1219
     AUTORADIOBUTTON "", IDD_CURSOR_ADVANCED, 14, 53, 0, 0,
 
     GROUPBOX        "Command History", -1, 115, 11, 120, 56, WS_GROUP

--- a/src/propsheet/dialogs.h
+++ b/src/propsheet/dialogs.h
@@ -43,6 +43,7 @@ Revision History:
 #define IDD_LANGUAGE_GROUPBOX       116
 #define DID_SETTINGS_COMCTL5        117
 #define DID_SETTINGS2_COMCTL5       118
+#define IDD_CURSOR_ADVANCED         119
 
 #define DID_FONTDLG                 200
 #define IDD_STATIC                  201

--- a/src/propsheet/globals.cpp
+++ b/src/propsheet/globals.cpp
@@ -55,3 +55,4 @@ COLORREF g_fakeBackgroundColor = RGB(12, 12, 12); // Default black
 COLORREF g_fakeCursorColor = RGB(242, 242, 242); // Default bright white
 
 HWND g_hTerminalDlg = static_cast<HWND>(INVALID_HANDLE_VALUE);
+HWND g_hOptionsDlg = static_cast<HWND>(INVALID_HANDLE_VALUE);

--- a/src/propsheet/globals.h
+++ b/src/propsheet/globals.h
@@ -53,3 +53,4 @@ extern COLORREF g_fakeBackgroundColor;
 extern COLORREF g_fakeCursorColor;
 
 extern HWND g_hTerminalDlg;
+extern HWND g_hOptionsDlg;

--- a/tools/bx.ps1
+++ b/tools/bx.ps1
@@ -21,13 +21,6 @@ $targets = $Metaproj.Project.Target
 #   [Conhost\Server, Conhost\Server:Clean, Conhost\Server:Rebuild, Conhost\Server:Publish]
 $matchingTargets = $targets | Where-Object { $_.MSBuild.Condition -eq $msBuildCondition }
 
-# If we didn't find a target, it's possible that the project doesn't have a metaproj
-if ($matchingTargets.length -eq 0)
-{
-    $conditionNoMeta = "'%(ProjectReference.Identity)' == '$projectPath'"
-    $matchingTargets = $targets | Where-Object { $_.MSBuild.Condition -eq $conditionNoMeta }
-}
-
 # Further filter to the targets that dont have a suffix (like ":Clean")
 $matchingTargets = $matchingTargets | Where-Object { $hasProperty = $_.MsBuild.PSobject.Properties.name -match "Targets" ; return -Not $hasProperty }
 

--- a/tools/bx.ps1
+++ b/tools/bx.ps1
@@ -21,6 +21,13 @@ $targets = $Metaproj.Project.Target
 #   [Conhost\Server, Conhost\Server:Clean, Conhost\Server:Rebuild, Conhost\Server:Publish]
 $matchingTargets = $targets | Where-Object { $_.MSBuild.Condition -eq $msBuildCondition }
 
+# If we didn't find a target, it's possible that the project doesn't have a metaproj
+if ($matchingTargets.length -eq 0)
+{
+    $conditionNoMeta = "'%(ProjectReference.Identity)' == '$projectPath'"
+    $matchingTargets = $targets | Where-Object { $_.MSBuild.Condition -eq $conditionNoMeta }
+}
+
 # Further filter to the targets that dont have a suffix (like ":Clean")
 $matchingTargets = $matchingTargets | Where-Object { $hasProperty = $_.MsBuild.PSobject.Properties.name -match "Targets" ; return -Not $hasProperty }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Whenever you'd open the "options" propsheet, we'd always revert the "cursor shape" to "legacy". This is obviously bad. This PR will make is so the cursor shape will persist, and only selecting a size manually will set the shape to "legacy".

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1219
* [x] I work here
* [n/a] Tests added/passed
* [n/a] Requires documentation to be updated

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
We actually need to add a hidden radio button to the "size" radio buttons on the options page, which acts as a placeholder for "non-legacy". Whenever we set the shape to not-legacy, we'll check that hidden radio button. Otherwise, whenever the Options page is activated, the selected radio button from each group gets a `BN_CLICKED` notification, and if there's no button selected, the _first_ will still get that notification.


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
I've opened the propsheet and really mucked with it a bunch. This feels right now. 