### PR TITLE
Configure CLI11 to stuff all unknown positionals into the cmdline

### DIFF
--- a/doc/user-docs/UsingCommandlineArguments.md
+++ b/doc/user-docs/UsingCommandlineArguments.md
@@ -128,29 +128,4 @@ This creates a new Windows Terminal window with one tab, and 3 panes:
   and will use `wsl.exe` as the commandline (instead of the default profile's
   `commandline`).
 
-### Running a specific linux distro in a specific distro
-
-Say you wanted to open a "Debian" WSL instance in `C:\Users`. According to the
-above reference, you might try:
-
-```
-wt -d c:\Users wsl -d Debian
-```
-
-Unfortunately, this _won't_ work, and will give you an error about "expected
-exactly 1 argument to `--startingDirectory`, got 2". This is because we'll
-erroneously try to parse the `-d Debian` parameter as a second
-`--startingDirectory` value. This is unexpected, and is a bug currently tracked
-in [#4277].
-
-As a workaround, you can try the following commandline:
-
-```
-wt -d c:\Users -- wsl -d Debian
-```
-
-In this commandline, the `--` will indicate to the Terminal that it should treat
-everything after that like a commandline.
-
 [#4023]: https://github.com/microsoft/terminal/pull/4023
-[#4277]: https://github.com/microsoft/terminal/issues/4277

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -292,9 +292,16 @@ void AppCommandlineArgs::_addNewTerminalArgs(AppCommandlineArgs::NewTerminalSubc
     subcommand.startingDirectoryOption = subcommand.subcommand->add_option("-d,--startingDirectory",
                                                                            _startingDirectory,
                                                                            NEEDS_LOC("Open in the given directory instead of the profile's set startingDirectory"));
-    subcommand.commandlineOption = subcommand.subcommand->add_option("cmdline",
-                                                                     _commandline,
-                                                                     NEEDS_LOC("Commandline to run in the given profile"));
+
+    // This construction (where we store command and arguments separately, with the "positionals_at_end" option turned on) allows us to
+    // support "wt new-tab -d wsl -d Ubuntu" without CLI11 thinking that we've specified -d twice.
+    // There's an alternate construction where we make all subcommands "prefix commands", which lets us get all remaining non-option args
+    // provided at the end, but that doesn't support "wt new-tab -- wsl -d Ubuntu -- sleep 10" because the first -- breaks out of the subcommand
+    // (instead of the subcommand options).
+    // See https://github.com/CLIUtils/CLI11/issues/417 for more info.
+    subcommand.commandlineOption = subcommand.subcommand->add_option("command", _command, NEEDS_LOC("An option command, with arguments, to be spawned in the new tab or pane"));
+    subcommand.subcommand->add_option("arguments", _commandArguments);
+    subcommand.subcommand->positionals_at_end(true);
 }
 
 // Method Description:
@@ -307,75 +314,33 @@ NewTerminalArgs AppCommandlineArgs::_getNewTerminalArgs(AppCommandlineArgs::NewT
 {
     auto args = winrt::make_self<implementation::NewTerminalArgs>();
 
-    // If a commandline was provided, we need to get a little tricky parsing
-    // here. The behavior we want is that once we see a string that we don't
-    // recognize, we want to treat the rest of the command as the commandline to
-    // pass to the NewTerminalArgs. However, if that commandline contains any
-    // options that _we_ understand, CLI11 will try to first grab those options
-    // from the provided string to parse our own args, and _not_ include them in
-    // the _commandline here. Consider for example, the following command:
-    //
-    //     wt.exe new-tab wsl.exe -d Alpine
-    //
-    // We want the commandline here to be "wsl.exe -d Alpine zsh". However, by
-    // default, that'll be parsed by CLI11 as a _startingDirectory of "Alpine",
-    // with a commandline of "wsl.exe zsh".
-    //
-    // So, instead, when we see that there's a commandlineOption that's been
-    // parsed, we'll use that as our cue to handle the commandline ourselves.
-    //  * We'll start by going through all the options that were parsed by
-    //    CLI11, and clearing all of the ones after the first commandline
-    //    option. This will prevent use from acting on their values later.
-    //  * Then, we'll grab all the strings starting with the first commandline
-    //    string, and add them to the commandline for the NewTerminalArgs.
-    if (*subcommand.commandlineOption)
+    if (_command.has_value())
     {
-        const std::vector<CLI::Option*>& opts = subcommand.subcommand->parse_order();
-        auto foundCommandlineStart = false;
-        for (auto opt : opts)
-        {
-            if (opt == subcommand.commandlineOption)
-            {
-                foundCommandlineStart = true;
-            }
-            else if (foundCommandlineStart)
-            {
-                opt->clear();
-            }
-            // otherwise, this option preceeded the start of the commandline
-        }
+        std::ostringstream cmdlineBuffer;
 
-        // Concatenate all the strings starting with the first arg in the
-        // _commandline as the _real_ commandline.
-        const auto& firstCmdlineArg = _commandline.at(0);
-        auto foundFirstArg = false;
-        std::string fullCommandlineBuffer;
-        for (const auto& arg : _currentCommandline->Args())
+        // It's easier to prepend the command to the arg list to get the same escaping behavior.
+        std::deque<std::string> argsAndCommand{ _commandArguments.cbegin(), _commandArguments.cend() };
+        argsAndCommand.emplace_front(_command.value());
+
+        for (const auto& arg : argsAndCommand)
         {
-            if (arg == firstCmdlineArg)
+            if (cmdlineBuffer.tellp() != 0)
             {
-                foundFirstArg = true;
+                // If there's already something in here, prepend a space
+                cmdlineBuffer << ' ';
             }
-            if (foundFirstArg)
+
+            if (arg.find(" ") != std::string::npos)
             {
-                if (arg.find(" ") != std::string::npos)
-                {
-                    fullCommandlineBuffer += "\"";
-                    fullCommandlineBuffer += arg;
-                    fullCommandlineBuffer += "\"";
-                }
-                else
-                {
-                    fullCommandlineBuffer += arg;
-                }
-                fullCommandlineBuffer += " ";
+                cmdlineBuffer << '"' << arg << '"';
+            }
+            else
+            {
+                cmdlineBuffer << arg;
             }
         }
 
-        // Discard the space from the last arg we appended.
-        std::string_view realCommandline = fullCommandlineBuffer;
-        realCommandline = realCommandline.substr(0, static_cast<size_t>(fullCommandlineBuffer.size() - 1));
-        args->Commandline(winrt::to_hstring(realCommandline));
+        args->Commandline(winrt::to_hstring(cmdlineBuffer.str()));
     }
 
     if (*subcommand.profileNameOption)
@@ -418,7 +383,8 @@ void AppCommandlineArgs::_resetStateToDefault()
 {
     _profileName.clear();
     _startingDirectory.clear();
-    _commandline.clear();
+    _command.reset();
+    _commandArguments.clear();
 
     _splitVertical = false;
     _splitHorizontal = false;

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -293,11 +293,13 @@ void AppCommandlineArgs::_addNewTerminalArgs(AppCommandlineArgs::NewTerminalSubc
                                                                            _startingDirectory,
                                                                            NEEDS_LOC("Open in the given directory instead of the profile's set startingDirectory"));
 
-    // This construction (where we store command and arguments separately, with the "positionals_at_end" option turned on) allows us to
-    // support "wt new-tab -d wsl -d Ubuntu" without CLI11 thinking that we've specified -d twice.
-    // There's an alternate construction where we make all subcommands "prefix commands", which lets us get all remaining non-option args
-    // provided at the end, but that doesn't support "wt new-tab -- wsl -d Ubuntu -- sleep 10" because the first -- breaks out of the subcommand
-    // (instead of the subcommand options).
+    // This construction (where we store command and arguments separately, with the
+    // "positionals_at_end" option turned on) allows us to support "wt new-tab -d wsl -d Ubuntu"
+    // without CLI11 thinking that we've specified -d twice.
+    // There's an alternate construction where we make all subcommands "prefix commands",
+    // which lets us get all remaining non-option args provided at the end, but that
+    // doesn't support "wt new-tab -- wsl -d Ubuntu -- sleep 10" because the first
+    // -- breaks out of the subcommand (instead of the subcommand options).
     // See https://github.com/CLIUtils/CLI11/issues/417 for more info.
     subcommand.commandlineOption = subcommand.subcommand->add_option("command", _command, NEEDS_LOC("An option command, with arguments, to be spawned in the new tab or pane"));
     subcommand.subcommand->add_option("arguments", _commandArguments);

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.h
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.h
@@ -64,8 +64,10 @@ private:
     std::string _profileName;
     std::string _startingDirectory;
 
-    // _commandline will receive the commandline as it's parsed by CLI11
-    std::vector<std::string> _commandline;
+    // _command and _commandArguments will contain the first and subsequent parts of the command line with which we'll be spawning a new terminal
+    std::optional<std::string> _command;
+    std::vector<std::string> _commandArguments;
+
     const Commandline* _currentCommandline{ nullptr };
 
     bool _splitVertical{ false };

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.h
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.h
@@ -64,9 +64,8 @@ private:
     std::string _profileName;
     std::string _startingDirectory;
 
-    // _command and _commandArguments will contain the first and subsequent parts of the command line with which we'll be spawning a new terminal
-    std::optional<std::string> _command;
-    std::vector<std::string> _commandArguments;
+    // _commandline will contain the command line with which we'll be spawning a new terminal
+    std::vector<std::string> _commandline;
 
     const Commandline* _currentCommandline{ nullptr };
 


### PR DESCRIPTION
This commit fixes an issue where "wt -d C: wsl -d Alpine" would be
parsed as "wt -d C: -d Alpine wsl" and rejected as invalid due to the
repeated -d. It also fixes support for the option parsing terminator,
--, in all command lines.

Fixes #4277.

## References

https://github.com/CLIUtils/CLI11/issues/417

## PR Checklist
* [x] Closes #4277
* [x] cla
* [x] Tests added/passed
* [x] docs fixed
* [x] The core one cometh

## Validation Steps

Tests, manual wailing.