### PR TITLE
Fix JSON syntax errors in UsingJsonSettings.md

### DIFF
--- a/doc/user-docs/UsingJsonSettings.md
+++ b/doc/user-docs/UsingJsonSettings.md
@@ -287,7 +287,7 @@ properties for all your profiles, like so:
             {
                 "guid": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
                 "name": "Windows PowerShell",
-                "commandline": "powershell.exe",
+                "commandline": "powershell.exe"
             },
             {
                 "guid": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
@@ -299,8 +299,8 @@ properties for all your profiles, like so:
                 "name" : "cmder",
                 "startingDirectory" : "%USERPROFILE%"
             }
-        ],
-    }
+        ]
+    },
 ```
 
 Note that the `profiles` property has changed in this example from a _list_ of
@@ -328,7 +328,7 @@ could achieve that with the following:
             {
                 "guid": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
                 "name": "Windows PowerShell",
-                "commandline": "powershell.exe",
+                "commandline": "powershell.exe"
             },
             {
                 "guid": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
@@ -341,8 +341,8 @@ could achieve that with the following:
                 "name" : "cmder",
                 "startingDirectory" : "%USERPROFILE%"
             }
-        ],
-    }
+        ]
+    },
 ```
 
 In the above settings, the `"fontFace"` in the `cmd.exe` profile overrides the


### PR DESCRIPTION
Corrected issues documented in #4783

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
Updated documentation that when used causes JSON syntax errors

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #4783 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
Validated based on syntax error checking in VSCode and based on a new profiles.json created using most recent version of Windows Terminal.
