### PR TITLE
Move Terminal UIA provider into Types & hook it up to the WPF control

### DIFF
--- a/src/cascadia/PublicTerminalCore/pch.h
+++ b/src/cascadia/PublicTerminalCore/pch.h
@@ -1,4 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN // If this is not defined, windows.h includes commdlg.h which defines FindText globally and conflicts with UIAutomation ITextRangeProvider.
+#endif
+
 #include <LibraryIncludes.h>

--- a/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
+++ b/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
@@ -11,6 +11,7 @@
 
 using namespace Microsoft::Console::Types;
 using namespace winrt::Windows::UI::Xaml::Automation::Peers;
+using namespace winrt::Windows::Graphics::Display;
 
 namespace UIA
 {
@@ -28,9 +29,10 @@ namespace XamlAutomation
 namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 {
     TermControlAutomationPeer::TermControlAutomationPeer(winrt::Microsoft::Terminal::TerminalControl::implementation::TermControl* owner) :
-        TermControlAutomationPeerT<TermControlAutomationPeer>(*owner) // pass owner to FrameworkElementAutomationPeer
+        TermControlAutomationPeerT<TermControlAutomationPeer>(*owner), // pass owner to FrameworkElementAutomationPeer
+        _termControl{ owner }
     {
-        THROW_IF_FAILED(::Microsoft::WRL::MakeAndInitialize<::Microsoft::Terminal::TermControlUiaProvider>(&_uiaProvider, owner, std::bind(&TermControlAutomationPeer::GetBoundingRectWrapped, this)));
+        THROW_IF_FAILED(::Microsoft::WRL::MakeAndInitialize<::Microsoft::Terminal::TermControlUiaProvider>(&_uiaProvider, _termControl->GetUiaData(), this));
     };
 
     // Method Description:
@@ -159,7 +161,13 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
 #pragma endregion
 
-    RECT TermControlAutomationPeer::GetBoundingRectWrapped()
+#pragma region IControlAccessibilityInfo
+    COORD TermControlAutomationPeer::GetFontSize() const
+    {
+        return _termControl->GetActualFont().GetSize();
+    }
+
+    RECT TermControlAutomationPeer::GetBounds() const
     {
         auto rect = GetBoundingRectangle();
         return {
@@ -170,6 +178,36 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         };
     }
 
+    HRESULT TermControlAutomationPeer::GetHostUiaProvider(IRawElementProviderSimple** provider)
+    {
+        RETURN_HR_IF(E_INVALIDARG, provider == nullptr);
+        *provider = nullptr;
+
+        return S_OK;
+    }
+
+    RECT TermControlAutomationPeer::GetPadding() const
+    {
+        auto padding = _termControl->GetPadding();
+        return {
+            gsl::narrow_cast<LONG>(padding.Left),
+            gsl::narrow_cast<LONG>(padding.Top),
+            gsl::narrow_cast<LONG>(padding.Right),
+            gsl::narrow_cast<LONG>(padding.Bottom)
+        };
+    }
+
+    double TermControlAutomationPeer::GetScaleFactor() const
+    {
+        return DisplayInformation::GetForCurrentView().RawPixelsPerViewPixel();
+    }
+
+    void TermControlAutomationPeer::ChangeViewport(const SMALL_RECT NewWindow)
+    {
+        _termControl->ScrollViewport(NewWindow.Top);
+    }
+#pragma endregion
+
     // Method Description:
     // - extracts the UiaTextRanges from the SAFEARRAY and converts them to Xaml ITextRangeProviders
     // Arguments:
@@ -179,7 +217,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     winrt::com_array<XamlAutomation::ITextRangeProvider> TermControlAutomationPeer::WrapArrayOfTextRangeProviders(SAFEARRAY* textRanges)
     {
         // transfer ownership of UiaTextRanges to this new vector
-        auto providers = SafeArrayToOwningVector<::Microsoft::Terminal::UiaTextRange>(textRanges);
+        auto providers = SafeArrayToOwningVector<::Microsoft::Terminal::TermControlUiaTextRange>(textRanges);
         int count = gsl::narrow<int>(providers.size());
 
         std::vector<XamlAutomation::ITextRangeProvider> vec;

--- a/src/cascadia/TerminalControl/TermControlAutomationPeer.h
+++ b/src/cascadia/TerminalControl/TermControlAutomationPeer.h
@@ -27,14 +27,16 @@ Author(s):
 #include "TermControl.h"
 #include "TermControlAutomationPeer.g.h"
 #include <winrt/Microsoft.Terminal.TerminalControl.h>
-#include "TermControlUiaProvider.hpp"
+#include "../types/TermControlUiaProvider.hpp"
 #include "../types/IUiaEventDispatcher.h"
+#include "../types/IControlAccessibilityInfo.h"
 
 namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 {
     struct TermControlAutomationPeer :
         public TermControlAutomationPeerT<TermControlAutomationPeer>,
-        ::Microsoft::Console::Types::IUiaEventDispatcher
+        ::Microsoft::Console::Types::IUiaEventDispatcher,
+        ::Microsoft::Console::Types::IControlAccessibilityInfo
     {
     public:
         TermControlAutomationPeer(winrt::Microsoft::Terminal::TerminalControl::implementation::TermControl* owner);
@@ -59,11 +61,21 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         Windows::UI::Xaml::Automation::Provider::ITextRangeProvider DocumentRange();
 #pragma endregion
 
+#pragma region IControlAccessibilityInfo Pattern
+        // Inherited via IControlAccessibilityInfo
+        virtual COORD GetFontSize() const override;
+        virtual RECT GetBounds() const override;
+        virtual RECT GetPadding() const override;
+        virtual double GetScaleFactor() const override;
+        virtual void ChangeViewport(SMALL_RECT NewWindow) override;
+        virtual HRESULT GetHostUiaProvider(IRawElementProviderSimple** provider) override;
+#pragma endregion
+
         RECT GetBoundingRectWrapped();
 
     private:
         ::Microsoft::WRL::ComPtr<::Microsoft::Terminal::TermControlUiaProvider> _uiaProvider;
-
+        winrt::Microsoft::Terminal::TerminalControl::implementation::TermControl* _termControl;
         winrt::com_array<Windows::UI::Xaml::Automation::Provider::ITextRangeProvider> WrapArrayOfTextRangeProviders(SAFEARRAY* textRanges);
     };
 }

--- a/src/cascadia/TerminalControl/TerminalControl.vcxproj
+++ b/src/cascadia/TerminalControl/TerminalControl.vcxproj
@@ -36,7 +36,6 @@
     <ClInclude Include="SearchBoxControl.h">
       <DependentUpon>SearchBoxControl.xaml</DependentUpon>
     </ClInclude>
-    <ClInclude Include="TermControlUiaProvider.hpp" />
     <ClInclude Include="TermControl.h">
       <DependentUpon>TermControl.idl</DependentUpon>
     </ClInclude>
@@ -46,7 +45,6 @@
     <ClInclude Include="TSFInputControl.h">
       <DependentUpon>TSFInputControl.idl</DependentUpon>
     </ClInclude>
-    <ClInclude Include="UiaTextRange.hpp" />
     <ClInclude Include="XamlUiaTextRange.h" />
   </ItemGroup>
   <ItemGroup>
@@ -57,7 +55,6 @@
     <ClCompile Include="SearchBoxControl.cpp">
       <DependentUpon>SearchBoxControl.xaml</DependentUpon>
     </ClCompile>
-    <ClCompile Include="TermControlUiaProvider.cpp" />
     <ClCompile Include="TermControl.cpp">
       <DependentUpon>TermControl.idl</DependentUpon>
     </ClCompile>
@@ -68,7 +65,6 @@
     <ClCompile Include="TermControlAutomationPeer.cpp">
       <DependentUpon>TermControlAutomationPeer.idl</DependentUpon>
     </ClCompile>
-    <ClCompile Include="UiaTextRange.cpp" />
     <ClCompile Include="XamlUiaTextRange.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/src/cascadia/TerminalControl/XamlUiaTextRange.cpp
+++ b/src/cascadia/TerminalControl/XamlUiaTextRange.cpp
@@ -3,7 +3,7 @@
 
 #include "pch.h"
 #include "XamlUiaTextRange.h"
-#include "UiaTextRange.hpp"
+#include "../types/TermControlUiaTextRange.hpp"
 #include <UIAutomationClient.h>
 
 // the same as COR_E_NOTSUPPORTED

--- a/src/cascadia/TerminalControl/XamlUiaTextRange.h
+++ b/src/cascadia/TerminalControl/XamlUiaTextRange.h
@@ -22,7 +22,7 @@ Author(s):
 
 #include "TermControlAutomationPeer.h"
 #include <UIAutomationCore.h>
-#include "UiaTextRange.hpp"
+#include "../types/TermControlUiaTextRange.hpp"
 
 namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 {

--- a/src/cascadia/WpfTerminalControl/NativeMethods.cs
+++ b/src/cascadia/WpfTerminalControl/NativeMethods.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Terminal.Wpf
 {
     using System;
     using System.Runtime.InteropServices;
+    using System.Windows.Automation.Provider;
 
 #pragma warning disable SA1600 // Elements should be documented
     internal static class NativeMethods
@@ -36,6 +37,8 @@ namespace Microsoft.Terminal.Wpf
             /// </summary>
             WM_MOUSEACTIVATE = 0x0021,
 
+            WM_GETOBJECT = 0x003D,
+            
             /// <summary>
             /// The WM_WINDOWPOSCHANGED message is sent to a window whose size, position, or place in the Z order has changed as a result of a call to the SetWindowPos function or another window-management function.
             /// </summary>

--- a/src/cascadia/WpfTerminalControl/TerminalContainer.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalContainer.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Terminal.Wpf
         private DispatcherTimer blinkTimer;
         private NativeMethods.ScrollCallback scrollCallback;
         private NativeMethods.WriteCallback writeCallback;
-
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="TerminalContainer"/> class.
         /// </summary>
@@ -35,7 +35,7 @@ namespace Microsoft.Terminal.Wpf
             this.MessageHook += this.TerminalContainer_MessageHook;
             this.GotFocus += this.TerminalContainer_GotFocus;
             this.Focusable = true;
-
+            
             var blinkTime = NativeMethods.GetCaretBlinkTime();
 
             if (blinkTime != uint.MaxValue)
@@ -71,6 +71,8 @@ namespace Microsoft.Terminal.Wpf
         /// Gets the character columns available to the terminal.
         /// </summary>
         internal int Columns { get; private set; }
+
+        internal IntPtr Hwnd => this.hwnd;
 
         /// <summary>
         /// Sets the connection to the terminal backend.
@@ -172,7 +174,6 @@ namespace Microsoft.Terminal.Wpf
         protected override HandleRef BuildWindowCore(HandleRef hwndParent)
         {
             var dpiScale = VisualTreeHelper.GetDpi(this);
-
             NativeMethods.CreateTerminal(hwndParent.Handle, out this.hwnd, out this.terminal);
 
             this.scrollCallback = this.OnScroll;

--- a/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Terminal.Wpf
     using System.Windows.Controls;
     using System.Windows.Input;
     using System.Windows.Media;
-
+    
     /// <summary>
     /// A basic terminal control. This control can receive and render standard VT100 sequences.
     /// </summary>

--- a/src/interactivity/win32/uiaTextRange.cpp
+++ b/src/interactivity/win32/uiaTextRange.cpp
@@ -13,7 +13,7 @@ using namespace Microsoft::WRL;
 using Microsoft::Console::Interactivity::ServiceLocator;
 
 // degenerate range constructor.
-HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData, _In_ IRawElementProviderSimple* const pProvider, _In_ const std::wstring_view wordDelimiters)
+HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData, _In_ IRawElementProviderSimple* const pProvider, _In_ const std::wstring_view wordDelimiters) noexcept
 {
     return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, wordDelimiters);
 }
@@ -22,7 +22,7 @@ HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData, _In_ IRawElem
 HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
                                              _In_ IRawElementProviderSimple* const pProvider,
                                              const Cursor& cursor,
-                                             const std::wstring_view wordDelimiters)
+                                             const std::wstring_view wordDelimiters) noexcept
 {
     return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, cursor, wordDelimiters);
 }
