### PR TITLE
Fix the search box in High Contrast by using the right theme resources

### DIFF
--- a/src/cascadia/TerminalControl/SearchBoxControl.xaml
+++ b/src/cascadia/TerminalControl/SearchBoxControl.xaml
@@ -19,7 +19,6 @@
                 <Setter Property="Width" Value="25" />
                 <Setter Property="Height" Value="25" />
                 <Setter Property="Background" Value="Transparent" />
-                <Setter Property="Foreground" Value="{ThemeResource ToggleButtonCustomForeground}"/>
                 <Setter Property="Padding" Value="1" />
                 <Setter Property="CornerRadius" Value="2"/>
             </Style>
@@ -39,7 +38,7 @@
                     </Style>
                     <!-- TextBox colors !-->
                     <SolidColorBrush x:Key="TextControlBackground" Color="#333333"/>
-                    <SolidColorBrush x:Key="TextBoxPlaceholderForeground" Color="#B5B5B5"/>
+                    <SolidColorBrush x:Key="TextBoxPlaceholderTextThemeBrush" Color="#B5B5B5"/>
                     <SolidColorBrush x:Key="TextControlForeground" Color="#B5B5B5"/>
                     <SolidColorBrush x:Key="TextControlBorderBrush" Color="#404040"/>
                     <SolidColorBrush x:Key="TextControlButtonForeground" Color="#B5B5B5"/>
@@ -56,7 +55,7 @@
                     <SolidColorBrush x:Key="TextControlButtonBackgroundPressed" Color="#FF4343"/>
                     
                     <!-- ToggleButton colors !-->
-                    <SolidColorBrush x:Key="ToggleButtonCustomForeground" Color="#B5B5B5"/>
+                    <SolidColorBrush x:Key="ToggleButtonForeground" Color="#B5B5B5"/>
 
                     <SolidColorBrush x:Key="ToggleButtonBackgroundPointerOver" Color="#404040"/>
                     <SolidColorBrush x:Key="ToggleButtonForegroundPointerOver" Color="#FFFFFF"/>
@@ -96,7 +95,7 @@
                     </Style>
                     <!-- TextBox colors !-->
                     <SolidColorBrush x:Key="TextControlBackground" Color="#CCCCCC"/>
-                    <SolidColorBrush x:Key="TextBoxPlaceholderForeground" Color="#636363"/>
+                    <SolidColorBrush x:Key="TextBoxPlaceholderTextThemeBrush" Color="#636363"/>
                     <SolidColorBrush x:Key="TextControlBorderBrush" Color="#636363"/>
                     <SolidColorBrush x:Key="TextControlButtonForeground" Color="#636363"/>
 
@@ -109,7 +108,7 @@
                     <SolidColorBrush x:Key="TextControlButtonForegroundPressed" Color="#FFFFFF"/>
                     <SolidColorBrush x:Key="TextControlButtonBackgroundPressed" Color="#FF4343"/>
                     <!-- ToggleButton colors !-->
-                    <SolidColorBrush x:Key="ToggleButtonCustomForeground" Color="#636363"/>
+                    <SolidColorBrush x:Key="ToggleButtonForeground" Color="#636363"/>
 
                     <SolidColorBrush x:Key="ToggleButtonBackgroundPointerOver" Color="#DADADA"/>
                     <SolidColorBrush x:Key="ToggleButtonForegroundPointerOver" Color="#000000"/>
@@ -155,7 +154,7 @@
 
     <StackPanel Orientation="Horizontal" Style="{ThemeResource SearchBoxBackground}" Padding="5" CornerRadius="0,0,2,2">
         <TextBox  x:Name="TextBox" x:Uid="TextBoxLocalizedText" AutomationProperties.Name="Search Text" CornerRadius="2" Width="160"
-                  PlaceholderForeground="{ThemeResource TextBoxPlaceholderForeground}"   FontSize="15" KeyDown = "TextBoxKeyDown"
+                  PlaceholderForeground="{ThemeResource TextBoxPlaceholderTextThemeBrush}"   FontSize="15" KeyDown = "TextBoxKeyDown"
                   Margin="5" HorizontalAlignment="Left" VerticalAlignment="Center">
         </TextBox>
 


### PR DESCRIPTION
We were overriding the button foreground and the placeholder foreground using our
own custom resource names. They didn't exist in HC.

Instead of making them exist in HC, I made us use and override the real resource
names. Those ones have HC colors defined by the platform!

Fixes #4393.