### PR TITLE
Kill NEEDS_LOC and move cmdline descriptions into resources

### DIFF
--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -164,7 +164,7 @@ void AppCommandlineArgs::_buildParser()
 // - <none>
 void AppCommandlineArgs::_buildNewTabParser()
 {
-    _newTabCommand.subcommand = _app.add_subcommand("new-tab", winrt::to_string(RS_(L"CmdNewTabDesc")));
+    _newTabCommand.subcommand = _app.add_subcommand("new-tab", RS_A(L"CmdNewTabDesc"));
     _addNewTerminalArgs(_newTabCommand);
 
     // When ParseCommand is called, if this subcommand was provided, this
@@ -192,14 +192,14 @@ void AppCommandlineArgs::_buildNewTabParser()
 // - <none>
 void AppCommandlineArgs::_buildSplitPaneParser()
 {
-    _newPaneCommand.subcommand = _app.add_subcommand("split-pane", winrt::to_string(RS_(L"CmdSplitPaneDesc")));
+    _newPaneCommand.subcommand = _app.add_subcommand("split-pane", RS_A(L"CmdSplitPaneDesc"));
     _addNewTerminalArgs(_newPaneCommand);
     _horizontalOption = _newPaneCommand.subcommand->add_flag("-H,--horizontal",
                                                              _splitHorizontal,
-                                                             winrt::to_string(RS_(L"CmdSplitPaneHorizontalArgDesc")));
+                                                             RS_A(L"CmdSplitPaneHorizontalArgDesc"));
     _verticalOption = _newPaneCommand.subcommand->add_flag("-V,--vertical",
                                                            _splitVertical,
-                                                           winrt::to_string(RS_(L"CmdSplitPaneVerticalArgDesc")));
+                                                           RS_A(L"CmdSplitPaneVerticalArgDesc"));
     _verticalOption->excludes(_horizontalOption);
 
     // When ParseCommand is called, if this subcommand was provided, this
@@ -242,14 +242,14 @@ void AppCommandlineArgs::_buildSplitPaneParser()
 // - <none>
 void AppCommandlineArgs::_buildFocusTabParser()
 {
-    _focusTabCommand = _app.add_subcommand("focus-tab", winrt::to_string(RS_(L"CmdFocusTabDesc")));
-    auto* indexOpt = _focusTabCommand->add_option("-t,--target", _focusTabIndex, winrt::to_string(RS_(L"CmdFocusTabTargetArgDesc")));
+    _focusTabCommand = _app.add_subcommand("focus-tab", RS_A(L"CmdFocusTabDesc"));
+    auto* indexOpt = _focusTabCommand->add_option("-t,--target", _focusTabIndex, RS_A(L"CmdFocusTabTargetArgDesc"));
     auto* nextOpt = _focusTabCommand->add_flag("-n,--next",
                                                _focusNextTab,
-                                               winrt::to_string(RS_(L"CmdFocusTabNextArgDesc")));
+                                               RS_A(L"CmdFocusTabNextArgDesc"));
     auto* prevOpt = _focusTabCommand->add_flag("-p,--previous",
                                                _focusPrevTab,
-                                               winrt::to_string(RS_(L"CmdFocusTabPrevArgDesc")));
+                                               RS_A(L"CmdFocusTabPrevArgDesc"));
     nextOpt->excludes(prevOpt);
     indexOpt->excludes(prevOpt);
     indexOpt->excludes(nextOpt);
@@ -289,10 +289,10 @@ void AppCommandlineArgs::_addNewTerminalArgs(AppCommandlineArgs::NewTerminalSubc
 {
     subcommand.profileNameOption = subcommand.subcommand->add_option("-p,--profile",
                                                                      _profileName,
-                                                                     winrt::to_string(RS_(L"CmdProfileArgDesc")));
+                                                                     RS_A(L"CmdProfileArgDesc"));
     subcommand.startingDirectoryOption = subcommand.subcommand->add_option("-d,--startingDirectory",
                                                                            _startingDirectory,
-                                                                           winrt::to_string(RS_(L"CmdStartingDirArgDesc")));
+                                                                           RS_A(L"CmdStartingDirArgDesc"));
 
     // Using positionals_at_end allows us to support "wt new-tab -d wsl -d Ubuntu"
     // without CLI11 thinking that we've specified -d twice.
