### PR TITLE
Make RIS switch back to the main buffer

### DIFF
--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1663,9 +1663,21 @@ bool AdaptDispatch::SoftReset()
 // True if handled successfully. False otherwise.
 bool AdaptDispatch::HardReset()
 {
+    bool success = true;
+
+    // If in the alt buffer, switch back to main before doing anything else.
+    if (_usingAltBuffer)
+    {
+        success = _pConApi->PrivateUseMainScreenBuffer();
+        _usingAltBuffer = !success;
+    }
+
     // Sets the SGR state to normal - this must be done before EraseInDisplay
     //      to ensure that it clears with the default background color.
-    bool success = SoftReset();
+    if (success)
+    {
+        success = SoftReset();
+    }
 
     // Clears the screen - Needs to be done in two operations.
     if (success)

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1645,6 +1645,8 @@ bool AdaptDispatch::SoftReset()
 //Routine Description:
 // Full Reset - Perform a hard reset of the terminal. http://vt100.net/docs/vt220-rm/chapter4.html
 //  RIS performs the following actions: (Items with sub-bullets are supported)
+//   - Switches to the main screen buffer if in the alt buffer.
+//      * This matches the XTerm behaviour, which is the de facto standard for the alt buffer.
 //   - Performs a communications line disconnect.
 //   - Clears UDKs.
 //   - Clears a down-line-loaded character set.


### PR DESCRIPTION
## Summary of the Pull Request

If we receive a _Reset to Initial State_ (`RIS`) sequence while in the alternate screen buffer, we should be switching back to the main buffer. This PR fixes that behavior.

## PR Checklist
* [x] Closes #3685
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments

I've added a condition at the start of the `AdaptDispatch::HardReset` method to check whether we're using the alt buffer, and if so, call the `ConGetSet::PrivateUseMainScreenBuffer` API to switch back to the main buffer.

Calling `AdaptDispatch::UseMainScreenBuffer` would probably be neater for this, but it would also attempt to restore the cursor state, which seems pointless when we're in the process of resetting everything anyway.

## Validation Steps Performed

I've added a screen buffer test to confirm that the `RIS` sequence does actually switch back to the main buffer. I've also manually confirmed that the test case in issue #3685 does now behave as expected.