### PR TITLE
html copy: fix null character in font face name

### DIFF
--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1599,32 +1599,27 @@ float DxEngine::GetScaling() const noexcept
         // Get the locale name out so at least the caller knows what locale this name goes with.
         UINT32 length = 0;
         THROW_IF_FAILED(familyNames->GetLocaleNameLength(index, &length));
+        localeName.resize(length);
 
         // https://docs.microsoft.com/en-us/windows/win32/api/dwrite/nf-dwrite-idwritelocalizedstrings-getlocalenamelength
         // https://docs.microsoft.com/en-us/windows/win32/api/dwrite/nf-dwrite-idwritelocalizedstrings-getlocalename
         // GetLocaleNameLength does not include space for null terminator, but GetLocaleName needs it so add one.
-        length++;
-
-        localeName.resize(length);
-
-        THROW_IF_FAILED(familyNames->GetLocaleName(index, localeName.data(), length));
+        THROW_IF_FAILED(familyNames->GetLocaleName(index, localeName.data(), length + 1));
     }
 
     // OK, now that we've decided which family name and the locale that it's in... let's go get it.
     UINT32 length = 0;
     THROW_IF_FAILED(familyNames->GetStringLength(index, &length));
 
-    // https://docs.microsoft.com/en-us/windows/win32/api/dwrite/nf-dwrite-idwritelocalizedstrings-getstringlength
-    // https://docs.microsoft.com/en-us/windows/win32/api/dwrite/nf-dwrite-idwritelocalizedstrings-getstring
-    // Once again, GetStringLength is without the null, but GetString needs the null. So add one.
-    length++;
-
     // Make our output buffer and resize it so it is allocated.
     std::wstring retVal;
     retVal.resize(length);
 
     // FINALLY, go fetch the string name.
-    THROW_IF_FAILED(familyNames->GetString(index, retVal.data(), length));
+    // https://docs.microsoft.com/en-us/windows/win32/api/dwrite/nf-dwrite-idwritelocalizedstrings-getstringlength
+    // https://docs.microsoft.com/en-us/windows/win32/api/dwrite/nf-dwrite-idwritelocalizedstrings-getstring
+    // Once again, GetStringLength is without the null, but GetString needs the null. So add one.
+    THROW_IF_FAILED(familyNames->GetString(index, retVal.data(), length + 1));
 
     // and return it.
     return retVal;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fixes off-by-one bug when copying font name, which resulted in null character being inside the string. The code assumed that `std::string::resize()` includes null, but it does not.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

It resulted in HTML string including null character (from font name) which was no good (#3252).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #3252
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
