### PR TITLE
Always use a VK in MapVirtualKeyW(..., MAPVK_VK_TO_VSC)

### DIFF
--- a/src/host/ut_host/ClipboardTests.cpp
+++ b/src/host/ut_host/ClipboardTests.cpp
@@ -176,7 +176,7 @@ class ClipboardTests
 
                 const short keyState = pInputServices->VkKeyScanW(wch);
                 VERIFY_ARE_NOT_EQUAL(-1, keyState);
-                const WORD virtualScanCode = static_cast<WORD>(pInputServices->MapVirtualKeyW(wch, MAPVK_VK_TO_VSC));
+                const WORD virtualScanCode = static_cast<WORD>(pInputServices->MapVirtualKeyW(LOBYTE(keyState), MAPVK_VK_TO_VSC));
 
                 VERIFY_ARE_EQUAL(wch, keyEvent->GetCharData());
                 VERIFY_ARE_EQUAL(isKeyDown, keyEvent->IsKeyDown());
@@ -217,7 +217,7 @@ class ClipboardTests
                 const short keyScanError = -1;
                 const short keyState = pInputServices->VkKeyScanW(wch);
                 VERIFY_ARE_NOT_EQUAL(keyScanError, keyState);
-                const WORD virtualScanCode = static_cast<WORD>(pInputServices->MapVirtualKeyW(wch, MAPVK_VK_TO_VSC));
+                const WORD virtualScanCode = static_cast<WORD>(pInputServices->MapVirtualKeyW(LOBYTE(keyState), MAPVK_VK_TO_VSC));
 
                 if (std::isupper(wch))
                 {
@@ -232,8 +232,8 @@ class ClipboardTests
                     events.pop_front();
 
                     const short keyState2 = pInputServices->VkKeyScanW(wch);
-                    VERIFY_ARE_NOT_EQUAL(keyScanError, keyState);
-                    const WORD virtualScanCode2 = static_cast<WORD>(pInputServices->MapVirtualKeyW(wch, MAPVK_VK_TO_VSC));
+                    VERIFY_ARE_NOT_EQUAL(keyScanError, keyState2);
+                    const WORD virtualScanCode2 = static_cast<WORD>(pInputServices->MapVirtualKeyW(LOBYTE(keyState2), MAPVK_VK_TO_VSC));
 
                     if (isKeyDown)
                     {

--- a/src/types/convert.cpp
+++ b/src/types/convert.cpp
@@ -206,7 +206,8 @@ std::deque<std::unique_ptr<KeyEvent>> SynthesizeKeyboardEvents(const wchar_t wch
                                                        SHIFT_PRESSED));
     }
 
-    const WORD virtualScanCode = gsl::narrow<WORD>(MapVirtualKeyW(wch, MAPVK_VK_TO_VSC));
+    const auto vk = LOBYTE(keyState);
+    const WORD virtualScanCode = gsl::narrow<WORD>(MapVirtualKeyW(vk, MAPVK_VK_TO_VSC));
     KeyEvent keyEvent{ true, 1, LOBYTE(keyState), virtualScanCode, wch, 0 };
 
     // add modifier flags if necessary


### PR DESCRIPTION
## Summary of the Pull Request

It was wrong. It is now not wrong.

## PR Checklist
* [x] Closes #2873
* [x] CLAlala
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [x] SIGSEGV Core contributor dump

## Detailed Description of the Pull Request / Additional comments

Some badly-behaved applications prefer to reconstitute a keyboard key out of a scancode and a modifier set.

## Validation Steps Performed
I tested `less` from the original bug!