### PR TITLE
Update cmd's default profile to disable acrylic

### DIFF
--- a/src/cascadia/TerminalApp/defaults.json
+++ b/src/cascadia/TerminalApp/defaults.json
@@ -45,8 +45,7 @@
             "icon": "ms-appx:///ProfileIcons/{0caa0dad-35be-5f56-a8ff-afceeeaa6101}.png",
             "padding": "8, 8, 8, 8",
             "snapOnInput": true,
-            "useAcrylic": true,
-            "acrylicOpacity": 0.75
+            "useAcrylic": false
         }
     ],
     "schemes":


### PR DESCRIPTION
As per prior agreement with WinUI team, disabling acrylic for Cmd (and Windows PowerShell, already complete) by default. 

PowerShell Core/7 and WSL distros allowed to have Acrylic enabled by default.