### PR TITLE
Add support for all the line feed control sequences

### DIFF
--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -74,6 +74,25 @@ try
 }
 CATCH_LOG_RETURN_FALSE()
 
+bool TerminalDispatch::LineFeed(const DispatchTypes::LineFeedType lineFeedType)
+{
+    switch (lineFeedType)
+    {
+    case DispatchTypes::LineFeedType::DependsOnMode:
+        // There is currently no need for mode-specific line feeds in the Terminal,
+        // so for now we just treat them as a line feed without carriage return.
+    case DispatchTypes::LineFeedType::WithoutReturn:
+        Execute(L'\n');
+        return true;
+    case DispatchTypes::LineFeedType::WithReturn:
+        Execute(L'\r');
+        Execute(L'\n');
+        return true;
+    default:
+        return false;
+    }
+}
+
 bool TerminalDispatch::EraseCharacters(const size_t numChars) noexcept
 try
 {

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -74,7 +74,8 @@ try
 }
 CATCH_LOG_RETURN_FALSE()
 
-bool TerminalDispatch::LineFeed(const DispatchTypes::LineFeedType lineFeedType)
+bool TerminalDispatch::LineFeed(const DispatchTypes::LineFeedType lineFeedType) noexcept
+try
 {
     switch (lineFeedType)
     {
@@ -92,6 +93,7 @@ bool TerminalDispatch::LineFeed(const DispatchTypes::LineFeedType lineFeedType)
         return false;
     }
 }
+CATCH_LOG_RETURN_FALSE()
 
 bool TerminalDispatch::EraseCharacters(const size_t numChars) noexcept
 try

--- a/src/cascadia/TerminalCore/TerminalDispatch.hpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.hpp
@@ -22,6 +22,8 @@ public:
     bool CursorBackward(const size_t distance) noexcept override;
     bool CursorUp(const size_t distance) noexcept override;
 
+    bool LineFeed(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::LineFeedType lineFeedType) override;
+
     bool EraseCharacters(const size_t numChars) noexcept override;
     bool SetWindowTitle(std::wstring_view title) noexcept override;
 

--- a/src/cascadia/TerminalCore/TerminalDispatch.hpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.hpp
@@ -22,7 +22,7 @@ public:
     bool CursorBackward(const size_t distance) noexcept override;
     bool CursorUp(const size_t distance) noexcept override;
 
-    bool LineFeed(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::LineFeedType lineFeedType) override;
+    bool LineFeed(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::LineFeedType lineFeedType) noexcept override;
 
     bool EraseCharacters(const size_t numChars) noexcept override;
     bool SetWindowTitle(std::wstring_view title) noexcept override;

