### PR TITLE
conhost: if we start with invalid terminal colors, reset them to sanity

### DIFF
--- a/src/host/settings.cpp
+++ b/src/host/settings.cpp
@@ -326,6 +326,22 @@ void Settings::Validate()
     WI_ClearAllFlags(_wFillAttribute, ~(FG_ATTRS | BG_ATTRS));
     WI_ClearAllFlags(_wPopupFillAttribute, ~(FG_ATTRS | BG_ATTRS));
 
+    // If the extended color options are set to invalid values (all the same color), reset them.
+    if (_CursorColor != Cursor::s_InvertCursorColor && _CursorColor == _DefaultBackground)
+    {
+        _CursorColor = Cursor::s_InvertCursorColor;
+    }
+
+    if (_DefaultForeground != INVALID_COLOR && _DefaultForeground == _DefaultBackground)
+    {
+        _DefaultForeground = _DefaultBackground = INVALID_COLOR;
+        // If the damaged settings _further_ propagated to the default fill attribute, fix it.
+        if (_wFillAttribute == 0)
+        {
+            _wFillAttribute = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
+        }
+    }
+
     FAIL_FAST_IF(!(_dwWindowSize.X > 0));
     FAIL_FAST_IF(!(_dwWindowSize.Y > 0));
     FAIL_FAST_IF(!(_dwScreenBufferSize.X > 0));

--- a/src/host/settings.cpp
+++ b/src/host/settings.cpp
@@ -334,10 +334,12 @@ void Settings::Validate()
 
     if (_DefaultForeground != INVALID_COLOR && _DefaultForeground == _DefaultBackground)
     {
+        // INVALID_COLOR is used as an "unset" sentinel in future attribute functions.
         _DefaultForeground = _DefaultBackground = INVALID_COLOR;
         // If the damaged settings _further_ propagated to the default fill attribute, fix it.
         if (_wFillAttribute == 0)
         {
+            // These attributes were taken from the Settings ctor and equal "gray on black"
             _wFillAttribute = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
         }
     }


### PR DESCRIPTION
We've seen a number of cases where the user's settings can get corrupted
and their default foreground/background and cursor color get set to all
black (black on black). This results in a fairly unhappy user and
probably a great number of support incidents.

Let's declare that an invalid state.

Related to #2651.