### PR TITLE
Escape HTML entities

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1150,7 +1150,7 @@ std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPo
                 const auto writeAccumulatedChars = [&](bool includeCurrent) {
                     if (col > startOffset)
                     {
-                        const auto unescapedText = std::wstring_view(rows.text.at(row)).substr(startOffset, col - startOffset + includeCurrent);
+                        const auto unescapedText = ConvertToA(CP_UTF8, std::wstring_view(rows.text.at(row)).substr(startOffset, col - startOffset + includeCurrent));
                         for (const auto c : unescapedText)
                         {
                             switch (c)
@@ -1165,7 +1165,7 @@ std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPo
                                 htmlBuilder << "&amp;";
                                 break;
                             default:
-                                htmlBuilder << ConvertToA(CP_UTF8, std::wstring_view(&c, 1));
+                                htmlBuilder << c;
                             }
                         }
 

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1150,9 +1150,25 @@ std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPo
                 const auto writeAccumulatedChars = [&](bool includeCurrent) {
                     if (col > startOffset)
                     {
-                        // note: this should be escaped (for '<', '>', and '&'),
-                        // however MS Word doesn't appear to support HTML entities
-                        htmlBuilder << ConvertToA(CP_UTF8, std::wstring_view(rows.text.at(row)).substr(startOffset, col - startOffset + includeCurrent));
+                        const auto unescapedText = std::wstring_view(rows.text.at(row)).substr(startOffset, col - startOffset + includeCurrent);
+                        for (const auto c : unescapedText)
+                        {
+                            switch (c)
+                            {
+                            case '<':
+                                htmlBuilder << "&lt;";
+                                break;
+                            case '>':
+                                htmlBuilder << "&gt;";
+                                break;
+                            case '&':
+                                htmlBuilder << "&amp;";
+                                break;
+                            default:
+                                htmlBuilder << ConvertToA(CP_UTF8, std::wstring_view(&c, 1));
+                            }
+                        }
+
                         startOffset = col;
                     }
                 };


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Since MS Word apparently just got support for HTML entities, we can now properly escape them.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
I omitted this in #2038 since Word didn't support them

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #2738
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx