### PR TITLE
hygiene: change default specifiers of some functions to delete

### DIFF
--- a/src/buffer/out/RowCellIterator.hpp
+++ b/src/buffer/out/RowCellIterator.hpp
@@ -31,7 +31,7 @@ public:
     RowCellIterator(const ROW& row, const size_t start, const size_t length);
     ~RowCellIterator() = default;
 
-    RowCellIterator& operator=(const RowCellIterator& it) = default;
+    RowCellIterator& operator=(const RowCellIterator& it) = delete;
 
     operator bool() const noexcept;
 

--- a/src/buffer/out/cursor.h
+++ b/src/buffer/out/cursor.h
@@ -37,7 +37,7 @@ public:
     Cursor& operator=(const Cursor&) & = delete;
 
     Cursor(Cursor&&) = default;
-    Cursor& operator=(Cursor&&) & = default;
+    Cursor& operator=(Cursor&&) & = delete;
 
     bool HasMoved() const noexcept;
     bool IsVisible() const noexcept;

--- a/src/cascadia/inc/cppwinrt_utils.h
+++ b/src/cascadia/inc/cppwinrt_utils.h
@@ -134,7 +134,7 @@ private:                                                                        
 #define BASIC_FACTORY(typeName)                                       \
     struct typeName : typeName##T<typeName, implementation::typeName> \
     {                                                                 \
-    };
+    }
 
 // This is a helper method for deserializing a SAFEARRAY of
 // COM objects and converting it to a vector that

--- a/src/cascadia/inc/cppwinrt_utils.h
+++ b/src/cascadia/inc/cppwinrt_utils.h
@@ -134,7 +134,7 @@ private:                                                                        
 #define BASIC_FACTORY(typeName)                                       \
     struct typeName : typeName##T<typeName, implementation::typeName> \
     {                                                                 \
-    }
+    };
 
 // This is a helper method for deserializing a SAFEARRAY of
 // COM objects and converting it to a vector that

--- a/src/types/ScreenInfoUiaProviderBase.h
+++ b/src/types/ScreenInfoUiaProviderBase.h
@@ -40,10 +40,10 @@ namespace Microsoft::Console::Types
     public:
         virtual HRESULT RuntimeClassInitialize(_In_ IUiaData* pData, _In_ std::wstring_view wordDelimiters = UiaTextRangeBase::DefaultWordDelimiter) noexcept;
 
-        ScreenInfoUiaProviderBase(const ScreenInfoUiaProviderBase&) = default;
-        ScreenInfoUiaProviderBase(ScreenInfoUiaProviderBase&&) = default;
-        ScreenInfoUiaProviderBase& operator=(const ScreenInfoUiaProviderBase&) = default;
-        ScreenInfoUiaProviderBase& operator=(ScreenInfoUiaProviderBase&&) = default;
+        ScreenInfoUiaProviderBase(const ScreenInfoUiaProviderBase&) = delete;
+        ScreenInfoUiaProviderBase(ScreenInfoUiaProviderBase&&) = delete;
+        ScreenInfoUiaProviderBase& operator=(const ScreenInfoUiaProviderBase&) = delete;
+        ScreenInfoUiaProviderBase& operator=(ScreenInfoUiaProviderBase&&) = delete;
         ~ScreenInfoUiaProviderBase() = default;
 
         [[nodiscard]] HRESULT Signal(_In_ EVENTID id);

--- a/src/types/UiaTextRangeBase.hpp
+++ b/src/types/UiaTextRangeBase.hpp
@@ -77,10 +77,10 @@ namespace Microsoft::Console::Types
 
         virtual HRESULT RuntimeClassInitialize(const UiaTextRangeBase& a) noexcept;
 
-        UiaTextRangeBase(const UiaTextRangeBase&) = default;
-        UiaTextRangeBase(UiaTextRangeBase&&) = default;
-        UiaTextRangeBase& operator=(const UiaTextRangeBase&) = default;
-        UiaTextRangeBase& operator=(UiaTextRangeBase&&) = default;
+        UiaTextRangeBase(const UiaTextRangeBase&) = delete;
+        UiaTextRangeBase(UiaTextRangeBase&&) = delete;
+        UiaTextRangeBase& operator=(const UiaTextRangeBase&) = delete;
+        UiaTextRangeBase& operator=(UiaTextRangeBase&&) = delete;
         ~UiaTextRangeBase() = default;
 
         const IdType GetId() const noexcept;

--- a/src/types/WindowUiaProviderBase.hpp
+++ b/src/types/WindowUiaProviderBase.hpp
@@ -37,10 +37,10 @@ namespace Microsoft::Console::Types
         WindowUiaProviderBase() = default;
         HRESULT RuntimeClassInitialize(IUiaWindow* baseWindow) noexcept;
 
-        WindowUiaProviderBase(const WindowUiaProviderBase&) = default;
-        WindowUiaProviderBase(WindowUiaProviderBase&&) = default;
-        WindowUiaProviderBase& operator=(const WindowUiaProviderBase&) = default;
-        WindowUiaProviderBase& operator=(WindowUiaProviderBase&&) = default;
+        WindowUiaProviderBase(const WindowUiaProviderBase&) = delete;
+        WindowUiaProviderBase(WindowUiaProviderBase&&) = delete;
+        WindowUiaProviderBase& operator=(const WindowUiaProviderBase&) = delete;
+        WindowUiaProviderBase& operator=(WindowUiaProviderBase&&) = delete;
 
     public:
         [[nodiscard]] virtual HRESULT Signal(_In_ EVENTID id) = 0;


### PR DESCRIPTION
For some functions, the overriding implementation is set to default, but
the deletion is not explicitly set at all. For those functions, I
changed default to delete.

## Validation Steps
- Manual Checking including testing the base and the subclasses.
- Compiler Refactorings
- Unit tests passed.