### PR TITLE
Add support for "Automatic" splits

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/KeyBindingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/KeyBindingsTests.cpp
@@ -362,7 +362,9 @@ namespace TerminalAppLocalTests
             { "keys": ["ctrl+d"], "command": { "action": "splitPane", "split": "vertical" } },
             { "keys": ["ctrl+e"], "command": { "action": "splitPane", "split": "horizontal" } },
             { "keys": ["ctrl+f"], "command": { "action": "splitPane", "split": "none" } },
-            { "keys": ["ctrl+g"], "command": { "action": "splitPane" } }
+            { "keys": ["ctrl+g"], "command": { "action": "splitPane" } },
+            { "keys": ["ctrl+h"], "command": { "action": "splitPane", "split": "auto" } },
+            { "keys": ["ctrl+i"], "command": { "action": "splitPane", "split": "foo" } }
         ])" };
 
         const auto bindings0Json = VerifyParseSucceeded(bindings0String);
@@ -371,7 +373,7 @@ namespace TerminalAppLocalTests
         VERIFY_IS_NOT_NULL(appKeyBindings);
         VERIFY_ARE_EQUAL(0u, appKeyBindings->_keyShortcuts.size());
         appKeyBindings->LayerJson(bindings0Json);
-        VERIFY_ARE_EQUAL(7u, appKeyBindings->_keyShortcuts.size());
+        VERIFY_ARE_EQUAL(9u, appKeyBindings->_keyShortcuts.size());
 
         {
             KeyChord kc{ true, false, false, static_cast<int32_t>('A') };
@@ -429,6 +431,24 @@ namespace TerminalAppLocalTests
         }
         {
             KeyChord kc{ true, false, false, static_cast<int32_t>('G') };
+            auto actionAndArgs = TestUtils::GetActionAndArgs(*appKeyBindings, kc);
+            VERIFY_ARE_EQUAL(ShortcutAction::SplitPane, actionAndArgs.Action());
+            const auto& realArgs = actionAndArgs.Args().try_as<SplitPaneArgs>();
+            VERIFY_IS_NOT_NULL(realArgs);
+            // Verify the args have the expected value
+            VERIFY_ARE_EQUAL(winrt::TerminalApp::SplitState::None, realArgs.SplitStyle());
+        }
+        {
+            KeyChord kc{ true, false, false, static_cast<int32_t>('H') };
+            auto actionAndArgs = TestUtils::GetActionAndArgs(*appKeyBindings, kc);
+            VERIFY_ARE_EQUAL(ShortcutAction::SplitPane, actionAndArgs.Action());
+            const auto& realArgs = actionAndArgs.Args().try_as<SplitPaneArgs>();
+            VERIFY_IS_NOT_NULL(realArgs);
+            // Verify the args have the expected value
+            VERIFY_ARE_EQUAL(winrt::TerminalApp::SplitState::Automatic, realArgs.SplitStyle());
+        }
+        {
+            KeyChord kc{ true, false, false, static_cast<int32_t>('I') };
             auto actionAndArgs = TestUtils::GetActionAndArgs(*appKeyBindings, kc);
             VERIFY_ARE_EQUAL(ShortcutAction::SplitPane, actionAndArgs.Action());
             const auto& realArgs = actionAndArgs.Args().try_as<SplitPaneArgs>();

--- a/src/cascadia/TerminalApp/ActionArgs.h
+++ b/src/cascadia/TerminalApp/ActionArgs.h
@@ -295,6 +295,7 @@ namespace winrt::TerminalApp::implementation
     // TODO:GH#2550/#3475 - move these to a centralized deserializing place
     static constexpr std::string_view VerticalKey{ "vertical" };
     static constexpr std::string_view HorizontalKey{ "horizontal" };
+    static constexpr std::string_view AutomaticKey{ "auto" };
     static TerminalApp::SplitState ParseSplitState(const std::string& stateString)
     {
         if (stateString == VerticalKey)
@@ -304,6 +305,10 @@ namespace winrt::TerminalApp::implementation
         else if (stateString == HorizontalKey)
         {
             return TerminalApp::SplitState::Horizontal;
+        }
+        else if (stateString == AutomaticKey)
+        {
+            return TerminalApp::SplitState::Automatic;
         }
         // default behavior for invalid data
         return TerminalApp::SplitState::None;

--- a/src/cascadia/TerminalApp/ActionArgs.idl
+++ b/src/cascadia/TerminalApp/ActionArgs.idl
@@ -25,6 +25,7 @@ namespace TerminalApp
 
     enum SplitState
     {
+        Automatic = -1,
         None = 0,
         Vertical = 1,
         Horizontal = 2

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -120,6 +120,7 @@ private:
     void _ControlGotFocusHandler(winrt::Windows::Foundation::IInspectable const& sender,
                                  winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
 
+    winrt::TerminalApp::SplitState _convertAutomaticSplitState(const winrt::TerminalApp::SplitState& splitType) const;
     // Function Description:
     // - Returns true if the given direction can be used with the given split
     //   type.


### PR DESCRIPTION
## Summary of the Pull Request

Adds support for `auto` as a potential value for a `splitPane` keybinding's `split` argument. For example:

```json
        { "keys": [ "ctrl+shift+z" ], "command": { "action": "splitPane", "profile": "matrix", "commandline": "cmd.exe", "split":"auto" } },
```

When set to `auto`, Panes will decide which direction to split based on the available space within the terminal. If the pane is wider than it is tall, the pane will introduce a new vertical split (and vice-versa).

## References

## PR Checklist
* [x] Closes #3960
* [x] I work here
* [x] Tests added/passed
* [n/a] Requires documentation to be updated

## Validation Steps Performed
Ran tests, played with it.