### PR TITLE
Disables auto-injected codesign validation task on CI

### DIFF
--- a/build/pipelines/ci.yml
+++ b/build/pipelines/ci.yml
@@ -19,6 +19,10 @@ pr:
       - samples/*
       - tools/*
 
+variables:
+  - name: runCodesignValidationInjection
+    value: false
+
 #     0.0.yyMM.dd##
 #     0.0.1904.0900
 name: 0.0.$(Date:yyMM).$(Date:dd)$(Rev:rr)

--- a/build/pipelines/ci.yml
+++ b/build/pipelines/ci.yml
@@ -20,7 +20,7 @@ pr:
       - tools/*
 
 variables:
-  - name: runCodesignValidationInjection
+  - name: runCodesignValidationInjectionBG
     value: false
 
 #     0.0.yyMM.dd##


### PR DESCRIPTION
## Summary of the Pull Request
Sets flag in CI YML that will turn off the auto-injected codesign validation task since CI is a non-production pipeline.

## PR Checklist
* [x] Closes an annoyance that Dustin and I had.
* [x] I work here.
* [x] Well, it went away in the CI.
* [x] Documentation? Nah.
* [x] Am core contributor. Discussed it with another core contributor.