### PR TITLE
Ignore right-click copy when copy on select is enabled

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -790,6 +790,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         if (!_focused)
         {
             Focus(FocusState::Pointer);
+            // Save the click position that brought this control into focus
+            // in case the user wants to perform a click-drag selection.
             _focusRaisedClickPos = point.Position();
         }
 
@@ -888,7 +890,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                 _clickDrag = true;
 
                 // PointerPressedHandler doesn't set the SelectionAnchor when the click was
-                // from out of focus, so PointerMoved gets to set it.
+                // from out of focus, so PointerMoved has to set it.
                 if (_focusRaisedClickPos)
                 {
                     _terminal->SetSelectionAnchor(_GetTerminalPosition(*_focusRaisedClickPos));
@@ -976,8 +978,9 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                 // macro directly with a VirtualKeyModifiers
                 const auto shiftEnabled = WI_IsFlagSet(modifiers, static_cast<uint32_t>(VirtualKeyModifiers::Shift));
 
-                // All left click drags should copy.
-                // Single left click releases on a focused pane should copy any active selection.
+                // In a Copy on Select scenario,
+                // All left click drags should copy,
+                // All left clicks on a focused control should copy if a selection is active.
                 if (_clickDrag || !_focusRaisedClickPos)
                 {
                     CopySelectionToClipboard(!shiftEnabled);

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -153,7 +153,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         // imported from WinUser
         // Used for PointerPoint.Timestamp Property (https://docs.microsoft.com/en-us/uwp/api/windows.ui.input.pointerpoint.timestamp#Windows_UI_Input_PointerPoint_Timestamp)
         Timestamp _multiClickTimer;
-        Timestamp _lastMouseClickTS;
+        Timestamp _lastMouseClickTimestamp;
         unsigned int _multiClickCounter;
         std::optional<winrt::Windows::Foundation::Point> _lastMouseClickPos;
 

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -159,7 +159,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         std::optional<winrt::Windows::Foundation::Point> _focusRaisedClickPos;
         bool _clickDrag;
-        bool _wasLeftButtonPressed;
 
         winrt::Windows::UI::Xaml::Controls::SwapChainPanel::LayoutUpdated_revoker _layoutUpdatedRevoker;
 

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -153,11 +153,13 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         // imported from WinUser
         // Used for PointerPoint.Timestamp Property (https://docs.microsoft.com/en-us/uwp/api/windows.ui.input.pointerpoint.timestamp#Windows_UI_Input_PointerPoint_Timestamp)
         Timestamp _multiClickTimer;
-        Timestamp _lastMouseClick;
+        Timestamp _lastMouseClickTS;
         unsigned int _multiClickCounter;
         std::optional<winrt::Windows::Foundation::Point> _lastMouseClickPos;
-        std::optional<winrt::Windows::Foundation::Point> _unfocusedClickPos;
-        bool _isClickDragSelection;
+
+        std::optional<winrt::Windows::Foundation::Point> _focusRaisedClickPos;
+        bool _clickDrag;
+        bool _wasLeftButtonPressed;
 
         winrt::Windows::UI::Xaml::Controls::SwapChainPanel::LayoutUpdated_revoker _layoutUpdatedRevoker;
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Right clicking on a focused tab while Copy On Select is active currently copies any active selection. This is because `PointerReleasedHandler` doesn't check for the mouse button that was released. 
During a mouse button release, only the left mouse button release should be doing anything.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #4740
* [x] CLA signed.
* [x] Tests added/passed

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
These are the scenarios I've tested. They're a combination of in focus/out of focus, Copy On Select on/off, left/right click pressed and their move and release variants.

From Out of Focus:
- Left Click = Focus
- Left Click Move = Focus + Selection
- Left Click Release
  - CoS on = Copy
  - CoS off = Nothing
- Shift Left Click = Focus
- Right Click 
  - Focus 
  - CoS on = Paste
  - CoS off = Copy if Active Selection, Paste if not.
- Right Click Move = Nothing
- Right Click Release = Nothing

From In Focus
- Left Click = Selection if CoS off
- Left Click Move = Selection
- Left Click Release
  - CoS on = Copy
  - CoS off = Nothing
- Shift Left Click = Set Selection Anchor
- Right Click 
  - CoS on = Paste
  - CoS off = Copy if Active Selection, Paste if not.
- Right Click Move = Nothing
- Right Click Release = Nothing

