### PR TITLE
Break if an early exit can not be found in InsertAttrRuns

### DIFF
--- a/src/buffer/out/AttrRow.cpp
+++ b/src/buffer/out/AttrRow.cpp
@@ -336,6 +336,13 @@ void ATTR_ROW::ReplaceAttrs(const TextAttribute& toBeReplacedAttr, const TextAtt
 
                 // Advance one run in the _list.
                 lowerBound = upperBound;
+
+                // The lowerBound is larger than iStart, which means we fail to find an early exit at the run
+                // where the insertion happens. We can just break out.
+                if (lowerBound > iStart)
+                {
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

A follow-up of #2937 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

#2937

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
