### PR TITLE
Remove a heap of legacy settings deserialization

### DIFF
--- a/doc/cascadia/SettingsSchema.md
+++ b/doc/cascadia/SettingsSchema.md
@@ -111,14 +111,13 @@ For commands with arguments:
 
 | Command | Command Description | Action (*=required) | Action Arguments | Argument Descriptions |
 | ------- | ------------------- | ------ | ---------------- | ----------------- |
+| `adjustFontSize` | Change the text size by a specified point amount. | `delta` | integer | Amount of size change per command invocation. |
 | `closePane` | Close the active pane. | | | |
 | `closeTab` | Close the current tab. | | | |
 | `closeWindow` | Close the current window and all tabs within it. | | | |
 | `copy` | Copy the selected terminal content to your Windows Clipboard. | `trimWhitespace` | boolean | When `true`, newlines persist from the selected text. When `false`, copied content will paste on one line. |
-| `decreaseFontSize` | Make the text smaller by one delta. | `delta` | integer | Amount of size decrease per command invocation. |
 | `duplicateTab` | Make a copy and open the current tab. | | | |
 | `find` | Open the search dialog box. | | | |
-| `increaseFontSize` | Make the text larger by one delta. | `delta` | integer | Amount of size increase per command invocation. |
 | `moveFocus` | Focus on a different pane depending on direction. | `direction`* | `left`, `right`, `up`, `down` | Direction in which the focus will move. |
 | `newTab` | Create a new tab. Without any arguments, this will open the default profile in a new tab. | 1. `commandLine`<br>2. `startingDirectory`<br>3. `tabTitle`<br>4. `index`<br>5. `profile` | 1. string<br>2. string<br>3. string<br>4. integer<br>5. string | 1. Executable run within the tab.<br>2. Directory in which the tab will open.<br>3. Title of the new tab.<br>4. Profile that will open based on its position in the dropdown (starting at 0).<br>5. Profile that will open based on its GUID or name. |
 | `nextTab` | Open the tab to the right of the current one. | | | |

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -25,29 +25,15 @@
     },
     "ShortcutActionName": {
       "enum": [
+        "adjustFontSize",
         "closePane",
         "closeTab",
         "closeWindow",
         "copy",
-        "copyTextWithoutNewlines",
         "decreaseFontSize",
         "duplicateTab",
-        "increaseFontSize",
         "moveFocus",
-        "moveFocusDown",
-        "moveFocusLeft",
-        "moveFocusRight",
-        "moveFocusUp",
         "newTab",
-        "newTabProfile0",
-        "newTabProfile1",
-        "newTabProfile2",
-        "newTabProfile3",
-        "newTabProfile4",
-        "newTabProfile5",
-        "newTabProfile6",
-        "newTabProfile7",
-        "newTabProfile8",
         "nextTab",
         "openNewTabDropdown",
         "openSettings",
@@ -55,27 +41,12 @@
         "prevTab",
         "resetFontSize",
         "resizePane",
-        "resizePaneDown",
-        "resizePaneLeft",
-        "resizePaneRight",
-        "resizePaneUp",
         "scrollDown",
         "scrollDownPage",
         "scrollUp",
         "scrollUpPage",
-        "splitHorizontal",
-        "splitVertical",
         "splitPane",
         "switchToTab",
-        "switchToTab0",
-        "switchToTab1",
-        "switchToTab2",
-        "switchToTab3",
-        "switchToTab4",
-        "switchToTab5",
-        "switchToTab6",
-        "switchToTab7",
-        "switchToTab8",
         "toggleFullscreen",
         "find"
       ],
@@ -134,6 +105,23 @@
         "action"
       ],
       "type": "object"
