### PR TITLE
utils: prevent the corruption of GUID strings

### DIFF
--- a/src/types/ut_types/UtilsTests.cpp
+++ b/src/types/ut_types/UtilsTests.cpp
@@ -20,6 +20,7 @@ class UtilsTests
 
     TEST_METHOD(TestClampToShortMax);
     TEST_METHOD(TestSwapColorPalette);
+    TEST_METHOD(TestGuidToString);
 };
 
 void UtilsTests::TestClampToShortMax()
@@ -74,4 +75,17 @@ void UtilsTests::TestSwapColorPalette()
     VERIFY_ARE_EQUAL(terminalTable[13], consoleTable[13]);
     VERIFY_ARE_EQUAL(terminalTable[14], consoleTable[11]);
     VERIFY_ARE_EQUAL(terminalTable[15], consoleTable[15]);
+}
+
+void UtilsTests::TestGuidToString()
+{
+    constexpr GUID constantGuid{
+        0x01020304, 0x0506, 0x0708, { 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10 }
+    };
+    constexpr std::wstring_view constantGuidString{ L"{01020304-0506-0708-090a-0b0c0d0e0f10}" };
+
+    auto generatedGuid{ GuidToString(constantGuid) };
+
+    VERIFY_ARE_EQUAL(constantGuidString.size(), generatedGuid.size());
+    VERIFY_ARE_EQUAL(constantGuidString, generatedGuid);
 }

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -15,12 +15,14 @@ using namespace Microsoft::Console;
 // - a string representation of the GUID. On failure, throws E_INVALIDARG.
 std::wstring Utils::GuidToString(const GUID guid)
 {
+    // 39: 38, plus swprintf needs somewhere to store the NUL terminator.
     std::array<wchar_t, 39> guid_cstr;
     const int written = swprintf(guid_cstr.data(), guid_cstr.size(), L"{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}", guid.Data1, guid.Data2, guid.Data3, guid.Data4[0], guid.Data4[1], guid.Data4[2], guid.Data4[3], guid.Data4[4], guid.Data4[5], guid.Data4[6], guid.Data4[7]);
 
     THROW_HR_IF(E_INVALIDARG, written == -1);
 
-    return std::wstring(guid_cstr.data(), guid_cstr.size());
+    // size - 1: The returned string should not be created including the NUL terminator.
+    return std::wstring(guid_cstr.data(), guid_cstr.size() - 1);
 }
 
 // Method Description:


### PR DESCRIPTION
## Summary of the Pull Request
This off-by-one (regression: #2607) resulted in the following profile and environment corruption:

```
                                                            vvvvvv
            "guid" : "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}\u0000",
            "icon" : "ms-appx:///ProfileIcons/{0caa0dad-35be-5f56-a8ff-afceeeaa6101}\u0000.png",
                                                                                    ^^^^^^
```

## PR Checklist
* [x] CLA signed.
* [x] Tests added/passed!
