### PR TITLE
Use estimated formatted lengths to optimize performance of VT rendering

### DIFF
--- a/src/host/ut_host/VtRendererTests.cpp
+++ b/src/host/ut_host/VtRendererTests.cpp
@@ -113,6 +113,10 @@ class Microsoft::Console::Render::VtRendererTest
     TEST_METHOD(WinTelnetTestColors);
     TEST_METHOD(WinTelnetTestCursor);
 
+    TEST_METHOD(FormatNoLength);
+    TEST_METHOD(FormatWithLength);
+    TEST_METHOD(FormatLengthTooBig);
+
     TEST_METHOD(TestWrapping);
 
     TEST_METHOD(TestResize);
@@ -1471,4 +1475,67 @@ void VtRendererTest::TestCursorVisibility()
     VERIFY_IS_FALSE(engine->_lastCursorIsVisible);
     VERIFY_IS_FALSE(engine->_nextCursorIsVisible);
     VERIFY_IS_FALSE(engine->_needToDisableCursor);
+}
+
+void VtRendererTest::FormatNoLength()
+{
+    // This test works with a static cache variable that
+    // can be affected by other tests
+    BEGIN_TEST_METHOD_PROPERTIES()
+        TEST_METHOD_PROPERTY(L"IsolationLevel", L"Method")
+    END_TEST_METHOD_PROPERTIES();
+
+    static const std::string format("\x1b[%dm");
+    const auto value = 12;
+    qExpectedInput.push_back("\x1b[12m");
+
+    Viewport view = SetUpViewport();
+    wil::unique_hfile hFile = wil::unique_hfile(INVALID_HANDLE_VALUE);
+    auto engine = std::make_unique<Xterm256Engine>(std::move(hFile), p, view, g_ColorTable, static_cast<WORD>(COLOR_TABLE_SIZE));
+    auto pfn = std::bind(&VtRendererTest::WriteCallback, this, std::placeholders::_1, std::placeholders::_2);
+    engine->SetTestCallback(pfn);
+
+    VERIFY_SUCCEEDED(engine->_WriteFormattedString(&format, value));
+}
+
+void VtRendererTest::FormatWithLength()
+{
+    // This test works with a static cache variable that
+    // can be affected by other tests
+    BEGIN_TEST_METHOD_PROPERTIES()
+        TEST_METHOD_PROPERTY(L"IsolationLevel", L"Method")
+    END_TEST_METHOD_PROPERTIES();
+
+    static const std::string format("\x1b[%dm");
+    const auto value = 12;
+    qExpectedInput.push_back("\x1b[12m");
+
+    Viewport view = SetUpViewport();
+    wil::unique_hfile hFile = wil::unique_hfile(INVALID_HANDLE_VALUE);
+    auto engine = std::make_unique<Xterm256Engine>(std::move(hFile), p, view, g_ColorTable, static_cast<WORD>(COLOR_TABLE_SIZE));
+    auto pfn = std::bind(&VtRendererTest::WriteCallback, this, std::placeholders::_1, std::placeholders::_2);
+    engine->SetTestCallback(pfn);
+
+    VERIFY_SUCCEEDED(engine->_WriteFormattedString(5, &format, value));
+}
+
+void VtRendererTest::FormatLengthTooBig()
+{
+    // This test works with a static cache variable that
+    // can be affected by other tests
+    BEGIN_TEST_METHOD_PROPERTIES()
+        TEST_METHOD_PROPERTY(L"IsolationLevel", L"Method")
+    END_TEST_METHOD_PROPERTIES();
+
+    static const std::string format("\x1b[%dm");
+    const auto value = 12;
+    qExpectedInput.push_back("\x1b[12m");
+
+    Viewport view = SetUpViewport();
+    wil::unique_hfile hFile = wil::unique_hfile(INVALID_HANDLE_VALUE);
+    auto engine = std::make_unique<Xterm256Engine>(std::move(hFile), p, view, g_ColorTable, static_cast<WORD>(COLOR_TABLE_SIZE));
+    auto pfn = std::bind(&VtRendererTest::WriteCallback, this, std::placeholders::_1, std::placeholders::_2);
+    engine->SetTestCallback(pfn);
+
+    VERIFY_SUCCEEDED(engine->_WriteFormattedString(1, &format, value));
 }

