### PR TITLE
Avoid processing VT Render Trace strings when no one is listening

### DIFF
--- a/src/renderer/vt/state.cpp
+++ b/src/renderer/vt/state.cpp
@@ -202,9 +202,8 @@ VtEngine::VtEngine(_In_ wil::unique_hfile pipe,
     // -1 is the _scprintf error case https://msdn.microsoft.com/en-us/library/t32cf9tb.aspx
     if (cchNeeded > -1)
     {
-        wil::str_printf()
-            wistd::unique_ptr<char[]>
-                psz = wil::make_unique_nothrow<char[]>(cchNeeded + 1);
+        wistd::unique_ptr<char[]>
+        psz = wil::make_unique_nothrow<char[]>(cchNeeded + 1);
         RETURN_IF_NULL_ALLOC(psz);
 
         int cchWritten = _vsnprintf_s(psz.get(), cchNeeded + 1, cchNeeded, pFormat->c_str(), argList);

--- a/src/renderer/vt/state.cpp
+++ b/src/renderer/vt/state.cpp
@@ -202,7 +202,9 @@ VtEngine::VtEngine(_In_ wil::unique_hfile pipe,
     // -1 is the _scprintf error case https://msdn.microsoft.com/en-us/library/t32cf9tb.aspx
     if (cchNeeded > -1)
     {
-        wistd::unique_ptr<char[]> psz = wil::make_unique_nothrow<char[]>(cchNeeded + 1);
+        wil::str_printf()
+            wistd::unique_ptr<char[]>
+                psz = wil::make_unique_nothrow<char[]>(cchNeeded + 1);
         RETURN_IF_NULL_ALLOC(psz);
 
         int cchWritten = _vsnprintf_s(psz.get(), cchNeeded + 1, cchNeeded, pFormat->c_str(), argList);

--- a/src/renderer/vt/state.cpp
+++ b/src/renderer/vt/state.cpp
@@ -202,8 +202,7 @@ VtEngine::VtEngine(_In_ wil::unique_hfile pipe,
     // -1 is the _scprintf error case https://msdn.microsoft.com/en-us/library/t32cf9tb.aspx
     if (cchNeeded > -1)
     {
-        wistd::unique_ptr<char[]>
-        psz = wil::make_unique_nothrow<char[]>(cchNeeded + 1);
+        wistd::unique_ptr<char[]> psz = wil::make_unique_nothrow<char[]>(cchNeeded + 1);
         RETURN_IF_NULL_ALLOC(psz);
 
         int cchWritten = _vsnprintf_s(psz.get(), cchNeeded + 1, cchNeeded, pFormat->c_str(), argList);

--- a/src/renderer/vt/tracing.cpp
+++ b/src/renderer/vt/tracing.cpp
@@ -67,12 +67,15 @@ std::string toPrintableString(const std::string_view& inString)
 void RenderTracing::TraceString(const std::string_view& instr) const
 {
 #ifndef UNIT_TESTING
-    const std::string _seq = toPrintableString(instr);
-    const char* const seq = _seq.c_str();
-    TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
-                      "VtEngine_TraceString",
-                      TraceLoggingString(seq),
-                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        const std::string _seq = toPrintableString(instr);
+        const char* const seq = _seq.c_str();
+        TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
+                          "VtEngine_TraceString",
+                          TraceLoggingString(seq),
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 #else
     UNREFERENCED_PARAMETER(instr);
 #endif UNIT_TESTING
@@ -117,12 +120,15 @@ std::string _CoordToString(const COORD& c)
 void RenderTracing::TraceInvalidate(const Viewport invalidRect) const
 {
 #ifndef UNIT_TESTING
-    const auto invalidatedStr = _ViewportToString(invalidRect);
-    const auto invalidated = invalidatedStr.c_str();
-    TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
-                      "VtEngine_TraceInvalidate",
-                      TraceLoggingString(invalidated),
-                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        const auto invalidatedStr = _ViewportToString(invalidRect);
+        const auto invalidated = invalidatedStr.c_str();
+        TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
+                          "VtEngine_TraceInvalidate",
+                          TraceLoggingString(invalidated),
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 #else
     UNREFERENCED_PARAMETER(invalidRect);
 #endif UNIT_TESTING
@@ -131,12 +137,15 @@ void RenderTracing::TraceInvalidate(const Viewport invalidRect) const
 void RenderTracing::TraceInvalidateAll(const Viewport viewport) const
 {
 #ifndef UNIT_TESTING
-    const auto invalidatedStr = _ViewportToString(viewport);
-    const auto invalidatedAll = invalidatedStr.c_str();
-    TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
-                      "VtEngine_TraceInvalidateAll",
-                      TraceLoggingString(invalidatedAll),
-                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        const auto invalidatedStr = _ViewportToString(viewport);
+        const auto invalidatedAll = invalidatedStr.c_str();
+        TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
+                          "VtEngine_TraceInvalidateAll",
+                          TraceLoggingString(invalidatedAll),
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 #else
     UNREFERENCED_PARAMETER(viewport);
 #endif UNIT_TESTING
@@ -162,21 +171,24 @@ void RenderTracing::TraceStartPaint(const bool quickReturn,
                                     const bool cursorMoved) const
 {
 #ifndef UNIT_TESTING
-    const auto invalidatedStr = _ViewportToString(invalidRect);
-    const auto invalidated = invalidatedStr.c_str();
-    const auto lastViewStr = _ViewportToString(lastViewport);
-    const auto lastView = lastViewStr.c_str();
-    const auto scrollDeltaStr = _CoordToString(scrollDelt);
-    const auto scrollDelta = scrollDeltaStr.c_str();
-    TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
-                      "VtEngine_TraceStartPaint",
-                      TraceLoggingBool(quickReturn),
-                      TraceLoggingBool(invalidRectUsed),
-                      TraceLoggingString(invalidated),
-                      TraceLoggingString(lastView),
-                      TraceLoggingString(scrollDelta),
-                      TraceLoggingBool(cursorMoved),
-                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        const auto invalidatedStr = _ViewportToString(invalidRect);
+        const auto invalidated = invalidatedStr.c_str();
+        const auto lastViewStr = _ViewportToString(lastViewport);
+        const auto lastView = lastViewStr.c_str();
+        const auto scrollDeltaStr = _CoordToString(scrollDelt);
+        const auto scrollDelta = scrollDeltaStr.c_str();
+        TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
+                          "VtEngine_TraceStartPaint",
+                          TraceLoggingBool(quickReturn),
+                          TraceLoggingBool(invalidRectUsed),
+                          TraceLoggingString(invalidated),
+                          TraceLoggingString(lastView),
+                          TraceLoggingString(scrollDelta),
+                          TraceLoggingBool(cursorMoved),
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 #else
     UNREFERENCED_PARAMETER(quickReturn);
     UNREFERENCED_PARAMETER(invalidRectUsed);
@@ -200,12 +212,15 @@ void RenderTracing::TraceEndPaint() const
 void RenderTracing::TraceLastText(const COORD lastTextPos) const
 {
 #ifndef UNIT_TESTING
-    const auto lastTextStr = _CoordToString(lastTextPos);
-    const auto lastText = lastTextStr.c_str();
-    TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
-                      "VtEngine_TraceLastText",
-                      TraceLoggingString(lastText),
-                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        const auto lastTextStr = _CoordToString(lastTextPos);
+        const auto lastText = lastTextStr.c_str();
+        TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
+                          "VtEngine_TraceLastText",
+                          TraceLoggingString(lastText),
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 #else
     UNREFERENCED_PARAMETER(lastTextPos);
 #endif UNIT_TESTING


### PR DESCRIPTION
## Summary of the Pull Request
- If no one is listening to the ETW provider for the VT Renderer for diagnostic purposes, do not spend time allocating/deleting/formatting strings for presentation in TraceLogging messages.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes something I noticed while working on the renderer.
* [x] I work here.
* [x] Existing tests should pass
* [x] No doc
* [x] Am core contributor.

## Validation Steps Performed
WPR/WPA

Before: 321/3016 samples on hot path (10.64%)
![image](https://user-images.githubusercontent.com/18221333/74568273-73500200-4f2c-11ea-9a62-9aa11ea163b9.png)

After: 0/1266 samples on the same path (0%)
![image](https://user-images.githubusercontent.com/18221333/74568361-a98d8180-4f2c-11ea-922e-fbc878ebe7d4.png)


