### PR TITLE
Revert "Throttle scroll position update"

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -116,7 +116,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         FontInfo _actualFont;
 
         std::optional<int> _lastScrollOffset;
-        std::optional<std::chrono::high_resolution_clock::time_point> _lastScrollTime;
 
         // Auto scroll occurs when user, while selecting, drags cursor outside viewport. View is then scrolled to 'follow' the cursor.
         double _autoScrollVelocity;


### PR DESCRIPTION
Reverts microsoft/terminal#3531

This caused #3622. Since we're about to ship v0.7, I'd rather be safe.

/cc @greg904 @skyline75489

Chester, happy to have you bring this back once we get #3622 cleared up.