### PR TITLE
Add enhanced key support for ConPty

### DIFF
--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -790,7 +790,7 @@ DWORD InputStateMachineEngine::_GetGenericKeysModifierState(const std::basic_str
     //   HOME, END, PAGE UP, PAGE DOWN, and direction keys in the clusters to the left
     //   of the keypad; and the divide (/) and ENTER keys in the keypad.
     // This snippet detects the non-direction keys
-    const auto identifier = (GenericKeyIdentifiers)til::at(parameters, 0);
+    const auto identifier = static_cast<GenericKeyIdentifiers>(til::at(parameters, 0));
     if (identifier <= GenericKeyIdentifiers::Next)
     {
         modifiers = WI_SetFlag(modifiers, ENHANCED_KEY);

--- a/src/terminal/parser/InputStateMachineEngine.hpp
+++ b/src/terminal/parser/InputStateMachineEngine.hpp
@@ -176,7 +176,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool _lookingForDSR;
         DWORD _mouseButtonState = 0;
 
-        DWORD _GetCursorKeysModifierState(const std::basic_string_view<size_t> parameters) noexcept;
+        DWORD _GetCursorKeysModifierState(const std::basic_string_view<size_t> parameters, const CsiActionCodes actionCode) noexcept;
         DWORD _GetGenericKeysModifierState(const std::basic_string_view<size_t> parameters) noexcept;
         DWORD _GetSGRMouseModifierState(const std::basic_string_view<size_t> parameters) noexcept;
         bool _GenerateKeyFromChar(const wchar_t wch, short& vkey, DWORD& modifierState) noexcept;

--- a/src/terminal/parser/ut_parser/InputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/InputEngineTest.cpp
@@ -806,7 +806,7 @@ void InputEngineTest::EnhancedKeysTest()
     // The following vkeys should be handled as enhanced keys
     // Reference: https://docs.microsoft.com/en-us/windows/console/key-event-record-str
     // clang-format off
-    const std::map<int, std::wstring> enhancedKeys{
+    const std::map<WORD, std::wstring> enhancedKeys{
         { VK_PRIOR,  L"\x1b[5~"},
         { VK_NEXT,   L"\x1b[6~"},
         { VK_END,    L"\x1b[F"},
@@ -824,14 +824,14 @@ void InputEngineTest::EnhancedKeysTest()
     {
         INPUT_RECORD inputRec;
 
-        wchar_t wch = (wchar_t)MapVirtualKeyW(vkey, MAPVK_VK_TO_CHAR);
-        WORD scanCode = (wchar_t)MapVirtualKeyW(vkey, MAPVK_VK_TO_VSC);
+        const wchar_t wch = (wchar_t)MapVirtualKeyW(vkey, MAPVK_VK_TO_CHAR);
+        const WORD scanCode = (WORD)MapVirtualKeyW(vkey, MAPVK_VK_TO_VSC);
 
         inputRec.EventType = KEY_EVENT;
         inputRec.Event.KeyEvent.bKeyDown = TRUE;
         inputRec.Event.KeyEvent.dwControlKeyState = ENHANCED_KEY;
         inputRec.Event.KeyEvent.wRepeatCount = 1;
-        inputRec.Event.KeyEvent.wVirtualKeyCode = static_cast<WORD>(vkey);
+        inputRec.Event.KeyEvent.wVirtualKeyCode = vkey;
         inputRec.Event.KeyEvent.wVirtualScanCode = scanCode;
         inputRec.Event.KeyEvent.uChar.UnicodeChar = wch;
 

--- a/src/terminal/parser/ut_parser/InputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/InputEngineTest.cpp
@@ -806,7 +806,7 @@ void InputEngineTest::EnhancedKeysTest()
     // The following vkeys should be handled as enhanced keys
     // Reference: https://docs.microsoft.com/en-us/windows/console/key-event-record-str
     // clang-format off
-    const std::map<WORD, std::wstring> enhancedKeys{
+    const std::map<int, std::wstring> enhancedKeys{
         { VK_PRIOR,  L"\x1b[5~"},
         { VK_NEXT,   L"\x1b[6~"},
         { VK_END,    L"\x1b[F"},
@@ -831,7 +831,7 @@ void InputEngineTest::EnhancedKeysTest()
         inputRec.Event.KeyEvent.bKeyDown = TRUE;
         inputRec.Event.KeyEvent.dwControlKeyState = ENHANCED_KEY;
         inputRec.Event.KeyEvent.wRepeatCount = 1;
-        inputRec.Event.KeyEvent.wVirtualKeyCode = vkey;
+        inputRec.Event.KeyEvent.wVirtualKeyCode = static_cast<WORD>(vkey);
         inputRec.Event.KeyEvent.wVirtualScanCode = scanCode;
         inputRec.Event.KeyEvent.uChar.UnicodeChar = wch;
 

--- a/src/terminal/parser/ut_parser/InputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/InputEngineTest.cpp
@@ -58,7 +58,8 @@ bool ModifiersEquivalent(DWORD a, DWORD b)
     bool fShift = IsShiftPressed(a) == IsShiftPressed(b);
     bool fAlt = IsAltPressed(a) == IsAltPressed(b);
     bool fCtrl = IsCtrlPressed(a) == IsCtrlPressed(b);
-    return fShift && fCtrl && fAlt;
+    bool fEnhanced = WI_IsFlagSet(a, ENHANCED_KEY) == WI_IsFlagSet(b, ENHANCED_KEY);
+    return fShift && fCtrl && fAlt && fEnhanced;
 }
 
 class TestState
@@ -251,6 +252,7 @@ class Microsoft::Console::VirtualTerminal::InputEngineTest
     TEST_METHOD(NonAsciiTest);
     TEST_METHOD(CursorPositioningTest);
     TEST_METHOD(CSICursorBackTabTest);
+    TEST_METHOD(EnhancedKeysTest);
     TEST_METHOD(AltBackspaceTest);
     TEST_METHOD(AltCtrlDTest);
     TEST_METHOD(AltIntermediateTest);
@@ -663,6 +665,7 @@ void InputEngineTest::WindowManipulationTest()
             L"Processing \"%s\"", seq.c_str()));
         _stateMachine->ProcessString(seq);
     }
+    VerifyExpectedInputDrained();
 }
 
 void InputEngineTest::NonAsciiTest()
@@ -716,6 +719,7 @@ void InputEngineTest::NonAsciiTest()
     test.Event.KeyEvent.bKeyDown = FALSE;
     testState.vExpectedInput.push_back(test);
     _stateMachine->ProcessString(utf8Input);
+    VerifyExpectedInputDrained();
 }
 
 void InputEngineTest::CursorPositioningTest()
@@ -759,6 +763,7 @@ void InputEngineTest::CursorPositioningTest()
     Log::Comment(NoThrowString().Format(
         L"Processing \"%s\"", seq.c_str()));
     _stateMachine->ProcessString(seq);
+    VerifyExpectedInputDrained();
 }
 
 void InputEngineTest::CSICursorBackTabTest()
