### PR TITLE
Update reference to the current WT commandline

### DIFF
--- a/doc/user-docs/index.md
+++ b/doc/user-docs/index.md
@@ -27,7 +27,7 @@ NOTE: The default shell is PowerShell; you can change this using the _Running a 
 
 ### Command line options
 
-Please check [Using the wt.exe Commandline](https://github.com/microsoft/terminal/blob/master/doc/user-docs/UsingCommandlineArguments.md)
+Please refer to [Using the wt.exe Commandline](https://github.com/microsoft/terminal/blob/master/doc/user-docs/UsingCommandlineArguments.md) for details on how to use the `wt.exe` commandline arguments.
 
 
 ## Multiple Tabs

--- a/doc/user-docs/index.md
+++ b/doc/user-docs/index.md
@@ -9,6 +9,8 @@ change. If you notice an error in the docs, please raise an issue. Or better yet
 
 To compile Windows Terminal yourself using the source code, follow the instructions in the [README](/README.md#developer-guidance).
 
+You check the WT [releases changes](https://github.com/microsoft/Terminal/releases).
+
 ### From the Microsoft Store
 
 1. Make sure you have upgraded to the current Windows 10 release (at least build `1903`). To determine your build number, see [winver](https://docs.microsoft.com/en-us/windows/client-management/windows-version-search).
@@ -25,7 +27,8 @@ NOTE: The default shell is PowerShell; you can change this using the _Running a 
 
 ### Command line options
 
-None at this time. See issue [#607](https://github.com/microsoft/terminal/issues/607)
+Please check [Using the wt.exe Commandline](https://github.com/microsoft/terminal/blob/master/doc/user-docs/UsingCommandlineArguments.md)
+
 
 ## Multiple Tabs
 


### PR DESCRIPTION
The index.md is outdate indicating there is not commandline options but since versio XXXX there. And some are docummented in UsingCommandlineArguments.md. 

I also added reference to list to changes of the WT releases.

I removed the line. "None at this time. See issue [#607](https://github.com/microsoft/terminal/issues/607)"

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
