### PR TITLE
Make loop in IInputEvent more consistent and modern

### DIFF
--- a/src/types/IInputEvent.cpp
+++ b/src/types/IInputEvent.cpp
@@ -29,7 +29,7 @@ std::deque<std::unique_ptr<IInputEvent>> IInputEvent::Create(gsl::span<const INP
 {
     std::deque<std::unique_ptr<IInputEvent>> outEvents;
 
-    for (auto& record : records)
+    for (const auto& record : records)
     {
         outEvents.push_back(Create(record));
     }
@@ -46,9 +46,9 @@ std::deque<std::unique_ptr<IInputEvent>> IInputEvent::Create(gsl::span<const INP
 std::deque<std::unique_ptr<IInputEvent>> IInputEvent::Create(const std::deque<INPUT_RECORD>& records)
 {
     std::deque<std::unique_ptr<IInputEvent>> outEvents;
-    for (size_t i = 0; i < records.size(); ++i)
+    for (const auto& record : records)
     {
-        std::unique_ptr<IInputEvent> event = IInputEvent::Create(records.at(i));
+        std::unique_ptr<IInputEvent> event = Create(record);
         outEvents.push_back(std::move(event));
     }
     return outEvents;


### PR DESCRIPTION
In IInputEvent, there are two for loops. One is a range based loop operating on "records", and the other is a classic for-loop doing the same. For consistency, the for-loop was changed into the more modern variation via a compiler refactoring, which has the exact same behavior as the other for-loop in the main function.

Yes, of course this was tested manually and with the unit tests.

# Validation Steps
Unit testing passed. In addition, for the manual validation tests, I compared the output for sample values between the two loops ensuring the same results.