### PR TITLE
Fix SetColorTableEntry off-by-one error

### DIFF
--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -382,15 +382,18 @@ bool Terminal::SetWindowTitle(std::wstring_view title)
 // - true iff we successfully updated the color table entry.
 bool Terminal::SetColorTableEntry(const size_t tableIndex, const COLORREF dwColor)
 {
-    if (tableIndex > _colorTable.size())
+    try
+    {
+        _colorTable.at(tableIndex) = dwColor;
+
+        // Repaint everything - the colors might have changed
+        _buffer->GetRenderTarget().TriggerRedrawAll();
+        return true;
+    }
+    catch (std::out_of_range&)
     {
         return false;
     }
-    _colorTable.at(tableIndex) = dwColor;
-
-    // Repaint everything - the colors might have changed
-    _buffer->GetRenderTarget().TriggerRedrawAll();
-    return true;
 }
 
 // Method Description:

--- a/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "precomp.h"
+#include <WexTestClass.h>
+
+#include "../cascadia/TerminalCore/Terminal.hpp"
+#include "MockTermSettings.h"
+#include "../renderer/inc/DummyRenderTarget.hpp"
+#include "consoletaeftemplates.hpp"
+
+using namespace winrt::Microsoft::Terminal::Settings;
+using namespace Microsoft::Terminal::Core;
+
+namespace TerminalCoreUnitTests
+{
+#define WCS(x) WCSHELPER(x)
+#define WCSHELPER(x) L#x
+
+    class TerminalApiTest
+    {
+        TEST_CLASS(TerminalApiTest);
+
+        TEST_METHOD(SetColorTableEntry)
+        {
+            Terminal term;
+            DummyRenderTarget emptyRT;
+            term.Create({ 100, 100 }, 0, emptyRT);
+
+            auto settings = winrt::make<MockTermSettings>(100, 100, 100);
+            term.UpdateSettings(settings);
+
+            VERIFY_IS_TRUE(term.SetColorTableEntry(0, 100));
+            VERIFY_IS_TRUE(term.SetColorTableEntry(128, 100));
+            VERIFY_IS_TRUE(term.SetColorTableEntry(255, 100));
+         
+            VERIFY_IS_FALSE(term.SetColorTableEntry(256, 100));
+            VERIFY_IS_FALSE(term.SetColorTableEntry(512, 100));
+        }
+    };
+}

--- a/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
@@ -33,7 +33,7 @@ namespace TerminalCoreUnitTests
             VERIFY_IS_TRUE(term.SetColorTableEntry(0, 100));
             VERIFY_IS_TRUE(term.SetColorTableEntry(128, 100));
             VERIFY_IS_TRUE(term.SetColorTableEntry(255, 100));
-         
+
             VERIFY_IS_FALSE(term.SetColorTableEntry(256, 100));
             VERIFY_IS_FALSE(term.SetColorTableEntry(512, 100));
         }

--- a/src/cascadia/UnitTests_TerminalCore/UnitTests.vcxproj
+++ b/src/cascadia/UnitTests_TerminalCore/UnitTests.vcxproj
@@ -8,10 +8,8 @@
     <TargetName>Terminal.Core.Unit.Tests</TargetName>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
   </PropertyGroup>
-
   <Import Project="$(SolutionDir)\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
   <Import Project="$(SolutionDir)\src\common.build.pre.props" />
-
   <ItemGroup>
     <ClCompile Include="ScreenSizeLimitsTest.cpp" />
     <ClCompile Include="SelectionTest.cpp" />
@@ -19,6 +17,7 @@
     <ClCompile Include="precomp.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="TerminalApiTest.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\buffer\out\lib\bufferout.vcxproj">


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Uses the verification in `at` to ensure the index is correct (as @j4james suggests). If `at` throws, then returns false.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #3720
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] ~~I've~~ discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #3720

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Can no longer repro the issue after the fix.