### PR TITLE
Fix EraseInLine off-by-one error

### DIFF
--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -265,11 +265,11 @@ bool Terminal::EraseInLine(const ::Microsoft::Console::VirtualTerminal::Dispatch
         break;
     case DispatchTypes::EraseType::ToEnd:
         startPos.X = cursorPos.X;
-        nlength = viewport.RightInclusive() - startPos.X;
+        nlength = viewport.RightExclusive() - startPos.X;
         break;
     case DispatchTypes::EraseType::All:
         startPos.X = viewport.Left();
-        nlength = viewport.RightInclusive() - startPos.X;
+        nlength = viewport.RightExclusive() - startPos.X;
         break;
     case DispatchTypes::EraseType::Scrollback:
         return false;


### PR DESCRIPTION
## Summary of the Pull Request

Making Terminal use EraseInLine when clearing exposed an off-by-one error.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #2878 
* [x] CLA signed.
* [x] ~Tests added/passed~

## Detailed Description of the Pull Request / Additional comments
None.

## Validation Steps Performed
Forced to use EraseInLine() and checked output.
