### PR TITLE
Implement text run “wideness” analysis, and HWID / FWID application

### DIFF
--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -237,8 +237,8 @@ CustomTextLayout::CustomTextLayout(gsl::not_null<IDWriteFactory1*> const factory
         { DWRITE_FONT_FEATURE_TAG::DWRITE_FONT_FEATURE_TAG_CONTEXTUAL_ALTERNATES, 1 }, // calt
         { DWRITE_FONT_FEATURE_TAG::DWRITE_FONT_FEATURE_TAG_HALF_WIDTH, 1 } // hwid
     };
-    static DWRITE_TYPOGRAPHIC_FEATURES fwidFeatureSet = { fwidFeatureArray, _countof(fwidFeatureArray) };
-    static DWRITE_TYPOGRAPHIC_FEATURES hwidFeatureSet = { hwidFeatureArray, _countof(hwidFeatureArray) };
+    static DWRITE_TYPOGRAPHIC_FEATURES fwidFeatureSet = { (DWRITE_FONT_FEATURE*) fwidFeatureArray, _countof(fwidFeatureArray) };
+    static DWRITE_TYPOGRAPHIC_FEATURES hwidFeatureSet = { (DWRITE_FONT_FEATURE*) hwidFeatureArray, _countof(hwidFeatureArray) };
 
     try
     {
@@ -283,7 +283,7 @@ CustomTextLayout::CustomTextLayout(gsl::not_null<IDWriteFactory1*> const factory
 
         // Get the glyphs from the text, retrying if needed.
         const DWRITE_TYPOGRAPHIC_FEATURES* featureSet = run.isWide ? &fwidFeatureSet : &hwidFeatureSet;
-        UINT32 featureRangeLengths[] = { textLength };
+        const UINT32 featureRangeLengths[] = { textLength };
 
         int tries = 0;
 
@@ -300,7 +300,7 @@ CustomTextLayout::CustomTextLayout(gsl::not_null<IDWriteFactory1*> const factory
                 _localeName.data(),
                 (run.isNumberSubstituted) ? _numberSubstitution.Get() : nullptr,
                 &featureSet, // features
-                featureRangeLengths, // featureLengths
+                (UINT32*) featureRangeLengths, // featureLengths
                 1, // featureCount
                 maxGlyphCount, // maxGlyphCount
                 &_glyphClusters.at(textStart),
@@ -350,7 +350,7 @@ CustomTextLayout::CustomTextLayout(gsl::not_null<IDWriteFactory1*> const factory
             &run.script,
             _localeName.data(),
             &featureSet, // features
-            featureRangeLengths, // featureLengths
+            (UINT32*) featureRangeLengths, // featureLengths
             1, // featureCount
             &_glyphAdvances.at(glyphStart),
             &_glyphOffsets.at(glyphStart));

--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -237,8 +237,8 @@ CustomTextLayout::CustomTextLayout(gsl::not_null<IDWriteFactory1*> const factory
         { DWRITE_FONT_FEATURE_TAG::DWRITE_FONT_FEATURE_TAG_CONTEXTUAL_ALTERNATES, 1 }, // calt
         { DWRITE_FONT_FEATURE_TAG::DWRITE_FONT_FEATURE_TAG_HALF_WIDTH, 1 } // hwid
     };
-    static DWRITE_TYPOGRAPHIC_FEATURES fwidFeatureSet = { (DWRITE_FONT_FEATURE*) fwidFeatureArray, _countof(fwidFeatureArray) };
-    static DWRITE_TYPOGRAPHIC_FEATURES hwidFeatureSet = { (DWRITE_FONT_FEATURE*) hwidFeatureArray, _countof(hwidFeatureArray) };
+    static DWRITE_TYPOGRAPHIC_FEATURES fwidFeatureSet = { (DWRITE_FONT_FEATURE*)fwidFeatureArray, _countof(fwidFeatureArray) };
+    static DWRITE_TYPOGRAPHIC_FEATURES hwidFeatureSet = { (DWRITE_FONT_FEATURE*)hwidFeatureArray, _countof(hwidFeatureArray) };
 
     try
     {
@@ -300,7 +300,7 @@ CustomTextLayout::CustomTextLayout(gsl::not_null<IDWriteFactory1*> const factory
                 _localeName.data(),
                 (run.isNumberSubstituted) ? _numberSubstitution.Get() : nullptr,
                 &featureSet, // features
-                (UINT32*) featureRangeLengths, // featureLengths
+                (UINT32*)featureRangeLengths, // featureLengths
                 1, // featureCount
                 maxGlyphCount, // maxGlyphCount
                 &_glyphClusters.at(textStart),
@@ -350,7 +350,7 @@ CustomTextLayout::CustomTextLayout(gsl::not_null<IDWriteFactory1*> const factory
             &run.script,
             _localeName.data(),
             &featureSet, // features
-            (UINT32*) featureRangeLengths, // featureLengths
+            (UINT32*)featureRangeLengths, // featureLengths
             1, // featureCount
             &_glyphAdvances.at(glyphStart),
             &_glyphOffsets.at(glyphStart));

--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -231,11 +231,11 @@ CustomTextLayout::CustomTextLayout(gsl::not_null<IDWriteFactory1*> const factory
 {
     static DWRITE_FONT_FEATURE fwidFeatureArray[] = {
         { DWRITE_FONT_FEATURE_TAG::DWRITE_FONT_FEATURE_TAG_CONTEXTUAL_ALTERNATES, 1 }, // calt
-        { DWRITE_FONT_FEATURE_TAG::DWRITE_FONT_FEATURE_TAG_FULL_WIDTH, 1 }             // fwid
+        { DWRITE_FONT_FEATURE_TAG::DWRITE_FONT_FEATURE_TAG_FULL_WIDTH, 1 } // fwid
     };
     static DWRITE_FONT_FEATURE hwidFeatureArray[] = {
         { DWRITE_FONT_FEATURE_TAG::DWRITE_FONT_FEATURE_TAG_CONTEXTUAL_ALTERNATES, 1 }, // calt
-        { DWRITE_FONT_FEATURE_TAG::DWRITE_FONT_FEATURE_TAG_HALF_WIDTH, 1 }   // hwid
+        { DWRITE_FONT_FEATURE_TAG::DWRITE_FONT_FEATURE_TAG_HALF_WIDTH, 1 } // hwid
     };
     static DWRITE_TYPOGRAPHIC_FEATURES fwidFeatureSet = { fwidFeatureArray, _countof(fwidFeatureArray) };
     static DWRITE_TYPOGRAPHIC_FEATURES hwidFeatureSet = { hwidFeatureArray, _countof(hwidFeatureArray) };
@@ -1024,7 +1024,6 @@ void CustomTextLayout::_SplitCurrentRun(const UINT32 splitPosition)
     _runIndex = gsl::narrow<UINT32>(totalRuns);
 }
 
-
 [[nodiscard]] HRESULT CustomTextLayout::_AnalyzeTextWideness(_In_count_(cwch) const WCHAR* text, const UINT32 cwch)
 {
     bool fWide = false;
@@ -1053,7 +1052,7 @@ void CustomTextLayout::_SplitCurrentRun(const UINT32 splitPosition)
     }
     if (ci > lastRunCharIndex)
         RETURN_IF_FAILED(_SetGlyphWideness(lastRunCharIndex, ci - lastRunCharIndex, fWide));
-    
+
     return S_OK;
 };
 

--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -144,7 +144,7 @@ CustomTextLayout::CustomTextLayout(gsl::not_null<IDWriteFactory1*> const factory
             RETURN_IF_FAILED(_AnalyzeFontFallback(this, 0, textLength));
         }
 
-        RETURN_IF_FAILED(_AnalyzeGlyphWidth(_text.c_str(), textLength));
+        RETURN_IF_FAILED(_AnalyzeTextWideness(_text.c_str(), textLength));
 
         // Ensure that a font face is attached to every run
         for (auto& run : _runs)
@@ -1025,7 +1025,7 @@ void CustomTextLayout::_SplitCurrentRun(const UINT32 splitPosition)
 }
 
 
-[[nodiscard]] HRESULT CustomTextLayout::_AnalyzeGlyphWidth(_In_count_(cwch) const WCHAR* text, const UINT32 cwch)
+[[nodiscard]] HRESULT CustomTextLayout::_AnalyzeTextWideness(_In_count_(cwch) const WCHAR* text, const UINT32 cwch)
 {
     bool fWide = false;
     bool fDecided = false;

--- a/src/renderer/dx/CustomTextLayout.h
+++ b/src/renderer/dx/CustomTextLayout.h
@@ -135,7 +135,7 @@ namespace Microsoft::Console::Render
                                              IDWriteTextRenderer* renderer,
                                              const D2D_POINT_2F origin) noexcept;
 
-        [[nodiscard]] HRESULT _AnalyzeGlyphWidth(_In_count_(cwch) const WCHAR* text, const UINT32 cwch);
+        [[nodiscard]] HRESULT _AnalyzeTextWideness(_In_count_(cwch) const WCHAR* text, const UINT32 cwch);
         [[nodiscard]] HRESULT _SetGlyphWideness(UINT32 textIndex, UINT32 textLength, const bool fWide);
 
 

--- a/src/renderer/dx/CustomTextLayout.h
+++ b/src/renderer/dx/CustomTextLayout.h
@@ -138,7 +138,6 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT _AnalyzeTextWideness(_In_count_(cwch) const WCHAR* text, const UINT32 cwch);
         [[nodiscard]] HRESULT _SetGlyphWideness(UINT32 textIndex, UINT32 textLength, const bool fWide);
 
-
         [[nodiscard]] static constexpr UINT32 _EstimateGlyphCount(const UINT32 textLength) noexcept;
 
     private:

--- a/src/renderer/dx/CustomTextLayout.h
+++ b/src/renderer/dx/CustomTextLayout.h
@@ -11,6 +11,7 @@
 #include <wrl/implements.h>
 
 #include "../inc/Cluster.hpp"
+#include "../types/inc/GlyphWidth.hpp"
 
 namespace Microsoft::Console::Render
 {
@@ -77,6 +78,7 @@ namespace Microsoft::Console::Render
                 script(),
                 isNumberSubstituted(),
                 isSideways(),
+                isWide(),
                 fontFace{ nullptr },
                 fontScale{ 1.0 }
             {
@@ -90,6 +92,7 @@ namespace Microsoft::Console::Render
             UINT8 bidiLevel;
             bool isNumberSubstituted;
             bool isSideways;
+            bool isWide;
             ::Microsoft::WRL::ComPtr<IDWriteFontFace1> fontFace;
             FLOAT fontScale;
 
@@ -131,6 +134,10 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT _DrawGlyphRuns(_In_opt_ void* clientDrawingContext,
                                              IDWriteTextRenderer* renderer,
                                              const D2D_POINT_2F origin) noexcept;
+
+        [[nodiscard]] HRESULT _AnalyzeGlyphWidth(_In_count_(cwch) const WCHAR* text, const UINT32 cwch);
+        [[nodiscard]] HRESULT _SetGlyphWideness(UINT32 textIndex, UINT32 textLength, const bool fWide);
+
 
         [[nodiscard]] static constexpr UINT32 _EstimateGlyphCount(const UINT32 textLength) noexcept;
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [X] <s>Tests added/passed</s> There are no tests for `CustomTextLayout` yet.
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

In a comment to #2066 I said that:

> If a text run is considered only having 0 or 1-cell characters, we apply hwid to them, so font makers can switch their glyphs to a narrower one.
> For a text run considered only having 0 or 2-cell characters, apply fwid instead.
> This is somehow like how UAX #50 works: Analyze runs first, then apply vert on upright runs and vrtr on rotated runs.

What it does it we added an extra analysis pass for text “wideness” analysis to further break text runs into "narrow" and "wide". After that, when we perform shaping, we apply `hwid` feature for narrow runs and `fwid` for wide to let the font we are using know what is the desired wideness the Terminal want. If a font support that (like Iosevka), it would transform the glyphs to the ones with proper width so the text won't get scaled.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Install font Iosevka, and print the character `①`.
It should be shown in a narrow oval, instead of a scaled-down circle.