### PR TITLE
Replace macros with constexpr part 2

### DIFF
--- a/src/host/cmdline.cpp
+++ b/src/host/cmdline.cpp
@@ -955,7 +955,7 @@ void CommandLine::_deleteCommandHistory(COOKED_READ_DATA& cookedReadData) noexce
     if (cookedReadData.HasHistory())
     {
         cookedReadData.History().Empty();
-        cookedReadData.History().Flags |= CLE_ALLOCATED;
+        cookedReadData.History().Flags |= CommandHistory::CLE_ALLOCATED;
     }
 }
 

--- a/src/host/history.h
+++ b/src/host/history.h
@@ -12,13 +12,13 @@ Abstract:
 
 #pragma once
 
-// CommandHistory Flags
-#define CLE_ALLOCATED 0x00000001
-#define CLE_RESET 0x00000002
-
 class CommandHistory
 {
 public:
+    // CommandHistory Flags
+    static constexpr int CLE_ALLOCATED = 0x00000001;
+    static constexpr int CLE_RESET = 0x00000002;
+
     static CommandHistory* s_Allocate(const std::wstring_view appName, const HANDLE processHandle);
     static CommandHistory* s_Find(const HANDLE processHandle);
     static CommandHistory* s_FindByExe(const std::wstring_view appName);

--- a/src/host/input.h
+++ b/src/host/input.h
@@ -28,9 +28,9 @@ Revision History:
 
 // indicates how much to change the opacity at each mouse/key toggle
 // Opacity is defined as 0-255. 12 is therefore approximately 5% per tick.
-#define OPACITY_DELTA_INTERVAL 12
+constexpr unsigned short OPACITY_DELTA_INTERVAL = 12;
 
-#define MAX_CHARS_FROM_1_KEYSTROKE 6
+constexpr unsigned short MAX_CHARS_FROM_1_KEYSTROKE = 6;
 
 #define KEY_TRANSITION_UP 0x80000000
 

--- a/src/host/settings.cpp
+++ b/src/host/settings.cpp
@@ -9,8 +9,8 @@
 
 #pragma hdrstop
 
-#define DEFAULT_NUMBER_OF_COMMANDS 25
-#define DEFAULT_NUMBER_OF_BUFFERS 4
+constexpr unsigned int DEFAULT_NUMBER_OF_COMMANDS = 25;
+constexpr unsigned int DEFAULT_NUMBER_OF_BUFFERS = 4;
 
 using Microsoft::Console::Interactivity::ServiceLocator;
 

--- a/src/host/ut_host/HistoryTests.cpp
+++ b/src/host/ut_host/HistoryTests.cpp
@@ -51,12 +51,12 @@ class HistoryTests
         const auto history = CommandHistory::s_Allocate(app, handle);
         VERIFY_IS_NOT_NULL(history);
 
-        VERIFY_IS_TRUE(WI_IsFlagSet(history->Flags, CLE_ALLOCATED));
+        VERIFY_IS_TRUE(WI_IsFlagSet(history->Flags, CommandHistory::CLE_ALLOCATED));
         VERIFY_ARE_EQUAL(1ul, CommandHistory::s_historyLists.size());
 
         CommandHistory::s_Free(handle);
         // We preserve the app history list for re-use if it reattaches in this session and doesn't age out.
-        VERIFY_IS_TRUE(WI_IsFlagClear(history->Flags, CLE_ALLOCATED), L"Shouldn't actually be gone, just deallocated.");
+        VERIFY_IS_TRUE(WI_IsFlagClear(history->Flags, CommandHistory::CLE_ALLOCATED), L"Shouldn't actually be gone, just deallocated.");
         VERIFY_ARE_EQUAL(1ul, CommandHistory::s_historyLists.size());
     }
 

--- a/src/host/ut_host/PopupTestHelper.hpp
+++ b/src/host/ut_host/PopupTestHelper.hpp
@@ -39,7 +39,7 @@ public:
     static void InitHistory(CommandHistory& history) noexcept
     {
         history.Empty();
-        history.Flags |= CLE_ALLOCATED;
+        history.Flags |= CommandHistory::CLE_ALLOCATED;
         VERIFY_SUCCEEDED(history.Add(L"I'm a little teapot", false));
         VERIFY_SUCCEEDED(history.Add(L"hear me shout", false));
         VERIFY_SUCCEEDED(history.Add(L"here is my handle", false));
@@ -50,7 +50,7 @@ public:
     static void InitLongHistory(CommandHistory& history) noexcept
     {
         history.Empty();
-        history.Flags |= CLE_ALLOCATED;
+        history.Flags |= CommandHistory::CLE_ALLOCATED;
         VERIFY_SUCCEEDED(history.Add(L"Because I could not stop for Death", false));
         VERIFY_SUCCEEDED(history.Add(L"He kindly stopped for me", false));
         VERIFY_SUCCEEDED(history.Add(L"The carriage held but just Ourselves", false));

--- a/src/inc/conime.h
+++ b/src/inc/conime.h
@@ -22,10 +22,10 @@ Revision History:
 
 #pragma once
 
-#define CONIME_ATTRCOLOR_SIZE 8
+constexpr unsigned short CONIME_ATTRCOLOR_SIZE = 8;
 
-#define CONIME_CURSOR_RIGHT 0x10
-#define CONIME_CURSOR_LEFT 0x20
+constexpr BYTE CONIME_CURSOR_RIGHT = 0x10;
+constexpr BYTE CONIME_CURSOR_LEFT = 0x20;
 
 [[nodiscard]] HRESULT ImeStartComposition();
 

--- a/src/tsf/TfConvArea.cpp
+++ b/src/tsf/TfConvArea.cpp
@@ -91,11 +91,11 @@ Notes:
     {
         if (CompCursorPos == 0)
         {
-            encodedAttrs[CompCursorPos] |= (BYTE)CONIME_CURSOR_LEFT; // special handling for ConSrv... 0x20 = COMMON_LVB_GRID_SINGLEFLAG + COMMON_LVB_GRID_LVERTICAL
+            encodedAttrs[CompCursorPos] |= CONIME_CURSOR_LEFT; // special handling for ConSrv... 0x20 = COMMON_LVB_GRID_SINGLEFLAG + COMMON_LVB_GRID_LVERTICAL
         }
         else if (CompCursorPos - 1 < DisplayAttributes.size())
         {
-            encodedAttrs[CompCursorPos - 1] |= (BYTE)CONIME_CURSOR_RIGHT; // special handling for ConSrv... 0x10 = COMMON_LVB_GRID_SINGLEFLAG + COMMON_LVB_GRID_RVERTICAL
+            encodedAttrs[CompCursorPos - 1] |= CONIME_CURSOR_RIGHT; // special handling for ConSrv... 0x10 = COMMON_LVB_GRID_SINGLEFLAG + COMMON_LVB_GRID_RVERTICAL
         }
     }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

A follow-up of #3362.

Replace some macros with modern constexpr

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

#2941

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
