### PR TITLE
Rename copy keybinding arg

### DIFF
--- a/doc/cascadia/SettingsSchema.md
+++ b/doc/cascadia/SettingsSchema.md
@@ -115,7 +115,7 @@ For commands with arguments:
 | `closePane` | Close the active pane. | | | |
 | `closeTab` | Close the current tab. | | | |
 | `closeWindow` | Close the current window and all tabs within it. | | | |
-| `copy` | Copy the selected terminal content to your Windows Clipboard. | `trimWhitespace` | boolean | When `true`, newlines persist from the selected text. When `false`, copied content will paste on one line. |
+| `copy` | Copy the selected terminal content to your Windows Clipboard. | `singleLine` | boolean | When `true`, the copied content will paste on one line. When `false`, newlines persist from the selected text. |
 | `duplicateTab` | Make a copy and open the current tab. | | | |
 | `find` | Open the search dialog box. | | | |
 | `moveFocus` | Focus on a different pane depending on direction. | `direction`* | `left`, `right`, `up`, `down` | Direction in which the focus will move. |

--- a/doc/cascadia/SettingsSchema.md
+++ b/doc/cascadia/SettingsSchema.md
@@ -115,7 +115,7 @@ For commands with arguments:
 | `closePane` | Close the active pane. | | | |
 | `closeTab` | Close the current tab. | | | |
 | `closeWindow` | Close the current window and all tabs within it. | | | |
-| `copy` | Copy the selected terminal content to your Windows Clipboard. | `singleLine` | boolean | When `true`, the copied content will paste on one line. When `false`, newlines persist from the selected text. |
+| `copy` | Copy the selected terminal content to your Windows Clipboard. | `singleLine` | boolean | When `true`, the copied content will be copied as a single line. When `false`, newlines persist from the selected text. |
 | `duplicateTab` | Make a copy and open the current tab. | | | |
 | `find` | Open the search dialog box. | | | |
 | `moveFocus` | Focus on a different pane depending on direction. | `direction`* | `left`, `right`, `up`, `down` | Direction in which the focus will move. |

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -130,10 +130,10 @@
         {
           "properties": {
             "action": { "type": "string", "pattern": "copy" },
-            "trimWhitespace": {
+            "singleLine": {
               "type": "boolean",
-              "default": true,
-              "description": "If true, whitespace is removed and newlines are maintained. If false, newlines are removed and whitespace is maintained."
+              "default": false,
+              "description": "If true, newlines are removed and whitespace is maintained. If false, whitespace is removed and newlines are maintained."
             }
           }
         }

--- a/src/cascadia/LocalTests_TerminalApp/KeyBindingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/KeyBindingsTests.cpp
@@ -170,8 +170,8 @@ namespace TerminalAppLocalTests
     {
         const std::string bindings0String{ R"([
             { "command": "copy", "keys": ["ctrl+c"] },
-            { "command": { "action": "copy", "trimWhitespace": false }, "keys": ["ctrl+shift+c"] },
-            { "command": { "action": "copy", "trimWhitespace": true }, "keys": ["alt+shift+c"] },
+            { "command": { "action": "copy", "singleLine": false }, "keys": ["ctrl+shift+c"] },
+            { "command": { "action": "copy", "singleLine": true }, "keys": ["alt+shift+c"] },
 
             { "command": "newTab", "keys": ["ctrl+t"] },
             { "command": { "action": "newTab", "index": 0 }, "keys": ["ctrl+shift+t"] },
@@ -195,13 +195,13 @@ namespace TerminalAppLocalTests
 
         {
             Log::Comment(NoThrowString().Format(
-                L"Verify that `copy` without args parses as Copy(TrimWhitespace=true)"));
+                L"Verify that `copy` without args parses as Copy(SingleLine=false)"));
             KeyChord kc{ true, false, false, static_cast<int32_t>('C') };
             auto actionAndArgs = TestUtils::GetActionAndArgs(*appKeyBindings, kc);
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_TRUE(realArgs.TrimWhitespace());
+            VERIFY_IS_FALSE(realArgs.SingleLine());
         }
 
         {
@@ -212,7 +212,7 @@ namespace TerminalAppLocalTests
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_FALSE(realArgs.TrimWhitespace());
+            VERIFY_IS_FALSE(realArgs.SingleLine());
         }
 
         {
@@ -223,7 +223,7 @@ namespace TerminalAppLocalTests
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_TRUE(realArgs.TrimWhitespace());
+            VERIFY_IS_TRUE(realArgs.SingleLine());
         }
 
         {
@@ -275,7 +275,7 @@ namespace TerminalAppLocalTests
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_TRUE(realArgs.TrimWhitespace());
+            VERIFY_IS_FALSE(realArgs.SingleLine());
         }
 
         {
@@ -287,7 +287,7 @@ namespace TerminalAppLocalTests
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_TRUE(realArgs.TrimWhitespace());
+            VERIFY_IS_FALSE(realArgs.SingleLine());
         }
 
         {
@@ -420,7 +420,7 @@ namespace TerminalAppLocalTests
             const auto& realArgs = actionAndArgs.Args().try_as<CopyTextArgs>();
             VERIFY_IS_NOT_NULL(realArgs);
             // Verify the args have the expected value
-            VERIFY_IS_TRUE(realArgs.TrimWhitespace());
+            VERIFY_IS_FALSE(realArgs.SingleLine());
         }
     }
 }

--- a/src/cascadia/TerminalApp/ActionArgs.h
+++ b/src/cascadia/TerminalApp/ActionArgs.h
@@ -93,9 +93,9 @@ namespace winrt::TerminalApp::implementation
     struct CopyTextArgs : public CopyTextArgsT<CopyTextArgs>
     {
         CopyTextArgs() = default;
-        GETSET_PROPERTY(bool, TrimWhitespace, true);
+        GETSET_PROPERTY(bool, SingleLine, false);
 
-        static constexpr std::string_view TrimWhitespaceKey{ "trimWhitespace" };
+        static constexpr std::string_view SingleLineKey{ "singleLine" };
 
     public:
         bool Equals(const IActionArgs& other)
@@ -103,7 +103,7 @@ namespace winrt::TerminalApp::implementation
             auto otherAsUs = other.try_as<CopyTextArgs>();
             if (otherAsUs)
             {
-                return otherAsUs->_TrimWhitespace == _TrimWhitespace;
+                return otherAsUs->_SingleLine == _SingleLine;
             }
             return false;
         };
@@ -111,9 +111,9 @@ namespace winrt::TerminalApp::implementation
         {
             // LOAD BEARING: Not using make_self here _will_ break you in the future!
             auto args = winrt::make_self<CopyTextArgs>();
-            if (auto trimWhitespace{ json[JsonKey(TrimWhitespaceKey)] })
+            if (auto singleLine{ json[JsonKey(SingleLineKey)] })
             {
-                args->_TrimWhitespace = trimWhitespace.asBool();
+                args->_SingleLine = singleLine.asBool();
             }
             return { *args, {} };
         }

--- a/src/cascadia/TerminalApp/ActionArgs.idl
+++ b/src/cascadia/TerminalApp/ActionArgs.idl
@@ -56,7 +56,7 @@ namespace TerminalApp
 
     [default_interface] runtimeclass CopyTextArgs : IActionArgs
     {
-        Boolean TrimWhitespace { get; };
+        Boolean SingleLine { get; };
     };
 
     [default_interface] runtimeclass NewTabArgs : IActionArgs

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -198,7 +198,7 @@ namespace winrt::TerminalApp::implementation
     {
         if (const auto& realArgs = args.ActionArgs().try_as<TerminalApp::CopyTextArgs>())
         {
-            const auto handled = _CopyText(realArgs.TrimWhitespace());
+            const auto handled = _CopyText(realArgs.SingleLine());
             args.Handled(handled);
         }
     }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1376,14 +1376,13 @@ namespace winrt::TerminalApp::implementation
     // Method Description:
     // - Copy text from the focused terminal to the Windows Clipboard
     // Arguments:
-    // - trimTrailingWhitespace: enable removing any whitespace from copied selection
-    //    and get text to appear on separate lines.
+    // - singleLine: if enabled, copy contents as a single line of text
     // Return Value:
     // - true iff we we able to copy text (if a selection was active)
-    bool TerminalPage::_CopyText(const bool trimTrailingWhitespace)
+    bool TerminalPage::_CopyText(const bool singleLine)
     {
         const auto control = _GetActiveControl();
-        return control.CopySelectionToClipboard(!trimTrailingWhitespace);
+        return control.CopySelectionToClipboard(singleLine);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1887,8 +1887,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     //     Windows Clipboard (CascadiaWin32:main.cpp).
     // - CopyOnSelect does NOT clear the selection
     // Arguments:
-    // - collapseText: collapse all of the text to one line
-    bool TermControl::CopySelectionToClipboard(bool collapseText)
+    // - singleLine: collapse all of the text to one line
+    bool TermControl::CopySelectionToClipboard(bool singleLine)
     {
         if (_closing)
         {
@@ -1905,7 +1905,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         _selectionNeedsToBeCopied = false;
 
         // extract text from buffer
-        const auto bufferData = _terminal->RetrieveSelectedTextFromBuffer(collapseText);
+        const auto bufferData = _terminal->RetrieveSelectedTextFromBuffer(singleLine);
 
         // convert text: vector<string> --> string
         std::wstring textData;

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -221,18 +221,18 @@ void Terminal::ClearSelection()
 // Method Description:
 // - get wstring text from highlighted portion of text buffer
 // Arguments:
-// - collapseText: collapse all of the text to one line
+// - singleLine: collapse all of the text to one line
 // Return Value:
 // - wstring text from buffer. If extended to multiple lines, each line is separated by \r\n
-const TextBuffer::TextAndColor Terminal::RetrieveSelectedTextFromBuffer(bool collapseText) const
+const TextBuffer::TextAndColor Terminal::RetrieveSelectedTextFromBuffer(bool singleLine) const
 {
     const auto selectionRects = _GetSelectionRects();
 
     std::function<COLORREF(TextAttribute&)> GetForegroundColor = std::bind(&Terminal::GetForegroundColor, this, std::placeholders::_1);
     std::function<COLORREF(TextAttribute&)> GetBackgroundColor = std::bind(&Terminal::GetBackgroundColor, this, std::placeholders::_1);
 
-    return _buffer->GetText(!collapseText,
-                            !collapseText,
+    return _buffer->GetText(!singleLine,
+                            !singleLine,
                             selectionRects,
                             GetForegroundColor,
                             GetBackgroundColor);


### PR DESCRIPTION
## Summary of the Pull Request
`TrimWhitespace` is misleading. So it is now renamed as 'singleLine'. If true, it comes out as a single line! That makes more sense!

## PR Checklist
* [X] Closes #3824 

## Validation Steps Performed
Attempted the keybinding with both settings (and none set).
Attempted mouse copy with and without shift.