--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -1360,6 +1360,8 @@ void DoSrvPrivateAllowCursorBlinking(SCREEN_INFORMATION& screenInfo, const bool 
     auto& textBuffer = screenInfo.GetTextBuffer();
     auto cursorPosition = textBuffer.GetCursor().GetPosition();
 
+    // We turn the cursor on before an operation that might scroll the viewport, otherwise
+    // that can result in an old copy of the cursor being left behind on the screen.
     textBuffer.GetCursor().SetIsOn(true);
 
     // Since we are explicitly moving down a row, clear the wrap status on the row we're leaving

--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -1348,6 +1348,33 @@ void DoSrvPrivateAllowCursorBlinking(SCREEN_INFORMATION& screenInfo, const bool 
 }
 
 // Routine Description:
+// - A private API call for performing a line feed, possibly preceded by carriage return.
+//    Moves the cursor down one line, and possibly also to the leftmost column.
+// Parameters:
+// - screenInfo - A pointer to the screen buffer that should perform the line feed.
+// - withReturn - Set to true if a carriage return should be performed as well.
+// Return value:
+// - STATUS_SUCCESS if handled successfully. Otherwise, an appropriate status code indicating the error.
+[[nodiscard]] NTSTATUS DoSrvPrivateLineFeed(SCREEN_INFORMATION& screenInfo, const bool withReturn)
+{
+    auto& textBuffer = screenInfo.GetTextBuffer();
+    auto cursorPosition = textBuffer.GetCursor().GetPosition();
+
+    textBuffer.GetCursor().SetIsOn(true);
+
+    // Since we are explicitly moving down a row, clear the wrap status on the row we're leaving
+    textBuffer.GetRowByOffset(cursorPosition.Y).GetCharRow().SetWrapForced(false);
+
+    cursorPosition.Y += 1;
+    if (withReturn)
+    {
+        cursorPosition.X = 0;
+    }
+
+    return AdjustCursorPosition(screenInfo, cursorPosition, FALSE, nullptr);
+}
+
+// Routine Description:
 // - A private API call for performing a "Reverse line feed", essentially, the opposite of '\n'.
 //    Moves the cursor up one line, and tries to keep its position in the line
 // Parameters:

--- a/src/host/getset.h
+++ b/src/host/getset.h
@@ -33,6 +33,7 @@ void DoSrvPrivateShowCursor(SCREEN_INFORMATION& screenInfo, const bool show) noe
 void DoSrvPrivateAllowCursorBlinking(SCREEN_INFORMATION& screenInfo, const bool fEnable);
 
 [[nodiscard]] NTSTATUS DoSrvPrivateSetScrollingRegion(SCREEN_INFORMATION& screenInfo, const SMALL_RECT& scrollMargins);
+[[nodiscard]] NTSTATUS DoSrvPrivateLineFeed(SCREEN_INFORMATION& screenInfo, const bool withReturn);
 [[nodiscard]] NTSTATUS DoSrvPrivateReverseLineFeed(SCREEN_INFORMATION& screenInfo);
 [[nodiscard]] HRESULT DoSrvMoveCursorVertically(SCREEN_INFORMATION& screenInfo, const short lines);
 

--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -387,6 +387,19 @@ bool ConhostInternalGetSet::PrivateSetScrollingRegion(const SMALL_RECT& scrollMa
 }
 
 // Routine Description:
+// - Connects the PrivateLineFeed call directly into our Driver Message servicing call inside Conhost.exe
+//   PrivateLineFeed is an internal-only "API" call that the vt commands can execute,
+//     but it is not represented as a function call on our public API surface.
+// Arguments:
+// - withReturn - Set to true if a carriage return should be performed as well.
+// Return Value:
+// - true if successful (see DoSrvPrivateLineFeed). false otherwise.
+bool ConhostInternalGetSet::PrivateLineFeed(const bool withReturn)
+{
+    return NT_SUCCESS(DoSrvPrivateLineFeed(_io.GetActiveOutputBuffer(), withReturn));
+}
+
+// Routine Description:
 // - Connects the PrivateReverseLineFeed call directly into our Driver Message servicing call inside Conhost.exe
 //   PrivateReverseLineFeed is an internal-only "API" call that the vt commands can execute,
 //     but it is not represented as a function call on out public API surface.

--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -386,6 +386,18 @@ bool ConhostInternalGetSet::PrivateSetScrollingRegion(const SMALL_RECT& scrollMa
     return NT_SUCCESS(DoSrvPrivateSetScrollingRegion(_io.GetActiveOutputBuffer(), scrollMargins));
 }
 
+// Method Description:
+// - Retrieves the current Line Feed/New Line (LNM) mode.
+// Arguments:
+// - None
+// Return Value:
+// - true if a line feed also produces a carriage return. false otherwise.
+bool ConhostInternalGetSet::PrivateGetLineFeedMode() const
+{
+    const auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
+    return gci.IsReturnOnNewlineAutomatic();
+}
+
 // Routine Description:
 // - Connects the PrivateLineFeed call directly into our Driver Message servicing call inside Conhost.exe
 //   PrivateLineFeed is an internal-only "API" call that the vt commands can execute,

--- a/src/host/outputStream.hpp
+++ b/src/host/outputStream.hpp
@@ -98,6 +98,7 @@ public:
 
     bool PrivateSetScrollingRegion(const SMALL_RECT& scrollMargins) override;
 
+    bool PrivateLineFeed(const bool withReturn) override;
     bool PrivateReverseLineFeed() override;
 
     bool MoveCursorVertically(const ptrdiff_t lines) override;

--- a/src/host/outputStream.hpp
+++ b/src/host/outputStream.hpp
@@ -98,6 +98,7 @@ public:
 
     bool PrivateSetScrollingRegion(const SMALL_RECT& scrollMargins) override;
 
+    bool PrivateGetLineFeedMode() const override;
     bool PrivateLineFeed(const bool withReturn) override;
     bool PrivateReverseLineFeed() override;
 

--- a/src/terminal/adapter/DispatchTypes.hpp
+++ b/src/terminal/adapter/DispatchTypes.hpp
@@ -125,6 +125,13 @@ namespace Microsoft::Console::VirtualTerminal::DispatchTypes
         SteadyBar = 6
     };
 
