### PR TITLE
Properly represent block selections in UIA

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -156,6 +156,7 @@ public:
 #pragma region IUiaData
     std::vector<Microsoft::Console::Types::Viewport> GetSelectionRects() noexcept override;
     const bool IsSelectionActive() const noexcept override;
+    const bool IsBlockSelection() const noexcept override;
     void ClearSelection() override;
     void SelectNewRegion(const COORD coordStart, const COORD coordEnd) override;
     const COORD GetSelectionAnchor() const noexcept override;

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -106,6 +106,11 @@ const bool Terminal::IsSelectionActive() const noexcept
     return _selection.has_value();
 }
 
+const bool Terminal::IsBlockSelection() const noexcept
+{
+    return _blockSelection;
+}
+
 // Method Description:
 // - Checks if the CopyOnSelect setting is active
 // Return Value:

--- a/src/host/renderData.cpp
+++ b/src/host/renderData.cpp
@@ -359,6 +359,11 @@ const bool RenderData::IsSelectionActive() const
     return Selection::Instance().IsAreaSelected();
 }
 
+const bool RenderData::IsBlockSelection() const noexcept
+{
+    return !Selection::Instance().IsLineSelection();
+}
+
 // Routine Description:
 // - If a selection exists, clears it and restores the state.
 //   Will also unblock a blocked write if one exists.

--- a/src/host/renderData.hpp
+++ b/src/host/renderData.hpp
@@ -60,6 +60,7 @@ public:
 
 #pragma region IUiaData
     const bool IsSelectionActive() const override;
+    const bool IsBlockSelection() const noexcept override;
     void ClearSelection() override;
     void SelectNewRegion(const COORD coordStart, const COORD coordEnd) override;
     const COORD GetSelectionAnchor() const noexcept;

--- a/src/interactivity/win32/screenInfoUiaProvider.cpp
+++ b/src/interactivity/win32/screenInfoUiaProvider.cpp
@@ -110,7 +110,7 @@ HRESULT ScreenInfoUiaProvider::GetSelectionRange(_In_ IRawElementProviderSimple*
 
     // TODO GH #4509: Box Selection is misrepresented here as a line selection.
     UiaTextRange* result;
-    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, start, end, wordDelimiters));
+    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, start, end, _pData->IsBlockSelection(), wordDelimiters));
     *ppUtr = result;
     return S_OK;
 }
@@ -147,7 +147,7 @@ HRESULT ScreenInfoUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* c
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
     UiaTextRange* result = nullptr;
-    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, start, end, wordDelimiters));
+    RETURN_IF_FAILED(MakeAndInitialize<UiaTextRange>(&result, _pData, pProvider, start, end, false, wordDelimiters));
     *ppUtr = result;
     return S_OK;
 }

--- a/src/interactivity/win32/uiaTextRange.cpp
+++ b/src/interactivity/win32/uiaTextRange.cpp
@@ -32,9 +32,10 @@ HRESULT UiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
                                              _In_ IRawElementProviderSimple* const pProvider,
                                              const COORD start,
                                              const COORD end,
+                                             bool blockRange,
                                              const std::wstring_view wordDelimiters) noexcept
 {
-    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, start, end, wordDelimiters);
+    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, start, end, blockRange, wordDelimiters);
 }
 
 // returns a degenerate text range of the start of the row closest to the y value of point

--- a/src/interactivity/win32/uiaTextRange.hpp
+++ b/src/interactivity/win32/uiaTextRange.hpp
@@ -42,6 +42,7 @@ namespace Microsoft::Console::Interactivity::Win32
                                        _In_ IRawElementProviderSimple* const pProvider,
                                        _In_ const COORD start,
                                        _In_ const COORD end,
+                                       _In_ bool blockRange = false,
                                        _In_ const std::wstring_view wordDelimiters = DefaultWordDelimiter) noexcept override;
 
         // range from a UiaPoint

