### PR TITLE
Add find action to keybinding commands in Settings Profile Schema

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -67,7 +67,8 @@
         "switchToTab6",
         "switchToTab7",
         "switchToTab8",
-        "toggleFullscreen"
+        "toggleFullscreen",
+        "find"
       ],
       "type": "string"
     },


### PR DESCRIPTION
## Summary of the Pull Request
Add `find` as a `ShortcutActionName`, so that it is recognized as a command for keybindings in profiles.json settings.

## References
This seems to have been missed by #3590.

## PR Checklist
* [X] Closes #4218 
* [X] CLA signed
* [N/A] Tests added/passed
* [N/A] Requires documentation to be updated
* [N/A] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
See #4218 

## Validation Steps Performed
The command is recognized when using the updated schema:

![image](https://user-images.githubusercontent.com/9403740/72377075-b708df00-36d4-11ea-9fc2-07822f90606f.png)
