### PR TITLE
Update comments to better indicate the supported VT functions

### DIFF
--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -33,14 +33,14 @@ public:
     virtual bool CursorUp(const size_t distance) = 0; // CUU
     virtual bool CursorDown(const size_t distance) = 0; // CUD
     virtual bool CursorForward(const size_t distance) = 0; // CUF
-    virtual bool CursorBackward(const size_t distance) = 0; // CUB
+    virtual bool CursorBackward(const size_t distance) = 0; // CUB, BS
     virtual bool CursorNextLine(const size_t distance) = 0; // CNL
     virtual bool CursorPrevLine(const size_t distance) = 0; // CPL
-    virtual bool CursorHorizontalPositionAbsolute(const size_t column) = 0; // CHA
+    virtual bool CursorHorizontalPositionAbsolute(const size_t column) = 0; // HPA, CHA
     virtual bool VerticalLinePositionAbsolute(const size_t line) = 0; // VPA
     virtual bool HorizontalPositionRelative(const size_t distance) = 0; // HPR
     virtual bool VerticalPositionRelative(const size_t distance) = 0; // VPR
-    virtual bool CursorPosition(const size_t line, const size_t column) = 0; // CUP
+    virtual bool CursorPosition(const size_t line, const size_t column) = 0; // CUP, HVP
     virtual bool CursorSaveState() = 0; // DECSC
     virtual bool CursorRestoreState() = 0; // DECRC
     virtual bool CursorVisibility(const bool isVisible) = 0; // DECTCEM
@@ -50,23 +50,23 @@ public:
     virtual bool ScrollDown(const size_t distance) = 0; // SD
     virtual bool InsertLine(const size_t distance) = 0; // IL
     virtual bool DeleteLine(const size_t distance) = 0; // DL
-    virtual bool SetColumns(const size_t columns) = 0; // DECSCPP, DECCOLM
+    virtual bool SetColumns(const size_t columns) = 0; // DECCOLM
     virtual bool SetCursorKeysMode(const bool applicationMode) = 0; // DECCKM
     virtual bool SetKeypadMode(const bool applicationMode) = 0; // DECKPAM, DECKPNM
     virtual bool EnableCursorBlinking(const bool enable) = 0; // ATT610
-    virtual bool SetScreenMode(const bool reverseMode) = 0; //DECSCNM
+    virtual bool SetScreenMode(const bool reverseMode) = 0; // DECSCNM
     virtual bool SetOriginMode(const bool relativeMode) = 0; // DECOM
     virtual bool SetAutoWrapMode(const bool wrapAtEOL) = 0; // DECAWM
     virtual bool SetTopBottomScrollingMargins(const size_t topMargin, const size_t bottomMargin) = 0; // DECSTBM
     virtual bool WarningBell() = 0; // BEL
     virtual bool CarriageReturn() = 0; // CR
-    virtual bool LineFeed(const DispatchTypes::LineFeedType lineFeedType) = 0; // IND, NEL
+    virtual bool LineFeed(const DispatchTypes::LineFeedType lineFeedType) = 0; // IND, NEL, LF, FF, VT
     virtual bool ReverseLineFeed() = 0; // RI
     virtual bool SetWindowTitle(std::wstring_view title) = 0; // OscWindowTitle
     virtual bool UseAlternateScreenBuffer() = 0; // ASBSET
     virtual bool UseMainScreenBuffer() = 0; // ASBRST
     virtual bool HorizontalTabSet() = 0; // HTS
-    virtual bool ForwardTab(const size_t numTabs) = 0; // CHT
+    virtual bool ForwardTab(const size_t numTabs) = 0; // CHT, HT
     virtual bool BackwardsTab(const size_t numTabs) = 0; // CBT
     virtual bool TabClear(const size_t clearType) = 0; // TBC
     virtual bool EnableDECCOLMSupport(const bool enabled) = 0; // ?40
@@ -90,10 +90,10 @@ public:
 
     virtual bool ResetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> params) = 0; // DECRST
 
