### PR TITLE
Fix the `UnitTests_TerminalCore`'s dependency on `RendererGdi`

### DIFF
--- a/OpenConsole.sln
+++ b/OpenConsole.sln
@@ -199,6 +199,9 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TerminalSettings", "src\cascadia\TerminalSettings\TerminalSettings.vcxproj", "{CA5CAD1A-D7EC-4107-B7C6-79CB77AE2907}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "UnitTests_TerminalCore", "src\cascadia\UnitTests_TerminalCore\UnitTests.vcxproj", "{2C2BEEF4-9333-4D05-B12A-1905CBF112F9}"
+	ProjectSection(ProjectDependencies) = postProject
+		{06EC74CB-9A12-429C-B551-8562EC954747} = {06EC74CB-9A12-429C-B551-8562EC954747}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Internal", "src\internal\internal.vcxproj", "{EF3E32A7-5FF6-42B4-B6E2-96CD7D033F00}"
 EndProject

--- a/src/cascadia/UnitTests_TerminalCore/UnitTests.vcxproj
+++ b/src/cascadia/UnitTests_TerminalCore/UnitTests.vcxproj
@@ -75,6 +75,9 @@
     <ProjectReference Include="..\..\internal\internal.vcxproj">
       <Project>{ef3e32a7-5ff6-42b4-b6e2-96cd7d033f00}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\..\renderer\gdi\lib\gdi.vcxproj">
+      <Project>{1c959542-bac2-4e55-9a6d-13251914cbb9}</Project>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MockTermSettings.h" />


### PR DESCRIPTION
## Summary of the Pull Request

In #4213 I added a dependency to the `UnitTests_TerminalCore` project on basically all of conhost. This _worked on my machine_, but it's consistently not working on other machines. This should fix those issues.

## References

## PR Checklist
* [x] Closes #4285 
* [x] I work here
* [n/a] Tests added/passed
* [n/a] Requires documentation to be updated

## Validation Steps Performed
Made a fresh clone and built it.
