### PR TITLE
Switch to the x64 hosted tools when building on x64

### DIFF
--- a/src/common.build.pre.props
+++ b/src/common.build.pre.props
@@ -66,6 +66,7 @@
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <LinkIncremental>false</LinkIncremental>
+    <PreferredToolArchitecture>x64</PreferredToolArchitecture>
   </PropertyGroup>
 
   <ItemDefinitionGroup>


### PR DESCRIPTION
This commit may help with the compiler and linker running out of memory.