-    virtual bool DeviceStatusReport(const DispatchTypes::AnsiStatusType statusType) = 0; // DSR
-    virtual bool DeviceAttributes() = 0; // DA
+    virtual bool DeviceStatusReport(const DispatchTypes::AnsiStatusType statusType) = 0; // DSR, DSR-CPR
+    virtual bool DeviceAttributes() = 0; // DA1
 
-    virtual bool DesignateCharset(const wchar_t wchCharset) = 0; // DesignateCharset
+    virtual bool DesignateCharset(const wchar_t wchCharset) = 0; // SCS
 
     virtual bool SoftReset() = 0; // DECSTR
     virtual bool HardReset() = 0; // RIS

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -39,14 +39,14 @@ namespace Microsoft::Console::VirtualTerminal
         bool CursorUp(const size_t distance) override; // CUU
         bool CursorDown(const size_t distance) override; // CUD
         bool CursorForward(const size_t distance) override; // CUF
-        bool CursorBackward(const size_t distance) override; // CUB
+        bool CursorBackward(const size_t distance) override; // CUB, BS
         bool CursorNextLine(const size_t distance) override; // CNL
         bool CursorPrevLine(const size_t distance) override; // CPL
-        bool CursorHorizontalPositionAbsolute(const size_t column) override; // CHA
+        bool CursorHorizontalPositionAbsolute(const size_t column) override; // HPA, CHA
         bool VerticalLinePositionAbsolute(const size_t line) override; // VPA
         bool HorizontalPositionRelative(const size_t distance) override; // HPR
         bool VerticalPositionRelative(const size_t distance) override; // VPR
-        bool CursorPosition(const size_t line, const size_t column) override; // CUP
+        bool CursorPosition(const size_t line, const size_t column) override; // CUP, HVP
         bool CursorSaveState() override; // DECSC
         bool CursorRestoreState() override; // DECRC
         bool CursorVisibility(const bool isVisible) override; // DECTCEM
@@ -56,35 +56,35 @@ namespace Microsoft::Console::VirtualTerminal
         bool InsertCharacter(const size_t count) override; // ICH
         bool DeleteCharacter(const size_t count) override; // DCH
         bool SetGraphicsRendition(const std::basic_string_view<DispatchTypes::GraphicsOptions> options) override; // SGR
-        bool DeviceStatusReport(const DispatchTypes::AnsiStatusType statusType) override; // DSR
-        bool DeviceAttributes() override; // DA
+        bool DeviceStatusReport(const DispatchTypes::AnsiStatusType statusType) override; // DSR, DSR-CPR
+        bool DeviceAttributes() override; // DA1
         bool ScrollUp(const size_t distance) override; // SU
         bool ScrollDown(const size_t distance) override; // SD
         bool InsertLine(const size_t distance) override; // IL
         bool DeleteLine(const size_t distance) override; // DL
-        bool SetColumns(const size_t columns) override; // DECSCPP, DECCOLM
+        bool SetColumns(const size_t columns) override; // DECCOLM
         bool SetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> params) override; // DECSET
         bool ResetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> params) override; // DECRST
         bool SetCursorKeysMode(const bool applicationMode) override; // DECCKM
         bool SetKeypadMode(const bool applicationMode) override; // DECKPAM, DECKPNM
         bool EnableCursorBlinking(const bool enable) override; // ATT610
-        bool SetScreenMode(const bool reverseMode) override; //DECSCNM
+        bool SetScreenMode(const bool reverseMode) override; // DECSCNM
         bool SetOriginMode(const bool relativeMode) noexcept override; // DECOM
         bool SetAutoWrapMode(const bool wrapAtEOL) override; // DECAWM
         bool SetTopBottomScrollingMargins(const size_t topMargin,
                                           const size_t bottomMargin) override; // DECSTBM
         bool WarningBell() override; // BEL
         bool CarriageReturn() override; // CR
