### PR TITLE
Increase left padding around tabs

### DIFF
--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -49,9 +49,6 @@ the MIT License. See LICENSE in the project root for license information. -->
                     is unfortunately static. -->
                     <SolidColorBrush x:Name="ErrorTextBrush" Color="{ThemeResource SystemErrorTextColor}" />
 
-                    <!-- Suppress all padding around the tabs. The TabView looks far better like this. -->
-                    <Thickness x:Key="TabViewHeaderPadding">0,0,0,0</Thickness>
-
                     <ResourceDictionary.ThemeDictionaries>
                         <ResourceDictionary x:Key="Dark">
                             <!-- Define resources for Dark mode here -->

--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -49,6 +49,10 @@ the MIT License. See LICENSE in the project root for license information. -->
                     is unfortunately static. -->
                     <SolidColorBrush x:Name="ErrorTextBrush" Color="{ThemeResource SystemErrorTextColor}" />
 
+                    <!-- Suppress all padding around the tabs. The TabView looks far better like this. -->
+                    <!--<Thickness x:Key="TabViewHeaderPadding">8,7,0,0</Thickness>-->
+                    <Thickness x:Key="TabViewHeaderPadding">8,0,0,0</Thickness>
+
                     <ResourceDictionary.ThemeDictionaries>
                         <ResourceDictionary x:Key="Dark">
                             <!-- Define resources for Dark mode here -->

--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -49,8 +49,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                     is unfortunately static. -->
                     <SolidColorBrush x:Name="ErrorTextBrush" Color="{ThemeResource SystemErrorTextColor}" />
 
-                    <!-- Suppress all padding around the tabs. The TabView looks far better like this. -->
-                    <!--<Thickness x:Key="TabViewHeaderPadding">8,7,0,0</Thickness>-->
+                    <!-- Suppress all padding except left around the tabs. The TabView looks far better like this. -->
                     <Thickness x:Key="TabViewHeaderPadding">8,0,0,0</Thickness>
 
                     <ResourceDictionary.ThemeDictionaries>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Reset the padding to default around the tabs.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #3370 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
### New padding
![image](https://user-images.githubusercontent.com/48369326/68612965-8f965b80-0472-11ea-823b-94923304b27a.png)

### Original padding
![image](https://user-images.githubusercontent.com/48369326/68563971-237d0e80-0404-11ea-951f-5b1566c5de0c.png)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
