### PR TITLE
Add support for the HPA escape sequence

### DIFF
--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -312,6 +312,7 @@ bool OutputStateMachineEngine::ActionCsiDispatch(const wchar_t wch,
         case VTActionCodes::CNL_CursorNextLine:
         case VTActionCodes::CPL_CursorPrevLine:
         case VTActionCodes::CHA_CursorHorizontalAbsolute:
+        case VTActionCodes::HPA_HorizontalPositionAbsolute:
         case VTActionCodes::VPA_VerticalLinePositionAbsolute:
         case VTActionCodes::ICH_InsertCharacter:
         case VTActionCodes::DCH_DeleteCharacter:
@@ -399,6 +400,7 @@ bool OutputStateMachineEngine::ActionCsiDispatch(const wchar_t wch,
                 TermTelemetry::Instance().Log(TermTelemetry::Codes::CPL);
                 break;
             case VTActionCodes::CHA_CursorHorizontalAbsolute:
+            case VTActionCodes::HPA_HorizontalPositionAbsolute:
                 fSuccess = _dispatch->CursorHorizontalPositionAbsolute(uiDistance);
                 TermTelemetry::Instance().Log(TermTelemetry::Codes::CHA);
                 break;

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -112,6 +112,7 @@ namespace Microsoft::Console::VirtualTerminal
             DECSCPP_SetColumnsPerPage = L'|',
             IL_InsertLine = L'L',
             DL_DeleteLine = L'M', // Yes, this is the same as RI, however, RI is not preceeded by a CSI, and DL is.
+            HPA_HorizontalPositionAbsolute = L'`',
             VPA_VerticalLinePositionAbsolute = L'd',
             DECSTBM_SetScrollingRegion = L'r',
             RI_ReverseLineFeed = L'M',

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -1054,6 +1054,8 @@ class StateMachineExternalTest final
         pDispatch->ClearState();
         TestCsiCursorMovement(L'G', uiDistance, true, &pDispatch->_fCursorHorizontalPositionAbsolute, mach, *pDispatch);
         pDispatch->ClearState();
+        TestCsiCursorMovement(L'`', uiDistance, true, &pDispatch->_fCursorHorizontalPositionAbsolute, mach, *pDispatch);
+        pDispatch->ClearState();
         TestCsiCursorMovement(L'd', uiDistance, true, &pDispatch->_fVerticalLinePositionAbsolute, mach, *pDispatch);
         pDispatch->ClearState();
         TestCsiCursorMovement(L'@', uiDistance, true, &pDispatch->_fInsertCharacter, mach, *pDispatch);
@@ -1081,6 +1083,8 @@ class StateMachineExternalTest final
         TestCsiCursorMovement(L'F', uiDistance, false, &pDispatch->_fCursorPreviousLine, mach, *pDispatch);
         pDispatch->ClearState();
         TestCsiCursorMovement(L'G', uiDistance, false, &pDispatch->_fCursorHorizontalPositionAbsolute, mach, *pDispatch);
+        pDispatch->ClearState();
+        TestCsiCursorMovement(L'`', uiDistance, false, &pDispatch->_fCursorHorizontalPositionAbsolute, mach, *pDispatch);
         pDispatch->ClearState();
         TestCsiCursorMovement(L'd', uiDistance, false, &pDispatch->_fVerticalLinePositionAbsolute, mach, *pDispatch);
         pDispatch->ClearState();


### PR DESCRIPTION
## Summary of the Pull Request

[`HPA`](https://vt100.net/docs/vt510-rm/HPA.html) (horizontal position absolute) is just an alias for the existing [`CHA`](https://vt100.net/docs/vt510-rm/CHA.html) (cursor horizontal absolute) escape sequence, which moves the cursor position to the specified column on the current line. This is needed in order to pass the `HPA` test in [Vttest](https://invisible-island.net/vttest/).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #3348
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #3348 

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

As discussed in issue #3348, the general consensus is that this can be considered an alias for the `CHA` escape sequence. So I've just added a new entry in the `VTActionCodes` enum for the `HPA` final character, and then updated the switch statements in `OutputStateMachineEngine::ActionCsiDispatch` to share the same code path as the existing `CHA` action.

I haven't bothered with giving it a unique telemetry code, since we haven't done that for the `CUP` and `HVP` codes either, so I assumed that would be OK.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

I've extended the existing output engine tests for CSI cursor movement to confirm that `HPA` is dispatched in the same way as `CHA`. I've also checked the `HPA` test in Vttest (under _Test non-VT100_ / _ISO-6429 cursor-movement_) and confirmed that it is now working as expected.
