### PR TITLE
Partially fix mapping of virtual keys to characters

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -638,41 +638,29 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         }
 
         const auto modifiers = _GetPressedModifierKeys();
-
-        // AltGr key combinations don't always contain any meaningful,
-        // pretranslated unicode character during WM_KEYDOWN.
-        // E.g. on a German keyboard AltGr+Q should result in a "@" character,
-        // but actually results in "Q" with Alt and Ctrl modifier states.
-        // By returning false though, we can abort handling this WM_KEYDOWN
-        // event and let the WM_CHAR handler kick in, which will be
-        // provided with an appropriate unicode character.
-        //
-        // GH#2235: Make sure to handle AltGr before trying keybindings,
-        // so Ctrl+Alt keybindings won't eat an AltGr keypress.
-        if (modifiers.IsAltGrPressed())
-        {
-            _HandleVoidKeyEvent();
-            e.Handled(false);
-            return;
-        }
-
         const auto vkey = static_cast<WORD>(e.OriginalKey());
+        const auto scanCode = e.KeyStatus().ScanCode;
         bool handled = false;
 
-        auto bindings = _settings.KeyBindings();
-        if (bindings)
+        // GH#2235: Terminal::Settings hasn't been modified to differentiate between AltGr and Ctrl+Alt yet.
+        // -> Don't check for key bindings if this is an AltGr key combination.
+        if (!modifiers.IsAltGrPressed())
         {
-            handled = bindings.TryKeyChord({
-                modifiers.IsCtrlPressed(),
-                modifiers.IsAltPressed(),
-                modifiers.IsShiftPressed(),
-                vkey,
-            });
+            auto bindings = _settings.KeyBindings();
+            if (bindings)
+            {
+                handled = bindings.TryKeyChord({
+                    modifiers.IsCtrlPressed(),
+                    modifiers.IsAltPressed(),
+                    modifiers.IsShiftPressed(),
+                    vkey,
+                });
+            }
         }
 
         if (!handled)
         {
-            handled = _TrySendKeyEvent(vkey, modifiers);
+            handled = _TrySendKeyEvent(vkey, scanCode, modifiers);
         }
 
         // Manually prevent keyboard navigation with tab. We want to send tab to
@@ -687,17 +675,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     }
 
     // Method Description:
-    // - Some key events cannot be handled (e.g. AltGr combinations) and are
-    //   delegated to the character handler. Just like with _TrySendKeyEvent(),
-    //   the character handler counts on us though to:
-    // - Clears the current selection.
-    // - Makes the cursor briefly visible during typing.
-    void TermControl::_HandleVoidKeyEvent()
-    {
-        _TrySendKeyEvent(0, {});
-    }
-
-    // Method Description:
     // - Send this particular key event to the terminal.
     //   See Terminal::SendKeyEvent for more information.
     // - Clears the current selection.
@@ -705,14 +682,14 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // Arguments:
     // - vkey: The vkey of the key pressed.
     // - states: The Microsoft::Terminal::Core::ControlKeyStates representing the modifier key states.
