### PR TITLE
correctly inform wpf pty connection of resize events

### DIFF
--- a/src/cascadia/WpfTerminalControl/TerminalContainer.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalContainer.cs
@@ -100,6 +100,13 @@ namespace Microsoft.Terminal.Wpf
         internal void SetTheme(TerminalTheme theme, string fontFamily, short fontSize, int newDpi)
         {
             NativeMethods.TerminalSetTheme(this.terminal, theme, fontFamily, fontSize, newDpi);
+
+            NativeMethods.TerminalTriggerResize(this.terminal, this.ActualWidth, this.ActualHeight, out var dimensions);
+
+            this.Rows = dimensions.Y;
+            this.Columns = dimensions.X;
+
+            this.connection?.Resize((uint)dimensions.Y, (uint)dimensions.X);
         }
 
         /// <summary>
@@ -115,6 +122,7 @@ namespace Microsoft.Terminal.Wpf
             this.Rows = dimensions.Y;
             this.Columns = dimensions.X;
 
+            this.connection?.Resize((uint)dimensions.Y, (uint)dimensions.X);
             return (dimensions.Y, dimensions.X);
         }
 
@@ -132,6 +140,11 @@ namespace Microsoft.Terminal.Wpf
             };
 
             NativeMethods.TerminalResize(this.terminal, dimensions);
+
+            this.Rows = dimensions.Y;
+            this.Columns = dimensions.X;
+
+            this.connection?.Resize((uint)dimensions.Y, (uint)dimensions.X);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #3227
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Visual studio terminal was patched to make sure connection messages got through