@@ -32,7 +32,7 @@ HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
                                              _In_ IRawElementProviderSimple* const pProvider,
                                              const COORD start,
                                              const COORD end,
-                                             const std::wstring_view wordDelimiters)
+                                             const std::wstring_view wordDelimiters) noexcept
 {
     return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, start, end, wordDelimiters);
 }

--- a/src/interactivity/win32/uiaTextRange.hpp
+++ b/src/interactivity/win32/uiaTextRange.hpp
@@ -29,20 +29,20 @@ namespace Microsoft::Console::Interactivity::Win32
         // degenerate range
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,
-                                       _In_ const std::wstring_view wordDelimiters = DefaultWordDelimiter);
+                                       _In_ const std::wstring_view wordDelimiters = DefaultWordDelimiter) noexcept override;
 
         // degenerate range at cursor position
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,
                                        const Cursor& cursor,
-                                       _In_ const std::wstring_view wordDelimiters = DefaultWordDelimiter);
+                                       _In_ const std::wstring_view wordDelimiters = DefaultWordDelimiter) noexcept override;
 
         // specific endpoint range
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,
                                        _In_ const COORD start,
                                        _In_ const COORD end,
-                                       _In_ const std::wstring_view wordDelimiters = DefaultWordDelimiter);
+                                       _In_ const std::wstring_view wordDelimiters = DefaultWordDelimiter) noexcept override;
 
         // range from a UiaPoint
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,