+    enum class LineFeedType : unsigned int
+    {
+        WithReturn,
+        WithoutReturn,
+        DependsOnMode
+    };
+
     constexpr short s_sDECCOLMSetColumns = 132;
     constexpr short s_sDECCOLMResetColumns = 80;
 

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -54,6 +54,7 @@ public:
     virtual bool EnableCursorBlinking(const bool enable) = 0; // ATT610
     virtual bool SetOriginMode(const bool relativeMode) = 0; // DECOM
     virtual bool SetTopBottomScrollingMargins(const size_t topMargin, const size_t bottomMargin) = 0; // DECSTBM
+    virtual bool LineFeed(const DispatchTypes::LineFeedType lineFeedType) = 0; // IND, NEL
     virtual bool ReverseLineFeed() = 0; // RI
     virtual bool SetWindowTitle(std::wstring_view title) = 0; // OscWindowTitle
     virtual bool UseAlternateScreenBuffer() = 0; // ASBSET

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1329,14 +1329,12 @@ bool AdaptDispatch::LineFeed(const DispatchTypes::LineFeedType lineFeedType)
     case DispatchTypes::LineFeedType::DependsOnMode:
         // Until we support the LNM mode, default to no carriage return.
     case DispatchTypes::LineFeedType::WithoutReturn:
-        Execute(L'\n');
-        break;
+        return _pConApi->PrivateLineFeed(false);
     case DispatchTypes::LineFeedType::WithReturn:
-        Execute(L'\r');
-        Execute(L'\n');
-        break;
+        return _pConApi->PrivateLineFeed(true);
+    default:
+        return false;
     }
-    return true;
 }
 
 // Routine Description:

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1316,6 +1316,30 @@ bool AdaptDispatch::SetTopBottomScrollingMargins(const size_t topMargin,
 }
 
 // Routine Description:
+// - IND/NEL - Performs a line feed, possibly preceded by carriage return.
+//    Moves the cursor down one line, and possibly also to the leftmost column.
+// Arguments:
+// - lineFeedType - Specify whether a carriage return should be performed as well.
+// Return Value:
+// - True if handled successfully. False otherwise.
+bool AdaptDispatch::LineFeed(const DispatchTypes::LineFeedType lineFeedType)
+{
+    switch (lineFeedType)
+    {
+    case DispatchTypes::LineFeedType::DependsOnMode:
+        // Until we support the LNM mode, default to no carriage return.
+    case DispatchTypes::LineFeedType::WithoutReturn:
+        Execute(L'\n');
+        break;
+    case DispatchTypes::LineFeedType::WithReturn:
+        Execute(L'\r');
+        Execute(L'\n');
+        break;
+    }
+    return true;
+}
+
+// Routine Description:
 // - RI - Performs a "Reverse line feed", essentially, the opposite of '\n'.
 //    Moves the cursor up one line, and tries to keep its position in the line
 // Arguments:

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1327,7 +1327,7 @@ bool AdaptDispatch::LineFeed(const DispatchTypes::LineFeedType lineFeedType)
     switch (lineFeedType)
     {
     case DispatchTypes::LineFeedType::DependsOnMode:
-        // Until we support the LNM mode, default to no carriage return.
+        return _pConApi->PrivateLineFeed(_pConApi->PrivateGetLineFeedMode());
     case DispatchTypes::LineFeedType::WithoutReturn:
         return _pConApi->PrivateLineFeed(false);
     case DispatchTypes::LineFeedType::WithReturn:

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -69,6 +69,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool SetOriginMode(const bool relativeMode) noexcept override; // DECOM
         bool SetTopBottomScrollingMargins(const size_t topMargin,
                                           const size_t bottomMargin) override; // DECSTBM
+        bool LineFeed(const DispatchTypes::LineFeedType lineFeedType) override; // IND, NEL
         bool ReverseLineFeed() override; // RI
         bool SetWindowTitle(const std::wstring_view title) override; // OscWindowTitle
         bool UseAlternateScreenBuffer() override; // ASBSET

--- a/src/terminal/adapter/conGetSet.hpp
+++ b/src/terminal/adapter/conGetSet.hpp
@@ -61,6 +61,7 @@ namespace Microsoft::Console::VirtualTerminal
         virtual bool PrivateAllowCursorBlinking(const bool enable) = 0;
 
         virtual bool PrivateSetScrollingRegion(const SMALL_RECT& scrollMargins) = 0;
+        virtual bool PrivateGetLineFeedMode() const = 0;
         virtual bool PrivateLineFeed(const bool withReturn) = 0;
         virtual bool PrivateReverseLineFeed() = 0;
         virtual bool SetConsoleTitleW(const std::wstring_view title) = 0;

--- a/src/terminal/adapter/conGetSet.hpp
+++ b/src/terminal/adapter/conGetSet.hpp
@@ -61,6 +61,7 @@ namespace Microsoft::Console::VirtualTerminal
         virtual bool PrivateAllowCursorBlinking(const bool enable) = 0;
 
         virtual bool PrivateSetScrollingRegion(const SMALL_RECT& scrollMargins) = 0;
+        virtual bool PrivateLineFeed(const bool withReturn) = 0;
         virtual bool PrivateReverseLineFeed() = 0;
         virtual bool SetConsoleTitleW(const std::wstring_view title) = 0;
         virtual bool PrivateUseAlternateScreenBuffer() = 0;

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -48,7 +48,7 @@ public:
     bool EnableCursorBlinking(const bool /*enable*/) noexcept override { return false; } // ATT610
     bool SetOriginMode(const bool /*relativeMode*/) noexcept override { return false; }; // DECOM
     bool SetTopBottomScrollingMargins(const size_t /*topMargin*/, const size_t /*bottomMargin*/) noexcept override { return false; } // DECSTBM
-    bool LineFeed(const DispatchTypes::LineFeedType /*lineFeedType*/) override { return false; } // IND, NEL
+    bool LineFeed(const DispatchTypes::LineFeedType /*lineFeedType*/) noexcept override { return false; } // IND, NEL
     bool ReverseLineFeed() noexcept override { return false; } // RI
     bool SetWindowTitle(std::wstring_view /*title*/) noexcept override { return false; } // OscWindowTitle
     bool UseAlternateScreenBuffer() noexcept override { return false; } // ASBSET

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -48,6 +48,7 @@ public:
     bool EnableCursorBlinking(const bool /*enable*/) noexcept override { return false; } // ATT610
     bool SetOriginMode(const bool /*relativeMode*/) noexcept override { return false; }; // DECOM
     bool SetTopBottomScrollingMargins(const size_t /*topMargin*/, const size_t /*bottomMargin*/) noexcept override { return false; } // DECSTBM
+    bool LineFeed(const DispatchTypes::LineFeedType /*lineFeedType*/) override { return false; } // IND, NEL
     bool ReverseLineFeed() noexcept override { return false; } // RI
     bool SetWindowTitle(std::wstring_view /*title*/) noexcept override { return false; } // OscWindowTitle
     bool UseAlternateScreenBuffer() noexcept override { return false; } // ASBSET

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -369,6 +369,13 @@ public:
         return _privateSetScrollingRegionResult;
     }
 
+    bool PrivateGetLineFeedMode() const override
+    {
+        Log::Comment(L"PrivateGetLineFeedMode MOCK called...");
+        // Not currently used. Return true for now.
+        return true;
+    }
+
     bool PrivateLineFeed(const bool /*withReturn*/) override
     {
         Log::Comment(L"PrivateLineFeed MOCK called...");

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -369,6 +369,13 @@ public:
         return _privateSetScrollingRegionResult;
     }
 
