### PR TITLE
Add UIA Provider Support for Block Selection

### DIFF
--- a/src/cascadia/TerminalControl/TermControlUiaProvider.cpp
+++ b/src/cascadia/TerminalControl/TermControlUiaProvider.cpp
@@ -113,12 +113,13 @@ HRESULT TermControlUiaProvider::CreateTextRange(const Cursor& cursor,
 
 HRESULT TermControlUiaProvider::CreateTextRange(const COORD start,
                                                 const COORD end,
+                                                bool blockSelection,
                                                 const std::wstring_view wordDelimiters,
                                                 _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
-    return MakeAndInitialize<UiaTextRange>(ppUtr, _pData, this, start, end, wordDelimiters);
+    return MakeAndInitialize<UiaTextRange>(ppUtr, _pData, this, start, end, blockSelection, wordDelimiters);
 }
 
 HRESULT TermControlUiaProvider::CreateTextRange(const UiaPoint point,

--- a/src/cascadia/TerminalControl/TermControlUiaProvider.cpp
+++ b/src/cascadia/TerminalControl/TermControlUiaProvider.cpp
@@ -95,72 +95,37 @@ const winrt::Windows::UI::Xaml::Thickness TermControlUiaProvider::GetPadding() c
     return _termControl->GetPadding();
 }
 
-HRESULT TermControlUiaProvider::GetSelectionRange(_In_ IRawElementProviderSimple* pProvider, const std::wstring_view wordDelimiters, _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
+HRESULT TermControlUiaProvider::CreateTextRange(const std::wstring_view wordDelimiters, _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
-    UiaTextRange* result = nullptr;
-    if (_pData->IsSelectionActive())
-    {
-        const auto start = _pData->GetSelectionAnchor();
-
-        // we need to make end exclusive
-        auto end = _pData->GetEndSelectionPosition();
-        _pData->GetTextBuffer().GetSize().IncrementInBounds(end, true);
-
-        // TODO GH #4509: Box Selection is misrepresented here as a line selection.
-        RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, start, end, wordDelimiters));
-    }
-    *ppUtr = result;
-    return S_OK;
+    return MakeAndInitialize<UiaTextRange>(ppUtr, _pData, this, wordDelimiters);
 }
 
-HRESULT TermControlUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, const std::wstring_view wordDelimiters, _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
-{
-    RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
-    *ppUtr = nullptr;
-    UiaTextRange* result = nullptr;
-    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, wordDelimiters));
-    *ppUtr = result;
-    return S_OK;
-}
-
-HRESULT TermControlUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
-                                                const Cursor& cursor,
+HRESULT TermControlUiaProvider::CreateTextRange(const Cursor& cursor,
                                                 const std::wstring_view wordDelimiters,
                                                 _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
-    UiaTextRange* result = nullptr;
-    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, cursor, wordDelimiters));
-    *ppUtr = result;
-    return S_OK;
+    return MakeAndInitialize<UiaTextRange>(ppUtr, _pData, this, cursor, wordDelimiters);
 }
 
-HRESULT TermControlUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
-                                                const COORD start,
+HRESULT TermControlUiaProvider::CreateTextRange(const COORD start,
                                                 const COORD end,
                                                 const std::wstring_view wordDelimiters,
                                                 _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
-    UiaTextRange* result = nullptr;
-    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, start, end, wordDelimiters));
-    *ppUtr = result;
-    return S_OK;
+    return MakeAndInitialize<UiaTextRange>(ppUtr, _pData, this, start, end, wordDelimiters);
 }
 
-HRESULT TermControlUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
-                                                const UiaPoint point,
+HRESULT TermControlUiaProvider::CreateTextRange(const UiaPoint point,
                                                 const std::wstring_view wordDelimiters,
                                                 _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
-    UiaTextRange* result = nullptr;
-    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, point, wordDelimiters));
-    *ppUtr = result;
-    return S_OK;
+    return MakeAndInitialize<UiaTextRange>(ppUtr, _pData, this, point, wordDelimiters);
 }

