### PR TITLE
Make sure to set an alpha channel during ColorRefToColor

### DIFF
--- a/src/cascadia/WinRTUtils/inc/Utils.h
+++ b/src/cascadia/WinRTUtils/inc/Utils.h
@@ -12,6 +12,7 @@
 inline winrt::Windows::UI::Color ColorRefToColor(const COLORREF& colorref)
 {
     winrt::Windows::UI::Color color;
+    color.A = 255;
     color.R = GetRValue(colorref);
     color.G = GetGValue(colorref);
     color.B = GetBValue(colorref);


### PR DESCRIPTION
It worked in debug because uninitialized memory.

Fixes #3664.