### PR TITLE
Prevents DWM crashing from also crashing us

### DIFF
--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -53,7 +53,7 @@ void NonClientIslandWindow::Initialize()
 {
     IslandWindow::Initialize();
 
-    THROW_IF_FAILED(_UpdateFrameMargins());
+    _UpdateFrameMargins();
 
     // Set up our grid of content. We'll use _rootGrid as our root element.
     // There will be two children of this grid - the TitlebarControl, and the
@@ -206,7 +206,7 @@ void NonClientIslandWindow::_OnMaximizeChange() noexcept
     }
 
     // no frame margin when maximized
-    THROW_IF_FAILED(_UpdateFrameMargins());
+    _UpdateFrameMargins();
 }
 
 // Method Description:
@@ -411,7 +411,7 @@ int NonClientIslandWindow::_GetResizeHandleHeight() const noexcept
 // - <none>
 // Return Value:
 // - the HRESULT returned by DwmExtendFrameIntoClientArea.
-[[nodiscard]] HRESULT NonClientIslandWindow::_UpdateFrameMargins() const noexcept
+void NonClientIslandWindow::_UpdateFrameMargins() const noexcept
 {
     MARGINS margins = {};
 
@@ -438,8 +438,11 @@ int NonClientIslandWindow::_GetResizeHandleHeight() const noexcept
         margins.cyTopHeight = -frame.top;
     }
 
-    // Extend the frame into the client area.
-    return DwmExtendFrameIntoClientArea(_window.get(), &margins);
+    // Extend the frame into the client area. microsoft/terminal#2735 - Just log
+    // the failure here, don't crash. If DWM crashes for any reason, calling
+    // THROW_IF_FAILED() will cause us to take a trip upstate. Just log, and
+    // we'll fix ourselves when DWM comes back.
+    LOG_IF_FAILED(DwmExtendFrameIntoClientArea(_window.get(), &margins));
 }
 
 // Method Description:

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.h
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.h
@@ -75,7 +75,7 @@ private:
     bool _ShouldUpdateStylesOnFullscreen() const override { return false; };
     bool _IsTitlebarVisible() const;
 
-    [[nodiscard]] HRESULT _UpdateFrameMargins() const noexcept;
+    void _UpdateFrameMargins() const noexcept;
     void _UpdateMaximizedState();
     void _UpdateIslandPosition(const UINT windowWidth, const UINT windowHeight);
     void _UpdateIslandRegion() const;


### PR DESCRIPTION
## Summary of the Pull Request
  
It's apparently perfectly possible that DWM will just crash or close, and when it does, `DwmExtendFrameIntoClientArea` will return a failure. If we THROW_IF_FAILED that call, then we'll also crash when DWM does.

This converts that THROW_IF_FAILED to a LOG_IF_FAILED. When DWM comes back, we'll hit this codepath again, and all will be right again in the world.

## PR Checklist
* [x] Closes #2735
* [x] I work here
* [n/a] Tests added/passed
* [n/a] Requires documentation to be updated


## Validation Steps Performed

`taskkill /f /im dwm.exe` used to crash us too, now it onlt takes down DWM.