### PR TITLE
Add support for setting the cursor visibility in Terminal

### DIFF
--- a/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
@@ -527,13 +527,13 @@ void _stdcall TerminalBlinkCursor(void* terminal)
         return;
     }
 
-    publicTerminal->_terminal->SetCursorVisible(!publicTerminal->_terminal->IsCursorVisible());
+    publicTerminal->_terminal->SetCursorOn(!publicTerminal->_terminal->IsCursorOn());
 }
 
 void _stdcall TerminalSetCursorVisible(void* terminal, const bool visible)
 {
     const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
-    publicTerminal->_terminal->SetCursorVisible(visible);
+    publicTerminal->_terminal->SetCursorOn(visible);
 }
 
 // Routine Description:

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -795,7 +795,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         {
             // Manually show the cursor when a key is pressed. Restarting
             // the timer prevents flickering.
-            _terminal->SetCursorVisible(true);
+            _terminal->SetCursorOn(true);
             _cursorTimer.value().Start();
         }
 
@@ -1447,7 +1447,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         if (_cursorTimer.has_value())
         {
             // When the terminal focuses, show the cursor immediately
-            _terminal->SetCursorVisible(true);
+            _terminal->SetCursorOn(true);
             _cursorTimer.value().Start();
         }
         _rowsToScroll = _settings.RowsToScroll();
@@ -1479,7 +1479,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         if (_cursorTimer.has_value())
         {
             _cursorTimer.value().Stop();
-            _terminal->SetCursorVisible(false);
+            _terminal->SetCursorOn(false);
         }
     }
 
@@ -1619,7 +1619,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         {
             return;
         }
-        _terminal->SetCursorVisible(!_terminal->IsCursorVisible());
+        _terminal->SetCursorOn(!_terminal->IsCursorOn());
     }
 
     // Method Description:

--- a/src/cascadia/TerminalCore/ITerminalApi.hpp
+++ b/src/cascadia/TerminalCore/ITerminalApi.hpp
@@ -30,7 +30,7 @@ namespace Microsoft::Terminal::Core
         virtual COORD GetCursorPosition() noexcept = 0;
         virtual bool SetCursorVisibility(const bool visible) noexcept = 0;
         virtual bool CursorLineFeed(const bool withReturn) noexcept = 0;
-        virtual bool EnableCursorBlinking(const bool enable) = 0;
+        virtual bool EnableCursorBlinking(const bool enable) noexcept = 0;
 
         virtual bool DeleteCharacter(const size_t count) noexcept = 0;
         virtual bool InsertCharacter(const size_t count) noexcept = 0;

--- a/src/cascadia/TerminalCore/ITerminalApi.hpp
+++ b/src/cascadia/TerminalCore/ITerminalApi.hpp
@@ -30,6 +30,7 @@ namespace Microsoft::Terminal::Core
         virtual COORD GetCursorPosition() noexcept = 0;
         virtual bool SetCursorVisibility(const bool visible) noexcept = 0;
         virtual bool CursorLineFeed(const bool withReturn) noexcept = 0;
+        virtual bool EnableCursorBlinking(const bool enable) = 0;
 
         virtual bool DeleteCharacter(const size_t count) noexcept = 0;
         virtual bool InsertCharacter(const size_t count) noexcept = 0;

--- a/src/cascadia/TerminalCore/ITerminalApi.hpp
+++ b/src/cascadia/TerminalCore/ITerminalApi.hpp
@@ -28,6 +28,7 @@ namespace Microsoft::Terminal::Core
 
         virtual bool SetCursorPosition(short x, short y) noexcept = 0;
         virtual COORD GetCursorPosition() noexcept = 0;
+        virtual bool SetCursorVisibility(const bool visible) noexcept = 0;
         virtual bool CursorLineFeed(const bool withReturn) noexcept = 0;
 
         virtual bool DeleteCharacter(const size_t count) noexcept = 0;

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -740,13 +740,16 @@ try
 CATCH_LOG()
 
 // Method Description:
-// - Sets the visibility of the text cursor.
+// - Sets the cursor to be currently on. On/Off is tracked independantly of
+//   cursor visibility (hidden/visible). On/off is controlled by the cursor
+//   blinker. Visibility is usually controlled by the client application. If the
+//   cursor is hidden, then the cursor will remain hidden. If the cursor is
+//   Visible, then it will immediately become visible.
 // Arguments:
 // - isVisible: whether the cursor should be visible
-void Terminal::SetCursorVisible(const bool isVisible) noexcept
+void Terminal::SetCursorOn(const bool isOn) noexcept
 {
-    auto& cursor = _buffer->GetCursor();
-    cursor.SetIsVisible(isVisible);
+    _buffer->GetCursor().SetIsOn(isOn);
 }
 
 bool Terminal::IsCursorBlinkingAllowed() const noexcept

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -740,7 +740,7 @@ try
 CATCH_LOG()
 
 // Method Description:
-// - Sets the cursor to be currently on. On/Off is tracked independantly of
+// - Sets the cursor to be currently on. On/Off is tracked independently of
 //   cursor visibility (hidden/visible). On/off is controlled by the cursor
 //   blinker. Visibility is usually controlled by the client application. If the
 //   cursor is hidden, then the cursor will remain hidden. If the cursor is

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -33,6 +33,7 @@ namespace Microsoft::Terminal::Core
 namespace TerminalCoreUnitTests
 {
     class TerminalBufferTests;
+    class TerminalApiTest;
     class ConptyRoundtripTests;
 };
 #endif
@@ -85,6 +86,7 @@ public:
     bool SetCursorPosition(short x, short y) noexcept override;
     COORD GetCursorPosition() noexcept override;
     bool SetCursorVisibility(const bool visible) noexcept override;
+    bool EnableCursorBlinking(const bool enable) noexcept override;
     bool CursorLineFeed(const bool withReturn) noexcept override;
     bool DeleteCharacter(const size_t count) noexcept override;
     bool InsertCharacter(const size_t count) noexcept override;
@@ -277,6 +279,7 @@ private:
 
 #ifdef UNIT_TESTING
     friend class TerminalCoreUnitTests::TerminalBufferTests;
+    friend class TerminalCoreUnitTests::TerminalApiTest;
     friend class TerminalCoreUnitTests::ConptyRoundtripTests;
 #endif
 };

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -84,6 +84,7 @@ public:
     bool ReverseText(bool reversed) noexcept override;
     bool SetCursorPosition(short x, short y) noexcept override;
     COORD GetCursorPosition() noexcept override;
+    bool SetCursorVisibility(const bool visible) noexcept override;
     bool CursorLineFeed(const bool withReturn) noexcept override;
     bool DeleteCharacter(const size_t count) noexcept override;
     bool InsertCharacter(const size_t count) noexcept override;
@@ -166,7 +167,7 @@ public:
     void SetScrollPositionChangedCallback(std::function<void(const int, const int, const int)> pfn) noexcept;
     void SetBackgroundCallback(std::function<void(const uint32_t)> pfn) noexcept;
 
-    void SetCursorVisible(const bool isVisible) noexcept;
+    void SetCursorOn(const bool isOn) noexcept;
     bool IsCursorBlinkingAllowed() const noexcept;
 
 #pragma region TextSelection

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -573,3 +573,9 @@ bool Terminal::IsVtInputEnabled() const noexcept
     // We should never be getting this call in Terminal.
     FAIL_FAST();
 }
+
+bool Terminal::SetCursorVisibility(const bool visible) noexcept
+{
+    _buffer->GetCursor().SetIsVisible(visible);
+    return true;
+}

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -579,3 +579,17 @@ bool Terminal::SetCursorVisibility(const bool visible) noexcept
     _buffer->GetCursor().SetIsVisible(visible);
     return true;
 }
