### PR TITLE
Copy RTF data to the clipboard

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1252,7 +1252,7 @@ std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPo
 // - htmlTitle - value used in title tag of html header. Used to name the application
 // Return Value:
 // - string containing the generated RTF
-std::string TextBuffer::GenRTF(const TextAndColor& rows, const int fontHeightPoints, const std::wstring_view fontFaceName, const COLORREF backgroundColor) noexcept
+std::string TextBuffer::GenRTF(const TextAndColor& rows, const int fontHeightPoints, const std::wstring_view fontFaceName, const COLORREF backgroundColor)
 {
     try
     {

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1252,7 +1252,7 @@ std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPo
 // - htmlTitle - value used in title tag of html header. Used to name the application
 // Return Value:
 // - string containing the generated RTF
-std::string TextBuffer::GenRTF(const TextAndColor& rows, const int fontHeightPoints, const std::wstring_view fontFaceName, const COLORREF backgroundColor)
+std::string TextBuffer::GenRTF(const TextAndColor& rows, const int fontHeightPoints, const std::wstring_view fontFaceName, const COLORREF backgroundColor) noexcept
 {
     try
     {
@@ -1355,7 +1355,7 @@ std::string TextBuffer::GenRTF(const TextAndColor& rows, const int fontHeightPoi
                 {
                     writeAccumulatedChars(false);
 
-                    int bkColorIndex, fgColorIndex;
+                    int bkColorIndex = 0;
                     if (colorMap.find(bkColor.value()) != colorMap.end())
                     {
                         // color already exists in the map, just retrieve the index
@@ -1372,6 +1372,7 @@ std::string TextBuffer::GenRTF(const TextAndColor& rows, const int fontHeightPoi
                         bkColorIndex = nextColorIndex++;
                     }
 
+                    int fgColorIndex = 0;
                     if (colorMap.find(fgColor.value()) != colorMap.end())
                     {
                         // color already exists in the map, just retrieve the index

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1243,6 +1243,7 @@ std::string TextBuffer::GenHTML(const TextAndColor& rows, const int fontHeightPo
 
 // Routine Description:
 // - Generates an RTF document based on the passed in text and color data
+//   RTF 1.5 Spec: https://www.biblioscape.com/rtf15_spec.htm
 // Arguments:
 // - rows - the text and color data we will format & encapsulate
 // - backgroundColor - default background color for characters, also used in padding
@@ -1260,7 +1261,12 @@ std::string TextBuffer::GenRTF(const TextAndColor& rows, const int fontHeightPoi
         // start rtf
         rtfBuilder << "{";
 
-        // rtf header
+        // Standard RTF header.
+        // This is similar to the header gnerated by WordPad.
+        // \ansi - specifies that the ANSI char set is used in the current doc
+        // \ansicpg1252 - represents the ANSI code page which is used to perform the Unicode to ANSI conversion when writing RTF text
+        // \deff0 - specifes that the default font for the document is the one at index 0 in the font table
+        // \nouicompat - ?
         rtfBuilder << "\\rtf1\\ansi\\ansicpg1252\\deff0\\nouicompat";
 
         // font table

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -153,7 +153,7 @@ public:
     static std::string GenRTF(const TextAndColor& rows,
                               const int fontHeightPoints,
                               const std::wstring_view fontFaceName,
-                              const COLORREF backgroundColor);
+                              const COLORREF backgroundColor) noexcept;
 
 private:
     std::deque<ROW> _storage;

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -150,6 +150,11 @@ public:
                                const COLORREF backgroundColor,
                                const std::string& htmlTitle);
 
+    static std::string GenRTF(const TextAndColor& rows,
+                              const int fontHeightPoints,
+                              const std::wstring_view fontFaceName,
+                              const COLORREF backgroundColor);
+
 private:
     std::deque<ROW> _storage;
     Cursor _cursor;

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -153,7 +153,7 @@ public:
     static std::string GenRTF(const TextAndColor& rows,
                               const int fontHeightPoints,
                               const std::wstring_view fontFaceName,
-                              const COLORREF backgroundColor) noexcept;
+                              const COLORREF backgroundColor);
 
 private:
     std::deque<ROW> _storage;

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1101,6 +1101,13 @@ namespace winrt::TerminalApp::implementation
                 dataPack.SetHtmlFormat(htmlData);
             }
 
+            // copy rtf data to dataPack
+            const auto rtfData = copiedData.Rtf();
+            if (!rtfData.empty())
+            {
+                dataPack.SetRtf(rtfData);
+            }
+
             try
             {
                 Clipboard::SetContent(dataPack);

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1468,13 +1468,21 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                                                   _settings.DefaultBackground(),
                                                   "Windows Terminal");
 
+        // convert to RTF format
+        const auto rtfData = TextBuffer::GenRTF(bufferData,
+                                                _actualFont.GetUnscaledSize().Y,
+                                                _actualFont.GetFaceName(),
+                                                _settings.DefaultBackground());
+
         if (!_terminal->IsCopyOnSelectActive())
         {
             _terminal->ClearSelection();
         }
 
         // send data up for clipboard
-        auto copyArgs = winrt::make_self<CopyToClipboardEventArgs>(winrt::hstring(textData.data(), gsl::narrow<winrt::hstring::size_type>(textData.size())), winrt::to_hstring(htmlData));
+        auto copyArgs = winrt::make_self<CopyToClipboardEventArgs>(winrt::hstring(textData.data(), gsl::narrow<winrt::hstring::size_type>(textData.size())),
+                                                                   winrt::to_hstring(htmlData),
+                                                                   winrt::to_hstring(rtfData));
         _clipboardCopyHandlers(*this, *copyArgs);
         return true;
     }

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -19,16 +19,19 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         public CopyToClipboardEventArgsT<CopyToClipboardEventArgs>
     {
     public:
-        CopyToClipboardEventArgs(hstring text, hstring html) :
+        CopyToClipboardEventArgs(hstring text, hstring html, hstring rtf) :
             _text(text),
-            _html(html) {}
+            _html(html),
+            _rtf(rtf) {}
 
         hstring Text() { return _text; };
         hstring Html() { return _html; };
+        hstring Rtf() { return _rtf; };
 
     private:
         hstring _text;
         hstring _html;
+        hstring _rtf;
     };
 
     struct PasteFromClipboardEventArgs :

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -11,6 +11,7 @@ namespace Microsoft.Terminal.TerminalControl
     {
         String Text { get; };
         String Html { get; };
+        String Rtf { get; };
     }
 
     runtimeclass PasteFromClipboardEventArgs


### PR DESCRIPTION
## Summary of the Pull Request
RTF data is now copied to the clipboard. Tested by copy pasting text from terminal to WordPad.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #2487
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #2487

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Mostly similar to PR #1224. Added a new static method `GenRTF` in `TextBuffer` that is responsible
for generating the RTF representation of a given text. The generated RTF is added to the `DataPackage` that is ultimately passed to the clipboard.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Validated by copy pasting text from the terminal to WordPad. Validated with different colors to make sure that is working. (MS Word seems to prefer HTML data from the clipboard instead of RTF.)