### PR TITLE
fix mouse events in the wpf control

### DIFF
--- a/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
@@ -347,46 +347,46 @@ void _stdcall TerminalUserScroll(void* terminal, int viewTop)
 }
 
 HRESULT HwndTerminal::_StartSelection(LPARAM lParam) noexcept
-    try
-    {
-        const bool altPressed = GetKeyState(VK_MENU) < 0;
-        COORD cursorPosition{
-            GET_X_LPARAM(lParam),
-            GET_Y_LPARAM(lParam),
-        };
+try
+{
+    const bool altPressed = GetKeyState(VK_MENU) < 0;
+    COORD cursorPosition{
+        GET_X_LPARAM(lParam),
+        GET_Y_LPARAM(lParam),
+    };
 
-        const auto fontSize = this->_actualFont.GetSize();
+    const auto fontSize = this->_actualFont.GetSize();
 
-        RETURN_HR_IF(E_NOT_VALID_STATE, fontSize.X == 0);
-        RETURN_HR_IF(E_NOT_VALID_STATE, fontSize.Y == 0);
+    RETURN_HR_IF(E_NOT_VALID_STATE, fontSize.X == 0);
+    RETURN_HR_IF(E_NOT_VALID_STATE, fontSize.Y == 0);
 
-        cursorPosition.X /= fontSize.X;
-        cursorPosition.Y /= fontSize.Y;
+    cursorPosition.X /= fontSize.X;
+    cursorPosition.Y /= fontSize.Y;
 
-        this->_terminal->SetSelectionAnchor(cursorPosition);
-        this->_terminal->SetBlockSelection(altPressed);
+    this->_terminal->SetSelectionAnchor(cursorPosition);
+    this->_terminal->SetBlockSelection(altPressed);
 
-        this->_renderer->TriggerSelection();
+    this->_renderer->TriggerSelection();
 
-        return S_OK;
-    }
-    CATCH_RETURN();
+    return S_OK;
+}
+CATCH_RETURN();
 
 HRESULT HwndTerminal::_MoveSelection(LPARAM lParam) noexcept
