### PR TITLE
Revert two cursor changes that cause crashing and rendering artifacts

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -178,18 +178,6 @@ void Terminal::UpdateSettings(winrt::Microsoft::Terminal::Settings::ICoreSetting
         proposedTop -= (proposedBottom - bufferSize.Y);
     }
 
-    Cursor& cursor = _buffer->GetCursor();
-    auto cursorPosition = cursor.GetPosition();
-
-    // If the cursor is positioned beyond the range of the viewport, then
-    // set the cursor position to a legal value.
-    cursorPosition.X = std::min(cursorPosition.X, static_cast<SHORT>(viewportSize.X - 1));
-    cursorPosition.Y = std::min(cursorPosition.Y, static_cast<SHORT>(viewportSize.Y - 1));
-
-    cursor.StartDeferDrawing();
-    cursor.SetPosition(cursorPosition);
-    cursor.EndDeferDrawing();
-
     _mutableViewport = Viewport::FromDimensions({ 0, proposedTop }, viewportSize);
     _scrollOffset = 0;
     _NotifyScrollEvent();
@@ -437,11 +425,6 @@ void Terminal::_WriteBuffer(const std::wstring_view& stringView)
             }
         }
 
-        if (proposedCursorPosition.X > bufferSize.RightInclusive())
-        {
-            proposedCursorPosition.X = 0;
-        }
-
         // If we're about to scroll past the bottom of the buffer, instead cycle the buffer.
         const auto newRows = proposedCursorPosition.Y - bufferSize.Height() + 1;
         if (newRows > 0)
@@ -550,8 +533,6 @@ void Terminal::_InitializeColorTable()
 // - isVisible: whether the cursor should be visible
 void Terminal::SetCursorVisible(const bool isVisible) noexcept
 {
-    auto lock = LockForWriting();
-
     auto& cursor = _buffer->GetCursor();
     cursor.SetIsVisible(isVisible);
 }

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -11,7 +11,6 @@
 #include "../../terminal/input/terminalInput.hpp"
 
 #include "../../types/inc/Viewport.hpp"
-#include "../../types/inc/GlyphWidth.hpp"
 #include "../../types/IUiaData.h"
 #include "../../cascadia/terminalcore/ITerminalApi.hpp"
 #include "../../cascadia/terminalcore/ITerminalInput.hpp"

--- a/src/cascadia/TerminalCore/terminalrenderdata.cpp
+++ b/src/cascadia/TerminalCore/terminalrenderdata.cpp
@@ -92,9 +92,7 @@ COLORREF Terminal::GetCursorColor() const noexcept
 
 bool Terminal::IsCursorDoubleWidth() const noexcept
 {
-    const auto position = _buffer->GetCursor().GetPosition();
-    TextBufferTextIterator it(TextBufferCellIterator(*_buffer, position));
-    return IsGlyphFullWidth(*it);
+    return false;
 }
 
 const std::vector<RenderOverlay> Terminal::GetOverlays() const noexcept


### PR DESCRIPTION
Revert "Fix cursor redrawing crash (#2965)"
This reverts commit 926a2e3d800a18a23139f8c6e9f97f3ccf63650c.

Revert "Fix double width cursor for CJK characters (#2932)"
This reverts commit eafa884fc40e566c4df4a4521850b14130a7ff24.

Fixes #3277.
Fully reverts #2965, #2932.

## Summary of the Pull Request

Chatted with @skyline75489 about the appropriate fix for #3277, and we decided that it'd be best to revert these two PRs until we can get them in better shape.

## PR Checklist
* [x] Closes #3277
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [x] .

## Validation

A whole bunch of bisecting.