### PR TITLE
Fix Search non-blocking follow-ups

### DIFF
--- a/src/cascadia/TerminalControl/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalControl/Resources/en-US/Resources.resw
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="TextBoxPlaceholderText.PlaceholderText" xml:space="preserve">
+    <value>Find...</value>
+    <comment>The placeholder text in the search dialog TextBox</comment>
+  </data>
+</root>

--- a/src/cascadia/TerminalControl/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalControl/Resources/en-US/Resources.resw
@@ -117,7 +117,23 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="TextBoxPlaceholderText.PlaceholderText" xml:space="preserve">
+  <data name="CaseSensitivityButtonLocalizedText.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Match Case</value>
+    <comment>The tooltip text for CaseSensitivityButton</comment>
+  </data>
+  <data name="CloseButtonLocalizedText.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Close</value>
+    <comment>The tooltip text for CloseButton</comment>
+  </data>
+  <data name="GoBackwardButtonLocalizedText.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Find Up</value>
+    <comment>The tooltip text for GoBackward Button</comment>
+  </data>
+  <data name="GoForwardButtonLocalizedText.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Find Down</value>
+    <comment>The tooltip text for GoForward Button</comment>
+  </data>
+  <data name="TextBoxLocalizedText.PlaceholderText" xml:space="preserve">
     <value>Find...</value>
     <comment>The placeholder text in the search dialog TextBox</comment>
   </data>

--- a/src/cascadia/TerminalControl/SearchBoxControl.cpp
+++ b/src/cascadia/TerminalControl/SearchBoxControl.cpp
@@ -19,7 +19,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         this->CharacterReceived({ this, &SearchBoxControl::_CharacterHandler });
         this->KeyDown({ this, &SearchBoxControl::_KeyDownHandler });
 
-        
         _focusableElements.insert(TextBox());
         _focusableElements.insert(CloseButton());
         _focusableElements.insert(CaseSensitivityButton());

--- a/src/cascadia/TerminalControl/SearchBoxControl.cpp
+++ b/src/cascadia/TerminalControl/SearchBoxControl.cpp
@@ -17,11 +17,10 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         InitializeComponent();
 
         this->CharacterReceived({ this, &SearchBoxControl::_CharacterHandler });
+        this->KeyDown({ this, &SearchBoxControl::_KeyDownHandler });
 
-        _textBox = TextBox();
-
-        if (_textBox)
-            _focusableElements.insert(_textBox);
+        
+        _focusableElements.insert(TextBox());
         _focusableElements.insert(CloseButton());
         _focusableElements.insert(CaseSensitivityButton());
         _focusableElements.insert(GoForwardButton());
@@ -67,13 +66,31 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             auto const state = CoreWindow::GetForCurrentThread().GetKeyState(winrt::Windows::System::VirtualKey::Shift);
             if (WI_IsFlagSet(state, CoreVirtualKeyStates::Down))
             {
-                _SearchHandlers(_textBox.Text(), !_GoForward(), _CaseSensitive());
+                _SearchHandlers(TextBox().Text(), !_GoForward(), _CaseSensitive());
             }
             else
             {
-                _SearchHandlers(_textBox.Text(), _GoForward(), _CaseSensitive());
+                _SearchHandlers(TextBox().Text(), _GoForward(), _CaseSensitive());
             }
             e.Handled(true);
+        }
+    }
+
+    // Method Description:
+    // - Handler for pressing "Esc" when focusing
+    //   on the search dialog, this triggers close
+    //   event of the Search dialog
+    // Arguments:
+    // - sender: not used
+    // - e: event data
+    // Return Value:
+    // - <none>
+    void SearchBoxControl::_KeyDownHandler(winrt::Windows::Foundation::IInspectable const& /*sender*/,
+                                           Input::KeyRoutedEventArgs const& e)
+    {
+        if (e.OriginalKey() == winrt::Windows::System::VirtualKey::Escape)
+        {
+            _ClosedHandlers(*this, e);
         }
     }
 
@@ -86,10 +103,10 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // - <none>
     void SearchBoxControl::SetFocusOnTextbox()
     {
-        if (_textBox)
+        if (TextBox())
         {
-            Input::FocusManager::TryFocusAsync(_textBox, FocusState::Keyboard);
-            _textBox.SelectAll();
+            Input::FocusManager::TryFocusAsync(TextBox(), FocusState::Keyboard);
+            TextBox().SelectAll();
         }
     }
 
