### PR TITLE
Add some retry support to Renderer::PaintFrame

### DIFF
--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -97,7 +97,7 @@ Renderer::~Renderer()
     _CheckViewportAndScroll();
 
     // Try to start painting a frame
-    HRESULT hr = pEngine->StartPaint();
+    HRESULT const hr = pEngine->StartPaint();
     RETURN_IF_FAILED(hr);
 
     // Return early if there's nothing to paint.
@@ -143,10 +143,10 @@ Renderer::~Renderer()
     unlock.reset();
 
     // Trigger out-of-lock presentation for renderers that can support it
-    RETURN_IF_FAILED(hr = pEngine->Present());
+    RETURN_IF_FAILED(pEngine->Present());
 
     // As we leave the scope, EndPaint will be called (declared above)
-    return hr;
+    return S_OK;
 }
 
 void Renderer::_NotifyPaintFrame()


### PR DESCRIPTION
If _PaintFrameForEngine returns E_PENDING, we'll give it another two
tries to get itself straight. If it continues to fail, we'll take down
the application.

We observed that the DX renderer was failing to present the swap chain
and failfast'ing when it did so; however, there are some errors from
which DXGI guidance suggests we try to recover. We'll now return
E_PENDING (and destroy our device resources) when we hit those errors.

Fixes #2265.

## PR Checklist
* [x] Closes #2265
* [x] Author works here
* [x] Tests added/passed/N/A (manual)
* [x] I've discussed this with ~core contributors~ Michael already.

## Validation Steps Performed

I TDR'd the heck out of my machine. While Visual Studio and Outlook were busy assuming ambient temperature and taking a dirt nap respectively, Terminal continued chugging along.