--- a/src/types/IControlAccessibilityInfo.h
+++ b/src/types/IControlAccessibilityInfo.h
@@ -1,0 +1,43 @@
+/*++
+Copyright (c) Microsoft Corporation
+Licensed under the MIT license.
+
+Module Name:
+- IControlAccessibilityInfo.h
+
+Abstract:
+- This serves as the interface defining all information known by the control
+  hosting the terminal renderer that is needed for the UI Automation Tree.
+
+Author(s):
+- Zoey Riordan (zorio) Feb-2020
+--*/
+
+#pragma once
+
+#include <wtypes.h>
+
+namespace Microsoft::Console::Types
+{
+    class IControlAccessibilityInfo
+    {
+    public:
+        virtual ~IControlAccessibilityInfo() = 0;
+
+        virtual COORD GetFontSize() const = 0;
+        virtual RECT GetBounds() const = 0;
+        virtual RECT GetPadding() const = 0;
+        virtual double GetScaleFactor() const = 0;
+        virtual void ChangeViewport(const SMALL_RECT NewWindow) = 0;
+        virtual HRESULT GetHostUiaProvider(IRawElementProviderSimple** provider) = 0;
+
+    protected:
+        IControlAccessibilityInfo() = default;
+        IControlAccessibilityInfo(const IControlAccessibilityInfo&) = default;
+        IControlAccessibilityInfo(IControlAccessibilityInfo&&) = default;
+        IControlAccessibilityInfo& operator=(const IControlAccessibilityInfo&) = default;
+        IControlAccessibilityInfo& operator=(IControlAccessibilityInfo&&) = default;
+    };
+
+    inline IControlAccessibilityInfo::~IControlAccessibilityInfo() {}
+}