@@ -301,7 +301,7 @@ void AppCommandlineArgs::_addNewTerminalArgs(AppCommandlineArgs::NewTerminalSubc
     // doesn't support "wt new-tab -- wsl -d Ubuntu -- sleep 10" because the first
     // -- breaks out of the subcommand (instead of the subcommand options).
     // See https://github.com/CLIUtils/CLI11/issues/417 for more info.
-    subcommand.commandlineOption = subcommand.subcommand->add_option("command", _commandline, winrt::to_string(RS_(L"CmdCommandArgDesc")));
+    subcommand.commandlineOption = subcommand.subcommand->add_option("command", _commandline, RS_A(L"CmdCommandArgDesc"));
     subcommand.subcommand->positionals_at_end(true);
 }
 

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -4,6 +4,7 @@
 #include "pch.h"
 #include "AppCommandlineArgs.h"
 #include "ActionArgs.h"
+#include <LibraryResources.h>
 
 using namespace winrt::TerminalApp;
 using namespace TerminalApp;
@@ -163,7 +164,7 @@ void AppCommandlineArgs::_buildParser()
 // - <none>
 void AppCommandlineArgs::_buildNewTabParser()
 {
-    _newTabCommand.subcommand = _app.add_subcommand("new-tab", NEEDS_LOC("Create a new tab"));
+    _newTabCommand.subcommand = _app.add_subcommand("new-tab", winrt::to_string(RS_(L"CmdNewTabDesc")));
     _addNewTerminalArgs(_newTabCommand);
 
     // When ParseCommand is called, if this subcommand was provided, this
@@ -191,14 +192,14 @@ void AppCommandlineArgs::_buildNewTabParser()
 // - <none>
 void AppCommandlineArgs::_buildSplitPaneParser()
 {
-    _newPaneCommand.subcommand = _app.add_subcommand("split-pane", NEEDS_LOC("Create a new pane"));
+    _newPaneCommand.subcommand = _app.add_subcommand("split-pane", winrt::to_string(RS_(L"CmdSplitPaneDesc")));
     _addNewTerminalArgs(_newPaneCommand);
     _horizontalOption = _newPaneCommand.subcommand->add_flag("-H,--horizontal",
                                                              _splitHorizontal,
-                                                             NEEDS_LOC("Create the new pane as a horizontal split (think [-])"));
+                                                             winrt::to_string(RS_(L"CmdSplitPaneHorizontalArgDesc")));
     _verticalOption = _newPaneCommand.subcommand->add_flag("-V,--vertical",
                                                            _splitVertical,
-                                                           NEEDS_LOC("Create the new pane as a vertical split (think [|])"));
+                                                           winrt::to_string(RS_(L"CmdSplitPaneVerticalArgDesc")));
     _verticalOption->excludes(_horizontalOption);
 
     // When ParseCommand is called, if this subcommand was provided, this
@@ -241,14 +242,14 @@ void AppCommandlineArgs::_buildSplitPaneParser()
 // - <none>
 void AppCommandlineArgs::_buildFocusTabParser()
 {
-    _focusTabCommand = _app.add_subcommand("focus-tab", NEEDS_LOC("Move focus to another tab"));
-    auto* indexOpt = _focusTabCommand->add_option("-t,--target", _focusTabIndex, NEEDS_LOC("Move focus the tab at the given index"));
+    _focusTabCommand = _app.add_subcommand("focus-tab", winrt::to_string(RS_(L"CmdFocusTabDesc")));
+    auto* indexOpt = _focusTabCommand->add_option("-t,--target", _focusTabIndex, winrt::to_string(RS_(L"CmdFocusTabTargetArgDesc")));
     auto* nextOpt = _focusTabCommand->add_flag("-n,--next",
                                                _focusNextTab,
-                                               NEEDS_LOC("Move focus to the next tab"));
+                                               winrt::to_string(RS_(L"CmdFocusTabNextArgDesc")));
     auto* prevOpt = _focusTabCommand->add_flag("-p,--previous",
                                                _focusPrevTab,
-                                               NEEDS_LOC("Move focus to the previous tab"));
+                                               winrt::to_string(RS_(L"CmdFocusTabPrevArgDesc")));
     nextOpt->excludes(prevOpt);
     indexOpt->excludes(prevOpt);
     indexOpt->excludes(nextOpt);
@@ -288,10 +289,10 @@ void AppCommandlineArgs::_addNewTerminalArgs(AppCommandlineArgs::NewTerminalSubc
 {
     subcommand.profileNameOption = subcommand.subcommand->add_option("-p,--profile",
                                                                      _profileName,
-                                                                     NEEDS_LOC("Open with the given profile. Accepts either the name or guid of a profile"));
+                                                                     winrt::to_string(RS_(L"CmdProfileArgDesc")));
     subcommand.startingDirectoryOption = subcommand.subcommand->add_option("-d,--startingDirectory",
                                                                            _startingDirectory,
-                                                                           NEEDS_LOC("Open in the given directory instead of the profile's set startingDirectory"));
+                                                                           winrt::to_string(RS_(L"CmdStartingDirArgDesc")));
 
     // Using positionals_at_end allows us to support "wt new-tab -d wsl -d Ubuntu"
     // without CLI11 thinking that we've specified -d twice.
