### PR TITLE
CascadiaSettings: Use map to find matching color scheme

### DIFF
--- a/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
@@ -524,9 +524,9 @@ void CascadiaSettings::_LayerOrCreateColorScheme(const Json::Value& schemeJson)
 
 // Method Description:
 // - Finds a color scheme from our list of color schemes that matches the given
-//   json object. Uses ColorScheme::ShouldBeLayered to determine if the
-//   Json::Value is a match or not. This method should be used to find a color
-//   scheme to layer the given settings upon.
+//   json object. Uses ColorScheme::GetNameFromJson to find the name and then
+//   performs a lookup in the global map. This method should be used to find a
+//   color scheme to layer the given settings upon.
 // - Returns nullptr if no such match exists.
 // Arguments:
 // - json: an object which should be a partial serialization of a ColorScheme object.
@@ -535,15 +535,17 @@ void CascadiaSettings::_LayerOrCreateColorScheme(const Json::Value& schemeJson)
 //   color scheme exists.
 ColorScheme* CascadiaSettings::_FindMatchingColorScheme(const Json::Value& schemeJson)
 {
-    for (auto& scheme : _globals.GetColorSchemes())
+    if (auto schemeName = ColorScheme::GetNameFromJson(schemeJson))
     {
-        if (scheme.second.ShouldBeLayered(schemeJson))
+        auto& schemes = _globals.GetColorSchemes();
+        auto iterator = schemes.find(*schemeName);
+        if (iterator != schemes.end())
         {
             // HERE BE DRAGONS: Returning a pointer to a type in the vector is
             // maybe not the _safest_ thing, but we have a mind to make Profile
             // and ColorScheme winrt types in the future, so this will be safer
             // then.
-            return &scheme.second;
+            return &iterator->second;
         }
     }
     return nullptr;

--- a/src/cascadia/TerminalApp/ColorScheme.cpp
+++ b/src/cascadia/TerminalApp/ColorScheme.cpp
@@ -203,3 +203,20 @@ COLORREF ColorScheme::GetBackground() const noexcept
 {
     return _defaultBackground;
 }
+
+// Method Description:
+// - Parse the name from the JSON representation of a ColorScheme.
+// Arguments:
+// - json: an object which should be a serialization of a ColorScheme object.
+// Return Value:
+// - the name of the color scheme represented by `json` as a std::wstring optional
+//   i.e. the value of the `name` property.
+// - returns std::nullopt if `json` doesn't have the `name` property
+std::optional<std::wstring> TerminalApp::ColorScheme::GetNameFromJson(const Json::Value& json)
+{
+    if (const auto name{ json[JsonKey(NameKey)] })
+    {
+        return GetWstringFromJson(name);
+    }
+    return std::nullopt;
+}

--- a/src/cascadia/TerminalApp/ColorScheme.h
+++ b/src/cascadia/TerminalApp/ColorScheme.h
@@ -50,6 +50,8 @@ public:
     COLORREF GetForeground() const noexcept;
     COLORREF GetBackground() const noexcept;
 
+    static std::optional<std::wstring> GetNameFromJson(const Json::Value& json);
+
 private:
     std::wstring _schemeName;
     std::array<COLORREF, COLOR_TABLE_SIZE> _table;


### PR DESCRIPTION
## Summary of the Pull Request
The `_FindMatchingColorScheme` function currently iterates through all pairs in
the map to find the matching color scheme for a given JSON.

Improved this by using the name from the JSON to lookup the color scheme
in the map.

Closes #3200 

### Testing
Verified that UTs are passing (especially `ColorSchemeTests`)
