### PR TITLE
Make ctrl+shift+scroll toggle acrylic on/off at extrema

### DIFF
--- a/doc/user-docs/index.md
+++ b/doc/user-docs/index.md
@@ -85,6 +85,6 @@ For an introduction to the various settings, see [Using Json Settings](UsingJson
     (ref [https://twitter.com/r_keith_hill/status/1142871145852440576](https://twitter.com/r_keith_hill/status/1142871145852440576))
 
 2. Terminal zoom can be changed by holding <kbd>Ctrl</kbd> and scrolling with mouse.
-3. If `useAcrylic` is enabled in profiles.json, background opacity can be changed by holding <kbd>Ctrl</kbd>+<kbd>Shift</kbd> and scrolling with mouse. Note that acrylic transparency is limited by the OS only to focused windows.
+3. Background opacity can be changed by holding <kbd>Ctrl</kbd>+<kbd>Shift</kbd> and scrolling with mouse. Note that acrylic transparency is limited by the OS only to focused windows.
 4. Open Windows Terminal in current directory by typing `wt -d .` in the address bar.
 5. Please add more Tips and Tricks.

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1097,6 +1097,11 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             }
             CATCH_LOG();
         }
+        else
+        {
+            _settings.UseAcrylic(true);
+            _InitializeBackgroundBrush();
+        }
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1100,6 +1100,9 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         else
         {
             _settings.UseAcrylic(true);
+
+            //Setting initial opacity set to 1 to ensure smooth transition to acrylic during mouse scroll
+            _settings.TintOpacity(1.0);
             _InitializeBackgroundBrush();
         }
     }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1094,10 +1094,17 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             {
                 auto acrylicBrush = RootGrid().Background().as<Media::AcrylicBrush>();
                 acrylicBrush.TintOpacity(acrylicBrush.TintOpacity() + effectiveDelta);
+                if (acrylicBrush.TintOpacity() == 1.0)
+                {
+                    _settings.UseAcrylic(false);
+                    _InitializeBackgroundBrush();
+                    uint32_t bg = _settings.DefaultBackground();
+                    _BackgroundColorChanged(bg);
+                }
             }
             CATCH_LOG();
         }
-        else
+        else if (mouseDelta < 0)
         {
             _settings.UseAcrylic(true);
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
If UseAcrylic is disabled, CTRL+SHIFT+SCROLL would enable it, without having to change the setting in profile.json manually.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
#661

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #661
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tested manually
* [x] Updated documentation

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
If UseAcrylic is disabled, CTRL+SHIFT+Scroll would enable it and acrylic background brush is initialized.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

1. Set "useAcrylic" to false for the any profile in profile.json
2. Open terminal window for that profile.
3. CTRL+SHIFT+MouseScroll
Acrylic background opacity should change according to mouse scroll

![acrylicTransition](https://user-images.githubusercontent.com/42885985/76288552-fb77bc00-62cc-11ea-974f-b2469718ed3b.gif)