### PR TITLE
Fixed throwing floating point cast

### DIFF
--- a/src/cascadia/WinRTUtils/inc/Utils.h
+++ b/src/cascadia/WinRTUtils/inc/Utils.h
@@ -28,7 +28,7 @@ inline winrt::Windows::UI::Color ColorRefToColor(const COLORREF& colorref)
 // - Rect scaled by scale
 inline winrt::Windows::Foundation::Rect ScaleRect(winrt::Windows::Foundation::Rect rect, double scale)
 {
-    const float scaleLocal = gsl::narrow<float>(scale);
+    const float scaleLocal = gsl::narrow_cast<float>(scale);
     rect.X *= scaleLocal;
     rect.Y *= scaleLocal;
     rect.Width *= scaleLocal;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Replaced a `gsl::narrow` call to `gsl::narrow_cast` call. The `gsl::narrow` call used to throw when the user had custom display scaling due to a bad comparison between floating point values.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
Possible other [startup crashes](https://github.com/microsoft/terminal/issues/3749#issuecomment-559900267). I'll update this as they're found.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #3749, likely #3747
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #3749

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
It's a one line fix. If you want more context, here's the [full description](https://github.com/microsoft/terminal/issues/3749#issuecomment-559911062) of the problem.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Set my machine to a custom scaling  and opened a fixed build of the WT. My WT started up without crashing and continued to operate without issues (including maximizing, minimizing, and fullscreen toggle).