### PR TITLE
Set actual background color in HTML copy

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1056,12 +1056,13 @@ const TextBuffer::TextAndColor TextBuffer::GetTextForClipboard(const bool lineSe
 // - Generates a CF_HTML compliant structure based on the passed in text and color data
 // Arguments:
 // - rows - the text and color data we will format & encapsulate
+// - backgroundColor - default background color for characters, also used in padding
 // - fontHeightPoints - the unscaled font height
 // - fontFaceName - the name of the font used
 // - htmlTitle - value used in title tag of html header. Used to name the application
 // Return Value:
 // - string containing the generated HTML
-std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPoints, const PCWCHAR fontFaceName, const std::string& htmlTitle)
+std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPoints, const PCWCHAR fontFaceName, COLORREF backgroundColor, const std::string& htmlTitle)
 {
     try
     {
@@ -1086,11 +1087,8 @@ std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPo
             htmlBuilder << "display:inline-block;";
             htmlBuilder << "white-space:pre;";
 
-            // fixme: this is only walkaround for filling background after last char of row.
-            // It is based on first char of first row, not the actual char at correct position.
             htmlBuilder << "background-color:";
-            const COLORREF globalBgColor = rows.BkAttr.at(0).at(0);
-            htmlBuilder << Utils::ColorToHexString(globalBgColor);
+            htmlBuilder << Utils::ColorToHexString(backgroundColor);
             htmlBuilder << ";";
 
             htmlBuilder << "font-family:";

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1062,7 +1062,7 @@ const TextBuffer::TextAndColor TextBuffer::GetTextForClipboard(const bool lineSe
 // - htmlTitle - value used in title tag of html header. Used to name the application
 // Return Value:
 // - string containing the generated HTML
-std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPoints, const PCWCHAR fontFaceName, COLORREF backgroundColor, const std::string& htmlTitle)
+std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPoints, const PCWCHAR fontFaceName, const COLORREF backgroundColor, const std::string& htmlTitle)
 {
     try
     {

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -148,6 +148,7 @@ public:
     static std::string GenHTML(const TextAndColor& rows,
                                const int fontHeightPoints,
                                const PCWCHAR fontFaceName,
+                               const COLORREF backgroundColor,
                                const std::string& htmlTitle);
 
 private:

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1436,10 +1436,10 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         // convert text to HTML format
         const auto htmlData = TextBuffer::GenHTML(bufferData,
-            _actualFont.GetUnscaledSize().Y,
-            _actualFont.GetFaceName(),
-            _settings.DefaultBackground(),
-            "Windows Terminal");
+                                                  _actualFont.GetUnscaledSize().Y,
+                                                  _actualFont.GetFaceName(),
+                                                  _settings.DefaultBackground(),
+                                                  "Windows Terminal");
 
         if (!_terminal->IsCopyOnSelectActive())
         {

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1435,7 +1435,11 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         }
 
         // convert text to HTML format
-        const auto htmlData = TextBuffer::GenHTML(bufferData, _actualFont.GetUnscaledSize().Y, _actualFont.GetFaceName(), "Windows Terminal");
+        const auto htmlData = TextBuffer::GenHTML(bufferData,
+            _actualFont.GetUnscaledSize().Y,
+            _actualFont.GetFaceName(),
+            _settings.DefaultBackground(),
+            "Windows Terminal");
 
         if (!_terminal->IsCopyOnSelectActive())
         {

--- a/src/interactivity/win32/Clipboard.cpp
+++ b/src/interactivity/win32/Clipboard.cpp
@@ -277,7 +277,8 @@ void Clipboard::CopyTextToSystemClipboard(const TextBuffer::TextAndColor& rows, 
     {
         const auto& fontData = ServiceLocator::LocateGlobals().getConsoleInformation().GetActiveOutputBuffer().GetCurrentFont();
         int const iFontHeightPoints = fontData.GetUnscaledSize().Y * 72 / ServiceLocator::LocateGlobals().dpi;
-        std::string HTMLToPlaceOnClip = TextBuffer::GenHTML(rows, iFontHeightPoints, fontData.GetFaceName(), "Windows Console Host");
+        const COLORREF bgColor = ServiceLocator::LocateGlobals().getConsoleInformation().GetDefaultBackground();
+        std::string HTMLToPlaceOnClip = TextBuffer::GenHTML(rows, iFontHeightPoints, fontData.GetFaceName(), bgColor, "Windows Console Host");
         const size_t cbNeededHTML = HTMLToPlaceOnClip.size();
         if (cbNeededHTML)
         {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

It just takes background color from terminal (or console) configured in settings, instead first copied 
character. Somewhat easier than I thought it would be.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #2128
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #990 