### PR TITLE
Add warning messages for bad keybindings

### DIFF
--- a/src/cascadia/TerminalApp/ActionArgs.h
+++ b/src/cascadia/TerminalApp/ActionArgs.h
@@ -261,7 +261,14 @@ namespace winrt::TerminalApp::implementation
             {
                 args->_Direction = ParseDirection(directionString.asString());
             }
-            return { *args, {} };
+            if (args->_Direction == TerminalApp::Direction::None)
+            {
+                return { nullptr, { ::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter } };
+            }
+            else
+            {
+                return { *args, {} };
+            }
         }
     };
 

--- a/src/cascadia/TerminalApp/ActionArgs.h
+++ b/src/cascadia/TerminalApp/ActionArgs.h
@@ -115,7 +115,7 @@ namespace winrt::TerminalApp::implementation
             {
                 args->_TrimWhitespace = trimWhitespace.asBool();
             }
-            return { *args, std::vector<::TerminalApp::SettingsLoadWarnings>{} };
+            return { *args, {} };
         }
     };
 
@@ -139,7 +139,7 @@ namespace winrt::TerminalApp::implementation
             // LOAD BEARING: Not using make_self here _will_ break you in the future!
             auto args = winrt::make_self<NewTabArgs>();
             args->_TerminalArgs = NewTerminalArgs::FromJson(json);
-            return { *args, std::vector<::TerminalApp::SettingsLoadWarnings>{} };
+            return { *args, {} };
         }
     };
 
@@ -168,7 +168,7 @@ namespace winrt::TerminalApp::implementation
             {
                 args->_TabIndex = tabIndex.asUInt();
             }
-            return { *args, std::vector<::TerminalApp::SettingsLoadWarnings>{} };
+            return { *args, {} };
         }
     };
 
@@ -232,7 +232,7 @@ namespace winrt::TerminalApp::implementation
             {
                 args->_Direction = ParseDirection(directionString.asString());
             }
-            return { *args, std::vector<::TerminalApp::SettingsLoadWarnings>{} };
+            return { *args, {} };
         }
     };
 
@@ -261,7 +261,7 @@ namespace winrt::TerminalApp::implementation
             {
                 args->_Direction = ParseDirection(directionString.asString());
             }
-            return { *args, std::vector<::TerminalApp::SettingsLoadWarnings>{} };
+            return { *args, {} };
         }
     };
 
@@ -290,7 +290,7 @@ namespace winrt::TerminalApp::implementation
             {
                 args->_Delta = jsonDelta.asInt();
             }
-            return { *args, std::vector<::TerminalApp::SettingsLoadWarnings>{} };
+            return { *args, {} };
         }
     };
 
@@ -345,7 +345,7 @@ namespace winrt::TerminalApp::implementation
             {
                 args->_SplitStyle = ParseSplitState(jsonStyle.asString());
             }
-            return { *args, std::vector<::TerminalApp::SettingsLoadWarnings>{} };
+            return { *args, {} };
         }
     };
 }

--- a/src/cascadia/TerminalApp/ActionArgs.h
+++ b/src/cascadia/TerminalApp/ActionArgs.h
@@ -232,7 +232,14 @@ namespace winrt::TerminalApp::implementation
             {
                 args->_Direction = ParseDirection(directionString.asString());
             }
-            return { *args, {} };
+            if (args->_Direction == TerminalApp::Direction::None)
+            {
+                return { nullptr, { ::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter } };
+            }
+            else
+            {
+                return { *args, {} };
+            }
         }
     };
 

--- a/src/cascadia/TerminalApp/ActionArgs.h
+++ b/src/cascadia/TerminalApp/ActionArgs.h
@@ -17,6 +17,7 @@
 
 #include "../../cascadia/inc/cppwinrt_utils.h"
 #include "Utils.h"
+#include "TerminalWarnings.h"
 
 // Notes on defining ActionArgs and ActionEventArgs:
 // * All properties specific to an action should be defined as an ActionArgs