--- a/src/types/ScreenInfoUiaProviderBase.h
+++ b/src/types/ScreenInfoUiaProviderBase.h
@@ -38,7 +38,7 @@ namespace Microsoft::Console::Types
         public WRL::RuntimeClass<WRL::RuntimeClassFlags<WRL::ClassicCom | WRL::InhibitFtmBase>, IRawElementProviderSimple, IRawElementProviderFragment, ITextProvider>
     {
     public:
-        HRESULT RuntimeClassInitialize(_In_ IUiaData* pData, _In_ std::wstring_view wordDelimiters = UiaTextRangeBase::DefaultWordDelimiter) noexcept;
+        virtual HRESULT RuntimeClassInitialize(_In_ IUiaData* pData, _In_ std::wstring_view wordDelimiters = UiaTextRangeBase::DefaultWordDelimiter) noexcept;
 
         ScreenInfoUiaProviderBase(const ScreenInfoUiaProviderBase&) = default;
         ScreenInfoUiaProviderBase(ScreenInfoUiaProviderBase&&) = default;
@@ -104,9 +104,9 @@ namespace Microsoft::Console::Types
                                         _COM_Outptr_result_maybenull_ UiaTextRangeBase** ppUtr) = 0;
 
         // weak reference to IUiaData
-        IUiaData* _pData;
+        IUiaData* _pData{ nullptr };
 
-        std::wstring _wordDelimiters;
+        std::wstring _wordDelimiters{};
 
     private:
         // this is used to prevent the object from
