### PR TITLE
Add explicit to bool operators of Point and Rect

### DIFF
--- a/src/inc/til/point.h
+++ b/src/inc/til/point.h
@@ -64,7 +64,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             return !(*this == other);
         }
 
-        operator bool() const noexcept
+        explicit operator bool() const noexcept
         {
             return _x != 0 || _y != 0;
         }

--- a/src/inc/til/point.h
+++ b/src/inc/til/point.h
@@ -64,11 +64,6 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             return !(*this == other);
         }
 
-        explicit operator bool() const noexcept
-        {
-            return _x != 0 || _y != 0;
-        }
-
         constexpr bool operator<(const point& other) const noexcept
         {
             if (_y < other._y)

--- a/src/inc/til/rectangle.h
+++ b/src/inc/til/rectangle.h
@@ -109,7 +109,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             return !(*this == other);
         }
 
-        constexpr operator bool() const noexcept
+        explicit constexpr operator bool() const noexcept
         {
             return _topLeft.x() < _bottomRight.x() &&
                    _topLeft.y() < _bottomRight.y();

--- a/src/inc/til/size.h
+++ b/src/inc/til/size.h
@@ -64,6 +64,11 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             return !(*this == other);
         }
 
+        explicit operator bool() const noexcept
+        {
+            return _width > 0 && _height > 0;
+        }
+
         size operator+(const size& other) const
         {
             ptrdiff_t width;

--- a/src/inc/til/size.h
+++ b/src/inc/til/size.h
@@ -64,7 +64,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             return !(*this == other);
         }
 
-        explicit operator bool() const noexcept
+        constexpr explicit operator bool() const noexcept
         {
             return _width > 0 && _height > 0;
         }

--- a/src/til/ut_til/PointTests.cpp
+++ b/src/til/ut_til/PointTests.cpp
@@ -168,21 +168,6 @@ class PointTests
         }
     }
 
-    TEST_METHOD(Boolean)
-    {
-        const til::point empty;
-        VERIFY_IS_FALSE(empty);
-
-        const til::point yOnly{ 0, 10 };
-        VERIFY_IS_TRUE(yOnly);
-
-        const til::point xOnly{ 10, 0 };
-        VERIFY_IS_TRUE(xOnly);
-
-        const til::point both{ 10, 10 };
-        VERIFY_IS_TRUE(both);
-    }
-
     TEST_METHOD(Addition)
     {
         Log::Comment(L"0.) Addition of two things that should be in bounds.");

--- a/src/til/ut_til/SizeTests.cpp
+++ b/src/til/ut_til/SizeTests.cpp
@@ -168,6 +168,30 @@ class SizeTests
         }
     }
 
+    TEST_METHOD(Boolean)
+    {
+        const til::size empty;
+        VERIFY_IS_TRUE(!!empty);
+
+        const til::size yOnly{ 0, 10 };
+        VERIFY_IS_TRUE(!!yOnly);
+
+        const til::size xOnly{ 10, 0 };
+        VERIFY_IS_TRUE(!!xOnly);
+
+        const til::size both{ 10, 10 };
+        VERIFY_IS_TRUE(!!both);
+
+        const til::size yNegative{ 10, -10 };
+        VERIFY_IS_TRUE(!!yNegative);
+
+        const til::size xNegative{ -10, 10 };
+        VERIFY_IS_TRUE(!!xNegative);
+
+        const til::size bothNegative{ -10, -10 };
+        VERIFY_IS_TRUE(!!bothNegative);
+    }
+
     TEST_METHOD(Addition)
     {
         Log::Comment(L"0.) Addition of two things that should be in bounds.");

--- a/src/til/ut_til/SizeTests.cpp
+++ b/src/til/ut_til/SizeTests.cpp
@@ -171,7 +171,7 @@ class SizeTests
     TEST_METHOD(Boolean)
     {
         const til::size empty;
-        VERIFY_IS_TRUE(!!empty);
+        VERIFY_IS_FALSE(!!empty);
 
         const til::size yOnly{ 0, 10 };
         VERIFY_IS_TRUE(!!yOnly);
@@ -183,13 +183,13 @@ class SizeTests
         VERIFY_IS_TRUE(!!both);
 
         const til::size yNegative{ 10, -10 };
-        VERIFY_IS_TRUE(!!yNegative);
+        VERIFY_IS_FALSE(!!yNegative);
 
         const til::size xNegative{ -10, 10 };
-        VERIFY_IS_TRUE(!!xNegative);
+        VERIFY_IS_FALSE(!!xNegative);
 
         const til::size bothNegative{ -10, -10 };
-        VERIFY_IS_TRUE(!!bothNegative);
+        VERIFY_IS_FALSE(!!bothNegative);
     }
 
     TEST_METHOD(Addition)

--- a/src/til/ut_til/SizeTests.cpp
+++ b/src/til/ut_til/SizeTests.cpp
@@ -174,10 +174,10 @@ class SizeTests
         VERIFY_IS_FALSE(!!empty);
 
         const til::size yOnly{ 0, 10 };
-        VERIFY_IS_TRUE(!!yOnly);
+        VERIFY_IS_FALSE(!!yOnly);
 
         const til::size xOnly{ 10, 0 };
-        VERIFY_IS_TRUE(!!xOnly);
+        VERIFY_IS_FALSE(!!xOnly);
 
         const til::size both{ 10, 10 };
         VERIFY_IS_TRUE(!!both);


### PR DESCRIPTION
Found a bug where the following won't work:
```c++
COORD inclusiveEnd{ _end };
```
where `_end` is a `til::point`.

The only fix for this is to replace these instances with this:
```c++
COORD inclusiveEnd = _end;
```

What was happening in the first notation is the implicit conversion of `til::point` to `bool` to `SHORT`. The constructor for COORD only sees one SHORT so it thinks the value should be the definition for X, and Y should stay as 0. So we end up getting `1, 0`.

By adding the explicit keyword to the bool operators, we prevent the accident above from occurring.