-    try
-    {
-        COORD cursorPosition{
-            GET_X_LPARAM(lParam),
-            GET_Y_LPARAM(lParam),
-        };
+try
+{
+    COORD cursorPosition{
+        GET_X_LPARAM(lParam),
+        GET_Y_LPARAM(lParam),
+    };
 
-        const auto fontSize = this->_actualFont.GetSize();
+    const auto fontSize = this->_actualFont.GetSize();
 
-        RETURN_HR_IF(E_NOT_VALID_STATE, fontSize.X == 0);
-        RETURN_HR_IF(E_NOT_VALID_STATE, fontSize.Y == 0);
+    RETURN_HR_IF(E_NOT_VALID_STATE, fontSize.X == 0);
+    RETURN_HR_IF(E_NOT_VALID_STATE, fontSize.Y == 0);
 
-        cursorPosition.X /= fontSize.X;
-        cursorPosition.Y /= fontSize.Y;
+    cursorPosition.X /= fontSize.X;
+    cursorPosition.Y /= fontSize.Y;
 
     try
     {
@@ -397,313 +397,313 @@ HRESULT HwndTerminal::_MoveSelection(LPARAM lParam) noexcept
     }
     CATCH_RETURN();
 
-void _stdcall TerminalClearSelection(void* terminal)
-{
-    const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
-    publicTerminal->_terminal->ClearSelection();
-}
-bool _stdcall TerminalIsSelectionActive(void* terminal)
-{
-    const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
-    const bool selectionActive = publicTerminal->_terminal->IsSelectionActive();
-    return selectionActive;
-}
-
-// Returns the selected text in the terminal.
-const wchar_t* _stdcall TerminalGetSelection(void* terminal)
-{
-    const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
-
-    const auto bufferData = publicTerminal->_terminal->RetrieveSelectedTextFromBuffer(false);
-
-    // convert text: vector<string> --> string
-    std::wstring selectedText;
-    for (const auto& text : bufferData.text)
+    void _stdcall TerminalClearSelection(void* terminal)
     {
-        selectedText += text;
+        const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
+        publicTerminal->_terminal->ClearSelection();
+    }
+    bool _stdcall TerminalIsSelectionActive(void* terminal)
+    {
+        const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
+        const bool selectionActive = publicTerminal->_terminal->IsSelectionActive();
+        return selectionActive;
     }
 
-    auto returnText = wil::make_cotaskmem_string_nothrow(selectedText.c_str());
-    TerminalClearSelection(terminal);
-
-    return returnText.release();
-}
-
-void _stdcall TerminalSendKeyEvent(void* terminal, WPARAM wParam)
-{
-    const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
-    const auto scanCode = MapVirtualKeyW((UINT)wParam, MAPVK_VK_TO_VSC);
-    struct KeyModifier
+    // Returns the selected text in the terminal.
+    const wchar_t* _stdcall TerminalGetSelection(void* terminal)
     {
-        int vkey;
+        const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
+
+        const auto bufferData = publicTerminal->_terminal->RetrieveSelectedTextFromBuffer(false);
+
+        // convert text: vector<string> --> string
+        std::wstring selectedText;
+        for (const auto& text : bufferData.text)
+        {
+            selectedText += text;
+        }
+
+        auto returnText = wil::make_cotaskmem_string_nothrow(selectedText.c_str());
+        TerminalClearSelection(terminal);
+
+        return returnText.release();
+    }
+
+    void _stdcall TerminalSendKeyEvent(void* terminal, WPARAM wParam)
+    {
+        const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
+        const auto scanCode = MapVirtualKeyW((UINT)wParam, MAPVK_VK_TO_VSC);
+        struct KeyModifier
+        {
+            int vkey;
+            ControlKeyStates flags;
+        };
+
+        constexpr std::array<KeyModifier, 5> modifiers{ {
+            { VK_RMENU, ControlKeyStates::RightAltPressed },
+            { VK_LMENU, ControlKeyStates::LeftAltPressed },
+            { VK_RCONTROL, ControlKeyStates::RightCtrlPressed },
+            { VK_LCONTROL, ControlKeyStates::LeftCtrlPressed },
+            { VK_SHIFT, ControlKeyStates::ShiftPressed },
+        } };
+
         ControlKeyStates flags;
-    };
 
-    constexpr std::array<KeyModifier, 5> modifiers{ {
-        { VK_RMENU, ControlKeyStates::RightAltPressed },
-        { VK_LMENU, ControlKeyStates::LeftAltPressed },
-        { VK_RCONTROL, ControlKeyStates::RightCtrlPressed },
-        { VK_LCONTROL, ControlKeyStates::LeftCtrlPressed },
-        { VK_SHIFT, ControlKeyStates::ShiftPressed },
-    } };
-
-    ControlKeyStates flags;
-
-    for (const auto& mod : modifiers)
-    {
-        const auto state = GetKeyState(mod.vkey);
-        const auto isDown = state < 0;
-
-        if (isDown)
+        for (const auto& mod : modifiers)
         {
-            flags |= mod.flags;
+            const auto state = GetKeyState(mod.vkey);
+            const auto isDown = state < 0;
+
+            if (isDown)
+            {
+                flags |= mod.flags;
+            }
         }
+
+        publicTerminal->_terminal->SendKeyEvent((WORD)wParam, (WORD)scanCode, flags);
     }
 
-    publicTerminal->_terminal->SendKeyEvent((WORD)wParam, (WORD)scanCode, flags);
-}
-
-void _stdcall TerminalSendCharEvent(void* terminal, wchar_t ch)
-{
-    if (ch == '\t')
+    void _stdcall TerminalSendCharEvent(void* terminal, wchar_t ch)
     {
-        return;
-    }
-
-    const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
-    publicTerminal->_terminal->SendCharEvent(ch);
-}
-
-void _stdcall DestroyTerminal(void* terminal)
-{
-    const auto publicTerminal = static_cast<HwndTerminal*>(terminal);
-    delete publicTerminal;
-}
-
-// Updates the terminal font type, size, color, as well as the background/foreground colors to a specified theme.
-void _stdcall TerminalSetTheme(void* terminal, TerminalTheme theme, LPCWSTR fontFamily, short fontSize, int newDpi)
-{
-    const auto publicTerminal = static_cast<HwndTerminal*>(terminal);
-    {
-        auto lock = publicTerminal->_terminal->LockForWriting();
-
-        publicTerminal->_terminal->SetDefaultForeground(theme.DefaultForeground);
-        publicTerminal->_terminal->SetDefaultBackground(theme.DefaultBackground);
-
-        // Set the font colors
-        for (size_t tableIndex = 0; tableIndex < 16; tableIndex++)
+        if (ch == '\t')
         {
-            // It's using gsl::at to check the index is in bounds, but the analyzer still calls this array-to-pointer-decay
-            [[gsl::suppress(bounds .3)]] publicTerminal->_terminal->SetColorTableEntry(tableIndex, gsl::at(theme.ColorTable, tableIndex));
+            return;
         }
+
+        const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
+        publicTerminal->_terminal->SendCharEvent(ch);
     }
 
-    publicTerminal->_terminal->SetCursorStyle(theme.CursorStyle);
-
-    publicTerminal->_desiredFont = { fontFamily, 0, 10, { 0, fontSize }, CP_UTF8 };
-    publicTerminal->_UpdateFont(newDpi);
-
-    // When the font changes the terminal dimensions need to be recalculated since the available row and column
-    // space will have changed.
-    RECT windowRect;
-    GetWindowRect(publicTerminal->_hwnd.get(), &windowRect);
-
-    COORD dimensions = {};
-    const SIZE windowSize{ windowRect.right - windowRect.left, windowRect.bottom - windowRect.top };
-    publicTerminal->Refresh(windowSize, &dimensions);
-}
-
-// Resizes the terminal to the specified rows and columns.
-HRESULT _stdcall TerminalResize(void* terminal, COORD dimensions)
-{
-    const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
-
-    return publicTerminal->_terminal->UserResize(dimensions);
-}
-
-void _stdcall TerminalBlinkCursor(void* terminal)
-{
-    const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
-    if (!publicTerminal->_terminal->IsCursorBlinkingAllowed() && publicTerminal->_terminal->IsCursorVisible())
+    void _stdcall DestroyTerminal(void* terminal)
     {
-        return;
+        const auto publicTerminal = static_cast<HwndTerminal*>(terminal);
+        delete publicTerminal;
     }
 
-    publicTerminal->_terminal->SetCursorVisible(!publicTerminal->_terminal->IsCursorVisible());
-}
-
-void _stdcall TerminalSetCursorVisible(void* terminal, const bool visible)
-{
-    const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
-    publicTerminal->_terminal->SetCursorVisible(visible);
-}
-
-// Routine Description:
-// - Copies the text given onto the global system clipboard.
-// Arguments:
-// - rows - Rows of text data to copy
-// - fAlsoCopyFormatting - true if the color and formatting should also be copied, false otherwise
-HRESULT HwndTerminal::_CopyTextToSystemClipboard(const TextBuffer::TextAndColor& rows, bool const fAlsoCopyFormatting)
-{
-    std::wstring finalString;
-
-    // Concatenate strings into one giant string to put onto the clipboard.
-    for (const auto& str : rows.text)
+    // Updates the terminal font type, size, color, as well as the background/foreground colors to a specified theme.
+    void _stdcall TerminalSetTheme(void* terminal, TerminalTheme theme, LPCWSTR fontFamily, short fontSize, int newDpi)
     {
-        finalString += str;
-    }
-
-    // allocate the final clipboard data
-    const size_t cchNeeded = finalString.size() + 1;
-    const size_t cbNeeded = sizeof(wchar_t) * cchNeeded;
-    wil::unique_hglobal globalHandle(GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, cbNeeded));
-    RETURN_LAST_ERROR_IF_NULL(globalHandle.get());
-
-    PWSTR pwszClipboard = static_cast<PWSTR>(GlobalLock(globalHandle.get()));
-    RETURN_LAST_ERROR_IF_NULL(pwszClipboard);
-
-    // The pattern gets a bit strange here because there's no good wil built-in for global lock of this type.
-    // Try to copy then immediately unlock. Don't throw until after (so the hglobal won't be freed until we unlock).
-    const HRESULT hr = StringCchCopyW(pwszClipboard, cchNeeded, finalString.data());
-    GlobalUnlock(globalHandle.get());
-    RETURN_IF_FAILED(hr);
-
-    // Set global data to clipboard
-    RETURN_LAST_ERROR_IF(!OpenClipboard(_hwnd.get()));
-
-    { // Clipboard Scope
-        auto clipboardCloser = wil::scope_exit([]() noexcept {
-            LOG_LAST_ERROR_IF(!CloseClipboard());
-        });
-
-        RETURN_LAST_ERROR_IF(!EmptyClipboard());
-        RETURN_LAST_ERROR_IF_NULL(SetClipboardData(CF_UNICODETEXT, globalHandle.get()));
-
-        if (fAlsoCopyFormatting)
+        const auto publicTerminal = static_cast<HwndTerminal*>(terminal);
         {
-            const auto& fontData = _actualFont;
-            int const iFontHeightPoints = fontData.GetUnscaledSize().Y * 72 / this->_currentDpi;
-            const COLORREF bgColor = _terminal->GetBackgroundColor(_terminal->GetDefaultBrushColors());
+            auto lock = publicTerminal->_terminal->LockForWriting();
 
-            std::string HTMLToPlaceOnClip = TextBuffer::GenHTML(rows, iFontHeightPoints, fontData.GetFaceName(), bgColor, "Hwnd Console Host");
-            _CopyToSystemClipboard(HTMLToPlaceOnClip, L"HTML Format");
+            publicTerminal->_terminal->SetDefaultForeground(theme.DefaultForeground);
+            publicTerminal->_terminal->SetDefaultBackground(theme.DefaultBackground);
 
-            std::string RTFToPlaceOnClip = TextBuffer::GenRTF(rows, iFontHeightPoints, fontData.GetFaceName(), bgColor);
-            _CopyToSystemClipboard(RTFToPlaceOnClip, L"Rich Text Format");
+            // Set the font colors
+            for (size_t tableIndex = 0; tableIndex < 16; tableIndex++)
+            {
+                // It's using gsl::at to check the index is in bounds, but the analyzer still calls this array-to-pointer-decay
+                [[gsl::suppress(bounds .3)]] publicTerminal->_terminal->SetColorTableEntry(tableIndex, gsl::at(theme.ColorTable, tableIndex));
+            }
         }
+
+        publicTerminal->_terminal->SetCursorStyle(theme.CursorStyle);
+
+        publicTerminal->_desiredFont = { fontFamily, 0, 10, { 0, fontSize }, CP_UTF8 };
+        publicTerminal->_UpdateFont(newDpi);
+
+        // When the font changes the terminal dimensions need to be recalculated since the available row and column
+        // space will have changed.
+        RECT windowRect;
+        GetWindowRect(publicTerminal->_hwnd.get(), &windowRect);
+
+        COORD dimensions = {};
+        const SIZE windowSize{ windowRect.right - windowRect.left, windowRect.bottom - windowRect.top };
+        publicTerminal->Refresh(windowSize, &dimensions);
     }
 
-    // only free if we failed.
-    // the memory has to remain allocated if we successfully placed it on the clipboard.
-    // Releasing the smart pointer will leave it allocated as we exit scope.
-    globalHandle.release();
-
-    return S_OK;
-}
-
-// Routine Description:
-// - Copies the given string onto the global system clipboard in the specified format
-// Arguments:
-// - stringToCopy - The string to copy
-// - lpszFormat - the name of the format
-HRESULT HwndTerminal::_CopyToSystemClipboard(std::string stringToCopy, LPCWSTR lpszFormat)
-{
-    const size_t cbData = stringToCopy.size() + 1; // +1 for '\0'
-    if (cbData)
+    // Resizes the terminal to the specified rows and columns.
+    HRESULT _stdcall TerminalResize(void* terminal, COORD dimensions)
     {
-        wil::unique_hglobal globalHandleData(GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, cbData));
-        RETURN_LAST_ERROR_IF_NULL(globalHandleData.get());
+        const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
 
-        PSTR pszClipboardHTML = static_cast<PSTR>(GlobalLock(globalHandleData.get()));
-        RETURN_LAST_ERROR_IF_NULL(pszClipboardHTML);
+        return publicTerminal->_terminal->UserResize(dimensions);
+    }
+
+    void _stdcall TerminalBlinkCursor(void* terminal)
+    {
+        const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
+        if (!publicTerminal->_terminal->IsCursorBlinkingAllowed() && publicTerminal->_terminal->IsCursorVisible())
+        {
+            return;
+        }
+
+        publicTerminal->_terminal->SetCursorVisible(!publicTerminal->_terminal->IsCursorVisible());
+    }
+
+    void _stdcall TerminalSetCursorVisible(void* terminal, const bool visible)
+    {
+        const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
+        publicTerminal->_terminal->SetCursorVisible(visible);
+    }
+
+    // Routine Description:
+    // - Copies the text given onto the global system clipboard.
+    // Arguments:
+    // - rows - Rows of text data to copy
+    // - fAlsoCopyFormatting - true if the color and formatting should also be copied, false otherwise
+    HRESULT HwndTerminal::_CopyTextToSystemClipboard(const TextBuffer::TextAndColor& rows, bool const fAlsoCopyFormatting)
+    {
+        std::wstring finalString;
+
+        // Concatenate strings into one giant string to put onto the clipboard.
+        for (const auto& str : rows.text)
+        {
+            finalString += str;
+        }
+
+        // allocate the final clipboard data
+        const size_t cchNeeded = finalString.size() + 1;
+        const size_t cbNeeded = sizeof(wchar_t) * cchNeeded;
+        wil::unique_hglobal globalHandle(GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, cbNeeded));
+        RETURN_LAST_ERROR_IF_NULL(globalHandle.get());
+
+        PWSTR pwszClipboard = static_cast<PWSTR>(GlobalLock(globalHandle.get()));
+        RETURN_LAST_ERROR_IF_NULL(pwszClipboard);
 
         // The pattern gets a bit strange here because there's no good wil built-in for global lock of this type.
         // Try to copy then immediately unlock. Don't throw until after (so the hglobal won't be freed until we unlock).
-        const HRESULT hr2 = StringCchCopyA(pszClipboardHTML, cbData, stringToCopy.data());
-        GlobalUnlock(globalHandleData.get());
-        RETURN_IF_FAILED(hr2);
+        const HRESULT hr = StringCchCopyW(pwszClipboard, cchNeeded, finalString.data());
+        GlobalUnlock(globalHandle.get());
+        RETURN_IF_FAILED(hr);
 
-        UINT const CF_FORMAT = RegisterClipboardFormatW(lpszFormat);
-        RETURN_LAST_ERROR_IF(0 == CF_FORMAT);
+        // Set global data to clipboard
+        RETURN_LAST_ERROR_IF(!OpenClipboard(_hwnd.get()));
 
-        RETURN_LAST_ERROR_IF_NULL(SetClipboardData(CF_FORMAT, globalHandleData.get()));
+        { // Clipboard Scope
+            auto clipboardCloser = wil::scope_exit([]() noexcept {
+                LOG_LAST_ERROR_IF(!CloseClipboard());
+            });
+
+            RETURN_LAST_ERROR_IF(!EmptyClipboard());
+            RETURN_LAST_ERROR_IF_NULL(SetClipboardData(CF_UNICODETEXT, globalHandle.get()));
+
+            if (fAlsoCopyFormatting)
+            {
+                const auto& fontData = _actualFont;
+                int const iFontHeightPoints = fontData.GetUnscaledSize().Y * 72 / this->_currentDpi;
+                const COLORREF bgColor = _terminal->GetBackgroundColor(_terminal->GetDefaultBrushColors());
+
+                std::string HTMLToPlaceOnClip = TextBuffer::GenHTML(rows, iFontHeightPoints, fontData.GetFaceName(), bgColor, "Hwnd Console Host");
+                _CopyToSystemClipboard(HTMLToPlaceOnClip, L"HTML Format");
+
+                std::string RTFToPlaceOnClip = TextBuffer::GenRTF(rows, iFontHeightPoints, fontData.GetFaceName(), bgColor);
+                _CopyToSystemClipboard(RTFToPlaceOnClip, L"Rich Text Format");
+            }
+        }
 
         // only free if we failed.
         // the memory has to remain allocated if we successfully placed it on the clipboard.
         // Releasing the smart pointer will leave it allocated as we exit scope.
-        globalHandleData.release();
+        globalHandle.release();
+
+        return S_OK;
     }
 
