### PR TITLE
Reset font size key bindings

### DIFF
--- a/doc/cascadia/SettingsSchema.md
+++ b/doc/cascadia/SettingsSchema.md
@@ -112,6 +112,7 @@ Bindings listed below are per the implementation in `src/cascadia/TerminalApp/Ap
 - prevTab
 - increaseFontSize
 - decreaseFontSize
+- resetFontSize
 - scrollUp
 - scrollDown
 - scrollUpPage

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -44,6 +44,7 @@
         "openSettings",
         "paste",
         "prevTab",
+        "resetFontSize",
         "resizePane",
         "resizePaneDown",
         "resizePaneLeft",

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -221,6 +221,14 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
+    void TerminalPage::_HandleResetFontSize(const IInspectable& /*sender*/,
+                                            const TerminalApp::ActionEventArgs& args)
+    {
+        const auto termControl = _GetFocusedControl();
+        termControl.ResetFontSize();
+        args.Handled(true);
+    }
+
     void TerminalPage::_HandleToggleFullscreen(const IInspectable& /*sender*/,
                                                const TerminalApp::ActionEventArgs& args)
     {

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -224,7 +224,7 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_HandleResetFontSize(const IInspectable& /*sender*/,
                                             const TerminalApp::ActionEventArgs& args)
     {
-        const auto termControl = _GetFocusedControl();
+        const auto termControl = _GetActiveControl();
         termControl.ResetFontSize();
         args.Handled(true);
     }

--- a/src/cascadia/TerminalApp/AppKeyBindings.cpp
+++ b/src/cascadia/TerminalApp/AppKeyBindings.cpp
@@ -239,6 +239,12 @@ namespace winrt::TerminalApp::implementation
             _AdjustFontSizeHandlers(*this, *eventArgs);
             break;
         }
+        case ShortcutAction::ResetFontSize:
+        {
+            auto eventArgs = winrt::make_self<ActionEventArgs>();
+            _ResetFontSizeHandlers(*this, *eventArgs);
+            return eventArgs->Handled();
+        }
         case ShortcutAction::ToggleFullscreen:
         {
             _ToggleFullscreenHandlers(*this, *eventArgs);

--- a/src/cascadia/TerminalApp/AppKeyBindings.h
+++ b/src/cascadia/TerminalApp/AppKeyBindings.h
@@ -70,6 +70,7 @@ namespace winrt::TerminalApp::implementation
         TYPED_EVENT(SplitVertical,     TerminalApp::AppKeyBindings, TerminalApp::ActionEventArgs);
         TYPED_EVENT(SplitHorizontal,   TerminalApp::AppKeyBindings, TerminalApp::ActionEventArgs);
         TYPED_EVENT(AdjustFontSize,    TerminalApp::AppKeyBindings, TerminalApp::ActionEventArgs);
+        TYPED_EVENT(ResetFontSize,     TerminalApp::AppKeyBindings, TerminalApp::ActionEventArgs);
         TYPED_EVENT(ScrollUp,          TerminalApp::AppKeyBindings, TerminalApp::ActionEventArgs);
         TYPED_EVENT(ScrollDown,        TerminalApp::AppKeyBindings, TerminalApp::ActionEventArgs);
         TYPED_EVENT(ScrollUpPage,      TerminalApp::AppKeyBindings, TerminalApp::ActionEventArgs);

--- a/src/cascadia/TerminalApp/AppKeyBindings.idl
+++ b/src/cascadia/TerminalApp/AppKeyBindings.idl
@@ -45,6 +45,7 @@ namespace TerminalApp
         SwitchToTab8, // Legacy
         IncreaseFontSize,
         DecreaseFontSize,
+        ResetFontSize,
         ScrollUp,
         ScrollDown,
         ScrollUpPage,
@@ -94,6 +95,7 @@ namespace TerminalApp
         event Windows.Foundation.TypedEventHandler<AppKeyBindings, ActionEventArgs> SplitVertical;
         event Windows.Foundation.TypedEventHandler<AppKeyBindings, ActionEventArgs> SplitHorizontal;
         event Windows.Foundation.TypedEventHandler<AppKeyBindings, ActionEventArgs> AdjustFontSize;
+        event Windows.Foundation.TypedEventHandler<AppKeyBindings, ActionEventArgs> ResetFontSize;
         event Windows.Foundation.TypedEventHandler<AppKeyBindings, ActionEventArgs> ScrollUp;
         event Windows.Foundation.TypedEventHandler<AppKeyBindings, ActionEventArgs> ScrollDown;
         event Windows.Foundation.TypedEventHandler<AppKeyBindings, ActionEventArgs> ScrollUpPage;

--- a/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
@@ -48,6 +48,7 @@ static constexpr std::string_view NextTabKey{ "nextTab" };
 static constexpr std::string_view PrevTabKey{ "prevTab" };
 static constexpr std::string_view IncreaseFontSizeKey{ "increaseFontSize" };
 static constexpr std::string_view DecreaseFontSizeKey{ "decreaseFontSize" };
+static constexpr std::string_view ResetFontSizeKey{ "resetFontSize" };
 static constexpr std::string_view ScrollupKey{ "scrollUp" };
 static constexpr std::string_view ScrolldownKey{ "scrollDown" };
 static constexpr std::string_view ScrolluppageKey{ "scrollUpPage" };
@@ -109,6 +110,7 @@ static const std::map<std::string_view, ShortcutAction, std::less<>> commandName
     { PrevTabKey, ShortcutAction::PrevTab },
     { IncreaseFontSizeKey, ShortcutAction::IncreaseFontSize },
     { DecreaseFontSizeKey, ShortcutAction::DecreaseFontSize },
+    { ResetFontSizeKey, ShortcutAction::ResetFontSize },
     { ScrollupKey, ShortcutAction::ScrollUp },
     { ScrolldownKey, ShortcutAction::ScrollDown },
     { ScrolluppageKey, ShortcutAction::ScrollUpPage },

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -609,6 +609,7 @@ namespace winrt::TerminalApp::implementation
         bindings.MoveFocus({ this, &TerminalPage::_HandleMoveFocus });
         bindings.CopyText({ this, &TerminalPage::_HandleCopyText });
         bindings.AdjustFontSize({ this, &TerminalPage::_HandleAdjustFontSize });
+        bindings.ResetFontSize({ this, &TerminalPage::_HandleResetFontSize });
         bindings.ToggleFullscreen({ this, &TerminalPage::_HandleToggleFullscreen });
     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -153,6 +153,7 @@ namespace winrt::TerminalApp::implementation
         void _HandleCopyText(const IInspectable& sender, const TerminalApp::ActionEventArgs& args);
         void _HandleCloseWindow(const IInspectable&, const TerminalApp::ActionEventArgs& args);
         void _HandleAdjustFontSize(const IInspectable& sender, const TerminalApp::ActionEventArgs& args);
+        void _HandleResetFontSize(const IInspectable& sender, const TerminalApp::ActionEventArgs& args);
         void _HandleToggleFullscreen(const IInspectable& sender, const TerminalApp::ActionEventArgs& args);
 #pragma endregion
     };

--- a/src/cascadia/TerminalApp/defaults.json
+++ b/src/cascadia/TerminalApp/defaults.json
@@ -225,6 +225,7 @@
         { "command": "openSettings", "keys": [ "ctrl+," ] },
         { "command": "paste", "keys": [ "ctrl+shift+v" ] },
         { "command": "prevTab", "keys": [ "ctrl+shift+tab" ] },
+        { "command": "resetFontSize", "keys": ["ctrl+0"]},
         { "command": { "action": "resizePane", "direction": "down" }, "keys": [ "alt+shift+down" ] },
         { "command": { "action": "resizePane", "direction": "left" }, "keys": [ "alt+shift+left" ] },
         { "command": { "action": "resizePane", "direction": "right" }, "keys": [ "alt+shift+right" ] },

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -995,9 +995,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // - none
     void TermControl::ResetFontSize()
     {
-        const auto currentSize = _desiredFont.GetEngineSize().Y;
-        const auto defaultSize = _settings.FontSize();
-        AdjustFontSize(defaultSize - currentSize);
+        _SetFontSize(_settings.FontSize());
     }
 
     // Method Description:
@@ -1006,24 +1004,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // - fontSizeDelta: The amount to increase or decrease the font size by.
     void TermControl::AdjustFontSize(int fontSizeDelta)
     {
-        try
-        {
-            // Make sure we have a non-zero font size
-            const auto newSize = std::max(gsl::narrow<short>(_desiredFont.GetEngineSize().Y + fontSizeDelta), static_cast<short>(1));
-            const auto* fontFace = _settings.FontFace().c_str();
-            _actualFont = { fontFace, 0, 10, { 0, newSize }, CP_UTF8, false };
-            _desiredFont = { _actualFont };
-
-            // Refresh our font with the renderer
-            _UpdateFont();
-            // Resize the terminal's BUFFER to match the new font size. This does
-            // NOT change the size of the window, because that can lead to more
-            // problems (like what happens when you change the font size while the
-            // window is maximized?)
-            auto lock = _terminal->LockForWriting();
-            _DoResize(_swapChainPanel.ActualWidth(), _swapChainPanel.ActualHeight());
-        }
-        CATCH_LOG();
+        const auto newSize = _desiredFont.GetEngineSize().Y + fontSizeDelta;
+        _SetFontSize(newSize);
     }
 
     // Method Description:
@@ -1301,6 +1283,32 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         // TODO: MSFT:20895307 If the font doesn't exist, this doesn't
         //      actually fail. We need a way to gracefully fallback.
         _renderer->TriggerFontChange(newDpi, _desiredFont, _actualFont);
+    }
+
+    // Method Description:
+    // - Set the font size of the terminal control.
+    // Arguments:
+    // - fontSize: The size of the font.
+    void TermControl::_SetFontSize(int fontSize)
+    {
+        try
+        {
+            // Make sure we have a non-zero font size
+            const auto newSize = std::max(gsl::narrow<short>(fontSize), static_cast<short>(1));
+            const auto* fontFace = _settings.FontFace().c_str();
+            _actualFont = { fontFace, 0, 10, { 0, newSize }, CP_UTF8, false };
+            _desiredFont = { _actualFont };
+
+            // Refresh our font with the renderer
+            _UpdateFont();
+            // Resize the terminal's BUFFER to match the new font size. This does
+            // NOT change the size of the window, because that can lead to more
+            // problems (like what happens when you change the font size while the
+            // window is maximized?)
+            auto lock = _terminal->LockForWriting();
+            _DoResize(_swapChainPanel.ActualWidth(), _swapChainPanel.ActualHeight());
+        }
+        CATCH_LOG();
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -990,6 +990,17 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     }
 
     // Method Description:
+    // - Reset the font size of the terminal to its default size.
+    // Arguments:
+    // - none
+    void TermControl::ResetFontSize()
+    {
+        const auto currentSize = _desiredFont.GetEngineSize().Y;
+        const auto defaultSize = _settings.FontSize();
+        AdjustFontSize(defaultSize - currentSize);
+    }
+
+    // Method Description:
     // - Adjust the font size of the terminal control.
     // Arguments:
     // - fontSizeDelta: The amount to increase or decrease the font size by.

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -72,6 +72,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         int GetViewHeight() const;
 
         void AdjustFontSize(int fontSizeDelta);
+        void ResetFontSize();
 
         void SwapChainChanged();
         ~TermControl();

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -158,7 +158,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _BackgroundColorChanged(const uint32_t color);
         bool _InitializeTerminal();
         void _UpdateFont();
-        void _SetFontSize(int fontSize); 
+        void _SetFontSize(int fontSize);
         void _KeyDownHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e);
         void _CharacterHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::CharacterReceivedRoutedEventArgs const& e);
         void _PointerPressedHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -158,6 +158,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _BackgroundColorChanged(const uint32_t color);
         bool _InitializeTerminal();
         void _UpdateFont();
+        void _SetFontSize(int fontSize); 
         void _KeyDownHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e);
         void _CharacterHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::CharacterReceivedRoutedEventArgs const& e);
         void _PointerPressedHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -49,5 +49,6 @@ namespace Microsoft.Terminal.TerminalControl
         event ScrollPositionChangedEventArgs ScrollPositionChanged;
 
         void AdjustFontSize(Int32 fontSizeDelta);
+        void ResetFontSize();
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request
This PR implements resetFontSize keybindings, with default keybindings `ctrl+0`.

## PR Checklist
* [x] Closes #3319
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated

## Validation Steps Performed
Tested manually.