### PR TITLE
make filling chars (and, thus, erase line/char) unset wrap

### DIFF
--- a/src/buffer/out/Row.cpp
+++ b/src/buffer/out/Row.cpp
@@ -204,7 +204,7 @@ OutputCellIterator ROW::WriteCells(OutputCellIterator it, const size_t index, co
 
             // If we're asked to (un)set the wrap status and we just filled the last column with some text...
             // NOTE:
-            //  - wrap = std::nullopt    --> we don't care about changing the value
+            //  - wrap = std::nullopt    --> don't change the wrap value
             //  - wrap = true            --> we're filling cells as a steam, consider this a wrap
             //  - wrap = false           --> we're filling cells as a block, unwrap
             if (wrap.has_value() && fillingLastColumn)

--- a/src/buffer/out/Row.hpp
+++ b/src/buffer/out/Row.hpp
@@ -57,7 +57,7 @@ public:
     UnicodeStorage& GetUnicodeStorage() noexcept;
     const UnicodeStorage& GetUnicodeStorage() const noexcept;
 
-    OutputCellIterator WriteCells(OutputCellIterator it, const size_t index, const bool setWrap, std::optional<size_t> limitRight = std::nullopt);
+    OutputCellIterator WriteCells(OutputCellIterator it, const size_t index, const std::optional<bool> wrap = std::nullopt, std::optional<size_t> limitRight = std::nullopt);
 
     friend bool operator==(const ROW& a, const ROW& b) noexcept;
 

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -318,10 +318,12 @@ OutputCellIterator TextBuffer::Write(const OutputCellIterator givenIt)
 // Arguments:
 // - givenIt - Iterator representing output cell data to write
 // - target - the row/column to start writing the text to
+// - wrap - change the wrap flag if we hit the end of the row while writing and there's still more data
 // Return Value:
 // - The final position of the iterator
 OutputCellIterator TextBuffer::Write(const OutputCellIterator givenIt,
-                                     const COORD target)
+                                     const COORD target,
+                                     const std::optional<bool> wrap)
 {
     // Make mutable copy so we can walk.
     auto it = givenIt;
@@ -336,7 +338,8 @@ OutputCellIterator TextBuffer::Write(const OutputCellIterator givenIt,
     while (it && size.IsInBounds(lineTarget))
     {
         // Attempt to write as much data as possible onto this line.
-        it = WriteLine(it, lineTarget, true);
+        // NOTE: if wrap = true/false, we want to set the line's wrap to true/false (respectively) if we reach the end of the line
+        it = WriteLine(it, lineTarget, wrap);
 
         // Move to the next line down.
         lineTarget.X = 0;
@@ -351,13 +354,13 @@ OutputCellIterator TextBuffer::Write(const OutputCellIterator givenIt,
 // Arguments:
 // - givenIt - The iterator that will dereference into cell data to insert
 // - target - Coordinate targeted within output buffer
-// - setWrap - Whether we should try to set the wrap flag if we write up to the end of the line and have more data
+// - wrap - change the wrap flag if we hit the end of the row while writing and there's still more data in the iterator.
 // - limitRight - Optionally restrict the right boundary for writing (e.g. stop writing earlier than the end of line)
 // Return Value:
 // - The iterator, but advanced to where we stopped writing. Use to find input consumed length or cells written length.
 OutputCellIterator TextBuffer::WriteLine(const OutputCellIterator givenIt,
                                          const COORD target,
-                                         const bool setWrap,
+                                         const std::optional<bool> wrap,
                                          std::optional<size_t> limitRight)
 {
     // If we're not in bounds, exit early.
@@ -368,7 +371,7 @@ OutputCellIterator TextBuffer::WriteLine(const OutputCellIterator givenIt,
 
     //  Get the row and write the cells
     ROW& row = GetRowByOffset(target.Y);
-    const auto newIt = row.WriteCells(givenIt, target.X, setWrap, limitRight);
+    const auto newIt = row.WriteCells(givenIt, target.X, wrap, limitRight);
 
     // Take the cell distance written and notify that it needs to be repainted.
     const auto written = newIt.GetCellDistance(givenIt);

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -89,11 +89,12 @@ public:
     OutputCellIterator Write(const OutputCellIterator givenIt);
 
     OutputCellIterator Write(const OutputCellIterator givenIt,
-                             const COORD target);
+                             const COORD target,
+                             const std::optional<bool> wrap = true);
 
     OutputCellIterator WriteLine(const OutputCellIterator givenIt,
                                  const COORD target,
-                                 const bool setWrap = false,
+                                 const std::optional<bool> setWrap = std::nullopt,
                                  const std::optional<size_t> limitRight = std::nullopt);
 
     bool InsertCharacter(const wchar_t wch, const DbcsAttribute dbcsAttribute, const TextAttribute attr);

--- a/src/host/_output.cpp
+++ b/src/host/_output.cpp
@@ -290,7 +290,10 @@ void WriteToScreen(SCREEN_INFORMATION& screenInfo, const Viewport& region)
     try
     {
         const OutputCellIterator it(character, lengthToWrite);
-        const auto done = screenInfo.Write(it, startingCoordinate);
+
+        // when writing to the buffer, specifically unset wrap if we get to the last line.
+        // a fill operation should UNSET wrap in that scenario. See GH #1126 for more details.
+        const auto done = screenInfo.Write(it, startingCoordinate, false);
         cellsModified = done.GetInputDistance(it);
 
         // Notify accessibility

--- a/src/host/_output.cpp
+++ b/src/host/_output.cpp
@@ -291,7 +291,7 @@ void WriteToScreen(SCREEN_INFORMATION& screenInfo, const Viewport& region)
     {
         const OutputCellIterator it(character, lengthToWrite);
 
-        // when writing to the buffer, specifically unset wrap if we get to the last line.
+        // when writing to the buffer, specifically unset wrap if we get to the last column.
         // a fill operation should UNSET wrap in that scenario. See GH #1126 for more details.
         const auto done = screenInfo.Write(it, startingCoordinate, false);
         cellsModified = done.GetInputDistance(it);

--- a/src/host/ft_host/API_FillOutputTests.cpp
+++ b/src/host/ft_host/API_FillOutputTests.cpp
@@ -58,4 +58,140 @@ class FillOutputTests
                                                                 &charsWritten));
         VERIFY_ARE_EQUAL(1u, charsWritten);
     }
+
+    TEST_METHOD(UnsetWrap)
+    {
+        // WARNING: If this test suddenly decides to start failing,
+        // this is because the wrap registry key is not set.
+        // TODO GH #2859: Get/Set Registry Key for Wrap
+
+        HANDLE hConsole = GetStdOutputHandle();
+        DWORD charsWritten = 0;
+
+        CONSOLE_SCREEN_BUFFER_INFOEX sbiex = { 0 };
+        sbiex.cbSize = sizeof(sbiex);
+        GetConsoleScreenBufferInfoEx(hConsole, &sbiex);
+
+        const auto ogConsoleWidth = sbiex.dwSize.X;
+
+        std::wstring input = L"";
+        for (SHORT i = 0; i < ogConsoleWidth + 2; i++)
+        {
+            input.append(L"a");
+        }
+
+        // Write until a wrap occurs
+        VERIFY_WIN32_BOOL_SUCCEEDED(WriteConsoleW(hConsole,
+                                                  input.data(),
+                                                  gsl::narrow_cast<DWORD>(input.size()),
+                                                  &charsWritten,
+                                                  nullptr));
+
+        // Verify wrap occurred
+        std::unique_ptr<wchar_t[]> bufferText = std::make_unique<wchar_t[]>(ogConsoleWidth);
+        DWORD readSize = 0;
+        VERIFY_WIN32_BOOL_SUCCEEDED(ReadConsoleOutputCharacterW(hConsole,
+                                                                bufferText.get(),
+                                                                ogConsoleWidth,
+                                                                { 0, 0 },
+                                                                &readSize));
+
+        for (DWORD i = 0; i < readSize; i++)
+        {
+            VERIFY_ARE_EQUAL(bufferText[i], L'a');
+        }
+
+        bufferText = std::make_unique<wchar_t[]>(2);
+        VERIFY_WIN32_BOOL_SUCCEEDED(ReadConsoleOutputCharacterW(hConsole,
+                                                                bufferText.get(),
+                                                                2,
+                                                                { 0, 1 },
+                                                                &readSize));
+
+        VERIFY_ARE_EQUAL(2u, readSize);
+        for (DWORD i = 0; i < readSize; i++)
+        {
+            VERIFY_ARE_EQUAL(bufferText[i], L'a');
+        }
+
+        // Fill Console Line with 'b's
+        VERIFY_WIN32_BOOL_SUCCEEDED(FillConsoleOutputCharacterW(hConsole,
+                                                                L'b',
+                                                                ogConsoleWidth,
+                                                                { 2, 0 },
+                                                                &charsWritten));
+
+        // Verify first line is full of 'a's then 'b's
+        bufferText = std::make_unique<wchar_t[]>(ogConsoleWidth);
+        VERIFY_WIN32_BOOL_SUCCEEDED(ReadConsoleOutputCharacterW(hConsole,
+                                                                bufferText.get(),
+                                                                ogConsoleWidth,
+                                                                { 0, 0 },
+                                                                &readSize));
+
+        for (DWORD i = 0; i < readSize; i++)
+        {
+            if (i < 2)
+            {
+                VERIFY_ARE_EQUAL(bufferText[i], L'a');
+            }
+            else
+            {
+                VERIFY_ARE_EQUAL(bufferText[i], L'b');
+            }
+        }
+
+        // Verify second line is still has 'a's that wrapped over
+        bufferText = std::make_unique<wchar_t[]>(2);
+        VERIFY_WIN32_BOOL_SUCCEEDED(ReadConsoleOutputCharacterW(hConsole,
+                                                                bufferText.get(),
+                                                                static_cast<SHORT>(2),
+                                                                { 0, 0 },
+                                                                &readSize));
+
+        VERIFY_ARE_EQUAL(2u, readSize);
+        for (DWORD i = 0; i < readSize; i++)
+        {
+            VERIFY_ARE_EQUAL(bufferText[i], L'a');
+        }
+
+        // Resize to be smaller by 2
+        sbiex.srWindow.Right -= 2;
+        sbiex.dwSize.X -= 2;
+        SetConsoleScreenBufferInfoEx(hConsole, &sbiex);
+
+        // Verify first line is full of 'a's then 'b's
+        bufferText = std::make_unique<wchar_t[]>(ogConsoleWidth - static_cast<SHORT>(2));
+        VERIFY_WIN32_BOOL_SUCCEEDED(ReadConsoleOutputCharacterW(hConsole,
+                                                                bufferText.get(),
+                                                                ogConsoleWidth - static_cast<SHORT>(2),
+                                                                { 0, 0 },
+                                                                &readSize));
+
+        for (DWORD i = 0; i < readSize; i++)
+        {
+            if (i < 2)
+            {
+                VERIFY_ARE_EQUAL(bufferText[i], L'a');
+            }
+            else
+            {
+                VERIFY_ARE_EQUAL(bufferText[i], L'b');
+            }
+        }
+
+        // Verify second line is still has 'a's ('b's didn't wrap over)
+        bufferText = std::make_unique<wchar_t[]>(static_cast<SHORT>(2));
+        VERIFY_WIN32_BOOL_SUCCEEDED(ReadConsoleOutputCharacterW(hConsole,
+                                                                bufferText.get(),
+                                                                static_cast<SHORT>(2),
+                                                                { 0, 0 },
+                                                                &readSize));
+
+        VERIFY_ARE_EQUAL(2u, readSize);
+        for (DWORD i = 0; i < readSize; i++)
+        {
+            VERIFY_ARE_EQUAL(bufferText[i], L'a');
+        }
+    }
 };

--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -2586,14 +2586,17 @@ OutputCellIterator SCREEN_INFORMATION::Write(const OutputCellIterator it)
 // Arguments:
 // - it - Iterator representing output cell data to write.
 // - target - The position to start writing at
+// - wrap - change the wrap flag if we hit the end of the row while writing and there's still more data
 // Return Value:
 // - the iterator at its final position
 // Note:
 // - will throw exception on error.
 OutputCellIterator SCREEN_INFORMATION::Write(const OutputCellIterator it,
-                                             const COORD target)
+                                             const COORD target,
+                                             const std::optional<bool> wrap)
 {
-    return _textBuffer->Write(it, target);
+    // NOTE: if wrap = true/false, we want to set the line's wrap to true/false (respectively) if we reach the end of the line
+    return _textBuffer->Write(it, target, wrap);
 }
 
 // Routine Description:

--- a/src/host/screenInfo.hpp
+++ b/src/host/screenInfo.hpp
@@ -131,7 +131,8 @@ public:
     OutputCellIterator Write(const OutputCellIterator it);
 
     OutputCellIterator Write(const OutputCellIterator it,
-                             const COORD target);
+                             const COORD target,
+                             const std::optional<bool> wrap = true);
 
     OutputCellIterator WriteRect(const OutputCellIterator it,
                                  const Microsoft::Console::Types::Viewport viewport);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

EraseInLine calls `FillConsoleOutputCharacterW()`. In filling the row with chars, we were setting the wrap flag. We need to specifically not do this on ANY _FILL_ operation. Now a fill operation UNSETS the wrap flag if we fill to the end of the line.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1126 
* [x] CLA signed.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I am a core contributor

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Originally, we had a boolean `setWrap` that would mean...
- **true**: if writing to the end of the row, SET the wrap value to true
- **false**: if writing to the end of the row, DON'T CHANGE the wrap value

Now we're making this bool a std::optional to allow for a ternary state. This allows for us to handle the following cases completely. Refer to the table below:

| current wrap value | are we filling the last cell in the row? | new wrap value | COMMENTS |
|-- |-- |-- |-- |
| 0 | 0 | 0 | |
| ~0~ | ~0~ | ~1~ | IMPOSSIBLE |
| 0 | 1 | 0 | |
| 0 | 1 | 1 | THIS CASE WAS RIGHTFULLY HANDLED |
| 1 | 0 | 0 | THIS CASE WAS UNHANDLED |
| 1 | 0 | 1 | |
| ~1~ | ~1~ | ~0~ | IMPOSSIBLE |
| 1 | 1 | 1 | |

To handle that special case (1-0-0), we need to UNSET the wrap. So now, we have ~setWrap~ `wrap` mean the following:
- **true**: if writing to the end of the row, SET the wrap value to TRUE
- **false**: if writing to the end of the row, SET the wrap value to FALSE
- **nullopt**: leave the wrap value as it is

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
I feel like we should add a test for this case. But idk where or how. Help?