### PR TITLE
Force the use of named forwarders in PublicTermCore for Win7

### DIFF
--- a/src/cascadia/PublicTerminalCore/PublicTerminalCore.vcxproj
+++ b/src/cascadia/PublicTerminalCore/PublicTerminalCore.vcxproj
@@ -49,4 +49,12 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <Import Project="$(SolutionDir)src\common.build.post.props" />
+
+  <!-- LATE LINK LINE OVERRIDES. This project must link named forwarders
+       instead of APISet forwarders for easier Windows 7 compatibility. -->
+  <ItemDefinitionGroup>
+    <Link>
+      <AdditionalDependencies>onecoreuap.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
In debug builds that haven't been LTO'd or had unused refs removed,
there will still be a spurious reference to api-ms-win-winrt-core (or
something similar.)

In release builds, that reference is gone.

Fixes #4519.