### PR TITLE
Fix LocalTests that were working before

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/ColorSchemeTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/ColorSchemeTests.cpp
@@ -20,15 +20,14 @@ namespace TerminalAppLocalTests
 
     class ColorSchemeTests : public JsonTestClass
     {
-        // Use a custom manifest to ensure that we can activate winrt types from
-        // our test. This property will tell taef to manually use this as the
-        // sxs manifest during this test class. It includes all the cppwinrt
-        // types we've defined, so if your test is crashing for an unknown
-        // reason, make sure it's included in that file.
-        // If you want to do anything XAML-y, you'll need to run your test in a
-        // packaged context. See TabTests.cpp for more details on that.
+        // Use a custom AppxManifest to ensure that we can activate winrt types
+        // from our test. This property will tell taef to manually use this as
+        // the AppxManifest for this test class.
+        // This does not yet work for anything XAML-y. See TabTests.cpp for more
+        // details on that.
         BEGIN_TEST_CLASS(ColorSchemeTests)
-            TEST_CLASS_PROPERTY(L"ActivationContext", L"TerminalApp.LocalTests.manifest")
+            TEST_CLASS_PROPERTY(L"RunAs", L"UAP")
+            TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"TerminalApp.LocalTests.AppxManifest.xml")
         END_TEST_CLASS()
 
         TEST_METHOD(CanLayerColorScheme);

--- a/src/cascadia/LocalTests_TerminalApp/ProfileTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/ProfileTests.cpp
@@ -20,15 +20,14 @@ namespace TerminalAppLocalTests
 
     class ProfileTests : public JsonTestClass
     {
-        // Use a custom manifest to ensure that we can activate winrt types from
-        // our test. This property will tell taef to manually use this as the
-        // sxs manifest during this test class. It includes all the cppwinrt
-        // types we've defined, so if your test is crashing for an unknown
-        // reason, make sure it's included in that file.
-        // If you want to do anything XAML-y, you'll need to run your test in a
-        // packaged context. See TabTests.cpp for more details on that.
+        // Use a custom AppxManifest to ensure that we can activate winrt types
+        // from our test. This property will tell taef to manually use this as
+        // the AppxManifest for this test class.
+        // This does not yet work for anything XAML-y. See TabTests.cpp for more
+        // details on that.
         BEGIN_TEST_CLASS(ProfileTests)
-            TEST_CLASS_PROPERTY(L"ActivationContext", L"TerminalApp.LocalTests.manifest")
+            TEST_CLASS_PROPERTY(L"RunAs", L"UAP")
+            TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"TerminalApp.LocalTests.AppxManifest.xml")
         END_TEST_CLASS()
 
         TEST_METHOD(CanLayerProfile);

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -29,7 +29,9 @@ namespace TerminalAppLocalTests
         // If you want to do anything XAML-y, you'll need to run your test in a
         // packaged context. See TabTests.cpp for more details on that.
         BEGIN_TEST_CLASS(SettingsTests)
-            TEST_CLASS_PROPERTY(L"ActivationContext", L"TerminalApp.LocalTests.manifest")
+            // TEST_CLASS_PROPERTY(L"ActivationContext", L"TerminalApp.LocalTests.manifest")
+            TEST_CLASS_PROPERTY(L"RunAs", L"UAP")
+            TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"TerminalApp.LocalTests.AppxManifest.xml")
         END_TEST_CLASS()
 
         TEST_METHOD(TryCreateWinRTType);
@@ -58,6 +60,8 @@ namespace TerminalAppLocalTests
 
         TEST_METHOD(TestCloseOnExitParsing);
         TEST_METHOD(TestCloseOnExitCompatibilityShim);
