### PR TITLE
UIA Word Navigation: Import Custom Word Delimiters

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -952,7 +952,7 @@ Microsoft::Console::Render::IRenderTarget& TextBuffer::GetRenderTarget() noexcep
 // - includeCharacterRun - include the character run located at the beginning of the word
 // Return Value:
 // - The COORD for the first character on the "word"  (inclusive)
-const COORD TextBuffer::GetWordStart(const COORD target, const std::wstring& wordDelimiters, bool includeCharacterRun) const
+const COORD TextBuffer::GetWordStart(const COORD target, const std::wstring_view wordDelimiters, bool includeCharacterRun) const
 {
     const auto bufferSize = GetSize();
     COORD result = target;
@@ -996,7 +996,7 @@ const COORD TextBuffer::GetWordStart(const COORD target, const std::wstring& wor
 // - includeDelimiterRun - include the delimiter runs located at the end of the word
 // Return Value:
 // - The COORD for the last character on the "word" (inclusive)
-const COORD TextBuffer::GetWordEnd(const COORD target, const std::wstring& wordDelimiters, bool includeDelimiterRun) const
+const COORD TextBuffer::GetWordEnd(const COORD target, const std::wstring_view wordDelimiters, bool includeDelimiterRun) const
 {
     const auto bufferSize = GetSize();
     COORD result = target;
@@ -1039,7 +1039,7 @@ const COORD TextBuffer::GetWordEnd(const COORD target, const std::wstring& wordD
 // - cellChar: the char saved to the buffer cell under observation
 // Return Value:
 // - the delimiter class for the given char
-TextBuffer::DelimiterClass TextBuffer::_GetDelimiterClass(const std::wstring_view cellChar, const std::wstring& wordDelimiters) const
+TextBuffer::DelimiterClass TextBuffer::_GetDelimiterClass(const std::wstring_view cellChar, const std::wstring_view wordDelimiters) const
 {
     if (cellChar.at(0) <= UNICODE_SPACE)
     {

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -130,8 +130,8 @@ public:
 
     Microsoft::Console::Render::IRenderTarget& GetRenderTarget() noexcept;
 
-    const COORD GetWordStart(const COORD target, const std::wstring& wordDelimiters, bool includeCharacterRun = false) const;
-    const COORD GetWordEnd(const COORD target, const std::wstring& wordDelimiters, bool includeDelimiterRun = false) const;
+    const COORD GetWordStart(const COORD target, const std::wstring_view wordDelimiters, bool includeCharacterRun = false) const;
+    const COORD GetWordEnd(const COORD target, const std::wstring_view wordDelimiters, bool includeDelimiterRun = false) const;
 
     class TextAndColor
     {
@@ -195,7 +195,7 @@ private:
         DelimiterChar,
         RegularChar
     };
-    DelimiterClass _GetDelimiterClass(const std::wstring_view cellChar, const std::wstring& wordDelimiters) const;
+    DelimiterClass _GetDelimiterClass(const std::wstring_view cellChar, const std::wstring_view wordDelimiters) const;
 
 #ifdef UNIT_TESTING
     friend class TextBufferTests;

--- a/src/cascadia/TerminalControl/TermControlUiaProvider.cpp
+++ b/src/cascadia/TerminalControl/TermControlUiaProvider.cpp
@@ -95,7 +95,7 @@ const winrt::Windows::UI::Xaml::Thickness TermControlUiaProvider::GetPadding() c
     return _termControl->GetPadding();
 }
 
-HRESULT TermControlUiaProvider::GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, const std::wstring& wordDelimiters, _Out_ std::deque<ComPtr<UiaTextRangeBase>>& result)
+HRESULT TermControlUiaProvider::GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, const std::wstring_view wordDelimiters, _Out_ std::deque<ComPtr<UiaTextRangeBase>>& result)
 {
     try
     {
@@ -117,7 +117,7 @@ HRESULT TermControlUiaProvider::GetSelectionRanges(_In_ IRawElementProviderSimpl
     CATCH_RETURN();
 }
 
-HRESULT TermControlUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, const std::wstring& wordDelimiters, _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
+HRESULT TermControlUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, const std::wstring_view wordDelimiters, _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
@@ -129,7 +129,7 @@ HRESULT TermControlUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* 
 
 HRESULT TermControlUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
                                                 const Cursor& cursor,
-                                                const std::wstring& wordDelimiters,
+                                                const std::wstring_view wordDelimiters,
                                                 _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
@@ -144,7 +144,7 @@ HRESULT TermControlUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* 
                                                 const Endpoint start,
                                                 const Endpoint end,
                                                 const bool degenerate,
-                                                const std::wstring& wordDelimiters,
+                                                const std::wstring_view wordDelimiters,
                                                 _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
@@ -157,7 +157,7 @@ HRESULT TermControlUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* 
 
 HRESULT TermControlUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
                                                 const UiaPoint point,
-                                                const std::wstring& wordDelimiters,
+                                                const std::wstring_view wordDelimiters,
                                                 _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);

--- a/src/cascadia/TerminalControl/TermControlUiaProvider.cpp
+++ b/src/cascadia/TerminalControl/TermControlUiaProvider.cpp
@@ -95,7 +95,7 @@ const winrt::Windows::UI::Xaml::Thickness TermControlUiaProvider::GetPadding() c
     return _termControl->GetPadding();
 }
 
-HRESULT TermControlUiaProvider::GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, _Out_ std::deque<ComPtr<UiaTextRangeBase>>& result)
+HRESULT TermControlUiaProvider::GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, const std::wstring& wordDelimiters, _Out_ std::deque<ComPtr<UiaTextRangeBase>>& result)
 {
     try
     {
@@ -103,7 +103,7 @@ HRESULT TermControlUiaProvider::GetSelectionRanges(_In_ IRawElementProviderSimpl
         typename std::remove_reference<decltype(result)>::type temporaryResult;
 
         std::deque<ComPtr<UiaTextRange>> ranges;
-        RETURN_IF_FAILED(UiaTextRange::GetSelectionRanges(_pData, pProvider, ranges));
+        RETURN_IF_FAILED(UiaTextRange::GetSelectionRanges(_pData, pProvider, wordDelimiters, ranges));
 
         while (!ranges.empty())
         {
@@ -117,24 +117,25 @@ HRESULT TermControlUiaProvider::GetSelectionRanges(_In_ IRawElementProviderSimpl
     CATCH_RETURN();
 }
 
-HRESULT TermControlUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
+HRESULT TermControlUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, const std::wstring& wordDelimiters, _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
     UiaTextRange* result = nullptr;
-    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider));
+    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, wordDelimiters));
     *ppUtr = result;
     return S_OK;
 }
 
 HRESULT TermControlUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
                                                 const Cursor& cursor,
+                                                const std::wstring& wordDelimiters,
                                                 _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
     UiaTextRange* result = nullptr;
-    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, cursor));
+    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, cursor, wordDelimiters));
     *ppUtr = result;
     return S_OK;
 }
@@ -143,24 +144,26 @@ HRESULT TermControlUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* 
                                                 const Endpoint start,
                                                 const Endpoint end,
                                                 const bool degenerate,
