### PR TITLE
Reduce InsertAttrRuns CPU usage

### DIFF
--- a/src/buffer/out/AttrRow.cpp
+++ b/src/buffer/out/AttrRow.cpp
@@ -278,31 +278,64 @@ void ATTR_ROW::ReplaceAttrs(const TextAttribute& toBeReplacedAttr, const TextAtt
         {
             return S_OK;
         }
-        // .. otherwise if we internally have a list of 2 and we're about to insert a single color
-        // it's probable that we're just walking left-to-right through the row and changing each
-        // cell one at a time.
-        // e.g.
-        // AAAAABBBBBBB
-        // AAAAAABBBBBB
-        // AAAAAAABBBBB
-        // Check for that circumstance by seeing if we're inserting a single run of the
-        // left side color right at the boundary and just adjust the counts in the existing
-        // two elements in our internal list.
-        else if (_list.size() == 2 && newAttrs.at(0).GetLength() == 1)
+        // .. otherwise if we internally have a list of 2 or more and we're about to insert a single color
+        // it's possible that we just walk left-to-right through the row and find a quick exit.
+        else if (iStart > 0 && iStart == iEnd)
         {
-            const auto left = _list.begin();
-            if (iStart == left->GetLength() && NewAttr == left->GetAttributes())
+            // First we try to find the run where the insertion happens, using lowerBound and upperBound to track
+            // where we are curretly at.
+            size_t lowerBound = 0;
+            size_t upperBound = 0;
+            for (size_t i = 0; i < _list.size(); i++)
             {
-                const auto right = left + 1;
-                left->IncrementLength();
-                right->DecrementLength();
-
-                // If we just reduced the right half to zero, just erase it out of the list.
-                if (right->GetLength() == 0)
+                upperBound += _list.at(i).GetLength();
+                if (iStart >= lowerBound && iStart < upperBound)
                 {
-                    _list.erase(right);
+                    const auto curr = std::next(_list.begin(), i);
+
+                    // The run that we try to insert into has the same color as the new one.
+                    // e.g.
+                    // AAAAABBBBBBBCCC
+                    //       ^
+                    // AAAAABBBBBBBCCC
+                    //
+                    // 'B' is the new color and '^' represents where iStart is. We don't have to
+                    // do anything.
+                    if (curr->GetAttributes() == NewAttr)
+                    {
+                        return S_OK;
+                    }
+
+                    // If the insertion happens at current run's lower boundary...
+                    if (iStart == lowerBound)
+                    {
+                        const auto prev = std::prev(curr, 1);
+                        // ... and the previous run has the same color as the new one, we can
+                        // just adjust the counts in the existing two elements in our internal list.
+                        // e.g.
+                        // AAAAABBBBBBBCCC
+                        //      ^
+                        // AAAAAABBBBBBCCC
+                        //
+                        // Here 'A' is the new color.
+                        if (NewAttr == prev->GetAttributes())
+                        {
+                            prev->IncrementLength();
+                            curr->DecrementLength();
+
+                            // If we just reduced the right half to zero, just erase it out of the list.
+                            if (curr->GetLength() == 0)
+                            {
+                                _list.erase(curr);
+                            }
+
+                            return S_OK;
+                        }
+                    }
                 }
-                return S_OK;
+
+                // Advance one run in the _list.
+                lowerBound = upperBound;
             }
         }
     }


### PR DESCRIPTION
## Summary of the Pull Request

Reduces CPU usage in `ATTR_ROW::InsertAttrRuns`.

## References

#806 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #806
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. 

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

I myself have experienced the slow cursor movement described in #806 . I found one hotspot is in `ATTR_ROW::InsertAttrRuns`. It is called many times during screen redrawing. All those vector initializing and copying consumes lots of CPU cycles. 

The idea is simple: exit as quickly as possible. The original author has already done this optimization when `_list.size()` is 1 or 2. I took a little further and aggresive way.

I added quick exit on these following condition

* Insert single color that is the same as the left color:

```plaintext
AAAAABBBBBBBCCC
     ^
AAAAAABBBBBBCCC
```

* Insert single color that is the same as surrouding ones

```plaintext
AAAAABBBBBBBCCC
       ^
AAAAABBBBBBBCCC
```

I didn't change the documentation cuz I wanna hear some feedback from the team before moving on. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Open `.vimrc` with vim and see for youself. It's not really "buttery smooth" but it it whole lot better. The CPU usage is dropped by about 30%.