@@ -300,7 +301,7 @@ void AppCommandlineArgs::_addNewTerminalArgs(AppCommandlineArgs::NewTerminalSubc
     // doesn't support "wt new-tab -- wsl -d Ubuntu -- sleep 10" because the first
     // -- breaks out of the subcommand (instead of the subcommand options).
     // See https://github.com/CLIUtils/CLI11/issues/417 for more info.
-    subcommand.commandlineOption = subcommand.subcommand->add_option("command", _commandline, NEEDS_LOC("An optional command, with arguments, to be spawned in the new tab or pane"));
+    subcommand.commandlineOption = subcommand.subcommand->add_option("command", _commandline, winrt::to_string(RS_(L"CmdCommandArgDesc")));
     subcommand.subcommand->positionals_at_end(true);
 }
 

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -223,4 +223,37 @@ Temporarily using the Windows Terminal default settings.
   <data name="InvalidIcon" xml:space="preserve">
     <value>Found a profile with an invalid "icon". Defaulting that profile to have no icon. Make sure that when setting an "icon", the value is a valid file path to an image.</value>
   </data>
+  <data name="CmdCommandArgDesc" xml:space="preserve">
+    <value>An optional command, with arguments, to be spawned in the new tab or pane</value>
+  </data>
+  <data name="CmdFocusTabDesc" xml:space="preserve">
+    <value>Move focus to another tab</value>
+  </data>
+  <data name="CmdFocusTabNextArgDesc" xml:space="preserve">
+    <value>Move focus to the next tab</value>
+  </data>
+  <data name="CmdFocusTabPrevArgDesc" xml:space="preserve">
+    <value>Move focus to the previous tab</value>
+  </data>
+  <data name="CmdFocusTabTargetArgDesc" xml:space="preserve">
+    <value>Move focus the tab at the given index</value>
+  </data>
+  <data name="CmdNewTabDesc" xml:space="preserve">
+    <value>Create a new tab</value>
+  </data>
+  <data name="CmdProfileArgDesc" xml:space="preserve">
+    <value>Open with the given profile. Accepts either the name or guid of a profile</value>
+  </data>
+  <data name="CmdSplitPaneDesc" xml:space="preserve">
+    <value>Create a new split pane</value>
+  </data>
+  <data name="CmdSplitPaneHorizontalArgDesc" xml:space="preserve">
+    <value>Create the new pane as a horizontal split (think [-])</value>
+  </data>
+  <data name="CmdSplitPaneVerticalArgDesc" xml:space="preserve">
+    <value>Create the new pane as a vertical split (think [|])</value>
+  </data>
+  <data name="CmdStartingDirArgDesc" xml:space="preserve">
+    <value>Open in the given directory instead of the profile's set startingDirectory</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/lib/pch.h
+++ b/src/cascadia/TerminalApp/lib/pch.h
@@ -62,9 +62,3 @@ TRACELOGGING_DECLARE_PROVIDER(g_hTerminalAppProvider);
 #include <winrt/Microsoft.Terminal.TerminalConnection.h>
 
 #include <CLI11/CLI11.hpp>
-
-// TODO:GH#4155 - This macro can be used to identify strings that need to
-// be localized in the future, but aren't localized currently due to some build
-// system restrictions, mainly due to breaking our unittests. All of these
-// strings should eventually be moved to Resources.resw.
-#define NEEDS_LOC(x) (x)

--- a/src/cascadia/WinRTUtils/inc/LibraryResources.h
+++ b/src/cascadia/WinRTUtils/inc/LibraryResources.h
@@ -59,6 +59,9 @@ namespace Microsoft::Console::Utils
 
 #endif
 
+// For things that need UTF-8 strings
+#define RS_A(x) (winrt::to_string(RS_(x)))
+
 // Array-to-pointer decay might technically be avoidable, but this is elegant and clean.
 #define UTILS_DEFINE_LIBRARY_RESOURCE_SCOPE(x) \
     __pragma(warning(suppress : 26485));       \


### PR DESCRIPTION
Fixes #4155.

## Validation steps

```
Summary: Total=23, Passed=22, Failed=1, Blocked=0, Not Run=0, Skipped=0
```

The failing test is the same one as before. It is not germane to this pull request.
