### PR TITLE
Update path to profiles.json in documentation

### DIFF
--- a/doc/user-docs/UsingJsonSettings.md
+++ b/doc/user-docs/UsingJsonSettings.md
@@ -4,7 +4,7 @@ One way (currently the only way) to configure Windows Terminal is by editing the
 `profiles.json` settings file. At the time of writing you can open the settings
 file in your default editor by selecting `Settings` from the WT pull down menu.
 
-The settings are stored in the file `$env:LocalAppData\Packages\Microsoft.WindowsTerminal_<randomString>\RoamingState\profiles.json`.
+The settings are stored in the file `$env:LocalAppData\Packages\Microsoft.WindowsTerminal_<randomString>\LocalState\profiles.json`.
 
 As of [#2515](https://github.com/microsoft/terminal/pull/2515), the settings are
 split into _two_ files: a hardcoded `defaults.json`, and `profiles.json`, which
@@ -200,14 +200,14 @@ like to hide all the WSL profiles, you could add the following setting:
 
 1. Download the Debian JPG logo https://www.debian.org/logos/openlogo-100.jpg
 2. Put the image in the
- `$env:LocalAppData\Packages\Microsoft.WindowsTerminal_<randomString>\RoamingState\`
+ `$env:LocalAppData\Packages\Microsoft.WindowsTerminal_<randomString>\LocalState\`
  directory (same directory as your `profiles.json` file).
 
     __NOTE__:  You can put the image anywhere you like, the above suggestion happens to be convenient.
 3. Open your WT json properties file.
 4. Under the Debian Linux profile, add the following fields:
 ```json
-    "backgroundImage": "ms-appdata:///Roaming/openlogo-100.jpg",
+    "backgroundImage": "ms-appdata:///Local/openlogo-100.jpg",
     "backgroundImageOpacity": 1,
     "backgroundImageStretchMode" : "none",
     "backgroundImageAlignment" : "topRight",

--- a/doc/user-docs/index.md
+++ b/doc/user-docs/index.md
@@ -67,7 +67,7 @@ Not currently supported "out of the box". See issue [#1060](https://github.com/m
 
 ## Configuring Windows Terminal
 
-All Windows Terminal settings are currently managed using the `profiles.json` file, located within `$env:LocalAppData\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe/RoamingState`.
+All Windows Terminal settings are currently managed using the `profiles.json` file, located within `$env:LocalAppData\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState`.
 
 To open the settings file from Windows Terminal:
 


### PR DESCRIPTION
## Summary of the Pull Request
The `profiles.json` file was moved from RoamingState to LocalState in PR #2298. This PR updates the documentation to reflect this change.

## References
PR #2298

## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments
I searched through the documentation for references to RoamingState in relation to `profiles.json` and changed RoamingState to LocalState for such instances. The configuration example for adding a custom background could technically continue to reference the roaming path, but I felt it was best to change it to the local path since it referenced this path as the "same directory as your `profiles.json` file."

## Validation Steps Performed
Documentation update only, so no validation was performed.