### PR TITLE
vt: make sure to Flush the entire parsed sequence

### DIFF
--- a/src/terminal/parser/stateMachine.hpp
+++ b/src/terminal/parser/stateMachine.hpp
@@ -115,6 +115,8 @@ namespace Microsoft::Console::VirtualTerminal
         std::wstring _oscString;
         size_t _oscParameter;
 
+        std::optional<std::wstring> _cachedSequence;
+
         // This is tracked per state machine instance so that separate calls to Process*
         //   can start and finish a sequence.
         bool _processingIndividually;


### PR DESCRIPTION
When we had to flush unknown sequences to the terminal, we were only
taking the _most recent run_ with us; therefore, if we received `\e[?12`
and `34h` in separate packets we would _only_ send out `34h`.

This change fixes that issue by ensuring that we cache partial bits of
sequences we haven't yet completed, just in case we need to flush them.

Fixes #3080.
Fixes #3081.

## PR Checklist
* [x] Closes #3080, Closes #3081
* [x] CLA signed
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [x] Core contributor

## Validation Steps Performed
Ran new tests!