-        bool LineFeed(const DispatchTypes::LineFeedType lineFeedType) override; // IND, NEL
+        bool LineFeed(const DispatchTypes::LineFeedType lineFeedType) override; // IND, NEL, LF, FF, VT
         bool ReverseLineFeed() override; // RI
         bool SetWindowTitle(const std::wstring_view title) override; // OscWindowTitle
         bool UseAlternateScreenBuffer() override; // ASBSET
         bool UseMainScreenBuffer() override; // ASBRST
         bool HorizontalTabSet() override; // HTS
-        bool ForwardTab(const size_t numTabs) override; // CHT
+        bool ForwardTab(const size_t numTabs) override; // CHT, HT
         bool BackwardsTab(const size_t numTabs) override; // CBT
         bool TabClear(const size_t clearType) override; // TBC
-        bool DesignateCharset(const wchar_t wchCharset) noexcept override; // DesignateCharset
+        bool DesignateCharset(const wchar_t wchCharset) noexcept override; // SCS
         bool SoftReset() override; // DECSTR
         bool HardReset() override; // RIS
         bool ScreenAlignmentPattern() override; // DECALN

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -27,14 +27,14 @@ public:
     bool CursorUp(const size_t /*distance*/) noexcept override { return false; } // CUU
     bool CursorDown(const size_t /*distance*/) noexcept override { return false; } // CUD
     bool CursorForward(const size_t /*distance*/) noexcept override { return false; } // CUF
-    bool CursorBackward(const size_t /*distance*/) noexcept override { return false; } // CUB
+    bool CursorBackward(const size_t /*distance*/) noexcept override { return false; } // CUB, BS
     bool CursorNextLine(const size_t /*distance*/) noexcept override { return false; } // CNL
     bool CursorPrevLine(const size_t /*distance*/) noexcept override { return false; } // CPL
-    bool CursorHorizontalPositionAbsolute(const size_t /*column*/) noexcept override { return false; } // CHA
+    bool CursorHorizontalPositionAbsolute(const size_t /*column*/) noexcept override { return false; } // HPA, CHA
     bool VerticalLinePositionAbsolute(const size_t /*line*/) noexcept override { return false; } // VPA
     bool HorizontalPositionRelative(const size_t /*distance*/) noexcept override { return false; } // HPR
     bool VerticalPositionRelative(const size_t /*distance*/) noexcept override { return false; } // VPR
-    bool CursorPosition(const size_t /*line*/, const size_t /*column*/) noexcept override { return false; } // CUP
+    bool CursorPosition(const size_t /*line*/, const size_t /*column*/) noexcept override { return false; } // CUP, HVP
     bool CursorSaveState() noexcept override { return false; } // DECSC
     bool CursorRestoreState() noexcept override { return false; } // DECRC
     bool CursorVisibility(const bool /*isVisible*/) noexcept override { return false; } // DECTCEM
@@ -44,23 +44,23 @@ public:
     bool ScrollDown(const size_t /*distance*/) noexcept override { return false; } // SD
     bool InsertLine(const size_t /*distance*/) noexcept override { return false; } // IL
     bool DeleteLine(const size_t /*distance*/) noexcept override { return false; } // DL
-    bool SetColumns(const size_t /*columns*/) noexcept override { return false; } // DECSCPP, DECCOLM
+    bool SetColumns(const size_t /*columns*/) noexcept override { return false; } // DECCOLM
     bool SetCursorKeysMode(const bool /*applicationMode*/) noexcept override { return false; } // DECCKM
     bool SetKeypadMode(const bool /*applicationMode*/) noexcept override { return false; } // DECKPAM, DECKPNM
     bool EnableCursorBlinking(const bool /*enable*/) noexcept override { return false; } // ATT610
-    bool SetScreenMode(const bool /*reverseMode*/) noexcept override { return false; } //DECSCNM
+    bool SetScreenMode(const bool /*reverseMode*/) noexcept override { return false; } // DECSCNM
     bool SetOriginMode(const bool /*relativeMode*/) noexcept override { return false; }; // DECOM
     bool SetAutoWrapMode(const bool /*wrapAtEOL*/) noexcept override { return false; }; // DECAWM
     bool SetTopBottomScrollingMargins(const size_t /*topMargin*/, const size_t /*bottomMargin*/) noexcept override { return false; } // DECSTBM
     bool WarningBell() noexcept override { return false; } // BEL
     bool CarriageReturn() noexcept override { return false; } // CR
