### PR TITLE
Compensate for non-minimal UTF-8 encodings

### DIFF
--- a/src/host/ut_host/Utf8ToWideCharParserTests.cpp
+++ b/src/host/ut_host/Utf8ToWideCharParserTests.cpp
@@ -286,7 +286,7 @@ class Utf8ToWideCharParserTests
             0x0060, 0x0012, 0x0008, 0x007f,
             0xfffd, 0xfffd, // The number of replacements per invalid sequence is not intended to be load-bearing
             0x0041, 0x0048, 0x0006, 0x0055,
-            0xfffd, 0xfffd, 0xfffd, // It is just representative of what it looked like when fixing this for GH#3380
+            0xfffd, 0xfffd, // It is just representative of what it looked like when fixing this for GH#3380
             0x0018, 0x0077, 0x0040, 0x0031,
             0xfffd, 0xfffd, 0xfffd, // Change if necessary when completing GH#3378
             0x0059, 0x001f, 0x0068, 0x0020

--- a/src/host/ut_host/Utf8ToWideCharParserTests.cpp
+++ b/src/host/ut_host/Utf8ToWideCharParserTests.cpp
@@ -272,7 +272,7 @@ class Utf8ToWideCharParserTests
 
         // Test data
         const unsigned char data[] = {
-            0x60, 0x12, 0x00, 0x7f, // single byte points
+            0x60, 0x12, 0x08, 0x7f, // single byte points
             0xc0, 0x80, // U+0000 as a 2-byte sequence (non-minimal)
             0x41, 0x48, 0x06, 0x55, // more single byte points
             0xe0, 0x80, 0x80, // U+0000 as a 3-byte sequence (non-minimal)
@@ -283,12 +283,12 @@ class Utf8ToWideCharParserTests
 
         // Expected conversion
         const wchar_t wideData[] = {
-            0x0060, 0x0012, 0x0000, 0x007f,
-            0xfffd, 0xfffd,
+            0x0060, 0x0012, 0x0008, 0x007f,
+            0xfffd, 0xfffd, // The number of replacements per invalid sequence is not intended to be load-bearing
             0x0041, 0x0048, 0x0006, 0x0055,
-            0xfffd, 0xfffd,
+            0xfffd, 0xfffd, 0xfffd, // It is just representative of what it looked like when fixing this for GH#3380
             0x0018, 0x0077, 0x0040, 0x0031,
-            0xfffd, 0xfffd, 0xfffd,
+            0xfffd, 0xfffd, 0xfffd, // Change if necessary when completing GH#3378
             0x0059, 0x001f, 0x0068, 0x0020
         };
 
@@ -306,10 +306,9 @@ class Utf8ToWideCharParserTests
         VERIFY_ARE_EQUAL(wideCount, generated);
         VERIFY_IS_NOT_NULL(output.get());
 
-        for (int i = 0; i < wideCount; i++)
-        {
-            VERIFY_ARE_EQUAL(wideData[i], output.get()[i]);
-        }
+        const auto expected = WEX::Common::String(wideData, wideCount);
+        const auto actual = WEX::Common::String(output.get(), generated);
+        VERIFY_ARE_EQUAL(expected, actual);
     }
 
     TEST_METHOD(PartialBytesAreDroppedOnCodePageChangeTest)

