### PR TITLE
Clamp the terminal buffer to `SHRT_MAX` on resize

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -173,11 +173,12 @@ void Terminal::UpdateSettings(winrt::Microsoft::Terminal::Settings::ICoreSetting
     {
         return S_FALSE;
     }
-    const auto dx = viewportSize.X - oldDimensions.X;
+
+    const auto dx = ::base::saturated_cast<short>(viewportSize.X - oldDimensions.X);
 
     const auto oldTop = _mutableViewport.Top();
 
-    const short newBufferHeight = viewportSize.Y + _scrollbackLines;
+    const short newBufferHeight = ::base::saturated_cast<short>(viewportSize.Y + _scrollbackLines);
     COORD bufferSize{ viewportSize.X, newBufferHeight };
 
     // Save cursor's relative height versus the viewport

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -174,15 +174,16 @@ void Terminal::UpdateSettings(winrt::Microsoft::Terminal::Settings::ICoreSetting
         return S_FALSE;
     }
 
-    const auto dx = ::base::saturated_cast<short>(viewportSize.X - oldDimensions.X);
+    const auto dx = ::base::ClampSub(viewportSize.X, oldDimensions.X);
 
     const auto oldTop = _mutableViewport.Top();
 
-    const short newBufferHeight = ::base::saturated_cast<short>(viewportSize.Y + _scrollbackLines);
+    const short newBufferHeight = ::base::ClampAdd(viewportSize.Y, _scrollbackLines);
+
     COORD bufferSize{ viewportSize.X, newBufferHeight };
 
     // Save cursor's relative height versus the viewport
-    const short sCursorHeightInViewportBefore = _buffer->GetCursor().GetPosition().Y - _mutableViewport.Top();
+    const short sCursorHeightInViewportBefore = ::base::ClampSub(_buffer->GetCursor().GetPosition().Y, _mutableViewport.Top());
 
     // This will be used to determine where the viewport should be in the new buffer.
     const short oldViewportTop = _mutableViewport.Top();
@@ -267,7 +268,7 @@ void Terminal::UpdateSettings(winrt::Microsoft::Terminal::Settings::ICoreSetting
 
     const auto maxRow = std::max(newLastChar.Y, newCursorPos.Y);
 
-    const short proposedTopFromLastLine = ::base::saturated_cast<short>(maxRow - viewportSize.Y + 1);
+    const short proposedTopFromLastLine = ::base::ClampSub(maxRow, ::base::ClampAdd(viewportSize.Y, 1));
     const short proposedTopFromScrollback = newViewportTop;
 
     short proposedTop = std::max(proposedTopFromLastLine,
@@ -295,7 +296,7 @@ void Terminal::UpdateSettings(winrt::Microsoft::Terminal::Settings::ICoreSetting
             {
                 try
                 {
-                    auto row = newTextBuffer->GetRowByOffset(::base::saturated_cast<short>(proposedTop - 1));
+                    auto row = newTextBuffer->GetRowByOffset(::base::ClampSub(proposedTop, 1));
                     if (row.GetCharRow().WasWrapForced())
                     {
                         proposedTop--;
@@ -325,7 +326,7 @@ void Terminal::UpdateSettings(winrt::Microsoft::Terminal::Settings::ICoreSetting
     const auto proposedBottom = newView.BottomExclusive();
     if (proposedBottom > bufferSize.Y)
     {
-        proposedTop = ::base::saturated_cast<short>(proposedTop - (proposedBottom - bufferSize.Y));
+        proposedTop = ::base::ClampSub(proposedTop, ::base::ClampSub(proposedBottom, bufferSize.Y));
     }
 
     _mutableViewport = Viewport::FromDimensions({ 0, proposedTop }, viewportSize);
@@ -340,7 +341,7 @@ void Terminal::UpdateSettings(winrt::Microsoft::Terminal::Settings::ICoreSetting
 
     // If the old scrolloffset was 0, then we weren't scrolled back at all
     // before, and shouldn't be now either.
-    _scrollOffset = originalOffsetWasZero ? 0 : _mutableViewport.Top() - newVisibleTop;
+    _scrollOffset = originalOffsetWasZero ? 0 : ::base::ClampSub(_mutableViewport.Top(), newVisibleTop);
     _NotifyScrollEvent();
 
     return S_OK;

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -268,7 +268,7 @@ void Terminal::UpdateSettings(winrt::Microsoft::Terminal::Settings::ICoreSetting
 
     const auto maxRow = std::max(newLastChar.Y, newCursorPos.Y);
 
-    const short proposedTopFromLastLine = ::base::ClampSub(maxRow, ::base::ClampAdd(viewportSize.Y, 1));
+    const short proposedTopFromLastLine = ::base::ClampAdd(::base::ClampSub(maxRow, viewportSize.Y), 1);
     const short proposedTopFromScrollback = newViewportTop;
 
     short proposedTop = std::max(proposedTopFromLastLine,

--- a/src/cascadia/UnitTests_TerminalCore/ScreenSizeLimitsTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ScreenSizeLimitsTest.cpp
@@ -11,6 +11,9 @@
 
 using namespace winrt::Microsoft::Terminal::Settings;
 using namespace Microsoft::Terminal::Core;
+using namespace WEX::Logging;
+using namespace WEX::TestExecution;
+using namespace WEX::Common;
 
 namespace TerminalCoreUnitTests
 {
@@ -21,66 +24,109 @@ namespace TerminalCoreUnitTests
     {
         TEST_CLASS(ScreenSizeLimitsTest);
 
-        TEST_METHOD(ScreenWidthAndHeightAreClampedToBounds)
-        {
-            DummyRenderTarget emptyRenderTarget;
+        TEST_METHOD(ScreenWidthAndHeightAreClampedToBounds);
+        TEST_METHOD(ScrollbackHistorySizeIsClampedToBounds);
 
-            // Negative values for initial visible row count or column count
-            // are clamped to 1. Too-large positive values are clamped to SHRT_MAX.
-            auto negativeColumnsSettings = winrt::make<MockTermSettings>(10000, 9999999, -1234);
-            Terminal negativeColumnsTerminal;
-            negativeColumnsTerminal.CreateFromSettings(negativeColumnsSettings, emptyRenderTarget);
-            COORD actualDimensions = negativeColumnsTerminal.GetViewport().Dimensions();
-            VERIFY_ARE_EQUAL(actualDimensions.Y, SHRT_MAX, L"Row count clamped to SHRT_MAX == " WCS(SHRT_MAX));
-            VERIFY_ARE_EQUAL(actualDimensions.X, 1, L"Column count clamped to 1");
-
-            // Zero values are clamped to 1 as well.
-            auto zeroRowsSettings = winrt::make<MockTermSettings>(10000, 0, 9999999);
-            Terminal zeroRowsTerminal;
-            zeroRowsTerminal.CreateFromSettings(zeroRowsSettings, emptyRenderTarget);
-            actualDimensions = zeroRowsTerminal.GetViewport().Dimensions();
-            VERIFY_ARE_EQUAL(actualDimensions.Y, 1, L"Row count clamped to 1");
-            VERIFY_ARE_EQUAL(actualDimensions.X, SHRT_MAX, L"Column count clamped to SHRT_MAX == " WCS(SHRT_MAX));
-        }
-
-        TEST_METHOD(ScrollbackHistorySizeIsClampedToBounds)
-        {
-            // What is actually clamped is the number of rows in the internal history buffer,
-            // which is the *sum* of the history size plus the number of rows
-            // actually visible on screen at the moment.
-
-            const unsigned int visibleRowCount = 100;
-            DummyRenderTarget emptyRenderTarget;
-
-            // Zero history size is acceptable.
-            auto noHistorySettings = winrt::make<MockTermSettings>(0, visibleRowCount, 100);
-            Terminal noHistoryTerminal;
-            noHistoryTerminal.CreateFromSettings(noHistorySettings, emptyRenderTarget);
-            VERIFY_ARE_EQUAL(noHistoryTerminal.GetTextBuffer().TotalRowCount(), visibleRowCount, L"History size of 0 is accepted");
-
-            // Negative history sizes are clamped to zero.
-            auto negativeHistorySizeSettings = winrt::make<MockTermSettings>(-100, visibleRowCount, 100);
-            Terminal negativeHistorySizeTerminal;
-            negativeHistorySizeTerminal.CreateFromSettings(negativeHistorySizeSettings, emptyRenderTarget);
-            VERIFY_ARE_EQUAL(negativeHistorySizeTerminal.GetTextBuffer().TotalRowCount(), visibleRowCount, L"Negative history size is clamped to 0");
-
-            // History size + initial visible rows == SHRT_MAX is acceptable.
-            auto maxHistorySizeSettings = winrt::make<MockTermSettings>(SHRT_MAX - visibleRowCount, visibleRowCount, 100);
-            Terminal maxHistorySizeTerminal;
-            maxHistorySizeTerminal.CreateFromSettings(maxHistorySizeSettings, emptyRenderTarget);
-            VERIFY_ARE_EQUAL(maxHistorySizeTerminal.GetTextBuffer().TotalRowCount(), static_cast<unsigned int>(SHRT_MAX), L"History size == SHRT_MAX - initial row count is accepted");
-
-            // History size + initial visible rows == SHRT_MAX + 1 will be clamped slightly.
-            auto justTooBigHistorySizeSettings = winrt::make<MockTermSettings>(SHRT_MAX - visibleRowCount + 1, visibleRowCount, 100);
-            Terminal justTooBigHistorySizeTerminal;
-            justTooBigHistorySizeTerminal.CreateFromSettings(justTooBigHistorySizeSettings, emptyRenderTarget);
-            VERIFY_ARE_EQUAL(justTooBigHistorySizeTerminal.GetTextBuffer().TotalRowCount(), static_cast<unsigned int>(SHRT_MAX), L"History size == 1 + SHRT_MAX - initial row count is clamped to SHRT_MAX - initial row count");
-
-            // Ridiculously large history sizes are also clamped.
-            auto farTooBigHistorySizeSettings = winrt::make<MockTermSettings>(99999999, visibleRowCount, 100);
-            Terminal farTooBigHistorySizeTerminal;
-            farTooBigHistorySizeTerminal.CreateFromSettings(farTooBigHistorySizeSettings, emptyRenderTarget);
-            VERIFY_ARE_EQUAL(farTooBigHistorySizeTerminal.GetTextBuffer().TotalRowCount(), static_cast<unsigned int>(SHRT_MAX), L"History size that is far too large is clamped to SHRT_MAX - initial row count");
-        }
+        TEST_METHOD(ResizeIsClampedToBounds);
     };
+}
+
+using namespace TerminalCoreUnitTests;
+
+void ScreenSizeLimitsTest::ScreenWidthAndHeightAreClampedToBounds()
+{
+    DummyRenderTarget emptyRenderTarget;
+
+    // Negative values for initial visible row count or column count
+    // are clamped to 1. Too-large positive values are clamped to SHRT_MAX.
+    auto negativeColumnsSettings = winrt::make<MockTermSettings>(10000, 9999999, -1234);
+    Terminal negativeColumnsTerminal;
+    negativeColumnsTerminal.CreateFromSettings(negativeColumnsSettings, emptyRenderTarget);
+    COORD actualDimensions = negativeColumnsTerminal.GetViewport().Dimensions();
+    VERIFY_ARE_EQUAL(actualDimensions.Y, SHRT_MAX, L"Row count clamped to SHRT_MAX == " WCS(SHRT_MAX));
+    VERIFY_ARE_EQUAL(actualDimensions.X, 1, L"Column count clamped to 1");
+
+    // Zero values are clamped to 1 as well.
+    auto zeroRowsSettings = winrt::make<MockTermSettings>(10000, 0, 9999999);
+    Terminal zeroRowsTerminal;
+    zeroRowsTerminal.CreateFromSettings(zeroRowsSettings, emptyRenderTarget);
+    actualDimensions = zeroRowsTerminal.GetViewport().Dimensions();
+    VERIFY_ARE_EQUAL(actualDimensions.Y, 1, L"Row count clamped to 1");
+    VERIFY_ARE_EQUAL(actualDimensions.X, SHRT_MAX, L"Column count clamped to SHRT_MAX == " WCS(SHRT_MAX));
+}
+
+void ScreenSizeLimitsTest::ScrollbackHistorySizeIsClampedToBounds()
+{
+    // What is actually clamped is the number of rows in the internal history buffer,
+    // which is the *sum* of the history size plus the number of rows
+    // actually visible on screen at the moment.
+
+    const unsigned int visibleRowCount = 100;
+    DummyRenderTarget emptyRenderTarget;
+
+    // Zero history size is acceptable.
+    auto noHistorySettings = winrt::make<MockTermSettings>(0, visibleRowCount, 100);
+    Terminal noHistoryTerminal;
+    noHistoryTerminal.CreateFromSettings(noHistorySettings, emptyRenderTarget);
+    VERIFY_ARE_EQUAL(noHistoryTerminal.GetTextBuffer().TotalRowCount(), visibleRowCount, L"History size of 0 is accepted");
+
+    // Negative history sizes are clamped to zero.
+    auto negativeHistorySizeSettings = winrt::make<MockTermSettings>(-100, visibleRowCount, 100);
+    Terminal negativeHistorySizeTerminal;
+    negativeHistorySizeTerminal.CreateFromSettings(negativeHistorySizeSettings, emptyRenderTarget);
+    VERIFY_ARE_EQUAL(negativeHistorySizeTerminal.GetTextBuffer().TotalRowCount(), visibleRowCount, L"Negative history size is clamped to 0");
+
+    // History size + initial visible rows == SHRT_MAX is acceptable.
+    auto maxHistorySizeSettings = winrt::make<MockTermSettings>(SHRT_MAX - visibleRowCount, visibleRowCount, 100);
+    Terminal maxHistorySizeTerminal;
+    maxHistorySizeTerminal.CreateFromSettings(maxHistorySizeSettings, emptyRenderTarget);
+    VERIFY_ARE_EQUAL(maxHistorySizeTerminal.GetTextBuffer().TotalRowCount(), static_cast<unsigned int>(SHRT_MAX), L"History size == SHRT_MAX - initial row count is accepted");
+
+    // History size + initial visible rows == SHRT_MAX + 1 will be clamped slightly.
+    auto justTooBigHistorySizeSettings = winrt::make<MockTermSettings>(SHRT_MAX - visibleRowCount + 1, visibleRowCount, 100);
+    Terminal justTooBigHistorySizeTerminal;
+    justTooBigHistorySizeTerminal.CreateFromSettings(justTooBigHistorySizeSettings, emptyRenderTarget);
+    VERIFY_ARE_EQUAL(justTooBigHistorySizeTerminal.GetTextBuffer().TotalRowCount(), static_cast<unsigned int>(SHRT_MAX), L"History size == 1 + SHRT_MAX - initial row count is clamped to SHRT_MAX - initial row count");
+
+    // Ridiculously large history sizes are also clamped.
+    auto farTooBigHistorySizeSettings = winrt::make<MockTermSettings>(99999999, visibleRowCount, 100);
+    Terminal farTooBigHistorySizeTerminal;
+    farTooBigHistorySizeTerminal.CreateFromSettings(farTooBigHistorySizeSettings, emptyRenderTarget);
+    VERIFY_ARE_EQUAL(farTooBigHistorySizeTerminal.GetTextBuffer().TotalRowCount(), static_cast<unsigned int>(SHRT_MAX), L"History size that is far too large is clamped to SHRT_MAX - initial row count");
+}
+
+void ScreenSizeLimitsTest::ResizeIsClampedToBounds()
+{
+    // What is actually clamped is the number of rows in the internal history buffer,
+    // which is the *sum* of the history size plus the number of rows
+    // actually visible on screen at the moment.
+    //
+    // This is a test for GH#2630, GH#2815.
+
+    const unsigned int initialVisibleColCount = 50;
+    const unsigned int initialVisibleRowCount = 50;
+    const auto historySize = SHRT_MAX - (initialVisibleRowCount * 2);
+    DummyRenderTarget emptyRenderTarget;
+
+    Log::Comment(L"Watch out - this test takes a while on debug, because "
+                 L"ResizeWithReflow takes a while on debug. This is expected.");
+
+    auto settings = winrt::make<MockTermSettings>(historySize, initialVisibleRowCount, initialVisibleColCount);
+    Log::Comment(L"First create a terminal with fewer than SHRT_MAX lines");
+    Terminal terminal;
+    terminal.CreateFromSettings(settings, emptyRenderTarget);
+    VERIFY_ARE_EQUAL(terminal.GetTextBuffer().TotalRowCount(), static_cast<unsigned int>(historySize + initialVisibleRowCount));
+
+    Log::Comment(L"Resize the terminal to have exactly SHRT_MAX lines");
+    VERIFY_SUCCEEDED(terminal.UserResize({ initialVisibleColCount, initialVisibleRowCount * 2 }));
+
+    VERIFY_ARE_EQUAL(terminal.GetTextBuffer().TotalRowCount(), static_cast<unsigned int>(SHRT_MAX));
+
+    Log::Comment(L"Resize the terminal to have MORE than SHRT_MAX lines - we should clamp to SHRT_MAX");
+    VERIFY_SUCCEEDED(terminal.UserResize({ initialVisibleColCount, initialVisibleRowCount * 3 }));
+    VERIFY_ARE_EQUAL(terminal.GetTextBuffer().TotalRowCount(), static_cast<unsigned int>(SHRT_MAX));
+
+    Log::Comment(L"Resize back down to the original size");
+    VERIFY_SUCCEEDED(terminal.UserResize({ initialVisibleColCount, initialVisibleRowCount }));
+    VERIFY_ARE_EQUAL(terminal.GetTextBuffer().TotalRowCount(), static_cast<unsigned int>(historySize + initialVisibleRowCount));
 }


### PR DESCRIPTION
## Summary of the Pull Request

This is 100% on me. Even after mucking around in this function for the last 3
months, I missed that there was a single addition where we weren't doing a
clamped addition. This would lead to us creating a buffer with negative height,
and all sorts of badness.

Clamping this addition was enough to fix the bug.

## PR Checklist
* [x] Closes #2815
* [x] Closes #4972
* [x] I work here
* [x] Tests added/passed
* [n/a] Requires documentation to be updated

## Validation Steps Performed
* ran tests
* Created a profile with `"historySize" : 32728`, then filled the viewport with
  text, then maximized, and saw that the viewport indeed did resize to the new
  size of the window.
