### PR TITLE
Fix double width cursor for CJK characters

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -11,6 +11,7 @@
 #include "../../terminal/input/terminalInput.hpp"
 
 #include "../../types/inc/Viewport.hpp"
+#include "../../types/inc/GlyphWidth.hpp"
 #include "../../types/IUiaData.h"
 #include "../../cascadia/terminalcore/ITerminalApi.hpp"
 #include "../../cascadia/terminalcore/ITerminalInput.hpp"

--- a/src/cascadia/TerminalCore/terminalrenderdata.cpp
+++ b/src/cascadia/TerminalCore/terminalrenderdata.cpp
@@ -92,7 +92,9 @@ COLORREF Terminal::GetCursorColor() const noexcept
 
 bool Terminal::IsCursorDoubleWidth() const noexcept
 {
-    return false;
+    const auto position = _buffer->GetCursor().GetPosition();
+    TextBufferTextIterator it(TextBufferCellIterator(*_buffer, position));
+    return IsGlyphFullWidth(*it);
 }
 
 const std::vector<RenderOverlay> Terminal::GetOverlays() const noexcept


### PR DESCRIPTION
## Summary of the Pull Request

Fix double width cursor for CJK characters

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

#2713 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #2713 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The code was copied from https://github.com/microsoft/terminal/blob/master/src/host/renderData.cpp#L266 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

![图片](https://user-images.githubusercontent.com/4710575/65739438-ceb55b00-e117-11e9-92da-1a04629a3ef8.png)

![图片](https://user-images.githubusercontent.com/4710575/65739556-41263b00-e118-11e9-965d-578c384623bc.png)

