### PR TITLE
Round and style buttons on close all tabs dialog

### DIFF
--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -30,21 +30,6 @@ the MIT License. See LICENSE in the project root for license information. -->
                         <Setter Property="Background" Value="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
                     </Style>
 
-                    <!-- Manually theme the CloseButton of a ContentDialog. We
-                    need to do this, because for whatever reason, if we show a
-                    ContentDialog when the app theme is opposite the system
-                    theme, the buttons will appear transparent. This only
-                    applies to the Close button of the dialog, since we're only
-                    using the Close button of the dialog. If we ever add other
-                    dialogs with more buttons, we'll probably want to make sure
-                    the buttons are styled differently. -->
-                    <Style TargetType="ContentDialog">
-                        <!-- the value `AccentButtonStyle` is taken straight
-                        from the ContentDialog source -->
-                        <Setter Target="CloseButtonStyle" Value="{StaticResource AccentButtonStyle}" />
-                        <Setter Target="PrimaryButtonStyle" Value="{StaticResource ButtonRevealStyle}" />
-                    </Style>
-
                     <!-- We need to manually create the error text brush as a
                     theme-dependent brush. SystemControlErrorTextForegroundBrush
                     is unfortunately static. -->

--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -42,6 +42,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                         <!-- the value `AccentButtonStyle` is taken straight
                         from the ContentDialog source -->
                         <Setter Target="CloseButtonStyle" Value="{StaticResource AccentButtonStyle}" />
+                        <Setter Target="PrimaryButtonStyle" Value="{StaticResource ButtonRevealStyle}" />
                     </Style>
 
                     <!-- We need to manually create the error text brush as a

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -279,6 +279,7 @@ namespace winrt::TerminalApp::implementation
         dialog.Title(winrt::box_value(title));
         dialog.Content(winrt::box_value(warningsTextBlock));
         dialog.CloseButtonText(buttonText);
+        dialog.DefaultButton(Controls::ContentDialogButton::Close);
 
         _ShowDialog(nullptr, dialog);
     }
@@ -315,6 +316,7 @@ namespace winrt::TerminalApp::implementation
         dialog.Title(winrt::box_value(title));
         dialog.Content(winrt::box_value(warningsTextBlock));
         dialog.CloseButtonText(buttonText);
+        dialog.DefaultButton(Controls::ContentDialogButton::Close);
 
         _ShowDialog(nullptr, dialog);
     }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -284,15 +284,15 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_ShowCloseWarningDialog()
     {
         auto title = RS_(L"CloseWindowWarningTitle");
-        auto primaryButtonText = RS_(L"CloseAll");
-        auto secondaryButtonText = RS_(L"Cancel");
+        auto closeButtonText = RS_(L"CloseAll");
+        auto primaryButtonText = RS_(L"Cancel");
 
         WUX::Controls::ContentDialog dialog;
         dialog.Title(winrt::box_value(title));
 
+        dialog.CloseButtonText(closeButtonText);
         dialog.PrimaryButtonText(primaryButtonText);
-        dialog.SecondaryButtonText(secondaryButtonText);
-        auto token = dialog.PrimaryButtonClick({ this, &TerminalPage::_CloseWarningPrimaryButtonOnClick });
+        auto token = dialog.CloseButtonClick({ this, &TerminalPage::_CloseWarningPrimaryButtonOnClick });
 
         _showDialogHandlers(*this, dialog);
     }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -286,16 +286,16 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_ShowCloseWarningDialog()
     {
         auto title = RS_(L"CloseWindowWarningTitle");
-        auto closeButtonText = RS_(L"CloseAll");
-        auto primaryButtonText = RS_(L"Cancel");
+        auto primaryButtonText = RS_(L"CloseAll");
+        auto closeButtonText = RS_(L"Cancel");
 
         WUX::Controls::ContentDialog dialog;
         dialog.Title(winrt::box_value(title));
 
         dialog.CloseButtonText(closeButtonText);
         dialog.PrimaryButtonText(primaryButtonText);
-        dialog.DefaultButton(WUX::Controls::ContentDialogButton::Close);
-        auto token = dialog.CloseButtonClick({ this, &TerminalPage::_CloseWarningPrimaryButtonOnClick });
+        dialog.DefaultButton(WUX::Controls::ContentDialogButton::Primary);
+        auto token = dialog.PrimaryButtonClick({ this, &TerminalPage::_CloseWarningPrimaryButtonOnClick });
 
         _showDialogHandlers(*this, dialog);
     }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -196,6 +196,7 @@ namespace winrt::TerminalApp::implementation
         dialog.Title(winrt::box_value(title));
         dialog.Content(winrt::box_value(message));
         dialog.CloseButtonText(buttonText);
+        dialog.DefaultButton(WUX::Controls::ContentDialogButton::Close);
 
         _showDialogHandlers(*this, dialog);
     }
@@ -270,6 +271,7 @@ namespace winrt::TerminalApp::implementation
         dialog.Title(winrt::box_value(title));
         dialog.Content(aboutTextBlock);
         dialog.CloseButtonText(buttonText);
+        dialog.DefaultButton(WUX::Controls::ContentDialogButton::Close);
 
         _showDialogHandlers(*this, dialog);
     }
@@ -292,6 +294,7 @@ namespace winrt::TerminalApp::implementation
 
         dialog.CloseButtonText(closeButtonText);
         dialog.PrimaryButtonText(primaryButtonText);
+        dialog.DefaultButton(WUX::Controls::ContentDialogButton::Close);
         auto token = dialog.CloseButtonClick({ this, &TerminalPage::_CloseWarningPrimaryButtonOnClick });
 
         _showDialogHandlers(*this, dialog);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Added styling to the buttons on the Close All Tabs dialog box.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #4307
* [x] Closes #3379  
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
![image](https://user-images.githubusercontent.com/48369326/73399080-7ba50d80-429b-11ea-8392-a43d4f52c0af.png)


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