+
+        TEST_METHOD(TestTerminalArgsForBinding);
 
         TEST_CLASS_SETUP(ClassSetup)
         {

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -21,15 +21,12 @@ namespace TerminalAppLocalTests
 
     class SettingsTests : public JsonTestClass
     {
-        // Use a custom manifest to ensure that we can activate winrt types from
-        // our test. This property will tell taef to manually use this as the
-        // sxs manifest during this test class. It includes all the cppwinrt
-        // types we've defined, so if your test is crashing for an unknown
-        // reason, make sure it's included in that file.
-        // If you want to do anything XAML-y, you'll need to run your test in a
-        // packaged context. See TabTests.cpp for more details on that.
+        // Use a custom AppxManifest to ensure that we can activate winrt types
+        // from our test. This property will tell taef to manually use this as
+        // the AppxManifest for this test class.
+        // This does not yet work for anything XAML-y. See TabTests.cpp for more
+        // details on that.
         BEGIN_TEST_CLASS(SettingsTests)
-            // TEST_CLASS_PROPERTY(L"ActivationContext", L"TerminalApp.LocalTests.manifest")
             TEST_CLASS_PROPERTY(L"RunAs", L"UAP")
             TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"TerminalApp.LocalTests.AppxManifest.xml")
         END_TEST_CLASS()
@@ -60,8 +57,6 @@ namespace TerminalAppLocalTests
 
         TEST_METHOD(TestCloseOnExitParsing);
         TEST_METHOD(TestCloseOnExitCompatibilityShim);
-
-        TEST_METHOD(TestTerminalArgsForBinding);
 
         TEST_CLASS_SETUP(ClassSetup)
         {

--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -18,54 +18,36 @@ namespace TerminalAppLocalTests
 
     class TabTests
     {
-        // For this set of tests, we need to activate some XAML content. To do
-        // that, we need to be able to activate Xaml Islands(XI), using the Xaml
-        // Hosting APIs. Because XI looks at the manifest of the exe running, we
-        // can't just use the TerminalApp.Unit.Tests.manifest as our
-        // ActivationContext. XI is going to inspect `te.exe`s manifest to try
-        // and find the maxversiontested property, but te.exe hasn't set that.
-        // Instead, this test will run as a UAP application, as a packaged
-        // centenial (win32) app. We'll specify our own AppxManifest, so that
-        // we'll be able to also load all the dll's for the types we've defined
-        // (and want to use here). This does come with a minor caveat, as
-        // deploying the appx takes a bit, so use sparingly (though it will
-        // deploy once per class when used like this.)
+        // For this set of tests, we need to activate some XAML content. For
+        // release builds, the application runs as a centennial application,
+        // which lets us run full trust, and means that we need to use XAML
+        // Islands to host our UI. However, in these tests, we don't really need
+        // to run full trust - we just need to get some UI elements created. So
+        // we can just rely on the normal UWP activation to create us.
+        // UNFORTUNATELY, this doesn't seem to work yet, and the tests fail when
+        // instantiating XAML elements
+
         BEGIN_TEST_CLASS(TabTests)
             TEST_CLASS_PROPERTY(L"RunAs", L"UAP")
-            TEST_CLASS_PROPERTY(L"UAP:Host", L"XAML")
             TEST_CLASS_PROPERTY(L"UAP:WaitForXamlWindowActivation", L"true")
-            // TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"TerminalApp.LocalTests.AppxManifest.xml")
-            TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"SUA")
+            TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"TerminalApp.LocalTests.AppxManifest.xml")
         END_TEST_CLASS()
 
         // These four tests act as canary tests. If one of them fails, then they
         // can help you identify if something much lower in the stack has
         // failed.
-        TEST_METHOD(TryInitXamlIslands);
+        TEST_METHOD(EnsureTestsActivate);
         TEST_METHOD(TryCreateLocalWinRTType);
+        TEST_METHOD(EnsureDispatcher);
         TEST_METHOD(TryCreateXamlObjects);
         TEST_METHOD(TryCreateTab);
-
-        TEST_CLASS_SETUP(ClassSetup)
-        {
-            // winrt::init_apartment(winrt::apartment_type::single_threaded);
-            // // Initialize the Xaml Hosting Manager
-            // _manager = winrt::Windows::UI::Xaml::Hosting::WindowsXamlManager::InitializeForCurrentThread();
-            // _source = winrt::Windows::UI::Xaml::Hosting::DesktopWindowXamlSource{};
-
-            return true;
-        }
-
-    private:
-        // winrt::Windows::UI::Xaml::Hosting::WindowsXamlManager _manager{ nullptr };
-        // winrt::Windows::UI::Xaml::Hosting::DesktopWindowXamlSource _source{ nullptr };
     };
 
-    void TabTests::TryInitXamlIslands()
+    void TabTests::EnsureTestsActivate()
     {
-        // Ensures that XAML Islands was initialized correctly
-        // VERIFY_IS_NOT_NULL(_manager);
-        // VERIFY_IS_NOT_NULL(_source);
+        // This test was originally used to ensure that XAML Islands was
+        // initialized correctly. Now, it's used to ensure that the tests
+        // actually deployed and activated. This test _should_ always pass.
         VERIFY_IS_TRUE(true);
     }
 
