### PR TITLE
Defer text buffer line painting

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -346,6 +346,11 @@ OutputCellIterator TextBuffer::Write(const OutputCellIterator givenIt,
         ++lineTarget.Y;
     }
 
+    // Take the cell distance written and notify that it needs to be repainted.
+    const auto written = it.GetCellDistance(givenIt);
+    const Viewport paint = Viewport::FromDimensions(target, { gsl::narrow<SHORT>(written), 1 });
+    _NotifyPaint(paint);
+
     return it;
 }
 
@@ -372,11 +377,6 @@ OutputCellIterator TextBuffer::WriteLine(const OutputCellIterator givenIt,
     //  Get the row and write the cells
     ROW& row = GetRowByOffset(target.Y);
     const auto newIt = row.WriteCells(givenIt, target.X, wrap, limitRight);
-
-    // Take the cell distance written and notify that it needs to be repainted.
-    const auto written = newIt.GetCellDistance(givenIt);
-    const Viewport paint = Viewport::FromDimensions(target, { gsl::narrow<SHORT>(written), 1 });
-    _NotifyPaint(paint);
 
     return newIt;
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Defer painting when writing a lots of text.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

#2960 #3075 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Calling `NotifyPaint` for every line is expensive and not really necessary. For performance reason, painting should wait for as much buffer as possible.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
