### PR TITLE
wpf: make the cursor blink

### DIFF
--- a/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
@@ -396,3 +396,20 @@ HRESULT _stdcall TerminalResize(void* terminal, COORD dimensions)
 
     return publicTerminal->_terminal->UserResize(dimensions);
 }
+
+void _stdcall BlinkCursor(void* terminal)
+{
+    const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
+    if (!publicTerminal->_terminal->IsCursorBlinkingAllowed() && publicTerminal->_terminal->IsCursorVisible())
+    {
+        return;
+    }
+
+    publicTerminal->_terminal->SetCursorVisible(!publicTerminal->_terminal->IsCursorVisible());
+}
+
+void _stdcall SetCursorVisible(void* terminal, const bool visible)
+{
+    const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
+    publicTerminal->_terminal->SetCursorVisible(visible);
+}

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
@@ -397,7 +397,7 @@ HRESULT _stdcall TerminalResize(void* terminal, COORD dimensions)
     return publicTerminal->_terminal->UserResize(dimensions);
 }
 
-void _stdcall BlinkCursor(void* terminal)
+void _stdcall TerminalBlinkCursor(void* terminal)
 {
     const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
     if (!publicTerminal->_terminal->IsCursorBlinkingAllowed() && publicTerminal->_terminal->IsCursorVisible())
@@ -408,7 +408,7 @@ void _stdcall BlinkCursor(void* terminal)
     publicTerminal->_terminal->SetCursorVisible(!publicTerminal->_terminal->IsCursorVisible());
 }
 
-void _stdcall SetCursorVisible(void* terminal, const bool visible)
+void _stdcall TerminalSetCursorVisible(void* terminal, const bool visible)
 {
     const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
     publicTerminal->_terminal->SetCursorVisible(visible);

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
@@ -35,6 +35,8 @@ __declspec(dllexport) void _stdcall TerminalSetTheme(void* terminal, TerminalThe
 __declspec(dllexport) void _stdcall TerminalRegisterWriteCallback(void* terminal, const void __stdcall callback(wchar_t*));
 __declspec(dllexport) void _stdcall TerminalSendKeyEvent(void* terminal, WPARAM wParam);
 __declspec(dllexport) void _stdcall TerminalSendCharEvent(void* terminal, wchar_t ch);
+__declspec(dllexport) void _stdcall BlinkCursor(void* terminal);
+__declspec(dllexport) void _stdcall SetCursorVisible(void* terminal, const bool visible);
 };
 
 struct HwndTerminal
@@ -69,5 +71,7 @@ private:
     friend void _stdcall TerminalSendKeyEvent(void* terminal, WPARAM wParam);
     friend void _stdcall TerminalSendCharEvent(void* terminal, wchar_t ch);
     friend void _stdcall TerminalSetTheme(void* terminal, TerminalTheme theme, LPCWSTR fontFamily, short fontSize, int newDpi);
+    friend void _stdcall BlinkCursor(void* terminal);
+    friend void _stdcall SetCursorVisible(void* terminal, const bool visible);
     void _UpdateFont(int newDpi);
 };

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
@@ -35,8 +35,8 @@ __declspec(dllexport) void _stdcall TerminalSetTheme(void* terminal, TerminalThe
 __declspec(dllexport) void _stdcall TerminalRegisterWriteCallback(void* terminal, const void __stdcall callback(wchar_t*));
 __declspec(dllexport) void _stdcall TerminalSendKeyEvent(void* terminal, WPARAM wParam);
 __declspec(dllexport) void _stdcall TerminalSendCharEvent(void* terminal, wchar_t ch);
-__declspec(dllexport) void _stdcall BlinkCursor(void* terminal);
-__declspec(dllexport) void _stdcall SetCursorVisible(void* terminal, const bool visible);
+__declspec(dllexport) void _stdcall TerminalBlinkCursor(void* terminal);
+__declspec(dllexport) void _stdcall TerminalSetCursorVisible(void* terminal, const bool visible);
 };
 
 struct HwndTerminal
@@ -71,7 +71,7 @@ private:
     friend void _stdcall TerminalSendKeyEvent(void* terminal, WPARAM wParam);
     friend void _stdcall TerminalSendCharEvent(void* terminal, wchar_t ch);
     friend void _stdcall TerminalSetTheme(void* terminal, TerminalTheme theme, LPCWSTR fontFamily, short fontSize, int newDpi);
-    friend void _stdcall BlinkCursor(void* terminal);
-    friend void _stdcall SetCursorVisible(void* terminal, const bool visible);
+    friend void _stdcall TerminalBlinkCursor(void* terminal);
+    friend void _stdcall TerminalSetCursorVisible(void* terminal, const bool visible);
     void _UpdateFont(int newDpi);
 };

