### PR TITLE
CUU and CUD should not move "across" margins.

### DIFF
--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -1417,21 +1417,42 @@ void DoSrvPrivateAllowCursorBlinking(SCREEN_INFORMATION& screenInfo, const bool 
     // Make sure the cursor doesn't move outside the viewport.
     screenInfo.GetViewport().Clamp(clampedPos);
 
-    // Make sure the cursor stays inside the margins, but only if it started there
-    if (screenInfo.AreMarginsSet()) // && screenInfo.IsCursorInMargins(cursor.GetPosition()))
+    // Make sure the cursor stays inside the margins
+    if (screenInfo.AreMarginsSet())
     {
         const auto margins = screenInfo.GetAbsoluteScrollMargins().ToInclusive();
-        const auto v = clampedPos.Y;
+
+        const auto newY = clampedPos.Y;
+        const auto cursorY = cursor.GetPosition().Y;
+
         const auto lo = margins.Top;
         const auto hi = margins.Bottom;
 
-        const bool cursorBelowTop = v < lo;
-        const bool cursorAboveBottom = v > hi;
-        if (cursorBelowTop || cursorAboveBottom)
+        // See microsoft/terminal#2929 - If the cursor is _below_ the top
+        // margin, it should stay below the top margin. If it's _above_ the
+        // bottom, it should stay above the bottom. Cursor movements that stay
+        // outside the margins shouldn't necessarily be affected. For example,
+        // moving up while below the bottom margin shouldn't just jump straight
+        // to the bottom margin. See
+        // ScreenBufferTests::CursorUpDownOutsideMargins for a test of that
+        // behavior.
+        const bool cursorBelowTop = cursorY > lo;
+        const bool cursorAboveBottom = cursorY < hi;
+
+        if (cursorBelowTop)
         {
             try
             {
-                clampedPos.Y = std::clamp(v, lo, hi);
+                clampedPos.Y = std::max(newY, lo);
+            }
+            CATCH_RETURN();
+        }
+
+        if (cursorAboveBottom)
+        {
+            try
+            {
+                clampedPos.Y = std::min(newY, hi);
             }
             CATCH_RETURN();
         }

--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -1422,7 +1422,6 @@ void DoSrvPrivateAllowCursorBlinking(SCREEN_INFORMATION& screenInfo, const bool 
     {
         const auto margins = screenInfo.GetAbsoluteScrollMargins().ToInclusive();
 
-        const auto newY = clampedPos.Y;
         const auto cursorY = cursor.GetPosition().Y;
 
         const auto lo = margins.Top;
@@ -1436,14 +1435,14 @@ void DoSrvPrivateAllowCursorBlinking(SCREEN_INFORMATION& screenInfo, const bool 
         // to the bottom margin. See
         // ScreenBufferTests::CursorUpDownOutsideMargins for a test of that
         // behavior.
-        const bool cursorBelowTop = cursorY > lo;
-        const bool cursorAboveBottom = cursorY < hi;
+        const bool cursorBelowTop = cursorY >= lo;
+        const bool cursorAboveBottom = cursorY <= hi;
 
         if (cursorBelowTop)
         {
             try
             {
-                clampedPos.Y = std::max(newY, lo);
+                clampedPos.Y = std::max(clampedPos.Y, lo);
             }
             CATCH_RETURN();
         }
@@ -1452,7 +1451,7 @@ void DoSrvPrivateAllowCursorBlinking(SCREEN_INFORMATION& screenInfo, const bool 
         {
             try
             {
-                clampedPos.Y = std::min(newY, hi);
+                clampedPos.Y = std::min(clampedPos.Y, hi);
             }
             CATCH_RETURN();
         }

--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -1418,17 +1418,23 @@ void DoSrvPrivateAllowCursorBlinking(SCREEN_INFORMATION& screenInfo, const bool 
     screenInfo.GetViewport().Clamp(clampedPos);
 
     // Make sure the cursor stays inside the margins, but only if it started there
-    if (screenInfo.AreMarginsSet() && screenInfo.IsCursorInMargins(cursor.GetPosition()))
+    if (screenInfo.AreMarginsSet()) // && screenInfo.IsCursorInMargins(cursor.GetPosition()))
     {
-        try
+        const auto margins = screenInfo.GetAbsoluteScrollMargins().ToInclusive();
+        const auto v = clampedPos.Y;
+        const auto lo = margins.Top;
+        const auto hi = margins.Bottom;
+
+        const bool cursorBelowTop = v < lo;
+        const bool cursorAboveBottom = v > hi;
+        if (cursorBelowTop || cursorAboveBottom)
         {
-            const auto margins = screenInfo.GetAbsoluteScrollMargins().ToInclusive();
-            const auto v = clampedPos.Y;
-            const auto lo = margins.Top;
-            const auto hi = margins.Bottom;
-            clampedPos.Y = std::clamp(v, lo, hi);
+            try
+            {
+                clampedPos.Y = std::clamp(v, lo, hi);
+            }
+            CATCH_RETURN();
         }
-        CATCH_RETURN();
     }
     cursor.SetPosition(clampedPos);
 

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -4527,6 +4527,7 @@ void ScreenBufferTests::CursorUpDownAcrossMargins()
         auto iter = tbi.GetCellDataAt({ 0, 18 });
         VERIFY_ARE_EQUAL(L"Y", iter->Chars());
     }
+    stateMachine.ProcessString(L"\x1b[r");
 }
 
 void ScreenBufferTests::CursorUpDownOutsideMargins()
@@ -4541,6 +4542,10 @@ void ScreenBufferTests::CursorUpDownOutsideMargins()
     // * moves to line 1 (i.e. above the top margin)
     // * executes the CUD sequence with a count of 1, to move down 1 lines (still above margins)
     // * writes out Y
+
+    // This test is different becasue the end location of the vertical movement
+    // should not be within the margins at all. WE should not clamp this
+    // movement to be within the margins.
 
     auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     auto& si = gci.GetActiveOutputBuffer();
@@ -4572,4 +4577,5 @@ void ScreenBufferTests::CursorUpDownOutsideMargins()
         auto iter = tbi.GetCellDataAt({ 0, 1 });
         VERIFY_ARE_EQUAL(L"Y", iter->Chars());
     }
+    stateMachine.ProcessString(L"\x1b[r");
 }


### PR DESCRIPTION
## Summary of the Pull Request

If we're moving the cursor up, its vertical movement should be stopped at the top margin. It should not magically jump up to the bottom margin. Similarly, this applies to moving down and the bottom margin. Furthermore, this constraint should always apply, not just when the start position is within BOTH margins

## References
#170


## PR Checklist
* [x] Closes #2929
* [x] I work here
* [x] Tests added/passed
* [n/a] Requires documentation to be updated

## Detailed Description of the Pull Request / Additional comments

Shout-out to @j4james as always, for keeping the VT implementation honest 😋 