### PR TITLE
Add validation for hiding all the profiles

### DIFF
--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -30,8 +30,9 @@ static const std::array<std::wstring_view, 2> settingsLoadWarningsLabels {
    L"MissingDefaultProfileText",
    L"DuplicateProfileText"
 };
-static const std::array<std::wstring_view, 1> settingsLoadErrorsLabels {
-    L"NoProfilesText"
+static const std::array<std::wstring_view, 2> settingsLoadErrorsLabels {
+    L"NoProfilesText",
+    L"AllProfilesHiddenText"
 };
 // clang-format on
 

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -355,4 +355,14 @@ void CascadiaSettings::_RemoveHiddenProfiles()
                                    _profiles.end(),
                                    [](auto&& profile) { return profile.IsHidden(); }),
                     _profiles.end());
+
+    // Ensure that we still have some profiles here. If we don't, then throw an
+    // exception, so the app can use the defaults.
+    const bool hasProfiles = !_profiles.empty();
+    if (!hasProfiles)
+    {
+        // Throw an exception. This is an invalid state, and we want the app to
+        // be able to gracefully use the default settings.
+        throw ::TerminalApp::SettingsException(::TerminalApp::SettingsLoadErrors::AllProfilesHidden);
+    }
 }

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -133,6 +133,10 @@
     <value>No profiles were found in your settings.
 </value>
   </data>
+  <data name="AllProfilesHiddenText" xml:space="preserve">
+    <value>All profiles were hidden in your settings. You must have at least one non-hidden profile.
+</value>
+  </data>
   <data name="ReloadJsonParseErrorText" xml:space="preserve">
     <value>Settings could not be reloaded from file. Check for syntax errors, including trailing commas.
 </value>

--- a/src/cascadia/TerminalApp/TerminalWarnings.h
+++ b/src/cascadia/TerminalApp/TerminalWarnings.h
@@ -29,7 +29,8 @@ namespace TerminalApp
     // that we could not recover from.
     enum class SettingsLoadErrors : uint32_t
     {
-        NoProfiles = 0
+        NoProfiles = 0,
+        AllProfilesHidden = 1
     };
 
     // This is a helper class to wrap up a SettingsLoadErrors into a proper


### PR DESCRIPTION
## Summary of the Pull Request

Prevent the Terminal from toasting it's marshmallows when the user hides all their profiles. In that case, we'll just revert to the defaults.

## PR Checklist
* [x] Closes #2794
* [x] I work here
* [x] Tests added/passed
* [n/a] Requires documentation to be updated

## Validation Steps Performed
* ran tests
* validated manually