### PR TITLE
doc: Disambiguate "Keybindings" reference; add example keys

### DIFF
--- a/doc/cascadia/SettingsSchema.md
+++ b/doc/cascadia/SettingsSchema.md
@@ -141,7 +141,7 @@ Commands listed below are per the implementation in `src/cascadia/TerminalApp/Ap
 ## Example Keys
 - ctrl+1
 - ctrl+pgdn
-- ctrl+pgup
+- ctrl+alt+shift+pgup
 
 ## Background Images and Icons
 Some Terminal settings allow you to specify custom background images and icons. It is recommended that custom images and icons are stored in system-provided folders and are referred to using the correct [URI Schemes](https://docs.microsoft.com/en-us/windows/uwp/app-resources/uri-schemes). URI Schemes provide a way to reference files independent of their physical paths (which may change in the future).

--- a/doc/cascadia/SettingsSchema.md
+++ b/doc/cascadia/SettingsSchema.md
@@ -85,9 +85,9 @@ Properties listed below are specific to each custom key binding.
 | `command` | _Required_ | String | The command executed when the associated key bindings are pressed. |
 | `keys` | _Required_ | Array[String] | Defines the key combinations used to call the command. |
 
-### Implemented Keybindings
+### Implemented Commands
 
-Bindings listed below are per the implementation in `src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp`
+Commands listed below are per the implementation in `src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp`
 
 - copy
 - copyTextWithoutNewlines
@@ -137,6 +137,11 @@ Bindings listed below are per the implementation in `src/cascadia/TerminalApp/Ap
 - moveFocusUp
 - moveFocusDown
 - toggleFullscreen
+
+## Example Keys
+- ctrl+1
+- ctrl+pgdn
+- ctrl+pgup
 
 ## Background Images and Icons
 Some Terminal settings allow you to specify custom background images and icons. It is recommended that custom images and icons are stored in system-provided folders and are referred to using the correct [URI Schemes](https://docs.microsoft.com/en-us/windows/uwp/app-resources/uri-schemes). URI Schemes provide a way to reference files independent of their physical paths (which may change in the future).

--- a/doc/cascadia/SettingsSchema.md
+++ b/doc/cascadia/SettingsSchema.md
@@ -140,6 +140,10 @@ Commands listed below are per the implementation in `src/cascadia/TerminalApp/Ap
 
 ## Example Keys
 - ctrl+1
+- ctrl+plus
+- alt+-
+- shift+numpad_1
+- ctrL+shift+numpad_plus
 - ctrl+pgdn
 - ctrl+alt+shift+pgup
 

--- a/doc/cascadia/SettingsSchema.md
+++ b/doc/cascadia/SettingsSchema.md
@@ -87,7 +87,7 @@ Properties listed below are specific to each custom key binding.
 
 ### Implemented Commands
 
-Commands listed below are per the implementation in `src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp`
+Commands listed below are per the implementation in [`src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp`](https://github.com/microsoft/terminal/blob/master/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp)
 
 - copy
 - copyTextWithoutNewlines


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
It took me some trial and error to figure out how to bind "ctrl+pgdn".  This patch adds a small amount of documentation for that key combination and a couple others (both of which I tested).

Since I was here anyway, I suspect the use of the word "keybinding" was unintentional, as the thing it refers to is later referred to as a "command".  So, I tidied that up.


Tested by visual inspection.


<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
None

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [N/A] Closes #xxx
* [CHECK] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [N/A] Tests added/passed
* [N/A] Requires documentation to be updated
* [READY] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
N/A
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Validated by manual inspection.

## Comments
The new terminal (combined with WSL) is a welcome improvement that makes developing on Windows about 5x easier.  I am also glad to learn that I can customize the keybindings, as I am an avid emacs user.  Thanks for all your efforts!
