### PR TITLE
Prevent cleanup of object given to handle that failed access check

### DIFF
--- a/src/host/ft_host/API_BufferTests.cpp
+++ b/src/host/ft_host/API_BufferTests.cpp
@@ -18,6 +18,8 @@ class BufferTests
 
     TEST_METHOD(TestSetConsoleActiveScreenBufferInvalid);
 
+    TEST_METHOD(TestCookedReadOnNonShareableScreenBuffer);
+
     BEGIN_TEST_METHOD(TestWritingInactiveScreenBuffer)
         TEST_METHOD_PROPERTY(L"Data:UseVtOutput", L"{true, false}")
     END_TEST_METHOD()
@@ -31,6 +33,54 @@ void BufferTests::TestSetConsoleActiveScreenBufferInvalid()
 {
     VERIFY_WIN32_BOOL_FAILED(SetConsoleActiveScreenBuffer(INVALID_HANDLE_VALUE));
     VERIFY_WIN32_BOOL_FAILED(SetConsoleActiveScreenBuffer(nullptr));
+}
+
+void BufferTests::TestCookedReadOnNonShareableScreenBuffer()
+{
+    Log::Comment(L"Get original handles");
+    const auto in = GetStdInputHandle();
+    const auto out = GetStdOutputHandle();
+
+    Log::Comment(L"Ensure cooked input is on (line input mode) and echoing to the screen.");
+    DWORD inMode = 0;
+    VERIFY_WIN32_BOOL_SUCCEEDED(GetConsoleMode(in, &inMode));
+    inMode |= ENABLE_LINE_INPUT;
+    inMode |= ENABLE_ECHO_INPUT;
+    VERIFY_WIN32_BOOL_SUCCEEDED(SetConsoleMode(in, inMode));
+
+    Log::Comment(L"Create alternate buffer that is read/writeable but not shareable.");
+    const auto otherBuffer = CreateConsoleScreenBuffer(GENERIC_READ | GENERIC_WRITE,
+                                                       0, // This says non-sharable
+                                                       nullptr,
+                                                       CONSOLE_TEXTMODE_BUFFER,
+                                                       nullptr);
+    VERIFY_WIN32_BOOL_SUCCEEDED(INVALID_HANDLE_VALUE != otherBuffer);
+
+    Log::Comment(L"Set the alternate buffer as active.");
+    VERIFY_WIN32_BOOL_SUCCEEDED(SetConsoleActiveScreenBuffer(otherBuffer));
+
+    // On a cooked read with echoing, the act of reading from the buffer will cause a handle to be
+    // taken to the active output buffer such that the cooked/line reading handler can display
+    // what is being typed on the screen as it is being typed before the enter key is hit.
+    // This should fail because we've denied anyone sharing access with us and we hold the primary
+    // active handle above.
+    Log::Comment(L"Perform a read operation to attempt to take handle to output buffer and hopefully fail.");
+    char buffer[1];
+    DWORD read = 0;
+    SetLastError(S_OK);
+    VERIFY_WIN32_BOOL_FAILED(ReadFile(in, buffer, sizeof(buffer), &read, nullptr));
+    VERIFY_ARE_EQUAL(static_cast<DWORD>(ERROR_SHARING_VIOLATION), GetLastError());
+
+    Log::Comment(L"Put the buffer back.");
+    VERIFY_WIN32_BOOL_SUCCEEDED(SetConsoleActiveScreenBuffer(out));
+
+    Log::Comment(L"Close the alternate buffer.");
+    VERIFY_WIN32_BOOL_SUCCEEDED(CloseHandle(otherBuffer));
+
+    Sleep(2000);
+
+    Log::Comment(L"Ensure that the console didn't die/crash");
+    VERIFY_IS_TRUE(IsConsoleStillRunning());
 }
 
 void BufferTests::TestWritingInactiveScreenBuffer()

--- a/src/host/ft_host/Common.cpp
+++ b/src/host/ft_host/Common.cpp
@@ -7,6 +7,14 @@ using WEX::Logging::Log;
 using namespace WEX::Common;
 
 HANDLE Common::_hConsole = INVALID_HANDLE_VALUE;
