### PR TITLE
Fix an off-by-one that made us use EL instead of ECH

### DIFF
--- a/src/host/ut_host/ConptyOutputTests.cpp
+++ b/src/host/ut_host/ConptyOutputTests.cpp
@@ -113,6 +113,7 @@ class ConptyOutputTests
     TEST_METHOD(SimpleWriteOutputTest);
     TEST_METHOD(WriteTwoLinesUsesNewline);
     TEST_METHOD(WriteAFewSimpleLines);
+    TEST_METHOD(InvalidateUntilOneBeforeEnd);
 
 private:
     bool _writeCallback(const char* const pch, size_t const cch);
@@ -124,10 +125,14 @@ private:
 
 bool ConptyOutputTests::_writeCallback(const char* const pch, size_t const cch)
 {
+    // Since rendering happens on a background thread that doesn't have the exception handler on it
+    // we need to rely on VERIFY's return codes instead of exceptions.
+    const WEX::TestExecution::DisableVerifyExceptions disableExceptionsScope;
+
     std::string actualString = std::string(pch, cch);
-    VERIFY_IS_GREATER_THAN(expectedOutput.size(),
-                           static_cast<size_t>(0),
-                           NoThrowString().Format(L"writing=\"%hs\", expecting %u strings", actualString.c_str(), expectedOutput.size()));
+    RETURN_BOOL_IF_FALSE(VERIFY_IS_GREATER_THAN(expectedOutput.size(),
+                                                static_cast<size_t>(0),
+                                                NoThrowString().Format(L"writing=\"%hs\", expecting %u strings", actualString.c_str(), expectedOutput.size())));
 
     std::string first = expectedOutput.front();
     expectedOutput.pop_front();
@@ -135,8 +140,8 @@ bool ConptyOutputTests::_writeCallback(const char* const pch, size_t const cch)
     Log::Comment(NoThrowString().Format(L"Expected =\t\"%hs\"", first.c_str()));
     Log::Comment(NoThrowString().Format(L"Actual =\t\"%hs\"", actualString.c_str()));
 
-    VERIFY_ARE_EQUAL(first.length(), cch);
-    VERIFY_ARE_EQUAL(first, actualString);
+    RETURN_BOOL_IF_FALSE(VERIFY_ARE_EQUAL(first.length(), cch));
+    RETURN_BOOL_IF_FALSE(VERIFY_ARE_EQUAL(first, actualString));
 
     return true;
 }
@@ -311,6 +316,58 @@ void ConptyOutputTests::WriteAFewSimpleLines()
     expectedOutput.push_back("   ");
     expectedOutput.push_back("\r\n");
     expectedOutput.push_back("CCC");
+
+    VERIFY_SUCCEEDED(renderer.PaintFrame());
+}
+
+void ConptyOutputTests::InvalidateUntilOneBeforeEnd()
+{
+    Log::Comment(NoThrowString().Format(
+        L"Make sure we don't use EL and wipe out the last column of text"));
+    VERIFY_IS_NOT_NULL(_pVtRenderEngine.get());
+
+    auto& g = ServiceLocator::LocateGlobals();
+    auto& renderer = *g.pRender;
+    auto& gci = g.getConsoleInformation();
+    auto& si = gci.GetActiveOutputBuffer();
+    auto& sm = si.GetStateMachine();
+    auto& tb = si.GetTextBuffer();
+
+    _flushFirstFrame();
+
+    // Move the cursor to width-15, draw 15 characters
+    sm.ProcessString(L"\x1b[1;66H");
+    sm.ProcessString(L"ABCDEFGHIJKLMNO");
+
+    {
+        auto iter = tb.GetCellDataAt({ 78, 0 });
+        VERIFY_ARE_EQUAL(L"N", (iter++)->Chars());
+        VERIFY_ARE_EQUAL(L"O", (iter++)->Chars());
+    }
+
+    expectedOutput.push_back("\x1b[65C");
+    expectedOutput.push_back("ABCDEFGHIJKLMNO");
+    expectedOutput.push_back("\x1b[1;80H"); // we move the cursor to the end of the line after paint
+
+    VERIFY_SUCCEEDED(renderer.PaintFrame());
+
+    // overstrike the first with X and the middle 8 with spaces
+    sm.ProcessString(L"\x1b[1;66H");
+    //                 ABCDEFGHIJKLMNO
+    sm.ProcessString(L"X             ");
+
+    {
+        auto iter = tb.GetCellDataAt({ 78, 0 });
+        VERIFY_ARE_EQUAL(L" ", (iter++)->Chars());
+        VERIFY_ARE_EQUAL(L"O", (iter++)->Chars());
+    }
+
+    expectedOutput.push_back("\x1b[1;66H");
+    expectedOutput.push_back("X"); // sequence optimizer should choose ECH here
+    expectedOutput.push_back("\x1b[13X");
+    expectedOutput.push_back("\x1b[13C");
+
+    expectedOutput.push_back("\x1b[?25h"); // we turn the cursor back on for good measure
 
     VERIFY_SUCCEEDED(renderer.PaintFrame());
 }

--- a/src/renderer/vt/paint.cpp
+++ b/src/renderer/vt/paint.cpp
@@ -529,7 +529,7 @@ using namespace Microsoft::Console::Types;
         //   before we need to print new text.
         _deferredCursorPos = { _lastText.X + sNumSpaces, _lastText.Y };
 
-        if (_deferredCursorPos.X < _lastViewport.RightInclusive())
+        if (_deferredCursorPos.X <= _lastViewport.RightInclusive())
         {
             RETURN_IF_FAILED(_EraseCharacter(sNumSpaces));
         }


### PR DESCRIPTION
When we painted spaces up until the character right before the right
edge of the screen, we would erroneously use Erase in Line instead of
Erase Character due to an off-by-one.

This commit also fixes how we'd crash during a verify failure on the
render thread.

Fixes #4727.

## Validation Steps Performed

Unit tests and manual verification.
