### PR TITLE
Add a schema reference to the userDefaults and patch one into user data

### DIFF
--- a/src/cascadia/TerminalApp/CascadiaSettings.h
+++ b/src/cascadia/TerminalApp/CascadiaSettings.h
@@ -87,6 +87,7 @@ private:
     void _ParseJsonString(std::string_view fileData, const bool isDefaultSettings);
     static const Json::Value& _GetProfilesJsonObject(const Json::Value& json);
     static const Json::Value& _GetDisabledProfileSourcesJsonObject(const Json::Value& json);
+    bool _PrependSchemaDirective();
     bool _AppendDynamicProfilesToUserSettings();
 
     void _LoadDynamicProfiles();

--- a/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
@@ -38,7 +38,7 @@ static constexpr std::string_view DisabledProfileSourcesKey{ "disabledProfileSou
 static constexpr std::string_view Utf8Bom{ u8"\uFEFF" };
 static constexpr std::string_view DefaultProfilesIndentation{ "        " };
 static constexpr std::string_view SettingsSchemaFragment{ "\n"
-                                                          R"(    "$schema": "https://aka.ms/terminal-profiles-schema",)" };
+                                                          R"(    "$schema": "https://aka.ms/terminal-profiles-schema")" };
 
 // Method Description:
 // - Creates a CascadiaSettings from whatever's saved on disk, or instantiates
@@ -279,8 +279,13 @@ bool CascadiaSettings::_PrependSchemaDirective()
     }
 
     // start points at the opening { for the root object.
-    auto start = _userSettings.getOffsetStart();
-    _userSettingsString.insert(start + 1, SettingsSchemaFragment);
+    auto offset = _userSettings.getOffsetStart() + 1;
+    _userSettingsString.insert(offset, SettingsSchemaFragment);
+    offset += SettingsSchemaFragment.size();
+    if (_userSettings.size() > 0)
+    {
+        _userSettingsString.insert(offset, ",");
+    }
     return true;
 }
 

--- a/src/cascadia/TerminalApp/userDefaults.json
+++ b/src/cascadia/TerminalApp/userDefaults.json
@@ -2,6 +2,8 @@
 // For documentation on these settings, see: https://aka.ms/terminal-documentation
 
 {
+    "$schema": "https://aka.ms/terminal-profiles-schema",
+
     "defaultProfile": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
 
     "profiles":


### PR DESCRIPTION
## Summary of the Pull Request
This pull request both adds a schema to the default JSON file written out for the user and adds code to patch a `$schema` into existing user settings.

## References
#2704 

## PR Checklist
* [ ] Tests added/passed/updated
* [ ] I've discussed this with core contributors already.

## Detailed Description of the Pull Request / Additional comments
We have to re-parse the settings string after every patch, because there's a chance the object offsets have moved around on us. Alternatively, we could always patch from the bottom up. That approach seems more fragile, even if it's technically faster.

## Validation Steps Performed

The tests probably fail, but I tried it locally against my settings file :P