-    return S_OK;
-}
-
-void HwndTerminal::_PasteTextFromClipboard() noexcept
-{
-    // Get paste data from clipboard
-    if (!OpenClipboard(_hwnd.get()))
+    // Routine Description:
+    // - Copies the given string onto the global system clipboard in the specified format
+    // Arguments:
+    // - stringToCopy - The string to copy
+    // - lpszFormat - the name of the format
+    HRESULT HwndTerminal::_CopyToSystemClipboard(std::string stringToCopy, LPCWSTR lpszFormat)
     {
-        return;
+        const size_t cbData = stringToCopy.size() + 1; // +1 for '\0'
+        if (cbData)
+        {
+            wil::unique_hglobal globalHandleData(GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, cbData));
+            RETURN_LAST_ERROR_IF_NULL(globalHandleData.get());
+
+            PSTR pszClipboardHTML = static_cast<PSTR>(GlobalLock(globalHandleData.get()));
+            RETURN_LAST_ERROR_IF_NULL(pszClipboardHTML);
+
+            // The pattern gets a bit strange here because there's no good wil built-in for global lock of this type.
+            // Try to copy then immediately unlock. Don't throw until after (so the hglobal won't be freed until we unlock).
+            const HRESULT hr2 = StringCchCopyA(pszClipboardHTML, cbData, stringToCopy.data());
+            GlobalUnlock(globalHandleData.get());
+            RETURN_IF_FAILED(hr2);
+
+            UINT const CF_FORMAT = RegisterClipboardFormatW(lpszFormat);
+            RETURN_LAST_ERROR_IF(0 == CF_FORMAT);
+
+            RETURN_LAST_ERROR_IF_NULL(SetClipboardData(CF_FORMAT, globalHandleData.get()));
+
+            // only free if we failed.
+            // the memory has to remain allocated if we successfully placed it on the clipboard.
+            // Releasing the smart pointer will leave it allocated as we exit scope.
+            globalHandleData.release();
+        }
+
+        return S_OK;
     }
 
