### PR TITLE
Chain assigning origin members to 0 to make the code more readable and make its context clearer.

### DIFF
--- a/src/host/settings.cpp
+++ b/src/host/settings.cpp
@@ -69,8 +69,7 @@ Settings::Settings() :
 
     _dwWindowSizePixels = { 0 };
 
-    _dwWindowOrigin.X = 0;
-    _dwWindowOrigin.Y = 0;
+    _dwWindowOrigin.X = _dwWindowOrigin.Y = 0;
 
     _dwFontSize.X = 0;
     _dwFontSize.Y = 16;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The origin is 0, 0. The X and Y, by definition, must be set to 0, which is the same in both .X and .Y members. Because of this, it makes more sense to chain assign them to 0.

Changes were tested manually and automatically.
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual Testing
Automated Testing