+    bool PrivateLineFeed(const bool /*withReturn*/) override
+    {
+        Log::Comment(L"PrivateLineFeed MOCK called...");
+        // We made it through the adapter, woo! Return true.
+        return true;
+    }
+
     bool PrivateReverseLineFeed() override
     {
         Log::Comment(L"PrivateReverseLineFeed MOCK called...");

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -372,15 +372,19 @@ public:
     bool PrivateGetLineFeedMode() const override
     {
         Log::Comment(L"PrivateGetLineFeedMode MOCK called...");
-        // Not currently used. Return true for now.
-        return true;
+        return _privateGetLineFeedModeResult;
     }
 
-    bool PrivateLineFeed(const bool /*withReturn*/) override
+    bool PrivateLineFeed(const bool withReturn) override
     {
         Log::Comment(L"PrivateLineFeed MOCK called...");
-        // We made it through the adapter, woo! Return true.
-        return true;
+
+        if (_privateLineFeedResult)
+        {
+            VERIFY_ARE_EQUAL(_expectedLineFeedWithReturn, withReturn);
+        }
+
+        return _privateLineFeedResult;
     }
 
     bool PrivateReverseLineFeed() override
@@ -907,6 +911,9 @@ public:
     bool _privateAllowCursorBlinkingResult = false;
     bool _enable = false; // for cursor blinking
     bool _privateSetScrollingRegionResult = false;
+    bool _privateGetLineFeedModeResult = false;
+    bool _privateLineFeedResult = false;
+    bool _expectedLineFeedWithReturn = false;
     bool _privateReverseLineFeedResult = false;
 
     bool _setConsoleTitleWResult = false;
@@ -2121,6 +2128,32 @@ public:
         _testGetSet->_SetMarginsHelper(&srTestMargins, 1, sScreenHeight + 1);
         _testGetSet->_privateSetScrollingRegionResult = TRUE;
         VERIFY_IS_FALSE(_pDispatch.get()->SetTopBottomScrollingMargins(srTestMargins.Top, srTestMargins.Bottom));
+    }
+
+    TEST_METHOD(LineFeedTest)
+    {
+        Log::Comment(L"Starting test...");
+
+        // All test cases need the LineFeed call to succeed.
+        _testGetSet->_privateLineFeedResult = TRUE;
+
+        Log::Comment(L"Test 1: Line feed without carriage return.");
+        _testGetSet->_expectedLineFeedWithReturn = false;
+        VERIFY_IS_TRUE(_pDispatch.get()->LineFeed(DispatchTypes::LineFeedType::WithoutReturn));
+
+        Log::Comment(L"Test 2: Line feed with carriage return.");
+        _testGetSet->_expectedLineFeedWithReturn = true;
+        VERIFY_IS_TRUE(_pDispatch.get()->LineFeed(DispatchTypes::LineFeedType::WithReturn));
+
+        Log::Comment(L"Test 3: Line feed depends on mode, and mode reset.");
+        _testGetSet->_privateGetLineFeedModeResult = false;
+        _testGetSet->_expectedLineFeedWithReturn = false;
+        VERIFY_IS_TRUE(_pDispatch.get()->LineFeed(DispatchTypes::LineFeedType::DependsOnMode));
+
+        Log::Comment(L"Test 4: Line feed depends on mode, and mode set.");
+        _testGetSet->_privateGetLineFeedModeResult = true;
+        _testGetSet->_expectedLineFeedWithReturn = true;
+        VERIFY_IS_TRUE(_pDispatch.get()->LineFeed(DispatchTypes::LineFeedType::DependsOnMode));
     }
 
     TEST_METHOD(TabSetClearTests)

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -39,15 +39,24 @@ ITermDispatch& OutputStateMachineEngine::Dispatch() noexcept
 // - true iff we successfully dispatched the sequence.
 bool OutputStateMachineEngine::ActionExecute(const wchar_t wch)
 {
-    // microsoft/terminal#1825 - VT applications expect to be able to write NUL
-    // and have _nothing_ happen. Filter the NULs here, so they don't fill the
-    // buffer with empty spaces.
-    if (wch == AsciiChars::NUL)
+    switch (wch)
     {
-        return true;
+    case AsciiChars::NUL:
+        // microsoft/terminal#1825 - VT applications expect to be able to write NUL
+        // and have _nothing_ happen. Filter the NULs here, so they don't fill the
+        // buffer with empty spaces.
+        break;
+    case AsciiChars::LF:
+    case AsciiChars::FF:
+    case AsciiChars::VT:
+        // LF, FF, and VT are identical in function.
+        _dispatch->LineFeed(DispatchTypes::LineFeedType::DependsOnMode);
+        break;
+    default:
+        _dispatch->Execute(wch);
+        break;
     }
 
-    _dispatch->Execute(wch);
     _ClearLastChar();
 
     if (wch == AsciiChars::BEL)

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -184,6 +184,10 @@ bool OutputStateMachineEngine::ActionEscDispatch(const wchar_t wch,
             success = _dispatch->SetKeypadMode(false);
             TermTelemetry::Instance().Log(TermTelemetry::Codes::DECKPNM);
             break;
+        case VTActionCodes::NEL_NextLine:
+            success = _dispatch->LineFeed(DispatchTypes::LineFeedType::WithReturn);
+            TermTelemetry::Instance().Log(TermTelemetry::Codes::NEL);
+            break;
         case VTActionCodes::RI_ReverseLineFeed:
             success = _dispatch->ReverseLineFeed();
             TermTelemetry::Instance().Log(TermTelemetry::Codes::RI);

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -197,6 +197,10 @@ bool OutputStateMachineEngine::ActionEscDispatch(const wchar_t wch,
             success = _dispatch->LineFeed(DispatchTypes::LineFeedType::WithReturn);
             TermTelemetry::Instance().Log(TermTelemetry::Codes::NEL);
             break;
+        case VTActionCodes::IND_Index:
+            success = _dispatch->LineFeed(DispatchTypes::LineFeedType::WithoutReturn);
+            TermTelemetry::Instance().Log(TermTelemetry::Codes::IND);
+            break;
         case VTActionCodes::RI_ReverseLineFeed:
             success = _dispatch->ReverseLineFeed();
             TermTelemetry::Instance().Log(TermTelemetry::Codes::RI);

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -106,6 +106,7 @@ namespace Microsoft::Console::VirtualTerminal
             HPA_HorizontalPositionAbsolute = L'`',
             VPA_VerticalLinePositionAbsolute = L'd',
             DECSTBM_SetScrollingRegion = L'r',
+            NEL_NextLine = L'E', // Not a CSI, so doesn't overlap with CNL
             RI_ReverseLineFeed = L'M',
             HTS_HorizontalTabSet = L'H', // Not a CSI, so doesn't overlap with CUP
             CHT_CursorForwardTab = L'I',

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -107,6 +107,7 @@ namespace Microsoft::Console::VirtualTerminal
             VPA_VerticalLinePositionAbsolute = L'd',
             DECSTBM_SetScrollingRegion = L'r',
             NEL_NextLine = L'E', // Not a CSI, so doesn't overlap with CNL
+            IND_Index = L'D', // Not a CSI, so doesn't overlap with CUB
             RI_ReverseLineFeed = L'M',
             HTS_HorizontalTabSet = L'H', // Not a CSI, so doesn't overlap with CUP
             CHT_CursorForwardTab = L'I',

--- a/src/terminal/parser/telemetry.cpp
+++ b/src/terminal/parser/telemetry.cpp
@@ -236,6 +236,7 @@ void TermTelemetry::WriteFinalTraceLog() const
                                       TraceLoggingUInt32(_uiTimesUsed[ANSISYSRC], "ANSISYSRC"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECSTBM], "DECSTBM"),
                                       TraceLoggingUInt32(_uiTimesUsed[NEL], "NEL"),
+                                      TraceLoggingUInt32(_uiTimesUsed[IND], "IND"),
                                       TraceLoggingUInt32(_uiTimesUsed[RI], "RI"),
                                       TraceLoggingUInt32(_uiTimesUsed[OSCWT], "OscWindowTitle"),
                                       TraceLoggingUInt32(_uiTimesUsed[HTS], "HTS"),

--- a/src/terminal/parser/telemetry.cpp
+++ b/src/terminal/parser/telemetry.cpp
@@ -235,6 +235,7 @@ void TermTelemetry::WriteFinalTraceLog() const
                                       TraceLoggingUInt32(_uiTimesUsed[ANSISYSSC], "ANSISYSSC"),
                                       TraceLoggingUInt32(_uiTimesUsed[ANSISYSRC], "ANSISYSRC"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECSTBM], "DECSTBM"),
+                                      TraceLoggingUInt32(_uiTimesUsed[NEL], "NEL"),
                                       TraceLoggingUInt32(_uiTimesUsed[RI], "RI"),
                                       TraceLoggingUInt32(_uiTimesUsed[OSCWT], "OscWindowTitle"),
                                       TraceLoggingUInt32(_uiTimesUsed[HTS], "HTS"),

--- a/src/terminal/parser/telemetry.hpp
+++ b/src/terminal/parser/telemetry.hpp
@@ -63,6 +63,7 @@ namespace Microsoft::Console::VirtualTerminal
             DL,
             DECSTBM,
             NEL,
+            IND,
             RI,
             OSCWT,
             HTS,

--- a/src/terminal/parser/telemetry.hpp
+++ b/src/terminal/parser/telemetry.hpp
@@ -62,6 +62,7 @@ namespace Microsoft::Console::VirtualTerminal
             IL,
             DL,
             DECSTBM,
+            NEL,
             RI,
             OSCWT,
             HTS,

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -677,6 +677,8 @@ public:
         _cursorKeysMode{ false },
         _cursorBlinking{ true },
         _isOriginModeRelative{ false },
+        _lineFeed{ false },
+        _lineFeedType{ (DispatchTypes::LineFeedType)-1 },
         _isDECCOLMAllowed{ false },
         _windowWidth{ 80 },
         _options{ s_cMaxOptions, static_cast<DispatchTypes::GraphicsOptions>(s_uiGraphicsCleared) } // fill with cleared option
@@ -904,6 +906,13 @@ public:
         return true;
     }
 
