### PR TITLE
Perf: save text buffer size for frequent access

### DIFF
--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -111,7 +111,7 @@ public:
 
     const SHORT GetFirstRowIndex() const noexcept;
 
-    const Microsoft::Console::Types::Viewport GetSize() const;
+    const Microsoft::Console::Types::Viewport GetSize() const noexcept;
 
     void ScrollRows(const SHORT firstRow, const SHORT size, const SHORT delta);
 
@@ -156,6 +156,8 @@ private:
 
     SHORT _firstRow; // indexes top row (not necessarily 0)
 
+    Microsoft::Console::Types::Viewport _size;
+
     TextAttribute _currentAttributes;
 
     // storage location for glyphs that can't fit into the buffer normally
@@ -163,11 +165,13 @@ private:
 
     void _RefreshRowIDs(std::optional<SHORT> newRowWidth);
 
+    void _UpdateSize();
+
     Microsoft::Console::Render::IRenderTarget& _renderTarget;
 
     void _SetFirstRowIndex(const SHORT FirstRowIndex) noexcept;
 
-    COORD _GetPreviousFromCursor() const;
+    COORD _GetPreviousFromCursor() const noexcept;
 
     void _SetWrapOnCurrentRow();
     void _AdjustWrapOnCurrentRow(const bool fSet);

--- a/src/types/ScreenInfoUiaProviderBase.cpp
+++ b/src/types/ScreenInfoUiaProviderBase.cpp
@@ -545,7 +545,7 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::get_SupportedTextSelection(_Out_ Suppo
 
 #pragma endregion
 
-const COORD ScreenInfoUiaProviderBase::_getScreenBufferCoords() const
+const COORD ScreenInfoUiaProviderBase::_getScreenBufferCoords() const noexcept
 {
     return _getTextBuffer().GetSize().Dimensions();
 }

--- a/src/types/ScreenInfoUiaProviderBase.h
+++ b/src/types/ScreenInfoUiaProviderBase.h
@@ -110,7 +110,7 @@ namespace Microsoft::Console::Types
         // mechanism for multi-threaded code.
         std::map<EVENTID, bool> _signalFiringMapping;
 
-        const COORD _getScreenBufferCoords() const;
+        const COORD _getScreenBufferCoords() const noexcept;
         const TextBuffer& _getTextBuffer() const noexcept;
         const Viewport _getViewport() const noexcept;
         void _LockConsole() noexcept;

--- a/src/types/UiaTextRangeBase.hpp
+++ b/src/types/UiaTextRangeBase.hpp
@@ -119,7 +119,7 @@ namespace Microsoft::Console::Types
 
             MoveState(IUiaData* pData,
                       const UiaTextRangeBase& range,
-                      const MovementDirection direction);
+                      const MovementDirection direction) noexcept;
 
         private:
             MoveState(const ScreenInfoRow startScreenInfoRow,
@@ -159,7 +159,7 @@ namespace Microsoft::Console::Types
                                         _In_ ITextRangeProvider* pTargetRange,
                                         _In_ TextPatternRangeEndpoint targetEndpoint,
                                         _Out_ int* pRetVal) noexcept override;
-        IFACEMETHODIMP ExpandToEnclosingUnit(_In_ TextUnit unit) override;
+        IFACEMETHODIMP ExpandToEnclosingUnit(_In_ TextUnit unit) noexcept override;
         IFACEMETHODIMP FindAttribute(_In_ TEXTATTRIBUTEID textAttributeId,
                                      _In_ VARIANT val,
                                      _In_ BOOL searchBackward,
@@ -176,14 +176,14 @@ namespace Microsoft::Console::Types
                                _Out_ BSTR* pRetVal) override;
         IFACEMETHODIMP Move(_In_ TextUnit unit,
                             _In_ int count,
-                            _Out_ int* pRetVal) override;
+                            _Out_ int* pRetVal) noexcept override;
         IFACEMETHODIMP MoveEndpointByUnit(_In_ TextPatternRangeEndpoint endpoint,
                                           _In_ TextUnit unit,
                                           _In_ int count,
-                                          _Out_ int* pRetVal) override;
+                                          _Out_ int* pRetVal) noexcept override;
         IFACEMETHODIMP MoveEndpointByRange(_In_ TextPatternRangeEndpoint endpoint,
                                            _In_ ITextRangeProvider* pTargetRange,
-                                           _In_ TextPatternRangeEndpoint targetEndpoint) override;
+                                           _In_ TextPatternRangeEndpoint targetEndpoint) noexcept override;
         IFACEMETHODIMP Select() override;
         IFACEMETHODIMP AddToSelection() noexcept override;
         IFACEMETHODIMP RemoveFromSelection() noexcept override;
@@ -255,41 +255,41 @@ namespace Microsoft::Console::Types
 
         RECT _getTerminalRect() const;
 
-        static const COORD _getScreenBufferCoords(gsl::not_null<IUiaData*> pData);
+        static const COORD _getScreenBufferCoords(gsl::not_null<IUiaData*> pData) noexcept;
         virtual const COORD _getScreenFontSize() const;
 
         static const unsigned int _getTotalRows(gsl::not_null<IUiaData*> pData) noexcept;
