### PR TITLE
Fix a rampant crash in `TSFInputControl` when opening new tabs

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -52,6 +52,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     }
 
     TermControl::TermControl(Settings::IControlSettings settings, TerminalConnection::ITerminalConnection connection) :
+        _terminal{ std::make_unique<::Microsoft::Terminal::Core::Terminal>() },
         _connection{ connection },
         _initializedTerminal{ false },
         _settings{ settings },
@@ -497,6 +498,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
     bool TermControl::_InitializeTerminal()
     {
+        auto lock = _terminal.LockForWriting();
+
         if (_initializedTerminal)
         {
             return false;
@@ -509,8 +512,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         {
             return false;
         }
-
-        _terminal = std::make_unique<::Microsoft::Terminal::Core::Terminal>();
 
         // First create the render thread.
         // Then stash a local pointer to the render thread so we can initialize it and enable it
@@ -1726,6 +1727,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
     void TermControl::Close()
     {
+        auto lock = _terminal.LockForWriting();
+
         if (!_closing.exchange(true))
         {
             // Stop accepting new output and state changes before we disconnect everything.

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -77,7 +77,18 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         // Initialize the terminal only once the swapchainpanel is loaded - that
         //      way, we'll be able to query the real pixel size it got on layout
-        _layoutUpdatedRevoker = SwapChainPanel().LayoutUpdated({ get_weak(), &TermControl::_LayoutUpdated });
+        _layoutUpdatedRevoker = SwapChainPanel().LayoutUpdated(winrt::auto_revoke, [this](auto /*s*/, auto /*e*/) {
+            // This event fires every time the layout changes, but it is always the last one to fire
+            // in any layout change chain. That gives us great flexibility in finding the right point
+            // at which to initialize our renderer (and our terminal).
+            // Any earlier than the last layout update and we may not know the terminal's starting size.
+
+            if (_InitializeTerminal())
+            {
+                // Only let this succeed once.
+                _layoutUpdatedRevoker.revoke();
+            }
+        });
 
         // Subscribe to the connection's disconnected event and call our connection closed handlers.
         _connectionStateChangedRevoker = _connection.StateChanged(winrt::auto_revoke, [this](auto&& /*s*/, auto&& /*v*/) {
@@ -85,21 +96,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         });
 
         _ApplyUISettings();
-    }
-
-    void TermControl::_LayoutUpdated(Windows::Foundation::IInspectable const& sender,
-                                     Windows::UI::Xaml::RoutedEventArgs const& e)
-    {
-        // This event fires every time the layout changes, but it is always the last one to fire
-        // in any layout change chain. That gives us great flexibility in finding the right point
-        // at which to initialize our renderer (and our terminal).
-        // Any earlier than the last layout update and we may not know the terminal's starting size.
-
-        if (_InitializeTerminal())
-        {
-            // Only let this succeed once.
-            _layoutUpdatedRevoker.revoke();
-        }
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -52,7 +52,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     }
 
     TermControl::TermControl(Settings::IControlSettings settings, TerminalConnection::ITerminalConnection connection) :
-        _terminal{ std::make_unique<::Microsoft::Terminal::Core::Terminal>() },
         _connection{ connection },
         _initializedTerminal{ false },
         _settings{ settings },
@@ -494,8 +493,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
     bool TermControl::_InitializeTerminal()
     {
-        auto lock = _terminal.LockForWriting();
-
         if (_initializedTerminal)
         {
             return false;
@@ -508,6 +505,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         {
             return false;
         }
+
+        _terminal = std::make_unique<::Microsoft::Terminal::Core::Terminal>();
 
         // First create the render thread.
         // Then stash a local pointer to the render thread so we can initialize it and enable it
@@ -1723,8 +1722,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
     void TermControl::Close()
     {
-        auto lock = _terminal.LockForWriting();
-
         if (!_closing.exchange(true))
         {
             // Stop accepting new output and state changes before we disconnect everything.

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -179,7 +179,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _ScrollbarChangeHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Controls::Primitives::RangeBaseValueChangedEventArgs const& e);
         void _GotFocusHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
         void _LostFocusHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
-        void _LayoutUpdated(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
         void _DragDropHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::DragEventArgs const& e);
         void _DragOverHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::DragEventArgs const& e);
         winrt::fire_and_forget _DoDragDrop(Windows::UI::Xaml::DragEventArgs const e);

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -163,6 +163,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         winrt::Windows::UI::Xaml::Controls::SwapChainPanel::LayoutUpdated_revoker _layoutUpdatedRevoker;
 
+        std::shared_mutex _createCloseLock;
+
         void _ApplyUISettings();
         void _InitializeBackgroundBrush();
         winrt::fire_and_forget _BackgroundColorChanged(const uint32_t color);

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -179,6 +179,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _ScrollbarChangeHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Controls::Primitives::RangeBaseValueChangedEventArgs const& e);
         void _GotFocusHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
         void _LostFocusHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
+        void _LayoutUpdated(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
         void _DragDropHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::DragEventArgs const& e);
         void _DragOverHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::DragEventArgs const& e);
         winrt::fire_and_forget _DoDragDrop(Windows::UI::Xaml::DragEventArgs const e);

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -163,8 +163,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         winrt::Windows::UI::Xaml::Controls::SwapChainPanel::LayoutUpdated_revoker _layoutUpdatedRevoker;
 
-        std::shared_mutex _createCloseLock;
-
         void _ApplyUISettings();
         void _InitializeBackgroundBrush();
         winrt::fire_and_forget _BackgroundColorChanged(const uint32_t color);


### PR DESCRIPTION
## Summary of the Pull Request

We're deref'ing a null `_terminal`. Don't do that. This is a _okay_ fix, mostly to stem the bleeding. @DHowett-MSFT's got a mind for a real fix to #4166, but this isn't it.

## PR Checklist
* [x] related to #4166
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated
