### PR TITLE
Enable changing the color of the active pane border

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -207,6 +207,17 @@
       "additionalProperties": true,
       "description": "Properties that affect the entire window, regardless of the profile settings.",
       "properties": {
+
+        "activePaneBorderColor": {
+          "default": "accent",
+          "oneOf": [
+            {"$ref": "#/definitions/Color"},
+            {"type": "string", "pattern": "accent" }
+          ],
+          "description": "The color to use for the active pane border. Should be null, \"accent\", or a color in format \"#RRGGBB\"",
+          "type": ["string", "null"]
+        },
+
         "alwaysShowTabs": {
           "default": true,
           "description": "When set to true, tabs are always displayed. When set to false and showTabsInTitlebar is set to false, tabs only appear after opening a new tab.",

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -27,10 +27,11 @@ namespace winrt
 // !!! IMPORTANT !!!
 // Make sure that these keys are in the same order as the
 // SettingsLoadWarnings/Errors enum is!
-static const std::array<std::wstring_view, 3> settingsLoadWarningsLabels {
+static const std::array<std::wstring_view, 4> settingsLoadWarningsLabels {
     USES_RESOURCE(L"MissingDefaultProfileText"),
     USES_RESOURCE(L"DuplicateProfileText"),
-    USES_RESOURCE(L"UnknownColorSchemeText")
+    USES_RESOURCE(L"UnknownColorSchemeText"),
+    USES_RESOURCE(L"BadActivePaneBorderColorValueText")
 };
 static const std::array<std::wstring_view, 2> settingsLoadErrorsLabels {
     USES_RESOURCE(L"NoProfilesText"),

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -146,6 +146,17 @@ GlobalAppSettings& CascadiaSettings::GlobalSettings()
 }
 
 // Method Description:
+// - Get a const reference to our global settings
+// Arguments:
+// - <none>
+// Return Value:
+// - a reference to our global settings
+const GlobalAppSettings& CascadiaSettings::GlobalSettings() const
+{
+    return _globals;
+}
+
+// Method Description:
 // - Gets our list of warnings we found during loading. These are things that we
 //   knew were bad when we called `_ValidateSettings` last.
 // Return Value:
@@ -202,6 +213,9 @@ void CascadiaSettings::_ValidateSettings()
     // TODO:GH#3522 With variable args to keybindings, it's possible that a user
     // set a keybinding without all the required args for an action. Display a
     // warning if an action didn't have a required arg.
+
+    // Validate that pane colors are either a color or "accent"
+    _ValidatePaneAccentColorValues();
 }
 
 // Method Description:
@@ -418,5 +432,41 @@ void CascadiaSettings::_ValidateAllSchemesExist()
     if (foundInvalidScheme)
     {
         _warnings.push_back(::TerminalApp::SettingsLoadWarnings::UnknownColorScheme);
+    }
+}
+
+// Method Description:
+// - Ensures that the value set for "activePaneBorderColor" is a reasonable
+//   value. This should be one of:
+//   - `null`: to clear the active pane border color
+//   - `"accent"`:
+//   - a color string in format `"#RRGGBB"`
+// - If the color is not set to one of these values, this will reset the value
+//   to null and display a warning.
+// Arguments:
+// - <none>
+// Return Value:
+// - <none>
+// - Appends a SettingsLoadWarnings::BadActivePaneBorderColorValue to our list
+//   of warnings if the color is not an appropriate value.
+void CascadiaSettings::_ValidatePaneAccentColorValues()
+{
+    // The only real case we need to check here is if the pane border color was
+    // set, but it wasn't set to "accent", nor was it otherwise able to be
+    // parsed.
+    if (_globals.HasPaneFocusBorderColor() && !_globals.IsPaneFocusColorAccentColor())
+    {
+        // Try parsing the color. If we fail to parse the color, then add the
+        // warning. Otherwise, the setting is good to go.
+        try
+        {
+            const auto color = _globals.GetPaneFocusColor();
+            color;
+        }
+        catch (...)
+        {
+            _warnings.push_back(::TerminalApp::SettingsLoadWarnings::BadActivePaneBorderColorValue);
+            _globals.SetPaneFocusColor(std::nullopt);
+        }
     }
 }

--- a/src/cascadia/TerminalApp/CascadiaSettings.h
+++ b/src/cascadia/TerminalApp/CascadiaSettings.h
@@ -54,6 +54,7 @@ public:
     winrt::Microsoft::Terminal::Settings::TerminalSettings MakeSettings(std::optional<GUID> profileGuid) const;
 
     GlobalAppSettings& GlobalSettings();
+    const GlobalAppSettings& GlobalSettings() const;
 
     std::basic_string_view<Profile> GetProfiles() const noexcept;
 
@@ -105,6 +106,7 @@ private:
     void _ReorderProfilesToMatchUserSettingsOrder();
     void _RemoveHiddenProfiles();
     void _ValidateAllSchemesExist();
+    void _ValidatePaneAccentColorValues();
 
     friend class TerminalAppLocalTests::SettingsTests;
     friend class TerminalAppLocalTests::ProfileTests;

--- a/src/cascadia/TerminalApp/GlobalAppSettings.h
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.h
@@ -76,6 +76,11 @@ public:
 
     void ApplyToSettings(winrt::Microsoft::Terminal::Settings::TerminalSettings& settings) const noexcept;
 
+    bool HasPaneFocusBorderColor() const noexcept;
+    bool IsPaneFocusColorAccentColor() const noexcept;
+    COLORREF GetPaneFocusColor() const;
+    void SetPaneFocusColor(std::optional<std::wstring> newValue);
+
 private:
     GUID _defaultProfile;
     winrt::com_ptr<winrt::TerminalApp::implementation::AppKeyBindings> _keybindings;
@@ -96,8 +101,8 @@ private:
     std::wstring _wordDelimiters;
     bool _copyOnSelect;
     winrt::Windows::UI::Xaml::ElementTheme _requestedTheme;
-
     winrt::TerminalApp::LaunchMode _launchMode;
+    std::optional<std::wstring> _activePaneBorderColor{ std::nullopt };
 
     static winrt::Windows::UI::Xaml::ElementTheme _ParseTheme(const std::wstring& themeString) noexcept;
     static std::wstring_view _SerializeTheme(const winrt::Windows::UI::Xaml::ElementTheme theme) noexcept;

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -5,6 +5,7 @@
 #include "Pane.h"
 #include "Profile.h"
 #include "CascadiaSettings.h"
+#include "../../WinRTUtils/inc/Utils.h"
 
 #include "winrt/Microsoft.Terminal.TerminalConnection.h"
 
@@ -545,6 +546,13 @@ void Pane::UpdateSettings(const TerminalSettings& settings, const GUID& profile)
         {
             _control.UpdateSettings(settings);
         }
+
+        _root.Dispatcher().RunAsync(CoreDispatcherPriority::Low, [this]() {
+            // Call _SetupResources to potentially reload the active pane brush,
+            // and UpdateVisuals to apply the brush
+            _SetupResources();
+            UpdateVisuals();
+        });
     }
 }
 
