### PR TITLE
readme: reintroduce the Store install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Related repositories include:
 
 Install the [Windows Terminal from the Microsoft Store][store-install-link]. This allows you to always be on the latest version when we release new builds with automatic upgrades. 
 
-This is our perferred method.
+This is our preferred method.
 
 ### Other install methods
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,15 @@ Related repositories include:
 
 > 👉 Note: Windows Terminal requires Windows 10 1903 (build 18362) or later
 
-### Manually installing builds from this repository
+### Microsoft Store [Recommneded]
+
+Install the [Windows Terminal from the Microsoft Store][store-install-link]. This allows you to always be on the latest version when we release new builds with automatic upgrades. 
+
+This is our perferred method.
+
+### Other install methods
+
+#### Via GitHub
 
 For users who are unable to install Terminal from the Microsoft Store, Terminal builds can be manually downloaded from this repository's [Releases page](https://github.com/microsoft/terminal/releases).
 
@@ -26,7 +34,7 @@ For users who are unable to install Terminal from the Microsoft Store, Terminal 
 > * Be sure to install the [Desktop Bridge VC++ v14 Redistributable Package](https://www.microsoft.com/en-us/download/details.aspx?id=53175) otherwise Terminal may not install and/or run and may crash at startup
 > * Terminal will not auto-update when new builds are released so you will need to regularly install the latest Terminal release to receive all the latest fixes and improvements!
 
-### Install via Chocolatey (unofficial)
+#### Via Chocolatey (unofficial)
 
 [Chocolatey](https://chocolatey.org) users can download and install the latest Terminal release by installing the `microsoft-windows-terminal` package:
 
@@ -219,3 +227,4 @@ For more information see the [Code of Conduct FAQ][conduct-FAQ] or contact [open
 [conduct-code]: https://opensource.microsoft.com/codeofconduct/
 [conduct-FAQ]: https://opensource.microsoft.com/codeofconduct/faq/
 [conduct-email]: mailto:opencode@microsoft.com
+[store-install-link]: https://www.microsoft.com/store/productId/9N0DX20HK701

--- a/README.md
+++ b/README.md
@@ -227,4 +227,4 @@ For more information see the [Code of Conduct FAQ][conduct-FAQ] or contact [open
 [conduct-code]: https://opensource.microsoft.com/codeofconduct/
 [conduct-FAQ]: https://opensource.microsoft.com/codeofconduct/faq/
 [conduct-email]: mailto:opencode@microsoft.com
-[store-install-link]: https://www.microsoft.com/store/productId/9N0DX20HK701
+[store-install-link]: https://aka.ms/windowsterminal

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Related repositories include:
 
 > 👉 Note: Windows Terminal requires Windows 10 1903 (build 18362) or later
 
-### Microsoft Store [Recommneded]
+### Microsoft Store [Recommended]
 
 Install the [Windows Terminal from the Microsoft Store][store-install-link]. This allows you to always be on the latest version when we release new builds with automatic upgrades. 
 


### PR DESCRIPTION
I noticed we are missing the install from Store link.  Here is my suggested text