--- a/src/host/ut_host/VtRendererTests.cpp
+++ b/src/host/ut_host/VtRendererTests.cpp
@@ -113,9 +113,7 @@ class Microsoft::Console::Render::VtRendererTest
     TEST_METHOD(WinTelnetTestColors);
     TEST_METHOD(WinTelnetTestCursor);
 
-    TEST_METHOD(FormatNoLength);
-    TEST_METHOD(FormatWithLength);
-    TEST_METHOD(FormatLengthTooBig);
+    TEST_METHOD(FormattedString);
 
     TEST_METHOD(TestWrapping);
 
@@ -1477,7 +1475,7 @@ void VtRendererTest::TestCursorVisibility()
     VERIFY_IS_FALSE(engine->_needToDisableCursor);
 }
 
-void VtRendererTest::FormatNoLength()
+void VtRendererTest::FormattedString()
 {
     // This test works with a static cache variable that
     // can be affected by other tests
@@ -1487,7 +1485,6 @@ void VtRendererTest::FormatNoLength()
 
     static const std::string format("\x1b[%dm");
     const auto value = 12;
-    qExpectedInput.push_back("\x1b[12m");
 
     Viewport view = SetUpViewport();
     wil::unique_hfile hFile = wil::unique_hfile(INVALID_HANDLE_VALUE);
@@ -1495,47 +1492,17 @@ void VtRendererTest::FormatNoLength()
     auto pfn = std::bind(&VtRendererTest::WriteCallback, this, std::placeholders::_1, std::placeholders::_2);
     engine->SetTestCallback(pfn);
 
+    Log::Comment(L"1.) Write it once. It should resize itself.");
+    qExpectedInput.push_back("\x1b[12m");
     VERIFY_SUCCEEDED(engine->_WriteFormattedString(&format, value));
-}
 
-void VtRendererTest::FormatWithLength()
-{
-    // This test works with a static cache variable that
-    // can be affected by other tests
-    BEGIN_TEST_METHOD_PROPERTIES()
-        TEST_METHOD_PROPERTY(L"IsolationLevel", L"Method")
-    END_TEST_METHOD_PROPERTIES();
-
-    static const std::string format("\x1b[%dm");
-    const auto value = 12;
+    Log::Comment(L"2.) Write the same thing again, should be fine.");
     qExpectedInput.push_back("\x1b[12m");
+    VERIFY_SUCCEEDED(engine->_WriteFormattedString(&format, value));
 
-    Viewport view = SetUpViewport();
-    wil::unique_hfile hFile = wil::unique_hfile(INVALID_HANDLE_VALUE);
-    auto engine = std::make_unique<Xterm256Engine>(std::move(hFile), p, view, g_ColorTable, static_cast<WORD>(COLOR_TABLE_SIZE));
-    auto pfn = std::bind(&VtRendererTest::WriteCallback, this, std::placeholders::_1, std::placeholders::_2);
-    engine->SetTestCallback(pfn);
-
-    VERIFY_SUCCEEDED(engine->_WriteFormattedString(5, &format, value));
-}
-
-void VtRendererTest::FormatLengthTooBig()
-{
-    // This test works with a static cache variable that
-    // can be affected by other tests
-    BEGIN_TEST_METHOD_PROPERTIES()
-        TEST_METHOD_PROPERTY(L"IsolationLevel", L"Method")
-    END_TEST_METHOD_PROPERTIES();
-
-    static const std::string format("\x1b[%dm");
-    const auto value = 12;
-    qExpectedInput.push_back("\x1b[12m");
-
-    Viewport view = SetUpViewport();
-    wil::unique_hfile hFile = wil::unique_hfile(INVALID_HANDLE_VALUE);
-    auto engine = std::make_unique<Xterm256Engine>(std::move(hFile), p, view, g_ColorTable, static_cast<WORD>(COLOR_TABLE_SIZE));
-    auto pfn = std::bind(&VtRendererTest::WriteCallback, this, std::placeholders::_1, std::placeholders::_2);
-    engine->SetTestCallback(pfn);
-
-    VERIFY_SUCCEEDED(engine->_WriteFormattedString(1, &format, value));
+    Log::Comment(L"3.) Now write something huge. Should resize itself and still be fine.");
+    static const std::string bigFormat("\x1b[28;3;%d;%d;%dm");
+    const auto bigValue = 500;
+    qExpectedInput.push_back("\x1b[28;3;500;500;500m");
+    VERIFY_SUCCEEDED(engine->_WriteFormattedString(&bigFormat, bigValue, bigValue, bigValue));
 }