--- a/src/cascadia/WpfTerminalControl/NativeMethods.cs
+++ b/src/cascadia/WpfTerminalControl/NativeMethods.cs
@@ -213,10 +213,10 @@ namespace Microsoft.Terminal.Wpf
         public static extern void TerminalSetTheme(IntPtr terminal, [MarshalAs(UnmanagedType.Struct)] TerminalTheme theme, string fontFamily, short fontSize, int newDpi);
 
         [DllImport("PublicTerminalCore.dll", CallingConvention = CallingConvention.StdCall)]
-        public static extern void BlinkCursor(IntPtr terminal);
+        public static extern void TerminalBlinkCursor(IntPtr terminal);
 
         [DllImport("PublicTerminalCore.dll", CallingConvention = CallingConvention.StdCall)]
-        public static extern void SetCursorVisible(IntPtr terminal, bool visible);
+        public static extern void TerminalSetCursorVisible(IntPtr terminal, bool visible);
 
         [DllImport("user32.dll", SetLastError = true)]
         public static extern IntPtr SetFocus(IntPtr hWnd);

--- a/src/cascadia/WpfTerminalControl/NativeMethods.cs
+++ b/src/cascadia/WpfTerminalControl/NativeMethods.cs
@@ -22,6 +22,16 @@ namespace Microsoft.Terminal.Wpf
         public enum WindowMessage : int
         {
             /// <summary>
+            /// The WM_SETFOCUS message is sent to a window after it has gained the keyboard focus.
+            /// </summary>
+            WM_SETFOCUS = 0x0007,
+
+            /// <summary>
+            /// The WM_KILLFOCUS message is sent to a window immediately before it loses the keyboard focus.
+            /// </summary>
+            WM_KILLFOCUS = 0x0008,
+
+            /// <summary>
             /// The WM_MOUSEACTIVATE message is sent when the cursor is in an inactive window and the user presses a mouse button. The parent window receives this message only if the child window passes it to the DefWindowProc function.
             /// </summary>
             WM_MOUSEACTIVATE = 0x0021,
@@ -202,11 +212,23 @@ namespace Microsoft.Terminal.Wpf
         [DllImport("PublicTerminalCore.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
         public static extern void TerminalSetTheme(IntPtr terminal, [MarshalAs(UnmanagedType.Struct)] TerminalTheme theme, string fontFamily, short fontSize, int newDpi);
 
+        [DllImport("PublicTerminalCore.dll", CallingConvention = CallingConvention.StdCall)]
+        public static extern void BlinkCursor(IntPtr terminal);
+
+        [DllImport("PublicTerminalCore.dll", CallingConvention = CallingConvention.StdCall)]
+        public static extern void SetCursorVisible(IntPtr terminal, bool visible);
+
         [DllImport("user32.dll", SetLastError = true)]
         public static extern IntPtr SetFocus(IntPtr hWnd);
 
         [DllImport("user32.dll", SetLastError = true)]
+        public static extern IntPtr GetFocus();
+
+        [DllImport("user32.dll", SetLastError = true)]
         public static extern short GetKeyState(int keyCode);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern uint GetCaretBlinkTime();
 
         [StructLayout(LayoutKind.Sequential)]
         public struct WINDOWPOS

--- a/src/cascadia/WpfTerminalControl/TerminalContainer.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalContainer.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Terminal.Wpf
                 {
                     if (this.terminal != IntPtr.Zero)
                     {
-                        NativeMethods.BlinkCursor(this.terminal);
+                        NativeMethods.TerminalBlinkCursor(this.terminal);
                     }
                 };
             }
@@ -193,7 +193,7 @@ namespace Microsoft.Terminal.Wpf
             }
             else
             {
-                NativeMethods.SetCursorVisible(this.terminal, false);
+                NativeMethods.TerminalSetCursorVisible(this.terminal, false);
             }
 
             return new HandleRef(this, this.hwnd);
@@ -223,7 +223,7 @@ namespace Microsoft.Terminal.Wpf
                         break;
                     case NativeMethods.WindowMessage.WM_KILLFOCUS:
                         this.blinkTimer?.Stop();
-                        NativeMethods.SetCursorVisible(this.terminal, false);
+                        NativeMethods.TerminalSetCursorVisible(this.terminal, false);
                         break;
                     case NativeMethods.WindowMessage.WM_MOUSEACTIVATE:
                         this.Focus();
@@ -247,7 +247,7 @@ namespace Microsoft.Terminal.Wpf
                         this.MouseMoveHandler((int)wParam, (int)lParam);
                         break;
                     case NativeMethods.WindowMessage.WM_KEYDOWN:
-                        NativeMethods.SetCursorVisible(this.terminal, true);
+                        NativeMethods.TerminalSetCursorVisible(this.terminal, true);
                         NativeMethods.TerminalClearSelection(this.terminal);
                         NativeMethods.TerminalSendKeyEvent(this.terminal, wParam);
                         this.blinkTimer?.Start();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Adds a blinking cursor to the WPF terminal control

## Validation Steps Performed
VS terminal was patched with new bits to verify cursor only blinked when it had keyboard focus.