+                                                const std::wstring& wordDelimiters,
                                                 _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
     UiaTextRange* result = nullptr;
-    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, start, end, degenerate));
+    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, start, end, degenerate, wordDelimiters));
     *ppUtr = result;
     return S_OK;
 }
 
 HRESULT TermControlUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
                                                 const UiaPoint point,
+                                                const std::wstring& wordDelimiters,
                                                 _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
     UiaTextRange* result = nullptr;
-    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, point));
+    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, point, wordDelimiters));
     *ppUtr = result;
     return S_OK;
 }

--- a/src/cascadia/TerminalControl/TermControlUiaProvider.hpp
+++ b/src/cascadia/TerminalControl/TermControlUiaProvider.hpp
@@ -47,14 +47,15 @@ namespace Microsoft::Terminal
         const winrt::Windows::UI::Xaml::Thickness GetPadding() const;
 
     protected:
-        HRESULT GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, _Out_ std::deque<WRL::ComPtr<Microsoft::Console::Types::UiaTextRangeBase>>& selectionRanges) override;
+        HRESULT GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, const std::wstring& wordDelimiters, _Out_ std::deque<WRL::ComPtr<Microsoft::Console::Types::UiaTextRangeBase>>& selectionRanges) override;
 
         // degenerate range
-        HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
+        HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, const std::wstring& wordDelimiters, _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
         // degenerate range at cursor position
         HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
                                 const Cursor& cursor,
+                                const std::wstring& wordDelimiters,
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
         // specific endpoint range
@@ -62,11 +63,13 @@ namespace Microsoft::Terminal
                                 const Endpoint start,
                                 const Endpoint end,
                                 const bool degenerate,
+                                const std::wstring& wordDelimiters,
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
         // range from a UiaPoint
         HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
                                 const UiaPoint point,
+                                const std::wstring& wordDelimiters,
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
     private:

--- a/src/cascadia/TerminalControl/TermControlUiaProvider.hpp
+++ b/src/cascadia/TerminalControl/TermControlUiaProvider.hpp
@@ -47,15 +47,15 @@ namespace Microsoft::Terminal
         const winrt::Windows::UI::Xaml::Thickness GetPadding() const;
 
     protected:
-        HRESULT GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, const std::wstring& wordDelimiters, _Out_ std::deque<WRL::ComPtr<Microsoft::Console::Types::UiaTextRangeBase>>& selectionRanges) override;
+        HRESULT GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, const std::wstring_view wordDelimiters, _Out_ std::deque<WRL::ComPtr<Microsoft::Console::Types::UiaTextRangeBase>>& selectionRanges) override;
 
         // degenerate range
-        HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, const std::wstring& wordDelimiters, _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
+        HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, const std::wstring_view wordDelimiters, _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
         // degenerate range at cursor position
         HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
                                 const Cursor& cursor,
-                                const std::wstring& wordDelimiters,
+                                const std::wstring_view wordDelimiters,
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
         // specific endpoint range
@@ -63,13 +63,13 @@ namespace Microsoft::Terminal
                                 const Endpoint start,
                                 const Endpoint end,
                                 const bool degenerate,
-                                const std::wstring& wordDelimiters,
+                                const std::wstring_view wordDelimiters,
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
         // range from a UiaPoint
         HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
                                 const UiaPoint point,
-                                const std::wstring& wordDelimiters,
+                                const std::wstring_view wordDelimiters,
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
     private:

--- a/src/cascadia/TerminalControl/UiaTextRange.cpp
+++ b/src/cascadia/TerminalControl/UiaTextRange.cpp
@@ -11,6 +11,7 @@ using namespace Microsoft::WRL;
 
 HRESULT UiaTextRange::GetSelectionRanges(_In_ IUiaData* pData,
                                          _In_ IRawElementProviderSimple* pProvider,
+                                         _In_ const std::wstring& wordDelimiters,
                                          _Out_ std::deque<ComPtr<UiaTextRange>>& ranges)
 {
     try
@@ -28,7 +29,7 @@ HRESULT UiaTextRange::GetSelectionRanges(_In_ IUiaData* pData,
             Endpoint end = _screenInfoRowToEndpoint(pData, currentRow) + rect.RightInclusive();
 
             ComPtr<UiaTextRange> range;
-            RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&range, pData, pProvider, start, end, false));
+            RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&range, pData, pProvider, start, end, false, wordDelimiters));
             temporaryResult.emplace_back(std::move(range));
         }
         std::swap(temporaryResult, ranges);
@@ -38,33 +39,36 @@ HRESULT UiaTextRange::GetSelectionRanges(_In_ IUiaData* pData,
 }
 
 // degenerate range constructor.
-HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData, _In_ IRawElementProviderSimple* const pProvider)
+HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData, _In_ IRawElementProviderSimple* const pProvider, _In_ const std::wstring& wordDelimiters)
 {
-    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider);
+    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, wordDelimiters);
 }
 
 HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
                                              _In_ IRawElementProviderSimple* const pProvider,
-                                             const Cursor& cursor)
+                                             const Cursor& cursor,
+                                             const std::wstring& wordDelimiters)
 {
-    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, cursor);
+    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, cursor, wordDelimiters);
 }
 
 HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
                                              _In_ IRawElementProviderSimple* const pProvider,
                                              const Endpoint start,
                                              const Endpoint end,
-                                             const bool degenerate)
+                                             const bool degenerate,
+                                             const std::wstring& wordDelimiters)
 {
-    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, start, end, degenerate);
+    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, start, end, degenerate, wordDelimiters);
 }
 
 // returns a degenerate text range of the start of the row closest to the y value of point
 HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
                                              _In_ IRawElementProviderSimple* const pProvider,
-                                             const UiaPoint point)
+                                             const UiaPoint point,
+                                             const std::wstring& wordDelimiters)
 {
-    RETURN_IF_FAILED(UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider));
+    RETURN_IF_FAILED(UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, wordDelimiters));
     Initialize(point);
     return S_OK;
 }

--- a/src/cascadia/TerminalControl/UiaTextRange.cpp
+++ b/src/cascadia/TerminalControl/UiaTextRange.cpp
@@ -11,7 +11,7 @@ using namespace Microsoft::WRL;
 
 HRESULT UiaTextRange::GetSelectionRanges(_In_ IUiaData* pData,
                                          _In_ IRawElementProviderSimple* pProvider,
-                                         _In_ const std::wstring& wordDelimiters,
+                                         _In_ const std::wstring_view wordDelimiters,
                                          _Out_ std::deque<ComPtr<UiaTextRange>>& ranges)
 {
     try
@@ -39,7 +39,7 @@ HRESULT UiaTextRange::GetSelectionRanges(_In_ IUiaData* pData,
 }
 
 // degenerate range constructor.
-HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData, _In_ IRawElementProviderSimple* const pProvider, _In_ const std::wstring& wordDelimiters)
+HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData, _In_ IRawElementProviderSimple* const pProvider, _In_ const std::wstring_view wordDelimiters)
 {
     return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, wordDelimiters);
 }
@@ -47,7 +47,7 @@ HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData, _In_ IRawElem
 HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
                                              _In_ IRawElementProviderSimple* const pProvider,
                                              const Cursor& cursor,
