### PR TITLE
Add support for VT52 emulation

### DIFF
--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -346,6 +346,21 @@ bool ConhostInternalGetSet::PrivateSetKeypadMode(const bool fApplicationMode)
 }
 
 // Routine Description:
+// - Sets the terminal emulation mode to either ANSI-compatible or VT52.
+//   PrivateSetAnsiMode is an internal-only "API" call that the vt commands can execute,
+//     but it is not represented as a function call on out public API surface.
+// Arguments:
+// - ansiMode - set to true to enable the ANSI mode, false for VT52 mode.
+// Return Value:
+// - true if successful. false otherwise.
+bool ConhostInternalGetSet::PrivateSetAnsiMode(const bool ansiMode)
+{
+    auto& stateMachine = _io.GetActiveOutputBuffer().GetStateMachine();
+    stateMachine.SetAnsiMode(ansiMode);
+    return true;
+}
+
+// Routine Description:
 // - Connects the PrivateSetScreenMode call directly into our Driver Message servicing call inside Conhost.exe
 //   PrivateSetScreenMode is an internal-only "API" call that the vt commands can execute,
 //     but it is not represented as a function call on our public API surface.

--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -357,6 +357,8 @@ bool ConhostInternalGetSet::PrivateSetAnsiMode(const bool ansiMode)
 {
     auto& stateMachine = _io.GetActiveOutputBuffer().GetStateMachine();
     stateMachine.SetAnsiMode(ansiMode);
+    auto& terminalInput = _io.GetActiveInputBuffer()->GetTerminalInput();
+    terminalInput.ChangeAnsiMode(ansiMode);
     return true;
 }
 

--- a/src/host/outputStream.hpp
+++ b/src/host/outputStream.hpp
@@ -93,6 +93,7 @@ public:
     bool PrivateSetCursorKeysMode(const bool applicationMode) override;
     bool PrivateSetKeypadMode(const bool applicationMode) override;
 
+    bool PrivateSetAnsiMode(const bool ansiMode) override;
     bool PrivateSetScreenMode(const bool reverseMode) override;
     bool PrivateSetAutoWrapMode(const bool wrapAtEOL) override;
 

--- a/src/terminal/adapter/DispatchTypes.hpp
+++ b/src/terminal/adapter/DispatchTypes.hpp
@@ -82,6 +82,7 @@ namespace Microsoft::Console::VirtualTerminal::DispatchTypes
     enum PrivateModeParams : unsigned short
     {
         DECCKM_CursorKeysMode = 1,
+        DECANM_AnsiMode = 2,
         DECCOLM_SetNumberOfColumns = 3,
         DECSCNM_ScreenMode = 5,
         DECOM_OriginMode = 6,

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -93,6 +93,7 @@ public:
 
     virtual bool DeviceStatusReport(const DispatchTypes::AnsiStatusType statusType) = 0; // DSR, DSR-OS, DSR-CPR
     virtual bool DeviceAttributes() = 0; // DA1
+    virtual bool Vt52DeviceAttributes() = 0; // VT52 Identify
 
     virtual bool DesignateCharset(const wchar_t wchCharset) = 0; // SCS
 

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -54,6 +54,7 @@ public:
     virtual bool SetCursorKeysMode(const bool applicationMode) = 0; // DECCKM
     virtual bool SetKeypadMode(const bool applicationMode) = 0; // DECKPAM, DECKPNM
     virtual bool EnableCursorBlinking(const bool enable) = 0; // ATT610
+    virtual bool SetAnsiMode(const bool ansiMode) = 0; // DECANM
     virtual bool SetScreenMode(const bool reverseMode) = 0; // DECSCNM
     virtual bool SetOriginMode(const bool relativeMode) = 0; // DECOM
     virtual bool SetAutoWrapMode(const bool wrapAtEOL) = 0; // DECAWM

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -710,6 +710,19 @@ bool AdaptDispatch::DeviceAttributes()
 }
 
 // Routine Description:
+// - VT52 Identify - Reports the identity of the terminal in VT52 emulation mode.
+//   An actual VT52 terminal would typically identify itself with ESC / K.
+//   But for a terminal that is emulating a VT52, the sequence should be ESC / Z.
+// Arguments:
+// - <none>
+// Return Value:
+// - True if handled successfully. False otherwise.
+bool AdaptDispatch::Vt52DeviceAttributes()
+{
+    return _WriteResponse(L"\x1b/Z");
+}
+
+// Routine Description:
 // - DSR-OS - Reports the operating status back to the input channel
 // Arguments:
 // - <none>

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -951,6 +951,9 @@ bool AdaptDispatch::_PrivateModeParamsHelper(const DispatchTypes::PrivateModePar
         // set - Enable Application Mode, reset - Normal mode
         success = SetCursorKeysMode(enable);
         break;
+    case DispatchTypes::PrivateModeParams::DECANM_AnsiMode:
+        success = SetAnsiMode(enable);
+        break;
     case DispatchTypes::PrivateModeParams::DECCOLM_SetNumberOfColumns:
         success = _DoDECCOLMHelper(enable ? DispatchTypes::s_sDECCOLMSetColumns : DispatchTypes::s_sDECCOLMResetColumns);
         break;
@@ -1128,6 +1131,16 @@ bool AdaptDispatch::InsertLine(const size_t distance)
 bool AdaptDispatch::DeleteLine(const size_t distance)
 {
     return _pConApi->DeleteLines(distance);
+}
+
+// - DECANM - Sets the terminal emulation mode to either ANSI-compatible or VT52.
+// Arguments:
+// - ansiMode - set to true to enable the ANSI mode, false for VT52 mode.
+// Return Value:
+// - True if handled successfully. False otherwise.
+bool AdaptDispatch::SetAnsiMode(const bool ansiMode)
+{
+    return _pConApi->PrivateSetAnsiMode(ansiMode);
 }
 
 // Routine Description:

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1153,6 +1153,10 @@ bool AdaptDispatch::DeleteLine(const size_t distance)
 // - True if handled successfully. False otherwise.
 bool AdaptDispatch::SetAnsiMode(const bool ansiMode)
 {
+    // When an attempt is made to update the mode, the designated character sets
+    // need to be reset to defaults, even if the mode doesn't actually change.
+    _termOutput = {};
+
     return _pConApi->PrivateSetAnsiMode(ansiMode);
 }
 

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -68,6 +68,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool SetCursorKeysMode(const bool applicationMode) override; // DECCKM
         bool SetKeypadMode(const bool applicationMode) override; // DECKPAM, DECKPNM
         bool EnableCursorBlinking(const bool enable) override; // ATT610
+        bool SetAnsiMode(const bool ansiMode) override; // DECANM
         bool SetScreenMode(const bool reverseMode) override; // DECSCNM
         bool SetOriginMode(const bool relativeMode) noexcept override; // DECOM
         bool SetAutoWrapMode(const bool wrapAtEOL) override; // DECAWM

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -58,6 +58,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool SetGraphicsRendition(const std::basic_string_view<DispatchTypes::GraphicsOptions> options) override; // SGR
         bool DeviceStatusReport(const DispatchTypes::AnsiStatusType statusType) override; // DSR, DSR-OS, DSR-CPR
         bool DeviceAttributes() override; // DA1
+        bool Vt52DeviceAttributes() override; // VT52 Identify
         bool ScrollUp(const size_t distance) override; // SU
         bool ScrollDown(const size_t distance) override; // SD
         bool InsertLine(const size_t distance) override; // IL

--- a/src/terminal/adapter/conGetSet.hpp
+++ b/src/terminal/adapter/conGetSet.hpp
@@ -60,6 +60,7 @@ namespace Microsoft::Console::VirtualTerminal
         virtual bool PrivateSetCursorKeysMode(const bool applicationMode) = 0;
         virtual bool PrivateSetKeypadMode(const bool applicationMode) = 0;
 
+        virtual bool PrivateSetAnsiMode(const bool ansiMode) = 0;
         virtual bool PrivateSetScreenMode(const bool reverseMode) = 0;
         virtual bool PrivateSetAutoWrapMode(const bool wrapAtEOL) = 0;
 

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -48,6 +48,7 @@ public:
     bool SetCursorKeysMode(const bool /*applicationMode*/) noexcept override { return false; } // DECCKM
     bool SetKeypadMode(const bool /*applicationMode*/) noexcept override { return false; } // DECKPAM, DECKPNM
     bool EnableCursorBlinking(const bool /*enable*/) noexcept override { return false; } // ATT610
+    bool SetAnsiMode(const bool /*ansiMode*/) noexcept override { return false; } // DECANM
     bool SetScreenMode(const bool /*reverseMode*/) noexcept override { return false; } // DECSCNM
     bool SetOriginMode(const bool /*relativeMode*/) noexcept override { return false; }; // DECOM
     bool SetAutoWrapMode(const bool /*wrapAtEOL*/) noexcept override { return false; }; // DECAWM

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -87,6 +87,7 @@ public:
 
     bool DeviceStatusReport(const DispatchTypes::AnsiStatusType /*statusType*/) noexcept override { return false; } // DSR, DSR-OS, DSR-CPR
     bool DeviceAttributes() noexcept override { return false; } // DA1
+    bool Vt52DeviceAttributes() noexcept override { return false; } // VT52 Identify
 
     bool DesignateCharset(const wchar_t /*wchCharset*/) noexcept override { return false; } // SCS
 

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -162,6 +162,13 @@ public:
         return _privateSetKeypadModeResult;
     }
 
+    bool PrivateSetAnsiMode(const bool /*ansiMode*/) override
+    {
+        Log::Comment(L"PrivateSetAnsiMode MOCK called...");
+
+        return true;
+    }
+
     bool PrivateSetScreenMode(const bool /*reverseMode*/) override
     {
         Log::Comment(L"PrivateSetScreenMode MOCK called...");

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -162,11 +162,16 @@ public:
         return _privateSetKeypadModeResult;
     }
 