--- a/src/cascadia/TerminalControl/TermControlUiaProvider.cpp
+++ b/src/cascadia/TerminalControl/TermControlUiaProvider.cpp
@@ -99,7 +99,10 @@ HRESULT TermControlUiaProvider::CreateTextRange(const std::wstring_view wordDeli
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
-    return MakeAndInitialize<UiaTextRange>(ppUtr, _pData, this, wordDelimiters);
+    UiaTextRange* result = nullptr;
+    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, this, wordDelimiters));
+    *ppUtr = result;
+    return S_OK;
 }
 
 HRESULT TermControlUiaProvider::CreateTextRange(const Cursor& cursor,
@@ -108,7 +111,10 @@ HRESULT TermControlUiaProvider::CreateTextRange(const Cursor& cursor,
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
-    return MakeAndInitialize<UiaTextRange>(ppUtr, _pData, this, cursor, wordDelimiters);
+    UiaTextRange* result = nullptr;
+    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, this, cursor, wordDelimiters));
+    *ppUtr = result;
+    return S_OK;
 }
 
 HRESULT TermControlUiaProvider::CreateTextRange(const COORD start,
@@ -119,7 +125,10 @@ HRESULT TermControlUiaProvider::CreateTextRange(const COORD start,
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
-    return MakeAndInitialize<UiaTextRange>(ppUtr, _pData, this, start, end, blockSelection, wordDelimiters);
+    UiaTextRange* result = nullptr;
+    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, this, start, end, blockSelection, wordDelimiters));
+    *ppUtr = result;
+    return S_OK;
 }
 
 HRESULT TermControlUiaProvider::CreateTextRange(const UiaPoint point,
@@ -128,5 +137,8 @@ HRESULT TermControlUiaProvider::CreateTextRange(const UiaPoint point,
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
-    return MakeAndInitialize<UiaTextRange>(ppUtr, _pData, this, point, wordDelimiters);
+    UiaTextRange* result = nullptr;
+    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, this, point, wordDelimiters));
+    *ppUtr = result;
+    return S_OK;
 }

--- a/src/cascadia/TerminalControl/TermControlUiaProvider.hpp
+++ b/src/cascadia/TerminalControl/TermControlUiaProvider.hpp
@@ -58,6 +58,7 @@ namespace Microsoft::Terminal
         // specific endpoint range
         HRESULT CreateTextRange(const COORD start,
                                 const COORD end,
+                                bool blockSelection,
                                 const std::wstring_view wordDelimiters,
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 

--- a/src/cascadia/TerminalControl/TermControlUiaProvider.hpp
+++ b/src/cascadia/TerminalControl/TermControlUiaProvider.hpp
@@ -47,27 +47,22 @@ namespace Microsoft::Terminal
         const winrt::Windows::UI::Xaml::Thickness GetPadding() const;
 
     protected:
-        HRESULT GetSelectionRange(_In_ IRawElementProviderSimple* pProvider, const std::wstring_view wordDelimiters, _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
-
         // degenerate range
-        HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, const std::wstring_view wordDelimiters, _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
+        HRESULT CreateTextRange(const std::wstring_view wordDelimiters, _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
         // degenerate range at cursor position
-        HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
-                                const Cursor& cursor,
+        HRESULT CreateTextRange(const Cursor& cursor,
                                 const std::wstring_view wordDelimiters,
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
         // specific endpoint range
-        HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
-                                const COORD start,
+        HRESULT CreateTextRange(const COORD start,
                                 const COORD end,
                                 const std::wstring_view wordDelimiters,
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
         // range from a UiaPoint
-        HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
-                                const UiaPoint point,
+        HRESULT CreateTextRange(const UiaPoint point,
                                 const std::wstring_view wordDelimiters,
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 

--- a/src/cascadia/TerminalControl/UiaTextRange.cpp
+++ b/src/cascadia/TerminalControl/UiaTextRange.cpp
@@ -27,9 +27,10 @@ HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
                                              _In_ IRawElementProviderSimple* const pProvider,
                                              const COORD start,
                                              const COORD end,
+                                             bool blockSelection,
                                              const std::wstring_view wordDelimiters)
 {
-    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, start, end, wordDelimiters);
+    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, start, end, blockSelection, wordDelimiters);
 }
 
 // returns a degenerate text range of the start of the row closest to the y value of point

--- a/src/cascadia/TerminalControl/UiaTextRange.hpp
+++ b/src/cascadia/TerminalControl/UiaTextRange.hpp
@@ -41,6 +41,7 @@ namespace Microsoft::Terminal
                                        _In_ IRawElementProviderSimple* const pProvider,
                                        const COORD start,
                                        const COORD end,
+                                       bool blockSelection,
                                        const std::wstring_view wordDelimiters = DefaultWordDelimiter);
 
         // range from a UiaPoint

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -139,6 +139,7 @@ public:
 #pragma region IUiaData
     std::vector<Microsoft::Console::Types::Viewport> GetSelectionRects() noexcept override;
     const bool IsSelectionActive() const noexcept override;
+    const bool IsLineSelection() const noexcept override;
     void ClearSelection() override;
     void SelectNewRegion(const COORD coordStart, const COORD coordEnd) override;
     const COORD GetSelectionAnchor() const noexcept override;

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -238,6 +238,15 @@ const bool Terminal::IsSelectionActive() const noexcept
 }
 
 // Method Description:
+// - Checks if selection is recorded line by line or as a block
+// Return Value:
+// - True if the selection is to be treated line by line. False if it is to be a block.
+const bool Terminal::IsLineSelection() const noexcept
+{
+    return !_boxSelection;
+}
+
+// Method Description:
 // - Checks if the CopyOnSelect setting is active
 // Return Value:
 // - true if feature is active, false otherwise.

--- a/src/host/renderData.cpp
+++ b/src/host/renderData.cpp
@@ -360,6 +360,17 @@ const bool RenderData::IsSelectionActive() const
 }
 
 // Routine Description:
