### PR TITLE
SnapOnInput on Paste

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1232,6 +1232,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         }
 
         _connection.WriteInput(stripped);
+        _terminal->TrySnapOnInput();
     }
 
     // Method Description:

--- a/src/cascadia/TerminalCore/ITerminalInput.hpp
+++ b/src/cascadia/TerminalCore/ITerminalInput.hpp
@@ -24,6 +24,8 @@ namespace Microsoft::Terminal::Core
         virtual void UserScrollViewport(const int viewTop) = 0;
         virtual int GetScrollOffset() = 0;
 
+        virtual void TrySnapOnInput() = 0;
+
     protected:
         ITerminalInput() = default;
     };

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -193,6 +193,24 @@ void Terminal::Write(std::wstring_view stringView)
 }
 
 // Method Description:
+// - Attempts to snap to the bottom of the buffer, if SnapOnInput is true. Does
+//   nothing if SnapOnInput is set to false, or we're already at the bottom of
+//   the buffer.
+// Arguments:
+// - <none>
+// Return Value:
+// - <none>
+void Terminal::TrySnapOnInput()
+{
+    if (_snapOnInput && _scrollOffset != 0)
+    {
+        auto lock = LockForWriting();
+        _scrollOffset = 0;
+        _NotifyScrollEvent();
+    }
+}
+
+// Method Description:
 // - Send this particular key event to the terminal. The terminal will translate
 //   the key and the modifiers pressed into the appropriate VT sequence for that
 //   key chord. If we do translate the key, we'll return true. In that case, the
@@ -207,12 +225,7 @@ void Terminal::Write(std::wstring_view stringView)
 // - false if we did not translate the key, and it should be processed into a character.
 bool Terminal::SendKeyEvent(const WORD vkey, const WORD scanCode, const ControlKeyStates states)
 {
-    if (_snapOnInput && _scrollOffset != 0)
-    {
-        auto lock = LockForWriting();
-        _scrollOffset = 0;
-        _NotifyScrollEvent();
-    }
+    TrySnapOnInput();
 
     // Alt key sequences _require_ the char to be in the keyevent. If alt is
     // pressed, manually get the character that's being typed, and put it in the

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -92,6 +92,8 @@ public:
     [[nodiscard]] HRESULT UserResize(const COORD viewportSize) noexcept override;
     void UserScrollViewport(const int viewTop) override;
     int GetScrollOffset() override;
+
+    void TrySnapOnInput() override;
 #pragma endregion
 
 #pragma region IBaseData(base to IRenderData and IUiaData)


### PR DESCRIPTION
## Summary of the Pull Request

We forgot to snapOnInput when text is pasted. This corrects that, by making sure that pasted output attempts to snap the Terminal as well.

## References

## PR Checklist
* [x] Closes #3518
* [x] I work here
* [ ] Huh, I suppose we do have Terminal Core tests, but paste isn't really exposed through the TerminalCore, so ¯\\\_(ツ)\_/¯
* [n/a] Requires documentation to be updated


## Validation Steps Performed

Tested manually.
