### PR TITLE
health: get rid of our hand-rolled sprintf->wstring helpers, prefer WIL

### DIFF
--- a/src/cascadia/TerminalConnection/AzureConnection.cpp
+++ b/src/cascadia/TerminalConnection/AzureConnection.cpp
@@ -435,7 +435,8 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
                 continue;
             }
 
-            _outputHandlers(_StrFormatHelper(ithTenant, _maxStored, nameJson.at(L"displayName").as_string().c_str(), nameJson.at(L"tenantID").as_string().c_str()));
+            auto tenantLine{ wil::str_printf<std::wstring>(ithTenant, _maxStored, nameJson.at(L"displayName").as_string().c_str(), nameJson.at(L"tenantID").as_string().c_str()) };
+            _outputHandlers(tenantLine);
             _maxStored++;
         }
 
@@ -582,7 +583,8 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             {
                 const auto& tenant = tenantListAsArray.at(i);
                 const auto [tenantId, tenantDisplayName] = _crackTenant(tenant);
-                _outputHandlers(_StrFormatHelper(ithTenant, i, tenantDisplayName.c_str(), tenantId.c_str()));
+                auto tenantLine{ wil::str_printf<std::wstring>(ithTenant, i, tenantDisplayName.c_str(), tenantId.c_str()) };
+                _outputHandlers(tenantLine);
             }
             _outputHandlers(winrt::to_hstring(enterTenant));
             // Use a lock to wait for the user to input a valid number
@@ -934,14 +936,5 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
                 return;
             }
         }
-    }
-
-    std::wstring AzureConnection::_StrFormatHelper(const wchar_t* const format, int i, const wchar_t* name, const wchar_t* ID)
-    {
-        const auto lengthRequired = _scwprintf(ithTenant, i, name, ID);
-        std::wstring buffer;
-        buffer.resize(lengthRequired + 1);
-        swprintf_s(buffer.data(), buffer.size(), ithTenant, i, name, ID);
-        return buffer;
     }
 }

--- a/src/cascadia/TerminalConnection/AzureConnection.h
+++ b/src/cascadia/TerminalConnection/AzureConnection.h
@@ -93,7 +93,6 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         void _HeaderHelper(web::http::http_request theRequest);
         void _StoreCredential();
         void _RemoveCredentials();
-        std::wstring _StrFormatHelper(const wchar_t* const format, int i, const wchar_t* name, const wchar_t* ID);
 
         web::websockets::client::websocket_client _cloudShellSocket;
     };

--- a/src/cascadia/WindowsTerminal/main.cpp
+++ b/src/cascadia/WindowsTerminal/main.cpp
@@ -85,18 +85,13 @@ static void EnsureNativeArchitecture()
         const auto nativeArchitecture = ImageArchitectureToString(nativeMachine);
         const auto processArchitecture = ImageArchitectureToString(processMachine);
 
-        const auto lengthRequired = _scwprintf(formatPattern.data(), nativeArchitecture.data(), processArchitecture.data());
-        const auto bufferSize = lengthRequired + 1;
-
-        std::wstring buffer;
-        buffer.resize(bufferSize);
-
-        swprintf_s(buffer.data(), buffer.size(), formatPattern.data(), nativeArchitecture.data(), processArchitecture.data());
+        auto buffer{ wil::str_printf<std::wstring>(formatPattern.data(), nativeArchitecture.data(), processArchitecture.data()) };
 
         MessageBoxW(nullptr,
                     buffer.data(),
                     GetStringResource(IDS_ERROR_DIALOG_TITLE).data(),
                     MB_OK | MB_ICONERROR);
+
         ExitProcess(0);
     }
 }

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -15,14 +15,7 @@ using namespace Microsoft::Console;
 // - a string representation of the GUID. On failure, throws E_INVALIDARG.
 std::wstring Utils::GuidToString(const GUID guid)
 {
-    // 39: 38, plus swprintf needs somewhere to store the NUL terminator.
-    std::array<wchar_t, 39> guid_cstr;
-    const int written = swprintf(guid_cstr.data(), guid_cstr.size(), L"{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}", guid.Data1, guid.Data2, guid.Data3, guid.Data4[0], guid.Data4[1], guid.Data4[2], guid.Data4[3], guid.Data4[4], guid.Data4[5], guid.Data4[6], guid.Data4[7]);
-
-    THROW_HR_IF(E_INVALIDARG, written == -1);
-
-    // size - 1: The returned string should not be created including the NUL terminator.
-    return std::wstring(guid_cstr.data(), guid_cstr.size() - 1);
+    return wil::str_printf<std::wstring>(L"{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}", guid.Data1, guid.Data2, guid.Data3, guid.Data4[0], guid.Data4[1], guid.Data4[2], guid.Data4[3], guid.Data4[4], guid.Data4[5], guid.Data4[6], guid.Data4[7]);
 }
 
 // Method Description:


### PR DESCRIPTION
## Summary of the Pull Request
This is a general code health PR. I was reading about WIL, and found out that they've got these helpers already.

## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes something (doesn't)
* [ ] CLA signed
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [x] `WI_IsFlagSet(..., CoreContributor)`

## Validation
I ran the UUIDgen tests and used the azure cloud shell connector, and launched WT on the wrong architecture.