@@ -26,6 +27,8 @@
 
 namespace winrt::TerminalApp::implementation
 {
+    using FromJsonResult = std::tuple<winrt::TerminalApp::IActionArgs, std::vector<::TerminalApp::SettingsLoadWarnings>>;
+
     struct ActionEventArgs : public ActionEventArgsT<ActionEventArgs>
     {
         ActionEventArgs() = default;
@@ -104,7 +107,7 @@ namespace winrt::TerminalApp::implementation
             }
             return false;
         };
-        static winrt::TerminalApp::IActionArgs FromJson(const Json::Value& json)
+        static FromJsonResult FromJson(const Json::Value& json)
         {
             // LOAD BEARING: Not using make_self here _will_ break you in the future!
             auto args = winrt::make_self<CopyTextArgs>();
@@ -112,7 +115,7 @@ namespace winrt::TerminalApp::implementation
             {
                 args->_TrimWhitespace = trimWhitespace.asBool();
             }
-            return *args;
+            return { *args, std::vector<::TerminalApp::SettingsLoadWarnings>{} };
         }
     };
 
@@ -131,12 +134,12 @@ namespace winrt::TerminalApp::implementation
             }
             return false;
         };
-        static winrt::TerminalApp::IActionArgs FromJson(const Json::Value& json)
+        static FromJsonResult FromJson(const Json::Value& json)
         {
             // LOAD BEARING: Not using make_self here _will_ break you in the future!
             auto args = winrt::make_self<NewTabArgs>();
             args->_TerminalArgs = NewTerminalArgs::FromJson(json);
-            return *args;
+            return { *args, std::vector<::TerminalApp::SettingsLoadWarnings>{} };
         }
     };
 
@@ -157,7 +160,7 @@ namespace winrt::TerminalApp::implementation
             }
             return false;
         };
-        static winrt::TerminalApp::IActionArgs FromJson(const Json::Value& json)
+        static FromJsonResult FromJson(const Json::Value& json)
         {
             // LOAD BEARING: Not using make_self here _will_ break you in the future!
             auto args = winrt::make_self<SwitchToTabArgs>();
@@ -165,7 +168,7 @@ namespace winrt::TerminalApp::implementation
             {
                 args->_TabIndex = tabIndex.asUInt();
             }
-            return *args;
+            return { *args, std::vector<::TerminalApp::SettingsLoadWarnings>{} };
         }
     };
 
@@ -221,7 +224,7 @@ namespace winrt::TerminalApp::implementation
             }
             return false;
         };
-        static winrt::TerminalApp::IActionArgs FromJson(const Json::Value& json)
+        static FromJsonResult FromJson(const Json::Value& json)
         {
             // LOAD BEARING: Not using make_self here _will_ break you in the future!
             auto args = winrt::make_self<ResizePaneArgs>();
@@ -229,7 +232,7 @@ namespace winrt::TerminalApp::implementation
             {
                 args->_Direction = ParseDirection(directionString.asString());
             }
-            return *args;
+            return { *args, std::vector<::TerminalApp::SettingsLoadWarnings>{} };
         }
     };
 
@@ -250,7 +253,7 @@ namespace winrt::TerminalApp::implementation
             }
             return false;
         };
-        static winrt::TerminalApp::IActionArgs FromJson(const Json::Value& json)
+        static FromJsonResult FromJson(const Json::Value& json)
         {
             // LOAD BEARING: Not using make_self here _will_ break you in the future!
             auto args = winrt::make_self<MoveFocusArgs>();
@@ -258,7 +261,7 @@ namespace winrt::TerminalApp::implementation
             {
                 args->_Direction = ParseDirection(directionString.asString());
             }
-            return *args;
+            return { *args, std::vector<::TerminalApp::SettingsLoadWarnings>{} };
         }
     };
 
@@ -279,7 +282,7 @@ namespace winrt::TerminalApp::implementation
             }
             return false;
         };
-        static winrt::TerminalApp::IActionArgs FromJson(const Json::Value& json)
+        static FromJsonResult FromJson(const Json::Value& json)
         {
             // LOAD BEARING: Not using make_self here _will_ break you in the future!
             auto args = winrt::make_self<AdjustFontSizeArgs>();
@@ -287,7 +290,7 @@ namespace winrt::TerminalApp::implementation
             {
                 args->_Delta = jsonDelta.asInt();
             }
-            return *args;
+            return { *args, std::vector<::TerminalApp::SettingsLoadWarnings>{} };
         }
     };
 
