### PR TITLE
consolidate PackageES versioning in /custom.props

### DIFF
--- a/custom.props
+++ b/custom.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- This file is read by XES, which we use in our Release builds. -->
+  <PropertyGroup Label="Version">
+    <XesUseOneStoreVersioning>true</XesUseOneStoreVersioning>
+    <XesBaseYearForStoreVersion>2019</XesBaseYearForStoreVersion>
+    <VersionMajor>0</VersionMajor>
+    <VersionMinor>7</VersionMinor>
+    <VersionInfoProductName>Windows Terminal</VersionInfoProductName>
+  </PropertyGroup>
+</Project>

--- a/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
+++ b/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
@@ -2,11 +2,6 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
   <Import Project="$(OpenConsoleDir)src\wap-common.build.pre.props" />
-  <PropertyGroup Label="Version">
-    <!-- These fields are picked up by PackageES -->
-    <VersionMajor>0</VersionMajor>
-    <VersionMinor>7</VersionMinor>
-  </PropertyGroup>
   <PropertyGroup Label="Configuration">
     <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>

--- a/src/cascadia/WpfTerminalControl/WpfTerminalControl.csproj
+++ b/src/cascadia/WpfTerminalControl/WpfTerminalControl.csproj
@@ -12,8 +12,7 @@
     <OutputPath>$(RepoBinPath)$(Platform)\$(Configuration)\$(MSBuildProjectName)</OutputPath>
     <BeforePack>CollectNativePackContents</BeforePack>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version Condition="'$(NuGetPackVersion)' == ''">0.5</Version>
-    <Version Condition="'$(NuGetPackVersion)' != ''">$(NuGetPackVersion)</Version>
+    <Version>0.1</Version>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/cascadia/WpfTerminalControl/WpfTerminalControl.csproj
+++ b/src/cascadia/WpfTerminalControl/WpfTerminalControl.csproj
@@ -1,4 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<?xml version="1.0"?>
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     

--- a/src/cascadia/WpfTerminalControl/WpfTerminalControl.csproj
+++ b/src/cascadia/WpfTerminalControl/WpfTerminalControl.csproj
@@ -1,5 +1,4 @@
-<?xml version="1.0"?>
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
     

--- a/src/cascadia/WpfTerminalControl/WpfTerminalControl.csproj
+++ b/src/cascadia/WpfTerminalControl/WpfTerminalControl.csproj
@@ -12,7 +12,8 @@
     <OutputPath>$(RepoBinPath)$(Platform)\$(Configuration)\$(MSBuildProjectName)</OutputPath>
     <BeforePack>CollectNativePackContents</BeforePack>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.5</Version>
+    <Version Condition="'$(NuGetPackVersion)' == ''">0.5</Version>
+    <Version Condition="'$(NuGetPackVersion)' != ''">$(NuGetPackVersion)</Version>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
This location and name is practically mandated by PackageES. Sorry ☹️.

This will ensure that all artifacts that we produce are versioned properly:

|thing|version (example)|
|-|-|
|exe, dll, .net assembly|`0.7.1911.22009`|
|nupkg|`0.7.191122009`|
|appx|`0.7.3269.0`|

For reference, here's the version format:

### EXE, DLL, .NET Assembly

```
0.7.1911.22009
^ ^  ^ ^  ^  ^
| |  | |  |  `-Build # on that date
| |  | |  `-Day
| |  | `-Month
| |  `-Year
| `-Minor
`-Major
```

### NuGet Package

```
0.7.191122009
^ ^  ^ ^ ^  ^
| |  | | |  `-Build # on that date
| |  | | `-Day
| |  | `-Month
| |  `-Year
| `-Minor
`-Major
```

### AppX Package

```
0.7.03269.0
^ ^ ^  ^^ ^
| | |  || `-Contractually always zero (a waste)
| | |  |`-Build # on that date
| | |  `-Number of days in [base year]
| | `-Number of years since [base year]
| `-Minor
`-Major

[base year] = $(XesBaseYearForStoreVersion)
```

It is expected that the base year is changed every time
the version number is changed.