+// - Determines whether we are performing a line selection right now
+// Arguments:
+// - <none>
+// Return Value:
+// - True if the selection is to be treated line by line. False if it is to be a block.
+const bool RenderData::IsLineSelection() const
+{
+    return Selection::Instance().IsLineSelection();
+}
+
+// Routine Description:
 // - If a selection exists, clears it and restores the state.
 //   Will also unblock a blocked write if one exists.
 // Arguments:

--- a/src/host/renderData.hpp
+++ b/src/host/renderData.hpp
@@ -58,6 +58,7 @@ public:
 
 #pragma region IUiaData
     const bool IsSelectionActive() const override;
+    const bool IsLineSelection() const override;
     void ClearSelection() override;
     void SelectNewRegion(const COORD coordStart, const COORD coordEnd) override;
     const COORD GetSelectionAnchor() const noexcept;

--- a/src/interactivity/win32/screenInfoUiaProvider.cpp
+++ b/src/interactivity/win32/screenInfoUiaProvider.cpp
@@ -101,7 +101,10 @@ HRESULT ScreenInfoUiaProvider::CreateTextRange(const std::wstring_view wordDelim
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
-    return MakeAndInitialize<UiaTextRange>(ppUtr, _pData, this, wordDelimiters);
+    UiaTextRange* result = nullptr;
+    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, this, wordDelimiters));
+    *ppUtr = result;
+    return S_OK;
 }
 
 HRESULT ScreenInfoUiaProvider::CreateTextRange(const Cursor& cursor,
@@ -110,7 +113,10 @@ HRESULT ScreenInfoUiaProvider::CreateTextRange(const Cursor& cursor,
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
-    return MakeAndInitialize<UiaTextRange>(ppUtr, _pData, this, cursor, wordDelimiters);
+    UiaTextRange* result = nullptr;
+    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, this, cursor, wordDelimiters));
+    *ppUtr = result;
+    return S_OK;
 }
 
 HRESULT ScreenInfoUiaProvider::CreateTextRange(const COORD start,
@@ -121,7 +127,10 @@ HRESULT ScreenInfoUiaProvider::CreateTextRange(const COORD start,
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
-    return MakeAndInitialize<UiaTextRange>(ppUtr, _pData, this, start, end, blockSelection, wordDelimiters));
+    UiaTextRange* result = nullptr;
+    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, this, start, end, blockSelection, wordDelimiters));
+    *ppUtr = result;
+    return S_OK;
 }
 
 HRESULT ScreenInfoUiaProvider::CreateTextRange(const UiaPoint point,
@@ -130,5 +139,8 @@ HRESULT ScreenInfoUiaProvider::CreateTextRange(const UiaPoint point,
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
-    return MakeAndInitialize<UiaTextRange>(ppUtr, _pData, this, point, wordDelimiters);
+    UiaTextRange* result = nullptr;
+    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, this, point, wordDelimiters));
+    *ppUtr = result;
+    return S_OK;
 }

