### PR TITLE
Always remove the drag bar when entering fullscreen

### DIFF
--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -718,6 +718,11 @@ void NonClientIslandWindow::_SetIsFullscreen(const bool fullscreenEnabled)
 {
     IslandWindow::_SetIsFullscreen(fullscreenEnabled);
     _titlebar.Visibility(!fullscreenEnabled ? Visibility::Visible : Visibility::Collapsed);
+    // GH#4224 - When the auto-hide taskbar setting is enabled, then we don't
+    // always get another window message to trigger us to remove the drag bar.
+    // So, make sure to update the size of the drag region here, so that it
+    // _definitely_ goes away.
+    _UpdateIslandRegion();
 }
 
 // Method Description:


### PR DESCRIPTION
## Summary of the Pull Request

  When the auto-hide taskbar setting is enabled, then we don't
  always get another window message to trigger us to remove the drag bar.
  So, make sure to update the size of the drag region here, so that it
  _definitely_ goes away.

## References

## PR Checklist
* [x] Closes #4224
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated

## Validation Steps Performed

Manually tested it