### PR TITLE
Fix json settings documentation

### DIFF
--- a/doc/user-docs/UsingJsonSettings.md
+++ b/doc/user-docs/UsingJsonSettings.md
@@ -170,3 +170,6 @@ You can even set multiple keybindings for a single action if you'd like. For exa
 
 will bind both <kbd>ctrl+shift+v</kbd> and
 <kbd>shift+Insert</kbd> to `paste`.
+
+Note: If you set your copy keybinding to `"ctrl+c"`, you'll only be able to send an interrupt to the commandline application using <kbd>Ctrl+C</kbd> when there's no text selection.
+Additionally, if you set `paste` to `"ctrl+v"`, commandline applications won't be able to read a ctrl+v from the input. For these reasons, we suggest `"ctrl+shift+c"` and `"ctrl+shift+v"`

--- a/doc/user-docs/UsingJsonSettings.md
+++ b/doc/user-docs/UsingJsonSettings.md
@@ -170,6 +170,3 @@ You can even set multiple keybindings for a single action if you'd like. For exa
 
 will bind both <kbd>ctrl+shift+v</kbd> and
 <kbd>shift+Insert</kbd> to `paste`.
-
-Note: If you set your copy keybinding to `"ctrl+c"`, you won't be able to send an interrupt to the commandline application using <kbd>Ctrl+C</kbd>. This is a bug, and being tracked by [#2258](https://github.com/microsoft/terminal/issues/2285). 
-Additionally, if you set `paste` to `"ctrl+v"`, commandline applications won't be able to read a ctrl+v from the input. For these reasons, we suggest `"ctrl+shift+c"` and `"ctrl+shift+v"`


### PR DESCRIPTION
The ctrl+c issue was fixed in [#2446](https://github.com/microsoft/terminal/pull/2446)

Release: `Windows Terminal Preview v0.4.2382.0`