### PR TITLE
Reduce text layout CPU usage when DWrite analysis is not needed

### DIFF
--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -130,10 +130,10 @@ CustomTextLayout::CustomTextLayout(gsl::not_null<IDWriteFactory1*> const factory
         _breakpoints.resize(_text.size());
 
         BOOL isTextSimple = FALSE;
-        UINT32 uiReadLength = 0;
-        RETURN_IF_FAILED(_analyzer->GetTextComplexity(_text.c_str(), textLength, _font.Get(), &isTextSimple, &uiReadLength, NULL));
+        UINT32 uiLengthRead = 0;
+        RETURN_IF_FAILED(_analyzer->GetTextComplexity(_text.c_str(), textLength, _font.Get(), &isTextSimple, &uiLengthRead, NULL));
 
-        if (!isTextSimple)
+        if (!(isTextSimple && uiLengthRead == _text.size()))
         {
             // Call each of the analyzers in sequence, recording their results.
             RETURN_IF_FAILED(_analyzer->AnalyzeLineBreakpoints(this, 0, textLength, this));


### PR DESCRIPTION
## Summary of the Pull Request

It takes many CPU cycles to calculate text layout & font fallback even it's not really necessary. This may seem a little aggresive but it indeed dramatically boost performance.

## References

#806 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

With the help of #2937 and this PR, vim performance is way more smooth than before.

