### PR TITLE
Fix Reverse Walking in AttrRowIterator

### DIFF
--- a/src/buffer/out/AttrRowIterator.cpp
+++ b/src/buffer/out/AttrRowIterator.cpp
@@ -123,14 +123,18 @@ void AttrRowIterator::_decrement(size_t count)
 {
     while (count > 0)
     {
+        // If there's still space within this color attribute to move left, do so.
         if (count <= _currentAttributeIndex)
         {
             _currentAttributeIndex -= count;
             return;
         }
+        // If there's not space, move the whole color attribute left by one
+        // and just take one away from the remaining movement.
+        // We'll walk through above on the if branch to move left further (if necessary)
         else
         {
-            count -= _currentAttributeIndex;
+            --count;
             --_run;
             _currentAttributeIndex = _run->GetLength() - 1;
         }

--- a/src/buffer/out/AttrRowIterator.cpp
+++ b/src/buffer/out/AttrRowIterator.cpp
@@ -136,11 +136,11 @@ void AttrRowIterator::_decrement(size_t count)
             _currentAttributeIndex -= count;
             return;
         }
-        // If there's not space, move the whole color attribute left by one
-        // and just take one away from the remaining movement.
+        // If there's not space, move to the previous attribute run
         // We'll walk through above on the if branch to move left further (if necessary)
         else
         {
+            // make sure we don't go out of bounds
             if (_run == _pAttrRow->_list.cbegin())
             {
                 _exceeded = true;

--- a/src/buffer/out/AttrRowIterator.hpp
+++ b/src/buffer/out/AttrRowIterator.hpp
@@ -54,6 +54,7 @@ private:
     std::vector<TextAttributeRun>::const_iterator _run;
     const ATTR_ROW* _pAttrRow;
     size_t _currentAttributeIndex; // index of TextAttribute within the current TextAttributeRun
+    bool _exceeded;
 
     void _increment(size_t count);
     void _decrement(size_t count);

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -366,7 +366,7 @@ COORD Terminal::_ExpandDoubleClickSelectionLeft(const COORD position) const
     while (positionWithOffsets.X > bufferViewport.Left() && (_GetDelimiterClass(*bufferIterator) == startedOnDelimiter))
     {
         bufferViewport.DecrementInBounds(positionWithOffsets);
-        bufferIterator--;
+        --bufferIterator;
     }
 
     if (_GetDelimiterClass(*bufferIterator) != startedOnDelimiter)
@@ -404,7 +404,7 @@ COORD Terminal::_ExpandDoubleClickSelectionRight(const COORD position) const
     while (positionWithOffsets.X < bufferViewport.RightInclusive() && (_GetDelimiterClass(*bufferIterator) == startedOnDelimiter))
     {
         bufferViewport.IncrementInBounds(positionWithOffsets);
-        bufferIterator++;
+        ++bufferIterator;
     }
 
     if (_GetDelimiterClass(*bufferIterator) != startedOnDelimiter)

--- a/src/host/ut_host/AttrRowTests.cpp
+++ b/src/host/ut_host/AttrRowTests.cpp
@@ -498,6 +498,57 @@ class AttrRowTests
         }
     }
 
+    TEST_METHOD(TestReverseIteratorWalkFromMiddle)
+    {
+        // GH #3409, walking backwards through color range runs out of bounds
+        // We're going to create an attribute row with assorted colors and varying lengths
+        // just like the row of text on the Ubuntu prompt line that triggered this bug being found.
+        // Then we're going to walk backwards through the iterator like a selection-expand-to-left
+        // operation and ensure we don't run off the bounds.
+        Log::Comment(L"Reverse iterate through ubuntu prompt");
+
+        // Create attr row representing a buffer that's 121 wide.
+        auto chain = std::make_unique<ATTR_ROW>(121, _DefaultAttr);
+
+        // The repro case had 4 chain segments.
+        chain->_list.resize(4);
+
+        // The color 10 went for the first 18.
+        chain->_list[0].SetAttributes(TextAttribute(0xA));
+        chain->_list[0].SetLength(18);
+
+        // Default color for the next 1
+        chain->_list[1].SetAttributes(TextAttribute());
+        chain->_list[1].SetLength(1);
+
+        // Color 12 for the next 29
+        chain->_list[2].SetAttributes(TextAttribute(0xC));
+        chain->_list[2].SetLength(29);
+
+        // Then default color to end the run
+        chain->_list[3].SetAttributes(TextAttribute());
+        chain->_list[3].SetLength(73);
+
+        // The sum of the lengths should be 121.
+        VERIFY_ARE_EQUAL(chain->_cchRowWidth, chain->_list[0]._cchLength + chain->_list[1]._cchLength + chain->_list[2]._cchLength + chain->_list[3]._cchLength);
+
+        // Get the beginning of the entire row of colors.
+        auto iter = chain->cbegin();
+
+        // Advance forward to what should be the second piece of the chain.
+        auto walkDistance = chain->_list[0].GetLength();
+        iter += walkDistance;
+
+        // Now walk backwards in a loop until 0.
+        while (walkDistance > 0)
+        {
+            --iter;
+            --walkDistance;
+        }
+
+        Log::Comment(L"We made it through without crashing!");
+    }
+
     TEST_METHOD(TestSetAttrToEnd)
     {
         const WORD wTestAttr = FOREGROUND_BLUE | BACKGROUND_GREEN;

--- a/src/host/ut_host/AttrRowTests.cpp
+++ b/src/host/ut_host/AttrRowTests.cpp
@@ -565,7 +565,7 @@ class AttrRowTests
 
         Log::Comment(L"Reverse iterate past one boundary");
         {
-            // Create attr row representing a buffer that's 12 wide.
+            // Create attr row representing a buffer that's 3 wide.
             auto chain = std::make_unique<ATTR_ROW>(3, _DefaultAttr);
 
             // The repro case had 3 chain segments.
@@ -593,7 +593,7 @@ class AttrRowTests
 
         Log::Comment(L"Reverse iterate past one boundary");
         {
-            // Create attr row representing a buffer that's 12 wide.
+            // Create attr row representing a buffer that's 3 wide.
             auto chain = std::make_unique<ATTR_ROW>(3, _DefaultAttr);
 
             // The repro case had 3 chain segments.

--- a/src/host/ut_host/AttrRowTests.cpp
+++ b/src/host/ut_host/AttrRowTests.cpp
@@ -505,48 +505,119 @@ class AttrRowTests
         // just like the row of text on the Ubuntu prompt line that triggered this bug being found.
         // Then we're going to walk backwards through the iterator like a selection-expand-to-left
         // operation and ensure we don't run off the bounds.
+
+        auto testWalk = [&](ATTR_ROW* chain, size_t index, int stepSize) {
+            // move to starting index
+            auto iter = chain->cbegin();
+            iter += (chain->_cchRowWidth - index);
+
+            // Now walk backwards in a loop until 0.
+            while (iter)
+            {
+                iter -= stepSize;
+            }
+
+            Log::Comment(L"We made it through without crashing!");
+        };
+
+        auto verifyStep = [&](ATTR_ROW* chain, size_t index, int stepSize, TextAttribute expectedAttribute) {
+            // move to starting index
+            auto iter = chain->cbegin();
+            iter += (chain->_cchRowWidth - index);
+
+            // Now step backwards
+            iter -= stepSize;
+
+            VERIFY_ARE_EQUAL(expectedAttribute, *iter);
+        };
+
         Log::Comment(L"Reverse iterate through ubuntu prompt");
-
-        // Create attr row representing a buffer that's 121 wide.
-        auto chain = std::make_unique<ATTR_ROW>(121, _DefaultAttr);
-
-        // The repro case had 4 chain segments.
-        chain->_list.resize(4);
-
-        // The color 10 went for the first 18.
-        chain->_list[0].SetAttributes(TextAttribute(0xA));
-        chain->_list[0].SetLength(18);
-
-        // Default color for the next 1
-        chain->_list[1].SetAttributes(TextAttribute());
-        chain->_list[1].SetLength(1);
-
-        // Color 12 for the next 29
-        chain->_list[2].SetAttributes(TextAttribute(0xC));
-        chain->_list[2].SetLength(29);
-
-        // Then default color to end the run
-        chain->_list[3].SetAttributes(TextAttribute());
-        chain->_list[3].SetLength(73);
-
-        // The sum of the lengths should be 121.
-        VERIFY_ARE_EQUAL(chain->_cchRowWidth, chain->_list[0]._cchLength + chain->_list[1]._cchLength + chain->_list[2]._cchLength + chain->_list[3]._cchLength);
-
-        // Get the beginning of the entire row of colors.
-        auto iter = chain->cbegin();
-
-        // Advance forward to what should be the second piece of the chain.
-        auto walkDistance = chain->_list[0].GetLength();
-        iter += walkDistance;
-
-        // Now walk backwards in a loop until 0.
-        while (walkDistance > 0)
         {
-            --iter;
-            --walkDistance;
+            // Create attr row representing a buffer that's 121 wide.
+            auto chain = std::make_unique<ATTR_ROW>(121, _DefaultAttr);
+
+            // The repro case had 4 chain segments.
+            chain->_list.resize(4);
+
+            // The color 10 went for the first 18.
+            chain->_list[0].SetAttributes(TextAttribute(0xA));
+            chain->_list[0].SetLength(18);
+
+            // Default color for the next 1
+            chain->_list[1].SetAttributes(TextAttribute());
+            chain->_list[1].SetLength(1);
+
+            // Color 12 for the next 29
+            chain->_list[2].SetAttributes(TextAttribute(0xC));
+            chain->_list[2].SetLength(29);
+
+            // Then default color to end the run
+            chain->_list[3].SetAttributes(TextAttribute());
+            chain->_list[3].SetLength(73);
+
+            // The sum of the lengths should be 121.
+            VERIFY_ARE_EQUAL(chain->_cchRowWidth, chain->_list[0]._cchLength + chain->_list[1]._cchLength + chain->_list[2]._cchLength + chain->_list[3]._cchLength);
+
+            auto index = chain->_list[0].GetLength();
+            auto stepSize = 1;
+            testWalk(chain.get(), index, stepSize);
         }
 
-        Log::Comment(L"We made it through without crashing!");
+        Log::Comment(L"Reverse iterate past one boundary");
+        {
+            // Create attr row representing a buffer that's 12 wide.
+            auto chain = std::make_unique<ATTR_ROW>(3, _DefaultAttr);
+
+            // The repro case had 3 chain segments.
+            chain->_list.resize(3);
+
+            // The color 10 went for the first 1.
+            chain->_list[0].SetAttributes(TextAttribute(0xA));
+            chain->_list[0].SetLength(1);
+
+            // The color 11 for the next 1
+            chain->_list[1].SetAttributes(TextAttribute(0xB));
+            chain->_list[1].SetLength(1);
+
+            // Color 12 for the next 1
+            chain->_list[2].SetAttributes(TextAttribute(0xC));
+            chain->_list[2].SetLength(1);
+
+            // The sum of the lengths should be 3.
+            VERIFY_ARE_EQUAL(chain->_cchRowWidth, chain->_list[0]._cchLength + chain->_list[1]._cchLength + chain->_list[2]._cchLength);
+
+            auto index = 1;
+            auto stepSize = 1;
+            verifyStep(chain.get(), index, stepSize, TextAttribute(0xB));
+        }
+
+        Log::Comment(L"Reverse iterate past one boundary");
+        {
+            // Create attr row representing a buffer that's 12 wide.
+            auto chain = std::make_unique<ATTR_ROW>(3, _DefaultAttr);
+
+            // The repro case had 3 chain segments.
+            chain->_list.resize(3);
+
+            // The color 10 went for the first 1.
+            chain->_list[0].SetAttributes(TextAttribute(0xA));
+            chain->_list[0].SetLength(1);
+
+            // The color 11 for the next 1
+            chain->_list[1].SetAttributes(TextAttribute(0xB));
+            chain->_list[1].SetLength(1);
+
+            // Color 12 for the next 1
+            chain->_list[2].SetAttributes(TextAttribute(0xC));
+            chain->_list[2].SetLength(1);
+
+            // The sum of the lengths should be 3.
+            VERIFY_ARE_EQUAL(chain->_cchRowWidth, chain->_list[0]._cchLength + chain->_list[1]._cchLength + chain->_list[2]._cchLength);
+
+            auto index = 2;
+            auto stepSize = 1;
+            verifyStep(chain.get(), index, stepSize, TextAttribute(0xA));
+        }
     }
 
     TEST_METHOD(TestSetAttrToEnd)

--- a/src/host/ut_host/AttrRowTests.cpp
+++ b/src/host/ut_host/AttrRowTests.cpp
@@ -506,10 +506,12 @@ class AttrRowTests
         // Then we're going to walk backwards through the iterator like a selection-expand-to-left
         // operation and ensure we don't run off the bounds.
 
-        auto testWalk = [&](ATTR_ROW* chain, size_t index, int stepSize) {
+        // walk the chain, from index, stepSize at a time
+        // ensure we don't crash
+        auto testWalk = [](ATTR_ROW* chain, size_t index, int stepSize) {
             // move to starting index
             auto iter = chain->cbegin();
-            iter += (chain->_cchRowWidth - index);
+            iter += index;
 
             // Now walk backwards in a loop until 0.
             while (iter)
@@ -520,10 +522,13 @@ class AttrRowTests
             Log::Comment(L"We made it through without crashing!");
         };
 
-        auto verifyStep = [&](ATTR_ROW* chain, size_t index, int stepSize, TextAttribute expectedAttribute) {
+        // take one step of size stepSize on the chain
+        // index is where we start from
+        // expectedAttribute is what we expect to read here
+        auto verifyStep = [](ATTR_ROW* chain, size_t index, int stepSize, TextAttribute expectedAttribute) {
             // move to starting index
             auto iter = chain->cbegin();
-            iter += (chain->_cchRowWidth - index);
+            iter += index;
 
             // Now step backwards
             iter -= stepSize;
@@ -563,7 +568,7 @@ class AttrRowTests
             testWalk(chain.get(), index, stepSize);
         }
 
-        Log::Comment(L"Reverse iterate from 1 to 0 (new run)");
+        Log::Comment(L"Reverse iterate across a text run in the chain");
         {
             // Create attr row representing a buffer that's 3 wide.
             auto chain = std::make_unique<ATTR_ROW>(3, _DefaultAttr);
@@ -586,12 +591,13 @@ class AttrRowTests
             // The sum of the lengths should be 3.
             VERIFY_ARE_EQUAL(chain->_cchRowWidth, chain->_list[0]._cchLength + chain->_list[1]._cchLength + chain->_list[2]._cchLength);
 
+            // on 'ABC', step from B to A
             auto index = 1;
             auto stepSize = 1;
-            verifyStep(chain.get(), index, stepSize, TextAttribute(0xB));
+            verifyStep(chain.get(), index, stepSize, TextAttribute(0xA));
         }
 
-        Log::Comment(L"Reverse iterate from 2 to 1 (new run)");
+        Log::Comment(L"Reverse iterate across two text runs in the chain");
         {
             // Create attr row representing a buffer that's 3 wide.
             auto chain = std::make_unique<ATTR_ROW>(3, _DefaultAttr);
@@ -614,8 +620,9 @@ class AttrRowTests
             // The sum of the lengths should be 3.
             VERIFY_ARE_EQUAL(chain->_cchRowWidth, chain->_list[0]._cchLength + chain->_list[1]._cchLength + chain->_list[2]._cchLength);
 
+            // on 'ABC', step from C to A
             auto index = 2;
-            auto stepSize = 1;
+            auto stepSize = 2;
             verifyStep(chain.get(), index, stepSize, TextAttribute(0xA));
         }
     }

--- a/src/host/ut_host/AttrRowTests.cpp
+++ b/src/host/ut_host/AttrRowTests.cpp
@@ -563,7 +563,7 @@ class AttrRowTests
             testWalk(chain.get(), index, stepSize);
         }
 
-        Log::Comment(L"Reverse iterate past one boundary");
+        Log::Comment(L"Reverse iterate from 1 to 0 (new run)");
         {
             // Create attr row representing a buffer that's 3 wide.
             auto chain = std::make_unique<ATTR_ROW>(3, _DefaultAttr);
@@ -591,7 +591,7 @@ class AttrRowTests
             verifyStep(chain.get(), index, stepSize, TextAttribute(0xB));
         }
 
-        Log::Comment(L"Reverse iterate past one boundary");
+        Log::Comment(L"Reverse iterate from 2 to 1 (new run)");
         {
             // Create attr row representing a buffer that's 3 wide.
             auto chain = std::make_unique<ATTR_ROW>(3, _DefaultAttr);

--- a/tools/ConsoleTypes.natvis
+++ b/tools/ConsoleTypes.natvis
@@ -12,14 +12,17 @@
         <!-- You can't do too much trickyness inside the DisplayString format
                 string, so we'd have to add entries for each flag if we really
                 wanted them to show up like that. -->
-        <DisplayString Condition="_isBold">{{FG:{_foreground},BG:{_background},{_wAttrLegacy}, Bold}}</DisplayString>
-        <DisplayString>{{FG:{_foreground},BG:{_background},{_wAttrLegacy}, Normal}}</DisplayString>
+        <DisplayString>{{FG: {_foreground}, BG: {_background}, Legacy: {_wAttrLegacy}, {_extendedAttrs}}</DisplayString>
         <Expand>
-            <Item Name="_wAttrLegacy">_wAttrLegacy</Item>
-            <Item Name="_isBold">_isBold</Item>
-            <Item Name="_foreground">_foreground</Item>
-            <Item Name="_background">_background</Item>
+            <Item Name="Legacy">_wAttrLegacy</Item>
+            <Item Name="FG">_foreground</Item>
+            <Item Name="BG">_background</Item>
+            <Item Name="Extended">_extendedAttrs</Item>
         </Expand>
+    </Type>
+
+    <Type Name="TextAttributeRun">
+        <DisplayString>Length={_cchLength} Attr={_attributes}</DisplayString>
     </Type>
 
     <Type Name="Microsoft::Console::Types::Viewport">


### PR DESCRIPTION
## Summary of the Pull Request
The `count -= _currentAttributeIndex` caused `_run` to go out of bounds. Removing the minor optimization fixes this potential crash.

## References
#3409 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #3409 
* [x] CLA signed
* [ ] Tests added/passed
* [x] Requires documentation to be updated
* [x] I am a core contributor

## Detailed Description of the Pull Request / Additional comments
@miniksa knows much more about this. He's the real MVP.

## Validation Steps Performed
1. Open ubuntu shell
2. double click the : or ~ in cazamor@PC-cazamor:~$

This used to crash. Not anymore!
