### PR TITLE
Don't draw the cursor if it's outside the viewport

### DIFF
--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -793,6 +793,8 @@ void Renderer::_PaintCursor(_In_ IRenderEngine* const pEngine)
         Viewport view = _pData->GetViewport();
         view.ConvertToOrigin(&coordCursor);
 
+        // if (view.IsInBounds(coordCursor))
+        // {
         COLORREF cursorColor = _pData->GetCursorColor();
         bool useColor = cursorColor != INVALID_COLOR;
 
@@ -805,10 +807,12 @@ void Renderer::_PaintCursor(_In_ IRenderEngine* const pEngine)
         options.cursorType = _pData->GetCursorStyle();
         options.fUseColor = useColor;
         options.cursorColor = cursorColor;
-        options.isOn = _pData->IsCursorOn();
+        options.isOn = _pData->IsCursorOn() && view.IsInBounds(_pData->GetCursorPosition());
+        // options.isOn = _pData->IsCursorOn();//  && view.IsInBounds(_pData->GetCursorPosition());
 
         // Draw it within the viewport
         LOG_IF_FAILED(pEngine->PaintCursor(options));
+        // }
     }
 }
 

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -789,30 +789,35 @@ void Renderer::_PaintCursor(_In_ IRenderEngine* const pEngine)
     {
         // Get cursor position in buffer
         COORD coordCursor = _pData->GetCursorPosition();
-        // Adjust cursor to viewport
+
+        // GH#3166: Only draw the cursor if it's actually in the viewport. It
+        // might be on the line that's in that partially visible row at the
+        // bottom of the viewport, the space that's not quite a full line in
+        // height. Since we don't draw that text, we shouldn't draw the cursor
+        // there either.
         Viewport view = _pData->GetViewport();
-        view.ConvertToOrigin(&coordCursor);
+        if (view.IsInBounds(coordCursor))
+        {
+            // Adjust cursor to viewport
+            view.ConvertToOrigin(&coordCursor);
 
-        // if (view.IsInBounds(coordCursor))
-        // {
-        COLORREF cursorColor = _pData->GetCursorColor();
-        bool useColor = cursorColor != INVALID_COLOR;
+            COLORREF cursorColor = _pData->GetCursorColor();
+            bool useColor = cursorColor != INVALID_COLOR;
 
-        // Build up the cursor parameters including position, color, and drawing options
-        IRenderEngine::CursorOptions options;
-        options.coordCursor = coordCursor;
-        options.ulCursorHeightPercent = _pData->GetCursorHeight();
-        options.cursorPixelWidth = _pData->GetCursorPixelWidth();
-        options.fIsDoubleWidth = _pData->IsCursorDoubleWidth();
-        options.cursorType = _pData->GetCursorStyle();
-        options.fUseColor = useColor;
-        options.cursorColor = cursorColor;
-        options.isOn = _pData->IsCursorOn() && view.IsInBounds(_pData->GetCursorPosition());
-        // options.isOn = _pData->IsCursorOn();//  && view.IsInBounds(_pData->GetCursorPosition());
+            // Build up the cursor parameters including position, color, and drawing options
+            IRenderEngine::CursorOptions options;
+            options.coordCursor = coordCursor;
+            options.ulCursorHeightPercent = _pData->GetCursorHeight();
+            options.cursorPixelWidth = _pData->GetCursorPixelWidth();
+            options.fIsDoubleWidth = _pData->IsCursorDoubleWidth();
+            options.cursorType = _pData->GetCursorStyle();
+            options.fUseColor = useColor;
+            options.cursorColor = cursorColor;
+            options.isOn = _pData->IsCursorOn();
 
-        // Draw it within the viewport
-        LOG_IF_FAILED(pEngine->PaintCursor(options));
-        // }
+            // Draw it within the viewport
+            LOG_IF_FAILED(pEngine->PaintCursor(options));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

This changes the renederer to make sure to not draw the cursor when it is placed outside the viewport. When the window height isn't an exact multiple of a row's height, then there's a little bit of space below the last line we're actually drawing. If cursor is on the line below the viewport, then it can actually get drawn into this space. Since we're not drawing the text for that line, this is a little odd. 

This PR fixes the issue by simply ensuring the cursor is in the veiwport before we draw it. 

## References

## PR Checklist
* [x] Closes #3166
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed
Checked with the GDI renderer as well as the DX renderer in conhost to make sure this is fixed for both of them, as well as the Terminal