@@ -333,7 +336,7 @@ namespace winrt::TerminalApp::implementation
             }
             return false;
         };
-        static winrt::TerminalApp::IActionArgs FromJson(const Json::Value& json)
+        static FromJsonResult FromJson(const Json::Value& json)
         {
             // LOAD BEARING: Not using make_self here _will_ break you in the future!
             auto args = winrt::make_self<SplitPaneArgs>();
@@ -342,7 +345,7 @@ namespace winrt::TerminalApp::implementation
             {
                 args->_SplitStyle = ParseSplitState(jsonStyle.asString());
             }
-            return *args;
+            return { *args, std::vector<::TerminalApp::SettingsLoadWarnings>{} };
         }
     };
 }

--- a/src/cascadia/TerminalApp/AppKeyBindings.h
+++ b/src/cascadia/TerminalApp/AppKeyBindings.h
@@ -53,7 +53,7 @@ namespace winrt::TerminalApp::implementation
         static Windows::System::VirtualKeyModifiers ConvertVKModifiers(winrt::Microsoft::Terminal::Settings::KeyModifiers modifiers);
 
         // Defined in AppKeyBindingsSerialization.cpp
-        void LayerJson(const Json::Value& json);
+        std::vector<::TerminalApp::SettingsLoadWarnings> LayerJson(const Json::Value& json);
         Json::Value ToJson();
 
         void SetDispatch(const winrt::TerminalApp::ShortcutActionDispatch& dispatch);

--- a/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
@@ -146,7 +146,6 @@ static const std::map<std::string_view, ShortcutAction, std::less<>> commandName
     { FindKey, ShortcutAction::Find },
 };
 
-// using ParseActionFunction = std::function<IActionArgs(const Json::Value
 using ParseResult = std::tuple<IActionArgs, std::vector<TerminalApp::SettingsLoadWarnings>>;
 using ParseActionFunction = std::function<ParseResult(const Json::Value&)>;
 
@@ -454,7 +453,7 @@ std::vector<::TerminalApp::SettingsLoadWarnings> winrt::TerminalApp::implementat
             const auto validString = keys.isString();
             const auto validArray = keys.isArray() && keys.size() == 1;
 
-            // microsoft/terminal#4239 - If the user provided more than one key
+            // GH#4239 - If the user provided more than one key
             // chord to a "keys" array, warn the user here.
             // TODO: GH#1334 - remove this check.
             if (keys.isArray() && keys.size() > 1)

