### PR TITLE
Re-add the keychords to the new tab flyout

### DIFF
--- a/src/cascadia/TerminalApp/ActionArgs.h
+++ b/src/cascadia/TerminalApp/ActionArgs.h
@@ -51,18 +51,13 @@ namespace winrt::TerminalApp::implementation
         static constexpr std::string_view ProfileKey{ "profile" };
 
     public:
-        bool Equals(const IActionArgs& other)
+        bool Equals(const winrt::TerminalApp::NewTerminalArgs& other)
         {
-            auto otherAsUs = other.try_as<NewTerminalArgs>();
-            if (otherAsUs)
-            {
-                return otherAsUs->_Commandline == _Commandline &&
-                       otherAsUs->_StartingDirectory == _StartingDirectory &&
-                       otherAsUs->_TabTitle == _TabTitle &&
-                       otherAsUs->_ProfileIndex == _ProfileIndex &&
-                       otherAsUs->_Profile == _Profile;
-            }
-            return false;
+            return other.Commandline() == _Commandline &&
+                   other.StartingDirectory() == _StartingDirectory &&
+                   other.TabTitle() == _TabTitle &&
+                   other.ProfileIndex() == _ProfileIndex &&
+                   other.Profile() == _Profile;
         };
         static winrt::TerminalApp::NewTerminalArgs FromJson(const Json::Value& json)
         {
@@ -132,7 +127,7 @@ namespace winrt::TerminalApp::implementation
             auto otherAsUs = other.try_as<NewTabArgs>();
             if (otherAsUs)
             {
-                return otherAsUs->_TerminalArgs == _TerminalArgs;
+                return otherAsUs->_TerminalArgs.Equals(_TerminalArgs);
             }
             return false;
         };

--- a/src/cascadia/TerminalApp/ActionArgs.idl
+++ b/src/cascadia/TerminalApp/ActionArgs.idl
@@ -39,6 +39,7 @@ namespace TerminalApp
         // ProfileIndex can be null (for "use the default"), so this needs to be
         // a IReference, so it's nullable
         Windows.Foundation.IReference<Int32> ProfileIndex { get; };
+        Boolean Equals(NewTerminalArgs other);
     };
 
     [default_interface] runtimeclass ActionEventArgs : IActionEventArgs


### PR DESCRIPTION
## Summary of the Pull Request

On this month's episode of "Mike accidentally breaks this": 
  Mike forgets that `==` is defined on a pair of winrt objects as "do these point to the _SAME_ object", not "do they have the same values". 

This just slipped right through code review.

## References

Broken in #3825

## PR Checklist
* [x] Closes #3896
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

Manually checked that these are still there