### PR TITLE
Defer text buffer redrawing

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -334,6 +334,8 @@ OutputCellIterator TextBuffer::Write(const OutputCellIterator givenIt,
     // Get size of the text buffer so we can stay in bounds.
     const auto size = GetSize();
 
+    _renderTarget.StartDeferRedrawing();
+
     // While there's still data in the iterator and we're still targeting in bounds...
     while (it && size.IsInBounds(lineTarget))
     {
@@ -345,6 +347,8 @@ OutputCellIterator TextBuffer::Write(const OutputCellIterator givenIt,
         lineTarget.X = 0;
         ++lineTarget.Y;
     }
+
+    _renderTarget.EndDeferRedrawing();
 
     return it;
 }

--- a/src/host/ScreenBufferRenderTarget.cpp
+++ b/src/host/ScreenBufferRenderTarget.cpp
@@ -11,6 +11,25 @@ ScreenBufferRenderTarget::ScreenBufferRenderTarget(SCREEN_INFORMATION& owner) :
 {
 }
 
+void ScreenBufferRenderTarget::StartDeferRedrawing()
+{
+    auto* pRenderer = ServiceLocator::LocateGlobals().pRender;
+    const auto* pActive = &ServiceLocator::LocateGlobals().getConsoleInformation().GetActiveOutputBuffer().GetActiveBuffer();
+    if (pRenderer != nullptr && pActive == &_owner)
+    {
+        pRenderer->StartDeferRedrawing();
+    }
+}
+void ScreenBufferRenderTarget::EndDeferRedrawing()
+{
+    auto* pRenderer = ServiceLocator::LocateGlobals().pRender;
+    const auto* pActive = &ServiceLocator::LocateGlobals().getConsoleInformation().GetActiveOutputBuffer().GetActiveBuffer();
+    if (pRenderer != nullptr && pActive == &_owner)
+    {
+        pRenderer->EndDeferRedrawing();
+    }
+}
+
 void ScreenBufferRenderTarget::TriggerRedraw(const Microsoft::Console::Types::Viewport& region)
 {
     auto* pRenderer = ServiceLocator::LocateGlobals().pRender;

--- a/src/host/ScreenBufferRenderTarget.hpp
+++ b/src/host/ScreenBufferRenderTarget.hpp
@@ -29,6 +29,8 @@ class ScreenBufferRenderTarget final : public Microsoft::Console::Render::IRende
 public:
     ScreenBufferRenderTarget(SCREEN_INFORMATION& owner);
 
+    void StartDeferRedrawing();
+    void EndDeferRedrawing();
     void TriggerRedraw(const Microsoft::Console::Types::Viewport& region) override;
     void TriggerRedraw(const COORD* const pcoord) override;
     void TriggerRedrawCursor(const COORD* const pcoord) override;

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -86,6 +86,11 @@ Renderer::~Renderer()
 
 [[nodiscard]] HRESULT Renderer::_PaintFrameForEngine(_In_ IRenderEngine* const pEngine)
 {
+    if (_redrawingDefered)
+    {
+        return S_OK;
+    }
+
     FAIL_FAST_IF_NULL(pEngine); // This is a programming error. Fail fast.
 
     _pData->LockConsole();
@@ -151,8 +156,22 @@ Renderer::~Renderer()
 
 void Renderer::_NotifyPaintFrame()
 {
+    if (_redrawingDefered)
+    {
+        return;
+    }
     // The thread will provide throttling for us.
     _pThread->NotifyPaint();
+}
+
+void Renderer::StartDeferRedrawing()
+{
+    _redrawingDefered = true;
+}
+
+void Renderer::EndDeferRedrawing()
+{
+    _redrawingDefered = false;
 }
 
 // Routine Description:

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -47,6 +47,8 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT PaintFrame();
 
+        void StartDeferRedrawing();
+        void EndDeferRedrawing();
         void TriggerSystemRedraw(const RECT* const prcDirtyClient) override;
         void TriggerRedraw(const Microsoft::Console::Types::Viewport& region) override;
         void TriggerRedraw(const COORD* const pcoord) override;
@@ -125,5 +127,7 @@ namespace Microsoft::Console::Render
         // Helper functions to diagnose issues with painting and layout.
         // These are only actually effective/on in Debug builds when the flag is set using an attached debugger.
         bool _fDebug = false;
+
+        bool _redrawingDefered = false;
     };
 }

--- a/src/renderer/inc/IRenderTarget.hpp
+++ b/src/renderer/inc/IRenderTarget.hpp
@@ -33,6 +33,8 @@ namespace Microsoft::Console::Render
         IRenderTarget& operator=(IRenderTarget&&) = default;
 
     public:
+        virtual void StartDeferRedrawing() = 0;
+        virtual void EndDeferRedrawing() = 0;
         virtual void TriggerRedraw(const Microsoft::Console::Types::Viewport& region) = 0;
         virtual void TriggerRedraw(const COORD* const pcoord) = 0;
         virtual void TriggerRedrawCursor(const COORD* const pcoord) = 0;

--- a/src/renderer/inc/IRenderer.hpp
+++ b/src/renderer/inc/IRenderer.hpp
@@ -28,6 +28,9 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] virtual HRESULT PaintFrame() = 0;
 
+        virtual void StartDeferRedrawing() = 0;
+        virtual void EndDeferRedrawing() = 0;
+
         virtual void TriggerSystemRedraw(const RECT* const prcDirtyClient) = 0;
 
         virtual void TriggerRedraw(const Microsoft::Console::Types::Viewport& region) = 0;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This is a draft PR that's intended to defer all kinds of redrawing.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

#2960  #3075 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Coming from #2960, combined with an inspiring issue from #3075 , we are indeed doing a lot of unnecessary redrawing when there are still incoming text.

I'd love to hear @miniksa 's thought on this. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
