### PR TITLE
Prevent tab reordering while elevated

### DIFF
--- a/src/cascadia/TerminalApp/AppLogic.h
+++ b/src/cascadia/TerminalApp/AppLogic.h
@@ -21,6 +21,7 @@ namespace winrt::TerminalApp::implementation
         void Create();
         bool IsUwp() const noexcept;
         void RunAsUwp();
+        bool IsElevated() const noexcept;
         void LoadSettings();
         [[nodiscard]] std::shared_ptr<::TerminalApp::CascadiaSettings> GetSettings() const noexcept;
 
@@ -47,6 +48,7 @@ namespace winrt::TerminalApp::implementation
 
     private:
         bool _isUwp{ false };
+        bool _isElevated{ false };
 
         // If you add controls here, but forget to null them either here or in
         // the ctor, you're going to have a bad time. It'll mysteriously fail to

--- a/src/cascadia/TerminalApp/AppLogic.idl
+++ b/src/cascadia/TerminalApp/AppLogic.idl
@@ -25,6 +25,7 @@ namespace TerminalApp
 
         Boolean IsUwp();
         void RunAsUwp();
+        Boolean IsElevated();
 
         Int32 SetStartupCommandline(String[] commands);
         String EarlyExitMessage { get; };

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -63,6 +63,14 @@ namespace winrt::TerminalApp::implementation
         _tabView = _tabRow.TabView();
         _rearranging = false;
 
+        // GH#3581 - There's a platform limitation that causes us to crash when we rearrange tabs.
+        // Xaml tries to send a drag visual (to wit: a screenshot) to the drag hosting process,
+        // but that process is running at a different IL than us.
+        // For now, we're disabling elevated drag.
+        const auto isElevated = ::winrt::Windows::UI::Xaml::Application::Current().as<::winrt::TerminalApp::App>().Logic().IsElevated();
+        _tabView.CanReorderTabs(!isElevated);
+        _tabView.CanDragTabs(!isElevated);
+
         _tabView.TabDragStarting([weakThis{ get_weak() }](auto&& /*o*/, auto&& /*a*/) {
             if (auto page{ weakThis.get() })
             {


### PR DESCRIPTION
There's a platform limitation that causes us to crash when we rearrange
tabs. Xaml tries to send a drag visual (to wit: a screenshot) to the
drag hosting process, but that process is running at a different IL than
us.

For now, we're disabling elevated drag.

Fixes #3581