### PR TITLE
doc: add cmder icon to ThirdPartyToolProfiles

### DIFF
--- a/doc/user-docs/ThirdPartyToolProfiles.md
+++ b/doc/user-docs/ThirdPartyToolProfiles.md
@@ -30,7 +30,7 @@ Assuming that you've installed cmder into `%CMDER_ROOT%`:
 {
     "commandline" : "cmd.exe /k \"%CMDER_ROOT%\\vendor\\init.bat\"",
     "name" : "cmder",
-    "icon": "%CMDER_ROOT%/icons/cmder.ico",
+    "icon" : "%CMDER_ROOT%/icons/cmder.ico",
     "startingDirectory" : "%USERPROFILE%"
 }
 ```

--- a/doc/user-docs/ThirdPartyToolProfiles.md
+++ b/doc/user-docs/ThirdPartyToolProfiles.md
@@ -30,6 +30,7 @@ Assuming that you've installed cmder into `%CMDER_ROOT%`:
 {
     "commandline" : "cmd.exe /k \"%CMDER_ROOT%\\vendor\\init.bat\"",
     "name" : "cmder",
+    "icon": "%CMDER_ROOT%/icons/cmder.ico",
     "startingDirectory" : "%USERPROFILE%"
 }
 ```


### PR DESCRIPTION
## Simply adding the icon property to the ThirdPartyToolProfiles examples md for cmder

## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments
I think not much detail needed since this only an update to a doc and not the main application.

## Validation Steps Performed
I tried it locally and worked without any adjustments to the cmder folder. Just making sure (as already stated) the `%CMDER_ROOT%` is set correctly.