### PR TITLE
Remove "wether" from dictionary, add "VTE"

### DIFF
--- a/.github/actions/spell-check/whitelist/whitelist.txt
+++ b/.github/actions/spell-check/whitelist/whitelist.txt
@@ -2627,6 +2627,7 @@ VSTT
 vstudio
 vswhere
 vtapp
+VTE
 vtio
 vtmode
 vtpipeterm


### PR DESCRIPTION
_Technically_, "wether" is a word but I'd be shocked if there's a scenario for us to use it properly in this repo, so I'm pulling it from the dictionary.

Also, in #5200, we added "VTE", which is totally a valid acronym, to the codebase, but not the whitelist. I'm not sure why the bot let me merge it anyways, but I'm fixing it now.