+extern wil::unique_process_information pi;
+
+bool IsConsoleStillRunning()
+{
+    DWORD exitCode = S_OK;
+    VERIFY_WIN32_BOOL_SUCCEEDED(GetExitCodeProcess(pi.hProcess, &exitCode));
+    return exitCode == STILL_ACTIVE;
+}
 
 void VerifySucceededGLE(BOOL bResult)
 {

--- a/src/host/ft_host/Common.hpp
+++ b/src/host/ft_host/Common.hpp
@@ -68,3 +68,5 @@ BOOL UnadjustWindowRectEx(
 
 HANDLE GetStdInputHandle();
 HANDLE GetStdOutputHandle();
+
+bool IsConsoleStillRunning();

--- a/src/host/ft_host/InitTests.cpp
+++ b/src/host/ft_host/InitTests.cpp
@@ -16,6 +16,7 @@ static PCWSTR pwszForceV2ValueName = L"ForceV2";
 // instead of using the Windows-default copy of console host.
 
 wil::unique_handle hJob;
+wil::unique_process_information pi;
 
 static FILE* std_out = nullptr;
 static FILE* std_in = nullptr;
@@ -135,7 +136,6 @@ MODULE_SETUP(ModuleSetup)
     // Setup and call create process.
     STARTUPINFOW si = { 0 };
     si.cb = sizeof(STARTUPINFOW);
-    wil::unique_process_information pi;
 
     // We start suspended so we can put it in the job before it does anything
     // We say new console so it doesn't run in the same window as our test.

--- a/src/host/ut_host/Host.UnitTests.vcxproj
+++ b/src/host/ut_host/Host.UnitTests.vcxproj
@@ -16,6 +16,7 @@
     <ClCompile Include="DbcsTests.cpp" />
     <ClCompile Include="HistoryTests.cpp" />
     <ClCompile Include="InitTests.cpp" />
+    <ClCompile Include="ObjectTests.cpp" />
     <ClCompile Include="OutputCellIteratorTests.cpp" />
     <ClCompile Include="ScreenBufferTests.cpp" />
     <ClCompile Include="SearchTests.cpp" />

--- a/src/host/ut_host/Host.UnitTests.vcxproj.filters
+++ b/src/host/ut_host/Host.UnitTests.vcxproj.filters
@@ -111,6 +111,9 @@
     <ClCompile Include="OutputCellIteratorTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ObjectTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="UnicodeLiteral.hpp">

--- a/src/host/ut_host/ObjectTests.cpp
+++ b/src/host/ut_host/ObjectTests.cpp
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "precomp.h"
+#include "WexTestClass.h"
+#include "..\..\inc\consoletaeftemplates.hpp"
+
+#include "CommonState.hpp"
+
+using namespace WEX::Common;
+using namespace WEX::Logging;
+using namespace WEX::TestExecution;
+using Microsoft::Console::Interactivity::ServiceLocator;
+
+class ObjectTests
+{
+    CommonState* m_state;
+
+    TEST_CLASS(ObjectTests);
+
+    TEST_CLASS_SETUP(ClassSetup)
+    {
+        m_state = new CommonState();
+
+        m_state->InitEvents();
+        m_state->PrepareGlobalFont();
+        m_state->PrepareGlobalScreenBuffer();
+        m_state->PrepareGlobalInputBuffer();
+
+        return true;
+    }
+
+    TEST_CLASS_CLEANUP(ClassCleanup)
+    {
+        m_state->CleanupGlobalScreenBuffer();
+        m_state->CleanupGlobalFont();
+        m_state->CleanupGlobalInputBuffer();
+
+        delete m_state;
+
+        return true;
+    }
+
+    TEST_METHOD_SETUP(MethodSetup)
+    {
+        return true;
+    }
+
+    TEST_METHOD_CLEANUP(MethodCleanup)
+    {
+        return true;
+    }
+
+    TEST_METHOD(TestFailedHandleAllocationWhenNotShared)
+    {
+        Log::Comment(L"Create a new output buffer modeled from the default/active one.");
+        const auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
+        const auto& existingOutput = gci.GetActiveOutputBuffer();
+
+        SCREEN_INFORMATION* newOutput;
+
+        VERIFY_NT_SUCCESS(SCREEN_INFORMATION::CreateInstance(existingOutput.GetViewport().Dimensions(),
+                                                             existingOutput.GetCurrentFont(),
+                                                             existingOutput.GetBufferSize().Dimensions(),
+                                                             existingOutput.GetAttributes(),
+                                                             *existingOutput.GetPopupAttributes(),
+                                                             existingOutput.GetTextBuffer().GetCursor().GetSize(),
+                                                             &newOutput));
+
+        ConsoleObjectHeader* newOutputAsHeader = static_cast<ConsoleObjectHeader*>(newOutput);
+
+        VERIFY_ARE_EQUAL(0ul, newOutputAsHeader->_ulOpenCount);
+        VERIFY_ARE_EQUAL(0ul, newOutputAsHeader->_ulReaderCount);
+        VERIFY_ARE_EQUAL(0ul, newOutputAsHeader->_ulReadShareCount);
+        VERIFY_ARE_EQUAL(0ul, newOutputAsHeader->_ulWriterCount);
+        VERIFY_ARE_EQUAL(0ul, newOutputAsHeader->_ulWriteShareCount);
+
+        std::unique_ptr<ConsoleHandleData> unsharedHandle;
+        VERIFY_SUCCEEDED(newOutput->AllocateIoHandle(ConsoleHandleData::HandleType::Output,
+                                                     GENERIC_READ | GENERIC_WRITE,
+                                                     0,
+                                                     unsharedHandle));
+        unsharedHandle.release(); // leak the pointer because destruction will attempt count decrement
+
+        VERIFY_ARE_EQUAL(1ul, newOutputAsHeader->_ulOpenCount);
+        VERIFY_ARE_EQUAL(1ul, newOutputAsHeader->_ulReaderCount);
+        VERIFY_ARE_EQUAL(0ul, newOutputAsHeader->_ulReadShareCount);
+        VERIFY_ARE_EQUAL(1ul, newOutputAsHeader->_ulWriterCount);
+        VERIFY_ARE_EQUAL(0ul, newOutputAsHeader->_ulWriteShareCount);
+
+        std::unique_ptr<ConsoleHandleData> secondHandleAttempt;
+        VERIFY_ARE_EQUAL(HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION), newOutput->AllocateIoHandle(ConsoleHandleData::HandleType::Output, GENERIC_READ | GENERIC_WRITE, 0, secondHandleAttempt));
+
+        VERIFY_ARE_EQUAL(1ul, newOutputAsHeader->_ulOpenCount);
+        VERIFY_ARE_EQUAL(1ul, newOutputAsHeader->_ulReaderCount);
+        VERIFY_ARE_EQUAL(0ul, newOutputAsHeader->_ulReadShareCount);
+        VERIFY_ARE_EQUAL(1ul, newOutputAsHeader->_ulWriterCount);
+        VERIFY_ARE_EQUAL(0ul, newOutputAsHeader->_ulWriteShareCount);
+    }
+};

--- a/src/host/ut_host/sources
+++ b/src/host/ut_host/sources
@@ -43,6 +43,7 @@ SOURCES = \
     CommandNumberPopupTests.cpp \
     CopyFromCharPopupTests.cpp \
     CopyToCharPopupTests.cpp \
+    ObjectTests.cpp \
     DefaultResource.rc \
 
 

--- a/src/server/ObjectHandle.h
+++ b/src/server/ObjectHandle.h
@@ -29,10 +29,11 @@ class SCREEN_INFORMATION;
 class ConsoleHandleData final
 {
 public:
-    ConsoleHandleData(const ULONG ulHandleType,
-                      const ACCESS_MASK amAccess,
-                      const ULONG ulShareAccess,
-                      _In_ PVOID const pvClientPointer);
+    ConsoleHandleData(const ACCESS_MASK amAccess,
+                      const ULONG ulShareAccess);
+
+    void Initialize(const ULONG ulHandleType,
+                    PVOID const pvClientPointer);
 
     ~ConsoleHandleData();
     ConsoleHandleData(const ConsoleHandleData&) = delete;
@@ -62,6 +63,7 @@ public:
 
     enum HandleType
     {
+        NotReady = 0x0,
         Input = 0x1,
         Output = 0x2
     };
@@ -73,9 +75,9 @@ private:
     [[nodiscard]] HRESULT _CloseInputHandle();
     [[nodiscard]] HRESULT _CloseOutputHandle();
 
-    ULONG const _ulHandleType;
     ACCESS_MASK const _amAccess;
     ULONG const _ulShareAccess;
+    ULONG _ulHandleType;
     PVOID _pvClientPointer; // This will be a pointer to a SCREEN_INFORMATION or INPUT_INFORMATION object.
     std::unique_ptr<INPUT_READ_HANDLE_DATA> _pClientInput;
 };

--- a/src/server/ObjectHeader.cpp
+++ b/src/server/ObjectHeader.cpp
@@ -48,7 +48,7 @@ ConsoleObjectHeader::ConsoleObjectHeader() :
             ((pHandleData->IsWriteAllowed()) && (_ulOpenCount > _ulWriteShareCount)) ||
             ((!pHandleData->IsWriteShared()) && (_ulWriterCount > 0)))
         {
-            return HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION);          
+            return HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION);
         }
 
         // Update share/open counts and store handle information.