-    bool LineFeed(const DispatchTypes::LineFeedType /*lineFeedType*/) noexcept override { return false; } // IND, NEL
+    bool LineFeed(const DispatchTypes::LineFeedType /*lineFeedType*/) noexcept override { return false; } // IND, NEL, LF, FF, VT
     bool ReverseLineFeed() noexcept override { return false; } // RI
     bool SetWindowTitle(std::wstring_view /*title*/) noexcept override { return false; } // OscWindowTitle
     bool UseAlternateScreenBuffer() noexcept override { return false; } // ASBSET
     bool UseMainScreenBuffer() noexcept override { return false; } // ASBRST
     bool HorizontalTabSet() noexcept override { return false; } // HTS
-    bool ForwardTab(const size_t /*numTabs*/) noexcept override { return false; } // CHT
+    bool ForwardTab(const size_t /*numTabs*/) noexcept override { return false; } // CHT, HT
     bool BackwardsTab(const size_t /*numTabs*/) noexcept override { return false; } // CBT
     bool TabClear(const size_t /*clearType*/) noexcept override { return false; } // TBC
     bool EnableDECCOLMSupport(const bool /*enabled*/) noexcept override { return false; } // ?40
@@ -84,10 +84,10 @@ public:
 
     bool ResetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> /*params*/) noexcept override { return false; } // DECRST
 
-    bool DeviceStatusReport(const DispatchTypes::AnsiStatusType /*statusType*/) noexcept override { return false; } // DSR
-    bool DeviceAttributes() noexcept override { return false; } // DA
+    bool DeviceStatusReport(const DispatchTypes::AnsiStatusType /*statusType*/) noexcept override { return false; } // DSR, DSR-CPR
+    bool DeviceAttributes() noexcept override { return false; } // DA1
 
-    bool DesignateCharset(const wchar_t /*wchCharset*/) noexcept override { return false; } // DesignateCharset
+    bool DesignateCharset(const wchar_t /*wchCharset*/) noexcept override { return false; } // SCS
 
     bool SoftReset() noexcept override { return false; } // DECSTR
     bool HardReset() noexcept override { return false; } // RIS


### PR DESCRIPTION
## Summary of the Pull Request

Most of the methods in the `ITermDispatch` interface have a comment following them that indicates the VT function that they implement. These comments are then used by the script in PR #1884 to generate a table of supported VT functions. This PR updates some of those comments, to more accurately reflect the functions that are actually supported.

## References

PR #1884 

## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed.
* [x] No new tests.
* [x] No new docs.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1884

## Detailed Description of the Pull Request / Additional comments

In some cases there are methods that implement multiple VT functions which are essentially aliases. Originally the comments listed only one of the functions, so I've now updated them to list both. This includes `HPA` as an alias of `CHA`, and `HVP` as an alias of `CUP`.

Similarly, some control characters are implemented in terms of another VT function, but only the main function was listed in the comment. Again I've now updated the comments to list both the main function and any related control characters. This includes `BS` (sharing the same method as `CUB`), `HT` (the same method as `CHT`), and `LF`, `FF`, and `VT` (the same method as `IND` and `NEL`).

Then there were some minor corrections. The `DeviceAttributes` method was commented as `DA`, but it really should be `DA1`. `DesignateCharset` was simply commented as _DesignateCharset_, when it should be `SCS`. The `DECSCNM` comment was missing a space, so it wasn't picked up by the script. And the `SetColumns` comment mistakenly included `DECSCPP`, but we don't actually support that.

Finally there is the `DeviceStatusReport` method, which potentially covers a wide range of different reports. But for now we only support the _Cursor Position Report_, so I've commented it as `DSR, DSR-CPR` to more clearly indicate our level of support. In the long term we'll probably need a better way of handling these reports though.

## Validation Steps Performed

I've run the script from PR #1884 and confirmed that the output is now a more accurate reflection of our actual VT support.