### PR TITLE
doc: add a tip about opening terminal in current directory

### DIFF
--- a/doc/user-docs/index.md
+++ b/doc/user-docs/index.md
@@ -86,4 +86,6 @@ For an introduction to the various settings, see [Using Json Settings](UsingJson
 
 2. Terminal zoom can be changed by holding <kbd>Ctrl</kbd> and scrolling with mouse.
 3. If `useAcrylic` is enabled in profiles.json, background opacity can be changed by holding <kbd>Ctrl</kbd>+<kbd>Shift</kbd> and scrolling with mouse. Note that acrylic transparency is limited by the OS only to focused windows.
-4. Please add more Tips and Tricks
+4. To open Windows Terminal in current directory by typing 'wt' in address bar, set "startingDirectory" to null in profile of your choice within profiles.json file.
+`"startingDirectory": null`
+5. Please add more Tips and Tricks.

--- a/doc/user-docs/index.md
+++ b/doc/user-docs/index.md
@@ -86,6 +86,5 @@ For an introduction to the various settings, see [Using Json Settings](UsingJson
 
 2. Terminal zoom can be changed by holding <kbd>Ctrl</kbd> and scrolling with mouse.
 3. If `useAcrylic` is enabled in profiles.json, background opacity can be changed by holding <kbd>Ctrl</kbd>+<kbd>Shift</kbd> and scrolling with mouse. Note that acrylic transparency is limited by the OS only to focused windows.
-4. To open Windows Terminal in current directory by typing 'wt' in address bar, set "startingDirectory" to null in profile of your choice within profiles.json file.
-`"startingDirectory": null`
+4. Open Windows Terminal in current directory by typing `wt -d .` in the address bar.
 5. Please add more Tips and Tricks.


### PR DESCRIPTION
Tip to open Windows Terminal in current directory

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Open Windows Terminal in current directory by typing `wt -d .` in the address bar.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