@@ -129,7 +146,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         }
 
         // kick off search
-        _SearchHandlers(_textBox.Text(), _GoForward(), _CaseSensitive());
+        _SearchHandlers(TextBox().Text(), _GoForward(), _CaseSensitive());
     }
 
     // Method Description:
@@ -150,7 +167,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         }
 
         // kick off search
-        _SearchHandlers(_textBox.Text(), _GoForward(), _CaseSensitive());
+        _SearchHandlers(TextBox().Text(), _GoForward(), _CaseSensitive());
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/SearchBoxControl.cpp
+++ b/src/cascadia/TerminalControl/SearchBoxControl.cpp
@@ -90,6 +90,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         if (e.OriginalKey() == winrt::Windows::System::VirtualKey::Escape)
         {
             _ClosedHandlers(*this, e);
+            e.Handled(true);
         }
     }
 

--- a/src/cascadia/TerminalControl/SearchBoxControl.cpp
+++ b/src/cascadia/TerminalControl/SearchBoxControl.cpp
@@ -4,7 +4,6 @@
 #include "pch.h"
 #include "SearchBoxControl.h"
 #include "SearchBoxControl.g.cpp"
-#include <LibraryResources.h>
 
 using namespace winrt;
 using namespace winrt::Windows::UI::Xaml;
@@ -38,14 +37,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     //         states of the two direction buttons
     bool SearchBoxControl::_GoForward()
     {
-        if (GoForwardButton().IsChecked().GetBoolean())
-        {
-            return true;
-        }
-        else
-        {
-            return false;
-        }
+        return GoForwardButton().IsChecked().GetBoolean();
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/SearchBoxControl.h
+++ b/src/cascadia/TerminalControl/SearchBoxControl.h
@@ -28,9 +28,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         void TextBoxKeyDown(winrt::Windows::Foundation::IInspectable const& /*sender*/, winrt::Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e);
 
-        bool GoForward();
-        bool IsCaseSensitive();
-
         void SetFocusOnTextbox();
         bool ContainsFocus();
 
@@ -38,19 +35,16 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void GoForwardClicked(winrt::Windows::Foundation::IInspectable const& /*sender*/, winrt::Windows::UI::Xaml::RoutedEventArgs const& /*e*/);
         void CloseClick(winrt::Windows::Foundation::IInspectable const& /*sender*/, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
 
-        TYPED_EVENT(Search, TerminalControl::SearchBoxControl, winrt::hstring);
+        WINRT_CALLBACK(Search, SearchHandler);
         TYPED_EVENT(Closed, TerminalControl::SearchBoxControl, Windows::UI::Xaml::RoutedEventArgs);
 
     private:
-        bool _goForward; // The direction of the search, controlled by the buttons with arrows
-
-        winrt::Windows::UI::Xaml::Controls::Primitives::ToggleButton _goForwardButton;
-        winrt::Windows::UI::Xaml::Controls::Primitives::ToggleButton _goBackwardButton;
-        winrt::Windows::UI::Xaml::Controls::Primitives::ToggleButton _caseButton;
         winrt::Windows::UI::Xaml::Controls::TextBox _textBox;
 
         std::unordered_set<winrt::Windows::Foundation::IInspectable> _focusableElements;
 
+        bool _GoForward();
+        bool _CaseSensitive();
         void _CharacterHandler(winrt::Windows::Foundation::IInspectable const& /*sender*/, winrt::Windows::UI::Xaml::Input::CharacterReceivedRoutedEventArgs const& e);
     };
 }

--- a/src/cascadia/TerminalControl/SearchBoxControl.h
+++ b/src/cascadia/TerminalControl/SearchBoxControl.h
@@ -39,12 +39,11 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         TYPED_EVENT(Closed, TerminalControl::SearchBoxControl, Windows::UI::Xaml::RoutedEventArgs);
 
     private:
-        winrt::Windows::UI::Xaml::Controls::TextBox _textBox;
-
         std::unordered_set<winrt::Windows::Foundation::IInspectable> _focusableElements;
 
         bool _GoForward();
         bool _CaseSensitive();
+        void _KeyDownHandler(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e);
         void _CharacterHandler(winrt::Windows::Foundation::IInspectable const& /*sender*/, winrt::Windows::UI::Xaml::Input::CharacterReceivedRoutedEventArgs const& e);
     };
 }

