### PR TITLE
schema: add support for "auto" split value

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -84,7 +84,8 @@
     "SplitState": {
       "enum": [
         "vertical",
-        "horizontal"
+        "horizontal",
+        "auto"
       ],
       "type": "string"
     },
@@ -215,7 +216,7 @@
             "split": {
               "$ref": "#/definitions/SplitState",
               "default": "vertical",
-              "description": "The orientation to split the pane in, either vertical (think [|]) or horizontal (think [-])"
+              "description": "The orientation to split the pane in, either vertical (think [|]), horizontal (think [-]), or auto"
             }
           }
         }

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -215,8 +215,8 @@
             "action": { "type": "string", "pattern": "splitPane" },
             "split": {
               "$ref": "#/definitions/SplitState",
-              "default": "vertical",
-              "description": "The orientation to split the pane in, either vertical (think [|]), horizontal (think [-]), or auto"
+              "default": "auto",
+              "description": "The orientation to split the pane in, either vertical (think [|]), horizontal (think [-]), or auto (splits pane based on remaining space)"
             }
           }
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
`profiles.schema.json` did not have `auto` as a valid value for the `split` attribute. This PR adds the support and makes a minor update to the details associated with the `split` attribute.
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #4245
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [x] Requires documentation to be updated :: PR technically updates docs
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #4245

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Potentially the [`default`](https://github.com/microsoft/terminal/blob/master/doc/cascadia/profiles.schema.json#L217) value for `SplitPaneAction` should be set to `auto` as well. Let me know your thoughts.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Changed the `$schema` attribute in my local `profiles.json` to the updated `profiles.schema.json` and ensured that `auto` did not have a squiggly line like in #4245.