### PR TITLE
Static-casts

### DIFF
--- a/src/buffer/out/ut_textbuffer/TextAttributeTests.cpp
+++ b/src/buffer/out/ut_textbuffer/TextAttributeTests.cpp
@@ -60,7 +60,7 @@ void TextAttributeTests::TestRoundtripLegacy()
     WORD expectedLegacy = FOREGROUND_BLUE | BACKGROUND_RED;
     WORD bgOnly = expectedLegacy & BG_ATTRS;
     WORD bgShifted = bgOnly >> 4;
-    BYTE bgByte = (BYTE)(bgShifted);
+    BYTE bgByte = static_cast<BYTE>(bgShifted);
 
     VERIFY_ARE_EQUAL(FOREGROUND_RED, bgByte);
 

--- a/src/buffer/out/ut_textbuffer/TextColorTests.cpp
+++ b/src/buffer/out/ut_textbuffer/TextColorTests.cpp
@@ -81,7 +81,7 @@ void TextColorTests::TestDefaultColor()
 
 void TextColorTests::TestDarkIndexColor()
 {
-    TextColor indexColor((BYTE)(7));
+    TextColor indexColor(static_cast<BYTE>(7));
 
     VERIFY_IS_FALSE(indexColor.IsDefault());
     VERIFY_IS_TRUE(indexColor.IsLegacy());
@@ -104,7 +104,7 @@ void TextColorTests::TestDarkIndexColor()
 
 void TextColorTests::TestBrightIndexColor()
 {
-    TextColor indexColor((BYTE)(15));
+    TextColor indexColor(static_cast<BYTE>(15));
 
     VERIFY_IS_FALSE(indexColor.IsDefault());
     VERIFY_IS_TRUE(indexColor.IsLegacy());

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
@@ -430,7 +430,7 @@ const wchar_t* _stdcall TerminalGetSelection(void* terminal)
 void _stdcall TerminalSendKeyEvent(void* terminal, WPARAM wParam)
 {
     const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
-    const auto scanCode = MapVirtualKeyW(static_cast<UINT>(wParam), MAPVK_VK_TO_VSC);
+    const auto scanCode = MapVirtualKeyW(gsl::narrow<UINT>(wParam), MAPVK_VK_TO_VSC);
     struct KeyModifier
     {
         int vkey;
@@ -458,7 +458,7 @@ void _stdcall TerminalSendKeyEvent(void* terminal, WPARAM wParam)
         }
     }
 
-    publicTerminal->_terminal->SendKeyEvent(static_cast<WORD>(wParam), static_cast<WORD>(scanCode), flags);
+    publicTerminal->_terminal->SendKeyEvent(gsl::narrow<WORD>(wParam), gsl::narrow<WORD>(scanCode), flags);
 }
 
 void _stdcall TerminalSendCharEvent(void* terminal, wchar_t ch)

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
@@ -430,7 +430,7 @@ const wchar_t* _stdcall TerminalGetSelection(void* terminal)
 void _stdcall TerminalSendKeyEvent(void* terminal, WPARAM wParam)
 {
     const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
-    const auto scanCode = MapVirtualKeyW((UINT)wParam, MAPVK_VK_TO_VSC);
+    const auto scanCode = MapVirtualKeyW(static_cast<UINT>(wParam), MAPVK_VK_TO_VSC);
     struct KeyModifier
     {
         int vkey;
@@ -458,7 +458,7 @@ void _stdcall TerminalSendKeyEvent(void* terminal, WPARAM wParam)
         }
     }
 
-    publicTerminal->_terminal->SendKeyEvent((WORD)wParam, (WORD)scanCode, flags);
+    publicTerminal->_terminal->SendKeyEvent(static_cast<WORD>(wParam), static_cast<WORD>(scanCode), flags);
 }
 
 void _stdcall TerminalSendCharEvent(void* terminal, wchar_t ch)

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -478,7 +478,7 @@ namespace winrt::TerminalApp::implementation
             LoadSettings();
         }
 
-        winrt::Windows::Foundation::Point point((float)defaultInitialX, (float)defaultInitialY);
+        winrt::Windows::Foundation::Point point(static_cast<float>(defaultInitialX), static_cast<float>(defaultInitialY));
 
         auto initialX = _settings->GlobalSettings().GetInitialX();
         auto initialY = _settings->GlobalSettings().GetInitialY();

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -310,7 +310,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         // convert from UTF-16LE to UTF-8 as ConPty expects UTF-8
         // TODO GH#3378 reconcile and unify UTF-8 converters
         std::string str = winrt::to_string(data);
-        LOG_IF_WIN32_BOOL_FALSE(WriteFile(_inPipe.get(), str.c_str(), (DWORD)str.length(), nullptr, nullptr));
+        LOG_IF_WIN32_BOOL_FALSE(WriteFile(_inPipe.get(), str.c_str(), static_cast<DWORD>(str.length()), nullptr, nullptr));
     }
 
     void ConptyConnection::Resize(uint32_t rows, uint32_t columns)

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1629,7 +1629,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         if (_renderEngine)
         {
             const auto scale = sender.CompositionScaleX();
-            const auto dpi = (int)(scale * USER_DEFAULT_SCREEN_DPI);
+            const auto dpi = static_cast<int>(scale * USER_DEFAULT_SCREEN_DPI);
 
             // TODO: MSFT: 21169071 - Shouldn't this all happen through _renderer and trigger the invalidate automatically on DPI change?
             THROW_IF_FAILED(_renderEngine->UpdateDpi(dpi));

--- a/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
@@ -95,7 +95,7 @@ void TerminalApiTest::PrintStringOfSurrogatePairs()
             SetEvent(baton.done);
             return 0;
         },
-        (LPVOID)&baton,
+        static_cast<LPVOID>(&baton),
         0,
         nullptr);
 

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -376,7 +376,7 @@ int NonClientIslandWindow::_GetResizeHandleHeight() const noexcept
         // First, check if we have an auto-hide taskbar at all:
         APPBARDATA autohide{ 0 };
         autohide.cbSize = sizeof(autohide);