+    bool LineFeed(const DispatchTypes::LineFeedType lineFeedType) override
+    {
+        _lineFeed = true;
+        _lineFeedType = lineFeedType;
+        return true;
+    }
+
     bool EnableDECCOLMSupport(const bool fEnabled) noexcept override
     {
         _isDECCOLMAllowed = fEnabled;
@@ -950,6 +959,8 @@ public:
     bool _cursorKeysMode;
     bool _cursorBlinking;
     bool _isOriginModeRelative;
+    bool _lineFeed;
+    DispatchTypes::LineFeedType _lineFeedType;
     bool _isDECCOLMAllowed;
     size_t _windowWidth;
 
@@ -1780,6 +1791,56 @@ class StateMachineExternalTest final
         VERIFY_IS_TRUE(pDispatch->_eraseDisplay);
 
         VERIFY_ARE_EQUAL(expectedDispatchTypes, pDispatch->_eraseType);
+
+        pDispatch->ClearState();
+    }
+
+    TEST_METHOD(TestLineFeed)
+    {
+        auto dispatch = std::make_unique<StatefulDispatch>();
+        auto pDispatch = dispatch.get();
+        auto engine = std::make_unique<OutputStateMachineEngine>(std::move(dispatch));
+        StateMachine mach(std::move(engine));
+
+        Log::Comment(L"IND (Index) escape sequence");
+        mach.ProcessCharacter(AsciiChars::ESC);
+        mach.ProcessCharacter(L'D');
+
+        VERIFY_IS_TRUE(pDispatch->_lineFeed);
+        VERIFY_ARE_EQUAL(DispatchTypes::LineFeedType::WithoutReturn, pDispatch->_lineFeedType);
+
+        pDispatch->ClearState();
+
+        Log::Comment(L"NEL (Next Line) escape sequence");
+        mach.ProcessCharacter(AsciiChars::ESC);
+        mach.ProcessCharacter(L'E');
+
+        VERIFY_IS_TRUE(pDispatch->_lineFeed);
+        VERIFY_ARE_EQUAL(DispatchTypes::LineFeedType::WithReturn, pDispatch->_lineFeedType);
+
+        pDispatch->ClearState();
+
+        Log::Comment(L"LF (Line Feed) control code");
+        mach.ProcessCharacter(AsciiChars::LF);
+
+        VERIFY_IS_TRUE(pDispatch->_lineFeed);
+        VERIFY_ARE_EQUAL(DispatchTypes::LineFeedType::DependsOnMode, pDispatch->_lineFeedType);
+
+        pDispatch->ClearState();
+
+        Log::Comment(L"FF (Form Feed) control code");
+        mach.ProcessCharacter(AsciiChars::FF);
+
+        VERIFY_IS_TRUE(pDispatch->_lineFeed);
+        VERIFY_ARE_EQUAL(DispatchTypes::LineFeedType::DependsOnMode, pDispatch->_lineFeedType);
+
+        pDispatch->ClearState();
+
+        Log::Comment(L"VT (Vertical Tab) control code");
+        mach.ProcessCharacter(AsciiChars::VT);
+
+        VERIFY_IS_TRUE(pDispatch->_lineFeed);
+        VERIFY_ARE_EQUAL(DispatchTypes::LineFeedType::DependsOnMode, pDispatch->_lineFeedType);
 
         pDispatch->ClearState();
     }

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -906,7 +906,7 @@ public:
         return true;
     }
 
