### PR TITLE
AzCon: improve input, usability, reliability (4 commits)

### DIFF
--- a/src/cascadia/TerminalConnection/AzureConnection.cpp
+++ b/src/cascadia/TerminalConnection/AzureConnection.cpp
@@ -693,11 +693,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         _WriteStringWithNewline(RS_(L"AzureSuccess"));
 
         // Request for a terminal for said cloud shell
-        // We only support bash for now, so don't bother with the user's preferred shell
-        // fyi: we can't call powershell yet because it sends VT sequences we don't support yet
-        // TODO: GitHub #1883
-        //const auto shellType = settingsResponse.at(L"properties").at(L"preferredShellType").as_string();
-        const auto shellType = L"bash";
+        const auto shellType = settingsResponse.at(L"properties").at(L"preferredShellType").as_string();
         _WriteStringWithNewline(RS_(L"AzureRequestingTerminal"));
         const auto socketUri = _GetTerminal(shellType);
         _TerminalOutputHandlers(L"\r\n");
@@ -880,9 +876,8 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         http_request shellRequest(L"PUT");
         shellRequest.set_request_uri(L"providers/Microsoft.Portal/consoles/default?api-version=2018-10-01");
         _HeaderHelper(shellRequest);
-        const auto innerBody = json::value::parse(U("{ \"osType\" : \"linux\" }"));
-        json::value body;
-        body[U("properties")] = innerBody;
+        // { "properties": { "osType": "linux" } }
+        auto body = json::value::object({ { U("properties"), json::value::object({ { U("osType"), json::value::string(U("linux")) } }) } });
         shellRequest.set_body(body);
 
         // Send the request and get the response as a json value

--- a/src/cascadia/TerminalConnection/AzureConnection.cpp
+++ b/src/cascadia/TerminalConnection/AzureConnection.cpp
@@ -956,17 +956,15 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             _WriteStringWithNewline(RS_(L"AzureNoTokens"));
             return;
         }
-        while (credList.Size() > 0)
+
+        for (const auto& cred : credList)
         {
             try
             {
-                vault.Remove(credList.GetAt(0));
+                vault.Remove(cred);
             }
-            catch (...)
-            {
-                _WriteStringWithNewline(RS_(L"AzureTokensRemoved"));
-                return;
-            }
+            CATCH_LOG();
         }
+        _WriteStringWithNewline(RS_(L"AzureTokensRemoved"));
     }
 }

--- a/src/cascadia/TerminalConnection/AzureConnection.h
+++ b/src/cascadia/TerminalConnection/AzureConnection.h
@@ -68,7 +68,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         utility::string_t _cloudShellUri;
         utility::string_t _terminalID;
 
-        void _WriteStringWithNewline(const winrt::hstring& str);
+        void _WriteStringWithNewline(const std::wstring_view str);
         web::json::value _RequestHelper(web::http::client::http_client theClient, web::http::http_request theRequest);
         web::json::value _GetDeviceCode();
         web::json::value _WaitForUser(utility::string_t deviceCode, int pollInterval, int expiresIn);

--- a/src/cascadia/TerminalConnection/AzureConnection.h
+++ b/src/cascadia/TerminalConnection/AzureConnection.h
@@ -31,12 +31,6 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
     private:
         uint32_t _initialRows{};
         uint32_t _initialCols{};
-        int _storedNumber{ -1 };
-        int _maxStored;
-        int _tenantNumber{ -1 };
-        int _maxSize;
-        std::condition_variable _canProceed;
-        std::mutex _commonMutex;
 
         enum class AzureState
         {
@@ -51,9 +45,6 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 
         AzureState _state{ AzureState::AccessStored };
 
-        std::optional<bool> _store;
-        std::optional<bool> _removeOrNew;
-
         wil::unique_handle _hOutputThread;
 
         static DWORD WINAPI StaticOutputThreadProc(LPVOID lpParameter);
@@ -67,13 +58,13 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         const utility::string_t _loginUri{ U("https://login.microsoftonline.com/") };
         const utility::string_t _resourceUri{ U("https://management.azure.com/") };
         const utility::string_t _wantedResource{ U("https://management.core.windows.net/") };
-        int _expireLimit{ 2700 };
+        const int _expireLimit{ 2700 };
         web::json::value _tenantList;
         utility::string_t _displayName;
         utility::string_t _tenantID;
         utility::string_t _accessToken;
         utility::string_t _refreshToken;
-        int _expiry;
+        int _expiry{ 0 };
         utility::string_t _cloudShellUri;
         utility::string_t _terminalID;
 
@@ -89,6 +80,18 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         void _HeaderHelper(web::http::http_request theRequest);
         void _StoreCredential();
         void _RemoveCredentials();
+
+        enum class InputMode
+        {
+            None = 0,
+            Line
+        };
+        InputMode _currentInputMode{ InputMode::None };
+        std::wstring _userInput;
+        std::condition_variable _inputEvent;
+        std::mutex _inputMutex;
+
+        std::optional<std::wstring> _ReadUserInput(InputMode mode);
 
         web::websockets::client::websocket_client _cloudShellSocket;
     };