@@ -85,7 +67,6 @@ namespace TerminalAppLocalTests
     {
         // Verify we can create a some XAML objects
         // Just creating all of them is enough to know that everything is working.
-        DebugBreak();
         winrt::Windows::UI::Xaml::Controls::UserControl controlRoot;
         VERIFY_IS_NOT_NULL(controlRoot);
         winrt::Windows::UI::Xaml::Controls::Grid root;

--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -38,7 +38,6 @@ namespace TerminalAppLocalTests
         // failed.
         TEST_METHOD(EnsureTestsActivate);
         TEST_METHOD(TryCreateLocalWinRTType);
-        TEST_METHOD(EnsureDispatcher);
         TEST_METHOD(TryCreateXamlObjects);
         TEST_METHOD(TryCreateTab);
     };

--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -32,7 +32,10 @@ namespace TerminalAppLocalTests
         // deploy once per class when used like this.)
         BEGIN_TEST_CLASS(TabTests)
             TEST_CLASS_PROPERTY(L"RunAs", L"UAP")
-            TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"TerminalApp.LocalTests.AppxManifest.xml")
+            TEST_CLASS_PROPERTY(L"UAP:Host", L"XAML")
+            TEST_CLASS_PROPERTY(L"UAP:WaitForXamlWindowActivation", L"true")
+            // TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"TerminalApp.LocalTests.AppxManifest.xml")
+            TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"SUA")
         END_TEST_CLASS()
 
         // These four tests act as canary tests. If one of them fails, then they
@@ -45,24 +48,25 @@ namespace TerminalAppLocalTests
 
         TEST_CLASS_SETUP(ClassSetup)
         {
-            winrt::init_apartment(winrt::apartment_type::single_threaded);
-            // Initialize the Xaml Hosting Manager
-            _manager = winrt::Windows::UI::Xaml::Hosting::WindowsXamlManager::InitializeForCurrentThread();
-            _source = winrt::Windows::UI::Xaml::Hosting::DesktopWindowXamlSource{};
+            // winrt::init_apartment(winrt::apartment_type::single_threaded);
+            // // Initialize the Xaml Hosting Manager
+            // _manager = winrt::Windows::UI::Xaml::Hosting::WindowsXamlManager::InitializeForCurrentThread();
+            // _source = winrt::Windows::UI::Xaml::Hosting::DesktopWindowXamlSource{};
 
             return true;
         }
 
     private:
-        winrt::Windows::UI::Xaml::Hosting::WindowsXamlManager _manager{ nullptr };
-        winrt::Windows::UI::Xaml::Hosting::DesktopWindowXamlSource _source{ nullptr };
+        // winrt::Windows::UI::Xaml::Hosting::WindowsXamlManager _manager{ nullptr };
+        // winrt::Windows::UI::Xaml::Hosting::DesktopWindowXamlSource _source{ nullptr };
     };
 
     void TabTests::TryInitXamlIslands()
     {
         // Ensures that XAML Islands was initialized correctly
-        VERIFY_IS_NOT_NULL(_manager);
-        VERIFY_IS_NOT_NULL(_source);
+        // VERIFY_IS_NOT_NULL(_manager);
+        // VERIFY_IS_NOT_NULL(_source);
+        VERIFY_IS_TRUE(true);
     }
 
     void TabTests::TryCreateLocalWinRTType()
