### PR TITLE
Don't explode name-only profiles

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -1093,7 +1093,9 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(2u, settings2._profiles.size());
             // Initialize the second settings object from the first settings
             // object's settings string, the one that we synthesized.
-            settings2._ParseJsonString(settings._userSettingsString, false);
+            const auto firstSettingsString = settings._userSettingsString;
+            settings2._ParseJsonString(firstSettingsString, false);
+            settings2.LayerJson(settings2._userSettings);
             VERIFY_ARE_EQUAL(5u, settings2._profiles.size());
             VERIFY_IS_TRUE(settings2._profiles.at(0)._guid.has_value());
             VERIFY_IS_TRUE(settings2._profiles.at(1)._guid.has_value());

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -45,6 +45,7 @@ namespace TerminalAppLocalTests
         TEST_METHOD(TestAllValidationsWithNullGuids);
         TEST_METHOD(TestReorderWithNullGuids);
         TEST_METHOD(TestReorderingWithoutGuid);
+        TEST_METHOD(TestExplodingNameOnlyProfiles);
 
         TEST_CLASS_SETUP(ClassSetup)
         {
@@ -966,5 +967,97 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(L"ThisProfileShouldNotCrash", settings._profiles.at(1)._name);
         VERIFY_ARE_EQUAL(L"Ubuntu", settings._profiles.at(2)._name);
         VERIFY_ARE_EQUAL(L"Windows PowerShell", settings._profiles.at(3)._name);
+    }
+
+    void SettingsTests::TestExplodingNameOnlyProfiles()
+    {
+        // This is a test for GH#2782. When we add a name-only profile, we'll
+        // generate a GUID for it. We should make sure that we don't re-append
+        // that profile to the list of profiles.
+
+        const std::string settings0String{ R"(
+        {
+            "defaultProfile" : "{00000000-0000-5f56-a8ff-afceeeaa6101}",
+            "profiles": [
+                {
+                    "guid" : "{00000000-0000-5f56-a8ff-afceeeaa6101}",
+                    "name" : "ThisProfileIsGood"
+
+                },
+                {
+                    "name" : "ThisProfileShouldNotDuplicate"
+                }
+            ]
+        })" };
+
+        const auto settings0Json = VerifyParseSucceeded(settings0String);
+
+        CascadiaSettings settings;
+        settings._ParseJsonString(DefaultJson, true);
+        settings.LayerJson(settings._defaultSettings);
+        VERIFY_ARE_EQUAL(2u, settings._profiles.size());
+        VERIFY_IS_TRUE(settings._profiles.at(0)._guid.has_value());
+        VERIFY_IS_TRUE(settings._profiles.at(1)._guid.has_value());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings._profiles.at(0)._name);
+        VERIFY_ARE_EQUAL(L"cmd", settings._profiles.at(1)._name);
+
+        Log::Comment(NoThrowString().Format(
+            L"Parse the user settings"));
+        settings._ParseJsonString(settings0String, false);
+        settings.LayerJson(settings._userSettings);
+
+        VERIFY_ARE_EQUAL(4u, settings._profiles.size());
+        VERIFY_IS_TRUE(settings._profiles.at(0)._guid.has_value());
+        VERIFY_IS_TRUE(settings._profiles.at(1)._guid.has_value());
+        VERIFY_IS_TRUE(settings._profiles.at(2)._guid.has_value());
+        VERIFY_IS_FALSE(settings._profiles.at(3)._guid.has_value());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings._profiles.at(0)._name);
+        VERIFY_ARE_EQUAL(L"cmd", settings._profiles.at(1)._name);
+        VERIFY_ARE_EQUAL(L"ThisProfileIsGood", settings._profiles.at(2)._name);
+        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotDuplicate", settings._profiles.at(3)._name);
+
+        Log::Comment(NoThrowString().Format(
+            L"Pretend like we're checking to append dynamic profiles to the "
+            L"user's settings file. We absolutely _shouldn't_ be adding anything here."));
+        bool const needToWriteFile = settings._AppendDynamicProfilesToUserSettings();
+        VERIFY_IS_FALSE(needToWriteFile);
+        VERIFY_ARE_EQUAL(settings0String.size(), settings._userSettingsString.size());
+
+        Log::Comment(NoThrowString().Format(
+            L"Re-parse the settings file. We should have the _same_ settings as before."));
+        Log::Comment(NoThrowString().Format(
+            L"Do this to a _new_ settings object, to make sure it turns out the same."));
+        {
+            CascadiaSettings settings2;
+            settings2._ParseJsonString(DefaultJson, true);
+            settings2.LayerJson(settings2._defaultSettings);
+            VERIFY_ARE_EQUAL(2u, settings2._profiles.size());
+            // Initialize the second settings object from the first settings
+            // object's settings string, the one that we synthesized.
+            settings2._ParseJsonString(settings._userSettingsString, false);
+            VERIFY_ARE_EQUAL(4u, settings2._profiles.size());
+            VERIFY_IS_TRUE(settings2._profiles.at(0)._guid.has_value());
+            VERIFY_IS_TRUE(settings2._profiles.at(1)._guid.has_value());
+            VERIFY_IS_TRUE(settings2._profiles.at(2)._guid.has_value());
+            VERIFY_IS_FALSE(settings2._profiles.at(3)._guid.has_value());
+            VERIFY_ARE_EQUAL(L"Windows PowerShell", settings2._profiles.at(0)._name);
+            VERIFY_ARE_EQUAL(L"cmd", settings2._profiles.at(1)._name);
+            VERIFY_ARE_EQUAL(L"ThisProfileIsGood", settings2._profiles.at(2)._name);
+            VERIFY_ARE_EQUAL(L"ThisProfileShouldNotDuplicate", settings2._profiles.at(3)._name);
+        }
+
+        Log::Comment(NoThrowString().Format(
+            L"Validate the settings. All the profiles we have should be valid."));
+        settings._ValidateSettings();
+
+        VERIFY_ARE_EQUAL(4u, settings._profiles.size());
+        VERIFY_IS_TRUE(settings._profiles.at(0)._guid.has_value());
+        VERIFY_IS_TRUE(settings._profiles.at(1)._guid.has_value());
+        VERIFY_IS_TRUE(settings._profiles.at(2)._guid.has_value());
+        VERIFY_IS_TRUE(settings._profiles.at(3)._guid.has_value());
+        VERIFY_ARE_EQUAL(L"ThisProfileIsGood", settings._profiles.at(0)._name);
+        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotDuplicate", settings._profiles.at(1)._name);
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings._profiles.at(2)._name);
+        VERIFY_ARE_EQUAL(L"cmd", settings._profiles.at(3)._name);
     }
 }

