### PR TITLE
Reveal the taskbar when the user has the Terminal maximized or fullscreen

### DIFF
--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -382,7 +382,7 @@ int NonClientIslandWindow::_GetResizeHandleHeight() const noexcept
         {
             // This helper can be used to determine if there's a auto-hide
             // taskbar on the given edge of the monitor we're currently on.
-            auto hasAutohideTaksbar = [&monInfo](const UINT edge) -> bool {
+            auto hasAutohideTaskbar = [&monInfo](const UINT edge) -> bool {
                 APPBARDATA data{ 0 };
                 data.cbSize = sizeof(data);
                 data.uEdge = edge;
@@ -391,10 +391,10 @@ int NonClientIslandWindow::_GetResizeHandleHeight() const noexcept
                 return hTaskbar != nullptr;
             };
 
-            const bool onTop = hasAutohideTaksbar(ABE_TOP);
-            const bool onBottom = hasAutohideTaksbar(ABE_BOTTOM);
-            const bool onLeft = hasAutohideTaksbar(ABE_LEFT);
-            const bool onRight = hasAutohideTaksbar(ABE_RIGHT);
+            const bool onTop = hasAutohideTaskbar(ABE_TOP);
+            const bool onBottom = hasAutohideTaskbar(ABE_BOTTOM);
+            const bool onLeft = hasAutohideTaskbar(ABE_LEFT);
+            const bool onRight = hasAutohideTaskbar(ABE_RIGHT);
 
             // If there's a taskbar on any side of the monitor, reduce our size
             // a little bit on that edge.

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -404,7 +404,7 @@ int NonClientIslandWindow::_GetResizeHandleHeight() const noexcept
             // However, testing a bunch of other apps with fullscreen modes
             // and an auto-hiding taskbar has shown that _none_ of them
             // reveal the taskbar from fullscreen mode. This includes Edge,
-            // Firefox, Chrom, Sublime Text, Powerpoint - none seemed to
+            // Firefox, Chrome, Sublime Text, Powerpoint - none seemed to
             // support this.
             //
             // This does however work fine for maximized.

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -398,16 +398,19 @@ int NonClientIslandWindow::_GetResizeHandleHeight() const noexcept
 
             // If there's a taskbar on any side of the monitor, reduce our size
             // a little bit on that edge.
+            //
+            // Note to future code archeologists:
+            // This doesn't seem to work for fullscreen on the primary display.
+            // However, testing a bunch of other apps with fullscreen modes
+            // and an auto-hiding taskbar has shown that _none_ of them
+            // reveal the taskbar from fullscreen mode. This includes Edge,
+            // Firefox, Chrom, Sublime Text, Powerpoint - none seemed to
+            // support this.
+            //
+            // This does however work fine for maximized.
             if (onTop)
             {
-                // Peculiarly, when we're fullscreen, this doesn't seem to work.
-                // However, testing a bunch of other apps with fullscreen modes
-                // and a top auto-hiding taskbar has shown that _none_ of them
-                // reveal the taskbar from fullscreen mode. This includes Edge,
-                // Firefox, Chrom, Sublime Text, Powerpoint - none seemed to
-                // support this.
-                //
-                // This does however work fine for maximized.
+                // Peculiarly, when we're fullscreen,
                 newSize.top += AutohideTaskbarSize;
             }
             if (onBottom)


### PR DESCRIPTION
## Summary of the Pull Request

When we are maximized or fullscreened, check for the presence of the taskbar in auto-hide mode. If the Terminal finds the taskbar on any side of the monitor, adjust our window rect by just a little bit, so that the taskbar can still be revealed by the user mousing over that edge.

## References

## PR Checklist
* [x] Closes #1438
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated

## Detailed Description of the Pull Request / Additional comments

Note to future code archeologists:
This doesn't seem to work for fullscreen on the primary display. However, testing a bunch of other apps with fullscreen modes and an auto-hiding taskbar has shown that _none_ of them reveal the taskbar from fullscreen mode. This includes Edge, Firefox, Chrome, Sublime Text, Powerpoint - none seemed to support this. 

This does however work fine for maximized.

## Validation Steps Performed

I'm maximized and fullscreened the Terminal a lot in the last two days.