### PR TITLE
fix latent DPI issues with the WPF control

### DIFF
--- a/src/cascadia/WpfTerminalControl/TerminalContainer.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalContainer.cs
@@ -100,12 +100,7 @@ namespace Microsoft.Terminal.Wpf
 
             NativeMethods.TerminalSetTheme(this.terminal, theme, fontFamily, fontSize, (int)dpiScale.PixelsPerInchX);
 
-            NativeMethods.TerminalTriggerResize(this.terminal, this.ActualWidth * dpiScale.DpiScaleX, this.ActualHeight * dpiScale.DpiScaleY, out var dimensions);
-
-            this.Rows = dimensions.Y;
-            this.Columns = dimensions.X;
-
-            this.connection?.Resize((uint)dimensions.Y, (uint)dimensions.X);
+            this.TriggerResize(this.RenderSize);
         }
 
         /// <summary>

--- a/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
@@ -67,10 +67,7 @@ namespace Microsoft.Terminal.Wpf
                 return;
             }
 
-            int dpiX;
-            dpiX = (int)(NativeMethods.USER_DEFAULT_SCREEN_DPI * source.CompositionTarget.TransformToDevice.M11);
-
-            this.termContainer.SetTheme(theme, fontFamily, fontSize, dpiX);
+            this.termContainer.SetTheme(theme, fontFamily, fontSize);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The WPF control incorrectly assumed that it would receive DPI changed events when launched on a screen with a non-default DPI. This turned out not to be the case so instead we manually get the current DPI when sending size information to the native control.

## Validation Steps Performed
Patched the VS terminal and verified that on 125% DPI the control was sized correctly.