### PR TITLE
Suppress run breaking for abs. differences < 0.001 in advance

### DIFF
--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -639,8 +639,12 @@ try
                                                    _glyphAdvances.cbegin() + clusterGlyphBegin + clusterGlyphLength,
                                                    0.0f);
 
+        // With certain font faces at certain sizes, the advances seem to be slightly more than
+        // the pixel grid; Cascadia Code at 13pt (though, 200% scale) had an advance of 10.000001.
+        // We don't want anything sub one hundredth of a cell to make us break up runs, because
+        // doing so results in suboptimal rendering.
         // If what we expect is bigger than what we have... pad it out.
-        if (advanceExpected > advanceActual)
+        if ((advanceExpected - advanceActual) > 0.001f)
         {
             // Get the amount of space we have leftover.
             const auto diff = advanceExpected - advanceActual;
@@ -657,7 +661,7 @@ try
             _glyphAdvances.at(static_cast<size_t>(clusterGlyphBegin) + clusterGlyphLength - 1) += diff;
         }
         // If what we expect is smaller than what we have... rescale the font size to get a smaller glyph to fit.
-        else if (advanceExpected < advanceActual)
+        else if ((advanceExpected - advanceActual) < -0.001f)
         {
             const auto scaleProposed = advanceExpected / advanceActual;
 


### PR DESCRIPTION
With certain font faces at certain sizes, the advances seem to be
slightly more than the pixel grid; Cascadia Code at 13pt (though, 200%
scale) had an advance of 10.000001.

This commit makes it so that anything sub-1/100 of a cell won't make us
break up runs, because doing so results in suboptimal rendering.

Fixes #4806.

---

I wrote a renderer hack that colors text runs by their origin x (blue+) and y (red+).

This shows that at font size 12, we were only doing one run per line.

![image](https://user-images.githubusercontent.com/14316954/76268446-696ba700-622b-11ea-9af1-d454217c9742.png)

This shows that at font size _13_, we were doing one run _per cell_.

![image](https://user-images.githubusercontent.com/14316954/76268466-72f50f00-622b-11ea-8e9e-4322ac48942c.png)