### PR TITLE
Don't reset the cursor X to 0 when we would otherwise wrap

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -437,11 +437,6 @@ void Terminal::_WriteBuffer(const std::wstring_view& stringView)
             }
         }
 
-        if (proposedCursorPosition.X > bufferSize.RightInclusive())
-        {
-            proposedCursorPosition.X = 0;
-        }
-
         // If we're about to scroll past the bottom of the buffer, instead cycle the buffer.
         const auto newRows = proposedCursorPosition.Y - bufferSize.Height() + 1;
         if (newRows > 0)


### PR DESCRIPTION
Fixes #3277.
Partially reverts #2965.

## Summary of the Pull Request

Resetting the cursor position to X=0 made it act pretty strange when some applications wanted to do a full screen repaint.

## PR Checklist
* [x] Closes #3277
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [x] Requires documentation to be updated
* [x] I've discussed this with core contributors already.

## Validation Steps Performed
I spent two hours bisecting this, so I've hit <kbd>Ctrl+B</kbd> quite a lot in vim.