--- a/src/host/utf8ToWideCharParser.cpp
+++ b/src/host/utf8ToWideCharParser.cpp
@@ -385,6 +385,7 @@ unsigned int Utf8ToWideCharParser::_InvolvedParse(_In_reads_(cb) const byte* con
     // replacement character treatment.
     // This issue and related concerns are fully captured in future work item GH#3378
     // for future cleanup and reconciliation.
+    // The original issue introducing this was GH#3320.
     int bufferSize = MultiByteToWideChar(_currentCodePage,
                                          0,
                                          reinterpret_cast<LPCCH>(validSequence.first.get()),

--- a/src/host/utf8ToWideCharParser.cpp
+++ b/src/host/utf8ToWideCharParser.cpp
@@ -377,8 +377,16 @@ unsigned int Utf8ToWideCharParser::_InvolvedParse(_In_reads_(cb) const byte* con
         _currentState = _State::AwaitingMoreBytes;
         return 0;
     }
+
+    // By this point, all obviously invalid sequences have been removed.
+    // But non-minimal forms of sequences might still exist.
+    // MB2WC will fail non-minimal forms with MB_ERR_INVALID_CHARS at this point.
+    // So we call with flags = 0 such that non-minimal forms get the U+FFFD
+    // replacement character treatment.
+    // This issue and related concerns are fully captured in future work item GH#3378
+    // for future cleanup and reconciliation.
     int bufferSize = MultiByteToWideChar(_currentCodePage,
-                                         MB_ERR_INVALID_CHARS,
+                                         0,
                                          reinterpret_cast<LPCCH>(validSequence.first.get()),
                                          validSequence.second,
                                          nullptr,


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- Permits substitution of Unicode Replacement for non-minimal codepoint encodings in UTF-8.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #3320
* [x] I work here
* [x] Tests added/passed
* [x] Comments added, follow on issue filed #3378 
* [x] I'm a core contributor

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- We do a lot of work to figure out whether or not we have some invalid UTF-8 inside our own internal parser. We're correctly identifying in the first full-conversion pass that something is amiss with the stream of text we were given. And inside the second pass for involved parsing, we are identifying and removing obviously wrong sequences like those that have a lead byte without the correct number of continuations, continuations that come from nowhere, and so on. But there's one big gap:

- We're not correctly identifying non-minimal forms of characters. Specifically, what is causing the crash, is non-minimal representations of the null character U+0000. The minimal form of this character in UTF-8 is 0x00. But technically, it could also be written as any of the following:
1. 0xC0 0x80 - Lead byte of 2 byte sequence and a single continuation. 
2. 0xE0 0x80 0x80 - Lead byte of 3 byte sequences and two continuations.
3. 0xF0 0x80 0x80 0x80 - Lead byte of 4 byte sequences and three continuations.
All of which didn't fill any of the payload bits.

- The OS does identify these as invalid non-minimal forms when the data is sent to `MultiByteToWideChar` after we believe we've removed all invalid data and then it errors out because we set the `MB_ERR_INVALID_CHARS` flag.

- If we remove the flag, the error goes away and the OS will substitute one or more U+FFFDs for these sequences and continue past them. 

- This is inconsistent with the rest of our invalid behavior (where we just eat the invalid bytes and walk on instead of substituting them) but the OS doesn't offer that provision as an option.

- We also can't straight up just call the OS in all cases because we want to be available for the case where a caller sends us part of a valid sequence at the end of the buffer and then continues with the next valid pieces in the next call. That is, think of the `putc` case where someone drops 0xe3, 0x81, and 0x99 on three calls in a row. We want to form those together into the correct U+3059 once the third one comes in. Just using `MultiByteToWideChar` straight up will convert each of them into their own U+FFFD on the three calls. Not OK. So we must have *some* knowledge of UTF-8 to allow this valid scenario to happen.

- The solution here is to let the somewhat inconsistent behavior of "replacements for non-minimal sequences but suppress clearly invalid things" to happen. We're doing this because the fix is needed in the Windows product for 20H1, which is today subject to ever-tightening requirements to prepare to ship. The smallest and least risky fix possible is preferable right now.

- #3378 is filed as a follow on to investigate reconciling the somewhat inconsistent behavior as well as other things noted during this investigation in the future to be consumed into Terminal and whatever Windows release comes after 20H1.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Ran the repro steps in #3320 on 20h1 previews with WSL2. No longer crashes after (because it no longer returns the error).

Added automated test in utf8ToWideCharParserTests.cpp to ensure that non-minimal forms don't cause `.Parse` to throw an error and turn into some number of replacements instead