### PR TITLE
wsl: actually close the pipe handle for wsl.exe, but only once

### DIFF
--- a/src/cascadia/TerminalApp/WslDistroGenerator.cpp
+++ b/src/cascadia/TerminalApp/WslDistroGenerator.cpp
@@ -88,7 +88,8 @@ std::vector<TerminalApp::Profile> WslDistroGenerator::GenerateProfiles()
     // (https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/open-osfhandle?view=vs-2019)
     // so, we detach_from_smart_pointer it -- but...
     // "File descriptors passed into _fdopen are owned by the returned FILE * stream.
-    // If _fdopen is successful, do not call _close on the file descriptor."
+    // If _fdopen is successful, do not call _close on the file descriptor.
+    // Calling fclose on the returned FILE * also closes the file descriptor."
     // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fdopen-wfdopen?view=vs-2019
     FILE* stdioPipeHandle = _wfdopen(_open_osfhandle((intptr_t)wil::detach_from_smart_pointer(readPipe), _O_WTEXT | _O_RDONLY), L"r");
     auto closeFile = wil::scope_exit([&]() { fclose(stdioPipeHandle); });

--- a/src/cascadia/TerminalApp/WslDistroGenerator.cpp
+++ b/src/cascadia/TerminalApp/WslDistroGenerator.cpp
@@ -84,9 +84,17 @@ std::vector<TerminalApp::Profile> WslDistroGenerator::GenerateProfiles()
     }
     DWORD bytesAvailable;
     THROW_IF_WIN32_BOOL_FALSE(PeekNamedPipe(readPipe.get(), nullptr, NULL, nullptr, &bytesAvailable, nullptr));
-    std::wfstream pipe{ _wfdopen(_open_osfhandle((intptr_t)readPipe.get(), _O_WTEXT | _O_RDONLY), L"r") };
-    // don't worry about the handle returned from wfdOpen, readPipe handle is already managed by wil
-    // and closing the file handle will cause an error.
+    // "The _open_osfhandle call transfers ownership of the Win32 file handle to the file descriptor."
+    // (https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/open-osfhandle?view=vs-2019)
+    // so, we detach_from_smart_pointer it -- but...
+    // "File descriptors passed into _fdopen are owned by the returned FILE * stream.
+    // If _fdopen is successful, do not call _close on the file descriptor."
+    // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fdopen-wfdopen?view=vs-2019
+    FILE* stdioPipeHandle = _wfdopen(_open_osfhandle((intptr_t)wil::detach_from_smart_pointer(readPipe), _O_WTEXT | _O_RDONLY), L"r");
+    auto closeFile = wil::scope_exit([&]() { fclose(stdioPipeHandle); });
+
+    std::wfstream pipe{ stdioPipeHandle };
+
     std::wstring wline;
     std::getline(pipe, wline); // remove the header from the output.
     while (pipe.tellp() < bytesAvailable)


### PR DESCRIPTION
We were eating an exception on exit in debug mode because we were using
wil to clean up half of a named pipe we'd already handed ownership of
over to the CRT. The CRT likes to tie up all its loose ends when it gets
unloaded, so it was coming along at exit and closing the handle again.
Big no-no.