### PR TITLE
Improve keybinding JSON schema

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -4,8 +4,9 @@
   "title": "Microsoft's Windows Terminal Settings Profile Schema'",
   "definitions": {
     "KeyChordSegment": {
-      "pattern": "^(?<modifier>(ctrl|alt|shift)\\+?((ctrl|alt|shift)(?<!\\2)\\+?)?((ctrl|alt|shift)(?<!\\2|\\4))?\\+?)?(?<key>[^+\\s]+?)?(?<=[^+\\s])$",
-      "type": "string"
+      "pattern": "^(?<modifier>(ctrl|alt|shift)(?:\\+(ctrl|alt|shift)(?<!\\2))?(?:\\+(ctrl|alt|shift)(?<!\\2|\\3))?\\+)?(?<key>[^\\s+]|backspace|tab|enter|esc|escape|space|pgup|pageup|pgdn|pagedown|end|home|left|up|right|down|insert|delete|(?<!shift.+)(?:numpad_?[0-9]|numpad_(?:period|decimal))|numpad_(?:multiply|plus|add|minus|subtract|divide)|f[1-9]|f1[0-9]|f2[0-4]|plus)$",
+      "type": "string",
+      "description": "The string should fit the format \"[ctrl+][alt+][shift+]<keyName>\", where each modifier is optional, separated by + symbols, and keyName is either one of the names listed in the table below, or any single key character. The string should be written in full lowercase.\nbackspace\tBACKSPACE key\ntab\tTAB key\nenter\tENTER key\nesc, escape\tESC key\nspace\tSPACEBAR\npgup, pageup\tPAGE UP key\npgdn, pagedown\tPAGE DOWN key\nend\tEND key\nhome\tHOME key\nleft\tLEFT ARROW key\nup\tUP ARROW key\nright\tRIGHT ARROW key\ndown\tDOWN ARROW key\ninsert\tINS key\ndelete\tDEL key\nnumpad_0-numpad_9, numpad0-numpad9\tNumeric keypad keys 0 to 9. Can't be combined with the shift modifier.\nnumpad_multiply\tNumeric keypad MULTIPLY key (*)\nnumpad_plus, numpad_add\tNumeric keypad ADD key (+)\nnumpad_minus, numpad_subtract\tNumeric keypad SUBTRACT key (-)\nnumpad_period, numpad_decimal\tNumeric keypad DECIMAL key (.). Can't be combined with the shift modifier.\nnumpad_divide\tNumeric keypad DIVIDE key (/)\nf1-f24\tF1 to F24 function keys\nplus\tADD key (+)"
     },
     "Color": {
       "default": "#",


### PR DESCRIPTION
## Summary of the Pull Request
The pattern regex in [profiles.schema.json](https://raw.githubusercontent.com/davidwin/terminal/keychords_schema/doc/cascadia/profiles.schema.json) now correctly disallows keybindings consisting of only modifiers, modifiers not separated by `+`, and unknown key names. Certain `shift+numpad` combinations are also not allowed.

The description lists allowed key names in tabular format (assuming the client renders `\t` correctly):
![image](https://user-images.githubusercontent.com/9844625/70371759-8fee0f00-18d7-11ea-85c2-b9f739252129.png)

## PR Checklist
* [x] Closes #3856 and #2967
* [x] CLA signed.
* [ ] Tests added/passed _(only manual validation in VSCode)_
* [ ] Requires documentation to be updated _(this is documentation)_
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #3856

## Detailed Description of the Pull Request / Additional comments
The problem with the current keybinding schema is primarily that it accepts invalid key combinations.
Also, there is no accessible documentation of valid keys and modifiers. Now the regular expression 
should be much closer to what the parser in [KeyChordSerialization.cpp](https://github.com/microsoft/terminal/blob/master/src/cascadia/TerminalApp/KeyChordSerialization.cpp) actually accepts, and the associated description explains the allowed string format.

One possible difference between the regexp and the parser is that the former accepts any single character except `+` and whitespace (e.g. `}`) for the key part while the latter relies on the `VkKeyScanW` Windows API for validation of single-character keys.

The regular expression might be a bit difficult to digest, so here it is with some added whitespace and no JSON string escapes:
```regexp
^
 (?<modifier> (ctrl|alt|shift) 
              (?:\+(ctrl|alt|shift)(?<!\2))? 
              (?:\+(ctrl|alt|shift)(?<!\2|\3))?
              \+
 )?
 (?<key> [^\s+]
         |backspace|tab|enter|esc|escape|space|pgup|pageup|pgdn|pagedown|end|home|left|up|right|down|insert|delete
         |(?<!shift.+)(?:numpad_?[0-9]|numpad_(?:period|decimal))
         |numpad_(?:multiply|plus|minus|divide)
         |f[1-9]|f1[0-9]|f2[0-4]
         |plus
 )
$
```
**Q**: Is named captures a good idea? It was used by the previous regular expression, but an alternative approach would be to use numbered captures and only capture the individual modifiers (1 to 3) and the key (4).

**Q**: Would it be better to not list key names _and_ descriptions in an attempted table, which currently isn't rendered very nicely in VS Code? The names are, after all, rather self explanatory.

## Validation Steps Performed
I have performed validation of the new schema in VS Code v1.43 by opening the `profiles.json` settings file and changing the `$schema` property to https://raw.githubusercontent.com/davidwin/terminal/keychords_schema/doc/cascadia/profiles.schema.json. I'm then able to see that I get a description of how to format the `globals.keybingings[].keys` strings if I hover over a `keys` item, and a yellow squiggly if I enter an invalid key combination. All the default key combinations pass without error, and examples of strings that don't validate are: `alt`, `shift+`, `ctrl++`, `+`, `shiftalt+up`.

You can try the regular expression and get a deeper understanding of it at [Regex101](https://regex101.com/r/mqlYhr/4).
