### PR TITLE
Apply dark window borders to NonClientIslandWindow using ThemeHelpers

### DIFF
--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -7,6 +7,7 @@
 #include "NonClientIslandWindow.h"
 #include "../types/inc/ThemeUtils.h"
 #include "../types/inc/utils.hpp"
+#include "TerminalThemeHelpers.h"
 
 extern "C" IMAGE_DOS_HEADER __ImageBase;
 
@@ -485,6 +486,9 @@ void NonClientIslandWindow::_UpdateFrameMargins() const noexcept
         return _OnNcHitTest({ GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) });
     case WM_PAINT:
         return _OnPaint();
+    case WM_ACTIVATE:
+        // If we do this every time we're activated, it should be close enough to correct.
+        TerminalTrySetDarkTheme(_window.get());
     }
 
     return IslandWindow::MessageHandler(message, wParam, lParam);

--- a/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
+++ b/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
@@ -112,6 +112,7 @@
     <Error Condition="!Exists('..\..\..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.0.0\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.0.0\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.props'))" />
     <Error Condition="!Exists('..\..\..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.0.0\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.0.0\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\Microsoft.VCRTForwarders.140.1.0.1-rc\build\native\Microsoft.VCRTForwarders.140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.VCRTForwarders.140.1.0.1-rc\build\native\Microsoft.VCRTForwarders.140.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Terminal.ThemeHelpers.0.1.200305005\build\native\Terminal.ThemeHelpers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Terminal.ThemeHelpers.0.1.200305005\build\native\Terminal.ThemeHelpers.targets'))" />
   </Target>
 
   <!-- Override GetPackagingOutputs to roll up all our dependencies.
@@ -142,4 +143,5 @@
   </Target>
 
   <Import Project="$(OpenConsoleDir)\build\rules\GenerateSxsManifestsFromWinmds.targets" />
-</Project>
+  <Import Project="..\..\..\packages\Terminal.ThemeHelpers.0.1.200305005\build\native\Terminal.ThemeHelpers.targets" Condition="Exists('..\..\..\packages\Terminal.ThemeHelpers.0.1.200305005\build\native\Terminal.ThemeHelpers.targets')" />
+</Project>

--- a/src/cascadia/WindowsTerminal/packages.config
+++ b/src/cascadia/WindowsTerminal/packages.config
@@ -4,4 +4,5 @@
   <package id="Microsoft.Toolkit.Win32.UI.XamlApplication" version="6.0.0" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.3.191217003-prerelease" targetFramework="native" />
   <package id="Microsoft.VCRTForwarders.140" version="1.0.1-rc" targetFramework="native" />
-</packages>
+  <package id="Terminal.ThemeHelpers" version="0.1.200305005" targetFramework="native" />
+</packages>


### PR DESCRIPTION
This solution was vetted by the DWM team.

Fixes #3425.