### PR TITLE
Polish AutomationProperties and UIA Tree Navigation

### DIFF
--- a/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
+++ b/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
@@ -132,7 +132,8 @@ the MIT License. See LICENSE in the project root for license information. -->
     </StackPanel.Resources>
 
     <Button Height="36.0" MinWidth="46.0" Width="46.0" x:Name="MinimizeButton" Style="{StaticResource CaptionButton}" Click="_MinimizeClick"
-            AutomationProperties.Name="Minimize">
+            AutomationProperties.Name="Minimize"
+            AutomationProperties.AccessibilityView="Raw">
         <Button.Resources>
             <ResourceDictionary>
                 <x:String x:Key="CaptionButtonPath">M 0 0 H 10</x:String>
@@ -140,7 +141,8 @@ the MIT License. See LICENSE in the project root for license information. -->
         </Button.Resources>
     </Button>
     <Button Height="36.0" MinWidth="46.0" Width="46.0" x:Name="MaximizeButton" Style="{StaticResource CaptionButton}" Click="_MaximizeClick"
-            AutomationProperties.Name="Maximize">
+            AutomationProperties.Name="Maximize"
+            AutomationProperties.AccessibilityView="Raw">
         <Button.Resources>
             <ResourceDictionary>
                 <x:String x:Key="CaptionButtonPath">M 0 0 H 10 V 10 H 0 V 0</x:String>
@@ -149,7 +151,8 @@ the MIT License. See LICENSE in the project root for license information. -->
         </Button.Resources>
     </Button>
     <Button Height="36.0" MinWidth="46.0" Width="46.0" x:Name="CloseButton" Style="{StaticResource CaptionButton}" Click="_CloseClick"
-            AutomationProperties.Name="Close">
+            AutomationProperties.Name="Close"
+            AutomationProperties.AccessibilityView="Raw">
         <Button.Resources>
             <ResourceDictionary>
                 <ResourceDictionary.ThemeDictionaries>

--- a/src/cascadia/TerminalApp/Resources/Resources.language-en.resw
+++ b/src/cascadia/TerminalApp/Resources/Resources.language-en.resw
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -255,5 +255,11 @@ Temporarily using the Windows Terminal default settings.
   </data>
   <data name="CmdStartingDirArgDesc" xml:space="preserve">
     <value>Open in the given directory instead of the profile's set startingDirectory</value>
+  </data>
+  <data name="NewTabSplitButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.HelpText" xml:space="preserve">
+    <value>Press the button to open a new terminal tab with your default profile. Open the flyout to select which profile you want to open.</value>
+  </data>
+  <data name="NewTabSplitButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>New Tab</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -192,6 +192,7 @@ namespace winrt::TerminalApp::implementation
         {
             IconPath(_lastIconPath);
             _tabViewItem.IconSource(GetColoredIcon<winrt::MUX::Controls::IconSource>(_lastIconPath));
+            Automation::AutomationProperties::SetAccessibilityView(_tabViewItem.IconSource(), Automation::Peers::AccessibilityView::Raw);
         }
     }
 

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -192,7 +192,6 @@ namespace winrt::TerminalApp::implementation
         {
             IconPath(_lastIconPath);
             _tabViewItem.IconSource(GetColoredIcon<winrt::MUX::Controls::IconSource>(_lastIconPath));
-            Automation::AutomationProperties::SetAccessibilityView(_tabViewItem.IconSource(), Automation::Peers::AccessibilityView::Raw);
         }
     }
 

--- a/src/cascadia/TerminalApp/TabRowControl.xaml
+++ b/src/cascadia/TerminalApp/TabRowControl.xaml
@@ -17,8 +17,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                  TabWidthMode="Equal"
                  CanReorderTabs="True"
                  CanDragTabs="True"
-                 AllowDropTabs="True"
-                 AutomationProperties.AccessibilityView="Raw">
+                 AllowDropTabs="True">
 
         <mux:TabView.TabStripFooter>
             <mux:SplitButton

--- a/src/cascadia/TerminalApp/TabRowControl.xaml
+++ b/src/cascadia/TerminalApp/TabRowControl.xaml
@@ -17,11 +17,13 @@ the MIT License. See LICENSE in the project root for license information. -->
                  TabWidthMode="Equal"
                  CanReorderTabs="True"
                  CanDragTabs="True"
-                 AllowDropTabs="True">
+                 AllowDropTabs="True"
+                 AutomationProperties.AccessibilityView="Raw">
 
         <mux:TabView.TabStripFooter>
             <mux:SplitButton
                 x:Name="NewTabButton"
+                x:Uid="NewTabSplitButton"
                 Click="OnNewTabButtonClick"
                 VerticalAlignment="Stretch"
                 HorizontalAlignment="Left"
@@ -29,7 +31,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                 UseLayoutRounding="true"
                 FontFamily="Segoe MDL2 Assets"
                 FontWeight="SemiLight"
-                FontSize="12">
+                FontSize="12"
+                AutomationProperties.AccessibilityView="Control">
                 <!-- U+E710 is the fancy plus icon. -->
                 <mux:SplitButton.Resources>
 		    <!-- Override the SplitButton* resources to match the tab view's button's styles. -->

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -63,6 +63,8 @@ namespace winrt::TerminalApp::implementation
         _tabView = _tabRow.TabView();
         _rearranging = false;
 
