### PR TITLE
Correct file name

### DIFF
--- a/doc/user-docs/UsingJsonSettings.md
+++ b/doc/user-docs/UsingJsonSettings.md
@@ -1,15 +1,15 @@
 # Editing Windows Terminal JSON Settings
 
 One way (currently the only way) to configure Windows Terminal is by editing the
-`settings.json` settings file. At the time of writing you can open the settings
+`profiles.json` settings file. At the time of writing you can open the settings
 file in your default editor by selecting `Settings` from the WT pull down menu.
 
-The settings are stored in the file `$env:LocalAppData\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState\settings.json`.
+The settings are stored in the file `$env:LocalAppData\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState\profiles.json`.
 
 As of [#2515](https://github.com/microsoft/terminal/pull/2515), the settings are
-split into _two_ files: a hardcoded `defaults.json`, and `settings.json`, which
+split into _two_ files: a hardcoded `defaults.json`, and `profiles.json`, which
 contains the user settings. Users should only be concerned with the contents of
-the `settings.json`, which contains their customizations. The `defaults.json`
+the `profiles.json`, which contains their customizations. The `defaults.json`
 file is only provided as a reference of what the default settings are. For more
 details on how these two files work, see [Settings
 Layering](#settings-layering). To view the default settings file, click on the
@@ -164,7 +164,7 @@ The values for background image stretch mode are documented [here](https://docs.
 ### Hiding a profile
 
 If you want to remove a profile from the list of profiles in the new tab
-dropdown, but keep the profile around in your `settings.json` file, you can add
+dropdown, but keep the profile around in your `profiles.json` file, you can add
 the property `"hidden": true` to the profile's json. This can also be used to
 remove the default `cmd` and PowerShell profiles, if the user does not wish to
 see them.
@@ -198,10 +198,10 @@ The runtime settings are actually constructed from _three_ sources:
   profiles for both Windows PowerShell and Command Prompt (`cmd.exe`).
 * Dynamic Profiles, which are generated at runtime. These include Powershell
   Core, the Azure Cloud Shell connector, and profiles for and WSL distros.
-* The user settings from `settings.json`.
+* The user settings from `profiles.json`.
 
 Settings from each of these sources are "layered" upon the settings from
-previous sources. In this manner, the user settings in `settings.json` can
+previous sources. In this manner, the user settings in `profiles.json` can
 contain _only the changes from the default settings_. For example, if a user
 would like to only change the color scheme of the default `cmd` profile to
 "Solarized Dark", you could change your cmd profile to the following:
@@ -220,7 +220,7 @@ with that GUID will all be treated as the same object. Any changes in that
 profile will overwrite those from the defaults.
 
 Similarly, you can overwrite settings from a color scheme by defining a color
-scheme in `settings.json` with the same name as a default color scheme.
+scheme in `profiles.json` with the same name as a default color scheme.
 
 If you'd like to unbind a keystroke that's bound to an action in the default
 keybindings, you can set the `"command"` to `"unbound"` or `null`. This will
@@ -230,9 +230,9 @@ performing the default action.
 ### Dynamic Profiles
 
 When dynamic profiles are created at runtime, they'll be added to the
-`settings.json` file. You can identify these profiles by the presence of a
+`profiles.json` file. You can identify these profiles by the presence of a
 `"source"` property. These profiles are tied to their source - if you uninstall
-a linux distro, then the profile will remain in your `settings.json` file, but
+a linux distro, then the profile will remain in your `profiles.json` file, but
 the profile will be hidden.
 
 The Windows Terminal uses the `guid` property of these dynamically-generated
@@ -371,7 +371,7 @@ In the above settings, the `"fontFace"` in the `cmd.exe` profile overrides the
 1. Download the [Debian JPG logo](https://www.debian.org/logos/openlogo-100.jpg)
 2. Put the image in the
  `$env:LocalAppData\Packages\Microsoft.WindowsTerminal_<randomString>\LocalState\`
- directory (same directory as your `settings.json` file).
+ directory (same directory as your `profiles.json` file).
 
     __NOTE__:  You can put the image anywhere you like, the above suggestion happens to be convenient.
 3. Open your WT json properties file.
@@ -392,7 +392,7 @@ Notes:
 
 1. You will need to experiment with different color settings
 and schemes to make your terminal text visible on top of your image
-2. If you store the image in the UWP directory (the same directory as your settings.json file),
+2. If you store the image in the UWP directory (the same directory as your profiles.json file),
 then you should use the URI style path name given in the above example.
 More information about UWP URI schemes [here](https://docs.microsoft.com/en-us/windows/uwp/app-resources/uri-schemes).
 3. Instead of using a UWP URI you can use a:


### PR DESCRIPTION
Documentation uses an old file name

## Updates all occurrences of settings.json to profiles.json

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.
