### PR TITLE
Always use the system's locale to render text

### DIFF
--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1983,7 +1983,10 @@ float DxEngine::GetScaling() const noexcept
         DWRITE_FONT_STRETCH stretch = DWRITE_FONT_STRETCH_NORMAL;
         std::wstring localeName = _GetLocaleName();
 
-        const auto face = _ResolveFontFaceWithFallback(fontName, weight, stretch, style, localeName);
+        // _ResolveFontFaceWithFallback overrides the last argument with the locale name of the font,
+        // but we should use the system's locale to render the text.
+        std::wstring fontLocaleName = localeName;
+        const auto face = _ResolveFontFaceWithFallback(fontName, weight, stretch, style, fontLocaleName);
 
         DWRITE_FONT_METRICS1 fontMetrics;
         face->GetMetrics(&fontMetrics);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Always use the system's locale to render text to ensure the correct font variants are used.

`_ResolveFontFaceWithFallback()` overrides the last argument with the locale name of the font, but users normally configure fonts with latin alphabet only and use font linking to display non-latin characters, which causes the the locale names of the latin fonts are used to render the non-latin fonts. https://github.com/microsoft/terminal/issues/4508#issuecomment-598552472

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #4508
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation
On a zh-hans system, simplified Chinese hans are used after this patch (above), versus Japanese hans before (below).
![](https://user-images.githubusercontent.com/1297550/76591589-c9b06080-652b-11ea-904a-f7dd6d178372.png)
