### PR TITLE
Fix scrollbar update after terminal close

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1375,8 +1375,22 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                                                      const int viewHeight,
                                                      const int bufferSize)
     {
+        // Since this callback fires from non-UI thread, we might be already
+        // closed/closing.
+        if (_closing.load())
+        {
+            return;
+        }
+
         // Update our scrollbar
         _scrollBar.Dispatcher().RunAsync(CoreDispatcherPriority::Low, [=]() {
+            // Even if we weren't closed/closing few lines above, we might be
+            // while waiting for this block of code to be dispatched.
+            if (_closing.load())
+            {
+                return;
+            }
+
             _ScrollbarUpdater(_scrollBar, viewTop, viewHeight, bufferSize);
         });
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This resolves (possibly not all) crashes when quickly opening and closing a tab that stem from accessing UI elements after control has closed. This looks strange to me that xaml sill runs dispatches after closing, but this seems to happen here (but it really shouldn't right?). If so, this might also explain some other crashes.

Other investigations:
- There is definitely some use after free going on, mostly at xaml level. It also looks like terminal is invalidated even before `TermControl::Close()` has a chance to run.

- The code seems to be not completely thread safe (e.g. removing `TerminalOutput` event handler on `ConhostConnection` is not synchronized). Although this could explain some occasional crashes like #2655, I rather doubt so; if these are only some single fields then x86, being strong architecture, should handle that. However I feel like it should be worthwhile to rewrite synchronization in the `Terminal`, `TermControl`, `TermConnection` circle.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

Partly solves #2248, but not #2947 (which got merged into #2248).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Open tab and instantly close it.
