### PR TITLE
Initialize the VT tab stops when a buffer is created in VT mode

### DIFF
--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -68,6 +68,9 @@ SCREEN_INFORMATION::SCREEN_INFORMATION(
     LineChar[3] = UNICODE_BOX_DRAW_LIGHT_VERTICAL;
     LineChar[4] = UNICODE_BOX_DRAW_LIGHT_UP_AND_RIGHT;
     LineChar[5] = UNICODE_BOX_DRAW_LIGHT_UP_AND_LEFT;
+
+    // Check if VT mode is enabled. Note that this can be true w/o calling
+    // SetConsoleMode, if VirtualTerminalLevel is set to !=0 in the registry.
     const CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     if (gci.GetVirtTermLevel() != 0)
     {
@@ -131,6 +134,16 @@ SCREEN_INFORMATION::~SCREEN_INFORMATION()
         pScreen->_textBuffer->GetCursor().SetType(gci.GetCursorType());
 
         const NTSTATUS status = pScreen->_InitializeOutputStateMachine();
+
+        if (pScreen->InVTMode())
+        {
+            // microsoft/terminal#411: If VT mode is enabled, lets construct the
+            // VT tab stops. Without this line, if a user has
+            // VirtualTerminalLevel set, then
+            // SetConsoleMode(ENABLE_VIRTUAL_TERMINAL_PROCESSING) won't set our
+            // tab stops, because we're never going from vt off -> on
+            pScreen->SetDefaultVtTabStops();
+        }
 
         if (NT_SUCCESS(status))
         {

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -4355,6 +4355,12 @@ void ScreenBufferTests::InitializeTabStopsInVTMode()
     // This is a test for microsoft/terminal#411. Refer to that issue for more
     // context.
 
+    // Run this test in isolation - Let's not pollute the VT level for other
+    // tests, or go blowing away other test's buffers
+    BEGIN_TEST_METHOD_PROPERTIES()
+        TEST_METHOD_PROPERTY(L"IsolationLevel", L"Method")
+    END_TEST_METHOD_PROPERTIES()
+
     auto& g = ServiceLocator::LocateGlobals();
     auto& gci = g.getConsoleInformation();
 

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -4352,8 +4352,8 @@ void ScreenBufferTests::ClearAlternateBuffer()
 
 void ScreenBufferTests::InitializeTabStopsInVTMode()
 {
-    // This is a test for microsoft/terminal#1189. Refer to that issue for more
-    // context
+    // This is a test for microsoft/terminal#411. Refer to that issue for more
+    // context.
 
     auto& g = ServiceLocator::LocateGlobals();
     auto& gci = g.getConsoleInformation();

--- a/src/host/ut_host/SelectionTests.cpp
+++ b/src/host/ut_host/SelectionTests.cpp
@@ -414,6 +414,7 @@ class SelectionInputTests
 
         m_state->PrepareGlobalFont();
         m_state->PrepareGlobalScreenBuffer();
+        m_state->PrepareGlobalInputBuffer();
 
         return true;
     }
@@ -422,6 +423,7 @@ class SelectionInputTests
     {
         m_state->CleanupGlobalScreenBuffer();
         m_state->CleanupGlobalFont();
+        m_state->CleanupGlobalInputBuffer();
 
         delete m_state;
 


### PR DESCRIPTION
## Summary of the Pull Request

If a user has `VirtualTerminalLevel` set, then `SetConsoleMode(ENABLE_VIRTUAL_TERMINAL_PROCESSING)` won't set our tab stops, because we're never going from vt off -> on.
So, if VT mode is enabled, construct the VT tab stops when the buffer is created.

## PR Checklist
* [x] Closes #411
* [x] I work here
* [x] Tests added/passed

## Detailed Description of the Pull Request / Additional comments

Big shout-out to @j4james for basically doing all the work on what I thought was an impossible bug. Thanks!

