### PR TITLE
doc: add Git Bash(WOW64) to ThirdPartyToolProfiles

### DIFF
--- a/doc/user-docs/ThirdPartyToolProfiles.md
+++ b/doc/user-docs/ThirdPartyToolProfiles.md
@@ -72,7 +72,7 @@ Assuming that you've installed Git Bash into `C:/Program Files/Git`:
 ```json
 {
     "name" : "Git Bash",
-    "commandline" : "C:/Program Files/Git/bin/bash.exe",
+    "commandline" : "C:/Program Files/Git/bin/bash.exe -li",
     "icon" : "C:/Program Files/Git/mingw64/share/git/git-for-windows.ico",
     "startingDirectory" : "%USERPROFILE%"
 }
@@ -85,7 +85,7 @@ Assuming that you've installed Git Bash into `C:/Program Files (x86)/Git`:
 ```json
 {
     "name" : "Git Bash",
-    "commandline" : "C:/Program Files (x86)/Git/bin/bash.exe -li",
+    "commandline" : "%ProgramFiles(x86)%/Git/bin/bash.exe -li",
     "icon" : "%ProgramFiles(x86)%/Git/mingw32/share/git/git-for-windows.ico",
     "startingDirectory" : "%USERPROFILE%"
 }

--- a/doc/user-docs/ThirdPartyToolProfiles.md
+++ b/doc/user-docs/ThirdPartyToolProfiles.md
@@ -86,7 +86,7 @@ Assuming that you've installed Git Bash into `C:/Program Files (x86)/Git`:
 {
     "name" : "Git Bash",
     "commandline" : "C:/Program Files (x86)/Git/bin/bash.exe -li",
-    "icon" : "C:/Program Files (x86)/Git/mingw32/share/git/git-for-windows.ico",
+    "icon" : "%ProgramFiles(x86)%/Git/mingw32/share/git/git-for-windows.ico",
     "startingDirectory" : "%USERPROFILE%"
 }
 ```

--- a/doc/user-docs/ThirdPartyToolProfiles.md
+++ b/doc/user-docs/ThirdPartyToolProfiles.md
@@ -78,6 +78,19 @@ Assuming that you've installed Git Bash into `C:/Program Files/Git`:
 }
 ````
 
+## Git Bash (WOW64)
+
+Assuming that you've installed Git Bash into `C:/Program Files (x86)/Git`:
+
+```json
+{
+    "name" : "Git Bash",
+    "commandline" : "C:/Program Files (x86)/Git/bin/bash.exe",
+    "icon" : "C:/Program Files (x86)/Git/mingw32/share/git/git-for-windows.ico",
+    "startingDirectory" : "%USERPROFILE%"
+}
+```
+
 ## MSYS2
 
 Assuming that you've installed MSYS2 into `C:/msys64`:

--- a/doc/user-docs/ThirdPartyToolProfiles.md
+++ b/doc/user-docs/ThirdPartyToolProfiles.md
@@ -85,7 +85,7 @@ Assuming that you've installed Git Bash into `C:/Program Files (x86)/Git`:
 ```json
 {
     "name" : "Git Bash",
-    "commandline" : "C:/Program Files (x86)/Git/bin/bash.exe",
+    "commandline" : "C:/Program Files (x86)/Git/bin/bash.exe -li",
     "icon" : "C:/Program Files (x86)/Git/mingw32/share/git/git-for-windows.ico",
     "startingDirectory" : "%USERPROFILE%"
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Added Git Bash (WOW64) profile.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The `mingw32` part is a catch. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
