### PR TITLE
Try to fix unicode layout issue

### DIFF
--- a/src/buffer/out/DbcsAttribute.hpp
+++ b/src/buffer/out/DbcsAttribute.hpp
@@ -23,7 +23,9 @@ public:
     {
         Single = 0x00,
         Leading = 0x01,
-        Trailing = 0x02
+        Trailing = 0x02,
+        ZeroLeading = 0x03,
+        ZeroTrailing = 0x04,
     };
 
     DbcsAttribute() noexcept :
@@ -53,9 +55,19 @@ public:
         return _attribute == Attribute::Trailing;
     }
 
+    constexpr bool IsZeroLeading() const noexcept
+    {
+        return _attribute == Attribute::ZeroLeading;
+    }
+
+    constexpr bool IsZeroTrailing() const noexcept
+    {
+        return _attribute == Attribute::ZeroTrailing;
+    }
+
     constexpr bool IsDbcs() const noexcept
     {
-        return IsLeading() || IsTrailing();
+        return IsLeading() || IsTrailing() || IsZeroLeading() || IsZeroTrailing();
     }
 
     constexpr bool IsGlyphStored() const noexcept
@@ -81,6 +93,16 @@ public:
     void SetTrailing() noexcept
     {
         _attribute = Attribute::Trailing;
+    }
+
+    void SetZeroLeading() noexcept
+    {
+        _attribute = Attribute::ZeroLeading;
+    }
+
+    void SetZeroTrailing() noexcept
+    {
+        _attribute = Attribute::ZeroTrailing;
     }
 
     void Reset() noexcept

--- a/src/buffer/out/OutputCellIterator.cpp
+++ b/src/buffer/out/OutputCellIterator.cpp
@@ -357,6 +357,17 @@ bool OutputCellIterator::_TryMoveTrailing() noexcept
                                       _currentView.TextAttrBehavior());
         return true;
     }