@@ -1111,26 +1119,10 @@ void Pane::_ControlGotFocusHandler(winrt::Windows::Foundation::IInspectable cons
 void Pane::_SetupResources()
 {
     const auto res = Application::Current().Resources();
-    const auto accentColorKey = winrt::box_value(L"SystemAccentColor");
-    if (res.HasKey(accentColorKey))
-    {
-        const auto colorFromResources = res.Lookup(accentColorKey);
-        // If SystemAccentColor is _not_ a Color for some reason, use
-        // Transparent as the color, so we don't do this process again on
-        // the next pane (by leaving s_focusedBorderBrush nullptr)
-        auto actualColor = winrt::unbox_value_or<Color>(colorFromResources, Colors::Black());
-        s_focusedBorderBrush = SolidColorBrush(actualColor);
-    }
-    else
-    {
-        // DON'T use Transparent here - if it's "Transparent", then it won't
-        // be able to hittest for clicks, and then clicking on the border
-        // will eat focus.
-        s_focusedBorderBrush = SolidColorBrush{ Colors::Black() };
-    }
 
+    // First setup the pane border TabViewBackground color
     const auto tabViewBackgroundKey = winrt::box_value(L"TabViewBackground");
-    if (res.HasKey(accentColorKey))
+    if (res.HasKey(tabViewBackgroundKey))
     {
         winrt::Windows::Foundation::IInspectable obj = res.Lookup(tabViewBackgroundKey);
         s_unfocusedBorderBrush = obj.try_as<winrt::Windows::UI::Xaml::Media::SolidColorBrush>();
@@ -1141,6 +1133,47 @@ void Pane::_SetupResources()
         // be able to hittest for clicks, and then clicking on the border
         // will eat focus.
         s_unfocusedBorderBrush = SolidColorBrush{ Colors::Black() };
+    }
+
+    // Now try and set the pane border color.
+    // - If it's null, we'll use the TabViewBackground color.
+    // - if it's "accent", we'll use the accent color
+    // - if it's "#rrbbgg", we'll use the given color
+    const auto& settings = CascadiaSettings::GetCurrentAppSettings();
+    const auto& globals = settings.GlobalSettings();
+    if (!globals.HasPaneFocusBorderColor())
+    {
+        s_focusedBorderBrush = s_unfocusedBorderBrush;
+    }
+    else
+    {
+        if (globals.IsPaneFocusColorAccentColor())
+        {
+            // Use the accent color for the pane border
+
+            const auto accentColorKey = winrt::box_value(L"SystemAccentColor");
+            if (res.HasKey(accentColorKey))
+            {
+                const auto colorFromResources = res.Lookup(accentColorKey);
+                // If SystemAccentColor is _not_ a Color for some reason, use
+                // Transparent as the color, so we don't do this process again on
+                // the next pane (by leaving s_focusedBorderBrush nullptr)
+                auto actualColor = winrt::unbox_value_or<Color>(colorFromResources, Colors::Black());
+                s_focusedBorderBrush = SolidColorBrush(actualColor);
+            }
+            else
+            {
+                // DON'T use Transparent here - see earlier comment for why
+                s_focusedBorderBrush = s_unfocusedBorderBrush;
+            }
+        }
+        else
+        {
+            // Create a brush for the color the user specified
+            const COLORREF focusColor = globals.GetPaneFocusColor();
+            s_focusedBorderBrush = Media::SolidColorBrush{};
+            s_focusedBorderBrush.Color(ColorRefToColor(focusColor));
+        }
     }
 }
 

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -133,6 +133,10 @@
     <value>Found a profile with an invalid "colorScheme". Defaulting that profile to the default colors. Make sure that when setting a "colorScheme", the value matches the "name" of a color scheme in the "schemes" list.
 </value>
   </data>
+  <data name="BadActivePaneBorderColorValueText" xml:space="preserve">
+    <value>Found an invalid value for "activePaneBorderColor". This must either be set to null, "accent", or a hex color code in format "#RRGGBB". Defaulting to no color.
+</value>
+  </data>
   <data name="NoProfilesText" xml:space="preserve">
     <value>No profiles were found in your settings.
 </value>

--- a/src/cascadia/TerminalApp/TerminalWarnings.h
+++ b/src/cascadia/TerminalApp/TerminalWarnings.h
@@ -23,7 +23,8 @@ namespace TerminalApp
     {
         MissingDefaultProfile = 0,
         DuplicateProfile = 1,
-        UnknownColorScheme = 2
+        UnknownColorScheme = 2,
+        BadActivePaneBorderColorValue = 3
     };
 
     // SettingsLoadWarnings are scenarios where the settings had invalid state

--- a/src/cascadia/TerminalApp/defaults.json
+++ b/src/cascadia/TerminalApp/defaults.json
@@ -1,6 +1,7 @@
 // THIS IS AN AUTO-GENERATED FILE! Changes to this file will be ignored.
 {
     "alwaysShowTabs": true,
+    "activePaneBorderColor": "accent",
     "defaultProfile": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
     "initialCols": 120,
     "initialRows": 30,

--- a/src/types/inc/utils.hpp
+++ b/src/types/inc/utils.hpp
@@ -47,7 +47,8 @@ namespace Microsoft::Console::Utils
     GUID CreateGuid();
 
     std::string ColorToHexString(const COLORREF color);
-    COLORREF ColorFromHexString(const std::string wstr);
+    COLORREF ColorFromHexString(const std::string& wstr);
+    COLORREF ColorFromHexString(const std::wstring& wstr);
 
     void InitializeCampbellColorTable(const gsl::span<COLORREF> table);
     void InitializeCampbellColorTableForConhost(const gsl::span<COLORREF> table);

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -70,7 +70,7 @@ std::string Utils::ColorToHexString(const COLORREF color)
 // Return Value:
 // - A COLORREF if the string could successfully be parsed. If the string is not
 //      the correct format, throws E_INVALIDARG
-COLORREF Utils::ColorFromHexString(const std::string str)
+COLORREF Utils::ColorFromHexString(const std::string& str)
 {
     THROW_HR_IF(E_INVALIDARG, str.size() != 7 && str.size() != 4);
     THROW_HR_IF(E_INVALIDARG, str.at(0) != '#');
@@ -90,6 +90,42 @@ COLORREF Utils::ColorFromHexString(const std::string str)
         rStr = std::string(&str.at(1), 2);
         gStr = std::string(&str.at(3), 2);
         bStr = std::string(&str.at(5), 2);
+    }
+
+    const BYTE r = gsl::narrow_cast<BYTE>(std::stoul(rStr, nullptr, 16));
+    const BYTE g = gsl::narrow_cast<BYTE>(std::stoul(gStr, nullptr, 16));
+    const BYTE b = gsl::narrow_cast<BYTE>(std::stoul(bStr, nullptr, 16));
+
+    return RGB(r, g, b);
+}
+
+// Function Description:
+// - Parses a color from a string. The string should be in the format "#RRGGBB" or "#RGB"
+// Arguments:
+// - str: a string representation of the COLORREF to parse
+// Return Value:
+// - A COLORREF if the string could successfully be parsed. If the string is not
+//      the correct format, throws E_INVALIDARG
+COLORREF Utils::ColorFromHexString(const std::wstring& str)
+{
+    THROW_HR_IF(E_INVALIDARG, str.size() != 7 && str.size() != 4);
+    THROW_HR_IF(E_INVALIDARG, str.at(0) != '#');
+
+    std::wstring rStr;
+    std::wstring gStr;
+    std::wstring bStr;
+
+    if (str.size() == 4)
+    {
+        rStr = std::wstring(2, str.at(1));
+        gStr = std::wstring(2, str.at(2));
+        bStr = std::wstring(2, str.at(3));
+    }
+    else
+    {
+        rStr = std::wstring(&str.at(1), 2);
+        gStr = std::wstring(&str.at(3), 2);
+        bStr = std::wstring(&str.at(5), 2);
     }
 
     const BYTE r = gsl::narrow_cast<BYTE>(std::stoul(rStr, nullptr, 16));


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Adds a new setting, `"activePaneBorderColor"`, which lets the user change the color of the active pane border. This setting can have 3 values:
   - `null`: to clear the active pane border color (and have no color there)
   - `"accent"`: to use the accent color
   - a color string in format `"#RRGGBB"`, to use that color

If it's not one of those values, it will display a warning, and default to `null`.

## PR Checklist
* [x] Closes #3061
* [x] I work here
* [ ] Tests added/passed
* [x] Requires documentation to be updated