+    },
+    "AdjustFontSizeAction": {
+      "description": "Arguments corresponding to an Adjust Font Size Action",
+      "allOf": [
+        { "$ref": "#/definitions/ShortcutAction" },
+        {
+          "properties": {
+            "action": { "type": "string", "pattern": "adjustFontSize" },
+            "delta": {
+              "type": "integer",
+              "default": 0,
+              "description": "How much to change the current font point size"
+            }
+          }
+        }
+      ],
+      "required": [ "delta" ]
     },
     "CopyAction": {
       "description": "Arguments corresponding to a Copy Text Action",
@@ -238,6 +226,7 @@
         "command": {
           "description": "The action executed when the associated key bindings are pressed.",
             "oneOf": [
+              { "$ref": "#/definitions/AdjustFontSizeAction" },
               { "$ref": "#/definitions/CopyAction" },
               { "$ref": "#/definitions/ShortcutActionName" },
               { "$ref": "#/definitions/NewTabAction" },

--- a/doc/user-docs/UsingJsonSettings.md
+++ b/doc/user-docs/UsingJsonSettings.md
@@ -414,7 +414,7 @@ following objects into your `globals.keybindings` array:
 { "command": "paste", "keys": ["ctrl+shift+v"] }
 ```
 
-> 👉 **Note**: you can also add a keybinding for the `copyTextWithoutNewlines` command. This removes newlines as the text is copied to your clipboard.
+> 👉 **Note**: you can also add a keybinding for the `copy` command with the argument `"trimWhitespace": true`. This removes newlines as the text is copied to your clipboard.
 
 This will add copy and paste on <kbd>ctrl+shift+c</kbd>
 and <kbd>ctrl+shift+v</kbd> respectively.

--- a/src/cascadia/LocalTests_TerminalApp/KeyBindingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/KeyBindingsTests.cpp
@@ -170,21 +170,18 @@ namespace TerminalAppLocalTests
     {
         const std::string bindings0String{ R"([
             { "command": "copy", "keys": ["ctrl+c"] },
-            { "command": "copyTextWithoutNewlines", "keys": ["alt+c"] },
             { "command": { "action": "copy", "trimWhitespace": false }, "keys": ["ctrl+shift+c"] },
             { "command": { "action": "copy", "trimWhitespace": true }, "keys": ["alt+shift+c"] },
 
             { "command": "newTab", "keys": ["ctrl+t"] },
             { "command": { "action": "newTab", "index": 0 }, "keys": ["ctrl+shift+t"] },
-            { "command": "newTabProfile0", "keys": ["alt+shift+t"] },
             { "command": { "action": "newTab", "index": 11 }, "keys": ["ctrl+shift+y"] },
-            { "command": "newTabProfile8", "keys": ["alt+shift+y"] },
 
             { "command": { "action": "copy", "madeUpBool": true }, "keys": ["ctrl+b"] },
             { "command": { "action": "copy" }, "keys": ["ctrl+shift+b"] },
 
-            { "command": "increaseFontSize", "keys": ["ctrl+f"] },
-            { "command": "decreaseFontSize", "keys": ["ctrl+g"] }
+            { "command": { "action": "adjustFontSize", "delta": 1 }, "keys": ["ctrl+f"] },
+            { "command": { "action": "adjustFontSize", "delta": -1 }, "keys": ["ctrl+g"] }
 
         ])" };
 
@@ -194,7 +191,7 @@ namespace TerminalAppLocalTests
         VERIFY_IS_NOT_NULL(appKeyBindings);
         VERIFY_ARE_EQUAL(0u, appKeyBindings->_keyShortcuts.size());
         appKeyBindings->LayerJson(bindings0Json);
-        VERIFY_ARE_EQUAL(13u, appKeyBindings->_keyShortcuts.size());
+        VERIFY_ARE_EQUAL(10u, appKeyBindings->_keyShortcuts.size());
 
         {
             Log::Comment(NoThrowString().Format(
@@ -205,17 +202,6 @@ namespace TerminalAppLocalTests
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
             VERIFY_IS_TRUE(realArgs.TrimWhitespace());
-        }
-
-        {
-            Log::Comment(NoThrowString().Format(
-                L"Verify that `copyTextWithoutNewlines` parses as Copy(TrimWhitespace=false)"));
-            KeyChord kc{ false, true, false, static_cast<int32_t>('C') };
-            auto actionAndArgs = TestUtils::GetActionAndArgs(*appKeyBindings, kc);
-            const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
-            VERIFY_IS_NOT_NULL(realArgs);
-            // Verify the args have the expected value
-            VERIFY_IS_FALSE(realArgs.TrimWhitespace());
         }
 
         {
@@ -267,19 +253,6 @@ namespace TerminalAppLocalTests
         }
         {
             Log::Comment(NoThrowString().Format(
-                L"Verify that `newTabProfile0` parses as NewTab(Index=0)"));
-            KeyChord kc{ false, true, true, static_cast<int32_t>('T') };
-            auto actionAndArgs = TestUtils::GetActionAndArgs(*appKeyBindings, kc);
-            VERIFY_ARE_EQUAL(ShortcutAction::NewTabProfile0, actionAndArgs.Action());
-            const auto& realArgs = actionAndArgs.Args().try_as<NewTabArgs>();
-            VERIFY_IS_NOT_NULL(realArgs);
-            // Verify the args have the expected value
-            VERIFY_IS_NOT_NULL(realArgs.TerminalArgs());
-            VERIFY_IS_NOT_NULL(realArgs.TerminalArgs().ProfileIndex());
-            VERIFY_ARE_EQUAL(0, realArgs.TerminalArgs().ProfileIndex().Value());
-        }
-        {
-            Log::Comment(NoThrowString().Format(
                 L"Verify that `newTab` with an index greater than the legacy "
                 L"args afforded parses correctly"));
             KeyChord kc{ true, false, true, static_cast<int32_t>('Y') };
@@ -291,19 +264,6 @@ namespace TerminalAppLocalTests
             VERIFY_IS_NOT_NULL(realArgs.TerminalArgs());
             VERIFY_IS_NOT_NULL(realArgs.TerminalArgs().ProfileIndex());
             VERIFY_ARE_EQUAL(11, realArgs.TerminalArgs().ProfileIndex().Value());
-        }
-        {
-            Log::Comment(NoThrowString().Format(
-                L"Verify that `newTabProfile8` parses as NewTab(Index=8)"));
-            KeyChord kc{ false, true, true, static_cast<int32_t>('Y') };
-            auto actionAndArgs = TestUtils::GetActionAndArgs(*appKeyBindings, kc);
-            VERIFY_ARE_EQUAL(ShortcutAction::NewTabProfile8, actionAndArgs.Action());
-            const auto& realArgs = actionAndArgs.Args().try_as<NewTabArgs>();
-            VERIFY_IS_NOT_NULL(realArgs);
-            // Verify the args have the expected value
-            VERIFY_IS_NOT_NULL(realArgs.TerminalArgs());
-            VERIFY_IS_NOT_NULL(realArgs.TerminalArgs().ProfileIndex());
-            VERIFY_ARE_EQUAL(8, realArgs.TerminalArgs().ProfileIndex().Value());
         }
 
         {
@@ -332,10 +292,10 @@ namespace TerminalAppLocalTests
 
         {
             Log::Comment(NoThrowString().Format(
-                L"Verify that `increaseFontSize` without args parses as AdjustFontSize(Delta=1)"));
+                L"Verify that `adjustFontSize` with a positive delta parses args correctly"));
             KeyChord kc{ true, false, false, static_cast<int32_t>('F') };
             auto actionAndArgs = TestUtils::GetActionAndArgs(*appKeyBindings, kc);
-            VERIFY_ARE_EQUAL(ShortcutAction::IncreaseFontSize, actionAndArgs.Action());
+            VERIFY_ARE_EQUAL(ShortcutAction::AdjustFontSize, actionAndArgs.Action());
             const auto& realArgs = actionAndArgs.Args().try_as<AdjustFontSizeArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
@@ -344,10 +304,10 @@ namespace TerminalAppLocalTests
 
         {
             Log::Comment(NoThrowString().Format(
-                L"Verify that `decreaseFontSize` without args parses as AdjustFontSize(Delta=-1)"));
+                L"Verify that `adjustFontSize` with a negative delta parses args correctly"));
             KeyChord kc{ true, false, false, static_cast<int32_t>('G') };
             auto actionAndArgs = TestUtils::GetActionAndArgs(*appKeyBindings, kc);
-            VERIFY_ARE_EQUAL(ShortcutAction::DecreaseFontSize, actionAndArgs.Action());
+            VERIFY_ARE_EQUAL(ShortcutAction::AdjustFontSize, actionAndArgs.Action());
             const auto& realArgs = actionAndArgs.Args().try_as<AdjustFontSizeArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
@@ -358,8 +318,6 @@ namespace TerminalAppLocalTests
     void KeyBindingsTests::TestSplitPaneArgs()
     {
         const std::string bindings0String{ R"([
-            { "keys": ["ctrl+a"], "command": "splitVertical" },
-            { "keys": ["ctrl+b"], "command": "splitHorizontal" },
             { "keys": ["ctrl+c"], "command": { "action": "splitPane", "split": null } },
             { "keys": ["ctrl+d"], "command": { "action": "splitPane", "split": "vertical" } },
             { "keys": ["ctrl+e"], "command": { "action": "splitPane", "split": "horizontal" } },
@@ -375,26 +333,8 @@ namespace TerminalAppLocalTests
         VERIFY_IS_NOT_NULL(appKeyBindings);
         VERIFY_ARE_EQUAL(0u, appKeyBindings->_keyShortcuts.size());
         appKeyBindings->LayerJson(bindings0Json);
-        VERIFY_ARE_EQUAL(9u, appKeyBindings->_keyShortcuts.size());
+        VERIFY_ARE_EQUAL(7u, appKeyBindings->_keyShortcuts.size());
 
-        {
-            KeyChord kc{ true, false, false, static_cast<int32_t>('A') };
-            auto actionAndArgs = TestUtils::GetActionAndArgs(*appKeyBindings, kc);
-            VERIFY_ARE_EQUAL(ShortcutAction::SplitVertical, actionAndArgs.Action());
-            const auto& realArgs = actionAndArgs.Args().try_as<SplitPaneArgs>();
-            VERIFY_IS_NOT_NULL(realArgs);
-            // Verify the args have the expected value
-            VERIFY_ARE_EQUAL(winrt::TerminalApp::SplitState::Vertical, realArgs.SplitStyle());
-        }
-        {
-            KeyChord kc{ true, false, false, static_cast<int32_t>('B') };
-            auto actionAndArgs = TestUtils::GetActionAndArgs(*appKeyBindings, kc);
-            VERIFY_ARE_EQUAL(ShortcutAction::SplitHorizontal, actionAndArgs.Action());
-            const auto& realArgs = actionAndArgs.Args().try_as<SplitPaneArgs>();
-            VERIFY_IS_NOT_NULL(realArgs);
-            // Verify the args have the expected value
-            VERIFY_ARE_EQUAL(winrt::TerminalApp::SplitState::Horizontal, realArgs.SplitStyle());
-        }
         {
             KeyChord kc{ true, false, false, static_cast<int32_t>('C') };
             auto actionAndArgs = TestUtils::GetActionAndArgs(*appKeyBindings, kc);

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -56,8 +56,6 @@ namespace TerminalAppLocalTests
         TEST_METHOD(TestInvalidColorSchemeName);
         TEST_METHOD(TestHelperFunctions);
 
-        TEST_METHOD(TestLayerGlobalsOnRoot);
-
         TEST_METHOD(TestProfileIconWithEnvVar);
         TEST_METHOD(TestProfileBackgroundImageWithEnvVar);
 
@@ -160,9 +158,7 @@ namespace TerminalAppLocalTests
     {
         const std::string goodProfiles{ R"(
         {
-            "globals": {
-                "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}"
-            },
+            "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
             "profiles": [
                 {
                     "name" : "profile0",
@@ -177,9 +173,7 @@ namespace TerminalAppLocalTests
 
         const std::string badProfiles{ R"(
         {
-            "globals": {
-                "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}"
-            },
+            "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
             "profiles": [
                 {
                     "name" : "profile0",
@@ -194,9 +188,7 @@ namespace TerminalAppLocalTests
 
         const std::string noDefaultAtAll{ R"(
         {
-            "globals": {
-                "alwaysShowTabs": true
-            },
+            "alwaysShowTabs": true,
             "profiles": [
                 {
                     "name" : "profile0",
@@ -388,9 +380,7 @@ namespace TerminalAppLocalTests
     {
         const std::string badProfiles{ R"(
         {
-            "globals": {
-                "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}"
-            },
+            "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
             "profiles": [
                 {
                     "name" : "profile0",
@@ -438,21 +428,17 @@ namespace TerminalAppLocalTests
     {
         const std::string settings0String{ R"(
         {
-            "globals": {
-                "alwaysShowTabs": true,
-                "initialCols" : 120,
-                "initialRows" : 30,
-                "rowsToScroll" :  4
-            }
+            "alwaysShowTabs": true,
+            "initialCols" : 120,
+            "initialRows" : 30,
+            "rowsToScroll" :  4
         })" };
         const std::string settings1String{ R"(
         {
-            "globals": {
-                "showTabsInTitlebar": false,
-                "initialCols" : 240,
-                "initialRows" : 60,
-                "rowsToScroll" : 8
-            }
+            "showTabsInTitlebar": false,
+            "initialCols" : 240,
+            "initialRows" : 60,
+            "rowsToScroll" : 8
         })" };
         const auto settings0Json = VerifyParseSucceeded(settings0String);
         const auto settings1Json = VerifyParseSucceeded(settings1String);
@@ -1348,114 +1334,6 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(name2, prof2->GetName());
     }
 
-    void SettingsTests::TestLayerGlobalsOnRoot()
-    {
-        // Test for microsoft/terminal#2906. We added the ability for the root
-        // to be used as the globals object in #2515. However, if you have a
-        // globals object, then the settings in the root would get ignored.
-        // This test ensures that settings from a child "globals" element
-        // _layer_ on top of root properties, and they don't cause the root
-        // properties to be totally ignored.
-
-        const std::string settings0String{ R"(
-        {
-            "globals": {
-                "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
-                "initialRows": 123
-            }
-        })" };
-        const std::string settings1String{ R"(
-        {
-            "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
-            "initialRows": 234
-        })" };
-        const std::string settings2String{ R"(
-        {
-            "defaultProfile": "{6239a42c-2222-49a3-80bd-e8fdd045185c}",
-            "initialRows": 345,
-            "globals": {
-                "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}"
-                // initialRows should not be cleared here
-            }
-        })" };
-        const std::string settings3String{ R"(
-        {
-            "defaultProfile": "{6239a42c-2222-49a3-80bd-e8fdd045185c}",
-            "globals": {
-                "initialRows": 456
-                // defaultProfile should not be cleared here
-            }
-        })" };
-        const std::string settings4String{ R"(
-        {
-            "defaultProfile": "{6239a42c-2222-49a3-80bd-e8fdd045185c}",
-            "globals": {
-                "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}"
-            },
-            "defaultProfile": "{6239a42c-3333-49a3-80bd-e8fdd045185c}"
-        })" };
-        const std::string settings5String{ R"(
-        {
-            "globals": {
-                "defaultProfile": "{6239a42c-1111-49a3-80bd-e8fdd045185c}"
-            },
-            "defaultProfile": "{6239a42c-2222-49a3-80bd-e8fdd045185c}",
-            "globals": {
-                "defaultProfile": "{6239a42c-3333-49a3-80bd-e8fdd045185c}"
-            }
-        })" };
-
-        VerifyParseSucceeded(settings0String);
-        VerifyParseSucceeded(settings1String);
-        VerifyParseSucceeded(settings2String);
-        VerifyParseSucceeded(settings3String);
-        VerifyParseSucceeded(settings4String);
-        VerifyParseSucceeded(settings5String);
-        const auto guid1 = Microsoft::Console::Utils::GuidFromString(L"{6239a42c-1111-49a3-80bd-e8fdd045185c}");
-        const auto guid2 = Microsoft::Console::Utils::GuidFromString(L"{6239a42c-2222-49a3-80bd-e8fdd045185c}");
-        const auto guid3 = Microsoft::Console::Utils::GuidFromString(L"{6239a42c-3333-49a3-80bd-e8fdd045185c}");
-
-        {
-            CascadiaSettings settings;
-            settings._ParseJsonString(settings0String, false);
-            settings.LayerJson(settings._userSettings);
-            VERIFY_ARE_EQUAL(guid1, settings._globals._defaultProfile);
-            VERIFY_ARE_EQUAL(123, settings._globals._initialRows);
-        }
-        {
-            CascadiaSettings settings;
-            settings._ParseJsonString(settings1String, false);
-            settings.LayerJson(settings._userSettings);
-            VERIFY_ARE_EQUAL(guid1, settings._globals._defaultProfile);
-            VERIFY_ARE_EQUAL(234, settings._globals._initialRows);
-        }
-        {
-            CascadiaSettings settings;
-            settings._ParseJsonString(settings2String, false);
-            settings.LayerJson(settings._userSettings);
-            VERIFY_ARE_EQUAL(guid1, settings._globals._defaultProfile);
-            VERIFY_ARE_EQUAL(345, settings._globals._initialRows);
-        }
-        {
-            CascadiaSettings settings;
-            settings._ParseJsonString(settings3String, false);
-            settings.LayerJson(settings._userSettings);
-            VERIFY_ARE_EQUAL(guid2, settings._globals._defaultProfile);
-            VERIFY_ARE_EQUAL(456, settings._globals._initialRows);
-        }
-        {
-            CascadiaSettings settings;
-            settings._ParseJsonString(settings4String, false);
-            settings.LayerJson(settings._userSettings);
-            VERIFY_ARE_EQUAL(guid1, settings._globals._defaultProfile);
-        }
-        {
-            CascadiaSettings settings;
-            settings._ParseJsonString(settings5String, false);
-            settings.LayerJson(settings._userSettings);
-            VERIFY_ARE_EQUAL(guid3, settings._globals._defaultProfile);
-        }
-    }
     void SettingsTests::TestProfileIconWithEnvVar()
     {
         const auto expectedPath = wil::ExpandEnvironmentStringsW<std::wstring>(L"%WINDIR%\\System32\\x_80.png");
@@ -2311,9 +2189,7 @@ namespace TerminalAppLocalTests
     {
         const std::string badSettings{ R"(
         {
-            "globals": {
-                "defaultProfile": "{6239a42c-2222-49a3-80bd-e8fdd045185c}"
-            },
+            "defaultProfile": "{6239a42c-2222-49a3-80bd-e8fdd045185c}",
             "profiles": [
                 {
                     "name" : "profile0",

--- a/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/AppKeyBindingsSerialization.cpp
@@ -25,20 +25,10 @@ static constexpr std::string_view ActionKey{ "action" };
 static constexpr std::string_view UnboundKey{ "unbound" };
 
 static constexpr std::string_view CopyTextKey{ "copy" };
-static constexpr std::string_view CopyTextWithoutNewlinesKey{ "copyTextWithoutNewlines" }; // Legacy
 static constexpr std::string_view PasteTextKey{ "paste" };
 static constexpr std::string_view OpenNewTabDropdownKey{ "openNewTabDropdown" };
 static constexpr std::string_view DuplicateTabKey{ "duplicateTab" };
 static constexpr std::string_view NewTabKey{ "newTab" };
-static constexpr std::string_view NewTabWithProfile0Key{ "newTabProfile0" }; // Legacy
-static constexpr std::string_view NewTabWithProfile1Key{ "newTabProfile1" }; // Legacy
-static constexpr std::string_view NewTabWithProfile2Key{ "newTabProfile2" }; // Legacy
-static constexpr std::string_view NewTabWithProfile3Key{ "newTabProfile3" }; // Legacy
-static constexpr std::string_view NewTabWithProfile4Key{ "newTabProfile4" }; // Legacy
-static constexpr std::string_view NewTabWithProfile5Key{ "newTabProfile5" }; // Legacy
-static constexpr std::string_view NewTabWithProfile6Key{ "newTabProfile6" }; // Legacy
-static constexpr std::string_view NewTabWithProfile7Key{ "newTabProfile7" }; // Legacy
-static constexpr std::string_view NewTabWithProfile8Key{ "newTabProfile8" }; // Legacy
 static constexpr std::string_view NewWindowKey{ "newWindow" };
 static constexpr std::string_view CloseWindowKey{ "closeWindow" };
 static constexpr std::string_view CloseTabKey{ "closeTab" };
@@ -46,37 +36,17 @@ static constexpr std::string_view ClosePaneKey{ "closePane" };
 static constexpr std::string_view SwitchtoTabKey{ "switchToTab" };
 static constexpr std::string_view NextTabKey{ "nextTab" };
 static constexpr std::string_view PrevTabKey{ "prevTab" };
-static constexpr std::string_view IncreaseFontSizeKey{ "increaseFontSize" };
-static constexpr std::string_view DecreaseFontSizeKey{ "decreaseFontSize" };
+static constexpr std::string_view AdjustFontSizeKey{ "adjustFontSize" };
 static constexpr std::string_view ResetFontSizeKey{ "resetFontSize" };
 static constexpr std::string_view ScrollupKey{ "scrollUp" };
 static constexpr std::string_view ScrolldownKey{ "scrollDown" };
 static constexpr std::string_view ScrolluppageKey{ "scrollUpPage" };
 static constexpr std::string_view ScrolldownpageKey{ "scrollDownPage" };
 static constexpr std::string_view SwitchToTabKey{ "switchToTab" };
-static constexpr std::string_view SwitchToTab0Key{ "switchToTab0" }; // Legacy
-static constexpr std::string_view SwitchToTab1Key{ "switchToTab1" }; // Legacy
-static constexpr std::string_view SwitchToTab2Key{ "switchToTab2" }; // Legacy
-static constexpr std::string_view SwitchToTab3Key{ "switchToTab3" }; // Legacy
-static constexpr std::string_view SwitchToTab4Key{ "switchToTab4" }; // Legacy
-static constexpr std::string_view SwitchToTab5Key{ "switchToTab5" }; // Legacy
-static constexpr std::string_view SwitchToTab6Key{ "switchToTab6" }; // Legacy
-static constexpr std::string_view SwitchToTab7Key{ "switchToTab7" }; // Legacy
-static constexpr std::string_view SwitchToTab8Key{ "switchToTab8" }; // Legacy
-static constexpr std::string_view OpenSettingsKey{ "openSettings" }; // Legacy
+static constexpr std::string_view OpenSettingsKey{ "openSettings" }; // TODO GH#2557: Add args for OpenSettings
 static constexpr std::string_view SplitPaneKey{ "splitPane" };
-static constexpr std::string_view SplitHorizontalKey{ "splitHorizontal" }; // Legacy
-static constexpr std::string_view SplitVerticalKey{ "splitVertical" }; // Legacy
 static constexpr std::string_view ResizePaneKey{ "resizePane" };
-static constexpr std::string_view ResizePaneLeftKey{ "resizePaneLeft" }; // Legacy
-static constexpr std::string_view ResizePaneRightKey{ "resizePaneRight" }; // Legacy
-static constexpr std::string_view ResizePaneUpKey{ "resizePaneUp" }; // Legacy
-static constexpr std::string_view ResizePaneDownKey{ "resizePaneDown" }; // Legacy
 static constexpr std::string_view MoveFocusKey{ "moveFocus" };
-static constexpr std::string_view MoveFocusLeftKey{ "moveFocusLeft" }; // Legacy
-static constexpr std::string_view MoveFocusRightKey{ "moveFocusRight" }; // Legacy
-static constexpr std::string_view MoveFocusUpKey{ "moveFocusUp" }; // Legacy
-static constexpr std::string_view MoveFocusDownKey{ "moveFocusDown" }; // Legacy
 static constexpr std::string_view FindKey{ "find" };
 static constexpr std::string_view ToggleFullscreenKey{ "toggleFullscreen" };
 
@@ -90,55 +60,25 @@ static constexpr std::string_view ToggleFullscreenKey{ "toggleFullscreen" };
 // about here.
 static const std::map<std::string_view, ShortcutAction, std::less<>> commandNames{
     { CopyTextKey, ShortcutAction::CopyText },
-    { CopyTextWithoutNewlinesKey, ShortcutAction::CopyTextWithoutNewlines },
     { PasteTextKey, ShortcutAction::PasteText },
     { OpenNewTabDropdownKey, ShortcutAction::OpenNewTabDropdown },
     { DuplicateTabKey, ShortcutAction::DuplicateTab },
     { NewTabKey, ShortcutAction::NewTab },
-    { NewTabWithProfile0Key, ShortcutAction::NewTabProfile0 },
-    { NewTabWithProfile1Key, ShortcutAction::NewTabProfile1 },
-    { NewTabWithProfile2Key, ShortcutAction::NewTabProfile2 },
-    { NewTabWithProfile3Key, ShortcutAction::NewTabProfile3 },
-    { NewTabWithProfile4Key, ShortcutAction::NewTabProfile4 },
-    { NewTabWithProfile5Key, ShortcutAction::NewTabProfile5 },
-    { NewTabWithProfile6Key, ShortcutAction::NewTabProfile6 },
-    { NewTabWithProfile7Key, ShortcutAction::NewTabProfile7 },
-    { NewTabWithProfile8Key, ShortcutAction::NewTabProfile8 },
     { NewWindowKey, ShortcutAction::NewWindow },
     { CloseWindowKey, ShortcutAction::CloseWindow },
     { CloseTabKey, ShortcutAction::CloseTab },
     { ClosePaneKey, ShortcutAction::ClosePane },
     { NextTabKey, ShortcutAction::NextTab },
     { PrevTabKey, ShortcutAction::PrevTab },
-    { IncreaseFontSizeKey, ShortcutAction::IncreaseFontSize },
-    { DecreaseFontSizeKey, ShortcutAction::DecreaseFontSize },
+    { AdjustFontSizeKey, ShortcutAction::AdjustFontSize },
     { ResetFontSizeKey, ShortcutAction::ResetFontSize },
     { ScrollupKey, ShortcutAction::ScrollUp },
     { ScrolldownKey, ShortcutAction::ScrollDown },
     { ScrolluppageKey, ShortcutAction::ScrollUpPage },
     { ScrolldownpageKey, ShortcutAction::ScrollDownPage },
     { SwitchToTabKey, ShortcutAction::SwitchToTab },
-    { SwitchToTab0Key, ShortcutAction::SwitchToTab0 },
-    { SwitchToTab1Key, ShortcutAction::SwitchToTab1 },
-    { SwitchToTab2Key, ShortcutAction::SwitchToTab2 },
-    { SwitchToTab3Key, ShortcutAction::SwitchToTab3 },
-    { SwitchToTab4Key, ShortcutAction::SwitchToTab4 },
-    { SwitchToTab5Key, ShortcutAction::SwitchToTab5 },
-    { SwitchToTab6Key, ShortcutAction::SwitchToTab6 },
-    { SwitchToTab7Key, ShortcutAction::SwitchToTab7 },
-    { SwitchToTab8Key, ShortcutAction::SwitchToTab8 },
-    { SplitHorizontalKey, ShortcutAction::SplitHorizontal },
-    { SplitVerticalKey, ShortcutAction::SplitVertical },
     { ResizePaneKey, ShortcutAction::ResizePane },
-    { ResizePaneLeftKey, ShortcutAction::ResizePaneLeft },
-    { ResizePaneRightKey, ShortcutAction::ResizePaneRight },
-    { ResizePaneUpKey, ShortcutAction::ResizePaneUp },
-    { ResizePaneDownKey, ShortcutAction::ResizePaneDown },
     { MoveFocusKey, ShortcutAction::MoveFocus },
-    { MoveFocusLeftKey, ShortcutAction::MoveFocusLeft },
-    { MoveFocusRightKey, ShortcutAction::MoveFocusRight },
-    { MoveFocusUpKey, ShortcutAction::MoveFocusUp },
-    { MoveFocusDownKey, ShortcutAction::MoveFocusDown },
     { OpenSettingsKey, ShortcutAction::OpenSettings },
     { ToggleFullscreenKey, ShortcutAction::ToggleFullscreen },
     { SplitPaneKey, ShortcutAction::SplitPane },
@@ -149,146 +89,6 @@ static const std::map<std::string_view, ShortcutAction, std::less<>> commandName
 using ParseResult = std::tuple<IActionArgs, std::vector<TerminalApp::SettingsLoadWarnings>>;
 using ParseActionFunction = std::function<ParseResult(const Json::Value&)>;
 
-// Function Description:
-// - Creates a function that can be used to generate a SplitPaneArgs for the
-//   legacy Split[SplitState] actions. These actions don't accept args from
-//   json, instead, they just return a SplitPaneArgs with the style already
-//   pre-defined, based on the input param.
-// - TODO: GH#1069 Remove this before 1.0, and force an upgrade to the new args.
-// Arguments:
-// - style: the split style to create the parse function for.
-// Return Value:
-// - A function that can be used to "parse" json into one of the legacy
-//   Split[SplitState] args.
-ParseActionFunction LegacyParseSplitPaneArgs(SplitState style)
-{
-    auto pfn = [style](const Json::Value & /*value*/) -> ParseResult {
-        auto args = winrt::make_self<winrt::TerminalApp::implementation::SplitPaneArgs>();
-        args->SplitStyle(style);
-        return { *args, {} };
-    };
-    return pfn;
-}
-
-// Function Description:
-// - Creates a function that can be used to generate a MoveFocusArgs for the
-//   legacy MoveFocus[Direction] actions. These actions don't accept args from
-//   json, instead, they just return a MoveFocusArgs with the Direction already
-//   per-defined, based on the input param.
-// - TODO: GH#1069 Remove this before 1.0, and force an upgrade to the new args.
-// Arguments:
-// - direction: the direction to create the parse function for.
-// Return Value:
-// - A function that can be used to "parse" json into one of the legacy
-//   MoveFocus[Direction] args.
-ParseActionFunction LegacyParseMoveFocusArgs(Direction direction)
-{
-    auto pfn = [direction](const Json::Value & /*value*/) -> ParseResult {
-        auto args = winrt::make_self<winrt::TerminalApp::implementation::MoveFocusArgs>();
-        args->Direction(direction);
-        return { *args, {} };
-    };
-    return pfn;
-}
-
-// Function Description:
-// - Creates a function that can be used to generate a ResizePaneArgs for the
-//   legacy ResizePane[Direction] actions. These actions don't accept args from
-//   json, instead, they just return a ResizePaneArgs with the Direction already
-//   per-defined, based on the input param.
-// - TODO: GH#1069 Remove this before 1.0, and force an upgrade to the new args.
-// Arguments:
-// - direction: the direction to create the parse function for.
-// Return Value:
-// - A function that can be used to "parse" json into one of the legacy
-//   ResizePane[Direction] args.
-ParseActionFunction LegacyParseResizePaneArgs(Direction direction)
-{
-    auto pfn = [direction](const Json::Value & /*value*/) -> ParseResult {
-        auto args = winrt::make_self<winrt::TerminalApp::implementation::ResizePaneArgs>();
-        args->Direction(direction);
-        return { *args, {} };
-    };
-    return pfn;
-}
-
-// Function Description:
-// - Creates a function that can be used to generate a NewTabWithProfileArgs for
-//   the legacy NewTabWithProfile[Index] actions. These actions don't accept
-//   args from json, instead, they just return a NewTabWithProfileArgs with the
-//   index already per-defined, based on the input param.
-// - TODO: GH#1069 Remove this before 1.0, and force an upgrade to the new args.
-// Arguments:
-// - index: the profile index to create the parse function for.
-// Return Value:
-// - A function that can be used to "parse" json into one of the legacy
-//   NewTabWithProfile[Index] args.
-ParseActionFunction LegacyParseNewTabWithProfileArgs(int index)
-{
-    auto pfn = [index](const Json::Value & /*value*/) -> ParseResult {
-        auto args = winrt::make_self<winrt::TerminalApp::implementation::NewTabArgs>();
-        auto newTerminalArgs = winrt::make_self<winrt::TerminalApp::implementation::NewTerminalArgs>();
-        newTerminalArgs->ProfileIndex(index);
-        args->TerminalArgs(*newTerminalArgs);
-        return { *args, {} };
-    };
-    return pfn;
-}
-
-// Function Description:
-// - Creates a function that can be used to generate a SwitchToTabArgs for the
-//   legacy SwitchToTab[Index] actions. These actions don't accept args from
-//   json, instead, they just return a SwitchToTabArgs with the index already
-//   per-defined, based on the input param.
-// - TODO: GH#1069 Remove this before 1.0, and force an upgrade to the new args.
-// Arguments:
-// - index: the tab index to create the parse function for.
-// Return Value:
-// - A function that can be used to "parse" json into one of the legacy
-//   SwitchToTab[Index] args.
-ParseActionFunction LegacyParseSwitchToTabArgs(int index)
-{
-    auto pfn = [index](const Json::Value & /*value*/) -> ParseResult {
-        auto args = winrt::make_self<winrt::TerminalApp::implementation::SwitchToTabArgs>();
-        args->TabIndex(index);
-        return { *args, {} };
-    };
-    return pfn;
-}
-
-// Function Description:
-// - Used to generate a CopyTextArgs for the legacy CopyTextWithoutNewlines
-//   action.
-// - TODO: GH#1069 Remove this before 1.0, and force an upgrade to the new args.
-// Arguments:
-// - direction: the direction to create the parse function for.
-// Return Value:
-// - A CopyTextArgs with TrimWhitespace set to true, to emulate "CopyTextWithoutNewlines".
-ParseResult LegacyParseCopyTextWithoutNewlinesArgs(const Json::Value& /*json*/)
-{
-    auto args = winrt::make_self<winrt::TerminalApp::implementation::CopyTextArgs>();
-    args->TrimWhitespace(false);
-    return { *args, {} };
-};
-
-// Function Description:
-// - Used to generate a AdjustFontSizeArgs for IncreaseFontSize/DecreaseFontSize
-//   actions with a delta of 1/-1.
-// - TODO: GH#1069 Remove this before 1.0, and force an upgrade to the new args.
-// Arguments:
-// - delta: the font size delta to create the parse function for.
-// Return Value:
-// - A function that can be used to "parse" json into an AdjustFontSizeArgs.
-ParseActionFunction LegacyParseAdjustFontSizeArgs(int delta)
-{
-    auto pfn = [delta](const Json::Value & /*value*/) -> ParseResult {
-        auto args = winrt::make_self<winrt::TerminalApp::implementation::AdjustFontSizeArgs>();
-        args->Delta(delta);
-        return { *args, {} };
-    };
-    return pfn;
-}
-
 // This is a map of ShortcutAction->function<IActionArgs(Json::Value)>. It holds
 // a set of deserializer functions that can be used to deserialize a IActionArgs
 // from json. Each type of IActionArgs that can accept arbitrary args should be
@@ -296,48 +96,18 @@ ParseActionFunction LegacyParseAdjustFontSizeArgs(int delta)
 // value.
 static const std::map<ShortcutAction, ParseActionFunction, std::less<>> argParsers{
     { ShortcutAction::CopyText, winrt::TerminalApp::implementation::CopyTextArgs::FromJson },
-    { ShortcutAction::CopyTextWithoutNewlines, LegacyParseCopyTextWithoutNewlinesArgs },
 
     { ShortcutAction::NewTab, winrt::TerminalApp::implementation::NewTabArgs::FromJson },
-    { ShortcutAction::NewTabProfile0, LegacyParseNewTabWithProfileArgs(0) },
-    { ShortcutAction::NewTabProfile1, LegacyParseNewTabWithProfileArgs(1) },
-    { ShortcutAction::NewTabProfile2, LegacyParseNewTabWithProfileArgs(2) },
-    { ShortcutAction::NewTabProfile3, LegacyParseNewTabWithProfileArgs(3) },
-    { ShortcutAction::NewTabProfile4, LegacyParseNewTabWithProfileArgs(4) },
-    { ShortcutAction::NewTabProfile5, LegacyParseNewTabWithProfileArgs(5) },
-    { ShortcutAction::NewTabProfile6, LegacyParseNewTabWithProfileArgs(6) },
-    { ShortcutAction::NewTabProfile7, LegacyParseNewTabWithProfileArgs(7) },
-    { ShortcutAction::NewTabProfile8, LegacyParseNewTabWithProfileArgs(8) },
 
     { ShortcutAction::SwitchToTab, winrt::TerminalApp::implementation::SwitchToTabArgs::FromJson },
-    { ShortcutAction::SwitchToTab0, LegacyParseSwitchToTabArgs(0) },
-    { ShortcutAction::SwitchToTab1, LegacyParseSwitchToTabArgs(1) },
-    { ShortcutAction::SwitchToTab2, LegacyParseSwitchToTabArgs(2) },
-    { ShortcutAction::SwitchToTab3, LegacyParseSwitchToTabArgs(3) },
-    { ShortcutAction::SwitchToTab4, LegacyParseSwitchToTabArgs(4) },
-    { ShortcutAction::SwitchToTab5, LegacyParseSwitchToTabArgs(5) },
-    { ShortcutAction::SwitchToTab6, LegacyParseSwitchToTabArgs(6) },
-    { ShortcutAction::SwitchToTab7, LegacyParseSwitchToTabArgs(7) },
-    { ShortcutAction::SwitchToTab8, LegacyParseSwitchToTabArgs(8) },
 
     { ShortcutAction::ResizePane, winrt::TerminalApp::implementation::ResizePaneArgs::FromJson },
-    { ShortcutAction::ResizePaneLeft, LegacyParseResizePaneArgs(Direction::Left) },
-    { ShortcutAction::ResizePaneRight, LegacyParseResizePaneArgs(Direction::Right) },
-    { ShortcutAction::ResizePaneUp, LegacyParseResizePaneArgs(Direction::Up) },
-    { ShortcutAction::ResizePaneDown, LegacyParseResizePaneArgs(Direction::Down) },
 
     { ShortcutAction::MoveFocus, winrt::TerminalApp::implementation::MoveFocusArgs::FromJson },
-    { ShortcutAction::MoveFocusLeft, LegacyParseMoveFocusArgs(Direction::Left) },
-    { ShortcutAction::MoveFocusRight, LegacyParseMoveFocusArgs(Direction::Right) },
-    { ShortcutAction::MoveFocusUp, LegacyParseMoveFocusArgs(Direction::Up) },
-    { ShortcutAction::MoveFocusDown, LegacyParseMoveFocusArgs(Direction::Down) },
 
-    { ShortcutAction::DecreaseFontSize, LegacyParseAdjustFontSizeArgs(-1) },
-    { ShortcutAction::IncreaseFontSize, LegacyParseAdjustFontSizeArgs(1) },
+    { ShortcutAction::AdjustFontSize, winrt::TerminalApp::implementation::AdjustFontSizeArgs::FromJson },
 
     { ShortcutAction::SplitPane, winrt::TerminalApp::implementation::SplitPaneArgs::FromJson },
-    { ShortcutAction::SplitVertical, LegacyParseSplitPaneArgs(SplitState::Vertical) },
-    { ShortcutAction::SplitHorizontal, LegacyParseSplitPaneArgs(SplitState::Horizontal) },
 
     { ShortcutAction::Invalid, nullptr },
 };

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -244,7 +244,7 @@ void CascadiaSettings::_ValidateProfilesHaveGuid()
 }
 
 // Method Description:
-// - Checks if the "globals.defaultProfile" is set to one of the profiles we
+// - Checks if the "defaultProfile" is set to one of the profiles we
 //   actually have. If the value is unset, or the value is set to something that
 //   doesn't exist in the list of profiles, we'll arbitrarily pick the first
 //   profile to use temporarily as the default.

--- a/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
@@ -33,7 +33,6 @@ static constexpr std::string_view ProfilesKey{ "profiles" };
 static constexpr std::string_view DefaultSettingsKey{ "defaults" };
 static constexpr std::string_view ProfilesListKey{ "list" };
 static constexpr std::string_view KeybindingsKey{ "keybindings" };
-static constexpr std::string_view GlobalsKey{ "globals" };
 static constexpr std::string_view SchemesKey{ "schemes" };
 
 static constexpr std::string_view DisabledProfileSourcesKey{ "disabledProfileSources" };
@@ -501,18 +500,7 @@ std::unique_ptr<CascadiaSettings> CascadiaSettings::FromJson(const Json::Value& 
 // <none>
 void CascadiaSettings::LayerJson(const Json::Value& json)
 {
-    // microsoft/terminal#2906: First layer the root object as our globals. If
-    // there is also a `globals` object, layer that one on top of the settings
-    // from the root.
     _globals.LayerJson(json);
-
-    if (auto globals{ json[GlobalsKey.data()] })
-    {
-        if (globals.isObject())
-        {
-            _globals.LayerJson(globals);
-        }
-    }
 
     if (auto schemes{ json[SchemesKey.data()] })
     {
@@ -919,10 +907,5 @@ const Json::Value& CascadiaSettings::_GetProfilesJsonObject(const Json::Value& j
 //   given object
 const Json::Value& CascadiaSettings::_GetDisabledProfileSourcesJsonObject(const Json::Value& json)
 {
-    // Check the globals first, then look in the root.
-    if (json.isMember(JsonKey(GlobalsKey)))
-    {
-        return json[JsonKey(GlobalsKey)][JsonKey(DisabledProfileSourcesKey)];
-    }
     return json[JsonKey(DisabledProfileSourcesKey)];
 }

--- a/src/cascadia/TerminalApp/ColorScheme.cpp
+++ b/src/cascadia/TerminalApp/ColorScheme.cpp
@@ -14,7 +14,6 @@ using namespace winrt::Microsoft::Terminal::Settings;
 using namespace winrt::Microsoft::Terminal::TerminalControl;
 
 static constexpr std::string_view NameKey{ "name" };
-static constexpr std::string_view TableKey{ "colors" };
 static constexpr std::string_view ForegroundKey{ "foreground" };
 static constexpr std::string_view BackgroundKey{ "background" };
 static constexpr std::string_view SelectionBackgroundKey{ "selectionBackground" };
@@ -175,22 +174,6 @@ void ColorScheme::LayerJson(const Json::Value& json)
     {
         const auto color = Utils::ColorFromHexString(sbString.asString());
         _cursorColor = color;
-    }
-
-    // Legacy Deserialization. Leave in place to allow forward compatibility
-    if (auto table{ json[JsonKey(TableKey)] })
-    {
-        int i = 0;
-
-        for (const auto& tableEntry : table)
-        {
-            if (tableEntry.isString())
-            {
-                auto color = Utils::ColorFromHexString(tableEntry.asString());
-                _table.at(i) = color;
-            }
-            i++;
-        }
     }
 
     int i = 0;

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -143,7 +143,6 @@ private:
     std::optional<uint32_t> _defaultBackground;
     std::optional<uint32_t> _selectionBackground;
     std::optional<uint32_t> _cursorColor;
-    std::array<uint32_t, COLOR_TABLE_SIZE> _colorTable;
     std::optional<std::wstring> _tabTitle;
     bool _suppressApplicationTitle;
     int32_t _historySize;

--- a/src/cascadia/TerminalApp/ShortcutActionDispatch.cpp
+++ b/src/cascadia/TerminalApp/ShortcutActionDispatch.cpp
@@ -33,11 +33,6 @@ namespace winrt::TerminalApp::implementation
             _CopyTextHandlers(*this, *eventArgs);
             break;
         }
-        case ShortcutAction::CopyTextWithoutNewlines:
-        {
-            _CopyTextHandlers(*this, *eventArgs);
-            break;
-        }
         case ShortcutAction::PasteText:
         {
             _PasteTextHandlers(*this, *eventArgs);
@@ -60,15 +55,6 @@ namespace winrt::TerminalApp::implementation
         }
 
         case ShortcutAction::NewTab:
-        case ShortcutAction::NewTabProfile0:
-        case ShortcutAction::NewTabProfile1:
-        case ShortcutAction::NewTabProfile2:
-        case ShortcutAction::NewTabProfile3:
-        case ShortcutAction::NewTabProfile4:
-        case ShortcutAction::NewTabProfile5:
-        case ShortcutAction::NewTabProfile6:
-        case ShortcutAction::NewTabProfile7:
-        case ShortcutAction::NewTabProfile8:
         {
             _NewTabHandlers(*this, *eventArgs);
             break;
@@ -136,46 +122,24 @@ namespace winrt::TerminalApp::implementation
         }
 
         case ShortcutAction::SwitchToTab:
-        case ShortcutAction::SwitchToTab0:
-        case ShortcutAction::SwitchToTab1:
-        case ShortcutAction::SwitchToTab2:
-        case ShortcutAction::SwitchToTab3:
-        case ShortcutAction::SwitchToTab4:
-        case ShortcutAction::SwitchToTab5:
-        case ShortcutAction::SwitchToTab6:
-        case ShortcutAction::SwitchToTab7:
-        case ShortcutAction::SwitchToTab8:
         {
             _SwitchToTabHandlers(*this, *eventArgs);
             break;
         }
 
         case ShortcutAction::ResizePane:
-        case ShortcutAction::ResizePaneLeft:
-        case ShortcutAction::ResizePaneRight:
-        case ShortcutAction::ResizePaneUp:
-        case ShortcutAction::ResizePaneDown:
         {
             _ResizePaneHandlers(*this, *eventArgs);
             break;
         }
 
         case ShortcutAction::MoveFocus:
-        case ShortcutAction::MoveFocusLeft:
-        case ShortcutAction::MoveFocusRight:
-        case ShortcutAction::MoveFocusUp:
-        case ShortcutAction::MoveFocusDown:
         {
             _MoveFocusHandlers(*this, *eventArgs);
             break;
         }
 
-        case ShortcutAction::IncreaseFontSize:
-        {
-            _AdjustFontSizeHandlers(*this, *eventArgs);
-            break;
-        }
-        case ShortcutAction::DecreaseFontSize:
+        case ShortcutAction::AdjustFontSize:
         {
             _AdjustFontSizeHandlers(*this, *eventArgs);
             break;

--- a/src/cascadia/TerminalApp/ShortcutActionDispatch.idl
+++ b/src/cascadia/TerminalApp/ShortcutActionDispatch.idl
@@ -11,20 +11,10 @@ namespace TerminalApp
     {
         Invalid = 0,
         CopyText,
-        CopyTextWithoutNewlines,
         PasteText,
         OpenNewTabDropdown,
         DuplicateTab,
         NewTab,
-        NewTabProfile0, // Legacy
-        NewTabProfile1, // Legacy
-        NewTabProfile2, // Legacy
-        NewTabProfile3, // Legacy
-        NewTabProfile4, // Legacy
-        NewTabProfile5, // Legacy
-        NewTabProfile6, // Legacy
-        NewTabProfile7, // Legacy
-        NewTabProfile8, // Legacy
         NewWindow,
         CloseWindow,
         CloseTab,
@@ -35,32 +25,14 @@ namespace TerminalApp
         SplitHorizontal,
         SplitPane,
         SwitchToTab,
-        SwitchToTab0, // Legacy
-        SwitchToTab1, // Legacy
-        SwitchToTab2, // Legacy
-        SwitchToTab3, // Legacy
-        SwitchToTab4, // Legacy
-        SwitchToTab5, // Legacy
-        SwitchToTab6, // Legacy
-        SwitchToTab7, // Legacy
-        SwitchToTab8, // Legacy
-        IncreaseFontSize,
-        DecreaseFontSize,
+        AdjustFontSize,
         ResetFontSize,
         ScrollUp,
         ScrollDown,
         ScrollUpPage,
         ScrollDownPage,
         ResizePane,
-        ResizePaneLeft, // Legacy
-        ResizePaneRight, // Legacy
-        ResizePaneUp, // Legacy
-        ResizePaneDown, // Legacy
         MoveFocus,
-        MoveFocusLeft, // Legacy
-        MoveFocusRight, // Legacy
-        MoveFocusUp, // Legacy
-        MoveFocusDown, // Legacy
         Find,
         ToggleFullscreen,
         OpenSettings

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -292,25 +292,16 @@ namespace winrt::TerminalApp::implementation
             // add the keyboard shortcuts for the first 9 profiles
             if (profileIndex < 9)
             {
-                // enum value for ShortcutAction::NewTabProfileX; 0==NewTabProfile0
-                const auto action = static_cast<ShortcutAction>(profileIndex + static_cast<int>(ShortcutAction::NewTabProfile0));
-                // First, attempt to search for the keybinding for the simple
-                // NewTabProfile0-9 ShortcutActions.
-                auto profileKeyChord = keyBindings.GetKeyBindingForAction(action);
-                if (!profileKeyChord)
-                {
-                    // If NewTabProfileN didn't have a binding, look for a
-                    // keychord that is bound to the equivalent
-                    // NewTab(ProfileIndex=N) action
-                    auto actionAndArgs = winrt::make_self<winrt::TerminalApp::implementation::ActionAndArgs>();
-                    actionAndArgs->Action(ShortcutAction::NewTab);
-                    auto newTabArgs = winrt::make_self<winrt::TerminalApp::implementation::NewTabArgs>();
-                    auto newTerminalArgs = winrt::make_self<winrt::TerminalApp::implementation::NewTerminalArgs>();
-                    newTerminalArgs->ProfileIndex(profileIndex);
-                    newTabArgs->TerminalArgs(*newTerminalArgs);
-                    actionAndArgs->Args(*newTabArgs);
-                    profileKeyChord = keyBindings.GetKeyBindingForActionWithArgs(*actionAndArgs);
-                }
+                // Look for a keychord that is bound to the equivalent
+                // NewTab(ProfileIndex=N) action
+                auto actionAndArgs = winrt::make_self<winrt::TerminalApp::implementation::ActionAndArgs>();
+                actionAndArgs->Action(ShortcutAction::NewTab);
+                auto newTabArgs = winrt::make_self<winrt::TerminalApp::implementation::NewTabArgs>();
+                auto newTerminalArgs = winrt::make_self<winrt::TerminalApp::implementation::NewTerminalArgs>();
+                newTerminalArgs->ProfileIndex(profileIndex);
+                newTabArgs->TerminalArgs(*newTerminalArgs);
+                actionAndArgs->Args(*newTabArgs);
+                auto profileKeyChord{ keyBindings.GetKeyBindingForActionWithArgs(*actionAndArgs) };
 
                 // make sure we find one to display
                 if (profileKeyChord)

--- a/src/cascadia/TerminalApp/defaults.json
+++ b/src/cascadia/TerminalApp/defaults.json
@@ -210,13 +210,13 @@
     ],
     "keybindings":
     [
+        { "command": { "action": "adjustFontSize", "delta": 1 }, "keys": "ctrl+=" },
+        { "command": { "action": "adjustFontSize", "delta": -1 }, "keys": "ctrl+-" },
         { "command": "closePane", "keys": "ctrl+shift+w" },
         { "command": "closeWindow", "keys": "alt+f4" },
         { "command": "copy", "keys": "ctrl+shift+c" },
         { "command": "copy", "keys": "ctrl+insert" },
-        { "command": "decreaseFontSize", "keys": "ctrl+-" },
         { "command": "duplicateTab", "keys": "ctrl+shift+d" },
-        { "command": "increaseFontSize", "keys": "ctrl+=" },
         { "command": { "action": "moveFocus", "direction": "down" }, "keys": "alt+down" },
         { "command": { "action": "moveFocus", "direction": "left" }, "keys": "alt+left" },
         { "command": { "action": "moveFocus", "direction": "right" }, "keys": "alt+right" },


### PR DESCRIPTION
This pull request removes support for:

* legacy keybindings of all types
* `colorScheme.colors`, as an array
* A `globals` object in the root of the settings file
* `profile.colorTable` and `profile.colorscheme` (the rare v0.1 all-lowercase variety)

### c637a6757fe33edd78123a549c41405c0e77ac3a - Settings: delete all legacy keybinding deserializers
### fc0d22e7fb62b5c30664c5513c07025a830dacad - Settings: remove support for colorScheme.colors (array)
### e3bc5a9afd255e478928512365cd80796c983381 - Settings: remove legacy colorscheme key and colorTable
### bba1d651f3d532f8d46be6e29c72a6097cab60b4 - Settings: Remove support for /globals

Fixes #4091.
Fixes #1069.