### PR TITLE
Add DxEngine drawing ETW tracing for debugging and diagnostics purposes

### DIFF
--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -943,6 +943,7 @@ void DxEngine::_InvalidOr(RECT rc) noexcept
     FAIL_FAST_IF_FAILED(InvalidateAll());
     RETURN_HR_IF(E_NOT_VALID_STATE, _isPainting); // invalid to start a paint while painting.
 
+    #pragma warning(suppress : 26477 26485 26494 26482 26446) // We don't control TraceLoggingWrite
     TraceLoggingWrite(g_hDxRenderProvider,
                       "Invalid",
                       TraceLoggingInt32(_invalidRect.bottom - _invalidRect.top, "InvalidHeight"),

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -943,7 +943,7 @@ void DxEngine::_InvalidOr(RECT rc) noexcept
     FAIL_FAST_IF_FAILED(InvalidateAll());
     RETURN_HR_IF(E_NOT_VALID_STATE, _isPainting); // invalid to start a paint while painting.
 
-    #pragma warning(suppress : 26477 26485 26494 26482 26446) // We don't control TraceLoggingWrite
+#pragma warning(suppress : 26477 26485 26494 26482 26446) // We don't control TraceLoggingWrite
     TraceLoggingWrite(g_hDxRenderProvider,
                       "Invalid",
                       TraceLoggingInt32(_invalidRect.bottom - _invalidRect.top, "InvalidHeight"),

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -946,11 +946,17 @@ void DxEngine::_InvalidOr(RECT rc) noexcept
     TraceLoggingWrite(g_hDxRenderProvider,
                       "Invalid",
                       TraceLoggingInt32(_invalidRect.bottom - _invalidRect.top, "InvalidHeight"),
+                      TraceLoggingInt32((_invalidRect.bottom - _invalidRect.top) / _glyphCell.cy, "InvalidHeightChars"),
                       TraceLoggingInt32(_invalidRect.right - _invalidRect.left, "InvalidWidth"),
+                      TraceLoggingInt32((_invalidRect.right - _invalidRect.left) / _glyphCell.cx, "InvalidWidthChars"),
                       TraceLoggingInt32(_invalidRect.left, "InvalidX"),
+                      TraceLoggingInt32(_invalidRect.left / _glyphCell.cx, "InvalidXChars"),
                       TraceLoggingInt32(_invalidRect.top, "InvalidY"),
+                      TraceLoggingInt32(_invalidRect.top / _glyphCell.cy, "InvalidYChars"),
                       TraceLoggingInt32(_invalidScroll.cx, "ScrollWidth"),
-                      TraceLoggingInt32(_invalidScroll.cy, "ScrollHeight"));
+                      TraceLoggingInt32(_invalidScroll.cx / _glyphCell.cx, "ScrollWidthChars"),
+                      TraceLoggingInt32(_invalidScroll.cy, "ScrollHeight"),
+                      TraceLoggingInt32(_invalidScroll.cy / _glyphCell.cy, "ScrollHeightChars"));
 
     if (_isEnabled)
     {

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -21,6 +21,7 @@
 using namespace DirectX;
 
 std::atomic<size_t> Microsoft::Console::Render::DxEngine::_tracelogCount{ 0 };
+#pragma warning(suppress : 26477)
 TRACELOGGING_DEFINE_PROVIDER(g_hDxRenderProvider,
                              "Microsoft.Windows.Terminal.Renderer.DirectX",
                              // {c93e739e-ae50-5a14-78e7-f171e947535d}
@@ -943,7 +944,7 @@ void DxEngine::_InvalidOr(RECT rc) noexcept
     FAIL_FAST_IF_FAILED(InvalidateAll());
     RETURN_HR_IF(E_NOT_VALID_STATE, _isPainting); // invalid to start a paint while painting.
 
-#pragma warning(suppress : 26477 26485 26494 26482 26446) // We don't control TraceLoggingWrite
+#pragma warning(suppress : 26477 26485 26494 26482 26446 26447) // We don't control TraceLoggingWrite
     TraceLoggingWrite(g_hDxRenderProvider,
                       "Invalid",
                       TraceLoggingInt32(_invalidRect.bottom - _invalidRect.top, "InvalidHeight"),

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -25,6 +25,10 @@
 
 #include "../../types/inc/Viewport.hpp"
 
+#include <TraceLoggingProvider.h>
+
+TRACELOGGING_DECLARE_PROVIDER(g_hDxRenderProvider);
+
 namespace Microsoft::Console::Render
 {
     class DxEngine final : public RenderEngineBase

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -155,6 +155,8 @@ namespace Microsoft::Console::Render
         POINT _presentOffset;
         DXGI_PRESENT_PARAMETERS _presentParams;
 
+        static std::atomic<size_t> _tracelogCount;
+
         static const ULONG s_ulMinCursorHeightPercent = 25;
         static const ULONG s_ulMaxCursorHeightPercent = 100;
 


### PR DESCRIPTION
## Summary of the Pull Request
Adds an ETW provider for tracing out operations inside the DirectX Renderer.

## References
This supports #2191 and #778 and other rendering issues.

## PR Checklist
* [x] I work here

## Detailed Description of the Pull Request / Additional comments
This declares and defines the provider with the a GUID appropriate for the namespace and adds an initial invalidation rectangle method for figuring out what is being drawn mostly to understand what could be differential.

## Validation Steps Performed
Implemented provider.
Opened real-time ETW tracing tool
Ran the Terminal and watched invalidation events appear live
