### PR TITLE
Allow string values (like "system") in the `rowsToScroll` schema

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -291,7 +291,7 @@
           "description": "The number of rows to scroll at a time with the mouse wheel. This will override the system setting if the value is not zero or 'system'.",
           "maximum": 999,
           "minimum": 0,
-          "type": "integer"
+          "type": ["integer", "string"]
         },
         "keybindings": {
           "description": "Properties are specific to each custom key binding.",


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

In https://github.com/microsoft/terminal/pull/3575, Terminal added support for the `rowsToScroll` field – which accepts integers or `"system"`. However, the settings schema only allows integers:

https://github.com/microsoft/terminal/blob/e675de3a881dfc70bd018e2593ad6e3043d2d13c/doc/cascadia/profiles.schema.json#L289-L295

which means writing `rowsToScroll: "system"` produces the following warning:

![image](https://user-images.githubusercontent.com/2953267/72982139-78b7a200-3def-11ea-8ab8-5e25e324cc6f.png)

This PR fixes the issue.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

1. Opened settings and replaced the `$schema` field with the updated schema from my fork (https://raw.githubusercontent.com/iamakulov/terminal/b5d4c9337d3f323613dd5209bb68decb86cce667/doc/cascadia/profiles.schema.json).
2. Validated that the `"system"` value doesn’t produce the warning anymore
3. Validated that the value of `false` (i.e., a boolean – a type that’s not accepted) still produces a warning