### PR TITLE
Rename 'requestedTheme' to 'theme'

### DIFF
--- a/doc/cascadia/SettingsSchema.md
+++ b/doc/cascadia/SettingsSchema.md
@@ -13,7 +13,7 @@ Properties listed below affect the entire window, regardless of the profile sett
 | `initialRows` | _Required_ | Integer | `30` | The number of rows displayed in the window upon first load. |
 | `launchMode` | Optional | String | `default` | Defines whether the Terminal will launch as maximized or not. Possible values: `"default"`, `"maximized"` |
 | `rowsToScroll` | Optional | Integer | `system` | The number of rows to scroll at a time with the mouse wheel. This will override the system setting if the value is not zero or "system". |
-| `requestedTheme` | _Required_ | String | `system` | Sets the theme of the application. Possible values: `"light"`, `"dark"`, `"system"` |
+| `theme` | _Required_ | String | `system` | Sets the theme of the application. Possible values: `"light"`, `"dark"`, `"system"` |
 | `showTerminalTitleInTitlebar` | _Required_ | Boolean | `true` | When set to `true`, titlebar displays the title of the selected tab. When set to `false`, titlebar displays "Windows Terminal". |
 | `showTabsInTitlebar` | Optional | Boolean | `true` | When set to `true`, the tabs are moved into the titlebar and the titlebar disappears. When set to `false`, the titlebar sits above the tabs. |
 | `snapToGridOnResize` | Optional | Boolean | `false` | When set to `true`, the window will snap to the nearest character boundary on resize. When `false`, the window will resize "smoothly" |

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -322,7 +322,7 @@
           },
           "type": "array"
         },