-    bool PrivateSetAnsiMode(const bool /*ansiMode*/) override
+    bool PrivateSetAnsiMode(const bool ansiMode) override
     {
         Log::Comment(L"PrivateSetAnsiMode MOCK called...");
 
-        return true;
+        if (_privateSetAnsiModeResult)
+        {
+            VERIFY_ARE_EQUAL(_expectedAnsiMode, ansiMode);
+        }
+
+        return _privateSetAnsiModeResult;
     }
 
     bool PrivateSetScreenMode(const bool /*reverseMode*/) override
@@ -878,6 +883,8 @@ public:
     bool _privateSetKeypadModeResult = false;
     bool _cursorKeysApplicationMode = false;
     bool _keypadApplicationMode = false;
+    bool _privateSetAnsiModeResult = false;
+    bool _expectedAnsiMode = false;
     bool _privateAllowCursorBlinkingResult = false;
     bool _enable = false; // for cursor blinking
     bool _privateSetScrollingRegionResult = false;
@@ -1877,6 +1884,26 @@ public:
         _testGetSet->_keypadApplicationMode = true;
 
         VERIFY_IS_TRUE(_pDispatch.get()->SetKeypadMode(true));
+    }
+
+    TEST_METHOD(AnsiModeTest)
+    {
+        Log::Comment(L"Starting test...");
+
+        // success cases
+        // set ansi mode = true
+        Log::Comment(L"Test 1: ansi mode = true");
+        _testGetSet->_privateSetAnsiModeResult = true;
+        _testGetSet->_expectedAnsiMode = true;
+
+        VERIFY_IS_TRUE(_pDispatch.get()->SetAnsiMode(true));
+
+        // set ansi mode = false
+        Log::Comment(L"Test 2: ansi mode = false.");
+        _testGetSet->_privateSetAnsiModeResult = true;
+        _testGetSet->_expectedAnsiMode = false;
+
+        VERIFY_IS_TRUE(_pDispatch.get()->SetAnsiMode(false));
     }
 
     TEST_METHOD(AllowBlinkingTest)

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -68,6 +68,15 @@ static constexpr std::array<TermKeyMap, 6> s_cursorKeysApplicationMapping{
     TermKeyMap{ VK_END, L"\x1bOF" },
 };
 
+static constexpr std::array<TermKeyMap, 6> s_cursorKeysVt52Mapping{
+    TermKeyMap{ VK_UP, L"\033A" },
+    TermKeyMap{ VK_DOWN, L"\033B" },
+    TermKeyMap{ VK_RIGHT, L"\033C" },
+    TermKeyMap{ VK_LEFT, L"\033D" },
+    TermKeyMap{ VK_HOME, L"\033H" },
+    TermKeyMap{ VK_END, L"\033F" },
+};
+
 static constexpr std::array<TermKeyMap, 20> s_keypadNumericMapping{
     TermKeyMap{ VK_TAB, L"\x09" },
     TermKeyMap{ VK_BACK, L"\x7f" },
@@ -150,6 +159,29 @@ static constexpr std::array<TermKeyMap, 20> s_keypadApplicationMapping{
     // TermKeyMap{ VK_TAB, L"\x1bOI" },   // So I left them here as a reference just in case.
 };
 
+static constexpr std::array<TermKeyMap, 20> s_keypadVt52Mapping{
+    TermKeyMap{ VK_TAB, L"\x09" },
+    TermKeyMap{ VK_BACK, L"\x7f" },
+    TermKeyMap{ VK_PAUSE, L"\x1a" },
+    TermKeyMap{ VK_ESCAPE, L"\x1b" },
+    TermKeyMap{ VK_INSERT, L"\x1b[2~" },
+    TermKeyMap{ VK_DELETE, L"\x1b[3~" },
+    TermKeyMap{ VK_PRIOR, L"\x1b[5~" },
+    TermKeyMap{ VK_NEXT, L"\x1b[6~" },
+    TermKeyMap{ VK_F1, L"\x1bP" },
+    TermKeyMap{ VK_F2, L"\x1bQ" },
+    TermKeyMap{ VK_F3, L"\x1bR" },
+    TermKeyMap{ VK_F4, L"\x1bS" },
+    TermKeyMap{ VK_F5, L"\x1b[15~" },
+    TermKeyMap{ VK_F6, L"\x1b[17~" },
+    TermKeyMap{ VK_F7, L"\x1b[18~" },
+    TermKeyMap{ VK_F8, L"\x1b[19~" },
+    TermKeyMap{ VK_F9, L"\x1b[20~" },
+    TermKeyMap{ VK_F10, L"\x1b[21~" },
+    TermKeyMap{ VK_F11, L"\x1b[23~" },
+    TermKeyMap{ VK_F12, L"\x1b[24~" },
+};
+
 // Sequences to send when a modifier is pressed with any of these keys
 // Basically, the 'm' will be replaced with a character indicating which
 //      modifier keys are pressed.
@@ -220,6 +252,11 @@ const wchar_t* const CTRL_QUESTIONMARK_SEQUENCE = L"\x7F";
 const wchar_t* const CTRL_ALT_SLASH_SEQUENCE = L"\x1b\x1f";
 const wchar_t* const CTRL_ALT_QUESTIONMARK_SEQUENCE = L"\x1b\x7F";
 
+void TerminalInput::ChangeAnsiMode(const bool ansiMode) noexcept
+{
+    _ansiMode = ansiMode;
+}
+
 void TerminalInput::ChangeKeypadMode(const bool applicationMode) noexcept
 {
     _keypadApplicationMode = applicationMode;
@@ -231,29 +268,44 @@ void TerminalInput::ChangeCursorKeysMode(const bool applicationMode) noexcept
 }
 
 static const std::basic_string_view<TermKeyMap> _getKeyMapping(const KeyEvent& keyEvent,
+                                                               const bool ansiMode,
                                                                const bool cursorApplicationMode,
                                                                const bool keypadApplicationMode) noexcept
 {
-    if (keyEvent.IsCursorKey())
+    if (ansiMode)
     {
-        if (cursorApplicationMode)
+        if (keyEvent.IsCursorKey())
         {
-            return { s_cursorKeysApplicationMapping.data(), s_cursorKeysApplicationMapping.size() };
+            if (cursorApplicationMode)
+            {
+                return { s_cursorKeysApplicationMapping.data(), s_cursorKeysApplicationMapping.size() };
+            }
+            else
+            {
+                return { s_cursorKeysNormalMapping.data(), s_cursorKeysNormalMapping.size() };
+            }
         }
         else
         {
-            return { s_cursorKeysNormalMapping.data(), s_cursorKeysNormalMapping.size() };
+            if (keypadApplicationMode)
+            {
+                return { s_keypadApplicationMapping.data(), s_keypadApplicationMapping.size() };
+            }
+            else
+            {
+                return { s_keypadNumericMapping.data(), s_keypadNumericMapping.size() };
+            }
         }
     }
     else
     {
-        if (keypadApplicationMode)
+        if (keyEvent.IsCursorKey())
         {
-            return { s_keypadApplicationMapping.data(), s_keypadApplicationMapping.size() };
+            return { s_cursorKeysVt52Mapping.data(), s_cursorKeysVt52Mapping.size() };
         }
         else
         {
-            return { s_keypadNumericMapping.data(), s_keypadNumericMapping.size() };
+            return { s_keypadVt52Mapping.data(), s_keypadVt52Mapping.size() };
         }
     }
 }
@@ -560,7 +612,7 @@ bool TerminalInput::HandleKey(const IInputEvent* const pInEvent)
     }
 
     // Check any other key mappings (like those for the F1-F12 keys).
