### PR TITLE
FindGuid helper function

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -1292,12 +1292,12 @@ namespace TerminalAppLocalTests
         auto name0{ L"profile0" };
         auto name1{ L"profile1" };
         auto name2{ L"Ubuntu" };
-        auto bad_name{ L"DoesNotExist" };
+        auto badName{ L"DoesNotExist" };
 
         auto guid0{ Microsoft::Console::Utils::GuidFromString(L"{6239a42c-5555-49a3-80bd-e8fdd045185c}") };
         auto guid1{ Microsoft::Console::Utils::GuidFromString(L"{6239a42c-6666-49a3-80bd-e8fdd045185c}") };
         auto guid2{ Microsoft::Console::Utils::GuidFromString(L"{2C4DE342-38B7-51CF-B940-2309A097F518}") };
-        GUID bad_guid{};
+        GUID badGuid{};
 
         VerifyParseSucceeded(settings0String);
 
@@ -1308,22 +1308,22 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(guid0, settings.FindGuid(name0));
         VERIFY_ARE_EQUAL(guid1, settings.FindGuid(name1));
         VERIFY_ARE_EQUAL(guid2, settings.FindGuid(name2));
-        VERIFY_ARE_EQUAL(bad_guid, settings.FindGuid(bad_name));
+        VERIFY_ARE_EQUAL(badGuid, settings.FindGuid(badName));
         // Following test will fail because GetGuid throws (despite being noexcept)
-        // VERIFY_ARE_EQUAL(bad_guid, settings.FindGuid(L"ThisProfileShouldNotCrash"));
+        // VERIFY_ARE_EQUAL(badGuid, settings.FindGuid(L"ThisProfileShouldNotCrash"));
 
         // Following lines only work because the GUID-less profile is last
         auto prof0{ settings.FindProfile(guid0) };
         auto prof1{ settings.FindProfile(guid1) };
         auto prof2{ settings.FindProfile(guid2) };
         // Following line will fail because GetGuid throws (despite being noexcept)
-        // auto bad_prof{ settings.FindProfile(bad_guid) };
+        // auto badProf{ settings.FindProfile(badGuid) };
         
         VERIFY_ARE_EQUAL(name0, prof0->GetName());
         VERIFY_ARE_EQUAL(name1, prof1->GetName());
         VERIFY_ARE_EQUAL(name2, prof2->GetName());
         // Following test will fail because GetGuid throws (despite being noexcept)
-        // VERIFY_ARE_EQUAL(bad_name, bad_prof->GetName());
+        // VERIFY_ARE_EQUAL(badName, badProf->GetName());
     }
 
     void SettingsTests::TestLayerGlobalsOnRoot()

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -49,6 +49,7 @@ namespace TerminalAppLocalTests
         TEST_METHOD(TestExplodingNameOnlyProfiles);
         TEST_METHOD(TestHideAllProfiles);
         TEST_METHOD(TestInvalidColorSchemeName);
+        TEST_METHOD(TestHelperFunctions);
 
         TEST_METHOD(TestLayerGlobalsOnRoot);
 
@@ -1262,6 +1263,67 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(L"schemeOne", settings._profiles.at(0)._schemeName.value());
         VERIFY_ARE_EQUAL(L"Campbell", settings._profiles.at(1)._schemeName.value());
         VERIFY_ARE_EQUAL(L"Campbell", settings._profiles.at(2)._schemeName.value());
