### PR TITLE
Display Emojis, Kaomojis, and symbols while in IME mode

### DIFF
--- a/src/cascadia/TerminalControl/TSFInputControl.cpp
+++ b/src/cascadia/TerminalControl/TSFInputControl.cpp
@@ -216,7 +216,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         // only need to do work if the current buffer has text
         if (!_inputBuffer.empty())
         {
-            _sendAndClearText();
+            _SendAndClearText();
         }
     }
 
@@ -317,7 +317,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             // They aren't composition, so we don't want to wait for the user to start and finish a composition to send the text.
             if (!_inComposition)
             {
-                _sendAndClearText();
+                _SendAndClearText();
             }
 
             // Notify the TSF that the update succeeded
@@ -340,7 +340,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // - <none>
     // Return Value:
     // - <none>
-    void TSFInputControl::_sendAndClearText()
+    void TSFInputControl::_SendAndClearText()
     {
         // call event handler with data handled by parent
         _compositionCompletedHandlers(_inputBuffer);

--- a/src/cascadia/TerminalControl/TSFInputControl.cpp
+++ b/src/cascadia/TerminalControl/TSFInputControl.cpp
@@ -254,8 +254,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         try
         {
-            const auto textRequested = _inputBuffer.substr(range.StartCaretPosition,
-                                                           std::min(static_cast<size_t>(range.EndCaretPosition), _inputBuffer.length()) - static_cast<size_t>(range.StartCaretPosition));
+            const auto textEnd = std::min(static_cast<size_t>(range.EndCaretPosition), _inputBuffer.length());
+            const auto textRequested = _inputBuffer.substr(range.StartCaretPosition, textEnd - static_cast<size_t>(range.StartCaretPosition));
 
             args.Request().Text(textRequested);
         }

--- a/src/cascadia/TerminalControl/TSFInputControl.cpp
+++ b/src/cascadia/TerminalControl/TSFInputControl.cpp
@@ -335,6 +335,14 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         }
     }
 
+    // Method Description:
+    // - Sends the currently held text in the input buffer to the parent and
+    //   clears the input buffer and text block for the next round of input.
+    //   Then hides the text block control until the next time text received.
+    // Arguments:
+    // - <none>
+    // Return Value:
+    // - <none>
     void TSFInputControl::_sendAndClearText()
     {
         // call event handler with data handled by parent

--- a/src/cascadia/TerminalControl/TSFInputControl.cpp
+++ b/src/cascadia/TerminalControl/TSFInputControl.cpp
@@ -308,10 +308,9 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             _canvas.Visibility(Visibility::Visible);
             _textBlock.Visibility(Visibility::Visible);
 
-            auto rangetoreplace = static_cast<size_t>(range.EndCaretPosition) - static_cast<size_t>(range.StartCaretPosition);
             _inputBuffer = _inputBuffer.replace(
                 range.StartCaretPosition,
-                rangetoreplace,
+                static_cast<size_t>(range.EndCaretPosition) - static_cast<size_t>(range.StartCaretPosition),
                 text);
 
             _textBlock.Text(_inputBuffer);

--- a/src/cascadia/TerminalControl/TSFInputControl.cpp
+++ b/src/cascadia/TerminalControl/TSFInputControl.cpp
@@ -180,10 +180,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         _canvas.SetLeft(_textBlock, clientCursorPos.X);
         _canvas.SetTop(_textBlock, ::base::ClampedNumeric<double>(clientCursorPos.Y));
 
-        // Set width of text block to the end of the window.
-        _textBlock.Width(::base::ClampSub<double>(windowBounds.Width, screenCursorPos.X));
         _textBlock.Height(fontHeight);
-
         // calculate FontSize in pixels from DIPs
         const double fontSizePx = (fontHeight * 72) / USER_DEFAULT_SCREEN_DPI;
         _textBlock.FontSize(fontSizePx);

--- a/src/cascadia/TerminalControl/TSFInputControl.h
+++ b/src/cascadia/TerminalControl/TSFInputControl.h
@@ -75,6 +75,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         std::wstring _inputBuffer;
 
         void _Create();
+
+        bool _inComposition;
     };
 }
 namespace winrt::Microsoft::Terminal::TerminalControl::factory_implementation

