### PR TITLE
Fixed self capture in TermControl

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1610,7 +1610,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             // Stop accepting new output and state changes before we disconnect everything.
             _connection.TerminalOutput(_connectionOutputEventToken);
             _connectionStateChangedRevoker.revoke();
-            
+
             if (auto localConnection{ std::exchange(_connection, nullptr) })
             {
                 localConnection.Close();

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -110,17 +110,22 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         _sizeChangedRevoker = swapChainPanel.SizeChanged(winrt::auto_revoke, { this, &TermControl::_SwapChainSizeChanged });
         _compositionScaleChangedRevoker = swapChainPanel.CompositionScaleChanged(winrt::auto_revoke, { this, &TermControl::_SwapChainScaleChanged });
 
+        // Initialize a weak pointer of this object
+        auto weakThis{ get_weak() };
+
         // Initialize the terminal only once the swapchainpanel is loaded - that
         //      way, we'll be able to query the real pixel size it got on layout
-        _layoutUpdatedRevoker = swapChainPanel.LayoutUpdated(winrt::auto_revoke, [this](auto /*s*/, auto /*e*/) {
+        _layoutUpdatedRevoker = swapChainPanel.LayoutUpdated(winrt::auto_revoke, [weakThis](auto /*s*/, auto /*e*/) {
             // This event fires every time the layout changes, but it is always the last one to fire
             // in any layout change chain. That gives us great flexibility in finding the right point
             // at which to initialize our renderer (and our terminal).
             // Any earlier than the last layout update and we may not know the terminal's starting size.
-            if (_InitializeTerminal())
+            auto control{ weakThis.get() };
+
+            if (control && control->_InitializeTerminal())
             {
                 // Only let this succeed once.
-                this->_layoutUpdatedRevoker.revoke();
+                control->_layoutUpdatedRevoker.revoke();
             }
         });
 
@@ -144,9 +149,12 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         // These are important:
         // 1. When we get tapped, focus us
-        this->Tapped([this](auto&, auto& e) {
-            this->Focus(FocusState::Pointer);
-            e.Handled(true);
+        this->Tapped([weakThis](auto&, auto& e) {
+            if (auto control{ weakThis.get() })
+            {
+                control->Focus(FocusState::Pointer);
+                e.Handled(true);
+            }
         });
         // 2. Make sure we can be focused (why this isn't `Focusable` I'll never know)
         this->IsTabStop(true);
@@ -156,10 +164,10 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         // DON'T CALL _InitializeTerminal here - wait until the swap chain is loaded to do that.
 
         // Subscribe to the connection's disconnected event and call our connection closed handlers.
-        _connectionStateChangedRevoker = _connection.StateChanged(winrt::auto_revoke, [weakThis = get_weak()](auto&& /*s*/, auto&& /*v*/) {
-            if (auto strongThis{ weakThis.get() })
+        _connectionStateChangedRevoker = _connection.StateChanged(winrt::auto_revoke, [weakThis](auto&& /*s*/, auto&& /*v*/) {
+            if (auto control{ weakThis.get() })
             {
-                strongThis->_ConnectionStateChangedHandlers(*strongThis, nullptr);
+                control->_ConnectionStateChangedHandlers(*control, nullptr);
             }
         });
     }
@@ -173,37 +181,41 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     void TermControl::UpdateSettings(Settings::IControlSettings newSettings)
     {
         _settings = newSettings;
+        auto weakThis{ get_weak() };
 
         // Dispatch a call to the UI thread to apply the new settings to the
         // terminal.
-        _root.Dispatcher().RunAsync(CoreDispatcherPriority::Normal, [this]() {
-            // Update our control settings
-            _ApplyUISettings();
-
-            // Update DxEngine's SelectionBackground
-            _renderEngine->SetSelectionBackground(_settings.SelectionBackground());
-
-            // Update the terminal core with its new Core settings
-            _terminal->UpdateSettings(_settings);
-
-            // Refresh our font with the renderer
-            _UpdateFont();
-
-            const auto width = _swapChainPanel.ActualWidth();
-            const auto height = _swapChainPanel.ActualHeight();
-            if (width != 0 && height != 0)
+        _root.Dispatcher().RunAsync(CoreDispatcherPriority::Normal, [weakThis]() {
+            if (auto control{ weakThis.get() })
             {
-                // If the font size changed, or the _swapchainPanel's size changed
-                // for any reason, we'll need to make sure to also resize the
-                // buffer. _DoResize will invalidate everything for us.
-                auto lock = _terminal->LockForWriting();
-                _DoResize(width, height);
-            }
+                // Update our control settings
+                control->_ApplyUISettings();
 
-            // set TSF Foreground
-            Media::SolidColorBrush foregroundBrush{};
-            foregroundBrush.Color(ColorRefToColor(_settings.DefaultForeground()));
-            _tsfInputControl.Foreground(foregroundBrush);
+                // Update DxEngine's SelectionBackground
+                control->_renderEngine->SetSelectionBackground(control->_settings.SelectionBackground());
+
+                // Update the terminal core with its new Core settings
+                control->_terminal->UpdateSettings(control->_settings);
+
+                // Refresh our font with the renderer
+                control->_UpdateFont();
+
+                const auto width = control->_swapChainPanel.ActualWidth();
+                const auto height = control->_swapChainPanel.ActualHeight();
+                if (width != 0 && height != 0)
+                {
+                    // If the font size changed, or the _swapchainPanel's size changed
+                    // for any reason, we'll need to make sure to also resize the
+                    // buffer. _DoResize will invalidate everything for us.
+                    auto lock = control->_terminal->LockForWriting();
+                    control->_DoResize(width, height);
+                }
+
+                // set TSF Foreground
+                Media::SolidColorBrush foregroundBrush{};
+                foregroundBrush.Color(ColorRefToColor(control->_settings.DefaultForeground()));
+                control->_tsfInputControl.Foreground(foregroundBrush);
+            }
         });
     }
 
@@ -361,30 +373,35 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // - <none>
     void TermControl::_BackgroundColorChanged(const uint32_t color)
     {
-        _root.Dispatcher().RunAsync(CoreDispatcherPriority::Normal, [this, color]() {
-            const auto R = GetRValue(color);
-            const auto G = GetGValue(color);
-            const auto B = GetBValue(color);
+        auto weakThis{ get_weak() };
 
-            winrt::Windows::UI::Color bgColor{};
-            bgColor.R = R;
-            bgColor.G = G;
-            bgColor.B = B;
-            bgColor.A = 255;
-
-            if (auto acrylic = _root.Background().try_as<Media::AcrylicBrush>())
+        _root.Dispatcher().RunAsync(CoreDispatcherPriority::Normal, [weakThis, color]() {
+            if (auto control{ weakThis.get() })
             {
-                acrylic.FallbackColor(bgColor);
-                acrylic.TintColor(bgColor);
-            }
-            else if (auto solidColor = _root.Background().try_as<Media::SolidColorBrush>())
-            {
-                solidColor.Color(bgColor);
-            }
+                const auto R = GetRValue(color);
+                const auto G = GetGValue(color);
+                const auto B = GetBValue(color);
 
-            // Set the default background as transparent to prevent the
-            // DX layer from overwriting the background image or acrylic effect
-            _settings.DefaultBackground(ARGB(0, R, G, B));
+                winrt::Windows::UI::Color bgColor{};
+                bgColor.R = R;
+                bgColor.G = G;
+                bgColor.B = B;
+                bgColor.A = 255;
+
+                if (auto acrylic = control->_root.Background().try_as<Media::AcrylicBrush>())
+                {
+                    acrylic.FallbackColor(bgColor);
+                    acrylic.TintColor(bgColor);
+                }
+                else if (auto solidColor = control->_root.Background().try_as<Media::SolidColorBrush>())
+                {
+                    solidColor.Color(bgColor);
+                }
+
+                // Set the default background as transparent to prevent the
+                // DX layer from overwriting the background image or acrylic effect
+                control->_settings.DefaultBackground(ARGB(0, R, G, B));
+            }
         });
     }
 
@@ -437,10 +454,15 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         }
 
         auto chain = _renderEngine->GetSwapChain();
-        _swapChainPanel.Dispatcher().RunAsync(CoreDispatcherPriority::High, [=]() {
-            auto lock = _terminal->LockForWriting();
-            auto nativePanel = _swapChainPanel.as<ISwapChainPanelNative>();
-            nativePanel->SetSwapChain(chain.Get());
+        auto weakThis{ get_weak() };
+
+        _swapChainPanel.Dispatcher().RunAsync(CoreDispatcherPriority::High, [weakThis, chain]() {
+            if (auto control{ weakThis.get() })
+            {
+                auto lock = control->_terminal->LockForWriting();
+                auto nativePanel = control->_swapChainPanel.as<ISwapChainPanelNative>();
+                nativePanel->SetSwapChain(chain.Get());
+            }
         });
     }
 
@@ -512,8 +534,13 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         THROW_IF_FAILED(dxEngine->Enable());
         _renderEngine = std::move(dxEngine);
 
-        auto onRecieveOutputFn = [this](const hstring str) {
-            _terminal->Write(str.c_str());
+        auto weakThis{ get_weak() };
+
+        auto onRecieveOutputFn = [weakThis](const hstring str) {
+            if (auto control{ weakThis.get() })
+            {
+                control->_terminal->Write(str.c_str());
+            }
         };
         _connectionOutputEventToken = _connection.TerminalOutput(onRecieveOutputFn);
 
@@ -521,11 +548,14 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         _terminal->SetWriteInputCallback(inputFn);
 
         auto chain = _renderEngine->GetSwapChain();
-        _swapChainPanel.Dispatcher().RunAsync(CoreDispatcherPriority::High, [this, chain]() {
-            _terminal->LockConsole();
-            auto nativePanel = _swapChainPanel.as<ISwapChainPanelNative>();
-            nativePanel->SetSwapChain(chain.Get());
-            _terminal->UnlockConsole();
+        _swapChainPanel.Dispatcher().RunAsync(CoreDispatcherPriority::High, [weakThis, chain]() {
+            if (auto control{ weakThis.get() })
+            {
+                control->_terminal->LockConsole();
+                auto nativePanel = control->_swapChainPanel.as<ISwapChainPanelNative>();
+                nativePanel->SetSwapChain(chain.Get());
+                control->_terminal->UnlockConsole();
+            }
         });
 
         // Set up the height of the ScrollViewer and the grid we're using to fake our scrolling height
@@ -1479,16 +1509,21 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             return;
         }
 
+        auto weakThis{ get_weak() };
+
         // Update our scrollbar
-        _scrollBar.Dispatcher().RunAsync(CoreDispatcherPriority::Low, [=]() {
+        _scrollBar.Dispatcher().RunAsync(CoreDispatcherPriority::Low, [weakThis, viewTop, viewHeight, bufferSize]() {
             // Even if we weren't closed/closing few lines above, we might be
             // while waiting for this block of code to be dispatched.
-            if (_closing.load())
+            if (auto control{ weakThis.get() })
             {
-                return;
-            }
+                if (control->_closing.load())
+                {
+                    return;
+                }
 
-            _ScrollbarUpdater(_scrollBar, viewTop, viewHeight, bufferSize);
+                control->_ScrollbarUpdater(control->_scrollBar, viewTop, viewHeight, bufferSize);
+            }
         });
 
         // Set this value as our next expected scroll position.
@@ -1575,20 +1610,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             // Stop accepting new output and state changes before we disconnect everything.
             _connection.TerminalOutput(_connectionOutputEventToken);
             _connectionStateChangedRevoker.revoke();
-
-            // Clear out the cursor timer, so it doesn't trigger again on us once we're destructed.
-            if (auto localCursorTimer{ std::exchange(_cursorTimer, std::nullopt) })
-            {
-                localCursorTimer->Stop();
-                // cursorTimer timer, now stopped, is destroyed.
-            }
-
-            if (auto localAutoScrollTimer{ std::exchange(_autoScrollTimer, nullptr) })
-            {
-                localAutoScrollTimer.Stop();
-                // _autoScrollTimer timer, now stopped, is destroyed.
-            }
-
+            
             if (auto localConnection{ std::exchange(_connection, nullptr) })
             {
                 localConnection.Close();

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -615,7 +615,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         static constexpr auto AutoScrollUpdateInterval = std::chrono::microseconds(static_cast<int>(1.0 / 30.0 * 1000000));
         _autoScrollTimer.Interval(AutoScrollUpdateInterval);
-        _autoScrollTimer.Tick({ this, &TermControl::_UpdateAutoScroll });
+        _autoScrollTimer.Tick({ get_weak(), &TermControl::_UpdateAutoScroll });
 
         // Set up blinking cursor
         int blinkTime = GetCaretBlinkTime();
@@ -624,7 +624,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             // Create a timer
             _cursorTimer = std::make_optional(DispatcherTimer());
             _cursorTimer.value().Interval(std::chrono::milliseconds(blinkTime));
-            _cursorTimer.value().Tick({ this, &TermControl::_BlinkCursor });
+            _cursorTimer.value().Tick({ get_weak(), &TermControl::_BlinkCursor });
             _cursorTimer.value().Start();
         }
         else

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -107,6 +107,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         TSFInputControl _tsfInputControl;
 
         event_token _connectionOutputEventToken;
+        TermControl::Tapped_revoker _tappedRevoker;
         TerminalConnection::ITerminalConnection::StateChanged_revoker _connectionStateChangedRevoker;
 
         std::unique_ptr<::Microsoft::Terminal::Core::Terminal> _terminal;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
An asynchronous event handler capturing raw `this` in `TermControl` was causing an exception to be thrown when a scroll update event occurred after closing the active tab. This PR replaces all non-auto_revoke lambda captures in `TermControl` to capture (and validate) a `winrt::weak_ref` instead of using raw `this`.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #2947
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #2947

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
`TermControl` is already a WinRT type so no changes were required to enable the `winrt::weak_ref` functionality. There was only one strange change I had to make. In the destructor's helper function `Close`, I had to remove two calls to [`Stop`](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.dispatchertimer.stop#Windows_UI_Xaml_DispatcherTimer_Stop) which were throwing under [some circumstances](https://github.com/microsoft/terminal/issues/2947#issuecomment-562914135). Fortunately, these calls don't appear to be critical, but definitely a spot to look into when reviewing this PR.

Beyond scrolling, any anomalous crash related to the following functionality while closing a tab or WT may be fixed by this PR:
- Settings updating
- Changing background color

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Before these changes I was able to consistently repro the issue in #2947. Now, I can no longer repro the issue.