-    const auto mapping = _getKeyMapping(keyEvent, _cursorApplicationMode, _keypadApplicationMode);
+    const auto mapping = _getKeyMapping(keyEvent, _ansiMode, _cursorApplicationMode, _keypadApplicationMode);
     if (_translateDefaultMapping(keyEvent, mapping, senderFunc))
     {
         return true;

--- a/src/terminal/input/terminalInput.hpp
+++ b/src/terminal/input/terminalInput.hpp
@@ -34,6 +34,7 @@ namespace Microsoft::Console::VirtualTerminal
         ~TerminalInput() = default;
 
         bool HandleKey(const IInputEvent* const pInEvent);
+        void ChangeAnsiMode(const bool ansiMode) noexcept;
         void ChangeKeypadMode(const bool applicationMode) noexcept;
         void ChangeCursorKeysMode(const bool applicationMode) noexcept;
 
@@ -67,6 +68,7 @@ namespace Microsoft::Console::VirtualTerminal
         // storage location for the leading surrogate of a utf-16 surrogate pair
         std::optional<wchar_t> _leadingSurrogate;
 
+        bool _ansiMode = true;
         bool _keypadApplicationMode = false;
         bool _cursorApplicationMode = false;
 

--- a/src/terminal/parser/IStateMachineEngine.hpp
+++ b/src/terminal/parser/IStateMachineEngine.hpp
@@ -32,6 +32,9 @@ namespace Microsoft::Console::VirtualTerminal
 
         virtual bool ActionEscDispatch(const wchar_t wch,
                                        const std::basic_string_view<wchar_t> intermediates) = 0;
+        virtual bool ActionVt52EscDispatch(const wchar_t wch,
+                                           const std::basic_string_view<wchar_t> intermediates,
+                                           const std::basic_string_view<size_t> parameters) = 0;
         virtual bool ActionCsiDispatch(const wchar_t wch,
                                        const std::basic_string_view<wchar_t> intermediates,
                                        const std::basic_string_view<size_t> parameters) = 0;

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -328,6 +328,24 @@ bool InputStateMachineEngine::ActionEscDispatch(const wchar_t wch,
 }
 
 // Method Description:
+// - Triggers the Vt52EscDispatch action to indicate that the listener should handle
+//      a VT52 escape sequence. These sequences start with ESC and a single letter,
+//      sometimes followed by parameters.
+// Arguments:
+// - wch - Character to dispatch.
+// - intermediates - Intermediate characters in the sequence.
+// - parameters - Set of parameters collected while parsing the sequence.
+// Return Value:
+// - true iff we successfully dispatched the sequence.
+bool InputStateMachineEngine::ActionVt52EscDispatch(const wchar_t /*wch*/,
+                                                    const std::basic_string_view<wchar_t> /*intermediates*/,
+                                                    const std::basic_string_view<size_t> /*parameters*/) noexcept
+{
+    // VT52 escape sequences are not used in the input state machine.
+    return false;
+}
+
+// Method Description:
 // - Triggers the CsiDispatch action to indicate that the listener should handle
 //      a control sequence. These sequences perform various API-type commands
 //      that can include many parameters.

--- a/src/terminal/parser/InputStateMachineEngine.hpp
+++ b/src/terminal/parser/InputStateMachineEngine.hpp
@@ -149,6 +149,10 @@ namespace Microsoft::Console::VirtualTerminal
         bool ActionEscDispatch(const wchar_t wch,
                                const std::basic_string_view<wchar_t> intermediates) override;
 
+        bool ActionVt52EscDispatch(const wchar_t wch,
+                                   const std::basic_string_view<wchar_t> intermediates,
+                                   const std::basic_string_view<size_t> parameters) noexcept override;
+
         bool ActionCsiDispatch(const wchar_t wch,
                                const std::basic_string_view<wchar_t> intermediates,
                                const std::basic_string_view<size_t> parameters) override;

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -345,6 +345,12 @@ bool OutputStateMachineEngine::ActionVt52EscDispatch(const wchar_t wch,
         case Vt52ActionCodes::Identify:
             success = _dispatch->Vt52DeviceAttributes();
             break;
+        case Vt52ActionCodes::EnterAlternateKeypadMode:
+            success = _dispatch->SetKeypadMode(true);
+            break;
+        case Vt52ActionCodes::ExitAlternateKeypadMode:
+            success = _dispatch->SetKeypadMode(false);
+            break;
         case Vt52ActionCodes::ExitVt52Mode:
         {
             const DispatchTypes::PrivateModeParams mode[] = { DispatchTypes::PrivateModeParams::DECANM_AnsiMode };

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -342,6 +342,9 @@ bool OutputStateMachineEngine::ActionVt52EscDispatch(const wchar_t wch,
             // the lowest value being a space, representing an address of 1.
             success = _dispatch->CursorPosition(parameters.at(0) - ' ' + 1, parameters.at(1) - ' ' + 1);
             break;
+        case Vt52ActionCodes::Identify:
+            success = _dispatch->Vt52DeviceAttributes();
+            break;
         case Vt52ActionCodes::ExitVt52Mode:
         {
             const DispatchTypes::PrivateModeParams mode[] = { DispatchTypes::PrivateModeParams::DECANM_AnsiMode };

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -296,12 +296,68 @@ bool OutputStateMachineEngine::ActionEscDispatch(const wchar_t wch,
 // - parameters - Set of parameters collected while parsing the sequence.
 // Return Value:
 // - true iff we successfully dispatched the sequence.
-bool OutputStateMachineEngine::ActionVt52EscDispatch(const wchar_t /*wch*/,
-                                                     const std::basic_string_view<wchar_t> /*intermediates*/,
-                                                     const std::basic_string_view<size_t> /*parameters*/)
+bool OutputStateMachineEngine::ActionVt52EscDispatch(const wchar_t wch,
+                                                     const std::basic_string_view<wchar_t> intermediates,
+                                                     const std::basic_string_view<size_t> parameters)
 {
-    // TBD
-    return false;
+    bool success = false;
+
+    // no intermediates.
+    if (intermediates.empty())
+    {
+        switch (wch)
+        {
+        case Vt52ActionCodes::CursorUp:
+            success = _dispatch->CursorUp(1);
+            break;
+        case Vt52ActionCodes::CursorDown:
+            success = _dispatch->CursorDown(1);
+            break;
+        case Vt52ActionCodes::CursorRight:
+            success = _dispatch->CursorForward(1);
+            break;
+        case Vt52ActionCodes::CursorLeft:
+            success = _dispatch->CursorBackward(1);
+            break;
+        case Vt52ActionCodes::EnterGraphicsMode:
+            success = _dispatch->DesignateCharset(DispatchTypes::VTCharacterSets::DEC_LineDrawing);
+            break;
+        case Vt52ActionCodes::ExitGraphicsMode:
+            success = _dispatch->DesignateCharset(DispatchTypes::VTCharacterSets::USASCII);
+            break;
+        case Vt52ActionCodes::CursorToHome:
+            success = _dispatch->CursorPosition(1, 1);
+            break;
+        case Vt52ActionCodes::ReverseLineFeed:
+            success = _dispatch->ReverseLineFeed();
+            break;
+        case Vt52ActionCodes::EraseToEndOfScreen:
+            success = _dispatch->EraseInDisplay(DispatchTypes::EraseType::ToEnd);
+            break;
+        case Vt52ActionCodes::EraseToEndOfLine:
+            success = _dispatch->EraseInLine(DispatchTypes::EraseType::ToEnd);
+            break;
+        case Vt52ActionCodes::DirectCursorAddress:
+            // VT52 cursor addresses are provided as ASCII characters, with
+            // the lowest value being a space, representing an address of 1.
+            success = _dispatch->CursorPosition(parameters.at(0) - ' ' + 1, parameters.at(1) - ' ' + 1);
+            break;
+        case Vt52ActionCodes::ExitVt52Mode:
+        {
+            const DispatchTypes::PrivateModeParams mode[] = { DispatchTypes::PrivateModeParams::DECANM_AnsiMode };
+            success = _dispatch->SetPrivateModes(mode);
+            break;
+        }
+        default:
+            // If no functions to call, overall dispatch was a failure.
+            success = false;
+            break;
+        }
+    }
+
+    _ClearLastChar();
+
+    return success;
 }
 
 // Routine Description:

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -286,6 +286,24 @@ bool OutputStateMachineEngine::ActionEscDispatch(const wchar_t wch,
     return success;
 }
 
+// Method Description:
+// - Triggers the Vt52EscDispatch action to indicate that the listener should handle
+//      a VT52 escape sequence. These sequences start with ESC and a single letter,
+//      sometimes followed by parameters.
+// Arguments:
+// - wch - Character to dispatch.
+// - intermediates - Intermediate characters in the sequence.
+// - parameters - Set of parameters collected while parsing the sequence.
+// Return Value:
+// - true iff we successfully dispatched the sequence.
+bool OutputStateMachineEngine::ActionVt52EscDispatch(const wchar_t /*wch*/,
+                                                     const std::basic_string_view<wchar_t> /*intermediates*/,
+                                                     const std::basic_string_view<size_t> /*parameters*/)
+{
+    // TBD
+    return false;
+}
+
 // Routine Description:
 // - Triggers the CsiDispatch action to indicate that the listener should handle
 //      a control sequence. These sequences perform various API-type commands

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -36,6 +36,10 @@ namespace Microsoft::Console::VirtualTerminal
         bool ActionEscDispatch(const wchar_t wch,
                                const std::basic_string_view<wchar_t> intermediates) override;
 
+        bool ActionVt52EscDispatch(const wchar_t wch,
+                                   const std::basic_string_view<wchar_t> intermediates,
+                                   const std::basic_string_view<size_t> parameters) override;
+
         bool ActionCsiDispatch(const wchar_t wch,
                                const std::basic_string_view<wchar_t> intermediates,
                                const std::basic_string_view<size_t> parameters) override;

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -144,6 +144,8 @@ namespace Microsoft::Console::VirtualTerminal
             EraseToEndOfLine = L'K',
             DirectCursorAddress = L'Y',
             Identify = L'Z',
+            EnterAlternateKeypadMode = L'=',
+            ExitAlternateKeypadMode = L'>',
             ExitVt52Mode = L'<'
         };
 

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -143,6 +143,7 @@ namespace Microsoft::Console::VirtualTerminal
             EraseToEndOfScreen = L'J',
             EraseToEndOfLine = L'K',
             DirectCursorAddress = L'Y',
+            Identify = L'Z',
             ExitVt52Mode = L'<'
         };
 

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -130,6 +130,22 @@ namespace Microsoft::Console::VirtualTerminal
             DECALN_ScreenAlignmentPattern = L'8'
         };
 
+        enum Vt52ActionCodes : wchar_t
+        {
+            CursorUp = L'A',
+            CursorDown = L'B',
+            CursorRight = L'C',
+            CursorLeft = L'D',
+            EnterGraphicsMode = L'F',
+            ExitGraphicsMode = L'G',
+            CursorToHome = L'H',
+            ReverseLineFeed = L'I',
+            EraseToEndOfScreen = L'J',
+            EraseToEndOfLine = L'K',
+            DirectCursorAddress = L'Y',
+            ExitVt52Mode = L'<'
+        };
+
         enum OscActionCodes : unsigned int
         {
             SetIconAndWindowTitle = 0,

--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -14,6 +14,7 @@ StateMachine::StateMachine(std::unique_ptr<IStateMachineEngine> engine) :
     _engine(std::move(engine)),
     _state(VTStates::Ground),
     _trace(Microsoft::Console::VirtualTerminal::ParserTracing()),
+    _isInAnsiMode(true),
     _intermediates{},
     _parameters{},
     _oscString{},
@@ -21,6 +22,11 @@ StateMachine::StateMachine(std::unique_ptr<IStateMachineEngine> engine) :
     _processingIndividually(false)
 {
     _ActionClear();
+}
+
+void StateMachine::SetAnsiMode(bool ansiMode) noexcept
+{
+    _isInAnsiMode = ansiMode;
 }
 
 const IStateMachineEngine& StateMachine::Engine() const noexcept
@@ -198,6 +204,19 @@ static constexpr bool _isSs3Indicator(const wchar_t wch) noexcept
 }
 
 // Routine Description:
+// - Determines if a character is the VT52 "Direct Cursor Address" command.
+//   This immediately follows an escape and signifies the start of a multiple
+//      character command sequence.
+// Arguments:
+// - wch - Character to check.
+// Return Value:
+// - True if it is. False if it isn't.
+static constexpr bool _isVt52CursorAddress(const wchar_t wch) noexcept
+{
+    return wch == L'Y'; // 0x59
+}
+
+// Routine Description:
 // - Determines if a character is a "Single Shift Select" indicator.
 //   This immediately follows an escape and signifies a varying length control string.
 // Arguments:
@@ -335,6 +354,31 @@ void StateMachine::_ActionEscDispatch(const wchar_t wch)
     _trace.TraceOnAction(L"EscDispatch");
 
     const bool success = _engine->ActionEscDispatch(wch, { _intermediates.data(), _intermediates.size() });
+
+    // Trace the result.
+    _trace.DispatchSequenceTrace(success);
+
+    if (!success)
+    {
+        // Suppress it and log telemetry on failed cases
+        TermTelemetry::Instance().LogFailed(wch);
+    }
+}
+
+// Routine Description:
+// - Triggers the Vt52EscDispatch action to indicate that the listener should handle a VT52 escape sequence.
+//   These sequences start with ESC and a single letter, sometimes followed by parameters.
+// Arguments:
+// - wch - Character to dispatch.
+// Return Value:
+// - <none>
+void StateMachine::_ActionVt52EscDispatch(const wchar_t wch)
+{
+    _trace.TraceOnAction(L"Vt52EscDispatch");
+
+    const bool success = _engine->ActionVt52EscDispatch(wch,
+                                                        { _intermediates.data(), _intermediates.size() },
+                                                        { _parameters.data(), _parameters.size() });
 
     // Trace the result.
     _trace.DispatchSequenceTrace(success);
@@ -700,6 +744,20 @@ void StateMachine::_EnterSs3Param() noexcept
 }
 
 // Routine Description:
+// - Moves the state machine into the VT52Param state.
+//   This state is entered:
+//   1. When a VT52 Cursor Address escape is detected, so parameters are expected to follow.
+// Arguments:
+// - <none>
+// Return Value:
+// - <none>
+void StateMachine::_EnterVt52Param() noexcept
+{
+    _state = VTStates::Vt52Param;
+    _trace.TraceStateChange(L"Vt52Param");
+}
+
+// Routine Description:
 // - Processes a character event into an Action that occurs while in the Ground state.
 //   Events in this state will:
 //   1. Execute C0 control characters
@@ -716,7 +774,7 @@ void StateMachine::_EventGround(const wchar_t wch)
     {
         _ActionExecute(wch);
     }
-    else if (_isC1Csi(wch))
+    else if (_isC1Csi(wch) && _isInAnsiMode)
     {
         _EnterCsiEntry();
     }
@@ -770,21 +828,33 @@ void StateMachine::_EventEscape(const wchar_t wch)
             _EnterEscapeIntermediate();
         }
     }