--- a/src/cascadia/TerminalControl/TSFInputControl.h
+++ b/src/cascadia/TerminalControl/TSFInputControl.h
@@ -77,6 +77,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _Create();
 
         bool _inComposition;
+        void _sendAndClearText();
     };
 }
 namespace winrt::Microsoft::Terminal::TerminalControl::factory_implementation

--- a/src/cascadia/TerminalControl/TSFInputControl.h
+++ b/src/cascadia/TerminalControl/TSFInputControl.h
@@ -77,7 +77,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _Create();
 
         bool _inComposition;
-        void _sendAndClearText();
+        void _SendAndClearText();
     };
 }
 namespace winrt::Microsoft::Terminal::TerminalControl::factory_implementation

--- a/src/cascadia/TerminalControl/TSFInputControl.h
+++ b/src/cascadia/TerminalControl/TSFInputControl.h
@@ -78,6 +78,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         bool _inComposition;
         void _sendAndClearText();
+        double convertWindowToScreenCoord(const SHORT& coord, const float& fontDimension, const float& windowBound, const float& margin);
     };
 }
 namespace winrt::Microsoft::Terminal::TerminalControl::factory_implementation

--- a/src/cascadia/TerminalControl/TSFInputControl.h
+++ b/src/cascadia/TerminalControl/TSFInputControl.h
@@ -78,7 +78,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         bool _inComposition;
         void _sendAndClearText();
-        double convertWindowToScreenCoord(const SHORT& coord, const float& fontDimension, const float& windowBound, const float& margin);
     };
 }
 namespace winrt::Microsoft::Terminal::TerminalControl::factory_implementation

--- a/src/cascadia/WinRTUtils/inc/Utils.h
+++ b/src/cascadia/WinRTUtils/inc/Utils.h
@@ -28,10 +28,10 @@ inline winrt::Windows::UI::Color ColorRefToColor(const COLORREF& colorref)
 // - Rect scaled by scale
 inline winrt::Windows::Foundation::Rect ScaleRect(winrt::Windows::Foundation::Rect rect, double scale)
 {
-    const float scaleLocal = gsl::narrow_cast<float>(scale);
-    rect.X *= scaleLocal;
-    rect.Y *= scaleLocal;
-    rect.Width *= scaleLocal;
-    rect.Height *= scaleLocal;
+    const auto scaleLocal = base::ClampedNumeric<float>(scale);
+    rect.X = base::ClampMul(rect.X, scaleLocal);
+    rect.Y = base::ClampMul(rect.Y, scaleLocal);
+    rect.Width = base::ClampMul(rect.Width, scaleLocal);
+    rect.Height = base::ClampMul(rect.Height, scaleLocal);
     return rect;
 }


### PR DESCRIPTION
## Summary of the Pull Request
Currently, while in IME mode, selections with the Emoji/Kaomoji/Symbol Picker (which is brought up with <kbd>win+.</kbd>) are not displayed until the user starts a new composition. This is due to the fact that we hide the TextBlock when we receive a CompositionCompleted event, and we only show the TextBlock when we receive a CompositionStarted event. Input from the picker does not count as a composition, so we were never showing the text box, even if the symbols were thrown into the inputBuffer. In addition, we weren't receiving CompositionStarted events when we expected to.

We should be showing the TextBlock when we receive _any_ text, so we should make the TextBlock visible inside of `TextUpdatingHandler`. Furthermore, some really helpful discussion in #3745 around wrapping the `NotifyTextChanged` call with a `NotifyFocusLeave` and a `NotifyFocusEnter` allowed the control to much more consistently determine when a CompositionStarted and a CompositionEnded.

I've also went around and replaced casts with saturating casts, and have removed the line that sets the `textBlock.Width()` so that it would automatically set its width. This resolves the issue where while composing a sentence, the textBlock would be too small to contain all the text, so it would be cut off, but the composition is still valid and still able to continue.

## PR Checklist
* [x] Closes #4148
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed

## Validation Steps Performed
Tested picking emojis, kaomojis, and symbols with numerous different languages.