@@ -120,7 +120,7 @@ namespace Microsoft::Console::Types
         // eventually overflowing the stack.
         // We aren't using this as a cheap locking
         // mechanism for multi-threaded code.
-        std::map<EVENTID, bool> _signalFiringMapping;
+        std::map<EVENTID, bool> _signalFiringMapping{};
 
         const COORD _getScreenBufferCoords() const;
         const TextBuffer& _getTextBuffer() const noexcept;

--- a/src/types/TermControlUiaProvider.hpp
+++ b/src/types/TermControlUiaProvider.hpp
@@ -19,32 +19,29 @@ Author(s):
 
 #pragma once
 
-#include "..\types\ScreenInfoUiaProviderBase.h"
-#include "..\types\UiaTextRangeBase.hpp"
-#include "UiaTextRange.hpp"
-
-namespace winrt::Microsoft::Terminal::TerminalControl::implementation
-{
-    struct TermControl;
-}
-
+#include "ScreenInfoUiaProviderBase.h"
+#include "UiaTextRangeBase.hpp"
+#include "IControlAccessibilityInfo.h"
+#include "TermControlUiaTextRange.hpp"
 namespace Microsoft::Terminal
 {
     class TermControlUiaProvider : public Microsoft::Console::Types::ScreenInfoUiaProviderBase
     {
     public:
         TermControlUiaProvider() = default;
-        HRESULT RuntimeClassInitialize(_In_ winrt::Microsoft::Terminal::TerminalControl::implementation::TermControl* termControl,
-                                       _In_ std::function<RECT()> GetBoundingRect);
+        HRESULT RuntimeClassInitialize(_In_ ::Microsoft::Console::Types::IUiaData* const uiaData,
+                                       _In_ ::Microsoft::Console::Types::IControlAccessibilityInfo* controlInfo) noexcept;
 
         // IRawElementProviderFragment methods
         IFACEMETHODIMP Navigate(_In_ NavigateDirection direction,
-                                _COM_Outptr_result_maybenull_ IRawElementProviderFragment** ppProvider) override;
+                                _COM_Outptr_result_maybenull_ IRawElementProviderFragment** ppProvider) noexcept override;
+        IFACEMETHODIMP get_HostRawElementProvider(IRawElementProviderSimple** ppProvider) noexcept override;
         IFACEMETHODIMP get_BoundingRectangle(_Out_ UiaRect* pRect) override;
-        IFACEMETHODIMP get_FragmentRoot(_COM_Outptr_result_maybenull_ IRawElementProviderFragmentRoot** ppProvider) override;
+        IFACEMETHODIMP get_FragmentRoot(_COM_Outptr_result_maybenull_ IRawElementProviderFragmentRoot** ppProvider) noexcept override;
 
         const COORD GetFontSize() const;
-        const winrt::Windows::UI::Xaml::Thickness GetPadding() const;
+        const RECT GetPadding() const;
+        const double GetScaleFactor() const;
         void ChangeViewport(const SMALL_RECT NewWindow) override;
 
     protected:
@@ -73,7 +70,6 @@ namespace Microsoft::Terminal
                                 _COM_Outptr_result_maybenull_ Microsoft::Console::Types::UiaTextRangeBase** ppUtr) override;
 
     private:
-        std::function<RECT(void)> _getBoundingRect;
-        winrt::Microsoft::Terminal::TerminalControl::implementation::TermControl* _termControl;
+        ::Microsoft::Console::Types::IControlAccessibilityInfo* _controlInfo{ nullptr };
     };
 }

--- a/src/types/TermControlUiaTextRange.hpp
+++ b/src/types/TermControlUiaTextRange.hpp
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation
 Licensed under the MIT license.
 
 Module Name:
-- UiaTextRange.hpp
+- TermControlUiaTextRange.hpp
 
 Abstract:
 - This module provides UI Automation access to the text of the console
@@ -20,28 +20,28 @@ Author(s):
 
 namespace Microsoft::Terminal
 {
-    class UiaTextRange final : public Microsoft::Console::Types::UiaTextRangeBase
+    class TermControlUiaTextRange final : public Microsoft::Console::Types::UiaTextRangeBase
     {
     public:
-        UiaTextRange() = default;
+        TermControlUiaTextRange() = default;
 
         // degenerate range
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,
-                                       _In_ const std::wstring_view wordDelimiters = DefaultWordDelimiter);
+                                       _In_ const std::wstring_view wordDelimiters = DefaultWordDelimiter) noexcept override;
 
         // degenerate range at cursor position
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,
                                        const Cursor& cursor,
