### PR TITLE
Fix a test that regressed during #3575

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -434,7 +434,7 @@ namespace TerminalAppLocalTests
                 "alwaysShowTabs": true,
                 "initialCols" : 120,
                 "initialRows" : 30,
-                "rowsToScroll" :  4,
+                "rowsToScroll" :  4
             }
         })" };
         const std::string settings1String{ R"(
@@ -443,7 +443,7 @@ namespace TerminalAppLocalTests
                 "showTabsInTitlebar": false,
                 "initialCols" : 240,
                 "initialRows" : 60,
-                "rowsToScroll" : 8 
+                "rowsToScroll" : 8
             }
         })" };
         const auto settings0Json = VerifyParseSucceeded(settings0String);


### PR DESCRIPTION
## Summary of the Pull Request

Fix a test that regressed during #3575. It wasn't caught, because the LocalTests don't run in CI unfortunately.

## PR Checklist
* [x] Closes #4137
* [x] I work here
* [x] Tests added/passed
* [n/a] Requires documentation to be updated

## Validation Steps Performed
Ran the local tests