### PR TITLE
Move cursor to left margin for IL and DL controls

### DIFF
--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -2021,6 +2021,7 @@ void DoSrvPrivateSetDefaultTabStops()
 
 // Routine Description:
 // - internal logic for adding or removing lines in the active screen buffer
+//   this also moves the cursor to the left margin, which is expected behaviour for IL and DL
 // Parameters:
 // - count - the number of lines to modify
 // - insert - true if inserting lines, false if deleting lines
@@ -2069,6 +2070,10 @@ void DoSrvPrivateModifyLinesImpl(const unsigned int count, const bool insert)
                          screenInfo.GetAttributes());
         }
         CATCH_LOG();
+
+        // The IL and DL controls are also expected to move the cursor to the left margin.
+        // For now this is just column 0, since we don't yet support DECSLRM.
+        LOG_IF_NTSTATUS_FAILED(screenInfo.SetCursorPosition({ 0, cursorPosition.Y }, false));
     }
 }
 

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -3230,8 +3230,16 @@ void ScreenBufferTests::ScrollOperations()
     VERIFY_SUCCEEDED(si.SetCursorPosition(cursorPos, true));
     stateMachine.ProcessString(escapeSequence.str());
 
-    Log::Comment(L"Verify cursor didn't move.");
-    VERIFY_ARE_EQUAL(cursorPos, cursor.GetPosition());
+    // The cursor shouldn't move.
+    auto expectedCursorPos = cursorPos;
+    // Unless this is an IL or DL control, which moves the cursor to the left margin.
+    if (scrollType == InsertLine || scrollType == DeleteLine)
+    {
+        expectedCursorPos.X = 0;
+    }
+
+    Log::Comment(L"Verify expected cursor position.");
+    VERIFY_ARE_EQUAL(expectedCursorPos, cursor.GetPosition());
 
     Log::Comment(L"Field of Zs outside viewport should remain unchanged.");
     VERIFY_IS_TRUE(_ValidateLinesContain(0, viewportStart, bufferChar, bufferAttr));
@@ -3749,7 +3757,8 @@ void ScreenBufferTests::InsertLinesInMargins()
     Log::Comment(NoThrowString().Format(
         L"viewport=%s", VerifyOutputTraits<SMALL_RECT>::ToString(si.GetViewport().ToInclusive()).GetBuffer()));
 
-    VERIFY_ARE_EQUAL(4, cursor.GetPosition().X);
+    // Verify cursor moved to left margin.
+    VERIFY_ARE_EQUAL(0, cursor.GetPosition().X);
     VERIFY_ARE_EQUAL(2, cursor.GetPosition().Y);
     {
         auto iter0 = tbi.GetCellDataAt({ 0, 0 });
@@ -3783,7 +3792,8 @@ void ScreenBufferTests::InsertLinesInMargins()
     Log::Comment(NoThrowString().Format(
         L"viewport=%s", VerifyOutputTraits<SMALL_RECT>::ToString(si.GetViewport().ToInclusive()).GetBuffer()));
 
-    VERIFY_ARE_EQUAL(4, cursor.GetPosition().X);
+    // Verify cursor moved to left margin.
+    VERIFY_ARE_EQUAL(0, cursor.GetPosition().X);
     VERIFY_ARE_EQUAL(1, cursor.GetPosition().Y);
     {
         auto iter0 = tbi.GetCellDataAt({ 0, 0 });
@@ -3824,7 +3834,8 @@ void ScreenBufferTests::DeleteLinesInMargins()
     Log::Comment(NoThrowString().Format(
         L"viewport=%s", VerifyOutputTraits<SMALL_RECT>::ToString(si.GetViewport().ToInclusive()).GetBuffer()));
 
-    VERIFY_ARE_EQUAL(4, cursor.GetPosition().X);
+    // Verify cursor moved to left margin.
+    VERIFY_ARE_EQUAL(0, cursor.GetPosition().X);
     VERIFY_ARE_EQUAL(2, cursor.GetPosition().Y);
     {
         auto iter0 = tbi.GetCellDataAt({ 0, 0 });
@@ -3858,7 +3869,8 @@ void ScreenBufferTests::DeleteLinesInMargins()
     Log::Comment(NoThrowString().Format(
         L"viewport=%s", VerifyOutputTraits<SMALL_RECT>::ToString(si.GetViewport().ToInclusive()).GetBuffer()));
 
-    VERIFY_ARE_EQUAL(4, cursor.GetPosition().X);
+    // Verify cursor moved to left margin.
+    VERIFY_ARE_EQUAL(0, cursor.GetPosition().X);
     VERIFY_ARE_EQUAL(1, cursor.GetPosition().Y);
     {
         auto iter0 = tbi.GetCellDataAt({ 0, 0 });


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

According to the DEC STD 070 manual, the cursor position should be moved to the left margin after the execution of the `IL` and `DL` escape sequences. This PR updates the code to implement that behaviour.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #2534
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests updated
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #2534

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

I've modified the `DoSrvPrivateModifyLinesImpl` function (which is where the `IL` and `DL` controls are ultimately handled), to update the cursor position - setting the column to 0 - after the screen has been scrolled. Note that this has to happen inside the `IsCursorInMargins` check, since the cursor is not supposed to be moved if it was outside the margin boundaries.

Also note that this should really be set to the left margin specified by [`DECSLRM`](https://vt100.net/docs/vt510-rm/DECSLRM.html), but we don't yet support that control, so for now it's hardcoded to 0.

When it came to actually setting the cursor position, I found there were a number of options to choose from, with quite different behaviours. Some operations use a variation of `SetConsoleCursorPosition`, some use `AdjustCursorPosition`, and some call the `SCREEN_INFORMATION::SetCursorPosition` method directly, or even just `Cursor::SetPosition`. It wasn't always clear to why a particular method was chosen.

I ultimately decided on `SCREEN_INFORMATION::SetCursorPosition` with the `TurnOn` parameter set to false, since that seemed the simplest option that also matched the behaviour of a carriage return. I'm not certain that's the best choice, though, so I'm open to other suggestions.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

There were a number of existing `IL` and `DL` tests that assumed the cursor position was not meant to move, and validated that behaviour. I've updated all of those tests to confirm that cursor position is now moved to column 0 when those escape sequences are executed.
