### PR TITLE
Fix duplicate copyOnSelect when clicking on an unfocused terminal

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -69,7 +69,9 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         _lastMouseClick{},
         _lastMouseClickPos{},
         _searchBox{ nullptr },
-        _tsfInputControl{ nullptr }
+        _tsfInputControl{ nullptr },
+        _unfocusedClickPos{ std::nullopt },
+        _isClickDragSelection{ false }
     {
         _EnsureStaticInitialization();
         _Create();

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -895,7 +895,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             // only want to start the selection when the user moves the pointer with
             // the left mouse button held down, the PointerMovedHandler will use
             // this saved position to set the SelectionAnchor.
-            _clickDragStartPos = point.Position();
+            _unfocusedClickPos = point.Position();
         }
 
         if (ptr.PointerDeviceType() == Windows::Devices::Input::PointerDeviceType::Mouse || ptr.PointerDeviceType() == Windows::Devices::Input::PointerDeviceType::Pen)
@@ -908,11 +908,11 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
             if (point.Properties().IsLeftButtonPressed())
             {
-                // _clickDragStartPos having a value signifies to us that
+                // _unfocusedClickPos having a value signifies to us that
                 // the user clicked on an unfocused terminal. We don't want
                 // a single left click from out of focus to start a selection,
                 // so we return fast here.
-                if (_clickDragStartPos)
+                if (_unfocusedClickPos)
                 {
                     args.Handled(true);
                     return;
@@ -994,13 +994,15 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         {
             if (point.Properties().IsLeftButtonPressed())
             {
+                _isClickDragSelection = true;
+
                 // If this does not have a value, it means that PointerPressedHandler already
                 // set the SelectionAnchor. If it does have a value, that means the user is
                 // performing a click-drag selection on an unfocused terminal, so
                 // a SelectionAnchor isn't set yet. We'll have to set it here.
-                if (_clickDragStartPos)
+                if (_unfocusedClickPos)
                 {
-                    _terminal->SetSelectionAnchor(_GetTerminalPosition(*_clickDragStartPos));
+                    _terminal->SetSelectionAnchor(_GetTerminalPosition(*_unfocusedClickPos));
                 }
 
                 const auto cursorPosition = point.Position();
@@ -1075,8 +1077,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         const auto ptr = args.Pointer();
 
-        _clickDragStartPos = std::nullopt;
-
         if (ptr.PointerDeviceType() == Windows::Devices::Input::PointerDeviceType::Mouse || ptr.PointerDeviceType() == Windows::Devices::Input::PointerDeviceType::Pen)
         {
             const auto modifiers = static_cast<uint32_t>(args.KeyModifiers());
@@ -1086,13 +1086,21 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
             if (_terminal->IsCopyOnSelectActive())
             {
-                CopySelectionToClipboard(!shiftEnabled);
+                // If the terminal was in focus, copy to clipboard.
+                // If the terminal was unfocused AND a click-drag selection happened, copy to clipboard.
+                if (!_unfocusedClickPos || (_unfocusedClickPos && _isClickDragSelection))
+                {
+                    CopySelectionToClipboard(!shiftEnabled);
+                }
             }
         }
         else if (ptr.PointerDeviceType() == Windows::Devices::Input::PointerDeviceType::Touch)
         {
             _touchAnchor = std::nullopt;
         }
+
+        _unfocusedClickPos = std::nullopt;
+        _isClickDragSelection = false;
 
         _TryStopAutoScroll(ptr.PointerId());
 

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -162,7 +162,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         Timestamp _lastMouseClick;
         unsigned int _multiClickCounter;
         std::optional<winrt::Windows::Foundation::Point> _lastMouseClickPos;
-        std::optional<winrt::Windows::Foundation::Point> _clickDragStartPos{ std::nullopt };
+        std::optional<winrt::Windows::Foundation::Point> _unfocusedClickPos{ std::nullopt };
+        bool _isClickDragSelection{ false };
 
         // Event revokers -- we need to deregister ourselves before we die,
         // lest we get callbacks afterwards.

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -162,8 +162,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         Timestamp _lastMouseClick;
         unsigned int _multiClickCounter;
         std::optional<winrt::Windows::Foundation::Point> _lastMouseClickPos;
-        std::optional<winrt::Windows::Foundation::Point> _unfocusedClickPos{ std::nullopt };
-        bool _isClickDragSelection{ false };
+        std::optional<winrt::Windows::Foundation::Point> _unfocusedClickPos;
+        bool _isClickDragSelection;
 
         // Event revokers -- we need to deregister ourselves before we die,
         // lest we get callbacks afterwards.


### PR DESCRIPTION
## Summary of the Pull Request
Currently, clicking on an unfocused terminal with a selection active will trigger `copyOnSelect`. This is because the check for `copyOnSelect` and copying to the clipboard is bound to when the Pointer is released. This works fine for when a user performs a click-drag selection, but it inadvertently also triggers when the user performs a single click on an unfocused terminal. We expect `copyOnSelect` to trigger only on the first time a selection is completed. 

This PR will allow the user to single click on an unfocused terminal that has a selection active without triggering a copyOnSelect. It also ensures that any click-drag selection, whether it's on an unfocused or focused terminal, will trigger copyOnSelect.

## PR Checklist
* [x] Closes #4255

## Validation Steps Performed
Performed manual testing involving permutations of multiple panes, tabs, in focus, and out of focus.