--- a/src/renderer/vt/VtSequences.cpp
+++ b/src/renderer/vt/VtSequences.cpp
@@ -82,10 +82,7 @@ using namespace Microsoft::Console::Render;
 [[nodiscard]] HRESULT VtEngine::_EraseCharacter(const short chars) noexcept
 {
     static const std::string format = "\x1b[%dX";
-
-    // Estimated length = 3 for ESC[ and X
-    // +5 for 5 digits max for positive value of short chars.
-    return _WriteFormattedString(3 + 5, &format, chars);
+    return _WriteFormattedString(&format, chars);
 }
 
 // Method Description:
@@ -97,10 +94,7 @@ using namespace Microsoft::Console::Render;
 [[nodiscard]] HRESULT VtEngine::_CursorForward(const short chars) noexcept
 {
     static const std::string format = "\x1b[%dC";
-
-    // Estimated length = 3 for ESC[ and C
-    // +5 for 5 digits max for positive value of short chars.
-    return _WriteFormattedString(3 + 5, &format, chars);
+    return _WriteFormattedString(&format, chars);
 }
 
 // Method Description:
@@ -135,9 +129,7 @@ using namespace Microsoft::Console::Render;
     }
     const std::string format = fInsertLine ? "\x1b[%dL" : "\x1b[%dM";
 
-    // Estimated length = 3 for ESC[ and L/M
-    // +5 for 5 digits max for positive value of short.
-    return _WriteFormattedString(3 + 5, &format, sLines);
+    return _WriteFormattedString(&format, sLines);
 }
 
 // Method Description:
@@ -181,10 +173,7 @@ using namespace Microsoft::Console::Render;
     coordVt.X++;
     coordVt.Y++;
 
-    // Estimated length = 4 for ESC[ and H and ;
-    // +5 for 5 digits max for positive value of short.
-    // +5 for 5 digits max for positive value of short.
-    return _WriteFormattedString(4 + 5 + 5, &cursorFormat, coordVt.Y, coordVt.X);
+    return _WriteFormattedString(&cursorFormat, coordVt.Y, coordVt.X);
 }
 
 // Method Description:
@@ -252,9 +241,7 @@ using namespace Microsoft::Console::Render;
                         (WI_IsFlagSet(wAttr, FOREGROUND_GREEN) ? 2 : 0) +
                         (WI_IsFlagSet(wAttr, FOREGROUND_BLUE) ? 4 : 0);
 
-    // Estimated length = 3 for ESC[ and m
-    // + 3 digits for an SGR from 0-999
-    return _WriteFormattedString(3 + 3, &fmt, vtIndex);
+    return _WriteFormattedString(&fmt, vtIndex);
 }
 
 // Method Description:
@@ -276,14 +263,7 @@ using namespace Microsoft::Console::Render;
     DWORD const g = GetGValue(color);
     DWORD const b = GetBValue(color);
 
-    // Estimated length = 3 for ESC[ and m
-    // + 4 semicolons
-    // + 2 for 38/48
-    // + 1 for 2
-    // + 3 digits for R
-    // + 3 digits for G
-    // + 3 digits for B
-    return _WriteFormattedString(3 + 4 + 2 + 1 + 3 + 3 + 3, &fmt, r, g, b);
+    return _WriteFormattedString(&fmt, r, g, b);
 }
 
 // Method Description:
@@ -315,12 +295,7 @@ using namespace Microsoft::Console::Render;
         return E_INVALIDARG;
     }
 
-    // Estimated length = 3 for ESC[ and t
-    // + 2 semicolons
-    // + 1 for 8
-    // + 5 digits for width (max positive short)
-    // + 5 digits for height (max positive short)
-    return _WriteFormattedString(3 + 2 + 1 + 5 + 5, &resizeFormat, sHeight, sWidth);
+    return _WriteFormattedString(&resizeFormat, sHeight, sWidth);
 }
 
 // Method Description:

--- a/src/renderer/vt/VtSequences.cpp
+++ b/src/renderer/vt/VtSequences.cpp
@@ -83,7 +83,9 @@ using namespace Microsoft::Console::Render;
 {
     static const std::string format = "\x1b[%dX";
 
-    return _WriteFormattedString(&format, chars);
+    // Estimated length = 3 for ESC[ and X
+    // +5 for 5 digits max for positive value of short chars.
+    return _WriteFormattedString(3 + 5, &format, chars);
 }
 
 // Method Description:
@@ -96,7 +98,9 @@ using namespace Microsoft::Console::Render;
 {
     static const std::string format = "\x1b[%dC";
 
-    return _WriteFormattedString(&format, chars);
+    // Estimated length = 3 for ESC[ and C
+    // +5 for 5 digits max for positive value of short chars.
+    return _WriteFormattedString(3 + 5, &format, chars);
 }
 
 // Method Description:
@@ -131,7 +135,9 @@ using namespace Microsoft::Console::Render;
     }
     const std::string format = fInsertLine ? "\x1b[%dL" : "\x1b[%dM";
 
-    return _WriteFormattedString(&format, sLines);
+    // Estimated length = 3 for ESC[ and L/M
+    // +5 for 5 digits max for positive value of short.
+    return _WriteFormattedString(3 + 5, &format, sLines);
 }
 
 // Method Description:
@@ -175,7 +181,10 @@ using namespace Microsoft::Console::Render;
     coordVt.X++;
     coordVt.Y++;
 
-    return _WriteFormattedString(&cursorFormat, coordVt.Y, coordVt.X);
+    // Estimated length = 4 for ESC[ and H and ;
+    // +5 for 5 digits max for positive value of short.
+    // +5 for 5 digits max for positive value of short.
+    return _WriteFormattedString(4 + 5 + 5, &cursorFormat, coordVt.Y, coordVt.X);
 }
 
 // Method Description:
@@ -243,7 +252,9 @@ using namespace Microsoft::Console::Render;
                         (WI_IsFlagSet(wAttr, FOREGROUND_GREEN) ? 2 : 0) +
                         (WI_IsFlagSet(wAttr, FOREGROUND_BLUE) ? 4 : 0);
 
-    return _WriteFormattedString(&fmt, vtIndex);
+    // Estimated length = 3 for ESC[ and m
+    // + 3 digits for an SGR from 0-999
+    return _WriteFormattedString(3 + 3, &fmt, vtIndex);
 }
 
 // Method Description:
@@ -265,7 +276,14 @@ using namespace Microsoft::Console::Render;
     DWORD const g = GetGValue(color);
     DWORD const b = GetBValue(color);
 
-    return _WriteFormattedString(&fmt, r, g, b);
+    // Estimated length = 3 for ESC[ and m
+    // + 4 semicolons
+    // + 2 for 38/48
+    // + 1 for 2
+    // + 3 digits for R
+    // + 3 digits for G
+    // + 3 digits for B
+    return _WriteFormattedString(3 + 4 + 2 + 1 + 3 + 3 + 3, &fmt, r, g, b);
 }
 
 // Method Description:
@@ -297,7 +315,12 @@ using namespace Microsoft::Console::Render;
         return E_INVALIDARG;
     }
 
-    return _WriteFormattedString(&resizeFormat, sHeight, sWidth);
+    // Estimated length = 3 for ESC[ and t
+    // + 2 semicolons
+    // + 1 for 8
+    // + 5 digits for width (max positive short)
+    // + 5 digits for height (max positive short)
+    return _WriteFormattedString(3 + 2 + 1 + 5 + 5, &resizeFormat, sHeight, sWidth);
 }
 
 // Method Description:

--- a/src/renderer/vt/state.cpp
+++ b/src/renderer/vt/state.cpp
@@ -261,24 +261,24 @@ try
     // the VT renderer will be formatting a LOT of strings and alloc/freeing them
     // over and over is going to be way worse for perf than just holding some extra
     // memory for formatting purposes.