-    else if (_isCsiIndicator(wch))
+    else if (_isInAnsiMode)
     {
-        _EnterCsiEntry();
+        if (_isCsiIndicator(wch))
+        {
+            _EnterCsiEntry();
+        }
+        else if (_isOscIndicator(wch))
+        {
+            _EnterOscParam();
+        }
+        else if (_isSs3Indicator(wch))
+        {
+            _EnterSs3Entry();
+        }
+        else
+        {
+            _ActionEscDispatch(wch);
+            _EnterGround();
+        }
     }
-    else if (_isOscIndicator(wch))
+    else if (_isVt52CursorAddress(wch))
     {
-        _EnterOscParam();
-    }
-    else if (_isSs3Indicator(wch))
-    {
-        _EnterSs3Entry();
+        _EnterVt52Param();
     }
     else
     {
-        _ActionEscDispatch(wch);
+        _ActionVt52EscDispatch(wch);
         _EnterGround();
     }
 }
@@ -815,9 +885,18 @@ void StateMachine::_EventEscapeIntermediate(const wchar_t wch)
     {
         _ActionIgnore();
     }
-    else
+    else if (_isInAnsiMode)
     {
         _ActionEscDispatch(wch);
+        _EnterGround();
+    }
+    else if (_isVt52CursorAddress(wch))
+    {
+        _EnterVt52Param();
+    }
+    else
+    {
+        _ActionVt52EscDispatch(wch);
         _EnterGround();
     }
 }
