### PR TITLE
ci: spelling: remove branch / tag filtering

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -1,10 +1,6 @@
 name: Spell checking
 on:
   push:
-    branches:
-      - "*"
-    tags-ignore:
-      - "*"
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron: '15 * * * *'


### PR DESCRIPTION
This repository tends to use `/`s in branch names.
Unfortunately, `branch: "*"` at present only matches a single
level, which means it would match a branch named `foo` but not `bar/foo`.

Given that I don't think this repository is actively using tags,
and given that the general cost for the spell checker isn't particularly
high, it's better to remove the filtering so that all branches get
checked.

Worst case, a branch that is also tagged and has spelling errors
will get two comments complaining about those spelling errors.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Testing by @DHowett-MSFT 
* https://github.com/microsoft/terminal/commit/4357854560d5e5b2ef0a29fd893381918ee0a342 -- null commit on DTI no slash branch
* https://github.com/microsoft/terminal/commit/30556187aee9ef7289055d8d70f28393582b7b71 -- null commit on DTI with slash branch
* https://github.com/microsoft/terminal/commit/065a96d8affb2cbb1abaeb35062ebd8758a64bfb -- null commit on master
* https://github.com/microsoft/terminal/commit/3377781d151d01bdb8fc779ab6612d9fb99a3c1f -- null commit on master with slashes

