### PR TITLE
ci: spelling: update and include advice

### DIFF
--- a/.github/actions/spell-check/advice.txt
+++ b/.github/actions/spell-check/advice.txt
@@ -1,0 +1,17 @@
+<details>
+<summary>
+:pencil2: Contributor please read this
+</summary>
+
+* If the items listed above are names, please add them to `.github/actions/spell-check/dictionary/names.txt`.
+* If they're APIs, you can add them to a file in `.github/actions/spell-check/dictionary/`.
+* If they're just things you're using, please add them to an appropriate file in `.github/actions/spell-check/whitelist/`.
+* If you need to use a specific token in one place and it shouldn't generally be used, you can
+add an item in an appropriate file in `.github/actions/spell-check/patterns/`.
+
+See the `README.md` in each directory for more information.
+</details>
+
+#### :warning: Reviewers
+At present, the action that triggered this message will not show its :x: in this PR unless the branch is within this repository.
+Thus, you **should** make sure that this comment has been addressed before encouraging the merge bot to merge this PR.

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2.0.0
       with:
         fetch-depth: 5
-    - uses: check-spelling/check-spelling@0.0.12-alpha
+    - uses: check-spelling/check-spelling@0.0.13-alpha
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         bucket: .github/actions

--- a/doc/specs/#607 - Commandline Arguments for the Windows Terminal.md
+++ b/doc/specs/#607 - Commandline Arguments for the Windows Terminal.md
@@ -507,7 +507,7 @@ runtimeclass TerminalParameters {
 * [ ] Add a `ShortcutAction` for `FocusPane`, which accepts a single parameter
   `index`.
   - We'll need to track each `Pane`'s ID as `Pane`s are created, so that we can
-    quickly switch to the i'th `Pane`.
+    quickly switch to the nth `Pane`.
   - This is in order to support the `-t,--target` parameter of `split-pane`.
 
 ## Capabilities


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This updates the spell checker.
Scheduled checks should now function, this means that if someone has a fork and isn't allowing actions to run in their fork, this repository should be able to run a spell check against the PR similar to the way checks would be run otherwise.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
This is designed to be merged after #5207

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: https://github.com/microsoft/terminal/pull/4799#issuecomment-604121242

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Note: due to a bug in a previous version, `i'th` was treated as an acceptable term. This update fixes that bug which makes the checking stricter. `nth` is in the dictionary, and thus I've used it instead.

You can see how advice works because I'm conveniently building on top of an unhappy commit. If @DHowett-MSFT / @miniksa / @zadjii-msft have input about how the advice should be worded, we can certainly adjust that here (or you're welcome to tune it later).

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

I pushed this commit (and a couple of variants) to my fork. That resulted in https://github.com/jsoref/terminal/commit/f2d57bcc3cac00252afea203f958971c6d3b4b58 (the ❌). 