### PR TITLE
Correct Copy Keybinding Arg Default Behavior

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -108,8 +108,8 @@
             "action": { "type": "string", "pattern": "copy" },
             "trimWhitespace": {
               "type": "boolean",
-              "default": false,
-              "description": "If true, will trim whitespace from the end of the line on copy."
+              "default": true,
+              "description": "If false, concatenates the copied text to one line."
             }
           }
         }

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -109,7 +109,7 @@
             "trimWhitespace": {
               "type": "boolean",
               "default": true,
-              "description": "If false, concatenates the copied text to one line."
+              "description": "If true, whitespace is removed and newlines are maintained. If false, newlines are removed and whitespace is maintained."
             }
           }
         }

--- a/src/cascadia/LocalTests_TerminalApp/KeyBindingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/KeyBindingsTests.cpp
@@ -214,24 +214,24 @@ namespace TerminalAppLocalTests
 
         {
             Log::Comment(NoThrowString().Format(
-                L"Verify that `copy` without args parses as Copy(TrimWhitespace=false)"));
+                L"Verify that `copy` without args parses as Copy(TrimWhitespace=true)"));
             KeyChord kc{ true, false, false, static_cast<int32_t>('C') };
             auto actionAndArgs = GetActionAndArgs(*appKeyBindings, kc);
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_FALSE(realArgs.TrimWhitespace());
+            VERIFY_IS_TRUE(realArgs.TrimWhitespace());
         }
 
         {
             Log::Comment(NoThrowString().Format(
-                L"Verify that `copyTextWithoutNewlines` parses as Copy(TrimWhitespace=true)"));
+                L"Verify that `copyTextWithoutNewlines` parses as Copy(TrimWhitespace=false)"));
             KeyChord kc{ false, true, false, static_cast<int32_t>('C') };
             auto actionAndArgs = GetActionAndArgs(*appKeyBindings, kc);
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_TRUE(realArgs.TrimWhitespace());
+            VERIFY_IS_FALSE(realArgs.TrimWhitespace());
         }
 
         {
@@ -326,7 +326,7 @@ namespace TerminalAppLocalTests
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_FALSE(realArgs.TrimWhitespace());
+            VERIFY_IS_TRUE(realArgs.TrimWhitespace());
         }
 
         {
@@ -338,7 +338,7 @@ namespace TerminalAppLocalTests
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_FALSE(realArgs.TrimWhitespace());
+            VERIFY_IS_TRUE(realArgs.TrimWhitespace());
         }
 
         {

--- a/src/cascadia/TerminalApp/ActionArgs.h
+++ b/src/cascadia/TerminalApp/ActionArgs.h
@@ -37,7 +37,7 @@ namespace winrt::TerminalApp::implementation
     struct CopyTextArgs : public CopyTextArgsT<CopyTextArgs>
     {
         CopyTextArgs() = default;
-        GETSET_PROPERTY(bool, TrimWhitespace, false);
+        GETSET_PROPERTY(bool, TrimWhitespace, true);
 
         static constexpr std::string_view TrimWhitespaceKey{ "trimWhitespace" };
 

--- a/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
@@ -260,7 +260,7 @@ std::function<IActionArgs(const Json::Value&)> LegacyParseSwitchToTabArgs(int in
 IActionArgs LegacyParseCopyTextWithoutNewlinesArgs(const Json::Value& /*json*/)
 {
     auto args = winrt::make_self<winrt::TerminalApp::implementation::CopyTextArgs>();
-    args->TrimWhitespace(true);
+    args->TrimWhitespace(false);
     return *args;
 };
 


### PR DESCRIPTION
## Summary of the Pull Request
Correct behavior for `copyTextWithoutNewlines`. Updated schema for clarity.

## References
Abandoned #3811 

## PR Checklist
* [x] Closes #3782 
* [ ] CLA signed.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