+
+bool Terminal::EnableCursorBlinking(const bool enable) noexcept
+{
+    _buffer->GetCursor().SetBlinkingAllowed(enable);
+
+    // GH#2642 - From what we've gathered from other terminals, when blinking is
+    // disabled, the cursor should remain On always, and have the visibility
+    // controlled by the IsVisible property. So when you do a printf "\e[?12l"
+    // to disable blinking, the cursor stays stuck On. At this point, only the
+    // cursor visibility property controls whether the user can see it or not.
+    // (Yes, the cursor can be On and NOT Visible)
+    _buffer->GetCursor().SetIsOn(true);
+    return true;
+}

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -52,6 +52,11 @@ bool TerminalDispatch::CursorVisibility(const bool isVisible) noexcept
     return _terminalApi.SetCursorVisibility(isVisible);
 }
 
+bool TerminalDispatch::EnableCursorBlinking(const bool enable) noexcept
+{
+    return _terminalApi.EnableCursorBlinking(enable);
+}
+
 bool TerminalDispatch::CursorForward(const size_t distance) noexcept
 try
 {
@@ -385,6 +390,9 @@ bool TerminalDispatch::_PrivateModeParamsHelper(const DispatchTypes::PrivateMode
         break;
     case DispatchTypes::PrivateModeParams::DECTCEM_TextCursorEnableMode:
         success = CursorVisibility(enable);
+        break;
+    case DispatchTypes::PrivateModeParams::ATT610_StartCursorBlink:
+        success = EnableCursorBlinking(enable);
         break;
     default:
         // If no functions to call, overall dispatch was a failure.

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -47,6 +47,11 @@ try
 }
 CATCH_LOG_RETURN_FALSE()
 
+bool TerminalDispatch::CursorVisibility(const bool isVisible) noexcept
+{
+    return _terminalApi.SetCursorVisibility(isVisible);
+}
+
 bool TerminalDispatch::CursorForward(const size_t distance) noexcept
 try
 {
@@ -377,6 +382,9 @@ bool TerminalDispatch::_PrivateModeParamsHelper(const DispatchTypes::PrivateMode
         break;
     case DispatchTypes::PrivateModeParams::ALTERNATE_SCROLL:
         success = EnableAlternateScroll(enable);
+        break;
+    case DispatchTypes::PrivateModeParams::DECTCEM_TextCursorEnableMode:
+        success = CursorVisibility(enable);
         break;
     default:
         // If no functions to call, overall dispatch was a failure.

--- a/src/cascadia/TerminalCore/TerminalDispatch.hpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.hpp
@@ -18,6 +18,8 @@ public:
     bool CursorPosition(const size_t line,
                         const size_t column) noexcept override; // CUP
 
+    bool CursorVisibility(const bool isVisible) noexcept override; // DECTCEM
+
     bool CursorForward(const size_t distance) noexcept override;
     bool CursorBackward(const size_t distance) noexcept override;
     bool CursorUp(const size_t distance) noexcept override;

--- a/src/cascadia/TerminalCore/TerminalDispatch.hpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.hpp
@@ -19,6 +19,7 @@ public:
                         const size_t column) noexcept override; // CUP
 
     bool CursorVisibility(const bool isVisible) noexcept override; // DECTCEM
+    bool EnableCursorBlinking(const bool enable) noexcept override; // ATT610
 
     bool CursorForward(const size_t distance) noexcept override;
     bool CursorBackward(const size_t distance) noexcept override;

--- a/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
@@ -24,90 +24,187 @@ namespace TerminalCoreUnitTests
     {
         TEST_CLASS(TerminalApiTest);
 
-        TEST_METHOD(SetColorTableEntry)
-        {
-            Terminal term;
-            DummyRenderTarget emptyRT;
-            term.Create({ 100, 100 }, 0, emptyRT);
+        TEST_METHOD(SetColorTableEntry);
 
-            auto settings = winrt::make<MockTermSettings>(100, 100, 100);
-            term.UpdateSettings(settings);
-
-            VERIFY_IS_TRUE(term.SetColorTableEntry(0, 100));
-            VERIFY_IS_TRUE(term.SetColorTableEntry(128, 100));
-            VERIFY_IS_TRUE(term.SetColorTableEntry(255, 100));
-
-            VERIFY_IS_FALSE(term.SetColorTableEntry(256, 100));
-            VERIFY_IS_FALSE(term.SetColorTableEntry(512, 100));
-        }
+        TEST_METHOD(CursorVisibility);
+        TEST_METHOD(CursorVisibilityViaStateMachine);
 
         // Terminal::_WriteBuffer used to enter infinite loops under certain conditions.
         // This test ensures that Terminal::_WriteBuffer doesn't get stuck when
         // PrintString() is called with more code units than the buffer width.
-        TEST_METHOD(PrintStringOfSurrogatePairs)
-        {
-            DummyRenderTarget renderTarget;
-            Terminal term;
-            term.Create({ 100, 100 }, 3, renderTarget);
-
-            std::wstring text;
-            text.reserve(600);
-
-            for (size_t i = 0; i < 100; ++i)
-            {
-                text.append(L"𐐌𐐜𐐬");
-            }
-
-            struct Baton
-            {
-                HANDLE done;
-                std::wstring text;
-                Terminal* pTerm;
-            } baton{
-                CreateEventW(nullptr, TRUE, FALSE, L"done signal"),
-                text,
-                &term,
-            };
-
-            Log::Comment(L"Launching thread to write data.");
-            const auto thread = CreateThread(
-                nullptr,
-                0,
-                [](LPVOID data) -> DWORD {
-                    const Baton& baton = *reinterpret_cast<Baton*>(data);
-                    Log::Comment(L"Writing data.");
-                    baton.pTerm->PrintString(baton.text);
-                    Log::Comment(L"Setting event.");
-                    SetEvent(baton.done);
-                    return 0;
-                },
-                (LPVOID)&baton,
-                0,
-                nullptr);
-
-            Log::Comment(L"Waiting for the write.");
-            switch (WaitForSingleObject(baton.done, 2000))
-            {
-            case WAIT_OBJECT_0:
-                Log::Comment(L"Didn't get stuck. Success.");
-                break;
-            case WAIT_TIMEOUT:
-                Log::Comment(L"Wait timed out. It got stuck.");
-                Log::Result(WEX::Logging::TestResults::Failed);
-                break;
-            case WAIT_FAILED:
-                Log::Comment(L"Wait failed for some reason. We didn't expect this.");
-                Log::Result(WEX::Logging::TestResults::Failed);
-                break;
-            default:
-                Log::Comment(L"Wait return code that no one expected. Fail.");
-                Log::Result(WEX::Logging::TestResults::Failed);
-                break;
-            }
-
-            TerminateThread(thread, 0);
-            CloseHandle(baton.done);
-            return;
-        }
+        TEST_METHOD(PrintStringOfSurrogatePairs);
     };
+};
+
+using namespace TerminalCoreUnitTests;
+
+void TerminalApiTest::SetColorTableEntry()
+{
+    Terminal term;
+    DummyRenderTarget emptyRT;
+    term.Create({ 100, 100 }, 0, emptyRT);
+
+    auto settings = winrt::make<MockTermSettings>(100, 100, 100);
+    term.UpdateSettings(settings);
+
+    VERIFY_IS_TRUE(term.SetColorTableEntry(0, 100));
+    VERIFY_IS_TRUE(term.SetColorTableEntry(128, 100));
+    VERIFY_IS_TRUE(term.SetColorTableEntry(255, 100));
+
+    VERIFY_IS_FALSE(term.SetColorTableEntry(256, 100));
+    VERIFY_IS_FALSE(term.SetColorTableEntry(512, 100));
+}
+
+// Terminal::_WriteBuffer used to enter infinite loops under certain conditions.
+// This test ensures that Terminal::_WriteBuffer doesn't get stuck when
+// PrintString() is called with more code units than the buffer width.
+void TerminalApiTest::PrintStringOfSurrogatePairs()
+{
+    DummyRenderTarget renderTarget;
+    Terminal term;
+    term.Create({ 100, 100 }, 3, renderTarget);
+
+    std::wstring text;
+    text.reserve(600);
+
+    for (size_t i = 0; i < 100; ++i)
+    {
+        text.append(L"𐐌𐐜𐐬");
+    }
+
+    struct Baton
+    {
+        HANDLE done;
+        std::wstring text;
+        Terminal* pTerm;
+    } baton{
+        CreateEventW(nullptr, TRUE, FALSE, L"done signal"),
+        text,
+        &term,
+    };
+
+    Log::Comment(L"Launching thread to write data.");
+    const auto thread = CreateThread(
+        nullptr,
+        0,
+        [](LPVOID data) -> DWORD {
+            const Baton& baton = *reinterpret_cast<Baton*>(data);
+            Log::Comment(L"Writing data.");
+            baton.pTerm->PrintString(baton.text);
+            Log::Comment(L"Setting event.");
+            SetEvent(baton.done);
+            return 0;
+        },
+        (LPVOID)&baton,
+        0,
+        nullptr);
+
+    Log::Comment(L"Waiting for the write.");
+    switch (WaitForSingleObject(baton.done, 2000))
+    {
+    case WAIT_OBJECT_0:
+        Log::Comment(L"Didn't get stuck. Success.");
+        break;
+    case WAIT_TIMEOUT:
+        Log::Comment(L"Wait timed out. It got stuck.");
+        Log::Result(WEX::Logging::TestResults::Failed);
+        break;
+    case WAIT_FAILED:
+        Log::Comment(L"Wait failed for some reason. We didn't expect this.");
+        Log::Result(WEX::Logging::TestResults::Failed);
+        break;
+    default:
+        Log::Comment(L"Wait return code that no one expected. Fail.");
+        Log::Result(WEX::Logging::TestResults::Failed);
+        break;
+    }
+
+    TerminateThread(thread, 0);
+    CloseHandle(baton.done);
+    return;
+}
+
+void TerminalApiTest::CursorVisibility()
+{
+    // GH#3093 - Cursor Visibility and On states shouldn't affect each other
+    Terminal term;
+    DummyRenderTarget emptyRT;
+    term.Create({ 100, 100 }, 0, emptyRT);
+
+    VERIFY_IS_TRUE(term._buffer->GetCursor().IsVisible());
+    VERIFY_IS_TRUE(term._buffer->GetCursor().IsOn());
+    VERIFY_IS_TRUE(term._buffer->GetCursor().IsBlinkingAllowed());
+
+    term.SetCursorOn(false);
+    VERIFY_IS_TRUE(term._buffer->GetCursor().IsVisible());
+    VERIFY_IS_FALSE(term._buffer->GetCursor().IsOn());
+    VERIFY_IS_TRUE(term._buffer->GetCursor().IsBlinkingAllowed());
+
+    term.SetCursorOn(true);
+    VERIFY_IS_TRUE(term._buffer->GetCursor().IsVisible());
+    VERIFY_IS_TRUE(term._buffer->GetCursor().IsOn());
+    VERIFY_IS_TRUE(term._buffer->GetCursor().IsBlinkingAllowed());
+
+    term.SetCursorVisibility(false);
+    VERIFY_IS_FALSE(term._buffer->GetCursor().IsVisible());
+    VERIFY_IS_TRUE(term._buffer->GetCursor().IsOn());
+    VERIFY_IS_TRUE(term._buffer->GetCursor().IsBlinkingAllowed());
+
+    term.SetCursorOn(false);
+    VERIFY_IS_FALSE(term._buffer->GetCursor().IsVisible());
+    VERIFY_IS_FALSE(term._buffer->GetCursor().IsOn());
+    VERIFY_IS_TRUE(term._buffer->GetCursor().IsBlinkingAllowed());
+}
+
+void TerminalApiTest::CursorVisibilityViaStateMachine()
+{
+    // This is a nearly literal copy-paste of ScreenBufferTests::TestCursorIsOn, adapted for the Terminal
+    Terminal term;
+    DummyRenderTarget emptyRT;
+    term.Create({ 100, 100 }, 0, emptyRT);
+
+    auto& tbi = *(term._buffer);
+    auto& stateMachine = *(term._stateMachine);
+    auto& cursor = tbi.GetCursor();
+
+    stateMachine.ProcessString(L"Hello World");
+    VERIFY_IS_TRUE(cursor.IsOn());
+    VERIFY_IS_TRUE(cursor.IsBlinkingAllowed());
+    VERIFY_IS_TRUE(cursor.IsVisible());
+
+    stateMachine.ProcessString(L"\x1b[?12l");
+    VERIFY_IS_TRUE(cursor.IsOn());
+    VERIFY_IS_FALSE(cursor.IsBlinkingAllowed());
+    VERIFY_IS_TRUE(cursor.IsVisible());
+
+    stateMachine.ProcessString(L"\x1b[?12h");
+    VERIFY_IS_TRUE(cursor.IsOn());
+    VERIFY_IS_TRUE(cursor.IsBlinkingAllowed());
+    VERIFY_IS_TRUE(cursor.IsVisible());
+
+    cursor.SetIsOn(false);
+    stateMachine.ProcessString(L"\x1b[?12l");
+    VERIFY_IS_TRUE(cursor.IsOn());
+    VERIFY_IS_FALSE(cursor.IsBlinkingAllowed());
+    VERIFY_IS_TRUE(cursor.IsVisible());
+
+    stateMachine.ProcessString(L"\x1b[?12h");
+    VERIFY_IS_TRUE(cursor.IsOn());
+    VERIFY_IS_TRUE(cursor.IsBlinkingAllowed());
+    VERIFY_IS_TRUE(cursor.IsVisible());
+
+    stateMachine.ProcessString(L"\x1b[?25l");
+    VERIFY_IS_TRUE(cursor.IsOn());
+    VERIFY_IS_TRUE(cursor.IsBlinkingAllowed());
+    VERIFY_IS_FALSE(cursor.IsVisible());
+
+    stateMachine.ProcessString(L"\x1b[?25h");
+    VERIFY_IS_TRUE(cursor.IsOn());
+    VERIFY_IS_TRUE(cursor.IsBlinkingAllowed());
+    VERIFY_IS_TRUE(cursor.IsVisible());
+
+    stateMachine.ProcessString(L"\x1b[?12;25l");
+    VERIFY_IS_TRUE(cursor.IsOn());
+    VERIFY_IS_FALSE(cursor.IsBlinkingAllowed());
+    VERIFY_IS_FALSE(cursor.IsVisible());
 }


### PR DESCRIPTION
Adds support for setting the cursor visibility in Terminal. Visibility
is a property entirely independent from whether the cursor is "on" or
not. The cursor blinker _should_ change the "IsOn" property. It was
actually changing the "Visible" property, which was incorrect. This PR
additionally corrects the naming of the method used by the cursor
blinker, and makes it do the right thing.

I added a pair of tests, one taken straight from conhost. In
copy-pasting that test, I took it a step further and implemented
`^[[?12h`, `^[[?12l`, which enables/disables cursor blinking, for the
`TerminalCore`. THIS DOES NOT ADD SUPPORT FOR DISABLING BLINKING IN THE
APP. Conpty doesn't emit the blinking on/off sequences quite yet, but
when it _does_, the Terminal will be ready.

## References
* I'd bet this conflicts with #2892
* This isn't a solution for #1379
* There shockingly isn't an issue for cursor blink state via conpty...?

## PR Checklist
* [x] Closes #3093
* [x] Closes #3499
* [x] Closes #4644
* [x] I work here
* [x] Tests added/passed
* [n/a] Requires documentation to be updated