-    HANDLE ClipboardDataHandle = GetClipboardData(CF_UNICODETEXT);
-    if (ClipboardDataHandle == nullptr)
+    void HwndTerminal::_PasteTextFromClipboard() noexcept
     {
+        // Get paste data from clipboard
+        if (!OpenClipboard(_hwnd.get()))
+        {
+            return;
+        }
+
+        HANDLE ClipboardDataHandle = GetClipboardData(CF_UNICODETEXT);
+        if (ClipboardDataHandle == nullptr)
+        {
+            CloseClipboard();
+            return;
+        }
+
+        PCWCH pwstr = static_cast<PCWCH>(GlobalLock(ClipboardDataHandle));
+
+        _StringPaste(pwstr);
+
+        GlobalUnlock(ClipboardDataHandle);
+
         CloseClipboard();
-        return;
     }
 
-    PCWCH pwstr = static_cast<PCWCH>(GlobalLock(ClipboardDataHandle));
-
-    _StringPaste(pwstr);
-
-    GlobalUnlock(ClipboardDataHandle);
-
-    CloseClipboard();
-}
-
-void HwndTerminal::_StringPaste(const wchar_t* const pData) noexcept
-{
-    if (pData == nullptr)
+    void HwndTerminal::_StringPaste(const wchar_t* const pData) noexcept
     {
-        return;
+        if (pData == nullptr)
+        {
+            return;
+        }
+
+        try
+        {
+            std::wstring text(pData);
+            _WriteTextToConnection(text);
+        }
+        CATCH_LOG();
     }
 
-    try
+    COORD HwndTerminal::GetFontSize() const
     {
-        std::wstring text(pData);
-        _WriteTextToConnection(text);
+        return _actualFont.GetSize();
     }
-    CATCH_LOG();
-}
 
