### PR TITLE
Retarget VtPipeTerm & terminalcore-lib to 18362

### DIFF
--- a/src/cascadia/TerminalCore/lib/terminalcore-lib.vcxproj
+++ b/src/cascadia/TerminalCore/lib/terminalcore-lib.vcxproj
@@ -13,7 +13,7 @@
     <ProjectName>TerminalCore</ProjectName>
     <TargetName>TerminalCore</TargetName>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <RootNamespace>Microsoft.Terminal.Core</RootNamespace>
   </PropertyGroup>
   <!-- ============================ References ============================  -->

--- a/src/tools/vtpipeterm/VtPipeTerm.vcxproj
+++ b/src/tools/vtpipeterm/VtPipeTerm.vcxproj
@@ -14,7 +14,7 @@
     <RootNamespace>VtPipeTerm</RootNamespace>
     <ProjectName>VtPipeTerm</ProjectName>
     <TargetName>VtPipeTerm</TargetName>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>


### PR DESCRIPTION
## Summary of the Pull Request

Retarget VtPipeTerm & terminalcore-lib to 18362. I'm not sure if we should also change the min SDK version. Let me know if it's needed.

Besides, the OpenConsolePackage appx target is still using lower SDK version

```xml
<TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
<TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
```

I wonder if it's intended so I left it intact.

## References

## PR Checklist
* [X] Closes #2718 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