@@ -1157,6 +1236,41 @@ void StateMachine::_EventSs3Param(const wchar_t wch)
 }
 
 // Routine Description:
+// - Processes a character event into an Action that occurs while in the Vt52Param state.
+//   Events in this state will:
+//   1. Execute C0 control characters
+//   2. Ignore Delete characters
+//   3. Store exactly two parameter characters
+//   4. Dispatch a control sequence with parameters for action (always Direct Cursor Address)
+// Arguments:
+// - wch - Character that triggered the event
+// Return Value:
+// - <none>
+void StateMachine::_EventVt52Param(const wchar_t wch)
+{
+    _trace.TraceOnEvent(L"Vt52Param");
+    if (_isC0Code(wch))
+    {
+        _ActionExecute(wch);
+    }
+    else if (_isDelete(wch))
+    {
+        _ActionIgnore();
+    }
+    else
+    {
+        _parameters.push_back(wch);
+        if (_parameters.size() == 2)
+        {
+            // The command character is processed before the parameter values,
+            // but it will always be 'Y', the Direct Cursor Address command.
+            _ActionVt52EscDispatch(L'Y');
+            _EnterGround();
+        }
+    }
+}
+
+// Routine Description:
 // - Entry to the state machine. Takes characters one by one and processes them according to the state machine rules.
 // Arguments:
 // - wch - New character to operate upon