--- a/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
@@ -282,6 +282,9 @@ bool CascadiaSettings::_AppendDynamicProfilesToUserSettings()
                 {
                     return true;
                 }
+                // If the profileJson doesn't have a GUID, then it might be in
+                // the file still. We returned false because it shouldn't be
+                // layered, but it might be a name-only profile.
             }
         }
         return false;
@@ -298,6 +301,20 @@ bool CascadiaSettings::_AppendDynamicProfilesToUserSettings()
 
     for (const auto& profile : _profiles)
     {
+        if (!profile.HasGuid())
+        {
+            // If the profile doesn't have a guid, it's a name-only profile.
+            // During validation, we'll generate a GUID for the profile, but
+            // validation occurs after this. We should ignore these types of
+            // profiles.
+            // If a dynamic profile was generated _without_ a GUID, we also
+            // don't want it serialized here. The first check in
+            // Profile::ShouldBeLayered checks that the profile hasa guid. For a
+            // dynamic profile without a GUID, that'll _never_ be true, so it
+            // would be impossible to be layered.
+            continue;
+        }
+
         // Skip profiles that are in the user settings or the default settings.
         if (isInJsonObj(profile, _userSettings) || isInJsonObj(profile, _defaultSettings))
         {

--- a/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
@@ -309,7 +309,7 @@ bool CascadiaSettings::_AppendDynamicProfilesToUserSettings()
             // profiles.
             // If a dynamic profile was generated _without_ a GUID, we also
             // don't want it serialized here. The first check in
-            // Profile::ShouldBeLayered checks that the profile hasa guid. For a
+            // Profile::ShouldBeLayered checks that the profile has a guid. For a
             // dynamic profile without a GUID, that'll _never_ be true, so it
             // would be impossible to be layered.
             continue;

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -429,7 +429,13 @@ Json::Value Profile::GenerateStub() const
 // - Generates a Json::Value which is a "stub" of this profile. This stub will
 //   have enough information that it could be layered with this profile.
 // - This generated stub might include a GUID. If generateGuid is true, and this
-//   profile doesn't have a GUID, the guid will be auto-generated.
+//   profile doesn't have a GUID, the guid will be auto-generated. Setting this
+//   to true is especially helpful for dynamic profiles, where they may only be
+//   generated with a source and name, but we'll want them to be written to the
+//   file with their generated GUID
+//      OH WAIT. This deosn't matter. If a DPG generates a profile w/o a GUID,
+//      then it'll be impossible to be layered correctly. The DPG profile will
+//      _never_ match another profile, since we MUST have a guid to layer.
 // - This method is used during dynamic profile generation - if a profile is
 //   ever generated that didn't already exist in the user's settings, we'll add
 //   this stub to the user's settings file, so the user has an easy point to

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -439,13 +439,7 @@ Json::Value Profile::GenerateStub() const
 // - Generates a Json::Value which is a "stub" of this profile. This stub will
 //   have enough information that it could be layered with this profile.
 // - This generated stub might include a GUID. If generateGuid is true, and this
-//   profile doesn't have a GUID, the guid will be auto-generated. Setting this
-//   to true is especially helpful for dynamic profiles, where they may only be
-//   generated with a source and name, but we'll want them to be written to the
-//   file with their generated GUID
-//      OH WAIT. This deosn't matter. If a DPG generates a profile w/o a GUID,
-//      then it'll be impossible to be layered correctly. The DPG profile will
-//      _never_ match another profile, since we MUST have a guid to layer.
+//   profile doesn't have a GUID, the guid will be auto-generated.
 // - This method is used during dynamic profile generation - if a profile is
 //   ever generated that didn't already exist in the user's settings, we'll add
 //   this stub to the user's settings file, so the user has an easy point to

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -263,7 +263,7 @@ TerminalSettings Profile::CreateTerminalSettings(const std::vector<ColorScheme>&
 // - a JsonObject which is an equivalent serialization of this object.
 Json::Value Profile::ToJson() const
 {
-    Json::Value root = _GenerateStub(false);
+    Json::Value root = GenerateStub();
 
     ///// Profile-specific settings /////
     root[JsonKey(HiddenKey)] = _hidden;
@@ -423,23 +423,6 @@ Json::Value Profile::DiffToJson(const Profile& other) const
 // Method Description:
 // - Generates a Json::Value which is a "stub" of this profile. This stub will
 //   have enough information that it could be layered with this profile.
-// - This generated stub will _always_ include a GUID. If this profile doesn't
-//   have a GUID, the guid will be auto-generated.
-// - See _GenerateStub for more details.
-// Arguments:
-// - <none>
-// Return Value:
-// - A json::Value with a guid, name and source (if applicable).
-Json::Value Profile::GenerateStub() const
-{
-    return _GenerateStub(true);
-}
-
-// Method Description:
-// - Generates a Json::Value which is a "stub" of this profile. This stub will
-//   have enough information that it could be layered with this profile.
-// - This generated stub might include a GUID. If generateGuid is true, and this
-//   profile doesn't have a GUID, the guid will be auto-generated.
 // - This method is used during dynamic profile generation - if a profile is
 //   ever generated that didn't already exist in the user's settings, we'll add
 //   this stub to the user's settings file, so the user has an easy point to
@@ -448,7 +431,7 @@ Json::Value Profile::GenerateStub() const
 // - <none>
 // Return Value:
 // - A json::Value with a guid, name and source (if applicable).
-Json::Value Profile::_GenerateStub(const bool generateGuid) const
+Json::Value Profile::GenerateStub() const
 {
     Json::Value stub;
 
@@ -456,11 +439,6 @@ Json::Value Profile::_GenerateStub(const bool generateGuid) const
     if (_guid.has_value())
     {
         stub[JsonKey(GuidKey)] = winrt::to_string(Utils::GuidToString(_guid.value()));
-    }
-    else if (generateGuid)
-    {
-        const auto guid = _GenerateGuidForProfile(_name, _source);
-        stub[JsonKey(GuidKey)] = winrt::to_string(Utils::GuidToString(guid));
     }
 
     stub[JsonKey(NameKey)] = winrt::to_string(_name);

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -119,6 +119,16 @@ Profile::~Profile()
 {
 }
 
+bool Profile::HasGuid() const noexcept
+{
+    return _guid.has_value();
+}
+
+bool Profile::HasSource() const noexcept
+{
+    return _source.has_value();
+}
+
 GUID Profile::GetGuid() const noexcept
 {
     // This can throw if we never had our guid set to a legitimate value.

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -253,7 +253,7 @@ TerminalSettings Profile::CreateTerminalSettings(const std::vector<ColorScheme>&
 // - a JsonObject which is an equivalent serialization of this object.
 Json::Value Profile::ToJson() const
 {
-    Json::Value root = GenerateStub();
+    Json::Value root = _GenerateStub(false);
 
     ///// Profile-specific settings /////
     root[JsonKey(HiddenKey)] = _hidden;
@@ -413,6 +413,23 @@ Json::Value Profile::DiffToJson(const Profile& other) const
 // Method Description:
 // - Generates a Json::Value which is a "stub" of this profile. This stub will
 //   have enough information that it could be layered with this profile.
+// - This generated stub will _always_ include a GUID. If this profile doesn't
+//   have a GUID, the guid will be auto-generated.
+// - See _GenerateStub for more details.
+// Arguments:
+// - <none>
+// Return Value:
+// - A json::Value with a guid, name and source (if applicable).
+Json::Value Profile::GenerateStub() const
+{
+    return _GenerateStub(true);
+}
+
+// Method Description:
+// - Generates a Json::Value which is a "stub" of this profile. This stub will
+//   have enough information that it could be layered with this profile.
+// - This generated stub might include a GUID. If generateGuid is true, and this
+//   profile doesn't have a GUID, the guid will be auto-generated.
 // - This method is used during dynamic profile generation - if a profile is
 //   ever generated that didn't already exist in the user's settings, we'll add
 //   this stub to the user's settings file, so the user has an easy point to
@@ -421,7 +438,7 @@ Json::Value Profile::DiffToJson(const Profile& other) const
 // - <none>
 // Return Value:
 // - A json::Value with a guid, name and source (if applicable).
-Json::Value Profile::GenerateStub() const
+Json::Value Profile::_GenerateStub(const bool generateGuid) const
 {
     Json::Value stub;
 
@@ -429,6 +446,11 @@ Json::Value Profile::GenerateStub() const
     if (_guid.has_value())
     {
         stub[JsonKey(GuidKey)] = winrt::to_string(Utils::GuidToString(_guid.value()));
+    }
+    else if (generateGuid)
+    {
+        const auto guid = _GenerateGuidForProfile(_name, _source);
+        stub[JsonKey(GuidKey)] = winrt::to_string(Utils::GuidToString(guid));
     }
 
     stub[JsonKey(NameKey)] = winrt::to_string(_name);

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -86,6 +86,8 @@ public:
     static GUID GetGuidOrGenerateForJson(const Json::Value& json) noexcept;
 
 private:
+    Json::Value _GenerateStub(const bool generateGuid) const;
+
     static std::wstring EvaluateStartingDirectory(const std::wstring& directory);
 
     static winrt::Microsoft::Terminal::Settings::ScrollbarState ParseScrollbarState(const std::wstring& scrollbarState);

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -55,6 +55,8 @@ public:
     void LayerJson(const Json::Value& json);
     static bool IsDynamicProfileObject(const Json::Value& json);
 
+    bool HasGuid() const noexcept;
+    bool HasSource() const noexcept;
     GUID GetGuid() const noexcept;
     void SetSource(std::wstring_view sourceNamespace) noexcept;
     std::wstring_view GetName() const noexcept;

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -88,8 +88,6 @@ public:
     static GUID GetGuidOrGenerateForJson(const Json::Value& json) noexcept;
 
 private:
-    Json::Value _GenerateStub(const bool generateGuid) const;
-
     static std::wstring EvaluateStartingDirectory(const std::wstring& directory);
 
     static winrt::Microsoft::Terminal::Settings::ScrollbarState ParseScrollbarState(const std::wstring& scrollbarState);


### PR DESCRIPTION
## Summary of the Pull Request

When the user adds a name-only profile, we shouldn't re-add that to their list of profiles each time they launch the terminal.

## References
Introduced in #2515 or #2603 


## PR Checklist
* [x] Closes #2782
* [x] I work here
* [x] Tests added/passed
* [n/a] Requires documentation to be updated
