### PR TITLE
When Conpty encounters an unknown string, flush immediately

### DIFF
--- a/src/cascadia/UnitTests_TerminalCore/ConptyRoundtripTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ConptyRoundtripTests.cpp
@@ -155,6 +155,8 @@ class TerminalCoreUnitTests::ConptyRoundtripTests final
 
     TEST_METHOD(PassthroughClearScrollback);
 
+    TEST_METHOD(PassthroughCursorShapeImmediately);
+
     TEST_METHOD(TestWrappingALongString);
     TEST_METHOD(TestAdvancedWrapping);
     TEST_METHOD(TestExactWrappingWithoutSpaces);
@@ -671,6 +673,36 @@ void ConptyRoundtripTests::MoveCursorAtEOL()
     VERIFY_SUCCEEDED(renderer.PaintFrame());
 
     verifyData1(termTb);
+}
+
+void ConptyRoundtripTests::PassthroughCursorShapeImmediately()
+{
+    // This is a test for GH#4106, and more indirectly, GH #2011.
+
+    Log::Comment(NoThrowString().Format(
+        L"Change the cursor shape with VT. This should immediately be flushed to the Terminal."));
+    VERIFY_IS_NOT_NULL(_pVtRenderEngine.get());
+
+    auto& g = ServiceLocator::LocateGlobals();
+    // auto& renderer = *g.pRender;
+    auto& gci = g.getConsoleInformation();
+    auto& si = gci.GetActiveOutputBuffer();
+    auto& hostSm = si.GetStateMachine();
+    auto& hostTb = si.GetTextBuffer();
+    auto& termTb = *term->_buffer;
+
+    _flushFirstFrame();
+
+    _logConpty = true;
+
+    VERIFY_ARE_NOT_EQUAL(CursorType::VerticalBar, hostTb.GetCursor().GetType());
+    VERIFY_ARE_NOT_EQUAL(CursorType::VerticalBar, termTb.GetCursor().GetType());
+
+    expectedOutput.push_back("\x1b[5 q");
+    hostSm.ProcessString(L"\x1b[5 q");
+
+    VERIFY_ARE_EQUAL(CursorType::VerticalBar, hostTb.GetCursor().GetType());
+    VERIFY_ARE_EQUAL(CursorType::VerticalBar, termTb.GetCursor().GetType());
 }
 
 void ConptyRoundtripTests::PassthroughClearScrollback()

--- a/src/cascadia/UnitTests_TerminalCore/ConptyRoundtripTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ConptyRoundtripTests.cpp
@@ -684,7 +684,6 @@ void ConptyRoundtripTests::PassthroughCursorShapeImmediately()
     VERIFY_IS_NOT_NULL(_pVtRenderEngine.get());
 
     auto& g = ServiceLocator::LocateGlobals();
-    // auto& renderer = *g.pRender;
     auto& gci = g.getConsoleInformation();
     auto& si = gci.GetActiveOutputBuffer();
     auto& hostSm = si.GetStateMachine();

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1847,13 +1847,6 @@ bool AdaptDispatch::EnableAlternateScroll(const bool enabled)
 // True if handled successfully. False otherwise.
 bool AdaptDispatch::SetCursorStyle(const DispatchTypes::CursorStyle cursorStyle)
 {
-    bool isPty = false;
-    _pConApi->IsConsolePty(isPty);
-    if (isPty)
-    {
-        return false;
-    }
-
     CursorType actualType = CursorType::Legacy;
     bool fEnableBlinking = false;
 
@@ -1892,6 +1885,15 @@ bool AdaptDispatch::SetCursorStyle(const DispatchTypes::CursorStyle cursorStyle)
     if (success)
     {
         success = _pConApi->PrivateAllowCursorBlinking(fEnableBlinking);
+    }
+
+    // If we're a conpty, always return false, so that this cursor state will be
+    // sent to the connected terminal
+    bool isPty = false;
+    _pConApi->IsConsolePty(isPty);
+    if (isPty)
+    {
+        return false;
     }
 
     return success;


### PR DESCRIPTION
When ConPTY encounters a string we don't understand, immediately flush the frame.

## References

This PR supersedes #2665. This solution is much simpler than what was proposed in that PR. 
As mentioned in #2665: "This might have some long-term consequences for #1173."

## PR Checklist
* [x] Closes #2011
* [x] Closes #4106
* [x] I work here
* [x] Tests added/passed