@@ -1213,6 +1327,8 @@ void StateMachine::ProcessCharacter(const wchar_t wch)
             return _EventSs3Entry(wch);
         case VTStates::Ss3Param:
             return _EventSs3Param(wch);
+        case VTStates::Vt52Param:
+            return _EventVt52Param(wch);
         default:
             return;
         }

--- a/src/terminal/parser/stateMachine.hpp
+++ b/src/terminal/parser/stateMachine.hpp
@@ -37,6 +37,8 @@ namespace Microsoft::Console::VirtualTerminal
     public:
         StateMachine(std::unique_ptr<IStateMachineEngine> engine);
 
+        void SetAnsiMode(bool ansiMode) noexcept;
+
         void ProcessCharacter(const wchar_t wch);
         void ProcessString(const std::wstring_view string);
 
@@ -52,6 +54,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _ActionExecuteFromEscape(const wchar_t wch);
         void _ActionPrint(const wchar_t wch);
         void _ActionEscDispatch(const wchar_t wch);
+        void _ActionVt52EscDispatch(const wchar_t wch);
         void _ActionCollect(const wchar_t wch);
         void _ActionParam(const wchar_t wch);
         void _ActionCsiDispatch(const wchar_t wch);
@@ -75,6 +78,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _EnterOscTermination() noexcept;
         void _EnterSs3Entry();
         void _EnterSs3Param() noexcept;
