### PR TITLE
teach wil about c++/winrt exceptions by including cppwinrt.h

### DIFF
--- a/src/cascadia/TerminalApp/lib/pch.h
+++ b/src/cascadia/TerminalApp/lib/pch.h
@@ -18,6 +18,8 @@
 #undef GetCurrentTime
 #endif
 
+#include <wil/cppwinrt.h>
+
 #include <unknwn.h>
 
 #include <hstring.h>

--- a/src/cascadia/TerminalConnection/pch.h
+++ b/src/cascadia/TerminalConnection/pch.h
@@ -15,6 +15,8 @@
 // Must be included before any WinRT headers.
 #include <unknwn.h>
 
+#include <wil/cppwinrt.h>
+
 #include "winrt/Windows.Foundation.h"
 #include "winrt/Windows.Security.Credentials.h"
 #include "winrt/Windows.Foundation.Collections.h"

--- a/src/cascadia/TerminalControl/pch.h
+++ b/src/cascadia/TerminalControl/pch.h
@@ -18,6 +18,8 @@
 #undef GetCurrentTime
 #endif
 
+#include <wil/cppwinrt.h>
+
 #include <unknwn.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>

--- a/src/cascadia/TerminalSettings/pch.h
+++ b/src/cascadia/TerminalSettings/pch.h
@@ -19,4 +19,5 @@
 #endif
 
 #include <unknwn.h>
+#include <wil/cppwinrt.h>
 #include <winrt/Windows.Foundation.h>

--- a/src/cascadia/WindowsTerminal/pch.h
+++ b/src/cascadia/WindowsTerminal/pch.h
@@ -38,6 +38,9 @@ Abstract:
 #ifdef GetCurrentTime
 #undef GetCurrentTime
 #endif
+
+#include <wil/cppwinrt.h>
+
 // Needed just for XamlIslands to work at all:
 #include <winrt/Windows.system.h>
 #include <winrt/Windows.Foundation.Collections.h>


### PR DESCRIPTION
It turns out that if you CATCH_LOG without including this file, and you
end up catching a C++/WinRT hresult_exception, IT TURNS IT INTO A
FAILFAST.

Fixes #2591
Fixes #2881
Fixes #2807

## PR Checklist
* [x] Closes some issues
* [x] author works here
* [x] Tests still pass
* [ ] ~Requires documentation to be updated~
* [x] I've discussed this with core contributors already.

## Validation Steps Performed
Really went ham on the clipboard. Like, wow.