### PR TITLE
Allow Emoji composition to be seen in the TSF TextBlock

### DIFF
--- a/src/cascadia/TerminalControl/TSFInputControl.cpp
+++ b/src/cascadia/TerminalControl/TSFInputControl.cpp
@@ -304,8 +304,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                 ::base::ClampSub<size_t>(range.EndCaretPosition, range.StartCaretPosition),
                 incomingText);
 
-            // If we receive tabbed IME input like emoji, kaomojis, and symbols, send it to the terminal immediately.
-            // They aren't composition, so we don't want to wait for the user to start and finish a composition to send the text.
+            // Emojis/Kaomojis/Symbols chosen through the IME without starting composition
+            // will be sent straight through to the terminal.
             if (!_inComposition)
             {
                 _SendAndClearText();
@@ -313,7 +313,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             else
             {
                 Canvas().Visibility(Visibility::Visible);
-                const auto text = _inputBuffer.substr(range.StartCaretPosition, range.EndCaretPosition - range.StartCaretPosition + 1);
+                const auto text = _inputBuffer.substr(_activeTextStart);
                 TextBlock().Text(text);
             }
 
@@ -338,7 +338,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // - <none>
     void TSFInputControl::_SendAndClearText()
     {
-        const auto text = _inputBuffer.substr(_activeTextStart, _inputBuffer.length() - _activeTextStart);
+        const auto text = _inputBuffer.substr(_activeTextStart);
 
         _compositionCompletedHandlers(text);
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Emoji composition was only being shown one letter at a time. This is because of the way I expected `CoreTextTextUpdatingEventArgs.Range` to be provided to TSFInputControl during composition (for Chinese/Japanese IME). Emoji IME composition gives the `StartCaretPosition` as the same as `EndCaretPosition`, unlike how for Chinese/Japanese IME, `StartCaretPosition` is usually the start of the composition and `EndCaretPosition` is the latest character in the composition. The solution is to change the `_inputBuffer.substr()` call to simply grab all of the buffer starting from `_activeTextStart`. This way I can ensure that I grab all of the "active text", instead of trusting the given `args.Range` to tell me the active text.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #4828
* [x] CLA signed.
* [x] Tests added/passed

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Chinese, Japanese, Korean, Emoji composition performed. Emoji selection through pointer also performed.