-                                             const std::wstring& wordDelimiters)
+                                             const std::wstring_view wordDelimiters)
 {
     return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, cursor, wordDelimiters);
 }
@@ -57,7 +57,7 @@ HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
                                              const Endpoint start,
                                              const Endpoint end,
                                              const bool degenerate,
-                                             const std::wstring& wordDelimiters)
+                                             const std::wstring_view wordDelimiters)
 {
     return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, start, end, degenerate, wordDelimiters);
 }
@@ -66,7 +66,7 @@ HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
 HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
                                              _In_ IRawElementProviderSimple* const pProvider,
                                              const UiaPoint point,
-                                             const std::wstring& wordDelimiters)
+                                             const std::wstring_view wordDelimiters)
 {
     RETURN_IF_FAILED(UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, wordDelimiters));
     Initialize(point);

--- a/src/cascadia/TerminalControl/UiaTextRange.hpp
+++ b/src/cascadia/TerminalControl/UiaTextRange.hpp
@@ -25,7 +25,7 @@ namespace Microsoft::Terminal
     public:
         static HRESULT GetSelectionRanges(_In_ Microsoft::Console::Types::IUiaData* pData,
                                           _In_ IRawElementProviderSimple* pProvider,
-                                          _In_ const std::wstring& wordDelimiters,
+                                          _In_ const std::wstring_view wordDelimiters,
                                           _Out_ std::deque<WRL::ComPtr<UiaTextRange>>& ranges);
 
         UiaTextRange() = default;
@@ -33,13 +33,13 @@ namespace Microsoft::Terminal
         // degenerate range
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,
-                                       _In_ const std::wstring& wordDelimiters = L" ");
+                                       _In_ const std::wstring_view wordDelimiters = defaultWordDelimiter);
 
         // degenerate range at cursor position
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,
                                        const Cursor& cursor,
-                                       const std::wstring& wordDelimiters = L" ");
+                                       const std::wstring_view wordDelimiters = defaultWordDelimiter);
 
         // specific endpoint range
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
@@ -47,13 +47,13 @@ namespace Microsoft::Terminal
                                        const Endpoint start,
                                        const Endpoint end,
                                        const bool degenerate,
-                                       const std::wstring& wordDelimiters = L" ");
+                                       const std::wstring_view wordDelimiters = defaultWordDelimiter);
 
         // range from a UiaPoint
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,
                                        const UiaPoint point,
-                                       const std::wstring& wordDelimiters = L" ");
+                                       const std::wstring_view wordDelimiters = defaultWordDelimiter);
 
         HRESULT RuntimeClassInitialize(const UiaTextRange& a);
 

--- a/src/cascadia/TerminalControl/UiaTextRange.hpp
+++ b/src/cascadia/TerminalControl/UiaTextRange.hpp
@@ -25,30 +25,35 @@ namespace Microsoft::Terminal
     public:
         static HRESULT GetSelectionRanges(_In_ Microsoft::Console::Types::IUiaData* pData,
                                           _In_ IRawElementProviderSimple* pProvider,
+                                          _In_ const std::wstring& wordDelimiters,
                                           _Out_ std::deque<WRL::ComPtr<UiaTextRange>>& ranges);
 
         UiaTextRange() = default;
 
         // degenerate range
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
-                                       _In_ IRawElementProviderSimple* const pProvider);
+                                       _In_ IRawElementProviderSimple* const pProvider,
+                                       _In_ const std::wstring& wordDelimiters = L" ");
 
         // degenerate range at cursor position
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,
-                                       const Cursor& cursor);
+                                       const Cursor& cursor,
+                                       const std::wstring& wordDelimiters = L" ");
 
         // specific endpoint range
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,
                                        const Endpoint start,
                                        const Endpoint end,
-                                       const bool degenerate);
+                                       const bool degenerate,
+                                       const std::wstring& wordDelimiters = L" ");
 
         // range from a UiaPoint
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,
-                                       const UiaPoint point);
+                                       const UiaPoint point,
+                                       const std::wstring& wordDelimiters = L" ");
 
         HRESULT RuntimeClassInitialize(const UiaTextRange& a);
 

--- a/src/interactivity/win32/screenInfoUiaProvider.cpp
+++ b/src/interactivity/win32/screenInfoUiaProvider.cpp
@@ -97,7 +97,7 @@ void ScreenInfoUiaProvider::ChangeViewport(const SMALL_RECT NewWindow)
     _pUiaParent->ChangeViewport(NewWindow);
 }
 
-HRESULT ScreenInfoUiaProvider::GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, _Out_ std::deque<ComPtr<UiaTextRangeBase>>& result)
+HRESULT ScreenInfoUiaProvider::GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, const std::wstring& wordDelimiters, _Out_ std::deque<ComPtr<UiaTextRangeBase>>& result)
 {
     try
     {
@@ -105,7 +105,7 @@ HRESULT ScreenInfoUiaProvider::GetSelectionRanges(_In_ IRawElementProviderSimple
         typename std::remove_reference<decltype(result)>::type temporaryResult;
 
         std::deque<ComPtr<UiaTextRange>> ranges;
-        RETURN_IF_FAILED(UiaTextRange::GetSelectionRanges(_pData, pProvider, ranges));
+        RETURN_IF_FAILED(UiaTextRange::GetSelectionRanges(_pData, pProvider, wordDelimiters, ranges));
 
         while (!ranges.empty())
         {
@@ -119,24 +119,25 @@ HRESULT ScreenInfoUiaProvider::GetSelectionRanges(_In_ IRawElementProviderSimple
     CATCH_RETURN();
 }
 
-HRESULT ScreenInfoUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
+HRESULT ScreenInfoUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, const std::wstring& wordDelimiters, _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
     UiaTextRange* result = nullptr;
-    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider));
+    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, wordDelimiters));
     *ppUtr = result;
     return S_OK;
 }
 
 HRESULT ScreenInfoUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
                                                const Cursor& cursor,
+                                               const std::wstring& wordDelimiters,
                                                _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
     UiaTextRange* result = nullptr;
-    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, cursor));
+    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, cursor, wordDelimiters));
     *ppUtr = result;
     return S_OK;
 }
@@ -145,24 +146,26 @@ HRESULT ScreenInfoUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* c
                                                const Endpoint start,
                                                const Endpoint end,
                                                const bool degenerate,
+                                               const std::wstring& wordDelimiters,
                                                _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
     UiaTextRange* result = nullptr;
-    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, start, end, degenerate));
+    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, start, end, degenerate, wordDelimiters));
     *ppUtr = result;
     return S_OK;
 }
 
 HRESULT ScreenInfoUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
                                                const UiaPoint point,
+                                               const std::wstring& wordDelimiters,
                                                _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
     UiaTextRange* result = nullptr;
-    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, point));
+    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, point, wordDelimiters));
     *ppUtr = result;
     return S_OK;
 }

--- a/src/interactivity/win32/screenInfoUiaProvider.cpp
+++ b/src/interactivity/win32/screenInfoUiaProvider.cpp
@@ -97,7 +97,7 @@ void ScreenInfoUiaProvider::ChangeViewport(const SMALL_RECT NewWindow)
     _pUiaParent->ChangeViewport(NewWindow);
 }
 