-    bool LineFeed(const DispatchTypes::LineFeedType lineFeedType) override
+    bool LineFeed(const DispatchTypes::LineFeedType lineFeedType) noexcept override
     {
         _lineFeed = true;
         _lineFeedType = lineFeedType;


### PR DESCRIPTION
## Summary of the Pull Request

This adds support for the `FF` (form feed) and `VT` (vertical tab) [control characters](https://vt100.net/docs/vt510-rm/chapter4.html#T4-1), as well as the [`NEL` (Next Line)](https://vt100.net/docs/vt510-rm/NEL.html) and [`IND` (Index)](https://vt100.net/docs/vt510-rm/IND.html) escape sequences.

## References

#976 discusses the conflict between VT100 Index sequence and the VT52 cursor back sequence.

## PR Checklist
* [x] Closes #3189
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #3189

## Detailed Description of the Pull Request / Additional comments

I've added a `LineFeed` method to the `ITermDispatch` interface, with an enum parameter specifying the required line feed type (i.e. with carriage return, without carriage return, or dependent on the [`LNM` mode](https://vt100.net/docs/vt510-rm/LNM.html)). The output state machine can then call that method to handle the various line feed control characters (parsed in the `ActionExecute` method), as well the `NEL` and `IND` escape sequences (parsed in the `ActionEscDispatch` method).

The `AdaptDispatch` implementation of `LineFeed` then forwards the call to a new `PrivateLineFeed` method in the `ConGetSet` interface, which simply takes a bool parameter specifying whether a carriage return is required or not. In the case of mode-dependent line feeds, the `AdaptDispatch` implementation determines whether the return is necessary or not, based on the existing _AutoReturnOnNewLine_ setting (which I'm obtaining via another new `PrivateGetLineFeedMode` method).

Ultimately we'll want to support changing the mode via the [`LNM` escape sequence](https://vt100.net/docs/vt510-rm/LNM.html), but there's no urgent need for that now. And using the existing _AutoReturnOnNewLine_ setting as a substitute for the mode gives us backwards compatible behaviour, since that will be true for the Windows shells (which expect a linefeed to also generate a carriage return), and false in a WSL bash shell (which won't want the carriage return by default).

As for the actual `PrivateLineFeed` implementation, that is just a simplified version of how the line feed would previously have been executed in the `WriteCharsLegacy` function. This includes setting the cursor to "On" (with `Cursor::SetIsOn`), potentially clearing the wrap property of the line being left (with `CharRow::SetWrapForced` false), and then setting the new position using `AdjustCursorPosition` with the _fKeepCursorVisible_ parameter set to false.

I'm unsure whether the `SetIsOn` call is really necessary, and I think the way the forced wrap is handled needs a rethink in general, but for now this should at least be compatible with the existing behaviour.

Finally, in order to make this all work in the _Windows Terminal_ app, I also had to add a basic implementation of the `ITermDispatch::LineFeed` method in the `TerminalDispatch` class. There is currently no need to support mode-specific line feeds here, so this simply forwards a `\n` or `\r\n` to the `Execute` method, which is ultimately handled by the `Terminal::_WriteBuffer` implementation.

## Validation Steps Performed

I've added output engine tests which confirm that the various control characters and escape sequences trigger the dispatch method correctly. Then I've added adapter tests which confirm the various dispatch options trigger the `PrivateLineFeed` API correctly. And finally I added some screen buffer tests that check the actual results of the `NEL` and `IND` sequences, which covers both forms of the `PrivateLineFeed` API (i.e. with and without a carriage return).

I've also run the _Test of cursor movements_ in the [Vttest](https://invisible-island.net/vttest/) utility, and confirmed that screens 1, 2, and 5 are now working correctly. The first two depend on `NEL` and `IND` being supported, and screen 5 requires the `VT` control character.