### PR TITLE
doc: remove "globals" from schema

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -783,37 +783,15 @@
       "type": "array"
     }
   },
-  "oneOf": [
+  "allOf": [
+    { "$ref": "#/definitions/Globals" },
     {
-      "allOf": [
-        { "$ref": "#/definitions/Globals" },
-        {
-          "additionalItems": true,
-          "properties": {
-            "profiles": {
-              "oneOf": [
-              { "$ref": "#/definitions/ProfileList" },
-              { "$ref": "#/definitions/ProfilesObject" }
-              ]
-            },
-            "schemes": { "$ref": "#/definitions/SchemeList" }
-          },
-          "required": [
-            "profiles",
-            "schemes",
-            "defaultProfile"
-          ]
-        }
-      ]
-    },
-    {
-      "additionalItems": false,
+      "additionalItems": true,
       "properties": {
-        "globals": { "$ref": "#/definitions/Globals" },
         "profiles": {
           "oneOf": [
-          { "$ref": "#/definitions/ProfileList" },
-          { "$ref": "#/definitions/ProfilesObject" }
+            { "$ref": "#/definitions/ProfileList" },
+            { "$ref": "#/definitions/ProfilesObject" }
           ]
         },
         "schemes": { "$ref": "#/definitions/SchemeList" }
@@ -821,7 +799,7 @@
       "required": [
         "profiles",
         "schemes",
-        "globals"
+        "defaultProfile"
       ]
     }
   ]


### PR DESCRIPTION
## Summary of the Pull Request
Minor cleanup on the schema. Globals isn't accepted anymore, so the schema should not help you autocomplete anymore.

## Validation Steps Performed
Imported the new schema. You do _not_ get a warning when globals is in. But, the schema won't suggest things when inside globals. It's just treated as an unknown item.

However, "defaultProfile" is still required (more of a sanity test)