### PR TITLE
hygiene: replace NULL/0 with nullptr where appropriate

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -1470,7 +1470,7 @@ namespace TerminalAppLocalTests
         CascadiaSettings settings{};
         settings._ParseJsonString(settingsJson, false);
         settings.LayerJson(settings._userSettings);
-        VERIFY_IS_FALSE(settings._profiles.empty(), 0);
+        VERIFY_IS_FALSE(settings._profiles.empty());
         VERIFY_ARE_EQUAL(expectedPath, settings._profiles[0].GetExpandedIconPath());
     }
     void SettingsTests::TestProfileBackgroundImageWithEnvVar()
@@ -1491,7 +1491,7 @@ namespace TerminalAppLocalTests
         CascadiaSettings settings{};
         settings._ParseJsonString(settingsJson, false);
         settings.LayerJson(settings._userSettings);
-        VERIFY_IS_FALSE(settings._profiles.empty(), 0);
+        VERIFY_IS_FALSE(settings._profiles.empty());
 
         GlobalAppSettings globalSettings{};
         auto terminalSettings = settings._profiles[0].CreateTerminalSettings(globalSettings.GetColorSchemes());

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
@@ -289,7 +289,7 @@ HRESULT _stdcall CreateTerminal(HWND parentHwnd, _Out_ void** hwnd, _Out_ void**
         parentHwnd,
         nullptr,
         nullptr,
-        0);
+        nullptr);
     auto _terminal = std::make_unique<HwndTerminal>(_hostWindow);
     RETURN_IF_FAILED(_terminal->Initialize());
 

--- a/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
@@ -704,7 +704,7 @@ ColorScheme* CascadiaSettings::_FindMatchingColorScheme(const Json::Value& schem
 bool CascadiaSettings::_IsPackaged()
 {
     UINT32 length = 0;
-    LONG rc = GetCurrentPackageFullName(&length, NULL);
+    LONG rc = GetCurrentPackageFullName(&length, nullptr);
     return rc != APPMODEL_ERROR_NO_PACKAGE;
 }
 
@@ -724,15 +724,15 @@ void CascadiaSettings::_WriteSettings(const std::string_view content)
     wil::unique_hfile hOut{ CreateFileW(pathToSettingsFile.c_str(),
                                         GENERIC_WRITE,
                                         FILE_SHARE_READ | FILE_SHARE_WRITE,
-                                        NULL,
+                                        nullptr,
                                         CREATE_ALWAYS,
                                         FILE_ATTRIBUTE_NORMAL,
-                                        NULL) };
+                                        nullptr) };
     if (!hOut)
     {
         THROW_LAST_ERROR();
     }
-    THROW_LAST_ERROR_IF(!WriteFile(hOut.get(), content.data(), gsl::narrow<DWORD>(content.size()), 0, 0));
+    THROW_LAST_ERROR_IF(!WriteFile(hOut.get(), content.data(), gsl::narrow<DWORD>(content.size()), nullptr, nullptr));
 }
 
 // Method Description:
@@ -853,7 +853,7 @@ std::wstring CascadiaSettings::GetSettingsPath(const bool useRoamingPath)
     // the new AppModel paths (Packages/xxx/RoamingState, etc.) for standard path requests.
     // Using this flag allows us to avoid Windows.Storage.ApplicationData completely.
     const auto knowFolderId = useRoamingPath ? FOLDERID_RoamingAppData : FOLDERID_LocalAppData;
-    if (FAILED(SHGetKnownFolderPath(knowFolderId, KF_FLAG_FORCE_APP_DATA_REDIRECTION, 0, &localAppDataFolder)))
+    if (FAILED(SHGetKnownFolderPath(knowFolderId, KF_FLAG_FORCE_APP_DATA_REDIRECTION, nullptr, &localAppDataFolder)))
     {
         THROW_LAST_ERROR();
     }

--- a/src/cascadia/TerminalApp/PowershellCoreProfileGenerator.cpp
+++ b/src/cascadia/TerminalApp/PowershellCoreProfileGenerator.cpp
@@ -196,7 +196,7 @@ catch (...)
 static void _accumulateStorePowerShellInstances(std::vector<PowerShellInstance>& out)
 {
     wil::unique_cotaskmem_string localAppDataFolder;
-    if (FAILED(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, 0, &localAppDataFolder)))
+    if (FAILED(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &localAppDataFolder)))
     {
         return;
     }

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -254,7 +254,7 @@ void IslandWindow::Initialize()
 void IslandWindow::OnSize(const UINT width, const UINT height)
 {
     // update the interop window size
-    SetWindowPos(_interopWindowHandle, 0, 0, 0, width, height, SWP_SHOWWINDOW);
+    SetWindowPos(_interopWindowHandle, nullptr, 0, 0, width, height, SWP_SHOWWINDOW);
 
     if (_rootGrid)
     {

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -639,7 +639,7 @@ void NonClientIslandWindow::_UpdateFrameMargins() const noexcept
         }
 
         ::FillRect(opaqueDc, &rcRest, _backgroundBrush.get());
-        ::BufferedPaintSetAlpha(buf, NULL, 255);
+        ::BufferedPaintSetAlpha(buf, nullptr, 255);
         ::EndBufferedPaint(buf, TRUE);
     }
 

--- a/src/host/CursorBlinker.cpp
+++ b/src/host/CursorBlinker.cpp
@@ -212,7 +212,7 @@ void CursorBlinker::KillCaretTimer()
 
         bRet = DeleteTimerQueueTimer(_hCaretBlinkTimerQueue,
                                      _hCaretBlinkTimer,
-                                     NULL);
+                                     nullptr);
 
         // According to https://msdn.microsoft.com/en-us/library/windows/desktop/ms682569(v=vs.85).aspx
         // A failure to delete the timer with the LastError being ERROR_IO_PENDING means that the timer is

--- a/src/host/exemain.cpp
+++ b/src/host/exemain.cpp
@@ -21,7 +21,7 @@ static bool ConhostV2ForcedInRegistry()
     // If the registry value doesn't exist, or exists and is non-zero, we should default to using the v2 console.
     // Otherwise, in the case of an explicit value of 0, we should use the legacy console.
     bool fShouldUseConhostV2 = true;
-    PCSTR pszErrorDescription = NULL;
+    PCSTR pszErrorDescription = nullptr;
     bool fIgnoreError = false;
 
     // open HKCU\Console
@@ -110,10 +110,10 @@ static bool ShouldUseLegacyConhost(const ConsoleArguments& args)
     // We expect legacy launches to be infrequent enough to not cause an issue.
     TraceLoggingWrite(g_ConhostLauncherProvider, "IsLegacyLoaded", TraceLoggingBool(true, "ConsoleLegacy"), TraceLoggingKeyword(MICROSOFT_KEYWORD_TELEMETRY));
 
-    PCWSTR pszConhostDllName = L"ConhostV1.dll";
+    const PCWSTR pszConhostDllName = L"ConhostV1.dll";
 
     // Load our implementation, and then Load/Launch the IO thread.