-HRESULT ScreenInfoUiaProvider::GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, const std::wstring& wordDelimiters, _Out_ std::deque<ComPtr<UiaTextRangeBase>>& result)
+HRESULT ScreenInfoUiaProvider::GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, const std::wstring_view wordDelimiters, _Out_ std::deque<ComPtr<UiaTextRangeBase>>& result)
 {
     try
     {
@@ -119,7 +119,7 @@ HRESULT ScreenInfoUiaProvider::GetSelectionRanges(_In_ IRawElementProviderSimple
     CATCH_RETURN();
 }
 
-HRESULT ScreenInfoUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, const std::wstring& wordDelimiters, _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
+HRESULT ScreenInfoUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, const std::wstring_view wordDelimiters, _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
@@ -131,7 +131,7 @@ HRESULT ScreenInfoUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* c
 
 HRESULT ScreenInfoUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
                                                const Cursor& cursor,
-                                               const std::wstring& wordDelimiters,
+                                               const std::wstring_view wordDelimiters,
                                                _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
@@ -146,7 +146,7 @@ HRESULT ScreenInfoUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* c
                                                const Endpoint start,
                                                const Endpoint end,
                                                const bool degenerate,
-                                               const std::wstring& wordDelimiters,
+                                               const std::wstring_view wordDelimiters,
                                                _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
@@ -159,7 +159,7 @@ HRESULT ScreenInfoUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* c
 
 HRESULT ScreenInfoUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
                                                const UiaPoint point,
-                                               const std::wstring& wordDelimiters,
+                                               const std::wstring_view wordDelimiters,
                                                _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);

--- a/src/interactivity/win32/screenInfoUiaProvider.hpp
+++ b/src/interactivity/win32/screenInfoUiaProvider.hpp
@@ -43,14 +43,15 @@ namespace Microsoft::Console::Interactivity::Win32
         void ChangeViewport(const SMALL_RECT NewWindow);
 
     protected:
-        HRESULT GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, _Out_ std::deque<WRL::ComPtr<Microsoft::Console::Types::UiaTextRangeBase>>& selectionRanges) override;
+        HRESULT GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, const std::wstring& wordDelimiters, _Out_ std::deque<WRL::ComPtr<Microsoft::Console::Types::UiaTextRangeBase>>& selectionRanges) override;
 
         // degenerate range
-        HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
+        HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, const std::wstring& wordDelimiters, _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
         // degenerate range at cursor position
         HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
                                 const Cursor& cursor,
+                                const std::wstring& wordDelimiters,
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
         // specific endpoint range
@@ -58,11 +59,13 @@ namespace Microsoft::Console::Interactivity::Win32
                                 const Endpoint start,
                                 const Endpoint end,
                                 const bool degenerate,
+                                const std::wstring& wordDelimiters,
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
         // range from a UiaPoint
         HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
                                 const UiaPoint point,
+                                const std::wstring& wordDelimiters,
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
     private:

--- a/src/interactivity/win32/screenInfoUiaProvider.hpp
+++ b/src/interactivity/win32/screenInfoUiaProvider.hpp
@@ -43,15 +43,15 @@ namespace Microsoft::Console::Interactivity::Win32
         void ChangeViewport(const SMALL_RECT NewWindow);
 
     protected:
-        HRESULT GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, const std::wstring& wordDelimiters, _Out_ std::deque<WRL::ComPtr<Microsoft::Console::Types::UiaTextRangeBase>>& selectionRanges) override;
+        HRESULT GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, const std::wstring_view wordDelimiters, _Out_ std::deque<WRL::ComPtr<Microsoft::Console::Types::UiaTextRangeBase>>& selectionRanges) override;
 
         // degenerate range
-        HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, const std::wstring& wordDelimiters, _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
+        HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, const std::wstring_view wordDelimiters, _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
         // degenerate range at cursor position
         HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
                                 const Cursor& cursor,
-                                const std::wstring& wordDelimiters,
+                                const std::wstring_view wordDelimiters,
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
         // specific endpoint range
@@ -59,13 +59,13 @@ namespace Microsoft::Console::Interactivity::Win32
                                 const Endpoint start,
                                 const Endpoint end,
                                 const bool degenerate,
-                                const std::wstring& wordDelimiters,
+                                const std::wstring_view wordDelimiters,
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
         // range from a UiaPoint
         HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
                                 const UiaPoint point,
-                                const std::wstring& wordDelimiters,
+                                const std::wstring_view wordDelimiters,
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
     private:

--- a/src/interactivity/win32/uiaTextRange.cpp
+++ b/src/interactivity/win32/uiaTextRange.cpp
@@ -15,6 +15,7 @@ using Microsoft::Console::Interactivity::ServiceLocator;
 
 HRESULT UiaTextRange::GetSelectionRanges(_In_ IUiaData* pData,
                                          _In_ IRawElementProviderSimple* pProvider,
+                                         const std::wstring& wordDelimiters,
                                          _Out_ std::deque<ComPtr<UiaTextRange>>& ranges)
 {
     try
@@ -32,7 +33,7 @@ HRESULT UiaTextRange::GetSelectionRanges(_In_ IUiaData* pData,
             Endpoint end = _screenInfoRowToEndpoint(pData, currentRow) + rect.RightInclusive();
 
             ComPtr<UiaTextRange> range;
-            RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&range, pData, pProvider, start, end, false));
+            RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&range, pData, pProvider, start, end, false, wordDelimiters));
             temporaryResult.emplace_back(std::move(range));
         }
         std::swap(temporaryResult, ranges);
@@ -42,17 +43,18 @@ HRESULT UiaTextRange::GetSelectionRanges(_In_ IUiaData* pData,
 }
 
 // degenerate range constructor.
-HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData, _In_ IRawElementProviderSimple* const pProvider)
+HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData, _In_ IRawElementProviderSimple* const pProvider, _In_ const std::wstring& wordDelimiters)
 {
-    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider);
+    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, wordDelimiters);
 }
 
 // degenerate range at cursor position
 HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
                                              _In_ IRawElementProviderSimple* const pProvider,
-                                             const Cursor& cursor)
+                                             const Cursor& cursor,
+                                             const std::wstring& wordDelimiters)
 {
-    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, cursor);
+    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, cursor, wordDelimiters);
 }
 
 // specific endpoint range
@@ -60,17 +62,19 @@ HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
                                              _In_ IRawElementProviderSimple* const pProvider,
                                              const Endpoint start,
                                              const Endpoint end,
-                                             const bool degenerate)
+                                             const bool degenerate,
+                                             const std::wstring& wordDelimiters)
 {
-    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, start, end, degenerate);
+    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, start, end, degenerate, wordDelimiters);
 }
 
 // returns a degenerate text range of the start of the row closest to the y value of point
 HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
                                              _In_ IRawElementProviderSimple* const pProvider,
-                                             const UiaPoint point)
+                                             const UiaPoint point,
+                                             const std::wstring& wordDelimiters)
 {
-    RETURN_IF_FAILED(UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider));
+    RETURN_IF_FAILED(UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, wordDelimiters));
     Initialize(point);
     return S_OK;
 }

