### PR TITLE
Fix issue where text copied to clipboard doesn't have line endings

### DIFF
--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -276,7 +276,9 @@ bool Terminal::EraseInLine(const ::Microsoft::Console::VirtualTerminal::Dispatch
     }
 
     auto eraseIter = OutputCellIterator(UNICODE_SPACE, _buffer->GetCurrentAttributes(), nlength);
-    _buffer->Write(eraseIter, startPos);
+
+    // Explicitly turn off end-of-line wrap-flag-setting when erasing cells.
+    _buffer->Write(eraseIter, startPos, false);
     return true;
 }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1073 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Fixes issue with console text copied to the clipboard not having correct line endings.

It appears the primary cause of the problem was the text erase code was using the default setting of the wrapped-text flag -- that is, when it erased lines (or the whole screen), it cleared cells up until the end of the line, and without end-of-line wrapping explicitly disabled, the rows with erased text all thought there was a wrapped line because the last cell in each row was written to...

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

1) Open up a Terminal window (for this example, a WSL instance)
2) Hit enter a couple of times to generate some duplicates of the prompt to copy/paste
3) Select multiple lines, copy, paste to Notepad
4) Note that the lines include line breaks as expected
5) Clear the terminal by the clear command
6) Hit enter a couple of times to generate some prompts
7) Select multiple lines, copy, paste to Notepad
8a) Note that in the unmodified version of Terminal, these lines have no line breaks
8b) Note that in the patched version of Terminal, line breaks exist
