### PR TITLE
Defer cursor redrawing when writing buffer

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -363,6 +363,10 @@ void Terminal::_WriteBuffer(const std::wstring_view& stringView)
     auto& cursor = _buffer->GetCursor();
     const Viewport bufferSize = _buffer->GetSize();
 
+    // Defer the cursor drawing while we are iterating the string, for a better performance.
+    // We can not waste time displaying a cursor event when we know more text is coming right behind it.
+    cursor.StartDeferDrawing();
+
     for (size_t i = 0; i < stringView.size(); i++)
     {
         wchar_t wch = stringView[i];
@@ -463,6 +467,8 @@ void Terminal::_WriteBuffer(const std::wstring_view& stringView)
             _NotifyScrollEvent();
         }
     }
+
+    cursor.EndDeferDrawing();
 }
 
 void Terminal::UserScrollViewport(const int viewTop)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Defer cursor redrawing when reading buffer

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

#2932 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

My previous PR #2932 introduces an overhead when writing a lot of text on screen. I found that this could be optimized by delaying cursor redraw

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
