### PR TITLE
Improve debugging experience of key events...

### DIFF
--- a/src/types/IInputEventStreams.cpp
+++ b/src/types/IInputEventStreams.cpp
@@ -57,7 +57,7 @@ std::wostream& operator<<(std::wostream& stream, const KeyEvent* const pKeyEvent
         L"keyCode: " << pKeyEvent->_virtualKeyCode << L", " <<
         L"scanCode: " << pKeyEvent->_virtualScanCode << L", " <<
         L"char: " << charData << L", " <<
-        L"mods: " << pKeyEvent->_activeModifierKeys << L")";
+        L"mods: " << pKeyEvent->GetActiveModifierKeys() << L")";
     // clang-format on
 }
 

--- a/src/types/KeyEvent.cpp
+++ b/src/types/KeyEvent.cpp
@@ -17,7 +17,7 @@ INPUT_RECORD KeyEvent::ToInputRecord() const noexcept
     record.Event.KeyEvent.wVirtualKeyCode = _virtualKeyCode;
     record.Event.KeyEvent.wVirtualScanCode = _virtualScanCode;
     record.Event.KeyEvent.uChar.UnicodeChar = _charData;
-    record.Event.KeyEvent.dwControlKeyState = _activeModifierKeys;
+    record.Event.KeyEvent.dwControlKeyState = GetActiveModifierKeys();
     return record;
 }
 
@@ -53,19 +53,23 @@ void KeyEvent::SetCharData(const wchar_t character) noexcept
 
 void KeyEvent::SetActiveModifierKeys(const DWORD activeModifierKeys) noexcept
 {
-    _activeModifierKeys = activeModifierKeys;
+    _activeModifierKeys = static_cast<KeyEvent::Modifiers>(activeModifierKeys);
 }
 
 void KeyEvent::DeactivateModifierKey(const ModifierKeyState modifierKey) noexcept
 {
     DWORD const bitFlag = ToConsoleControlKeyFlag(modifierKey);
-    WI_ClearAllFlags(_activeModifierKeys, bitFlag);
+    auto keys = GetActiveModifierKeys();
+    WI_ClearAllFlags(keys, bitFlag);
+    SetActiveModifierKeys(keys);
 }
 
 void KeyEvent::ActivateModifierKey(const ModifierKeyState modifierKey) noexcept
 {
     DWORD const bitFlag = ToConsoleControlKeyFlag(modifierKey);
-    WI_SetAllFlags(_activeModifierKeys, bitFlag);
+    auto keys = GetActiveModifierKeys();
+    WI_SetAllFlags(keys, bitFlag);
+    SetActiveModifierKeys(keys);
 }
 
 bool KeyEvent::DoActiveModifierKeysMatch(const std::unordered_set<ModifierKeyState>& consoleModifiers) const
@@ -75,7 +79,7 @@ bool KeyEvent::DoActiveModifierKeysMatch(const std::unordered_set<ModifierKeySta
     {
         WI_SetAllFlags(consoleBits, ToConsoleControlKeyFlag(mod));
     }
-    return consoleBits == _activeModifierKeys;
+    return consoleBits == GetActiveModifierKeys();
 }
 
 // Routine Description:

--- a/src/types/inc/IInputEvent.hpp
+++ b/src/types/inc/IInputEvent.hpp
@@ -120,6 +120,28 @@ DWORD ToConsoleControlKeyFlag(const ModifierKeyState modifierKey) noexcept;
 class KeyEvent : public IInputEvent
 {
 public:
+    enum class Modifiers : DWORD
+    {
+        None = 0,
+        RightAlt = RIGHT_ALT_PRESSED,
+        LeftAlt = LEFT_ALT_PRESSED,
+        RightCtrl = RIGHT_CTRL_PRESSED,
+        LeftCtrl = LEFT_CTRL_PRESSED,
+        Shift = SHIFT_PRESSED,
+        NumLock = NUMLOCK_ON,
+        ScrollLock = SCROLLLOCK_ON,
+        CapsLock = CAPSLOCK_ON,
+        EnhancedKey = ENHANCED_KEY,
+        DbcsChar = NLS_DBCSCHAR,
+        Alphanumeric = NLS_ALPHANUMERIC,
+        Katakana = NLS_KATAKANA,
+        Hiragana = NLS_HIRAGANA,
+        Roman = NLS_ROMAN,
+        ImeConvert = NLS_IME_CONVERSION,
+        AltNumpad = ALTNUMPAD_BIT,
+        ImeDisable = NLS_IME_DISABLE
+    };
+
     constexpr KeyEvent(const KEY_EVENT_RECORD& record) :
         _keyDown{ !!record.bKeyDown },
         _repeatCount{ record.wRepeatCount },
@@ -166,28 +188,28 @@ public:
 
     constexpr bool IsShiftPressed() const noexcept
     {
-        return WI_IsFlagSet(_activeModifierKeys, SHIFT_PRESSED);
+        return WI_IsFlagSet(GetActiveModifierKeys(), SHIFT_PRESSED);
     }
 
     constexpr bool IsAltPressed() const noexcept
     {
-        return WI_IsAnyFlagSet(_activeModifierKeys, ALT_PRESSED);
+        return WI_IsAnyFlagSet(GetActiveModifierKeys(), ALT_PRESSED);
     }
 
     constexpr bool IsCtrlPressed() const noexcept
     {
-        return WI_IsAnyFlagSet(_activeModifierKeys, CTRL_PRESSED);
+        return WI_IsAnyFlagSet(GetActiveModifierKeys(), CTRL_PRESSED);
     }
 
     constexpr bool IsAltGrPressed() const noexcept
     {
-        return WI_IsFlagSet(_activeModifierKeys, LEFT_CTRL_PRESSED) &&
-               WI_IsFlagSet(_activeModifierKeys, RIGHT_ALT_PRESSED);
+        return WI_IsFlagSet(GetActiveModifierKeys(), LEFT_CTRL_PRESSED) &&
+               WI_IsFlagSet(GetActiveModifierKeys(), RIGHT_ALT_PRESSED);
     }
 
     constexpr bool IsModifierPressed() const noexcept
     {
-        return WI_IsAnyFlagSet(_activeModifierKeys, MOD_PRESSED);
+        return WI_IsAnyFlagSet(GetActiveModifierKeys(), MOD_PRESSED);
     }
 
     constexpr bool IsCursorKey() const noexcept
@@ -198,7 +220,7 @@ public:
 
     constexpr bool IsAltNumpadSet() const noexcept
     {
-        return WI_IsFlagSet(_activeModifierKeys, ALTNUMPAD_BIT);
+        return WI_IsFlagSet(GetActiveModifierKeys(), ALTNUMPAD_BIT);
     }
 
     constexpr bool IsKeyDown() const noexcept
@@ -233,7 +255,7 @@ public:
 
     constexpr DWORD GetActiveModifierKeys() const noexcept
     {
-        return _activeModifierKeys;
+        return static_cast<DWORD>(_activeModifierKeys);
     }
 
     void SetKeyDown(const bool keyDown) noexcept;
@@ -255,7 +277,7 @@ private:
     WORD _virtualKeyCode;
     WORD _virtualScanCode;
     wchar_t _charData;
-    DWORD _activeModifierKeys;
+    Modifiers _activeModifierKeys;
 
     friend constexpr bool operator==(const KeyEvent& a, const KeyEvent& b) noexcept;
 #ifdef UNIT_TESTING

--- a/tools/ConsoleTypes.natvis
+++ b/tools/ConsoleTypes.natvis
@@ -72,4 +72,9 @@
             <ExpandedItem>_Mypair._Myval2</ExpandedItem>
         </Expand>
     </Type>
+
+    <Type Name="KeyEvent">
+        <DisplayString Condition="_keyDown">{{↓  wch:{_charData} mod:{_activeModifierKeys} repeat:{_repeatCount} vk:{_virtualKeyCode} vsc:{_virtualScanCode}}</DisplayString>
+        <DisplayString Condition="!_keyDown">{{↑ wch:{_charData} mod:{_activeModifierKeys} repeat:{_repeatCount} vk:{_virtualKeyCode} vsc:{_virtualScanCode}}</DisplayString>
+    </Type>
 </AutoVisualizer>


### PR DESCRIPTION
...by adding natvis rules for display and by typifying the flags field so the debugger presents it as flags naturally.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

I was investigating #2770 and needed to visualize some of the input records more easily.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes nothing. It's a standalone debugging aid.
* [X] I work here.
* [X] No tests.
* [X] No documentation.
* [X] I'm a core contributor.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
I added a natvis rule that helps present the contents of a `KEY_EVENT` in a condensed way that is easier to navigate in the debugger than expanding all of the fields from the structure.

I also changed the definition of the flags field inside the `KEY_EVENT` to be an enum class because the debugger will auto-visualize these. To reduce the scope of the change, I made it static_cast things in and out of the enum class type (since they're both just DWORD defined with the same thing anyway) and changed all complaining reads/writes to round through the existing constexpr methods.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Rebuilt it and looked at it under the debugger. Looks way better than before.

Everything else still runs.