### PR TITLE
Patch fix for #1360 until WriteStream (#780) can be implemented.

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -381,6 +381,18 @@ void Terminal::_WriteBuffer(const std::wstring_view& stringView)
             }
         }
 
+        // If we're about to try to place the cursor past the right edge of the buffer, move it down a row
+        // This is another patch that GH#780 should supercede. This is really correcting for other bad situations
+        // like bisecting (writing only the leading half because there's no room for the trailing) a wide character
+        // into the buffer. However, it's not really all-up correctable without implementing a full WriteStream here.
+        // Also, this particular code RIGHT HERE shouldn't need to know anything about the cursor or the cells advanced
+        // which also will be solved by GH#780 (hopefully).
+        if (proposedCursorPosition.X > bufferSize.RightInclusive())
+        {
+            proposedCursorPosition.X = 0;
+            proposedCursorPosition.Y++;
+        }
+
         // If we're about to scroll past the bottom of the buffer, instead cycle the buffer.
         const auto newRows = proposedCursorPosition.Y - bufferSize.Height() + 1;
         if (newRows > 0)

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -382,7 +382,7 @@ void Terminal::_WriteBuffer(const std::wstring_view& stringView)
         }
 
         // If we're about to try to place the cursor past the right edge of the buffer, move it down a row
-        // This is another patch that GH#780 should supercede. This is really correcting for other bad situations
+        // This is another patch that GH#780 should supersede. This is really correcting for other bad situations
         // like bisecting (writing only the leading half because there's no room for the trailing) a wide character
         // into the buffer. However, it's not really all-up correctable without implementing a full WriteStream here.
         // Also, this particular code RIGHT HERE shouldn't need to know anything about the cursor or the cells advanced

--- a/src/cascadia/UnitTests_TerminalCore/TerminalApiTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/TerminalApiTests.cpp
@@ -61,9 +61,9 @@ namespace TerminalCoreUnitTests
                     SetEvent(b.ev);
                     return 0;
                 },
-                (LPVOID)& b,
-                    0,
-                    nullptr);
+                (LPVOID)&b,
+                0,
+                nullptr);
 
             Log::Comment(L"Waiting for the write.");
             switch (WaitForSingleObject(b.ev, 2000))

--- a/src/cascadia/UnitTests_TerminalCore/TerminalApiTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/TerminalApiTests.cpp
@@ -1,0 +1,92 @@
+/*
+* Copyright (c) Microsoft Corporation.
+* Licensed under the MIT license.
+*/
+#include "precomp.h"
+#include <WexTestClass.h>
+
+#include "../cascadia/TerminalCore/Terminal.hpp"
+#include "../cascadia/UnitTests_TerminalCore/MockTermSettings.h"
+#include "../renderer/inc/DummyRenderTarget.hpp"
+#include "consoletaeftemplates.hpp"
+
+using namespace WEX::Logging;
+using namespace WEX::TestExecution;
+
+using namespace Microsoft::Terminal::Core;
+using namespace winrt::Microsoft::Terminal::Settings;
+
+namespace TerminalCoreUnitTests
+{
+    class TerminalApiTests
+    {
+        TEST_CLASS(TerminalApiTests);
+
+        struct Baton
+        {
+            HANDLE ev;
+            std::wstring text;
+            Terminal* pTerm;
+        };
+
+        TEST_METHOD(PrintStringOfEmojiBisectingFinalColumn)
+        {
+            Terminal term;
+            DummyRenderTarget emptyRT;
+            term.Create({ 100, 100 }, 0, emptyRT);
+
+            std::wstring textToPrint;
+            textToPrint.push_back(L'A'); // A is half-width, push it in.
+
+            // Put a ton of copies of a full-width emoji here.
+            const wchar_t* emoji = L"\xD83D\xDE00"; // 1F600 is wide in https://www.unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt
+            for (size_t i = 0; i < 120; ++i)
+            {
+                textToPrint = textToPrint.append(emoji);
+            }
+
+            Baton b;
+            b.ev = CreateEventW(nullptr, TRUE, FALSE, L"It is an event");
+            b.text = textToPrint;
+            b.pTerm = &term;
+
+            Log::Comment(L"Launching thread to write data.");
+
+            HANDLE hThread = CreateThread(
+                nullptr, 0, [](LPVOID c) -> DWORD {
+                    Baton& b = *reinterpret_cast<Baton*>(c);
+                    Log::Comment(L"Writing data.");
+                    b.pTerm->PrintString(b.text);
+                    Log::Comment(L"Setting event.");
+                    SetEvent(b.ev);
+                    return 0;
+                },
+                (LPVOID)& b,
+                    0,
+                    nullptr);
+
+            Log::Comment(L"Waiting for the write.");
+            switch (WaitForSingleObject(b.ev, 2000))
+            {
+            case WAIT_OBJECT_0:
+                Log::Comment(L"Didn't get stuck. Success.");
+                break;
+            case WAIT_TIMEOUT:
+                Log::Comment(L"Wait timed out. It got stuck.");
+                Log::Result(WEX::Logging::TestResults::Failed);
+                break;
+            case WAIT_FAILED:
+                Log::Comment(L"Wait failed for some reason. We didn't expect this.");
+                Log::Result(WEX::Logging::TestResults::Failed);
+                break;
+            default:
+                Log::Comment(L"Wait return code that no one expected. Fail.");
+                Log::Result(WEX::Logging::TestResults::Failed);
+                break;
+            }
+
+            TerminateThread(hThread, 0);
+            return;
+        }
+    };
+}

--- a/src/cascadia/UnitTests_TerminalCore/UnitTests.vcxproj
+++ b/src/cascadia/UnitTests_TerminalCore/UnitTests.vcxproj
@@ -9,6 +9,7 @@
     <ClCompile Include="precomp.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="TerminalApiTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\buffer\out\lib\bufferout.vcxproj">


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Writing can enter an infinite loop with full-width characters being inserted into the last column of the buffer.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
#780

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #1360
* [X] I work here
* [ ] Draft because I'm going to try to turn the code @treit gave me for repro into a test
* [X] Documented by comments at the hack and noted for #780
* [X] I'm a core contributor

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
This is because the "WriteCharsLegacy2ElectricBoogaloo" implementation in the Terminal (`Terminal::_WriteBuffer`) is a hacky thing that we put together knowing full well that we'd have to do #780 but we had to get this working enough for now. Turns out, it's not super complete and fragile. Surprise.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Manual run of @treit's sample against the Terminal.
- Attempting to author automated test with @treit's sample
- I need to run it against conhost and make sure it's not failing too (and fix it there too if it is)