### PR TITLE
Improve the DECSC/DECRC implementation

### DIFF
--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -299,6 +299,31 @@ BOOL ConhostInternalGetSet::PrivateSetExtendedTextAttributes(const ExtendedAttri
     return TRUE;
 }
 
+// Method Description:
+// - Retrieves the current TextAttribute of the active screen buffer.
+// Arguments:
+// - pAttrs: Receives the TextAttribute value.
+// Return Value:
+// - TRUE if successful. FALSE otherwise.
+BOOL ConhostInternalGetSet::PrivateGetTextAttributes(TextAttribute* const pAttrs) const
+{
+    *pAttrs = _io.GetActiveOutputBuffer().GetAttributes();
+    return TRUE;
+}
+
+// Method Description:
+// - Sets the current TextAttribute of the active screen buffer. Text
+//   written to this buffer will be written with these attributes.
+// Arguments:
+// - attrs: The new TextAttribute to use
+// Return Value:
+// - TRUE if successful. FALSE otherwise.
+BOOL ConhostInternalGetSet::PrivateSetTextAttributes(const TextAttribute& attrs)
+{
+    _io.GetActiveOutputBuffer().SetAttributes(attrs);
+    return TRUE;
+}
+
 // Routine Description:
 // - Connects the WriteConsoleInput API call directly into our Driver Message servicing call inside Conhost.exe
 // Arguments:

--- a/src/host/outputStream.hpp
+++ b/src/host/outputStream.hpp
@@ -90,6 +90,8 @@ public:
     BOOL PrivateBoldText(const bool bolded) override;
     BOOL PrivateGetExtendedTextAttributes(ExtendedAttributes* const pAttrs) override;
     BOOL PrivateSetExtendedTextAttributes(const ExtendedAttributes attrs) override;
+    BOOL PrivateGetTextAttributes(TextAttribute* const pAttrs) const override;
+    BOOL PrivateSetTextAttributes(const TextAttribute& attrs) override;
 
     BOOL PrivateWriteConsoleInputW(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& events,
                                    _Out_ size_t& eventsWritten) override;

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -36,8 +36,8 @@ public:
     virtual bool CursorHorizontalPositionAbsolute(const unsigned int uiColumn) = 0; // CHA
     virtual bool VerticalLinePositionAbsolute(const unsigned int uiLine) = 0; // VPA
     virtual bool CursorPosition(const unsigned int uiLine, const unsigned int uiColumn) = 0; // CUP
