### PR TITLE
Add support for solid cursor blinking style

### DIFF
--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -30,6 +30,7 @@ static constexpr std::string_view HistorySizeKey{ "historySize" };
 static constexpr std::string_view SnapOnInputKey{ "snapOnInput" };
 static constexpr std::string_view CursorColorKey{ "cursorColor" };
 static constexpr std::string_view CursorShapeKey{ "cursorShape" };
+static constexpr std::string_view CursorBlinkingKey{ "cursorBlinking" };
 static constexpr std::string_view CursorHeightKey{ "cursorHeight" };
 
 static constexpr std::string_view ConnectionTypeKey{ "connectionType" };
@@ -58,6 +59,10 @@ static constexpr std::wstring_view CursorShapeBar{ L"bar" };
 static constexpr std::wstring_view CursorShapeUnderscore{ L"underscore" };
 static constexpr std::wstring_view CursorShapeFilledbox{ L"filledBox" };
 static constexpr std::wstring_view CursorShapeEmptybox{ L"emptyBox" };
+
+// Possible values for Cursor Blinking Style
+static constexpr std::wstring_view CursorBlinkingStyleBlink{ L"blink" };
+static constexpr std::wstring_view CursorBlinkingStyleSolid{ L"solid" };
 
 // Possible values for Image Stretch Mode
 static constexpr std::string_view ImageStretchModeNone{ "none" };
@@ -184,6 +189,7 @@ TerminalSettings Profile::CreateTerminalSettings(const std::vector<ColorScheme>&
     terminalSettings.CursorColor(_cursorColor);
     terminalSettings.CursorHeight(_cursorHeight);
     terminalSettings.CursorShape(_cursorShape);
+    terminalSettings.CursorBlinking(_cursorBlinking);
 
     // Fill in the remaining properties from the profile
     terminalSettings.UseAcrylic(_useAcrylic);
@@ -302,6 +308,7 @@ Json::Value Profile::ToJson() const
         root[JsonKey(CursorHeightKey)] = _cursorHeight;
     }
     root[JsonKey(CursorShapeKey)] = winrt::to_string(_SerializeCursorStyle(_cursorShape));
+    root[JsonKey(CursorBlinkingKey)] = winrt::to_string(_SerializeCursorBlinkingStyle(_cursorBlinking));
 
     ///// Control Settings /////
     root[JsonKey(CommandlineKey)] = winrt::to_string(_commandline);
@@ -648,6 +655,12 @@ void Profile::LayerJson(const Json::Value& json)
         auto cursorShape{ json[JsonKey(CursorShapeKey)] };
         _cursorShape = _ParseCursorShape(GetWstringFromJson(cursorShape));
     }
+    if (json.isMember(JsonKey(CursorBlinkingKey)))
+    {
+        auto cursorBlinking{ json[JsonKey(CursorBlinkingKey)] };
+        _cursorBlinking = _ParseCursorBlinkingStyle(GetWstringFromJson(cursorBlinking));
+    }
+
     JsonUtils::GetOptionalString(json, TabTitleKey, _tabTitle);
 
     // Control Settings
@@ -1106,6 +1119,47 @@ std::wstring_view Profile::_SerializeCursorStyle(const CursorStyle cursorShape)
     default:
     case CursorStyle::Bar:
         return CursorShapeBar;
+    }
+}
+
+// Method Description:
+// - Helper function for converting a user-specified cursor blinking style corresponding
+//   CursorBlinkingStyle enum value
+// Arguments:
+// - cursorBlinkingStyleString: The string value from the settings file to parse
+// Return Value:
+// - The corresponding enum value which maps to the string provided by the user
+CursorBlinkingStyle Profile::_ParseCursorBlinkingStyle(const std::wstring& cursorBlinkingStyleString)
+{
+    if (cursorBlinkingStyleString == CursorBlinkingStyleBlink)
+    {
+        return CursorBlinkingStyle::Blink;
+    }
+    else if (cursorBlinkingStyleString == CursorBlinkingStyleSolid)
+    {
+        return CursorBlinkingStyle::Solid;
+    }
+
+    // default behavior for invalid data
+    return CursorBlinkingStyle::Blink;
+}
+
+// Method Description:
+// - Helper function for converting a CursorBlinkingStyle to its corresponding string
+//   value.
+// Arguments:
+// - cursorBlinkingStyle: The enum value to convert to a string.
+// Return Value:
+// - The string value for the given CursorBlinkingStyle
+std::wstring_view Profile::_SerializeCursorBlinkingStyle(const CursorBlinkingStyle cursorBlinkingStyle)
+{
+    switch (cursorBlinkingStyle)
+    {
+    case CursorBlinkingStyle::Solid:
+        return CursorBlinkingStyleSolid;
+    default:
+    case CursorBlinkingStyle::Blink:
+        return CursorBlinkingStyleBlink;
     }
 }
 

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -100,6 +100,8 @@ private:
     static std::string_view SerializeImageAlignment(const std::tuple<winrt::Windows::UI::Xaml::HorizontalAlignment, winrt::Windows::UI::Xaml::VerticalAlignment> imageAlignment);
     static winrt::Microsoft::Terminal::Settings::CursorStyle _ParseCursorShape(const std::wstring& cursorShapeString);
     static std::wstring_view _SerializeCursorStyle(const winrt::Microsoft::Terminal::Settings::CursorStyle cursorShape);
