### PR TITLE
Synthesize VT mouse events and add mouse support to Terminal

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -820,7 +820,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // - point: the PointerPoint object representing a mouse event from our XAML input handler
     // - goingDown: true, if the button was pressed. False, if it was released.
     //              Mouse moved events must only be encoded as the button being pressed, not released.
-    bool TermControl::_TrySendMouseEvent(Windows::UI::Input::PointerPoint const& point, bool goingDown)
+    bool TermControl::_TrySendMouseEvent(Windows::UI::Input::PointerPoint const& point)
     {
         // If the user is holding down Shift, suppress mouse events
         // TODO GH#4875: disable/customize this functionality
@@ -907,7 +907,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             const auto altEnabled = WI_IsFlagSet(modifiers, static_cast<uint32_t>(VirtualKeyModifiers::Menu));
             const auto shiftEnabled = WI_IsFlagSet(modifiers, static_cast<uint32_t>(VirtualKeyModifiers::Shift));
 
-            if (_TrySendMouseEvent(point, true))
+            if (_TrySendMouseEvent(point))
             {
                 args.Handled(true);
                 return;
@@ -995,7 +995,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         if (ptr.PointerDeviceType() == Windows::Devices::Input::PointerDeviceType::Mouse || ptr.PointerDeviceType() == Windows::Devices::Input::PointerDeviceType::Pen)
         {
-            if (_TrySendMouseEvent(point, true))
+            if (_TrySendMouseEvent(point))
             {
                 args.Handled(true);
                 return;
@@ -1092,7 +1092,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             // macro directly with a VirtualKeyModifiers
             const auto shiftEnabled = WI_IsFlagSet(modifiers, static_cast<uint32_t>(VirtualKeyModifiers::Shift));
 
-            if (_TrySendMouseEvent(point, false))
+            if (_TrySendMouseEvent(point))
             {
                 args.Handled(true);
                 return;
@@ -1148,7 +1148,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         const auto ctrlPressed = WI_IsFlagSet(modifiers, static_cast<uint32_t>(VirtualKeyModifiers::Control));
         const auto shiftPressed = WI_IsFlagSet(modifiers, static_cast<uint32_t>(VirtualKeyModifiers::Shift));
 
-        if (_TrySendMouseEvent(point, true))
+        if (_TrySendMouseEvent(point))
         {
             args.Handled(true);
             return;

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -818,8 +818,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     //   See Terminal::SendMouseEvent for more information.
     // Arguments:
     // - point: the PointerPoint object representing a mouse event from our XAML input handler
-    // - goingDown: true, if the button was pressed. False, if it was released.
-    //              Mouse moved events must only be encoded as the button being pressed, not released.
     bool TermControl::_TrySendMouseEvent(Windows::UI::Input::PointerPoint const& point)
     {
         // If the user is holding down Shift, suppress mouse events
@@ -993,6 +991,12 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         const auto ptr = args.Pointer();
         const auto point = args.GetCurrentPoint(*this);
 
+        if (!_focused)
+        {
+            args.Handled(true);
+            return;
+        }
+
         if (ptr.PointerDeviceType() == Windows::Devices::Input::PointerDeviceType::Mouse || ptr.PointerDeviceType() == Windows::Devices::Input::PointerDeviceType::Pen)
         {
             if (_TrySendMouseEvent(point))
@@ -1087,11 +1091,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         if (ptr.PointerDeviceType() == Windows::Devices::Input::PointerDeviceType::Mouse || ptr.PointerDeviceType() == Windows::Devices::Input::PointerDeviceType::Pen)
         {
-            const auto modifiers = static_cast<uint32_t>(args.KeyModifiers());
-            // static_cast to a uint32_t because we can't use the WI_IsFlagSet
-            // macro directly with a VirtualKeyModifiers
-            const auto shiftEnabled = WI_IsFlagSet(modifiers, static_cast<uint32_t>(VirtualKeyModifiers::Shift));
-
             if (_TrySendMouseEvent(point))
             {
                 args.Handled(true);

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -211,6 +211,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         ::Microsoft::Terminal::Core::ControlKeyStates _GetPressedModifierKeys() const;
         bool _TrySendKeyEvent(const WORD vkey, const WORD scanCode, ::Microsoft::Terminal::Core::ControlKeyStates modifiers);
+        bool _TrySendMouseEvent(Windows::UI::Input::PointerPoint const& point, bool goingDown);
 
         const COORD _GetTerminalPosition(winrt::Windows::Foundation::Point cursorPosition);
         const unsigned int _NumberOfClicks(winrt::Windows::Foundation::Point clickPos, Timestamp clickTime);

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -212,6 +212,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         ::Microsoft::Terminal::Core::ControlKeyStates _GetPressedModifierKeys() const;
         bool _TrySendKeyEvent(const WORD vkey, const WORD scanCode, ::Microsoft::Terminal::Core::ControlKeyStates modifiers);
         bool _TrySendMouseEvent(Windows::UI::Input::PointerPoint const& point);
+        bool _CanSendVTMouseInput();
 
         const COORD _GetTerminalPosition(winrt::Windows::Foundation::Point cursorPosition);
         const unsigned int _NumberOfClicks(winrt::Windows::Foundation::Point clickPos, Timestamp clickTime);

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -211,7 +211,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         ::Microsoft::Terminal::Core::ControlKeyStates _GetPressedModifierKeys() const;
         bool _TrySendKeyEvent(const WORD vkey, const WORD scanCode, ::Microsoft::Terminal::Core::ControlKeyStates modifiers);
-        bool _TrySendMouseEvent(Windows::UI::Input::PointerPoint const& point, bool goingDown);
+        bool _TrySendMouseEvent(Windows::UI::Input::PointerPoint const& point);
 
         const COORD _GetTerminalPosition(winrt::Windows::Foundation::Point cursorPosition);
         const unsigned int _NumberOfClicks(winrt::Windows::Foundation::Point clickPos, Timestamp clickTime);

--- a/src/cascadia/TerminalCore/ITerminalApi.hpp
+++ b/src/cascadia/TerminalCore/ITerminalApi.hpp
@@ -45,6 +45,17 @@ namespace Microsoft::Terminal::Core
         virtual bool SetDefaultForeground(const DWORD color) noexcept = 0;
         virtual bool SetDefaultBackground(const DWORD color) noexcept = 0;
 
+        virtual bool SetCursorKeysMode(const bool applicationMode) noexcept = 0;
+        virtual bool SetKeypadMode(const bool applicationMode) noexcept = 0;
+        virtual bool EnableVT200MouseMode(const bool enabled) noexcept = 0;
+        virtual bool EnableUTF8ExtendedMouseMode(const bool enabled) noexcept = 0;
+        virtual bool EnableSGRExtendedMouseMode(const bool enabled) noexcept = 0;
+        virtual bool EnableButtonEventMouseMode(const bool enabled) noexcept = 0;
+        virtual bool EnableAnyEventMouseMode(const bool enabled) noexcept = 0;
+        virtual bool EnableAlternateScrollMode(const bool enabled) noexcept = 0;
+
+        virtual bool IsVtInputEnabled() const = 0;
+
     protected:
         ITerminalApi() = default;
     };

--- a/src/cascadia/TerminalCore/ITerminalInput.hpp
+++ b/src/cascadia/TerminalCore/ITerminalInput.hpp
@@ -17,6 +17,7 @@ namespace Microsoft::Terminal::Core
         ITerminalInput& operator=(ITerminalInput&&) = default;
 
         virtual bool SendKeyEvent(const WORD vkey, const WORD scanCode, const ControlKeyStates states) = 0;
+        virtual bool SendMouseEvent(const COORD viewportPos, const unsigned int uiButton, const ControlKeyStates states, const short wheelDelta) = 0;
         virtual bool SendCharEvent(const wchar_t ch) = 0;
 
         // void SendMouseEvent(uint row, uint col, KeyModifiers modifiers);

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -284,6 +284,27 @@ bool Terminal::SendKeyEvent(const WORD vkey, const WORD scanCode, const ControlK
     return translated && manuallyHandled;
 }
 
+// Method Description:
+// - Send this particular mouse event to the terminal. The terminal will translate
+//   the button and the modifiers pressed into the appropriate VT sequence for that
+//   mouse event. If we do translate the key, we'll return true. In that case, the
+//   event should NOT be processed any further. If we return false, the event
+//   was NOT translated, and we should instead use the event normally
+// Arguments:
+// - viewportPos: the position of the mouse event relative to the viewport origin.
+// - uiButton: the WM mouse button event code
+// - states: The Microsoft::Terminal::Core::ControlKeyStates representing the modifier key states.
+// - wheelDelta: the amount that the scroll wheel changed (should be 0 unless button is a WM_MOUSE*WHEEL)
+// Return Value:
+// - true if we translated the key event, and it should not be processed any further.
+// - false if we did not translate the key, and it should be processed into a character.
+bool Terminal::SendMouseEvent(const COORD viewportPos, const unsigned int uiButton, const ControlKeyStates states, const short wheelDelta)
+{
+    const COORD bufferPos = _ConvertToBufferCell(viewportPos);
+
+    return _terminalInput->HandleMouse(bufferPos, uiButton, GET_KEYSTATE_WPARAM(states.Value()), wheelDelta);
+}
+
 bool Terminal::SendCharEvent(const wchar_t ch)
 {
     return _terminalInput->HandleChar(ch);

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -222,6 +222,17 @@ void Terminal::TrySnapOnInput()
     }
 }
 
+// Routine Description:
+// - Relays if we are tracking mouse input
+// Parameters:
+// - <none>
+// Return value:
+// - true, if we are tracking mouse input. False, otherwise
+bool Terminal::IsTrackingMouseInput() const
+{
+    return _terminalInput->IsTrackingMouseInput();
+}
+
 // Method Description:
 // - Send this particular key event to the terminal. The terminal will translate
 //   the key and the modifiers pressed into the appropriate VT sequence for that

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -228,7 +228,7 @@ void Terminal::TrySnapOnInput()
 // - <none>
 // Return value:
 // - true, if we are tracking mouse input. False, otherwise
-bool Terminal::IsTrackingMouseInput() const
+bool Terminal::IsTrackingMouseInput() const noexcept
 {
     return _terminalInput->IsTrackingMouseInput();
 }

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -300,9 +300,7 @@ bool Terminal::SendKeyEvent(const WORD vkey, const WORD scanCode, const ControlK
 // - false if we did not translate the key, and it should be processed into a character.
 bool Terminal::SendMouseEvent(const COORD viewportPos, const unsigned int uiButton, const ControlKeyStates states, const short wheelDelta)
 {
-    const COORD bufferPos = _ConvertToBufferCell(viewportPos);
-
-    return _terminalInput->HandleMouse(bufferPos, uiButton, GET_KEYSTATE_WPARAM(states.Value()), wheelDelta);
+    return _terminalInput->HandleMouse(viewportPos, uiButton, GET_KEYSTATE_WPARAM(states.Value()), wheelDelta);
 }
 
 bool Terminal::SendCharEvent(const wchar_t ch)

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -300,6 +300,13 @@ bool Terminal::SendKeyEvent(const WORD vkey, const WORD scanCode, const ControlK
 // - false if we did not translate the key, and it should be processed into a character.
 bool Terminal::SendMouseEvent(const COORD viewportPos, const unsigned int uiButton, const ControlKeyStates states, const short wheelDelta)
 {
+    // viewportPos must be within the dimensions of the viewport
+    const auto viewportDimensions = _mutableViewport.Dimensions();
+    if (viewportPos.X < 0 || viewportPos.X >= viewportDimensions.X || viewportPos.Y < 0 || viewportPos.Y >= viewportDimensions.Y)
+    {
+        return false;
+    }
+
     return _terminalInput->HandleMouse(viewportPos, uiButton, GET_KEYSTATE_WPARAM(states.Value()), wheelDelta);
 }
 

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -119,6 +119,7 @@ public:
     int GetScrollOffset() noexcept override;
 
     void TrySnapOnInput() override;
+    bool IsTrackingMouseInput() const;
 #pragma endregion
 
 #pragma region IBaseData(base to IRenderData and IUiaData)

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -105,7 +105,7 @@ public:
     bool EnableAnyEventMouseMode(const bool enabled) noexcept override;
     bool EnableAlternateScrollMode(const bool enabled) noexcept override;
 
-    bool IsVtInputEnabled() const noexcept;
+    bool IsVtInputEnabled() const noexcept override;
 #pragma endregion
 
 #pragma region ITerminalInput
@@ -119,7 +119,7 @@ public:
     int GetScrollOffset() noexcept override;
 
     void TrySnapOnInput() override;
-    bool IsTrackingMouseInput() const;
+    bool IsTrackingMouseInput() const noexcept;
 #pragma endregion
 
 #pragma region IBaseData(base to IRenderData and IUiaData)

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -95,11 +95,23 @@ public:
     bool SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) noexcept override;
     bool SetDefaultForeground(const COLORREF color) noexcept override;
     bool SetDefaultBackground(const COLORREF color) noexcept override;
+
+    bool SetCursorKeysMode(const bool applicationMode) noexcept override;
+    bool SetKeypadMode(const bool applicationMode) noexcept override;
+    bool EnableVT200MouseMode(const bool enabled) noexcept override;
+    bool EnableUTF8ExtendedMouseMode(const bool enabled) noexcept override;
+    bool EnableSGRExtendedMouseMode(const bool enabled) noexcept override;
+    bool EnableButtonEventMouseMode(const bool enabled) noexcept override;
+    bool EnableAnyEventMouseMode(const bool enabled) noexcept override;
+    bool EnableAlternateScrollMode(const bool enabled) noexcept override;
+
+    bool IsVtInputEnabled() const noexcept;
 #pragma endregion
 
 #pragma region ITerminalInput
     // These methods are defined in Terminal.cpp
     bool SendKeyEvent(const WORD vkey, const WORD scanCode, const Microsoft::Terminal::Core::ControlKeyStates states) override;
+    bool SendMouseEvent(const COORD viewportPos, const unsigned int uiButton, const ControlKeyStates states, const short wheelDelta) override;
     bool SendCharEvent(const wchar_t ch) override;
 
     [[nodiscard]] HRESULT UserResize(const COORD viewportSize) noexcept override;

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -567,5 +567,4 @@ bool Terminal::IsVtInputEnabled() const noexcept
 {
     // We should never be getting this call in Terminal.
     FAIL_FAST();
-    return true;
 }

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -514,3 +514,56 @@ try
     return true;
 }
 CATCH_LOG_RETURN_FALSE()
+
+bool Terminal::SetCursorKeysMode(const bool applicationMode) noexcept
+{
+    _terminalInput->ChangeCursorKeysMode(applicationMode);
+    return true;
+}
+
+bool Terminal::SetKeypadMode(const bool applicationMode) noexcept
+{
+    _terminalInput->ChangeKeypadMode(applicationMode);
+    return true;
+}
+
+bool Terminal::EnableVT200MouseMode(const bool enabled) noexcept
+{
+    _terminalInput->EnableDefaultTracking(enabled);
+    return true;
+}
+
+bool Terminal::EnableUTF8ExtendedMouseMode(const bool enabled) noexcept
+{
+    _terminalInput->SetUtf8ExtendedMode(enabled);
+    return true;
+}
+
+bool Terminal::EnableSGRExtendedMouseMode(const bool enabled) noexcept
+{
+    _terminalInput->SetSGRExtendedMode(enabled);
+    return true;
+}
+
+bool Terminal::EnableButtonEventMouseMode(const bool enabled) noexcept
+{
+    _terminalInput->EnableButtonEventTracking(enabled);
+    return true;
+}
+
+bool Terminal::EnableAnyEventMouseMode(const bool enabled) noexcept
+{
+    _terminalInput->EnableAnyEventTracking(enabled);
+    return true;
+}
+
+bool Terminal::EnableAlternateScrollMode(const bool enabled) noexcept
+{
+    _terminalInput->EnableAlternateScroll(enabled);
+    return true;
+}
+
+bool Terminal::IsVtInputEnabled() const noexcept
+{
+    return true;
+}

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -565,5 +565,7 @@ bool Terminal::EnableAlternateScrollMode(const bool enabled) noexcept
 
 bool Terminal::IsVtInputEnabled() const noexcept
 {
+    // We should never be getting this call in Terminal.
+    FAIL_FAST();
     return true;
 }

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -222,7 +222,7 @@ CATCH_LOG_RETURN_FALSE()
 bool TerminalDispatch::SetKeypadMode(const bool fApplicationMode) noexcept
 {
     _terminalApi.SetKeypadMode(fApplicationMode);
-    return false;
+    return true;
 }
 
 // - DECCKM - Sets the cursor keys input mode to either Application mode or Normal mode (true, false respectively)
@@ -233,7 +233,7 @@ bool TerminalDispatch::SetKeypadMode(const bool fApplicationMode) noexcept
 bool TerminalDispatch::SetCursorKeysMode(const bool applicationMode) noexcept
 {
     _terminalApi.SetCursorKeysMode(applicationMode);
-    return false;
+    return true;
 }
 
 //Routine Description:
@@ -245,7 +245,7 @@ bool TerminalDispatch::SetCursorKeysMode(const bool applicationMode) noexcept
 bool TerminalDispatch::EnableVT200MouseMode(const bool enabled) noexcept
 {
     _terminalApi.EnableVT200MouseMode(enabled);
-    return false;
+    return true;
 }
 
 //Routine Description:
@@ -258,7 +258,7 @@ bool TerminalDispatch::EnableVT200MouseMode(const bool enabled) noexcept
 bool TerminalDispatch::EnableUTF8ExtendedMouseMode(const bool enabled) noexcept
 {
     _terminalApi.EnableUTF8ExtendedMouseMode(enabled);
-    return false;
+    return true;
 }
 
 //Routine Description:
@@ -271,7 +271,7 @@ bool TerminalDispatch::EnableUTF8ExtendedMouseMode(const bool enabled) noexcept
 bool TerminalDispatch::EnableSGRExtendedMouseMode(const bool enabled) noexcept
 {
     _terminalApi.EnableSGRExtendedMouseMode(enabled);
-    return false;
+    return true;
 }
 
 //Routine Description:
@@ -283,7 +283,7 @@ bool TerminalDispatch::EnableSGRExtendedMouseMode(const bool enabled) noexcept
 bool TerminalDispatch::EnableButtonEventMouseMode(const bool enabled) noexcept
 {
     _terminalApi.EnableButtonEventMouseMode(enabled);
-    return false;
+    return true;
 }
 
 //Routine Description:
@@ -296,7 +296,7 @@ bool TerminalDispatch::EnableButtonEventMouseMode(const bool enabled) noexcept
 bool TerminalDispatch::EnableAnyEventMouseMode(const bool enabled) noexcept
 {
     _terminalApi.EnableAnyEventMouseMode(enabled);
-    return false;
+    return true;
 }
 
 //Routine Description:
@@ -309,7 +309,7 @@ bool TerminalDispatch::EnableAnyEventMouseMode(const bool enabled) noexcept
 bool TerminalDispatch::EnableAlternateScroll(const bool enabled) noexcept
 {
     _terminalApi.EnableAlternateScrollMode(enabled);
-    return false;
+    return true;
 }
 
 bool TerminalDispatch::SetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> params) noexcept

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -213,3 +213,207 @@ try
     return _terminalApi.EraseInDisplay(eraseType);
 }
 CATCH_LOG_RETURN_FALSE()
+
+// - DECKPAM, DECKPNM - Sets the keypad input mode to either Application mode or Numeric mode (true, false respectively)
+// Arguments:
+// - applicationMode - set to true to enable Application Mode Input, false for Numeric Mode Input.
+// Return Value:
+// - True if handled successfully. False otherwise.
+bool TerminalDispatch::SetKeypadMode(const bool fApplicationMode) noexcept
+{
+    // TODO GH#XXXX:
+    //   This is a temporary replacement to enable passhthrough
+    //   mode for Windows Terminal. Replace with proper _pConApi
+    //   call below when ConPty has been properly updated.
+    _terminalApi.SetKeypadMode(fApplicationMode);
+    return false;
+}
+
+// - DECCKM - Sets the cursor keys input mode to either Application mode or Normal mode (true, false respectively)
+// Arguments:
+// - applicationMode - set to true to enable Application Mode Input, false for Normal Mode Input.
+// Return Value:
+// - True if handled successfully. False otherwise.
+bool TerminalDispatch::SetCursorKeysMode(const bool applicationMode) noexcept
+{
+    // TODO GH#XXXX:
+    //   This is a temporary replacement to enable passhthrough
+    //   mode for Windows Terminal. Replace with proper _pConApi
+    //   call below when ConPty has been properly updated.
+    _terminalApi.SetCursorKeysMode(applicationMode);
+    return false;
+}
+
+//Routine Description:
+// Enable VT200 Mouse Mode - Enables/disables the mouse input handler in default tracking mode.
+//Arguments:
+// - enabled - true to enable, false to disable.
+// Return value:
+// True if handled successfully. False otherwise.
+bool TerminalDispatch::EnableVT200MouseMode(const bool enabled) noexcept
+{
+    // TODO GH#XXXX:
+    //   This is a temporary replacement to enable passhthrough
+    //   mode for Windows Terminal. Replace with proper _pConApi
+    //   call below when ConPty has been properly updated.
+    _terminalApi.EnableVT200MouseMode(enabled);
+    return false;
+}
+
+//Routine Description:
+// Enable UTF-8 Extended Encoding - this changes the encoding scheme for sequences
+//      emitted by the mouse input handler. Does not enable/disable mouse mode on its own.
+//Arguments:
+// - enabled - true to enable, false to disable.
+// Return value:
+// True if handled successfully. False otherwise.
+bool TerminalDispatch::EnableUTF8ExtendedMouseMode(const bool enabled) noexcept
+{
+    // TODO GH#XXXX:
+    //   This is a temporary replacement to enable passhthrough
+    //   mode for Windows Terminal. Replace with proper _pConApi
+    //   call below when ConPty has been properly updated.
+    _terminalApi.EnableUTF8ExtendedMouseMode(enabled);
+    return false;
+}
+
+//Routine Description:
+// Enable SGR Extended Encoding - this changes the encoding scheme for sequences
+//      emitted by the mouse input handler. Does not enable/disable mouse mode on its own.
+//Arguments:
+// - enabled - true to enable, false to disable.
+// Return value:
+// True if handled successfully. False otherwise.
+bool TerminalDispatch::EnableSGRExtendedMouseMode(const bool enabled) noexcept
+{
+    // TODO GH#XXXX:
+    //   This is a temporary replacement to enable passhthrough
+    //   mode for Windows Terminal. Replace with proper _pConApi
+    //   call below when ConPty has been properly updated.
+    _terminalApi.EnableSGRExtendedMouseMode(enabled);
+    return false;
+}
+
+//Routine Description:
+// Enable Button Event mode - send mouse move events WITH A BUTTON PRESSED to the input.
+//Arguments:
+// - enabled - true to enable, false to disable.
+// Return value:
+// True if handled successfully. False otherwise.
+bool TerminalDispatch::EnableButtonEventMouseMode(const bool enabled) noexcept
+{
+    // TODO GH#XXXX:
+    //   This is a temporary replacement to enable passhthrough
+    //   mode for Windows Terminal. Replace with proper _pConApi
+    //   call below when ConPty has been properly updated.
+    _terminalApi.EnableButtonEventMouseMode(enabled);
+    return false;
+}
+
+//Routine Description:
+// Enable Any Event mode - send all mouse events to the input.
+
+//Arguments:
+// - enabled - true to enable, false to disable.
+// Return value:
+// True if handled successfully. False otherwise.
+bool TerminalDispatch::EnableAnyEventMouseMode(const bool enabled) noexcept
+{
+    // TODO GH#XXXX:
+    //   This is a temporary replacement to enable passhthrough
+    //   mode for Windows Terminal. Replace with proper _pConApi
+    //   call below when ConPty has been properly updated.
+    _terminalApi.EnableAnyEventMouseMode(enabled);
+    return false;
+}
+
+//Routine Description:
+// Enable Alternate Scroll Mode - When in the Alt Buffer, send CUP and CUD on
+//      scroll up/down events instead of the usual sequences
+//Arguments:
+// - enabled - true to enable, false to disable.
+// Return value:
+// True if handled successfully. False otherwise.
+bool TerminalDispatch::EnableAlternateScroll(const bool enabled) noexcept
+{
+    // TODO GH#XXXX:
+    //   This is a temporary replacement to enable passhthrough
+    //   mode for Windows Terminal. Replace with proper _pConApi
+    //   call below when ConPty has been properly updated.
+    _terminalApi.EnableAlternateScrollMode(enabled);
+    return false;
+}
+
+bool TerminalDispatch::SetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> params) noexcept
+{
+    return _SetResetPrivateModes(params, true);
+}
+
+bool TerminalDispatch::ResetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> params) noexcept
+{
+    return _SetResetPrivateModes(params, false);
+}
+
+// Routine Description:
+// - Generalized handler for the setting/resetting of DECSET/DECRST parameters.
+//     All params in the rgParams will attempt to be executed, even if one
+//     fails, to allow us to successfully re/set params that are chained with
+//     params we don't yet support.
+// Arguments:
+// - params - array of params to set/reset
+// - enable - True for set, false for unset.
+// Return Value:
+// - True if ALL params were handled successfully. False otherwise.
+bool TerminalDispatch::_SetResetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> params, const bool enable) noexcept
+{
+    // because the user might chain together params we don't support with params we DO support, execute all
+    // params in the sequence, and only return failure if we failed at least one of them
+    size_t failures = 0;
+    for (const auto& p : params)
+    {
+        failures += _PrivateModeParamsHelper(p, enable) ? 0 : 1; // increment the number of failures if we fail.
+    }
+    return failures == 0;
+}
+
+// Routine Description:
+// - Support routine for routing private mode parameters to be set/reset as flags
+// Arguments:
+// - params - array of params to set/reset
+// - enable - True for set, false for unset.
+// Return Value:
+// - True if handled successfully. False otherwise.
+bool TerminalDispatch::_PrivateModeParamsHelper(const DispatchTypes::PrivateModeParams param, const bool enable) noexcept
+{
+    bool success = false;
+    switch (param)
+    {
+    case DispatchTypes::PrivateModeParams::DECCKM_CursorKeysMode:
+        // set - Enable Application Mode, reset - Normal mode
+        success = SetCursorKeysMode(enable);
+        break;
+    case DispatchTypes::PrivateModeParams::VT200_MOUSE_MODE:
+        success = EnableVT200MouseMode(enable);
+        break;
+    case DispatchTypes::PrivateModeParams::BUTTON_EVENT_MOUSE_MODE:
+        success = EnableButtonEventMouseMode(enable);
+        break;
+    case DispatchTypes::PrivateModeParams::ANY_EVENT_MOUSE_MODE:
+        success = EnableAnyEventMouseMode(enable);
+        break;
+    case DispatchTypes::PrivateModeParams::UTF8_EXTENDED_MODE:
+        success = EnableUTF8ExtendedMouseMode(enable);
+        break;
+    case DispatchTypes::PrivateModeParams::SGR_EXTENDED_MODE:
+        success = EnableSGRExtendedMouseMode(enable);
+        break;
+    case DispatchTypes::PrivateModeParams::ALTERNATE_SCROLL:
+        success = EnableAlternateScroll(enable);
+        break;
+    default:
+        // If no functions to call, overall dispatch was a failure.
+        success = false;
+        break;
+    }
+    return success;
+}

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -221,10 +221,6 @@ CATCH_LOG_RETURN_FALSE()
 // - True if handled successfully. False otherwise.
 bool TerminalDispatch::SetKeypadMode(const bool fApplicationMode) noexcept
 {
-    // TODO GH#XXXX:
-    //   This is a temporary replacement to enable passhthrough
-    //   mode for Windows Terminal. Replace with proper _pConApi
-    //   call below when ConPty has been properly updated.
     _terminalApi.SetKeypadMode(fApplicationMode);
     return false;
 }
@@ -236,10 +232,6 @@ bool TerminalDispatch::SetKeypadMode(const bool fApplicationMode) noexcept
 // - True if handled successfully. False otherwise.
 bool TerminalDispatch::SetCursorKeysMode(const bool applicationMode) noexcept
 {
-    // TODO GH#XXXX:
-    //   This is a temporary replacement to enable passhthrough
-    //   mode for Windows Terminal. Replace with proper _pConApi
-    //   call below when ConPty has been properly updated.
     _terminalApi.SetCursorKeysMode(applicationMode);
     return false;
 }
@@ -252,10 +244,6 @@ bool TerminalDispatch::SetCursorKeysMode(const bool applicationMode) noexcept
 // True if handled successfully. False otherwise.
 bool TerminalDispatch::EnableVT200MouseMode(const bool enabled) noexcept
 {
-    // TODO GH#XXXX:
-    //   This is a temporary replacement to enable passhthrough
-    //   mode for Windows Terminal. Replace with proper _pConApi
-    //   call below when ConPty has been properly updated.
     _terminalApi.EnableVT200MouseMode(enabled);
     return false;
 }
@@ -269,10 +257,6 @@ bool TerminalDispatch::EnableVT200MouseMode(const bool enabled) noexcept
 // True if handled successfully. False otherwise.
 bool TerminalDispatch::EnableUTF8ExtendedMouseMode(const bool enabled) noexcept
 {
-    // TODO GH#XXXX:
-    //   This is a temporary replacement to enable passhthrough
-    //   mode for Windows Terminal. Replace with proper _pConApi
-    //   call below when ConPty has been properly updated.
     _terminalApi.EnableUTF8ExtendedMouseMode(enabled);
     return false;
 }
@@ -286,10 +270,6 @@ bool TerminalDispatch::EnableUTF8ExtendedMouseMode(const bool enabled) noexcept
 // True if handled successfully. False otherwise.
 bool TerminalDispatch::EnableSGRExtendedMouseMode(const bool enabled) noexcept
 {
-    // TODO GH#XXXX:
-    //   This is a temporary replacement to enable passhthrough
-    //   mode for Windows Terminal. Replace with proper _pConApi
-    //   call below when ConPty has been properly updated.
     _terminalApi.EnableSGRExtendedMouseMode(enabled);
     return false;
 }
@@ -302,10 +282,6 @@ bool TerminalDispatch::EnableSGRExtendedMouseMode(const bool enabled) noexcept
 // True if handled successfully. False otherwise.
 bool TerminalDispatch::EnableButtonEventMouseMode(const bool enabled) noexcept
 {
-    // TODO GH#XXXX:
-    //   This is a temporary replacement to enable passhthrough
-    //   mode for Windows Terminal. Replace with proper _pConApi
-    //   call below when ConPty has been properly updated.
     _terminalApi.EnableButtonEventMouseMode(enabled);
     return false;
 }
@@ -319,10 +295,6 @@ bool TerminalDispatch::EnableButtonEventMouseMode(const bool enabled) noexcept
 // True if handled successfully. False otherwise.
 bool TerminalDispatch::EnableAnyEventMouseMode(const bool enabled) noexcept
 {
-    // TODO GH#XXXX:
-    //   This is a temporary replacement to enable passhthrough
-    //   mode for Windows Terminal. Replace with proper _pConApi
-    //   call below when ConPty has been properly updated.
     _terminalApi.EnableAnyEventMouseMode(enabled);
     return false;
 }
@@ -336,10 +308,6 @@ bool TerminalDispatch::EnableAnyEventMouseMode(const bool enabled) noexcept
 // True if handled successfully. False otherwise.
 bool TerminalDispatch::EnableAlternateScroll(const bool enabled) noexcept
 {
-    // TODO GH#XXXX:
-    //   This is a temporary replacement to enable passhthrough
-    //   mode for Windows Terminal. Replace with proper _pConApi
-    //   call below when ConPty has been properly updated.
     _terminalApi.EnableAlternateScrollMode(enabled);
     return false;
 }

--- a/src/cascadia/TerminalCore/TerminalDispatch.hpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.hpp
@@ -38,6 +38,19 @@ public:
     bool InsertCharacter(const size_t count) noexcept override;
     bool EraseInDisplay(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) noexcept override;
 
+    bool SetCursorKeysMode(const bool applicationMode) noexcept override; // DECCKM
+    bool SetKeypadMode(const bool applicationMode) noexcept override; // DECKPAM, DECKPNM
+
+    bool EnableVT200MouseMode(const bool enabled) noexcept override; // ?1000
+    bool EnableUTF8ExtendedMouseMode(const bool enabled) noexcept override; // ?1005
+    bool EnableSGRExtendedMouseMode(const bool enabled) noexcept override; // ?1006
+    bool EnableButtonEventMouseMode(const bool enabled) noexcept override; // ?1002
+    bool EnableAnyEventMouseMode(const bool enabled) noexcept override; // ?1003
+    bool EnableAlternateScroll(const bool enabled) noexcept override; // ?1007
+
+    bool SetPrivateModes(const std::basic_string_view<::Microsoft::Console::VirtualTerminal::DispatchTypes::PrivateModeParams> /*params*/) noexcept override; // DECSET
+    bool ResetPrivateModes(const std::basic_string_view<::Microsoft::Console::VirtualTerminal::DispatchTypes::PrivateModeParams> /*params*/) noexcept override; // DECRST
+
 private:
     ::Microsoft::Terminal::Core::ITerminalApi& _terminalApi;
 
@@ -46,4 +59,7 @@ private:
     bool _SetBoldColorHelper(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::GraphicsOptions opt) noexcept;
     bool _SetDefaultColorHelper(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::GraphicsOptions opt) noexcept;
     void _SetGraphicsOptionHelper(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::GraphicsOptions opt) noexcept;
+
+    bool _SetResetPrivateModes(const std::basic_string_view<::Microsoft::Console::VirtualTerminal::DispatchTypes::PrivateModeParams> params, const bool enable) noexcept;
+    bool _PrivateModeParamsHelper(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::PrivateModeParams param, const bool enable) noexcept;
 };

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -112,6 +112,16 @@ void NonClientIslandWindow::SetContent(winrt::Windows::UI::Xaml::UIElement conte
 void NonClientIslandWindow::SetTitlebarContent(winrt::Windows::UI::Xaml::UIElement content)
 {
     _titlebar.Content(content);
+
+    // GH#4288 - add a SizeChanged handler to this content. It's possible that
+    // this element's size will change after the dragbar's. When that happens,
+    // the drag bar won't send another SizeChanged event, because the dragbar's
+    // _size_ didn't change, only it's position.
+    const auto fwe = content.try_as<winrt::Windows::UI::Xaml::FrameworkElement>();
+    if (fwe)
+    {
+        fwe.SizeChanged({ this, &NonClientIslandWindow::_OnDragBarSizeChanged });
+    }
 }
 
 // Method Description:

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -112,16 +112,6 @@ void NonClientIslandWindow::SetContent(winrt::Windows::UI::Xaml::UIElement conte
 void NonClientIslandWindow::SetTitlebarContent(winrt::Windows::UI::Xaml::UIElement content)
 {
     _titlebar.Content(content);
-
-    // GH#4288 - add a SizeChanged handler to this content. It's possible that
-    // this element's size will change after the dragbar's. When that happens,
-    // the drag bar won't send another SizeChanged event, because the dragbar's
-    // _size_ didn't change, only it's position.
-    const auto fwe = content.try_as<winrt::Windows::UI::Xaml::FrameworkElement>();
-    if (fwe)
-    {
-        fwe.SizeChanged({ this, &NonClientIslandWindow::_OnDragBarSizeChanged });
-    }
 }
 
 // Method Description:

--- a/src/terminal/input/mouseInput.cpp
+++ b/src/terminal/input/mouseInput.cpp
@@ -265,6 +265,17 @@ static constexpr short _encodeDefaultCoordinate(const short sCoordinateValue) no
 }
 
 // Routine Description:
+// - Relays if we are tracking mouse input
+// Parameters:
+// - <none>
+// Return value:
+// - true, if we are tracking mouse input. False, otherwise
+bool TerminalInput::IsTrackingMouseInput() const
+{
+    return (_mouseInputState.trackingMode != TrackingMode::None);
+}
+
+// Routine Description:
 // - Attempt to handle the given mouse coordinates and windows button as a VT-style mouse event.
 //     If the event should be transmitted in the selected mouse mode, then we'll try and
 //     encode the event according to the rules of the selected ExtendedMode, and insert those characters into the input buffer.

--- a/src/terminal/input/mouseInput.cpp
+++ b/src/terminal/input/mouseInput.cpp
@@ -270,7 +270,7 @@ static constexpr short _encodeDefaultCoordinate(const short sCoordinateValue) no
 // - <none>
 // Return value:
 // - true, if we are tracking mouse input. False, otherwise
-bool TerminalInput::IsTrackingMouseInput() const
+bool TerminalInput::IsTrackingMouseInput() const noexcept
 {
     return (_mouseInputState.trackingMode != TrackingMode::None);
 }

--- a/src/terminal/input/terminalInput.hpp
+++ b/src/terminal/input/terminalInput.hpp
@@ -45,7 +45,7 @@ namespace Microsoft::Console::VirtualTerminal
                          const short modifierKeyState,
                          const short delta);
 
-        bool IsTrackingMouseInput() const;
+        bool IsTrackingMouseInput() const noexcept;
 #pragma endregion
 
 #pragma region MouseInputState Management

--- a/src/terminal/input/terminalInput.hpp
+++ b/src/terminal/input/terminalInput.hpp
@@ -44,6 +44,8 @@ namespace Microsoft::Console::VirtualTerminal
                          const unsigned int button,
                          const short modifierKeyState,
                          const short delta);
+
+        bool IsTrackingMouseInput() const;
 #pragma endregion
 
 #pragma region MouseInputState Management


### PR DESCRIPTION
## Summary of the Pull Request
Make TerminalControl synthesize mouse events and Terminal send them to
the TerminalInput's MouseInput module.

The implementation here takes significant inspiration from how we handle
KeyEvents.

## References
Closes #545 - VT Mouse Mode (Terminal)
References #376 - VT Mouse Mode (ConPty)

### TerminalControl
- `_TrySendMouseEvent` attempts to send a mouse event via TermInput.
  Similar to `_TrySendKeyEvent`
- Use the above function to try and send the mouse event _before_
  deciding to modify the selection

### TerminalApi
- Hookup (re)setting the various modes to handle VT Input
- Terminal is _always_ in VT Input mode (important for #4856)

### TerminalDispatch
- Hookup (re)setting the various modes to handle VT Input

### TerminalInput
- Convert the mouse input position from viewport position to buffer
  position
- Then send it over to the MouseInput in TerminalInput to actually do it
  (#4848)

## Validation Steps Performed
Tests should still pass.
