### PR TITLE
Correct the behaviour of the IS_GLYPH_CHAR macro

### DIFF
--- a/src/host/_stream.cpp
+++ b/src/host/_stream.cpp
@@ -27,7 +27,7 @@ using namespace Microsoft::Console::Types;
 using Microsoft::Console::Interactivity::ServiceLocator;
 using Microsoft::Console::VirtualTerminal::StateMachine;
 // Used by WriteCharsLegacy.
-#define IS_GLYPH_CHAR(wch) (((wch) < L' ') || ((wch) == 0x007F))
+#define IS_GLYPH_CHAR(wch) (((wch) >= L' ') && ((wch) != 0x007F))
 
 constexpr unsigned int LOCAL_BUFFER_SIZE = 100;
 
@@ -395,7 +395,7 @@ constexpr unsigned int LOCAL_BUFFER_SIZE = 100;
 #pragma prefast(suppress : 26019, "Buffer is taken in multiples of 2. Validation is ok.")
             const wchar_t Char = *lpString;
             const wchar_t RealUnicodeChar = *pwchRealUnicode;
-            if (!IS_GLYPH_CHAR(RealUnicodeChar) || fUnprocessed)
+            if (IS_GLYPH_CHAR(RealUnicodeChar) || fUnprocessed)
             {
                 if (IsGlyphFullWidth(Char))
                 {


### PR DESCRIPTION
## Summary of the Pull Request

This PR reverses the behaviour of the `IS_GLYPH_CHAR` macro, so it now actually returns true if the given char is a glyph, and false if it isn't. Previously it returned the opposite of that, which meant it had to be called as `!IS_GLYPH_CHAR` to get the correct result.

## PR Checklist
* [x] Closes #4185
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #4185

## Detailed Description of the Pull Request / Additional comments

The original implementation returned true if the given character was a C0 control, or a DEL:

    #define IS_GLYPH_CHAR(wch) (((wch) < L' ') || ((wch) == 0x007F))

It's now the exact opposite, so returns true for characters that are _not_ C0 controls, and are not the DEL character either: 

    #define IS_GLYPH_CHAR(wch) (((wch) >= L' ') && ((wch) != 0x007F))

The macro was only used in one place, where is was being called as `!IS_GLYPH_CHAR` when the intent was actually to test whether the char _was_ a glyph. That code could now be updated to remove the `!`, so it makes more sense.

## Validation Steps Performed

I've just tested manually and confirmed that basic output of text and control chars still worked as expected in a conhost shell.