@@ -81,6 +85,7 @@ namespace TerminalAppLocalTests
     {
         // Verify we can create a some XAML objects
         // Just creating all of them is enough to know that everything is working.
+        DebugBreak();
         winrt::Windows::UI::Xaml::Controls::UserControl controlRoot;
         VERIFY_IS_NOT_NULL(controlRoot);
         winrt::Windows::UI::Xaml::Controls::Grid root;

--- a/src/cascadia/LocalTests_TerminalApp/TerminalApp.LocalTests.AppxManifest.prototype.xml
+++ b/src/cascadia/LocalTests_TerminalApp/TerminalApp.LocalTests.AppxManifest.prototype.xml
@@ -22,21 +22,25 @@
           Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
           Version="1.0.0.0"
           ResourceId="en-us" />
+
   <Properties>
     <DisplayName>TerminalApp.LocalTests.Package Host Process</DisplayName>
     <PublisherDisplayName>Microsoft Corp.</PublisherDisplayName>
     <Logo>taef.png</Logo>
     <Description>TAEF Packaged Cwa FullTrust Application Host Process</Description>
   </Properties>
+
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.18362.0" MaxVersionTested="10.0.18362.0" />
     <PackageDependency Name="Microsoft.VCLibs.140.00.Debug" MinVersion="14.0.27023.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
     <PackageDependency Name="Microsoft.VCLibs.140.00.Debug.UWPDesktop" MinVersion="14.0.27027.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
+
   <Resources>
     <Resource Language="en-us" />
   </Resources>
-  <Applications>
+
+  <!-- <Applications>
     <Application Id="TE.ProcessHost" Executable="TE.ProcessHost.exe" EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements DisplayName="TAEF Packaged Cwa FullTrust Application Host Process" Square150x150Logo="taef.png" Square44x44Logo="taef.png" Description="TAEF Packaged Cwa Application Host Process" BackgroundColor="#222222">
         <uap:SplashScreen Image="taef.png" />
@@ -45,7 +49,16 @@
   </Applications>
   <Capabilities>
     <rescap:Capability Name="runFullTrust"/>
-  </Capabilities>
+  </Capabilities> -->
+
+  <Applications>
+    <Application Id="TE.ProcessHost" Executable="TE.ProcessHost.UAP.exe" EntryPoint="ProcessHostApplication">
+      <uap:VisualElements DisplayName="TAEF UWA Host Process" Square150x150Logo="taef.png" Square44x44Logo="taef.png" Description="TAEF UWA Host Process" BackgroundColor="#222222">
+        <uap:SplashScreen Image="taef.png" />
+      </uap:VisualElements>
+    </Application>
+  </Applications>
+
 
 
 

--- a/src/cascadia/LocalTests_TerminalApp/TerminalApp.LocalTests.AppxManifest.prototype.xml
+++ b/src/cascadia/LocalTests_TerminalApp/TerminalApp.LocalTests.AppxManifest.prototype.xml
@@ -3,19 +3,16 @@
 
   <!-- This file is used as the Appxmanifest for tests that _need_ to run in a
   packaged environment. It will be copied to the test's OutDir as part of the
-  PostBuid step. It's highly similar to the "PackagedCwaFullTrust" manifest that
+  PostBuid step. It's highly similar to the "SUA" manifest that
   TAEF ships with, with the following modifications:
 
   1. All of our winrt types are included in this manifest, including types from
-     MUX.dll. Should this list of types ever change, we'll need to manually
-     update this file. The easiest way of doing that is deploying the app from
-     VS, then copying the Extensions from the Appxmanifest.xml that's generated
-     under `src/cascadia/CascadiaPackage/bin/$(platform)/$(configuration)/appx`.
+     MUX.dll. This is done in a custom build step that automatically adds each
+     of our types to this manifest.
 
   2. We also _NEED_ the two vclibs listed under the `PackageDependency` block.
 
-  If your test fails for whatever reason, it's likely possible you're testing a
-  type that's _not_ included in this file for some reason. So, here be dragons. -->
+  -->
 
   <Identity Name="TerminalApp.LocalTests.Package"
           ProcessorArchitecture="neutral"
@@ -27,7 +24,7 @@
     <DisplayName>TerminalApp.LocalTests.Package Host Process</DisplayName>
     <PublisherDisplayName>Microsoft Corp.</PublisherDisplayName>
     <Logo>taef.png</Logo>
-    <Description>TAEF Packaged Cwa FullTrust Application Host Process</Description>
+    <Description>TAEF Packaged UWP Application Host Process</Description>
   </Properties>
 
   <Dependencies>
@@ -39,17 +36,6 @@
   <Resources>
     <Resource Language="en-us" />
   </Resources>
-
-  <!-- <Applications>
-    <Application Id="TE.ProcessHost" Executable="TE.ProcessHost.exe" EntryPoint="Windows.FullTrustApplication">
-      <uap:VisualElements DisplayName="TAEF Packaged Cwa FullTrust Application Host Process" Square150x150Logo="taef.png" Square44x44Logo="taef.png" Description="TAEF Packaged Cwa Application Host Process" BackgroundColor="#222222">
-        <uap:SplashScreen Image="taef.png" />
-      </uap:VisualElements>
-    </Application>
-  </Applications>
-  <Capabilities>
-    <rescap:Capability Name="runFullTrust"/>
-  </Capabilities> -->
 
   <Applications>
     <Application Id="TE.ProcessHost" Executable="TE.ProcessHost.UAP.exe" EntryPoint="ProcessHostApplication">


### PR DESCRIPTION
## Summary of the Pull Request

Fixes the LocalTests that should work. This does _not_ fix the TabTests.


## PR Checklist
* [x] Closes #3536
* [x] I work here
* [x] This is literally making the tests work
* [n/a] Requires documentation to be updated

## Detailed Description of the Pull Request / Additional comments

In a previous PR, we broke unpackaged activation. This had the unintended side-effect of breaking these tests. The solution here is to run these unittests _packaged_.

This also makes things a little bit better for the TabTests, but doesn't fix them (inexplicably). A mail thread internally is tracking the progress of fixing those tests.
