### PR TITLE
Allow IME Text Wrapping

### DIFF
--- a/src/cascadia/TerminalControl/TSFInputControl.cpp
+++ b/src/cascadia/TerminalControl/TSFInputControl.cpp
@@ -174,8 +174,9 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         TextBlock().MaxWidth(Canvas().ActualWidth() - clientCursorPos.X);
 
         // Set the text block bounds
-        const auto yOffset = ::base::ClampedNumeric<float>(TextBlock().ActualHeight() - fontHeight);
-        Rect selectionRect = Rect(screenCursorPos.X, screenCursorPos.Y + yOffset, 0, fontHeight);
+        const auto yOffset = ::base::ClampSub(::base::ClampedNumeric<float>(TextBlock().ActualHeight()), fontHeight);
+        const auto textBottom = ::base::ClampAdd(::base::ClampedNumeric<float>(screenCursorPos.Y), yOffset);
+        Rect selectionRect = Rect(screenCursorPos.X, textBottom, 0, fontHeight);
         request.LayoutBounds().TextBounds(ScaleRect(selectionRect, scaleFactor));
 
         // Set the control bounds of the whole control

--- a/src/cascadia/TerminalControl/TSFInputControl.cpp
+++ b/src/cascadia/TerminalControl/TSFInputControl.cpp
@@ -163,24 +163,24 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         // Get scale factor for view
         const double scaleFactor = DisplayInformation::GetForCurrentView().RawPixelsPerViewPixel();
 
-        // Set the selection layout bounds
-        Rect selectionRect = Rect(screenCursorPos.X, screenCursorPos.Y, 0, fontHeight);
+        // position textblock to cursor position
+        Canvas().SetLeft(TextBlock(), clientCursorPos.X);
+        Canvas().SetTop(TextBlock(), ::base::ClampedNumeric<double>(clientCursorPos.Y));
+
+        // calculate FontSize in pixels from DIPs
+        const double fontSizePx = (fontHeight * 72) / USER_DEFAULT_SCREEN_DPI;
+        TextBlock().FontSize(fontSizePx);
+        TextBlock().FontFamily(Media::FontFamily(fontArgs->FontFace()));
+        TextBlock().MaxWidth(Canvas().ActualWidth() - clientCursorPos.X);
+
+        // Set the text block bounds
+        const auto yOffset = ::base::ClampedNumeric<float>(TextBlock().ActualHeight() - fontHeight);
+        Rect selectionRect = Rect(screenCursorPos.X, screenCursorPos.Y + yOffset, 0, fontHeight);
         request.LayoutBounds().TextBounds(ScaleRect(selectionRect, scaleFactor));
 
         // Set the control bounds of the whole control
         Rect controlRect = Rect(screenCursorPos.X, screenCursorPos.Y, 0, fontHeight);
         request.LayoutBounds().ControlBounds(ScaleRect(controlRect, scaleFactor));
-
-        // position textblock to cursor position
-        Canvas().SetLeft(TextBlock(), clientCursorPos.X);
-        Canvas().SetTop(TextBlock(), ::base::ClampedNumeric<double>(clientCursorPos.Y));
-
-        TextBlock().Height(fontHeight);
-        // calculate FontSize in pixels from DIPs
-        const double fontSizePx = (fontHeight * 72) / USER_DEFAULT_SCREEN_DPI;
-        TextBlock().FontSize(fontSizePx);
-
-        TextBlock().FontFamily(Media::FontFamily(fontArgs->FontFace()));
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/TSFInputControl.cpp
+++ b/src/cascadia/TerminalControl/TSFInputControl.cpp
@@ -172,12 +172,12 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         TextBlock().FontSize(fontSizePx);
         TextBlock().FontFamily(Media::FontFamily(fontArgs->FontFace()));
 
-        const auto widthToTerminalEnd = ::base::ClampSub(Canvas().ActualWidth(), ::base::ClampedNumeric<double>(clientCursorPos.X));
+        const auto widthToTerminalEnd = Canvas().ActualWidth() - ::base::ClampedNumeric<double>(clientCursorPos.X);
         TextBlock().MaxWidth(widthToTerminalEnd);
 
         // Set the text block bounds
-        const auto yOffset = ::base::ClampSub(::base::ClampedNumeric<float>(TextBlock().ActualHeight()), fontHeight);
-        const auto textBottom = ::base::ClampAdd(::base::ClampedNumeric<float>(screenCursorPos.Y), yOffset);
+        const auto yOffset = ::base::ClampedNumeric<float>(TextBlock().ActualHeight()) - fontHeight;
+        const auto textBottom = ::base::ClampedNumeric<float>(screenCursorPos.Y) + yOffset;
         Rect selectionRect = Rect(screenCursorPos.X, textBottom, 0, fontHeight);
         request.LayoutBounds().TextBounds(ScaleRect(selectionRect, scaleFactor));
 

--- a/src/cascadia/TerminalControl/TSFInputControl.cpp
+++ b/src/cascadia/TerminalControl/TSFInputControl.cpp
@@ -171,7 +171,9 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         const double fontSizePx = (fontHeight * 72) / USER_DEFAULT_SCREEN_DPI;
         TextBlock().FontSize(fontSizePx);
         TextBlock().FontFamily(Media::FontFamily(fontArgs->FontFace()));
-        TextBlock().MaxWidth(Canvas().ActualWidth() - clientCursorPos.X);
+
+        const auto widthToTerminalEnd = ::base::ClampSub(Canvas().ActualWidth(), ::base::ClampedNumeric<double>(clientCursorPos.X));
+        TextBlock().MaxWidth(widthToTerminalEnd);
 
         // Set the text block bounds
         const auto yOffset = ::base::ClampSub(::base::ClampedNumeric<float>(TextBlock().ActualHeight()), fontHeight);

--- a/src/cascadia/TerminalControl/TSFInputControl.xaml
+++ b/src/cascadia/TerminalControl/TSFInputControl.xaml
@@ -12,6 +12,7 @@
             Visibility="Collapsed">
         <TextBlock x:Name="TextBlock"
                    IsTextSelectionEnabled="false"
+                   TextWrapping="Wrap"
                    TextDecorations="Underline" />
     </Canvas>
 </UserControl>


### PR DESCRIPTION
## Summary of the Pull Request
This PR turns on TextWrapping on `TSFInputControl::TextBlock`. Once the TextBlock hits the end of the Terminal window, it will wrap downwards, but the TextBlock will have as much width as it had when composition started. Unfortunately, this means if composition starts right at the end of the Terminal with enough width for just one character, there will be a vertical line of characters down the right side of the Terminal 😅. It's definitely not ideal, and I imagine this won't be the last time we visit this issue, but for now users can see what they're typing.

## PR Checklist
* [x] Closes #3657
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed

## Validation Steps Performed
Played around with IME towards the edge of the Terminal window.