--- a/src/interactivity/win32/screenInfoUiaProvider.cpp
+++ b/src/interactivity/win32/screenInfoUiaProvider.cpp
@@ -115,12 +115,13 @@ HRESULT ScreenInfoUiaProvider::CreateTextRange(const Cursor& cursor,
 
 HRESULT ScreenInfoUiaProvider::CreateTextRange(const COORD start,
                                                const COORD end,
+                                               bool blockSelection,
                                                const std::wstring_view wordDelimiters,
                                                _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
-    return MakeAndInitialize<UiaTextRange>(ppUtr, _pData, this, start, end, wordDelimiters));
+    return MakeAndInitialize<UiaTextRange>(ppUtr, _pData, this, start, end, blockSelection, wordDelimiters));
 }
 
 HRESULT ScreenInfoUiaProvider::CreateTextRange(const UiaPoint point,

--- a/src/interactivity/win32/screenInfoUiaProvider.cpp
+++ b/src/interactivity/win32/screenInfoUiaProvider.cpp
@@ -97,72 +97,37 @@ void ScreenInfoUiaProvider::ChangeViewport(const SMALL_RECT NewWindow)
     _pUiaParent->ChangeViewport(NewWindow);
 }
 
-HRESULT ScreenInfoUiaProvider::GetSelectionRange(_In_ IRawElementProviderSimple* pProvider, const std::wstring_view wordDelimiters, _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr)
+HRESULT ScreenInfoUiaProvider::CreateTextRange(const std::wstring_view wordDelimiters, _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
-    UiaTextRange* result = nullptr;
-    if (_pData->IsSelectionActive())
-    {
-        const auto start = _pData->GetSelectionAnchor();
-
-        // we need to make end exclusive
-        auto end = _pData->GetEndSelectionPosition();
-        _pData->GetTextBuffer().GetSize().IncrementInBounds(end, true);
-
-        // TODO GH #4509: Box Selection is misrepresented here as a line selection.
-        RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, start, end, wordDelimiters));
-    }
-    *ppUtr = result;
-    return S_OK;
+    return MakeAndInitialize<UiaTextRange>(ppUtr, _pData, this, wordDelimiters);
 }
 
-HRESULT ScreenInfoUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, const std::wstring_view wordDelimiters, _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
-{
-    RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
-    *ppUtr = nullptr;
-    UiaTextRange* result = nullptr;
-    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, wordDelimiters));
-    *ppUtr = result;
-    return S_OK;
-}
-
-HRESULT ScreenInfoUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
-                                               const Cursor& cursor,
+HRESULT ScreenInfoUiaProvider::CreateTextRange(const Cursor& cursor,
                                                const std::wstring_view wordDelimiters,
                                                _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
-    UiaTextRange* result = nullptr;
-    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, cursor, wordDelimiters));
-    *ppUtr = result;
-    return S_OK;
+    return MakeAndInitialize<UiaTextRange>(ppUtr, _pData, this, cursor, wordDelimiters);
 }
 
-HRESULT ScreenInfoUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
-                                               const COORD start,
+HRESULT ScreenInfoUiaProvider::CreateTextRange(const COORD start,
                                                const COORD end,
                                                const std::wstring_view wordDelimiters,
                                                _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
-    UiaTextRange* result = nullptr;
-    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, start, end, wordDelimiters));
-    *ppUtr = result;
-    return S_OK;
+    return MakeAndInitialize<UiaTextRange>(ppUtr, _pData, this, start, end, wordDelimiters));
 }
 
-HRESULT ScreenInfoUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
-                                               const UiaPoint point,
+HRESULT ScreenInfoUiaProvider::CreateTextRange(const UiaPoint point,
                                                const std::wstring_view wordDelimiters,
                                                _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
-    UiaTextRange* result = nullptr;
-    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, point, wordDelimiters));
-    *ppUtr = result;
-    return S_OK;
+    return MakeAndInitialize<UiaTextRange>(ppUtr, _pData, this, point, wordDelimiters);
 }