-    virtual bool CursorSavePosition() = 0; // DECSC
-    virtual bool CursorRestorePosition() = 0; // DECRC
+    virtual bool CursorSaveState() = 0; // DECSC
+    virtual bool CursorRestoreState() = 0; // DECRC
     virtual bool CursorVisibility(const bool fIsVisible) = 0; // DECTCEM
     virtual bool InsertCharacter(const unsigned int uiCount) = 0; // ICH
     virtual bool DeleteCharacter(const unsigned int uiCount) = 0; // DCH

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -417,7 +417,7 @@ bool AdaptDispatch::CursorPosition(_In_ unsigned int const uiLine, _In_ unsigned
 // - <none>
 // Return Value:
 // - True if handled successfully. False otherwise.
-bool AdaptDispatch::CursorSavePosition()
+bool AdaptDispatch::CursorSaveState()
 {
     // First retrieve some information about the buffer
     CONSOLE_SCREEN_BUFFER_INFOEX csbiex = { 0 };
@@ -456,7 +456,7 @@ bool AdaptDispatch::CursorSavePosition()
 // - <none>
 // Return Value:
 // - True if handled successfully. False otherwise.
-bool AdaptDispatch::CursorRestorePosition()
+bool AdaptDispatch::CursorRestoreState()
 {
     auto& savedCursorState = _savedCursorState[_usingAltBuffer];
 
@@ -1369,7 +1369,7 @@ bool AdaptDispatch::SetWindowTitle(std::wstring_view title)
 // - True if handled successfully. False otherwise.
 bool AdaptDispatch::UseAlternateScreenBuffer()
 {
-    bool fSuccess = CursorSavePosition();
+    bool fSuccess = CursorSaveState();
     if (fSuccess)
     {
         fSuccess = !!_conApi->PrivateUseAlternateScreenBuffer();
@@ -1396,7 +1396,7 @@ bool AdaptDispatch::UseMainScreenBuffer()
         _usingAltBuffer = false;
         if (fSuccess)
         {
-            fSuccess = CursorRestorePosition();
+            fSuccess = CursorRestoreState();
         }
     }
     return fSuccess;

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -459,9 +459,20 @@ bool AdaptDispatch::CursorRestorePosition()
 {
     auto& savedCursorState = _savedCursorState[_usingAltBuffer];
 
+    auto uiRow = savedCursorState.Row;
+    auto uiCol = savedCursorState.Column;
+
+    // If the origin mode is relative, and the scrolling region is set (the bottom is non-zero),
+    // we need to make sure the restored position is clamped within the margins.
+    if (savedCursorState.IsOriginModeRelative && _srScrollMargins.Bottom != 0)
+    {
+        // VT origin is at 1,1 so we need to add 1 to these margins.
+        uiRow = std::clamp(uiRow, _srScrollMargins.Top + 1u, _srScrollMargins.Bottom + 1u);
+    }
+
     // The saved coordinates are always absolute, so we need reset the origin mode temporarily.
     _fIsOriginModeRelative = false;
-    bool fSuccess = _CursorMovePosition(&savedCursorState.Row, &savedCursorState.Column);
+    bool fSuccess = _CursorMovePosition(&uiRow, &uiCol);
 
     // Once the cursor position is restored, we can then restore the actual origin mode.
     _fIsOriginModeRelative = savedCursorState.IsOriginModeRelative;

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -27,6 +27,7 @@ AdaptDispatch::AdaptDispatch(ConGetSet* const pConApi,
                              AdaptDefaults* const pDefaults) :
     _conApi{ THROW_IF_NULL_ALLOC(pConApi) },
     _pDefaults{ THROW_IF_NULL_ALLOC(pDefaults) },
+    _usingAltBuffer(false),
     _fIsOriginModeRelative(false), // by default, the DECOM origin mode is absolute.
     _fIsDECCOLMAllowed(false), // by default, DECCOLM is not allowed.
     _fChangedBackground(false),

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -412,7 +412,9 @@ bool AdaptDispatch::CursorPosition(_In_ unsigned int const uiLine, _In_ unsigned
 }
 
 // Routine Description:
-// - DECSC - Saves the current cursor position into a memory buffer.
+// - DECSC - Saves the current "cursor state" into a memory buffer. This
+//   includes the cursor position, origin mode, graphic rendition, and
+//   active character set.
 // Arguments:
 // - <none>
 // Return Value:
@@ -450,8 +452,9 @@ bool AdaptDispatch::CursorSaveState()
 }
 
 // Routine Description:
-// - DECRC - Restores a saved cursor position from the DECSC command back into the console state.
-// - If no position was set, this defaults to the top left corner (see AdaptDispatch constructor.)
+// - DECRC - Restores a saved "cursor state" from the DECSC command back into
+//   the console state. This includes the cursor position, origin mode, graphic
+//   rendition, and active character set.
 // Arguments:
 // - <none>
 // Return Value:

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -156,7 +156,9 @@ namespace Microsoft::Console::VirtualTerminal
         std::unique_ptr<AdaptDefaults> _pDefaults;
         TerminalOutput _TermOutput;
 
-        CursorState _savedCursorState;
+        CursorState _savedCursorState[2];
+        bool _usingAltBuffer;
+
         SMALL_RECT _srScrollMargins;
 
         bool _fIsOriginModeRelative;

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -156,6 +156,11 @@ namespace Microsoft::Console::VirtualTerminal
         std::unique_ptr<AdaptDefaults> _pDefaults;
         TerminalOutput _TermOutput;
 
+        // We have two instances of the saved cursor state, because we need
+        // one for the main buffer (at index 0), and another for the alt buffer
+        // (at index 1). The _usingAltBuffer property keeps tracks of which
+        // buffer is active, so can be used as an index into this array to
+        // obtain the saved state that should be currently active.
         CursorState _savedCursorState[2];
         bool _usingAltBuffer;
 

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -48,8 +48,8 @@ namespace Microsoft::Console::VirtualTerminal
         bool CursorHorizontalPositionAbsolute(_In_ unsigned int const uiColumn) override; // CHA
         bool VerticalLinePositionAbsolute(_In_ unsigned int const uiLine) override; // VPA
         bool CursorPosition(_In_ unsigned int const uiLine, _In_ unsigned int const uiColumn) override; // CUP
-        bool CursorSavePosition() override; // DECSC
-        bool CursorRestorePosition() override; // DECRC
+        bool CursorSaveState() override; // DECSC
+        bool CursorRestoreState() override; // DECRC
         bool CursorVisibility(const bool fIsVisible) override; // DECTCEM
         bool EraseInDisplay(const DispatchTypes::EraseType eraseType) override; // ED
         bool EraseInLine(const DispatchTypes::EraseType eraseType) override; // EL

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -120,6 +120,14 @@ namespace Microsoft::Console::VirtualTerminal
             Up,
             Down
         };
+        struct CursorState
+        {
+            unsigned int Row = 1;
+            unsigned int Column = 1;
+            bool IsOriginModeRelative = false;
+            TextAttribute Attributes = {};
+            TerminalOutput TermOutput = {};
+        };
 
         bool _CursorMovement(const CursorDirection dir, _In_ unsigned int const uiDistance) const;
         bool _CursorMovePosition(_In_opt_ const unsigned int* const puiRow, _In_opt_ const unsigned int* const puiCol) const;
@@ -148,11 +156,10 @@ namespace Microsoft::Console::VirtualTerminal
         std::unique_ptr<AdaptDefaults> _pDefaults;
         TerminalOutput _TermOutput;
 
-        COORD _coordSavedCursor;
+        CursorState _savedCursorState;
         SMALL_RECT _srScrollMargins;
 
         bool _fIsOriginModeRelative;
-        bool _fIsSavedOriginModeRelative;
 
         bool _fIsSetColumnsEnabled;
 

--- a/src/terminal/adapter/conGetSet.hpp
+++ b/src/terminal/adapter/conGetSet.hpp
@@ -16,6 +16,7 @@ Author(s):
 #pragma once
 
 #include "..\..\types\inc\IInputEvent.hpp"
+#include "..\..\buffer\out\TextAttribute.hpp"
 #include "..\..\inc\conattrs.hpp"
 
 #include <deque>
@@ -54,6 +55,8 @@ namespace Microsoft::Console::VirtualTerminal
         virtual BOOL PrivateBoldText(const bool bolded) = 0;
         virtual BOOL PrivateGetExtendedTextAttributes(ExtendedAttributes* const pAttrs) = 0;
         virtual BOOL PrivateSetExtendedTextAttributes(const ExtendedAttributes attrs) = 0;
+        virtual BOOL PrivateGetTextAttributes(TextAttribute* const pAttrs) const = 0;
+        virtual BOOL PrivateSetTextAttributes(const TextAttribute& attrs) = 0;
 
         virtual BOOL PrivateWriteConsoleInputW(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& events,
                                                _Out_ size_t& eventsWritten) = 0;

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -33,8 +33,8 @@ public:
     bool CursorHorizontalPositionAbsolute(const unsigned int /*uiColumn*/) override { return false; } // CHA
     bool VerticalLinePositionAbsolute(const unsigned int /*uiLine*/) override { return false; } // VPA
     bool CursorPosition(const unsigned int /*uiLine*/, const unsigned int /*uiColumn*/) override { return false; } // CUP
-    bool CursorSavePosition() override { return false; } // DECSC
-    bool CursorRestorePosition() override { return false; } // DECRC
+    bool CursorSaveState() override { return false; } // DECSC
+    bool CursorRestoreState() override { return false; } // DECRC
     bool CursorVisibility(const bool /*fIsVisible*/) override { return false; } // DECTCEM
     bool InsertCharacter(const unsigned int /*uiCount*/) override { return false; } // ICH
     bool DeleteCharacter(const unsigned int /*uiCount*/) override { return false; } // DCH

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -1617,11 +1617,11 @@ public:
         _testGetSet->PrepData(CursorX::XCENTER, CursorY::YCENTER);
         _testGetSet->_coordExpectedCursorPos = coordExpected;
 
-        VERIFY_IS_TRUE(_pDispatch->CursorRestorePosition(), L"By default, restore to top left corner (0,0 offset from viewport).");
+        VERIFY_IS_TRUE(_pDispatch->CursorRestoreState(), L"By default, restore to top left corner (0,0 offset from viewport).");
 
         Log::Comment(L"Test 2: Place cursor in center. Save. Move cursor to corner. Restore. Should come back to center.");
         _testGetSet->PrepData(CursorX::XCENTER, CursorY::YCENTER);
-        VERIFY_IS_TRUE(_pDispatch->CursorSavePosition(), L"Succeed at saving position.");
+        VERIFY_IS_TRUE(_pDispatch->CursorSaveState(), L"Succeed at saving position.");
 
         Log::Comment(L"Backup expected cursor (in the middle). Move cursor to corner. Then re-set expected cursor to middle.");
         // save expected cursor position
@@ -1633,7 +1633,7 @@ public:
         // restore expected cursor position to center.
         _testGetSet->_coordExpectedCursorPos = coordExpected;
 
-        VERIFY_IS_TRUE(_pDispatch->CursorRestorePosition(), L"Restoring to corner should succeed. API call inside will test that cursor matched expected position.");
+        VERIFY_IS_TRUE(_pDispatch->CursorRestoreState(), L"Restoring to corner should succeed. API call inside will test that cursor matched expected position.");
     }
 
     TEST_METHOD(CursorHideShowTest)

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -351,6 +351,18 @@ public:
         return true;
     }
 
+    BOOL PrivateGetTextAttributes(TextAttribute* const /*pAttrs*/) const
+    {
+        Log::Comment(L"PrivateGetTextAttributes MOCK called...");
+        return true;
+    }
+
+    BOOL PrivateSetTextAttributes(const TextAttribute& /*attrs*/)
+    {
+        Log::Comment(L"PrivateSetTextAttributes MOCK called...");
+        return true;
+    }
+
     BOOL PrivateWriteConsoleInputW(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& events,
                                    _Out_ size_t& eventsWritten) override
     {

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -194,11 +194,11 @@ bool OutputStateMachineEngine::ActionEscDispatch(const wchar_t wch,
             TermTelemetry::Instance().Log(TermTelemetry::Codes::CUB);
             break;
         case VTActionCodes::DECSC_CursorSave:
-            fSuccess = _dispatch->CursorSavePosition();
+            fSuccess = _dispatch->CursorSaveState();
             TermTelemetry::Instance().Log(TermTelemetry::Codes::DECSC);
             break;
         case VTActionCodes::DECRC_CursorRestore:
-            fSuccess = _dispatch->CursorRestorePosition();
+            fSuccess = _dispatch->CursorRestoreState();
             TermTelemetry::Instance().Log(TermTelemetry::Codes::DECRC);
             break;
         case VTActionCodes::DECKPAM_KeypadApplicationMode:
@@ -452,11 +452,11 @@ bool OutputStateMachineEngine::ActionCsiDispatch(const wchar_t wch,
                 TermTelemetry::Instance().Log(TermTelemetry::Codes::SD);
                 break;
             case VTActionCodes::ANSISYSSC_CursorSave:
-                fSuccess = _dispatch->CursorSavePosition();
+                fSuccess = _dispatch->CursorSaveState();
                 TermTelemetry::Instance().Log(TermTelemetry::Codes::ANSISYSSC);
                 break;
             case VTActionCodes::ANSISYSRC_CursorRestore:
-                fSuccess = _dispatch->CursorRestorePosition();
+                fSuccess = _dispatch->CursorRestoreState();
                 TermTelemetry::Instance().Log(TermTelemetry::Codes::ANSISYSRC);
                 break;
             case VTActionCodes::IL_InsertLine:

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -718,13 +718,13 @@ public:
         return true;
     }
 
-    bool CursorSavePosition() override
+    bool CursorSaveState() override
     {
         _fCursorSave = true;
         return true;
     }
 
-    bool CursorRestorePosition() override
+    bool CursorRestoreState() override
     {
         _fCursorLoad = true;
         return true;


### PR DESCRIPTION
## Summary of the Pull Request

The current [DECSC](https://www.vt100.net/docs/vt510-rm/DECSC.html) implementation only saves the cursor position and origin mode. This PR improves that functionality with additional support for saving the SGR attributes, as well as the active character set.

It also fixes the way the saved state interacts with the alt buffer (private mode 1049), triggering a save when switching to the alt buffer, and a restore when switching back, and tracking the alt buffer state independently from the main state.

## PR Checklist
* [x] Closes #148
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've not discussed this with core contributors already. I'm ready to accept this work might be rejected in favor of a different grand plan.

## Detailed Description of the Pull Request / Additional comments

In order to properly save and restore the SGR attributes, we first needed to add a pair of APIs in the `ConGetSet` interface which could round-trip the attributes with full 32-bit colors (the existing methods only work with legacy attributes).

I then added a struct in the `AdaptDispatch` implementation to make it easier to manage all of the parameters that needed to be saved. This includes the cursor position and origin mode that we were already tracking, and now also the SGR text attributes and the active character set (via the `TermOutput` class).

Two instances of this structure are required, since changes made to the saved state in the alt buffer need to be tracked separately from changes in the main buffer. I've added a boolean property that specifies whether we're in the alt buffer or not, and use that to decide which of the two instances we're working with.

I also needed to explicitly trigger a save when switching to the alt buffer, and a restore when switching back, since we weren't already doing that (the existing implementation gave the impression that the state was saved, because each buffer has its own cursor position, but that doesn't properly match the XTerm behaviour).

For the state tracking itself, we've now got two additional properties - the SGR attributes, which we obtain via the new private API, and the active character set, which we get from a local `AdaptDispatch` field. I'm saving the whole `TermOutput` class for the character set, since I'm hoping that will make it automatically supports future enhancements. 

When restoring the cursor position, there is also now a fix to handle the relative origin mode correctly. If the margins are changed between the position being saved and restored, it's possible for the cursor to end up outside of the new margins, which would be illegal. So there is now an additional step that clamps the Y coordinate within the margin boundaries if the origin mode is relative.

## Validation Steps Performed

I've added a couple of screen buffer tests which check that the various parameters are saved and restored as expected, as well as checking that the Y coordinate is clamped appropriately when the relative origin mode is set.

I've also tested manually with [Vttest](https://invisible-island.net/vttest/) and confirmed that the _SAVE/RESTORE CURSOR_ test (the last page of the _Test of screen features_)) is now working a lot better than it used to.