--- a/src/interactivity/win32/uiaTextRange.cpp
+++ b/src/interactivity/win32/uiaTextRange.cpp
@@ -15,7 +15,7 @@ using Microsoft::Console::Interactivity::ServiceLocator;
 
 HRESULT UiaTextRange::GetSelectionRanges(_In_ IUiaData* pData,
                                          _In_ IRawElementProviderSimple* pProvider,
-                                         const std::wstring& wordDelimiters,
+                                         const std::wstring_view wordDelimiters,
                                          _Out_ std::deque<ComPtr<UiaTextRange>>& ranges)
 {
     try
@@ -43,7 +43,7 @@ HRESULT UiaTextRange::GetSelectionRanges(_In_ IUiaData* pData,
 }
 
 // degenerate range constructor.
-HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData, _In_ IRawElementProviderSimple* const pProvider, _In_ const std::wstring& wordDelimiters)
+HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData, _In_ IRawElementProviderSimple* const pProvider, _In_ const std::wstring_view wordDelimiters)
 {
     return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, wordDelimiters);
 }
@@ -52,7 +52,7 @@ HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData, _In_ IRawElem
 HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
                                              _In_ IRawElementProviderSimple* const pProvider,
                                              const Cursor& cursor,
-                                             const std::wstring& wordDelimiters)
+                                             const std::wstring_view wordDelimiters)
 {
     return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, cursor, wordDelimiters);
 }
@@ -63,7 +63,7 @@ HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
                                              const Endpoint start,
                                              const Endpoint end,
                                              const bool degenerate,
-                                             const std::wstring& wordDelimiters)
+                                             const std::wstring_view wordDelimiters)
 {
     return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, start, end, degenerate, wordDelimiters);
 }
@@ -72,7 +72,7 @@ HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
 HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
                                              _In_ IRawElementProviderSimple* const pProvider,
                                              const UiaPoint point,
-                                             const std::wstring& wordDelimiters)
+                                             const std::wstring_view wordDelimiters)
 {
     RETURN_IF_FAILED(UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, wordDelimiters));
     Initialize(point);

--- a/src/interactivity/win32/uiaTextRange.hpp
+++ b/src/interactivity/win32/uiaTextRange.hpp
@@ -26,30 +26,35 @@ namespace Microsoft::Console::Interactivity::Win32
     public:
         static HRESULT GetSelectionRanges(_In_ Microsoft::Console::Types::IUiaData* pData,
                                           _In_ IRawElementProviderSimple* pProvider,
+                                          _In_ const std::wstring& wordDelimiters,
                                           _Out_ std::deque<WRL::ComPtr<UiaTextRange>>& ranges);
 
         UiaTextRange() = default;
 
         // degenerate range
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
-                                       _In_ IRawElementProviderSimple* const pProvider);
+                                       _In_ IRawElementProviderSimple* const pProvider,
+                                       _In_ const std::wstring& wordDelimiters = L" ");
 
         // degenerate range at cursor position
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,
-                                       const Cursor& cursor);
+                                       const Cursor& cursor,
+                                       _In_ const std::wstring& wordDelimiters = L" ");
 
         // specific endpoint range
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,
                                        const Endpoint start,
                                        const Endpoint end,
-                                       const bool degenerate);
+                                       const bool degenerate,
+                                       _In_ const std::wstring& wordDelimiters = L" ");
 
         // range from a UiaPoint
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,
-                                       const UiaPoint point);
+                                       const UiaPoint point,
+                                       _In_ const std::wstring& wordDelimiters = L" ");
 
         HRESULT RuntimeClassInitialize(const UiaTextRange& a);
 

--- a/src/interactivity/win32/uiaTextRange.hpp
+++ b/src/interactivity/win32/uiaTextRange.hpp
@@ -26,7 +26,7 @@ namespace Microsoft::Console::Interactivity::Win32
     public:
         static HRESULT GetSelectionRanges(_In_ Microsoft::Console::Types::IUiaData* pData,
                                           _In_ IRawElementProviderSimple* pProvider,
-                                          _In_ const std::wstring& wordDelimiters,
+                                          _In_ const std::wstring_view wordDelimiters,
                                           _Out_ std::deque<WRL::ComPtr<UiaTextRange>>& ranges);
 
         UiaTextRange() = default;
@@ -34,13 +34,13 @@ namespace Microsoft::Console::Interactivity::Win32
         // degenerate range
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,
-                                       _In_ const std::wstring& wordDelimiters = L" ");
+                                       _In_ const std::wstring_view wordDelimiters = defaultWordDelimiter);
 
         // degenerate range at cursor position
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,
                                        const Cursor& cursor,
-                                       _In_ const std::wstring& wordDelimiters = L" ");
+                                       _In_ const std::wstring_view wordDelimiters = defaultWordDelimiter);
 
         // specific endpoint range
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
@@ -48,13 +48,13 @@ namespace Microsoft::Console::Interactivity::Win32
                                        const Endpoint start,
                                        const Endpoint end,
                                        const bool degenerate,
-                                       _In_ const std::wstring& wordDelimiters = L" ");
+                                       _In_ const std::wstring_view wordDelimiters = defaultWordDelimiter);
 
         // range from a UiaPoint
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,
                                        const UiaPoint point,
-                                       _In_ const std::wstring& wordDelimiters = L" ");
+                                       _In_ const std::wstring_view wordDelimiters = defaultWordDelimiter);
 
         HRESULT RuntimeClassInitialize(const UiaTextRange& a);
 

--- a/src/types/ScreenInfoUiaProviderBase.cpp
+++ b/src/types/ScreenInfoUiaProviderBase.cpp
@@ -32,7 +32,7 @@ SAFEARRAY* BuildIntSafeArray(std::basic_string_view<int> data)
 }
 
 #pragma warning(suppress : 26434) // WRL RuntimeClassInitialize base is a no-op and we need this for MakeAndInitialize
-HRESULT ScreenInfoUiaProviderBase::RuntimeClassInitialize(_In_ IUiaData* pData, _In_ std::wstring wordDelimiters) noexcept
+HRESULT ScreenInfoUiaProviderBase::RuntimeClassInitialize(_In_ IUiaData* pData, _In_ std::wstring_view wordDelimiters) noexcept
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, pData);
     _pData = pData;

--- a/src/types/ScreenInfoUiaProviderBase.cpp
+++ b/src/types/ScreenInfoUiaProviderBase.cpp
@@ -32,10 +32,11 @@ SAFEARRAY* BuildIntSafeArray(std::basic_string_view<int> data)
 }
 
 #pragma warning(suppress : 26434) // WRL RuntimeClassInitialize base is a no-op and we need this for MakeAndInitialize
-HRESULT ScreenInfoUiaProviderBase::RuntimeClassInitialize(_In_ IUiaData* pData) noexcept
+HRESULT ScreenInfoUiaProviderBase::RuntimeClassInitialize(_In_ IUiaData* pData, _In_ std::wstring wordDelimiters) noexcept
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, pData);
     _pData = pData;
