### PR TITLE
Enable VT processing by default for conpty

### DIFF
--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -139,6 +139,17 @@ static bool s_IsOnDesktop()
             reg.LoadFromRegistry(Title);
         }
     }
+    else
+    {
+        // microsoft/terminal#1965 - Let's just always enable VT processing by
+        // default for conpty clients. This prevents peculiar differences in
+        // behavior between conhost and terminal applications when the user has
+        // VirtualTerminalLevel=1 in their registry.
+        // We want everone to be using VT by default anyways, so this is a
+        // strong nudge in that direction. If an application _doesn't_ want VT
+        // processing, it's free to disable this setting, even in conpty mode.
+        settings.SetVirtTermLevel(1);
+    }
 
     // 1. The settings we were passed contains STARTUPINFO structure settings to be applied last.
     settings.ApplyStartupInfo(pStartupSettings);

--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -145,7 +145,7 @@ static bool s_IsOnDesktop()
         // default for conpty clients. This prevents peculiar differences in
         // behavior between conhost and terminal applications when the user has
         // VirtualTerminalLevel=1 in their registry.
-        // We want everone to be using VT by default anyways, so this is a
+        // We want everyone to be using VT by default anyways, so this is a
         // strong nudge in that direction. If an application _doesn't_ want VT
         // processing, it's free to disable this setting, even in conpty mode.
         settings.SetVirtTermLevel(1);


### PR DESCRIPTION

## Summary of the Pull Request

This change enables VT processing by default for _all_ conpty clients. See #1965 for a discussion on why we believe this is a righteous change.

## PR Checklist
* [x] Closes #1965 
* [x] I work here
* [ ] Tests added/passed - this might need them? 
* [ ] Requires documentation to be updated


## Detailed Description of the Pull Request / Additional comments

Also mentioned in the issue was the idea of only checking the `VirtualTerminalLevel` reg key in the conpty startup. I don't think this would be a more difficult change, looks like all we'd need is a simple `reg.LoadGlobalsFromRegistry();` call instead of this change.

## Validation Steps Performed
Manually launched a scratch app in both the terminal and the console. The console launch's output mode was 0x3, and the terminal's was 0x7. 0x4 is the ` ENABLE_VIRTUAL_TERMINAL_PROCESSING` flag, which the client now had by default in the Terminal.