-        static const unsigned int _getRowWidth(gsl::not_null<IUiaData*> pData);
+        static const unsigned int _getRowWidth(gsl::not_null<IUiaData*> pData) noexcept;
 
         static const unsigned int _getFirstScreenInfoRowIndex() noexcept;
         static const unsigned int _getLastScreenInfoRowIndex(gsl::not_null<IUiaData*> pData) noexcept;
 
         static const Column _getFirstColumnIndex() noexcept;
-        static const Column _getLastColumnIndex(gsl::not_null<IUiaData*> pData);
+        static const Column _getLastColumnIndex(gsl::not_null<IUiaData*> pData) noexcept;
 
-        const unsigned int _rowCountInRange(gsl::not_null<IUiaData*> pData) const;
+        const unsigned int _rowCountInRange(gsl::not_null<IUiaData*> pData) const noexcept;
 
         static const TextBufferRow _endpointToTextBufferRow(gsl::not_null<IUiaData*> pData,
-                                                            const Endpoint endpoint);
+                                                            const Endpoint endpoint) noexcept;
         static const ScreenInfoRow _textBufferRowToScreenInfoRow(gsl::not_null<IUiaData*> pData,
                                                                  const TextBufferRow row) noexcept;
 
         static const TextBufferRow _screenInfoRowToTextBufferRow(gsl::not_null<IUiaData*> pData,
                                                                  const ScreenInfoRow row) noexcept;
-        static const Endpoint _textBufferRowToEndpoint(gsl::not_null<IUiaData*> pData, const TextBufferRow row);
+        static const Endpoint _textBufferRowToEndpoint(gsl::not_null<IUiaData*> pData, const TextBufferRow row) noexcept;
 
         static const ScreenInfoRow _endpointToScreenInfoRow(gsl::not_null<IUiaData*> pData,
-                                                            const Endpoint endpoint);
+                                                            const Endpoint endpoint) noexcept;
         static const Endpoint _screenInfoRowToEndpoint(gsl::not_null<IUiaData*> pData,
-                                                       const ScreenInfoRow row);
+                                                       const ScreenInfoRow row) noexcept;
 
         static COORD _endpointToCoord(gsl::not_null<IUiaData*> pData,
-                                      const Endpoint endpoint);
+                                      const Endpoint endpoint) noexcept;
         static Endpoint _coordToEndpoint(gsl::not_null<IUiaData*> pData,
-                                         const COORD coord);
+                                         const COORD coord) noexcept;
 
         static const Column _endpointToColumn(gsl::not_null<IUiaData*> pData,
-                                              const Endpoint endpoint);
+                                              const Endpoint endpoint) noexcept;
 
         static const Row _normalizeRow(gsl::not_null<IUiaData*> pData, const Row row) noexcept;
 
@@ -324,7 +324,7 @@ namespace Microsoft::Console::Types
                                               const ScreenInfoRow rowA,
                                               const Column colA,
                                               const ScreenInfoRow rowB,
-                                              const Column colB);
+                                              const Column colB) noexcept;
 
         static std::pair<Endpoint, Endpoint> _moveByCharacter(gsl::not_null<IUiaData*> pData,
                                                               const int moveCount,
@@ -344,12 +344,12 @@ namespace Microsoft::Console::Types
         static std::pair<Endpoint, Endpoint> _moveByLine(gsl::not_null<IUiaData*> pData,
                                                          const int moveCount,
                                                          const MoveState moveState,
-                                                         _Out_ gsl::not_null<int*> const pAmountMoved);
+                                                         _Out_ gsl::not_null<int*> const pAmountMoved) noexcept;
 
         static std::pair<Endpoint, Endpoint> _moveByDocument(gsl::not_null<IUiaData*> pData,
                                                              const int moveCount,
                                                              const MoveState moveState,
-                                                             _Out_ gsl::not_null<int*> const pAmountMoved);
+                                                             _Out_ gsl::not_null<int*> const pAmountMoved) noexcept;
 
         static std::tuple<Endpoint, Endpoint, bool>
         _moveEndpointByUnitCharacter(gsl::not_null<IUiaData*> pData,
@@ -377,14 +377,14 @@ namespace Microsoft::Console::Types
                                 const int moveCount,
                                 const TextPatternRangeEndpoint endpoint,
                                 const MoveState moveState,
-                                _Out_ gsl::not_null<int*> const pAmountMoved);
+                                _Out_ gsl::not_null<int*> const pAmountMoved) noexcept;
 
         static std::tuple<Endpoint, Endpoint, bool>
         _moveEndpointByUnitDocument(gsl::not_null<IUiaData*> pData,
                                     const int moveCount,
                                     const TextPatternRangeEndpoint endpoint,
                                     const MoveState moveState,
-                                    _Out_ gsl::not_null<int*> const pAmountMoved);
+                                    _Out_ gsl::not_null<int*> const pAmountMoved) noexcept;
 
 #ifdef UNIT_TESTING
         friend class ::UiaTextRangeTests;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Save buffer size as a property. Update it when necessary.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The `GetSize` in text buffer is called intensively across the entire code base. The buffer size is frequently accessed but seldom modified. This is an attempt to make use of that.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