--- a/src/types/IUiaData.h
+++ b/src/types/IUiaData.h
@@ -34,6 +34,7 @@ namespace Microsoft::Console::Types
 
     public:
         virtual const bool IsSelectionActive() const = 0;
+        virtual const bool IsBlockSelection() const = 0;
         virtual void ClearSelection() = 0;
         virtual void SelectNewRegion(const COORD coordStart, const COORD coordEnd) = 0;
         virtual const COORD GetSelectionAnchor() const noexcept = 0;

--- a/src/types/TermControlUiaProvider.cpp
+++ b/src/types/TermControlUiaProvider.cpp
@@ -128,9 +128,8 @@ HRESULT TermControlUiaProvider::GetSelectionRange(_In_ IRawElementProviderSimple
     auto end = _pData->GetSelectionEnd();
     _pData->GetTextBuffer().GetSize().IncrementInBounds(end, true);
 
-    // TODO GH #4509: Box Selection is misrepresented here as a line selection.
     TermControlUiaTextRange* result = nullptr;
-    RETURN_IF_FAILED(MakeAndInitialize<TermControlUiaTextRange>(&result, _pData, pProvider, start, end, wordDelimiters));
+    RETURN_IF_FAILED(MakeAndInitialize<TermControlUiaTextRange>(&result, _pData, pProvider, start, end, _pData->IsBlockSelection(), wordDelimiters));
     *ppUtr = result;
     return S_OK;
 }
@@ -167,7 +166,7 @@ HRESULT TermControlUiaProvider::CreateTextRange(_In_ IRawElementProviderSimple* 
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
     TermControlUiaTextRange* result = nullptr;
-    RETURN_IF_FAILED(MakeAndInitialize<TermControlUiaTextRange>(&result, _pData, pProvider, start, end, wordDelimiters));
+    RETURN_IF_FAILED(MakeAndInitialize<TermControlUiaTextRange>(&result, _pData, pProvider, start, end, false, wordDelimiters));
     *ppUtr = result;
     return S_OK;
 }

--- a/src/types/TermControlUiaTextRange.cpp
+++ b/src/types/TermControlUiaTextRange.cpp
@@ -27,9 +27,10 @@ HRESULT TermControlUiaTextRange::RuntimeClassInitialize(_In_ IUiaData* pData,
                                                         _In_ IRawElementProviderSimple* const pProvider,
                                                         const COORD start,
                                                         const COORD end,
+                                                        bool blockRange,
                                                         const std::wstring_view wordDelimiters) noexcept
 {
-    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, start, end, wordDelimiters);
+    return UiaTextRangeBase::RuntimeClassInitialize(pData, pProvider, start, end, blockRange, wordDelimiters);
 }
 
 // returns a degenerate text range of the start of the row closest to the y value of point

--- a/src/types/TermControlUiaTextRange.hpp
+++ b/src/types/TermControlUiaTextRange.hpp
@@ -41,6 +41,7 @@ namespace Microsoft::Terminal
                                        _In_ IRawElementProviderSimple* const pProvider,
                                        const COORD start,
                                        const COORD end,
+                                       bool blockRange = false,
                                        const std::wstring_view wordDelimiters = DefaultWordDelimiter) noexcept override;
 
         // range from a UiaPoint

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -23,6 +23,7 @@ try
     _pData = pData;
     _start = pData->GetViewport().Origin();
     _end = pData->GetViewport().Origin();
+    _blockRange = false;
     _wordDelimiters = wordDelimiters;
 
     _id = id;
@@ -55,6 +56,7 @@ HRESULT UiaTextRangeBase::RuntimeClassInitialize(_In_ IUiaData* pData,
                                                  _In_ IRawElementProviderSimple* const pProvider,
                                                  _In_ const COORD start,
                                                  _In_ const COORD end,
+                                                 _In_ bool blockRange,
                                                  _In_ std::wstring_view wordDelimiters) noexcept
 try
 {
@@ -72,6 +74,10 @@ try
         _start = end;
         _end = start;
     }