--- a/src/cascadia/TerminalConnection/Resources/Resources.language-en.resw
+++ b/src/cascadia/TerminalConnection/Resources/Resources.language-en.resw
@@ -123,14 +123,14 @@
   <data name="AzureEnterTenant" xml:space="preserve">
     <value>Please enter the desired tenant number.</value>
   </data>
-  <data name="AzureNewLogin" xml:space="preserve">
-    <value>Enter "n" to login with a different account.</value>
+  <data name="AzureNewLogin" xml:space="default">
+    <value>Enter %s to login with a different account</value>
   </data>
-  <data name="AzureRemoveStored" xml:space="preserve">
-    <value>Enter "r" to remove the above saved connection settings.</value>
+  <data name="AzureRemoveStored" xml:space="default">
+    <value>Enter %s to remove the above saved connection settings.</value>
   </data>
-  <data name="AzureInvalidAccessInput" xml:space="preserve">
-    <value>Please enter a valid number to access the stored connection settings, n to make a new one, or r to remove the stored ones.</value>
+  <data name="AzureInvalidAccessInput" xml:space="default">
+    <value>Please enter a valid number to access the stored connection settings, %s to make a new one, or %s to remove the stored ones.</value>
   </data>
   <data name="AzureNonNumberError" xml:space="preserve">
     <value>Please enter a number.</value>
@@ -144,11 +144,11 @@
   <data name="AzureNoCloudAccount" xml:space="preserve">
     <value>You have not set up your cloud shell account yet. Please go to https://shell.azure.com to set it up.</value>
   </data>
-  <data name="AzureStorePrompt" xml:space="preserve">
-    <value>Do you want to save these connection settings for future logins? [y/n]</value>
+  <data name="AzureStorePrompt" xml:space="default">
+    <value>Do you want to save these connection settings for future logins? [%s/%s]</value>
   </data>
-  <data name="AzureInvalidStoreInput" xml:space="preserve">
-    <value>Please enter y or n</value>
+  <data name="AzureInvalidStoreInput" xml:space="default">
+    <value>Please enter %s or %s</value>
   </data>
   <data name="AzureRequestingCloud" xml:space="preserve">
     <value>Requesting a cloud shell instance...</value>
@@ -183,8 +183,8 @@
   <data name="AzureUnknownTenantName" xml:space="preserve">
     <value>&lt;unknown tenant name&gt;</value>
   </data>
-  <data name="AzureIthTenant" xml:space="preserve">
-    <value>Tenant %d: %s (%s)</value>
+  <data name="AzureIthTenant" xml:space="default">
+    <value>Tenant %s: %s (%s)</value>
   </data>
   <data name="AzureSuccessfullyAuthenticated" xml:space="preserve">
     <value>Authenticated.</value>


### PR DESCRIPTION
This pull request comprises four commits that improve the Azure connection.

## Azure: rewrite user input handler

This commit replaces the AzureConnection's input handler with one that
acts more like "getline()". Instead of the Read thread setting a state
and WriteInput filling in the right member variable, the reader blocks
on the user's input and receives it in an optional<string>.

This moves the input number parsing and error case handling closer to
the point where those inputs are used, as opposed to where they're
collected.

It also switches our input to be "line-based", which is a huge boon for
typing tenant numbers >9. This fixes #3233. A simple line editor
(supporting only backspace and CR) is included.

It also enables echo on user input, and prints it in a nice pretty green
color.

It also enables input queueing: if the user types anything before the
connection is established, it'll be sent once it is.

Fixes #3233.

## Azure: display the user's options and additional information in color

This commit colorizes parts of the AzCon's strings that include "user
options" -- things the user can type -- in yellow. This is to help with
accessibility.

The implementation here is based on a discussion with the team.
Alternative options for coloration were investigated, such as:

* Embedding escape sequences in the resource file.
  This would have been confusing for translators.
  The RESW file format doesn't support &amp;#x1B; escapes, so we would need
  some magic post-processing.
* Embedding "markup" in the resource file (like #{93m}, ...)
  This still would have been annoying for translators.

We settled on an implementation that takes resource names, colorizes
them, and string-formats them into other resources.

## Azure: follow the user's shell choice from the online portal

Fixes #2266.

## Azure: remove all credentials instead of just the first one

just a silly bug.

