### PR TITLE
Resize the drag bar on `WM_DISPLAYCHANGE`

### DIFF
--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -480,6 +480,11 @@ void NonClientIslandWindow::_UpdateFrameMargins() const noexcept
 {
     switch (message)
     {
+    case WM_DISPLAYCHANGE:
+        // GH#4166: When the DPI of the monitor changes out from underneath us,
+        // resize our drag bar, to reflect its newly scaled size.
+        _UpdateIslandRegion();
+        return 0;
     case WM_NCCALCSIZE:
         return _OnNcCalcSize(wParam, lParam);
     case WM_NCHITTEST:


### PR DESCRIPTION
## Summary of the Pull Request

Pretty straightforward. When we get a `WM_DISPLAYCHANGE`, that means the display's DPI changed. When that happens, resize the drag bar, so that it'll reflect the new scaling.

## References

I'm doing this to unblock #4778 

## PR Checklist
* [x] Closes #4166
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated

## Validation Steps Performed

Man I've changed the DPI of my displays so many times in the last 30 minutes. I draged the window across a bunch of DPI boundaries too.