### PR TITLE
Fixed a deadlock when printing surrogate pairs

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -460,13 +460,11 @@ void Terminal::_WriteBuffer(const std::wstring_view& stringView)
             // If wch is a surrogate character we need to read 2 code units
             // from the stringView to form a single code point.
             const auto isSurrogate = wch >= 0xD800 && wch <= 0xDFFF;
-            const size_t codePointLength = isSurrogate ? 2 : 1;
-            const auto view = stringView.substr(i, codePointLength);
+            const auto view = stringView.substr(i, isSurrogate ? 2 : 1);
             const OutputCellIterator it{ view, _buffer->GetCurrentAttributes() };
             const auto end = _buffer->Write(it);
-            const auto cellDistance = end.GetCellDistance(it);
-            proposedCursorPosition.X += gsl::narrow<SHORT>(cellDistance);
-            i += codePointLength - 1;
+            proposedCursorPosition.X += gsl::narrow<SHORT>(end.GetCellDistance(it));
+            i += end.GetInputDistance(it) - 1;
         }
 
         // If we're about to scroll past the bottom of the buffer, instead cycle the buffer.

--- a/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
@@ -12,6 +12,9 @@
 using namespace winrt::Microsoft::Terminal::Settings;
 using namespace Microsoft::Terminal::Core;
 
+using namespace WEX::Logging;
+using namespace WEX::TestExecution;
+
 namespace TerminalCoreUnitTests
 {
 #define WCS(x) WCSHELPER(x)
@@ -36,6 +39,75 @@ namespace TerminalCoreUnitTests
 
             VERIFY_IS_FALSE(term.SetColorTableEntry(256, 100));
             VERIFY_IS_FALSE(term.SetColorTableEntry(512, 100));
+        }
+
+        // Terminal::_WriteBuffer used to enter infinite loops under certain conditions.
+        // This test ensures that Terminal::_WriteBuffer doesn't get stuck when
+        // PrintString() is called with more code units than the buffer width.
+        TEST_METHOD(PrintStringOfSurrogatePairs)
+        {
+            DummyRenderTarget renderTarget;
+            Terminal term;
+            term.Create({ 100, 100 }, 3, renderTarget);
+
+            std::wstring text;
+            text.reserve(600);
+
+            for (size_t i = 0; i < 100; ++i)
+            {
+                text.append(L"𐐌𐐜𐐬");
+            }
+
+            struct Baton
+            {
+                HANDLE done;
+                std::wstring text;
+                Terminal* pTerm;
+            } baton{
+                CreateEventW(nullptr, TRUE, FALSE, L"done signal"),
+                text,
+                &term,
+            };
+
+            Log::Comment(L"Launching thread to write data.");
+            const auto thread = CreateThread(
+                nullptr,
+                0,
+                [](LPVOID data) -> DWORD {
+                    const Baton& baton = *reinterpret_cast<Baton*>(data);
+                    Log::Comment(L"Writing data.");
+                    baton.pTerm->PrintString(baton.text);
+                    Log::Comment(L"Setting event.");
+                    SetEvent(baton.done);
+                    return 0;
+                },
+                (LPVOID)&baton,
+                0,
+                nullptr);
+
+            Log::Comment(L"Waiting for the write.");
+            switch (WaitForSingleObject(baton.done, 2000))
+            {
+            case WAIT_OBJECT_0:
+                Log::Comment(L"Didn't get stuck. Success.");
+                break;
+            case WAIT_TIMEOUT:
+                Log::Comment(L"Wait timed out. It got stuck.");
+                Log::Result(WEX::Logging::TestResults::Failed);
+                break;
+            case WAIT_FAILED:
+                Log::Comment(L"Wait failed for some reason. We didn't expect this.");
+                Log::Result(WEX::Logging::TestResults::Failed);
+                break;
+            default:
+                Log::Comment(L"Wait return code that no one expected. Fail.");
+                Log::Result(WEX::Logging::TestResults::Failed);
+                break;
+            }
+
+            TerminateThread(thread, 0);
+            CloseHandle(baton.done);
+            return;
         }
     };
 }


### PR DESCRIPTION
## Summary of the Pull Request

See [my code comment](https://github.com/microsoft/terminal/pull/4150#discussion_r364392640) below for technical details of the issue that caused #4145.

## PR Checklist
* [x] Closes #1360, Closes #4145.
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments

TBH I kinda hope this project could migrate to an internal use of UTF-8 in the future. 😶

## Validation Steps Performed

Followed the "Steps to reproduce" in #4145 and ensured the "Expected behavior" happens.