-    wil::unique_hmodule hConhostBin(LoadLibraryExW(pszConhostDllName, NULL, LOAD_LIBRARY_SEARCH_SYSTEM32));
+    wil::unique_hmodule hConhostBin(LoadLibraryExW(pszConhostDllName, nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32));
     if (hConhostBin.get() != nullptr)
     {
         typedef NTSTATUS (*PFNCONSOLECREATEIOTHREAD)(__in HANDLE Server);

--- a/src/host/ft_host/API_AliasTestsHelpers.hpp
+++ b/src/host/ft_host/API_AliasTestsHelpers.hpp
@@ -153,7 +153,7 @@ void TestGetConsoleAliasHelper(TCH* ptszSourceGiven,
     // This is strange because it's a scope exit so we need to declare in the parent scope, then let it go if we didn't actually need it.
     // I just prefer keeping the exit next to the allocation so it doesn't get lost.
     auto removeAliasOnExit = wil::scope_exit([&] {
-        AddConsoleAliasT(ptszSource, NULL, ptszExeName);
+        AddConsoleAliasT(ptszSource, nullptr, ptszExeName);
     });
     if (!bSetFirst)
     {

--- a/src/host/ft_host/API_BufferTests.cpp
+++ b/src/host/ft_host/API_BufferTests.cpp
@@ -219,7 +219,7 @@ void BufferTests::ChafaGifPerformance()
     SetConsoleOutputCP(CP_UTF8);
 
     // Taken from: https://blog.kowalczyk.info/article/zy/Embedding-binary-resources-on-Windows.html
-    HGLOBAL res_handle = NULL;
+    HGLOBAL res_handle = nullptr;
     HRSRC res;
     char* res_data;
     DWORD res_size;

--- a/src/host/ft_host/API_FileTests.cpp
+++ b/src/host/ft_host/API_FileTests.cpp
@@ -61,7 +61,7 @@ class FileTests
     END_TEST_METHOD();*/
 };
 
-static HANDLE _cancellationEvent = 0;
+static HANDLE _cancellationEvent = nullptr;
 
 bool FileTests::ClassSetup()
 {

--- a/src/host/ft_host/API_InputTests.cpp
+++ b/src/host/ft_host/API_InputTests.cpp
@@ -243,7 +243,7 @@ void InputTests::TestPeekConsoleInvalid()
 void InputTests::TestReadConsoleInvalid()
 {
     DWORD nRead = (DWORD)-1;
-    VERIFY_WIN32_BOOL_FAILED(ReadConsoleInput(0, nullptr, 0, &nRead));
+    VERIFY_WIN32_BOOL_FAILED(ReadConsoleInput(nullptr, nullptr, 0, &nRead));
     VERIFY_ARE_EQUAL(nRead, (DWORD)0);
 
     nRead = (DWORD)-1;
@@ -275,7 +275,7 @@ void InputTests::TestReadConsoleInvalid()
 void InputTests::TestWriteConsoleInvalid()
 {
     DWORD nWrite = (DWORD)-1;
-    VERIFY_WIN32_BOOL_FAILED(WriteConsoleInput(0, nullptr, 0, &nWrite));
+    VERIFY_WIN32_BOOL_FAILED(WriteConsoleInput(nullptr, nullptr, 0, &nWrite));
     VERIFY_ARE_EQUAL(nWrite, (DWORD)0);
 
     // weird: WriteConsoleInput with INVALID_HANDLE_VALUE writes garbage to lpNumberOfEventsWritten, whereas
@@ -358,7 +358,7 @@ void InputTests::TestReadConsolePasswordScenario()
     {
         wchar_t ch;
         DWORD c;
-        int err = ReadConsoleW(hIn, &ch, 1, &c, 0);
+        int err = ReadConsoleW(hIn, &ch, 1, &c, nullptr);
 
         if (!err || c != 1)
         {

--- a/src/host/ft_host/Common.cpp
+++ b/src/host/ft_host/Common.cpp
@@ -186,9 +186,9 @@ bool Common::TestBufferSetup()
 
     _hConsole = CreateConsoleScreenBuffer(GENERIC_READ | GENERIC_WRITE,
                                           0 /*dwShareMode*/,
-                                          NULL /*lpSecurityAttributes*/,
+                                          nullptr /*lpSecurityAttributes*/,
                                           CONSOLE_TEXTMODE_BUFFER,
-                                          NULL /*lpReserved*/);
+                                          nullptr /*lpReserved*/);
 
     VERIFY_ARE_NOT_EQUAL(_hConsole, INVALID_HANDLE_VALUE, L"Creating our test screen buffer.");
 

--- a/src/host/ntprivapi.cpp
+++ b/src/host/ntprivapi.cpp
@@ -13,7 +13,7 @@
 
     CLIENT_ID ClientId;
     ClientId.UniqueProcess = UlongToHandle(*ProcessId);
-    ClientId.UniqueThread = 0;
+    ClientId.UniqueThread = nullptr;
 
     HANDLE ProcessHandle;
     NTSTATUS Status = s_NtOpenProcess(&ProcessHandle, PROCESS_QUERY_LIMITED_INFORMATION, &oa, &ClientId);

--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -269,7 +269,7 @@ void ConsoleCheckDebug()
     ServerInformation.InputAvailableEvent = ServiceLocator::LocateGlobals().hInputEvent.get();
     RETURN_IF_FAILED(g.pDeviceComm->SetServerInformation(&ServerInformation));
 
-    HANDLE const hThread = CreateThread(nullptr, 0, ConsoleIoThread, 0, 0, nullptr);
+    HANDLE const hThread = CreateThread(nullptr, 0, ConsoleIoThread, nullptr, 0, nullptr);
     RETURN_HR_IF(E_HANDLE, hThread == nullptr);
     LOG_IF_WIN32_BOOL_FALSE(CloseHandle(hThread)); // The thread will run on its own and close itself. Free the associated handle.
 

--- a/src/host/ut_host/CommandLineTests.cpp
+++ b/src/host/ut_host/CommandLineTests.cpp
@@ -44,7 +44,7 @@ class CommandLineTests
         m_state->PrepareGlobalInputBuffer();
         m_state->PrepareReadHandle();
         m_state->PrepareCookedReadData();
-        m_pHistory = CommandHistory::s_Allocate(L"cmd.exe", (HANDLE)0);
+        m_pHistory = CommandHistory::s_Allocate(L"cmd.exe", nullptr);
         if (!m_pHistory)
         {
             return false;
@@ -54,7 +54,7 @@ class CommandLineTests
 
     TEST_METHOD_CLEANUP(MethodCleanup)
     {
-        CommandHistory::s_Free((HANDLE)0);
+        CommandHistory::s_Free(nullptr);
         m_pHistory = nullptr;
         m_state->CleanupCookedReadData();
         m_state->CleanupReadHandle();

--- a/src/host/ut_host/CommandListPopupTests.cpp
+++ b/src/host/ut_host/CommandListPopupTests.cpp
@@ -50,7 +50,7 @@ class CommandListPopupTests
         m_state->PrepareGlobalInputBuffer();
         m_state->PrepareReadHandle();
         m_state->PrepareCookedReadData();
-        m_pHistory = CommandHistory::s_Allocate(L"cmd.exe", (HANDLE)0);
+        m_pHistory = CommandHistory::s_Allocate(L"cmd.exe", nullptr);
         // resize command history storage to 50 items so that we don't cycle on accident
         // when PopupTestHelper::InitLongHistory() is called.
         CommandHistory::s_ResizeAll(50);

--- a/src/host/ut_host/CommandNumberPopupTests.cpp
+++ b/src/host/ut_host/CommandNumberPopupTests.cpp
@@ -46,7 +46,7 @@ class CommandNumberPopupTests
         m_state->PrepareGlobalInputBuffer();
         m_state->PrepareReadHandle();
         m_state->PrepareCookedReadData();
-        m_pHistory = CommandHistory::s_Allocate(L"cmd.exe", (HANDLE)0);
+        m_pHistory = CommandHistory::s_Allocate(L"cmd.exe", nullptr);
         if (!m_pHistory)
         {
             return false;
@@ -56,7 +56,7 @@ class CommandNumberPopupTests
 
     TEST_METHOD_CLEANUP(MethodCleanup)
     {
-        CommandHistory::s_Free((HANDLE)0);
+        CommandHistory::s_Free(nullptr);
         m_pHistory = nullptr;
         m_state->CleanupCookedReadData();
         m_state->CleanupReadHandle();

--- a/src/host/ut_host/ConsoleArgumentsTests.cpp
+++ b/src/host/ut_host/ConsoleArgumentsTests.cpp
@@ -689,7 +689,7 @@ void ConsoleArgumentsTests::IsVtHandleValidTests()
     // We use both 0 and INVALID_HANDLE_VALUE as invalid handles since we're not sure
     // exactly what will get passed in on the STDIN/STDOUT handles as it can vary wildly
     // depending on who is passing it.
-    VERIFY_IS_FALSE(IsValidHandle(0), L"Zero handle invalid.");
+    VERIFY_IS_FALSE(IsValidHandle(nullptr), L"Zero handle invalid.");
     VERIFY_IS_FALSE(IsValidHandle(INVALID_HANDLE_VALUE), L"Invalid handle invalid.");
     VERIFY_IS_TRUE(IsValidHandle(UlongToHandle(0x4)), L"0x4 is valid.");
 }

--- a/src/host/ut_host/UtilsTests.cpp
+++ b/src/host/ut_host/UtilsTests.cpp
@@ -32,7 +32,7 @@ class UtilsTests
         m_state->PrepareGlobalFont();
         m_state->PrepareGlobalScreenBuffer();
 
-        UINT const seed = (UINT)time(NULL);
+        UINT const seed = (UINT)time(nullptr);
         Log::Comment(String().Format(L"Setting random seed to : %d", seed));
         srand(seed);
 

--- a/src/interactivity/base/InteractivityFactory.cpp
+++ b/src/interactivity/base/InteractivityFactory.cpp
@@ -336,7 +336,7 @@ using namespace Microsoft::Console::Interactivity;
 // - STATUS_SUCCESS on success, otherwise an appropriate error.
 [[nodiscard]] NTSTATUS InteractivityFactory::CreatePseudoWindow(HWND& hwnd)
 {
-    hwnd = 0;
+    hwnd = nullptr;
     ApiLevel level;
     NTSTATUS status = ApiDetector::DetectNtUserWindow(&level);
     ;

--- a/src/interactivity/base/ServiceLocator.cpp
+++ b/src/interactivity/base/ServiceLocator.cpp
@@ -28,7 +28,7 @@ IConsoleWindow* ServiceLocator::s_consoleWindow = nullptr;
 Globals ServiceLocator::s_globals;
 
 bool ServiceLocator::s_pseudoWindowInitialized = false;
-wil::unique_hwnd ServiceLocator::s_pseudoWindow = 0;
+wil::unique_hwnd ServiceLocator::s_pseudoWindow = nullptr;
 
 #pragma endregion
 

--- a/src/interactivity/win32/consoleKeyInfo.cpp
+++ b/src/interactivity/win32/consoleKeyInfo.cpp
@@ -10,7 +10,7 @@
 // structure when a keydown message is translated. Then when we receive a
 // wm_[sys][dead]char message, we retrieve it and clear out the record.
 
-#define CONSOLE_FREE_KEY_INFO 0
+#define CONSOLE_FREE_KEY_INFO nullptr
 #define CONSOLE_MAX_KEY_INFO 32
 
 typedef struct _CONSOLE_KEY_INFO

--- a/src/interactivity/win32/menu.cpp
+++ b/src/interactivity/win32/menu.cpp
@@ -45,22 +45,20 @@ Menu::Menu(HMENU hMenu, HMENU hHeirMenu) :
 [[nodiscard]] NTSTATUS Menu::CreateInstance(HWND hWnd)
 {
     NTSTATUS status = STATUS_SUCCESS;
-    HMENU hMenu = nullptr;
-    HMENU hHeirMenu = nullptr;
 
-    int ItemLength;
     WCHAR ItemString[32];
 
     // This gets the title bar menu.
-    hMenu = GetSystemMenu(hWnd, FALSE);
-    hHeirMenu = LoadMenuW(ServiceLocator::LocateGlobals().hInstance,
-                          MAKEINTRESOURCE(ID_CONSOLE_SYSTEMMENU));
+    HMENU hMenu = GetSystemMenu(hWnd, FALSE);
+    HMENU hHeirMenu = LoadMenuW(ServiceLocator::LocateGlobals().hInstance,
+                                MAKEINTRESOURCE(ID_CONSOLE_SYSTEMMENU));
 
     Menu* pNewMenu = new (std::nothrow) Menu(hMenu, hHeirMenu);
     status = NT_TESTNULL(pNewMenu);
 
     if (NT_SUCCESS(status))
     {
+        int ItemLength;
         // Load the submenu to the system menu.
         if (hHeirMenu)
         {
@@ -248,7 +246,7 @@ void Menu::s_ShowPropertiesDialog(HWND const hwnd, BOOL const Defaults)
     UnlockConsole();
 
     // First try to find the console.dll next to the launched exe, else default to /windows/system32/console.dll
-    HANDLE hLibrary = LoadLibraryExW(gwszRelativePropertiesDll, 0, 0);
+    HANDLE hLibrary = LoadLibraryExW(gwszRelativePropertiesDll, nullptr, 0);
     bool fLoadedDll = hLibrary != nullptr;
     if (!fLoadedDll)
     {
@@ -260,7 +258,7 @@ void Menu::s_ShowPropertiesDialog(HWND const hwnd, BOOL const Defaults)
             {
                 wszFilePath[ARRAYSIZE(wszFilePath) - 1] = UNICODE_NULL;
 
-                hLibrary = LoadLibraryExW(wszFilePath, 0, LOAD_WITH_ALTERED_SEARCH_PATH);
+                hLibrary = LoadLibraryExW(wszFilePath, nullptr, LOAD_WITH_ALTERED_SEARCH_PATH);
                 fLoadedDll = hLibrary != nullptr;
             }
         }

--- a/src/interactivity/win32/window.cpp
+++ b/src/interactivity/win32/window.cpp
@@ -53,7 +53,7 @@ Window* Window::s_Instance = nullptr;
 Window::Window() :
     _fIsInFullscreen(false),
     _pSettings(nullptr),
-    _hWnd(0),
+    _hWnd(nullptr),
     _pUiaProvider(nullptr)
 {
     ZeroMemory((void*)&_rcClientLast, sizeof(_rcClientLast));
@@ -217,7 +217,7 @@ void Window::_UpdateSystemMetrics() const
             // determine the initial window size, which happens BEFORE the
             // window is created, we'll want to make sure the DX engine does
             // math in the hwnd mode, not the Composition mode.
-            THROW_IF_FAILED(pDxEngine->SetHwnd(0));
+            THROW_IF_FAILED(pDxEngine->SetHwnd(nullptr));
             g.pRender->AddRenderEngine(pDxEngine);
         }
         else

--- a/src/interactivity/win32/windowproc.cpp
+++ b/src/interactivity/win32/windowproc.cpp
@@ -131,7 +131,7 @@ using namespace Microsoft::Console::Types;
         RECT rectProposed = { rc.left, rc.top, 0, 0 };
         _CalculateWindowRect(_pSettings->GetWindowSize(), &rectProposed);
 
-        SetWindowPos(hWnd, NULL, rectProposed.left, rectProposed.top, RECT_WIDTH(&rectProposed), RECT_HEIGHT(&rectProposed), SWP_NOACTIVATE | SWP_NOZORDER);
+        SetWindowPos(hWnd, nullptr, rectProposed.left, rectProposed.top, RECT_WIDTH(&rectProposed), RECT_HEIGHT(&rectProposed), SWP_NOACTIVATE | SWP_NOZORDER);
 
         // Save the proposed window rect dimensions here so we can adjust if the system comes back and changes them on what we asked for.
         ServiceLocator::LocateWindowMetrics<WindowMetrics>()->ConvertWindowRectToClientRect(&rectProposed);
@@ -156,7 +156,7 @@ using namespace Microsoft::Console::Types;
         // signal to uia that they can disconnect our uia provider
         if (_pUiaProvider)
         {
-            UiaReturnRawElementProvider(hWnd, 0, 0, NULL);
+            UiaReturnRawElementProvider(hWnd, 0, 0, nullptr);
         }
         break;
     }
@@ -695,7 +695,7 @@ using namespace Microsoft::Console::Types;
     {
         // Re-read the edit key settings from registry.
         Registry reg(&gci);
-        reg.GetEditKeys(NULL);
+        reg.GetEditKeys(nullptr);
         break;
     }
 

--- a/src/propsheet/ColorControl.cpp
+++ b/src/propsheet/ColorControl.cpp
@@ -33,7 +33,7 @@ void SimpleColorDoPaint(const HWND hColor, PAINTSTRUCT& ps, const int ColorId)
 
     GetClientRect(hColor, &rColor);
     rgbBrush = GetNearestColor(ps.hdc, GetColorForItem(ColorId));
-    if ((hbr = CreateSolidBrush(rgbBrush)) != NULL)
+    if ((hbr = CreateSolidBrush(rgbBrush)) != nullptr)
     {
         InflateRect(&rColor, -1, -1);
         FillRect(ps.hdc, &rColor, hbr);

--- a/src/propsheet/ColorsPage.cpp
+++ b/src/propsheet/ColorsPage.cpp
@@ -178,12 +178,12 @@ INT_PTR WINAPI ColorDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
 
             // repaint new color
             hWnd = GetDlgItem(hDlg, ColorArray[iColor] + IDD_COLOR_1);
-            InvalidateRect(hWnd, NULL, TRUE);
+            InvalidateRect(hWnd, nullptr, TRUE);
 
             // repaint old color
             if (hWndOld != hWnd)
             {
-                InvalidateRect(hWndOld, NULL, TRUE);
+                InvalidateRect(hWndOld, nullptr, TRUE);
             }
 
             return TRUE;
@@ -247,11 +247,11 @@ INT_PTR WINAPI ColorDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
                              * Update the preview windows with the new value
                              */
                 hWnd = GetDlgItem(hDlg, IDD_COLOR_SCREEN_COLORS);
-                InvalidateRect(hWnd, NULL, FALSE);
+                InvalidateRect(hWnd, nullptr, FALSE);
                 hWnd = GetDlgItem(hDlg, IDD_COLOR_POPUP_COLORS);
-                InvalidateRect(hWnd, NULL, FALSE);
+                InvalidateRect(hWnd, nullptr, FALSE);
                 hWnd = GetDlgItem(hDlg, ColorArray[iColor] + IDD_COLOR_1);
-                InvalidateRect(hWnd, NULL, FALSE);
+                InvalidateRect(hWnd, nullptr, FALSE);
                 break;
             }
             return TRUE;
@@ -357,11 +357,11 @@ INT_PTR WINAPI ColorDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
         {
             hWnd = GetDlgItem(hDlg, IDD_COLOR_POPUP_COLORS);
         }
-        InvalidateRect(hWnd, NULL, TRUE);
+        InvalidateRect(hWnd, nullptr, TRUE);
 
         // repaint new color
         hWnd = GetDlgItem(hDlg, ColorArray[iColor] + IDD_COLOR_1);
-        InvalidateRect(hWnd, NULL, TRUE);
+        InvalidateRect(hWnd, nullptr, TRUE);
         SetFocus(hWnd);
 
         UpdateItem(hDlg, IDD_COLOR_RED, GetRValue(AttrToRGB(ColorArray[iColor])));
@@ -371,7 +371,7 @@ INT_PTR WINAPI ColorDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
         // repaint old color
         if (hWndOld != hWnd)
         {
-            InvalidateRect(hWndOld, NULL, TRUE);
+            InvalidateRect(hWndOld, nullptr, TRUE);
         }
         return TRUE;
 

--- a/src/propsheet/OptionsPage.cpp
+++ b/src/propsheet/OptionsPage.cpp
@@ -261,11 +261,11 @@ INT_PTR WINAPI SettingsDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lPara
                 PNMLINK pnmLink = (PNMLINK)lParam;
                 if (0 == pnmLink->item.iLink)
                 {
-                    ShellExecute(NULL,
+                    ShellExecute(nullptr,
                                  L"open",
                                  pnmLink->item.szUrl,
-                                 NULL,
-                                 NULL,
+                                 nullptr,
+                                 nullptr,
                                  SW_SHOW);
                 }
 

--- a/src/propsheet/PropSheetHandler.cpp
+++ b/src/propsheet/PropSheetHandler.cpp
@@ -144,7 +144,7 @@ private:
         *ppidl = nullptr;
 
         IShellLink* psl;
-        HRESULT hr = psiLink->BindToHandler(NULL, BHID_SFUIObject, IID_PPV_ARGS(&psl));
+        HRESULT hr = psiLink->BindToHandler(nullptr, BHID_SFUIObject, IID_PPV_ARGS(&psl));
         if (SUCCEEDED(hr))
         {
             hr = psl->GetIDList(ppidl);
@@ -218,6 +218,7 @@ private:
                             // Second expensive portion of this method -- cracks the PE header of the .lnk file target
                             // if it's an executable
                             SHFILEINFO sfi = { 0 };
+
                             DWORD_PTR dwFileType = SHGetFileInfo(szFileExpanded,
                                                                  0 /*dwFileAttributes*/,
                                                                  &sfi,

--- a/src/propsheet/TerminalPage.cpp
+++ b/src/propsheet/TerminalPage.cpp
@@ -170,9 +170,9 @@ bool InitTerminalDialog(const HWND hDlg) noexcept
     _UseBackground(hDlg, initialTerminalBG);
     _UseCursorColor(hDlg, !initialCursorLegacy);
 
-    InvalidateRect(GetDlgItem(hDlg, IDD_TERMINAL_FGCOLOR), NULL, FALSE);
-    InvalidateRect(GetDlgItem(hDlg, IDD_TERMINAL_BGCOLOR), NULL, FALSE);
-    InvalidateRect(GetDlgItem(hDlg, IDD_TERMINAL_CURSOR_COLOR), NULL, FALSE);
+    InvalidateRect(GetDlgItem(hDlg, IDD_TERMINAL_FGCOLOR), nullptr, FALSE);
+    InvalidateRect(GetDlgItem(hDlg, IDD_TERMINAL_BGCOLOR), nullptr, FALSE);
+    InvalidateRect(GetDlgItem(hDlg, IDD_TERMINAL_CURSOR_COLOR), nullptr, FALSE);
 
     CheckRadioButton(hDlg,
                      IDD_TERMINAL_LEGACY_CURSOR,
@@ -221,7 +221,7 @@ void _ChangeColorControl(const HWND hDlg,
         setting = RGB(r, g, b);
     }
 
-    InvalidateRect(GetDlgItem(hDlg, colorControl), NULL, FALSE);
+    InvalidateRect(GetDlgItem(hDlg, colorControl), nullptr, FALSE);
 }
 
 void _ChangeForegroundRGB(const HWND hDlg, const WORD item) noexcept
@@ -378,11 +378,11 @@ INT_PTR WINAPI TerminalDlgProc(const HWND hDlg, const UINT wMsg, const WPARAM wP
                 PNMLINK pnmLink = (PNMLINK)lParam;
                 if (0 == pnmLink->item.iLink)
                 {
-                    ShellExecute(NULL,
+                    ShellExecute(nullptr,
                                  L"open",
                                  pnmLink->item.szUrl,
-                                 NULL,
-                                 NULL,
+                                 nullptr,
+                                 nullptr,
                                  SW_SHOW);
                 }
 

--- a/src/propsheet/console.cpp
+++ b/src/propsheet/console.cpp
@@ -94,7 +94,7 @@ void SaveConsoleSettingsIfNeeded(const HWND hwnd)
             gpStateInfo->FaceName[0] = TEXT('\0');
         }
 
-        if (gpStateInfo->LinkTitle != NULL)
+        if (gpStateInfo->LinkTitle != nullptr)
         {
             SetGlobalRegistryValues();
             if (!NT_SUCCESS(ShortcutSerialization::s_SetLinkValues(gpStateInfo,
@@ -175,16 +175,16 @@ void CreateAndAssociateToolTipToControl(const UINT dlgItem, const HWND hDlg, con
 {
     HWND hwndTooltip = CreateWindowEx(0 /*dwExtStyle*/,
                                       TOOLTIPS_CLASS,
-                                      NULL /*lpWindowName*/,
+                                      nullptr /*lpWindowName*/,
                                       TTS_ALWAYSTIP,
                                       CW_USEDEFAULT,
                                       CW_USEDEFAULT,
                                       CW_USEDEFAULT,
                                       CW_USEDEFAULT,
                                       hDlg,
-                                      NULL /*hMenu*/,
+                                      nullptr /*hMenu*/,
                                       ghInstance,
-                                      NULL /*lpParam*/);
+                                      nullptr /*lpParam*/);
 
     if (hwndTooltip)
     {
@@ -615,7 +615,7 @@ INT_PTR ConsolePropertySheet(__in HWND hWnd, __in PCONSOLE_STATE_INFO pStateInfo
     // Get the current page number
     //
 
-    gnCurrentPage = GetRegistryValues(NULL);
+    gnCurrentPage = GetRegistryValues(nullptr);
 
     //
     // Initialize the property sheet structures
@@ -648,7 +648,7 @@ INT_PTR ConsolePropertySheet(__in HWND hWnd, __in PCONSOLE_STATE_INFO pStateInfo
     psh.nPages = g_fForceV2 ? NUMBER_OF_PAGES : V1_NUMBER_OF_PAGES;
     psh.nStartPage = std::min<UINT>(gnCurrentPage, ARRAYSIZE(psp));
     psh.ppsp = psp;
-    psh.pfnCallback = NULL;
+    psh.pfnCallback = nullptr;
 
     //
     // Create the property sheet
@@ -665,7 +665,7 @@ INT_PTR ConsolePropertySheet(__in HWND hWnd, __in PCONSOLE_STATE_INFO pStateInfo
 
     if (!gpStateInfo->Defaults)
     {
-        if (gpStateInfo->OriginalTitle != NULL)
+        if (gpStateInfo->OriginalTitle != nullptr)
         {
             HeapFree(GetProcessHeap(), 0, gpStateInfo->OriginalTitle);
         }
@@ -685,9 +685,9 @@ void RegisterClasses(HINSTANCE hModule)
     wc.lpszClassName = TEXT("SimpleColor");
     wc.hInstance = hModule;
     wc.lpfnWndProc = SimpleColorControlProc;
-    wc.hCursor = LoadCursor(NULL, IDC_ARROW);
-    wc.hIcon = NULL;
-    wc.lpszMenuName = NULL;
+    wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
+    wc.hIcon = nullptr;
+    wc.lpszMenuName = nullptr;
     wc.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
     wc.style = CS_HREDRAW | CS_VREDRAW;
     wc.cbClsExtra = 0;
@@ -697,9 +697,9 @@ void RegisterClasses(HINSTANCE hModule)
     wc.lpszClassName = TEXT("ColorTableColor");
     wc.hInstance = hModule;
     wc.lpfnWndProc = ColorTableControlProc;
-    wc.hCursor = LoadCursor(NULL, IDC_ARROW);
-    wc.hIcon = NULL;
-    wc.lpszMenuName = NULL;
+    wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
+    wc.hIcon = nullptr;
+    wc.lpszMenuName = nullptr;
     wc.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
     wc.style = CS_HREDRAW | CS_VREDRAW;
     wc.cbClsExtra = 0;

--- a/src/propsheet/dbcs.cpp
+++ b/src/propsheet/dbcs.cpp
@@ -124,7 +124,7 @@ BOOL IsDisableBoldTTFont(
     LPTTFONTLIST pTTFontList;
 
     pTTFontList = SearchTTFont(ptszFace, FALSE, 0);
-    if (pTTFontList != NULL)
+    if (pTTFontList != nullptr)
     {
         return pTTFontList->fDisableBold;
     }
@@ -141,7 +141,7 @@ GetAltFaceName(
     LPTTFONTLIST pTTFontList;
 
     pTTFontList = SearchTTFont(ptszFace, FALSE, 0);
-    if (pTTFontList != NULL)
+    if (pTTFontList != nullptr)
     {
         if (wcscmp(ptszFace, pTTFontList->FaceName1) == 0)
         {
@@ -154,7 +154,7 @@ GetAltFaceName(
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 [[nodiscard]] NTSTATUS

--- a/src/propsheet/fontdlg.cpp
+++ b/src/propsheet/fontdlg.cpp
@@ -50,7 +50,7 @@ void RecreateFontHandles(const HWND hWnd);
 
 /* ----- Globals ----- */
 
-HBITMAP hbmTT = NULL; // handle of TT logo bitmap
+HBITMAP hbmTT = nullptr; // handle of TT logo bitmap
 BITMAP bmTT; // attributes of TT source bitmap
 
 BOOL gbPointSizeError = FALSE;
@@ -68,10 +68,10 @@ WCHAR wszRasterFonts[CCH_RASTERFONTS + 1];
 UINT GetItemHeight(const HWND hDlg)
 {
     // Load the TrueType logo bitmap
-    if (hbmTT != NULL)
+    if (hbmTT != nullptr)
     {
         DeleteObject(hbmTT);
-        hbmTT = NULL;
+        hbmTT = nullptr;
     }
 
     hbmTT = LoadBitmap(ghInstance, MAKEINTRESOURCE(BM_TRUETYPE_ICON));
@@ -132,7 +132,7 @@ BOOL IsBoldOnlyTTFont(_In_ PCWSTR pwszTTFace, _In_opt_ PCWSTR pwszAltTTFace)
 
         // only care if this TT font's name matches
         if ((0 != lstrcmp(FontInfo[i].FaceName, pwszTTFace)) && // wrong face name and
-            (pwszAltTTFace == NULL || // either pwszAltTTFace is NULL or
+            (!pwszAltTTFace || // either pwszAltTTFace is NULL or
              (0 != lstrcmp(FontInfo[i].FaceName, pwszAltTTFace)))) // pwszAltTTFace is wrong too
         {
             // A TrueType font, but not the one we're interested in
@@ -281,7 +281,7 @@ FontDlgProc(
         {
             // if we're bold, we need to figure out if it's because the user chose this font or if it's because the font
             // is only available in bold
-            if (IsBoldOnlyTTFont(FontInfo[g_currentFontIndex].FaceName, NULL))
+            if (IsBoldOnlyTTFont(FontInfo[g_currentFontIndex].FaceName, nullptr))
             {
                 // Bold-only TT font, disable the bold checkbox
                 EnableWindow(GetDlgItem(hDlg, IDD_BOLDFONT), FALSE);
@@ -295,7 +295,7 @@ FontDlgProc(
         }
 
         FontListCreate(hDlg,
-                       bLB ? NULL : FontInfo[g_currentFontIndex].FaceName,
+                       bLB ? nullptr : FontInfo[g_currentFontIndex].FaceName,
                        TRUE);
 
         /* Initialize the preview window - selects current face & size too */
@@ -310,7 +310,7 @@ FontDlgProc(
     case WM_FONTCHANGE:
         gbEnumerateFaces = TRUE;
         bLB = !TM_IS_TT_FONT(gpStateInfo->FontFamily);
-        FontListCreate(hDlg, NULL, TRUE);
+        FontListCreate(hDlg, nullptr, TRUE);
         FontIndex = FindCreateFont(gpStateInfo->FontFamily,
                                    gpStateInfo->FaceName,
                                    gpStateInfo->FontSize,
@@ -327,10 +327,10 @@ FontDlgProc(
             /* Create the list of suitable fonts */
             bLB = !TM_IS_TT_FONT(gpStateInfo->FontFamily);
             FontListCreate(hDlg,
-                           !bLB ? NULL : gpStateInfo->FaceName,
+                           !bLB ? nullptr : gpStateInfo->FaceName,
                            TRUE);
             FontIndex = FontListCreate(hDlg,
-                                       bLB ? NULL : gpStateInfo->FaceName,
+                                       bLB ? nullptr : gpStateInfo->FaceName,
                                        TRUE);
 
             /* Initialize the preview window - selects current face & size too */
@@ -358,7 +358,7 @@ FontDlgProc(
                 // for bold earlier, then unset bold. note that we're depending on the fact that by this point
                 // FontIndex hasn't yet been updated to refer to the new font that the user selected.
                 if (IS_BOLD(FontInfo[FontIndex].Weight) &&
-                    IsBoldOnlyTTFont(FontInfo[FontIndex].FaceName, NULL) &&
+                    IsBoldOnlyTTFont(FontInfo[FontIndex].FaceName, nullptr) &&
                     !gbUserChoseBold)
                 {
                     gbBold = FALSE;
@@ -376,7 +376,7 @@ FontDlgProc(
                     DBGFONTS(("LBN_EDITUPDATE, got TT face \"%ls\"\n", atchNewFace));
                 }
                 FontIndex = FontListCreate(hDlg,
-                                           bLB ? NULL : atchNewFace,
+                                           bLB ? nullptr : atchNewFace,
                                            FALSE);
                 SelectCurrentSize(hDlg, bLB, FontIndex);
                 PreviewUpdate(hDlg, bLB);
@@ -400,7 +400,7 @@ FontDlgProc(
                 if (!gbPointSizeError)
                 {
                     hWndFocus = GetFocus();
-                    if (hWndFocus != NULL && IsChild(hDlg, hWndFocus) &&
+                    if (hWndFocus != nullptr && IsChild(hDlg, hWndFocus) &&
                         hWndFocus != GetDlgItem(hDlg, IDCANCEL))
                     {
                         AddCustomFontSizeToListIfNeeded(hDlg);
@@ -444,7 +444,7 @@ FontDlgProc(
             // If the TT combo box is visible, update selection
             //
             hWndList = GetDlgItem(hDlg, IDD_POINTSLIST);
-            if (hWndList != NULL && IsWindowVisible(hWndList))
+            if (hWndList != nullptr && IsWindowVisible(hWndList))
             {
                 if (!PreviewUpdate(hDlg, FALSE))
                 {
@@ -502,10 +502,10 @@ FontDlgProc(
         /*
          * Delete the TrueType logo bitmap
          */
-        if (hbmTT != NULL)
+        if (hbmTT != nullptr)
         {
             DeleteObject(hbmTT);
-            hbmTT = NULL;
+            hbmTT = nullptr;
         }
         return TRUE;
 
@@ -706,7 +706,7 @@ int FontListCreate(
     bLB = ((pwszTTFace == nullptr) || (pwszTTFace[0] == TEXT('\0')));
     if (bLB)
     {
-        pwszAltTTFace = NULL;
+        pwszAltTTFace = nullptr;
     }
     else
     {
@@ -977,7 +977,7 @@ VOID DrawItemFontList(const HWND hDlg, const LPDRAWITEMSTRUCT lpdis)
         DBGFONTS(("DrawItemFontList must redraw \"%ls\" %s\n", wszFace, bLB ? "Raster" : "TrueType"));
 
         // draw the text
-        TabbedTextOut(hDC, lpdis->rcItem.left + dxttbmp, lpdis->rcItem.top, wszFace, (UINT)wcslen(wszFace), 0, NULL, dxttbmp);
+        TabbedTextOut(hDC, lpdis->rcItem.left + dxttbmp, lpdis->rcItem.top, wszFace, (UINT)wcslen(wszFace), 0, nullptr, dxttbmp);
 
         // and the TT bitmap if needed
         if (!bLB)
@@ -1155,7 +1155,7 @@ int FindCreateFont(
     {
         if (IS_DBCS_OR_OEM_CHARSET(CharSet))
         {
-            if (pwszFace == NULL || *pwszFace == TEXT('\0'))
+            if (pwszFace == nullptr || *pwszFace == TEXT('\0'))
             {
                 pwszFace = DefaultFaceName;
             }
@@ -1168,7 +1168,7 @@ int FindCreateFont(
         {
             MakeAltRasterFont(CodePage, &AltFontSize, &AltFontFamily, &AltFontIndex, AltFaceName);
 
-            if (pwszFace == NULL || *pwszFace == TEXT('\0'))
+            if (pwszFace == nullptr || *pwszFace == TEXT('\0'))
             {
                 pwszFace = AltFaceName;
             }
@@ -1181,7 +1181,7 @@ int FindCreateFont(
     }
     else
     {
-        if (pwszFace == NULL || *pwszFace == TEXT('\0'))
+        if (pwszFace == nullptr || *pwszFace == TEXT('\0'))
         {
             pwszFace = DefaultFaceName;
         }
@@ -1256,7 +1256,7 @@ TryFindExactFont:
          * if it matches, use this font. Otherwise, if name doesn't match and
          * it is a raster font, consider it.
          */
-        if ((pwszFace == NULL) || (pwszFace[0] == TEXT('\0')) ||
+        if ((pwszFace == nullptr) || (pwszFace[0] == TEXT('\0')) ||
             (lstrcmp(FontInfo[i].FaceName, pwszFace) == 0) ||
             (lstrcmp(FontInfo[i].FaceName, pwszAltFace) == 0))
         {
@@ -1278,7 +1278,7 @@ TryFindExactFont:
         {
             Size.Y = -Size.Y;
         }
-        bFontOK = DoFontEnum(NULL, pwszFace, &Size.Y, 1);
+        bFontOK = DoFontEnum(nullptr, pwszFace, &Size.Y, 1);
         if (bFontOK)
         {
             DBGFONTS(("FindCreateFont created font!\n"));
@@ -1617,17 +1617,17 @@ BOOL PreviewUpdate(
     StringCchPrintf(wszText, ARRAYSIZE(wszText), TEXT("%u"), lpFont->Size.X);
     hWnd = GetDlgItem(hDlg, IDD_FONTWIDTH);
     SetWindowText(hWnd, wszText);
-    InvalidateRect(hWnd, NULL, TRUE);
+    InvalidateRect(hWnd, nullptr, TRUE);
     StringCchPrintf(wszText, ARRAYSIZE(wszText), TEXT("%u"), lpFont->Size.Y);
     hWnd = GetDlgItem(hDlg, IDD_FONTHEIGHT);
     SetWindowText(hWnd, wszText);
-    InvalidateRect(hWnd, NULL, TRUE);
+    InvalidateRect(hWnd, nullptr, TRUE);
 
     /* Force the preview windows to repaint */
     hWnd = GetDlgItem(hDlg, IDD_PREVIEWWINDOW);
     SendMessage(hWnd, CM_PREVIEW_UPDATE, 0, 0);
     hWnd = GetDlgItem(hDlg, IDD_FONTWINDOW);
-    InvalidateRect(hWnd, NULL, TRUE);
+    InvalidateRect(hWnd, nullptr, TRUE);
 
     DBGFONTS(("Font %x, (%d,%d) %ls\n",
               FontIndex,

--- a/src/propsheet/globals.cpp
+++ b/src/propsheet/globals.cpp
@@ -40,11 +40,11 @@ BYTE DefaultFontFamily;
 ULONG DefaultFontIndex = 0;
 ULONG g_currentFontIndex = 0;
 
-PFONT_INFO FontInfo = NULL;
+PFONT_INFO FontInfo = nullptr;
 ULONG NumberOfFonts;
 ULONG FontInfoLength;
 BOOL gbEnumerateFaces = FALSE;
-PFACENODE gpFaceNames = NULL;
+PFACENODE gpFaceNames = nullptr;
 
 BOOL g_fSettingsDlgInitialized = FALSE;
 

--- a/src/propsheet/init.cpp
+++ b/src/propsheet/init.cpp
@@ -82,7 +82,7 @@ LONG CPlApplet(
 
         lpCPlInfo = (LPNEWCPLINFO)lParam2;
 
-        lpCPlInfo->hIcon = LoadIcon(NULL, MAKEINTRESOURCE(IDI_CONSOLE));
+        lpCPlInfo->hIcon = LoadIcon(nullptr, MAKEINTRESOURCE(IDI_CONSOLE));
 
         if (!LoadString(ghInstance, IDS_NAME, lpCPlInfo->szName, ARRAYSIZE(lpCPlInfo->szName)))
         {

--- a/src/propsheet/misc.cpp
+++ b/src/propsheet/misc.cpp
@@ -107,12 +107,12 @@ AddFaceNode(
     pNew = (PFACENODE)HeapAlloc(GetProcessHeap(),
                                 0,
                                 sizeof(FACENODE) + ((cch + 1) * sizeof(WCHAR)));
-    if (pNew == NULL)
+    if (pNew == nullptr)
     {
-        return NULL;
+        return nullptr;
     }
 
-    pNew->pNext = NULL;
+    pNew->pNext = nullptr;
     pNew->dwFlag = 0;
     StringCchCopy(pNew->atch, cch + 1, ptsz);
     *ppTmp = pNew;
@@ -126,14 +126,14 @@ VOID
     PFACENODE pNext, pTmp;
 
     pTmp = gpFaceNames;
-    while (pTmp != NULL)
+    while (pTmp != nullptr)
     {
         pNext = pTmp->pNext;
         HeapFree(GetProcessHeap(), 0, pTmp);
         pTmp = pNext;
     }
 
-    gpFaceNames = NULL;
+    gpFaceNames = nullptr;
 }
 
 // TODO: Refactor into lib for use by both conhost and console.dll
@@ -188,7 +188,7 @@ void RecreateFontHandles(const HWND hWnd)
                 if (SUCCEEDED(StringCchCopy(lf.lfFaceName, ARRAYSIZE(lf.lfFaceName), FontInfo[iCurrFont].FaceName)))
                 {
                     HFONT hRescaledFont = CreateFontIndirect(&lf);
-                    if (hRescaledFont != NULL)
+                    if (hRescaledFont != nullptr)
                     {
                         // Only replace the existing font if we've got a replacement. The worst that can happen is that
                         // we fail to create our scaled font, so the user sees an incorrectly-scaled font preview.
@@ -281,7 +281,7 @@ CreateBoldFont:
     {
         COORD SizeShown;
 
-        if (FontInfo[nFont].hFont == NULL)
+        if (FontInfo[nFont].hFont == nullptr)
         {
             DBGFONTS(("!   Font %x has a NULL hFont\n", nFont));
             continue;
@@ -351,7 +351,7 @@ CreateBoldFont:
      */
     if (NumberOfFonts == FontInfoLength)
     {
-        PFONT_INFO Temp = NULL;
+        PFONT_INFO Temp = nullptr;
 
         FontInfoLength += FONT_INCREMENT;
         if (FontInfoLength < MAX_FONT_INFO_ALLOC)
@@ -362,7 +362,7 @@ CreateBoldFont:
                                            sizeof(FONT_INFO) * FontInfoLength);
         }
 
-        if (Temp == NULL)
+        if (Temp == nullptr)
         {
             FontInfoLength -= FONT_INCREMENT;
             return FE_ABANDONFONT; // no point enumerating more - no memory!
@@ -448,14 +448,14 @@ VOID
 {
     ULONG FontIndex;
 
-    if (FontInfo != NULL)
+    if (FontInfo != nullptr)
     {
         for (FontIndex = 0; FontIndex < NumberOfFonts; FontIndex++)
         {
             DeleteObject(FontInfo[FontIndex].hFont);
         }
         HeapFree(GetProcessHeap(), 0, FontInfo);
-        FontInfo = NULL;
+        FontInfo = nullptr;
         NumberOfFonts = 0;
     }
 
@@ -542,7 +542,7 @@ int CALLBACK FontEnumForV2Console(ENUMLOGFONT* pelf, NEWTEXTMETRIC* pntm, int nF
      * Add or find the facename
      */
     pFN = AddFaceNode(ptszFace);
-    if (pFN == NULL)
+    if (pFN == nullptr)
     {
         return FE_ABANDONFONT;
     }
@@ -712,7 +712,7 @@ int
      * Add or find the facename
      */
     pFN = AddFaceNode(ptszFace);
-    if (pFN == NULL)
+    if (pFN == nullptr)
     {
         return FE_ABANDONFONT;
     }
@@ -791,14 +791,14 @@ BOOL DoFontEnum(
     LOGFONT LogFont;
 
     DBGFONTS(("DoFontEnum \"%ls\"\n", ptszFace));
-    if (hDC == NULL)
+    if (hDC == nullptr)
     {
-        hDC = CreateCompatibleDC(NULL);
+        hDC = CreateCompatibleDC(nullptr);
         bDeleteDC = TRUE;
     }
 
     fed.hDC = hDC;
-    fed.bFindFaces = (ptszFace == NULL);
+    fed.bFindFaces = (ptszFace == nullptr);
     fed.ulFE = 0;
     fed.pTTPoints = pTTPoints;
     fed.nTTPoints = nTTPoints;
@@ -851,7 +851,7 @@ VOID RemoveFace(__in_ecount(LF_FACESIZE) LPCTSTR ptszFace)
                       FontInfo[i].hFont,
                       bDeleted ? "" : "NOT "));
             bDeleted; // to fix x86 build complaining
-            FontInfo[i].hFont = NULL;
+            FontInfo[i].hFont = nullptr;
             nToRemove++;
         }
         else if (nToRemove > 0)
@@ -912,7 +912,7 @@ static bool IsCurrentFontSizeCustom()
 // font sizes)
 void CreateSizeForAllTTFonts(__in const SHORT sSize)
 {
-    HDC hDC = CreateCompatibleDC(NULL);
+    HDC hDC = CreateCompatibleDC(nullptr);
 
     // for each font face
     for (PFACENODE pFN = gpFaceNames; pFN; pFN = pFN->pNext)
@@ -939,7 +939,7 @@ EnumerateFonts(
 
     dwFontType = (EF_TTFONT | EF_OEMFONT | EF_DEFFACE) & Flags;
 
-    if (FontInfo == NULL)
+    if (FontInfo == nullptr)
     {
         //
         // allocate memory for the font array
@@ -947,7 +947,7 @@ EnumerateFonts(
         NumberOfFonts = 0;
 
         FontInfo = (PFONT_INFO)HeapAlloc(GetProcessHeap(), 0, sizeof(FONT_INFO) * INITIAL_FONTS);
-        if (FontInfo == NULL)
+        if (FontInfo == nullptr)
         {
             return STATUS_NO_MEMORY;
         }
@@ -955,7 +955,7 @@ EnumerateFonts(
         FontInfoLength = INITIAL_FONTS;
     }
 
-    hDC = CreateCompatibleDC(NULL);
+    hDC = CreateCompatibleDC(nullptr);
 
     if (Flags & EF_DEFFACE)
     {
@@ -976,7 +976,7 @@ EnumerateFonts(
 
         // Make sure we are going to enumerate the OEM face.
         pFN = AddFaceNode(DefaultFaceName);
-        if (pFN != NULL)
+        if (pFN != nullptr)
         {
             pFN->dwFlag |= EF_DEFFACE | EF_OEMFONT;
         }
@@ -999,7 +999,7 @@ EnumerateFonts(
         // All facenames found will be put in gpFaceNames with
         // the EF_NEW bit set.
         //
-        DoFontEnum(hDC, NULL, TTPoints, 1);
+        DoFontEnum(hDC, nullptr, TTPoints, 1);
         gbEnumerateFaces = FALSE;
     }
 
@@ -1037,7 +1037,7 @@ EnumerateFonts(
         }
         else
         {
-            DoFontEnum(hDC, pFN->atch, NULL, 0);
+            DoFontEnum(hDC, pFN->atch, nullptr, 0);
         }
         pFN->dwFlag |= EF_ENUMERATED;
     }

--- a/src/propsheet/preview.cpp
+++ b/src/propsheet/preview.cpp
@@ -405,7 +405,7 @@ VOID PreviewPaint(
         cy = AspectScale(gcyScreen, gcxScreen, cx);
         if (cy != rcWindow.bottom - rcWindow.top)
         {
-            SetWindowPos(hWnd, NULL, 0, 0, cx, cy, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOZORDER);
+            SetWindowPos(hWnd, nullptr, 0, 0, cx, cy, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOZORDER);
         }
 
         InvalidatePreviewRect(hWnd);

--- a/src/propsheet/registry.cpp
+++ b/src/propsheet/registry.cpp
@@ -124,9 +124,9 @@ VOID InitRegistryValues(
     // clang-format on
 
     pStateInfo->CodePage = OEMCP;
-    pStateInfo->hWnd = NULL;
-    pStateInfo->OriginalTitle = NULL;
-    pStateInfo->LinkTitle = NULL;
+    pStateInfo->hWnd = nullptr;
+    pStateInfo->OriginalTitle = nullptr;
+    pStateInfo->LinkTitle = nullptr;
 
     // v2 console state
     pStateInfo->fWrapText = TRUE;
@@ -193,7 +193,7 @@ DWORD GetRegistryValues(
                                                      sizeof(dwValue),
                                                      REG_DWORD,
                                                      (PBYTE)&dwValue,
-                                                     NULL);
+                                                     nullptr);
         if (NT_SUCCESS(Status))
         {
             dwRet = dwValue;
@@ -231,7 +231,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->ScreenAttributes = (WORD)dwValue;
@@ -246,7 +246,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->PopupAttributes = (WORD)dwValue;
@@ -267,7 +267,7 @@ DWORD GetRegistryValues(
                                                      sizeof(dwValue),
                                                      REG_DWORD,
                                                      (PBYTE)&dwValue,
-                                                     NULL);
+                                                     nullptr);
         if (NT_SUCCESS(Status))
         {
             pStateInfo->ColorTable[i] = dwValue;
@@ -282,7 +282,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->InsertMode = !!dwValue;
@@ -296,7 +296,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->QuickEdit = !!dwValue;
@@ -312,7 +312,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         if (IsValidCodePage(dwValue))
@@ -329,7 +329,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->ScreenBufferSize.X = LOWORD(dwValue);
@@ -344,7 +344,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->WindowSize.X = LOWORD(dwValue);
@@ -359,7 +359,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->WindowPosX = (SHORT)LOWORD(dwValue);
@@ -376,7 +376,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->FontSize.X = LOWORD(dwValue);
@@ -391,7 +391,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->FontFamily = dwValue;
@@ -405,7 +405,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->FontWeight = dwValue;
@@ -419,7 +419,7 @@ DWORD GetRegistryValues(
                                                  sizeof(awchBuffer),
                                                  REG_SZ,
                                                  (PBYTE)awchBuffer,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         RtlCopyMemory(pStateInfo->FaceName, awchBuffer, sizeof(awchBuffer));
@@ -433,7 +433,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->CursorSize = dwValue;
@@ -447,7 +447,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->HistoryBufferSize = dwValue;
@@ -461,7 +461,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->NumberOfHistoryBuffers = dwValue;
@@ -475,7 +475,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->HistoryNoDup = dwValue;
@@ -489,7 +489,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->fWrapText = dwValue;
@@ -503,7 +503,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->fFilterOnPaste = dwValue;
@@ -517,7 +517,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->fCtrlKeyShortcutsDisabled = dwValue;
@@ -531,7 +531,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->fLineSelection = dwValue;
@@ -545,7 +545,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         if (dwValue <= BYTE_MAX)
@@ -560,7 +560,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->CursorColor = dwValue;
@@ -571,7 +571,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->CursorType = dwValue;
@@ -583,7 +583,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->InterceptCopyPaste = !!dwValue;
@@ -595,7 +595,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->DefaultForeground = dwValue;
@@ -607,7 +607,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->DefaultBackground = dwValue;
@@ -619,7 +619,7 @@ DWORD GetRegistryValues(
                                                  sizeof(dwValue),
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
-                                                 NULL);
+                                                 nullptr);
     if (NT_SUCCESS(Status))
     {
         pStateInfo->TerminalScrolling = dwValue;

--- a/src/propslib/ShortcutSerialization.cpp
+++ b/src/propslib/ShortcutSerialization.cpp
@@ -290,7 +290,7 @@ void ShortcutSerialization::s_GetLinkTitle(_In_ PCWSTR pwszShortcutFilename,
     *ppsl = nullptr;
     *ppPf = nullptr;
     IShellLink* psl;
-    HRESULT hr = SHCoCreateInstance(NULL, &CLSID_ShellLink, NULL, IID_PPV_ARGS(&psl));
+    HRESULT hr = SHCoCreateInstance(nullptr, &CLSID_ShellLink, nullptr, IID_PPV_ARGS(&psl));
     if (SUCCEEDED(hr))
     {
         IPersistFile* pPf;
@@ -517,7 +517,7 @@ void ShortcutSerialization::s_GetLinkTitle(_In_ PCWSTR pwszShortcutFilename,
         if (SUCCEEDED(hr))
         {
             // Only persist changes if we've successfully made them.
-            hr = ppf->Save(NULL, TRUE);
+            hr = ppf->Save(nullptr, TRUE);
         }
 
         ppf->Release();

--- a/src/propslib/precomp.h
+++ b/src/propslib/precomp.h
@@ -50,7 +50,7 @@ PopEntryList(
     PSINGLE_LIST_ENTRY FirstEntry;
 
     FirstEntry = ListHead->Next;
-    if (FirstEntry != NULL)
+    if (FirstEntry != nullptr)
     {
         ListHead->Next = FirstEntry->Next;
     }

--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -331,8 +331,8 @@ CustomTextLayout::CustomTextLayout(gsl::not_null<IDWriteFactory1*> const factory
             (run.bidiLevel & 1), // isRightToLeft
             &run.script,
             _localeName.data(),
-            NULL, // features
-            NULL, // featureRangeLengths
+            nullptr, // features
+            nullptr, // featureRangeLengths
             0, // featureRanges
             &_glyphAdvances.at(glyphStart),
             &_glyphOffsets.at(glyphStart));

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1624,7 +1624,7 @@ CATCH_RETURN()
         _ComputePixelShaderSettings();
         try
         {
-            _d3dDeviceContext->UpdateSubresource(_pixelShaderSettingsBuffer.Get(), 0, NULL, &_pixelShaderSettings, 0, 0);
+            _d3dDeviceContext->UpdateSubresource(_pixelShaderSettingsBuffer.Get(), 0, nullptr, &_pixelShaderSettings, 0, 0);
         }
         CATCH_RETURN();
     }

--- a/src/renderer/gdi/paint.cpp
+++ b/src/renderer/gdi/paint.cpp
@@ -667,7 +667,7 @@ void GdiEngine::_CreateDebugWindow()
                                        0,
                                        0,
                                        0,
-                                       0,
+                                       nullptr,
                                        nullptr,
                                        nullptr,
                                        nullptr);

--- a/src/renderer/gdi/state.cpp
+++ b/src/renderer/gdi/state.cpp
@@ -134,7 +134,7 @@ GdiEngine::~GdiEngine()
     }
 
 #if DBG
-    if (_debugWindow != INVALID_HANDLE_VALUE && _debugWindow != 0)
+    if (_debugWindow != INVALID_HANDLE_VALUE && _debugWindow != nullptr)
     {
         RECT rc = { 0 };
         THROW_IF_WIN32_BOOL_FALSE(GetWindowRect(_hwndTargetWindow, &rc));

--- a/src/server/Entrypoints.cpp
+++ b/src/server/Entrypoints.cpp
@@ -102,7 +102,7 @@
 
         // Call first time to find size
         SIZE_T AttributeListSize;
-        InitializeProcThreadAttributeList(NULL,
+        InitializeProcThreadAttributeList(nullptr,
                                           2,
                                           0,
                                           &AttributeListSize);

--- a/src/terminal/parser/ft_fuzzer/VTCommandFuzzer.cpp
+++ b/src/terminal/parser/ft_fuzzer/VTCommandFuzzer.cpp
@@ -513,7 +513,7 @@ int __cdecl wmain(int argc, WCHAR* argv[])
         return -1;
     }
 
-    HRESULT hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+    HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
     if (SUCCEEDED(hr))
     {
         LPWSTR pwszOutputDir = argv[2];

--- a/src/tools/vtpipeterm/VtConsole.cpp
+++ b/src/tools/vtpipeterm/VtConsole.cpp
@@ -51,8 +51,8 @@ HRESULT AttachPseudoConsole(HPCON hPC, LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeL
                                               PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
                                               hPC,
                                               sizeof(HPCON),
-                                              NULL,
-                                              NULL);
+                                              nullptr,
+                                              nullptr);
     return fSuccess ? S_OK : HRESULT_FROM_WIN32(GetLastError());
 }
 
@@ -70,7 +70,7 @@ HRESULT CreatePseudoConsoleAndHandles(COORD size,
                                       _Out_ HANDLE* phOutput,
                                       _Out_ HPCON* phPC)
 {
-    if (phPC == NULL || phInput == NULL || phOutput == NULL)
+    if (phPC == nullptr || phInput == nullptr || phOutput == nullptr)
     {
         return E_INVALIDARG;
     }
@@ -81,13 +81,13 @@ HRESULT CreatePseudoConsoleAndHandles(COORD size,
     HANDLE inPipePseudoConsoleSide;
 
     HRESULT hr = S_OK;
-    if (!CreatePipe(&inPipePseudoConsoleSide, &inPipeOurSide, NULL, 0))
+    if (!CreatePipe(&inPipePseudoConsoleSide, &inPipeOurSide, nullptr, 0))
     {
         hr = HRESULT_FROM_WIN32(GetLastError());
     }
     if (SUCCEEDED(hr))
     {
-        if (!CreatePipe(&outPipeOurSide, &outPipePseudoConsoleSide, NULL, 0))
+        if (!CreatePipe(&outPipeOurSide, &outPipePseudoConsoleSide, nullptr, 0))
         {
             hr = HRESULT_FROM_WIN32(GetLastError());
         }
@@ -165,7 +165,7 @@ void VtConsole::_createPseudoConsole(const std::wstring& command)
     siEx = { 0 };
     siEx.StartupInfo.cb = sizeof(STARTUPINFOEX);
     size_t size;
-    InitializeProcThreadAttributeList(NULL, 1, 0, (PSIZE_T)&size);
+    InitializeProcThreadAttributeList(nullptr, 1, 0, (PSIZE_T)&size);
     BYTE* attrList = new BYTE[size];
     siEx.lpAttributeList = reinterpret_cast<PPROC_THREAD_ATTRIBUTE_LIST>(attrList);
     fSuccess = InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, (PSIZE_T)&size);

--- a/src/tools/vtpipeterm/main.cpp
+++ b/src/tools/vtpipeterm/main.cpp
@@ -525,7 +525,7 @@ BOOL WINAPI CtrlHandler(DWORD fdwCtrlType)
 int __cdecl wmain(int argc, WCHAR* argv[])
 {
     // initialize random seed:
-    srand((unsigned int)time(NULL));
+    srand((unsigned int)time(nullptr));
     SetConsoleCtrlHandler(CtrlHandler, TRUE);
 
     hOut = GetStdHandle(STD_OUTPUT_HANDLE);
@@ -567,7 +567,7 @@ int __cdecl wmain(int argc, WCHAR* argv[])
 
     if (g_useOutfile)
     {
-        hOutFile = CreateFileW(outfile.c_str(), GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+        hOutFile = CreateFileW(outfile.c_str(), GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
         if (hOutFile == INVALID_HANDLE_VALUE)
         {
             printf("Failed to open outfile (%ls) for writing\n", outfile.c_str());

--- a/src/tsf/ConsoleTSF.cpp
+++ b/src/tsf/ConsoleTSF.cpp
@@ -32,7 +32,7 @@ const GUID GUID_APPLICATION = { 0x626761ad, 0x78d2, 0x44d2, { 0xbe, 0x8b, 0x75, 
 
     // Activate per-thread Cicero in custom UI mode (TF_TMAE_UIELEMENTENABLEDONLY).
 
-    hr = ::CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+    hr = ::CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
     Init_CheckResult();
     _fCoInitialized = TRUE;
 
@@ -120,7 +120,7 @@ void CConsoleTSF::Uninitialize()
     if (_pConversionArea)
     {
         delete _pConversionArea;
-        _pConversionArea = NULL;
+        _pConversionArea = nullptr;
     }
 
     // Detach Cicero event sinks.
@@ -177,7 +177,7 @@ void CConsoleTSF::Uninitialize()
     if (_spITfThreadMgr && _spITfDocumentMgr)
     {
         wil::com_ptr_nothrow<ITfDocumentMgr> spDocMgr;
-        _spITfThreadMgr->AssociateFocus(_hwndConsole, NULL, &spDocMgr);
+        _spITfThreadMgr->AssociateFocus(_hwndConsole, nullptr, &spDocMgr);
     }
 
     // Dismiss the input context and document manager.
@@ -218,7 +218,7 @@ STDMETHODIMP CConsoleTSF::QueryInterface(REFIID riid, void** ppvObj)
     {
         return E_FAIL;
     }
-    *ppvObj = NULL;
+    *ppvObj = nullptr;
 
     if (IsEqualIID(riid, IID_ITfCleanupContextSink))
     {
@@ -269,7 +269,7 @@ CConsoleTSF::Release()
     {
         if (g_pConsoleTSF == this)
         {
-            g_pConsoleTSF = NULL;
+            g_pConsoleTSF = nullptr;
         }
         delete this;
     }
@@ -294,7 +294,7 @@ STDMETHODIMP CConsoleTSF::OnCleanupContext(TfEditCookie ecWrite, ITfContext* pic
         if (SUCCEEDED(prop->EnumRanges(ecWrite, &enumranges, nullptr)))
         {
             wil::com_ptr_nothrow<ITfRange> rangeTmp;
-            while (enumranges->Next(1, &rangeTmp, NULL) == S_OK)
+            while (enumranges->Next(1, &rangeTmp, nullptr) == S_OK)
             {
                 VARIANT var;
                 VariantInit(&var);
@@ -459,7 +459,7 @@ STDMETHODIMP CConsoleTSF::EndUIElement(DWORD /*dwUIElementId*/)
 
 CConversionArea* CConsoleTSF::CreateConversionArea()
 {
-    BOOL fHadConvArea = (_pConversionArea != NULL);
+    BOOL fHadConvArea = (_pConversionArea != nullptr);
 
     if (!_pConversionArea)
     {
@@ -470,7 +470,7 @@ CConversionArea* CConsoleTSF::CreateConversionArea()
     if (!fHadConvArea)
     {
         wil::com_ptr_nothrow<ITfDocumentMgr> spPrevDocMgr;
-        _spITfThreadMgr->AssociateFocus(_hwndConsole, _pConversionArea ? _spITfDocumentMgr.get() : NULL, &spPrevDocMgr);
+        _spITfThreadMgr->AssociateFocus(_hwndConsole, _pConversionArea ? _spITfDocumentMgr.get() : nullptr, &spPrevDocMgr);
     }
 
     return _pConversionArea;

--- a/src/tsf/ConsoleTSF.h
+++ b/src/tsf/ConsoleTSF.h
@@ -154,7 +154,7 @@ public:
                 wil::com_ptr_nothrow<ITfContextOwnerCompositionServices> spCompositionServices(_spITfInputContext.try_query<ITfContextOwnerCompositionServices>());
                 if (spCompositionServices)
                 {
-                    spCompositionServices->TerminateComposition(NULL);
+                    spCompositionServices->TerminateComposition(nullptr);
                 }
             }
         }

--- a/src/tsf/TfDispAttr.cpp
+++ b/src/tsf/TfDispAttr.cpp
@@ -64,7 +64,7 @@ CicDisplayAttributeMgr::~CicDisplayAttributeMgr()
             }
 
             wil::com_ptr<ITfReadOnlyProperty> pProp;
-            if (SUCCEEDED(hr = pic->TrackProperties(ppguidProp.get(), ulNumProp, 0, NULL, &pProp)))
+            if (SUCCEEDED(hr = pic->TrackProperties(ppguidProp.get(), ulNumProp, nullptr, NULL, &pProp)))
             {
                 hr = pProp->EnumRanges(ec, ppEnum, pRange);
                 if (SUCCEEDED(hr))
@@ -109,7 +109,7 @@ CicDisplayAttributeMgr::~CicDisplayAttributeMgr()
         if (wil::try_com_query_to(var.punkVal, &pEnumPropertyVal))
         {
             TF_PROPERTYVAL tfPropVal;
-            while (pEnumPropertyVal->Next(1, &tfPropVal, NULL) == S_OK)
+            while (pEnumPropertyVal->Next(1, &tfPropVal, nullptr) == S_OK)
             {
                 if (tfPropVal.varValue.vt == VT_EMPTY)
                 {
@@ -189,7 +189,7 @@ CicDisplayAttributeMgr::~CicDisplayAttributeMgr()
             //
             m_DispAttrProp.emplace_back(GUID_PROP_ATTRIBUTE);
 
-            while (pEnumProp->Next(1, &guidProp, NULL) == S_OK)
+            while (pEnumProp->Next(1, &guidProp, nullptr) == S_OK)
             {
                 if (!IsEqualGUID(guidProp, GUID_PROP_ATTRIBUTE))
                 {

--- a/src/tsf/TfEditses.cpp
+++ b/src/tsf/TfEditses.cpp
@@ -35,7 +35,7 @@ Notes:
 
 STDAPI CEditSessionObject::QueryInterface(REFIID riid, void** ppvObj)
 {
-    *ppvObj = NULL;
+    *ppvObj = nullptr;
 
     if (IsEqualIID(riid, IID_ITfEditSession))
     {
@@ -154,7 +154,7 @@ CEditSessionObject::Release()
     //
     // Clear the text in Cicero TOM
     //
-    return SetTextInRange(ec, range, NULL, 0);
+    return SetTextInRange(ec, range, nullptr, 0);
 }
 
 //+---------------------------------------------------------------------------
@@ -165,8 +165,8 @@ CEditSessionObject::Release()
 
 [[nodiscard]] HRESULT CEditSessionObject::_GetCursorPosition(TfEditCookie ec, CCompCursorPos& CompCursorPos)
 {
-    ITfContext* pic = g_pConsoleTSF ? g_pConsoleTSF->GetInputContext() : NULL;
-    if (pic == NULL)
+    ITfContext* pic = g_pConsoleTSF ? g_pConsoleTSF->GetInputContext() : nullptr;
+    if (pic == nullptr)
     {
         return E_FAIL;
     }
@@ -175,7 +175,7 @@ CEditSessionObject::Release()
     ULONG cFetched;
 
     TF_SELECTION sel;
-    sel.range = NULL;
+    sel.range = nullptr;
 
     if (SUCCEEDED(hr = pic->GetSelection(ec, TF_DEFAULT_SELECTION, 1, &sel, &cFetched)))
     {
@@ -235,8 +235,8 @@ CEditSessionObject::Release()
 {
     HRESULT hr;
 
-    ITfContext* pic = g_pConsoleTSF ? g_pConsoleTSF->GetInputContext() : NULL;
-    if (pic == NULL)
+    ITfContext* pic = g_pConsoleTSF ? g_pConsoleTSF->GetInputContext() : nullptr;
+    if (pic == nullptr)
     {
         return E_FAIL;
     }
@@ -276,7 +276,7 @@ CEditSessionObject::Release()
     }
 
     wil::com_ptr_nothrow<ITfRange> range;
-    while (enumComp->Next(1, &range, NULL) == S_OK)
+    while (enumComp->Next(1, &range, nullptr) == S_OK)
     {
         VARIANT var;
         BOOL fCompExist = FALSE;
@@ -289,7 +289,7 @@ CEditSessionObject::Release()
             {
                 TF_PROPERTYVAL tfPropertyVal;
 
-                while (EnumPropVal->Next(1, &tfPropertyVal, NULL) == S_OK)
+                while (EnumPropVal->Next(1, &tfPropertyVal, nullptr) == S_OK)
                 {
                     for (int i = 0; i < guid_size; i++)
                     {
@@ -339,7 +339,7 @@ CEditSessionObject::Release()
         }
 
         wil::com_ptr_nothrow<ITfRange> pPropRange;
-        while (enumProp->Next(1, &pPropRange, NULL) == S_OK)
+        while (enumProp->Next(1, &pPropRange, nullptr) == S_OK)
         {
             // pick up the gap up to the next property
             gap_range->ShiftEndToRange(ec, pPropRange.get(), TF_ANCHOR_START);
@@ -592,15 +592,15 @@ CEditSessionObject::Release()
                                                                       const int guid_size,
                                                                       ITfRange* no_display_attribute_range)
 {
-    ITfContext* pic = g_pConsoleTSF ? g_pConsoleTSF->GetInputContext() : NULL;
-    if (pic == NULL)
+    ITfContext* pic = g_pConsoleTSF ? g_pConsoleTSF->GetInputContext() : nullptr;
+    if (pic == nullptr)
     {
         return E_FAIL;
     }
 
     wil::com_ptr_nothrow<ITfReadOnlyProperty> propComp;
     HRESULT hr = pic->TrackProperties(guids, guid_size, // system property
-                                      NULL,
+                                      nullptr,
                                       0, // application property
                                       &propComp);
     if (FAILED(hr))
@@ -617,7 +617,7 @@ CEditSessionObject::Release()
 
     wil::com_ptr_nothrow<ITfRange> pRange;
 
-    while (enumComp->Next(1, &pRange, NULL) == S_OK)
+    while (enumComp->Next(1, &pRange, nullptr) == S_OK)
     {
         VARIANT var;
         BOOL fCompExist = FALSE;
@@ -630,7 +630,7 @@ CEditSessionObject::Release()
             {
                 TF_PROPERTYVAL tfPropertyVal;
 
-                while (EnumPropVal->Next(1, &tfPropertyVal, NULL) == S_OK)
+                while (EnumPropVal->Next(1, &tfPropertyVal, nullptr) == S_OK)
                 {
                     for (int i = 0; i < guid_size; i++)
                     {
@@ -674,7 +674,7 @@ CEditSessionObject::Release()
 
 [[nodiscard]] HRESULT CEditSessionCompositionComplete::CompComplete(TfEditCookie ec)
 {
-    ITfContext* pic = g_pConsoleTSF ? g_pConsoleTSF->GetInputContext() : NULL;
+    ITfContext* pic = g_pConsoleTSF ? g_pConsoleTSF->GetInputContext() : nullptr;
     RETURN_HR_IF_NULL(E_FAIL, pic);
 
     // Get the whole text, finalize it, and set empty string in TOM
@@ -749,7 +749,7 @@ CEditSessionObject::Release()
 
     HRESULT hr = E_FAIL;
     ITfContext* pic = g_pConsoleTSF->GetInputContext();
-    if (pic != NULL)
+    if (pic != nullptr)
     {
         // Cleanup (empty the context range) after the last composition.
 
@@ -765,7 +765,7 @@ CEditSessionObject::Release()
                 // Clean up only the completed part (which start is expected to coincide with the start of the full range).
                 if (cchCompleted < cch)
                 {
-                    spRange->ShiftEnd(ec, (cchCompleted - cch), &cch, NULL);
+                    spRange->ShiftEnd(ec, (cchCompleted - cch), &cch, nullptr);
                 }
                 hr = ClearTextInRange(ec, spRange.get());
                 g_pConsoleTSF->SetCompletedRangeLength(0); // cleaned up all completed text
@@ -786,8 +786,8 @@ CEditSessionObject::Release()
 {
     HRESULT hr;
 
-    ITfContext* pic = g_pConsoleTSF ? g_pConsoleTSF->GetInputContext() : NULL;
-    if (pic == NULL)
+    ITfContext* pic = g_pConsoleTSF ? g_pConsoleTSF->GetInputContext() : nullptr;
+    if (pic == nullptr)
     {
         return E_FAIL;
     }
@@ -821,8 +821,8 @@ CEditSessionObject::Release()
         return hr;
     }
 
-    CicCategoryMgr* pCicCat = NULL;
-    CicDisplayAttributeMgr* pDispAttr = NULL;
+    CicCategoryMgr* pCicCat = nullptr;
+    CicDisplayAttributeMgr* pDispAttr = nullptr;
 
     //
     // Create Cicero Category Manager and Display Attribute Manager
@@ -868,8 +868,8 @@ CEditSessionObject::Release()
                                                                                ITfRange** pInterimRange,
                                                                                BOOL* pfInterim)
 {
-    ITfContext* pic = g_pConsoleTSF ? g_pConsoleTSF->GetInputContext() : NULL;
-    if (pic == NULL)
+    ITfContext* pic = g_pConsoleTSF ? g_pConsoleTSF->GetInputContext() : nullptr;
+    if (pic == nullptr)
     {
         return E_FAIL;
     }
@@ -877,7 +877,7 @@ CEditSessionObject::Release()
     ULONG cFetched;
 
     TF_SELECTION sel;
-    sel.range = NULL;
+    sel.range = nullptr;
 
     *pfInterim = FALSE;
     if (pic->GetSelection(ec, TF_DEFAULT_SELECTION, 1, &sel, &cFetched) != S_OK)
@@ -952,7 +952,7 @@ CEditSessionObject::Release()
     try
     {
         // Get conversion area service.
-        CConversionArea* conv_area = g_pConsoleTSF ? g_pConsoleTSF->GetConversionArea() : NULL;
+        CConversionArea* conv_area = g_pConsoleTSF ? g_pConsoleTSF->GetConversionArea() : nullptr;
         RETURN_HR_IF_NULL(E_FAIL, conv_area);
 
         if (!ResultStr.empty() && !fIgnorePreviousCompositionResult)
@@ -1072,7 +1072,7 @@ CEditSessionObject::Release()
     try
     {
         // Get conversion area service.
-        CConversionArea* conv_area = g_pConsoleTSF ? g_pConsoleTSF->GetConversionArea() : NULL;
+        CConversionArea* conv_area = g_pConsoleTSF ? g_pConsoleTSF->GetConversionArea() : nullptr;
         RETURN_HR_IF_NULL(E_FAIL, conv_area);
 
         if (!CompStr.empty())
@@ -1121,8 +1121,8 @@ CEditSessionObject::Release()
 {
     HRESULT hr = E_OUTOFMEMORY;
 
-    CicCategoryMgr* pTmpCat = NULL;
-    CicDisplayAttributeMgr* pTmpDispAttr = NULL;
+    CicCategoryMgr* pTmpCat = nullptr;
+    CicDisplayAttributeMgr* pTmpDispAttr = nullptr;
 
     //
     // Create Cicero Category Manager

--- a/src/tsf/TfEditses.h
+++ b/src/tsf/TfEditses.h
@@ -79,7 +79,7 @@ public:
                                                  ITfContext* ic,
                                                  ITfRange** range,
                                                  LONG* lpTextLength,
-                                                 TF_HALTCOND* lpHaltCond = NULL);
+                                                 TF_HALTCOND* lpHaltCond = nullptr);
 
 protected:
     [[nodiscard]] HRESULT SetTextInRange(TfEditCookie ec,

--- a/src/tsf/TfTxtevCb.cpp
+++ b/src/tsf/TfTxtevCb.cpp
@@ -59,7 +59,7 @@ BOOL CConsoleTSF::_HasCompositionChanged(ITfContext* pInputContext, TfEditCookie
             HRESULT hr;
             wil::com_ptr_nothrow<ITfRange> range;
 
-            while ((hr = EnumFindFirstTrackCompRange->Next(1, &range, NULL)) == S_OK)
+            while ((hr = EnumFindFirstTrackCompRange->Next(1, &range, nullptr)) == S_OK)
             {
                 VARIANT var;
                 VariantInit(&var);
@@ -94,7 +94,7 @@ BOOL CConsoleTSF::_HasCompositionChanged(ITfContext* pInputContext, TfEditCookie
         return TRUE;
     }
 
-    if (FoundRange == NULL)
+    if (FoundRange == nullptr)
     {
         return FALSE;
     }
@@ -149,7 +149,7 @@ BOOL CConsoleTSF::_HasCompositionChanged(ITfContext* pInputContext, TfEditCookie
                         HRESULT hr;
                         wil::com_ptr_nothrow<ITfRange> range;
 
-                        while ((hr = EnumPropertyChanged->Next(1, &range, NULL)) == S_OK)
+                        while ((hr = EnumPropertyChanged->Next(1, &range, nullptr)) == S_OK)
                         {
                             BOOL empty;
                             if (range->IsEmpty(ecReadOnly, &empty) == S_OK && empty)

--- a/src/tsf/contsf.cpp
+++ b/src/tsf/contsf.cpp
@@ -3,7 +3,7 @@
 
 #include "precomp.h"
 
-CConsoleTSF* g_pConsoleTSF = NULL;
+CConsoleTSF* g_pConsoleTSF = nullptr;
 
 extern "C" BOOL ActivateTextServices(HWND hwndConsole, GetSuggestionWindowPos pfnPosition)
 {

--- a/src/winconpty/ft_pty/ConPtyTests.cpp
+++ b/src/winconpty/ft_pty/ConPtyTests.cpp
@@ -38,8 +38,8 @@ HRESULT AttachPseudoConsole(HPCON hPC, LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeL
                                               PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
                                               hPC,
                                               sizeof(HANDLE),
-                                              NULL,
-                                              NULL);
+                                              nullptr,
+                                              nullptr);
     return fSuccess ? S_OK : HRESULT_FROM_WIN32(GetLastError());
 }
 
@@ -112,7 +112,7 @@ void ConPtyTests::GoodCreate()
     SECURITY_ATTRIBUTES sa;
     sa.nLength = sizeof(sa);
     sa.bInheritHandle = TRUE;
-    sa.lpSecurityDescriptor = NULL;
+    sa.lpSecurityDescriptor = nullptr;
 
     VERIFY_IS_TRUE(CreatePipe(inPipePseudoConsoleSide.addressof(), inPipeOurSide.addressof(), &sa, 0));
     VERIFY_IS_TRUE(CreatePipe(outPipeOurSide.addressof(), outPipePseudoConsoleSide.addressof(), &sa, 0));
@@ -143,7 +143,7 @@ void ConPtyTests::GoodCreateMultiple()
     SECURITY_ATTRIBUTES sa;
     sa.nLength = sizeof(sa);
     sa.bInheritHandle = TRUE;
-    sa.lpSecurityDescriptor = NULL;
+    sa.lpSecurityDescriptor = nullptr;
     VERIFY_IS_TRUE(CreatePipe(inPipePseudoConsoleSide.addressof(), inPipeOurSide.addressof(), &sa, 0));
     VERIFY_IS_TRUE(CreatePipe(outPipeOurSide.addressof(), outPipePseudoConsoleSide.addressof(), &sa, 0));
     VERIFY_IS_TRUE(SetHandleInformation(inPipeOurSide.get(), HANDLE_FLAG_INHERIT, 0));
@@ -180,7 +180,7 @@ void ConPtyTests::SurvivesOnBreakInput()
     SECURITY_ATTRIBUTES sa;
     sa.nLength = sizeof(sa);
     sa.bInheritHandle = TRUE;
-    sa.lpSecurityDescriptor = NULL;
+    sa.lpSecurityDescriptor = nullptr;
     VERIFY_IS_TRUE(CreatePipe(inPipePseudoConsoleSide.addressof(), inPipeOurSide.addressof(), &sa, 0));
     VERIFY_IS_TRUE(CreatePipe(outPipeOurSide.addressof(), outPipePseudoConsoleSide.addressof(), &sa, 0));
     VERIFY_IS_TRUE(SetHandleInformation(inPipeOurSide.get(), HANDLE_FLAG_INHERIT, 0));
@@ -243,7 +243,7 @@ void ConPtyTests::SurvivesOnBreakOutput()
     SECURITY_ATTRIBUTES sa;
     sa.nLength = sizeof(sa);
     sa.bInheritHandle = TRUE;
-    sa.lpSecurityDescriptor = NULL;
+    sa.lpSecurityDescriptor = nullptr;
     VERIFY_IS_TRUE(CreatePipe(inPipePseudoConsoleSide.addressof(), inPipeOurSide.addressof(), &sa, 0));
     VERIFY_IS_TRUE(CreatePipe(outPipeOurSide.addressof(), outPipePseudoConsoleSide.addressof(), &sa, 0));
     VERIFY_IS_TRUE(SetHandleInformation(inPipeOurSide.get(), HANDLE_FLAG_INHERIT, 0));
@@ -306,7 +306,7 @@ void ConPtyTests::DiesOnBreakBoth()
     SECURITY_ATTRIBUTES sa;
     sa.nLength = sizeof(sa);
     sa.bInheritHandle = TRUE;
-    sa.lpSecurityDescriptor = NULL;
+    sa.lpSecurityDescriptor = nullptr;
     VERIFY_IS_TRUE(CreatePipe(inPipePseudoConsoleSide.addressof(), inPipeOurSide.addressof(), &sa, 0));
     VERIFY_IS_TRUE(CreatePipe(outPipeOurSide.addressof(), outPipePseudoConsoleSide.addressof(), &sa, 0));
     VERIFY_IS_TRUE(SetHandleInformation(inPipeOurSide.get(), HANDLE_FLAG_INHERIT, 0));
@@ -395,7 +395,7 @@ void ConPtyTests::DiesOnClose()
     SECURITY_ATTRIBUTES sa;
     sa.nLength = sizeof(sa);
     sa.bInheritHandle = TRUE;
-    sa.lpSecurityDescriptor = NULL;
+    sa.lpSecurityDescriptor = nullptr;
     VERIFY_IS_TRUE(CreatePipe(inPipePseudoConsoleSide.addressof(), inPipeOurSide.addressof(), &sa, 0));
     VERIFY_IS_TRUE(CreatePipe(outPipeOurSide.addressof(), outPipePseudoConsoleSide.addressof(), &sa, 0));
     VERIFY_IS_TRUE(SetHandleInformation(inPipeOurSide.get(), HANDLE_FLAG_INHERIT, 0));


### PR DESCRIPTION
Some functions and variables are having NULL assigned to them when they are in fact pointers, so nullptr might be more accurate here.