### PR TITLE
Prevent the horizontal tab character wrapping at the end of a line

### DIFF
--- a/src/host/_stream.cpp
+++ b/src/host/_stream.cpp
@@ -744,7 +744,6 @@ using Microsoft::Console::VirtualTerminal::StateMachine;
             if (screenInfo.InVTMode())
             {
                 const COORD cCursorOld = cursor.GetPosition();
-                // Get Forward tab handles tabbing past the end of the buffer
                 CursorPosition = screenInfo.GetForwardTab(cCursorOld);
             }
             else

--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -1567,19 +1567,15 @@ void DoSrvPrivateUseMainScreenBuffer(SCREEN_INFORMATION& screenInfo)
 {
     CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     SCREEN_INFORMATION& _screenBuffer = gci.GetActiveOutputBuffer().GetActiveBuffer();
+    COORD cursorPos = _screenBuffer.GetTextBuffer().GetCursor().GetPosition();
 
-    NTSTATUS Status = STATUS_SUCCESS;
     FAIL_FAST_IF(!(sNumTabs >= 0));
-    for (SHORT sTabsExecuted = 0; sTabsExecuted < sNumTabs && NT_SUCCESS(Status); sTabsExecuted++)
+    for (SHORT sTabsExecuted = 0; sTabsExecuted < sNumTabs; sTabsExecuted++)
     {
-        const COORD cursorPos = _screenBuffer.GetTextBuffer().GetCursor().GetPosition();
-        COORD cNewPos = (fForward) ? _screenBuffer.GetForwardTab(cursorPos) : _screenBuffer.GetReverseTab(cursorPos);
-        // GetForwardTab is smart enough to move the cursor to the next line if
-        // it's at the end of the current one already. AdjustCursorPos shouldn't
-        // to be doing anything funny, just moving the cursor to the location GetForwardTab returns
-        Status = AdjustCursorPosition(_screenBuffer, cNewPos, TRUE, nullptr);
+        cursorPos = (fForward) ? _screenBuffer.GetForwardTab(cursorPos) : _screenBuffer.GetReverseTab(cursorPos);
     }
-    return Status;
+
+    return AdjustCursorPosition(_screenBuffer, cursorPos, TRUE, nullptr);
 }
 
 // Routine Description:

--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -2230,7 +2230,8 @@ COORD SCREEN_INFORMATION::GetForwardTab(const COORD cCurrCursorPos) const noexce
         {
             if (*it > cCurrCursorPos.X)
             {
-                cNewCursorPos.X = *it;
+                // make sure we don't exceed the width of the buffer
+                cNewCursorPos.X = std::min(*it, sWidth);
                 break;
             }
         }

--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -2219,12 +2219,7 @@ COORD SCREEN_INFORMATION::GetForwardTab(const COORD cCurrCursorPos) const noexce
 {
     COORD cNewCursorPos = cCurrCursorPos;
     SHORT sWidth = GetBufferSize().RightInclusive();
-    if (cCurrCursorPos.X == sWidth)
-    {
-        cNewCursorPos.X = 0;
-        cNewCursorPos.Y += 1;
-    }
-    else if (_tabStops.empty() || cCurrCursorPos.X >= _tabStops.back())
+    if (_tabStops.empty() || cCurrCursorPos.X >= _tabStops.back())
     {
         cNewCursorPos.X = sWidth;
     }

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -597,6 +597,19 @@ void ScreenBufferTests::TestGetForwardTab()
                          L"Cursor advanced to end of screen buffer.");
     }
 
+    Log::Comment(L"Find next tab from rightmost column.");
+    {
+        coordCursor.X = coordScreenBufferSize.X - 1;
+
+        COORD coordCursorExpected;
+        coordCursorExpected = coordCursor;
+
+        COORD const coordCursorResult = si.GetForwardTab(coordCursor);
+        VERIFY_ARE_EQUAL(coordCursorExpected,
+                         coordCursorResult,
+                         L"Cursor remains in rightmost column.");
+    }
+
     si._tabStops.clear();
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

When a horizontal tab ('\t') is output on the last column of the screen, the current implementation moves the cursor position to the start of the next line. However, the _DEC STD 070_ manual specifies that a horizontal tab shouldn't move past the last column of the active line (or the right margin, if we supported horizontal margins). This PR updates the forward tab implementation, to prevent it wrapping onto a new line when it reaches the end of a line.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #3168
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #3168

## Detailed Description of the Pull Request / Additional comments

Originally the `SCREEN_INFORMATION::GetForwardTab` method had a condition which handled a tab at the end of the line as a special case, moving the cursor to the start of the next line. I've simply removed that condition, so an end-of-line tab is handled the same way as any other position (in this case it will just leaves the cursor where it is).

While testing, though, I found that there were circumstances where you could have tab stops greater than the width of the screen, and when that happens, a tab can still end up wrapping onto the next line. To fix that I had to add an additional check to make sure the tab position was always clamped to the width of the buffer.

With these fixes in place, a tab control should now never move off the active line, so I realised that the `DoPrivateTabHelper` function could be optimized to calculate all of the tab movements in advance, and then only make a single call to `AdjustCursorPosition` with the final coordinates. This change is not strictly necessary, though, so it can easily be reverted if there are any objections.

Regarding backwards compatibility, note that the `GetForwardTab` method is only used in two places:
- when handling a tab character in the `WriteCharsLegacy` function, but this only applies in VT mode (see [here](https://github.com/microsoft/terminal/blob/b9233c03d12bc7addab16647dba07196bd554f6f/src/host/_stream.cpp#L742-L749)).
- when handling the `CHT` escape sequence in the `DoPrivateTabHelper` function, and obviously an escape sequence would also only be applicable in VT mode.

So this change should have no effect on legacy console applications, which wouldn't have VT mode activated.

## Validation Steps Performed

I've added another step to the `TestGetForwardTab` test which makes sure that a horizontal tab won't wrap at the end of a line.

I've also confirmed that this fixes the last remaining issue in the _Test of autowrap_ in [Vttest](https://invisible-island.net/vttest/) (pages 3 and 4 of the _Test of cursor movements_). Although I should note that this only works in conhost.