### PR TITLE
Fix the build on VS 2019 Update 5

### DIFF
--- a/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
+++ b/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
@@ -93,9 +93,7 @@
        roll up our subproject resources. We have to suppress that rule but keep part of its logic, because that rule is
        where the AppxPackagePayload items are created. -->
   <PropertyGroup>
-    <!-- Only for MSBuild versions <= 16.4.0 -->
-    <!-- TODO: Change this to hard less than once the 16.4.0 previews fix the bug. -->
-    <WapProjBeforeGenerateAppxManifestDependsOn Condition="$(MSBuildVersion) &lt;= '16.4.0'">
+    <WapProjBeforeGenerateAppxManifestDependsOn>
         $([MSBuild]::Unescape('$(WapProjBeforeGenerateAppxManifestDependsOn.Replace('_RemoveAllNonWapUWPItems', '_OpenConsoleRemoveAllNonWapUWPItems'))'))
     </WapProjBeforeGenerateAppxManifestDependsOn>
   </PropertyGroup>

--- a/src/terminal/adapter/adaptDefaults.hpp
+++ b/src/terminal/adapter/adaptDefaults.hpp
@@ -21,6 +21,7 @@ namespace Microsoft::Console::VirtualTerminal
     class AdaptDefaults
     {
     public:
+        virtual ~AdaptDefaults() = default;
         virtual void Print(const wchar_t wch) = 0;
         // These characters need to be mutable so that they can be processed by the TerminalInput translater.
         virtual void PrintString(const std::wstring_view string) = 0;

--- a/src/terminal/adapter/conGetSet.hpp
+++ b/src/terminal/adapter/conGetSet.hpp
@@ -27,6 +27,7 @@ namespace Microsoft::Console::VirtualTerminal
     class ConGetSet
     {
     public:
+        virtual ~ConGetSet() = default;
         virtual bool GetConsoleCursorInfo(CONSOLE_CURSOR_INFO& cursorInfo) const = 0;
         virtual bool GetConsoleScreenBufferInfoEx(CONSOLE_SCREEN_BUFFER_INFOEX& screenBufferInfo) const = 0;
         virtual bool SetConsoleScreenBufferInfoEx(const CONSOLE_SCREEN_BUFFER_INFOEX& screenBufferInfo) = 0;


### PR DESCRIPTION
This commit introduces two fixes for C5205 (delete of an abtract class
without a virtual dtor) and one fix for a very hopeful VS version gating
that didn't pan out.