### PR TITLE
Improve wide glyph support in UIA

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1266,7 +1266,7 @@ bool TextBuffer::MoveToPreviousWord(COORD& pos, std::wstring_view wordDelimiters
 // - pos - a COORD on the word you are currently on
 // Return Value:
 // - pos - The COORD for the first cell of the current glyph (inclusive)
-const til::point TextBuffer::GetGlyphStart(til::point pos) const
+const til::point TextBuffer::GetGlyphStart(const til::point pos) const
 {
     COORD resultPos = pos;
 
@@ -1285,7 +1285,7 @@ const til::point TextBuffer::GetGlyphStart(til::point pos) const
 // - pos - a COORD on the word you are currently on
 // Return Value:
 // - pos - The COORD for the last cell of the current glyph (exclusive)
-const til::point TextBuffer::GetGlyphEnd(til::point pos) const
+const til::point TextBuffer::GetGlyphEnd(const til::point pos) const
 {
     COORD resultPos = pos;
 

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1315,7 +1315,7 @@ bool TextBuffer::MoveToNextGlyph(til::point& pos, bool allowBottomExclusive) con
     // try to move. If we can't, we're done.
     const auto bufferSize = GetSize();
     const bool success = bufferSize.IncrementInBounds(resultPos, allowBottomExclusive);
-    if (success && GetCellDataAt(resultPos)->DbcsAttr().IsTrailing())
+    if (resultPos != bufferSize.EndExclusive() && GetCellDataAt(resultPos)->DbcsAttr().IsTrailing())
     {
         bufferSize.IncrementInBounds(resultPos, allowBottomExclusive);
     }
@@ -1339,7 +1339,7 @@ bool TextBuffer::MoveToPreviousGlyph(til::point& pos, bool allowBottomExclusive)
     // try to move. If we can't, we're done.
     const auto bufferSize = GetSize();
     const bool success = bufferSize.DecrementInBounds(resultPos, allowBottomExclusive);
-    if (success && GetCellDataAt(resultPos)->DbcsAttr().IsLeading())
+    if (resultPos != bufferSize.EndExclusive() && GetCellDataAt(resultPos)->DbcsAttr().IsLeading())
     {
         bufferSize.DecrementInBounds(resultPos, allowBottomExclusive);
     }

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1271,7 +1271,7 @@ const til::point TextBuffer::GetGlyphStart(const til::point pos) const
     COORD resultPos = pos;
 
     const auto bufferSize = GetSize();
-    if (resultPos == bufferSize.EndExclusive() || GetCellDataAt(resultPos)->DbcsAttr().IsTrailing())
+    if (resultPos != bufferSize.EndExclusive() && GetCellDataAt(resultPos)->DbcsAttr().IsTrailing())
     {
         bufferSize.DecrementInBounds(resultPos, true);
     }
@@ -1290,7 +1290,7 @@ const til::point TextBuffer::GetGlyphEnd(const til::point pos) const
     COORD resultPos = pos;
 
     const auto bufferSize = GetSize();
-    if (resultPos == bufferSize.EndExclusive() || GetCellDataAt(resultPos)->DbcsAttr().IsLeading())
+    if (resultPos != bufferSize.EndExclusive() && GetCellDataAt(resultPos)->DbcsAttr().IsLeading())
     {
         bufferSize.IncrementInBounds(resultPos, true);
     }

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1261,6 +1261,94 @@ bool TextBuffer::MoveToPreviousWord(COORD& pos, std::wstring_view wordDelimiters
 }
 
 // Method Description:
+// - Update pos to be the beginning of the current glyph/character. This is used for accessibility
+// Arguments:
+// - pos - a COORD on the word you are currently on
+// Return Value:
+// - pos - The COORD for the first cell of the current glyph (inclusive)
+const til::point TextBuffer::GetGlyphStart(til::point pos) const
+{
+    COORD resultPos = pos;
+
+    const auto bufferSize = GetSize();
+    if (resultPos == bufferSize.EndExclusive() || GetCellDataAt(resultPos)->DbcsAttr().IsTrailing())
+    {
+        bufferSize.DecrementInBounds(resultPos, true);
+    }
+
+    return resultPos;
+}
+
+// Method Description:
+// - Update pos to be the end of the current glyph/character. This is used for accessibility
+// Arguments:
+// - pos - a COORD on the word you are currently on
+// Return Value:
+// - pos - The COORD for the last cell of the current glyph (exclusive)
+const til::point TextBuffer::GetGlyphEnd(til::point pos) const
+{
+    COORD resultPos = pos;
+
+    const auto bufferSize = GetSize();
+    if (resultPos == bufferSize.EndExclusive() || GetCellDataAt(resultPos)->DbcsAttr().IsLeading())
+    {
+        bufferSize.IncrementInBounds(resultPos, true);
+    }
+
+    // increment one more time to become exclusive
+    bufferSize.IncrementInBounds(resultPos, true);
+    return resultPos;
+}
+
+// Method Description:
+// - Update pos to be the beginning of the next glyph/character. This is used for accessibility
+// Arguments:
+// - pos - a COORD on the word you are currently on
+// - allowBottomExclusive - allow the nonexistent end-of-buffer cell to be encountered
+// Return Value:
+// - true, if successfully updated pos. False, if we are unable to move (usually due to a buffer boundary)
+// - pos - The COORD for the first cell of the current glyph (inclusive)
+bool TextBuffer::MoveToNextGlyph(til::point& pos, bool allowBottomExclusive) const
+{
+    COORD resultPos = pos;
+
+    // try to move. If we can't, we're done.
+    const auto bufferSize = GetSize();
+    bool success = bufferSize.IncrementInBounds(resultPos, allowBottomExclusive);
+    if (success && GetCellDataAt(resultPos)->DbcsAttr().IsTrailing())
+    {
+        bufferSize.IncrementInBounds(resultPos, allowBottomExclusive);
+    }
+
+    pos = resultPos;
+    return success;
+}
+
+// Method Description:
+// - Update pos to be the beginning of the previous glyph/character. This is used for accessibility
+// Arguments:
+// - pos - a COORD on the word you are currently on
+// - allowBottomExclusive - allow the nonexistent end-of-buffer cell to be encountered
+// Return Value:
+// - true, if successfully updated pos. False, if we are unable to move (usually due to a buffer boundary)
+// - pos - The COORD for the first cell of the previous glyph (inclusive)
+bool TextBuffer::MoveToPreviousGlyph(til::point& pos, bool allowBottomExclusive) const
+{
+    COORD resultPos = pos;
+
+    // try to move. If we can't, we're done.
+    const auto bufferSize = GetSize();
+    bool success = bufferSize.DecrementInBounds(resultPos, allowBottomExclusive);
+    if (success && GetCellDataAt(resultPos)->DbcsAttr().IsLeading())
+    {
+        bufferSize.DecrementInBounds(resultPos, allowBottomExclusive);
+    }
+
+    pos = resultPos;
+    return success;
+}
+
+// Method Description:
 // - Determines the line-by-line rectangles based on two COORDs
 // - expands the rectangles to support wide glyphs
 // - used for selection rects and UIA bounding rects

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1314,7 +1314,7 @@ bool TextBuffer::MoveToNextGlyph(til::point& pos, bool allowBottomExclusive) con
 
     // try to move. If we can't, we're done.
     const auto bufferSize = GetSize();
-    bool success = bufferSize.IncrementInBounds(resultPos, allowBottomExclusive);
+    const bool success = bufferSize.IncrementInBounds(resultPos, allowBottomExclusive);
     if (success && GetCellDataAt(resultPos)->DbcsAttr().IsTrailing())
     {
         bufferSize.IncrementInBounds(resultPos, allowBottomExclusive);
@@ -1338,7 +1338,7 @@ bool TextBuffer::MoveToPreviousGlyph(til::point& pos, bool allowBottomExclusive)
 
     // try to move. If we can't, we're done.
     const auto bufferSize = GetSize();
-    bool success = bufferSize.DecrementInBounds(resultPos, allowBottomExclusive);
+    const bool success = bufferSize.DecrementInBounds(resultPos, allowBottomExclusive);
     if (success && GetCellDataAt(resultPos)->DbcsAttr().IsLeading())
     {
         bufferSize.DecrementInBounds(resultPos, allowBottomExclusive);

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -134,8 +134,8 @@ public:
     bool MoveToNextWord(COORD& pos, const std::wstring_view wordDelimiters, COORD lastCharPos) const;
     bool MoveToPreviousWord(COORD& pos, const std::wstring_view wordDelimiters) const;
 
-    const til::point GetGlyphStart(til::point pos) const;
-    const til::point GetGlyphEnd(til::point pos) const;
+    const til::point GetGlyphStart(const til::point pos) const;
+    const til::point GetGlyphEnd(const til::point pos) const;
     bool MoveToNextGlyph(til::point& pos, bool allowBottomExclusive = false) const;
     bool MoveToPreviousGlyph(til::point& pos, bool allowBottomExclusive = false) const;
 

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -134,6 +134,11 @@ public:
     bool MoveToNextWord(COORD& pos, const std::wstring_view wordDelimiters, COORD lastCharPos) const;
     bool MoveToPreviousWord(COORD& pos, const std::wstring_view wordDelimiters) const;
 
+    const til::point GetGlyphStart(til::point pos) const;
+    const til::point GetGlyphEnd(til::point pos) const;
+    bool MoveToNextGlyph(til::point& pos, bool allowBottomExclusive = false) const;
+    bool MoveToPreviousGlyph(til::point& pos, bool allowBottomExclusive = false) const;
+
     const std::vector<SMALL_RECT> GetTextRects(COORD start, COORD end, bool blockSelection = false) const;
 
     class TextAndColor

--- a/src/interactivity/win32/ut_interactivity_win32/UiaTextRangeTests.cpp
+++ b/src/interactivity/win32/ut_interactivity_win32/UiaTextRangeTests.cpp
@@ -83,15 +83,15 @@ class UiaTextRangeTests
     struct ExpectedResult
     {
         int moveAmt;
-        til::point start;
-        til::point end;
+        COORD start;
+        COORD end;
     };
 
     struct MoveTest
     {
         std::wstring comment;
-        til::point start;
-        til::point end;
+        COORD start;
+        COORD end;
         int moveAmt;
         ExpectedResult expected;
     };
@@ -99,8 +99,8 @@ class UiaTextRangeTests
     struct MoveEndpointTest
     {
         std::wstring comment;
-        til::point start;
-        til::point end;
+        COORD start;
+        COORD end;
         int moveAmt;
         TextPatternRangeEndpoint endpoint;
         ExpectedResult expected;
@@ -326,8 +326,8 @@ class UiaTextRangeTests
 
         struct TextUnitBoundaries
         {
-            til::point start;
-            til::point end;
+            COORD start;
+            COORD end;
         };
 
         const std::map<TextUnit, TextUnitBoundaries> textUnitBoundaries = {
@@ -375,7 +375,7 @@ class UiaTextRangeTests
             if (textUnit != TextUnit_Character)
             {
                 Log::Comment(NoThrowString().Format(L"%s - Test 2", toString(textUnit)));
-                const til::point end = { boundaries.start.x() + 1, boundaries.start.y() };
+                const COORD end = { boundaries.start.X + 1, boundaries.start.Y };
                 verifyExpansion(textUnit, boundaries.start, end);
             }
 
@@ -387,7 +387,7 @@ class UiaTextRangeTests
             if (textUnit != TextUnit_Character && textUnit != TextUnit_Document)
             {
                 Log::Comment(NoThrowString().Format(L"%s - Test 4", toString(textUnit)));
-                const til::point end = { boundaries.end.x() + 1, boundaries.end.y() };
+                const COORD end = { boundaries.end.X + 1, boundaries.end.Y };
                 verifyExpansion(textUnit, boundaries.start, end);
             }
 
@@ -395,7 +395,7 @@ class UiaTextRangeTests
             if (textUnit != TextUnit_Character)
             {
                 Log::Comment(NoThrowString().Format(L"%s - Test 5", toString(textUnit)));
-                const til::point start = { boundaries.start.x() + 1, boundaries.start.y() };
+                const COORD start = { boundaries.start.X + 1, boundaries.start.Y };
                 verifyExpansion(textUnit, start, start);
             }
 
@@ -403,8 +403,8 @@ class UiaTextRangeTests
             if (textUnit != TextUnit_Character)
             {
                 Log::Comment(NoThrowString().Format(L"%s - Test 6", toString(textUnit)));
-                const til::point start = { boundaries.start.x() + 1, boundaries.start.y() };
-                const til::point end = { start.x() + 1, start.y() };
+                const COORD start = { boundaries.start.X + 1, boundaries.start.Y };
+                const COORD end = { start.X + 1, start.Y };
                 verifyExpansion(textUnit, start, end);
             }
 
@@ -412,7 +412,7 @@ class UiaTextRangeTests
             if (textUnit != TextUnit_Character)
             {
                 Log::Comment(NoThrowString().Format(L"%s - Test 7", toString(textUnit)));
-                const til::point start = { boundaries.start.x() + 1, boundaries.start.y() };
+                const COORD start = { boundaries.start.X + 1, boundaries.start.Y };
                 verifyExpansion(textUnit, start, boundaries.end);
             }
 
@@ -420,8 +420,8 @@ class UiaTextRangeTests
             if (textUnit != TextUnit_Character && textUnit != TextUnit_Document)
             {
                 Log::Comment(NoThrowString().Format(L"%s - Test 8", toString(textUnit)));
-                const til::point start = { boundaries.start.x() + 1, boundaries.start.y() };
-                const til::point end = { boundaries.end.x() + 1, boundaries.end.y() };
+                const COORD start = { boundaries.start.X + 1, boundaries.start.Y };
+                const COORD end = { boundaries.end.X + 1, boundaries.end.Y };
                 verifyExpansion(textUnit, start, end);
             }
         }
@@ -429,8 +429,8 @@ class UiaTextRangeTests
 
     TEST_METHOD(MoveEndpointByRange)
     {
-        const til::point start{ 0, 1 };
-        const til::point end{ 1, 2 };
+        const COORD start{ 0, 1 };
+        const COORD end{ 1, 2 };
         Microsoft::WRL::ComPtr<UiaTextRange> utr;
         THROW_IF_FAILED(Microsoft::WRL::MakeAndInitialize<UiaTextRange>(&utr,
                                                                         _pUiaData,
@@ -439,7 +439,7 @@ class UiaTextRangeTests
                                                                         end));
 
         const auto bufferSize = _pTextBuffer->GetSize();
-        const til::point origin = bufferSize.Origin();
+        const auto origin = bufferSize.Origin();
         Microsoft::WRL::ComPtr<UiaTextRange> target;
 
         auto resetTargetUTR = [&]() {

--- a/src/interactivity/win32/ut_interactivity_win32/UiaTextRangeTests.cpp
+++ b/src/interactivity/win32/ut_interactivity_win32/UiaTextRangeTests.cpp
@@ -83,15 +83,15 @@ class UiaTextRangeTests
     struct ExpectedResult
     {
         int moveAmt;
-        COORD start;
-        COORD end;
+        til::point start;
+        til::point end;
     };
 
     struct MoveTest
     {
         std::wstring comment;
-        COORD start;
-        COORD end;
+        til::point start;
+        til::point end;
         int moveAmt;
         ExpectedResult expected;
     };
@@ -99,8 +99,8 @@ class UiaTextRangeTests
     struct MoveEndpointTest
     {
         std::wstring comment;
-        COORD start;
-        COORD end;
+        til::point start;
+        til::point end;
         int moveAmt;
         TextPatternRangeEndpoint endpoint;
         ExpectedResult expected;
@@ -326,8 +326,8 @@ class UiaTextRangeTests
 
         struct TextUnitBoundaries
         {
-            COORD start;
-            COORD end;
+            til::point start;
+            til::point end;
         };
 
         const std::map<TextUnit, TextUnitBoundaries> textUnitBoundaries = {
@@ -375,7 +375,7 @@ class UiaTextRangeTests
             if (textUnit != TextUnit_Character)
             {
                 Log::Comment(NoThrowString().Format(L"%s - Test 2", toString(textUnit)));
-                const COORD end = { boundaries.start.X + 1, boundaries.start.Y };
+                const til::point end = { boundaries.start.x() + 1, boundaries.start.y() };
                 verifyExpansion(textUnit, boundaries.start, end);
             }
 
@@ -387,7 +387,7 @@ class UiaTextRangeTests
             if (textUnit != TextUnit_Character && textUnit != TextUnit_Document)
             {
                 Log::Comment(NoThrowString().Format(L"%s - Test 4", toString(textUnit)));
-                const COORD end = { boundaries.end.X + 1, boundaries.end.Y };
+                const til::point end = { boundaries.end.x() + 1, boundaries.end.y() };
                 verifyExpansion(textUnit, boundaries.start, end);
             }
 
@@ -395,7 +395,7 @@ class UiaTextRangeTests
             if (textUnit != TextUnit_Character)
             {
                 Log::Comment(NoThrowString().Format(L"%s - Test 5", toString(textUnit)));
-                const COORD start = { boundaries.start.X + 1, boundaries.start.Y };
+                const til::point start = { boundaries.start.x() + 1, boundaries.start.y() };
                 verifyExpansion(textUnit, start, start);
             }
 
@@ -403,8 +403,8 @@ class UiaTextRangeTests
             if (textUnit != TextUnit_Character)
             {
                 Log::Comment(NoThrowString().Format(L"%s - Test 6", toString(textUnit)));
-                const COORD start = { boundaries.start.X + 1, boundaries.start.Y };
-                const COORD end = { start.X + 1, start.Y };
+                const til::point start = { boundaries.start.x() + 1, boundaries.start.y() };
+                const til::point end = { start.x() + 1, start.y() };
                 verifyExpansion(textUnit, start, end);
             }
 
@@ -412,7 +412,7 @@ class UiaTextRangeTests
             if (textUnit != TextUnit_Character)
             {
                 Log::Comment(NoThrowString().Format(L"%s - Test 7", toString(textUnit)));
-                const COORD start = { boundaries.start.X + 1, boundaries.start.Y };
+                const til::point start = { boundaries.start.x() + 1, boundaries.start.y() };
                 verifyExpansion(textUnit, start, boundaries.end);
             }
 
@@ -420,8 +420,8 @@ class UiaTextRangeTests
             if (textUnit != TextUnit_Character && textUnit != TextUnit_Document)
             {
                 Log::Comment(NoThrowString().Format(L"%s - Test 8", toString(textUnit)));
-                const COORD start = { boundaries.start.X + 1, boundaries.start.Y };
-                const COORD end = { boundaries.end.X + 1, boundaries.end.Y };
+                const til::point start = { boundaries.start.x() + 1, boundaries.start.y() };
+                const til::point end = { boundaries.end.x() + 1, boundaries.end.y() };
                 verifyExpansion(textUnit, start, end);
             }
         }
@@ -429,8 +429,8 @@ class UiaTextRangeTests
 
     TEST_METHOD(MoveEndpointByRange)
     {
-        const COORD start{ 0, 1 };
-        const COORD end{ 1, 2 };
+        const til::point start{ 0, 1 };
+        const til::point end{ 1, 2 };
         Microsoft::WRL::ComPtr<UiaTextRange> utr;
         THROW_IF_FAILED(Microsoft::WRL::MakeAndInitialize<UiaTextRange>(&utr,
                                                                         _pUiaData,
@@ -439,7 +439,7 @@ class UiaTextRangeTests
                                                                         end));
 
         const auto bufferSize = _pTextBuffer->GetSize();
-        const auto origin = bufferSize.Origin();
+        const til::point origin = bufferSize.Origin();
         Microsoft::WRL::ComPtr<UiaTextRange> target;
 
         auto resetTargetUTR = [&]() {

--- a/src/types/ScreenInfoUiaProviderBase.cpp
+++ b/src/types/ScreenInfoUiaProviderBase.cpp
@@ -256,6 +256,8 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::GetSelection(_Outptr_result_maybenull_
         return hr;
     }
 
+    UiaTracing::TextProvider::GetSelection(*this, *range.Get());
+
     LONG currentIndex = 0;
     hr = SafeArrayPutElement(*ppRetVal, &currentIndex, range.Detach());
     if (FAILED(hr))
@@ -265,7 +267,6 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::GetSelection(_Outptr_result_maybenull_
         return hr;
     }
 
-    UiaTracing::TextProvider::GetSelection(*this, *range.Get());
     return S_OK;
 }
 

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -323,7 +323,7 @@ try
     const auto sensitivity = ignoreCase ? Search::Sensitivity::CaseInsensitive : Search::Sensitivity::CaseSensitive;
 
     auto searchDirection = Search::Direction::Forward;
-    COORD searchAnchor = _start;
+    auto searchAnchor = _start;
     if (searchBackward)
     {
         searchDirection = Search::Direction::Backward;
@@ -405,7 +405,7 @@ IFACEMETHODIMP UiaTextRangeBase::GetBoundingRectangles(_Outptr_result_maybenull_
         const auto viewportEnd = viewport.EndExclusive();
 
         // startAnchor: the earliest COORD we will get a bounding rect for
-        COORD startAnchor = GetEndpoint(TextPatternRangeEndpoint_Start);
+        auto startAnchor = GetEndpoint(TextPatternRangeEndpoint_Start);
         if (bufferSize.CompareInBounds(startAnchor, viewportOrigin, true) < 0)
         {
             // earliest we can be is the origin
@@ -413,7 +413,7 @@ IFACEMETHODIMP UiaTextRangeBase::GetBoundingRectangles(_Outptr_result_maybenull_
         }
 
         // endAnchor: the latest COORD we will get a bounding rect for
-        COORD endAnchor = GetEndpoint(TextPatternRangeEndpoint_End);
+        auto endAnchor = GetEndpoint(TextPatternRangeEndpoint_End);
         if (bufferSize.CompareInBounds(endAnchor, viewportEnd, true) > 0)
         {
             // latest we can be is the viewport end
@@ -526,7 +526,7 @@ try
         const auto bufferSize = buffer.GetSize();
 
         // convert _end to be inclusive
-        COORD inclusiveEnd = _end;
+        auto inclusiveEnd = _end;
         bufferSize.DecrementInBounds(inclusiveEnd, true);
 
         const auto textRects = buffer.GetTextRects(_start, inclusiveEnd, _blockRange);
@@ -687,7 +687,7 @@ try
     }
     else
     {
-        COORD inclusiveEnd = _end;
+        auto inclusiveEnd = _end;
         _pData->GetTextBuffer().GetSize().DecrementInBounds(inclusiveEnd);
         _pData->SelectNewRegion(_start, inclusiveEnd);
     }
@@ -967,11 +967,11 @@ void UiaTextRangeBase::_moveEndpointByUnitWord(_In_ const int moveCount,
     const auto& buffer = _pData->GetTextBuffer();
     const auto bufferSize = _getBufferSize();
     const auto bufferOrigin = bufferSize.Origin();
-    const til::point bufferEnd = bufferSize.EndExclusive();
+    const auto bufferEnd = bufferSize.EndExclusive();
     const auto lastCharPos = buffer.GetLastNonSpaceCharacter(bufferSize);
 
     auto resultPos = GetEndpoint(endpoint);
-    COORD nextPos = resultPos;
+    auto nextPos = resultPos;
 
     bool success = true;
     while (std::abs(*pAmountMoved) < std::abs(moveCount) && success)
@@ -1060,7 +1060,7 @@ void UiaTextRangeBase::_moveEndpointByUnitLine(_In_ const int moveCount,
     auto resultPos = GetEndpoint(endpoint);
     while (std::abs(*pAmountMoved) < std::abs(moveCount) && success)
     {
-        COORD nextPos = resultPos;
+        auto nextPos = resultPos;
         switch (moveDirection)
         {
         case MovementDirection::Forward:
@@ -1144,7 +1144,7 @@ void UiaTextRangeBase::_moveEndpointByUnitDocument(_In_ const int moveCount,
     {
     case MovementDirection::Forward:
     {
-        const til::point documentEnd = bufferSize.EndExclusive();
+        const auto documentEnd = bufferSize.EndExclusive();
         if (preventBufferEnd || target == documentEnd)
         {
             return;
@@ -1158,7 +1158,7 @@ void UiaTextRangeBase::_moveEndpointByUnitDocument(_In_ const int moveCount,
     }
     case MovementDirection::Backward:
     {
-        const til::point documentBegin = bufferSize.Origin();
+        const auto documentBegin = bufferSize.Origin();
         if (target == documentBegin)
         {
             return;

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -136,7 +136,7 @@ const IdType UiaTextRangeBase::GetId() const noexcept
     return _id;
 }
 
-const til::point UiaTextRangeBase::GetEndpoint(TextPatternRangeEndpoint endpoint) const noexcept
+const COORD UiaTextRangeBase::GetEndpoint(TextPatternRangeEndpoint endpoint) const noexcept
 {
     switch (endpoint)
     {
@@ -158,8 +158,6 @@ const til::point UiaTextRangeBase::GetEndpoint(TextPatternRangeEndpoint endpoint
 // - true if range is degenerate, false otherwise.
 bool UiaTextRangeBase::SetEndpoint(TextPatternRangeEndpoint endpoint, const COORD val) noexcept
 {
-#pragma warning(push)
-#pragma warning(disable : 26447)
     const auto bufferSize = _getBufferSize();
     switch (endpoint)
     {
@@ -186,7 +184,6 @@ bool UiaTextRangeBase::SetEndpoint(TextPatternRangeEndpoint endpoint, const COOR
     }
     return IsDegenerate();
 }
-#pragma warning(pop)
 
 // Routine Description:
 // - returns true if the range is currently degenerate (empty range).
@@ -285,8 +282,9 @@ IFACEMETHODIMP UiaTextRangeBase::ExpandToEnclosingUnit(_In_ TextUnit unit) noexc
         else if (unit <= TextUnit_Line)
         {
             // expand to line
-            _start = til::point{ ptrdiff_t{ 0 }, _start.y() };
-            _end = til::point{ ptrdiff_t{ 0 }, base::ClampAdd(_start.y(), 1) };
+            _start.X = 0;
+            _end.X = 0;
+            _end.Y = base::ClampAdd(_start.Y, 1);
         }
         else
         {
@@ -724,8 +722,8 @@ try
     const auto oldViewport = _pData->GetViewport().ToInclusive();
     const auto viewportHeight = _getViewportHeight(oldViewport);
     // range rows
-    const base::ClampedNumeric<short> startScreenInfoRow = _start.y();
-    const base::ClampedNumeric<short> endScreenInfoRow = _end.y();
+    const base::ClampedNumeric<short> startScreenInfoRow = _start.Y;
+    const base::ClampedNumeric<short> endScreenInfoRow = _end.Y;
     // screen buffer rows
     const base::ClampedNumeric<short> topRow = 0;
     const base::ClampedNumeric<short> bottomRow = _pData->GetTextBuffer().TotalRowCount() - 1;
@@ -899,7 +897,7 @@ void UiaTextRangeBase::_getBoundingRect(const til::rectangle textRect, _Inout_ s
 void UiaTextRangeBase::_moveEndpointByUnitCharacter(_In_ const int moveCount,
                                                     _In_ const TextPatternRangeEndpoint endpoint,
                                                     _Out_ gsl::not_null<int*> const pAmountMoved,
-                                                    _In_ const bool preventBufferEnd)
+                                                    _In_ const bool preventBufferEnd) noexcept
 {
     *pAmountMoved = 0;
 
@@ -913,7 +911,7 @@ void UiaTextRangeBase::_moveEndpointByUnitCharacter(_In_ const int moveCount,
     const auto& buffer = _pData->GetTextBuffer();
 
     bool success = true;
-    auto target = GetEndpoint(endpoint);
+    til::point target = GetEndpoint(endpoint);
     while (std::abs(*pAmountMoved) < std::abs(moveCount) && success)
     {
         switch (moveDirection)
@@ -1045,7 +1043,7 @@ void UiaTextRangeBase::_moveEndpointByUnitWord(_In_ const int moveCount,
 void UiaTextRangeBase::_moveEndpointByUnitLine(_In_ const int moveCount,
                                                _In_ const TextPatternRangeEndpoint endpoint,
                                                _Out_ gsl::not_null<int*> const pAmountMoved,
-                                               _In_ const bool preventBufferEnd)
+                                               _In_ const bool preventBufferEnd) noexcept
 {
     *pAmountMoved = 0;
 
@@ -1129,7 +1127,7 @@ void UiaTextRangeBase::_moveEndpointByUnitLine(_In_ const int moveCount,
 void UiaTextRangeBase::_moveEndpointByUnitDocument(_In_ const int moveCount,
                                                    _In_ const TextPatternRangeEndpoint endpoint,
                                                    _Out_ gsl::not_null<int*> const pAmountMoved,
-                                                   _In_ const bool preventBufferEnd)
+                                                   _In_ const bool preventBufferEnd) noexcept
 {
     *pAmountMoved = 0;
 

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -158,6 +158,8 @@ const til::point UiaTextRangeBase::GetEndpoint(TextPatternRangeEndpoint endpoint
 // - true if range is degenerate, false otherwise.
 bool UiaTextRangeBase::SetEndpoint(TextPatternRangeEndpoint endpoint, const COORD val) noexcept
 {
+#pragma warning(push)
+#pragma warning(disable : 26447)
     const auto bufferSize = _getBufferSize();
     switch (endpoint)
     {
@@ -184,6 +186,7 @@ bool UiaTextRangeBase::SetEndpoint(TextPatternRangeEndpoint endpoint, const COOR
     }
     return IsDegenerate();
 }
+#pragma warning(pop)
 
 // Routine Description:
 // - returns true if the range is currently degenerate (empty range).
@@ -896,7 +899,7 @@ void UiaTextRangeBase::_getBoundingRect(const til::rectangle textRect, _Inout_ s
 void UiaTextRangeBase::_moveEndpointByUnitCharacter(_In_ const int moveCount,
                                                     _In_ const TextPatternRangeEndpoint endpoint,
                                                     _Out_ gsl::not_null<int*> const pAmountMoved,
-                                                    _In_ const bool preventBufferEnd) noexcept
+                                                    _In_ const bool preventBufferEnd)
 {
     *pAmountMoved = 0;
 
@@ -1042,7 +1045,7 @@ void UiaTextRangeBase::_moveEndpointByUnitWord(_In_ const int moveCount,
 void UiaTextRangeBase::_moveEndpointByUnitLine(_In_ const int moveCount,
                                                _In_ const TextPatternRangeEndpoint endpoint,
                                                _Out_ gsl::not_null<int*> const pAmountMoved,
-                                               _In_ const bool preventBufferEnd) noexcept
+                                               _In_ const bool preventBufferEnd)
 {
     *pAmountMoved = 0;
 
@@ -1126,7 +1129,7 @@ void UiaTextRangeBase::_moveEndpointByUnitLine(_In_ const int moveCount,
 void UiaTextRangeBase::_moveEndpointByUnitDocument(_In_ const int moveCount,
                                                    _In_ const TextPatternRangeEndpoint endpoint,
                                                    _Out_ gsl::not_null<int*> const pAmountMoved,
-                                                   _In_ const bool preventBufferEnd) noexcept
+                                                   _In_ const bool preventBufferEnd)
 {
     *pAmountMoved = 0;
 

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -897,7 +897,7 @@ void UiaTextRangeBase::_getBoundingRect(const til::rectangle textRect, _Inout_ s
 void UiaTextRangeBase::_moveEndpointByUnitCharacter(_In_ const int moveCount,
                                                     _In_ const TextPatternRangeEndpoint endpoint,
                                                     _Out_ gsl::not_null<int*> const pAmountMoved,
-                                                    _In_ const bool preventBufferEnd) noexcept
+                                                    _In_ const bool preventBufferEnd)
 {
     *pAmountMoved = 0;
 

--- a/src/types/UiaTextRangeBase.hpp
+++ b/src/types/UiaTextRangeBase.hpp
@@ -170,7 +170,7 @@ namespace Microsoft::Console::Types
         _moveEndpointByUnitCharacter(_In_ const int moveCount,
                                      _In_ const TextPatternRangeEndpoint endpoint,
                                      gsl::not_null<int*> const pAmountMoved,
-                                     _In_ const bool preventBufferEnd = false) noexcept;
+                                     _In_ const bool preventBufferEnd = false);
 
         void
         _moveEndpointByUnitWord(_In_ const int moveCount,

--- a/src/types/UiaTextRangeBase.hpp
+++ b/src/types/UiaTextRangeBase.hpp
@@ -85,7 +85,7 @@ namespace Microsoft::Console::Types
         ~UiaTextRangeBase() = default;
 
         const IdType GetId() const noexcept;
-        const COORD GetEndpoint(TextPatternRangeEndpoint endpoint) const noexcept;
+        const til::point GetEndpoint(TextPatternRangeEndpoint endpoint) const noexcept;
         bool SetEndpoint(TextPatternRangeEndpoint endpoint, const COORD val) noexcept;
         const bool IsDegenerate() const noexcept;
 

--- a/src/types/UiaTextRangeBase.hpp
+++ b/src/types/UiaTextRangeBase.hpp
@@ -170,7 +170,7 @@ namespace Microsoft::Console::Types
         _moveEndpointByUnitCharacter(_In_ const int moveCount,
                                      _In_ const TextPatternRangeEndpoint endpoint,
                                      gsl::not_null<int*> const pAmountMoved,
-                                     _In_ const bool preventBufferEnd = false) noexcept;
+                                     _In_ const bool preventBufferEnd = false);
 
         void
         _moveEndpointByUnitWord(_In_ const int moveCount,
@@ -182,13 +182,13 @@ namespace Microsoft::Console::Types
         _moveEndpointByUnitLine(_In_ const int moveCount,
                                 _In_ const TextPatternRangeEndpoint endpoint,
                                 gsl::not_null<int*> const pAmountMoved,
-                                _In_ const bool preventBufferEnd = false) noexcept;
+                                _In_ const bool preventBufferEnd = false);
 
         void
         _moveEndpointByUnitDocument(_In_ const int moveCount,
                                     _In_ const TextPatternRangeEndpoint endpoint,
                                     gsl::not_null<int*> const pAmountMoved,
-                                    _In_ const bool preventBufferEnd = false) noexcept;
+                                    _In_ const bool preventBufferEnd = false);
 
 #ifdef UNIT_TESTING
         friend class ::UiaTextRangeTests;

--- a/src/types/UiaTextRangeBase.hpp
+++ b/src/types/UiaTextRangeBase.hpp
@@ -85,7 +85,7 @@ namespace Microsoft::Console::Types
         ~UiaTextRangeBase() = default;
 
         const IdType GetId() const noexcept;
-        const til::point GetEndpoint(TextPatternRangeEndpoint endpoint) const noexcept;
+        const COORD GetEndpoint(TextPatternRangeEndpoint endpoint) const noexcept;
         bool SetEndpoint(TextPatternRangeEndpoint endpoint, const COORD val) noexcept;
         const bool IsDegenerate() const noexcept;
 
@@ -170,7 +170,7 @@ namespace Microsoft::Console::Types
         _moveEndpointByUnitCharacter(_In_ const int moveCount,
                                      _In_ const TextPatternRangeEndpoint endpoint,
                                      gsl::not_null<int*> const pAmountMoved,
-                                     _In_ const bool preventBufferEnd = false);
+                                     _In_ const bool preventBufferEnd = false) noexcept;
 
         void
         _moveEndpointByUnitWord(_In_ const int moveCount,
@@ -182,13 +182,13 @@ namespace Microsoft::Console::Types
         _moveEndpointByUnitLine(_In_ const int moveCount,
                                 _In_ const TextPatternRangeEndpoint endpoint,
                                 gsl::not_null<int*> const pAmountMoved,
-                                _In_ const bool preventBufferEnd = false);
+                                _In_ const bool preventBufferEnd = false) noexcept;
 
         void
         _moveEndpointByUnitDocument(_In_ const int moveCount,
                                     _In_ const TextPatternRangeEndpoint endpoint,
                                     gsl::not_null<int*> const pAmountMoved,
-                                    _In_ const bool preventBufferEnd = false);
+                                    _In_ const bool preventBufferEnd = false) noexcept;
 
 #ifdef UNIT_TESTING
         friend class ::UiaTextRangeTests;

--- a/src/types/UiaTracing.cpp
+++ b/src/types/UiaTracing.cpp
@@ -38,8 +38,8 @@ try
 
     std::wstringstream stream;
     stream << " _id: " << utr.GetId();
-    stream << " _start: { " << start.X << ", " << start.Y << " }";
-    stream << " _end: { " << end.X << ", " << end.Y << " }";
+    stream << " _start: { " << start.x() << ", " << start.y() << " }";
+    stream << " _end: { " << end.x() << ", " << end.y() << " }";
     stream << " _degenerate: " << utr.IsDegenerate();
     stream << " _wordDelimiters: " << utr._wordDelimiters;
     stream << " content: " << utr._getTextValue();
@@ -88,9 +88,9 @@ inline std::wstring UiaTracing::_getValue(const TextUnit unit) noexcept
 
 void UiaTracing::TextRange::Constructor(const UiaTextRangeBase& result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::Constructor",
@@ -101,9 +101,9 @@ void UiaTracing::TextRange::Constructor(const UiaTextRangeBase& result) noexcept
 
 void UiaTracing::TextRange::Clone(const UiaTextRangeBase& utr, const UiaTextRangeBase& result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::Clone",
@@ -115,9 +115,9 @@ void UiaTracing::TextRange::Clone(const UiaTextRangeBase& utr, const UiaTextRang
 
 void UiaTracing::TextRange::Compare(const UiaTextRangeBase& utr, const UiaTextRangeBase& other, bool result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::Compare",
@@ -130,9 +130,9 @@ void UiaTracing::TextRange::Compare(const UiaTextRangeBase& utr, const UiaTextRa
 
 void UiaTracing::TextRange::CompareEndpoints(const UiaTextRangeBase& utr, const TextPatternRangeEndpoint endpoint, const UiaTextRangeBase& other, TextPatternRangeEndpoint otherEndpoint, int result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::CompareEndpoints",
@@ -147,9 +147,9 @@ void UiaTracing::TextRange::CompareEndpoints(const UiaTextRangeBase& utr, const 
 
 void UiaTracing::TextRange::ExpandToEnclosingUnit(TextUnit unit, const UiaTextRangeBase& utr) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::ExpandToEnclosingUnit",
@@ -161,9 +161,9 @@ void UiaTracing::TextRange::ExpandToEnclosingUnit(TextUnit unit, const UiaTextRa
 
 void UiaTracing::TextRange::FindAttribute(const UiaTextRangeBase& utr) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::FindAttribute (UNSUPPORTED)",
@@ -174,9 +174,9 @@ void UiaTracing::TextRange::FindAttribute(const UiaTextRangeBase& utr) noexcept
 
 void UiaTracing::TextRange::FindText(const UiaTextRangeBase& base, std::wstring text, bool searchBackward, bool ignoreCase, const UiaTextRangeBase& result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::FindText",
@@ -191,9 +191,9 @@ void UiaTracing::TextRange::FindText(const UiaTextRangeBase& base, std::wstring 
 
 void UiaTracing::TextRange::GetAttributeValue(const UiaTextRangeBase& base, TEXTATTRIBUTEID id, VARIANT result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::GetAttributeValue",
@@ -206,9 +206,9 @@ void UiaTracing::TextRange::GetAttributeValue(const UiaTextRangeBase& base, TEXT
 
 void UiaTracing::TextRange::GetBoundingRectangles(const UiaTextRangeBase& utr) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::GetBoundingRectangles",
@@ -219,9 +219,9 @@ void UiaTracing::TextRange::GetBoundingRectangles(const UiaTextRangeBase& utr) n
 
 void UiaTracing::TextRange::GetEnclosingElement(const UiaTextRangeBase& utr) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::GetEnclosingElement",
@@ -232,9 +232,9 @@ void UiaTracing::TextRange::GetEnclosingElement(const UiaTextRangeBase& utr) noe
 
 void UiaTracing::TextRange::GetText(const UiaTextRangeBase& utr, int maxLength, std::wstring result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::GetText",
@@ -247,9 +247,9 @@ void UiaTracing::TextRange::GetText(const UiaTextRangeBase& utr, int maxLength, 
 
 void UiaTracing::TextRange::Move(TextUnit unit, int count, int resultCount, const UiaTextRangeBase& result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::Move",
@@ -263,9 +263,9 @@ void UiaTracing::TextRange::Move(TextUnit unit, int count, int resultCount, cons
 
 void UiaTracing::TextRange::MoveEndpointByUnit(TextPatternRangeEndpoint endpoint, TextUnit unit, int count, int resultCount, const UiaTextRangeBase& result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::MoveEndpointByUnit",
@@ -280,9 +280,9 @@ void UiaTracing::TextRange::MoveEndpointByUnit(TextPatternRangeEndpoint endpoint
 
 void UiaTracing::TextRange::MoveEndpointByRange(TextPatternRangeEndpoint endpoint, const UiaTextRangeBase& other, TextPatternRangeEndpoint otherEndpoint, const UiaTextRangeBase& result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::MoveEndpointByRange",
@@ -296,9 +296,9 @@ void UiaTracing::TextRange::MoveEndpointByRange(TextPatternRangeEndpoint endpoin
 
 void UiaTracing::TextRange::Select(const UiaTextRangeBase& result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::Select",
@@ -309,9 +309,9 @@ void UiaTracing::TextRange::Select(const UiaTextRangeBase& result) noexcept
 
 void UiaTracing::TextRange::AddToSelection(const UiaTextRangeBase& result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::AddToSelection (UNSUPPORTED)",
@@ -322,9 +322,9 @@ void UiaTracing::TextRange::AddToSelection(const UiaTextRangeBase& result) noexc
 
 void UiaTracing::TextRange::RemoveFromSelection(const UiaTextRangeBase& result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::RemoveFromSelection (UNSUPPORTED)",
@@ -335,9 +335,9 @@ void UiaTracing::TextRange::RemoveFromSelection(const UiaTextRangeBase& result) 
 
 void UiaTracing::TextRange::ScrollIntoView(bool alignToTop, const UiaTextRangeBase& result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::ScrollIntoView",
@@ -349,9 +349,9 @@ void UiaTracing::TextRange::ScrollIntoView(bool alignToTop, const UiaTextRangeBa
 
 void UiaTracing::TextRange::GetChildren(const UiaTextRangeBase& result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::AddToSelection (UNSUPPORTED)",
@@ -362,9 +362,9 @@ void UiaTracing::TextRange::GetChildren(const UiaTextRangeBase& result) noexcept
 
 void UiaTracing::TextProvider::Constructor(const ScreenInfoUiaProviderBase& result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::Constructor",
@@ -375,6 +375,7 @@ void UiaTracing::TextProvider::Constructor(const ScreenInfoUiaProviderBase& resu
 
 void UiaTracing::TextProvider::get_ProviderOptions(const ScreenInfoUiaProviderBase& siup, ProviderOptions options) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
         auto getOptions = [options]() {
@@ -387,7 +388,6 @@ void UiaTracing::TextProvider::get_ProviderOptions(const ScreenInfoUiaProviderBa
             }
         };
 
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::get_ProviderOptions",
@@ -399,6 +399,7 @@ void UiaTracing::TextProvider::get_ProviderOptions(const ScreenInfoUiaProviderBa
 
 void UiaTracing::TextProvider::GetPatternProvider(const ScreenInfoUiaProviderBase& siup, PATTERNID patternId) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
         auto getPattern = [patternId]() {
@@ -411,7 +412,6 @@ void UiaTracing::TextProvider::GetPatternProvider(const ScreenInfoUiaProviderBas
             }
         };
 
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::get_ProviderOptions",
@@ -423,6 +423,7 @@ void UiaTracing::TextProvider::GetPatternProvider(const ScreenInfoUiaProviderBas
 
 void UiaTracing::TextProvider::GetPropertyValue(const ScreenInfoUiaProviderBase& siup, PROPERTYID propertyId) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
         auto getProperty = [propertyId]() {
@@ -451,7 +452,6 @@ void UiaTracing::TextProvider::GetPropertyValue(const ScreenInfoUiaProviderBase&
             }
         };
 
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::GetPropertyValue",
@@ -463,9 +463,9 @@ void UiaTracing::TextProvider::GetPropertyValue(const ScreenInfoUiaProviderBase&
 
 void UiaTracing::TextProvider::get_HostRawElementProvider(const ScreenInfoUiaProviderBase& siup) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::get_HostRawElementProvider (UNSUPPORTED)",
@@ -476,9 +476,9 @@ void UiaTracing::TextProvider::get_HostRawElementProvider(const ScreenInfoUiaPro
 
 void UiaTracing::TextProvider::GetRuntimeId(const ScreenInfoUiaProviderBase& siup) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::GetRuntimeId",
@@ -489,9 +489,9 @@ void UiaTracing::TextProvider::GetRuntimeId(const ScreenInfoUiaProviderBase& siu
 
 void UiaTracing::TextProvider::GetEmbeddedFragmentRoots(const ScreenInfoUiaProviderBase& siup) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::GetEmbeddedFragmentRoots (UNSUPPORTED)",
@@ -502,9 +502,9 @@ void UiaTracing::TextProvider::GetEmbeddedFragmentRoots(const ScreenInfoUiaProvi
 
 void UiaTracing::TextProvider::SetFocus(const ScreenInfoUiaProviderBase& siup) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::SetFocus",
@@ -515,9 +515,9 @@ void UiaTracing::TextProvider::SetFocus(const ScreenInfoUiaProviderBase& siup) n
 
 void UiaTracing::TextProvider::GetSelection(const ScreenInfoUiaProviderBase& siup, const UiaTextRangeBase& result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::GetSelection",
@@ -529,9 +529,9 @@ void UiaTracing::TextProvider::GetSelection(const ScreenInfoUiaProviderBase& siu
 
 void UiaTracing::TextProvider::GetVisibleRanges(const ScreenInfoUiaProviderBase& siup, const UiaTextRangeBase& result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::GetVisibleRanges",
@@ -543,9 +543,9 @@ void UiaTracing::TextProvider::GetVisibleRanges(const ScreenInfoUiaProviderBase&
 
 void UiaTracing::TextProvider::RangeFromChild(const ScreenInfoUiaProviderBase& siup, const UiaTextRangeBase& result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::GetVisibleRanges",
@@ -557,6 +557,7 @@ void UiaTracing::TextProvider::RangeFromChild(const ScreenInfoUiaProviderBase& s
 
 void UiaTracing::TextProvider::RangeFromPoint(const ScreenInfoUiaProviderBase& siup, UiaPoint point, const UiaTextRangeBase& result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
         auto getPoint = [point]() {
@@ -565,7 +566,6 @@ void UiaTracing::TextProvider::RangeFromPoint(const ScreenInfoUiaProviderBase& s
             return stream.str();
         };
 
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::RangeFromPoint",
@@ -578,9 +578,9 @@ void UiaTracing::TextProvider::RangeFromPoint(const ScreenInfoUiaProviderBase& s
 
 void UiaTracing::TextProvider::get_DocumentRange(const ScreenInfoUiaProviderBase& siup, const UiaTextRangeBase& result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::GetVisibleRanges",
@@ -592,6 +592,7 @@ void UiaTracing::TextProvider::get_DocumentRange(const ScreenInfoUiaProviderBase
 
 void UiaTracing::TextProvider::get_SupportedTextSelection(const ScreenInfoUiaProviderBase& siup, SupportedTextSelection result) noexcept
 {
+    EnsureRegistration();
     if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {
         auto getResult = [result]() {
@@ -604,7 +605,6 @@ void UiaTracing::TextProvider::get_SupportedTextSelection(const ScreenInfoUiaPro
             }
         };
 
-        EnsureRegistration();
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::get_SupportedTextSelection",

--- a/src/types/UiaTracing.cpp
+++ b/src/types/UiaTracing.cpp
@@ -38,8 +38,8 @@ try
 
     std::wstringstream stream;
     stream << " _id: " << utr.GetId();
-    stream << " _start: { " << start.x() << ", " << start.y() << " }";
-    stream << " _end: { " << end.x() << ", " << end.y() << " }";
+    stream << " _start: { " << start.X << ", " << start.Y << " }";
+    stream << " _end: { " << end.X << ", " << end.Y << " }";
     stream << " _degenerate: " << utr.IsDegenerate();
     stream << " _wordDelimiters: " << utr._wordDelimiters;
     stream << " content: " << utr._getTextValue();


### PR DESCRIPTION
## Summary of the Pull Request
- Added better wide glyph support for UIA. We used to move one _cell_ at a time, so wide glyphs would be read twice.
- Converted a few things to use til::point since I'm already here.
- fixed telemetry for UIA

## PR Checklist
* [x] Closes #1354

## Detailed Description of the Pull Request / Additional comments
The text buffer has a concept of word boundaries, so it makes sense to have a concept of glyph boundaries too.

_start and _end in UiaTextRange are now til::point

## Validation Steps Performed
Verified using Narrator