### PR TITLE
wpf: Add .NET Core target to WPF control

### DIFF
--- a/src/cascadia/WpfTerminalControl/WpfTerminalControl.csproj
+++ b/src/cascadia/WpfTerminalControl/WpfTerminalControl.csproj
@@ -1,12 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project>
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
-  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
   <PropertyGroup>
     
-    <TargetFrameworks>net472</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
     <RootNamespace>Microsoft.Terminal.Wpf</RootNamespace>
     <AssemblyName>Microsoft.Terminal.Wpf</AssemblyName>
+    <UseWpf>true</UseWpf>
 
     <RepoBinPath>$(MSBuildThisFileDirectory)..\..\..\bin\</RepoBinPath>
     <IntermediateOutputPath>$(RepoBinPath)..\obj\$(Platform)\$(Configuration)\$(MSBuildProjectName)</IntermediateOutputPath>
@@ -29,17 +28,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
-  <ItemGroup>
-    <Page Include="**\*.xaml" Exclude="App.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Compile Update="**\*.xaml.cs">
-      <DependentUpon>%(Filename)</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-  </ItemGroup>
 
   <Target Name="CollectNativePackContents">
     <ItemGroup>
@@ -54,12 +42,4 @@
     </ItemGroup>
   </Target>
 
-  <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-      
-  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 </Project>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Add .NET Core target to WPF control.
Developer side requirement update: forces Visual Studio version to support .NET Core SDK 3.0. The supported minimal version is 16.3.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Use `Microsoft.NET.Sdk.WindowsDesktop`
  The SDK is designed for WPF and/or WinForms. It handles all item definitions and references for WPF, and also hides difference of desktop WPF and netcore WPF.
- Add .NET Core target to WPF control
  WPF in .NET Core is getting feature parity, and it's the future. As simple as an addition in `TargetFrameworks`.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
No actual code changed.
Requires to test if the WPF control works in .NET Core. But I can't find .NET Framework test to compare.