### PR TITLE
Maintain scrollbar position during a resize operation

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1869,15 +1869,15 @@ std::string TextBuffer::GenRTF(const TextAndColor& rows, const int fontHeightPoi
 // - lastCharacterViewport - Optional. If the caller knows that the last
 //   nonspace character is in a particular Viewport, the caller can provide this
 //   parameter as an optimization, as opposed to searching the entire buffer.
-// - oldRows - Optional. The caller can provide a pair of rows in this parameter
-//   and we'll calculate the position of the _end_ of those rows in the new
-//   buffer. The rows's new value is placed back into this parameter.
+// - positionInfo - Optional. The caller can provide a pair of rows in this
+//   parameter and we'll calculate the position of the _end_ of those rows in
+//   the new buffer. The rows's new value is placed back into this parameter.
 // Return Value:
 // - S_OK if we successfully copied the contents to the new buffer, otherwise an appropriate HRESULT.
 HRESULT TextBuffer::Reflow(TextBuffer& oldBuffer,
                            TextBuffer& newBuffer,
                            const std::optional<Viewport> lastCharacterViewport,
-                           std::optional<std::reference_wrapper<LinesToReflow>> oldRows)
+                           std::optional<std::reference_wrapper<PositionInformation>> positionInfo)
 {
     Cursor& oldCursor = oldBuffer.GetCursor();
     Cursor& newCursor = newBuffer.GetCursor();
@@ -1961,22 +1961,22 @@ HRESULT TextBuffer::Reflow(TextBuffer& oldBuffer,
         // If we found the old row that the caller was interested in, set the
         // out value of that parameter to the cursor's current Y position (the
         // new location of the _end_ of that row in the buffer).
-        if (oldRows.has_value())
+        if (positionInfo.has_value())
         {
             if (!foundOldMutable)
             {
-                if (iOldRow >= oldRows.value().get().mutableViewportTop)
+                if (iOldRow >= positionInfo.value().get().mutableViewportTop)
                 {
-                    oldRows.value().get().mutableViewportTop = newCursor.GetPosition().Y;
+                    positionInfo.value().get().mutableViewportTop = newCursor.GetPosition().Y;
                     foundOldMutable = true;
                 }
             }
 
             if (!foundOldVisible)
             {
-                if (iOldRow >= oldRows.value().get().visibleViewportTop)
+                if (iOldRow >= positionInfo.value().get().visibleViewportTop)
                 {
-                    oldRows.value().get().visibleViewportTop = newCursor.GetPosition().Y;
+                    positionInfo.value().get().visibleViewportTop = newCursor.GetPosition().Y;
                     foundOldVisible = true;
                 }
             }

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1869,9 +1869,9 @@ std::string TextBuffer::GenRTF(const TextAndColor& rows, const int fontHeightPoi
 // - lastCharacterViewport - Optional. If the caller knows that the last
 //   nonspace character is in a particular Viewport, the caller can provide this
 //   parameter as an optimization, as opposed to searching the entire buffer.
-// - oldViewportTop - Optional. The caller can provide a row in this parameter
-//   and we'll calculate the position of the _end_ of that row in the new
-//   buffer. The row's new value is placed back into this parameter.
+// - oldRows - Optional. The caller can provide a pair of rows in this parameter
+//   and we'll calculate the position of the _end_ of those rows in the new
+//   buffer. The rows's new value is placed back into this parameter.
 // Return Value:
 // - S_OK if we successfully copied the contents to the new buffer, otherwise an appropriate HRESULT.
 HRESULT TextBuffer::Reflow(TextBuffer& oldBuffer,

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -161,7 +161,7 @@ public:
                               const std::wstring_view fontFaceName,
                               const COLORREF backgroundColor);
 
-    struct LinesToReflow
+    struct PositionInformation
     {
         short mutableViewportTop{ 0 };
         short visibleViewportTop{ 0 };
@@ -170,7 +170,7 @@ public:
     static HRESULT Reflow(TextBuffer& oldBuffer,
                           TextBuffer& newBuffer,
                           const std::optional<Microsoft::Console::Types::Viewport> lastCharacterViewport,
-                          std::optional<std::reference_wrapper<LinesToReflow>> oldRows);
+                          std::optional<std::reference_wrapper<PositionInformation>> positionInfo);
 
 private:
     std::deque<ROW> _storage;

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -161,10 +161,16 @@ public:
                               const std::wstring_view fontFaceName,
                               const COLORREF backgroundColor);
 
+    struct LinesToReflow
+    {
+        short mutableViewportTop{ 0 };
+        short visibleViewportTop{ 0 };
+    };
+
     static HRESULT Reflow(TextBuffer& oldBuffer,
                           TextBuffer& newBuffer,
                           const std::optional<Microsoft::Console::Types::Viewport> lastCharacterViewport,
-                          std::optional<short>& oldViewportTop);
+                          std::optional<std::reference_wrapper<LinesToReflow>> oldRows);
 
 private:
     std::deque<ROW> _storage;

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -201,8 +201,8 @@ void Terminal::UpdateSettings(winrt::Microsoft::Terminal::Settings::ICoreSetting
                                                      0, // temporarily set size to 0 so it won't render.
                                                      _buffer->GetRenderTarget());
 
-        // Build a LinesToReflow to track the position of both the top of the
-        // mutable viewport and the top of the visible viewport in the new
+        // Build a PositionInformation to track the position of both the top of
+        // the mutable viewport and the top of the visible viewport in the new
         // buffer.
         // * the new value of mutableViewportTop will be used to figure out
         //   where we should place the mutable viewport in the new buffer. This
@@ -211,11 +211,11 @@ void Terminal::UpdateSettings(winrt::Microsoft::Terminal::Settings::ICoreSetting
         // * then new value of visibleViewportTop will be used to calculate the
         //   new scrollOffsett in the new buffer, so that the visible lines on
         //   the sceren remain roughly the same.
-        TextBuffer::LinesToReflow oldRows{ 0 };
+        TextBuffer::PositionInformation oldRows{ 0 };
         oldRows.mutableViewportTop = oldViewportTop;
         oldRows.visibleViewportTop = newVisibleTop;
 
-        std::optional<short> oldViewStart{ oldViewportTop };
+        const std::optional<short> oldViewStart{ oldViewportTop };
         RETURN_IF_FAILED(TextBuffer::Reflow(*_buffer.get(),
                                             *newTextBuffer.get(),
                                             _mutableViewport,

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -210,7 +210,7 @@ void Terminal::UpdateSettings(winrt::Microsoft::Terminal::Settings::ICoreSetting
         //   buffer (as seen below).
         // * the new value of visibleViewportTop will be used to calculate the
         //   new scrollOffsett in the new buffer, so that the visible lines on
-        //   the sceren remain roughly the same.
+        //   the screen remain roughly the same.
         TextBuffer::PositionInformation oldRows{ 0 };
         oldRows.mutableViewportTop = oldViewportTop;
         oldRows.visibleViewportTop = newVisibleTop;

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -187,7 +187,11 @@ void Terminal::UpdateSettings(winrt::Microsoft::Terminal::Settings::ICoreSetting
     const short oldViewportTop = _mutableViewport.Top();
     short newViewportTop = oldViewportTop;
     short newVisibleTop = ::base::saturated_cast<short>(_VisibleStartIndex());
+
+    // If the original buffer had _no_ scroll offset, then we should be at the
+    // bottom in the new buffer as well. Track that case now.
     const bool originalOffsetWasZero = _scrollOffset == 0;
+
     // First allocate a new text buffer to take the place of the current one.
     std::unique_ptr<TextBuffer> newTextBuffer;
     try
@@ -197,6 +201,16 @@ void Terminal::UpdateSettings(winrt::Microsoft::Terminal::Settings::ICoreSetting
                                                      0, // temporarily set size to 0 so it won't render.
                                                      _buffer->GetRenderTarget());
 
+        // Build a LinesToReflow to track the position of both the top of the
+        // mutable viewport and the top of the visible viewport in the new
+        // buffer.
+        // * the new value of mutableViewportTop will be used to figure out
+        //   where we should place the mutable viewport in the new buffer. This
+        //   requires a bit of trickiness to remain consistent with conpty's
+        //   buffer (as seen below).
+        // * then new value of visibleViewportTop will be used to calculate the
+        //   new scrollOffsett in the new buffer, so that the visible lines on
+        //   the sceren remain roughly the same.
         TextBuffer::LinesToReflow oldRows{ 0 };
         oldRows.mutableViewportTop = oldViewportTop;
         oldRows.visibleViewportTop = newVisibleTop;
@@ -323,6 +337,8 @@ void Terminal::UpdateSettings(winrt::Microsoft::Terminal::Settings::ICoreSetting
     // Make sure we don't scroll past the top of the scrollback
     newVisibleTop = std::max<short>(newVisibleTop, 0);
 
+    // If the old scrolloffset was 0, then we weren't scrolled back at all
+    // before, and shouldn't be now either.
     _scrollOffset = originalOffsetWasZero ? 0 : _mutableViewport.Top() - newVisibleTop;
     _NotifyScrollEvent();
 

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -208,7 +208,7 @@ void Terminal::UpdateSettings(winrt::Microsoft::Terminal::Settings::ICoreSetting
         //   where we should place the mutable viewport in the new buffer. This
         //   requires a bit of trickiness to remain consistent with conpty's
         //   buffer (as seen below).
-        // * then new value of visibleViewportTop will be used to calculate the
+        // * the new value of visibleViewportTop will be used to calculate the
         //   new scrollOffsett in the new buffer, so that the visible lines on
         //   the sceren remain roughly the same.
         TextBuffer::PositionInformation oldRows{ 0 };

--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -1414,9 +1414,7 @@ bool SCREEN_INFORMATION::IsMaximizedY() const
     // Save cursor's relative height versus the viewport
     SHORT const sCursorHeightInViewportBefore = _textBuffer->GetCursor().GetPosition().Y - _viewport.Top();
 
-    // Reflow requires a optional<short>& , which can't just be done inline with the call.
-    std::optional<short> unused{ std::nullopt };
-    HRESULT hr = TextBuffer::Reflow(*_textBuffer.get(), *newTextBuffer.get(), std::nullopt, unused);
+    HRESULT hr = TextBuffer::Reflow(*_textBuffer.get(), *newTextBuffer.get(), std::nullopt, std::nullopt);
 
     if (SUCCEEDED(hr))
     {


### PR DESCRIPTION
## Summary of the Pull Request

Currently, when the user resizes the Terminal, we'll snap the visible viewport back to the bottom of the buffer. This PR changes the visible viewport of the Terminal to instead remain in the same relative location it was before the resize.  

## References
Made possible by our sponsors at #4741, and listeners like you. 

## PR Checklist
* [x] Closes #3494
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated

## Detailed Description of the Pull Request / Additional comments

We already hated the `std::optional<short>&` thing I yeet'd into #4741 right at the end to replace a `short*`. So I was already going to change that to a `std::optional<std::reference_wrapper<short>>`, which is more idomatic. But then I was looking through the list of bugs and #3494 caught my eye. I realized it would be trivial to not only track the top of the `mutableViewport` during a resize, but we could use the same code path to track the _visible_ viewport's start as well. 

So basically I'm re-using that bit of code in `Reflow` to calculate the visible viewport's position too.

## Validation Steps Performed

Gotta love just resizing things all day, errday