### PR TITLE
Fix move focus between grouped panes (#3045)

### DIFF
--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -230,7 +230,7 @@ bool Pane::_NavigateFocus(const Direction& direction)
 
     // If the child we want to move focus to is _already_ focused, return false,
     // to try and let our parent figure it out.
-    if (newlyFocusedChild->WasLastFocused())
+    if (newlyFocusedChild->_HasFocusedChild())
     {
         return false;
     }


### PR DESCRIPTION
This PR fixes the ability to move between already-split panes
## Summary of the Pull Request

## PR Checklist
* [x] Closes #3045
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed
Tested manually.