### PR TITLE
Correct improper usage of THROW_IF_NULL_ALLOC

### DIFF
--- a/src/host/PtySignalInputThread.cpp
+++ b/src/host/PtySignalInputThread.cpp
@@ -34,7 +34,7 @@ PtySignalInputThread::PtySignalInputThread(_In_ wil::unique_hfile hPipe) :
     _consoleConnected{ false }
 {
     THROW_HR_IF(E_HANDLE, _hFile.get() == INVALID_HANDLE_VALUE);
-    THROW_IF_NULL_ALLOC(_pConApi.get());
+    THROW_HR_IF_NULL(E_INVALIDARG, _pConApi.get());
 }
 
 PtySignalInputThread::~PtySignalInputThread()

--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -103,10 +103,10 @@ SCREEN_INFORMATION::~SCREEN_INFORMATION()
     try
     {
         IWindowMetrics* pMetrics = ServiceLocator::LocateWindowMetrics();
-        THROW_IF_NULL_ALLOC(pMetrics);
+        THROW_HR_IF_NULL(E_FAIL, pMetrics);
 
         IAccessibilityNotifier* pNotifier = ServiceLocator::LocateAccessibilityNotifier();
-        THROW_IF_NULL_ALLOC(pNotifier);
+        THROW_HR_IF_NULL(E_FAIL, pNotifier);
 
         SCREEN_INFORMATION* const pScreen = new SCREEN_INFORMATION(pMetrics, pNotifier, popupAttributes, fontInfo);
 

--- a/src/interactivity/win32/Clipboard.cpp
+++ b/src/interactivity/win32/Clipboard.cpp
@@ -133,7 +133,7 @@ void Clipboard::StringPaste(_In_reads_(cchData) const wchar_t* const pData,
 std::deque<std::unique_ptr<IInputEvent>> Clipboard::TextToKeyEvents(_In_reads_(cchData) const wchar_t* const pData,
                                                                     const size_t cchData)
 {
-    THROW_IF_NULL_ALLOC(pData);
+    THROW_HR_IF_NULL(E_INVALIDARG, pData);
 
     std::deque<std::unique_ptr<IInputEvent>> keyEvents;
 

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -931,6 +931,6 @@ std::vector<SMALL_RECT> Renderer::_GetSelectionRects() const
 //      engine to our collection.
 void Renderer::AddRenderEngine(_In_ IRenderEngine* const pEngine)
 {
-    THROW_IF_NULL_ALLOC(pEngine);
+    THROW_HR_IF_NULL(E_INVALIDARG, pEngine);
     _rgpEngines.push_back(pEngine);
 }

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1735,7 +1735,7 @@ float DxEngine::GetScaling() const noexcept
         }
     }
 
-    THROW_IF_NULL_ALLOC(face);
+    THROW_HR_IF_NULL(E_FAIL, face);
 
     return face;
 }

--- a/src/terminal/adapter/InteractDispatch.cpp
+++ b/src/terminal/adapter/InteractDispatch.cpp
@@ -17,7 +17,7 @@ using namespace Microsoft::Console::VirtualTerminal;
 InteractDispatch::InteractDispatch(std::unique_ptr<ConGetSet> pConApi) :
     _pConApi(std::move(pConApi))
 {
-    THROW_IF_NULL_ALLOC(_pConApi.get());
+    THROW_HR_IF_NULL(E_INVALIDARG, _pConApi.get());
 }
 
 // Method Description:

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -36,8 +36,8 @@ AdaptDispatch::AdaptDispatch(std::unique_ptr<ConGetSet> pConApi,
     _changedMetaAttrs(false),
     _termOutput()
 {
-    THROW_IF_NULL_ALLOC(_pConApi.get());
-    THROW_IF_NULL_ALLOC(_pDefaults.get());
+    THROW_HR_IF_NULL(E_INVALIDARG, _pConApi.get());
+    THROW_HR_IF_NULL(E_INVALIDARG, _pDefaults.get());
     _scrollMargins = { 0 }; // initially, there are no scroll margins.
 }
 

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -170,7 +170,7 @@ InputStateMachineEngine::InputStateMachineEngine(std::unique_ptr<IInteractDispat
     _pDispatch(std::move(pDispatch)),
     _lookingForDSR(lookingForDSR)
 {
-    THROW_IF_NULL_ALLOC(_pDispatch.get());
+    THROW_HR_IF_NULL(E_INVALIDARG, _pDispatch.get());
 }
 
 // Method Description:

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -17,7 +17,7 @@ OutputStateMachineEngine::OutputStateMachineEngine(std::unique_ptr<ITermDispatch
     _pTtyConnection(nullptr),
     _lastPrintedChar(AsciiChars::NUL)
 {
-    THROW_IF_NULL_ALLOC(_dispatch.get());
+    THROW_HR_IF_NULL(E_INVALIDARG, _dispatch.get());
 }
 
 const ITermDispatch& OutputStateMachineEngine::Dispatch() const noexcept

--- a/src/tools/vtpipeterm/VtConsole.cpp
+++ b/src/tools/vtpipeterm/VtConsole.cpp
@@ -24,7 +24,7 @@ VtConsole::VtConsole(PipeReadCallback const pfnReadCallback,
     _fUseConPty(fUseConpty),
     _lastDimensions(initialSize)
 {
-    THROW_IF_NULL_ALLOC(pfnReadCallback);
+    THROW_HR_IF_NULL(E_INVALIDARG, pfnReadCallback);
 }
 
 void VtConsole::spawn()


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

FIx incorrect usage of THROW_IF_NULL_ALLOC which will throw E_OUTOFMEMORY unintentionally.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #4099
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Build and run it. 