### PR TITLE
Prevent the cursor type being reset when changing the visibility

### DIFF
--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -1547,10 +1547,18 @@ void SCREEN_INFORMATION::SetCursorInformation(const ULONG Size,
                                               const bool Visible) noexcept
 {
     Cursor& cursor = _textBuffer->GetCursor();
+    const auto originalSize = cursor.GetSize();
 
     cursor.SetSize(Size);
     cursor.SetIsVisible(Visible);
-    cursor.SetType(CursorType::Legacy);
+
+    // If we are just trying to change the visibility, we don't want to reset
+    // the cursor type. We only need to force it to the Legacy style if the
+    // size is actually being changed.
+    if (Size != originalSize)
+    {
+        cursor.SetType(CursorType::Legacy);
+    }
 
     // If we're an alt buffer, also update our main buffer.
     // Users of the API expect both to be set - this can't be set by VT


### PR DESCRIPTION
A side effect of the `SetConsoleCursorInfo` API is that it resets the
cursor type to _Legacy_. This makes it impossible to change the cursor
visibility via the console APIs without also resetting the user's
preferred cursor type. This PR attempts to fix that limitation, by only
resetting the cursor type if the size has also been changed.

## PR Checklist
* [x] Closes #4124
* [x] CLA signed
* [ ] Tests added/passed
* [ ] Requires documentation to be updated

## Detailed Description of the Pull Request / Additional comments

I suspect the reason for the original behaviour was because the
`SetConsoleCursorInfo` API sets both the visibility and the size, and if
you're setting the size, it's assumed you'd want the _Legacy_ cursor
type, because that's the only style for which the size is applicable.

So my solution was to only reset the cursor type if the requested cursor
size was actually different from the current size. That should be
reasonably backwards compatible with most size-changing code, but also
allow for changing the visibility without resetting the cursor type.

## Validation Steps Performed

I've tested the example code from issue #4124, and confirmed that it now
works correctly without resetting the cursor type.

I've also tested the console's _mark mode_, which temporarily changes
the cursor size while selecting. I've confirmed that the size still
changes, and that the original cursor type is restored afterwards.