### PR TITLE
Force WslDistroGenerator to timeout after 10s and return Profiles

### DIFF
--- a/src/cascadia/TerminalApp/WslDistroGenerator.cpp
+++ b/src/cascadia/TerminalApp/WslDistroGenerator.cpp
@@ -63,7 +63,7 @@ std::vector<TerminalApp::Profile> WslDistroGenerator::GenerateProfiles()
                                              nullptr,
                                              &si,
                                              &pi));
-    switch (WaitForSingleObject(pi.hProcess, 15000))
+    switch (WaitForSingleObject(pi.hProcess, 10000))
     {
     case WAIT_OBJECT_0:
         break;

--- a/src/cascadia/TerminalApp/WslDistroGenerator.cpp
+++ b/src/cascadia/TerminalApp/WslDistroGenerator.cpp
@@ -63,7 +63,7 @@ std::vector<TerminalApp::Profile> WslDistroGenerator::GenerateProfiles()
                                              nullptr,
                                              &si,
                                              &pi));
-    switch (WaitForSingleObject(pi.hProcess, 10000))
+    switch (WaitForSingleObject(pi.hProcess, 2000))
     {
     case WAIT_OBJECT_0:
         break;

--- a/src/cascadia/TerminalApp/WslDistroGenerator.cpp
+++ b/src/cascadia/TerminalApp/WslDistroGenerator.cpp
@@ -63,13 +63,13 @@ std::vector<TerminalApp::Profile> WslDistroGenerator::GenerateProfiles()
                                              nullptr,
                                              &si,
                                              &pi));
-    switch (WaitForSingleObject(pi.hProcess, INFINITE))
+    switch (WaitForSingleObject(pi.hProcess, 15000))
     {
     case WAIT_OBJECT_0:
         break;
     case WAIT_ABANDONED:
     case WAIT_TIMEOUT:
-        THROW_HR(ERROR_CHILD_NOT_COMPLETE);
+        return profiles;
     case WAIT_FAILED:
         THROW_LAST_ERROR();
     default:


### PR DESCRIPTION
When WSL.exe would hang for users, WslDistroGenerator would also hang
while waiting for its `wsl.exe --list` call to return. The timeout was
`INFINITE` in the `WaitForSingleObject` call, but we should slap a
timeout on it instead (here we choose 2 seconds). In addition, if it
times out, we should also just return profiles and let the Terminal
continue to start up without the WSL distro profiles loaded.

# Validation Steps Performed
Made a sleep 30 executable as the command instead, made sure it hit the
`WAIT_TIMEOUT` and continued to start up without loading my Ubuntu
profile.

Closes #3987