### PR TITLE
Throttle SetEvent call in render thread

### DIFF
--- a/src/renderer/base/thread.cpp
+++ b/src/renderer/base/thread.cpp
@@ -15,6 +15,7 @@ RenderThread::RenderThread() :
     _hEvent(nullptr),
     _hPaintCompletedEvent(nullptr),
     _fKeepRunning(true),
+    _fPainting(false),
     _hPaintEnabledEvent(nullptr)
 {
 }
@@ -162,8 +163,9 @@ DWORD WINAPI RenderThread::_ThreadProc()
 
         ResetEvent(_hPaintCompletedEvent);
 
-        LOG_IF_FAILED(_pRenderer->PaintFrame());
+        _fPainting = true;
 
+        LOG_IF_FAILED(_pRenderer->PaintFrame());
         SetEvent(_hPaintCompletedEvent);
 
         // extra check before we sleep since it's a "long" activity, relatively speaking.
@@ -171,6 +173,8 @@ DWORD WINAPI RenderThread::_ThreadProc()
         {
             Sleep(s_FrameLimitMilliseconds);
         }
+
+        _fPainting = false;
     }
 
     return S_OK;
@@ -178,6 +182,11 @@ DWORD WINAPI RenderThread::_ThreadProc()
 
 void RenderThread::NotifyPaint()
 {
+    if (_fPainting)
+    {
+        return;
+    }
+
     SetEvent(_hEvent);
 }
 

--- a/src/renderer/base/thread.hpp
+++ b/src/renderer/base/thread.hpp
@@ -47,5 +47,6 @@ namespace Microsoft::Console::Render
         IRenderer* _pRenderer; // Non-ownership pointer
 
         bool _fKeepRunning;
+        volatile bool _fPainting;
     };
 }

--- a/src/renderer/base/thread.hpp
+++ b/src/renderer/base/thread.hpp
@@ -47,7 +47,7 @@ namespace Microsoft::Console::Render
         IRenderer* _pRenderer; // Non-ownership pointer
 
         bool _fKeepRunning;
-        bool _fNextFrameRequested;
+        std::atomic_flag _fNextFrameRequested;
         std::atomic_flag _fPainting;
     };
 }

--- a/src/renderer/base/thread.hpp
+++ b/src/renderer/base/thread.hpp
@@ -47,6 +47,7 @@ namespace Microsoft::Console::Render
         IRenderer* _pRenderer; // Non-ownership pointer
 
         bool _fKeepRunning;
-        volatile bool _fPainting;
+        bool _fNextFrameRequested;
+        std::atomic_flag _fPainting;
     };
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This is an attempt to reduce unnecessary `SetEvent` CPU overhead.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Redrawing is triggered intensively when terminal is under load. The code here indicates that the redraw call will be throttled:

https://github.com/microsoft/terminal/blob/94fc40ed31c0de050304248644458b21d0cce2e9/src/renderer/base/renderer.cpp#L154

Still, the `SetEvent` call itself stands out a 7% usage of CPU in Release build. Those `SetEvent` calls are mostly useless because most of them are invoked while the rendering thread is sleeping (for `s_FrameLimitMilliseconds` long). 

![图片](https://user-images.githubusercontent.com/4710575/68544415-e9107300-03fd-11ea-8929-89e2ac7753eb.png)

I've tried to guard all the useless calls with `_fPainting` flag, as in this PR. It works great for the CPU. But the rendering became noticeably sluggish. 

I've figured that the rendering thread design is flawed in the perspective of this certain issue, probably also future unknown issues. Instead of being a thread that can be notified, it should behave more like a *timer* that invokes rendering opereation every `s_FrameLimitMilliseconds`. In this way, the rendering thread will be more focused on its own work without being distracted from others.

Maybe @egmontkob can provide us some insight about this. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