--- a/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
@@ -433,6 +433,10 @@ static ShortcutAction GetActionFromString(const std::string_view actionString)
 // - json: and array of JsonObject's to deserialize into our _keyShortcuts mapping.
 std::vector<::TerminalApp::SettingsLoadWarnings> winrt::TerminalApp::implementation::AppKeyBindings::LayerJson(const Json::Value& json)
 {
+    // It's possible that the user provided keybindings have some warnings in
+    // them - problems that we should alert the user to, but we can recover
+    // from. Most of these warnings cannot be detected later in the Validate
+    // settings phase, so we'll collect them now.
     std::vector<::TerminalApp::SettingsLoadWarnings> warnings;
 
     for (const auto& value : json)
@@ -450,6 +454,9 @@ std::vector<::TerminalApp::SettingsLoadWarnings> winrt::TerminalApp::implementat
             const auto validString = keys.isString();
             const auto validArray = keys.isArray() && keys.size() == 1;
 
+            // microsoft/terminal#4239 - If the user provided more than one key
+            // chord to a "keys" array, warn the user here.
+            // TODO: GH#1334 - remove this check.
             if (keys.isArray() && keys.size() > 1)
             {
                 warnings.push_back(::TerminalApp::SettingsLoadWarnings::TooManyKeysForChord);

--- a/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
@@ -146,6 +146,8 @@ static const std::map<std::string_view, ShortcutAction, std::less<>> commandName
     { FindKey, ShortcutAction::Find },
 };
 
+using ParseActionFunction = std::function<IActionArgs(const Json::Value&)>;
+
 // Function Description:
 // - Creates a function that can be used to generate a SplitPaneArgs for the
 //   legacy Split[SplitState] actions. These actions don't accept args from
@@ -157,7 +159,7 @@ static const std::map<std::string_view, ShortcutAction, std::less<>> commandName
 // Return Value:
 // - A function that can be used to "parse" json into one of the legacy
 //   Split[SplitState] args.
-std::function<IActionArgs(const Json::Value&)> LegacyParseSplitPaneArgs(SplitState style)
+ParseActionFunction LegacyParseSplitPaneArgs(SplitState style)
 {
     auto pfn = [style](const Json::Value & /*value*/) -> IActionArgs {
         auto args = winrt::make_self<winrt::TerminalApp::implementation::SplitPaneArgs>();
@@ -178,7 +180,7 @@ std::function<IActionArgs(const Json::Value&)> LegacyParseSplitPaneArgs(SplitSta
 // Return Value:
 // - A function that can be used to "parse" json into one of the legacy
 //   MoveFocus[Direction] args.
-std::function<IActionArgs(const Json::Value&)> LegacyParseMoveFocusArgs(Direction direction)
+ParseActionFunction LegacyParseMoveFocusArgs(Direction direction)
 {
     auto pfn = [direction](const Json::Value & /*value*/) -> IActionArgs {
         auto args = winrt::make_self<winrt::TerminalApp::implementation::MoveFocusArgs>();
@@ -199,7 +201,7 @@ std::function<IActionArgs(const Json::Value&)> LegacyParseMoveFocusArgs(Directio
 // Return Value:
 // - A function that can be used to "parse" json into one of the legacy
 //   ResizePane[Direction] args.
-std::function<IActionArgs(const Json::Value&)> LegacyParseResizePaneArgs(Direction direction)
+ParseActionFunction LegacyParseResizePaneArgs(Direction direction)
 {
     auto pfn = [direction](const Json::Value & /*value*/) -> IActionArgs {
         auto args = winrt::make_self<winrt::TerminalApp::implementation::ResizePaneArgs>();
@@ -220,7 +222,7 @@ std::function<IActionArgs(const Json::Value&)> LegacyParseResizePaneArgs(Directi
 // Return Value:
 // - A function that can be used to "parse" json into one of the legacy
 //   NewTabWithProfile[Index] args.
-std::function<IActionArgs(const Json::Value&)> LegacyParseNewTabWithProfileArgs(int index)
+ParseActionFunction LegacyParseNewTabWithProfileArgs(int index)
 {
     auto pfn = [index](const Json::Value & /*value*/) -> IActionArgs {
         auto args = winrt::make_self<winrt::TerminalApp::implementation::NewTabArgs>();
@@ -243,7 +245,7 @@ std::function<IActionArgs(const Json::Value&)> LegacyParseNewTabWithProfileArgs(
 // Return Value:
 // - A function that can be used to "parse" json into one of the legacy
 //   SwitchToTab[Index] args.
-std::function<IActionArgs(const Json::Value&)> LegacyParseSwitchToTabArgs(int index)
+ParseActionFunction LegacyParseSwitchToTabArgs(int index)
 {
     auto pfn = [index](const Json::Value & /*value*/) -> IActionArgs {
         auto args = winrt::make_self<winrt::TerminalApp::implementation::SwitchToTabArgs>();
@@ -276,7 +278,7 @@ IActionArgs LegacyParseCopyTextWithoutNewlinesArgs(const Json::Value& /*json*/)
 // - delta: the font size delta to create the parse function for.
 // Return Value:
 // - A function that can be used to "parse" json into an AdjustFontSizeArgs.
-std::function<IActionArgs(const Json::Value&)> LegacyParseAdjustFontSizeArgs(int delta)
+ParseActionFunction LegacyParseAdjustFontSizeArgs(int delta)
 {
     auto pfn = [delta](const Json::Value & /*value*/) -> IActionArgs {
         auto args = winrt::make_self<winrt::TerminalApp::implementation::AdjustFontSizeArgs>();
@@ -291,7 +293,7 @@ std::function<IActionArgs(const Json::Value&)> LegacyParseAdjustFontSizeArgs(int
 // from json. Each type of IActionArgs that can accept arbitrary args should be
 // placed into this map, with the corresponding deserializer function as the
 // value.
-static const std::map<ShortcutAction, std::function<IActionArgs(const Json::Value&)>, std::less<>> argParsers{
+static const std::map<ShortcutAction, ParseActionFunction, std::less<>> argParsers{
     { ShortcutAction::CopyText, winrt::TerminalApp::implementation::CopyTextArgs::FromJson },
     { ShortcutAction::CopyTextWithoutNewlines, LegacyParseCopyTextWithoutNewlinesArgs },
 

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -27,14 +27,17 @@ namespace winrt
 // !!! IMPORTANT !!!
 // Make sure that these keys are in the same order as the
 // SettingsLoadWarnings/Errors enum is!
-static const std::array<std::wstring_view, 5> settingsLoadWarningsLabels {
+static const std::array<std::wstring_view, static_cast<uint32_t>(SettingsLoadWarnings::WARNINGS_SIZE)> settingsLoadWarningsLabels {
     USES_RESOURCE(L"MissingDefaultProfileText"),
     USES_RESOURCE(L"DuplicateProfileText"),
     USES_RESOURCE(L"UnknownColorSchemeText"),
     USES_RESOURCE(L"InvalidBackgroundImage"),
-    USES_RESOURCE(L"InvalidIcon")
+    USES_RESOURCE(L"InvalidIcon"),
+    USES_RESOURCE(L"AtLeastOneKeybindingWarning"),
+    USES_RESOURCE(L"TooManyKeysForChord"),
+    USES_RESOURCE(L"MissingRequiredParameter")
 };
-static const std::array<std::wstring_view, 2> settingsLoadErrorsLabels {
+static const std::array<std::wstring_view, static_cast<uint32_t>(SettingsLoadErrors::ERRORS_SIZE)> settingsLoadErrorsLabels {
     USES_RESOURCE(L"NoProfilesText"),
     USES_RESOURCE(L"AllProfilesHiddenText")
 };

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -209,6 +209,7 @@ void CascadiaSettings::_ValidateSettings()
     // TODO:GH#3522 With variable args to keybindings, it's possible that a user
     // set a keybinding without all the required args for an action. Display a
     // warning if an action didn't have a required arg.
+    _ValidateKeybindings();
 }
 
 // Method Description:
@@ -650,4 +651,26 @@ GUID CascadiaSettings::_GetProfileForIndex(std::optional<int> index) const
         profileGuid = _globals.GetDefaultProfile();
     }
     return profileGuid;
+}
+
+// Method Description:
+// - Ensures that all specified images resources (icons and background images) are valid URIs.
+//   This does not verify that the icon or background image files are encoded as an image.
+// Arguments:
+// - <none>
+// Return Value:
+// - <none>
+// - Appends a SettingsLoadWarnings::InvalidBackgroundImage to our list of warnings if
+//   we find any invalid background images.
+// - Appends a SettingsLoadWarnings::InvalidIconImage to our list of warnings if
+//   we find any invalid icon images.
+void CascadiaSettings::_ValidateKeybindings()
+{
+    auto keybindingWarnings = _globals.GetKeybindingsWarnings();
+
+    if (!keybindingWarnings.empty())
+    {
+        _warnings.push_back(::TerminalApp::SettingsLoadWarnings::AtLeastOneKeybindingWarning);
+        _warnings.insert(_warnings.end(), keybindingWarnings.begin(), keybindingWarnings.end());
+    }
 }

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -206,9 +206,10 @@ void CascadiaSettings::_ValidateSettings()
     // there's _NO_ keys bound to any actions. That's highly irregular, and
     // likely an indication of an error somehow.
 
-    // TODO:GH#3522 With variable args to keybindings, it's possible that a user
+    // GH#3522 - With variable args to keybindings, it's possible that a user
     // set a keybinding without all the required args for an action. Display a
     // warning if an action didn't have a required arg.
+    // This will also catch other keybinding warnings, like from GH#4239
     _ValidateKeybindings();
 }
 
@@ -654,16 +655,14 @@ GUID CascadiaSettings::_GetProfileForIndex(std::optional<int> index) const
 }
 
 // Method Description:
-// - Ensures that all specified images resources (icons and background images) are valid URIs.
-//   This does not verify that the icon or background image files are encoded as an image.
+// - If there were any warnings we generated while parsing the user's
+//   keybindings, add them to the list of warnings here. If there were warnings
+//   generated in this way, we'll add a AtLeastOneKeybindingWarning, which will
+//   act as a header for the other warnings
 // Arguments:
 // - <none>
 // Return Value:
 // - <none>
-// - Appends a SettingsLoadWarnings::InvalidBackgroundImage to our list of warnings if
-//   we find any invalid background images.
-// - Appends a SettingsLoadWarnings::InvalidIconImage to our list of warnings if
-//   we find any invalid icon images.
 void CascadiaSettings::_ValidateKeybindings()
 {
     auto keybindingWarnings = _globals.GetKeybindingsWarnings();

--- a/src/cascadia/TerminalApp/CascadiaSettings.h
+++ b/src/cascadia/TerminalApp/CascadiaSettings.h
@@ -116,6 +116,7 @@ private:
     void _RemoveHiddenProfiles();
     void _ValidateAllSchemesExist();
     void _ValidateMediaResources();
+    void _ValidateKeybindings();
 
     friend class TerminalAppLocalTests::SettingsTests;
     friend class TerminalAppLocalTests::ProfileTests;

--- a/src/cascadia/TerminalApp/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.cpp
@@ -332,6 +332,12 @@ void GlobalAppSettings::LayerJson(const Json::Value& json)
     if (auto keybindings{ json[JsonKey(KeybindingsKey)] })
     {
         auto warnings = _keybindings->LayerJson(keybindings);
+        // It's possible that the user provided keybindings have some warnings
+        // in them - problems that we should alert the user to, but we can
+        // recover from. Most of these warnings cannot be detected later in the
+        // Validate settings phase, so we'll collect them now. If there were any
+        // warnings generated from parsing these keybindings, add them to our
+        // list of warnings.
         _keybindingsWarnings.insert(_keybindingsWarnings.end(), warnings.begin(), warnings.end());
     }
 
@@ -540,6 +546,15 @@ void GlobalAppSettings::AddColorScheme(ColorScheme scheme)
     _colorSchemes[name] = std::move(scheme);
 }
 
+// Method Description:
+// - Return the warnings that we've collected during parsing the JSON for the
+//   keybindings. It's possible that the user provided keybindings have some
+//   warnings in them - problems that we should alert the user to, but we can
+//   recover from.
+// Arguments:
+// - <none>
+// Return Value:
+// - <none>
 std::vector<TerminalApp::SettingsLoadWarnings> GlobalAppSettings::GetKeybindingsWarnings() const
 {
     return _keybindingsWarnings;

--- a/src/cascadia/TerminalApp/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.cpp
@@ -43,6 +43,7 @@ static constexpr std::wstring_view SystemThemeValue{ L"system" };
 
 GlobalAppSettings::GlobalAppSettings() :
     _keybindings{ winrt::make_self<winrt::TerminalApp::implementation::AppKeyBindings>() },
+    _keybindingsWarnings{},
     _colorSchemes{},
     _defaultProfile{},
     _alwaysShowTabs{ true },
@@ -330,7 +331,8 @@ void GlobalAppSettings::LayerJson(const Json::Value& json)
 
     if (auto keybindings{ json[JsonKey(KeybindingsKey)] })
     {
-        _keybindings->LayerJson(keybindings);
+        auto warnings = _keybindings->LayerJson(keybindings);
+        _keybindingsWarnings.insert(_keybindingsWarnings.end(), warnings.begin(), warnings.end());
     }
 
     if (auto snapToGridOnResize{ json[JsonKey(SnapToGridOnResizeKey)] })
@@ -536,4 +538,9 @@ void GlobalAppSettings::AddColorScheme(ColorScheme scheme)
 {
     std::wstring name{ scheme.GetName() };
     _colorSchemes[name] = std::move(scheme);
+}
+
+std::vector<TerminalApp::SettingsLoadWarnings> GlobalAppSettings::GetKeybindingsWarnings() const
+{
+    return _keybindingsWarnings;
 }

--- a/src/cascadia/TerminalApp/GlobalAppSettings.h
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.h
@@ -83,11 +83,14 @@ public:
 
     void ApplyToSettings(winrt::Microsoft::Terminal::Settings::TerminalSettings& settings) const noexcept;
 
+    std::vector<TerminalApp::SettingsLoadWarnings> GetKeybindingsWarnings() const;
+
     GETSET_PROPERTY(bool, SnapToGridOnResize, true);
 
 private:
     GUID _defaultProfile;
     winrt::com_ptr<winrt::TerminalApp::implementation::AppKeyBindings> _keybindings;
+    std::vector<::TerminalApp::SettingsLoadWarnings> _keybindingsWarnings;
 
     std::unordered_map<std::wstring, ColorScheme> _colorSchemes;
 

--- a/src/cascadia/TerminalApp/Resources/Resources.language-en.resw
+++ b/src/cascadia/TerminalApp/Resources/Resources.language-en.resw
@@ -223,6 +223,18 @@ Temporarily using the Windows Terminal default settings.
   <data name="InvalidIcon" xml:space="preserve">
     <value>Found a profile with an invalid "icon". Defaulting that profile to have no icon. Make sure that when setting an "icon", the value is a valid file path to an image.</value>
   </data>
+  <data name="AtLeastOneKeybindingWarning" xml:space="preserve">
+    <value>Warnings were found while parsing your keybindings:
+  </value>
+  </data>
+  <data name="TooManyKeysForChord" xml:space="preserve">
+    <value>    Found a keybinding with too many strings for the "keys" array. There should only be one string value in the "keys" array.
+  </value>
+  </data>
+  <data name="MissingRequiredParameter" xml:space="preserve">
+    <value>    Found a keybinding that was missing a required parameter value. This keybinding will be ignored.
+  </value>
+  </data>
   <data name="CmdCommandArgDesc" xml:space="preserve">
     <value>An optional command, with arguments, to be spawned in the new tab or pane</value>
   </data>

--- a/src/cascadia/TerminalApp/TerminalWarnings.h
+++ b/src/cascadia/TerminalApp/TerminalWarnings.h
@@ -25,7 +25,11 @@ namespace TerminalApp
         DuplicateProfile = 1,
         UnknownColorScheme = 2,
         InvalidBackgroundImage = 3,
-        InvalidIcon = 4
+        InvalidIcon = 4,
+        AtLeastOneKeybindingWarning = 5,
+        TooManyKeysForChord = 6,
+        MissingRequiredParameter = 7,
+        WARNINGS_SIZE // IMPORTANT: This MUST be the last value in this enum. It's an unused placeholder.
     };
 
     // SettingsLoadWarnings are scenarios where the settings had invalid state
@@ -33,7 +37,8 @@ namespace TerminalApp
     enum class SettingsLoadErrors : uint32_t
     {
         NoProfiles = 0,
-        AllProfilesHidden = 1
+        AllProfilesHidden = 1,
+        ERRORS_SIZE // IMPORTANT: This MUST be the last value in this enum. It's an unused placeholder.
     };
 
     // This is a helper class to wrap up a SettingsLoadErrors into a proper


### PR DESCRIPTION
## Summary of the Pull Request

Adds warning messages for a pair of keybindings-related scenarios. This covers the following two bugs:
* #4239 - If the user has supplied more than one key chord in their `"keys"` array.
* #3522 - If a keybinding has a _required_ argument, then we'll display a message to the user
  - currently, the only required parameter is the `direction` parameter for both `resizePane` and `moveFocus`

## References

When we get to #1334, we'll want to remove the `TooManyKeysForChord` warning.

## PR Checklist
* [x] Closes #4239
* [x] Closes #3522
* [x] I work here
* [x] Tests added/passed
* [n/a] Requires documentation to be updated

![image](https://user-images.githubusercontent.com/18356694/75593132-f18ec700-5a49-11ea-9d26-6acd0d28b0b7.png)


## Validation Steps Performed
Tested manually, added tests.