### PR TITLE
prevent double handling of tab in wpf control

### DIFF
--- a/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
@@ -341,6 +341,11 @@ void _stdcall TerminalSendKeyEvent(void* terminal, WPARAM wParam)
 
 void _stdcall TerminalSendCharEvent(void* terminal, wchar_t ch)
 {
+    if (ch == '\t')
+    {
+        return;
+    }
+
     const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
     publicTerminal->_terminal->SendCharEvent(ch);
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The WPF control was sending the tab character to the pty twice because in Win32-land tab comes in as both a WM_CHAR and WM_KEYDOWN event. This is contrary to UWP which only gets a key event for tab.

## Validation Steps Performed
VS terminal was patched to verify that the terminal no longer double tabs.