-    bool TermControl::_TrySendKeyEvent(WORD vkey, const ControlKeyStates modifiers)
+    bool TermControl::_TrySendKeyEvent(const WORD vkey, const WORD scanCode, const ControlKeyStates modifiers)
     {
         _terminal->ClearSelection();
 
         // If the terminal translated the key, mark the event as handled.
         // This will prevent the system from trying to get the character out
         // of it and sending us a CharacterRecieved event.
-        const auto handled = vkey ? _terminal->SendKeyEvent(vkey, modifiers) : true;
+        const auto handled = vkey ? _terminal->SendKeyEvent(vkey, scanCode, modifiers) : true;
 
         if (_cursorTimer.has_value())
         {

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -184,8 +184,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         static Windows::UI::Xaml::Thickness _ParseThicknessFromPadding(const hstring padding);
 
         ::Microsoft::Terminal::Core::ControlKeyStates _GetPressedModifierKeys() const;
-        void _HandleVoidKeyEvent();
-        bool _TrySendKeyEvent(WORD vkey, ::Microsoft::Terminal::Core::ControlKeyStates modifiers);
+        bool _TrySendKeyEvent(const WORD vkey, const WORD scanCode, ::Microsoft::Terminal::Core::ControlKeyStates modifiers);
 
         const COORD _GetTerminalPosition(winrt::Windows::Foundation::Point cursorPosition);
         const unsigned int _NumberOfClicks(winrt::Windows::Foundation::Point clickPos, Timestamp clickTime);

--- a/src/cascadia/TerminalCore/ITerminalInput.hpp
+++ b/src/cascadia/TerminalCore/ITerminalInput.hpp
@@ -12,7 +12,7 @@ namespace Microsoft::Terminal::Core
     public:
         virtual ~ITerminalInput() {}
 
-        virtual bool SendKeyEvent(const WORD vkey, const ControlKeyStates states) = 0;
+        virtual bool SendKeyEvent(const WORD vkey, const WORD scanCode, const ControlKeyStates states) = 0;
 
         // void SendMouseEvent(uint row, uint col, KeyModifiers modifiers);
         [[nodiscard]] virtual HRESULT UserResize(const COORD size) noexcept = 0;

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -205,7 +205,7 @@ void Terminal::Write(std::wstring_view stringView)
 // Return Value:
 // - true if we translated the key event, and it should not be processed any further.
 // - false if we did not translate the key, and it should be processed into a character.
-bool Terminal::SendKeyEvent(const WORD vkey, const ControlKeyStates states)
+bool Terminal::SendKeyEvent(const WORD vkey, const WORD scanCode, const ControlKeyStates states)
 {
     if (_snapOnInput && _scrollOffset != 0)
     {
@@ -222,14 +222,7 @@ bool Terminal::SendKeyEvent(const WORD vkey, const ControlKeyStates states)
     wchar_t ch = UNICODE_NULL;
     if (states.IsAltPressed() && vkey != VK_SPACE)
     {
-        ch = static_cast<wchar_t>(LOWORD(MapVirtualKey(vkey, MAPVK_VK_TO_CHAR)));
-        // MapVirtualKey will give us the capitalized version of the char.
-        // However, if shift isn't pressed, we want to send the lowercase version.
-        // (See GH#637)
-        if (!states.IsShiftPressed())
-        {
-            ch = towlower(ch);
-        }
+        ch = _CharacterFromKeyEvent(vkey, scanCode, states);
     }
 
     if (states.IsCtrlPressed())
@@ -260,10 +253,52 @@ bool Terminal::SendKeyEvent(const WORD vkey, const ControlKeyStates states)
 
     const bool manuallyHandled = ch != UNICODE_NULL;
 
-    KeyEvent keyEv{ true, 0, vkey, 0, ch, states.Value() };
+    KeyEvent keyEv{ true, 0, vkey, scanCode, ch, states.Value() };
     const bool translated = _terminalInput->HandleKey(&keyEv);
 
     return translated && manuallyHandled;
+}
+
+// Method Description:
+// - Returns the keyboard's scan code for the given virtual key code.
+// Arguments:
+// - vkey: The virtual key code.
+// Return Value:
+// - The keyboard's scan code.
+WORD Terminal::_ScanCodeFromVirtualKey(const WORD vkey) noexcept
+{
+    return LOWORD(MapVirtualKeyW(vkey, MAPVK_VK_TO_VSC));
+}
+
+// Method Description:
+// - Translates the specified virtual key code and keyboard state to the corresponding character.
+// Arguments:
+// - vkey: The virtual key code that initiated this keyboard event.
+// - scanCode: The scan code that initiated this keyboard event.
+// - states: The current keyboard state.
+// Return Value:
+// - The character that would result from this virtual key code and keyboard state.
+wchar_t Terminal::_CharacterFromKeyEvent(const WORD vkey, const WORD scanCode, const ControlKeyStates states) noexcept
+{
+    const auto sc = scanCode != 0 ? scanCode : _ScanCodeFromVirtualKey(vkey);
+
+    // We might want to use GetKeyboardState() instead of building our own keyState.
+    // The question is whether that's necessary though. For now it seems to work fine as it is.
+    BYTE keyState[256] = {};
+    keyState[VK_SHIFT] = states.IsShiftPressed() ? 0x80 : 0;
+    keyState[VK_CONTROL] = states.IsCtrlPressed() ? 0x80 : 0;
+    keyState[VK_MENU] = states.IsAltPressed() ? 0x80 : 0;
+
+    // Technically ToUnicodeEx() can produce arbitrarily long sequences of diacritics etc.
+    // Since we only handle the case of a single UTF-16 code point, we can set the buffer size to 2 though.
+    constexpr size_t bufferSize = 2;
+    wchar_t buffer[bufferSize];
+
+    // wFlags: If bit 2 is set, keyboard state is not changed (Windows 10, version 1607 and newer)
+    const auto result = ToUnicodeEx(vkey, sc, keyState, buffer, bufferSize, 0b100, nullptr);
+
+    // TODO:GH#2853 We're only handling single UTF-16 code points right now, since that's the only thing KeyEvent supports.
+    return result == 1 || result == -1 ? buffer[0] : 0;
 }
 
 // Method Description:

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -82,7 +82,7 @@ public:
 
 #pragma region ITerminalInput
     // These methods are defined in Terminal.cpp
-    bool SendKeyEvent(const WORD vkey, const Microsoft::Terminal::Core::ControlKeyStates states) override;
+    bool SendKeyEvent(const WORD vkey, const WORD scanCode, const Microsoft::Terminal::Core::ControlKeyStates states) override;
     [[nodiscard]] HRESULT UserResize(const COORD viewportSize) noexcept override;
     void UserScrollViewport(const int viewTop) override;
     int GetScrollOffset() override;
@@ -206,6 +206,9 @@ private:
     // Additionally, maybe some people want to scroll into the history, then have that scroll out from
     //      underneath them, while others would prefer to anchor it in place.
     //      Either way, we sohould make this behavior controlled by a setting.
+
+    static WORD _ScanCodeFromVirtualKey(const WORD vkey) noexcept;
+    static wchar_t _CharacterFromKeyEvent(const WORD vkey, const WORD scanCode, const ControlKeyStates states) noexcept;
 
     int _ViewStartIndex() const noexcept;
     int _VisibleStartIndex() const noexcept;

--- a/src/cascadia/UnitTests_TerminalCore/InputTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/InputTest.cpp
@@ -48,12 +48,12 @@ namespace TerminalCoreUnitTests
         // Verify that Alt+a generates a lowercase a on the input
         expectedinput = L"\x1b"
                         "a";
-        VERIFY_IS_TRUE(term.SendKeyEvent(L'A', ControlKeyStates::LeftAltPressed));
+        VERIFY_IS_TRUE(term.SendKeyEvent(L'A', 0, ControlKeyStates::LeftAltPressed));
 
         // Verify that Alt+shift+a generates a uppercase a on the input
         expectedinput = L"\x1b"
                         "A";
-        VERIFY_IS_TRUE(term.SendKeyEvent(L'A', ControlKeyStates::LeftAltPressed | ControlKeyStates::ShiftPressed));
+        VERIFY_IS_TRUE(term.SendKeyEvent(L'A', 0, ControlKeyStates::LeftAltPressed | ControlKeyStates::ShiftPressed));
     }
 
     void InputTest::AltSpace()
@@ -61,6 +61,6 @@ namespace TerminalCoreUnitTests
         // Make sure we don't handle Alt+Space. The system will use this to
         // bring up the system menu for restore, min/maximimize, size, move,
         // close
-        VERIFY_IS_FALSE(term.SendKeyEvent(L' ', ControlKeyStates::LeftAltPressed));
+        VERIFY_IS_FALSE(term.SendKeyEvent(L' ', 0, ControlKeyStates::LeftAltPressed));
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

This PR mostly fixes the mapping of <kbd>Alt</kbd> combinations to unicode characters.

The case of <kbd>AltGr</kbd> was originally hotfixed by returning early in `TerminalControl`.
But this didn't fix e.g. <kbd>Alt</kbd><kbd>Shift</kbd> combinations. See #2771 for instance.

This PR now fixes this particular remaining issue.
Cases where a single keypress generates more than a single UTF-16 code point (e.g. when diacritics come into play) are not fixed though, due to a limitation in the design of the low level `KeyEvent` class.

## PR Checklist
* [x] Closes
  * #2771
  * #1819
  * #1694 (Not sure about that one - I don't understand the issue description)
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [x] Requires documentation to be updated
  * I changed the `ITerminalInput` interface
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #2771

## Detailed Description of the Pull Request / Additional comments

This removes the special handling of AltGr in `TerminalControl`, so that `terminalInput` may now handle it by itself.

I believe it'd be nice to extend `InputTest.cpp` to include a test for the translation of <kbd>Shift</kbd><kbd>.</kbd> to ">", but unfortunately this would be exclusive to US keyboard layouts.
My german keyboard layout for instance uses <kbd>Shift</kbd><kbd><</kbd> for this (there's a dedicated "<" key).
How would I build a unit test for this that works independent of "internationalization"?

## Validation Steps Performed

* Ensured that the expected behavior of #2771 can be observed.
* The special handling of AltGr is being removed in this PR.
  -> Ensured that AltGr combinations still work.