+        void _EnterVt52Param() noexcept;
 
         void _EventGround(const wchar_t wch);
         void _EventEscape(const wchar_t wch);
@@ -88,6 +92,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _EventOscTermination(const wchar_t wch);
         void _EventSs3Entry(const wchar_t wch);
         void _EventSs3Param(const wchar_t wch);
+        void _EventVt52Param(const wchar_t wch);
 
         void _AccumulateTo(const wchar_t wch, size_t& value) noexcept;
 
@@ -104,7 +109,8 @@ namespace Microsoft::Console::VirtualTerminal
             OscString,
             OscTermination,
             Ss3Entry,
-            Ss3Param
+            Ss3Param,
+            Vt52Param
         };
 
         Microsoft::Console::VirtualTerminal::ParserTracing _trace;
@@ -112,6 +118,8 @@ namespace Microsoft::Console::VirtualTerminal
         std::unique_ptr<IStateMachineEngine> _engine;
 
         VTStates _state;
+
+        bool _isInAnsiMode;
 
         std::wstring_view _run;
 

--- a/src/terminal/parser/ut_parser/StateMachineTest.cpp
+++ b/src/terminal/parser/ut_parser/StateMachineTest.cpp
@@ -53,6 +53,10 @@ public:
     bool ActionEscDispatch(const wchar_t /* wch */,
                            const std::basic_string_view<wchar_t> /* intermediates */) override { return true; };
 
+    bool ActionVt52EscDispatch(const wchar_t /*wch*/,
+                               const std::basic_string_view<wchar_t> /*intermediates*/,
+                               const std::basic_string_view<size_t> /*parameters*/) override { return true; };
+
     bool ActionClear() override { return true; };
 
     bool ActionIgnore() override { return true; };


### PR DESCRIPTION
## Summary of the Pull Request

This PR adds support for the core VT52 commands, and implements the `DECANM` private mode sequence, which switches the terminal between ANSI mode and VT52-compatible mode.

## References

PR #2017 defined the initial specification for VT52 support.
PR #4044 removed the original VT52 cursor ops that conflicted with VT100 sequences.

## PR Checklist
* [x] Closes #976
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #2017

## Detailed Description of the Pull Request / Additional comments

Most of the work involves updates to the parsing state machine, which behaves differently in VT52 mode. `CSI`, `OSC`, and `SS3` sequences are not applicable, and there is one special-case escape sequence (_Direct Cursor Address_), which requires an additional state to handle parameters that come _after_ the final character.

Once the parsing is handled though, it's mostly just a matter of dispatching the commands to existing methods in the `ITermDispatch` interface. Only one new method was required in the interface to handle the _Identify_ command.

The only real new functionality is in the `TerminalInput` class, which needs to generate different escape sequences for certain keys in VT52 mode. This does not yet support _all_ of the VT52 key sequences, because the VT100 support is itself not yet complete. But the basics are in place, and I think the rest is best left for a follow-up issue, and potentially a refactor of the `TerminalInput` class.

I should point out that the original spec called for a new _Graphic Mode_ character set, but I've since discovered that the VT terminals that _emulate_ VT52 just use the existing VT100 _Special Graphics_ set, so that is really what we should be doing too. We can always consider adding the VT52 graphic set as a option later, if there is demand for strict VT52 compatibility. 

## Validation Steps Performed

I've added state machine and adapter tests to confirm that the `DECANM` mode changing sequences are correctly dispatched and forwarded to the `ConGetSet` handler. I've also added state machine tests that confirm the VT52 escape sequences are dispatched correctly when the ANSI mode is reset.

For fuzzing support, I've extended the VT command fuzzer to generate the different kinds of VT52 sequences, as well as mode change sequences to switch between the ANSI and VT52 modes.

In terms of manual testing, I've confirmed that the _Test of VT52 mode_ in Vttest now works as expected.