### PR TITLE
Batch up to 64 files per clang-format to speed it up

### DIFF
--- a/build/pipelines/templates/check-formatting.yml
+++ b/build/pipelines/templates/check-formatting.yml
@@ -6,6 +6,7 @@ jobs:
 
   steps:
   - checkout: self
+    fetchDepth: 1
     submodules: false
     clean: true
 

--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -326,11 +326,21 @@ function Invoke-ClangFormat {
         [string[]]$Path
     )
 
+    Begin {
+        $BatchSize = [int]64
+        $Paths = @()
+    }
+
     Process {
         ForEach($_ in $Path) {
+            $Paths += Get-Item $_ -ErrorAction Stop | Select -Expand FullName
+        }
+    }
+
+    End {
+        For($i = [int]0; $i -Lt $Paths.Length; $i += $BatchSize) {
             Try {
-                $n = Get-Item $_ -ErrorAction Stop | Select -Expand FullName
-                & "$env:OpenconsoleRoot/dep/llvm/clang-format" -i $n
+                & "$env:OpenconsoleRoot/dep/llvm/clang-format" -i $Paths[$i .. ($i + $BatchSize - 1)]
             } Catch {
                 Write-Error $_
             }


### PR DESCRIPTION
This will make `Invoke-CodeFormat` less bad.