### PR TITLE
Don't generate WSL distributions for docker-desktop*

### DIFF
--- a/src/cascadia/TerminalApp/WslDistroGenerator.cpp
+++ b/src/cascadia/TerminalApp/WslDistroGenerator.cpp
@@ -13,6 +13,8 @@
 #include <fcntl.h>
 #include "DefaultProfileUtils.h"
 
+static constexpr std::wstring_view DockerDistributionPrefix{ L"docker-desktop" };
+
 using namespace ::TerminalApp;
 
 // Legacy GUIDs:
@@ -97,6 +99,13 @@ std::vector<TerminalApp::Profile> WslDistroGenerator::GenerateProfiles()
         {
             std::wstring distName;
             std::getline(wlinestream, distName, L'\r');
+
+            if (distName.substr(0, std::min(distName.size(), DockerDistributionPrefix.size())) == DockerDistributionPrefix)
+            {
+                // Skip all of the known Docker WSL2 distributions.
+                continue;
+            }
+
             size_t firstChar = distName.find_first_of(L"( ");
             // Some localizations don't have a space between the name and "(Default)"
             // https://github.com/microsoft/terminal/issues/1168#issuecomment-500187109

--- a/src/cascadia/TerminalApp/WslDistroGenerator.cpp
+++ b/src/cascadia/TerminalApp/WslDistroGenerator.cpp
@@ -102,7 +102,8 @@ std::vector<TerminalApp::Profile> WslDistroGenerator::GenerateProfiles()
 
             if (distName.substr(0, std::min(distName.size(), DockerDistributionPrefix.size())) == DockerDistributionPrefix)
             {
-                // Skip all of the known Docker WSL2 distributions.
+                // Docker for Windows creates some utility distributions to handle Docker commands.
+                // Pursuant to GH#3556, because they are _not_ user-facing we want to hide them.
                 continue;
             }
 


### PR DESCRIPTION
These utility distributions are used by Docker for Windows' WSL2
integration. They are not intended for user consumption.

* [x] Closes #3556
* [x] CLA signed.
* [x] Tests added/passed
* [x] Requires documentation to be updated
* [x] I've discussed this with core contributors already.

There is a minimal chance that a user _has_ a distribution named `docker-desktop` or some superstring thereof, but this is taken as an acceptable level of risk.