-        UINT state = (UINT)SHAppBarMessage(ABM_GETSTATE, &autohide);
+        UINT state = static_cast<UINT>(SHAppBarMessage(ABM_GETSTATE, &autohide));
         if (WI_IsFlagSet(state, ABS_AUTOHIDE))
         {
             // This helper can be used to determine if there's a auto-hide

--- a/src/host/CommandListPopup.cpp
+++ b/src/host/CommandListPopup.cpp
@@ -107,17 +107,17 @@ CommandListPopup::CommandListPopup(SCREEN_INFORMATION& screenInfo, const Command
             break;
         case VK_END:
             // Move waaay forward, UpdateCommandListPopup() can handle it.
-            _update((SHORT)(cookedReadData.History().GetNumberOfCommands()));
+            _update(static_cast<SHORT>(cookedReadData.History().GetNumberOfCommands()));
             break;
         case VK_HOME:
             // Move waaay back, UpdateCommandListPopup() can handle it.
-            _update(-(SHORT)(cookedReadData.History().GetNumberOfCommands()));
+            _update(-static_cast<SHORT>(cookedReadData.History().GetNumberOfCommands()));
             break;
         case VK_PRIOR:
-            _update(-(SHORT)Height());
+            _update(-static_cast<SHORT>(Height()));
             break;
         case VK_NEXT:
-            _update((SHORT)Height());
+            _update(static_cast<SHORT>(Height()));
             break;
         case VK_DELETE:
             return _deleteSelection(cookedReadData);
@@ -125,7 +125,7 @@ CommandListPopup::CommandListPopup(SCREEN_INFORMATION& screenInfo, const Command
         case VK_RIGHT:
             Index = _currentCommand;
             CommandLine::Instance().EndCurrentPopup();
-            SetCurrentCommandLine(cookedReadData, (SHORT)Index);
+            SetCurrentCommandLine(cookedReadData, static_cast<SHORT>(Index));
             return CONSOLE_STATUS_WAIT_NO_BLOCK;
         default:
             break;
@@ -137,13 +137,13 @@ CommandListPopup::CommandListPopup(SCREEN_INFORMATION& screenInfo, const Command
 
 void CommandListPopup::_setBottomIndex()
 {
-    if (_currentCommand < (SHORT)(_history.GetNumberOfCommands() - Height()))
+    if (_currentCommand < static_cast<SHORT>(_history.GetNumberOfCommands() - Height()))
     {
         _bottomIndex = std::max(_currentCommand, gsl::narrow<SHORT>(Height() - 1i16));
     }
     else
     {
-        _bottomIndex = (SHORT)(_history.GetNumberOfCommands() - 1);
+        _bottomIndex = static_cast<SHORT>(_history.GetNumberOfCommands() - 1);
     }
 }
 
@@ -223,7 +223,7 @@ void CommandListPopup::_handleReturn(COOKED_READ_DATA& cookedReadData)
     DWORD LineCount = 1;
     Index = _currentCommand;
     CommandLine::Instance().EndCurrentPopup();
-    SetCurrentCommandLine(cookedReadData, (SHORT)Index);
+    SetCurrentCommandLine(cookedReadData, static_cast<SHORT>(Index));
     cookedReadData.ProcessInput(UNICODE_CARRIAGERETURN, 0, Status);
     // complete read
     if (cookedReadData.IsEchoInput())
@@ -274,7 +274,7 @@ void CommandListPopup::_cycleSelectionToMatchingCommands(COOKED_READ_DATA& cooke
                                                      Index,
                                                      CommandHistory::MatchOptions::JustLooking))
     {
-        _update((SHORT)(Index - _currentCommand), true);
+        _update(static_cast<SHORT>(Index - _currentCommand), true);
     }
 }
 

--- a/src/host/_stream.cpp
+++ b/src/host/_stream.cpp
@@ -52,8 +52,8 @@ constexpr unsigned int LOCAL_BUFFER_SIZE = 100;
     {
         if (coordCursor.Y > 0)
         {
-            coordCursor.X = (SHORT)(bufferSize.X + coordCursor.X);
-            coordCursor.Y = (SHORT)(coordCursor.Y - 1);
+            coordCursor.X = static_cast<SHORT>(bufferSize.X + coordCursor.X);
+            coordCursor.Y = static_cast<SHORT>(coordCursor.Y - 1);
         }
         else
         {
@@ -233,9 +233,9 @@ constexpr unsigned int LOCAL_BUFFER_SIZE = 100;
 
         if (nullptr != psScrollY)
         {
-            *psScrollY += (SHORT)(bufferSize.Y - coordCursor.Y - 1);
+            *psScrollY += static_cast<SHORT>(bufferSize.Y - coordCursor.Y - 1);
         }
-        coordCursor.Y += (SHORT)(bufferSize.Y - coordCursor.Y - 1);
+        coordCursor.Y += static_cast<SHORT>(bufferSize.Y - coordCursor.Y - 1);
     }
 
     const bool cursorMovedPastViewport = coordCursor.Y > screenInfo.GetViewport().BottomInclusive();
@@ -413,7 +413,7 @@ constexpr unsigned int LOCAL_BUFFER_SIZE = 100;
                 case UNICODE_TAB:
                 {
                     const ULONG TabSize = NUMBER_OF_SPACES_IN_TAB(XPosition);
-                    XPosition = (SHORT)(XPosition + TabSize);
+                    XPosition = static_cast<SHORT>(XPosition + TabSize);
                     if (XPosition >= coordScreenBufferSize.X)
                     {
                         goto EndWhile;
@@ -439,12 +439,12 @@ constexpr unsigned int LOCAL_BUFFER_SIZE = 100;
                     CtrlChar:
                         if (i < (LOCAL_BUFFER_SIZE - 1))
                         {
-                            *LocalBufPtr = (WCHAR)'^';
+                            *LocalBufPtr = static_cast<WCHAR>('^');
                             LocalBufPtr++;
                             XPosition++;
                             i++;
 
-                            *LocalBufPtr = (WCHAR)(RealUnicodeChar + (WCHAR)'@');
+                            *LocalBufPtr = static_cast<WCHAR>(RealUnicodeChar + static_cast<WCHAR>('@'));
                             LocalBufPtr++;
                             XPosition++;
                             i++;
@@ -618,9 +618,9 @@ constexpr unsigned int LOCAL_BUFFER_SIZE = 100;
 
                 if (LastChar == UNICODE_TAB)
                 {
-                    CursorPosition.X -= (SHORT)(RetrieveNumberOfSpaces(sOriginalXPosition,
-                                                                       pwchBufferBackupLimit,
-                                                                       (ULONG)(pwchBuffer - pwchBufferBackupLimit - 1)));
+                    CursorPosition.X -= static_cast<SHORT>(RetrieveNumberOfSpaces(sOriginalXPosition,
+                                                                                  pwchBufferBackupLimit,
+                                                                                  static_cast<ULONG>(pwchBuffer - pwchBufferBackupLimit - 1)));
                     if (CursorPosition.X < 0)
                     {
                         CursorPosition.X = (coordScreenBufferSize.X - 1) / TAB_SIZE;
@@ -697,7 +697,7 @@ constexpr unsigned int LOCAL_BUFFER_SIZE = 100;
                                         dwFlags & WC_ECHO))
                 {
                     CursorPosition.X = coordScreenBufferSize.X - 1;
-                    CursorPosition.Y = (SHORT)(cursor.GetPosition().Y - 1);
+                    CursorPosition.Y = static_cast<SHORT>(cursor.GetPosition().Y - 1);
 
                     // since you just backspaced yourself back up into the previous row, unset the wrap flag
                     // on the prev row if it was set
@@ -711,7 +711,7 @@ constexpr unsigned int LOCAL_BUFFER_SIZE = 100;
         case UNICODE_TAB:
         {
             const size_t TabSize = gsl::narrow_cast<size_t>(NUMBER_OF_SPACES_IN_TAB(cursor.GetPosition().X));
-            CursorPosition.X = (SHORT)(cursor.GetPosition().X + TabSize);
+            CursorPosition.X = static_cast<SHORT>(cursor.GetPosition().X + TabSize);
 
             // move cursor forward to next tab stop.  fill space with blanks.
             // we get here when the tab extends beyond the right edge of the
@@ -771,7 +771,7 @@ constexpr unsigned int LOCAL_BUFFER_SIZE = 100;
                 CursorPosition.X = 0;
             }
 
-            CursorPosition.Y = (SHORT)(cursor.GetPosition().Y + 1);
+            CursorPosition.Y = static_cast<SHORT>(cursor.GetPosition().Y + 1);
 
             {
                 // since we explicitly just moved down a row, clear the wrap status on the row we just came from
@@ -815,7 +815,7 @@ constexpr unsigned int LOCAL_BUFFER_SIZE = 100;
                 }
 
                 CursorPosition.X = 0;
-                CursorPosition.Y = (SHORT)(TargetPoint.Y + 1);
+                CursorPosition.Y = static_cast<SHORT>(TargetPoint.Y + 1);
 
                 // since you just moved yourself down onto the next row with 1 character, that sounds like a
                 // forced wrap so set the flag

--- a/src/host/cmdline.cpp
+++ b/src/host/cmdline.cpp
@@ -281,9 +281,9 @@ void RedrawCommandLine(COOKED_READ_DATA& cookedReadData)
 
         // Move the cursor back to the right position
         COORD CursorPosition = cookedReadData.OriginalCursorPosition();
-        CursorPosition.X += (SHORT)RetrieveTotalNumberOfSpaces(cookedReadData.OriginalCursorPosition().X,
-                                                               cookedReadData.BufferStartPtr(),
-                                                               cookedReadData.InsertionPoint());
+        CursorPosition.X += static_cast<SHORT>(RetrieveTotalNumberOfSpaces(cookedReadData.OriginalCursorPosition().X,
+                                                                           cookedReadData.BufferStartPtr(),
+                                                                           cookedReadData.InsertionPoint()));
         if (CheckBisectStringW(cookedReadData.BufferStartPtr(),
                                cookedReadData.InsertionPoint(),
                                cookedReadData.ScreenInfo().GetBufferSize().Width() - cookedReadData.OriginalCursorPosition().X))
@@ -534,7 +534,7 @@ void CommandLine::_setPromptToNewestCommand(COOKED_READ_DATA& cookedReadData)
     DeleteCommandLine(cookedReadData, true);
     if (cookedReadData.HasHistory() && cookedReadData.History().GetNumberOfCommands())
     {
-        const short commandNumber = (SHORT)(cookedReadData.History().GetNumberOfCommands() - 1);
+        const short commandNumber = static_cast<SHORT>(cookedReadData.History().GetNumberOfCommands() - 1);
         THROW_IF_FAILED(cookedReadData.History().RetrieveNth(commandNumber,
                                                              cookedReadData.SpanWholeBuffer(),
                                                              cookedReadData.BytesRead()));
@@ -620,7 +620,7 @@ COORD CommandLine::_moveCursorToEndOfPrompt(COOKED_READ_DATA& cookedReadData) no
     cookedReadData.InsertionPoint() = cookedReadData.BytesRead() / sizeof(WCHAR);
     cookedReadData.SetBufferCurrentPtr(cookedReadData.BufferStartPtr() + cookedReadData.InsertionPoint());
     COORD cursorPosition{ 0, 0 };
-    cursorPosition.X = (SHORT)(cookedReadData.OriginalCursorPosition().X + cookedReadData.VisibleCharCount());
+    cursorPosition.X = static_cast<SHORT>(cookedReadData.OriginalCursorPosition().X + cookedReadData.VisibleCharCount());
     cursorPosition.Y = cookedReadData.OriginalCursorPosition().Y;
 
     const SHORT sScreenBufferSizeX = cookedReadData.ScreenInfo().GetBufferSize().Width();
@@ -716,12 +716,12 @@ COORD CommandLine::_moveCursorLeftByWord(COOKED_READ_DATA& cookedReadData) noexc
             }
             cookedReadData.SetBufferCurrentPtr(LastWord);
         }
-        cookedReadData.InsertionPoint() = (ULONG)(cookedReadData.BufferCurrentPtr() - cookedReadData.BufferStartPtr());
+        cookedReadData.InsertionPoint() = static_cast<ULONG>(cookedReadData.BufferCurrentPtr() - cookedReadData.BufferStartPtr());
         cursorPosition = cookedReadData.OriginalCursorPosition();
-        cursorPosition.X = (SHORT)(cursorPosition.X +
-                                   RetrieveTotalNumberOfSpaces(cookedReadData.OriginalCursorPosition().X,
-                                                               cookedReadData.BufferStartPtr(),
-                                                               cookedReadData.InsertionPoint()));
+        cursorPosition.X = static_cast<SHORT>(cursorPosition.X +
+                                              RetrieveTotalNumberOfSpaces(cookedReadData.OriginalCursorPosition().X,
+                                                                          cookedReadData.BufferStartPtr(),
+                                                                          cookedReadData.InsertionPoint()));
         const SHORT sScreenBufferSizeX = cookedReadData.ScreenInfo().GetBufferSize().Width();
         if (CheckBisectStringW(cookedReadData.BufferStartPtr(),
                                cookedReadData.InsertionPoint() + 1,
@@ -748,10 +748,10 @@ COORD CommandLine::_moveCursorLeft(COOKED_READ_DATA& cookedReadData)
         cookedReadData.InsertionPoint()--;
         cursorPosition.X = cookedReadData.ScreenInfo().GetTextBuffer().GetCursor().GetPosition().X;
         cursorPosition.Y = cookedReadData.ScreenInfo().GetTextBuffer().GetCursor().GetPosition().Y;
-        cursorPosition.X = (SHORT)(cursorPosition.X -
-                                   RetrieveNumberOfSpaces(cookedReadData.OriginalCursorPosition().X,
-                                                          cookedReadData.BufferStartPtr(),
-                                                          cookedReadData.InsertionPoint()));
+        cursorPosition.X = static_cast<SHORT>(cursorPosition.X -
+                                              RetrieveNumberOfSpaces(cookedReadData.OriginalCursorPosition().X,
+                                                                     cookedReadData.BufferStartPtr(),
+                                                                     cookedReadData.InsertionPoint()));
         const SHORT sScreenBufferSizeX = cookedReadData.ScreenInfo().GetBufferSize().Width();
         if (CheckBisectProcessW(cookedReadData.ScreenInfo(),
                                 cookedReadData.BufferStartPtr(),
@@ -825,12 +825,12 @@ COORD CommandLine::_moveCursorRightByWord(COOKED_READ_DATA& cookedReadData) noex
         }
 
         cookedReadData.SetBufferCurrentPtr(NextWord);
-        cookedReadData.InsertionPoint() = (ULONG)(cookedReadData.BufferCurrentPtr() - cookedReadData.BufferStartPtr());
+        cookedReadData.InsertionPoint() = static_cast<ULONG>(cookedReadData.BufferCurrentPtr() - cookedReadData.BufferStartPtr());
         cursorPosition = cookedReadData.OriginalCursorPosition();
-        cursorPosition.X = (SHORT)(cursorPosition.X +
-                                   RetrieveTotalNumberOfSpaces(cookedReadData.OriginalCursorPosition().X,
-                                                               cookedReadData.BufferStartPtr(),
-                                                               cookedReadData.InsertionPoint()));
+        cursorPosition.X = static_cast<SHORT>(cursorPosition.X +
+                                              RetrieveTotalNumberOfSpaces(cookedReadData.OriginalCursorPosition().X,
+                                                                          cookedReadData.BufferStartPtr(),
+                                                                          cookedReadData.InsertionPoint()));
         const SHORT sScreenBufferSizeX = cookedReadData.ScreenInfo().GetBufferSize().Width();
         if (CheckBisectStringW(cookedReadData.BufferStartPtr(),
                                cookedReadData.InsertionPoint() + 1,
@@ -856,10 +856,10 @@ COORD CommandLine::_moveCursorRight(COOKED_READ_DATA& cookedReadData) noexcept
     if (cookedReadData.InsertionPoint() < (cookedReadData.BytesRead() / sizeof(WCHAR)))
     {
         cursorPosition = cookedReadData.ScreenInfo().GetTextBuffer().GetCursor().GetPosition();
-        cursorPosition.X = (SHORT)(cursorPosition.X +
-                                   RetrieveNumberOfSpaces(cookedReadData.OriginalCursorPosition().X,
-                                                          cookedReadData.BufferStartPtr(),
-                                                          cookedReadData.InsertionPoint()));
+        cursorPosition.X = static_cast<SHORT>(cursorPosition.X +
+                                              RetrieveNumberOfSpaces(cookedReadData.OriginalCursorPosition().X,
+                                                                     cookedReadData.BufferStartPtr(),
+                                                                     cookedReadData.InsertionPoint()));
         if (CheckBisectProcessW(cookedReadData.ScreenInfo(),
                                 cookedReadData.BufferStartPtr(),
                                 cookedReadData.InsertionPoint() + 2,
@@ -924,7 +924,7 @@ void CommandLine::_insertCtrlZ(COOKED_READ_DATA& cookedReadData) noexcept
 {
     size_t NumSpaces = 0;
 
-    *cookedReadData.BufferCurrentPtr() = (WCHAR)0x1a; // ctrl-z
+    *cookedReadData.BufferCurrentPtr() = static_cast<WCHAR>(0x1a); // ctrl-z
     cookedReadData.BytesRead() += sizeof(WCHAR);
     cookedReadData.InsertionPoint()++;
     if (cookedReadData.IsEchoInput())
@@ -1018,10 +1018,10 @@ COORD CommandLine::_cycleMatchingCommandHistoryToPrompt(COOKED_READ_DATA& cooked
             SHORT CurrentPos;
 
             // save cursor position
-            CurrentPos = (SHORT)cookedReadData.InsertionPoint();
+            CurrentPos = static_cast<SHORT>(cookedReadData.InsertionPoint());
 
             DeleteCommandLine(cookedReadData, true);
-            THROW_IF_FAILED(cookedReadData.History().RetrieveNth((SHORT)index,
+            THROW_IF_FAILED(cookedReadData.History().RetrieveNth(static_cast<SHORT>(index),
                                                                  cookedReadData.SpanWholeBuffer(),
                                                                  cookedReadData.BytesRead()));
             FAIL_FAST_IF(!(cookedReadData.BufferStartPtr() == cookedReadData.BufferCurrentPtr()));
@@ -1077,7 +1077,7 @@ COORD CommandLine::DeleteFromRightOfCursor(COOKED_READ_DATA& cookedReadData) noe
 
         {
             PWCHAR buf = (PWCHAR)((PBYTE)cookedReadData.BufferStartPtr() + cookedReadData.BytesRead());
-            *buf = (WCHAR)' ';
+            *buf = static_cast<WCHAR>(' ');
         }
 
         // Write commandline.

--- a/src/host/conattrs.cpp
+++ b/src/host/conattrs.cpp
@@ -24,9 +24,9 @@ struct _HSL
     // constructs an HSL color from a RGB Color.
     _HSL(const COLORREF rgb)
     {
-        const double r = (double)GetRValue(rgb);
-        const double g = (double)GetGValue(rgb);
-        const double b = (double)GetBValue(rgb);
+        const double r = static_cast<double>(GetRValue(rgb));
+        const double g = static_cast<double>(GetGValue(rgb));
+        const double b = static_cast<double>(GetBValue(rgb));
 
         const auto [min, max] = std::minmax({ r, g, b });
 

--- a/src/host/conimeinfo.cpp
+++ b/src/host/conimeinfo.cpp
@@ -337,7 +337,7 @@ std::vector<OutputCell>::const_iterator ConsoleImeInfo::_WriteConversionArea(con
 
     // The end is the smaller of the remaining number of cells or the amount of line cells we can write before
     // hitting the right edge of the viewport
-    auto lineEnd = lineBegin + std::min(size, (ptrdiff_t)lineWidth);
+    auto lineEnd = lineBegin + std::min(size, static_cast<ptrdiff_t>(lineWidth));
 
     // We must attempt to compensate for ending on a leading byte. We can't split a full-width character across lines.
     // As such, if the last item is a leading byte, back the end up by one.

--- a/src/host/consoleInformation.cpp
+++ b/src/host/consoleInformation.cpp
@@ -39,8 +39,8 @@ CONSOLE_INFORMATION::CONSOLE_INFORMATION() :
     _blinker{},
     renderData{}
 {
-    ZeroMemory((void*)&CPInfo, sizeof(CPInfo));
-    ZeroMemory((void*)&OutputCPInfo, sizeof(OutputCPInfo));
+    ZeroMemory(static_cast<void*>(&CPInfo), sizeof(CPInfo));
+    ZeroMemory(static_cast<void*>(&OutputCPInfo), sizeof(OutputCPInfo));
     InitializeCriticalSection(&_csConsoleLock);
 }
 

--- a/src/host/dbcs.cpp
+++ b/src/host/dbcs.cpp
@@ -107,7 +107,7 @@ bool IsDBCSLeadByteConsole(const CHAR ch, const CPINFO* const pCPInfo)
     FAIL_FAST_IF_NULL(pCPInfo);
     // NOTE: This must be unsigned for the comparison. If we compare signed, this will never hit
     // because lead bytes are ironically enough always above 0x80 (signed char negative range).
-    unsigned char const uchComparison = (unsigned char)ch;
+    unsigned char const uchComparison = static_cast<unsigned char>(ch);
 
     int i = 0;
     // this is ok because the array is guaranteed to have 2
@@ -128,12 +128,12 @@ BYTE CodePageToCharSet(const UINT uiCodePage)
     CHARSETINFO csi;
 
     const auto inputServices = ServiceLocator::LocateInputServices();
-    if (nullptr == inputServices || !inputServices->TranslateCharsetInfo((DWORD*)IntToPtr(uiCodePage), &csi, TCI_SRCCODEPAGE))
+    if (nullptr == inputServices || !inputServices->TranslateCharsetInfo(static_cast<DWORD*>(IntToPtr(uiCodePage)), &csi, TCI_SRCCODEPAGE))
     {
         csi.ciCharset = OEM_CHARSET;
     }
 
-    return (BYTE)csi.ciCharset;
+    return static_cast<BYTE>(csi.ciCharset);
 }
 
 BOOL IsAvailableEastAsianCodePage(const UINT uiCodePage)

--- a/src/host/ft_host/API_AliasTestsHelpers.hpp
+++ b/src/host/ft_host/API_AliasTestsHelpers.hpp
@@ -97,7 +97,7 @@ void TestGetConsoleAliasHelper(TCH* ptszSourceGiven,
         VERIFY_FAIL(L"Unknown type.");
     }
 
-    DWORD const cbExpectedTargetString = (DWORD)TLEN(ptszExpectedTargetGiven) * sizeof(TCH);
+    DWORD const cbExpectedTargetString = static_cast<DWORD>(TLEN(ptszExpectedTargetGiven)) * sizeof(TCH);
 
     switch (dwTarget)
     {

--- a/src/host/ft_host/API_BufferTests.cpp
+++ b/src/host/ft_host/API_BufferTests.cpp
@@ -239,7 +239,7 @@ void BufferTests::ChafaGifPerformance()
         VERIFY_FAIL(L"Couldn't load resource.");
         return;
     }
-    res_data = (char*)LockResource(res_handle);
+    res_data = static_cast<char*>(LockResource(res_handle));
     res_size = SizeofResource(hModule, res);
     /* you can now use the resource data */
 

--- a/src/host/ft_host/API_DimensionsTests.cpp
+++ b/src/host/ft_host/API_DimensionsTests.cpp
@@ -114,8 +114,8 @@ void DimensionsTests::TestGetLargestConsoleWindowSize()
     // Do not reserve space for scroll bars.
 
     // Now take width and height and divide them by the size of a character to get the max character count.
-    coordExpected.X = (SHORT)((rcPixels.right - rcPixels.left) / cfi.dwFontSize.X);
-    coordExpected.Y = (SHORT)((rcPixels.bottom - rcPixels.top) / cfi.dwFontSize.Y);
+    coordExpected.X = static_cast<SHORT>((rcPixels.right - rcPixels.left) / cfi.dwFontSize.X);
+    coordExpected.Y = static_cast<SHORT>((rcPixels.bottom - rcPixels.top) / cfi.dwFontSize.Y);
 
     // Now finally ask the console what it thinks its largest size should be and compare.
     COORD const coordLargest = GetLargestConsoleWindowSize(Common::_hConsole);
@@ -454,7 +454,7 @@ void DimensionsTests::TestSetConsoleScreenBufferInfoEx()
     if (sbiex.dwSize.Y > ((sbiex.srWindow.Bottom - sbiex.srWindow.Top) + 1)) // the bottom index counts as valid, so bottom - top + 1 for total height.
     {
         // Get pixel size of a vertical scroll bar.
-        short const sVerticalScrollWidthPx = (SHORT)GetSystemMetrics(SM_CXVSCROLL);
+        short const sVerticalScrollWidthPx = static_cast<SHORT>(GetSystemMetrics(SM_CXVSCROLL));
 
         // Get the current font size
         CONSOLE_FONT_INFO cfi;

--- a/src/host/ft_host/API_FileTests.cpp
+++ b/src/host/ft_host/API_FileTests.cpp
@@ -110,7 +110,7 @@ void FileTests::TestUtf8WriteFileInvalid()
     // \x80 is an invalid UTF-8 continuation
     // \x40 is the @ symbol which is valid.
     str = "\x80\x40";
-    cbStr = (DWORD)strlen(str);
+    cbStr = static_cast<DWORD>(strlen(str));
     dwWritten = 0;
     dwExpectedWritten = cbStr;
 
@@ -120,7 +120,7 @@ void FileTests::TestUtf8WriteFileInvalid()
     // \x80 is an invalid UTF-8 continuation
     // \x40 is the @ symbol which is valid.
     str = "\x80\x40\x40";
-    cbStr = (DWORD)strlen(str);
+    cbStr = static_cast<DWORD>(strlen(str));
     dwWritten = 0;
     dwExpectedWritten = cbStr;
 
@@ -130,7 +130,7 @@ void FileTests::TestUtf8WriteFileInvalid()
     // \x80 is an invalid UTF-8 continuation
     // \x40 is the @ symbol which is valid.
     str = "\x80\x80\x80\x40";
-    cbStr = (DWORD)strlen(str);
+    cbStr = static_cast<DWORD>(strlen(str));
     dwWritten = 0;
     dwExpectedWritten = cbStr;
 
@@ -147,7 +147,7 @@ void FileTests::TestWriteFileRaw()
     // \xd is carriage return
     // All should be ignored/printed in raw mode.
     PCSTR strTest = "z\x7y\x8z\x9y\xaz\xdy";
-    DWORD const cchTest = (DWORD)strlen(strTest);
+    DWORD const cchTest = static_cast<DWORD>(strlen(strTest));
     String strReadBackExpected(strTest);
 
     HANDLE const hOut = GetStdOutputHandle();
@@ -170,7 +170,7 @@ void FileTests::TestWriteFileRaw()
     csbiexAfter.cbSize = sizeof(csbiexAfter);
     VERIFY_WIN32_BOOL_SUCCEEDED(GetConsoleScreenBufferInfoEx(hOut, &csbiexAfter), L"Retrieve screen buffer properties after writing.");
 
-    csbiexBefore.dwCursorPosition.X += (SHORT)cchTest;
+    csbiexBefore.dwCursorPosition.X += static_cast<SHORT>(cchTest);
     VERIFY_ARE_EQUAL(csbiexBefore.dwCursorPosition, csbiexAfter.dwCursorPosition, L"Verify cursor moved expected number of squares for the write length.");
 
     DWORD const cbReadBackBuffer = cchTest + 2; // +1 so we can read back a "space" that should be after what we wrote. +1 more so this can be null terminated for String class comparison.
@@ -254,9 +254,9 @@ void FileTests::TestWriteFileProcessed()
     // 1. Test bell (\x7)
     {
         pszTest = "z\x7";
-        cchTest = (DWORD)strlen(pszTest);
+        cchTest = static_cast<DWORD>(strlen(pszTest));
         pszReadBackExpected = "z ";
-        cchReadBack = (DWORD)strlen(pszReadBackExpected);
+        cchReadBack = static_cast<DWORD>(strlen(pszReadBackExpected));
 
         // Write z and a bell. Cursor should move once as bell should have made audible noise (can't really test) and not moved or printed anything.
         WriteFileHelper(hOut, csbiexBefore, csbiexAfter, pszTest, cchTest);
@@ -272,9 +272,9 @@ void FileTests::TestWriteFileProcessed()
     // 2. Test backspace (\x8)
     {
         pszTest = "yx\x8";
-        cchTest = (DWORD)strlen(pszTest);
+        cchTest = static_cast<DWORD>(strlen(pszTest));
         pszReadBackExpected = "yx ";
-        cchReadBack = (DWORD)strlen(pszReadBackExpected);
+        cchReadBack = static_cast<DWORD>(strlen(pszReadBackExpected));
 
         // Write two characters and a backspace. Cursor should move only one forward as the backspace should have moved the cursor back one after printing the second character.
         // The backspace character itself is typically non-destructive so it should only affect the cursor, not the buffer contents.
@@ -293,9 +293,9 @@ void FileTests::TestWriteFileProcessed()
         // The tab character will space pad out the buffer to the next multiple-of-8 boundary.
         // NOTE: This is dependent on the previous tests running first.
         pszTest = "\x9";
-        cchTest = (DWORD)strlen(pszTest);
+        cchTest = static_cast<DWORD>(strlen(pszTest));
         pszReadBackExpected = "     ";
-        cchReadBack = (DWORD)strlen(pszReadBackExpected);
+        cchReadBack = static_cast<DWORD>(strlen(pszReadBackExpected));
 
         // Write tab character. Cursor should move out to the next multiple-of-8 and leave space characters in its wake.
         WriteFileHelper(hOut, csbiexBefore, csbiexAfter, pszTest, cchTest);
@@ -312,9 +312,9 @@ void FileTests::TestWriteFileProcessed()
     {
         // The line feed character should move us down to the next line.
         pszTest = "\xaQ";
-        cchTest = (DWORD)strlen(pszTest);
+        cchTest = static_cast<DWORD>(strlen(pszTest));
         pszReadBackExpected = "Q ";
-        cchReadBack = (DWORD)strlen(pszReadBackExpected);
+        cchReadBack = static_cast<DWORD>(strlen(pszReadBackExpected));
 
         // Write line feed character. Cursor should move down a line and then the Q from our string should be printed.
         WriteFileHelper(hOut, csbiexBefore, csbiexAfter, pszTest, cchTest);
@@ -334,9 +334,9 @@ void FileTests::TestWriteFileProcessed()
     {
         // The carriage return character should move us to the front of the line.
         pszTest = "J\xd";
-        cchTest = (DWORD)strlen(pszTest);
+        cchTest = static_cast<DWORD>(strlen(pszTest));
         pszReadBackExpected = "QJ "; // J written, then move to beginning of line.
-        cchReadBack = (DWORD)strlen(pszReadBackExpected);
+        cchReadBack = static_cast<DWORD>(strlen(pszReadBackExpected));
 
         // Write text and carriage return character. Cursor should end up at the beginning of this line. The J should have been printed in the line before we moved.
         WriteFileHelper(hOut, csbiexBefore, csbiexAfter, pszTest, cchTest);
@@ -353,9 +353,9 @@ void FileTests::TestWriteFileProcessed()
     {
         // After the carriage return, try typing on top of the Q with a K
         pszTest = "K";
-        cchTest = (DWORD)strlen(pszTest);
+        cchTest = static_cast<DWORD>(strlen(pszTest));
         pszReadBackExpected = "KJ "; // NOTE: This is based on the previous test(s).
-        cchReadBack = (DWORD)strlen(pszReadBackExpected);
+        cchReadBack = static_cast<DWORD>(strlen(pszReadBackExpected));
 
         // Write text. Cursor should end up on top of the J.
         WriteFileHelper(hOut, csbiexBefore, csbiexAfter, pszTest, cchTest);
@@ -450,7 +450,7 @@ void FileTests::TestWriteFileVTProcessing()
 
     PCSTR pszTestString = "\x1b"
                           "[14m";
-    DWORD const cchTest = (DWORD)strlen(pszTestString);
+    DWORD const cchTest = static_cast<DWORD>(strlen(pszTestString));
 
     CONSOLE_SCREEN_BUFFER_INFOEX csbiexBefore = { 0 };
     csbiexBefore.cbSize = sizeof(csbiexBefore);
@@ -465,7 +465,7 @@ void FileTests::TestWriteFileVTProcessing()
     if (fProcessedNotPrinted)
     {
         PCSTR pszReadBackExpected = "      ";
-        DWORD const cchReadBackExpected = (DWORD)strlen(pszReadBackExpected);
+        DWORD const cchReadBackExpected = static_cast<DWORD>(strlen(pszReadBackExpected));
 
         VERIFY_ARE_EQUAL(csbiexBefore.dwCursorPosition, csbiexAfter.dwCursorPosition, L"Verify cursor didn't move because the VT sequence was processed instead of printed.");
 
@@ -476,7 +476,7 @@ void FileTests::TestWriteFileVTProcessing()
     else
     {
         COORD coordExpected = csbiexBefore.dwCursorPosition;
-        coordExpected.X += (SHORT)cchTest;
+        coordExpected.X += static_cast<SHORT>(cchTest);
         VERIFY_ARE_EQUAL(coordExpected, csbiexAfter.dwCursorPosition, L"Verify cursor moved as characters should have been emitted, not consumed.");
 
         wistd::unique_ptr<char[]> pszReadBack;
@@ -605,7 +605,7 @@ void SendFullKeyStrokeHelper(HANDLE hIn, char ch)
     ir[0].Event.KeyEvent.dwControlKeyState = ch < 0x20 ? LEFT_CTRL_PRESSED : 0; // set left_ctrl_pressed for control keys.
     ir[0].Event.KeyEvent.uChar.AsciiChar = ch;
     ir[0].Event.KeyEvent.wVirtualKeyCode = VkKeyScanA(ir[0].Event.KeyEvent.uChar.AsciiChar);
-    ir[0].Event.KeyEvent.wVirtualScanCode = (WORD)MapVirtualKeyA(ir[0].Event.KeyEvent.wVirtualKeyCode, MAPVK_VK_TO_VSC);
+    ir[0].Event.KeyEvent.wVirtualScanCode = static_cast<WORD>(MapVirtualKeyA(ir[0].Event.KeyEvent.wVirtualKeyCode, MAPVK_VK_TO_VSC));
     ir[0].Event.KeyEvent.wRepeatCount = 1;
     ir[1] = ir[0];
     ir[1].Event.KeyEvent.bKeyDown = FALSE;

--- a/src/host/ft_host/API_FontTests.cpp
+++ b/src/host/ft_host/API_FontTests.cpp
@@ -76,22 +76,22 @@ void FontTests::TestCurrentFontAPIsInvalid()
 
         if (bUseValidOutputHandle)
         {
-            VERIFY_WIN32_BOOL_SUCCEEDED(OneCoreDelay::GetCurrentConsoleFont(hConsoleOutput, (BOOL)bMaximumWindow, &cfi));
+            VERIFY_WIN32_BOOL_SUCCEEDED(OneCoreDelay::GetCurrentConsoleFont(hConsoleOutput, static_cast<BOOL>(bMaximumWindow), &cfi));
         }
         else
         {
-            VERIFY_WIN32_BOOL_FAILED(OneCoreDelay::GetCurrentConsoleFont(hConsoleOutput, (BOOL)bMaximumWindow, &cfi));
+            VERIFY_WIN32_BOOL_FAILED(OneCoreDelay::GetCurrentConsoleFont(hConsoleOutput, static_cast<BOOL>(bMaximumWindow), &cfi));
         }
     }
     else if (strOperation == L"GetEx")
     {
         CONSOLE_FONT_INFOEX cfie = { 0 };
-        VERIFY_WIN32_BOOL_FAILED(OneCoreDelay::GetCurrentConsoleFontEx(hConsoleOutput, (BOOL)bMaximumWindow, &cfie));
+        VERIFY_WIN32_BOOL_FAILED(OneCoreDelay::GetCurrentConsoleFontEx(hConsoleOutput, static_cast<BOOL>(bMaximumWindow), &cfie));
     }
     else if (strOperation == L"SetEx")
     {
         CONSOLE_FONT_INFOEX cfie = { 0 };
-        VERIFY_WIN32_BOOL_FAILED(OneCoreDelay::SetCurrentConsoleFontEx(hConsoleOutput, (BOOL)bMaximumWindow, &cfie));
+        VERIFY_WIN32_BOOL_FAILED(OneCoreDelay::SetCurrentConsoleFontEx(hConsoleOutput, static_cast<BOOL>(bMaximumWindow), &cfie));
     }
     else
     {

--- a/src/host/ft_host/API_InputTests.cpp
+++ b/src/host/ft_host/API_InputTests.cpp
@@ -59,7 +59,7 @@ class InputTests
 void VerifyNumberOfInputRecords(const HANDLE hConsoleInput, _In_ DWORD nInputs)
 {
     WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-    DWORD nInputEvents = (DWORD)-1;
+    DWORD nInputEvents = static_cast<DWORD>(-1);
     VERIFY_WIN32_BOOL_SUCCEEDED(GetNumberOfConsoleInputEvents(hConsoleInput, &nInputEvents));
     VERIFY_ARE_EQUAL(nInputEvents,
                      nInputs,
@@ -84,13 +84,13 @@ bool InputTests::TestCleanup()
 
 void InputTests::TestGetMouseButtonsValid()
 {
-    DWORD nMouseButtons = (DWORD)-1;
+    DWORD nMouseButtons = static_cast<DWORD>(-1);
     VERIFY_WIN32_BOOL_SUCCEEDED(OneCoreDelay::GetNumberOfConsoleMouseButtons(&nMouseButtons));
 
-    DWORD dwButtonsExpected = (DWORD)-1;
+    DWORD dwButtonsExpected = static_cast<DWORD>(-1);
     if (OneCoreDelay::IsGetSystemMetricsPresent())
     {
-        dwButtonsExpected = (DWORD)GetSystemMetrics(SM_CMOUSEBUTTONS);
+        dwButtonsExpected = static_cast<DWORD>(GetSystemMetrics(SM_CMOUSEBUTTONS));
     }
     else
     {
@@ -112,7 +112,7 @@ void GenerateAndWriteInputRecords(const HANDLE hConsoleInput,
         prgRecs[iRecord].EventType = KEY_EVENT;
         prgRecs[iRecord].Event.KeyEvent.bKeyDown = FALSE;
         prgRecs[iRecord].Event.KeyEvent.wRepeatCount = 1;
-        prgRecs[iRecord].Event.KeyEvent.wVirtualKeyCode = ('A' + (WORD)iRecord);
+        prgRecs[iRecord].Event.KeyEvent.wVirtualKeyCode = ('A' + static_cast<WORD>(iRecord));
     }
 
     Log::Comment(L"Writing events");
@@ -127,7 +127,7 @@ void InputTests::TestInputScenario()
     Log::Comment(L"Get input handle");
     HANDLE hConsoleInput = GetStdInputHandle();
 
-    DWORD nWrittenEvents = (DWORD)-1;
+    DWORD nWrittenEvents = static_cast<DWORD>(-1);
     INPUT_RECORD rgInputRecords[NUMBER_OF_SCENARIO_INPUTS] = { 0 };
     GenerateAndWriteInputRecords(hConsoleInput, NUMBER_OF_SCENARIO_INPUTS, rgInputRecords, ARRAYSIZE(rgInputRecords), &nWrittenEvents);
 
@@ -135,7 +135,7 @@ void InputTests::TestInputScenario()
 
     Log::Comment(L"Peeking events");
     INPUT_RECORD rgPeekedRecords[NUMBER_OF_SCENARIO_INPUTS] = { 0 };
-    DWORD nPeekedEvents = (DWORD)-1;
+    DWORD nPeekedEvents = static_cast<DWORD>(-1);
     VERIFY_WIN32_BOOL_SUCCEEDED(PeekConsoleInput(hConsoleInput, rgPeekedRecords, ARRAYSIZE(rgPeekedRecords), &nPeekedEvents));
     VERIFY_ARE_EQUAL(nPeekedEvents, nWrittenEvents, L"We should be able to peek at all of the records we've written");
     for (UINT iPeekedRecord = 0; iPeekedRecord < nPeekedEvents; iPeekedRecord++)
@@ -157,7 +157,7 @@ void InputTests::TestInputScenario()
                                      fIsLastIteration ? L" (last one)" : L""));
 
         INPUT_RECORD rgReadRecords[READ_BATCH] = { 0 };
-        DWORD nReadEvents = (DWORD)-1;
+        DWORD nReadEvents = static_cast<DWORD>(-1);
         VERIFY_WIN32_BOOL_SUCCEEDED(ReadConsoleInput(hConsoleInput, rgReadRecords, ARRAYSIZE(rgReadRecords), &nReadEvents));
 
         DWORD dwExpectedEventsRead = READ_BATCH;
@@ -176,7 +176,7 @@ void InputTests::TestInputScenario()
                              String().Format(L"verify record %d", iInputRecord));
         }
 
-        DWORD nInputEventsAfterRead = (DWORD)-1;
+        DWORD nInputEventsAfterRead = static_cast<DWORD>(-1);
         VERIFY_WIN32_BOOL_SUCCEEDED(GetNumberOfConsoleInputEvents(hConsoleInput, &nInputEventsAfterRead));
 
         DWORD dwExpectedEventsAfterRead = (NUMBER_OF_SCENARIO_INPUTS - (READ_BATCH * (iIteration + 1)));
@@ -195,7 +195,7 @@ void InputTests::TestFlushValid()
     Log::Comment(L"Get input handle");
     HANDLE hConsoleInput = GetStdInputHandle();
 
-    DWORD nWrittenEvents = (DWORD)-1;
+    DWORD nWrittenEvents = static_cast<DWORD>(-1);
     INPUT_RECORD rgInputRecords[NUMBER_OF_SCENARIO_INPUTS] = { 0 };
     GenerateAndWriteInputRecords(hConsoleInput, NUMBER_OF_SCENARIO_INPUTS, rgInputRecords, ARRAYSIZE(rgInputRecords), &nWrittenEvents);
 
@@ -214,26 +214,26 @@ void InputTests::TestFlushInvalid()
 
 void InputTests::TestPeekConsoleInvalid()
 {
-    DWORD nPeeked = (DWORD)-1;
+    DWORD nPeeked = static_cast<DWORD>(-1);
     VERIFY_WIN32_BOOL_FAILED(PeekConsoleInput(INVALID_HANDLE_VALUE, nullptr, 0, &nPeeked)); // NOTE: nPeeked is required
-    VERIFY_ARE_EQUAL(nPeeked, (DWORD)0);
+    VERIFY_ARE_EQUAL(nPeeked, static_cast<DWORD>(0));
 
     HANDLE hConsoleInput = GetStdInputHandle();
 
-    nPeeked = (DWORD)-1;
+    nPeeked = static_cast<DWORD>(-1);
     VERIFY_WIN32_BOOL_FAILED(PeekConsoleInput(hConsoleInput, nullptr, 5, &nPeeked));
-    VERIFY_ARE_EQUAL(nPeeked, (DWORD)0);
+    VERIFY_ARE_EQUAL(nPeeked, static_cast<DWORD>(0));
 
-    DWORD nWritten = (DWORD)-1;
+    DWORD nWritten = static_cast<DWORD>(-1);
     INPUT_RECORD ir = { 0 };
     GenerateAndWriteInputRecords(hConsoleInput, 1, &ir, 1, &nWritten);
 
     VerifyNumberOfInputRecords(hConsoleInput, 1);
 
-    nPeeked = (DWORD)-1;
+    nPeeked = static_cast<DWORD>(-1);
     INPUT_RECORD irPeeked = { 0 };
     VERIFY_WIN32_BOOL_SUCCEEDED(PeekConsoleInput(hConsoleInput, &irPeeked, 0, &nPeeked));
-    VERIFY_ARE_EQUAL(nPeeked, (DWORD)0, L"Verify that an empty array doesn't cause peeks to get written");
+    VERIFY_ARE_EQUAL(nPeeked, static_cast<DWORD>(0), L"Verify that an empty array doesn't cause peeks to get written");
 
     VerifyNumberOfInputRecords(hConsoleInput, 1);
 
@@ -242,57 +242,57 @@ void InputTests::TestPeekConsoleInvalid()
 
 void InputTests::TestReadConsoleInvalid()
 {
-    DWORD nRead = (DWORD)-1;
+    DWORD nRead = static_cast<DWORD>(-1);
     VERIFY_WIN32_BOOL_FAILED(ReadConsoleInput(nullptr, nullptr, 0, &nRead));
-    VERIFY_ARE_EQUAL(nRead, (DWORD)0);
+    VERIFY_ARE_EQUAL(nRead, static_cast<DWORD>(0));
 
-    nRead = (DWORD)-1;
+    nRead = static_cast<DWORD>(-1);
     VERIFY_WIN32_BOOL_FAILED(ReadConsoleInput(INVALID_HANDLE_VALUE, nullptr, 0, &nRead));
-    VERIFY_ARE_EQUAL(nRead, (DWORD)0);
+    VERIFY_ARE_EQUAL(nRead, static_cast<DWORD>(0));
 
     // NOTE: ReadConsoleInput blocks until at least one input event is read, even if the operation would result in no
     // records actually being read (e.g. valid handle, NULL lpBuffer)
 
     HANDLE hConsoleInput = GetStdInputHandle();
 
-    DWORD nWritten = (DWORD)-1;
+    DWORD nWritten = static_cast<DWORD>(-1);
     INPUT_RECORD irWrite = { 0 };
     GenerateAndWriteInputRecords(hConsoleInput, 1, &irWrite, 1, &nWritten);
     VerifyNumberOfInputRecords(hConsoleInput, 1);
 
-    nRead = (DWORD)-1;
+    nRead = static_cast<DWORD>(-1);
     VERIFY_WIN32_BOOL_SUCCEEDED(ReadConsoleInput(hConsoleInput, nullptr, 0, &nRead));
-    VERIFY_ARE_EQUAL(nRead, (DWORD)0);
+    VERIFY_ARE_EQUAL(nRead, static_cast<DWORD>(0));
 
     INPUT_RECORD irRead = { 0 };
-    nRead = (DWORD)-1;
+    nRead = static_cast<DWORD>(-1);
     VERIFY_WIN32_BOOL_SUCCEEDED(ReadConsoleInput(hConsoleInput, &irRead, 0, &nRead));
-    VERIFY_ARE_EQUAL(nRead, (DWORD)0);
+    VERIFY_ARE_EQUAL(nRead, static_cast<DWORD>(0));
 
     VERIFY_WIN32_BOOL_SUCCEEDED(FlushConsoleInputBuffer(hConsoleInput));
 }
 
 void InputTests::TestWriteConsoleInvalid()
 {
-    DWORD nWrite = (DWORD)-1;
+    DWORD nWrite = static_cast<DWORD>(-1);
     VERIFY_WIN32_BOOL_FAILED(WriteConsoleInput(nullptr, nullptr, 0, &nWrite));
-    VERIFY_ARE_EQUAL(nWrite, (DWORD)0);
+    VERIFY_ARE_EQUAL(nWrite, static_cast<DWORD>(0));
 
     // weird: WriteConsoleInput with INVALID_HANDLE_VALUE writes garbage to lpNumberOfEventsWritten, whereas
     // [Read|Peek]ConsoleInput don't. This is a legacy behavior that we don't want to change.
-    nWrite = (DWORD)-1;
+    nWrite = static_cast<DWORD>(-1);
     VERIFY_WIN32_BOOL_FAILED(WriteConsoleInput(INVALID_HANDLE_VALUE, nullptr, 0, &nWrite));
 
     HANDLE hConsoleInput = GetStdInputHandle();
 
-    nWrite = (DWORD)-1;
+    nWrite = static_cast<DWORD>(-1);
     VERIFY_WIN32_BOOL_SUCCEEDED(WriteConsoleInput(hConsoleInput, nullptr, 0, &nWrite));
-    VERIFY_ARE_EQUAL(nWrite, (DWORD)0);
+    VERIFY_ARE_EQUAL(nWrite, static_cast<DWORD>(0));
 
-    nWrite = (DWORD)-1;
+    nWrite = static_cast<DWORD>(-1);
     INPUT_RECORD irWrite = { 0 };
     VERIFY_WIN32_BOOL_SUCCEEDED(WriteConsoleInput(hConsoleInput, &irWrite, 0, &nWrite));
-    VERIFY_ARE_EQUAL(nWrite, (DWORD)0);
+    VERIFY_ARE_EQUAL(nWrite, static_cast<DWORD>(0));
 }
 
 void FillInputRecordHelper(_Inout_ INPUT_RECORD* const pir, _In_ wchar_t wch, _In_ bool fIsKeyDown)
@@ -603,8 +603,8 @@ void InputTests::TestVtInputGeneration()
     DWORD dwMode;
     GetConsoleMode(hIn, &dwMode);
 
-    DWORD dwWritten = (DWORD)-1;
-    DWORD dwRead = (DWORD)-1;
+    DWORD dwWritten = static_cast<DWORD>(-1);
+    DWORD dwRead = static_cast<DWORD>(-1);
     INPUT_RECORD rgInputRecords[64] = { 0 };
 
     Log::Comment(L"First make sure that an arrow keydown is not translated in not-VT mode");
@@ -621,11 +621,11 @@ void InputTests::TestVtInputGeneration()
 
     Log::Comment(L"Writing events");
     VERIFY_WIN32_BOOL_SUCCEEDED(WriteConsoleInput(hIn, rgInputRecords, 1, &dwWritten));
-    VERIFY_ARE_EQUAL(dwWritten, (DWORD)1);
+    VERIFY_ARE_EQUAL(dwWritten, static_cast<DWORD>(1));
 
     Log::Comment(L"Reading events");
     VERIFY_WIN32_BOOL_SUCCEEDED(ReadConsoleInput(hIn, rgInputRecords, ARRAYSIZE(rgInputRecords), &dwRead));
-    VERIFY_ARE_EQUAL(dwRead, (DWORD)1);
+    VERIFY_ARE_EQUAL(dwRead, static_cast<DWORD>(1));
     VERIFY_ARE_EQUAL(rgInputRecords[0].EventType, KEY_EVENT);
     VERIFY_ARE_EQUAL(rgInputRecords[0].Event.KeyEvent.bKeyDown, TRUE);
     VERIFY_ARE_EQUAL(rgInputRecords[0].Event.KeyEvent.wVirtualKeyCode, VK_UP);
@@ -647,11 +647,11 @@ void InputTests::TestVtInputGeneration()
 
     Log::Comment(L"Writing events");
     VERIFY_WIN32_BOOL_SUCCEEDED(WriteConsoleInput(hIn, rgInputRecords, 1, &dwWritten));
-    VERIFY_ARE_EQUAL(dwWritten, (DWORD)1);
+    VERIFY_ARE_EQUAL(dwWritten, static_cast<DWORD>(1));
 
     Log::Comment(L"Reading events");
     VERIFY_WIN32_BOOL_SUCCEEDED(ReadConsoleInput(hIn, rgInputRecords, ARRAYSIZE(rgInputRecords), &dwRead));
-    VERIFY_ARE_EQUAL(dwRead, (DWORD)3);
+    VERIFY_ARE_EQUAL(dwRead, static_cast<DWORD>(3));
     VERIFY_ARE_EQUAL(rgInputRecords[0].EventType, KEY_EVENT);
     VERIFY_ARE_EQUAL(rgInputRecords[0].Event.KeyEvent.bKeyDown, TRUE);
     VERIFY_ARE_EQUAL(rgInputRecords[0].Event.KeyEvent.wVirtualKeyCode, 0);

--- a/src/host/ft_host/API_ModeTests.cpp
+++ b/src/host/ft_host/API_ModeTests.cpp
@@ -43,13 +43,13 @@ void ModeTests::TestGetConsoleModeInvalid()
         TEST_METHOD_PROPERTY(L"IsPerfTest", L"true")
     END_TEST_METHOD_PROPERTIES()
 
-    DWORD dwConsoleMode = (DWORD)-1;
+    DWORD dwConsoleMode = static_cast<DWORD>(-1);
     VERIFY_WIN32_BOOL_FAILED(GetConsoleMode(INVALID_HANDLE_VALUE, &dwConsoleMode));
-    VERIFY_ARE_EQUAL(dwConsoleMode, (DWORD)-1);
+    VERIFY_ARE_EQUAL(dwConsoleMode, static_cast<DWORD>(-1));
 
-    dwConsoleMode = (DWORD)-1;
+    dwConsoleMode = static_cast<DWORD>(-1);
     VERIFY_WIN32_BOOL_FAILED(GetConsoleMode(nullptr, &dwConsoleMode));
-    VERIFY_ARE_EQUAL(dwConsoleMode, (DWORD)-1);
+    VERIFY_ARE_EQUAL(dwConsoleMode, static_cast<DWORD>(-1));
 }
 
 void ModeTests::TestSetConsoleModeInvalid()
@@ -72,7 +72,7 @@ void ModeTests::TestConsoleModeInputScenario()
     const DWORD dwInputModeToSet = ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT | ENABLE_WINDOW_INPUT;
     VERIFY_WIN32_BOOL_SUCCEEDED(SetConsoleMode(hConsoleInput, dwInputModeToSet), L"Set valid flags for input");
 
-    DWORD dwInputMode = (DWORD)-1;
+    DWORD dwInputMode = static_cast<DWORD>(-1);
     VERIFY_WIN32_BOOL_SUCCEEDED(GetConsoleMode(hConsoleInput, &dwInputMode), L"Get recently set flags for input");
     VERIFY_ARE_EQUAL(dwInputMode, dwInputModeToSet, L"Make sure SetConsoleMode worked for input");
 }
@@ -83,15 +83,15 @@ void ModeTests::TestConsoleModeScreenBufferScenario()
     VERIFY_WIN32_BOOL_SUCCEEDED(SetConsoleMode(Common::_hConsole, dwOutputModeToSet),
                                 L"Set initial output flags");
 
-    DWORD dwOutputMode = (DWORD)-1;
+    DWORD dwOutputMode = static_cast<DWORD>(-1);
     VERIFY_WIN32_BOOL_SUCCEEDED(GetConsoleMode(Common::_hConsole, &dwOutputMode), L"Get new output flags");
     VERIFY_ARE_EQUAL(dwOutputMode, dwOutputModeToSet, L"Make sure output flags applied appropriately");
 
     VERIFY_WIN32_BOOL_SUCCEEDED(SetConsoleMode(Common::_hConsole, 0), L"Set zero output flags");
 
-    dwOutputMode = (DWORD)-1;
+    dwOutputMode = static_cast<DWORD>(-1);
     VERIFY_WIN32_BOOL_SUCCEEDED(GetConsoleMode(Common::_hConsole, &dwOutputMode), L"Get zero output flags");
-    VERIFY_ARE_EQUAL(dwOutputMode, (DWORD)0, L"Verify able to set zero output flags");
+    VERIFY_ARE_EQUAL(dwOutputMode, static_cast<DWORD>(0), L"Verify able to set zero output flags");
 }
 
 void ModeTests::TestGetConsoleDisplayMode()

--- a/src/host/ft_host/API_RgbColorTests.cpp
+++ b/src/host/ft_host/API_RgbColorTests.cpp
@@ -97,7 +97,7 @@ WORD WinToVTColor(int winColor, bool isForeground)
 
 WORD MakeAttribute(int fg, int bg)
 {
-    return (WORD)((bg << 4) | (fg));
+    return static_cast<WORD>((bg << 4) | (fg));
 }
 
 // Takes a windows 16 color table index, and returns the equivalent xterm table index

--- a/src/host/ft_host/API_TitleTests.cpp
+++ b/src/host/ft_host/API_TitleTests.cpp
@@ -106,7 +106,7 @@ void TestGetConsoleTitleAVerifyHelper(_Inout_updates_(cchReadBuffer) char* const
     VERIFY_ARE_EQUAL(cchExpected, cchReadBuffer);
 
     SetLastError(0);
-    DWORD const dwRetVal = GetConsoleTitleA(chReadBuffer, (DWORD)cchTryToRead);
+    DWORD const dwRetVal = GetConsoleTitleA(chReadBuffer, static_cast<DWORD>(cchTryToRead));
     DWORD const dwLastError = GetLastError();
 
     VERIFY_ARE_EQUAL(dwExpectedRetVal, dwRetVal);
@@ -116,8 +116,8 @@ void TestGetConsoleTitleAVerifyHelper(_Inout_updates_(cchReadBuffer) char* const
     {
         for (size_t i = 0; i < cchExpected; i++)
         {
-            wchar_t const wchExpectedVis = chReadExpected[i] < 0x30 ? (wchar_t)chReadExpected[i] + 0x2400 : chReadExpected[i];
-            wchar_t const wchBufferVis = chReadBuffer[i] < 0x30 ? (wchar_t)chReadBuffer[i] + 0x2400 : chReadBuffer[i];
+            wchar_t const wchExpectedVis = chReadExpected[i] < 0x30 ? static_cast<wchar_t>(chReadExpected[i]) + 0x2400 : chReadExpected[i];
+            wchar_t const wchBufferVis = chReadBuffer[i] < 0x30 ? static_cast<wchar_t>(chReadBuffer[i]) + 0x2400 : chReadBuffer[i];
 
             // We must verify every individual character, not as a string, because we might be expecting a null
             // in the middle and need to verify it then keep going and read what's past that.
@@ -142,7 +142,7 @@ void TestGetConsoleTitleWVerifyHelper(_Inout_updates_(cchReadBuffer) wchar_t* co
     VERIFY_ARE_EQUAL(cchExpected, cchReadBuffer);
 
     SetLastError(0);
-    DWORD const dwRetVal = GetConsoleTitleW(wchReadBuffer, (DWORD)cchTryToRead);
+    DWORD const dwRetVal = GetConsoleTitleW(wchReadBuffer, static_cast<DWORD>(cchTryToRead));
     DWORD const dwLastError = GetLastError();
 
     VERIFY_ARE_EQUAL(dwExpectedRetVal, dwRetVal);
@@ -212,7 +212,7 @@ void TitleTests::TestGetConsoleTitleA()
                                            cchTryToRead);
 
     // Run the call and test it out.
-    TestGetConsoleTitleAVerifyHelper(chReadBuffer.get(), cchReadBuffer, cchTryToRead, (DWORD)cchTestTitle, S_OK, chReadExpected.get(), cchReadBuffer);
+    TestGetConsoleTitleAVerifyHelper(chReadBuffer.get(), cchReadBuffer, cchTryToRead, static_cast<DWORD>(cchTestTitle), S_OK, chReadExpected.get(), cchReadBuffer);
 
     Log::Comment(L"Test 3: Say we have have the string length plus one null space.");
     cchTryToRead = cchTestTitle + 1;
@@ -227,7 +227,7 @@ void TitleTests::TestGetConsoleTitleA()
                                            cchTryToRead);
 
     // Run the call and test it out.
-    TestGetConsoleTitleAVerifyHelper(chReadBuffer.get(), cchReadBuffer, cchTryToRead, (DWORD)cchTestTitle, S_OK, chReadExpected.get(), cchReadBuffer);
+    TestGetConsoleTitleAVerifyHelper(chReadBuffer.get(), cchReadBuffer, cchTryToRead, static_cast<DWORD>(cchTestTitle), S_OK, chReadExpected.get(), cchReadBuffer);
 
     Log::Comment(L"Test 4: Say we have the string length with a null space and an extra space.");
     cchTryToRead = cchTestTitle + 1 + 1;
@@ -242,7 +242,7 @@ void TitleTests::TestGetConsoleTitleA()
                                            cchTryToRead);
 
     // Run the call and test it out.
-    TestGetConsoleTitleAVerifyHelper(chReadBuffer.get(), cchReadBuffer, cchTryToRead, (DWORD)cchTestTitle, S_OK, chReadExpected.get(), cchReadBuffer);
+    TestGetConsoleTitleAVerifyHelper(chReadBuffer.get(), cchReadBuffer, cchTryToRead, static_cast<DWORD>(cchTestTitle), S_OK, chReadExpected.get(), cchReadBuffer);
 
     Log::Comment(L"Test 5: Say we have no buffer.");
     cchTryToRead = cchTestTitle;
@@ -281,7 +281,7 @@ void TitleTests::TestGetConsoleTitleW()
                                            cchTryToRead);
 
     // Run the call and test it out.
-    TestGetConsoleTitleWVerifyHelper(wchReadBuffer.get(), cchReadBuffer, cchTryToRead, (DWORD)cchTestTitle, S_OK, wchReadExpected.get(), cchReadBuffer);
+    TestGetConsoleTitleWVerifyHelper(wchReadBuffer.get(), cchReadBuffer, cchTryToRead, static_cast<DWORD>(cchTestTitle), S_OK, wchReadExpected.get(), cchReadBuffer);
 
     Log::Comment(L"Test 2: Say we have have exactly the string length with no null space.");
     cchTryToRead = cchTestTitle;
@@ -296,7 +296,7 @@ void TitleTests::TestGetConsoleTitleW()
                                            cchTryToRead);
 
     // Run the call and test it out.
-    TestGetConsoleTitleWVerifyHelper(wchReadBuffer.get(), cchReadBuffer, cchTryToRead, (DWORD)cchTestTitle, S_OK, wchReadExpected.get(), cchReadBuffer);
+    TestGetConsoleTitleWVerifyHelper(wchReadBuffer.get(), cchReadBuffer, cchTryToRead, static_cast<DWORD>(cchTestTitle), S_OK, wchReadExpected.get(), cchReadBuffer);
 
     Log::Comment(L"Test 3: Say we have have the string length plus one null space.");
     cchTryToRead = cchTestTitle + 1;
@@ -311,7 +311,7 @@ void TitleTests::TestGetConsoleTitleW()
                                            cchTryToRead);
 
     // Run the call and test it out.
-    TestGetConsoleTitleWVerifyHelper(wchReadBuffer.get(), cchReadBuffer, cchTryToRead, (DWORD)cchTestTitle, S_OK, wchReadExpected.get(), cchReadBuffer);
+    TestGetConsoleTitleWVerifyHelper(wchReadBuffer.get(), cchReadBuffer, cchTryToRead, static_cast<DWORD>(cchTestTitle), S_OK, wchReadExpected.get(), cchReadBuffer);
 
     Log::Comment(L"Test 4: Say we have the string length with a null space and an extra space.");
     cchTryToRead = cchTestTitle + 1 + 1;
@@ -326,7 +326,7 @@ void TitleTests::TestGetConsoleTitleW()
                                            cchTryToRead);
 
     // Run the call and test it out.
-    TestGetConsoleTitleWVerifyHelper(wchReadBuffer.get(), cchReadBuffer, cchTryToRead, (DWORD)cchTestTitle, S_OK, wchReadExpected.get(), cchReadBuffer);
+    TestGetConsoleTitleWVerifyHelper(wchReadBuffer.get(), cchReadBuffer, cchTryToRead, static_cast<DWORD>(cchTestTitle), S_OK, wchReadExpected.get(), cchReadBuffer);
 
     Log::Comment(L"Test 5: Say we have no buffer.");
     cchTryToRead = cchTestTitle;

--- a/src/host/ft_host/CJK_DbcsTests.cpp
+++ b/src/host/ft_host/CJK_DbcsTests.cpp
@@ -367,7 +367,7 @@ void DbcsWriteRead::SendOutput(const HANDLE hOut,
 {
     // DBCS is very dependent on knowing the byte length in the original codepage of the input text.
     // Save off the original length of the string so we know what its A length was.
-    SHORT const cTestString = (SHORT)strlen(pszTestString);
+    SHORT const cTestString = static_cast<SHORT>(strlen(pszTestString));
 
     // If we're in Unicode mode, we will need to translate the test string to Unicode before passing into the console
     PWSTR pwszTestString = nullptr;
@@ -387,7 +387,7 @@ void DbcsWriteRead::SendOutput(const HANDLE hOut,
     SHORT cChars = 0;
     if (fIsUnicode)
     {
-        cChars = (SHORT)wcslen(pwszTestString);
+        cChars = static_cast<SHORT>(wcslen(pwszTestString));
     }
     else
     {
@@ -551,7 +551,7 @@ void DbcsWriteRead::SendOutput(const HANDLE hOut,
     else if (fUseDwordWritten)
     {
         Log::Comment(NoThrowString().Format(L"Chars Written: %d", dwWritten));
-        VERIFY_ARE_EQUAL((DWORD)cChars, dwWritten);
+        VERIFY_ARE_EQUAL(static_cast<DWORD>(cChars), dwWritten);
     }
 }
 
@@ -1850,7 +1850,7 @@ void DbcsWriteRead::TestRunner(_In_ unsigned int const uiCodePage,
     CHAR_INFO* pciActual = new CHAR_INFO[cTestData];
     VERIFY_IS_NOT_NULL(pciActual);
     ZeroMemory(pciActual, sizeof(CHAR_INFO) * cTestData);
-    DbcsWriteRead::RetrieveOutput(hOut, ReadMode, fReadWithUnicode, pciActual, (SHORT)cTestData);
+    DbcsWriteRead::RetrieveOutput(hOut, ReadMode, fReadWithUnicode, pciActual, static_cast<SHORT>(cTestData));
 
     // Loop through and verify that our expected array matches what was actually returned by the given API.
     DbcsWriteRead::Verify(pciExpected, cExpected, pciActual);
@@ -1870,14 +1870,14 @@ void DbcsTests::TestDbcsWriteRead()
 
     int iWriteMode;
     VERIFY_SUCCEEDED(TestData::TryGetValue(L"WriteMode", iWriteMode));
-    DbcsWriteRead::WriteMode WriteMode = (DbcsWriteRead::WriteMode)iWriteMode;
+    DbcsWriteRead::WriteMode WriteMode = static_cast<DbcsWriteRead::WriteMode>(iWriteMode);
 
     bool fWriteInUnicode;
     VERIFY_SUCCEEDED(TestData::TryGetValue(L"fWriteInUnicode", fWriteInUnicode));
 
     int iReadMode;
     VERIFY_SUCCEEDED(TestData::TryGetValue(L"ReadMode", iReadMode));
-    DbcsWriteRead::ReadMode ReadMode = (DbcsWriteRead::ReadMode)iReadMode;
+    DbcsWriteRead::ReadMode ReadMode = static_cast<DbcsWriteRead::ReadMode>(iReadMode);
 
     bool fReadInUnicode;
     VERIFY_SUCCEEDED(TestData::TryGetValue(L"fReadInUnicode", fReadInUnicode));
@@ -2284,7 +2284,7 @@ void WriteStringToInput(HANDLE hIn, PCWSTR pwszString)
     }
 
     DWORD dwWritten;
-    VERIFY_WIN32_BOOL_SUCCEEDED(WriteConsoleInputW(hIn, irString, (DWORD)cRecords, &dwWritten));
+    VERIFY_WIN32_BOOL_SUCCEEDED(WriteConsoleInputW(hIn, irString, static_cast<DWORD>(cRecords), &dwWritten));
 
     VERIFY_ARE_EQUAL(cRecords, dwWritten, L"We should have written the number of records that were sent in by our buffer.");
 
@@ -2297,7 +2297,7 @@ void ReadStringWithGetCh(PCSTR pszExpectedText)
 
     for (size_t i = 0; i < cchString; i++)
     {
-        if (!VERIFY_ARE_EQUAL((BYTE)pszExpectedText[i], _getch()))
+        if (!VERIFY_ARE_EQUAL(static_cast<BYTE>(pszExpectedText[i]), _getch()))
         {
             break;
         }
@@ -2321,15 +2321,15 @@ void ReadStringWithReadConsoleInputAHelper(HANDLE hIn, PCSTR pszExpectedText, si
     while (cchRead < cchExpectedText)
     {
         // expected read is either the size of the buffer or the number of characters remaining, whichever is smaller.
-        DWORD const dwReadExpected = (DWORD)std::min(cbBuffer, cchExpectedText - cchRead);
+        DWORD const dwReadExpected = static_cast<DWORD>(std::min(cbBuffer, cchExpectedText - cchRead));
 
         DWORD dwRead;
-        if (!VERIFY_WIN32_BOOL_SUCCEEDED(ReadConsoleInputA(hIn, irRead, (DWORD)cbBuffer, &dwRead), L"Attempt to read input into buffer."))
+        if (!VERIFY_WIN32_BOOL_SUCCEEDED(ReadConsoleInputA(hIn, irRead, static_cast<DWORD>(cbBuffer), &dwRead), L"Attempt to read input into buffer."))
         {
             break;
         }
 
-        VERIFY_IS_GREATER_THAN_OR_EQUAL(dwRead, (DWORD)0, L"Verify we read non-negative bytes.");
+        VERIFY_IS_GREATER_THAN_OR_EQUAL(dwRead, static_cast<DWORD>(0), L"Verify we read non-negative bytes.");
 
         for (size_t i = 0; i < dwRead; i++)
         {
@@ -2338,7 +2338,7 @@ void ReadStringWithReadConsoleInputAHelper(HANDLE hIn, PCSTR pszExpectedText, si
             if (irRead[i].EventType == KEY_EVENT &&
                 irRead[i].Event.KeyEvent.bKeyDown == TRUE)
             {
-                if (!VERIFY_ARE_EQUAL((BYTE)pszExpectedText[cchRead], (BYTE)irRead[i].Event.KeyEvent.uChar.AsciiChar))
+                if (!VERIFY_ARE_EQUAL(static_cast<BYTE>(pszExpectedText[cchRead]), static_cast<BYTE>(irRead[i].Event.KeyEvent.uChar.AsciiChar)))
                 {
                     break;
                 }
@@ -2434,14 +2434,14 @@ void DbcsTests::TestDbcsOneByOne()
         if (fIsLeadByte)
         {
             Log::Comment(L"Characters should be empty (space) because we only wrote a lead. It should be held for later.");
-            VERIFY_ARE_EQUAL((unsigned char)' ', (unsigned char)chReadBack[0]);
-            VERIFY_ARE_EQUAL((unsigned char)' ', (unsigned char)chReadBack[1]);
+            VERIFY_ARE_EQUAL(static_cast<unsigned char>(' '), static_cast<unsigned char>(chReadBack[0]));
+            VERIFY_ARE_EQUAL(static_cast<unsigned char>(' '), static_cast<unsigned char>(chReadBack[1]));
         }
         else
         {
             Log::Comment(L"After trailing is written, character should be valid from Chinese plane (not checking exactly, just that it was composed.");
-            VERIFY_IS_LESS_THAN((unsigned char)'\x80', (unsigned char)chReadBack[0]);
-            VERIFY_IS_LESS_THAN((unsigned char)'\x80', (unsigned char)chReadBack[1]);
+            VERIFY_IS_LESS_THAN(static_cast<unsigned char>('\x80'), static_cast<unsigned char>(chReadBack[0]));
+            VERIFY_IS_LESS_THAN(static_cast<unsigned char>('\x80'), static_cast<unsigned char>(chReadBack[1]));
             coordReadPos.X += 2; // advance X for next read back. Move 2 positions because it's a wide char.
         }
     }
@@ -2469,42 +2469,42 @@ void DbcsTests::TestDbcsTrailLead()
     DWORD cchTestLength = 0;
 
     Log::Comment(L"1. Write lead byte only.");
-    cchTestLength = (DWORD)strlen(test);
+    cchTestLength = static_cast<DWORD>(strlen(test));
     VERIFY_WIN32_BOOL_SUCCEEDED(WriteConsoleA(hOut, test, cchTestLength, &dwReadOrWritten, nullptr), L"Write the string.");
     VERIFY_ARE_EQUAL(cchTestLength, dwReadOrWritten, L"Verify all characters reported as written.");
     dwReadOrWritten = 0;
     VERIFY_WIN32_BOOL_SUCCEEDED(ReadConsoleOutputCharacterA(hOut, chReadBack, 2, coordReadPos, &dwReadOrWritten), L"Read back buffer.");
     Log::Comment(L"Verify nothing is written/displayed yet. The read byte should have been consumed/stored but not yet displayed.");
-    VERIFY_ARE_EQUAL((unsigned char)' ', (unsigned char)chReadBack[0]);
-    VERIFY_ARE_EQUAL((unsigned char)' ', (unsigned char)chReadBack[1]);
+    VERIFY_ARE_EQUAL(static_cast<unsigned char>(' '), static_cast<unsigned char>(chReadBack[0]));
+    VERIFY_ARE_EQUAL(static_cast<unsigned char>(' '), static_cast<unsigned char>(chReadBack[1]));
 
     Log::Comment(L"2. Write trailing and next lead.");
-    cchTestLength = (DWORD)strlen(test2);
+    cchTestLength = static_cast<DWORD>(strlen(test2));
     VERIFY_WIN32_BOOL_SUCCEEDED(WriteConsoleA(hOut, test2, cchTestLength, &dwReadOrWritten, nullptr), L"Write the string.");
     VERIFY_ARE_EQUAL(cchTestLength, dwReadOrWritten, L"Verify all characters reported as written.");
     dwReadOrWritten = 0;
     VERIFY_WIN32_BOOL_SUCCEEDED(ReadConsoleOutputCharacterA(hOut, chReadBack, 4, coordReadPos, &dwReadOrWritten), L"Read back buffer.");
     Log::Comment(L"Verify previous lead and the trailing we just wrote formed a character. The final lead should have been consumed/stored and not yet displayed.");
-    VERIFY_ARE_EQUAL((unsigned char)test[0], (unsigned char)chReadBack[0]);
-    VERIFY_ARE_EQUAL((unsigned char)test2[0], (unsigned char)chReadBack[1]);
-    VERIFY_ARE_EQUAL((unsigned char)' ', (unsigned char)chReadBack[2]);
-    VERIFY_ARE_EQUAL((unsigned char)' ', (unsigned char)chReadBack[3]);
+    VERIFY_ARE_EQUAL(static_cast<unsigned char>(test[0]), static_cast<unsigned char>(chReadBack[0]));
+    VERIFY_ARE_EQUAL(static_cast<unsigned char>(test2[0]), static_cast<unsigned char>(chReadBack[1]));
+    VERIFY_ARE_EQUAL(static_cast<unsigned char>(' '), static_cast<unsigned char>(chReadBack[2]));
+    VERIFY_ARE_EQUAL(static_cast<unsigned char>(' '), static_cast<unsigned char>(chReadBack[3]));
 
     Log::Comment(L"3. Write trailing and finish string.");
-    cchTestLength = (DWORD)strlen(test3);
+    cchTestLength = static_cast<DWORD>(strlen(test3));
     VERIFY_WIN32_BOOL_SUCCEEDED(WriteConsoleA(hOut, test3, cchTestLength, &dwReadOrWritten, nullptr), L"Write the string.");
     VERIFY_ARE_EQUAL(cchTestLength, dwReadOrWritten, L"Verify all characters reported as written.");
     dwReadOrWritten = 0;
     VERIFY_WIN32_BOOL_SUCCEEDED(ReadConsoleOutputCharacterA(hOut, chReadBack, cchReadBack, coordReadPos, &dwReadOrWritten), L"Read back buffer.");
     Log::Comment(L"Verify everything is displayed now that we've finished it off with the final trailing and rest of the string.");
-    VERIFY_ARE_EQUAL((unsigned char)test[0], (unsigned char)chReadBack[0]);
-    VERIFY_ARE_EQUAL((unsigned char)test2[0], (unsigned char)chReadBack[1]);
-    VERIFY_ARE_EQUAL((unsigned char)test2[1], (unsigned char)chReadBack[2]);
-    VERIFY_ARE_EQUAL((unsigned char)test3[0], (unsigned char)chReadBack[3]);
-    VERIFY_ARE_EQUAL((unsigned char)test3[1], (unsigned char)chReadBack[4]);
-    VERIFY_ARE_EQUAL((unsigned char)test3[2], (unsigned char)chReadBack[5]);
-    VERIFY_ARE_EQUAL((unsigned char)test3[3], (unsigned char)chReadBack[6]);
-    VERIFY_ARE_EQUAL((unsigned char)test3[4], (unsigned char)chReadBack[7]);
+    VERIFY_ARE_EQUAL(static_cast<unsigned char>(test[0]), static_cast<unsigned char>(chReadBack[0]));
+    VERIFY_ARE_EQUAL(static_cast<unsigned char>(test2[0]), static_cast<unsigned char>(chReadBack[1]));
+    VERIFY_ARE_EQUAL(static_cast<unsigned char>(test2[1]), static_cast<unsigned char>(chReadBack[2]));
+    VERIFY_ARE_EQUAL(static_cast<unsigned char>(test3[0]), static_cast<unsigned char>(chReadBack[3]));
+    VERIFY_ARE_EQUAL(static_cast<unsigned char>(test3[1]), static_cast<unsigned char>(chReadBack[4]));
+    VERIFY_ARE_EQUAL(static_cast<unsigned char>(test3[2]), static_cast<unsigned char>(chReadBack[5]));
+    VERIFY_ARE_EQUAL(static_cast<unsigned char>(test3[3]), static_cast<unsigned char>(chReadBack[6]));
+    VERIFY_ARE_EQUAL(static_cast<unsigned char>(test3[4]), static_cast<unsigned char>(chReadBack[7]));
 }
 
 void DbcsTests::TestDbcsStdCoutScenario()
@@ -2523,7 +2523,7 @@ void DbcsTests::TestDbcsStdCoutScenario()
 
     // Prepare structures for readback.
     COORD coordReadPos = { 0 };
-    DWORD const cchReadBack = (DWORD)strlen(test);
+    DWORD const cchReadBack = static_cast<DWORD>(strlen(test));
     wistd::unique_ptr<char[]> const psReadBack = wil::make_unique_failfast<char[]>(cchReadBack + 1);
     DWORD dwRead = 0;
 

--- a/src/host/ft_host/Message_KeyPressTests.cpp
+++ b/src/host/ft_host/Message_KeyPressTests.cpp
@@ -89,7 +89,7 @@ class KeyPressTests
         expectedRecord.Event.KeyEvent.dwControlKeyState |= (GetKeyState(VK_NUMLOCK) & KEY_STATE_TOGGLED) ? NUMLOCK_ON : 0;
         expectedRecord.Event.KeyEvent.wRepeatCount = SINGLE_KEY_REPEAT;
         expectedRecord.Event.KeyEvent.wVirtualKeyCode = VK_APPS;
-        expectedRecord.Event.KeyEvent.wVirtualScanCode = (WORD)scanCode;
+        expectedRecord.Event.KeyEvent.wVirtualScanCode = static_cast<WORD>(scanCode);
 
         // get the input record back and test it
         INPUT_RECORD record;
@@ -384,7 +384,7 @@ void KeyPressTests::TestAltGr()
     expectedRecord.Event.KeyEvent.dwControlKeyState = RIGHT_ALT_PRESSED | LEFT_CTRL_PRESSED;
     expectedRecord.Event.KeyEvent.wRepeatCount = SINGLE_KEY_REPEAT;
     expectedRecord.Event.KeyEvent.wVirtualKeyCode = L'Q';
-    expectedRecord.Event.KeyEvent.wVirtualScanCode = (WORD)scanCode;
+    expectedRecord.Event.KeyEvent.wVirtualScanCode = static_cast<WORD>(scanCode);
 
     // read input records and compare
     const int maxRecordLookup = 20; // some arbitrary value to grab some records

--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -751,8 +751,8 @@ void ApiRoutines::GetLargestConsoleWindowSizeImpl(const SCREEN_INFORMATION& cont
         RETURN_HR_IF(E_INVALIDARG, (Window.Right < Window.Left || Window.Bottom < Window.Top));
 
         COORD NewWindowSize;
-        NewWindowSize.X = (SHORT)(CalcWindowSizeX(Window));
-        NewWindowSize.Y = (SHORT)(CalcWindowSizeY(Window));
+        NewWindowSize.X = static_cast<SHORT>(CalcWindowSizeX(Window));
+        NewWindowSize.Y = static_cast<SHORT>(CalcWindowSizeY(Window));
 
         // see MSFT:17415266
         // If we have a actual head, we care about the maximum size the window can be.

--- a/src/host/history.cpp
+++ b/src/host/history.cpp
@@ -122,7 +122,7 @@ void CommandHistory::_Reset()
             }
 
             // find free record.  if all records are used, free the lru one.
-            if ((SHORT)_commands.size() == _maxCommands)
+            if (static_cast<SHORT>(_commands.size()) == _maxCommands)
             {
                 _commands.erase(_commands.cbegin());
                 // move LastDisplayed back one in order to stay synced with the
@@ -177,7 +177,7 @@ std::wstring_view CommandHistory::GetNth(const SHORT index) const
     try
     {
         const auto& cmd = _commands.at(index);
-        if (cmd.size() > (size_t)buffer.size())
+        if (cmd.size() > static_cast<size_t>(buffer.size()))
         {
             commandSize = buffer.size(); // room for CRLF?
         }
@@ -260,24 +260,24 @@ bool CommandHistory::AtFirstCommand() const
         return FALSE;
     }
 
-    SHORT i = (SHORT)(LastDisplayed - 1);
+    SHORT i = static_cast<SHORT>(LastDisplayed - 1);
     if (i == -1)
     {
-        i = ((SHORT)_commands.size()) - 1i16;
+        i = static_cast<SHORT>(_commands.size()) - 1i16;
     }
 
-    return (i == ((SHORT)_commands.size()) - 1i16);
+    return (i == static_cast<SHORT>(_commands.size()) - 1i16);
 }
 
 bool CommandHistory::AtLastCommand() const
 {
-    return LastDisplayed == ((SHORT)_commands.size()) - 1i16;
+    return LastDisplayed == static_cast<SHORT>(_commands.size()) - 1i16;
 }
 
 void CommandHistory::Realloc(const size_t commands)
 {
     // To protect ourselves from overflow and general arithmetic errors, a limit of SHORT_MAX is put on the size of the command history.
-    if (_maxCommands == (SHORT)commands || commands > SHORT_MAX)
+    if (_maxCommands == static_cast<SHORT>(commands) || commands > SHORT_MAX)
     {
         return;
     }
@@ -293,7 +293,7 @@ void CommandHistory::Realloc(const size_t commands)
 
     WI_SetFlag(Flags, CLE_RESET);
     LastDisplayed = gsl::narrow<SHORT>(_commands.size()) - 1;
-    _maxCommands = (SHORT)commands;
+    _maxCommands = static_cast<SHORT>(commands);
 }
 
 void CommandHistory::s_ReallocExeToFront(const std::wstring_view appName, const size_t commands)
@@ -422,7 +422,7 @@ void CommandHistory::_Prev(SHORT& ind) const
 void CommandHistory::_Next(SHORT& ind) const
 {
     ++ind;
-    if (ind >= (SHORT)_commands.size())
+    if (ind >= static_cast<SHORT>(_commands.size()))
     {
         ind = 0;
     }

--- a/src/host/input.cpp
+++ b/src/host/input.cpp
@@ -287,7 +287,7 @@ void ProcessCtrlEvents()
     //        CONSOLE_CTRL_LOGOFF_FLAG
     //        CONSOLE_CTRL_SHUTDOWN_FLAG
 
-    DWORD EventType = (DWORD)-1;
+    DWORD EventType = static_cast<DWORD>(-1);
     switch (CtrlFlags & (CONSOLE_CTRL_CLOSE_FLAG | CONSOLE_CTRL_BREAK_FLAG | CONSOLE_CTRL_C_FLAG | CONSOLE_CTRL_LOGOFF_FLAG | CONSOLE_CTRL_SHUTDOWN_FLAG))
     {
     case CONSOLE_CTRL_CLOSE_FLAG:

--- a/src/host/misc.cpp
+++ b/src/host/misc.cpp
@@ -172,7 +172,7 @@ BOOL CheckBisectProcessW(const SCREEN_INFORMATION& ScreenInfo,
                 case UNICODE_TAB:
                 {
                     size_t TabSize = NUMBER_OF_SPACES_IN_TAB(sOriginalXPosition);
-                    sOriginalXPosition = (SHORT)(sOriginalXPosition + TabSize);
+                    sOriginalXPosition = static_cast<SHORT>(sOriginalXPosition + TabSize);
                     if (cBytes < TabSize)
                         return TRUE;
                     cBytes -= TabSize;

--- a/src/host/ntprivapi.cpp
+++ b/src/host/ntprivapi.cpp
@@ -33,7 +33,7 @@
 
     // This is the actual field name, but in the public SDK, it's named Reserved3. We need to pursue publishing the real name.
     //*ProcessId = (ULONG)BasicInfo.InheritedFromUniqueProcessId;
-    *ProcessId = (ULONG)BasicInfo.Reserved3;
+    *ProcessId = static_cast<ULONG>(BasicInfo.Reserved3);
     return STATUS_SUCCESS;
 }
 

--- a/src/host/popup.cpp
+++ b/src/host/popup.cpp
@@ -163,7 +163,7 @@ void Popup::_DrawPrompt(const UINT id)
 
     // write prompt to screen
     lStringLength = text.size();
-    if (lStringLength > (ULONG)Width())
+    if (lStringLength > static_cast<ULONG>(Width()))
     {
         text = text.substr(0, Width());
     }
@@ -192,8 +192,8 @@ void Popup::UpdateStoredColors(const TextAttribute& newAttr,
     const WORD wOldPopupLegacy = oldPopupAttr.GetLegacyAttributes();
     const WORD wNewPopupLegacy = newPopupAttr.GetLegacyAttributes();
 
-    const WORD wOldPopupAttrInv = (WORD)(((wOldPopupLegacy << 4) & 0xf0) | ((wOldPopupLegacy >> 4) & 0x0f));
-    const WORD wNewPopupAttrInv = (WORD)(((wNewPopupLegacy << 4) & 0xf0) | ((wNewPopupLegacy >> 4) & 0x0f));
+    const WORD wOldPopupAttrInv = static_cast<WORD>(((wOldPopupLegacy << 4) & 0xf0) | ((wOldPopupLegacy >> 4) & 0x0f));
+    const WORD wNewPopupAttrInv = static_cast<WORD>(((wNewPopupLegacy << 4) & 0xf0) | ((wNewPopupLegacy >> 4) & 0x0f));
 
     const TextAttribute oldPopupInv{ wOldPopupAttrInv };
     const TextAttribute newPopupInv{ wNewPopupAttrInv };

--- a/src/host/readDataCooked.cpp
+++ b/src/host/readDataCooked.cpp
@@ -106,7 +106,7 @@ COOKED_READ_DATA::COOKED_READ_DATA(_In_ InputBuffer* const pInputBuffer,
         _currentPosition = cchInitialData;
 
         OriginalCursorPosition() = screenInfo.GetTextBuffer().GetCursor().GetPosition();
-        OriginalCursorPosition().X -= (SHORT)_currentPosition;
+        OriginalCursorPosition().X -= static_cast<SHORT>(_currentPosition);
 
         const SHORT sScreenBufferSizeX = screenInfo.GetBufferSize().Width();
         while (OriginalCursorPosition().X < 0)
@@ -552,7 +552,7 @@ bool COOKED_READ_DATA::ProcessInput(const wchar_t wchOrig,
                     // clang-format off
 #pragma prefast(suppress: __WARNING_POTENTIAL_BUFFER_OVERFLOW_HIGH_PRIORITY, "This access is fine")
                     // clang-format on
-                    *_bufPtr = (WCHAR)' ';
+                    *_bufPtr = static_cast<WCHAR>(' ');
                     _bufPtr -= 1;
                     _currentPosition -= 1;
 
@@ -630,7 +630,7 @@ bool COOKED_READ_DATA::ProcessInput(const wchar_t wchOrig,
                             _bytesRead - (_currentPosition * sizeof(WCHAR)));
                     {
                         PWCHAR buf = (PWCHAR)((PBYTE)_backupLimit + _bytesRead);
-                        *buf = (WCHAR)' ';
+                        *buf = static_cast<WCHAR>(' ');
                     }
                     NumSpaces = 0;
 
@@ -705,7 +705,7 @@ bool COOKED_READ_DATA::ProcessInput(const wchar_t wchOrig,
 
             // save cursor position
             CursorPosition = _screenInfo.GetTextBuffer().GetCursor().GetPosition();
-            CursorPosition.X = (SHORT)(CursorPosition.X + NumSpaces);
+            CursorPosition.X = static_cast<SHORT>(CursorPosition.X + NumSpaces);
 
             // clear the current command line from the screen
             // clang-format off
@@ -1074,7 +1074,7 @@ void COOKED_READ_DATA::SavePendingInput(const size_t index, const bool multiline
                 FAIL_FAST_IF(!(Tmp < (_backupLimit + _bytesRead)));
             }
 
-            numBytes = (ULONG)(Tmp - _backupLimit + 1) * sizeof(*Tmp);
+            numBytes = static_cast<ULONG>(Tmp - _backupLimit + 1) * sizeof(*Tmp);
         }
         else
         {

--- a/src/host/registry.cpp
+++ b/src/host/registry.cpp
@@ -118,8 +118,8 @@ void Registry::GetEditKeys(_In_opt_ HKEY hConsoleKey) const
 
     if (hCurrentUserKey)
     {
-        RegCloseKey((HKEY)hConsoleKey);
-        RegCloseKey((HKEY)hCurrentUserKey);
+        RegCloseKey(static_cast<HKEY>(hConsoleKey));
+        RegCloseKey(static_cast<HKEY>(hCurrentUserKey));
     }
 }
 
@@ -176,8 +176,8 @@ void Registry::LoadGlobalsFromRegistry()
     {
         _LoadMappedProperties(RegistrySerialization::s_GlobalPropMappings, RegistrySerialization::s_GlobalPropMappingsSize, hConsoleKey);
 
-        RegCloseKey((HKEY)hConsoleKey);
-        RegCloseKey((HKEY)hCurrentUserKey);
+        RegCloseKey(static_cast<HKEY>(hConsoleKey));
+        RegCloseKey(static_cast<HKEY>(hCurrentUserKey));
     }
 }
 

--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -392,8 +392,8 @@ COORD SCREEN_INFORMATION::GetMinWindowSizeInCharacters(const COORD coordFontSize
 
     // assign the pixel widths and heights to the final output
     COORD coordClientAreaSize;
-    coordClientAreaSize.X = (SHORT)RECT_WIDTH(&rcWindowInPixels);
-    coordClientAreaSize.Y = (SHORT)RECT_HEIGHT(&rcWindowInPixels);
+    coordClientAreaSize.X = static_cast<SHORT>(RECT_WIDTH(&rcWindowInPixels));
+    coordClientAreaSize.Y = static_cast<SHORT>(RECT_HEIGHT(&rcWindowInPixels));
 
     // now retrieve the font size and divide the pixel counts into character counts
     COORD coordFont = coordFontSize; // by default, use the size we were given
@@ -462,8 +462,8 @@ COORD SCREEN_INFORMATION::GetLargestWindowSizeInCharacters(const COORD coordFont
 
     // first assign the pixel widths and heights to the final output
     COORD coordClientAreaSize;
-    coordClientAreaSize.X = (SHORT)RECT_WIDTH(&rcClientInPixels);
-    coordClientAreaSize.Y = (SHORT)RECT_HEIGHT(&rcClientInPixels);
+    coordClientAreaSize.X = static_cast<SHORT>(RECT_WIDTH(&rcClientInPixels));
+    coordClientAreaSize.Y = static_cast<SHORT>(RECT_HEIGHT(&rcClientInPixels));
 
     // now retrieve the font size and divide the pixel counts into character counts
     COORD coordFont = coordFontSize; // by default, use the size we were given
@@ -760,8 +760,8 @@ void SCREEN_INFORMATION::SetViewportSize(const COORD* const pcoordSize)
         NewWindow.Left = coordWindowOrigin.X;
         NewWindow.Top = coordWindowOrigin.Y;
     }
-    NewWindow.Right = (SHORT)(NewWindow.Left + WindowSize.X - 1);
-    NewWindow.Bottom = (SHORT)(NewWindow.Top + WindowSize.Y - 1);
+    NewWindow.Right = static_cast<SHORT>(NewWindow.Left + WindowSize.X - 1);
+    NewWindow.Bottom = static_cast<SHORT>(NewWindow.Top + WindowSize.Y - 1);
 
     const CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
 
@@ -935,8 +935,8 @@ void SCREEN_INFORMATION::ProcessResizeWindow(const RECT* const prcClientNew,
     }
 
     // Now with the scroll bars removed, calculate how many characters could fit into the new window area.
-    pcoordClientNewCharacters->X = (SHORT)(sizeClientNewPixels.cx / coordFontSize.X);
-    pcoordClientNewCharacters->Y = (SHORT)(sizeClientNewPixels.cy / coordFontSize.Y);
+    pcoordClientNewCharacters->X = static_cast<SHORT>(sizeClientNewPixels.cx / coordFontSize.X);
+    pcoordClientNewCharacters->Y = static_cast<SHORT>(sizeClientNewPixels.cy / coordFontSize.Y);
 
     // If the new client is too tiny, our viewport will be 1x1.
     pcoordClientNewCharacters->X = std::max(pcoordClientNewCharacters->X, 1i16);
@@ -1060,8 +1060,8 @@ void SCREEN_INFORMATION::_CalculateViewportSize(const RECT* const prcClientArea,
         sizeClientPixels.cx -= ServiceLocator::LocateGlobals().sVerticalScrollSize;
     }
 
-    pcoordSize->X = (SHORT)(sizeClientPixels.cx / coordFontSize.X);
-    pcoordSize->Y = (SHORT)(sizeClientPixels.cy / coordFontSize.Y);
+    pcoordSize->X = static_cast<SHORT>(sizeClientPixels.cx / coordFontSize.X);
+    pcoordSize->Y = static_cast<SHORT>(sizeClientPixels.cy / coordFontSize.Y);
 }
 
 // Routine Description:
@@ -1101,7 +1101,7 @@ void SCREEN_INFORMATION::_InternalSetViewportSize(const COORD* const pcoordSize,
             // content above as we can, but we can't show more
             // than the left of the window
             srNewViewport.Left = 0;
-            srNewViewport.Right += (SHORT)abs(sLeftProposed);
+            srNewViewport.Right += static_cast<SHORT>(abs(sLeftProposed));
         }
     }
     else
@@ -1152,7 +1152,7 @@ void SCREEN_INFORMATION::_InternalSetViewportSize(const COORD* const pcoordSize,
             // content above as we can, but we can't show more
             // than the top of the window
             srNewViewport.Top = 0;
-            srNewViewport.Bottom += (SHORT)abs(sTopProposed);
+            srNewViewport.Bottom += static_cast<SHORT>(abs(sTopProposed));
         }
     }
     else
@@ -1391,7 +1391,7 @@ bool SCREEN_INFORMATION::IsMaximizedY() const
 // - Success if successful. Invalid parameter if screen buffer size is unexpected. No memory if allocation failed.
 [[nodiscard]] NTSTATUS SCREEN_INFORMATION::ResizeWithReflow(const COORD coordNewScreenSize)
 {
-    if ((USHORT)coordNewScreenSize.X >= SHORT_MAX || (USHORT)coordNewScreenSize.Y >= SHORT_MAX)
+    if (static_cast<USHORT>(coordNewScreenSize.X) >= SHORT_MAX || static_cast<USHORT>(coordNewScreenSize.Y) >= SHORT_MAX)
     {
         RIPMSG2(RIP_WARNING, "Invalid screen buffer size (0x%x, 0x%x)", coordNewScreenSize.X, coordNewScreenSize.Y);
         return STATUS_INVALID_PARAMETER;
@@ -1494,7 +1494,7 @@ bool SCREEN_INFORMATION::IsMaximizedY() const
 
     if (NT_SUCCESS(status))
     {
-        NotifyAccessibilityEventing(0, 0, (SHORT)(coordNewScreenSize.X - 1), (SHORT)(coordNewScreenSize.Y - 1));
+        NotifyAccessibilityEventing(0, 0, static_cast<SHORT>(coordNewScreenSize.X - 1), static_cast<SHORT>(coordNewScreenSize.Y - 1));
 
         if ((!ConvScreenInfo))
         {
@@ -2348,7 +2348,7 @@ OutputCellRect SCREEN_INFORMATION::ReadRect(const Viewport viewport) const
     for (size_t rowIndex = 0; rowIndex < gsl::narrow<size_t>(viewport.Height()); ++rowIndex)
     {
         COORD location = viewport.Origin();
-        location.Y += (SHORT)rowIndex;
+        location.Y += static_cast<SHORT>(rowIndex);
 
         auto data = GetCellLineDataAt(location);
         const auto span = result.GetRow(rowIndex);

--- a/src/host/scrolling.cpp
+++ b/src/host/scrolling.cpp
@@ -84,8 +84,8 @@ void Scrolling::s_ScrollIfNecessary(const SCREEN_INFORMATION& ScreenInfo)
             pWindow->ConvertScreenToClient(&CursorPos);
 
             COORD MousePosition;
-            MousePosition.X = (SHORT)CursorPos.x;
-            MousePosition.Y = (SHORT)CursorPos.y;
+            MousePosition.X = static_cast<SHORT>(CursorPos.x);
+            MousePosition.Y = static_cast<SHORT>(CursorPos.y);
 
             COORD coordFontSize = ScreenInfo.GetScreenFontSize();
 
@@ -124,7 +124,7 @@ void Scrolling::s_HandleMouseWheel(_In_ bool isMouseWheel,
             ScreenInfo.WheelDelta = wheelDelta;
         }
 
-        if ((ULONG)abs(ScreenInfo.WheelDelta) >= ulActualDelta)
+        if (static_cast<ULONG>(abs(ScreenInfo.WheelDelta)) >= ulActualDelta)
         {
             /*
             * By default, SHIFT + WM_MOUSEWHEEL will scroll 1/2 the
@@ -142,7 +142,7 @@ void Scrolling::s_HandleMouseWheel(_In_ bool isMouseWheel,
             }
             else
             {
-                delta *= (ScreenInfo.WheelDelta / (short)ulActualDelta);
+                delta *= (ScreenInfo.WheelDelta / static_cast<short>(ulActualDelta));
                 ScreenInfo.WheelDelta %= ulActualDelta;
             }
 
@@ -172,7 +172,7 @@ void Scrolling::s_HandleMouseWheel(_In_ bool isMouseWheel,
             ScreenInfo.HWheelDelta = wheelDelta;
         }
 
-        if ((ULONG)abs(ScreenInfo.HWheelDelta) >= ulActualDelta)
+        if (static_cast<ULONG>(abs(ScreenInfo.HWheelDelta)) >= ulActualDelta)
         {
             SHORT delta = 1;
 
@@ -181,7 +181,7 @@ void Scrolling::s_HandleMouseWheel(_In_ bool isMouseWheel,
                 delta = std::max(ScreenInfo.GetViewport().RightInclusive(), 1i16);
             }
 
-            delta *= (ScreenInfo.HWheelDelta / (short)ulActualDelta);
+            delta *= (ScreenInfo.HWheelDelta / static_cast<short>(ulActualDelta));
             ScreenInfo.HWheelDelta %= ulActualDelta;
 
             NewOrigin.X += delta;

--- a/src/host/selection.cpp
+++ b/src/host/selection.cpp
@@ -23,9 +23,9 @@ Selection::Selection() :
     _fUseAlternateSelection(false),
     _allowMouseDragSelection{ true }
 {
-    ZeroMemory((void*)&_srSelectionRect, sizeof(_srSelectionRect));
-    ZeroMemory((void*)&_coordSelectionAnchor, sizeof(_coordSelectionAnchor));
-    ZeroMemory((void*)&_coordSavedCursorPosition, sizeof(_coordSavedCursorPosition));
+    ZeroMemory(static_cast<void*>(&_srSelectionRect), sizeof(_srSelectionRect));
+    ZeroMemory(static_cast<void*>(&_coordSelectionAnchor), sizeof(_coordSelectionAnchor));
+    ZeroMemory(static_cast<void*>(&_coordSavedCursorPosition), sizeof(_coordSavedCursorPosition));
 }
 
 Selection& Selection::Instance()

--- a/src/host/settings.cpp
+++ b/src/host/settings.cpp
@@ -75,7 +75,7 @@ Settings::Settings() :
     _dwFontSize.X = 0;
     _dwFontSize.Y = 16;
 
-    ZeroMemory((void*)&_FaceName, sizeof(_FaceName));
+    ZeroMemory(static_cast<void*>(&_FaceName), sizeof(_FaceName));
     wcscpy_s(_FaceName, DEFAULT_TT_FONT_FACENAME);
 
     _CursorColor = Cursor::s_InvertCursorColor;
@@ -207,8 +207,8 @@ void Settings::InitFromStateInfo(_In_ PCONSOLE_STATE_INFO pStateInfo)
     _wPopupFillAttribute = pStateInfo->PopupAttributes;
     _dwScreenBufferSize = pStateInfo->ScreenBufferSize;
     _dwWindowSize = pStateInfo->WindowSize;
-    _dwWindowOrigin.X = (SHORT)pStateInfo->WindowPosX;
-    _dwWindowOrigin.Y = (SHORT)pStateInfo->WindowPosY;
+    _dwWindowOrigin.X = static_cast<SHORT>(pStateInfo->WindowPosX);
+    _dwWindowOrigin.Y = static_cast<SHORT>(pStateInfo->WindowPosY);
     _dwFontSize = pStateInfo->FontSize;
     _uFontFamily = pStateInfo->FontFamily;
     _uFontWeight = pStateInfo->FontWeight;
@@ -249,8 +249,8 @@ CONSOLE_STATE_INFO Settings::CreateConsoleStateInfo() const
     csi.PopupAttributes = _wPopupFillAttribute;
     csi.ScreenBufferSize = _dwScreenBufferSize;
     csi.WindowSize = _dwWindowSize;
-    csi.WindowPosX = (SHORT)_dwWindowOrigin.X;
-    csi.WindowPosY = (SHORT)_dwWindowOrigin.Y;
+    csi.WindowPosX = static_cast<SHORT>(_dwWindowOrigin.X);
+    csi.WindowPosY = static_cast<SHORT>(_dwWindowOrigin.Y);
     csi.FontSize = _dwFontSize;
     csi.FontFamily = _uFontFamily;
     csi.FontWeight = _uFontWeight;

--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -207,7 +207,7 @@ static bool s_IsOnDesktop()
     LockConsole();
     NTSTATUS Status = STATUS_SUCCESS;
 
-    CommandHistory::s_Free((HANDLE)ProcessData);
+    CommandHistory::s_Free(static_cast<HANDLE>(ProcessData));
 
     bool const fRecomputeOwner = ProcessData->fRootProcess;
     gci.ProcessHandleList.FreeProcessData(ProcessData);
@@ -316,8 +316,8 @@ PWSTR TranslateConsoleTitle(_In_ PCWSTR pwszConsoleTitle, const BOOL fUnexpand, 
             if (SUCCEEDED(StringCbLengthW(pwszConsoleTitle, STRSAFE_MAX_CCH, &cbConsoleTitle)) &&
                 SUCCEEDED(StringCbLengthW(pwszSysRoot, MAX_PATH, &cbSystemRoot)))
             {
-                int const cchSystemRoot = (int)(cbSystemRoot / sizeof(WCHAR));
-                int const cchConsoleTitle = (int)(cbConsoleTitle / sizeof(WCHAR));
+                int const cchSystemRoot = static_cast<int>(cbSystemRoot / sizeof(WCHAR));
+                int const cchConsoleTitle = static_cast<int>(cbConsoleTitle / sizeof(WCHAR));
                 cbConsoleTitle += sizeof(WCHAR); // account for nullptr terminator
 
                 if (fUnexpand &&
@@ -352,7 +352,7 @@ PWSTR TranslateConsoleTitle(_In_ PCWSTR pwszConsoleTitle, const BOOL fUnexpand, 
                     if (fSubstitute && *pwszConsoleTitle == '\\')
                     {
 #pragma prefast(suppress : 26019, "Console title must contain system root if this path was followed.")
-                        *pszTranslatedConsoleTitle++ = (WCHAR)'_';
+                        *pszTranslatedConsoleTitle++ = static_cast<WCHAR>('_');
                     }
                     else
                     {

--- a/src/host/stream.cpp
+++ b/src/host/stream.cpp
@@ -210,7 +210,7 @@ size_t RetrieveTotalNumberOfSpaces(const SHORT sOriginalCursorPositionX,
         {
             NumSpacesForChar = 1;
         }
-        XPosition = (SHORT)(XPosition + NumSpacesForChar);
+        XPosition = static_cast<SHORT>(XPosition + NumSpacesForChar);
         NumSpaces += NumSpacesForChar;
     }
 
@@ -248,7 +248,7 @@ size_t RetrieveNumberOfSpaces(_In_ SHORT sOriginalCursorPositionX,
             {
                 NumSpaces = 1;
             }
-            XPosition = (SHORT)(XPosition + NumSpaces);
+            XPosition = static_cast<SHORT>(XPosition + NumSpaces);
         }
 
         return NumSpaces;

--- a/src/host/telemetry.cpp
+++ b/src/host/telemetry.cpp
@@ -342,8 +342,8 @@ void Telemetry::LogProcessConnected(const HANDLE hProcess)
 
                     // Packed arrays start with a UINT16 value indicating the number of elements in the array.
                     BYTE* pbFileNames = reinterpret_cast<BYTE*>(_wchProcessFileNames);
-                    pbFileNames[0] = (BYTE)_uiNumberProcessFileNames;
-                    pbFileNames[1] = (BYTE)(_uiNumberProcessFileNames >> 8);
+                    pbFileNames[0] = static_cast<BYTE>(_uiNumberProcessFileNames);
+                    pbFileNames[1] = static_cast<BYTE>(_uiNumberProcessFileNames >> 8);
                 }
             }
         }
@@ -419,7 +419,7 @@ void Telemetry::WriteFinalTraceLog()
                                     TraceLoggingBool(gci.GetQuickEdit(), "QuickEdit"),
                                     TraceLoggingValue(gci.GetWindowAlpha(), "WindowAlpha"),
                                     TraceLoggingBool(gci.GetWrapText(), "WrapText"),
-                                    TraceLoggingUInt32Array((UINT32 const*)gci.GetColorTable(), (UINT16)gci.GetColorTableSize(), "ColorTable"),
+                                    TraceLoggingUInt32Array((UINT32 const*)gci.GetColorTable(), static_cast<UINT16>(gci.GetColorTableSize()), "ColorTable"),
                                     TraceLoggingValue(gci.CP, "CodePageInput"),
                                     TraceLoggingValue(gci.OutputCP, "CodePageOutput"),
                                     TraceLoggingValue(gci.GetFontSize().X, "FontSizeX"),

--- a/src/host/ut_host/AttrRowTests.cpp
+++ b/src/host/ut_host/AttrRowTests.cpp
@@ -153,7 +153,7 @@ class AttrRowTests
 
             VERIFY_ARE_EQUAL(pUnderTest->_list.size(), 1u);
             VERIFY_ARE_EQUAL(pUnderTest->_list[0].GetAttributes(), attr);
-            VERIFY_ARE_EQUAL(pUnderTest->_list[0].GetLength(), (unsigned int)_sDefaultLength);
+            VERIFY_ARE_EQUAL(pUnderTest->_list[0].GetLength(), static_cast<unsigned int>(_sDefaultLength));
         }
     }
 
@@ -246,7 +246,7 @@ class AttrRowTests
 
             for (size_t i = 1; i < chain.size(); i++)
             {
-                str.AppendFormat(L"->%s", (const wchar_t*)(LogRunElement(chain[i])));
+                str.AppendFormat(L"->%s", static_cast<const wchar_t*>(LogRunElement(chain[i])));
             }
         }
 
@@ -344,7 +344,7 @@ class AttrRowTests
         VERIFY_SUCCEEDED(PackAttrs(unpackedOriginal.data(), originalRow._cchRowWidth, packedRun, &cPackedRun));
 
         // Now send parameters into InsertAttrRuns and get its opinion on the subject.
-        VERIFY_SUCCEEDED(originalRow.InsertAttrRuns({ insertRow.data(), insertRow.size() }, uiStartPos, uiEndPos, (UINT)originalRow._cchRowWidth));
+        VERIFY_SUCCEEDED(originalRow.InsertAttrRuns({ insertRow.data(), insertRow.size() }, uiStartPos, uiEndPos, static_cast<UINT>(originalRow._cchRowWidth)));
 
         // Compare and ensure that the expected and actual match.
         VERIFY_ARE_EQUAL(cPackedRun, originalRow._list.size(), L"Ensure that number of array elements required for RLE are the same.");
@@ -643,10 +643,10 @@ class AttrRowTests
         VERIFY_ARE_EQUAL(pSingle->_list.size(), 2u);
 
         VERIFY_ARE_EQUAL(pSingle->_list[0].GetAttributes(), _DefaultAttr);
-        VERIFY_ARE_EQUAL(pSingle->_list[0].GetLength(), (unsigned int)(_sDefaultLength - (_sDefaultLength - iTestIndex)));
+        VERIFY_ARE_EQUAL(pSingle->_list[0].GetLength(), static_cast<unsigned int>(_sDefaultLength -(_sDefaultLength - iTestIndex)));
 
         VERIFY_ARE_EQUAL(pSingle->_list[1].GetAttributes(), TestAttr);
-        VERIFY_ARE_EQUAL(pSingle->_list[1].GetLength(), (unsigned int)(_sDefaultLength - iTestIndex));
+        VERIFY_ARE_EQUAL(pSingle->_list[1].GetLength(), static_cast<unsigned int>(_sDefaultLength - iTestIndex));
 
         Log::Comment(L"SetAttrToEnd for existing chain of multiple colors.");
         pChain->SetAttrToEnd(iTestIndex, TestAttr);
@@ -656,19 +656,19 @@ class AttrRowTests
 
         // Verify chain colors and lengths
         VERIFY_ARE_EQUAL(TextAttribute(0), pChain->_list[0].GetAttributes());
-        VERIFY_ARE_EQUAL(pChain->_list[0].GetLength(), (unsigned int)13);
+        VERIFY_ARE_EQUAL(pChain->_list[0].GetLength(), static_cast<unsigned int>(13));
 
         VERIFY_ARE_EQUAL(TextAttribute(1), pChain->_list[1].GetAttributes());
-        VERIFY_ARE_EQUAL(pChain->_list[1].GetLength(), (unsigned int)13);
+        VERIFY_ARE_EQUAL(pChain->_list[1].GetLength(), static_cast<unsigned int>(13));
 
         VERIFY_ARE_EQUAL(TextAttribute(2), pChain->_list[2].GetAttributes());
-        VERIFY_ARE_EQUAL(pChain->_list[2].GetLength(), (unsigned int)13);
+        VERIFY_ARE_EQUAL(pChain->_list[2].GetLength(), static_cast<unsigned int>(13));
 
         VERIFY_ARE_EQUAL(TextAttribute(3), pChain->_list[3].GetAttributes());
-        VERIFY_ARE_EQUAL(pChain->_list[3].GetLength(), (unsigned int)11);
+        VERIFY_ARE_EQUAL(pChain->_list[3].GetLength(), static_cast<unsigned int>(11));
 
         VERIFY_ARE_EQUAL(TestAttr, pChain->_list[4].GetAttributes());
-        VERIFY_ARE_EQUAL(pChain->_list[4].GetLength(), (unsigned int)30);
+        VERIFY_ARE_EQUAL(pChain->_list[4].GetLength(), static_cast<unsigned int>(30));
 
         Log::Comment(L"SECOND: Set index to 0 to test replacing anything with a single");
 
@@ -687,7 +687,7 @@ class AttrRowTests
             VERIFY_ARE_EQUAL(pUnderTest->_list[0].GetAttributes(), TestAttr);
 
             // and its length should be the length of the whole string
-            VERIFY_ARE_EQUAL(pUnderTest->_list[0].GetLength(), (unsigned int)_sDefaultLength);
+            VERIFY_ARE_EQUAL(pUnderTest->_list[0].GetLength(), static_cast<unsigned int>(_sDefaultLength));
         }
     }
 
@@ -701,7 +701,7 @@ class AttrRowTests
 
             const size_t Result = pUnderTest->_cchRowWidth;
 
-            VERIFY_ARE_EQUAL((short)Result, _sDefaultLength);
+            VERIFY_ARE_EQUAL(static_cast<short>(Result), _sDefaultLength);
         }
     }
 

--- a/src/host/ut_host/AttrRowTests.cpp
+++ b/src/host/ut_host/AttrRowTests.cpp
@@ -643,7 +643,7 @@ class AttrRowTests
         VERIFY_ARE_EQUAL(pSingle->_list.size(), 2u);
 
         VERIFY_ARE_EQUAL(pSingle->_list[0].GetAttributes(), _DefaultAttr);
-        VERIFY_ARE_EQUAL(pSingle->_list[0].GetLength(), static_cast<unsigned int>(_sDefaultLength -(_sDefaultLength - iTestIndex)));
+        VERIFY_ARE_EQUAL(pSingle->_list[0].GetLength(), static_cast<unsigned int>(_sDefaultLength - (_sDefaultLength - iTestIndex)));
 
         VERIFY_ARE_EQUAL(pSingle->_list[1].GetAttributes(), TestAttr);
         VERIFY_ARE_EQUAL(pSingle->_list[1].GetLength(), static_cast<unsigned int>(_sDefaultLength - iTestIndex));

--- a/src/host/ut_host/ClipboardTests.cpp
+++ b/src/host/ut_host/ClipboardTests.cpp
@@ -101,7 +101,7 @@ class ClipboardTests
         // verify trailing bytes were trimmed
         // there are 2 double-byte characters in our sample string (see CommonState.hpp for sample)
         // the width is right - left
-        VERIFY_ARE_EQUAL((short)wcslen(text[0].data()), selection[0].Right - selection[0].Left + 1);
+        VERIFY_ARE_EQUAL(static_cast<short>(wcslen(text[0].data())), selection[0].Right - selection[0].Left + 1);
 
         // since we're not in line selection, the line should be \r\n terminated
         PCWCHAR tempPtr = text[0].data();

--- a/src/host/ut_host/HistoryTests.cpp
+++ b/src/host/ut_host/HistoryTests.cpp
@@ -145,7 +145,7 @@ class HistoryTests
 
         Log::Comment(L"Retrieve items/order.");
         std::vector<std::wstring> commandsStored;
-        for (SHORT i = 0; i < (SHORT)history->GetNumberOfCommands(); i++)
+        for (SHORT i = 0; i < static_cast<SHORT>(history->GetNumberOfCommands()); i++)
         {
             commandsStored.emplace_back(history->GetNth(i));
         }
@@ -153,7 +153,7 @@ class HistoryTests
         Log::Comment(L"Reallocate larger and ensure items and order are preserved.");
         history->Realloc(_manyHistoryItems.size());
         VERIFY_ARE_EQUAL(s_BufferSize, history->GetNumberOfCommands());
-        for (SHORT i = 0; i < (SHORT)commandsStored.size(); i++)
+        for (SHORT i = 0; i < static_cast<SHORT>(commandsStored.size()); i++)
         {
             VERIFY_ARE_EQUAL(String(commandsStored[i].data()), String(history->GetNth(i).data()));
         }
@@ -179,7 +179,7 @@ class HistoryTests
 
         Log::Comment(L"Retrieve items/order.");
         std::vector<std::wstring> commandsStored;
-        for (SHORT i = 0; i < (SHORT)history->GetNumberOfCommands(); i++)
+        for (SHORT i = 0; i < static_cast<SHORT>(history->GetNumberOfCommands()); i++)
         {
             commandsStored.emplace_back(history->GetNth(i));
         }

--- a/src/host/ut_host/SelectionTests.cpp
+++ b/src/host/ut_host/SelectionTests.cpp
@@ -71,7 +71,7 @@ class SelectionTests
                 // ensure each rectangle is exactly the width requested (block selection)
                 const SMALL_RECT* const psrRect = &selectionRects[iRect];
 
-                const short sRectangleLineNumber = (short)iRect + m_pSelection->_srSelectionRect.Top;
+                const short sRectangleLineNumber = static_cast<short>(iRect) + m_pSelection->_srSelectionRect.Top;
 
                 VERIFY_ARE_EQUAL(psrRect->Top, sRectangleLineNumber);
                 VERIFY_ARE_EQUAL(psrRect->Bottom, sRectangleLineNumber);
@@ -170,7 +170,7 @@ class SelectionTests
                     // ensure each rectangle is exactly the width requested (block selection)
                     const SMALL_RECT* const psrRect = &selectionRects[iRect];
 
-                    const short sRectangleLineNumber = (short)iRect + m_pSelection->_srSelectionRect.Top;
+                    const short sRectangleLineNumber = static_cast<short>(iRect) + m_pSelection->_srSelectionRect.Top;
 
                     VERIFY_ARE_EQUAL(psrRect->Top, sRectangleLineNumber);
                     VERIFY_ARE_EQUAL(psrRect->Bottom, sRectangleLineNumber);
@@ -495,7 +495,7 @@ class SelectionInputTests
         // 1. If the original cooked cursor was valid (which it was this first time), it's NumberOfVisibleChars ahead.
         COORD coordFinalPos;
 
-        const short cCharsToAdjust = ((short)readData.VisibleCharCount() - 1); // then -1 to be on the last piece of text, not past it
+        const short cCharsToAdjust = (static_cast<short>(readData.VisibleCharCount()) - 1); // then -1 to be on the last piece of text, not past it
 
         coordFinalPos.X = (readData.OriginalCursorPosition().X + cCharsToAdjust) % sRowWidth;
         coordFinalPos.Y = readData.OriginalCursorPosition().Y + ((readData.OriginalCursorPosition().X + cCharsToAdjust) / sRowWidth);

--- a/src/host/ut_host/TextBufferIteratorTests.cpp
+++ b/src/host/ut_host/TextBufferIteratorTests.cpp
@@ -496,7 +496,7 @@ void TextBufferIteratorTests::DereferenceOperatorCell()
 
     const auto& row = outputBuffer._textBuffer->GetRowByOffset(it._pos.Y);
 
-    const auto textExpected = (std::wstring_view)row.GetCharRow().GlyphAt(it._pos.X);
+    const auto textExpected = static_cast<std::wstring_view>(row.GetCharRow().GlyphAt(it._pos.X));
     const auto dbcsExpected = row.GetCharRow().DbcsAttrAt(it._pos.X);
     const auto attrExpected = row.GetAttrRow().GetAttrByColumn(it._pos.X).GetLegacyAttributes();
 
@@ -505,7 +505,7 @@ void TextBufferIteratorTests::DereferenceOperatorCell()
     const auto dbcsActual = cellActual.DbcsAttr();
     const auto attrActual = cellActual.TextAttr();
 
-    VERIFY_ARE_EQUAL(String(textExpected.data(), (int)textExpected.size()), String(textActual.data(), (int)textActual.size()));
+    VERIFY_ARE_EQUAL(String(textExpected.data(), static_cast<int>(textExpected.size())), String(textActual.data(), static_cast<int>(textActual.size())));
     VERIFY_ARE_EQUAL(dbcsExpected, dbcsActual);
     VERIFY_ARE_EQUAL(attrExpected, attrActual);
 }

--- a/src/host/ut_host/Utf8ToWideCharParserTests.cpp
+++ b/src/host/ut_host/Utf8ToWideCharParserTests.cpp
@@ -34,8 +34,8 @@ class Utf8ToWideCharParserTests
         unique_ptr<wchar_t[]> output{ nullptr };
 
         VERIFY_SUCCEEDED(parser.Parse(hello, count, consumed, output, generated));
-        VERIFY_ARE_EQUAL(consumed, (unsigned int)5);
-        VERIFY_ARE_EQUAL(generated, (unsigned int)5);
+        VERIFY_ARE_EQUAL(consumed, static_cast<unsigned int>(5));
+        VERIFY_ARE_EQUAL(generated, static_cast<unsigned int>(5));
         VERIFY_ARE_NOT_EQUAL(output.get(), nullptr);
 
         unsigned char* pReturnedBytes = reinterpret_cast<unsigned char*>(output.get());
@@ -58,8 +58,8 @@ class Utf8ToWideCharParserTests
         unique_ptr<wchar_t[]> output{ nullptr };
 
         VERIFY_SUCCEEDED(parser.Parse(sushi, count, consumed, output, generated));
-        VERIFY_ARE_EQUAL(consumed, (unsigned int)6);
-        VERIFY_ARE_EQUAL(generated, (unsigned int)2);
+        VERIFY_ARE_EQUAL(consumed, static_cast<unsigned int>(6));
+        VERIFY_ARE_EQUAL(generated, static_cast<unsigned int>(2));
         VERIFY_ARE_NOT_EQUAL(output.get(), nullptr);
 
         unsigned char* pReturnedBytes = reinterpret_cast<unsigned char*>(output.get());
@@ -84,15 +84,15 @@ class Utf8ToWideCharParserTests
         for (int i = 0; i < 2; ++i)
         {
             VERIFY_SUCCEEDED(parser.Parse(shi + i, count, consumed, output, generated));
-            VERIFY_ARE_EQUAL(consumed, (unsigned int)1);
-            VERIFY_ARE_EQUAL(generated, (unsigned int)0);
+            VERIFY_ARE_EQUAL(consumed, static_cast<unsigned int>(1));
+            VERIFY_ARE_EQUAL(generated, static_cast<unsigned int>(0));
             VERIFY_ARE_EQUAL(output.get(), nullptr);
             count = 1;
         }
 
         VERIFY_SUCCEEDED(parser.Parse(shi + 2, count, consumed, output, generated));
-        VERIFY_ARE_EQUAL(consumed, (unsigned int)1);
-        VERIFY_ARE_EQUAL(generated, (unsigned int)1);
+        VERIFY_ARE_EQUAL(consumed, static_cast<unsigned int>(1));
+        VERIFY_ARE_EQUAL(generated, static_cast<unsigned int>(1));
         VERIFY_ARE_NOT_EQUAL(output.get(), nullptr);
 
         unsigned char* pReturnedBytes = reinterpret_cast<unsigned char*>(output.get());
@@ -116,8 +116,8 @@ class Utf8ToWideCharParserTests
 
         VERIFY_SUCCEEDED(parser.Parse(sushi, count, consumed, output, generated));
         // check that we got the first wide char back
-        VERIFY_ARE_EQUAL(consumed, (unsigned int)4);
-        VERIFY_ARE_EQUAL(generated, (unsigned int)1);
+        VERIFY_ARE_EQUAL(consumed, static_cast<unsigned int>(4));
+        VERIFY_ARE_EQUAL(generated, static_cast<unsigned int>(1));
         VERIFY_ARE_NOT_EQUAL(output.get(), nullptr);
 
         unsigned char* pReturnedBytes = reinterpret_cast<unsigned char*>(output.get());
@@ -132,8 +132,8 @@ class Utf8ToWideCharParserTests
         generated = 0;
         output.reset(nullptr);
         VERIFY_SUCCEEDED(parser.Parse(sushi + 4, count, consumed, output, generated));
-        VERIFY_ARE_EQUAL(consumed, (unsigned int)1);
-        VERIFY_ARE_EQUAL(generated, (unsigned int)0);
+        VERIFY_ARE_EQUAL(consumed, static_cast<unsigned int>(1));
+        VERIFY_ARE_EQUAL(generated, static_cast<unsigned int>(0));
         VERIFY_ARE_EQUAL(output.get(), nullptr);
 
         // add last byte
@@ -142,8 +142,8 @@ class Utf8ToWideCharParserTests
         generated = 0;
         output.reset(nullptr);
         VERIFY_SUCCEEDED(parser.Parse(sushi + 5, count, consumed, output, generated));
-        VERIFY_ARE_EQUAL(consumed, (unsigned int)1);
-        VERIFY_ARE_EQUAL(generated, (unsigned int)1);
+        VERIFY_ARE_EQUAL(consumed, static_cast<unsigned int>(1));
+        VERIFY_ARE_EQUAL(generated, static_cast<unsigned int>(1));
         VERIFY_ARE_NOT_EQUAL(output.get(), nullptr);
 
         pReturnedBytes = reinterpret_cast<unsigned char*>(output.get());
@@ -189,8 +189,8 @@ class Utf8ToWideCharParserTests
         auto parser = Utf8ToWideCharParser{ utf8CodePage };
 
         VERIFY_SUCCEEDED(parser.Parse(doomoArigatoo, count, consumed, output, generated));
-        VERIFY_ARE_EQUAL(consumed, (unsigned int)4);
-        VERIFY_ARE_EQUAL(generated, (unsigned int)1);
+        VERIFY_ARE_EQUAL(consumed, static_cast<unsigned int>(4));
+        VERIFY_ARE_EQUAL(generated, static_cast<unsigned int>(1));
         VERIFY_ARE_NOT_EQUAL(output.get(), nullptr);
 
         unsigned char* pReturnedBytes = reinterpret_cast<unsigned char*>(output.get());
@@ -205,8 +205,8 @@ class Utf8ToWideCharParserTests
         generated = 0;
         output.reset(nullptr);
         VERIFY_SUCCEEDED(parser.Parse(doomoArigatoo + 4, count, consumed, output, generated));
-        VERIFY_ARE_EQUAL(consumed, (unsigned int)16);
-        VERIFY_ARE_EQUAL(generated, (unsigned int)5);
+        VERIFY_ARE_EQUAL(consumed, static_cast<unsigned int>(16));
+        VERIFY_ARE_EQUAL(generated, static_cast<unsigned int>(5));
         VERIFY_ARE_NOT_EQUAL(output.get(), nullptr);
 
         pReturnedBytes = reinterpret_cast<unsigned char*>(output.get());
@@ -221,8 +221,8 @@ class Utf8ToWideCharParserTests
         generated = 0;
         output.reset(nullptr);
         VERIFY_SUCCEEDED(parser.Parse(doomoArigatoo + 20, count, consumed, output, generated));
-        VERIFY_ARE_EQUAL(consumed, (unsigned int)4);
-        VERIFY_ARE_EQUAL(generated, (unsigned int)2);
+        VERIFY_ARE_EQUAL(consumed, static_cast<unsigned int>(4));
+        VERIFY_ARE_EQUAL(generated, static_cast<unsigned int>(2));
         VERIFY_ARE_NOT_EQUAL(output.get(), nullptr);
 
         pReturnedBytes = reinterpret_cast<unsigned char*>(output.get());
@@ -253,8 +253,8 @@ class Utf8ToWideCharParserTests
         auto parser = Utf8ToWideCharParser{ utf8CodePage };
 
         VERIFY_SUCCEEDED(parser.Parse(sushi, count, consumed, output, generated));
-        VERIFY_ARE_EQUAL(consumed, (unsigned int)9);
-        VERIFY_ARE_EQUAL(generated, (unsigned int)2);
+        VERIFY_ARE_EQUAL(consumed, static_cast<unsigned int>(9));
+        VERIFY_ARE_EQUAL(generated, static_cast<unsigned int>(2));
         VERIFY_ARE_NOT_EQUAL(output.get(), nullptr);
 
         unsigned char* pReturnedBytes = reinterpret_cast<unsigned char*>(output.get());
@@ -333,7 +333,7 @@ class Utf8ToWideCharParserTests
         // change to a different codepage, ensure parser is reset
         parser.SetCodePage(USACodePage);
         VERIFY_ARE_EQUAL(parser._currentState, Utf8ToWideCharParser::_State::Ready);
-        VERIFY_ARE_EQUAL(parser._bytesStored, (unsigned int)0);
+        VERIFY_ARE_EQUAL(parser._bytesStored, static_cast<unsigned int>(0));
     }
 
     TEST_METHOD(_IsLeadByteTest)
@@ -390,16 +390,16 @@ class Utf8ToWideCharParserTests
     {
         Log::Comment(L"Testing that _Utf8SequenceSize correctly counts the number of MSB 1's");
         auto parser = Utf8ToWideCharParser{ utf8CodePage };
-        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0x00), (unsigned int)0);
-        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0x80), (unsigned int)1);
-        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0xC2), (unsigned int)2);
-        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0xE3), (unsigned int)3);
-        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0xF0), (unsigned int)4);
-        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0xF3), (unsigned int)4);
-        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0xF8), (unsigned int)5);
-        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0xFC), (unsigned int)6);
-        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0xFD), (unsigned int)6);
-        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0xFE), (unsigned int)7);
-        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0xFF), (unsigned int)8);
+        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0x00), static_cast<unsigned int>(0));
+        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0x80), static_cast<unsigned int>(1));
+        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0xC2), static_cast<unsigned int>(2));
+        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0xE3), static_cast<unsigned int>(3));
+        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0xF0), static_cast<unsigned int>(4));
+        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0xF3), static_cast<unsigned int>(4));
+        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0xF8), static_cast<unsigned int>(5));
+        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0xFC), static_cast<unsigned int>(6));
+        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0xFD), static_cast<unsigned int>(6));
+        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0xFE), static_cast<unsigned int>(7));
+        VERIFY_ARE_EQUAL(parser._Utf8SequenceSize(0xFF), static_cast<unsigned int>(8));
     }
 };

--- a/src/host/ut_host/UtilsTests.cpp
+++ b/src/host/ut_host/UtilsTests.cpp
@@ -32,7 +32,7 @@ class UtilsTests
         m_state->PrepareGlobalFont();
         m_state->PrepareGlobalScreenBuffer();
 
-        UINT const seed = (UINT)time(nullptr);
+        UINT const seed = static_cast<UINT>(time(nullptr));
         Log::Comment(String().Format(L"Setting random seed to : %d", seed));
         srand(seed);
 
@@ -55,7 +55,7 @@ class UtilsTests
 
         do
         {
-            s = (SHORT)rand() % SHORT_MAX;
+            s = static_cast<SHORT>(rand()) % SHORT_MAX;
         } while (s == 0i16);
 
         return s;

--- a/src/host/ut_host/ViewportTests.cpp
+++ b/src/host/ut_host/ViewportTests.cpp
@@ -674,7 +674,7 @@ class ViewportTests
 
         do
         {
-            s = (SHORT)rand() % SHORT_MAX;
+            s = static_cast<SHORT>(rand()) % SHORT_MAX;
         } while (s == 0i16);
 
         return s;

--- a/src/host/utils.cpp
+++ b/src/host/utils.cpp
@@ -100,7 +100,7 @@ UINT s_LoadStringEx(_In_ HINSTANCE hModule, _In_ UINT wID, _Out_writes_(cchBuffe
     UINT cch = 0;
 
     // String Tables are broken up into 16 string segments.  Find the segment containing the string we are interested in.
-    HANDLE const hResInfo = FindResourceEx(hModule, RT_STRING, (LPTSTR)static_cast<LONG_PTR>((static_cast<USHORT>(wID) >> 4) + 1), wLangId);
+    HANDLE const hResInfo = FindResourceEx(hModule, RT_STRING, (LPTSTR) static_cast<LONG_PTR>((static_cast<USHORT>(wID) >> 4) + 1), wLangId);
     if (hResInfo != nullptr)
     {
         // Load that segment.

--- a/src/host/utils.cpp
+++ b/src/host/utils.cpp
@@ -25,7 +25,7 @@ short CalcCursorYOffsetInPixels(const short sFontSizeY, const ULONG ulSize) noex
 {
     // TODO: MSFT 10229700 - Note, we want to likely enforce that this isn't negative.
     // Pretty sure there's not a valid case for negative offsets here.
-    return (short)((sFontSizeY) - (ulSize));
+    return static_cast<short>((sFontSizeY) - (ulSize));
 }
 
 WORD ConvertStringToDec(_In_ PCWSTR pwchToConvert, _Out_opt_ PCWSTR* const ppwchEnd) noexcept
@@ -100,15 +100,15 @@ UINT s_LoadStringEx(_In_ HINSTANCE hModule, _In_ UINT wID, _Out_writes_(cchBuffe
     UINT cch = 0;
 
     // String Tables are broken up into 16 string segments.  Find the segment containing the string we are interested in.
-    HANDLE const hResInfo = FindResourceEx(hModule, RT_STRING, (LPTSTR)((LONG_PTR)(((USHORT)wID >> 4) + 1)), wLangId);
+    HANDLE const hResInfo = FindResourceEx(hModule, RT_STRING, (LPTSTR)static_cast<LONG_PTR>((static_cast<USHORT>(wID) >> 4) + 1), wLangId);
     if (hResInfo != nullptr)
     {
         // Load that segment.
-        HANDLE const hStringSeg = (HRSRC)LoadResource(hModule, (HRSRC)hResInfo);
+        HANDLE const hStringSeg = static_cast<HRSRC>(LoadResource(hModule, static_cast<HRSRC>(hResInfo)));
 
         // Lock the resource.
         LPTSTR lpsz;
-        if (hStringSeg != nullptr && (lpsz = (LPTSTR)LockResource(hStringSeg)) != nullptr)
+        if (hStringSeg != nullptr && (lpsz = static_cast<LPTSTR>(LockResource(hStringSeg))) != nullptr)
         {
             // Move past the other strings in this segment. (16 strings in a segment -> & 0x0F)
             wID &= 0x0F;
@@ -116,7 +116,7 @@ UINT s_LoadStringEx(_In_ HINSTANCE hModule, _In_ UINT wID, _Out_writes_(cchBuffe
             {
                 // PASCAL like string count
                 // first WCHAR is count of WCHARs
-                cch = *((WCHAR*)lpsz++);
+                cch = *static_cast<WCHAR*>(lpsz++);
                 if (wID-- == 0)
                 {
                     break;

--- a/src/interactivity/inc/IConsoleInputThread.hpp
+++ b/src/interactivity/inc/IConsoleInputThread.hpp
@@ -34,7 +34,7 @@ namespace Microsoft::Console::Interactivity
         // .ctor
         IConsoleInputThread() :
             _hThread(nullptr),
-            _dwThreadId((DWORD)(-1)) {}
+            _dwThreadId(static_cast<DWORD>(-1)) {}
 
         // Protected Variables
         HANDLE _hThread;

--- a/src/interactivity/win32/Clipboard.cpp
+++ b/src/interactivity/win32/Clipboard.cpp
@@ -70,8 +70,8 @@ void Clipboard::Paste()
         return;
     }
 
-    PWCHAR pwstr = (PWCHAR)GlobalLock(ClipboardDataHandle);
-    StringPaste(pwstr, (ULONG)GlobalSize(ClipboardDataHandle) / sizeof(WCHAR));
+    PWCHAR pwstr = static_cast<PWCHAR>(GlobalLock(ClipboardDataHandle));
+    StringPaste(pwstr, static_cast<ULONG>(GlobalSize(ClipboardDataHandle)) / sizeof(WCHAR));
 
     // WIP auditing if user is enrolled
     static std::wstring DestinationName = _LoadString(ID_CONSOLE_WIP_DESTINATIONNAME);
@@ -251,7 +251,7 @@ void Clipboard::CopyTextToSystemClipboard(const TextBuffer::TextAndColor& rows, 
     wil::unique_hglobal globalHandle(GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, cbNeeded));
     THROW_LAST_ERROR_IF_NULL(globalHandle.get());
 
-    PWSTR pwszClipboard = (PWSTR)GlobalLock(globalHandle.get());
+    PWSTR pwszClipboard = static_cast<PWSTR>(GlobalLock(globalHandle.get()));
     THROW_LAST_ERROR_IF_NULL(pwszClipboard);
 
     // The pattern gets a bit strange here because there's no good wil built-in for global lock of this type.
@@ -304,7 +304,7 @@ void Clipboard::CopyToSystemClipboard(std::string stringToCopy, LPCWSTR lpszForm
         wil::unique_hglobal globalHandleData(GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, cbData));
         THROW_LAST_ERROR_IF_NULL(globalHandleData.get());
 
-        PSTR pszClipboardHTML = (PSTR)GlobalLock(globalHandleData.get());
+        PSTR pszClipboardHTML = static_cast<PSTR>(GlobalLock(globalHandleData.get()));
         THROW_LAST_ERROR_IF_NULL(pszClipboardHTML);
 
         // The pattern gets a bit strange here because there's no good wil built-in for global lock of this type.

--- a/src/interactivity/win32/ConsoleInputThread.cpp
+++ b/src/interactivity/win32/ConsoleInputThread.cpp
@@ -14,7 +14,7 @@ using namespace Microsoft::Console::Interactivity::Win32;
 HANDLE ConsoleInputThread::Start()
 {
     HANDLE hThread = nullptr;
-    DWORD dwThreadId = (DWORD)-1;
+    DWORD dwThreadId = static_cast<DWORD>(-1);
 
     hThread = CreateThread(nullptr,
                            0,

--- a/src/interactivity/win32/consoleKeyInfo.cpp
+++ b/src/interactivity/win32/consoleKeyInfo.cpp
@@ -38,7 +38,7 @@ void StoreKeyInfo(_In_ PMSG msg)
     {
         ConsoleKeyInfo[i].hWnd = msg->hwnd;
         ConsoleKeyInfo[i].wVirtualKeyCode = LOWORD(msg->wParam);
-        ConsoleKeyInfo[i].wVirtualScanCode = (BYTE)(HIWORD(msg->lParam));
+        ConsoleKeyInfo[i].wVirtualScanCode = static_cast<BYTE>((HIWORD(msg->lParam)));
     }
     else
     {
@@ -69,7 +69,7 @@ void RetrieveKeyInfo(_In_ HWND hWnd, _Out_ PWORD pwVirtualKeyCode, _Inout_ PWORD
     }
     else
     {
-        *pwVirtualKeyCode = (WORD)MapVirtualKeyW(*pwVirtualScanCode, 3);
+        *pwVirtualKeyCode = static_cast<WORD>(MapVirtualKeyW(*pwVirtualScanCode, 3));
     }
 }
 

--- a/src/interactivity/win32/find.cpp
+++ b/src/interactivity/win32/find.cpp
@@ -40,7 +40,7 @@ INT_PTR CALLBACK FindDialogProc(HWND hWnd, UINT Message, WPARAM wParam, LPARAM l
         {
         case IDOK:
         {
-            USHORT const StringLength = (USHORT)GetDlgItemTextW(hWnd, ID_CONSOLE_FINDSTR, szBuf, ARRAYSIZE(szBuf));
+            USHORT const StringLength = static_cast<USHORT>(GetDlgItemTextW(hWnd, ID_CONSOLE_FINDSTR, szBuf, ARRAYSIZE(szBuf)));
             if (StringLength == 0)
             {
                 lastFindString.clear();

--- a/src/interactivity/win32/icon.cpp
+++ b/src/interactivity/win32/icon.cpp
@@ -186,12 +186,12 @@ Icon& Icon::Instance()
         {
 #pragma warning(push)
 #pragma warning(disable : 4302) // typecast warning from MAKEINTRESOURCE
-            _hDefaultSmIcon = (HICON)LoadImageW(nullptr,
-                                                MAKEINTRESOURCE(IDI_APPLICATION),
-                                                IMAGE_ICON,
-                                                GetSystemMetrics(SM_CXSMICON),
-                                                GetSystemMetrics(SM_CYSMICON),
-                                                LR_SHARED);
+            _hDefaultSmIcon = static_cast<HICON>(LoadImageW(nullptr,
+                                                            MAKEINTRESOURCE(IDI_APPLICATION),
+                                                            IMAGE_ICON,
+                                                            GetSystemMetrics(SM_CXSMICON),
+                                                            GetSystemMetrics(SM_CYSMICON),
+                                                            LR_SHARED));
 #pragma warning(pop)
 
             if (_hDefaultSmIcon == nullptr)

--- a/src/interactivity/win32/menu.cpp
+++ b/src/interactivity/win32/menu.cpp
@@ -266,7 +266,7 @@ void Menu::s_ShowPropertiesDialog(HWND const hwnd, BOOL const Defaults)
 
     if (fLoadedDll)
     {
-        APPLET_PROC const pfnCplApplet = (APPLET_PROC)GetProcAddress((HMODULE)hLibrary, "CPlApplet");
+        APPLET_PROC const pfnCplApplet = (APPLET_PROC)GetProcAddress(static_cast<HMODULE>(hLibrary), "CPlApplet");
         if (pfnCplApplet != nullptr)
         {
             (*pfnCplApplet)(hwnd, CPL_INIT, 0, 0);
@@ -274,7 +274,7 @@ void Menu::s_ShowPropertiesDialog(HWND const hwnd, BOOL const Defaults)
             (*pfnCplApplet)(hwnd, CPL_EXIT, 0, 0);
         }
 
-        LOG_IF_WIN32_BOOL_FALSE(FreeLibrary((HMODULE)hLibrary));
+        LOG_IF_WIN32_BOOL_FALSE(FreeLibrary(static_cast<HMODULE>(hLibrary)));
     }
 
     LockConsole();

--- a/src/interactivity/win32/window.cpp
+++ b/src/interactivity/win32/window.cpp
@@ -56,9 +56,9 @@ Window::Window() :
     _hWnd(nullptr),
     _pUiaProvider(nullptr)
 {
-    ZeroMemory((void*)&_rcClientLast, sizeof(_rcClientLast));
-    ZeroMemory((void*)&_rcNonFullscreenWindowSize, sizeof(_rcNonFullscreenWindowSize));
-    ZeroMemory((void*)&_rcFullscreenWindowSize, sizeof(_rcFullscreenWindowSize));
+    ZeroMemory(static_cast<void*>(&_rcClientLast), sizeof(_rcClientLast));
+    ZeroMemory(static_cast<void*>(&_rcNonFullscreenWindowSize), sizeof(_rcNonFullscreenWindowSize));
+    ZeroMemory(static_cast<void*>(&_rcFullscreenWindowSize), sizeof(_rcFullscreenWindowSize));
 }
 
 Window::~Window()
@@ -167,8 +167,8 @@ void Window::_UpdateSystemMetrics() const
 
     Scrolling::s_UpdateSystemMetrics();
 
-    g.sVerticalScrollSize = (SHORT)dpiApi->GetSystemMetricsForDpi(SM_CXVSCROLL, g.dpi);
-    g.sHorizontalScrollSize = (SHORT)dpiApi->GetSystemMetricsForDpi(SM_CYHSCROLL, g.dpi);
+    g.sVerticalScrollSize = static_cast<SHORT>(dpiApi->GetSystemMetricsForDpi(SM_CXVSCROLL, g.dpi));
+    g.sHorizontalScrollSize = static_cast<SHORT>(dpiApi->GetSystemMetricsForDpi(SM_CYHSCROLL, g.dpi));
 
     gci.GetCursorBlinker().UpdateSystemMetrics();
 
@@ -832,7 +832,7 @@ void Window::HorizontalScroll(const WORD wScrollCommand, const WORD wAbsoluteCha
 
     case SB_BOTTOM:
     {
-        NewOrigin.X = (WORD)(sScreenBufferSizeX - viewport.Width());
+        NewOrigin.X = static_cast<WORD>(sScreenBufferSizeX - viewport.Width());
         break;
     }
 
@@ -955,13 +955,13 @@ void Window::s_CalculateWindowRect(const COORD coordWindowInChars,
     // If the window is smaller than the buffer in width, add space at the bottom for a horizontal scroll bar
     if (coordWindowInChars.X < coordBufferSize.X)
     {
-        rectProposed.bottom += (SHORT)ServiceLocator::LocateHighDpiApi<WindowDpiApi>()->GetSystemMetricsForDpi(SM_CYHSCROLL, iDpi);
+        rectProposed.bottom += static_cast<SHORT>(ServiceLocator::LocateHighDpiApi<WindowDpiApi>()->GetSystemMetricsForDpi(SM_CYHSCROLL, iDpi));
     }
 
     // If the window is smaller than the buffer in height, add space at the right for a vertical scroll bar
     if (coordWindowInChars.Y < coordBufferSize.Y)
     {
-        rectProposed.right += (SHORT)ServiceLocator::LocateHighDpiApi<WindowDpiApi>()->GetSystemMetricsForDpi(SM_CXVSCROLL, iDpi);
+        rectProposed.right += static_cast<SHORT>(ServiceLocator::LocateHighDpiApi<WindowDpiApi>()->GetSystemMetricsForDpi(SM_CXVSCROLL, iDpi));
     }
 
     // Apply the calculated sizes to the existing window pointer
@@ -1062,7 +1062,7 @@ void Window::ChangeWindowOpacity(const short sOpacityDelta)
     }
 
     //Opacity bool is set to true when keyboard or mouse short cut used.
-    SetWindowOpacity((BYTE)iAlpha); // cast to fit is guaranteed to be within byte bounds by the checks above.
+    SetWindowOpacity(static_cast<BYTE>(iAlpha)); // cast to fit is guaranteed to be within byte bounds by the checks above.
     ApplyWindowOpacity();
 }
 

--- a/src/interactivity/win32/windowdpiapi.cpp
+++ b/src/interactivity/win32/windowdpiapi.cpp
@@ -44,7 +44,7 @@ BOOL WindowDpiApi::EnablePerMonitorDialogScaling()
 
         if (pfnFunc != nullptr)
         {
-            return (BOOL)pfnFunc();
+            return static_cast<BOOL>(pfnFunc());
         }
     }
 

--- a/src/interactivity/win32/windowio.cpp
+++ b/src/interactivity/win32/windowio.cpp
@@ -425,7 +425,7 @@ void HandleKeyEvent(const HWND hWnd,
             BYTE KeyState[256];
             if (GetKeyboardState(KeyState))
             {
-                int cwch = ToUnicodeEx((UINT)wParam, HIWORD(lParam), KeyState, awch, ARRAYSIZE(awch), TM_POSTCHARBREAKS, nullptr);
+                int cwch = ToUnicodeEx(static_cast<UINT>(wParam), HIWORD(lParam), KeyState, awch, ARRAYSIZE(awch), TM_POSTCHARBREAKS, nullptr);
                 if (cwch != 0)
                 {
                     return;
@@ -458,7 +458,7 @@ BOOL HandleSysKeyEvent(const HWND hWnd, const UINT Message, const WPARAM wParam,
 
     if (Message == WM_SYSCHAR || Message == WM_SYSDEADCHAR)
     {
-        VirtualKeyCode = (WORD)MapVirtualKeyW(LOBYTE(HIWORD(lParam)), MAPVK_VSC_TO_VK_EX);
+        VirtualKeyCode = static_cast<WORD>(MapVirtualKeyW(LOBYTE(HIWORD(lParam)), MAPVK_VSC_TO_VK_EX));
     }
     else
     {
@@ -603,7 +603,7 @@ BOOL HandleMouseEvent(const SCREEN_INFORMATION& ScreenInfo,
     {
         POINT coords = { x, y };
         ScreenToClient(ServiceLocator::LocateConsoleWindow()->GetWindowHandle(), &coords);
-        MousePosition = { (SHORT)coords.x, (SHORT)coords.y };
+        MousePosition = { static_cast<SHORT>(coords.x), static_cast<SHORT>(coords.y) };
     }
     else
     {
@@ -889,11 +889,11 @@ BOOL HandleMouseEvent(const SCREEN_INFORMATION& ScreenInfo,
         EventFlags = DOUBLE_CLICK;
         break;
     case WM_MOUSEWHEEL:
-        ButtonFlags = ((UINT)wParam & 0xFFFF0000);
+        ButtonFlags = (static_cast<UINT>(wParam) & 0xFFFF0000);
         EventFlags = MOUSE_WHEELED;
         break;
     case WM_MOUSEHWHEEL:
-        ButtonFlags = ((UINT)wParam & 0xFFFF0000);
+        ButtonFlags = (static_cast<UINT>(wParam) & 0xFFFF0000);
         EventFlags = MOUSE_HWHEELED;
         break;
     default:

--- a/src/interactivity/win32/windowproc.cpp
+++ b/src/interactivity/win32/windowproc.cpp
@@ -122,7 +122,7 @@ using namespace Microsoft::Console::Types;
         GetDpiForMonitor(hmon, MDT_EFFECTIVE_DPI, &dpix, &dpiy); // If this fails, we'll use the default of 96.
 
         // Pick one and set it to the global DPI.
-        ServiceLocator::LocateGlobals().dpi = (int)dpix;
+        ServiceLocator::LocateGlobals().dpi = static_cast<int>(dpix);
 
         _UpdateSystemMetrics(); // scroll bars and cursors and such.
         s_ReinitializeFontsForDPIChange(); // font sizes.
@@ -180,7 +180,7 @@ using namespace Microsoft::Console::Types;
         // the same client rendering that we have now.
 
         // First retrieve the new DPI and the current DPI.
-        DWORD const dpiProposed = (WORD)wParam;
+        DWORD const dpiProposed = static_cast<WORD>(wParam);
         DWORD const dpiCurrent = g.dpi;
 
         // Now we need to get what the font size *would be* if we had this new DPI. We need to ask the renderer about that.
@@ -432,7 +432,7 @@ using namespace Microsoft::Console::Types;
                 // been resized for the DPI change, so we're likely to shrink the window too much
                 // or worse yet, keep it from moving entirely. We'll get a WM_DPICHANGED,
                 // resize the window, and then process the restriction in a few window messages.
-                if (((int)dpiOfMaximum == g.dpi) &&
+                if ((static_cast<int>(dpiOfMaximum) == g.dpi) &&
                     ((szSuggested.cx > RECT_WIDTH(&rcMaximum)) || (szSuggested.cy > RECT_HEIGHT(&rcMaximum))))
                 {
                     lpwpos->cx = std::min(RECT_WIDTH(&rcMaximum), szSuggested.cx);
@@ -650,7 +650,7 @@ using namespace Microsoft::Console::Types;
 
         if (isMouseWheel || isMouseHWheel)
         {
-            short wheelDelta = (short)HIWORD(wParam);
+            short wheelDelta = static_cast<short>(HIWORD(wParam));
             bool hasShift = (wParam & MK_SHIFT) ? true : false;
 
             Scrolling::s_HandleMouseWheel(isMouseWheel,
@@ -742,7 +742,7 @@ using namespace Microsoft::Console::Types;
     case EVENT_CONSOLE_START_APPLICATION:
     case EVENT_CONSOLE_END_APPLICATION:
     {
-        NotifyWinEvent(Message, hWnd, (LONG)wParam, (LONG)lParam);
+        NotifyWinEvent(Message, hWnd, static_cast<LONG>(wParam), static_cast<LONG>(lParam));
         break;
     }
 

--- a/src/propsheet/ColorsPage.cpp
+++ b/src/propsheet/ColorsPage.cpp
@@ -26,7 +26,7 @@ static int iColor;
     switch (wMsg)
     {
     case WM_SETFOCUS:
-        if (ColorArray[iColor] != (BYTE)(ColorId - IDD_COLOR_1))
+        if (ColorArray[iColor] != static_cast<BYTE>(ColorId - IDD_COLOR_1))
         {
             hWnd = GetDlgItem(hDlg, ColorArray[iColor] + IDD_COLOR_1);
             SetFocus(hWnd);
@@ -81,12 +81,12 @@ static int iColor;
         GetClientRect(hColor, &rColor);
 
         // are we the selected color for the current object?
-        if (ColorArray[iColor] == (BYTE)(ColorId - IDD_COLOR_1))
+        if (ColorArray[iColor] == static_cast<BYTE>(ColorId - IDD_COLOR_1))
         {
             // highlight the selected color
-            FrameRect(ps.hdc, &rColor, (HBRUSH)GetStockObject(BLACK_BRUSH));
+            FrameRect(ps.hdc, &rColor, static_cast<HBRUSH>(GetStockObject(BLACK_BRUSH)));
             InflateRect(&rColor, -1, -1);
-            FrameRect(ps.hdc, &rColor, (HBRUSH)GetStockObject(BLACK_BRUSH));
+            FrameRect(ps.hdc, &rColor, static_cast<HBRUSH>(GetStockObject(BLACK_BRUSH)));
         }
 
         SimpleColorDoPaint(hColor, ps, ColorId);
@@ -129,7 +129,7 @@ bool InitColorsDialog(HWND hDlg)
 
     CreateAndAssociateToolTipToControl(IDD_TRANSPARENCY, hDlg, IDS_TOOLTIP_OPACITY);
 
-    SendMessage(GetDlgItem(hDlg, IDD_TRANSPARENCY), TBM_SETRANGE, FALSE, (LPARAM)MAKELONG(TRANSPARENCY_RANGE_MIN, BYTE_MAX));
+    SendMessage(GetDlgItem(hDlg, IDD_TRANSPARENCY), TBM_SETRANGE, FALSE, static_cast<LPARAM>(MAKELONG(TRANSPARENCY_RANGE_MIN, BYTE_MAX)));
     ToggleV2ColorControls(hDlg);
 
     return TRUE;
@@ -273,7 +273,7 @@ INT_PTR WINAPI ColorDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
             // Ignore opacity in v1 console
             if (g_fForceV2)
             {
-                gpStateInfo->bWindowTransparency = (BYTE)SendDlgItemMessage(hDlg, IDD_TRANSPARENCY, TBM_GETPOS, 0, 0);
+                gpStateInfo->bWindowTransparency = static_cast<BYTE>(SendDlgItemMessage(hDlg, IDD_TRANSPARENCY, TBM_GETPOS, 0, 0));
             }
 
             EndDlgPage(hDlg, !pshn->lParam);
@@ -324,12 +324,12 @@ INT_PTR WINAPI ColorDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
             //When moving slider with the mouse
             case TB_THUMBPOSITION:
             case TB_THUMBTRACK:
-                g_bPreviewOpacity = (BYTE)HIWORD(wParam);
+                g_bPreviewOpacity = static_cast<BYTE>(HIWORD(wParam));
                 break;
 
                 //moving via keyboard
             default:
-                g_bPreviewOpacity = (BYTE)SendMessage((HWND)lParam, TBM_GETPOS, 0, 0);
+                g_bPreviewOpacity = static_cast<BYTE>(SendMessage((HWND)lParam, TBM_GETPOS, 0, 0));
             }
 
             PreviewOpacity(hDlg, g_bPreviewOpacity);
@@ -340,12 +340,12 @@ INT_PTR WINAPI ColorDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
         break;
 
     case CM_SETCOLOR:
-        UpdateStateInfo(hDlg, iColor + IDD_COLOR_SCREEN_TEXT, (UINT)wParam);
+        UpdateStateInfo(hDlg, iColor + IDD_COLOR_SCREEN_TEXT, static_cast<UINT>(wParam));
         UpdateApplyButton(hDlg);
 
         hWndOld = GetDlgItem(hDlg, ColorArray[iColor] + IDD_COLOR_1);
 
-        ColorArray[iColor] = (BYTE)wParam;
+        ColorArray[iColor] = static_cast<BYTE>(wParam);
 
         /* Force the preview window to repaint */
 
@@ -402,7 +402,7 @@ void PreviewOpacity(HWND hDlg, BYTE bOpacity)
         WCHAR wszOpacityValue[4];
         HWND hWndConsole = gpStateInfo->hWnd;
 
-        StringCchPrintf(wszOpacityValue, ARRAYSIZE(wszOpacityValue), L"%d", (int)((float)bOpacity / BYTE_MAX * 100));
+        StringCchPrintf(wszOpacityValue, ARRAYSIZE(wszOpacityValue), L"%d", static_cast<int>(static_cast<float>(bOpacity) / BYTE_MAX * 100));
         SetDlgItemText(hDlg, IDD_OPACITY_VALUE, wszOpacityValue);
 
         if (hWndConsole)
@@ -428,6 +428,6 @@ void SetOpacitySlider(__in HWND hDlg)
         g_bPreviewOpacity = BYTE_MAX; //always fully opaque in V1
     }
 
-    SendMessage(GetDlgItem(hDlg, IDD_TRANSPARENCY), TBM_SETPOS, TRUE, (LPARAM)(g_bPreviewOpacity));
+    SendMessage(GetDlgItem(hDlg, IDD_TRANSPARENCY), TBM_SETPOS, TRUE, static_cast<LPARAM>(g_bPreviewOpacity));
     PreviewOpacity(hDlg, g_bPreviewOpacity);
 }

--- a/src/propsheet/LayoutPage.cpp
+++ b/src/propsheet/LayoutPage.cpp
@@ -143,10 +143,10 @@ INT_PTR WINAPI ScreenSizeDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lPa
                 /*
                  * Update the state info structure
                  */
-                Value = (UINT)SendDlgItemMessage(hDlg, Item + 1, UDM_GETPOS, 0, 0);
+                Value = static_cast<UINT>(SendDlgItemMessage(hDlg, Item + 1, UDM_GETPOS, 0, 0));
                 if (HIWORD(Value) == 0)
                 {
-                    UpdateStateInfo(hDlg, Item, (SHORT)LOWORD(Value));
+                    UpdateStateInfo(hDlg, Item, static_cast<SHORT>(LOWORD(Value)));
                 }
                 else
                 {

--- a/src/propsheet/OptionsPage.cpp
+++ b/src/propsheet/OptionsPage.cpp
@@ -43,8 +43,8 @@ bool OptionsCommandCallback(HWND hDlg, const unsigned int Item, const unsigned i
             LONG lListIndex;
 
             hWndLanguageCombo = GetDlgItem(hDlg, IDD_LANGUAGELIST);
-            lListIndex = (LONG)SendMessage(hWndLanguageCombo, CB_GETCURSEL, 0, 0);
-            Value = (UINT)SendMessage(hWndLanguageCombo, CB_GETITEMDATA, lListIndex, 0);
+            lListIndex = static_cast<LONG>(SendMessage(hWndLanguageCombo, CB_GETCURSEL, 0, 0));
+            Value = static_cast<UINT>(SendMessage(hWndLanguageCombo, CB_GETITEMDATA, lListIndex, 0));
             if (Value != -1)
             {
                 fChangeCodePage = (Value != gpStateInfo->CodePage);
@@ -202,7 +202,7 @@ INT_PTR WINAPI SettingsDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lPara
 
         SetDlgItemInt(hDlg, IDD_HISTORY_NUM, gpStateInfo->NumberOfHistoryBuffers, FALSE);
         SendDlgItemMessage(hDlg, IDD_HISTORY_NUM, EM_LIMITTEXT, 3, 0);
-        SendDlgItemMessage(hDlg, IDD_HISTORY_NUM, EM_SETSEL, 0, (DWORD)-1);
+        SendDlgItemMessage(hDlg, IDD_HISTORY_NUM, EM_SETSEL, 0, static_cast<DWORD>(-1));
         SendDlgItemMessage(hDlg, IDD_HISTORY_NUMSCROLL, UDM_SETRANGE, 0, MAKELONG(999, 1));
 
         if (g_fEastAsianSystem)

--- a/src/propsheet/console.cpp
+++ b/src/propsheet/console.cpp
@@ -207,38 +207,38 @@ BOOL UpdateStateInfo(HWND hDlg, UINT Item, int Value)
     switch (Item)
     {
     case IDD_SCRBUF_WIDTH:
-        gpStateInfo->ScreenBufferSize.X = (SHORT)Value;
+        gpStateInfo->ScreenBufferSize.X = static_cast<SHORT>(Value);
 
         // If we're in V2 mode with wrap text on OR if the window is larger than the buffer, adjust the window to match.
         if ((g_fForceV2 && gpStateInfo->fWrapText) || gpStateInfo->WindowSize.X > Value)
         {
-            gpStateInfo->WindowSize.X = (SHORT)Value;
+            gpStateInfo->WindowSize.X = static_cast<SHORT>(Value);
             UpdateItem(hDlg, IDD_WINDOW_WIDTH, Value);
         }
         break;
     case IDD_SCRBUF_HEIGHT:
-        gpStateInfo->ScreenBufferSize.Y = (SHORT)Value;
+        gpStateInfo->ScreenBufferSize.Y = static_cast<SHORT>(Value);
         if (gpStateInfo->WindowSize.Y > Value)
         {
-            gpStateInfo->WindowSize.Y = (SHORT)Value;
+            gpStateInfo->WindowSize.Y = static_cast<SHORT>(Value);
             UpdateItem(hDlg, IDD_WINDOW_HEIGHT, Value);
         }
         break;
     case IDD_WINDOW_WIDTH:
-        gpStateInfo->WindowSize.X = (SHORT)Value;
+        gpStateInfo->WindowSize.X = static_cast<SHORT>(Value);
 
         // If we're in V2 mode with wrap text on OR if the buffer is smaller than the window, adjust the buffer to match.
         if ((g_fForceV2 && gpStateInfo->fWrapText) || gpStateInfo->ScreenBufferSize.X < Value)
         {
-            gpStateInfo->ScreenBufferSize.X = (SHORT)Value;
+            gpStateInfo->ScreenBufferSize.X = static_cast<SHORT>(Value);
             UpdateItem(hDlg, IDD_SCRBUF_WIDTH, Value);
         }
         break;
     case IDD_WINDOW_HEIGHT:
-        gpStateInfo->WindowSize.Y = (SHORT)Value;
+        gpStateInfo->WindowSize.Y = static_cast<SHORT>(Value);
         if (gpStateInfo->ScreenBufferSize.Y < Value)
         {
-            gpStateInfo->ScreenBufferSize.Y = (SHORT)Value;
+            gpStateInfo->ScreenBufferSize.Y = static_cast<SHORT>(Value);
             UpdateItem(hDlg, IDD_SCRBUF_HEIGHT, Value);
         }
         break;
@@ -273,7 +273,7 @@ BOOL UpdateStateInfo(HWND hDlg, UINT Item, int Value)
     case IDD_COLOR_SCREEN_BKGND:
         gpStateInfo->ScreenAttributes =
             (gpStateInfo->ScreenAttributes & 0x0F) |
-            (WORD)(Value << 4);
+            static_cast<WORD>(Value << 4);
         break;
     case IDD_COLOR_POPUP_TEXT:
         gpStateInfo->PopupAttributes =
@@ -283,7 +283,7 @@ BOOL UpdateStateInfo(HWND hDlg, UINT Item, int Value)
     case IDD_COLOR_POPUP_BKGND:
         gpStateInfo->PopupAttributes =
             (gpStateInfo->PopupAttributes & 0x0F) |
-            (WORD)(Value << 4);
+            static_cast<WORD>(Value << 4);
         break;
     case IDD_COLOR_1:
     case IDD_COLOR_2:
@@ -402,8 +402,8 @@ PWSTR TranslateConsoleTitle(_In_ PCWSTR pwszConsoleTitle)
             if (SUCCEEDED(StringCbLengthW(pwszConsoleTitle, STRSAFE_MAX_CCH, &cbConsoleTitle)) &&
                 SUCCEEDED(StringCbLengthW(pwszSysRoot, MAX_PATH, &cbSystemRoot)))
             {
-                int const cchSystemRoot = (int)(cbSystemRoot / sizeof(WCHAR));
-                int const cchConsoleTitle = (int)(cbConsoleTitle / sizeof(WCHAR));
+                int const cchSystemRoot = static_cast<int>(cbSystemRoot / sizeof(WCHAR));
+                int const cchConsoleTitle = static_cast<int>(cbConsoleTitle / sizeof(WCHAR));
                 cbConsoleTitle += sizeof(WCHAR); // account for nullptr terminator
 
                 if (fUnexpand &&
@@ -422,7 +422,7 @@ PWSTR TranslateConsoleTitle(_In_ PCWSTR pwszConsoleTitle)
 
                 LPWSTR TranslatedConsoleTitle;
                 // This has to be a HeapAlloc, because it gets HeapFree'd later
-                Tmp = TranslatedConsoleTitle = (LPWSTR)HeapAlloc(GetProcessHeap(), 0, (cchSystemRoot + cchConsoleTitle) * sizeof(WCHAR));
+                Tmp = TranslatedConsoleTitle = static_cast<LPWSTR>(HeapAlloc(GetProcessHeap(), 0, (cchSystemRoot + cchConsoleTitle) * sizeof(WCHAR)));
 
                 if (TranslatedConsoleTitle == nullptr)
                 {
@@ -438,7 +438,7 @@ PWSTR TranslateConsoleTitle(_In_ PCWSTR pwszConsoleTitle)
                     if (fSubstitute && *pwszConsoleTitle == '\\')
                     {
 #pragma prefast(suppress : 26019, "Console title must contain system root if this path was followed.")
-                        *TranslatedConsoleTitle++ = (WCHAR)'_';
+                        *TranslatedConsoleTitle++ = static_cast<WCHAR>('_');
                     }
                     else
                     {
@@ -714,7 +714,7 @@ void RegisterClasses(HINSTANCE hModule)
 
     wc.lpszClassName = TEXT("WOAFontPreview");
     wc.lpfnWndProc = FontPreviewWndProc;
-    wc.hbrBackground = (HBRUSH)GetStockObject(BLACK_BRUSH);
+    wc.hbrBackground = static_cast<HBRUSH>(GetStockObject(BLACK_BRUSH));
     wc.style = 0;
     RegisterClass(&wc);
 }

--- a/src/propsheet/dbcs.cpp
+++ b/src/propsheet/dbcs.cpp
@@ -38,17 +38,17 @@ void MakeAltRasterFont(
     BOOL fDbcsCharSet = IS_ANY_DBCS_CHARSET(CodePageToCharSet(CodePage));
 
     FontIndex = 0;
-    Find = (DWORD)-1;
+    Find = static_cast<DWORD>(-1);
     for (i = 0; i < NumberOfFonts; i++)
     {
         if (!TM_IS_TT_FONT(FontInfo[i].Family) &&
             IS_ANY_DBCS_CHARSET(FontInfo[i].tmCharSet) == fDbcsCharSet)
         {
-            FontDelta.X = (SHORT)abs(FontSize.X - FontInfo[i].Size.X);
-            FontDelta.Y = (SHORT)abs(FontSize.Y - FontInfo[i].Size.Y);
-            if (Find > (DWORD)(FontDelta.X + FontDelta.Y))
+            FontDelta.X = static_cast<SHORT>(abs(FontSize.X - FontInfo[i].Size.X));
+            FontDelta.Y = static_cast<SHORT>(abs(FontSize.Y - FontInfo[i].Size.Y));
+            if (Find > static_cast<DWORD>(FontDelta.X + FontDelta.Y))
             {
-                Find = (DWORD)(FontDelta.X + FontDelta.Y);
+                Find = static_cast<DWORD>(FontDelta.X + FontDelta.Y);
                 FontIndex = i;
             }
         }
@@ -74,12 +74,12 @@ BYTE CodePageToCharSet(
 {
     CHARSETINFO csi;
 
-    if (!TranslateCharsetInfo((DWORD*)IntToPtr(CodePage), &csi, TCI_SRCCODEPAGE))
+    if (!TranslateCharsetInfo(static_cast<DWORD*>(IntToPtr(CodePage)), &csi, TCI_SRCCODEPAGE))
     {
         csi.ciCharset = OEM_CHARSET;
     }
 
-    return (BYTE)csi.ciCharset;
+    return static_cast<BYTE>(csi.ciCharset);
 }
 
 LPTTFONTLIST
@@ -191,10 +191,10 @@ int LanguageListCreate(
     oemcp = GetOEMCP();
     if (GetCPInfoExW(oemcp, 0, &cpinfo))
     {
-        lListIndex = (LONG)SendMessage(hWndLanguageCombo, CB_ADDSTRING, 0, (LPARAM)cpinfo.CodePageName);
+        lListIndex = static_cast<LONG>(SendMessage(hWndLanguageCombo, CB_ADDSTRING, 0, (LPARAM)cpinfo.CodePageName));
         if (lListIndex != CB_ERR)
         {
-            SendMessage(hWndLanguageCombo, CB_SETITEMDATA, (DWORD)lListIndex, oemcp);
+            SendMessage(hWndLanguageCombo, CB_SETITEMDATA, static_cast<DWORD>(lListIndex), oemcp);
 
             if (CodePage == oemcp)
             {
@@ -206,10 +206,10 @@ int LanguageListCreate(
     // Add SBCS 437 OEM - United States to the list
     if (GetCPInfoExW(437, 0, &cpinfo))
     {
-        lListIndex = (LONG)SendMessage(hWndLanguageCombo, CB_ADDSTRING, 0, (LPARAM)cpinfo.CodePageName);
+        lListIndex = static_cast<LONG>(SendMessage(hWndLanguageCombo, CB_ADDSTRING, 0, (LPARAM)cpinfo.CodePageName));
         if (lListIndex != CB_ERR)
         {
-            SendMessage(hWndLanguageCombo, CB_SETITEMDATA, (DWORD)lListIndex, 437);
+            SendMessage(hWndLanguageCombo, CB_SETITEMDATA, static_cast<DWORD>(lListIndex), 437);
 
             if (CodePage == 437)
             {
@@ -222,8 +222,8 @@ int LanguageListCreate(
      * Get the LocaleIndex from the currently selected item.
      * (i will be LB_ERR if no currently selected item).
      */
-    lListIndex = (LONG)SendMessage(hWndLanguageCombo, CB_GETCURSEL, 0, 0L);
-    const int iRet = (int)SendMessage(hWndLanguageCombo, CB_GETITEMDATA, lListIndex, 0L);
+    lListIndex = static_cast<LONG>(SendMessage(hWndLanguageCombo, CB_GETCURSEL, 0, 0L));
+    const int iRet = static_cast<int>(SendMessage(hWndLanguageCombo, CB_GETITEMDATA, lListIndex, 0L));
 
     EnableWindow(hWndLanguageCombo, g_fEastAsianSystem);
 

--- a/src/propsheet/fontdlg.cpp
+++ b/src/propsheet/fontdlg.cpp
@@ -82,7 +82,7 @@ UINT GetItemHeight(const HWND hDlg)
     HFONT hFont = GetWindowFont(hDlg);
     if (hFont)
     {
-        hFont = (HFONT)SelectObject(hDC, hFont);
+        hFont = static_cast<HFONT>(SelectObject(hDC, hFont));
     }
     TEXTMETRIC tm;
     GetTextMetrics(hDC, &tm);
@@ -164,32 +164,32 @@ static void AddCustomFontSizeToListIfNeeded(__in const HWND hDlg)
     {
         // we have text, now retrieve it as an actual size
         BOOL fTranslated;
-        const SHORT nPointSize = (SHORT)GetDlgItemInt(hDlg, IDD_POINTSLIST, &fTranslated, TRUE);
+        const SHORT nPointSize = static_cast<SHORT>(GetDlgItemInt(hDlg, IDD_POINTSLIST, &fTranslated, TRUE));
         if (fTranslated &&
             nPointSize >= MIN_PIXEL_HEIGHT &&
             nPointSize <= MAX_PIXEL_HEIGHT &&
             IsFontSizeCustom(gpStateInfo->FaceName, nPointSize))
         {
             // we got a proper custom size. let's see if it's in our point size list
-            LONG iSize = (LONG)SendDlgItemMessage(hDlg, IDD_POINTSLIST, CB_FINDSTRINGEXACT, (WPARAM)-1, (LPARAM)wszBuf);
+            LONG iSize = static_cast<LONG>(SendDlgItemMessage(hDlg, IDD_POINTSLIST, CB_FINDSTRINGEXACT, static_cast<WPARAM>(-1), (LPARAM)wszBuf));
             if (iSize == CB_ERR)
             {
                 // the size isn't in our list, so we haven't created them yet. do so now.
                 CreateSizeForAllTTFonts(nPointSize);
 
                 // add the size to the dialog list and select it
-                iSize = (LONG)SendDlgItemMessage(hDlg, IDD_POINTSLIST, CB_ADDSTRING, 0, (LPARAM)wszBuf);
+                iSize = static_cast<LONG>(SendDlgItemMessage(hDlg, IDD_POINTSLIST, CB_ADDSTRING, 0, (LPARAM)wszBuf));
                 SendDlgItemMessage(hDlg, IDD_POINTSLIST, CB_SETCURSEL, iSize, 0);
 
                 // get the current font selection
-                LONG lCurrentFont = (LONG)SendDlgItemMessage(hDlg, IDD_FACENAME, LB_GETCURSEL, 0, 0);
+                LONG lCurrentFont = static_cast<LONG>(SendDlgItemMessage(hDlg, IDD_FACENAME, LB_GETCURSEL, 0, 0));
 
                 // now get the current font's face name
                 WCHAR wszFontFace[LF_FACESIZE];
                 SendDlgItemMessage(hDlg,
                                    IDD_FACENAME,
                                    LB_GETTEXT,
-                                   (WPARAM)lCurrentFont,
+                                   static_cast<WPARAM>(lCurrentFont),
                                    (LPARAM)wszFontFace);
 
                 // now cause the hFont for this face/size combination to get loaded -- we need to do this so that the
@@ -202,7 +202,7 @@ static void AddCustomFontSizeToListIfNeeded(__in const HWND hDlg)
                                                  coordFontSize,
                                                  0,
                                                  gpStateInfo->CodePage);
-                SendDlgItemMessage(hDlg, IDD_POINTSLIST, CB_SETITEMDATA, (WPARAM)iSize, (LPARAM)iFont);
+                SendDlgItemMessage(hDlg, IDD_POINTSLIST, CB_SETITEMDATA, static_cast<WPARAM>(iSize), static_cast<LPARAM>(iFont));
             }
         }
     }
@@ -368,8 +368,8 @@ FontDlgProc(
                 LONG l;
 
                 DBGFONTS(("LBN_SELCHANGE from FACENAME\n"));
-                l = (LONG)SendDlgItemMessage(hDlg, IDD_FACENAME, LB_GETCURSEL, 0, 0L);
-                bLB = (BOOL)SendDlgItemMessage(hDlg, IDD_FACENAME, LB_GETITEMDATA, l, 0L);
+                l = static_cast<LONG>(SendDlgItemMessage(hDlg, IDD_FACENAME, LB_GETCURSEL, 0, 0L));
+                bLB = static_cast<BOOL>(SendDlgItemMessage(hDlg, IDD_FACENAME, LB_GETITEMDATA, l, 0L));
                 if (!bLB)
                 {
                     SendDlgItemMessage(hDlg, IDD_FACENAME, LB_GETTEXT, l, (LPARAM)atchNewFace);
@@ -673,7 +673,7 @@ void AddFontSizesToList(PCWSTR pwszTTFace,
                   fRasterFont ? "PIXEL" : "POINT",
                   hWndShow,
                   lListIndex));
-        lcbSETITEMDATA(hWndShow, fRasterFont, (DWORD)lListIndex, i);
+        lcbSETITEMDATA(hWndShow, fRasterFont, static_cast<DWORD>(lListIndex), i);
     }
 }
 
@@ -744,7 +744,7 @@ int FontListCreate(
 
         // before doing anything else, add raster fonts to the list. Note that the item data being set here indicates
         // that it's a raster font. the actual font indices are stored as item data on the pixels list.
-        lListIndex = (LONG)SendMessage(hWndFaceCombo, LB_ADDSTRING, 0, (LPARAM)wszRasterFonts);
+        lListIndex = static_cast<LONG>(SendMessage(hWndFaceCombo, LB_ADDSTRING, 0, (LPARAM)wszRasterFonts));
         SendMessage(hWndFaceCombo, LB_SETITEMDATA, lListIndex, TRUE);
         DBGFONTS(("Added \"%ls\", set Item Data %d = TRUE\n", wszRasterFonts, lListIndex));
 
@@ -774,7 +774,7 @@ int FontListCreate(
                     fFindTTFont = TRUE;
                 }
 
-                lListIndex = (LONG)SendMessage(hWndFaceCombo, LB_ADDSTRING, 0, (LPARAM)panFace->atch);
+                lListIndex = static_cast<LONG>(SendMessage(hWndFaceCombo, LB_ADDSTRING, 0, (LPARAM)panFace->atch));
                 SendMessage(hWndFaceCombo, LB_SETITEMDATA, lListIndex, FALSE);
                 DBGFONTS(("Added \"%ls\", set Item Data %d = FALSE\n",
                           panFace->atch,
@@ -888,7 +888,7 @@ int FontListCreate(
     i = lcbGETITEMDATA(hWndShow, bLB, lListIndex);
 
     DBGFONTS(("FontListCreate returns 0x%x\n", i));
-    FAIL_FAST_IF(!(i == LB_ERR || (ULONG)i < NumberOfFonts));
+    FAIL_FAST_IF(!(i == LB_ERR || static_cast<ULONG>(i) < NumberOfFonts));
     return i;
 }
 
@@ -916,7 +916,7 @@ VOID DrawItemFontList(const HWND hDlg, const LPDRAWITEMSTRUCT lpdis)
     HWND hWndItem;
     BOOL bLB;
 
-    if ((int)lpdis->itemID < 0)
+    if (static_cast<int>(lpdis->itemID) < 0)
     {
         return;
     }
@@ -971,13 +971,13 @@ VOID DrawItemFontList(const HWND hDlg, const LPDRAWITEMSTRUCT lpdis)
         }
 
         SendMessage(hWndItem, LB_GETTEXT, lpdis->itemID, (LPARAM)wszFace);
-        bLB = (BOOL)SendMessage(hWndItem, LB_GETITEMDATA, lpdis->itemID, 0L);
+        bLB = static_cast<BOOL>(SendMessage(hWndItem, LB_GETITEMDATA, lpdis->itemID, 0L));
         dxttbmp = bLB ? 0 : bmTT.bmWidth;
 
         DBGFONTS(("DrawItemFontList must redraw \"%ls\" %s\n", wszFace, bLB ? "Raster" : "TrueType"));
 
         // draw the text
-        TabbedTextOut(hDC, lpdis->rcItem.left + dxttbmp, lpdis->rcItem.top, wszFace, (UINT)wcslen(wszFace), 0, nullptr, dxttbmp);
+        TabbedTextOut(hDC, lpdis->rcItem.left + dxttbmp, lpdis->rcItem.top, wszFace, static_cast<UINT>(wcslen(wszFace)), 0, nullptr, dxttbmp);
 
         // and the TT bitmap if needed
         if (!bLB)
@@ -985,7 +985,7 @@ VOID DrawItemFontList(const HWND hDlg, const LPDRAWITEMSTRUCT lpdis)
             hdcMem = CreateCompatibleDC(hDC);
             if (hdcMem)
             {
-                hOld = (HBITMAP)SelectObject(hdcMem, hbmTT);
+                hOld = static_cast<HBITMAP>(SelectObject(hdcMem, hbmTT));
 
                 dy = ((lpdis->rcItem.bottom - lpdis->rcItem.top) - bmTT.bmHeight) / 2;
 
@@ -1086,9 +1086,9 @@ Return Value:
         SetTextColor(ps.hdc, rgbText);
         SetBkColor(ps.hdc, rgbBk);
         GetClientRect(hWnd, &rect);
-        hfontOld = (HFONT)SelectObject(ps.hdc, FontInfo[g_currentFontIndex].hFont);
+        hfontOld = static_cast<HFONT>(SelectObject(ps.hdc, FontInfo[g_currentFontIndex].hFont));
         hbrNew = CreateSolidBrush(rgbBk);
-        hbrOld = (HBRUSH)SelectObject(ps.hdc, hbrNew);
+        hbrOld = static_cast<HBRUSH>(SelectObject(ps.hdc, hbrNew));
         PatBlt(ps.hdc, rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top, PATCOPY);
         InflateRect(&rect, -2, -2);
         DrawText(ps.hdc, g_szPreviewText, -1, &rect, 0);
@@ -1222,7 +1222,7 @@ TryFindExactFont:
         /*
          * If looking for a particular Family, skip non-matches
          */
-        if (Family != 0 && (BYTE)Family != FontInfo[i].Family)
+        if (Family != 0 && static_cast<BYTE>(Family) != FontInfo[i].Family)
         {
             continue;
         }
@@ -1304,7 +1304,7 @@ TryFindExactFont:
     {
         if (g_fEastAsianSystem)
         {
-            if (Family != 0 && (BYTE)Family != FontInfo[i].Family)
+            if (Family != 0 && static_cast<BYTE>(Family) != FontInfo[i].Family)
             {
                 continue;
             }
@@ -1317,7 +1317,7 @@ TryFindExactFont:
         }
         else
         {
-            if ((BYTE)Family != FontInfo[i].Family)
+            if (static_cast<BYTE>(Family) != FontInfo[i].Family)
             {
                 continue;
             }
@@ -1352,7 +1352,7 @@ TryFindExactFont:
     }
 
 FoundFont:
-    FAIL_FAST_IF(!(FontIndex < (int)NumberOfFonts));
+    FAIL_FAST_IF(!(FontIndex < static_cast<int>(NumberOfFonts)));
     DBGFONTS(("FindCreateFont returns %x : %ls (%d,%d)\n", FontIndex, FontInfo[FontIndex].FaceName, FontInfo[FontIndex].Size.X, FontInfo[FontIndex].Size.Y));
     return FontIndex;
 
@@ -1423,7 +1423,7 @@ int SelectCurrentSize(HWND hDlg, BOOL bLB, int FontIndex)
             while (iCB > 0)
             {
                 iCB--;
-                if (lcbGETITEMDATA(hWndList, bLB, iCB) == (int)AltFontIndex)
+                if (lcbGETITEMDATA(hWndList, bLB, iCB) == static_cast<int>(AltFontIndex))
                 {
                     lcbSETCURSEL(hWndList, bLB, iCB);
                     break;
@@ -1462,7 +1462,7 @@ BOOL SelectCurrentFont(
     SendDlgItemMessage(hDlg,
                        IDD_FACENAME,
                        LB_SELECTSTRING,
-                       (WPARAM)-1,
+                       static_cast<WPARAM>(-1),
                        bLB ? (LPARAM)wszRasterFonts : (LPARAM)FontInfo[FontIndex].FaceName);
 
     SelectCurrentSize(hDlg, bLB, FontIndex);
@@ -1495,7 +1495,7 @@ BOOL PreviewInit(
     DBGFONTS(("Changing Font Number from %d to %d\n",
               g_currentFontIndex,
               nFont));
-    FAIL_FAST_IF(!((ULONG)nFont < NumberOfFonts));
+    FAIL_FAST_IF(!(static_cast<ULONG>(nFont) < NumberOfFonts));
     g_currentFontIndex = nFont;
 
     if (g_fHostedInFileProperties)
@@ -1542,10 +1542,10 @@ BOOL PreviewUpdate(
     {
         COORD NewSize;
 
-        lIndex = (LONG)SendDlgItemMessage(hDlg, IDD_FACENAME, LB_GETCURSEL, 0, 0L);
+        lIndex = static_cast<LONG>(SendDlgItemMessage(hDlg, IDD_FACENAME, LB_GETCURSEL, 0, 0L));
         SendDlgItemMessage(hDlg, IDD_FACENAME, LB_GETTEXT, lIndex, (LPARAM)wszFace);
         NewSize.X = 0;
-        NewSize.Y = (SHORT)GetPointSizeInRange(hDlg, MIN_PIXEL_HEIGHT, MAX_PIXEL_HEIGHT);
+        NewSize.Y = static_cast<SHORT>(GetPointSizeInRange(hDlg, MIN_PIXEL_HEIGHT, MAX_PIXEL_HEIGHT));
 
         if (NewSize.Y == 0)
         {
@@ -1587,13 +1587,13 @@ BOOL PreviewUpdate(
     /*
      * If we've selected a new font, tell the property sheet we've changed
      */
-    FAIL_FAST_IF(!((ULONG)FontIndex < NumberOfFonts));
-    if ((ULONG)FontIndex >= NumberOfFonts)
+    FAIL_FAST_IF(!(static_cast<ULONG>(FontIndex) < NumberOfFonts));
+    if (static_cast<ULONG>(FontIndex) >= NumberOfFonts)
     {
         FontIndex = 0;
     }
 
-    if (g_currentFontIndex != (ULONG)FontIndex)
+    if (g_currentFontIndex != static_cast<ULONG>(FontIndex))
     {
         g_currentFontIndex = FontIndex;
     }

--- a/src/propsheet/init.cpp
+++ b/src/propsheet/init.cpp
@@ -98,7 +98,7 @@ LONG CPlApplet(
         lpCPlInfo->dwHelpContext = 0;
         lpCPlInfo->szHelpFile[0] = TEXT('\0');
 
-        return (LONG)TRUE;
+        return static_cast<LONG>(TRUE);
 
     case CPL_DBLCLK:
         ConsolePropertySheet(hwnd, (PCONSOLE_STATE_INFO)lParam1);
@@ -109,5 +109,5 @@ LONG CPlApplet(
         break;
     }
 
-    return (LONG)0;
+    return static_cast<LONG>(0);
 }

--- a/src/propsheet/misc.cpp
+++ b/src/propsheet/misc.cpp
@@ -104,9 +104,9 @@ AddFaceNode(
     }
 
     cch = wcslen(ptsz);
-    pNew = (PFACENODE)HeapAlloc(GetProcessHeap(),
-                                0,
-                                sizeof(FACENODE) + ((cch + 1) * sizeof(WCHAR)));
+    pNew = static_cast<PFACENODE>(HeapAlloc(GetProcessHeap(),
+                                            0,
+                                            sizeof(FACENODE) + ((cch + 1) * sizeof(WCHAR))));
     if (pNew == nullptr)
     {
         return nullptr;
@@ -221,12 +221,12 @@ int AddFont(
     LPTSTR ptszFace = pelf->elfLogFont.lfFaceName;
 
     /* get font info */
-    SizeWant.X = (SHORT)pelf->elfLogFont.lfWidth;
-    SizeWant.Y = (SHORT)pelf->elfLogFont.lfHeight;
+    SizeWant.X = static_cast<SHORT>(pelf->elfLogFont.lfWidth);
+    SizeWant.Y = static_cast<SHORT>(pelf->elfLogFont.lfHeight);
 
     /* save original size request so that we can use it unmodified when doing DPI calculations */
-    SizeOriginal.X = (SHORT)pelf->elfLogFont.lfWidth;
-    SizeOriginal.Y = (SHORT)pelf->elfLogFont.lfHeight;
+    SizeOriginal.X = static_cast<SHORT>(pelf->elfLogFont.lfWidth);
+    SizeOriginal.Y = static_cast<SHORT>(pelf->elfLogFont.lfHeight);
 
 CreateBoldFont:
     pelf->elfLogFont.lfQuality = DEFAULT_QUALITY;
@@ -243,8 +243,8 @@ CreateBoldFont:
     GetTextMetrics(hDC, &tm);
 
     GetTextExtentPoint32(hDC, TEXT("0"), 1, &Size);
-    SizeActual.X = (SHORT)Size.cx;
-    SizeActual.Y = (SHORT)(tm.tmHeight + tm.tmExternalLeading);
+    SizeActual.X = static_cast<SHORT>(Size.cx);
+    SizeActual.Y = static_cast<SHORT>(tm.tmHeight + tm.tmExternalLeading);
     DBGFONTS2(("    actual size %d,%d\n", SizeActual.X, SizeActual.Y));
     tmFamily = tm.tmPitchAndFamily;
     if (TM_IS_TT_FONT(tmFamily) && (SizeWant.Y >= 0))
@@ -356,10 +356,10 @@ CreateBoldFont:
         FontInfoLength += FONT_INCREMENT;
         if (FontInfoLength < MAX_FONT_INFO_ALLOC)
         {
-            Temp = (PFONT_INFO)HeapReAlloc(GetProcessHeap(),
-                                           0,
-                                           FontInfo,
-                                           sizeof(FONT_INFO) * FontInfoLength);
+            Temp = static_cast<PFONT_INFO>(HeapReAlloc(GetProcessHeap(),
+                                                       0,
+                                                       FontInfo,
+                                                       sizeof(FONT_INFO) * FontInfoLength));
         }
 
         if (Temp == nullptr)
@@ -946,7 +946,7 @@ EnumerateFonts(
         //
         NumberOfFonts = 0;
 
-        FontInfo = (PFONT_INFO)HeapAlloc(GetProcessHeap(), 0, sizeof(FONT_INFO) * INITIAL_FONTS);
+        FontInfo = static_cast<PFONT_INFO>(HeapAlloc(GetProcessHeap(), 0, sizeof(FONT_INFO) * INITIAL_FONTS));
         if (FontInfo == nullptr)
         {
             return STATUS_NO_MEMORY;
@@ -963,8 +963,8 @@ EnumerateFonts(
         GetTextMetrics(hDC, &tm);
         GetTextFace(hDC, LF_FACESIZE, DefaultFaceName);
 
-        DefaultFontSize.X = (SHORT)(tm.tmMaxCharWidth);
-        DefaultFontSize.Y = (SHORT)(tm.tmHeight + tm.tmExternalLeading);
+        DefaultFontSize.X = static_cast<SHORT>(tm.tmMaxCharWidth);
+        DefaultFontSize.Y = static_cast<SHORT>(tm.tmHeight + tm.tmExternalLeading);
         DefaultFontFamily = tm.tmPitchAndFamily;
 
         if (IS_ANY_DBCS_CHARSET(tm.tmCharSet))

--- a/src/propsheet/preview.cpp
+++ b/src/propsheet/preview.cpp
@@ -226,7 +226,7 @@ VOID PreviewPaint(
     hBitmap = CreateCompatibleBitmap(pPS->hdc,
                                      rectPreview.right,
                                      rectPreview.bottom);
-    hBitmapOld = (HBITMAP)SelectObject(hDC, hBitmap);
+    hBitmapOld = static_cast<HBITMAP>(SelectObject(hDC, hBitmap));
 
     /*
      * Create the brushes
@@ -248,7 +248,7 @@ VOID PreviewPaint(
     /*
      * Fill in the whole window with the client brush
      */
-    hbrOld = (HBRUSH)SelectObject(hDC, hbrClient);
+    hbrOld = static_cast<HBRUSH>(SelectObject(hDC, hbrClient));
     PatBlt(hDC, rectWin.left, rectWin.top, rectWin.right - 1, rectWin.bottom - 1, PATCOPY);
 
     /*

--- a/src/propsheet/registry.cpp
+++ b/src/propsheet/registry.cpp
@@ -234,7 +234,7 @@ DWORD GetRegistryValues(
                                                  nullptr);
     if (NT_SUCCESS(Status))
     {
-        pStateInfo->ScreenAttributes = (WORD)dwValue;
+        pStateInfo->ScreenAttributes = static_cast<WORD>(dwValue);
     }
 
     //
@@ -249,7 +249,7 @@ DWORD GetRegistryValues(
                                                  nullptr);
     if (NT_SUCCESS(Status))
     {
-        pStateInfo->PopupAttributes = (WORD)dwValue;
+        pStateInfo->PopupAttributes = static_cast<WORD>(dwValue);
     }
 
     //
@@ -317,7 +317,7 @@ DWORD GetRegistryValues(
     {
         if (IsValidCodePage(dwValue))
         {
-            pStateInfo->CodePage = (UINT)dwValue;
+            pStateInfo->CodePage = static_cast<UINT>(dwValue);
         }
     }
 
@@ -362,8 +362,8 @@ DWORD GetRegistryValues(
                                                  nullptr);
     if (NT_SUCCESS(Status))
     {
-        pStateInfo->WindowPosX = (SHORT)LOWORD(dwValue);
-        pStateInfo->WindowPosY = (SHORT)HIWORD(dwValue);
+        pStateInfo->WindowPosX = static_cast<SHORT>(LOWORD(dwValue));
+        pStateInfo->WindowPosY = static_cast<SHORT>(HIWORD(dwValue));
         pStateInfo->AutoPosition = FALSE;
     }
 
@@ -550,7 +550,7 @@ DWORD GetRegistryValues(
     {
         if (dwValue <= BYTE_MAX)
         {
-            pStateInfo->bWindowTransparency = (BYTE)dwValue;
+            pStateInfo->bWindowTransparency = static_cast<BYTE>(dwValue);
         }
     }
 
@@ -781,7 +781,7 @@ VOID SetRegistryValues(
     FAIL_FAST_IF(!(OEMCP != 0));
     if (g_fEastAsianSystem)
     {
-        dwValue = (DWORD)pStateInfo->CodePage;
+        dwValue = static_cast<DWORD>(pStateInfo->CodePage);
         LOG_IF_FAILED(RegistrySerialization::s_UpdateValue(hConsoleKey,
                                                            hTitleKey,
                                                            CONSOLE_REGISTRY_CODEPAGE,
@@ -867,7 +867,7 @@ VOID SetRegistryValues(
                                                        CONSOLE_REGISTRY_FACENAME,
                                                        REG_SZ,
                                                        (BYTE*)(pStateInfo->FaceName),
-                                                       (DWORD)(wcslen(pStateInfo->FaceName) + 1) * sizeof(TCHAR)));
+                                                       static_cast<DWORD>(wcslen(pStateInfo->FaceName)+ 1) * sizeof(TCHAR)));
 
     //
     // Save cursor size

--- a/src/propsheet/registry.cpp
+++ b/src/propsheet/registry.cpp
@@ -867,7 +867,7 @@ VOID SetRegistryValues(
                                                        CONSOLE_REGISTRY_FACENAME,
                                                        REG_SZ,
                                                        (BYTE*)(pStateInfo->FaceName),
-                                                       static_cast<DWORD>(wcslen(pStateInfo->FaceName)+ 1) * sizeof(TCHAR)));
+                                                       static_cast<DWORD>(wcslen(pStateInfo->FaceName) + 1) * sizeof(TCHAR)));
 
     //
     // Save cursor size

--- a/src/propslib/ShortcutSerialization.cpp
+++ b/src/propslib/ShortcutSerialization.cpp
@@ -434,8 +434,8 @@ void ShortcutSerialization::s_GetLinkTitle(_In_ PCWSTR pwszShortcutFilename,
         {
             // Now the link is loaded, generate new console settings section to replace the one in the link.
             NT_CONSOLE_PROPS props;
-            ((LPDBLIST)&props)->cbSize = sizeof(props);
-            ((LPDBLIST)&props)->dwSignature = NT_CONSOLE_PROPS_SIG;
+            reinterpret_cast<LPDBLIST>(&props)->cbSize = sizeof(props);
+            reinterpret_cast<LPDBLIST>(&props)->dwSignature = NT_CONSOLE_PROPS_SIG;
             props.wFillAttribute = pStateInfo->ScreenAttributes;
             props.wPopupFillAttribute = pStateInfo->PopupAttributes;
             props.dwScreenBufferSize = pStateInfo->ScreenBufferSize;
@@ -468,8 +468,8 @@ void ShortcutSerialization::s_GetLinkTitle(_In_ PCWSTR pwszShortcutFilename,
             if (SUCCEEDED(hr) && fEastAsianSystem)
             {
                 NT_FE_CONSOLE_PROPS fe_props;
-                ((LPDBLIST)&fe_props)->cbSize = sizeof(fe_props);
-                ((LPDBLIST)&fe_props)->dwSignature = NT_FE_CONSOLE_PROPS_SIG;
+                reinterpret_cast<LPDBLIST>(&fe_props)->cbSize = sizeof(fe_props);
+                reinterpret_cast<LPDBLIST>(&fe_props)->dwSignature = NT_FE_CONSOLE_PROPS_SIG;
                 fe_props.uCodePage = pStateInfo->CodePage;
 
                 hr = psldl->RemoveDataBlock(NT_FE_CONSOLE_PROPS_SIG);

--- a/src/propslib/ShortcutSerialization.cpp
+++ b/src/propslib/ShortcutSerialization.cpp
@@ -95,7 +95,7 @@ void ShortcutSerialization::s_SetLinkPropertyDwordValue(_Inout_ IPropertyStore* 
             hr = (sValue >= 0 && sValue <= BYTE_MAX) ? S_OK : E_INVALIDARG;
             if (SUCCEEDED(hr))
             {
-                *pbValue = (BYTE)sValue;
+                *pbValue = static_cast<BYTE>(sValue);
             }
         }
     }
@@ -206,7 +206,7 @@ void ShortcutSerialization::s_SetLinkPropertyDwordValue(_Inout_ IPropertyStore* 
             hr = s_GetPropertyDwordValue(pPropStoreLnk, PKEY_Console_CursorType, &placeholder);
             if (SUCCEEDED(hr))
             {
-                pStateInfo->CursorType = (unsigned int)placeholder;
+                pStateInfo->CursorType = static_cast<unsigned int>(placeholder);
             }
         }
         if (SUCCEEDED(hr))
@@ -440,8 +440,8 @@ void ShortcutSerialization::s_GetLinkTitle(_In_ PCWSTR pwszShortcutFilename,
             props.wPopupFillAttribute = pStateInfo->PopupAttributes;
             props.dwScreenBufferSize = pStateInfo->ScreenBufferSize;
             props.dwWindowSize = pStateInfo->WindowSize;
-            props.dwWindowOrigin.X = (SHORT)pStateInfo->WindowPosX;
-            props.dwWindowOrigin.Y = (SHORT)pStateInfo->WindowPosY;
+            props.dwWindowOrigin.X = static_cast<SHORT>(pStateInfo->WindowPosX);
+            props.dwWindowOrigin.Y = static_cast<SHORT>(pStateInfo->WindowPosY);
             props.nFont = 0;
             props.nInputBufferSize = 0;
             props.dwFontSize = pStateInfo->FontSize;
@@ -462,7 +462,7 @@ void ShortcutSerialization::s_GetLinkTitle(_In_ PCWSTR pwszShortcutFilename,
             hr = psldl->RemoveDataBlock(NT_CONSOLE_PROPS_SIG);
             if (SUCCEEDED(hr))
             {
-                hr = psldl->AddDataBlock((LPVOID)&props);
+                hr = psldl->AddDataBlock(static_cast<LPVOID>(&props));
             }
 
             if (SUCCEEDED(hr) && fEastAsianSystem)
@@ -475,7 +475,7 @@ void ShortcutSerialization::s_GetLinkTitle(_In_ PCWSTR pwszShortcutFilename,
                 hr = psldl->RemoveDataBlock(NT_FE_CONSOLE_PROPS_SIG);
                 if (SUCCEEDED(hr))
                 {
-                    hr = psldl->AddDataBlock((LPVOID)&fe_props);
+                    hr = psldl->AddDataBlock(static_cast<LPVOID>(&fe_props));
                 }
             }
 

--- a/src/propslib/TrueTypeFontList.cpp
+++ b/src/propslib/TrueTypeFontList.cpp
@@ -55,7 +55,7 @@ WORD ConvertStringToDec(
             Status = RegistrySerialization::s_EnumValue(hkRegistry,
                                                         dwIndex,
                                                         sizeof(awchValue),
-                                                        (LPWSTR)awchValue,
+                                                        static_cast<LPWSTR>(awchValue),
                                                         sizeof(awchData),
                                                         (PBYTE)awchData);
 
@@ -70,7 +70,7 @@ WORD ConvertStringToDec(
                 break;
             }
 
-            pTTFontList = (TTFONTLIST*)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(TTFONTLIST));
+            pTTFontList = static_cast<TTFONTLIST*>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(TTFONTLIST)));
             if (pTTFontList == nullptr)
             {
                 break;

--- a/src/renderer/base/thread.cpp
+++ b/src/renderer/base/thread.cpp
@@ -151,7 +151,7 @@ DWORD WINAPI RenderThread::s_ThreadProc(_In_ LPVOID lpParameter)
     }
     else
     {
-        return (DWORD)E_INVALIDARG;
+        return static_cast<DWORD>(E_INVALIDARG);
     }
 }
 

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -225,7 +225,7 @@ _CompileShader(
 HRESULT DxEngine::_SetupTerminalEffects()
 {
     ::Microsoft::WRL::ComPtr<ID3D11Texture2D> swapBuffer;
-    RETURN_IF_FAILED(_dxgiSwapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), (LPVOID*)&swapBuffer));
+    RETURN_IF_FAILED(_dxgiSwapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), static_cast<LPVOID*>(&swapBuffer)));
 
     // Setup render target.
     RETURN_IF_FAILED(_d3dDevice->CreateRenderTargetView(swapBuffer.Get(), nullptr, &_renderTargetView));

--- a/src/renderer/gdi/paint.cpp
+++ b/src/renderer/gdi/paint.cpp
@@ -331,7 +331,7 @@ using namespace Microsoft::Console::Render;
             // dispatch conversion into our codepage
 
             // Find out the bytes required
-            int const cbRequired = WideCharToMultiByte(_fontCodepage, 0, pwsPoly.get(), (int)cchLine, nullptr, 0, nullptr, nullptr);
+            int const cbRequired = WideCharToMultiByte(_fontCodepage, 0, pwsPoly.get(), static_cast<int>(cchLine), nullptr, 0, nullptr, nullptr);
 
             if (cbRequired != 0)
             {
@@ -339,7 +339,7 @@ using namespace Microsoft::Console::Render;
                 auto psConverted = std::make_unique<char[]>(cbRequired);
 
                 // Attempt conversion to current codepage
-                int const cbConverted = WideCharToMultiByte(_fontCodepage, 0, pwsPoly.get(), (int)cchLine, psConverted.get(), cbRequired, nullptr, nullptr);
+                int const cbConverted = WideCharToMultiByte(_fontCodepage, 0, pwsPoly.get(), static_cast<int>(cchLine), psConverted.get(), cbRequired, nullptr, nullptr);
 
                 // If successful...
                 if (cbConverted != 0)
@@ -371,7 +371,7 @@ using namespace Microsoft::Console::Render;
         pPolyTextLine->uiFlags = ETO_OPAQUE | ETO_CLIPPED;
         pPolyTextLine->rcl.left = pPolyTextLine->x;
         pPolyTextLine->rcl.top = pPolyTextLine->y;
-        pPolyTextLine->rcl.right = pPolyTextLine->rcl.left + ((SHORT)cchCharWidths * coordFontSize.X);
+        pPolyTextLine->rcl.right = pPolyTextLine->rcl.left + (static_cast<SHORT>(cchCharWidths) * coordFontSize.X);
         pPolyTextLine->rcl.bottom = pPolyTextLine->rcl.top + coordFontSize.Y;
         pPolyTextLine->pdx = rgdxPoly.release();
 
@@ -405,7 +405,7 @@ using namespace Microsoft::Console::Render;
 
     if (_cPolyText > 0)
     {
-        if (!PolyTextOutW(_hdcMemoryContext, _pPolyText, (UINT)_cPolyText))
+        if (!PolyTextOutW(_hdcMemoryContext, _pPolyText, static_cast<UINT>(_cPolyText)))
         {
             hr = E_FAIL;
         }

--- a/src/renderer/gdi/precomp.h
+++ b/src/renderer/gdi/precomp.h
@@ -31,7 +31,7 @@ typedef _Return_type_success_(return >= 0) long NTSTATUS;
 #define FACILITY_NTWIN32 0x7
 __inline int NTSTATUS_FROM_WIN32(long x)
 {
-    return x <= 0 ? static_cast<NTSTATUS>(x) : static_cast<NTSTATUS>(((x) & 0x0000FFFF) | (FACILITY_NTWIN32 << 16) | ERROR_SEVERITY_ERROR);
+    return x <= 0 ? static_cast<NTSTATUS>(x) : static_cast<NTSTATUS>(((x)&0x0000FFFF) | (FACILITY_NTWIN32 << 16) | ERROR_SEVERITY_ERROR);
 }
 
 #define NT_TESTNULL(var) (((var) == nullptr) ? STATUS_NO_MEMORY : STATUS_SUCCESS)

--- a/src/renderer/gdi/precomp.h
+++ b/src/renderer/gdi/precomp.h
@@ -31,7 +31,7 @@ typedef _Return_type_success_(return >= 0) long NTSTATUS;
 #define FACILITY_NTWIN32 0x7
 __inline int NTSTATUS_FROM_WIN32(long x)
 {
-    return x <= 0 ? (NTSTATUS)x : (NTSTATUS)(((x)&0x0000FFFF) | (FACILITY_NTWIN32 << 16) | ERROR_SEVERITY_ERROR);
+    return x <= 0 ? static_cast<NTSTATUS>(x) : static_cast<NTSTATUS>(((x) & 0x0000FFFF) | (FACILITY_NTWIN32 << 16) | ERROR_SEVERITY_ERROR);
 }
 
 #define NT_TESTNULL(var) (((var) == nullptr) ? STATUS_NO_MEMORY : STATUS_SUCCESS)

--- a/src/renderer/gdi/state.cpp
+++ b/src/renderer/gdi/state.cpp
@@ -19,7 +19,7 @@ using namespace Microsoft::Console::Render;
 // Return Value:
 // - An instance of a Renderer.
 GdiEngine::GdiEngine() :
-    _hwndTargetWindow((HWND)INVALID_HANDLE_VALUE),
+    _hwndTargetWindow(static_cast<HWND>(INVALID_HANDLE_VALUE)),
 #if DBG
     _debugWindow((HWND)INVALID_HANDLE_VALUE),
 #endif
@@ -30,7 +30,7 @@ GdiEngine::GdiEngine() :
     _lastFg(INVALID_COLOR),
     _lastBg(INVALID_COLOR),
     _fPaintStarted(false),
-    _hfont((HFONT)INVALID_HANDLE_VALUE)
+    _hfont(static_cast<HFONT>(INVALID_HANDLE_VALUE))
 {
     ZeroMemory(_pPolyText, sizeof(POLYTEXTW) * s_cPolyTextCache);
     _rcInvalid = { 0 };
@@ -341,7 +341,7 @@ GdiEngine::~GdiEngine()
         // We do this because, for instance, if we ask GDI for an 8x12 OEM_FIXED_FONT,
         // it may very well decide to choose Courier New instead of the Terminal raster.
 #pragma prefast(suppress : 38037, "raster fonts get special handling, we need to get it this way")
-        hFont.reset((HFONT)GetStockObject(OEM_FIXED_FONT));
+        hFont.reset(static_cast<HFONT>(GetStockObject(OEM_FIXED_FONT)));
     }
     else
     {
@@ -381,14 +381,14 @@ GdiEngine::~GdiEngine()
         else
         {
             CHARSETINFO csi;
-            if (!TranslateCharsetInfo((DWORD*)IntToPtr(FontDesired.GetCodePage()), &csi, TCI_SRCCODEPAGE))
+            if (!TranslateCharsetInfo(static_cast<DWORD*>(IntToPtr(FontDesired.GetCodePage())), &csi, TCI_SRCCODEPAGE))
             {
                 // if we failed to translate from codepage to charset, choose our charset depending on what kind of font we're
                 // dealing with. Raster Fonts need to be presented with the OEM charset, while TT fonts need to be ANSI.
                 csi.ciCharset = FontDesired.IsTrueTypeFont() ? ANSI_CHARSET : OEM_CHARSET;
             }
 
-            lf.lfCharSet = (BYTE)csi.ciCharset;
+            lf.lfCharSet = static_cast<BYTE>(csi.ciCharset);
         }
 
         lf.lfQuality = DRAFT_QUALITY;
@@ -453,7 +453,7 @@ GdiEngine::~GdiEngine()
         }
         else if (coordFontRequested.X == 0)
         {
-            coordFontRequested.X = (SHORT)s_ShrinkByDpi(coordFont.X, iDpi);
+            coordFontRequested.X = static_cast<SHORT>(s_ShrinkByDpi(coordFont.X, iDpi));
         }
 
         Font.SetFromEngine(currentFaceName,

--- a/src/server/ApiDispatchers.cpp
+++ b/src/server/ApiDispatchers.cpp
@@ -311,7 +311,7 @@
     CATCH_RETURN();
 
     // ReadConsole needs this to get the command history list associated with an attached process, but it can be an opaque value.
-    HANDLE const hConsoleClient = (HANDLE)m->GetProcessHandle();
+    HANDLE const hConsoleClient = static_cast<HANDLE>(m->GetProcessHandle());
 
     // ReadConsole needs this to store context information across "processed reads" e.g. reads on the same handle
     // across multiple calls when we are simulating a command prompt input line for the client application.
@@ -372,7 +372,7 @@
         if (a->ProcessControlZ != FALSE &&
             a->NumBytes > 0 &&
             m->State.OutputBuffer != nullptr &&
-            *(PUCHAR)m->State.OutputBuffer == 0x1a)
+            *static_cast<PUCHAR>(m->State.OutputBuffer) == 0x1a)
         {
             a->NumBytes = 0;
         }

--- a/src/server/ApiDispatchersInternal.cpp
+++ b/src/server/ApiDispatchersInternal.cpp
@@ -44,14 +44,14 @@ using Microsoft::Console::Interactivity::ServiceLocator;
     * (but we still return S_OK).
     */
 
-    LPDWORD lpdwProcessList = (PDWORD)Buffer;
+    LPDWORD lpdwProcessList = static_cast<PDWORD>(Buffer);
     size_t cProcessList = a->dwProcessCount;
     if (SUCCEEDED(gci.ProcessHandleList.GetProcessList(lpdwProcessList, &cProcessList)))
     {
         m->SetReplyInformation(cProcessList * sizeof(ULONG));
     }
 
-    a->dwProcessCount = (ULONG)cProcessList;
+    a->dwProcessCount = static_cast<ULONG>(cProcessList);
 
     return S_OK;
 }

--- a/src/server/ApiMessage.cpp
+++ b/src/server/ApiMessage.cpp
@@ -160,7 +160,7 @@ ConsoleHandleData* _CONSOLE_API_MSG::GetObjectHandle() const
             IoOperation.Identifier = Descriptor.Identifier;
             IoOperation.Buffer.Offset = State.WriteOffset;
             IoOperation.Buffer.Data = State.OutputBuffer;
-            IoOperation.Buffer.Size = (ULONG)Complete.IoStatus.Information;
+            IoOperation.Buffer.Size = static_cast<ULONG>(Complete.IoStatus.Information);
 
             LOG_IF_FAILED(_pDeviceComm->WriteOutput(&IoOperation));
         }

--- a/src/server/IoDispatchers.cpp
+++ b/src/server/IoDispatchers.cpp
@@ -147,8 +147,8 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleHandleConnectionRequest(_In_ PCONSOLE_API
 
     LockConsole();
 
-    DWORD const dwProcessId = (DWORD)pReceiveMsg->Descriptor.Process;
-    DWORD const dwThreadId = (DWORD)pReceiveMsg->Descriptor.Object;
+    DWORD const dwProcessId = static_cast<DWORD>(pReceiveMsg->Descriptor.Process);
+    DWORD const dwThreadId = static_cast<DWORD>(pReceiveMsg->Descriptor.Object);
 
     CONSOLE_API_CONNECTINFO Cac;
     NTSTATUS Status = ConsoleInitializeConnectInfo(pReceiveMsg, &Cac);
@@ -191,7 +191,7 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleHandleConnectionRequest(_In_ PCONSOLE_API
 
     try
     {
-        CommandHistory::s_Allocate({ Cac.AppName, Cac.AppNameLength / sizeof(wchar_t) }, (HANDLE)ProcessData);
+        CommandHistory::s_Allocate({ Cac.AppName, Cac.AppNameLength / sizeof(wchar_t) }, static_cast<HANDLE>(ProcessData));
     }
     catch (...)
     {
@@ -234,7 +234,7 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleHandleConnectionRequest(_In_ PCONSOLE_API
 
     if (FAILED(ServiceLocator::LocateGlobals().pDeviceComm->CompleteIo(&pReceiveMsg->Complete)))
     {
-        CommandHistory::s_Free((HANDLE)ProcessData);
+        CommandHistory::s_Free(static_cast<HANDLE>(ProcessData));
         gci.ProcessHandleList.FreeProcessData(ProcessData);
     }
 
@@ -247,7 +247,7 @@ Error:
 
     if (ProcessData != nullptr)
     {
-        CommandHistory::s_Free((HANDLE)ProcessData);
+        CommandHistory::s_Free(static_cast<HANDLE>(ProcessData));
         gci.ProcessHandleList.FreeProcessData(ProcessData);
     }
 

--- a/src/server/WaitBlock.cpp
+++ b/src/server/WaitBlock.cpp
@@ -194,7 +194,7 @@ bool ConsoleWaitBlock::Notify(const WaitTerminationReason TerminationReason)
             if (a->ProcessControlZ != FALSE &&
                 a->NumBytes > 0 &&
                 _WaitReplyMessage.State.OutputBuffer != nullptr &&
-                *(PUCHAR)_WaitReplyMessage.State.OutputBuffer == 0x1a)
+                *static_cast<PUCHAR>(_WaitReplyMessage.State.OutputBuffer) == 0x1a)
             {
                 // On changing this, we also need to notify the Reply Information because it was stowed above into the reply packet.
                 a->NumBytes = 0;

--- a/src/terminal/adapter/ut_adapter/MouseInputTest.cpp
+++ b/src/terminal/adapter/ut_adapter/MouseInputTest.cpp
@@ -126,7 +126,7 @@ public:
 
         // Change the expected button value
         wchar_t wch = GetDefaultCharFromButton(uiButton, sModifierKeystate, sScrollDelta);
-        Log::Comment(NoThrowString().Format(L"Button Char was:\'%d\' for uiButton '%d", (int)wch, uiButton));
+        Log::Comment(NoThrowString().Format(L"Button Char was:\'%d\' for uiButton '%d", static_cast<int>(wch), uiButton));
 
         s_pwszExpectedBuffer[3] = wch;
         Log::Comment(NoThrowString().Format(L"Expected Input:\'%s\'", s_pwszExpectedBuffer));
@@ -284,7 +284,7 @@ public:
 
         unsigned int uiModifierKeystate = 0;
         VERIFY_SUCCEEDED_RETURN(TestData::TryGetValue(L"uiModifierKeystate", uiModifierKeystate));
-        short sModifierKeystate = (SHORT)uiModifierKeystate;
+        short sModifierKeystate = static_cast<SHORT>(uiModifierKeystate);
         short sScrollDelta = 0;
 
         unsigned int uiButton;
@@ -363,7 +363,7 @@ public:
 
         unsigned int uiModifierKeystate = 0;
         VERIFY_SUCCEEDED_RETURN(TestData::TryGetValue(L"uiModifierKeystate", uiModifierKeystate));
-        short sModifierKeystate = (SHORT)uiModifierKeystate;
+        short sModifierKeystate = static_cast<SHORT>(uiModifierKeystate);
         short sScrollDelta = 0;
 
         unsigned int uiButton;
@@ -445,7 +445,7 @@ public:
         std::unique_ptr<TerminalInput> mouseInput = std::make_unique<TerminalInput>(s_MouseInputTestCallback);
         unsigned int uiModifierKeystate = 0;
         VERIFY_SUCCEEDED_RETURN(TestData::TryGetValue(L"uiModifierKeystate", uiModifierKeystate));
-        short sModifierKeystate = (SHORT)uiModifierKeystate;
+        short sModifierKeystate = static_cast<SHORT>(uiModifierKeystate);
         short sScrollDelta = 0;
 
         unsigned int uiButton;
@@ -523,12 +523,12 @@ public:
         std::unique_ptr<TerminalInput> mouseInput = std::make_unique<TerminalInput>(s_MouseInputTestCallback);
         unsigned int uiModifierKeystate = 0;
         VERIFY_SUCCEEDED_RETURN(TestData::TryGetValue(L"uiModifierKeystate", uiModifierKeystate));
-        short sModifierKeystate = (SHORT)uiModifierKeystate;
+        short sModifierKeystate = static_cast<SHORT>(uiModifierKeystate);
 
         unsigned int uiButton = WM_MOUSEWHEEL;
         int iScrollDelta = 0;
         VERIFY_SUCCEEDED_RETURN(TestData::TryGetValue(L"sScrollDelta", iScrollDelta));
-        short sScrollDelta = (short)(iScrollDelta);
+        short sScrollDelta = static_cast<short>(iScrollDelta);
 
         bool fExpectedKeyHandled = false;
         s_pwszInputExpected = L"\x0";

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -829,7 +829,7 @@ public:
             const KeyEvent* const keyEvent = static_cast<const KeyEvent* const>(_events[iInput].get());
 
             // every even key is down. every odd key is up. DOWN = 0, UP = 1. DOWN = 2, UP = 3. and so on.
-            VERIFY_ARE_EQUAL((bool)!(iInput % 2), keyEvent->IsKeyDown());
+            VERIFY_ARE_EQUAL(static_cast<bool>(!(iInput % 2)), keyEvent->IsKeyDown());
             VERIFY_ARE_EQUAL(0u, keyEvent->GetActiveModifierKeys());
             Log::Comment(NoThrowString().Format(L"Comparing '%c' with '%c'...", wch, keyEvent->GetCharData()));
             VERIFY_ARE_EQUAL(wch, keyEvent->GetCharData());
@@ -852,7 +852,7 @@ public:
     {
     }
 
-    static const WCHAR s_wchErase = (WCHAR)0x20;
+    static const WCHAR s_wchErase = static_cast<WCHAR>(0x20);
     static const WCHAR s_wchDefault = L'Z';
     static const WORD s_wAttrErase = FOREGROUND_BLUE | FOREGROUND_GREEN | BACKGROUND_RED | BACKGROUND_INTENSITY;
     static const WORD s_wDefaultAttribute = 0;
@@ -1025,7 +1025,7 @@ public:
         CursorDirection direction;
         size_t dir;
         VERIFY_SUCCEEDED_RETURN(TestData::TryGetValue(L"uiDirection", dir));
-        direction = (CursorDirection)dir;
+        direction = static_cast<CursorDirection>(dir);
 
         switch (direction)
         {
@@ -1243,7 +1243,7 @@ public:
         AbsolutePosition direction;
         size_t dir;
         VERIFY_SUCCEEDED_RETURN(TestData::TryGetValue(L"uiDirection", dir));
-        direction = (AbsolutePosition)dir;
+        direction = static_cast<AbsolutePosition>(dir);
         _testGetSet->PrepData();
 
         switch (direction)
@@ -1403,7 +1403,7 @@ public:
         _testGetSet->PrepData();
         _testGetSet->_setConsoleTextAttributeResult = FALSE;
         // Need at least one option in order for the call to be able to fail.
-        rgOptions[0] = (DispatchTypes::GraphicsOptions)0;
+        rgOptions[0] = static_cast<DispatchTypes::GraphicsOptions>(0);
         cOptions = 1;
         VERIFY_IS_FALSE(_pDispatch.get()->SetGraphicsRendition({ rgOptions, cOptions }));
     }
@@ -1421,7 +1421,7 @@ public:
         DispatchTypes::GraphicsOptions graphicsOption;
         size_t uiGraphicsOption;
         VERIFY_SUCCEEDED_RETURN(TestData::TryGetValue(L"uiGraphicsOptions", uiGraphicsOption));
-        graphicsOption = (DispatchTypes::GraphicsOptions)uiGraphicsOption;
+        graphicsOption = static_cast<DispatchTypes::GraphicsOptions>(uiGraphicsOption);
 
         DispatchTypes::GraphicsOptions rgOptions[16];
         size_t cOptions = 1;
@@ -1433,7 +1433,7 @@ public:
         {
         case DispatchTypes::GraphicsOptions::Off:
             Log::Comment(L"Testing graphics 'Off/Reset'");
-            _testGetSet->_attribute = (WORD)~_testGetSet->s_defaultFill;
+            _testGetSet->_attribute = static_cast<WORD>(~_testGetSet->s_defaultFill);
             _testGetSet->_expectedAttribute = 0;
             _testGetSet->_privateSetDefaultAttributesResult = true;
             _testGetSet->_expectedForeground = true;
@@ -1526,7 +1526,7 @@ public:
         case DispatchTypes::GraphicsOptions::ForegroundDefault:
             Log::Comment(L"Testing graphics 'Foreground Color Default'");
             _testGetSet->_privateSetDefaultAttributesResult = true;
-            _testGetSet->_attribute = (WORD)~_testGetSet->s_wDefaultAttribute; // set the current attribute to the opposite of default so we can ensure all relevant bits flip.
+            _testGetSet->_attribute = static_cast<WORD>(~_testGetSet->s_wDefaultAttribute); // set the current attribute to the opposite of default so we can ensure all relevant bits flip.
             // To get expected value, take what we started with and change ONLY the background series of bits to what the Default says.
             _testGetSet->_expectedAttribute = _testGetSet->_attribute; // expect = starting
             _testGetSet->_expectedAttribute &= ~(FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY); // turn off all bits related to the background
@@ -1584,7 +1584,7 @@ public:
         case DispatchTypes::GraphicsOptions::BackgroundDefault:
             Log::Comment(L"Testing graphics 'Background Color Default'");
             _testGetSet->_privateSetDefaultAttributesResult = true;
-            _testGetSet->_attribute = (WORD)~_testGetSet->s_wDefaultAttribute; // set the current attribute to the opposite of default so we can ensure all relevant bits flip.
+            _testGetSet->_attribute = static_cast<WORD>(~_testGetSet->s_wDefaultAttribute); // set the current attribute to the opposite of default so we can ensure all relevant bits flip.
             // To get expected value, take what we started with and change ONLY the background series of bits to what the Default says.
             _testGetSet->_expectedAttribute = _testGetSet->_attribute; // expect = starting
             _testGetSet->_expectedAttribute &= ~(BACKGROUND_BLUE | BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_INTENSITY); // turn off all bits related to the background
@@ -1824,7 +1824,7 @@ public:
 
         Log::Comment(L"Test 1: Verify failure when using bad status.");
         _testGetSet->PrepData();
-        VERIFY_IS_FALSE(_pDispatch.get()->DeviceStatusReport((DispatchTypes::AnsiStatusType)-1));
+        VERIFY_IS_FALSE(_pDispatch.get()->DeviceStatusReport(static_cast<DispatchTypes::AnsiStatusType>(-1)));
     }
 
     TEST_METHOD(DeviceStatus_CursorPositionReportTests)
@@ -2152,7 +2152,7 @@ public:
         Log::Comment(L"Test 1: Change Foreground");
         rgOptions[0] = DispatchTypes::GraphicsOptions::ForegroundExtended;
         rgOptions[1] = DispatchTypes::GraphicsOptions::BlinkOrXterm256Index;
-        rgOptions[2] = (DispatchTypes::GraphicsOptions)2; // Green
+        rgOptions[2] = static_cast<DispatchTypes::GraphicsOptions>(2); // Green
         _testGetSet->_expectedAttribute = FOREGROUND_GREEN;
         _testGetSet->_iExpectedXtermTableEntry = 2;
         _testGetSet->_expectedIsForeground = true;
@@ -2162,7 +2162,7 @@ public:
         Log::Comment(L"Test 2: Change Background");
         rgOptions[0] = DispatchTypes::GraphicsOptions::BackgroundExtended;
         rgOptions[1] = DispatchTypes::GraphicsOptions::BlinkOrXterm256Index;
-        rgOptions[2] = (DispatchTypes::GraphicsOptions)9; // Bright Red
+        rgOptions[2] = static_cast<DispatchTypes::GraphicsOptions>(9); // Bright Red
         _testGetSet->_expectedAttribute = FOREGROUND_GREEN | BACKGROUND_RED | BACKGROUND_INTENSITY;
         _testGetSet->_iExpectedXtermTableEntry = 9;
         _testGetSet->_expectedIsForeground = false;
@@ -2172,7 +2172,7 @@ public:
         Log::Comment(L"Test 3: Change Foreground to RGB color");
         rgOptions[0] = DispatchTypes::GraphicsOptions::ForegroundExtended;
         rgOptions[1] = DispatchTypes::GraphicsOptions::BlinkOrXterm256Index;
-        rgOptions[2] = (DispatchTypes::GraphicsOptions)42; // Arbitrary Color
+        rgOptions[2] = static_cast<DispatchTypes::GraphicsOptions>(42); // Arbitrary Color
         _testGetSet->_iExpectedXtermTableEntry = 42;
         _testGetSet->_expectedIsForeground = true;
         _testGetSet->_usingRgbColor = true;
@@ -2181,7 +2181,7 @@ public:
         Log::Comment(L"Test 4: Change Background to RGB color");
         rgOptions[0] = DispatchTypes::GraphicsOptions::BackgroundExtended;
         rgOptions[1] = DispatchTypes::GraphicsOptions::BlinkOrXterm256Index;
-        rgOptions[2] = (DispatchTypes::GraphicsOptions)142; // Arbitrary Color
+        rgOptions[2] = static_cast<DispatchTypes::GraphicsOptions>(142); // Arbitrary Color
         _testGetSet->_iExpectedXtermTableEntry = 142;
         _testGetSet->_expectedIsForeground = false;
         _testGetSet->_usingRgbColor = true;
@@ -2193,7 +2193,7 @@ public:
         // Fortunately, the ft_api:RgbColorTests IS smart enough to test that.
         rgOptions[0] = DispatchTypes::GraphicsOptions::ForegroundExtended;
         rgOptions[1] = DispatchTypes::GraphicsOptions::BlinkOrXterm256Index;
-        rgOptions[2] = (DispatchTypes::GraphicsOptions)9; // Bright Red
+        rgOptions[2] = static_cast<DispatchTypes::GraphicsOptions>(9); // Bright Red
         _testGetSet->_expectedAttribute = FOREGROUND_RED | FOREGROUND_INTENSITY | BACKGROUND_RED | BACKGROUND_INTENSITY;
         _testGetSet->_iExpectedXtermTableEntry = 9;
         _testGetSet->_expectedIsForeground = true;

--- a/src/terminal/adapter/ut_adapter/inputTest.cpp
+++ b/src/terminal/adapter/ut_adapter/inputTest.cpp
@@ -176,7 +176,7 @@ void InputTest::TerminalInputTests()
 // from the cast.
 #pragma warning(push)
 #pragma warning(disable : 4242)
-        irTest.Event.KeyEvent.uChar.UnicodeChar = (wchar_t)MapVirtualKey(vkey, MAPVK_VK_TO_CHAR);
+        irTest.Event.KeyEvent.uChar.UnicodeChar = static_cast<wchar_t>(MapVirtualKey(vkey, MAPVK_VK_TO_CHAR));
 #pragma warning(pop)
 
         // Set up expected result

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -980,7 +980,7 @@ bool InputStateMachineEngine::_GetGenericVkey(const std::basic_string_view<size_
         return false;
     }
 
-    const auto identifier = (GenericKeyIdentifiers)til::at(parameters, 0);
+    const auto identifier = static_cast<GenericKeyIdentifiers>(til::at(parameters, 0));
 
     const auto mapping = std::find(s_genericMap.cbegin(), s_genericMap.cend(), identifier);
     if (mapping != s_genericMap.end())
@@ -1003,7 +1003,7 @@ bool InputStateMachineEngine::_GetCursorKeysVkey(const wchar_t wch, short& vkey)
 {
     vkey = 0;
 
-    const auto mapping = std::find(s_csiMap.cbegin(), s_csiMap.cend(), (CsiActionCodes)wch);
+    const auto mapping = std::find(s_csiMap.cbegin(), s_csiMap.cend(), static_cast<CsiActionCodes>(wch));
     if (mapping != s_csiMap.end())
     {
         vkey = mapping->vkey;
@@ -1024,7 +1024,7 @@ bool InputStateMachineEngine::_GetSs3KeysVkey(const wchar_t wch, short& vkey) co
 {
     vkey = 0;
 
-    const auto mapping = std::find(s_ss3Map.cbegin(), s_ss3Map.cend(), (Ss3ActionCodes)wch);
+    const auto mapping = std::find(s_ss3Map.cbegin(), s_ss3Map.cend(), static_cast<Ss3ActionCodes>(wch));
     if (mapping != s_ss3Map.end())
     {
         vkey = mapping->vkey;

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -841,7 +841,7 @@ bool OutputStateMachineEngine::_GetGraphicsOptions(const std::basic_string_view<
     {
         for (const auto& p : parameters)
         {
-            options.push_back((DispatchTypes::GraphicsOptions)p);
+            options.push_back(static_cast<DispatchTypes::GraphicsOptions>(p));
         }
         success = true;
     }
@@ -1113,7 +1113,7 @@ bool OutputStateMachineEngine::_GetDeviceStatusOperation(const std::basic_string
         switch (param)
         {
         // This looks kinda silly, but I want the parser to reject (success = false) any status types we haven't put here.
-        case (unsigned short)DispatchTypes::AnsiStatusType::CPR_CursorPositionReport:
+        case static_cast<unsigned short>(DispatchTypes::AnsiStatusType::CPR_CursorPositionReport):
             statusType = DispatchTypes::AnsiStatusType::CPR_CursorPositionReport;
             success = true;
             break;
@@ -1139,7 +1139,7 @@ bool OutputStateMachineEngine::_GetPrivateModeParams(const std::basic_string_vie
     {
         for (const auto& p : parameters)
         {
-            privateModes.push_back((DispatchTypes::PrivateModeParams)p);
+            privateModes.push_back(static_cast<DispatchTypes::PrivateModeParams>(p));
         }
         success = true;
     }
@@ -1665,7 +1665,7 @@ bool OutputStateMachineEngine::_GetCursorStyle(const std::basic_string_view<size
     else if (parameters.size() == 1)
     {
         // If there's one parameter, use it.
-        cursorStyle = (DispatchTypes::CursorStyle)til::at(parameters, 0);
+        cursorStyle = static_cast<DispatchTypes::CursorStyle>(til::at(parameters, 0));
         success = true;
     }
 

--- a/src/terminal/parser/ft_fuzzer/VTCommandFuzzer.cpp
+++ b/src/terminal/parser/ft_fuzzer/VTCommandFuzzer.cpp
@@ -42,7 +42,7 @@ static std::string GenerateOscColorTableToken();
 const fuzz::_fuzz_type_entry<BYTE> g_repeatMap[] = {
     { 4, [](BYTE) { return CFuzzChance::GetRandom<BYTE>(2, 0xF); } },
     { 1, [](BYTE) { return CFuzzChance::GetRandom<BYTE>(2, 0xFF); } },
-    { 20, [](BYTE) { return (BYTE)0; } }
+    { 20, [](BYTE) { return static_cast<BYTE>(0); } }
 };
 
 const std::function<std::string()> g_tokenGenerators[] = {
@@ -71,7 +71,7 @@ std::string GenerateTokenLowProbability()
     };
     CFuzzType<std::string> ft(FUZZ_MAP(tokenGeneratorMap), std::string(""));
 
-    return (std::string)ft;
+    return static_cast<std::string>(ft);
 }
 
 std::string GenerateToken()
@@ -84,7 +84,7 @@ std::string GenerateToken()
     };
     CFuzzType<std::string> ft(FUZZ_MAP(tokenGeneratorMap), std::string(""));
 
-    return (std::string)ft;
+    return static_cast<std::string>(ft);
 }
 
 std::string GenerateWhiteSpaceToken()
@@ -96,7 +96,7 @@ std::string GenerateWhiteSpaceToken()
     CFuzzType<DWORD> ft(FUZZ_MAP(ftMap), 0);
 
     std::string s;
-    for (DWORD i = 0; i < (DWORD)ft; i++)
+    for (DWORD i = 0; i < static_cast<DWORD>(ft); i++)
     {
         s.append(" ");
     }
@@ -141,12 +141,12 @@ std::string GenerateFuzzedToken(
     std::string csis[] = { CSI, C1CSI };
     std::string s = CFuzzChance::SelectOne(csis);
 
-    BYTE manipulations = (BYTE)CFuzzType<BYTE>(FUZZ_MAP(g_repeatMap), 1);
+    BYTE manipulations = static_cast<BYTE>(CFuzzType<BYTE>(FUZZ_MAP(g_repeatMap), 1));
     for (BYTE i = 0; i < manipulations; i++)
     {
         CFuzzType<std::string> ft(map, cmap, std::string(""));
         s += GenerateTokenLowProbability();
-        s += (std::string)ft;
+        s += static_cast<std::string>(ft);
         s += GenerateTokenLowProbability();
         s += (i + 1 == manipulations) ? "" : ";";
         s += GenerateTokenLowProbability();
@@ -163,12 +163,12 @@ std::string GenerateFuzzedOscToken(
     __in DWORD ctokens)
 {
     std::string s(OSC);
-    BYTE manipulations = (BYTE)CFuzzType<BYTE>(FUZZ_MAP(g_repeatMap), 1);
+    BYTE manipulations = static_cast<BYTE>(CFuzzType<BYTE>(FUZZ_MAP(g_repeatMap), 1));
     for (BYTE i = 0; i < manipulations; i++)
     {
         CFuzzType<std::string> ft(map, cmap, std::string(""));
         s += GenerateTokenLowProbability();
-        s += (std::string)ft;
+        s += static_cast<std::string>(ft);
         s += GenerateTokenLowProbability();
         s += (i + 1 == manipulations) ? "" : ";";
         s += GenerateTokenLowProbability();

--- a/src/terminal/parser/ft_fuzzer/fuzzing_logic.h
+++ b/src/terminal/parser/ft_fuzzer/fuzzing_logic.h
@@ -321,7 +321,7 @@ namespace fuzz
                 // Performance optimization: 95% of the time the buffer returned from eval will not be reallocated
                 // and thus will still be pointing at pszReallocTemp.  In this case, it is not necessary to duplicate
                 // the string a second time, just transfer ownership to the calling function.
-                if ((LPSTR)eval == pszReallocTemp)
+                if (static_cast<LPSTR>(eval) == pszReallocTemp)
                 {
                     pszRealloc = pszReallocTemp;
                 }
@@ -468,7 +468,7 @@ namespace fuzz
         while (token)
         {
             CFuzzType<DWORD> repeat(FUZZ_MAP(repeatMap), 1);
-            for (DWORD i = 0; i < (DWORD)repeat; i++)
+            for (DWORD i = 0; i < static_cast<DWORD>(repeat); i++)
             {
                 sFuzzed += token;
                 sFuzzed += " ";

--- a/src/terminal/parser/ft_fuzzwrapper/main.cpp
+++ b/src/terminal/parser/ft_fuzzwrapper/main.cpp
@@ -31,7 +31,7 @@ bool GetChar(wchar_t* pwch)
     {
         int ch = fgetc(hFile);
         *pwch = 0;
-        *pwch = (wchar_t)ch;
+        *pwch = static_cast<wchar_t>(ch);
         return ch != EOF;
     }
     else
@@ -53,7 +53,7 @@ int __cdecl wmain(int argc, wchar_t* argv[])
     }
     else
     {
-        uiCodePage = (UINT)_wtoi(argv[2]);
+        uiCodePage = static_cast<UINT>(_wtoi(argv[2]));
         wprintf(L"Using codepage '%d'", uiCodePage);
 
         wprintf(L"Opening file '%s'...\r\n", argv[1]);

--- a/src/terminal/parser/ut_parser/InputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/InputEngineTest.cpp
@@ -102,7 +102,7 @@ public:
     void TestInputCallback(std::deque<std::unique_ptr<IInputEvent>>& inEvents)
     {
         auto records = IInputEvent::ToInputRecords(inEvents);
-        VERIFY_ARE_EQUAL((size_t)1, vExpectedInput.size());
+        VERIFY_ARE_EQUAL(static_cast<size_t>(1), vExpectedInput.size());
 
         bool foundEqual = false;
         INPUT_RECORD irExpected = vExpectedInput.back();
@@ -428,7 +428,7 @@ void InputEngineTest::C0Test()
         short keyscan = VkKeyScanW(expectedWch);
         short vkey = keyscan & 0xff;
         short keyscanModifiers = (keyscan >> 8) & 0xff;
-        WORD scanCode = (WORD)MapVirtualKeyW(vkey, MAPVK_VK_TO_VSC);
+        WORD scanCode = static_cast<WORD>(MapVirtualKeyW(vkey, MAPVK_VK_TO_VSC));
 
         DWORD dwModifierState = 0;
         if (writeCtrl)
@@ -505,7 +505,7 @@ void InputEngineTest::AlphanumericTest()
 
         short keyscan = VkKeyScanW(wch);
         short vkey = keyscan & 0xff;
-        WORD scanCode = (wchar_t)MapVirtualKeyW(vkey, MAPVK_VK_TO_VSC);
+        WORD scanCode = static_cast<wchar_t>(MapVirtualKeyW(vkey, MAPVK_VK_TO_VSC));
 
         short keyscanModifiers = (keyscan >> 8) & 0xff;
         // Because of course, these are not the same flags.
@@ -824,8 +824,8 @@ void InputEngineTest::EnhancedKeysTest()
     {
         INPUT_RECORD inputRec;
 
-        const wchar_t wch = (wchar_t)MapVirtualKeyW(vkey, MAPVK_VK_TO_CHAR);
-        const WORD scanCode = (WORD)MapVirtualKeyW(vkey, MAPVK_VK_TO_VSC);
+        const wchar_t wch = static_cast<wchar_t>(MapVirtualKeyW(vkey, MAPVK_VK_TO_CHAR));
+        const WORD scanCode = static_cast<WORD>(MapVirtualKeyW(vkey, MAPVK_VK_TO_VSC));
 
         inputRec.EventType = KEY_EVENT;
         inputRec.Event.KeyEvent.bKeyDown = TRUE;
@@ -1222,7 +1222,7 @@ void InputEngineTest::CtrlAltZCtrlAltXTest()
         wchar_t expectedWch = L'Z';
         short keyscan = VkKeyScanW(expectedWch);
         short vkey = keyscan & 0xff;
-        WORD scanCode = (WORD)MapVirtualKeyW(vkey, MAPVK_VK_TO_VSC);
+        WORD scanCode = static_cast<WORD>(MapVirtualKeyW(vkey, MAPVK_VK_TO_VSC));
 
         INPUT_RECORD inputRec;
 
@@ -1244,7 +1244,7 @@ void InputEngineTest::CtrlAltZCtrlAltXTest()
         wchar_t expectedWch = L'X';
         short keyscan = VkKeyScanW(expectedWch);
         short vkey = keyscan & 0xff;
-        WORD scanCode = (WORD)MapVirtualKeyW(vkey, MAPVK_VK_TO_VSC);
+        WORD scanCode = static_cast<WORD>(MapVirtualKeyW(vkey, MAPVK_VK_TO_VSC));
 
         INPUT_RECORD inputRec;
 

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -304,7 +304,7 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         }
         for (int i = 0; i < 5; i++) // We're only expecting to be able to keep 5 digits max
         {
-            mach.ProcessCharacter((wchar_t)(L'1' + i));
+            mach.ProcessCharacter(static_cast<wchar_t>(L'1' + i));
             VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiParam);
         }
         VERIFY_ARE_EQUAL(mach._parameters.back(), 12345u);
@@ -465,7 +465,7 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::OscParam);
         for (int i = 0; i < 5; i++) // We're only expecting to be able to keep 5 digits max
         {
-            mach.ProcessCharacter((wchar_t)(L'1' + i));
+            mach.ProcessCharacter(static_cast<wchar_t>(L'1' + i));
             VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::OscParam);
         }
         VERIFY_ARE_EQUAL(mach._oscParameter, 12345u);
@@ -495,7 +495,7 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         }
         for (int i = 0; i < 5; i++) // We're only expecting to be able to keep 5 digits max
         {
-            mach.ProcessCharacter((wchar_t)(L'1' + i));
+            mach.ProcessCharacter(static_cast<wchar_t>(L'1' + i));
             VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::OscParam);
         }
         VERIFY_ARE_EQUAL(mach._oscParameter, 12345u);
@@ -670,9 +670,9 @@ public:
         _eraseLine{ false },
         _insertCharacter{ false },
         _deleteCharacter{ false },
-        _eraseType{ (DispatchTypes::EraseType)-1 },
+        _eraseType{ static_cast<DispatchTypes::EraseType>(-1) },
         _setGraphics{ false },
-        _statusReportType{ (DispatchTypes::AnsiStatusType)-1 },
+        _statusReportType{ static_cast<DispatchTypes::AnsiStatusType>(-1) },
         _deviceStatusReport{ false },
         _deviceAttributes{ false },
         _isAltBuffer{ false },
@@ -684,7 +684,7 @@ public:
         _warningBell{ false },
         _carriageReturn{ false },
         _lineFeed{ false },
-        _lineFeedType{ (DispatchTypes::LineFeedType)-1 },
+        _lineFeedType{ static_cast<DispatchTypes::LineFeedType>(-1) },
         _forwardTab{ false },
         _numTabs{ 0 },
         _isDECCOLMAllowed{ false },
@@ -1239,7 +1239,7 @@ class StateMachineExternalTest final
 
         VERIFY_IS_TRUE(pDispatch->_cursorPosition);
         VERIFY_ARE_EQUAL(pDispatch->_line, uiRow);
-        VERIFY_ARE_EQUAL(pDispatch->_column, (size_t)1); // Without the second param, the column should always be the default
+        VERIFY_ARE_EQUAL(pDispatch->_column, static_cast<size_t>(1)); // Without the second param, the column should always be the default
     }
 
     TEST_METHOD(TestCursorSaveLoad)
@@ -1545,7 +1545,7 @@ class StateMachineExternalTest final
 
         for (size_t i = 0; i < dispatch._options.size(); i++)
         {
-            auto expectedOption = (DispatchTypes::GraphicsOptions)dispatch.s_uiGraphicsCleared;
+            auto expectedOption = static_cast<DispatchTypes::GraphicsOptions>(dispatch.s_uiGraphicsCleared);
 
             if (i < expectedOptions.size())
             {

--- a/src/til/ut_til/RectangleTests.cpp
+++ b/src/til/ut_til/RectangleTests.cpp
@@ -427,7 +427,7 @@ class RectangleTests
 
         const bool expected = left < right && top < bottom;
         const til::rectangle actual{ left, top, right, bottom };
-        VERIFY_ARE_EQUAL(expected, (bool)actual);
+        VERIFY_ARE_EQUAL(expected, static_cast<bool>(actual));
     }
 
     TEST_METHOD(OrUnion)

--- a/src/tools/closetest/closetest.cpp
+++ b/src/tools/closetest/closetest.cpp
@@ -527,7 +527,7 @@ static int shiftInt(std::deque<std::wstring>& container)
 
 static HANDLE shiftHandle(std::deque<std::wstring>& container)
 {
-    return (HANDLE)static_cast<uintptr_t>(shiftInt(container));
+    return (HANDLE) static_cast<uintptr_t>(shiftInt(container));
 }
 
 static int doChild(std::deque<std::wstring> argv)

--- a/src/tools/closetest/closetest.cpp
+++ b/src/tools/closetest/closetest.cpp
@@ -255,7 +255,7 @@ static HANDLE makeJob()
 static std::wstring exeName()
 {
     std::array<wchar_t, 4096> self{};
-    DWORD len = GetModuleFileNameW(nullptr, self.data(), (DWORD)self.size());
+    DWORD len = GetModuleFileNameW(nullptr, self.data(), static_cast<DWORD>(self.size()));
     UNREFERENCED_PARAMETER(len); // to make release builds happy.
     assert(len >= 1 && len < self.size() && "GetModuleFileNameW failed");
     return self.data();
@@ -285,7 +285,7 @@ static void trace(const char* fmt, ...)
     buf[written + 1] = '\n';
     if (g_hLogging != INVALID_HANDLE_VALUE)
     {
-        WriteFile(g_hLogging, buf.data(), (DWORD)written + 2, nullptr, nullptr);
+        WriteFile(g_hLogging, buf.data(), static_cast<DWORD>(written) + 2, nullptr, nullptr);
     }
 
     OutputDebugStringA(buf.data());
@@ -295,10 +295,10 @@ static std::vector<DWORD> getConsoleProcessList()
 {
     std::vector<DWORD> ret;
     ret.resize(1);
-    const DWORD count1 = GetConsoleProcessList(&ret[0], (DWORD)ret.size());
+    const DWORD count1 = GetConsoleProcessList(&ret[0], static_cast<DWORD>(ret.size()));
     assert(count1 >= 1 && "GetConsoleProcessList failed");
     ret.resize(count1);
-    const DWORD count2 = GetConsoleProcessList(&ret[0], (DWORD)ret.size());
+    const DWORD count2 = GetConsoleProcessList(&ret[0], static_cast<DWORD>(ret.size()));
     assert(count1 == count2 && "GetConsoleProcessList failed");
     return ret;
 }
@@ -507,7 +507,7 @@ static std::deque<std::wstring> getCommandLine()
     {
         ret.push_back(argv[i]);
     }
-    LocalFree((HLOCAL)argv);
+    LocalFree(static_cast<HLOCAL>(argv));
     return ret;
 }
 
@@ -527,7 +527,7 @@ static int shiftInt(std::deque<std::wstring>& container)
 
 static HANDLE shiftHandle(std::deque<std::wstring>& container)
 {
-    return (HANDLE)(uintptr_t)shiftInt(container);
+    return (HANDLE)static_cast<uintptr_t>(shiftInt(container));
 }
 
 static int doChild(std::deque<std::wstring> argv)
@@ -723,7 +723,7 @@ static int doParent(std::deque<std::wstring> argv)
         else if (arg == L"--alloc" && hasNext)
         {
             const auto next = shift(argv);
-            allocChunk = (int)(_wtof(next.c_str()) * 1024.0 * 1024.0);
+            allocChunk = static_cast<int>(_wtof(next.c_str()) * 1024.0 * 1024.0);
         }
         else if (arg == L"-m" && hasNext)
         {

--- a/src/tools/echokey/main.cpp
+++ b/src/tools/echokey/main.cpp
@@ -105,7 +105,7 @@ void toPrintableBuffer(char c, char* printBuffer, int* printCch)
     }
     else
     {
-        printBuffer[0] = (char)c;
+        printBuffer[0] = static_cast<char>(c);
         printBuffer[1] = ' ';
         printBuffer[2] = '\0';
         *printCch = 2;

--- a/src/tools/vtpipeterm/VtConsole.cpp
+++ b/src/tools/vtpipeterm/VtConsole.cpp
@@ -141,7 +141,7 @@ void VtConsole::_spawn(const std::wstring& command)
 
     // Create our own output handling thread
     // Each console needs to make sure to drain the output from its backing host.
-    _dwOutputThreadId = (DWORD)-1;
+    _dwOutputThreadId = static_cast<DWORD>(-1);
     _hOutputThread = CreateThread(nullptr,
                                   0,
                                   StaticOutputThreadProc,
@@ -165,10 +165,10 @@ void VtConsole::_createPseudoConsole(const std::wstring& command)
     siEx = { 0 };
     siEx.StartupInfo.cb = sizeof(STARTUPINFOEX);
     size_t size;
-    InitializeProcThreadAttributeList(nullptr, 1, 0, (PSIZE_T)&size);
+    InitializeProcThreadAttributeList(nullptr, 1, 0, static_cast<PSIZE_T>(&size));
     BYTE* attrList = new BYTE[size];
     siEx.lpAttributeList = reinterpret_cast<PPROC_THREAD_ATTRIBUTE_LIST>(attrList);
-    fSuccess = InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, (PSIZE_T)&size);
+    fSuccess = InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, static_cast<PSIZE_T>(&size));
     THROW_LAST_ERROR_IF(!fSuccess);
 
     THROW_IF_FAILED(AttachPseudoConsole(_hPC, siEx.lpAttributeList));
@@ -315,7 +315,7 @@ void VtConsole::_createConptyViaCommandline(const std::wstring& command)
     {
         HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
         std::string msg = "Failed to launch Openconsole";
-        WriteFile(hOut, msg.c_str(), (DWORD)msg.length(), nullptr, nullptr);
+        WriteFile(hOut, msg.c_str(), static_cast<DWORD>(msg.length()), nullptr, nullptr);
     }
 }
 
@@ -331,7 +331,7 @@ void VtConsole::deactivate()
 
 DWORD WINAPI VtConsole::StaticOutputThreadProc(LPVOID lpParameter)
 {
-    VtConsole* const pInstance = (VtConsole*)lpParameter;
+    VtConsole* const pInstance = static_cast<VtConsole*>(lpParameter);
     return pInstance->_OutputThread();
 }
 
@@ -368,7 +368,7 @@ bool VtConsole::Resize(const unsigned short rows, const unsigned short cols)
 {
     if (_fUseConPty)
     {
-        return SUCCEEDED(ResizePseudoConsole(_hPC, { (SHORT)cols, (SHORT)rows }));
+        return SUCCEEDED(ResizePseudoConsole(_hPC, { static_cast<SHORT>(cols), static_cast<SHORT>(rows) }));
     }
     else
     {
@@ -392,7 +392,7 @@ void VtConsole::signalWindow(unsigned short sx, unsigned short sy)
 
 bool VtConsole::WriteInput(std::string& seq)
 {
-    bool fSuccess = !!WriteFile(inPipe(), seq.c_str(), (DWORD)seq.length(), nullptr, nullptr);
+    bool fSuccess = !!WriteFile(inPipe(), seq.c_str(), static_cast<DWORD>(seq.length()), nullptr, nullptr);
     if (!fSuccess)
     {
         HRESULT hr = GetLastError();

--- a/src/tools/vtpipeterm/VtConsole.cpp
+++ b/src/tools/vtpipeterm/VtConsole.cpp
@@ -165,10 +165,10 @@ void VtConsole::_createPseudoConsole(const std::wstring& command)
     siEx = { 0 };
     siEx.StartupInfo.cb = sizeof(STARTUPINFOEX);
     size_t size;
-    InitializeProcThreadAttributeList(nullptr, 1, 0, static_cast<PSIZE_T>(&size));
+    InitializeProcThreadAttributeList(nullptr, 1, 0, &size);
     BYTE* attrList = new BYTE[size];
     siEx.lpAttributeList = reinterpret_cast<PPROC_THREAD_ATTRIBUTE_LIST>(attrList);
-    fSuccess = InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, static_cast<PSIZE_T>(&size));
+    fSuccess = InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, &size);
     THROW_LAST_ERROR_IF(!fSuccess);
 
     THROW_IF_FAILED(AttachPseudoConsole(_hPC, siEx.lpAttributeList));

--- a/src/tools/vtpipeterm/main.cpp
+++ b/src/tools/vtpipeterm/main.cpp
@@ -210,7 +210,7 @@ void toPrintableBuffer(char c, char* printBuffer, int* printCch)
     }
     else
     {
-        printBuffer[0] = (char)c;
+        printBuffer[0] = static_cast<char>(c);
         *printCch = 1;
     }
 }
@@ -495,7 +495,7 @@ void CreateIOThreads()
 {
     // The VtConsoles themselves handle their output threads.
 
-    DWORD dwInputThreadId = (DWORD)-1;
+    DWORD dwInputThreadId = static_cast<DWORD>(-1);
     HANDLE hInputThread = CreateThread(nullptr,
                                        0,
                                        InputThread,
@@ -525,7 +525,7 @@ BOOL WINAPI CtrlHandler(DWORD fdwCtrlType)
 int __cdecl wmain(int argc, WCHAR* argv[])
 {
     // initialize random seed:
-    srand((unsigned int)time(nullptr));
+    srand(static_cast<unsigned int>(time(nullptr)));
     SetConsoleCtrlHandler(CtrlHandler, TRUE);
 
     hOut = GetStdHandle(STD_OUTPUT_HANDLE);

--- a/src/tsf/TfConvArea.cpp
+++ b/src/tsf/TfConvArea.cpp
@@ -81,7 +81,7 @@ Notes:
             }
             else
             {
-                bAttr = (BYTE)da.bAttr;
+                bAttr = static_cast<BYTE>(da.bAttr);
             }
         }
         encodedAttrs.emplace_back(bAttr);

--- a/src/tsf/TfDispAttr.cpp
+++ b/src/tsf/TfDispAttr.cpp
@@ -118,7 +118,7 @@ CicDisplayAttributeMgr::~CicDisplayAttributeMgr()
 
                 FAIL_FAST_IF(!(tfPropVal.varValue.vt == VT_I4)); // expecting GUIDATOMs
 
-                TfGuidAtom gaVal = (TfGuidAtom)tfPropVal.varValue.lVal;
+                TfGuidAtom gaVal = static_cast<TfGuidAtom>(tfPropVal.varValue.lVal);
 
                 GUID guid;
                 pcat->GetGUID(gaVal, &guid);

--- a/src/tsf/TfEditSession.cpp
+++ b/src/tsf/TfEditSession.cpp
@@ -716,7 +716,7 @@ CEditSessionObject::Release()
         auto wstr = std::make_unique<WCHAR[]>(cch + 1);
 
         // Get the whole text, finalize it, and erase the whole text.
-        if (SUCCEEDED(spRange->GetText(ec, TF_TF_IGNOREEND, wstr.get(), (ULONG)cch, (ULONG*)&cch)))
+        if (SUCCEEDED(spRange->GetText(ec, TF_TF_IGNOREEND, wstr.get(), static_cast<ULONG>(cch), (ULONG*)&cch)))
         {
             // Make Result String.
             hr = conv_area->DrawResult({ wstr.get(), static_cast<size_t>(cch) });
@@ -1036,7 +1036,7 @@ CEditSessionObject::Release()
                 auto wstr = std::make_unique<WCHAR[]>(lTextLength + 1);
 
                 // Get the result text, finalize it, and erase the result text.
-                if (SUCCEEDED(FullTextRange->GetText(ec, TF_TF_IGNOREEND, wstr.get(), (ULONG)lTextLength, (ULONG*)&lTextLength)))
+                if (SUCCEEDED(FullTextRange->GetText(ec, TF_TF_IGNOREEND, wstr.get(), static_cast<ULONG>(lTextLength), (ULONG*)&lTextLength)))
                 {
                     // Clear the TOM
                     LOG_IF_FAILED(ClearTextInRange(ec, FullTextRange));

--- a/src/winconpty/ft_pty/ConPtyTests.cpp
+++ b/src/winconpty/ft_pty/ConPtyTests.cpp
@@ -204,14 +204,14 @@ void ConPtyTests::SurvivesOnBreakInput()
     siEx = { 0 };
     siEx.StartupInfo.cb = sizeof(STARTUPINFOEXW);
     size_t size;
-    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, &size));
+    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, (PSIZE_T)&size));
     BYTE* attrList = new BYTE[size];
     auto freeAttrList = wil::scope_exit([&] {
         delete[] attrList;
     });
 
     siEx.lpAttributeList = reinterpret_cast<PPROC_THREAD_ATTRIBUTE_LIST>(attrList);
-    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, &size));
+    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, (PSIZE_T)&size));
     auto deleteAttrList = wil::scope_exit([&] {
         DeleteProcThreadAttributeList(siEx.lpAttributeList);
     });
@@ -267,14 +267,14 @@ void ConPtyTests::SurvivesOnBreakOutput()
     siEx = { 0 };
     siEx.StartupInfo.cb = sizeof(STARTUPINFOEXW);
     size_t size;
-    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, &size));
+    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, (PSIZE_T)&size));
     BYTE* attrList = new BYTE[size];
     auto freeAttrList = wil::scope_exit([&] {
         delete[] attrList;
     });
 
     siEx.lpAttributeList = reinterpret_cast<PPROC_THREAD_ATTRIBUTE_LIST>(attrList);
-    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, &size));
+    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, (PSIZE_T)&size));
     auto deleteAttrList = wil::scope_exit([&] {
         DeleteProcThreadAttributeList(siEx.lpAttributeList);
     });
@@ -330,14 +330,14 @@ void ConPtyTests::DiesOnBreakBoth()
     siEx = { 0 };
     siEx.StartupInfo.cb = sizeof(STARTUPINFOEXW);
     size_t size;
-    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, &size));
+    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, (PSIZE_T)&size));
     BYTE* attrList = new BYTE[size];
     auto freeAttrList = wil::scope_exit([&] {
         delete[] attrList;
     });
 
     siEx.lpAttributeList = reinterpret_cast<PPROC_THREAD_ATTRIBUTE_LIST>(attrList);
-    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, &size));
+    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, (PSIZE_T)&size));
     auto deleteAttrList = wil::scope_exit([&] {
         DeleteProcThreadAttributeList(siEx.lpAttributeList);
     });
@@ -419,14 +419,14 @@ void ConPtyTests::DiesOnClose()
     siEx = { 0 };
     siEx.StartupInfo.cb = sizeof(STARTUPINFOEXW);
     size_t size;
-    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, &size));
+    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, (PSIZE_T)&size));
     BYTE* attrList = new BYTE[size];
     auto freeAttrList = wil::scope_exit([&] {
         delete[] attrList;
     });
 
     siEx.lpAttributeList = reinterpret_cast<PPROC_THREAD_ATTRIBUTE_LIST>(attrList);
-    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, &size));
+    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, (PSIZE_T)&size));
     auto deleteAttrList = wil::scope_exit([&] {
         DeleteProcThreadAttributeList(siEx.lpAttributeList);
     });

--- a/src/winconpty/ft_pty/ConPtyTests.cpp
+++ b/src/winconpty/ft_pty/ConPtyTests.cpp
@@ -204,14 +204,14 @@ void ConPtyTests::SurvivesOnBreakInput()
     siEx = { 0 };
     siEx.StartupInfo.cb = sizeof(STARTUPINFOEXW);
     size_t size;
-    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, (PSIZE_T)&size));
+    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, static_cast<PSIZE_T>(&size)));
     BYTE* attrList = new BYTE[size];
     auto freeAttrList = wil::scope_exit([&] {
         delete[] attrList;
     });
 
     siEx.lpAttributeList = reinterpret_cast<PPROC_THREAD_ATTRIBUTE_LIST>(attrList);
-    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, (PSIZE_T)&size));
+    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, static_cast<PSIZE_T>(&size)));
     auto deleteAttrList = wil::scope_exit([&] {
         DeleteProcThreadAttributeList(siEx.lpAttributeList);
     });
@@ -267,14 +267,14 @@ void ConPtyTests::SurvivesOnBreakOutput()
     siEx = { 0 };
     siEx.StartupInfo.cb = sizeof(STARTUPINFOEXW);
     size_t size;
-    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, (PSIZE_T)&size));
+    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, static_cast<PSIZE_T>(&size)));
     BYTE* attrList = new BYTE[size];
     auto freeAttrList = wil::scope_exit([&] {
         delete[] attrList;
     });
 
     siEx.lpAttributeList = reinterpret_cast<PPROC_THREAD_ATTRIBUTE_LIST>(attrList);
-    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, (PSIZE_T)&size));
+    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, static_cast<PSIZE_T>(&size)));
     auto deleteAttrList = wil::scope_exit([&] {
         DeleteProcThreadAttributeList(siEx.lpAttributeList);
     });
@@ -330,14 +330,14 @@ void ConPtyTests::DiesOnBreakBoth()
     siEx = { 0 };
     siEx.StartupInfo.cb = sizeof(STARTUPINFOEXW);
     size_t size;
-    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, (PSIZE_T)&size));
+    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, static_cast<PSIZE_T>(&size)));
     BYTE* attrList = new BYTE[size];
     auto freeAttrList = wil::scope_exit([&] {
         delete[] attrList;
     });
 
     siEx.lpAttributeList = reinterpret_cast<PPROC_THREAD_ATTRIBUTE_LIST>(attrList);
-    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, (PSIZE_T)&size));
+    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, static_cast<PSIZE_T>(&size)));
     auto deleteAttrList = wil::scope_exit([&] {
         DeleteProcThreadAttributeList(siEx.lpAttributeList);
     });
@@ -419,14 +419,14 @@ void ConPtyTests::DiesOnClose()
     siEx = { 0 };
     siEx.StartupInfo.cb = sizeof(STARTUPINFOEXW);
     size_t size;
-    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, (PSIZE_T)&size));
+    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, static_cast<PSIZE_T>(&size)));
     BYTE* attrList = new BYTE[size];
     auto freeAttrList = wil::scope_exit([&] {
         delete[] attrList;
     });
 
     siEx.lpAttributeList = reinterpret_cast<PPROC_THREAD_ATTRIBUTE_LIST>(attrList);
-    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, (PSIZE_T)&size));
+    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, static_cast<PSIZE_T>(&size)));
     auto deleteAttrList = wil::scope_exit([&] {
         DeleteProcThreadAttributeList(siEx.lpAttributeList);
     });

--- a/src/winconpty/ft_pty/ConPtyTests.cpp
+++ b/src/winconpty/ft_pty/ConPtyTests.cpp
@@ -204,14 +204,14 @@ void ConPtyTests::SurvivesOnBreakInput()
     siEx = { 0 };
     siEx.StartupInfo.cb = sizeof(STARTUPINFOEXW);
     size_t size;
-    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, static_cast<PSIZE_T>(&size)));
+    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, &size));
     BYTE* attrList = new BYTE[size];
     auto freeAttrList = wil::scope_exit([&] {
         delete[] attrList;
     });
 
     siEx.lpAttributeList = reinterpret_cast<PPROC_THREAD_ATTRIBUTE_LIST>(attrList);
-    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, static_cast<PSIZE_T>(&size)));
+    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, &size));
     auto deleteAttrList = wil::scope_exit([&] {
         DeleteProcThreadAttributeList(siEx.lpAttributeList);
     });
@@ -267,14 +267,14 @@ void ConPtyTests::SurvivesOnBreakOutput()
     siEx = { 0 };
     siEx.StartupInfo.cb = sizeof(STARTUPINFOEXW);
     size_t size;
-    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, static_cast<PSIZE_T>(&size)));
+    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, &size));
     BYTE* attrList = new BYTE[size];
     auto freeAttrList = wil::scope_exit([&] {
         delete[] attrList;
     });
 
     siEx.lpAttributeList = reinterpret_cast<PPROC_THREAD_ATTRIBUTE_LIST>(attrList);
-    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, static_cast<PSIZE_T>(&size)));
+    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, &size));
     auto deleteAttrList = wil::scope_exit([&] {
         DeleteProcThreadAttributeList(siEx.lpAttributeList);
     });
@@ -330,14 +330,14 @@ void ConPtyTests::DiesOnBreakBoth()
     siEx = { 0 };
     siEx.StartupInfo.cb = sizeof(STARTUPINFOEXW);
     size_t size;
-    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, static_cast<PSIZE_T>(&size)));
+    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, &size));
     BYTE* attrList = new BYTE[size];
     auto freeAttrList = wil::scope_exit([&] {
         delete[] attrList;
     });
 
     siEx.lpAttributeList = reinterpret_cast<PPROC_THREAD_ATTRIBUTE_LIST>(attrList);
-    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, static_cast<PSIZE_T>(&size)));
+    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, &size));
     auto deleteAttrList = wil::scope_exit([&] {
         DeleteProcThreadAttributeList(siEx.lpAttributeList);
     });
