### PR TITLE
Replace \r\n with \r to get rid of double newlines

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -165,6 +165,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _BlinkCursor(Windows::Foundation::IInspectable const& sender, Windows::Foundation::IInspectable const& e);
         void _SetEndSelectionPointAtCursor(Windows::Foundation::Point const& cursorPosition);
         void _SendInputToConnection(const std::wstring& wstr);
+        void _SendPastedTextToConnection(const std::wstring& wstr);
         void _SwapChainSizeChanged(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::SizeChangedEventArgs const& e);
         void _SwapChainScaleChanged(Windows::UI::Xaml::Controls::SwapChainPanel const& sender, Windows::Foundation::IInspectable const& args);
         void _DoResize(const double newWidth, const double newHeight);


### PR DESCRIPTION
## Summary of the Pull Request

Continuation of https://github.com/microsoft/terminal/pull/2390
As this MR seems to have been abandoned, I'm opening a new one with the same change.
As per the discussion in #2390, unconditionally replace `\r\n` with `\r`.

## References
https://github.com/microsoft/terminal/pull/2390
https://github.com/microsoft/terminal/pull/1094
https://github.com/microsoft/terminal/issues/1091

## PR Checklist
* [X] Closes #1091 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments
I'm sure I'm not the only one going insane from hitting this bug all the time.
Please let me know what extra steps I need to take with this MR to get it merged.

Rudely CC-ing @DHowett-MSFT, who seems to have been active on #2390.

## Validation Steps Performed
No unit tests are added.

Manually verified the terminal to, with this patch, have the same behavior as the built in Windows Command Prompt by writing a program that list out what keys are pressed, and then paste
```
a
b
c
d
```
From left to right: 0.5.2762.0, this branch, Windows built in Command Prompt.
![image](https://user-images.githubusercontent.com/2367571/67499154-e2090700-f680-11e9-8907-43dfd653d4c1.png)

Manually tested that pasting now works as expected in vim both on Windows and WSL2.