### PR TITLE
Add "format : color" to Profiles Schema color items

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -6,7 +6,8 @@
     "Color": {
       "default": "#",
       "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
-      "type": "string"
+      "type": "string",
+      "format": "color"
     },
     "ProfileGuid": {
       "default": "{}",


### PR DESCRIPTION
## Summary of the Pull Request
A simple one-liner addition to `profiles.schema.json`.

Enables VSCode to recognize Color-type entries in `profiles.json` and show a color decorator in the editor.

`"format" : "color"` is a nonstandard, VSCode-specific extension to the schema format, but it shouldn't hurt validation for this case.

## PR Checklist

- [ ] Closes #3287 
- [x] CLA signed. If not, go over here and sign the CLA
- [ ] Tests added/passed
- [ ]    Requires documentation to be updated
- [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

Tested manually.