### PR TITLE
Fix matches of multiple schemas on "profiles"

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -622,7 +622,8 @@
           "description": "The default settings that apply to every profile.",
           "$ref": "#/definitions/Profile"
         }
-      }
+      },
+      "type": "object"
     },
     "SchemeList": {
       "description": "Properties are specific to each color scheme. ColorTool is a great tool you can use to create and explore new color schemes. All colors use hex color format.",


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds proper `type` for `ProfilesObject` definition to avoid warnings about matches of multiple schemas.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
Original issue: #3909
Related PR: #3892
Relates VSCode issue: https://github.com/microsoft/vscode/issues/86738

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #3909
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] No new tests ~Tests added/passed~
* [ ] No docs update needed ~Requires documentation to be updated~
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #3909 (marked as help wanted)

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Download `doc/cascadia/profiles.schema.json` locally
1. Open `profiles.json` from WT in VSCode
1. Replace `$schema` value with path to local copy (verified that all errors are still in place and validations works as before)
1. Update it with `type` on `ProfilesObject`
1. Check that `Matches multiple schemas when only one must validate` warning is fixed