--- a/src/cascadia/TerminalControl/SearchBoxControl.idl
+++ b/src/cascadia/TerminalControl/SearchBoxControl.idl
@@ -5,7 +5,7 @@ namespace Microsoft.Terminal.TerminalControl
 {
     delegate void SearchHandler(String query, Boolean goFarward, Boolean isCaseSensitive);
 
-	[default_interface] runtimeclass SearchBoxControl : Windows.UI.Xaml.Controls.UserControl
+    [default_interface] runtimeclass SearchBoxControl : Windows.UI.Xaml.Controls.UserControl
     {
         SearchBoxControl();
         void SetFocusOnTextbox();

--- a/src/cascadia/TerminalControl/SearchBoxControl.idl
+++ b/src/cascadia/TerminalControl/SearchBoxControl.idl
@@ -3,15 +3,15 @@
 
 namespace Microsoft.Terminal.TerminalControl
 {
-    [default_interface] runtimeclass SearchBoxControl : Windows.UI.Xaml.Controls.UserControl
+    delegate void SearchHandler(String query, Boolean goFarward, Boolean isCaseSensitive);
+
+	[default_interface] runtimeclass SearchBoxControl : Windows.UI.Xaml.Controls.UserControl
     {
         SearchBoxControl();
-        Boolean GoForward { get; };
-        Boolean IsCaseSensitive { get; };
         void SetFocusOnTextbox();
         Boolean ContainsFocus();
 
-        event Windows.Foundation.TypedEventHandler<SearchBoxControl, String> Search;
+        event SearchHandler Search;
         event Windows.Foundation.TypedEventHandler<SearchBoxControl, Windows.UI.Xaml.RoutedEventArgs> Closed;
     }
 }

--- a/src/cascadia/TerminalControl/SearchBoxControl.xaml
+++ b/src/cascadia/TerminalControl/SearchBoxControl.xaml
@@ -154,8 +154,8 @@
     </UserControl.Resources>
 
     <StackPanel Orientation="Horizontal" Style="{ThemeResource SearchBoxBackground}" Padding="5" CornerRadius="0,0,2,2">
-        <TextBox  x:Name="TextBox" AutomationProperties.Name="Search Text" CornerRadius="2" Width="160"
-                  PlaceholderForeground="{ThemeResource TextBoxPlaceholderForeground}"   FontSize="15" PlaceholderText="Find..." KeyDown = "TextBoxKeyDown"
+        <TextBox  x:Name="TextBox" x:Uid="TextBoxPlaceholderText" AutomationProperties.Name="Search Text" CornerRadius="2" Width="160"
+                  PlaceholderForeground="{ThemeResource TextBoxPlaceholderForeground}"   FontSize="15" KeyDown = "TextBoxKeyDown"
                   Margin="5" HorizontalAlignment="Left" VerticalAlignment="Center">
         </TextBox>
 

--- a/src/cascadia/TerminalControl/SearchBoxControl.xaml
+++ b/src/cascadia/TerminalControl/SearchBoxControl.xaml
@@ -154,29 +154,29 @@
     </UserControl.Resources>
 
     <StackPanel Orientation="Horizontal" Style="{ThemeResource SearchBoxBackground}" Padding="5" CornerRadius="0,0,2,2">
-        <TextBox  x:Name="TextBox" x:Uid="TextBoxPlaceholderText" AutomationProperties.Name="Search Text" CornerRadius="2" Width="160"
+        <TextBox  x:Name="TextBox" x:Uid="TextBoxLocalizedText" AutomationProperties.Name="Search Text" CornerRadius="2" Width="160"
                   PlaceholderForeground="{ThemeResource TextBoxPlaceholderForeground}"   FontSize="15" KeyDown = "TextBoxKeyDown"
                   Margin="5" HorizontalAlignment="Left" VerticalAlignment="Center">
         </TextBox>
 
-        <ToggleButton x:Name="GoBackwardButton" AutomationProperties.Name="Set Search Backward" HorizontalAlignment="Right"
-                      Style="{StaticResource ToggleButtonStyle}" ToolTipService.ToolTip="Find Up"
+        <ToggleButton x:Name="GoBackwardButton" x:Uid="GoBackwardButtonLocalizedText" AutomationProperties.Name="Set Search Backward"
+                      HorizontalAlignment="Right" Style="{StaticResource ToggleButtonStyle}"
                       Click="GoBackwardClicked" IsChecked="True">
             <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE74A;" Style="{ThemeResource FontIconStyle}"/>
         </ToggleButton>
-        <ToggleButton x:Name="GoForwardButton" AutomationProperties.Name="Set Search Forward"
-                      Style="{StaticResource ToggleButtonStyle}" ToolTipService.ToolTip="Find Down"
+        <ToggleButton x:Name="GoForwardButton" x:Uid="GoForwardButtonLocalizedText"
+                      AutomationProperties.Name="Set Search Forward" Style="{StaticResource ToggleButtonStyle}"
                       Click="GoForwardClicked">
             <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE74B;" Style="{ThemeResource FontIconStyle}"/>
         </ToggleButton>
 
-        <ToggleButton x:Name="CaseSensitivityButton" AutomationProperties.Name="CaseSensitivity"
-                      Style="{StaticResource ToggleButtonStyle}" ToolTipService.ToolTip="Match Case">
+        <ToggleButton x:Name="CaseSensitivityButton" x:Uid="CaseSensitivityButtonLocalizedText"
+                      AutomationProperties.Name="CaseSensitivity" Style="{StaticResource ToggleButtonStyle}">
             <PathIcon Data="M8.87305 10H7.60156L6.5625 7.25195H2.40625L1.42871 10H0.150391L3.91016 0.197266H5.09961L8.87305 10ZM6.18652 6.21973L4.64844 2.04297C4.59831 1.90625 4.54818 1.6875 4.49805 1.38672H4.4707C4.42513 1.66471 4.37272 1.88346 4.31348 2.04297L2.78906 6.21973H6.18652ZM15.1826 10H14.0615V8.90625H14.0342C13.5465 9.74479 12.8288 10.1641 11.8809 10.1641C11.1836 10.1641 10.6367 9.97949 10.2402 9.61035C9.84831 9.24121 9.65234 8.7513 9.65234 8.14062C9.65234 6.83268 10.4225 6.07161 11.9629 5.85742L14.0615 5.56348C14.0615 4.37402 13.5807 3.7793 12.6191 3.7793C11.776 3.7793 11.015 4.06641 10.3359 4.64062V3.49219C11.0241 3.05469 11.8171 2.83594 12.7148 2.83594C14.36 2.83594 15.1826 3.70638 15.1826 5.44727V10ZM14.0615 6.45898L12.373 6.69141C11.8535 6.76432 11.4616 6.89421 11.1973 7.08105C10.9329 7.26335 10.8008 7.58919 10.8008 8.05859C10.8008 8.40039 10.9215 8.68066 11.1631 8.89941C11.4092 9.11361 11.735 9.2207 12.1406 9.2207C12.6966 9.2207 13.1546 9.02702 13.5146 8.63965C13.8792 8.24772 14.0615 7.75326 14.0615 7.15625V6.45898Z"/>
         </ToggleButton>
 
-        <Button x:Name="CloseButton" AutomationProperties.Name="Close" Padding="0" Click="CloseClick"
-                Style="{ ThemeResource ButtonStyle}" ToolTipService.ToolTip="Close">
+        <Button x:Name="CloseButton" x:Uid="CloseButtonLocalizedText" AutomationProperties.Name="Close"
+                Padding="0" Click="CloseClick" Style="{ ThemeResource ButtonStyle}">
             <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE711;" FontSize="12"/>
         </Button>
     </StackPanel>

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -197,24 +197,25 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // - Search text in text buffer. This is triggered if the user click
     //   search button or press enter.
     // Arguments:
-    // - IInspectable: not used
     // - text: the text to search
+    // - goForward: boolean that represents if the current search direction is forward
+    // - caseSensitive: boolean that represents if the current search is case sensitive
     // Return Value:
     // - <none>
-    void TermControl::_Search(const winrt::Windows::Foundation::IInspectable&, const winrt::hstring& text)
+    void TermControl::_Search(const winrt::hstring& text, const bool goForward, const bool caseSensitive)
     {
         if (text.size() == 0)
         {
             return;
         }
 
-        const Search::Direction direction = _searchBox->GoForward() ?
-                                                Search::Direction::Forward :
-                                                Search::Direction::Backward;
+        const Search::Direction direction = goForward ?
+                                            Search::Direction::Forward :
+                                            Search::Direction::Backward;
 
-        const Search::Sensitivity sensitivity = _searchBox->IsCaseSensitive() ?
-                                                    Search::Sensitivity::CaseSensitive :
-                                                    Search::Sensitivity::CaseInsensitive;
+        const Search::Sensitivity sensitivity = caseSensitive ?
+                                                Search::Sensitivity::CaseSensitive :
+                                                Search::Sensitivity::CaseInsensitive;
 
         Search search(*GetUiaData(), text.c_str(), direction, sensitivity);
         auto lock = _terminal->LockForWriting();

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -210,12 +210,12 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         }
 
         const Search::Direction direction = goForward ?
-                                            Search::Direction::Forward :
-                                            Search::Direction::Backward;
+                                                Search::Direction::Forward :
+                                                Search::Direction::Backward;
 
         const Search::Sensitivity sensitivity = caseSensitive ?
-                                                Search::Sensitivity::CaseSensitive :
-                                                Search::Sensitivity::CaseInsensitive;
+                                                    Search::Sensitivity::CaseSensitive :
+                                                    Search::Sensitivity::CaseInsensitive;
 
         Search search(*GetUiaData(), text.c_str(), direction, sensitivity);
         auto lock = _terminal->LockForWriting();

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -210,12 +210,12 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         }
 
         const Search::Direction direction = goForward ?
-                                                Search::Direction::Forward :
-                                                Search::Direction::Backward;
+                                            Search::Direction::Forward :
+                                            Search::Direction::Backward;
 
         const Search::Sensitivity sensitivity = caseSensitive ?
-                                                    Search::Sensitivity::CaseSensitive :
-                                                    Search::Sensitivity::CaseInsensitive;
+                                                Search::Sensitivity::CaseSensitive :
+                                                Search::Sensitivity::CaseInsensitive;
 
         Search search(*GetUiaData(), text.c_str(), direction, sensitivity);
         auto lock = _terminal->LockForWriting();

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -210,12 +210,12 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         }
 
         const Search::Direction direction = goForward ?
