### PR TITLE
ci: return to the original oneshot build config

### DIFF
--- a/build/pipelines/templates/build-console-steps.yml
+++ b/build/pipelines/templates/build-console-steps.yml
@@ -36,31 +36,14 @@ steps:
     restoreDirectory: '$(Build.SourcesDirectory)/packages'
 
 - task: VSBuild@1
-  displayName: 'Build solution **\OpenConsole.sln (no packages)'
+  displayName: 'Build solution **\OpenConsole.sln'
   inputs:
     solution: '**\OpenConsole.sln'
     vsVersion: 16.0
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
-    # Until there is a servicing release of Visual Studio 2019 Update 3, we must force the values of:
-    # BuildingInsideVisualStudio
-    # _WapBuildingInsideVisualStudio
-    # GenerateAppxPackageOnBuild
-    # because otherwise, they will cause a build instability where MSBuild considers all projects
-    # to always be out-of-date.
-    msbuildArgs: "${{ parameters.additionalBuildArguments }} /p:BuildingInsideVisualStudio=false;_WapBuildingInsideVisualStudio=false;GenerateAppxPackageOnBuild=false"
+    msbuildArgs: "${{ parameters.additionalBuildArguments }}"
     clean: true
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: 'Build solution **\OpenConsole.sln (CascadiaPackage only)'
-  inputs:
-    solution: '**\OpenConsole.sln'
-    vsVersion: 16.0
-    platform: '$(BuildPlatform)'
-    configuration: '$(BuildConfiguration)'
-    msbuildArgs: "${{ parameters.additionalBuildArguments }} /p:BuildingInsideVisualStudio=false;_WapBuildingInsideVisualStudio=false;GenerateAppxPackageOnBuild=true /t:Terminal\\CascadiaPackage"
-    clean: false # we're relying on build output fropm the previous run
     maximumCpuCount: true
 
 - task: PowerShell@2

--- a/src/common.build.post.props
+++ b/src/common.build.post.props
@@ -54,7 +54,7 @@
   <Target Name="CleanUpPrecompForSmallCIAgents"
           DependsOnTargets="_ComputePrecompToCleanUp"
           AfterTargets="AfterBuild"
-          Condition="'$(AGENT_ID)' != '' and !$(ProjectName.Contains('TerminalApp'))">
+          Condition="'$(AGENT_ID)' != ''">
     <!-- We just need to keep *TerminalApp*'s PCHs because they get rebuilt more often. -->
     <Delete Files="@(_PCHFileToCleanWithTimestamp)"/>
     <Touch Files="@(_PCHFileToCleanWithTimestamp)" Time="%(LastWriteTime)" AlwaysCreate="true" />


### PR DESCRIPTION
I've received word that the standard build agents have been bumped to a version of Visual Studio 2019 with the servicing fix we needed.