-    static std::string formatString;
+    // See _formatBuffer for its location.
 
     // If we were given an estimated size, attempt to plow ahead using our pre-reserved string space.
     if (estimatedSize != 0)
     {
-        formatString.resize(estimatedSize + 1);
+        _formatBuffer.resize(estimatedSize + 1);
 
         LPSTR destEnd = nullptr;
         size_t destRemaining = 0;
-        if (SUCCEEDED(StringCchVPrintfExA(formatString.data(),
-                                          formatString.size(),
+        if (SUCCEEDED(StringCchVPrintfExA(_formatBuffer.data(),
+                                          _formatBuffer.size(),
                                           &destEnd,
                                           &destRemaining,
                                           STRSAFE_NO_TRUNCATION,
                                           pFormat->c_str(),
                                           args)))
         {
-            return _Write({ formatString.data(), formatString.size() - destRemaining });
+            return _Write({ _formatBuffer.data(), _formatBuffer.size() - destRemaining });
         }
     }
 
@@ -290,10 +290,10 @@ try
     // -1 is the _scprintf error case https://msdn.microsoft.com/en-us/library/t32cf9tb.aspx
     if (needed > -1)
     {
-        formatString.resize(needed + 1);
+        _formatBuffer.resize(needed + 1);
 
-        const auto written = _vsnprintf_s(formatString.data(), formatString.size(), needed, pFormat->c_str(), args);
-        hr = _Write({ formatString.data(), gsl::narrow<size_t>(written) });
+        const auto written = _vsnprintf_s(_formatBuffer.data(), _formatBuffer.size(), needed, pFormat->c_str(), args);
+        hr = _Write({ _formatBuffer.data(), gsl::narrow<size_t>(written) });
     }
     else
     {

--- a/src/renderer/vt/state.cpp
+++ b/src/renderer/vt/state.cpp
@@ -193,64 +193,11 @@ VtEngine::VtEngine(_In_ wil::unique_hfile pipe,
 // - S_OK, E_INVALIDARG for a invalid format string, or suitable HRESULT error
 //      from writing pipe.
 [[nodiscard]] HRESULT VtEngine::_WriteFormattedString(const std::string* const pFormat, ...) noexcept
-{
-    // NOTE: pFormat is a pointer because varargs refuses to operate with a ref in that position
-    // NOTE: We're not using string_view because it doesn't guarantee null (which will be needed
-    //       later in the formatting method).
-
-    va_list argList;
-    va_start(argList, pFormat);
-    const auto hr = _WriteFormattedString(0, pFormat, argList);
-    va_end(argList);
-    return hr;
-}
-
-// Method Description:
-// - Helper for calling _Write with a string for formatting a sequence. Used
-//      extensively by VtSequences.cpp
-// Arguments:
-// - estimatedSize: If you have a guess on how big the result will be, specify a non-zero
-//                  value here.
-//                  This is a performance optimization to skip counting the formatted string
-//                  prior to allocating memory and reformatting it again into the buffer.
-//                  If your guess is wrong, we will still fall back to the slow-way and
-//                  count then format.
-// - pFormat: pointer to format string to write to the pipe
-// - ...: a va_list of args to format the string with.
-// Return Value:
-// - S_OK, E_INVALIDARG for a invalid format string, or suitable HRESULT error
-//      from writing pipe.
-[[nodiscard]] HRESULT VtEngine::_WriteFormattedString(const size_t estimatedSize, const std::string* const pFormat, ...) noexcept
-{
-    // NOTE: pFormat is a pointer because varargs refuses to operate with a ref in that position
-    // NOTE: We're not using string_view because it doesn't guarantee null (which will be needed
-    //       later in the formatting method).
-
-    va_list argList;
-    va_start(argList, pFormat);
-    const auto hr = _WriteFormattedString(estimatedSize, pFormat, argList);
-    va_end(argList);
-    return hr;
-}
-
-// Method Description:
-// - Helper for calling _Write with a string for formatting a sequence. Used
-//      extensively by VtSequences.cpp
-// Arguments:
-// - estimatedSize: If you have a guess on how big the result will be, specify a non-zero
-//                  value here.
-//                  This is a performance optimization to skip counting the formatted string
-//                  prior to allocating memory and reformatting it again into the buffer.
-//                  If your guess is wrong, we will still fall back to the slow-way and
-//                  count then format.
-// - pFormat: pointer to format string to write to the pipe
-// - args: a va_list of args to format the string with.
-// Return Value:
-// - S_OK, E_INVALIDARG for a invalid format string, or suitable HRESULT error
-//      from writing pipe.
-[[nodiscard]] HRESULT VtEngine::_WriteFormattedString(const size_t estimatedSize, const std::string* const pFormat, va_list args) noexcept
 try
 {
+    va_list args;
+    va_start(args, pFormat);
+
     // NOTE: pFormat is a pointer because varargs refuses to operate with a ref in that position
     // NOTE: We're not using string_view because it doesn't guarantee null (which will be needed
     //       later in the formatting method).
@@ -263,34 +210,29 @@ try
     // memory for formatting purposes.
     // See _formatBuffer for its location.
 
-    // If we were given an estimated size, attempt to plow ahead using our pre-reserved string space.
-    if (estimatedSize != 0)
+    // First, plow ahead using our pre-reserved string space.
+    LPSTR destEnd = nullptr;
+    size_t destRemaining = 0;
+    if (SUCCEEDED(StringCchVPrintfExA(_formatBuffer.data(),
+                                      _formatBuffer.size(),
+                                      &destEnd,
+                                      &destRemaining,
+                                      STRSAFE_NO_TRUNCATION,
+                                      pFormat->c_str(),
+                                      args)))
     {
-        _formatBuffer.resize(estimatedSize + 1);
-
-        LPSTR destEnd = nullptr;
-        size_t destRemaining = 0;
-        if (SUCCEEDED(StringCchVPrintfExA(_formatBuffer.data(),
-                                          _formatBuffer.size(),
-                                          &destEnd,
-                                          &destRemaining,
-                                          STRSAFE_NO_TRUNCATION,
-                                          pFormat->c_str(),
-                                          args)))
-        {
-            return _Write({ _formatBuffer.data(), _formatBuffer.size() - destRemaining });
-        }
+        return _Write({ _formatBuffer.data(), _formatBuffer.size() - destRemaining });
     }
 
-    // If we didn't have an estimated size or we didn't succeed at filling/using it, then
-    // we're going to take the long way by counting the space required and reserving up to that
+    // If we didn't succeed at filling/using the existing space, then
+    // we're going to take the long way by counting the space required and resizing up to that
     // space and formatting.
 
     const auto needed = _scprintf(pFormat->c_str(), args);
     // -1 is the _scprintf error case https://msdn.microsoft.com/en-us/library/t32cf9tb.aspx
     if (needed > -1)
     {
-        _formatBuffer.resize(needed + 1);
+        _formatBuffer.resize(static_cast<size_t>(needed) + 1);
 
         const auto written = _vsnprintf_s(_formatBuffer.data(), _formatBuffer.size(), needed, pFormat->c_str(), args);
         hr = _Write({ _formatBuffer.data(), gsl::narrow<size_t>(written) });
@@ -299,6 +241,8 @@ try
     {
         hr = E_INVALIDARG;
     }
+
+    va_end(args);
 
     return hr;
 }

--- a/src/renderer/vt/state.cpp
+++ b/src/renderer/vt/state.cpp
@@ -187,35 +187,122 @@ VtEngine::VtEngine(_In_ wil::unique_hfile pipe,
 // - Helper for calling _Write with a string for formatting a sequence. Used
 //      extensively by VtSequences.cpp
 // Arguments:
-// - pFormat: the pointer to the string to write to the pipe.
+// - pFormat: pointer to format string to write to the pipe
 // - ...: a va_list of args to format the string with.
 // Return Value:
 // - S_OK, E_INVALIDARG for a invalid format string, or suitable HRESULT error
 //      from writing pipe.
 [[nodiscard]] HRESULT VtEngine::_WriteFormattedString(const std::string* const pFormat, ...) noexcept
 {
-    HRESULT hr = E_FAIL;
+    // NOTE: pFormat is a pointer because varargs refuses to operate with a ref in that position
+    // NOTE: We're not using string_view because it doesn't guarantee null (which will be needed
+    //       later in the formatting method).
+
     va_list argList;
     va_start(argList, pFormat);
+    const auto hr = _WriteFormattedString(0, pFormat, argList);
+    va_end(argList);
+    return hr;
+}
 
-    int cchNeeded = _scprintf(pFormat->c_str(), argList);
-    // -1 is the _scprintf error case https://msdn.microsoft.com/en-us/library/t32cf9tb.aspx
-    if (cchNeeded > -1)
+// Method Description:
+// - Helper for calling _Write with a string for formatting a sequence. Used
+//      extensively by VtSequences.cpp
+// Arguments:
+// - estimatedSize: If you have a guess on how big the result will be, specify a non-zero
+//                  value here.
+//                  This is a performance optimization to skip counting the formatted string
+//                  prior to allocating memory and reformatting it again into the buffer.
+//                  If your guess is wrong, we will still fall back to the slow-way and
+//                  count then format.
+// - pFormat: pointer to format string to write to the pipe
+// - ...: a va_list of args to format the string with.
+// Return Value:
+// - S_OK, E_INVALIDARG for a invalid format string, or suitable HRESULT error
+//      from writing pipe.
+[[nodiscard]] HRESULT VtEngine::_WriteFormattedString(const size_t estimatedSize, const std::string* const pFormat, ...) noexcept
+{
+    // NOTE: pFormat is a pointer because varargs refuses to operate with a ref in that position
+    // NOTE: We're not using string_view because it doesn't guarantee null (which will be needed
+    //       later in the formatting method).
+
+    va_list argList;
+    va_start(argList, pFormat);
+    const auto hr = _WriteFormattedString(estimatedSize, pFormat, argList);
+    va_end(argList);
+    return hr;
+}
+
+// Method Description:
+// - Helper for calling _Write with a string for formatting a sequence. Used
+//      extensively by VtSequences.cpp
+// Arguments:
+// - estimatedSize: If you have a guess on how big the result will be, specify a non-zero
+//                  value here.
+//                  This is a performance optimization to skip counting the formatted string
+//                  prior to allocating memory and reformatting it again into the buffer.
+//                  If your guess is wrong, we will still fall back to the slow-way and
+//                  count then format.
+// - pFormat: pointer to format string to write to the pipe
+// - args: a va_list of args to format the string with.
+// Return Value:
+// - S_OK, E_INVALIDARG for a invalid format string, or suitable HRESULT error
+//      from writing pipe.
+[[nodiscard]] HRESULT VtEngine::_WriteFormattedString(const size_t estimatedSize, const std::string* const pFormat, va_list args) noexcept
+try
+{
+    // NOTE: pFormat is a pointer because varargs refuses to operate with a ref in that position
+    // NOTE: We're not using string_view because it doesn't guarantee null (which will be needed
+    //       later in the formatting method).
+
+    HRESULT hr = E_FAIL;
+
+    // We're going to hold onto our format string space across calls because
+    // the VT renderer will be formatting a LOT of strings and alloc/freeing them
+    // over and over is going to be way worse for perf than just holding some extra
+    // memory for formatting purposes.
+    static std::string formatString;
+
+    // If we were given an estimated size, attempt to plow ahead using our pre-reserved string space.
+    if (estimatedSize != 0)
     {
-        wistd::unique_ptr<char[]> psz = wil::make_unique_nothrow<char[]>(cchNeeded + 1);
-        RETURN_IF_NULL_ALLOC(psz);
+        formatString.resize(estimatedSize + 1);
 
-        int cchWritten = _vsnprintf_s(psz.get(), cchNeeded + 1, cchNeeded, pFormat->c_str(), argList);
-        hr = _Write({ psz.get(), gsl::narrow<size_t>(cchWritten) });
+        LPSTR destEnd = nullptr;
+        size_t destRemaining = 0;
+        if (SUCCEEDED(StringCchVPrintfExA(formatString.data(),
+                                          formatString.size(),
+                                          &destEnd,
+                                          &destRemaining,
+                                          STRSAFE_NO_TRUNCATION,
+                                          pFormat->c_str(),
+                                          args)))
+        {
+            return _Write({ formatString.data(), formatString.size() - destRemaining });
+        }
+    }
+
+    // If we didn't have an estimated size or we didn't succeed at filling/using it, then
+    // we're going to take the long way by counting the space required and reserving up to that
+    // space and formatting.
+
+    const auto needed = _scprintf(pFormat->c_str(), args);
+    // -1 is the _scprintf error case https://msdn.microsoft.com/en-us/library/t32cf9tb.aspx
+    if (needed > -1)
+    {
+        formatString.resize(needed + 1);
+
+        const auto written = _vsnprintf_s(formatString.data(), formatString.size(), needed, pFormat->c_str(), args);
+        hr = _Write({ formatString.data(), gsl::narrow<size_t>(written) });
     }
     else
     {
         hr = E_INVALIDARG;
     }
 
-    va_end(argList);
     return hr;
 }
+CATCH_RETURN();
 
 // Method Description:
 // - This method will update the active font on the current device context

--- a/src/renderer/vt/vtrenderer.hpp
+++ b/src/renderer/vt/vtrenderer.hpp
@@ -110,6 +110,8 @@ namespace Microsoft::Console::Render
         wil::unique_hfile _hFile;
         std::string _buffer;
 
+        std::string _formatBuffer;
+
         const Microsoft::Console::IDefaultColorProvider& _colorProvider;
 
         COLORREF _LastFG;

--- a/src/renderer/vt/vtrenderer.hpp
+++ b/src/renderer/vt/vtrenderer.hpp
@@ -152,8 +152,6 @@ namespace Microsoft::Console::Render
         bool _delayedEolWrap{ false };
 
         [[nodiscard]] HRESULT _Write(std::string_view const str) noexcept;
-        [[nodiscard]] HRESULT _WriteFormattedString(const size_t estimatedSize, const std::string* const pFormat, ...) noexcept;
-        [[nodiscard]] HRESULT _WriteFormattedString(const size_t estimatedSize, const std::string* const pFormat, va_list args) noexcept;
         [[nodiscard]] HRESULT _WriteFormattedString(const std::string* const pFormat, ...) noexcept;
         [[nodiscard]] HRESULT _Flush() noexcept;
 

--- a/src/renderer/vt/vtrenderer.hpp
+++ b/src/renderer/vt/vtrenderer.hpp
@@ -150,6 +150,8 @@ namespace Microsoft::Console::Render
         bool _delayedEolWrap{ false };
 
         [[nodiscard]] HRESULT _Write(std::string_view const str) noexcept;
+        [[nodiscard]] HRESULT _WriteFormattedString(const size_t estimatedSize, const std::string* const pFormat, ...) noexcept;
+        [[nodiscard]] HRESULT _WriteFormattedString(const size_t estimatedSize, const std::string* const pFormat, va_list args) noexcept;
         [[nodiscard]] HRESULT _WriteFormattedString(const std::string* const pFormat, ...) noexcept;
         [[nodiscard]] HRESULT _Flush() noexcept;
 


### PR DESCRIPTION
## Summary of the Pull Request
Allows VT engine methods that print formatted strings (cursor movements, color changes, etc.) to provide a guess at the max buffer size required eliminating the double-call for formatting in the common case.

## PR Checklist
* [x] Found while working on #778
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [x] Am core contributor. 

## Detailed Description of the Pull Request / Additional comments
- The most common case for VT rendering is formatting a few numbers into a sequence. For the most part, we can already tell the maximum length that the string could be based on the number of substitutions and the size of the parameters.
- The existing formatting method would always double-call. It would first call for how long the string was going to be post-formatting, allocate that memory, then call again and fill it up. This cost two full times of running through the string to find a length we probably already knew for the most part.
- Now if a size is provided, we allocate that first and attempt the "second pass" of formatting directly into the buffer. This saves the count step in the common case.
- If this fails, we fall back and do the two-pass method (which theoretically means the bad case is now 3 passes.)
- The next biggest waste of time in this method was allocating and freeing strings for every format pass. Due to the nature of the VT renderer, many things need to be formatted this way. I've now instead moved the format method to hold a static string that really only grows over the course of the session for all of these format operations. I expect a majority of the time, it will only be consuming approximately 5-15 length of a std::string of memory space. I cannot currently see a circumstance where it would use more than that, but I'm consciously trading memory usage when running as a PTY for overall runtime performance here.

## Validation Steps Performed
- Ran the thing manually and checked it out with wsl and cmatrix and Powershell and such attached to Terminal
- Wrote and ran automated tests on formatting method
