### PR TITLE
Remove global namespaced min/max and replace it with STL min/max

### DIFF
--- a/src/host/ft_host/API_BufferTests.cpp
+++ b/src/host/ft_host/API_BufferTests.cpp
@@ -250,7 +250,7 @@ void BufferTests::ChafaGifPerformance()
     for (DWORD pos = 0; pos < res_size; pos += 1000)
     {
         DWORD written = 0;
-        WriteConsoleA(Out, res_data + pos, min(1000, res_size - pos), &written, nullptr);
+        WriteConsoleA(Out, res_data + pos, std::min<DWORD>(1000, res_size - pos), &written, nullptr);
         count++;
     }
 

--- a/src/host/ft_host/API_DimensionsTests.cpp
+++ b/src/host/ft_host/API_DimensionsTests.cpp
@@ -477,7 +477,7 @@ void DimensionsTests::TestSetConsoleScreenBufferInfoEx()
     }
 
     // 2b. Do the comparison. Y should be correct, but X will be the lesser of the size we asked for or the window limit for word wrap.
-    if (sbiex.dwSize.Y == sbiexAfter.dwSize.Y && min(sbiex.dwSize.X, sWidthLimit) == sbiexAfter.dwSize.X)
+    if (sbiex.dwSize.Y == sbiexAfter.dwSize.Y && std::min(sbiex.dwSize.X, sWidthLimit) == sbiexAfter.dwSize.X)
     {
         fBufferSizePassed = true;
     }

--- a/src/host/ft_host/API_OutputTests.cpp
+++ b/src/host/ft_host/API_OutputTests.cpp
@@ -237,10 +237,10 @@ void OutputTests::WriteConsoleOutputWWithClipping()
     adjustedRegion.Bottom += bufferSize.Y / 2;
 
     auto expectedRegion = adjustedRegion;
-    expectedRegion.Left = max(0, adjustedRegion.Left);
-    expectedRegion.Top = max(0, adjustedRegion.Top);
-    expectedRegion.Right = min(bufferSize.X - 1, adjustedRegion.Right);
-    expectedRegion.Bottom = min(bufferSize.Y - 1, adjustedRegion.Bottom);
+    expectedRegion.Left = std::max<SHORT>(0, adjustedRegion.Left);
+    expectedRegion.Top = std::max<SHORT>(0, adjustedRegion.Top);
+    expectedRegion.Right = std::min<SHORT>(bufferSize.X - 1, adjustedRegion.Right);
+    expectedRegion.Bottom = std::min<SHORT>(bufferSize.Y - 1, adjustedRegion.Bottom);
 
     // Call the API and confirm results.
     auto affected = adjustedRegion;
@@ -324,10 +324,10 @@ void OutputTests::WriteConsoleOutputWNegativePositions()
     adjustedRegion.Bottom -= 10;
 
     auto expectedRegion = adjustedRegion;
-    expectedRegion.Left = max(0, adjustedRegion.Left);
-    expectedRegion.Top = max(0, adjustedRegion.Top);
-    expectedRegion.Right = min(bufferSize.X - 1, adjustedRegion.Right);
-    expectedRegion.Bottom = min(bufferSize.Y - 1, adjustedRegion.Bottom);
+    expectedRegion.Left = std::max<SHORT>(0, adjustedRegion.Left);
+    expectedRegion.Top = std::max<SHORT>(0, adjustedRegion.Top);
+    expectedRegion.Right = std::min<SHORT>(bufferSize.X - 1, adjustedRegion.Right);
+    expectedRegion.Bottom = std::min<SHORT>(bufferSize.Y - 1, adjustedRegion.Bottom);
 
     // Call the API and confirm results.
     auto affected = adjustedRegion;
@@ -758,10 +758,10 @@ void OutputTests::ReadConsoleOutputWWithClipping()
     adjustedRegion.Bottom += bufferSize.Y / 2;
 
     auto expectedRegion = adjustedRegion;
