### PR TITLE
Update Setting the `startingDirectory` of WSL Profiles to `~`

### DIFF
--- a/doc/user-docs/UsingJsonSettings.md
+++ b/doc/user-docs/UsingJsonSettings.md
@@ -435,6 +435,6 @@ distro in it's home path:
 {
     "name": "Ubuntu-18.04",
     "commandline" : "wsl -d Ubuntu-18.04",
-    "startingDirectory" : "//wsl$/Ubuntu-18.04/home/<Your Ubuntu Username>",
+    "startingDirectory" : "\\\\wsl$\\Ubuntu-18.04\\home\\<Your Ubuntu Username>",
 }
 ```


### PR DESCRIPTION
As the instructions already state, `startingDirectory` only accepts a Windows-style path. The example used a linux style path. Replaced forward slash '/' with escaped backslash '\\' which is what was required for this to work on my system.