### PR TITLE
Update SignConfig to use SHA2 variant per governance request.

### DIFF
--- a/src/tools/ColorTool/signing/SignConfig.xml
+++ b/src/tools/ColorTool/signing/SignConfig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <SignConfigXML>
   <job platform="anycpu" configuration="release" dest="__RELBINPATH__\..\..\..\s\signed" jobname="Console ColorTool" approvers="miniksa;migrie;duhowett;austdi">
-    <file src="__RELBINPATH__\..\..\..\s\tosign\colortool.exe" signType="Authenticode" dest="__RELBINPATH__\..\..\..\s\signed\colortool.exe" />
+    <file src="__RELBINPATH__\..\..\..\s\tosign\colortool.exe" signType="AuthenticodeFormer" dest="__RELBINPATH__\..\..\..\s\signed\colortool.exe" />
   </job>
 </SignConfigXML>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

We've been requested to move to SHA2 certificates where possible. This replaces the friendly name that internally converts to a variant containing a non-zero amount of SHA1 stuff into one that is fully SHA2.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes internal mail notification
* [X] I work here
* [X] I have to change the code to test the build and wait for the job authorization to update. Unfortunately because the signed builds are triggered by an authorized person, I'll have to do it manually once this is in. I cannot auto-trigger a signed build in a PR.
* [X] Docs for signing are available in the existing Engineering System wiki pages.
* [X] I'm a core contributor

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

This literally just replaces the friendly name for the old certificate with the one for the new certificate so the signing tool knows which cert to pick up out of the certificate store. It has to dovetail with the authorization which I've already submitted for review.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
As I mentioned above, I can't validate it until it's in and the authorization is approved. I'll manually launch a signed build and check it out (and maybe even release it) once we're all authorized and updated.