+    _wordDelimiters = wordDelimiters;
     return S_OK;
 }
 
@@ -272,7 +273,7 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::GetSelection(_Outptr_result_maybenull_
         }
 
         WRL::ComPtr<UiaTextRangeBase> range;
-        hr = CreateTextRange(this, cursor, &range);
+        hr = CreateTextRange(this, cursor, _wordDelimiters, &range);
         if (FAILED(hr))
         {
             SafeArrayDestroy(*ppRetVal);
@@ -293,7 +294,7 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::GetSelection(_Outptr_result_maybenull_
     {
         // get the selection ranges
         std::deque<WRL::ComPtr<UiaTextRangeBase>> ranges;
-        RETURN_IF_FAILED(GetSelectionRanges(this, ranges));
+        RETURN_IF_FAILED(GetSelectionRanges(this, _wordDelimiters, ranges));
 
         // TODO GitHub #1914: Re-attach Tracing to UIA Tree
         //apiMsg.AreaSelected = true;
@@ -363,6 +364,7 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::GetVisibleRanges(_Outptr_result_mayben
                              start,
                              end,
                              false,
+                             _wordDelimiters,
                              &range);
         if (FAILED(hr))
         {
@@ -393,7 +395,7 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::RangeFromChild(_In_ IRawElementProvide
     *ppRetVal = nullptr;
 
     WRL::ComPtr<UiaTextRangeBase> utr;
-    RETURN_IF_FAILED(CreateTextRange(this, &utr));
+    RETURN_IF_FAILED(CreateTextRange(this, _wordDelimiters, &utr));
     RETURN_IF_FAILED(utr.CopyTo(ppRetVal));
     return S_OK;
 }
@@ -410,6 +412,7 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::RangeFromPoint(_In_ UiaPoint point,
     WRL::ComPtr<UiaTextRangeBase> utr;
     RETURN_IF_FAILED(CreateTextRange(this,
                                      point,
+                                     _wordDelimiters,
                                      &utr));
     RETURN_IF_FAILED(utr.CopyTo(ppRetVal));
     return S_OK;
@@ -424,7 +427,7 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::get_DocumentRange(_COM_Outptr_result_m
     *ppRetVal = nullptr;
 
     WRL::ComPtr<UiaTextRangeBase> utr;
-    RETURN_IF_FAILED(CreateTextRange(this, &utr));
+    RETURN_IF_FAILED(CreateTextRange(this, _wordDelimiters, &utr));
     RETURN_IF_FAILED(utr->ExpandToEnclosingUnit(TextUnit::TextUnit_Document));
     RETURN_IF_FAILED(utr.CopyTo(ppRetVal));
     return S_OK;

--- a/src/types/ScreenInfoUiaProviderBase.h
+++ b/src/types/ScreenInfoUiaProviderBase.h
@@ -37,7 +37,7 @@ namespace Microsoft::Console::Types
         public WRL::RuntimeClass<WRL::RuntimeClassFlags<WRL::ClassicCom | WRL::InhibitFtmBase>, IRawElementProviderSimple, IRawElementProviderFragment, ITextProvider>
     {
     public:
-        HRESULT RuntimeClassInitialize(_In_ IUiaData* pData, _In_ std::wstring wordDelimiters = L" ") noexcept;
+        HRESULT RuntimeClassInitialize(_In_ IUiaData* pData, _In_ std::wstring_view wordDelimiters = defaultWordDelimiter) noexcept;
 
         ScreenInfoUiaProviderBase(const ScreenInfoUiaProviderBase&) = default;
         ScreenInfoUiaProviderBase(ScreenInfoUiaProviderBase&&) = default;
@@ -77,15 +77,15 @@ namespace Microsoft::Console::Types
     protected:
         ScreenInfoUiaProviderBase() = default;
 
-        virtual HRESULT GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, const std::wstring& wordDelimiters, _Out_ std::deque<WRL::ComPtr<UiaTextRangeBase>>& selectionRanges) = 0;
+        virtual HRESULT GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, const std::wstring_view wordDelimiters, _Out_ std::deque<WRL::ComPtr<UiaTextRangeBase>>& selectionRanges) = 0;
 
         // degenerate range
-        virtual HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, const std::wstring& wordDelimiters, _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr) = 0;
+        virtual HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, const std::wstring_view wordDelimiters, _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr) = 0;
 
         // degenerate range at cursor position
         virtual HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
                                         const Cursor& cursor,
-                                        const std::wstring& wordDelimiters,
+                                        const std::wstring_view wordDelimiters,
                                         _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr) = 0;
 
         // specific endpoint range
@@ -93,13 +93,13 @@ namespace Microsoft::Console::Types
                                         const Endpoint start,
                                         const Endpoint end,
                                         const bool degenerate,
-                                        const std::wstring& wordDelimiters,
+                                        const std::wstring_view wordDelimiters,
                                         _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr) = 0;
 
         // range from a UiaPoint
         virtual HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
                                         const UiaPoint point,
-                                        const std::wstring& wordDelimiters,
+                                        const std::wstring_view wordDelimiters,
                                         _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr) = 0;
 
         // weak reference to IUiaData

--- a/src/types/ScreenInfoUiaProviderBase.h
+++ b/src/types/ScreenInfoUiaProviderBase.h
@@ -37,7 +37,7 @@ namespace Microsoft::Console::Types
         public WRL::RuntimeClass<WRL::RuntimeClassFlags<WRL::ClassicCom | WRL::InhibitFtmBase>, IRawElementProviderSimple, IRawElementProviderFragment, ITextProvider>
     {
     public:
-        HRESULT RuntimeClassInitialize(_In_ IUiaData* pData) noexcept;
+        HRESULT RuntimeClassInitialize(_In_ IUiaData* pData, _In_ std::wstring wordDelimiters = L" ") noexcept;
 
         ScreenInfoUiaProviderBase(const ScreenInfoUiaProviderBase&) = default;
         ScreenInfoUiaProviderBase(ScreenInfoUiaProviderBase&&) = default;
@@ -77,14 +77,15 @@ namespace Microsoft::Console::Types
     protected:
         ScreenInfoUiaProviderBase() = default;
 
-        virtual HRESULT GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, _Out_ std::deque<WRL::ComPtr<UiaTextRangeBase>>& selectionRanges) = 0;
+        virtual HRESULT GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, const std::wstring& wordDelimiters, _Out_ std::deque<WRL::ComPtr<UiaTextRangeBase>>& selectionRanges) = 0;
 
         // degenerate range
-        virtual HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr) = 0;
+        virtual HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, const std::wstring& wordDelimiters, _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr) = 0;
 
         // degenerate range at cursor position
         virtual HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
                                         const Cursor& cursor,
+                                        const std::wstring& wordDelimiters,
                                         _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr) = 0;
 
         // specific endpoint range
@@ -92,15 +93,19 @@ namespace Microsoft::Console::Types
                                         const Endpoint start,
                                         const Endpoint end,
                                         const bool degenerate,
+                                        const std::wstring& wordDelimiters,
                                         _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr) = 0;
 
         // range from a UiaPoint
         virtual HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
                                         const UiaPoint point,
