### PR TITLE
Force all our dialogs into the application theme, forcibly

### DIFF
--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -279,15 +279,8 @@ namespace winrt::TerminalApp::implementation
             }
         } };
 
-        FrameworkElement::Loaded_revoker loadedRevoker{};
-        if (dialog.Parent()) // Dialog is already in a visual tree
-        {
-            themingLambda(dialog, nullptr);
-        }
-        else
-        {
-            loadedRevoker = dialog.Loaded(winrt::auto_revoke, themingLambda);
-        }
+        themingLambda(dialog, nullptr); // if it's already in the tree
+        auto loadedRevoker{ dialog.Loaded(winrt::auto_revoke, themingLambda) }; // if it's not yet in the tree
 
         // Display the dialog.
         co_await dialog.ShowAsync(Controls::ContentDialogPlacement::Popup);


### PR DESCRIPTION
Because we cannot set RequestedTheme at the application level, we
occasionally run into issues where parts of our UI end up themed
incorrectly.  Dialogs, for example, live under a different Xaml root
element than the rest of our application. This makes our popup menus and
buttons "disappear" when the user wants Terminal to be in a different
theme than the rest of the system.  This hack---and it _is_ a
hack--walks up a dialog's ancestry and forces the theme on each element
up to the root. We're relying a bit on Xaml's implementation details
here, but it does have the desired effect.

It's not enough to set the theme on the dialog alone.

Fixes #3654.
Fixes #5195.