### PR TITLE
uia: add support for scrolling the viewport

### DIFF
--- a/src/cascadia/TerminalControl/TermControlUiaProvider.cpp
+++ b/src/cascadia/TerminalControl/TermControlUiaProvider.cpp
@@ -95,6 +95,11 @@ const winrt::Windows::UI::Xaml::Thickness TermControlUiaProvider::GetPadding() c
     return _termControl->GetPadding();
 }
 
+void TermControlUiaProvider::ChangeViewport(const SMALL_RECT NewWindow)
+{
+    _termControl->ScrollViewport(NewWindow.Top);
+}
+
 HRESULT TermControlUiaProvider::GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, const std::wstring_view wordDelimiters, _Out_ std::deque<ComPtr<UiaTextRangeBase>>& result)
 {
     try

--- a/src/cascadia/TerminalControl/TermControlUiaProvider.hpp
+++ b/src/cascadia/TerminalControl/TermControlUiaProvider.hpp
@@ -45,6 +45,7 @@ namespace Microsoft::Terminal
 
         const COORD GetFontSize() const;
         const winrt::Windows::UI::Xaml::Thickness GetPadding() const;
+        void ChangeViewport(const SMALL_RECT NewWindow) override;
 
     protected:
         HRESULT GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, const std::wstring_view wordDelimiters, _Out_ std::deque<WRL::ComPtr<Microsoft::Console::Types::UiaTextRangeBase>>& selectionRanges) override;

--- a/src/cascadia/TerminalControl/UiaTextRange.cpp
+++ b/src/cascadia/TerminalControl/UiaTextRange.cpp
@@ -105,9 +105,10 @@ IFACEMETHODIMP UiaTextRange::Clone(_Outptr_result_maybenull_ ITextRangeProvider*
     return S_OK;
 }
 
-void UiaTextRange::_ChangeViewport(const SMALL_RECT /*NewWindow*/)
+void UiaTextRange::_ChangeViewport(const SMALL_RECT NewWindow)
 {
-    // TODO GitHub #2361: Update viewport when calling UiaTextRangeBase::ScrollIntoView()
+    auto provider = static_cast<TermControlUiaProvider*>(_pProvider);
+    provider->ChangeViewport(NewWindow);
 }
 
 // Method Description:

--- a/src/interactivity/win32/screenInfoUiaProvider.hpp
+++ b/src/interactivity/win32/screenInfoUiaProvider.hpp
@@ -41,7 +41,7 @@ namespace Microsoft::Console::Interactivity::Win32
         IFACEMETHODIMP get_FragmentRoot(_COM_Outptr_result_maybenull_ IRawElementProviderFragmentRoot** ppProvider) override;
 
         HWND GetWindowHandle() const;
-        void ChangeViewport(const SMALL_RECT NewWindow);
+        void ChangeViewport(const SMALL_RECT NewWindow) override;
 
     protected:
         HRESULT GetSelectionRanges(_In_ IRawElementProviderSimple* pProvider, const std::wstring_view wordDelimiters, _Out_ std::deque<WRL::ComPtr<Microsoft::Console::Types::UiaTextRangeBase>>& selectionRanges) override;

--- a/src/types/ScreenInfoUiaProviderBase.h
+++ b/src/types/ScreenInfoUiaProviderBase.h
@@ -47,6 +47,7 @@ namespace Microsoft::Console::Types
         ~ScreenInfoUiaProviderBase() = default;
 
         [[nodiscard]] HRESULT Signal(_In_ EVENTID id);
+        virtual void ChangeViewport(const SMALL_RECT NewWindow) = 0;
 
         // IRawElementProviderSimple methods
         IFACEMETHODIMP get_ProviderOptions(_Out_ ProviderOptions* pOptions) noexcept override;


### PR DESCRIPTION
## Summary of the Pull Request
The UIA Provider now scrolls the viewport when necessary. This just fills in the missing virtual function in Terminal to have the same behavior as what it does in ConHost.

## PR Checklist
* [X] Closes #2361 
* [X] CLA signed.

## Detailed Description of the Pull Request / Additional comments
`ChangeViewport` is now a virtual function at the `ScreenInfoUiaProvider` layer to have access to the TermControl.

In ConHost, we pass this call up to the WindowUiaProvider layer. In Terminal, we don't need to do that because the concept of updating the viewport is handled at the TermControl layer. So we just call that function and _voila_!

## Validation Steps Performed
Verified using Accessibility Insights and Narrator.