### PR TITLE
Don't let ConptyConnection be UAF

### DIFF
--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -359,6 +359,10 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 
     DWORD ConptyConnection::_OutputThread()
     {
+        // Keep us alive until the output thread terminates; the destructor
+        // won't wait for us, and the known exit points _do_.
+        auto strongThis{ get_strong() };
+
         // process the data of the output pipe in a loop
         while (true)
         {


### PR DESCRIPTION
I noticed a crash in debug builds when a connected application terminates; we get its exit code, then we destruct, and the u16state is used after it's destructed by the process's last words.
