### PR TITLE
Replace some macros with constexpr

### DIFF
--- a/src/buffer/out/cursor.h
+++ b/src/buffer/out/cursor.h
@@ -19,14 +19,14 @@ Revision History:
 
 #include "../inc/conattrs.hpp"
 
-// the following values are used to create the textmode cursor.
-#define CURSOR_SMALL_SIZE 25 // large enough to be one pixel on a six pixel font
 class TextBuffer;
 
 class Cursor final
 {
 public:
     static const unsigned int s_InvertCursorColor = INVALID_COLOR;
+    // the following values are used to create the textmode cursor.
+    static constexpr unsigned int CURSOR_SMALL_SIZE = 25; // large enough to be one pixel on a six pixel font
 
     Cursor(const ULONG ulSize, TextBuffer& parentBuffer) noexcept;
 

--- a/src/host/_stream.cpp
+++ b/src/host/_stream.cpp
@@ -29,6 +29,8 @@ using Microsoft::Console::VirtualTerminal::StateMachine;
 // Used by WriteCharsLegacy.
 #define IS_GLYPH_CHAR(wch) (((wch) < L' ') || ((wch) == 0x007F))
 
+constexpr unsigned int LOCAL_BUFFER_SIZE = 100;
+
 // Routine Description:
 // - This routine updates the cursor position.  Its input is the non-special
 //   cased new location of the cursor.  For example, if the cursor were being

--- a/src/host/_stream.h
+++ b/src/host/_stream.h
@@ -40,8 +40,6 @@ Return Value:
                                             const BOOL fKeepCursorVisible,
                                             _Inout_opt_ PSHORT psScrollY);
 
-#define LOCAL_BUFFER_SIZE 100
-
 /*++
 Routine Description:
     This routine writes a string to the screen, processing any embedded

--- a/src/host/cmdline.cpp
+++ b/src/host/cmdline.cpp
@@ -412,7 +412,7 @@ void SetCurrentCommandLine(COOKED_READ_DATA& cookedReadData, _In_ SHORT Index) /
 {
     if (cookedReadData.HasHistory() &&
         cookedReadData.History().GetNumberOfCommands() &&
-        cookedReadData.ScreenInfo().GetBufferSize().Width() >= MINIMUM_COMMAND_PROMPT_SIZE + 2)
+        cookedReadData.ScreenInfo().GetBufferSize().Width() >= Popup::MINIMUM_COMMAND_PROMPT_SIZE + 2)
     {
         try
         {

--- a/src/host/directio.cpp
+++ b/src/host/directio.cpp
@@ -1223,7 +1223,7 @@ void EventsToUnicode(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& inEvents,
                                                          WindowSize,
                                                          siExisting.GetAttributes(),
                                                          siExisting.GetAttributes(),
-                                                         CURSOR_SMALL_SIZE,
+                                                         Cursor::CURSOR_SMALL_SIZE,
                                                          &ScreenInfo);
 
     if (!NT_SUCCESS(Status))

--- a/src/host/popup.h
+++ b/src/host/popup.h
@@ -24,13 +24,13 @@ Revision History:
 #include "screenInfo.hpp"
 #include "readDataCooked.hpp"
 
-#define MINIMUM_COMMAND_PROMPT_SIZE 5
-
 class CommandHistory;
 
 class Popup
 {
 public:
+    static constexpr unsigned int MINIMUM_COMMAND_PROMPT_SIZE = 5;
+
     using UserInputFunction = std::function<NTSTATUS(COOKED_READ_DATA&, bool&, DWORD&, wchar_t&)>;
 
     Popup(SCREEN_INFORMATION& screenInfo, const COORD proposedSize);

--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -2040,7 +2040,7 @@ const SCREEN_INFORMATION& SCREEN_INFORMATION::GetMainBuffer() const
                                                          WindowSize,
                                                          GetAttributes(),
                                                          *GetPopupAttributes(),
-                                                         CURSOR_SMALL_SIZE,
+                                                         Cursor::CURSOR_SMALL_SIZE,
                                                          ppsiNewScreenBuffer);
     if (NT_SUCCESS(Status))
     {

--- a/src/host/settings.cpp
+++ b/src/host/settings.cpp
@@ -29,7 +29,7 @@ Settings::Settings() :
     _uFontFamily(0),
     _uFontWeight(0),
     // FaceName initialized below
-    _uCursorSize(CURSOR_SMALL_SIZE),
+    _uCursorSize(Cursor::CURSOR_SMALL_SIZE),
     _bFullScreen(false),
     _bQuickEdit(true),
     _bInsertMode(true),

--- a/src/host/settings.hpp
+++ b/src/host/settings.hpp
@@ -21,7 +21,7 @@ Revision History:
 #include "../buffer/out/TextAttribute.hpp"
 
 // To prevent invisible windows, set a lower threshold on window alpha channel.
-#define MIN_WINDOW_OPACITY 0x4D // 0x4D is approximately 30% visible/opaque (70% transparent). Valid range is 0x00-0xff.
+constexpr unsigned short MIN_WINDOW_OPACITY = 0x4D; // 0x4D is approximately 30% visible/opaque (70% transparent). Valid range is 0x00-0xff.
 
 #include "ConsoleArguments.hpp"
 #include "../inc/conattrs.hpp"

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -21,8 +21,6 @@ Author(s):
 #include "terminalOutput.hpp"
 #include <math.h>
 
-#define XTERM_COLOR_TABLE_SIZE (256)
-
 namespace Microsoft::Console::VirtualTerminal
 {
     class AdaptDispatch : public ITermDispatch


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Replace some macros with modern constexpr.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

#2941 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Macros are just very 1980s and should be used less.

I'm not sure which one is preferred, `auto` or concrete type.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Not needed.