### PR TITLE
doc: fix link to Contributor's Guide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ All project documentation is located in the `./doc` folder. If you would like to
 
 We are excited to work alongside you, our amazing community, to build and enhance Windows Terminal\!
 
-***BEFORE you start work on a feature/fix***, please read & follow our [Contributor's Guide](https://github.com/microsoft/terminal/blob/master/contributing.md) to help avoid any wasted or duplicate effort.
+***BEFORE you start work on a feature/fix***, please read & follow our [Contributor's Guide](https://github.com/microsoft/terminal/blob/master/CONTRIBUTING.md) to help avoid any wasted or duplicate effort.
 
 ## Communicating with the Team
 


### PR DESCRIPTION
New Link https://github.com/microsoft/terminal/blob/master/CONTRIBUTING.md

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Just updating a link.


<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Link for Contributors Guide change from https://github.com/microsoft/terminal/blob/master/contributing.md to https://github.com/microsoft/terminal/blob/master/CONTRIBUTING.md


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Well, the link is working.