### PR TITLE
Fix a crash when calling SetConsoleScreenBufferSize in conpty

### DIFF
--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -504,18 +504,18 @@ void ApiRoutines::GetLargestConsoleWindowSizeImpl(const SCREEN_INFORMATION& cont
 
         SCREEN_INFORMATION& screenInfo = context.GetActiveBuffer();
 
+        // microsoft/terminal#3907 - We shouldn't resize the buffer to be
+        // smaller than the viewport. This was previously erroneously checked
+        // when the host was not in conpty mode.
+        RETURN_HR_IF(E_INVALIDARG, (size.X < screenInfo.GetViewport().Width() || size.Y < screenInfo.GetViewport().Height()));
+
         // see MSFT:17415266
         // We only really care about the minimum window size if we have a head.
         if (!ServiceLocator::LocateGlobals().IsHeadless())
         {
             COORD const coordMin = screenInfo.GetMinWindowSizeInCharacters();
-            // clang-format off
             // Make sure requested screen buffer size isn't smaller than the window.
-            RETURN_HR_IF(E_INVALIDARG, (size.X < screenInfo.GetViewport().Width() ||
-                                        size.Y < screenInfo.GetViewport().Height() ||
-                                        size.Y < coordMin.Y ||
-                                        size.X < coordMin.X));
-            // clang-format on
+            RETURN_HR_IF(E_INVALIDARG, (size.Y < coordMin.Y || size.X < coordMin.X));
         }
 
         // Ensure the requested size isn't larger than we can handle in our data type.


### PR DESCRIPTION
## Summary of the Pull Request

Fixes the bug @DHowett-MSFT found in conpty. Before conpty, this check was all one statement. With the addition of conpty, that statement was moved into a "am I not headless" check, to not restrict the conpty size based on the window size. However, the "is the user trying to resize the buffer smaller than the viewport" should have been done outside the headless check. This just splits that statement up.


## PR Checklist
* [x] Closes #3907
* [x] I work here
* [ ] I didn't add tests, since that's being tracked in #3941
* [n/a] Requires documentation to be updated

## Validation Steps Performed
Ran the tiny repro program Dustin provided - we no longer crash.