+    }
+
+    void SettingsTests::TestHelperFunctions()
+    {
+        const std::string settings0String{ R"(
+        {
+            "defaultProfile" : "{2C4DE342-38B7-51CF-B940-2309A097F518}",
+            "profiles": [
+                {
+                    "name" : "profile0",
+                    "guid": "{6239a42c-5555-49a3-80bd-e8fdd045185c}"
+                },
+                {
+                    "name" : "profile1",
+                    "guid": "{6239a42c-6666-49a3-80bd-e8fdd045185c}"
+                },
+                {
+                    "name" : "Ubuntu",
+                    "guid" : "{2C4DE342-38B7-51CF-B940-2309A097F518}"
+                },
+                {
+                    "name" : "ThisProfileShouldNotCrash"
+                }
+            ]
+        })" };
+
+        auto name0{ L"profile0" };
+        auto name1{ L"profile1" };
+        auto name2{ L"Ubuntu" };
+        auto bad_name{ L"DoesNotExist" };
+
+        auto guid0{ Microsoft::Console::Utils::GuidFromString(L"{6239a42c-5555-49a3-80bd-e8fdd045185c}") };
+        auto guid1{ Microsoft::Console::Utils::GuidFromString(L"{6239a42c-6666-49a3-80bd-e8fdd045185c}") };
+        auto guid2{ Microsoft::Console::Utils::GuidFromString(L"{2C4DE342-38B7-51CF-B940-2309A097F518}") };
+        GUID bad_guid{};
+
+        VerifyParseSucceeded(settings0String);
+
+        CascadiaSettings settings;
+        settings._ParseJsonString(settings0String, false);
+        settings.LayerJson(settings._userSettings);
+
+        VERIFY_ARE_EQUAL(guid0, settings.FindGuid(name0));
+        VERIFY_ARE_EQUAL(guid1, settings.FindGuid(name1));
+        VERIFY_ARE_EQUAL(guid2, settings.FindGuid(name2));
+        VERIFY_ARE_EQUAL(bad_guid, settings.FindGuid(bad_name));
+        // Following test will fail because GetGuid throws (despite being noexcept)
+        //VERIFY_ARE_EQUAL(bad_guid, settings.FindGuid(L"ThisProfileShouldNotCrash"));
+
+        // Following lines only work because the GUID-less profile is last
+        auto prof0{ settings.FindProfile(guid0) };
+        auto prof1{ settings.FindProfile(guid1) };
+        auto prof2{ settings.FindProfile(guid2) };
+        // Following line will fail because GetGuid throws (despite being noexcept)
+        //auto bad_prof{ settings.FindProfile(bad_guid) };
+        
+        VERIFY_ARE_EQUAL(name0, prof0->GetName());
+        VERIFY_ARE_EQUAL(name1, prof1->GetName());
+        VERIFY_ARE_EQUAL(name2, prof2->GetName());
+        // Following test will fail because GetGuid throws (despite being noexcept)
+        //VERIFY_ARE_EQUAL(bad_name, bad_prof->GetName());
     }
 
     void SettingsTests::TestLayerGlobalsOnRoot()

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -1310,20 +1310,20 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(guid2, settings.FindGuid(name2));
         VERIFY_ARE_EQUAL(bad_guid, settings.FindGuid(bad_name));
         // Following test will fail because GetGuid throws (despite being noexcept)
-        //VERIFY_ARE_EQUAL(bad_guid, settings.FindGuid(L"ThisProfileShouldNotCrash"));
+        // VERIFY_ARE_EQUAL(bad_guid, settings.FindGuid(L"ThisProfileShouldNotCrash"));
 
         // Following lines only work because the GUID-less profile is last
         auto prof0{ settings.FindProfile(guid0) };
         auto prof1{ settings.FindProfile(guid1) };
         auto prof2{ settings.FindProfile(guid2) };
         // Following line will fail because GetGuid throws (despite being noexcept)
-        //auto bad_prof{ settings.FindProfile(bad_guid) };
+        // auto bad_prof{ settings.FindProfile(bad_guid) };
         
         VERIFY_ARE_EQUAL(name0, prof0->GetName());
         VERIFY_ARE_EQUAL(name1, prof1->GetName());
         VERIFY_ARE_EQUAL(name2, prof2->GetName());
         // Following test will fail because GetGuid throws (despite being noexcept)
-        //VERIFY_ARE_EQUAL(bad_name, bad_prof->GetName());
+        // VERIFY_ARE_EQUAL(bad_name, bad_prof->GetName());
     }
 
     void SettingsTests::TestLayerGlobalsOnRoot()

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -1297,7 +1297,7 @@ namespace TerminalAppLocalTests
         auto guid0{ Microsoft::Console::Utils::GuidFromString(L"{6239a42c-5555-49a3-80bd-e8fdd045185c}") };
         auto guid1{ Microsoft::Console::Utils::GuidFromString(L"{6239a42c-6666-49a3-80bd-e8fdd045185c}") };
         auto guid2{ Microsoft::Console::Utils::GuidFromString(L"{2C4DE342-38B7-51CF-B940-2309A097F518}") };
-        GUID badGuid{};
+        std::optional<GUID> badGuid{};
 
         VerifyParseSucceeded(settings0String);
 
@@ -1318,7 +1318,7 @@ namespace TerminalAppLocalTests
         auto prof2{ settings.FindProfile(guid2) };
         // Following line will fail because GetGuid throws (despite being noexcept)
         // auto badProf{ settings.FindProfile(badGuid) };
-        
+
         VERIFY_ARE_EQUAL(name0, prof0->GetName());
         VERIFY_ARE_EQUAL(name1, prof1->GetName());
         VERIFY_ARE_EQUAL(name2, prof2->GetName());

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -64,8 +64,8 @@ CascadiaSettings::CascadiaSettings(const bool addDynamicProfiles)
 }
 
 // Method Description:
-// - Finds a GUID associated with the given profile name. If there is no GUID in this
-//      settings object that matches, returns a null GUID.
+// - Finds a GUID associated with the given profile name. If no profile matches
+//      the profile name, returns a null GUID.
 // Arguments:
 // - profileName: the name of the profile's GUID to return.
 // Return Value:
@@ -74,7 +74,7 @@ GUID CascadiaSettings::FindGuid(const std::wstring& profileName) const noexcept
 {
     GUID profileGuid{};
 
-    for (auto const& profile : _profiles)
+    for (const auto& profile : _profiles)
     {
         if (profileName == profile.GetName())
         {

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -70,9 +70,9 @@ CascadiaSettings::CascadiaSettings(const bool addDynamicProfiles)
 // - profileName: the name of the profile's GUID to return.
 // Return Value:
 // - the GUID associated with the profile name.
-GUID CascadiaSettings::FindGuid(const std::wstring& profileName) const noexcept
+std::optional<GUID> CascadiaSettings::FindGuid(const std::wstring& profileName) const noexcept
 {
-    GUID profileGuid{};
+    std::optional<GUID> profileGuid{};
 
     for (const auto& profile : _profiles)
     {

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -65,7 +65,7 @@ CascadiaSettings::CascadiaSettings(const bool addDynamicProfiles)
 
 // Method Description:
 // - Finds a GUID associated with the given profile name. If no profile matches
-//      the profile name, returns a null GUID.
+//      the profile name, returns a std::nullopt.
 // Arguments:
 // - profileName: the name of the profile's GUID to return.
 // Return Value:

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -64,6 +64,29 @@ CascadiaSettings::CascadiaSettings(const bool addDynamicProfiles)
 }
 
 // Method Description:
+// - Finds a GUID associated with the given profile name. If there is no GUID in this
+//      settings object that matches, returns a null GUID.
+// Arguments:
+// - profileName: the name of the profile's GUID to return.
+// Return Value:
+// - the GUID associated with the profile name.
+GUID CascadiaSettings::FindGuid(const std::wstring& profileName) const noexcept
+{
+    GUID profileGuid{};
+
+    for (auto const& profile : _profiles)
+    {
+        if (profileName == profile.GetName())
+        {
+            profileGuid = profile.GetGuid();
+            break;
+        }
+    }
+
+    return profileGuid;
+}
+
+// Method Description:
 // - Finds a profile that matches the given GUID. If there is no profile in this
 //      settings object that matches, returns nullptr.
 // Arguments:

--- a/src/cascadia/TerminalApp/CascadiaSettings.h
+++ b/src/cascadia/TerminalApp/CascadiaSettings.h
@@ -65,6 +65,7 @@ public:
     static std::wstring GetSettingsPath(const bool useRoamingPath = false);
     static std::wstring GetDefaultSettingsPath();
 
+    GUID FindGuid(const std::wstring& profileName) const noexcept;
     const Profile* FindProfile(GUID profileGuid) const noexcept;
 
     std::vector<TerminalApp::SettingsLoadWarnings>& GetWarnings();

--- a/src/cascadia/TerminalApp/CascadiaSettings.h
+++ b/src/cascadia/TerminalApp/CascadiaSettings.h
@@ -65,7 +65,7 @@ public:
     static std::wstring GetSettingsPath(const bool useRoamingPath = false);
     static std::wstring GetDefaultSettingsPath();
 
-    GUID FindGuid(const std::wstring& profileName) const noexcept;
+    std::optional<GUID> FindGuid(const std::wstring& profileName) const noexcept;
     const Profile* FindProfile(GUID profileGuid) const noexcept;
 
     std::vector<TerminalApp::SettingsLoadWarnings>& GetWarnings();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds a simple helper function to look up the GUID associated with a profile name.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #3680
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed. Yes, new test group in `SettingsTests`!
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #3680

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Very simple function, for-each through profiles checking for a match. Returns the associated GUID if found, else returns the null GUID.

This function is marked as `noexcept` to comply with assumption made by other `CascadiaSettings` functions that [`Profiles::GetGuid`](https://github.com/microsoft/terminal/blob/master/src/cascadia/TerminalApp/Profile.cpp#L141) does not throw, despite it throwing.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
The new function is simple and can be visually validated, but added tests regardless. A new test group was added in `SettingsTests` called `TestHelperFunctions` to validate the new function `FindGuid` and older function `FindProfile`. This test group could be used to validate more helper functions in `CascadiaSettings` as they're added. The new test group passes after running `te.exe TerminalApp.LocalTests.dll`. 