+    static winrt::Microsoft::Terminal::Settings::CursorBlinkingStyle _ParseCursorBlinkingStyle(const std::wstring& cursorBlinkingStyleString);
+    static std::wstring_view _SerializeCursorBlinkingStyle(const winrt::Microsoft::Terminal::Settings::CursorBlinkingStyle cursorBlinkingStyle);
 
     static GUID _GenerateGuidForProfile(const std::wstring& name, const std::optional<std::wstring>& source) noexcept;
 
@@ -121,6 +123,7 @@ private:
     uint32_t _cursorColor;
     uint32_t _cursorHeight;
     winrt::Microsoft::Terminal::Settings::CursorStyle _cursorShape;
+    winrt::Microsoft::Terminal::Settings::CursorBlinkingStyle _cursorBlinking;
 
     std::wstring _commandline;
     std::wstring _fontFace;

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -150,6 +150,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _BackgroundColorChanged(const uint32_t color);
         void _InitializeTerminal();
         void _UpdateFont();
+        void _UpdateCursorBlinking();
         void _KeyDownHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e);
         void _CharacterHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::CharacterReceivedRoutedEventArgs const& e);
         void _PointerPressedHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
@@ -160,6 +161,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _GotFocusHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
         void _LostFocusHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
 
+        void _CreateBlinkTimer();
         void _BlinkCursor(Windows::Foundation::IInspectable const& sender, Windows::Foundation::IInspectable const& e);
         void _SetEndSelectionPointAtCursor(Windows::Foundation::Point const& cursorPosition);
         void _SendInputToConnection(const std::wstring& wstr);

--- a/src/cascadia/TerminalSettings/ICoreSettings.idl
+++ b/src/cascadia/TerminalSettings/ICoreSettings.idl
@@ -12,6 +12,12 @@ namespace Microsoft.Terminal.Settings
         EmptyBox
     };
 
+    enum CursorBlinkingStyle
+    {
+        Blink = 0,
+        Solid = 1,
+    };
+
     interface ICoreSettings
     {
         UInt32 DefaultForeground;
@@ -26,6 +32,7 @@ namespace Microsoft.Terminal.Settings
 
         UInt32 CursorColor;
         CursorStyle CursorShape;
+        CursorBlinkingStyle CursorBlinking;
         UInt32 CursorHeight;
         String WordDelimiters;
         Boolean CopyOnSelect;

--- a/src/cascadia/TerminalSettings/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettings/TerminalSettings.cpp
@@ -130,6 +130,16 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         _cursorShape = value;
     }
 
+    Settings::CursorBlinkingStyle TerminalSettings::CursorBlinking() const noexcept
+    {
+        return _cursorBlinking;
+    }
+
+    void TerminalSettings::CursorBlinking(Settings::CursorBlinkingStyle const& value) noexcept
+    {
+        _cursorBlinking = value;
+    }
+
     uint32_t TerminalSettings::CursorHeight()
     {
         return _cursorHeight;

--- a/src/cascadia/TerminalSettings/terminalsettings.h
+++ b/src/cascadia/TerminalSettings/terminalsettings.h
@@ -43,6 +43,8 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         void CursorColor(uint32_t value);
         CursorStyle CursorShape() const noexcept;
         void CursorShape(winrt::Microsoft::Terminal::Settings::CursorStyle const& value) noexcept;
+        CursorBlinkingStyle CursorBlinking() const noexcept;
+        void CursorBlinking(winrt::Microsoft::Terminal::Settings::CursorBlinkingStyle const& value) noexcept;
         uint32_t CursorHeight();
         void CursorHeight(uint32_t value);
         hstring WordDelimiters();
@@ -104,6 +106,7 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         bool _snapOnInput;
         uint32_t _cursorColor;
         Settings::CursorStyle _cursorShape;
+        Settings::CursorBlinkingStyle _cursorBlinking;
         uint32_t _cursorHeight;
         hstring _wordDelimiters;
 

--- a/src/cascadia/UnitTests_TerminalCore/MockTermSettings.h
+++ b/src/cascadia/UnitTests_TerminalCore/MockTermSettings.h
@@ -30,6 +30,7 @@ namespace TerminalCoreUnitTests
         bool SnapOnInput() { return false; }
         uint32_t CursorColor() { return COLOR_WHITE; }
         CursorStyle CursorShape() const noexcept { return CursorStyle::Vintage; }
+        CursorBlinkingStyle CursorBlinking() const noexcept { return CursorBlinkingStyle::Blink; }
         uint32_t CursorHeight() { return 42UL; }
         winrt::hstring WordDelimiters() { return winrt::to_hstring(DEFAULT_WORD_DELIMITERS.c_str()); }
         bool CopyOnSelect() { return _copyOnSelect; }
@@ -46,6 +47,7 @@ namespace TerminalCoreUnitTests
         void SnapOnInput(bool) {}
         void CursorColor(uint32_t) {}
         void CursorShape(CursorStyle const&) noexcept {}
+        void CursorBlinking(CursorBlinkingStyle const&) noexcept {}
         void CursorHeight(uint32_t) {}
         void WordDelimiters(winrt::hstring) {}
         void CopyOnSelect(bool copyOnSelect) { _copyOnSelect = copyOnSelect; }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Added cursor blinking style. Mainly for solid cursor blinking style which simply disables binking.

## References

## PR Checklist
* [X] Closes #1379
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [X] Requires documentation to be updated
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The idea is from #1379 and VSCode. VSCode has several cursor blinking style, including `blink`, `solid`, and other animated styles.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Add configurationi to profile and see how it looks like:
```json
{
    "cursorShape": "filledBox",
    "cursorBlinking": "solid",
}
```