### PR TITLE
ci: update spelling allowlists/dictionaries

### DIFF
--- a/.github/actions/spell-check/dictionary/math.txt
+++ b/.github/actions/spell-check/dictionary/math.txt
@@ -1,0 +1,2 @@
+powf
+sqrtf

--- a/.github/actions/spell-check/dictionary/microsoft.txt
+++ b/.github/actions/spell-check/dictionary/microsoft.txt
@@ -3,4 +3,5 @@ microsoft
 microsoftonline
 osgvsowi
 powershell
+tdbuildteamid
 visualstudio

--- a/.github/actions/spell-check/dictionary/names.txt
+++ b/.github/actions/spell-check/dictionary/names.txt
@@ -17,6 +17,7 @@ Illhardt
 jantari
 jerrysh
 Kaiyu
+kimwalisch
 KMehrain
 Kourosh
 kowalczyk
@@ -45,7 +46,9 @@ Somuah
 sonph
 sonpham
 stakx
+Walisch
 Wirt
+Wojciech
 zadjii
 Zamor
 Zoey

--- a/.github/actions/spell-check/whitelist/whitelist.txt
+++ b/.github/actions/spell-check/whitelist/whitelist.txt
@@ -291,6 +291,7 @@ Clcompile
 CLE
 cleartype
 CLICKACTIVE
+clickdown
 climits
 clipbrd
 CLIPCHILDREN
@@ -595,6 +596,7 @@ deff
 DEFFACE
 defing
 DEFPUSHBUTTON
+defterm
 DELAYLOAD
 deletable
 DELETEONRELEASE
@@ -1143,10 +1145,12 @@ INITDIALOG
 initguid
 INITMENU
 inl
+INLINEPREFIX
 Inlines
 INotify
 inout
 INPATHROOT
+Inplace
 inproc
 inputdev
 Inputkeyinfo
@@ -1282,6 +1286,7 @@ LEFTALIGN
 LEFTSHIFT
 len
 lhs
+libpopcnt
 LIMITTEXT
 LINEDOWN
 LINESELECTION
@@ -1486,6 +1491,7 @@ msixbundle
 msrc
 msvcrt
 MSVS
+msys
 msysgit
 mui
 Mul
@@ -1781,6 +1787,7 @@ pid
 pidl
 PIDLIST
 pii
+pinam
 pinvoke
 pipename
 pipestr
@@ -2206,6 +2213,8 @@ SOLIDBOX
 Solutiondir
 somefile
 sourced
+SOURCESDIRECTORY
+SPACEBAR
 spammy
 spand
 Spc


### PR DESCRIPTION
This is just some minor whitelisting/additions to dictionaries to catch up between when the spell checker PR was written and when it was finally merged.

This is basically taking the output from https://github.com/microsoft/terminal/commit/499f24a29e6f321d6c4da8eb22c2ef0d30f13770#commitcomment-38053489 and putting it into files.

The choice of files is arbitrary. I'm adding a `math.txt` dictionary because it's a reasonable example.

The goal here is to get master to a green check mark

## Summary of the Pull Request

## References

## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

When I pushed this commit to my fork, the spell check action ran and gave me a check mark:
https://github.com/jsoref/terminal/runs/534783276