-                                       const std::wstring_view wordDelimiters = DefaultWordDelimiter);
+                                       const std::wstring_view wordDelimiters = DefaultWordDelimiter) noexcept override;
 
         // specific endpoint range
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
                                        _In_ IRawElementProviderSimple* const pProvider,
                                        const COORD start,
                                        const COORD end,
-                                       const std::wstring_view wordDelimiters = DefaultWordDelimiter);
+                                       const std::wstring_view wordDelimiters = DefaultWordDelimiter) noexcept override;
 
         // range from a UiaPoint
         HRESULT RuntimeClassInitialize(_In_ Microsoft::Console::Types::IUiaData* pData,
@@ -49,7 +49,7 @@ namespace Microsoft::Terminal
                                        const UiaPoint point,
                                        const std::wstring_view wordDelimiters = DefaultWordDelimiter);
 
-        HRESULT RuntimeClassInitialize(const UiaTextRange& a);
+        HRESULT RuntimeClassInitialize(const TermControlUiaTextRange& a) noexcept;
 
         IFACEMETHODIMP Clone(_Outptr_result_maybenull_ ITextRangeProvider** ppRetVal) override;
 

--- a/src/types/UiaTextRangeBase.hpp
+++ b/src/types/UiaTextRangeBase.hpp
@@ -58,25 +58,26 @@ namespace Microsoft::Console::Types
         static constexpr std::wstring_view DefaultWordDelimiter{ &UNICODE_SPACE, 1 };
 
         // degenerate range
-        HRESULT RuntimeClassInitialize(_In_ IUiaData* pData,
-                                       _In_ IRawElementProviderSimple* const pProvider,
-                                       _In_ std::wstring_view wordDelimiters = DefaultWordDelimiter) noexcept;
+        virtual HRESULT RuntimeClassInitialize(_In_ IUiaData* pData,
+                                               _In_ IRawElementProviderSimple* const pProvider,
+                                               _In_ std::wstring_view wordDelimiters = DefaultWordDelimiter) noexcept;
 
         // degenerate range at cursor position
-        HRESULT RuntimeClassInitialize(_In_ IUiaData* pData,
-                                       _In_ IRawElementProviderSimple* const pProvider,
-                                       _In_ const Cursor& cursor,
-                                       _In_ std::wstring_view wordDelimiters = DefaultWordDelimiter) noexcept;
+        virtual HRESULT RuntimeClassInitialize(_In_ IUiaData* pData,
+                                               _In_ IRawElementProviderSimple* const pProvider,
+                                               _In_ const Cursor& cursor,
+                                               _In_ std::wstring_view wordDelimiters = DefaultWordDelimiter) noexcept;
 
         // specific endpoint range
-        HRESULT RuntimeClassInitialize(_In_ IUiaData* pData,
-                                       _In_ IRawElementProviderSimple* const pProvider,
-                                       _In_ const COORD start,
-                                       _In_ const COORD end,
-                                       _In_ std::wstring_view wordDelimiters = DefaultWordDelimiter) noexcept;
+        virtual HRESULT RuntimeClassInitialize(_In_ IUiaData* pData,
+                                               _In_ IRawElementProviderSimple* const pProvider,
+                                               _In_ const COORD start,
+                                               _In_ const COORD end,
+                                               _In_ std::wstring_view wordDelimiters = DefaultWordDelimiter) noexcept;
 
-        HRESULT RuntimeClassInitialize(const UiaTextRangeBase& a) noexcept;
+        virtual HRESULT RuntimeClassInitialize(const UiaTextRangeBase& a) noexcept;
 
+        UiaTextRangeBase(const UiaTextRangeBase&) = default;
         UiaTextRangeBase(UiaTextRangeBase&&) = default;
         UiaTextRangeBase& operator=(const UiaTextRangeBase&) = default;
         UiaTextRangeBase& operator=(UiaTextRangeBase&&) = default;