-                                            Search::Direction::Forward :
-                                            Search::Direction::Backward;
+                                                Search::Direction::Forward :
+                                                Search::Direction::Backward;
 
         const Search::Sensitivity sensitivity = caseSensitive ?
-                                                Search::Sensitivity::CaseSensitive :
-                                                Search::Sensitivity::CaseInsensitive;
+                                                    Search::Sensitivity::CaseSensitive :
+                                                    Search::Sensitivity::CaseInsensitive;
 
         Search search(*GetUiaData(), text.c_str(), direction, sensitivity);
         auto lock = _terminal->LockForWriting();
@@ -775,7 +775,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         {
             return;
         }
-        
+
         // mark event as handled and do nothing if...
         //   - closing
         //   - key modifier is pressed

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -210,12 +210,12 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         }
 
         const Search::Direction direction = goForward ?
-                                                Search::Direction::Forward :
-                                                Search::Direction::Backward;
+                                            Search::Direction::Forward :
+                                            Search::Direction::Backward;
 
         const Search::Sensitivity sensitivity = caseSensitive ?
-                                                    Search::Sensitivity::CaseSensitive :
-                                                    Search::Sensitivity::CaseInsensitive;
+                                                Search::Sensitivity::CaseSensitive :
+                                                Search::Sensitivity::CaseInsensitive;
 
         Search search(*GetUiaData(), text.c_str(), direction, sensitivity);
         auto lock = _terminal->LockForWriting();