-        "requestedTheme": {
+        "theme": {
           "default": "system",
           "description": "Sets the theme of the application.",
           "enum": [

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -218,7 +218,7 @@ namespace winrt::TerminalApp::implementation
         _root->Loaded({ this, &AppLogic::_OnLoaded });
         _root->Create();
 
-        _ApplyTheme(_settings->GlobalSettings().GetRequestedTheme());
+        _ApplyTheme(_settings->GlobalSettings().GetTheme());
 
         TraceLoggingWrite(
             g_hTerminalAppProvider,
@@ -270,7 +270,7 @@ namespace winrt::TerminalApp::implementation
         // details here, but it does have the desired effect.
         // It's not enough to set the theme on the dialog alone.
         auto themingLambda{ [this](const Windows::Foundation::IInspectable& sender, const RoutedEventArgs&) {
-            auto theme{ _settings->GlobalSettings().GetRequestedTheme() };
+            auto theme{ _settings->GlobalSettings().GetTheme() };
             auto element{ sender.try_as<winrt::Windows::UI::Xaml::FrameworkElement>() };
             while (element)
             {
@@ -522,7 +522,7 @@ namespace winrt::TerminalApp::implementation
             LoadSettings();
         }
 
-        return _settings->GlobalSettings().GetRequestedTheme();
+        return _settings->GlobalSettings().GetTheme();
     }
 
     bool AppLogic::GetShowTabsInTitlebar()
@@ -703,7 +703,7 @@ namespace winrt::TerminalApp::implementation
         co_await winrt::resume_foreground(_root->Dispatcher());
 
         // Refresh the UI theme
-        _ApplyTheme(_settings->GlobalSettings().GetRequestedTheme());
+        _ApplyTheme(_settings->GlobalSettings().GetTheme());
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.cpp
@@ -25,7 +25,7 @@ static constexpr std::string_view InitialColsKey{ "initialCols" };
 static constexpr std::string_view RowsToScrollKey{ "rowsToScroll" };
 static constexpr std::string_view InitialPositionKey{ "initialPosition" };
 static constexpr std::string_view ShowTitleInTitlebarKey{ "showTerminalTitleInTitlebar" };
-static constexpr std::string_view RequestedThemeKey{ "requestedTheme" };
+static constexpr std::string_view ThemeKey{ "theme" };
 static constexpr std::string_view TabWidthModeKey{ "tabWidthMode" };
 static constexpr std::wstring_view EqualTabWidthModeValue{ L"equal" };
 static constexpr std::wstring_view TitleLengthTabWidthModeValue{ L"titleLength" };
@@ -63,7 +63,7 @@ GlobalAppSettings::GlobalAppSettings() :
     _initialY{},
     _showTitleInTitlebar{ true },
     _showTabsInTitlebar{ true },
-    _requestedTheme{ ElementTheme::Default },
+    _theme{ ElementTheme::Default },
     _tabWidthMode{ TabViewWidthMode::Equal },
     _wordDelimiters{ DEFAULT_WORD_DELIMITERS },
     _copyOnSelect{ false },
@@ -121,14 +121,14 @@ void GlobalAppSettings::SetShowTitleInTitlebar(const bool showTitleInTitlebar) n
     _showTitleInTitlebar = showTitleInTitlebar;
 }
 
-ElementTheme GlobalAppSettings::GetRequestedTheme() const noexcept
+ElementTheme GlobalAppSettings::GetTheme() const noexcept
 {
-    return _requestedTheme;
+    return _theme;
 }
 
-void GlobalAppSettings::SetRequestedTheme(const ElementTheme requestedTheme) noexcept
+void GlobalAppSettings::SetTheme(const ElementTheme theme) noexcept
 {
-    _requestedTheme = requestedTheme;
+    _theme = theme;
 }
 
 TabViewWidthMode GlobalAppSettings::GetTabWidthMode() const noexcept
@@ -246,7 +246,7 @@ Json::Value GlobalAppSettings::ToJson() const
     jsonObject[JsonKey(WordDelimitersKey)] = winrt::to_string(_wordDelimiters);
     jsonObject[JsonKey(CopyOnSelectKey)] = _copyOnSelect;
     jsonObject[JsonKey(LaunchModeKey)] = winrt::to_string(_SerializeLaunchMode(_launchMode));
-    jsonObject[JsonKey(RequestedThemeKey)] = winrt::to_string(_SerializeTheme(_requestedTheme));
+    jsonObject[JsonKey(ThemeKey)] = winrt::to_string(_SerializeTheme(_theme));
     jsonObject[JsonKey(TabWidthModeKey)] = winrt::to_string(_SerializeTabWidthMode(_tabWidthMode));
     jsonObject[JsonKey(KeybindingsKey)] = _keybindings->ToJson();
     jsonObject[JsonKey(ConfirmCloseAllKey)] = _confirmCloseAllTabs;
@@ -316,9 +316,9 @@ void GlobalAppSettings::LayerJson(const Json::Value& json)
         _launchMode = _ParseLaunchMode(GetWstringFromJson(launchMode));
     }
 
-    if (auto requestedTheme{ json[JsonKey(RequestedThemeKey)] })
+    if (auto theme{ json[JsonKey(ThemeKey)] })
     {
-        _requestedTheme = _ParseTheme(GetWstringFromJson(requestedTheme));
+        _theme = _ParseTheme(GetWstringFromJson(theme));
     }
 
     if (auto tabWidthMode{ json[JsonKey(TabWidthModeKey)] })

--- a/src/cascadia/TerminalApp/GlobalAppSettings.h
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.h
@@ -53,8 +53,10 @@ public:
     bool GetConfirmCloseAllTabs() const noexcept;
     void SetConfirmCloseAllTabs(const bool confirmCloseAllTabs) noexcept;
 
-    void SetRequestedTheme(const winrt::Windows::UI::Xaml::ElementTheme requestedTheme) noexcept;
+    winrt::Windows::UI::Xaml::ElementTheme GetTheme() const noexcept;
+    void SetTheme(const winrt::Windows::UI::Xaml::ElementTheme requestedTheme) noexcept;
 
+    winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode GetTabWidthMode() const noexcept;
     void SetTabWidthMode(const winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode tabWidthMode);
 
     bool GetShowTabsInTitlebar() const noexcept;
@@ -72,10 +74,6 @@ public:
 
     winrt::TerminalApp::LaunchMode GetLaunchMode() const noexcept;
     void SetLaunchMode(const winrt::TerminalApp::LaunchMode launchMode);
-
-    winrt::Windows::UI::Xaml::ElementTheme GetRequestedTheme() const noexcept;
-
-    winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode GetTabWidthMode() const noexcept;
 
     bool DebugFeaturesEnabled() const noexcept;
 
@@ -112,7 +110,7 @@ private:
     bool _showTabsInTitlebar;
     std::wstring _wordDelimiters;
     bool _copyOnSelect;
-    winrt::Windows::UI::Xaml::ElementTheme _requestedTheme;
+    winrt::Windows::UI::Xaml::ElementTheme _theme;
     winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode _tabWidthMode;
 
     winrt::TerminalApp::LaunchMode _launchMode;

--- a/src/cascadia/TerminalApp/defaults-universal.json
+++ b/src/cascadia/TerminalApp/defaults-universal.json
@@ -4,7 +4,7 @@
     "defaultProfile": "{550ce7b8-d500-50ad-8a1a-c400c3262db3}",
     "initialCols": 120,
     "initialRows": 30,
-    "requestedTheme": "system",
+    "theme": "system",
     "showTabsInTitlebar": false,
     "showTerminalTitleInTitlebar": true,
     "wordDelimiters": " /\\()\"'-.,:;<>~!@#$%^&*|+=[]{}~?\u2502",

--- a/src/cascadia/TerminalApp/defaults.json
+++ b/src/cascadia/TerminalApp/defaults.json
@@ -4,7 +4,7 @@
     "defaultProfile": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
     "initialCols": 120,
     "initialRows": 30,
-    "requestedTheme": "system",
+    "theme": "system",
     "showTabsInTitlebar": true,
     "showTerminalTitleInTitlebar": true,
     "tabWidthMode": "equal",


### PR DESCRIPTION
## Summary of the Pull Request

Renames the `requestedTheme` global setting to `theme`. Propagates updates to...
- schema
- doc
- defaults.json
- universal-defaults.json
 
## PR Checklist
* [X] Closes #5264 

## Validation Steps Performed
| `theme` | Success? |
|--|--|
| `system` | ✔ |
| `light` | ✔ |
| `dark` | ✔ |

But we really know that `dark` is the one we care about here 😉