@@ -786,6 +791,57 @@ void InputEngineTest::CSICursorBackTabTest()
     Log::Comment(NoThrowString().Format(
         L"Processing \"%s\"", seq.c_str()));
     _stateMachine->ProcessString(seq);
+    VerifyExpectedInputDrained();
+}
+
+void InputEngineTest::EnhancedKeysTest()
+{
+    auto pfn = std::bind(&TestState::TestInputCallback, &testState, std::placeholders::_1);
+    auto dispatch = std::make_unique<TestInteractDispatch>(pfn, &testState);
+    auto inputEngine = std::make_unique<InputStateMachineEngine>(std::move(dispatch));
+    auto _stateMachine = std::make_unique<StateMachine>(std::move(inputEngine));
+    VERIFY_IS_NOT_NULL(_stateMachine);
+    testState._stateMachine = _stateMachine.get();
+
+    // The following vkeys should be handled as enhanced keys
+    // Reference: https://docs.microsoft.com/en-us/windows/console/key-event-record-str
+    // clang-format off
+    const std::map<int, std::wstring> enhancedKeys{
+        { VK_PRIOR,  L"\x1b[5~"},
+        { VK_NEXT,   L"\x1b[6~"},
+        { VK_END,    L"\x1b[F"},
+        { VK_HOME,   L"\x1b[H"},
+        { VK_LEFT,   L"\x1b[D"},
+        { VK_UP,     L"\x1b[A"},
+        { VK_RIGHT,  L"\x1b[C"},
+        { VK_DOWN,   L"\x1b[B"},
+        { VK_INSERT, L"\x1b[2~"},
+        { VK_DELETE, L"\x1b[3~"}
+    };
+    // clang-format on
+
+    for (const auto& [vkey, seq] : enhancedKeys)
+    {
+        INPUT_RECORD inputRec;
+
+        wchar_t wch = (wchar_t)MapVirtualKeyW(vkey, MAPVK_VK_TO_CHAR);
+        WORD scanCode = (wchar_t)MapVirtualKeyW(vkey, MAPVK_VK_TO_VSC);
+
+        inputRec.EventType = KEY_EVENT;
+        inputRec.Event.KeyEvent.bKeyDown = TRUE;
+        inputRec.Event.KeyEvent.dwControlKeyState = ENHANCED_KEY;
+        inputRec.Event.KeyEvent.wRepeatCount = 1;
+        inputRec.Event.KeyEvent.wVirtualKeyCode = static_cast<WORD>(vkey);
+        inputRec.Event.KeyEvent.wVirtualScanCode = scanCode;
+        inputRec.Event.KeyEvent.uChar.UnicodeChar = wch;
+
+        testState.vExpectedInput.push_back(inputRec);
+
+        Log::Comment(NoThrowString().Format(
+            L"Processing \"%s\"", seq.c_str()));
+        _stateMachine->ProcessString(seq);
+    }
+    VerifyExpectedInputDrained();
 }
 
 void InputEngineTest::AltBackspaceTest()


