### PR TITLE
Add C-c, C-v as bindings to _new_ user's `profiles.json` by default

### DIFF
--- a/src/cascadia/TerminalApp/userDefaults.json
+++ b/src/cascadia/TerminalApp/userDefaults.json
@@ -29,5 +29,9 @@
 
     // Add any keybinding overrides to this array.
     // To unbind a default keybinding, set the command to "unbound"
-    "keybindings": []
+    "keybindings": [
+        { "command": "copy", "keys": [ "ctrl+c" ] },
+        { "command": "paste", "keys": [ "ctrl+v" ] },
+        { "command": "paste", "keys": [ "shift+insert" ] }
+    ]
 }


### PR DESCRIPTION
## Summary of the Pull Request

Adds <kbd>Ctrl+C</kbd> as a copy keybinding, as well as <kbd>Ctrl+V</kbd> and <kbd>Shift+Insert</kbd> for paste, to the `userDefaults.json` file. New users will get these keybindings by default in their `profiles.json` file. If they _don't_ want these keybindings, they can just delete them from the file. <kbd>Ctrl+Shift+C/V</kbd> are unmodified, and remain **default** keybindings that have to be `unbound`

<kbd>Shift+Insert</kbd> was also added at @DHowett-MSFT's request. <kbd>Enter</kbd> for copy is also an idea, considering we won't eat the keystroke unless there's a selection.
## PR Checklist
* [x] Closes nothing, this is just a shower thought
* [x] I work here
* [ ] Tests added/passed - I didn't even run them tbh
* [n/a] Requires documentation to be updated

## Validation Steps Performed

I cannot stress enough that I haven't even tried building this change. It's a json change, so _it should be fine<sup>TM</sup>_