### PR TITLE
Don't ever try to pass "" as a starting directory, no way

### DIFF
--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -106,6 +106,8 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             siEx.StartupInfo.lpTitle = mutableTitle.data();
         }
 
+        const wchar_t* const startingDirectory = _startingDirectory.size() > 0 ? _startingDirectory.c_str() : nullptr;
+
         RETURN_IF_WIN32_BOOL_FALSE(CreateProcessW(
             nullptr,
             cmdline.data(),
@@ -114,7 +116,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             false, // bInheritHandles
             EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT, // dwCreationFlags
             lpEnvironment, // lpEnvironment
-            _startingDirectory.c_str(),
+            startingDirectory,
             &siEx.StartupInfo, // lpStartupInfo
             &_piClient // lpProcessInformation
             ));


### PR DESCRIPTION
## Summary of the Pull Request
I misunderstood the docs for HSTRING and thought the empty string was represented as `nullptr`. It isn't.

## PR Checklist
* [x] Closes #3504
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] Core

## Validation
Self-tested.