### PR TITLE
Relax locking around the swapchain

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -484,14 +484,9 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
     winrt::fire_and_forget TermControl::RenderEngineSwapChainChanged()
     {
-        { // lock scope
-            auto terminalLock = _terminal->LockForReading();
-            if (!_initializedTerminal)
-            {
-                return;
-            }
-        }
-
+        // This event is only registered during terminal initialization,
+        // so we don't need to check _initializedTerminal.
+        // We also don't lock for things that come back from the renderer.
         auto chain = _renderEngine->GetSwapChain();
         auto weakThis{ get_weak() };
 
@@ -499,8 +494,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         if (auto control{ weakThis.get() })
         {
-            auto terminalLock = _terminal->LockForWriting();
-
             _AttachDxgiSwapChainToXaml(chain.Get());
         }
     }


### PR DESCRIPTION
## Summary of the Pull Request
The terminal lock is really only for the terminal; since the renderer is
fully owned by the control, not the Terminal, and we'll only be
receiving swap chain events after we register them during
initialization, we don't need to lock before _or_ after firing off the
coroutine.

## PR Checklist
* [x] Closes #5203

## Validation Steps Performed
Manual validation.