### PR TITLE
Replace `splitPane` with `splitHorizontal` and `splitVertical` in docs

### DIFF
--- a/doc/cascadia/SettingsSchema.md
+++ b/doc/cascadia/SettingsSchema.md
@@ -131,7 +131,8 @@ Commands listed below are per the implementation in [`src/cascadia/TerminalApp/A
 - switchToTab7
 - switchToTab8
 - openSettings
-- splitPane
+- splitHorizontal
+- splitHorizontal
 - resizePaneLeft
 - resizePaneRight
 - resizePaneUp


### PR DESCRIPTION
## Summary of the Pull Request
Replaces `splitPane` in Windows Terminal keybinding documentation with `splitHorizontal` and `splitVertical` because it looks like `splitPane` doesn't do anything when I was setting up my `profiles.json`

## References 
N/A

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
I found this when trying to find a list of valid keybind options and discovered `splitPane` didn't work as intended.