--- a/src/interactivity/win32/screenInfoUiaProvider.hpp
+++ b/src/interactivity/win32/screenInfoUiaProvider.hpp
@@ -55,6 +55,7 @@ namespace Microsoft::Console::Interactivity::Win32
         // specific endpoint range
         HRESULT CreateTextRange(const COORD start,
                                 const COORD end,
+                                bool blockSelection,
                                 const std::wstring_view wordDelimiters,
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 

--- a/src/interactivity/win32/screenInfoUiaProvider.hpp
+++ b/src/interactivity/win32/screenInfoUiaProvider.hpp
@@ -44,27 +44,22 @@ namespace Microsoft::Console::Interactivity::Win32
         void ChangeViewport(const SMALL_RECT NewWindow);
 
     protected:
-        HRESULT GetSelectionRange(_In_ IRawElementProviderSimple* pProvider, const std::wstring_view wordDelimiters, _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
-
         // degenerate range
-        HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, const std::wstring_view wordDelimiters, _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
+        HRESULT CreateTextRange(const std::wstring_view wordDelimiters, _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
         // degenerate range at cursor position
-        HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
-                                const Cursor& cursor,
+        HRESULT CreateTextRange(const Cursor& cursor,
                                 const std::wstring_view wordDelimiters,
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
         // specific endpoint range
-        HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
-                                const COORD start,
+        HRESULT CreateTextRange(const COORD start,
                                 const COORD end,
                                 const std::wstring_view wordDelimiters,
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
         // range from a UiaPoint
-        HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
-                                const UiaPoint point,
+        HRESULT CreateTextRange(const UiaPoint point,
                                 const std::wstring_view wordDelimiters,
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 

--- a/src/interactivity/win32/uiaTextRange.cpp
+++ b/src/interactivity/win32/uiaTextRange.cpp
@@ -34,7 +34,18 @@ HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
                                              const COORD end,
                                              const std::wstring_view wordDelimiters)
 {
-    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, start, end, wordDelimiters);
+    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, start, end, false, wordDelimiters);
+}
+
+// specific endpoint range (selection)
+HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
+                                             _In_ IRawElementProviderSimple* const pProvider,
+                                             const COORD start,
+                                             const COORD end,
+                                             bool blockSelection,
+                                             const std::wstring_view wordDelimiters)
+{
+    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, start, end, blockSelection, wordDelimiters);
 }
 
 // returns a degenerate text range of the start of the row closest to the y value of point

--- a/src/interactivity/win32/uiaTextRange.hpp
+++ b/src/interactivity/win32/uiaTextRange.hpp
@@ -44,6 +44,14 @@ namespace Microsoft::Console::Interactivity::Win32
                                        _In_ const COORD end,
                                        _In_ const std::wstring_view wordDelimiters = DefaultWordDelimiter);
 
+        // specific endpoint range (selection)
+        HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
+                                       _In_ IRawElementProviderSimple* const pProvider,
+                                       _In_ const COORD start,
+                                       _In_ const COORD end,
+                                       _In_ bool blockSelection,
+                                       _In_ const std::wstring_view wordDelimiters = DefaultWordDelimiter);
+
         // range from a UiaPoint
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,

--- a/src/types/IUiaData.h
+++ b/src/types/IUiaData.h
@@ -34,6 +34,7 @@ namespace Microsoft::Console::Types
 
     public:
         virtual const bool IsSelectionActive() const = 0;
+        virtual const bool IsLineSelection() const = 0;
         virtual void ClearSelection() = 0;
         virtual void SelectNewRegion(const COORD coordStart, const COORD coordEnd) = 0;
         virtual const COORD GetSelectionAnchor() const noexcept = 0;

--- a/src/types/ScreenInfoUiaProviderBase.cpp
+++ b/src/types/ScreenInfoUiaProviderBase.cpp
@@ -276,7 +276,8 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::GetSelection(_Outptr_result_maybenull_
         auto end = _pData->GetEndSelectionPosition();
         _pData->GetTextBuffer().GetSize().IncrementInBounds(end, true);
 
-        hr = CreateTextRange(start, end, _wordDelimiters, &range);
+        const bool blockSelection = !_pData->IsLineSelection();
+        hr = CreateTextRange(start, end, blockSelection, _wordDelimiters, &range);
     }
 
     if (FAILED(hr))
