### PR TITLE
Don't crash when restor-down'ing the alt buffer

### DIFF
--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -1231,10 +1231,13 @@ void SCREEN_INFORMATION::_InternalSetViewportSize(const COORD* const pcoordSize,
 
     // See MSFT:19917443
     // If we're in terminal scrolling mode, and we've changed the height of the
-    //      viewport, the new viewport's bottom to the _virtualBottom
+    //      viewport, the new viewport's bottom to the _virtualBottom.
+    // GH#1206 - Only do this if the viewport is _growing_ in height. This can
+    // cause unexpected behavior if we try to anchor the _virtualBottom to a
+    // position that will be greater than the height of the buffer.
     const auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     auto newViewport = Viewport::FromInclusive(srNewViewport);
-    if (gci.IsTerminalScrolling() && newViewport.Height() != _viewport.Height())
+    if (gci.IsTerminalScrolling() && newViewport.Height() >= _viewport.Height())
     {
         const short newTop = static_cast<short>(std::max(0, _virtualBottom - (newViewport.Height() - 1)));
 

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -3586,6 +3586,9 @@ void ScreenBufferTests::HardResetBuffer()
 
 void ScreenBufferTests::RestoreDownAltBufferWithTerminalScrolling()
 {
+    // This is a test for microsoft/terminal#1206. Refer to that issue for more
+    // context
+
     CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     gci.SetTerminalScrolling(true);
     gci.LockConsole(); // Lock must be taken to manipulate buffer.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

When a user had "Disable Scroll Forward" enabled and switched to the alt buffer and maximized the console, then restored down, we'd crash. Now we don't.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1206 
* [x] I work here
* [x] Tests added/passed

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The problem is that we'd previously try to "anchor" the viewport to the virtual bottom when resizing like this. This would also cause us to move the top of the viewport down, into the buffer. However, if the alt buffer is getting smaller, we don't want to do this - if we anchor to the old _virtualBottom, the bottom of the viewport will actually be outside the current buffer.

This could theoretically happen with the main buffer too, but it's much easier to repro with the alt buffer.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Added tests. 
Tried the original repro. Really went wild on the resizing.