### PR DESCRIPTION
## Summary of the Pull Request
ConPty did not set the ENHANCED_KEY flag when generating new input. This change helps detect when it's supposed to do so, and sends it.

## References
[Enhanced Key Documentation](https://docs.microsoft.com/en-us/windows/console/key-event-record-str)

## PR Checklist
* [X] Closes #2397

## Detailed Description of the Pull Request / Additional comments
| KEY_EVENT_RECORD modifiers | VT encodable? | Detectable on the way out? |
|----------------------------|---------------|----------------------------|
| CAPSLOCK_ON                | No            | No                         |
| ENHANCED_KEY               | No            | Yes**                      |
| LEFT_ALT_PRESSED           | Yes*          | Yes*                       |
| LEFT_CTRL_PRESSED          | Yes*          | Yes*                       |
| NUMLOCK_ON                 | No            | No                         |
| RIGHT_ALT_PRESSED          | Yes*          | Yes*                       |
| RIGHT_CTRL_PRESSED         | Yes*          | Yes*                       |
| SCROLLLOCK_ON              | No            | No                         |
| SHIFT_PRESSED              | Yes           | Yes                        |
```
* We can detect Alt and Ctrl, but not necessarily which one
** Enhanced Keys are limited to the following:
    - off keypad: INS, DEL, HOME, END, PAGE UP, PAGE DOWN, direction keys
    - on keypad: / and ENTER
   Since we can't detect the keypad keys, those will _not_ send the ENHANCED_KEY modifier.
   For the following CSI action codes, we can assume that they are Enhanced Keys:
     case CsiActionCodes::ArrowUp:
     case CsiActionCodes::ArrowDown:
     case CsiActionCodes::ArrowRight:
     case CsiActionCodes::ArrowLeft:
     case CsiActionCodes::Home:
     case CsiActionCodes::End:
     case CsiActionCodes::CSI_F1:
     case CsiActionCodes::CSI_F3:
     case CsiActionCodes::CSI_F2:
     case CsiActionCodes::CSI_F4:
   These cases are handled in ActionCsiDispatch
```
## Validation Steps Performed
Followed bug repro steps. It now matches!