### PR TITLE
Ctrl+Backspace works, and two other small fixes

### DIFF
--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -382,15 +382,18 @@ bool Terminal::SetWindowTitle(std::wstring_view title)
 // - true iff we successfully updated the color table entry.
 bool Terminal::SetColorTableEntry(const size_t tableIndex, const COLORREF dwColor)
 {
-    if (tableIndex > _colorTable.size())
+    try
+    {
+        _colorTable.at(tableIndex) = dwColor;
+
+        // Repaint everything - the colors might have changed
+        _buffer->GetRenderTarget().TriggerRedrawAll();
+        return true;
+    }
+    catch (std::out_of_range&)
     {
         return false;
     }
-    _colorTable.at(tableIndex) = dwColor;
-
-    // Repaint everything - the colors might have changed
-    _buffer->GetRenderTarget().TriggerRedrawAll();
-    return true;
 }
 
 // Method Description:

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -171,7 +171,7 @@ const TerminalInput::_TermKeyMap TerminalInput::s_rgModifierKeyMapping[]{
 //      rules above.
 const TerminalInput::_TermKeyMap TerminalInput::s_rgSimpleModifedKeyMapping[]{
     // HEY YOU. UPDATE THE MAX LENGTH DEF WHEN YOU MAKE CHANGES HERE.
-    { VK_BACK, CTRL_PRESSED, L"\x8" },
+    { VK_BACK, CTRL_PRESSED, L"\x1b\x8" },
     { VK_BACK, ALT_PRESSED, L"\x1b\x7f" },
     { VK_BACK, CTRL_PRESSED | ALT_PRESSED, L"\x1b\x8" },
     { VK_TAB, CTRL_PRESSED, L"\t" },

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -119,7 +119,9 @@ bool InputStateMachineEngine::_DoControlCharacter(const wchar_t wch, const bool 
         switch (wch)
         {
         case L'\b':
-            fSuccess = _GenerateKeyFromChar(wch + 0x40, &vkey, nullptr);
+            // A received Ctrl+Backspace needs to be processed as Delete
+            actualChar = L'\x7f';
+            fSuccess = _GenerateKeyFromChar(actualChar, &vkey, nullptr);
             break;
         case L'\r':
             writeCtrl = false;
@@ -148,7 +150,8 @@ bool InputStateMachineEngine::_DoControlCharacter(const wchar_t wch, const bool 
             {
                 WI_SetFlag(dwModifierState, LEFT_CTRL_PRESSED);
             }
-            if (writeAlt)
+            // Some Ctrl+Backspace paths trigger the Alt flag, but WSL doesn't like this.
+            if (writeAlt && actualChar != L'\x7f')
             {
                 WI_SetFlag(dwModifierState, LEFT_ALT_PRESSED);
             }

--- a/src/winconpty/winconpty.cpp
+++ b/src/winconpty/winconpty.cpp
@@ -200,7 +200,7 @@ HRESULT _CreatePseudoConsole(const HANDLE hToken,
 //      write the resize message to the pty.
 HRESULT _ResizePseudoConsole(_In_ const PseudoConsole* const pPty, _In_ const COORD size)
 {
-    if (pPty == NULL)
+    if (pPty == NULL || size.X < 0 || size.Y < 0)
     {
         return E_INVALIDARG;
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Changes the <kbd>Ctrl+Backspace</kbd> input sequence and how it is processed by `InputStateMachineEngine`. Now <kbd>Ctrl+Backspace</kbd> deletes a whole word at a time (tested on WSL, CMD, and PS).

PR also fixes two other issues which just needed some someone to implement them.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #755, #3447, #3720
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #755

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Changed the input sequence for <kbd>Ctrl+Backspace</kbd> to `\x1b\x8` so the sequence would pass through `_DoControlCharacter`. Changed `_DoControlCharacter` to process `\b` in a way which forms the correct `INPUT_RECORD`s to delete whole words.

Fixed #3447 by verifying that `COORD` X,Y values are positive.
Fixed #3720 by wrapping the `at` call in a try-catch.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
<kbd>Ctrl+Backspace</kbd> works 🎉 
Can no longer repro #3720