+                                        const std::wstring& wordDelimiters,
                                         _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr) = 0;
 
         // weak reference to IUiaData
         IUiaData* _pData;
+
+        std::wstring _wordDelimiters;
 
     private:
         // this is used to prevent the object from

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -103,7 +103,7 @@ void UiaTextRangeBase::_outputObjectState()
 
 // degenerate range constructor.
 #pragma warning(suppress : 26434) // WRL RuntimeClassInitialize base is a no-op and we need this for MakeAndInitialize
-HRESULT UiaTextRangeBase::RuntimeClassInitialize(_In_ IUiaData* pData, _In_ IRawElementProviderSimple* const pProvider, _In_ std::wstring wordDelimiters)
+HRESULT UiaTextRangeBase::RuntimeClassInitialize(_In_ IUiaData* pData, _In_ IRawElementProviderSimple* const pProvider, _In_ std::wstring_view wordDelimiters)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, pProvider);
     RETURN_HR_IF_NULL(E_INVALIDARG, pData);
@@ -131,7 +131,7 @@ HRESULT UiaTextRangeBase::RuntimeClassInitialize(_In_ IUiaData* pData, _In_ IRaw
 HRESULT UiaTextRangeBase::RuntimeClassInitialize(_In_ IUiaData* pData,
                                                  _In_ IRawElementProviderSimple* const pProvider,
                                                  const Cursor& cursor,
-                                                 _In_ std::wstring wordDelimiters)
+                                                 _In_ std::wstring_view wordDelimiters)
 {
     RETURN_IF_FAILED(RuntimeClassInitialize(pData, pProvider, wordDelimiters));
 
@@ -159,7 +159,7 @@ HRESULT UiaTextRangeBase::RuntimeClassInitialize(_In_ IUiaData* pData,
                                                  const Endpoint start,
                                                  const Endpoint end,
                                                  const bool degenerate,
-                                                 _In_ std::wstring wordDelimiters)
+                                                 _In_ std::wstring_view wordDelimiters)
 {
     RETURN_IF_FAILED(RuntimeClassInitialize(pData, pProvider, wordDelimiters));
     RETURN_HR_IF(E_INVALIDARG, !degenerate && start > end);
@@ -1185,7 +1185,7 @@ const Endpoint UiaTextRangeBase::_textBufferRowToEndpoint(gsl::not_null<IUiaData
 // - wordDelimiters - characters to determine the separation between words
 // Return Value:
 // - the equivalent Endpoint, starting at the beginning of the word where _start is located.
-const Endpoint UiaTextRangeBase::_wordBeginEndpoint(gsl::not_null<IUiaData*> pData, Endpoint target, const std::wstring& wordDelimiters)
+const Endpoint UiaTextRangeBase::_wordBeginEndpoint(gsl::not_null<IUiaData*> pData, Endpoint target, const std::wstring_view wordDelimiters)
 {
     auto coord = _endpointToCoord(pData, target);
     coord = pData->GetTextBuffer().GetWordStart(coord, wordDelimiters);
@@ -1201,7 +1201,7 @@ const Endpoint UiaTextRangeBase::_wordBeginEndpoint(gsl::not_null<IUiaData*> pDa
 // - wordDelimiters - characters to determine the separation between words
 // Return Value:
 // - the equivalent Endpoint, starting at the end of the word where _start is located.
-const Endpoint UiaTextRangeBase::_wordEndEndpoint(gsl::not_null<IUiaData*> pData, Endpoint target, const std::wstring& wordDelimiters)
+const Endpoint UiaTextRangeBase::_wordEndEndpoint(gsl::not_null<IUiaData*> pData, Endpoint target, const std::wstring_view wordDelimiters)
 {
     auto coord = _endpointToCoord(pData, target);
     coord = pData->GetTextBuffer().GetWordEnd(coord, wordDelimiters, true);
@@ -1517,7 +1517,7 @@ std::pair<Endpoint, Endpoint> UiaTextRangeBase::_moveByCharacterBackward(gsl::no
 std::pair<Endpoint, Endpoint> UiaTextRangeBase::_moveByWord(gsl::not_null<IUiaData*> pData,
                                                             const int moveCount,
                                                             const MoveState moveState,
-                                                            const std::wstring& wordDelimiters,
+                                                            const std::wstring_view wordDelimiters,
                                                             _Out_ gsl::not_null<int*> const pAmountMoved)
 {
     if (moveState.Direction == MovementDirection::Forward)
@@ -1533,7 +1533,7 @@ std::pair<Endpoint, Endpoint> UiaTextRangeBase::_moveByWord(gsl::not_null<IUiaDa
 std::pair<Endpoint, Endpoint> UiaTextRangeBase::_moveByWordForward(gsl::not_null<IUiaData*> pData,
                                                                    const int moveCount,
                                                                    const MoveState moveState,
-                                                                   const std::wstring& wordDelimiters,
+                                                                   const std::wstring_view wordDelimiters,
                                                                    _Out_ gsl::not_null<int*> const pAmountMoved)
 {
     // STRATEGY:
@@ -1604,7 +1604,7 @@ std::pair<Endpoint, Endpoint> UiaTextRangeBase::_moveByWordForward(gsl::not_null
 std::pair<Endpoint, Endpoint> UiaTextRangeBase::_moveByWordBackward(gsl::not_null<IUiaData*> pData,
                                                                     const int moveCount,
                                                                     const MoveState moveState,
-                                                                    const std::wstring& wordDelimiters,
+                                                                    const std::wstring_view wordDelimiters,
                                                                     _Out_ gsl::not_null<int*> const pAmountMoved)
 {
     // STRATEGY:
@@ -1970,7 +1970,7 @@ std::tuple<Endpoint, Endpoint, bool> UiaTextRangeBase::_moveEndpointByUnitWord(g
                                                                                const int moveCount,
                                                                                const TextPatternRangeEndpoint endpoint,
                                                                                const MoveState moveState,
-                                                                               const std::wstring& wordDelimiters,
+                                                                               const std::wstring_view wordDelimiters,
                                                                                _Out_ gsl::not_null<int*> const pAmountMoved)
 {
     if (moveState.Direction == MovementDirection::Forward)
@@ -1988,7 +1988,7 @@ UiaTextRangeBase::_moveEndpointByUnitWordForward(gsl::not_null<IUiaData*> pData,
                                                  const int moveCount,
                                                  const TextPatternRangeEndpoint endpoint,
                                                  const MoveState moveState,
-                                                 const std::wstring& wordDelimiters,
+                                                 const std::wstring_view wordDelimiters,
                                                  _Out_ gsl::not_null<int*> const pAmountMoved)
 {
     *pAmountMoved = 0;
@@ -2108,7 +2108,7 @@ UiaTextRangeBase::_moveEndpointByUnitWordBackward(gsl::not_null<IUiaData*> pData
                                                   const int moveCount,
                                                   const TextPatternRangeEndpoint endpoint,
                                                   const MoveState moveState,
-                                                  const std::wstring& wordDelimiters,
+                                                  const std::wstring_view wordDelimiters,
                                                   _Out_ gsl::not_null<int*> const pAmountMoved)
 {
     *pAmountMoved = 0;

--- a/src/types/UiaTextRangeBase.hpp
+++ b/src/types/UiaTextRangeBase.hpp
@@ -23,6 +23,7 @@ Author(s):
 #include "inc/viewport.hpp"
 #include "../buffer/out/textBuffer.hpp"
 #include "IUiaData.h"
+#include "unicode.hpp"
 
 #include <deque>
 #include <tuple>
@@ -72,7 +73,7 @@ typedef unsigned int Endpoint;
 
 constexpr IdType InvalidId = 0;
 
-constexpr auto defaultWordDelimiter = L" ";
+static constexpr std::wstring_view defaultWordDelimiter = std::wstring_view(&UNICODE_SPACE, 1);
 
 namespace Microsoft::Console::Types
 {

--- a/src/types/UiaTextRangeBase.hpp
+++ b/src/types/UiaTextRangeBase.hpp
@@ -72,6 +72,8 @@ typedef unsigned int Endpoint;
 
 constexpr IdType InvalidId = 0;
 
+constexpr auto defaultWordDelimiter = L" ";
+
 namespace Microsoft::Console::Types
 {
     class UiaTextRangeBase : public WRL::RuntimeClass<WRL::RuntimeClassFlags<WRL::ClassicCom | WRL::InhibitFtmBase>, ITextRangeProvider>
@@ -141,13 +143,13 @@ namespace Microsoft::Console::Types
         // degenerate range
         HRESULT RuntimeClassInitialize(_In_ IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,
-                                       _In_ std::wstring wordDelimiters = L" ");
+                                       _In_ std::wstring_view wordDelimiters = defaultWordDelimiter);
 
         // degenerate range at cursor position
         HRESULT RuntimeClassInitialize(_In_ IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,
                                        const Cursor& cursor,
-                                       _In_ std::wstring wordDelimiters = L" ");
+                                       _In_ std::wstring_view wordDelimiters = defaultWordDelimiter);
 
         // specific endpoint range
         HRESULT RuntimeClassInitialize(_In_ IUiaData* pData,
@@ -155,7 +157,7 @@ namespace Microsoft::Console::Types
                                        const Endpoint start,
                                        const Endpoint end,
                                        const bool degenerate,
-                                       _In_ std::wstring wordDelimiters = L" ");
+                                       _In_ std::wstring_view wordDelimiters = defaultWordDelimiter);
 
         HRESULT RuntimeClassInitialize(const UiaTextRangeBase& a) noexcept;
 
@@ -221,7 +223,7 @@ namespace Microsoft::Console::Types
 
         IRawElementProviderSimple* _pProvider;
 
-        std::wstring _wordDelimiters;
+        std::wstring_view _wordDelimiters;
 
         virtual void _ChangeViewport(const SMALL_RECT NewWindow) = 0;
         virtual void _TranslatePointToScreen(LPPOINT clientPoint) const = 0;
@@ -281,8 +283,8 @@ namespace Microsoft::Console::Types
                                                                  const ScreenInfoRow row) noexcept;
         static const Endpoint _textBufferRowToEndpoint(gsl::not_null<IUiaData*> pData, const TextBufferRow row);
 
-        static const Endpoint _wordBeginEndpoint(gsl::not_null<IUiaData*> pData, Endpoint target, const std::wstring& wordDelimiters);
-        static const Endpoint _wordEndEndpoint(gsl::not_null<IUiaData*> pData, Endpoint target, const std::wstring& wordDelimiters);
+        static const Endpoint _wordBeginEndpoint(gsl::not_null<IUiaData*> pData, Endpoint target, const std::wstring_view wordDelimiters);
+        static const Endpoint _wordEndEndpoint(gsl::not_null<IUiaData*> pData, Endpoint target, const std::wstring_view wordDelimiters);
 
         static const ScreenInfoRow _endpointToScreenInfoRow(gsl::not_null<IUiaData*> pData,
                                                             const Endpoint endpoint);
@@ -350,19 +352,19 @@ namespace Microsoft::Console::Types
         static std::pair<Endpoint, Endpoint> _moveByWord(gsl::not_null<IUiaData*> pData,
                                                          const int moveCount,
                                                          const MoveState moveState,
-                                                         const std::wstring& wordDelimiters,
+                                                         const std::wstring_view wordDelimiters,
                                                          _Out_ gsl::not_null<int*> const pAmountMoved);
 
         static std::pair<Endpoint, Endpoint> _moveByWordForward(gsl::not_null<IUiaData*> pData,
                                                                 const int moveCount,
                                                                 const MoveState moveState,
-                                                                const std::wstring& wordDelimiters,
+                                                                const std::wstring_view wordDelimiters,
                                                                 _Out_ gsl::not_null<int*> const pAmountMoved);
 
         static std::pair<Endpoint, Endpoint> _moveByWordBackward(gsl::not_null<IUiaData*> pData,
                                                                  const int moveCount,
                                                                  const MoveState moveState,
-                                                                 const std::wstring& wordDelimiters,
+                                                                 const std::wstring_view wordDelimiters,
                                                                  _Out_ gsl::not_null<int*> const pAmountMoved);
 
         static std::pair<Endpoint, Endpoint> _moveByLine(gsl::not_null<IUiaData*> pData,
@@ -401,7 +403,7 @@ namespace Microsoft::Console::Types
                                 const int moveCount,
                                 const TextPatternRangeEndpoint endpoint,
                                 const MoveState moveState,
-                                const std::wstring& wordDelimiters,
+                                const std::wstring_view wordDelimiters,
                                 _Out_ gsl::not_null<int*> const pAmountMoved);
 
         static std::tuple<Endpoint, Endpoint, bool>
@@ -409,7 +411,7 @@ namespace Microsoft::Console::Types
                                        const int moveCount,
                                        const TextPatternRangeEndpoint endpoint,
                                        const MoveState moveState,
-                                       const std::wstring& wordDelimiters,
+                                       const std::wstring_view wordDelimiters,
                                        _Out_ gsl::not_null<int*> const pAmountMoved);
 
         static std::tuple<Endpoint, Endpoint, bool>
@@ -417,7 +419,7 @@ namespace Microsoft::Console::Types
                                         const int moveCount,
                                         const TextPatternRangeEndpoint endpoint,
                                         const MoveState moveState,
-                                        const std::wstring& wordDelimiters,
+                                        const std::wstring_view wordDelimiters,
                                         _Out_ gsl::not_null<int*> const pAmountMoved);
 
         static std::tuple<Endpoint, Endpoint, bool>


### PR DESCRIPTION
## Summary of the Pull Request
This allows the developer to define word delimiters for our accessibility model via multiple avenues.
1. import a word delimiter into the constructor of the `ScreenInfoUiaProvider` (SIUP)
  - this defines a word delimiter for _all_ the `UiaTextRange`s (UTR) created by in this context
2. import a word delimiter into the UTR directly
  - this provides more control over what a "word" is
  - this can be useful if you have an idea of what text a particular UTR will encounter and you want to customize the word navigation for it (i.e consider adding `/` or `\\` for file paths)

The default param of `" "` is scattered throughout because this is the word delimiter used in the English language.

## References
#3659 
#3161 