@@ -127,11 +128,11 @@ namespace Microsoft::Console::Types
 
     protected:
         UiaTextRangeBase() = default;
-        IUiaData* _pData;
+        IUiaData* _pData{ nullptr };
 
-        IRawElementProviderSimple* _pProvider;
+        IRawElementProviderSimple* _pProvider{ nullptr };
 
-        std::wstring _wordDelimiters;
+        std::wstring _wordDelimiters{};
 
         virtual void _ChangeViewport(const SMALL_RECT NewWindow) = 0;
         virtual void _TranslatePointToScreen(LPPOINT clientPoint) const = 0;
@@ -141,13 +142,13 @@ namespace Microsoft::Console::Types
 
         // used to debug objects passed back and forth
         // between the provider and the client
-        IdType _id;
+        IdType _id{};
 
         // measure units in the form [_start, _end).
         // These are in the TextBuffer coordinate space.
         // NOTE: _start is inclusive, but _end is exclusive
-        COORD _start;
-        COORD _end;
+        COORD _start{};
+        COORD _end{};
 
         // This is used by tracing to extract the text value
         // that the UiaTextRange currently encompasses.

--- a/src/types/lib/types.vcxproj
+++ b/src/types/lib/types.vcxproj
@@ -24,6 +24,8 @@
     <ClCompile Include="..\ThemeUtils.cpp" />
     <ClCompile Include="..\UiaTextRangeBase.cpp" />
     <ClCompile Include="..\UiaTracing.cpp" />
+    <ClCompile Include="..\TermControlUiaTextRange.cpp" />
+    <ClCompile Include="..\TermControlUiaProvider.cpp" />
     <ClCompile Include="..\Utf16Parser.cpp" />
     <ClCompile Include="..\Viewport.cpp" />
     <ClCompile Include="..\WindowBufferSizeEvent.cpp" />
@@ -36,6 +38,7 @@
   <ItemGroup>
     <ClInclude Include="..\IBaseData.h" />
     <ClInclude Include="..\IConsoleWindow.hpp" />
+    <ClInclude Include="..\IControlAccessibilityInfo.h" />
     <ClInclude Include="..\inc\CodepointWidthDetector.hpp" />
     <ClInclude Include="..\inc\convert.hpp" />
     <ClInclude Include="..\inc\Environment.hpp" />
@@ -48,6 +51,8 @@
     <ClInclude Include="..\IUiaData.h" />
     <ClInclude Include="..\IUiaEventDispatcher.h" />
     <ClInclude Include="..\IUiaWindow.h" />
+    <ClInclude Include="..\TermControlUiaTextRange.hpp" />
+    <ClInclude Include="..\TermControlUiaProvider.hpp" />
     <ClInclude Include="..\precomp.h" />
     <ClInclude Include="..\ScreenInfoUiaProviderBase.h" />
     <ClInclude Include="..\UiaTextRangeBase.hpp" />

--- a/src/types/lib/types.vcxproj.filters
+++ b/src/types/lib/types.vcxproj.filters
@@ -75,6 +75,12 @@
     <ClCompile Include="..\UiaTracing.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\TermControlUiaProvider.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\TermControlUiaTextRange.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\inc\IInputEvent.hpp">
@@ -99,6 +105,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\IConsoleWindow.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\IControlAccessibilityInfo.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\UiaTextRangeBase.hpp">
@@ -135,6 +144,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\WindowUiaProviderBase.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\TermControlUiaProvider.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\TermControlUiaTextRange.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\IUiaWindow.h">

--- a/src/types/sources.inc
+++ b/src/types/sources.inc
@@ -45,6 +45,8 @@ SOURCES= \
     ..\WindowUiaProviderBase.cpp \
     ..\ScreenInfoUiaProviderBase.cpp \
     ..\UiaTextRangeBase.cpp \
+    ..\TermControlUiaProvider.cpp \
+    ..\TermControlUiaTextRange.cpp \
 
 INCLUDES= \
     $(INCLUDES); \


### PR DESCRIPTION
This PR hooks up the existing UIA implementation to the WPF control. Some existing code that was specific to the UWP terminal control could be shared so that has been refactored to a common location as well.

## Validation Steps Performed
WPF control was brought up in UISpy and the UIA tree was verified. NVDA was then used to check that screen readers were operating properly.