### PR TITLE
[WIP] Perf: construct & reuse clusters in output thread

### DIFF
--- a/src/buffer/out/AttrRow.cpp
+++ b/src/buffer/out/AttrRow.cpp
@@ -120,6 +120,11 @@ size_t ATTR_ROW::GetNumberOfRuns() const noexcept
     return _list.size();
 }
 
+TextAttributeRun ATTR_ROW::GetRunByIndex(size_t index) const
+{
+    return _list.at(index);
+}
+
 // Routine Description:
 // - This routine finds the nth attribute in this ATTR_ROW.
 // Arguments:

--- a/src/buffer/out/AttrRow.hpp
+++ b/src/buffer/out/AttrRow.hpp
@@ -37,6 +37,7 @@ public:
                                   size_t* const pApplies) const;
 
     size_t GetNumberOfRuns() const noexcept;
+    TextAttributeRun GetRunByIndex(size_t index) const;
 
     size_t FindAttrIndex(const size_t index,
                          size_t* const pApplies) const;

--- a/src/buffer/out/Row.cpp
+++ b/src/buffer/out/Row.cpp
@@ -173,9 +173,7 @@ OutputCellIterator ROW::WriteCells(OutputCellIterator it, const size_t index, co
     THROW_HR_IF(E_INVALIDARG, limitRight.value_or(0) >= _charRow.size());
     size_t currentIndex = index;
 
-    // how many dbcs are there?
-    size_t dbcsCount = _rowWidth - _clusters.size();
-    size_t clusterIndex = currentIndex - dbcsCount;
+    size_t clusterIndex = index;
 
     // If we're given a right-side column limit, use it. Otherwise, the write limit is the final column index available in the char row.
     const auto finalColumnInRow = limitRight.value_or(_charRow.size() - 1);
@@ -224,12 +222,11 @@ OutputCellIterator ROW::WriteCells(OutputCellIterator it, const size_t index, co
                 {
                     if (it->DbcsAttr().IsLeading())
                     {
-                        clusterIndex -= 1;
+                        _clusters.at(clusterIndex).SetColumns(0);
                     }
                     if (it->DbcsAttr().IsTrailing())
                     {
                         _clusters.at(clusterIndex).SetColumns(2);
-                        _clusters.erase(_clusters.begin() + clusterIndex + 1);
                     }
                 }
 

--- a/src/buffer/out/Row.cpp
+++ b/src/buffer/out/Row.cpp
@@ -73,6 +73,7 @@ void ROW::SetId(const SHORT id) noexcept
 bool ROW::Reset(const TextAttribute Attr)
 {
     _charRow.Reset();
+    _clusters.clear();
     try
     {
         _attrRow.Reset(Attr);
@@ -222,13 +223,12 @@ OutputCellIterator ROW::WriteCells(OutputCellIterator it, const size_t index, co
                     }
                     if (it->DbcsAttr().IsTrailing())
                     {
-                        _clusters.resize(_clusters.size() - 1);
-                        _clusters.at(clusterIndex) = Microsoft::Console::Render::Cluster(it->Chars(), it->Columns());
+                        _clusters.at(clusterIndex).SetColumns(2);
+                        _clusters.erase(_clusters.begin() + clusterIndex + 1);
                     }
                 }
                 else
                 {
-                    _clusters.at(clusterIndex) = Microsoft::Console::Render::Cluster(it->Chars(), it->Columns());
                 }
 
                 ++it;

--- a/src/buffer/out/Row.cpp
+++ b/src/buffer/out/Row.cpp
@@ -23,7 +23,7 @@ ROW::ROW(const SHORT rowId, const short rowWidth, const TextAttribute fillAttrib
     _attrRow{ gsl::narrow<UINT>(rowWidth), fillAttribute },
     _pParent{ pParent }
 {
-    for (size_t i = 0; i < rowWidth; i++)
+    for (size_t i = 0; i < rowWidth; ++i)
     {
         _clusters.emplace_back(_charRow.GlyphAt(i), _charRow.GlyphAt(i).operator std::basic_string_view<wchar_t>().size());
     }
@@ -74,6 +74,11 @@ bool ROW::Reset(const TextAttribute Attr)
 {
     _charRow.Reset();
     _clusters.clear();
+    for (size_t i = 0; i < _rowWidth; ++i)
+    {
+        _clusters.emplace_back(_charRow.GlyphAt(i), _charRow.GlyphAt(i).operator std::basic_string_view<wchar_t>().size());
+    }
+
     try
     {
         _attrRow.Reset(Attr);
@@ -226,9 +231,6 @@ OutputCellIterator ROW::WriteCells(OutputCellIterator it, const size_t index, co
                         _clusters.at(clusterIndex).SetColumns(2);
                         _clusters.erase(_clusters.begin() + clusterIndex + 1);
                     }
-                }
-                else
-                {
                 }
 
                 ++it;

--- a/src/buffer/out/Row.hpp
+++ b/src/buffer/out/Row.hpp
@@ -27,6 +27,8 @@ Revision History:
 #include "RowCellIterator.hpp"
 #include "UnicodeStorage.hpp"
 
+#include "../renderer/inc/Cluster.hpp"
+
 class TextBuffer;
 
 class ROW final
@@ -50,6 +52,7 @@ public:
 
     void ClearColumn(const size_t column);
     std::wstring GetText() const;
+    std::vector<Microsoft::Console::Render::Cluster> GetClusters() const;
 
     RowCellIterator AsCellIter(const size_t startIndex) const;
     RowCellIterator AsCellIter(const size_t startIndex, const size_t count) const;
@@ -68,6 +71,7 @@ public:
 private:
     CharRow _charRow;
     ATTR_ROW _attrRow;
+    std::vector<Microsoft::Console::Render::Cluster> _clusters;
     SHORT _id;
     size_t _rowWidth;
     TextBuffer* _pParent; // non ownership pointer

--- a/src/buffer/out/Row.hpp
+++ b/src/buffer/out/Row.hpp
@@ -69,6 +69,9 @@ public:
 #endif
 
 private:
+
+    void RefreshClusters(const size_t width);
+
     CharRow _charRow;
     ATTR_ROW _attrRow;
     std::vector<Microsoft::Console::Render::Cluster> _clusters;

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -791,8 +791,7 @@ void TextBuffer::Reset()
 
     for (auto& row : _storage)
     {
-        row.GetCharRow().Reset();
-        row.GetAttrRow().Reset(attr);
+        row.Reset(attr);
     }
 }
 

--- a/src/renderer/base/Cluster.cpp
+++ b/src/renderer/base/Cluster.cpp
@@ -78,3 +78,8 @@ Cluster& Cluster::operator=(const Cluster& other)
     _columns = other.GetColumns();
     return *this;
 }
+
+void Cluster::SetColumns(size_t column)
+{
+    _columns = column;
+}

--- a/src/renderer/base/Cluster.cpp
+++ b/src/renderer/base/Cluster.cpp
@@ -9,6 +9,12 @@
 
 using namespace Microsoft::Console::Render;
 
+Cluster::Cluster() :
+    _text(L" "),
+    _columns(1)
+{
+}
+
 // Routine Description:
 // - Instantiates a new cluster structure
 // Arguments:
@@ -58,4 +64,17 @@ const std::wstring_view& Cluster::GetText() const noexcept
 const size_t Cluster::GetColumns() const noexcept
 {
     return _columns;
+}
+
+Cluster::Cluster(const Cluster& other)
+{
+    _text = other.GetText();
+    _columns = other.GetColumns();
+} 
+
+Cluster& Cluster::operator=(const Cluster& other)
+{
+    _text = other.GetText();
+    _columns = other.GetColumns();
+    return *this;
 }

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -695,6 +695,7 @@ void Renderer::_PaintBufferLineOutputHelper(_In_ IRenderEngine* const pEngine,
         cols = 0;
 
         size_t count = 0;
+        std::vector<Cluster> clusters;
         for (auto it = rowClusters.cbegin() + runStart;
            cols < runLength && it != rowClusters.cend(); ++it)
         {
@@ -702,11 +703,14 @@ void Renderer::_PaintBufferLineOutputHelper(_In_ IRenderEngine* const pEngine,
             const auto columnCount = cluster.GetColumns();
             cols += columnCount;
             count++;
-        }
 
-        std::vector<Cluster> clusters(
-            rowClusters.cbegin() + runStart,
-            rowClusters.cbegin() + runStart + count);
+            if (cluster.GetColumns() <= 0)
+            {
+                continue;
+            }
+
+            clusters.emplace_back(cluster);
+        }
 
         // Do the painting.
         // TODO: Calculate when trim left should be TRUE

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -696,6 +696,7 @@ void Renderer::_PaintBufferLineOutputHelper(_In_ IRenderEngine* const pEngine,
 
         size_t count = 0;
         std::vector<Cluster> clusters;
+        clusters.reserve(runLength);
         for (auto it = rowClusters.cbegin() + runStart;
            cols < runLength && it != rowClusters.cend(); ++it)
         {

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -695,12 +695,9 @@ void Renderer::_PaintBufferLineOutputHelper(_In_ IRenderEngine* const pEngine,
         // Advance the point by however many columns we've just outputted and reset the accumulator.
         screenPoint.X += gsl::narrow<SHORT>(cols);
 
-        std::vector<Cluster> clusters;
-
-        for (auto i = rowClusters.cbegin() + cols; i != rowClusters.cbegin() + cols + runLength; i++)
-        {
-            clusters.emplace_back((*i).GetText(), (*i).GetColumns());
-        }
+        std::vector<Cluster> clusters(
+            rowClusters.cbegin() + cols,
+            rowClusters.cbegin() + std::min(cols + runLength, rowClusters.size()));
 
         // Do the painting.
         // TODO: Calculate when trim left should be TRUE

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -585,7 +585,7 @@ void Renderer::_PaintBufferOutput(_In_ IRenderEngine* const pEngine)
             //auto it = buffer.GetCellDataAt(bufferLine.Origin(), bufferLine);
             //_PaintBufferOutputHelper(pEngine, it, screenLine.Origin());
 
-            auto rowData = buffer.GetRowByOffset(row);
+            const auto rowData = buffer.GetRowByOffset(row);
             _PaintBufferLineOutputHelper(pEngine, rowData, screenLine.Origin());
         }
     }
@@ -665,11 +665,11 @@ void Renderer::_PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine,
 }
 
 void Renderer::_PaintBufferLineOutputHelper(_In_ IRenderEngine* const pEngine,
-                                            ROW& row,
+                                            const ROW& row,
                                             const COORD target)
 {
     size_t cols = 0;
-    ATTR_ROW& attrRow = row.GetAttrRow();
+    const ATTR_ROW& attrRow = row.GetAttrRow();
     std::vector<Cluster> rowClusters = row.GetClusters();
 
     const size_t length = row.size();
@@ -681,7 +681,7 @@ void Renderer::_PaintBufferLineOutputHelper(_In_ IRenderEngine* const pEngine,
     while (cols < length)
     {
         size_t runLength = 0;
-        TextAttribute attr = attrRow.GetAttrByColumn(cols, &runLength);
+        const TextAttribute attr = attrRow.GetAttrByColumn(cols, &runLength);
 
         // Hold onto the current run color right here for the length of the outer loop.
         // We'll be changing the persistent one as we run through the inner loops to detect
@@ -696,7 +696,7 @@ void Renderer::_PaintBufferLineOutputHelper(_In_ IRenderEngine* const pEngine,
         screenPoint.X += gsl::narrow<SHORT>(cols);
 
         std::vector<Cluster> clusters(
-            rowClusters.cbegin() + cols,
+            rowClusters.cbegin() + std::min(cols, rowClusters.size()),
             rowClusters.cbegin() + std::min(cols + runLength, rowClusters.size()));
 
         // Do the painting.

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -99,7 +99,7 @@ namespace Microsoft::Console::Render
                                       const COORD target);
 
         void _PaintBufferLineOutputHelper(_In_ IRenderEngine* const pEngine,
-                                          ROW& row,
+                                          const ROW& row,
                                           const COORD target);
 
         static IRenderEngine::GridLines s_GetGridlines(const TextAttribute& textAttribute) noexcept;

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -98,6 +98,10 @@ namespace Microsoft::Console::Render
                                       TextBufferCellIterator it,
                                       const COORD target);
 
+        void _PaintBufferLineOutputHelper(_In_ IRenderEngine* const pEngine,
+                                          ROW& row,
+                                          const COORD target);
+
         static IRenderEngine::GridLines s_GetGridlines(const TextAttribute& textAttribute) noexcept;
 
         void _PaintBufferOutputGridLineHelper(_In_ IRenderEngine* const pEngine,

--- a/src/renderer/inc/Cluster.hpp
+++ b/src/renderer/inc/Cluster.hpp
@@ -35,6 +35,8 @@ namespace Microsoft::Console::Render
 
         Cluster& operator=(const Cluster&);
 
+        void SetColumns(size_t column);
+
     private:
         // This is the UTF-16 string of characters that form a particular drawing cluster
         std::wstring_view _text;

--- a/src/renderer/inc/Cluster.hpp
+++ b/src/renderer/inc/Cluster.hpp
@@ -21,6 +21,8 @@ namespace Microsoft::Console::Render
     class Cluster
     {
     public:
+        Cluster();
+
         Cluster(const std::wstring_view text, const size_t columns);
 
         const wchar_t GetTextAsSingle() const noexcept;
@@ -29,11 +31,15 @@ namespace Microsoft::Console::Render
 
         const size_t GetColumns() const noexcept;
 
+        Cluster(const Cluster&);
+
+        Cluster& operator=(const Cluster&);
+
     private:
         // This is the UTF-16 string of characters that form a particular drawing cluster
-        const std::wstring_view _text;
+        std::wstring_view _text;
 
         // This is how many columns we're expecting this cluster to take in the display grid
-        const size_t _columns;
+        size_t _columns;
     };
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

By constructing clusters for rendering early in the output thread, the rendering thread will be relieved, making overall performance better when under heavy load.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

#3075 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

This is an attempt to tackle the TODO listed here:

https://github.com/microsoft/terminal/blob/94fc40ed31c0de050304248644458b21d0cce2e9/src/renderer/base/renderer.cpp#L601

I may be doing a lots of thing wrong but the performance boost is so good that I gotta share it with you guys. With this PR, catting my `/etc/services` takes only about 1.5 second, comparing to current release which takes about 5 seconds to do the same thing.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
