### PR TITLE
Reduce CursorChanged Events for Accessibility

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1817,11 +1817,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             if (!_closing.load())
             {
                 TSFInputControl().TryRedrawCanvas();
-
-                if (_uiaEngine.get())
-                {
-                    _uiaEngine->CursorPositionChanged();
-                }
             }
         }
     }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1817,6 +1817,11 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             if (!_closing.load())
             {
                 TSFInputControl().TryRedrawCanvas();
+
+                if (_uiaEngine.get())
+                {
+                    _uiaEngine->CursorPositionChanged();
+                }
             }
         }
     }

--- a/src/renderer/uia/UiaRenderer.cpp
+++ b/src/renderer/uia/UiaRenderer.cpp
@@ -71,7 +71,6 @@ UiaEngine::UiaEngine(IUiaEventDispatcher* dispatcher) :
 // - S_FALSE
 [[nodiscard]] HRESULT UiaEngine::InvalidateCursor(const COORD* const /*pcoordCursor*/) noexcept
 {
-    _cursorChanged = true;
     return S_FALSE;
 }
 
@@ -452,6 +451,11 @@ UiaEngine::UiaEngine(IUiaEventDispatcher* dispatcher) :
 [[nodiscard]] HRESULT UiaEngine::IsGlyphWideByFont(const std::wstring_view /*glyph*/, _Out_ bool* const /*pResult*/) noexcept
 {
     return S_FALSE;
+}
+
+void UiaEngine::CursorPositionChanged() noexcept
+{
+    _cursorChanged = true;
 }
 
 // Method Description:

--- a/src/renderer/uia/UiaRenderer.cpp
+++ b/src/renderer/uia/UiaRenderer.cpp
@@ -69,9 +69,14 @@ UiaEngine::UiaEngine(IUiaEventDispatcher* dispatcher) :
 // - pcoordCursor - the new position of the cursor
 // Return Value:
 // - S_FALSE
-[[nodiscard]] HRESULT UiaEngine::InvalidateCursor(const COORD* const /*pcoordCursor*/) noexcept
+[[nodiscard]] HRESULT UiaEngine::InvalidateCursor(const COORD* const pcoordCursor) noexcept
 {
-    _cursorChanged = true;
+    // check if cursor moved
+    if (*pcoordCursor != _prevCursorPos)
+    {
+        _prevCursorPos = *pcoordCursor;
+        _cursorChanged = true;
+    }
     return S_FALSE;
 }
 
@@ -246,7 +251,6 @@ UiaEngine::UiaEngine(IUiaEventDispatcher* dispatcher) :
     _selectionChanged = false;
     _textBufferChanged = false;
     _cursorChanged = false;
-    _prevSelection.clear();
     _isPainting = false;
 
     return S_OK;

--- a/src/renderer/uia/UiaRenderer.cpp
+++ b/src/renderer/uia/UiaRenderer.cpp
@@ -71,6 +71,7 @@ UiaEngine::UiaEngine(IUiaEventDispatcher* dispatcher) :
 // - S_FALSE
 [[nodiscard]] HRESULT UiaEngine::InvalidateCursor(const COORD* const /*pcoordCursor*/) noexcept
 {
+    _cursorChanged = true;
     return S_FALSE;
 }
 
@@ -451,11 +452,6 @@ UiaEngine::UiaEngine(IUiaEventDispatcher* dispatcher) :
 [[nodiscard]] HRESULT UiaEngine::IsGlyphWideByFont(const std::wstring_view /*glyph*/, _Out_ bool* const /*pResult*/) noexcept
 {
     return S_FALSE;
-}
-
-void UiaEngine::CursorPositionChanged() noexcept
-{
-    _cursorChanged = true;
 }
 
 // Method Description:

--- a/src/renderer/uia/UiaRenderer.cpp
+++ b/src/renderer/uia/UiaRenderer.cpp
@@ -70,7 +70,10 @@ UiaEngine::UiaEngine(IUiaEventDispatcher* dispatcher) :
 // Return Value:
 // - S_OK
 [[nodiscard]] HRESULT UiaEngine::InvalidateCursor(const COORD* const pcoordCursor) noexcept
+try
 {
+    RETURN_HR_IF_NULL(E_INVALIDARG, pcoordCursor);
+
     // check if cursor moved
     if (*pcoordCursor != _prevCursorPos)
     {
@@ -79,6 +82,7 @@ UiaEngine::UiaEngine(IUiaEventDispatcher* dispatcher) :
     }
     return S_OK;
 }
+CATCH_RETURN();
 
 // Routine Description:
 // - Invalidates a rectangle describing a pixel area on the display

--- a/src/renderer/uia/UiaRenderer.cpp
+++ b/src/renderer/uia/UiaRenderer.cpp
@@ -77,7 +77,7 @@ UiaEngine::UiaEngine(IUiaEventDispatcher* dispatcher) :
         _prevCursorPos = *pcoordCursor;
         _cursorChanged = true;
     }
-    return S_FALSE;
+    return S_OK;
 }
 
 // Routine Description:

--- a/src/renderer/uia/UiaRenderer.cpp
+++ b/src/renderer/uia/UiaRenderer.cpp
@@ -68,7 +68,7 @@ UiaEngine::UiaEngine(IUiaEventDispatcher* dispatcher) :
 // Arguments:
 // - pcoordCursor - the new position of the cursor
 // Return Value:
-// - S_FALSE
+// - S_OK
 [[nodiscard]] HRESULT UiaEngine::InvalidateCursor(const COORD* const pcoordCursor) noexcept
 {
     // check if cursor moved

--- a/src/renderer/uia/UiaRenderer.hpp
+++ b/src/renderer/uia/UiaRenderer.hpp
@@ -88,5 +88,6 @@ namespace Microsoft::Console::Render
         Microsoft::Console::Types::IUiaEventDispatcher* _dispatcher;
 
         std::vector<SMALL_RECT> _prevSelection;
+        til::point _prevCursorPos;
     };
 }

--- a/src/renderer/uia/UiaRenderer.hpp
+++ b/src/renderer/uia/UiaRenderer.hpp
@@ -75,6 +75,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT GetFontSize(_Out_ COORD* const pFontSize) noexcept override;
         [[nodiscard]] HRESULT IsGlyphWideByFont(const std::wstring_view glyph, _Out_ bool* const pResult) noexcept override;
 
+        void CursorPositionChanged() noexcept;
     protected:
         [[nodiscard]] HRESULT _DoUpdateTitle(const std::wstring& newTitle) noexcept override;
 

--- a/src/renderer/uia/UiaRenderer.hpp
+++ b/src/renderer/uia/UiaRenderer.hpp
@@ -75,7 +75,6 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT GetFontSize(_Out_ COORD* const pFontSize) noexcept override;
         [[nodiscard]] HRESULT IsGlyphWideByFont(const std::wstring_view glyph, _Out_ bool* const pResult) noexcept override;
 
-        void CursorPositionChanged() noexcept;
     protected:
         [[nodiscard]] HRESULT _DoUpdateTitle(const std::wstring& newTitle) noexcept override;
 


### PR DESCRIPTION
## Summary of the Pull Request
Reduce the number of times we dispatch a cursor changed event. We were firing it every time the renderer had to do anything related to the cursor. Unfortunately, blinking the cursor triggered this behavior. Now we just check if the position has changed.

## PR Checklist
* [X] Closes #5143


## Validation Steps Performed
Verified using Narrator
Also verified #3791 still works right