-    expectedRegion.Left = max(0, adjustedRegion.Left);
-    expectedRegion.Top = max(0, adjustedRegion.Top);
-    expectedRegion.Right = min(bufferSize.X - 1, adjustedRegion.Right);
-    expectedRegion.Bottom = min(bufferSize.Y - 1, adjustedRegion.Bottom);
+    expectedRegion.Left = std::max<SHORT>(0, adjustedRegion.Left);
+    expectedRegion.Top = std::max<SHORT>(0, adjustedRegion.Top);
+    expectedRegion.Right = std::min<SHORT>(bufferSize.X - 1, adjustedRegion.Right);
+    expectedRegion.Bottom = std::min<SHORT>(bufferSize.Y - 1, adjustedRegion.Bottom);
 
     // Call the API and confirm results.
     // NOTE: We expect this to be broken for v1. It's always been wrong there (returning a clipped count of bytes instead of the whole rectangle).
@@ -852,10 +852,10 @@ void OutputTests::ReadConsoleOutputWNegativePositions()
     adjustedRegion.Bottom -= 10;
 
     auto expectedRegion = adjustedRegion;
-    expectedRegion.Left = max(0, adjustedRegion.Left);
-    expectedRegion.Top = max(0, adjustedRegion.Top);
-    expectedRegion.Right = min(bufferSize.X - 1, adjustedRegion.Right);
-    expectedRegion.Bottom = min(bufferSize.Y - 1, adjustedRegion.Bottom);
+    expectedRegion.Left = std::max<SHORT>(0, adjustedRegion.Left);
+    expectedRegion.Top = std::max<SHORT>(0, adjustedRegion.Top);
+    expectedRegion.Right = std::min<SHORT>(bufferSize.X - 1, adjustedRegion.Right);
+    expectedRegion.Bottom = std::min<SHORT>(bufferSize.Y - 1, adjustedRegion.Bottom);
 
     // Call the API
     // NOTE: Due to the same reason as the ReadConsoleOutputWWithClipping test (the v1 buffer told the driver the wrong return buffer byte length)

--- a/src/host/ft_host/API_TitleTests.cpp
+++ b/src/host/ft_host/API_TitleTests.cpp
@@ -91,7 +91,7 @@ void TestGetConsoleTitleWPrepExpectedHelper(_In_reads_(cchTitle) const wchar_t* 
     TestGetConsoleTitleWFillHelper(wchReadExpected, cchReadExpected, L'Z');
 
     // Prep expected data
-    size_t const cchCopy = min(cchTitle, cchTryToRead);
+    size_t const cchCopy = std::min(cchTitle, cchTryToRead);
     VERIFY_SUCCEEDED(StringCchCopyNW(wchReadExpected, cchReadBuffer, wchTitle, cchCopy - 1)); // Copy as much room as we said we had leaving space for null terminator
 }
 

--- a/src/host/ft_host/CJK_DbcsTests.cpp
+++ b/src/host/ft_host/CJK_DbcsTests.cpp
@@ -2321,7 +2321,7 @@ void ReadStringWithReadConsoleInputAHelper(HANDLE hIn, PCSTR pszExpectedText, si
     while (cchRead < cchExpectedText)
     {
         // expected read is either the size of the buffer or the number of characters remaining, whichever is smaller.
-        DWORD const dwReadExpected = (DWORD)min(cbBuffer, cchExpectedText - cchRead);
+        DWORD const dwReadExpected = (DWORD)std::min(cbBuffer, cchExpectedText - cchRead);
 
         DWORD dwRead;
         if (!VERIFY_WIN32_BOOL_SUCCEEDED(ReadConsoleInputA(hIn, irRead, (DWORD)cbBuffer, &dwRead), L"Attempt to read input into buffer."))

--- a/src/host/ft_host/precomp.h
+++ b/src/host/ft_host/precomp.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#define NOMINMAX
+
 #include "windows.h"
 #include "wincon.h"
 #include "windowsx.h"

--- a/src/propsheet/console.cpp
+++ b/src/propsheet/console.cpp
@@ -245,21 +245,21 @@ BOOL UpdateStateInfo(HWND hDlg, UINT Item, int Value)
     case IDD_WINDOW_POSX:
         if (Value < 0)
         {
-            gpStateInfo->WindowPosX = max(SHORT_MIN, Value);
+            gpStateInfo->WindowPosX = std::max(SHORT_MIN, Value);
         }
         else
         {
-            gpStateInfo->WindowPosX = min(SHORT_MAX, Value);
+            gpStateInfo->WindowPosX = std::min(SHORT_MAX, Value);
         }
         break;
     case IDD_WINDOW_POSY:
         if (Value < 0)
         {
-            gpStateInfo->WindowPosY = max(SHORT_MIN, Value);
+            gpStateInfo->WindowPosY = std::max(SHORT_MIN, Value);
         }
         else
         {
-            gpStateInfo->WindowPosY = min(SHORT_MAX, Value);
+            gpStateInfo->WindowPosY = std::min(SHORT_MAX, Value);
         }
         break;
     case IDD_AUTO_POSITION:
@@ -316,10 +316,10 @@ BOOL UpdateStateInfo(HWND hDlg, UINT Item, int Value)
         gpStateInfo->InsertMode = Value;
         break;
     case IDD_HISTORY_SIZE:
-        gpStateInfo->HistoryBufferSize = max(Value, 1);
+        gpStateInfo->HistoryBufferSize = std::max(Value, 1);
         break;
     case IDD_HISTORY_NUM:
-        gpStateInfo->NumberOfHistoryBuffers = max(Value, 1);
+        gpStateInfo->NumberOfHistoryBuffers = std::max(Value, 1);
         break;
     case IDD_HISTORY_NODUP:
         gpStateInfo->HistoryNoDup = Value;
@@ -646,7 +646,7 @@ INT_PTR ConsolePropertySheet(__in HWND hWnd, __in PCONSOLE_STATE_INFO pStateInfo
     psh.hInstance = ghInstance;
     psh.pszCaption = awchBuffer;
     psh.nPages = g_fForceV2 ? NUMBER_OF_PAGES : V1_NUMBER_OF_PAGES;
-    psh.nStartPage = min(gnCurrentPage, ARRAYSIZE(psp));
+    psh.nStartPage = std::min<UINT>(gnCurrentPage, ARRAYSIZE(psp));
     psh.ppsp = psp;
     psh.pfnCallback = NULL;
 

--- a/src/propsheet/fontdlg.cpp
+++ b/src/propsheet/fontdlg.cpp
@@ -91,7 +91,7 @@ UINT GetItemHeight(const HWND hDlg)
         SelectObject(hDC, hFont);
     }
     ReleaseDC(hDlg, hDC);
-    return max(tm.tmHeight, bmTT.bmHeight);
+    return std::max(tm.tmHeight, bmTT.bmHeight);
 }
 
 // The V1 console doesn't support arbitrary TTF fonts, so only allow the enumeration of all TT fonts in the conditions below:

--- a/src/propsheet/precomp.h
+++ b/src/propsheet/precomp.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#define NOMINMAX
+
 // -- WARNING -- LOAD BEARING CODE --
 // This define ABSOLUTELY MUST be included (and equal to 1, or more specifically != 0)
 // prior to the import of Common Controls.

--- a/src/propsheet/preview.cpp
+++ b/src/propsheet/preview.cpp
@@ -72,8 +72,8 @@ VOID
     MinSize.y = (GetSystemMetrics(SM_CYMIN) - NonClientSize.y) / lpFont->Size.Y;
     MaxSize.x = GetSystemMetrics(SM_CXFULLSCREEN) / lpFont->Size.X;
     MaxSize.y = GetSystemMetrics(SM_CYFULLSCREEN) / lpFont->Size.Y;
-    WindowSize.x = max(MinSize.x, min(MaxSize.x, gpStateInfo->WindowSize.X));
-    WindowSize.y = max(MinSize.y, min(MaxSize.y, gpStateInfo->WindowSize.Y));
+    WindowSize.x = std::max(MinSize.x, std::min<LONG>(MaxSize.x, gpStateInfo->WindowSize.X));
+    WindowSize.y = std::max(MinSize.y, std::min<LONG>(MaxSize.y, gpStateInfo->WindowSize.Y));
 
     /*
      * Get the window rectangle, making sure it's at least twice the


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

It's 2020 now. It's *about* time that we move on from 1990's macros.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #4152 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Remove global namespaced min/max and replace it with STL min/max.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Run it.