### PR TITLE
Bugfix: correct copy vs copyTextWithoutNewlines behavior

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -108,8 +108,8 @@
             "action": { "type": "string", "pattern": "copy" },
             "trimWhitespace": {
               "type": "boolean",
-              "default": false,
-              "description": "If true, will trim whitespace from the end of the line on copy."
+              "default": true,
+              "description": "If false, concatenates the copied text to one line."
             }
           }
         }

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -106,7 +106,7 @@
         {
           "properties": {
             "action": { "type": "string", "pattern": "copy" },
-            "trimWhitespace": {
+            "copyNewlines": {
               "type": "boolean",
               "default": true,
               "description": "If false, concatenates the copied text to one line."

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -106,10 +106,10 @@
         {
           "properties": {
             "action": { "type": "string", "pattern": "copy" },
-            "copyNewlines": {
+            "stripNewlines": {
               "type": "boolean",
-              "default": true,
-              "description": "If false, concatenates the copied text to one line."
+              "default": false,
+              "description": "If true, concatenates the copied text to one line."
             }
           }
         }

--- a/src/cascadia/LocalTests_TerminalApp/KeyBindingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/KeyBindingsTests.cpp
@@ -187,8 +187,8 @@ namespace TerminalAppLocalTests
         const std::string bindings0String{ R"([
             { "command": "copy", "keys": ["ctrl+c"] },
             { "command": "copyTextWithoutNewlines", "keys": ["alt+c"] },
-            { "command": { "action": "copy", "copyNewlines": false }, "keys": ["ctrl+shift+c"] },
-            { "command": { "action": "copy", "copyNewlines": true }, "keys": ["alt+shift+c"] },
+            { "command": { "action": "copy", "stripNewlines": false }, "keys": ["ctrl+shift+c"] },
+            { "command": { "action": "copy", "stripNewlines": true }, "keys": ["alt+shift+c"] },
 
             { "command": "newTab", "keys": ["ctrl+t"] },
             { "command": { "action": "newTab", "index": 0 }, "keys": ["ctrl+shift+t"] },
@@ -214,24 +214,24 @@ namespace TerminalAppLocalTests
 
         {
             Log::Comment(NoThrowString().Format(
-                L"Verify that `copy` without args parses as Copy(CopyNewlines=true)"));
+                L"Verify that `copy` without args parses as Copy(StripNewlines=true)"));
             KeyChord kc{ true, false, false, static_cast<int32_t>('C') };
             auto actionAndArgs = GetActionAndArgs(*appKeyBindings, kc);
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_TRUE(realArgs.CopyNewlines());
+            VERIFY_IS_FALSE(realArgs.StripNewlines());
         }
 
         {
             Log::Comment(NoThrowString().Format(
-                L"Verify that `copyTextWithoutNewlines` parses as Copy(CopyNewlines=false)"));
+                L"Verify that `copyTextWithoutNewlines` parses as Copy(StripNewlines=false)"));
             KeyChord kc{ false, true, false, static_cast<int32_t>('C') };
             auto actionAndArgs = GetActionAndArgs(*appKeyBindings, kc);
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_FALSE(realArgs.CopyNewlines());
+            VERIFY_IS_TRUE(realArgs.StripNewlines());
         }
 
         {
@@ -242,7 +242,7 @@ namespace TerminalAppLocalTests
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_FALSE(realArgs.CopyNewlines());
+            VERIFY_IS_FALSE(realArgs.StripNewlines());
         }
 
         {
@@ -253,7 +253,7 @@ namespace TerminalAppLocalTests
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_TRUE(realArgs.CopyNewlines());
+            VERIFY_IS_TRUE(realArgs.StripNewlines());
         }
 
         {
@@ -326,7 +326,7 @@ namespace TerminalAppLocalTests
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_TRUE(realArgs.CopyNewlines());
+            VERIFY_IS_FALSE(realArgs.StripNewlines());
         }
 
         {
@@ -338,7 +338,7 @@ namespace TerminalAppLocalTests
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_TRUE(realArgs.CopyNewlines());
+            VERIFY_IS_FALSE(realArgs.StripNewlines());
         }
 
         {

--- a/src/cascadia/LocalTests_TerminalApp/KeyBindingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/KeyBindingsTests.cpp
@@ -187,8 +187,8 @@ namespace TerminalAppLocalTests
         const std::string bindings0String{ R"([
             { "command": "copy", "keys": ["ctrl+c"] },
             { "command": "copyTextWithoutNewlines", "keys": ["alt+c"] },
-            { "command": { "action": "copy", "trimWhitespace": false }, "keys": ["ctrl+shift+c"] },
-            { "command": { "action": "copy", "trimWhitespace": true }, "keys": ["alt+shift+c"] },
+            { "command": { "action": "copy", "copyNewlines": false }, "keys": ["ctrl+shift+c"] },
+            { "command": { "action": "copy", "copyNewlines": true }, "keys": ["alt+shift+c"] },
 
             { "command": "newTab", "keys": ["ctrl+t"] },
             { "command": { "action": "newTab", "index": 0 }, "keys": ["ctrl+shift+t"] },
@@ -214,24 +214,24 @@ namespace TerminalAppLocalTests
 
         {
             Log::Comment(NoThrowString().Format(
-                L"Verify that `copy` without args parses as Copy(TrimWhitespace=false)"));
+                L"Verify that `copy` without args parses as Copy(CopyNewlines=true)"));
             KeyChord kc{ true, false, false, static_cast<int32_t>('C') };
             auto actionAndArgs = GetActionAndArgs(*appKeyBindings, kc);
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_FALSE(realArgs.TrimWhitespace());
+            VERIFY_IS_TRUE(realArgs.CopyNewlines());
         }
 
         {
             Log::Comment(NoThrowString().Format(
-                L"Verify that `copyTextWithoutNewlines` parses as Copy(TrimWhitespace=true)"));
+                L"Verify that `copyTextWithoutNewlines` parses as Copy(CopyNewlines=false)"));
             KeyChord kc{ false, true, false, static_cast<int32_t>('C') };
             auto actionAndArgs = GetActionAndArgs(*appKeyBindings, kc);
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_TRUE(realArgs.TrimWhitespace());
+            VERIFY_IS_FALSE(realArgs.CopyNewlines());
         }
 
         {
@@ -242,7 +242,7 @@ namespace TerminalAppLocalTests
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_FALSE(realArgs.TrimWhitespace());
+            VERIFY_IS_FALSE(realArgs.CopyNewlines());
         }
 
         {
@@ -253,7 +253,7 @@ namespace TerminalAppLocalTests
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_TRUE(realArgs.TrimWhitespace());
+            VERIFY_IS_TRUE(realArgs.CopyNewlines());
         }
 
         {
@@ -326,7 +326,7 @@ namespace TerminalAppLocalTests
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_FALSE(realArgs.TrimWhitespace());
+            VERIFY_IS_TRUE(realArgs.CopyNewlines());
         }
 
         {
@@ -338,7 +338,7 @@ namespace TerminalAppLocalTests
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_FALSE(realArgs.TrimWhitespace());
+            VERIFY_IS_TRUE(realArgs.CopyNewlines());
         }
 
         {

--- a/src/cascadia/TerminalApp/ActionArgs.h
+++ b/src/cascadia/TerminalApp/ActionArgs.h
@@ -37,9 +37,9 @@ namespace winrt::TerminalApp::implementation
     struct CopyTextArgs : public CopyTextArgsT<CopyTextArgs>
     {
         CopyTextArgs() = default;
-        GETSET_PROPERTY(bool, CopyNewlines, true);
+        GETSET_PROPERTY(bool, StripNewlines, false);
 
-        static constexpr std::string_view CopyNewlinesKey{ "copyNewlines" };
+        static constexpr std::string_view StripNewlinesKey{ "stripNewlines" };
 
     public:
         bool Equals(const IActionArgs& other)
@@ -47,7 +47,7 @@ namespace winrt::TerminalApp::implementation
             auto otherAsUs = other.try_as<CopyTextArgs>();
             if (otherAsUs)
             {
-                return otherAsUs->_CopyNewlines == _CopyNewlines;
+                return otherAsUs->_StripNewlines == _StripNewlines;
             }
             return false;
         };
@@ -55,9 +55,9 @@ namespace winrt::TerminalApp::implementation
         {
             // LOAD BEARING: Not using make_self here _will_ break you in the future!
             auto args = winrt::make_self<CopyTextArgs>();
-            if (auto copyNewlines{ json[JsonKey(CopyNewlinesKey)] })
+            if (auto stripNewlines{ json[JsonKey(StripNewlinesKey)] })
             {
-                args->_CopyNewlines = copyNewlines.asBool();
+                args->_StripNewlines = stripNewlines.asBool();
             }
             return *args;
         }

--- a/src/cascadia/TerminalApp/ActionArgs.h
+++ b/src/cascadia/TerminalApp/ActionArgs.h
@@ -37,9 +37,9 @@ namespace winrt::TerminalApp::implementation
     struct CopyTextArgs : public CopyTextArgsT<CopyTextArgs>
     {
         CopyTextArgs() = default;
-        GETSET_PROPERTY(bool, TrimWhitespace, false);
+        GETSET_PROPERTY(bool, CopyNewlines, true);
 
-        static constexpr std::string_view TrimWhitespaceKey{ "trimWhitespace" };
+        static constexpr std::string_view CopyNewlinesKey{ "copyNewlines" };
 
     public:
         bool Equals(const IActionArgs& other)
@@ -47,7 +47,7 @@ namespace winrt::TerminalApp::implementation
             auto otherAsUs = other.try_as<CopyTextArgs>();
             if (otherAsUs)
             {
-                return otherAsUs->_TrimWhitespace == _TrimWhitespace;
+                return otherAsUs->_CopyNewlines == _CopyNewlines;
             }
             return false;
         };
@@ -55,9 +55,9 @@ namespace winrt::TerminalApp::implementation
         {
             // LOAD BEARING: Not using make_self here _will_ break you in the future!
             auto args = winrt::make_self<CopyTextArgs>();
-            if (auto trimWhitespace{ json[JsonKey(TrimWhitespaceKey)] })
+            if (auto copyNewlines{ json[JsonKey(CopyNewlinesKey)] })
             {
-                args->_TrimWhitespace = trimWhitespace.asBool();
+                args->_CopyNewlines = copyNewlines.asBool();
             }
             return *args;
         }

--- a/src/cascadia/TerminalApp/ActionArgs.idl
+++ b/src/cascadia/TerminalApp/ActionArgs.idl
@@ -37,7 +37,7 @@ namespace TerminalApp
 
     [default_interface] runtimeclass CopyTextArgs : IActionArgs
     {
-        Boolean CopyNewlines { get; };
+        Boolean StripNewlines { get; };
     };
 
     [default_interface] runtimeclass NewTabArgs : IActionArgs

--- a/src/cascadia/TerminalApp/ActionArgs.idl
+++ b/src/cascadia/TerminalApp/ActionArgs.idl
@@ -37,7 +37,7 @@ namespace TerminalApp
 
     [default_interface] runtimeclass CopyTextArgs : IActionArgs
     {
-        Boolean TrimWhitespace { get; };
+        Boolean CopyNewlines { get; };
     };
 
     [default_interface] runtimeclass NewTabArgs : IActionArgs

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -205,7 +205,7 @@ namespace winrt::TerminalApp::implementation
     {
         if (const auto& realArgs = args.ActionArgs().try_as<TerminalApp::CopyTextArgs>())
         {
-            const auto handled = _CopyText(realArgs.TrimWhitespace());
+            const auto handled = _CopyText(realArgs.CopyNewlines());
             args.Handled(handled);
         }
     }

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -205,7 +205,7 @@ namespace winrt::TerminalApp::implementation
     {
         if (const auto& realArgs = args.ActionArgs().try_as<TerminalApp::CopyTextArgs>())
         {
-            const auto handled = _CopyText(realArgs.CopyNewlines());
+            const auto handled = _CopyText(realArgs.StripNewlines());
             args.Handled(handled);
         }
     }

--- a/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
@@ -260,7 +260,7 @@ std::function<IActionArgs(const Json::Value&)> LegacyParseSwitchToTabArgs(int in
 IActionArgs LegacyParseCopyTextWithoutNewlinesArgs(const Json::Value& /*json*/)
 {
     auto args = winrt::make_self<winrt::TerminalApp::implementation::CopyTextArgs>();
-    args->CopyNewlines(false);
+    args->StripNewlines(true);
     return *args;
 };
 

--- a/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
@@ -260,7 +260,7 @@ std::function<IActionArgs(const Json::Value&)> LegacyParseSwitchToTabArgs(int in
 IActionArgs LegacyParseCopyTextWithoutNewlinesArgs(const Json::Value& /*json*/)
 {
     auto args = winrt::make_self<winrt::TerminalApp::implementation::CopyTextArgs>();
-    args->TrimWhitespace(true);
+    args->CopyNewlines(false);
     return *args;
 };
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1157,14 +1157,13 @@ namespace winrt::TerminalApp::implementation
     // Method Description:
     // - Copy text from the focused terminal to the Windows Clipboard
     // Arguments:
-    // - trimTrailingWhitespace: enable removing any whitespace from copied selection
-    //    and get text to appear on separate lines.
+    // - copyNewlines: if true, copies the text data as separate lines
     // Return Value:
     // - true iff we we able to copy text (if a selection was active)
-    bool TerminalPage::_CopyText(const bool trimTrailingWhitespace)
+    bool TerminalPage::_CopyText(const bool copyNewlines)
     {
         const auto control = _GetActiveControl();
-        return control.CopySelectionToClipboard(trimTrailingWhitespace);
+        return control.CopySelectionToClipboard(copyNewlines);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1157,13 +1157,13 @@ namespace winrt::TerminalApp::implementation
     // Method Description:
     // - Copy text from the focused terminal to the Windows Clipboard
     // Arguments:
-    // - copyNewlines: if true, copies the text data as separate lines
+    // - stripNewlines: if true, copies the text data as one line
     // Return Value:
     // - true iff we we able to copy text (if a selection was active)
-    bool TerminalPage::_CopyText(const bool copyNewlines)
+    bool TerminalPage::_CopyText(const bool stripNewlines)
     {
         const auto control = _GetActiveControl();
-        return control.CopySelectionToClipboard(copyNewlines);
+        return control.CopySelectionToClipboard(stripNewlines);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1510,9 +1510,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     //     Windows Clipboard (CascadiaWin32:main.cpp).
     // - CopyOnSelect does NOT clear the selection
     // Arguments:
-    // - trimTrailingWhitespace: enable removing any whitespace from copied selection
-    //    and get text to appear on separate lines.
-    bool TermControl::CopySelectionToClipboard(bool trimTrailingWhitespace)
+    // - copyNewlines: if true, copies the text data as separate lines
+    bool TermControl::CopySelectionToClipboard(bool copyNewlines)
     {
         // no selection --> nothing to copy
         if (_terminal == nullptr || !_terminal->IsSelectionActive())
@@ -1520,7 +1519,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             return false;
         }
         // extract text from buffer
-        const auto bufferData = _terminal->RetrieveSelectedTextFromBuffer(trimTrailingWhitespace);
+        const auto bufferData = _terminal->RetrieveSelectedTextFromBuffer(copyNewlines);
 
         // convert text: vector<string> --> string
         std::wstring textData;

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -806,7 +806,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                 }
                 else
                 {
-                    CopySelectionToClipboard(!shiftEnabled);
+                    CopySelectionToClipboard(shiftEnabled);
                 }
             }
         }
@@ -919,7 +919,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
             if (_terminal->IsCopyOnSelectActive())
             {
-                CopySelectionToClipboard(!shiftEnabled);
+                CopySelectionToClipboard(shiftEnabled);
             }
         }
         else if (ptr.PointerDeviceType() == Windows::Devices::Input::PointerDeviceType::Touch)
@@ -1510,8 +1510,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     //     Windows Clipboard (CascadiaWin32:main.cpp).
     // - CopyOnSelect does NOT clear the selection
     // Arguments:
-    // - copyNewlines: if true, copies the text data as separate lines
-    bool TermControl::CopySelectionToClipboard(bool copyNewlines)
+    // - stripNewlines: if true, copies the text data as one line
+    bool TermControl::CopySelectionToClipboard(bool stripNewlines)
     {
         // no selection --> nothing to copy
         if (_terminal == nullptr || !_terminal->IsSelectionActive())
@@ -1519,7 +1519,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             return false;
         }
         // extract text from buffer
-        const auto bufferData = _terminal->RetrieveSelectedTextFromBuffer(copyNewlines);
+        const auto bufferData = _terminal->RetrieveSelectedTextFromBuffer(!stripNewlines);
 
         // convert text: vector<string> --> string
         std::wstring textData;

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -59,7 +59,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         hstring Title();
 
-        bool CopySelectionToClipboard(bool trimTrailingWhitespace);
+        bool CopySelectionToClipboard(bool copyNewlines);
         void PasteTextFromClipboard();
         void Close();
         Windows::Foundation::Size CharacterDimensions() const;

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -59,7 +59,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         hstring Title();
 
-        bool CopySelectionToClipboard(bool copyNewlines);
+        bool CopySelectionToClipboard(bool stripNewlines);
         void PasteTextFromClipboard();
         void Close();
         Windows::Foundation::Size CharacterDimensions() const;


### PR DESCRIPTION
## Summary of the Pull Request
Corrected behavior for (de)serialization. Changed variable name for clarification.

## References
N/A

## PR Checklist
* [ ] Closes #3782
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments
This was on me. Should've caught it in the code review. Sorry!

## Validation Steps Performed
Tests
And personal tests