-COORD HwndTerminal::GetFontSize() const
-{
-    return _actualFont.GetSize();
-}
+    RECT HwndTerminal::GetBounds() const noexcept
+    {
+        RECT windowRect;
+        GetWindowRect(_hwnd.get(), &windowRect);
+        return windowRect;
+    }
 
-RECT HwndTerminal::GetBounds() const noexcept
-{
-    RECT windowRect;
-    GetWindowRect(_hwnd.get(), &windowRect);
-    return windowRect;
-}
+    RECT HwndTerminal::GetPadding() const noexcept
+    {
+        return { 0 };
+    }
 
-RECT HwndTerminal::GetPadding() const noexcept
-{
-    return { 0 };
-}
+    double HwndTerminal::GetScaleFactor() const noexcept
+    {
+        return static_cast<double>(_currentDpi) / static_cast<double>(USER_DEFAULT_SCREEN_DPI);
+    }
 
-double HwndTerminal::GetScaleFactor() const noexcept
-{
-    return static_cast<double>(_currentDpi) / static_cast<double>(USER_DEFAULT_SCREEN_DPI);
-}
+    void HwndTerminal::ChangeViewport(const SMALL_RECT NewWindow)
+    {
+        _terminal->UserScrollViewport(NewWindow.Top);
+    }
 