+
+    // This should be the only way to set if we are a blockRange
+    // This is used for blockSelection
+    _blockRange = blockRange;
 
     UiaTracing::TextRange::Constructor(*this);
     return S_OK;
@@ -429,8 +435,7 @@ IFACEMETHODIMP UiaTextRangeBase::GetBoundingRectangles(_Outptr_result_maybenull_
         }
         else
         {
-            // TODO CARLOS: when we have block selection ranges, pass in var instead of false
-            const auto textRects = _pData->GetTextBuffer().GetTextRects(startAnchor, endAnchor, false);
+            const auto textRects = _pData->GetTextBuffer().GetTextRects(startAnchor, endAnchor, _blockRange);
 
             for (const auto &rect : textRects)
             {

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -437,7 +437,7 @@ IFACEMETHODIMP UiaTextRangeBase::GetBoundingRectangles(_Outptr_result_maybenull_
         {
             const auto textRects = _pData->GetTextBuffer().GetTextRects(startAnchor, endAnchor, _blockRange);
 
-            for (const auto &rect : textRects)
+            for (const auto& rect : textRects)
             {
                 _getBoundingRect(rect, coords);
             }
@@ -529,7 +529,7 @@ try
         auto inclusiveEnd{ _end };
         bufferSize.DecrementInBounds(inclusiveEnd, true);
 
-        const auto textRects = buffer.GetTextRects(_start, inclusiveEnd);
+        const auto textRects = buffer.GetTextRects(_start, inclusiveEnd, _blockRange);
         const auto bufferData = buffer.GetText(true,
                                                false,
                                                textRects);

--- a/src/types/UiaTextRangeBase.hpp
+++ b/src/types/UiaTextRangeBase.hpp
@@ -73,6 +73,7 @@ namespace Microsoft::Console::Types
                                                _In_ IRawElementProviderSimple* const pProvider,
                                                _In_ const COORD start,
                                                _In_ const COORD end,
+                                               _In_ bool blockRange = false,
                                                _In_ std::wstring_view wordDelimiters = DefaultWordDelimiter) noexcept;
 
         virtual HRESULT RuntimeClassInitialize(const UiaTextRangeBase& a) noexcept;
@@ -149,6 +150,7 @@ namespace Microsoft::Console::Types
         // NOTE: _start is inclusive, but _end is exclusive
         COORD _start{};
         COORD _end{};
+        bool _blockRange;
 
         // This is used by tracing to extract the text value
         // that the UiaTextRange currently encompasses.

--- a/src/types/UiaTextRangeBase.hpp
+++ b/src/types/UiaTextRangeBase.hpp
@@ -162,7 +162,7 @@ namespace Microsoft::Console::Types
         const unsigned int _getViewportHeight(const SMALL_RECT viewport) const noexcept;
         const Viewport _getBufferSize() const noexcept;
 
-        void _getBoundingRect(_In_ const COORD startAnchor, _In_ const COORD endAnchor, _Inout_ std::vector<double>& coords) const;
+        void _getBoundingRect(const til::rectangle textRect, _Inout_ std::vector<double>& coords) const;
 
         void
         _moveEndpointByUnitCharacter(_In_ const int moveCount,


### PR DESCRIPTION
## Summary of the Pull Request
Block selections were always read and displayed as line selections in UIA. This fixes that.

## PR Checklist
* [x] Closes #4509 

## Detailed Description of the Pull Request / Additional comments
1. Expose `IsBlockSelection()` via IUiaData
2. Update the constructor to be able to take in a block selection parameter
3. Make ScreenInfoUiaProviders pass step 1 output into step 2 constructor
4. Update all instances of `UiaTextRange::GetTextRects()` to include this new flag

## Validation Steps Performed
Manually tested.
Additional tests would be redundant as GetTextRects() is tested in the text buffer.