--- a/src/server/ObjectHeader.h
+++ b/src/server/ObjectHeader.h
@@ -47,4 +47,8 @@ private:
     ULONG _ulWriterCount;
     ULONG _ulReadShareCount;
     ULONG _ulWriteShareCount;
+
+#ifdef UNIT_TESTING
+    friend class ObjectTests;
+#endif
 };


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Stops a crash that occurs when Cooked Read fails to acquire the screen buffer handle and accidentally cleans up the entire buffer on failure.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #3216
* [x] I work here
* [x] Tests added/passed
* [x] Doc comments added, MSDN docs should be fine
* [x] I'm a core contributor and I was the one that broke this

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
When I refactored the object management and server layer in the console host, I divided each segment into objects with their own role and tried to ensure that things cleaned themselves up appropriately when errors occurred. 

Turns out, one of those things got a little bit too aggressive.

`ObjectHandle` is given out for each client process or activity touching either the input or output objects (the input buffer and output buffers, respectively.) They also track their own permission state because each access can have different permission to the same object.

However, the objects themselves in the `ObjectHeader` have to keep track of their open count, that is how many outstanding `ObjectHandle`s there should be referencing a particular object.

When an `ObjectHandle` closes, it decrements the counts on the object to represent itself going away, but it will also finally check if the outstanding count reaches zero and trigger the object itself to leave when there are no longer any references.

This all sounds good, except for the fact that a Handle was created referencing the screen buffer before the access check occurred, the check failed, and the Handle was freed as we exited early.... which then decremented the count to zero despite the increment never happening... cleaned up the object... and then later when the client application came by to shut the object... crash. It's already gone.

The resolution here is to not actually give `Handle` the rights to the object until the access check and increment has occurred. The `Handle` still has cleanup rights if it has the object pointer, now given after all the checks. Otherwise, it should just leave everything alone.

The problem is actually in the read operation. Because the read is a "cooked read" where the conhost is supposed to process the characters interactively, it acquires a handle to the active screen buffer before operating. However, if that buffer doesn't have share rights, it's not allowed and did the cleanup (oops). It should probably just fail and go on. That's what V1 did. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

* [x] Used the sample application in #3216 
* [x] Put in an automated test from this sample application (feature test)
* [x] Put in automated tests exercising handle counts (unit tests)
* [x] Check that `conhostv1` did indeed have the sharing error