@@ -333,8 +334,7 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::GetVisibleRanges(_Outptr_result_mayben
 
         HRESULT hr = S_OK;
         WRL::ComPtr<UiaTextRangeBase> range;
-        hr = CreateTextRange(this,
-                             start,
+        hr = CreateTextRange(start,
                              end,
                              _wordDelimiters,
                              &range);
@@ -367,7 +367,7 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::RangeFromChild(_In_ IRawElementProvide
     *ppRetVal = nullptr;
 
     WRL::ComPtr<UiaTextRangeBase> utr;
-    RETURN_IF_FAILED(CreateTextRange(this, _wordDelimiters, &utr));
+    RETURN_IF_FAILED(CreateTextRange(_wordDelimiters, &utr));
     RETURN_IF_FAILED(utr.CopyTo(ppRetVal));
     return S_OK;
 }
@@ -382,8 +382,7 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::RangeFromPoint(_In_ UiaPoint point,
     *ppRetVal = nullptr;
 
     WRL::ComPtr<UiaTextRangeBase> utr;
-    RETURN_IF_FAILED(CreateTextRange(this,
-                                     point,
+    RETURN_IF_FAILED(CreateTextRange(point,
                                      _wordDelimiters,
                                      &utr));
     RETURN_IF_FAILED(utr.CopyTo(ppRetVal));
@@ -399,7 +398,7 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::get_DocumentRange(_COM_Outptr_result_m
     *ppRetVal = nullptr;
 
     WRL::ComPtr<UiaTextRangeBase> utr;
-    RETURN_IF_FAILED(CreateTextRange(this, _wordDelimiters, &utr));
+    RETURN_IF_FAILED(CreateTextRange(_wordDelimiters, &utr));
     RETURN_IF_FAILED(utr->ExpandToEnclosingUnit(TextUnit::TextUnit_Document));
     RETURN_IF_FAILED(utr.CopyTo(ppRetVal));
     return S_OK;

--- a/src/types/ScreenInfoUiaProviderBase.cpp
+++ b/src/types/ScreenInfoUiaProviderBase.cpp
@@ -266,15 +266,17 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::GetSelection(_Outptr_result_maybenull_
 
         // return a degenerate range at the cursor position
         const Cursor& cursor = _getTextBuffer().GetCursor();
-        hr = CreateTextRange(this, cursor, _wordDelimiters, &range);
+        hr = CreateTextRange(cursor, _wordDelimiters, &range);
     }
     else
     {
-        // TODO GitHub #1914: Re-attach Tracing to UIA Tree
-        //apiMsg.AreaSelected = true;
+        const auto start = _pData->GetSelectionAnchor();
 
-        // get the selection range
-        hr = GetSelectionRange(this, _wordDelimiters, &range);
+        // we need to make end exclusive
+        auto end = _pData->GetEndSelectionPosition();
+        _pData->GetTextBuffer().GetSize().IncrementInBounds(end, true);
+
+        hr = CreateTextRange(start, end, _wordDelimiters, &range);
     }
 
     if (FAILED(hr))

--- a/src/types/ScreenInfoUiaProviderBase.cpp
+++ b/src/types/ScreenInfoUiaProviderBase.cpp
@@ -336,6 +336,7 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::GetVisibleRanges(_Outptr_result_mayben
         WRL::ComPtr<UiaTextRangeBase> range;
         hr = CreateTextRange(start,
                              end,
+                             false,
                              _wordDelimiters,
                              &range);
         if (FAILED(hr))

--- a/src/types/ScreenInfoUiaProviderBase.h
+++ b/src/types/ScreenInfoUiaProviderBase.h
@@ -78,27 +78,22 @@ namespace Microsoft::Console::Types
     protected:
         ScreenInfoUiaProviderBase() = default;
 
-        virtual HRESULT GetSelectionRange(_In_ IRawElementProviderSimple* pProvider, const std::wstring_view wordDelimiters, _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr) = 0;
-
         // degenerate range
-        virtual HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider, const std::wstring_view wordDelimiters, _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr) = 0;
+        virtual HRESULT CreateTextRange(const std::wstring_view wordDelimiters, _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr) = 0;
 
         // degenerate range at cursor position
-        virtual HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
-                                        const Cursor& cursor,
+        virtual HRESULT CreateTextRange(const Cursor& cursor,
                                         const std::wstring_view wordDelimiters,
                                         _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr) = 0;
 
         // specific endpoint range
-        virtual HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
-                                        const COORD start,
+        virtual HRESULT CreateTextRange(const COORD start,
                                         const COORD end,
                                         const std::wstring_view wordDelimiters,
                                         _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr) = 0;
 
         // range from a UiaPoint
-        virtual HRESULT CreateTextRange(_In_ IRawElementProviderSimple* const pProvider,
-                                        const UiaPoint point,
+        virtual HRESULT CreateTextRange(const UiaPoint point,
                                         const std::wstring_view wordDelimiters,
                                         _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr) = 0;
 

--- a/src/types/ScreenInfoUiaProviderBase.h
+++ b/src/types/ScreenInfoUiaProviderBase.h
@@ -89,6 +89,7 @@ namespace Microsoft::Console::Types
         // specific endpoint range
         virtual HRESULT CreateTextRange(const COORD start,
                                         const COORD end,
+                                        bool blockSelection,
                                         const std::wstring_view wordDelimiters,
                                         _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr) = 0;
 

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -90,6 +90,7 @@ HRESULT UiaTextRangeBase::RuntimeClassInitialize(_In_ IUiaData* pData,
                                                  _In_ IRawElementProviderSimple* const pProvider,
                                                  _In_ const COORD start,
                                                  _In_ const COORD end,
+                                                 _In_ bool blockSelection,
                                                  _In_ std::wstring_view wordDelimiters) noexcept
 try
 {
@@ -107,6 +108,7 @@ try
         _start = end;
         _end = start;
     }
+    _blockSelection = blockSelection;
 
 #if defined(_DEBUG) && defined(UIATEXTRANGE_DEBUG_MSGS)
     OutputDebugString(L"Constructor\n");

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -494,13 +494,13 @@ IFACEMETHODIMP UiaTextRangeBase::GetBoundingRectangles(_Outptr_result_maybenull_
                 COORD startCoord = { 0, row };
                 COORD endCoord = { viewport.RightInclusive(), row };
 
-                if (row == startAnchor.Y)
+                if (_blockSelection || row == startAnchor.Y)
                 {
                     // first row --> reduce left side
                     startCoord.X = startAnchor.X;
                 }
 
-                if (row == endAnchor.Y)
+                if (_blockSelection || row == endAnchor.Y)
                 {
                     // last row --> reduce right side
                     endCoord.X = endAnchor.X;
@@ -595,12 +595,12 @@ try
                 const size_t rowRight = row.GetCharRow().MeasureRight();
                 size_t startIndex = 0;
                 size_t endIndex = rowRight;
-                if (currentScreenInfoRow == _start.Y)
+                if (_blockSelection || currentScreenInfoRow == _start.Y)
                 {
                     startIndex = _start.X;
                 }
 
-                if (currentScreenInfoRow == _end.Y)
+                if (_blockSelection || currentScreenInfoRow == _end.Y)
                 {
                     // prevent the end from going past the last non-whitespace char in the row
                     endIndex = std::max<size_t>(startIndex + 1, std::min(gsl::narrow_cast<size_t>(_end.X), rowRight));

--- a/src/types/UiaTextRangeBase.hpp
+++ b/src/types/UiaTextRangeBase.hpp
@@ -76,6 +76,7 @@ namespace Microsoft::Console::Types
                                        _In_ IRawElementProviderSimple* const pProvider,
                                        _In_ const COORD start,
                                        _In_ const COORD end,
+                                       _In_ bool blockSelection,
                                        _In_ std::wstring_view wordDelimiters = DefaultWordDelimiter) noexcept;
 
         HRESULT RuntimeClassInitialize(const UiaTextRangeBase& a) noexcept;
@@ -138,6 +139,11 @@ namespace Microsoft::Console::Types
         IRawElementProviderSimple* _pProvider;
 
         std::wstring _wordDelimiters;
+
+        // when enabled, this should be treated as a block selection
+        // This means that only text in the rect from start to end
+        // is included in this text range.
+        bool _blockSelection = false;
 
         virtual void _ChangeViewport(const SMALL_RECT NewWindow) = 0;
         virtual void _TranslatePointToScreen(LPPOINT clientPoint) const = 0;


### PR DESCRIPTION
## Summary of the Pull Request
If a block selection was created, we would interpret the selection as a regular span of text. This modifies the UiaTextRange to appropriately define such a selection.

## PR Checklist
* [x] Closes #4509 
* [x] CLA signed.

## Detailed Description of the Pull Request / Additional comments
I added a `IsLineSelection` function to UiaData to provide access to that knowledge to the Uia Providers.

### ScreenInfoUiaProviderBase
- removed unnecessary parameters referencing the "parent" of a UiaTextRange (it was always `this`).]
- removed GetSelectionRange. No longer necessary as everything is abstracted away
- abstracted logic of GetSelectionRange to the base class

### UiaTextRangeBase
- added a bool flag to keep track of whether we should treat the text range as a block selection
- updated GetText, GetBoundingRect, and constructor appropriately

## Validation Steps Performed
Did a `GetSelection` call using accessibility insights during a box selection. Extracted text and bounding rects are correct.