### PR TITLE
Improve Word Navigation/Selection Performance

### DIFF
--- a/src/buffer/out/CharRow.cpp
+++ b/src/buffer/out/CharRow.cpp
@@ -269,6 +269,33 @@ std::wstring CharRow::GetText() const
     return wstr;
 }
 
+// Method Description:
+// - get delimiter class for a position in the char row
+// - used for double click selection and uia word navigation
+// Arguments:
+// - column: column to get text data for
+// - wordDelimiters: the delimiters defined as a part of the DelimiterClass::DelimiterChar
+// Return Value:
+// - the delimiter class for the given char
+const DelimiterClass CharRow::DelimiterClassAt(const size_t column, std::wstring_view wordDelimiters) const
+{
+    THROW_HR_IF(E_INVALIDARG, column >= _data.size());
+
+    const auto glyph = GlyphAt(column).begin();
+    if (*glyph <= UNICODE_SPACE)
+    {
+        return DelimiterClass::ControlChar;
+    }
+    else if (wordDelimiters.find(*glyph) != std::wstring_view::npos)
+    {
+        return DelimiterClass::DelimiterChar;
+    }
+    else
+    {
+        return DelimiterClass::RegularChar;
+    }
+}
+
 UnicodeStorage& CharRow::GetUnicodeStorage() noexcept
 {
     return _pParent->GetUnicodeStorage();

--- a/src/buffer/out/CharRow.cpp
+++ b/src/buffer/out/CharRow.cpp
@@ -277,16 +277,16 @@ std::wstring CharRow::GetText() const
 // - wordDelimiters: the delimiters defined as a part of the DelimiterClass::DelimiterChar
 // Return Value:
 // - the delimiter class for the given char
-const DelimiterClass CharRow::DelimiterClassAt(const size_t column, std::wstring_view wordDelimiters) const
+const DelimiterClass CharRow::DelimiterClassAt(const size_t column, const std::wstring_view wordDelimiters) const
 {
     THROW_HR_IF(E_INVALIDARG, column >= _data.size());
 
-    const auto glyph = GlyphAt(column).begin();
-    if (*glyph <= UNICODE_SPACE)
+    const auto glyph = *GlyphAt(column).begin();
+    if (glyph <= UNICODE_SPACE)
     {
         return DelimiterClass::ControlChar;
     }
-    else if (wordDelimiters.find(*glyph) != std::wstring_view::npos)
+    else if (wordDelimiters.find(glyph) != std::wstring_view::npos)
     {
         return DelimiterClass::DelimiterChar;
     }

--- a/src/buffer/out/CharRow.hpp
+++ b/src/buffer/out/CharRow.hpp
@@ -27,6 +27,13 @@ Revision History:
 
 class ROW;
 
+enum class DelimiterClass
+{
+    ControlChar,
+    DelimiterChar,
+    RegularChar
+};
+
 // the characters of one row of screen buffer
 // we keep the following values so that we don't write
 // more pixels to the screen than we have to:
@@ -63,6 +70,8 @@ public:
     DbcsAttribute& DbcsAttrAt(const size_t column);
     void ClearGlyph(const size_t column);
     std::wstring GetText() const;
+
+    const DelimiterClass DelimiterClassAt(const size_t column, std::wstring_view wordDelimiters) const;
 
     // working with glyphs
     const reference GlyphAt(const size_t column) const;

--- a/src/buffer/out/CharRow.hpp
+++ b/src/buffer/out/CharRow.hpp
@@ -71,7 +71,7 @@ public:
     void ClearGlyph(const size_t column);
     std::wstring GetText() const;
 
-    const DelimiterClass DelimiterClassAt(const size_t column, std::wstring_view wordDelimiters) const;
+    const DelimiterClass DelimiterClassAt(const size_t column, const std::wstring_view wordDelimiters) const;
 
     // working with glyphs
     const reference GlyphAt(const size_t column) const;

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -197,13 +197,7 @@ private:
 
     void _ExpandTextRow(SMALL_RECT& selectionRow) const;
 
-    enum class DelimiterClass
-    {
-        ControlChar,
-        DelimiterChar,
-        RegularChar
-    };
-    DelimiterClass _GetDelimiterClass(const std::wstring_view cellChar, const std::wstring_view wordDelimiters) const noexcept;
+    const DelimiterClass _GetDelimiterClassAt(const COORD pos, const std::wstring_view wordDelimiters) const;
     const COORD _GetWordStartForAccessibility(const COORD target, const std::wstring_view wordDelimiters) const;
     const COORD _GetWordStartForSelection(const COORD target, const std::wstring_view wordDelimiters) const;
     const COORD _GetWordEndForAccessibility(const COORD target, const std::wstring_view wordDelimiters) const;

--- a/src/types/ScreenInfoUiaProviderBase.cpp
+++ b/src/types/ScreenInfoUiaProviderBase.cpp
@@ -265,7 +265,7 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::GetSelection(_Outptr_result_maybenull_
         return hr;
     }
 
-    UiaTracing::TextProvider::GetSelection(*this);
+    UiaTracing::TextProvider::GetSelection(*this, *range.Get());
     return S_OK;
 }
 

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -1045,6 +1045,10 @@ void UiaTextRangeBase::_moveEndpointByUnitWord(_In_ const int moveCount,
                 resultPos = bufferEnd;
                 (*pAmountMoved)++;
             }
+            else
+            {
+                success = false;
+            }
             break;
         }
         case MovementDirection::Backward:

--- a/src/types/UiaTracing.cpp
+++ b/src/types/UiaTracing.cpp
@@ -88,429 +88,529 @@ inline std::wstring UiaTracing::_getValue(const TextUnit unit) noexcept
 
 void UiaTracing::TextRange::Constructor(const UiaTextRangeBase& result) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "UiaTextRange::Constructor",
-        TraceLoggingValue(_getValue(result).c_str(), "UiaTextRange"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "UiaTextRange::Constructor",
+            TraceLoggingValue(_getValue(result).c_str(), "UiaTextRange"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextRange::Clone(const UiaTextRangeBase& utr, const UiaTextRangeBase& result) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "UiaTextRange::Clone",
-        TraceLoggingValue(_getValue(utr).c_str(), "base"),
-        TraceLoggingValue(_getValue(result).c_str(), "clone"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "UiaTextRange::Clone",
+            TraceLoggingValue(_getValue(utr).c_str(), "base"),
+            TraceLoggingValue(_getValue(result).c_str(), "clone"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextRange::Compare(const UiaTextRangeBase& utr, const UiaTextRangeBase& other, bool result) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "UiaTextRange::Compare",
-        TraceLoggingValue(_getValue(utr).c_str(), "base"),
-        TraceLoggingValue(_getValue(other).c_str(), "other"),
-        TraceLoggingValue(result, "result"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "UiaTextRange::Compare",
+            TraceLoggingValue(_getValue(utr).c_str(), "base"),
+            TraceLoggingValue(_getValue(other).c_str(), "other"),
+            TraceLoggingValue(result, "result"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextRange::CompareEndpoints(const UiaTextRangeBase& utr, const TextPatternRangeEndpoint endpoint, const UiaTextRangeBase& other, TextPatternRangeEndpoint otherEndpoint, int result) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "UiaTextRange::CompareEndpoints",
-        TraceLoggingValue(_getValue(utr).c_str(), "base"),
-        TraceLoggingValue(_getValue(endpoint).c_str(), "baseEndpoint"),
-        TraceLoggingValue(_getValue(other).c_str(), "other"),
-        TraceLoggingValue(_getValue(otherEndpoint).c_str(), "otherEndpoint"),
-        TraceLoggingValue(result, "result"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "UiaTextRange::CompareEndpoints",
+            TraceLoggingValue(_getValue(utr).c_str(), "base"),
+            TraceLoggingValue(_getValue(endpoint).c_str(), "baseEndpoint"),
+            TraceLoggingValue(_getValue(other).c_str(), "other"),
+            TraceLoggingValue(_getValue(otherEndpoint).c_str(), "otherEndpoint"),
+            TraceLoggingValue(result, "result"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextRange::ExpandToEnclosingUnit(TextUnit unit, const UiaTextRangeBase& utr) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "UiaTextRange::ExpandToEnclosingUnit",
-        TraceLoggingValue(_getValue(unit).c_str(), "textUnit"),
-        TraceLoggingValue(_getValue(utr).c_str(), "result"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "UiaTextRange::ExpandToEnclosingUnit",
+            TraceLoggingValue(_getValue(unit).c_str(), "textUnit"),
+            TraceLoggingValue(_getValue(utr).c_str(), "result"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextRange::FindAttribute(const UiaTextRangeBase& utr) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "UiaTextRange::FindAttribute (UNSUPPORTED)",
-        TraceLoggingValue(_getValue(utr).c_str(), "base"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "UiaTextRange::FindAttribute (UNSUPPORTED)",
+            TraceLoggingValue(_getValue(utr).c_str(), "base"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextRange::FindText(const UiaTextRangeBase& base, std::wstring text, bool searchBackward, bool ignoreCase, const UiaTextRangeBase& result) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "UiaTextRange::FindText",
-        TraceLoggingValue(_getValue(base).c_str(), "base"),
-        TraceLoggingValue(text.c_str(), "text"),
-        TraceLoggingValue(searchBackward, "searchBackward"),
-        TraceLoggingValue(ignoreCase, "ignoreCase"),
-        TraceLoggingValue(_getValue(result).c_str(), "result"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "UiaTextRange::FindText",
+            TraceLoggingValue(_getValue(base).c_str(), "base"),
+            TraceLoggingValue(text.c_str(), "text"),
+            TraceLoggingValue(searchBackward, "searchBackward"),
+            TraceLoggingValue(ignoreCase, "ignoreCase"),
+            TraceLoggingValue(_getValue(result).c_str(), "result"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextRange::GetAttributeValue(const UiaTextRangeBase& base, TEXTATTRIBUTEID id, VARIANT result) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "UiaTextRange::GetAttributeValue",
-        TraceLoggingValue(_getValue(base).c_str(), "base"),
-        TraceLoggingValue(id, "textAttributeId"),
-        TraceLoggingValue(result.vt, "result (type)"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "UiaTextRange::GetAttributeValue",
+            TraceLoggingValue(_getValue(base).c_str(), "base"),
+            TraceLoggingValue(id, "textAttributeId"),
+            TraceLoggingValue(result.vt, "result (type)"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextRange::GetBoundingRectangles(const UiaTextRangeBase& utr) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "UiaTextRange::GetBoundingRectangles",
-        TraceLoggingValue(_getValue(utr).c_str(), "base"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "UiaTextRange::GetBoundingRectangles",
+            TraceLoggingValue(_getValue(utr).c_str(), "base"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextRange::GetEnclosingElement(const UiaTextRangeBase& utr) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "UiaTextRange::GetEnclosingElement",
-        TraceLoggingValue(_getValue(utr).c_str(), "base"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "UiaTextRange::GetEnclosingElement",
+            TraceLoggingValue(_getValue(utr).c_str(), "base"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextRange::GetText(const UiaTextRangeBase& utr, int maxLength, std::wstring result) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "UiaTextRange::GetText",
-        TraceLoggingValue(_getValue(utr).c_str(), "base"),
-        TraceLoggingValue(maxLength, "maxLength"),
-        TraceLoggingValue(result.c_str(), "result"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "UiaTextRange::GetText",
+            TraceLoggingValue(_getValue(utr).c_str(), "base"),
+            TraceLoggingValue(maxLength, "maxLength"),
+            TraceLoggingValue(result.c_str(), "result"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextRange::Move(TextUnit unit, int count, int resultCount, const UiaTextRangeBase& result) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "UiaTextRange::Move",
-        TraceLoggingValue(_getValue(unit).c_str(), "textUnit"),
-        TraceLoggingValue(count, "count"),
-        TraceLoggingValue(resultCount, "resultCount"),
-        TraceLoggingValue(_getValue(result).c_str(), "result"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "UiaTextRange::Move",
+            TraceLoggingValue(_getValue(unit).c_str(), "textUnit"),
+            TraceLoggingValue(count, "count"),
+            TraceLoggingValue(resultCount, "resultCount"),
+            TraceLoggingValue(_getValue(result).c_str(), "result"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextRange::MoveEndpointByUnit(TextPatternRangeEndpoint endpoint, TextUnit unit, int count, int resultCount, const UiaTextRangeBase& result) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "UiaTextRange::MoveEndpointByUnit",
-        TraceLoggingValue(_getValue(endpoint).c_str(), "endpoint"),
-        TraceLoggingValue(_getValue(unit).c_str(), "textUnit"),
-        TraceLoggingValue(count, "count"),
-        TraceLoggingValue(resultCount, "resultCount"),
-        TraceLoggingValue(_getValue(result).c_str(), "result"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "UiaTextRange::MoveEndpointByUnit",
+            TraceLoggingValue(_getValue(endpoint).c_str(), "endpoint"),
+            TraceLoggingValue(_getValue(unit).c_str(), "textUnit"),
+            TraceLoggingValue(count, "count"),
+            TraceLoggingValue(resultCount, "resultCount"),
+            TraceLoggingValue(_getValue(result).c_str(), "result"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextRange::MoveEndpointByRange(TextPatternRangeEndpoint endpoint, const UiaTextRangeBase& other, TextPatternRangeEndpoint otherEndpoint, const UiaTextRangeBase& result) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "UiaTextRange::MoveEndpointByRange",
-        TraceLoggingValue(_getValue(endpoint).c_str(), "endpoint"),
-        TraceLoggingValue(_getValue(other).c_str(), "other"),
-        TraceLoggingValue(_getValue(otherEndpoint).c_str(), "otherEndpoint"),
-        TraceLoggingValue(_getValue(result).c_str(), "result"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "UiaTextRange::MoveEndpointByRange",
+            TraceLoggingValue(_getValue(endpoint).c_str(), "endpoint"),
+            TraceLoggingValue(_getValue(other).c_str(), "other"),
+            TraceLoggingValue(_getValue(otherEndpoint).c_str(), "otherEndpoint"),
+            TraceLoggingValue(_getValue(result).c_str(), "result"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextRange::Select(const UiaTextRangeBase& result) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "UiaTextRange::Select",
-        TraceLoggingValue(_getValue(result).c_str(), "base"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "UiaTextRange::Select",
+            TraceLoggingValue(_getValue(result).c_str(), "base"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextRange::AddToSelection(const UiaTextRangeBase& result) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "UiaTextRange::AddToSelection (UNSUPPORTED)",
-        TraceLoggingValue(_getValue(result).c_str(), "base"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "UiaTextRange::AddToSelection (UNSUPPORTED)",
+            TraceLoggingValue(_getValue(result).c_str(), "base"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextRange::RemoveFromSelection(const UiaTextRangeBase& result) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "UiaTextRange::RemoveFromSelection (UNSUPPORTED)",
-        TraceLoggingValue(_getValue(result).c_str(), "base"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "UiaTextRange::RemoveFromSelection (UNSUPPORTED)",
+            TraceLoggingValue(_getValue(result).c_str(), "base"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
+
 void UiaTracing::TextRange::ScrollIntoView(bool alignToTop, const UiaTextRangeBase& result) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "UiaTextRange::ScrollIntoView",
-        TraceLoggingValue(alignToTop, "alignToTop"),
-        TraceLoggingValue(_getValue(result).c_str(), "result"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "UiaTextRange::ScrollIntoView",
+            TraceLoggingValue(alignToTop, "alignToTop"),
+            TraceLoggingValue(_getValue(result).c_str(), "result"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextRange::GetChildren(const UiaTextRangeBase& result) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "UiaTextRange::AddToSelection (UNSUPPORTED)",
-        TraceLoggingValue(_getValue(result).c_str(), "base"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "UiaTextRange::AddToSelection (UNSUPPORTED)",
+            TraceLoggingValue(_getValue(result).c_str(), "base"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextProvider::Constructor(const ScreenInfoUiaProviderBase& result) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "ScreenInfoUiaProvider::Constructor",
-        TraceLoggingValue(_getValue(result).c_str(), "ScreenInfoUiaProvider"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "ScreenInfoUiaProvider::Constructor",
+            TraceLoggingValue(_getValue(result).c_str(), "ScreenInfoUiaProvider"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextProvider::get_ProviderOptions(const ScreenInfoUiaProviderBase& siup, ProviderOptions options) noexcept
 {
-    auto getOptions = [options]() {
-        switch (options)
-        {
-        case ProviderOptions_ServerSideProvider:
-            return L"ServerSideProvider";
-        default:
-            return L"UNKNOWN VALUE";
-        }
-    };
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        auto getOptions = [options]() {
+            switch (options)
+            {
+            case ProviderOptions_ServerSideProvider:
+                return L"ServerSideProvider";
+            default:
+                return L"UNKNOWN VALUE";
+            }
+        };
 
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "ScreenInfoUiaProvider::get_ProviderOptions",
-        TraceLoggingValue(_getValue(siup).c_str(), "base"),
-        TraceLoggingValue(getOptions(), "providerOptions"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "ScreenInfoUiaProvider::get_ProviderOptions",
+            TraceLoggingValue(_getValue(siup).c_str(), "base"),
+            TraceLoggingValue(getOptions(), "providerOptions"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextProvider::GetPatternProvider(const ScreenInfoUiaProviderBase& siup, PATTERNID patternId) noexcept
 {
-    auto getPattern = [patternId]() {
-        switch (patternId)
-        {
-        case UIA_TextPatternId:
-            return L"TextPattern";
-        default:
-            return L"UNKNOWN VALUE";
-        }
-    };
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        auto getPattern = [patternId]() {
+            switch (patternId)
+            {
+            case UIA_TextPatternId:
+                return L"TextPattern";
+            default:
+                return L"UNKNOWN VALUE";
+            }
+        };
 
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "ScreenInfoUiaProvider::get_ProviderOptions",
-        TraceLoggingValue(_getValue(siup).c_str(), "base"),
-        TraceLoggingValue(getPattern(), "patternId"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "ScreenInfoUiaProvider::get_ProviderOptions",
+            TraceLoggingValue(_getValue(siup).c_str(), "base"),
+            TraceLoggingValue(getPattern(), "patternId"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextProvider::GetPropertyValue(const ScreenInfoUiaProviderBase& siup, PROPERTYID propertyId) noexcept
 {
-    auto getProperty = [propertyId]() {
-        switch (propertyId)
-        {
-        case UIA_ControlTypePropertyId:
-            return L"ControlTypePropertyId";
-        case UIA_NamePropertyId:
-            return L"NamePropertyId";
-        case UIA_AutomationIdPropertyId:
-            return L"AutomationIdPropertyId";
-        case UIA_IsControlElementPropertyId:
-            return L"IsControlElementPropertyId";
-        case UIA_IsContentElementPropertyId:
-            return L"IsContentElementPropertyId";
-        case UIA_IsKeyboardFocusablePropertyId:
-            return L"IsKeyboardFocusablePropertyId";
-        case UIA_HasKeyboardFocusPropertyId:
-            return L"HasKeyboardFocusPropertyId";
-        case UIA_ProviderDescriptionPropertyId:
-            return L"ProviderDescriptionPropertyId";
-        case UIA_IsEnabledPropertyId:
-            return L"IsEnabledPropertyId";
-        default:
-            return L"UNKNOWN VALUE";
-        }
-    };
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        auto getProperty = [propertyId]() {
+            switch (propertyId)
+            {
+            case UIA_ControlTypePropertyId:
+                return L"ControlTypePropertyId";
+            case UIA_NamePropertyId:
+                return L"NamePropertyId";
+            case UIA_AutomationIdPropertyId:
+                return L"AutomationIdPropertyId";
+            case UIA_IsControlElementPropertyId:
+                return L"IsControlElementPropertyId";
+            case UIA_IsContentElementPropertyId:
+                return L"IsContentElementPropertyId";
+            case UIA_IsKeyboardFocusablePropertyId:
+                return L"IsKeyboardFocusablePropertyId";
+            case UIA_HasKeyboardFocusPropertyId:
+                return L"HasKeyboardFocusPropertyId";
+            case UIA_ProviderDescriptionPropertyId:
+                return L"ProviderDescriptionPropertyId";
+            case UIA_IsEnabledPropertyId:
+                return L"IsEnabledPropertyId";
+            default:
+                return L"UNKNOWN VALUE";
+            }
+        };
 
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "ScreenInfoUiaProvider::GetPropertyValue",
-        TraceLoggingValue(_getValue(siup).c_str(), "base"),
-        TraceLoggingValue(getProperty(), "propertyId"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "ScreenInfoUiaProvider::GetPropertyValue",
+            TraceLoggingValue(_getValue(siup).c_str(), "base"),
+            TraceLoggingValue(getProperty(), "propertyId"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextProvider::get_HostRawElementProvider(const ScreenInfoUiaProviderBase& siup) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "ScreenInfoUiaProvider::get_HostRawElementProvider (UNSUPPORTED)",
-        TraceLoggingValue(_getValue(siup).c_str(), "base"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "ScreenInfoUiaProvider::get_HostRawElementProvider (UNSUPPORTED)",
+            TraceLoggingValue(_getValue(siup).c_str(), "base"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextProvider::GetRuntimeId(const ScreenInfoUiaProviderBase& siup) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "ScreenInfoUiaProvider::GetRuntimeId",
-        TraceLoggingValue(_getValue(siup).c_str(), "base"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "ScreenInfoUiaProvider::GetRuntimeId",
+            TraceLoggingValue(_getValue(siup).c_str(), "base"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextProvider::GetEmbeddedFragmentRoots(const ScreenInfoUiaProviderBase& siup) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "ScreenInfoUiaProvider::GetEmbeddedFragmentRoots (UNSUPPORTED)",
-        TraceLoggingValue(_getValue(siup).c_str(), "base"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "ScreenInfoUiaProvider::GetEmbeddedFragmentRoots (UNSUPPORTED)",
+            TraceLoggingValue(_getValue(siup).c_str(), "base"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextProvider::SetFocus(const ScreenInfoUiaProviderBase& siup) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "ScreenInfoUiaProvider::SetFocus",
-        TraceLoggingValue(_getValue(siup).c_str(), "base"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "ScreenInfoUiaProvider::SetFocus",
+            TraceLoggingValue(_getValue(siup).c_str(), "base"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
-void UiaTracing::TextProvider::GetSelection(const ScreenInfoUiaProviderBase& siup) noexcept
+void UiaTracing::TextProvider::GetSelection(const ScreenInfoUiaProviderBase& siup, const UiaTextRangeBase& result) noexcept
 {
-    // TODO GH #4466: there's currently a PR out for this. Once that gets fixed, I'll update this appropriately
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "ScreenInfoUiaProvider::GetSelection",
-        TraceLoggingValue(_getValue(siup).c_str(), "base"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "ScreenInfoUiaProvider::GetSelection",
+            TraceLoggingValue(_getValue(siup).c_str(), "base"),
+            TraceLoggingValue(_getValue(result).c_str(), "result (utr)"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextProvider::GetVisibleRanges(const ScreenInfoUiaProviderBase& siup, const UiaTextRangeBase& result) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "ScreenInfoUiaProvider::GetVisibleRanges",
-        TraceLoggingValue(_getValue(siup).c_str(), "base"),
-        TraceLoggingValue(_getValue(result).c_str(), "result (utr)"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "ScreenInfoUiaProvider::GetVisibleRanges",
+            TraceLoggingValue(_getValue(siup).c_str(), "base"),
+            TraceLoggingValue(_getValue(result).c_str(), "result (utr)"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextProvider::RangeFromChild(const ScreenInfoUiaProviderBase& siup, const UiaTextRangeBase& result) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "ScreenInfoUiaProvider::GetVisibleRanges",
-        TraceLoggingValue(_getValue(siup).c_str(), "base"),
-        TraceLoggingValue(_getValue(result).c_str(), "result (utr)"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "ScreenInfoUiaProvider::GetVisibleRanges",
+            TraceLoggingValue(_getValue(siup).c_str(), "base"),
+            TraceLoggingValue(_getValue(result).c_str(), "result (utr)"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextProvider::RangeFromPoint(const ScreenInfoUiaProviderBase& siup, UiaPoint point, const UiaTextRangeBase& result) noexcept
 {
-    auto getPoint = [point]() {
-        std::wstringstream stream;
-        stream << "{ " << point.x << ", " << point.y << " }";
-        return stream.str();
-    };
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        auto getPoint = [point]() {
+            std::wstringstream stream;
+            stream << "{ " << point.x << ", " << point.y << " }";
+            return stream.str();
+        };
 
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "ScreenInfoUiaProvider::RangeFromPoint",
-        TraceLoggingValue(_getValue(siup).c_str(), "base"),
-        TraceLoggingValue(getPoint().c_str(), "uiaPoint"),
-        TraceLoggingValue(_getValue(result).c_str(), "result (utr)"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "ScreenInfoUiaProvider::RangeFromPoint",
+            TraceLoggingValue(_getValue(siup).c_str(), "base"),
+            TraceLoggingValue(getPoint().c_str(), "uiaPoint"),
+            TraceLoggingValue(_getValue(result).c_str(), "result (utr)"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextProvider::get_DocumentRange(const ScreenInfoUiaProviderBase& siup, const UiaTextRangeBase& result) noexcept
 {
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "ScreenInfoUiaProvider::GetVisibleRanges",
-        TraceLoggingValue(_getValue(siup).c_str(), "base"),
-        TraceLoggingValue(_getValue(result).c_str(), "result (utr)"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "ScreenInfoUiaProvider::GetVisibleRanges",
+            TraceLoggingValue(_getValue(siup).c_str(), "base"),
+            TraceLoggingValue(_getValue(result).c_str(), "result (utr)"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 
 void UiaTracing::TextProvider::get_SupportedTextSelection(const ScreenInfoUiaProviderBase& siup, SupportedTextSelection result) noexcept
 {
-    auto getResult = [result]() {
-        switch (result)
-        {
-        case SupportedTextSelection_Single:
-            return L"Single";
-        default:
-            return L"UNKNOWN VALUE";
-        }
-    };
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        auto getResult = [result]() {
+            switch (result)
+            {
+            case SupportedTextSelection_Single:
+                return L"Single";
+            default:
+                return L"UNKNOWN VALUE";
+            }
+        };
 
-    EnsureRegistration();
-    TraceLoggingWrite(
-        g_UiaProviderTraceProvider,
-        "ScreenInfoUiaProvider::get_SupportedTextSelection",
-        TraceLoggingValue(_getValue(siup).c_str(), "base"),
-        TraceLoggingValue(getResult(), "result"),
-        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+        EnsureRegistration();
+        TraceLoggingWrite(
+            g_UiaProviderTraceProvider,
+            "ScreenInfoUiaProvider::get_SupportedTextSelection",
+            TraceLoggingValue(_getValue(siup).c_str(), "base"),
+            TraceLoggingValue(getResult(), "result"),
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+    }
 }
 #pragma warning(pop)

--- a/src/types/UiaTracing.h
+++ b/src/types/UiaTracing.h
@@ -64,7 +64,7 @@ namespace Microsoft::Console::Types
             static void GetRuntimeId(const ScreenInfoUiaProviderBase& base) noexcept;
             static void GetEmbeddedFragmentRoots(const ScreenInfoUiaProviderBase& base) noexcept;
             static void SetFocus(const ScreenInfoUiaProviderBase& base) noexcept;
-            static void GetSelection(const ScreenInfoUiaProviderBase& base) noexcept;
+            static void GetSelection(const ScreenInfoUiaProviderBase& base, const UiaTextRangeBase& result) noexcept;
             static void GetVisibleRanges(const ScreenInfoUiaProviderBase& base, const UiaTextRangeBase& result) noexcept;
             static void RangeFromChild(const ScreenInfoUiaProviderBase& base, const UiaTextRangeBase& result) noexcept;
             static void RangeFromPoint(const ScreenInfoUiaProviderBase& base, UiaPoint point, const UiaTextRangeBase& result) noexcept;


### PR DESCRIPTION
## Summary of the Pull Request
1) Improves the performance of word-recognition operations such as word
   navigation in UIA and selection.

2) Fixes a bug where attempting to find the next word in UIA, when none
   exists, would hang

3) TraceLogging code only runs when somebody is listening

## Detailed Description of the Pull Request / Additional comments
- The concept of a delimiter class got moved to the CharRow.
- The buffer iterator used to save a lot more information than we needed
- I missed updating a tracing function after making GetSelection return
  one text range. That is fixed now.


## Validation Steps Performed
Performed Word Navigation under Narrator and NVDA.
NOTE: The release build should be used when testing to optimize
performance

Closes #4703