### PR TITLE
Set DxRenderer non-text alias mode

### DIFF
--- a/src/renderer/dx/CustomTextRenderer.cpp
+++ b/src/renderer/dx/CustomTextRenderer.cpp
@@ -273,7 +273,7 @@ using namespace Microsoft::Console::Render;
     rect.right = std::accumulate(advancesSpan.cbegin(), advancesSpan.cend(), rect.right);
 
     // Clip all drawing in this glyph run to where we expect.
-    d2dContext->PushAxisAlignedClip(rect, D2D1_ANTIALIAS_MODE_PER_PRIMITIVE);
+    d2dContext->PushAxisAlignedClip(rect, D2D1_ANTIALIAS_MODE_ALIASED);
     // Ensure we pop it on the way out
     auto popclip = wil::scope_exit([&d2dContext]() noexcept {
         d2dContext->PopAxisAlignedClip();

--- a/src/renderer/dx/CustomTextRenderer.cpp
+++ b/src/renderer/dx/CustomTextRenderer.cpp
@@ -273,7 +273,12 @@ using namespace Microsoft::Console::Render;
     rect.right = std::accumulate(advancesSpan.cbegin(), advancesSpan.cend(), rect.right);
 
     // Clip all drawing in this glyph run to where we expect.
+    // We need the AntialiasMode here to be Aliased to ensure
+    //  that background boxes line up with each other and don't leave behind
+    //  stray colors.
+    // See GH#3626 for more details.
     d2dContext->PushAxisAlignedClip(rect, D2D1_ANTIALIAS_MODE_ALIASED);
+
     // Ensure we pop it on the way out
     auto popclip = wil::scope_exit([&d2dContext]() noexcept {
         d2dContext->PopAxisAlignedClip();

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -533,6 +533,10 @@ void DxEngine::_ComputePixelShaderSettings() noexcept
                                                                     &props,
                                                                     &_d2dRenderTarget));
 
+        // We need the AntialiasMode for non-text object to be Aliased to ensure
+        //  that background boxes line up with each other and don't leave behind
+        //  stray colors.
+        // See GH#3626 for more details.
         _d2dRenderTarget->SetAntialiasMode(D2D1_ANTIALIAS_MODE_ALIASED);
         _d2dRenderTarget->SetTextAntialiasMode(_antialiasingMode);
 

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -533,6 +533,7 @@ void DxEngine::_ComputePixelShaderSettings() noexcept
                                                                     &props,
                                                                     &_d2dRenderTarget));
 
+        _d2dRenderTarget->SetAntialiasMode(D2D1_ANTIALIAS_MODE_ALIASED);
         _d2dRenderTarget->SetTextAntialiasMode(_antialiasingMode);
 
         RETURN_IF_FAILED(_d2dRenderTarget->CreateSolidColorBrush(D2D1::ColorF(D2D1::ColorF::DarkRed),


### PR DESCRIPTION
There are two antialias modes that can be set on the ID2D1RenderTarget:
- one for text/glyph drawing [1]
- one for everything else [2]
We had to configure that in the RenderTarget.

Additionally, when clipping the background color rect, we need to make
sure that's aliased too. [3]

## References
[1] ID2D1RenderTarget::SetTextAntialiasMode
    https://docs.microsoft.com/en-us/windows/win32/api/d2d1/nf-d2d1-id2d1rendertarget-settextantialiasmode
[2] ID2D1RenderTarget::SetAntialiasMode
    https://docs.microsoft.com/en-us/windows/win32/api/d2d1/nf-d2d1-id2d1rendertarget-setantialiasmode)
[3] ID2D1CommandSink::PushAxisAlignedClip
    https://docs.microsoft.com/en-us/windows/win32/api/d2d1_1/nf-d2d1_1-id2d1commandsink-pushaxisalignedclip)

## Validation
Open and interact with midnight commander with the display scaling set
to...
- 100%
- 125%
- 150%
- 175%
- 200%

Closes #3626