### PR TITLE
Fix a typo in this doc

### DIFF
--- a/doc/user-docs/UsingJsonSettings.md
+++ b/doc/user-docs/UsingJsonSettings.md
@@ -246,7 +246,7 @@ like to hide all the WSL profiles, you could add the following setting:
 
 ```json
 
-    "disabledProfileSources": ["Microsoft.Terminal.WSL"],
+    "disabledProfileSources": ["Windows.Terminal.WSL"],
     ...
 
 ```


### PR DESCRIPTION
In the spec for this feature I was using `Microsoft.Terminal.*` for dynamic profile generators, but in the PR this changed to `Windows.Terminal.*`. Noticed this in the morning.