@@ -228,27 +228,16 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     }
 
     // Method Description:
-    // - The handler for the close button in the search box.
-    //   This is a wrapper method that calls _CloseSearchBoxControlHelper().
+    // - The handler for the close button or pressing "Esc" when focusing on the
+    //   search dialog.
+    //   This removes the SearchBoxControl object from the XAML tree,
+    //   reset smart pointer and set focus back to Terminal
     // Arguments:
     // - IInspectable: not used
     // - RoutedEventArgs: not used
     // Return Value:
     // - <none>
     void TermControl::_CloseSearchBoxControl(const winrt::Windows::Foundation::IInspectable& /*sender*/, RoutedEventArgs const& /*args*/)
-    {
-        _CloseSearchBoxControlHelper();
-    }
-
-    // Method Description:
-    // - The helper method that removes the SearchBoxControl
-    //   object from the XAML tree, reset smart pointer and
-    //   set focus back to Terminal
-    // Arguments:
-    // - <none>
-    // Return Value:
-    // - <none>
-    void TermControl::_CloseSearchBoxControlHelper()
     {
         unsigned int idx;
         _root.Children().IndexOf(*_searchBox, idx);
@@ -780,20 +769,13 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     void TermControl::_KeyDownHandler(winrt::Windows::Foundation::IInspectable const& /*sender*/,
                                       Input::KeyRoutedEventArgs const& e)
     {
-        // If Esc is pressed and the search box is opened, we close the search box
-        if (_searchBox && e.OriginalKey() == winrt::Windows::System::VirtualKey::Escape)
-        {
-            _CloseSearchBoxControlHelper();
-            return;
-        }
-
         // If the current focused element is a child element of searchbox,
         // we do not send this event up to terminal
         if (_searchBox && _searchBox->ContainsFocus())
         {
             return;
         }
-
+        
         // mark event as handled and do nothing if...
         //   - closing
         //   - key modifier is pressed

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -216,7 +216,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         void _Search(const winrt::hstring& text, const bool goForward, const bool caseSensitive);
         void _CloseSearchBoxControl(const winrt::Windows::Foundation::IInspectable& sender, Windows::UI::Xaml::RoutedEventArgs const& args);
-        void _CloseSearchBoxControlHelper();
 
         // TSFInputControl Handlers
         void _CompositionCompleted(winrt::hstring text);

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -214,7 +214,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         const unsigned int _NumberOfClicks(winrt::Windows::Foundation::Point clickPos, Timestamp clickTime);
         double _GetAutoScrollSpeed(double cursorDistanceFromBorder) const;
 
-        void _Search(const winrt::Windows::Foundation::IInspectable& sender, const winrt::hstring& text);
+        void _Search(const winrt::hstring& text, const bool goForward, const bool caseSensitive);
         void _CloseSearchBoxControl(const winrt::Windows::Foundation::IInspectable& sender, Windows::UI::Xaml::RoutedEventArgs const& args);
         void _CloseSearchBoxControlHelper();
 

--- a/src/cascadia/TerminalControl/TerminalControl.vcxproj
+++ b/src/cascadia/TerminalControl/TerminalControl.vcxproj
@@ -83,6 +83,9 @@
     <None Include="packages.config" />
     <None Include="TerminalControl.def" />
   </ItemGroup>
+  <ItemGroup>
+    <PRIResource Include="Resources/en-US/Resources.resw" />
+  </ItemGroup>
   <!-- ========================= Project References ======================== -->
   <ItemGroup>
     <ProjectReference Include="..\..\types\lib\types.vcxproj" />
@@ -100,6 +103,10 @@
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalConnection\TerminalConnection.vcxproj">
       <Private>false</Private>
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+    </ProjectReference>
+    <ProjectReference Include="$(OpenConsoleDir)src\cascadia\WinRTUtils\WinRTUtils.vcxproj">
+      <Project>{CA5CAD1A-039A-4929-BA2A-8BEB2E4106FE}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/cascadia/TerminalControl/init.cpp
+++ b/src/cascadia/TerminalControl/init.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 #include "pch.h"
+#include <LibraryResources.h>
 
 // Note: Generate GUID using TlgGuid.exe tool
 TRACELOGGING_DEFINE_PROVIDER(
@@ -29,3 +30,5 @@ BOOL WINAPI DllMain(HINSTANCE hInstDll, DWORD reason, LPVOID /*reserved*/)
 
     return TRUE;
 }
+
+UTILS_DEFINE_LIBRARY_RESOURCE_SCOPE(L"Microsoft.Terminal.TerminalControl/Resources");


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR includes the non-blocking follow-ups of Search, which are addressed in this issue: https://github.com/microsoft/terminal/issues/3942

At current, the following two issues have been resolved: 

1. The place holder text in the TextBox ("Find...") needs to be localizable.
2. Search event should have a delegate with more args. This is illustrated below in Issue

The third issue, which is related to KeyDown events handling, is still under investigation. KeyDown events are now first sent to root TermControl, I need to figure out a way to make sure SearchBoxControl receives and handles the events first. 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes https://github.com/microsoft/terminal/issues/3942
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
