### PR TITLE
[Trivial] Fixed GetMessage errors being ignored

### DIFF
--- a/src/cascadia/WindowsTerminal/main.cpp
+++ b/src/cascadia/WindowsTerminal/main.cpp
@@ -139,10 +139,10 @@ int __stdcall wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int)
 
     MSG message;
 
-    while (GetMessage(&message, nullptr, 0, 0))
+    while (GetMessageW(&message, nullptr, 0, 0) > 0)
     {
         TranslateMessage(&message);
-        DispatchMessage(&message);
+        DispatchMessageW(&message);
     }
     return 0;
 }


### PR DESCRIPTION
## Summary of the Pull Request

I happened to notice that the `GetMessage()` return value is not being checked properly. It will be -1 in case of an error even if the return type is a `BOOL`.

## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments

See: https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getmessagew#return-value
I've also taken the liberty to specify the `W` suffix directly.

## Validation Steps Performed

The app still works. 😄