@@ -419,14 +419,14 @@ void ConPtyTests::DiesOnClose()
     siEx = { 0 };
     siEx.StartupInfo.cb = sizeof(STARTUPINFOEXW);
     size_t size;
-    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, static_cast<PSIZE_T>(&size)));
+    VERIFY_IS_FALSE(InitializeProcThreadAttributeList(NULL, 1, 0, &size));
     BYTE* attrList = new BYTE[size];
     auto freeAttrList = wil::scope_exit([&] {
         delete[] attrList;
     });
 
     siEx.lpAttributeList = reinterpret_cast<PPROC_THREAD_ATTRIBUTE_LIST>(attrList);
-    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, static_cast<PSIZE_T>(&size)));
+    VERIFY_IS_TRUE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, &size));
     auto deleteAttrList = wil::scope_exit([&] {
         DeleteProcThreadAttributeList(siEx.lpAttributeList);
     });

--- a/src/winconpty/winconpty.cpp
+++ b/src/winconpty/winconpty.cpp
@@ -339,7 +339,7 @@ extern "C" HRESULT ConptyCreatePseudoConsoleAsUser(_In_ HANDLE hToken,
         return E_INVALIDARG;
     }
 
-    PseudoConsole* pPty = (PseudoConsole*)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(PseudoConsole));
+    PseudoConsole* pPty = static_cast<PseudoConsole*>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(PseudoConsole)));
     RETURN_IF_NULL_ALLOC(pPty);
     auto cleanupPty = wil::scope_exit([&]() noexcept {
         _ClosePseudoConsole(pPty);
@@ -352,7 +352,7 @@ extern "C" HRESULT ConptyCreatePseudoConsoleAsUser(_In_ HANDLE hToken,
 
     RETURN_IF_FAILED(_CreatePseudoConsole(hToken, size, duplicatedInput.get(), duplicatedOutput.get(), dwFlags, pPty));
 
-    *phPC = (HPCON)pPty;
+    *phPC = static_cast<HPCON>(pPty);
     cleanupPty.release();
 
     return S_OK;
@@ -362,7 +362,7 @@ extern "C" HRESULT ConptyCreatePseudoConsoleAsUser(_In_ HANDLE hToken,
 // Resizes the given conpty to the specified size, in characters.
 extern "C" HRESULT WINAPI ConptyResizePseudoConsole(_In_ HPCON hPC, _In_ COORD size)
 {
-    const PseudoConsole* const pPty = (PseudoConsole*)hPC;
+    const PseudoConsole* const pPty = static_cast<PseudoConsole*>(hPC);
     HRESULT hr = pPty == nullptr ? E_INVALIDARG : S_OK;
     if (SUCCEEDED(hr))
     {
@@ -379,7 +379,7 @@ extern "C" HRESULT WINAPI ConptyResizePseudoConsole(_In_ HPCON hPC, _In_ COORD s
 //      terminated, or if the pseudoconsole was already terminated.
 extern "C" VOID WINAPI ConptyClosePseudoConsole(_In_ HPCON hPC)
 {
-    PseudoConsole* const pPty = (PseudoConsole*)hPC;
+    PseudoConsole* const pPty = static_cast<PseudoConsole*>(hPC);
     if (pPty != nullptr)
     {
         _ClosePseudoConsole(pPty);

--- a/src/winconpty/winconpty.cpp
+++ b/src/winconpty/winconpty.cpp
@@ -352,7 +352,7 @@ extern "C" HRESULT ConptyCreatePseudoConsoleAsUser(_In_ HANDLE hToken,
 
     RETURN_IF_FAILED(_CreatePseudoConsole(hToken, size, duplicatedInput.get(), duplicatedOutput.get(), dwFlags, pPty));
 
-    *phPC = static_cast<HPCON>(pPty);
+    *phPC = pPty;
     cleanupPty.release();
 
     return S_OK;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
A lot of casts are in the C-style, but this is hugely ambiguous to the compiler, which may put some casts at runtime, others during compile time. This applies the stats cast to the primitive data types, or the types that are typedef from a basic data type, as well as reinterpret casts where needed.
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [X] Tests added/passed

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Unit Tests