+    else if (_currentView.DbcsAttr().IsZeroLeading())
+    {
+        auto dbcsAttr = _currentView.DbcsAttr();
+        dbcsAttr.SetZeroTrailing();
+
+        _currentView = OutputCellView(_currentView.Chars(),
+                                      dbcsAttr,
+                                      _currentView.TextAttr(),
+                                      _currentView.TextAttrBehavior());
+        return true;
+    }
     else
     {
         return false;
@@ -410,9 +421,14 @@ OutputCellView OutputCellIterator::s_GenerateView(const std::wstring_view view,
 {
     const auto glyph = Utf16Parser::ParseNext(view);
     DbcsAttribute dbcsAttr;
-    if (IsGlyphFullWidth(glyph))
+    CodepointWidth width = GetGlyphWidth(glyph);
+    if (width == CodepointWidth::Wide)
     {
         dbcsAttr.SetLeading();
+    }
+    else if (width == CodepointWidth::Combining)
+    {
+        dbcsAttr.SetZeroLeading();
     }
 
     return OutputCellView(glyph, dbcsAttr, attr, behavior);
@@ -432,9 +448,14 @@ OutputCellView OutputCellIterator::s_GenerateView(const wchar_t& wch) noexcept
     const auto glyph = std::wstring_view(&wch, 1);
 
     DbcsAttribute dbcsAttr;
-    if (IsGlyphFullWidth(wch))
+    CodepointWidth width = GetGlyphWidth(glyph);
+    if (width == CodepointWidth::Wide)
     {
         dbcsAttr.SetLeading();
+    }
+    else if (width == CodepointWidth::Combining)
+    {
+        dbcsAttr.SetZeroLeading();
     }
 
     return OutputCellView(glyph, dbcsAttr, InvalidTextAttribute, TextAttributeBehavior::Current);
@@ -469,9 +490,14 @@ OutputCellView OutputCellIterator::s_GenerateView(const wchar_t& wch, const Text
     const auto glyph = std::wstring_view(&wch, 1);
 
     DbcsAttribute dbcsAttr;
-    if (IsGlyphFullWidth(wch))
+    CodepointWidth width = GetGlyphWidth(glyph);
+    if (width == CodepointWidth::Wide)
     {
         dbcsAttr.SetLeading();
+    }
+    else if (width == CodepointWidth::Combining)
+    {
+        dbcsAttr.SetZeroLeading();
     }
 
     return OutputCellView(glyph, dbcsAttr, attr, TextAttributeBehavior::Stored);

--- a/src/buffer/out/OutputCellView.cpp
+++ b/src/buffer/out/OutputCellView.cpp
@@ -52,6 +52,14 @@ size_t OutputCellView::Columns() const noexcept
     {
         return 1;
     }
+    else if (DbcsAttr().IsZeroLeading())
+    {
+        return 0;
+    }
+    else if (DbcsAttr().IsZeroTrailing())
+    {
+        return 0;
+    }
 
     return 1;
 }

--- a/src/renderer/base/Cluster.cpp
+++ b/src/renderer/base/Cluster.cpp
@@ -9,6 +9,12 @@
 
 using namespace Microsoft::Console::Render;
 
+Cluster::Cluster() :
+    _text(L""),
+    _columns(0)
+{
+}
+
 // Routine Description:
 // - Instantiates a new cluster structure
 // Arguments:

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -645,7 +645,7 @@ void Renderer::_PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine,
 
                 // Advance the cluster and column counts.
                 const auto columnCount = clusters.back().GetColumns();
-                it += columnCount > 0 ? columnCount : 1; // prevent infinite loop for no visible columns
+                it += columnCount > 0 ? columnCount : 2; // prevent infinite loop for no visible columns
                 cols += columnCount;
 
             } while (it);

--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -409,7 +409,7 @@ CustomTextLayout::CustomTextLayout(gsl::not_null<IDWriteFactory1*> const factory
             const auto advanceExpected = static_cast<float>(columns * _width);
 
             // If what we expect is bigger than what we have... pad it out.
-            if (advanceExpected > advance)
+            if (advanceExpected > advance && advance > FLT_EPSILON)
             {
                 // Get the amount of space we have leftover.
                 const auto diff = advanceExpected - advance;
@@ -422,7 +422,7 @@ CustomTextLayout::CustomTextLayout(gsl::not_null<IDWriteFactory1*> const factory
                 advance = advanceExpected;
             }
             // If what we expect is smaller than what we have... rescale the font size to get a smaller glyph to fit.
-            else if (advanceExpected < advance)
+            else if (advanceExpected < advance && advanceExpected > FLT_EPSILON)
             {
                 // We need to retrieve the design information for this specific glyph so we can figure out the appropriate
                 // height proportional to the width that we desire.

--- a/src/renderer/dx/CustomTextLayout.h
+++ b/src/renderer/dx/CustomTextLayout.h
@@ -148,7 +148,7 @@ namespace Microsoft::Console::Render
 
         // The text we're analyzing and processing into a layout
         std::wstring _text;
-        std::vector<UINT16> _textClusterColumns;
+        std::vector<Cluster> _textClusters;
         size_t _width;
 
         // Properties of the text that might be relevant.
@@ -158,6 +158,7 @@ namespace Microsoft::Console::Render
 
         // Text analysis results
         std::vector<LinkedRun> _runs;
+        std::vector<std::vector<Cluster>> _runClusters;
         std::vector<DWRITE_LINE_BREAKPOINT> _breakpoints;
 
         // Text analysis interim status variable (to assist the Analyzer Sink in operations involving _runs)

--- a/src/renderer/inc/Cluster.hpp
+++ b/src/renderer/inc/Cluster.hpp
@@ -21,6 +21,8 @@ namespace Microsoft::Console::Render
     class Cluster
     {
     public:
+        Cluster();
+
         Cluster(const std::wstring_view text, const size_t columns);
 
         const wchar_t GetTextAsSingle() const noexcept;

--- a/src/renderer/vt/paint.cpp
+++ b/src/renderer/vt/paint.cpp
@@ -347,7 +347,7 @@ using namespace Microsoft::Console::Types;
         for (const auto& cluster : clusters)
         {
             wstr.append(cluster.GetText());
-            RETURN_IF_FAILED(ShortAdd(totalWidth, gsl::narrow<short>(cluster.GetColumns()), &totalWidth));
+            RETURN_IF_FAILED(ShortAdd(totalWidth, gsl::narrow<short>(cluster.GetColumns() > 0 ? cluster.GetColumns() : 2), &totalWidth));
         }
 
         RETURN_IF_FAILED(VtEngine::_WriteTerminalAscii(wstr));
@@ -384,7 +384,7 @@ using namespace Microsoft::Console::Types;
     for (const auto& cluster : clusters)
     {
         unclusteredString.append(cluster.GetText());
-        RETURN_IF_FAILED(ShortAdd(totalWidth, static_cast<short>(cluster.GetColumns()), &totalWidth));
+        RETURN_IF_FAILED(ShortAdd(totalWidth, static_cast<short>(cluster.GetColumns() > 0 ? cluster.GetColumns() : 2), &totalWidth));
     }
     const size_t cchLine = unclusteredString.size();
 

--- a/src/types/GlyphWidth.cpp
+++ b/src/types/GlyphWidth.cpp
@@ -9,6 +9,11 @@
 // TODO GH 2676 - remove warning suppression and decide what to do re: singleton instance of CodepointWidthDetector
 static CodepointWidthDetector widthDetector;
 
+CodepointWidth GetGlyphWidth(const std::wstring_view glyph)
+{
+    return widthDetector.GetWidthFast(glyph);
+}
+
 // Function Description:
 // - determines if the glyph represented by the string of characters should be
 //      wide or not. See CodepointWidthDetector::IsWide

--- a/src/types/convert.cpp
+++ b/src/types/convert.cpp
@@ -366,7 +366,7 @@ CodepointWidth GetQuickCharWidth(const wchar_t wch) noexcept
         // From Unicode 9.0, Hangul Choseong is wide
         return CodepointWidth::Wide;
     }
-    else if (0x1160 <= wch && wch <= 0x200F)
+    else if (0x1200 <= wch && wch <= 0x200F)
     {
         // From Unicode 9.0, this range is narrow (assorted languages)
         return CodepointWidth::Narrow;

--- a/src/types/inc/CodepointWidthDetector.hpp
+++ b/src/types/inc/CodepointWidthDetector.hpp
@@ -30,6 +30,7 @@ public:
     CodepointWidthDetector& operator=(const CodepointWidthDetector&) = delete;
     CodepointWidthDetector& operator=(CodepointWidthDetector&&) = delete;
 
+    CodepointWidth GetWidthFast(const std::wstring_view glyph) const;
     CodepointWidth GetWidth(const std::wstring_view glyph) const;
     bool IsWide(const std::wstring_view glyph) const;
     bool IsWide(const wchar_t wch) const noexcept;
@@ -41,7 +42,7 @@ public:
 #endif
 
 private:
-    bool _lookupIsWide(const std::wstring_view glyph) const noexcept;
+    CodepointWidth _lookupWidth(const std::wstring_view glyph) const noexcept;
     bool _checkFallbackViaCache(const std::wstring_view glyph) const;
     static unsigned int _extractCodepoint(const std::wstring_view glyph) noexcept;
 

--- a/src/types/inc/GlyphWidth.hpp
+++ b/src/types/inc/GlyphWidth.hpp
@@ -12,6 +12,9 @@ Abstract:
 #include <functional>
 #include <string_view>
 
+enum class CodepointWidth : BYTE;
+
+CodepointWidth GetGlyphWidth(const std::wstring_view glyph);
 bool IsGlyphFullWidth(const std::wstring_view glyph);
 bool IsGlyphFullWidth(const wchar_t wch) noexcept;
 void SetGlyphWidthFallback(std::function<bool(std::wstring_view)> pfnFallback);

--- a/src/types/inc/convert.hpp
+++ b/src/types/inc/convert.hpp
@@ -24,6 +24,7 @@ enum class CodepointWidth : BYTE
 {
     Narrow,
     Wide,
+    Combining, // zero-width combiner
     Ambiguous, // could be narrow or wide depending on the current codepage and font
     Invalid // not a valid unicode codepoint
 };

--- a/src/winconpty/winconpty.vcxproj
+++ b/src/winconpty/winconpty.vcxproj
@@ -6,7 +6,7 @@
     <RootNamespace>winconpty</RootNamespace>
     <ProjectName>winconpty</ProjectName>
     <TargetName>conpty</TargetName>
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(SolutionDir)src\common.build.pre.props" />
   <ItemGroup>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This could be the first of a series PRs intended to fix unicode layout issue.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

#3546

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Contrary to what @reli-msft emphasize in #3546, I found that zero length Unicode codepoint handling is the key here. 

I searched a little and found https://gitlab.freedesktop.org/terminal-wg/specifications/issues/9 which refers https://github.com/ridiculousfish/widecharwidth. Then I was like, oh so there's bunch of unicode codepoint that's not included in WT currently.

Handling zero-width Unicode characters makes a lot of things weird. But here's what I got so far:

![图片](https://user-images.githubusercontent.com/4710575/68852271-84f9f180-0712-11ea-9170-0d2e27d4a060.png)

Would love to hear your guys' opinion on this.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