-void HwndTerminal::ChangeViewport(const SMALL_RECT NewWindow)
-{
-    _terminal->UserScrollViewport(NewWindow.Top);
-}
-
-HRESULT HwndTerminal::GetHostUiaProvider(IRawElementProviderSimple** provider) noexcept
-{
-    return UiaHostProviderFromHwnd(_hwnd.get(), provider);
-}
+    HRESULT HwndTerminal::GetHostUiaProvider(IRawElementProviderSimple * *provider) noexcept
+    {
+        return UiaHostProviderFromHwnd(_hwnd.get(), provider);
+    }

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
@@ -39,7 +39,7 @@ LRESULT CALLBACK HwndTerminal::HwndTerminalWndProc(
             LOG_IF_FAILED(terminal->_StartSelection(lParam));
             return 0;
         case WM_MOUSEMOVE:
-            if ((wParam & 0x0001) == 1)
+            if (WI_IsFlagSet(wParam, MK_LBUTTON))
             {
                 LOG_IF_FAILED(terminal->_MoveSelection(lParam));
                 return 0;
@@ -93,8 +93,8 @@ HwndTerminal::HwndTerminal(HWND parentHwnd) :
     _actualFont{ DEFAULT_FONT_FACE, 0, 10, { 0, 14 }, CP_UTF8, false },
     _uiaProvider{ nullptr },
     _uiaProviderInitialized{ false },
-    _currentDpi{ USER_DEFAULT_SCREEN_DPI }
-//_pfnWriteCallback{ nullptr }
+    _currentDpi{ USER_DEFAULT_SCREEN_DPI },
+    _pfnWriteCallback{ nullptr }
 {
     HINSTANCE hInstance = wil::GetModuleInstanceHandle();
 

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.h"
 #include "HwndTerminal.hpp"
+#include <windowsx.h>
 #include "../../types/TermControlUiaProvider.hpp"
 #include <DefaultSettings.h>
 #include "../../renderer/base/Renderer.hpp"
@@ -33,6 +34,36 @@ LRESULT CALLBACK HwndTerminal::HwndTerminalWndProc(
             {
                 return UiaReturnRawElementProvider(hwnd, wParam, lParam, terminal->_GetUiaProvider());
             }
+            break;
+        case WM_LBUTTONDOWN:
+            LOG_IF_FAILED(terminal->_StartSelection(lParam));
+            return 0;
+        case WM_MOUSEMOVE:
+            if ((wParam & 0x0001) == 1)
+            {
+                LOG_IF_FAILED(terminal->_MoveSelection(lParam));
+                return 0;
+            }
+            break;
+        case WM_RBUTTONDOWN:
+            if (terminal->_terminal->IsSelectionActive())
+            {
+                try
+                {
+                    const auto bufferData = terminal->_terminal->RetrieveSelectedTextFromBuffer(false);
+                    LOG_IF_FAILED(terminal->_CopyTextToSystemClipboard(bufferData, true));
+                    terminal->_terminal->ClearSelection();
+                }
+                catch (...)
+                {
+                    LOG_HR(wil::ResultFromCaughtException());
+                }
+            }
+            else
+            {
+                terminal->_PasteTextFromClipboard();
+            }
+            return 0;
         }
     }
     return DefWindowProc(hwnd, uMsg, wParam, lParam);
@@ -66,6 +97,7 @@ HwndTerminal::HwndTerminal(HWND parentHwnd) :
     _uiaProvider{ nullptr },
     _uiaProviderInitialized{ false },
     _currentDpi{ USER_DEFAULT_SCREEN_DPI }
+//_pfnWriteCallback{ nullptr }
 {
     HINSTANCE hInstance = wil::GetModuleInstanceHandle();
 
@@ -128,7 +160,7 @@ HRESULT HwndTerminal::Initialize()
     _terminal->Create(COORD{ 80, 25 }, 1000, *_renderer);
     _terminal->SetDefaultBackground(RGB(5, 27, 80));
     _terminal->SetDefaultForeground(RGB(255, 255, 255));
-
+    _terminal->SetWriteInputCallback([=](std::wstring& input) { _WriteTextToConnection(input); });
     localPointerToThread->EnablePainting();
 
     return S_OK;
@@ -139,27 +171,35 @@ void HwndTerminal::RegisterScrollCallback(std::function<void(int, int, int)> cal
     _terminal->SetScrollPositionChangedCallback(callback);
 }
 
+void HwndTerminal::_WriteTextToConnection(std::wstring& input) noexcept
+{
+    if (!_pfnWriteCallback)
+    {
+        return;
+    }
+
+    const wchar_t* text = input.c_str();
+    const size_t textChars = wcslen(text) + 1;
+    const size_t textBytes = textChars * sizeof(wchar_t);
+    wchar_t* callingText = nullptr;
+
+    callingText = static_cast<wchar_t*>(::CoTaskMemAlloc(textBytes));
+
+    if (callingText == nullptr)
+    {
+        _pfnWriteCallback(nullptr);
+    }
+    else
+    {
+        wcscpy_s(callingText, textChars, text);
+
+        _pfnWriteCallback(callingText);
+    }
+}
+
 void HwndTerminal::RegisterWriteCallback(const void _stdcall callback(wchar_t*))
 {
-    _terminal->SetWriteInputCallback([=](std::wstring & input) noexcept {
-        const wchar_t* text = input.c_str();
-        const size_t textChars = wcslen(text) + 1;
-        const size_t textBytes = textChars * sizeof(wchar_t);
-        wchar_t* callingText = nullptr;
-
-        callingText = static_cast<wchar_t*>(::CoTaskMemAlloc(textBytes));
-
-        if (callingText == nullptr)
-        {
-            callback(nullptr);
-        }
-        else
-        {
-            wcscpy_s(callingText, textChars, text);
-
-            callback(callingText);
-        }
-    });
+    _pfnWriteCallback = callback;
 }
 
 ::Microsoft::Console::Types::IUiaData* HwndTerminal::GetUiaData() const noexcept
@@ -320,42 +360,61 @@ void _stdcall TerminalUserScroll(void* terminal, int viewTop)
     publicTerminal->_terminal->UserScrollViewport(viewTop);
 }
 
-HRESULT _stdcall TerminalStartSelection(void* terminal, COORD cursorPosition, bool altPressed)
+HRESULT HwndTerminal::_StartSelection(LPARAM lParam) noexcept
 {
-    COORD terminalPosition = { cursorPosition };
+    bool altPressed = GetKeyState(VK_MENU) < 0;
+    COORD cursorPosition{
+        GET_X_LPARAM(lParam),
+        GET_Y_LPARAM(lParam),
+    };
 
-    const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
-    const auto fontSize = publicTerminal->_actualFont.GetSize();
+    const auto fontSize = this->_actualFont.GetSize();
 
     RETURN_HR_IF(E_NOT_VALID_STATE, fontSize.X == 0);
     RETURN_HR_IF(E_NOT_VALID_STATE, fontSize.Y == 0);
 
-    terminalPosition.X /= fontSize.X;
-    terminalPosition.Y /= fontSize.Y;
+    cursorPosition.X /= fontSize.X;
+    cursorPosition.Y /= fontSize.Y;
 
-    publicTerminal->_terminal->SetSelectionAnchor(terminalPosition);
-    publicTerminal->_terminal->SetBlockSelection(altPressed);
+    try
+    {
+        this->_terminal->SetSelectionAnchor(cursorPosition);
+        this->_terminal->SetBlockSelection(altPressed);
 
-    publicTerminal->_renderer->TriggerSelection();
+        this->_renderer->TriggerSelection();
+    }
+    catch (...)
+    {
+        RETURN_HR(wil::ResultFromCaughtException());
+    }
 
     return S_OK;
 }
 
-HRESULT _stdcall TerminalMoveSelection(void* terminal, COORD cursorPosition)
+HRESULT HwndTerminal::_MoveSelection(LPARAM lParam) noexcept
 {
-    COORD terminalPosition = { cursorPosition };
+    COORD cursorPosition{
+        GET_X_LPARAM(lParam),
+        GET_Y_LPARAM(lParam),
+    };
 
-    const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
-    const auto fontSize = publicTerminal->_actualFont.GetSize();
+    const auto fontSize = this->_actualFont.GetSize();
 
     RETURN_HR_IF(E_NOT_VALID_STATE, fontSize.X == 0);
     RETURN_HR_IF(E_NOT_VALID_STATE, fontSize.Y == 0);
 
-    terminalPosition.X /= fontSize.X;
-    terminalPosition.Y /= fontSize.Y;
+    cursorPosition.X /= fontSize.X;
+    cursorPosition.Y /= fontSize.Y;
 
-    publicTerminal->_terminal->SetSelectionEnd(terminalPosition);
-    publicTerminal->_renderer->TriggerSelection();
+    try
+    {
+        this->_terminal->SetSelectionEnd(cursorPosition);
+        this->_renderer->TriggerSelection();
+    }
+    catch (...)
+    {
+        RETURN_HR(wil::ResultFromCaughtException());
+    }
 
     return S_OK;
 }
@@ -499,6 +558,152 @@ void _stdcall TerminalSetCursorVisible(void* terminal, const bool visible)
 {
     const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
     publicTerminal->_terminal->SetCursorVisible(visible);
+}
+
+// Routine Description:
+// - Copies the text given onto the global system clipboard.
+// Arguments:
+// - rows - Rows of text data to copy
+// - fAlsoCopyFormatting - true if the color and formatting should also be copied, false otherwise
+HRESULT HwndTerminal::_CopyTextToSystemClipboard(const TextBuffer::TextAndColor& rows, bool const fAlsoCopyFormatting) noexcept
+{
+    std::wstring finalString;
+
+    // Concatenate strings into one giant string to put onto the clipboard.
+    for (const auto& str : rows.text)
+    {
+        finalString += str;
+    }
+
+    // allocate the final clipboard data
+    const size_t cchNeeded = finalString.size() + 1;
+    const size_t cbNeeded = sizeof(wchar_t) * cchNeeded;
+    wil::unique_hglobal globalHandle(GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, cbNeeded));
+    RETURN_LAST_ERROR_IF_NULL(globalHandle.get());
+
+    PWSTR pwszClipboard = (PWSTR)GlobalLock(globalHandle.get());
+    RETURN_LAST_ERROR_IF_NULL(pwszClipboard);
+
+    // The pattern gets a bit strange here because there's no good wil built-in for global lock of this type.
+    // Try to copy then immediately unlock. Don't throw until after (so the hglobal won't be freed until we unlock).
+    const HRESULT hr = StringCchCopyW(pwszClipboard, cchNeeded, finalString.data());
+    GlobalUnlock(globalHandle.get());
+    RETURN_IF_FAILED(hr);
+
+    // Set global data to clipboard
+    RETURN_LAST_ERROR_IF(!OpenClipboard(_hwnd.get()));
+
+    { // Clipboard Scope
+        auto clipboardCloser = wil::scope_exit([]() {
+            LOG_LAST_ERROR_IF(!CloseClipboard());
+        });
+
+        RETURN_LAST_ERROR_IF(!EmptyClipboard());
+        RETURN_LAST_ERROR_IF_NULL(SetClipboardData(CF_UNICODETEXT, globalHandle.get()));
+
+        if (fAlsoCopyFormatting)
+        {
+            const auto& fontData = _actualFont;
+            int const iFontHeightPoints = fontData.GetUnscaledSize().Y * 72 / this->_currentDpi;
+            const COLORREF bgColor = _terminal->GetBackgroundColor(_terminal->GetDefaultBrushColors());
+
+            std::string HTMLToPlaceOnClip = TextBuffer::GenHTML(rows, iFontHeightPoints, fontData.GetFaceName(), bgColor, "Hwnd Console Host");
+            _CopyToSystemClipboard(HTMLToPlaceOnClip, L"HTML Format");
+
+            std::string RTFToPlaceOnClip = TextBuffer::GenRTF(rows, iFontHeightPoints, fontData.GetFaceName(), bgColor);
+            _CopyToSystemClipboard(RTFToPlaceOnClip, L"Rich Text Format");
+        }
+    }
+
+    // only free if we failed.
+    // the memory has to remain allocated if we successfully placed it on the clipboard.
+    // Releasing the smart pointer will leave it allocated as we exit scope.
+    globalHandle.release();
+
+    return S_OK;
+}
+
+// Routine Description:
+// - Copies the given string onto the global system clipboard in the specified format
+// Arguments:
+// - stringToCopy - The string to copy
+// - lpszFormat - the name of the format
+HRESULT HwndTerminal::_CopyToSystemClipboard(std::string stringToCopy, LPCWSTR lpszFormat) noexcept
+{
+    const size_t cbData = stringToCopy.size() + 1; // +1 for '\0'
+    if (cbData)
+    {
+        wil::unique_hglobal globalHandleData(GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, cbData));
+        RETURN_LAST_ERROR_IF_NULL(globalHandleData.get());
+
+        PSTR pszClipboardHTML = (PSTR)GlobalLock(globalHandleData.get());
+        RETURN_LAST_ERROR_IF_NULL(pszClipboardHTML);
+
+        // The pattern gets a bit strange here because there's no good wil built-in for global lock of this type.
+        // Try to copy then immediately unlock. Don't throw until after (so the hglobal won't be freed until we unlock).
+        const HRESULT hr2 = StringCchCopyA(pszClipboardHTML, cbData, stringToCopy.data());
+        GlobalUnlock(globalHandleData.get());
+        RETURN_IF_FAILED(hr2);
+
+        UINT const CF_FORMAT = RegisterClipboardFormatW(lpszFormat);
+        RETURN_LAST_ERROR_IF(0 == CF_FORMAT);
+
+        RETURN_LAST_ERROR_IF_NULL(SetClipboardData(CF_FORMAT, globalHandleData.get()));
+
+        // only free if we failed.
+        // the memory has to remain allocated if we successfully placed it on the clipboard.
+        // Releasing the smart pointer will leave it allocated as we exit scope.
+        globalHandleData.release();
+    }
+
+    return S_OK;
+}
+
+void HwndTerminal::_PasteTextFromClipboard() noexcept
+{
+    HANDLE ClipboardDataHandle;
+
+    // Clear any selection or scrolling that may be active.
+    _terminal->ClearSelection();
+
+    // Get paste data from clipboard
+    if (!OpenClipboard(_hwnd.get()))
+    {
+        return;
+    }
+
+    ClipboardDataHandle = GetClipboardData(CF_UNICODETEXT);
+    if (ClipboardDataHandle == nullptr)
+    {
+        CloseClipboard();
+        return;
+    }
+
+    PWCHAR pwstr = (PWCHAR)GlobalLock(ClipboardDataHandle);
+
+    _StringPaste(pwstr);
+
+    GlobalUnlock(ClipboardDataHandle);
+
+    CloseClipboard();
+}
+
+void HwndTerminal::_StringPaste(const wchar_t* const pData) noexcept
+{
+    if (pData == nullptr)
+    {
+        return;
+    }
+
+    try
+    {
+        std::wstring text(pData);
+        _WriteTextToConnection(text);
+    }
+    catch (...)
+    {
+        LOG_HR(wil::ResultFromCaughtException());
+    }
 }
 
 COORD HwndTerminal::GetFontSize() const

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
@@ -89,9 +89,9 @@ private:
     friend void _stdcall TerminalSetCursorVisible(void* terminal, const bool visible);
 
     void _UpdateFont(int newDpi);
