### PR TITLE
schema: add default colors for foreground and background

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -381,7 +381,7 @@
         "background": {
           "$ref": "#/definitions/Color",
           "default": "#000000",
-          "description": "Sets the background color of the profile. Overrides background set in color scheme if colorscheme is set. Uses hex color format: \"#rrggbb\". Default \"#000000\" (black).",
+          "description": "Sets the background color of the profile. Overrides background set in color scheme if colorscheme is set. Uses hex color format: \"#rrggbb\". Default \"#0c0c0c\" (background color of Campbell).",
           "type": ["string", "null"]
         },
         "backgroundImage": {
@@ -573,7 +573,7 @@
         "foreground": {
           "$ref": "#/definitions/Color",
           "default": "#ffffff",
-          "description": "Sets the foreground color of the profile. Overrides foreground set in color scheme if colorscheme is set. Uses hex color format: \"#rrggbb\". Default \"#ffffff\" (white).",
+          "description": "Sets the foreground color of the profile. Overrides foreground set in color scheme if colorscheme is set. Uses hex color format: \"#rrggbb\". Default \"#cccccc\" (foreground color of Campbell).",
           "type": ["string", "null"]
         },
         "guid": {

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -381,7 +381,7 @@
         "background": {
           "$ref": "#/definitions/Color",
           "default": "#0c0c0c",
-          "description": "Sets the background color of the profile. Overrides background set in color scheme if colorscheme is set. Uses hex color format: \"#rrggbb\". Default \"#0c0c0c\" (background color of Campbell).",
+          "description": "Sets the background color of the profile. Overrides background set in color scheme if colorscheme is set. Uses hex color format: \"#rrggbb\".",
           "type": ["string", "null"]
         },
         "backgroundImage": {

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -573,7 +573,7 @@
         "foreground": {
           "$ref": "#/definitions/Color",
           "default": "#cccccc",
-          "description": "Sets the foreground color of the profile. Overrides foreground set in color scheme if colorscheme is set. Uses hex color format: \"#rrggbb\". Default \"#cccccc\" (foreground color of Campbell).",
+          "description": "Sets the foreground color of the profile. Overrides foreground set in color scheme if colorscheme is set. Uses hex color format: \"#rrggbb\".",
           "type": ["string", "null"]
         },
         "guid": {

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -380,6 +380,7 @@
         },
         "background": {
           "$ref": "#/definitions/Color",
+          "default": "#000000",
           "description": "Sets the background color of the profile. Overrides background set in color scheme if colorscheme is set. Uses hex color format: \"#rrggbb\". Default \"#000000\" (black).",
           "type": ["string", "null"]
         },
@@ -571,6 +572,7 @@
         },
         "foreground": {
           "$ref": "#/definitions/Color",
+          "default": "#ffffff",
           "description": "Sets the foreground color of the profile. Overrides foreground set in color scheme if colorscheme is set. Uses hex color format: \"#rrggbb\". Default \"#ffffff\" (white).",
           "type": ["string", "null"]
         },

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -380,7 +380,7 @@
         },
         "background": {
           "$ref": "#/definitions/Color",
-          "default": "#000000",
+          "default": "#0c0c0c",
           "description": "Sets the background color of the profile. Overrides background set in color scheme if colorscheme is set. Uses hex color format: \"#rrggbb\". Default \"#0c0c0c\" (background color of Campbell).",
           "type": ["string", "null"]
         },
@@ -572,7 +572,7 @@
         },
         "foreground": {
           "$ref": "#/definitions/Color",
-          "default": "#ffffff",
+          "default": "#cccccc",
           "description": "Sets the foreground color of the profile. Overrides foreground set in color scheme if colorscheme is set. Uses hex color format: \"#rrggbb\". Default \"#cccccc\" (foreground color of Campbell).",
           "type": ["string", "null"]
         },


### PR DESCRIPTION
Added `#000000` as default for `background` and `#FFFFFF` as default for `foreground` in JSON schema.

## PR Checklist
* [x] Closes #3466