+        Automation::AutomationProperties::SetAccessibilityView(_tabView, Automation::Peers::AccessibilityView::Raw);
+
         _tabView.TabDragStarting([weakThis{ get_weak() }](auto&& /*o*/, auto&& /*a*/) {
             if (auto page{ weakThis.get() })
             {
@@ -372,6 +374,7 @@ namespace winrt::TerminalApp::implementation
                 WUX::Controls::IconSourceElement iconElement;
                 iconElement.IconSource(iconSource);
                 profileMenuItem.Icon(iconElement);
+                Automation::AutomationProperties::SetAccessibilityView(iconElement, Automation::Peers::AccessibilityView::Raw);
             }
 
             if (profile.GetGuid() == defaultProfileGuid)

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -63,8 +63,6 @@ namespace winrt::TerminalApp::implementation
         _tabView = _tabRow.TabView();
         _rearranging = false;
 
-        Automation::AutomationProperties::SetAccessibilityView(_tabView, Automation::Peers::AccessibilityView::Raw);
-
         _tabView.TabDragStarting([weakThis{ get_weak() }](auto&& /*o*/, auto&& /*a*/) {
             if (auto page{ weakThis.get() })
             {

--- a/src/cascadia/TerminalApp/lib/pch.h
+++ b/src/cascadia/TerminalApp/lib/pch.h
@@ -36,6 +36,7 @@
 #include <winrt/Windows.UI.Xaml.Hosting.h>
 #include "winrt/Windows.UI.Xaml.Markup.h"
 #include "winrt/Windows.UI.Xaml.Documents.h"
+#include "winrt/Windows.UI.Xaml.Automation.h"
 #include <winrt/Windows.ApplicationModel.DataTransfer.h>
 
 #include <winrt/Microsoft.Toolkit.Win32.UI.XamlHost.h>

--- a/src/cascadia/TerminalControl/Resources/Resources.language-en.resw
+++ b/src/cascadia/TerminalControl/Resources/Resources.language-en.resw
@@ -161,4 +161,7 @@
     <value>terminal</value>
     <comment>The type of control that the terminal ahderes to. Used to identify how a user can interact with this kind of control.</comment>
   </data>
+  <data name="SearchBox_Close.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Close Search Box</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalControl/TSFInputControl.xaml
+++ b/src/cascadia/TerminalControl/TSFInputControl.xaml
@@ -8,9 +8,11 @@
     d:DesignHeight="768"
     d:DesignWidth="1024">
 
-    <Canvas x:Name="Canvas" Visibility="Collapsed">
+    <Canvas x:Name="Canvas"
+            Visibility="Collapsed">
         <TextBlock x:Name="TextBlock"
                    IsTextSelectionEnabled="false"
-                   TextDecorations="Underline" />
+                   TextDecorations="Underline"
+                   AutomationProperties.AccessibilityView="Raw"/>
     </Canvas>
 </UserControl>

--- a/src/cascadia/TerminalControl/TSFInputControl.xaml
+++ b/src/cascadia/TerminalControl/TSFInputControl.xaml
@@ -12,7 +12,6 @@
             Visibility="Collapsed">
         <TextBlock x:Name="TextBlock"
                    IsTextSelectionEnabled="false"
-                   TextDecorations="Underline"
-                   AutomationProperties.AccessibilityView="Raw"/>
+                   TextDecorations="Underline"/>
     </Canvas>
 </UserControl>

--- a/src/cascadia/TerminalControl/TermControl.xaml
+++ b/src/cascadia/TerminalControl/TermControl.xaml
@@ -29,7 +29,8 @@
     -->
 
     <Grid x:Name="RootGrid">
-        <Image x:Name="BackgroundImage" />
+        <Image x:Name="BackgroundImage"
+               AutomationProperties.AccessibilityView="Raw"/>
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />


### PR DESCRIPTION
## Summary of the Pull Request
AutomationProperties of interest in this PR include...
- Name: the name of a UI element (generally used as the main identifier for it)
- HelpText: an additional description for a more complex UI element
- [AccessibilityView](https://docs.microsoft.com/en-us/windows/win32/winauto/uiauto-treeoverview):
  - Raw: hide from the UIA tree. Only navigate to this if you know what you're doing
  - Control: a control without any content in it. Basically, a point at which the user can make a decision as to how to navigate the tree or invoke an action.
  - Content: a control that also has content to present to the user.

I set a few more AutomationProperties throughout Windows Terminal...
- MinMaxClose Control: hidden (we can/should rely on the true buttons that we are hiding)
- SplitButton: Name and Help text (currently ignored due to #4804, but having it in the resource file won't cause any problems)
- SearchBox: added a more specific name to the close button
- BackgroundImage: hide it

## References
A few additional work items have been created for tracking...
- SplitButton: https://github.com/microsoft/terminal/issues/4804
- Tabs: <coming soon>

## PR Checklist
* [X] Closes #2099 
* [X] Closes #2102 

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed
Verified using Accessibility Insights and Inspect.exe