-    void _WriteTextToConnection(std::wstring& text) noexcept;
-    HRESULT _CopyTextToSystemClipboard(const TextBuffer::TextAndColor& rows, bool const fAlsoCopyFormatting) noexcept;
-    HRESULT _CopyToSystemClipboard(std::string stringToCopy, LPCWSTR lpszFormat) noexcept;
+    void _WriteTextToConnection(const std::wstring& text) noexcept;
+    HRESULT _CopyTextToSystemClipboard(const TextBuffer::TextAndColor& rows, bool const fAlsoCopyFormatting);
+    HRESULT _CopyToSystemClipboard(std::string stringToCopy, LPCWSTR lpszFormat);
     void _PasteTextFromClipboard() noexcept;
     void _StringPaste(const wchar_t* const pData) noexcept;
 

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
@@ -28,8 +28,6 @@ __declspec(dllexport) HRESULT _stdcall TerminalTriggerResize(void* terminal, dou
 __declspec(dllexport) HRESULT _stdcall TerminalResize(void* terminal, COORD dimensions);
 __declspec(dllexport) void _stdcall TerminalDpiChanged(void* terminal, int newDpi);
 __declspec(dllexport) void _stdcall TerminalUserScroll(void* terminal, int viewTop);
-__declspec(dllexport) HRESULT _stdcall TerminalStartSelection(void* terminal, COORD cursorPosition, bool altPressed);
-__declspec(dllexport) HRESULT _stdcall TerminalMoveSelection(void* terminal, COORD cursorPosition);
 __declspec(dllexport) void _stdcall TerminalClearSelection(void* terminal);
 __declspec(dllexport) const wchar_t* _stdcall TerminalGetSelection(void* terminal);
 __declspec(dllexport) bool _stdcall TerminalIsSelectionActive(void* terminal);
@@ -69,7 +67,7 @@ private:
     FontInfo _actualFont;
     int _currentDpi;
     bool _uiaProviderInitialized;
-
+    std::function<void(wchar_t*)> _pfnWriteCallback;
     ::Microsoft::WRL::ComPtr<::Microsoft::Terminal::TermControlUiaProvider> _uiaProvider;
 
     std::unique_ptr<::Microsoft::Terminal::Core::Terminal> _terminal;
@@ -81,8 +79,6 @@ private:
     friend HRESULT _stdcall TerminalResize(void* terminal, COORD dimensions);
     friend void _stdcall TerminalDpiChanged(void* terminal, int newDpi);
     friend void _stdcall TerminalUserScroll(void* terminal, int viewTop);
-    friend HRESULT _stdcall TerminalStartSelection(void* terminal, COORD cursorPosition, bool altPressed);
-    friend HRESULT _stdcall TerminalMoveSelection(void* terminal, COORD cursorPosition);
     friend void _stdcall TerminalClearSelection(void* terminal);
     friend const wchar_t* _stdcall TerminalGetSelection(void* terminal);
     friend bool _stdcall TerminalIsSelectionActive(void* terminal);
@@ -91,7 +87,16 @@ private:
     friend void _stdcall TerminalSetTheme(void* terminal, TerminalTheme theme, LPCWSTR fontFamily, short fontSize, int newDpi);
     friend void _stdcall TerminalBlinkCursor(void* terminal);
     friend void _stdcall TerminalSetCursorVisible(void* terminal, const bool visible);
+
     void _UpdateFont(int newDpi);
+    void _WriteTextToConnection(std::wstring& text) noexcept;
+    HRESULT _CopyTextToSystemClipboard(const TextBuffer::TextAndColor& rows, bool const fAlsoCopyFormatting) noexcept;
+    HRESULT _CopyToSystemClipboard(std::string stringToCopy, LPCWSTR lpszFormat) noexcept;
+    void _PasteTextFromClipboard() noexcept;
+    void _StringPaste(const wchar_t* const pData) noexcept;
+
+    HRESULT _StartSelection(LPARAM lParam) noexcept;
+    HRESULT _MoveSelection(LPARAM lParam) noexcept;
     IRawElementProviderSimple* _GetUiaProvider() noexcept;
 
     // Inherited via IControlAccessibilityInfo

--- a/src/cascadia/WpfTerminalControl/TerminalContainer.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalContainer.cs
@@ -230,23 +230,6 @@ namespace Microsoft.Terminal.Wpf
                         this.Focus();
                         NativeMethods.SetFocus(this.hwnd);
                         break;
-                    case NativeMethods.WindowMessage.WM_LBUTTONDOWN:
-                        this.LeftClickHandler((int)lParam);
-                        break;
-                    case NativeMethods.WindowMessage.WM_RBUTTONDOWN:
-                        if (NativeMethods.TerminalIsSelectionActive(this.terminal))
-                        {
-                            Clipboard.SetText(NativeMethods.TerminalGetSelection(this.terminal));
-                        }
-                        else
-                        {
-                            this.connection.WriteInput(Clipboard.GetText());
-                        }
-
-                        break;
-                    case NativeMethods.WindowMessage.WM_MOUSEMOVE:
-                        this.MouseMoveHandler((int)wParam, (int)lParam);
-                        break;
                     case NativeMethods.WindowMessage.WM_KEYDOWN:
                         NativeMethods.TerminalSetCursorVisible(this.terminal, true);
                         NativeMethods.TerminalClearSelection(this.terminal);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
PR #4548 inadvertantly broke mouse button input in the WPF control. This happened due to the extra layer of HWND indirection. The fix is to move the mouse button handling down into the native control where the window messages are now being sent.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place:

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
VS was patched with new bits to ensure correct behavior.