### PR TITLE
ci: spelling: update to 0.0.14a

### DIFF
--- a/.github/actions/spell-check/whitelist/whitelist.txt
+++ b/.github/actions/spell-check/whitelist/whitelist.txt
@@ -1135,7 +1135,7 @@ IList
 ime
 Imm
 IMouse
-Impl
+impl
 implementingtextandtextrange
 inbox
 inclusivity
@@ -2437,7 +2437,6 @@ traceloggingprovider
 trackbar
 TRACKCOMPOSITION
 trackpad
-trackpads
 transcoder
 transitioning
 trc
@@ -2588,7 +2587,6 @@ vcrt
 vcvarsall
 vcxitems
 vcxproj
-ve
 vec
 VERCTRL
 versioning
@@ -2872,7 +2870,7 @@ xvalue
 XVIRTUALSCREEN
 XWalk
 xxxx
-XY
+xy
 yact
 YAML
 YCast

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2.0.0
       with:
         fetch-depth: 5
-    - uses: check-spelling/check-spelling@0.0.13-alpha
+    - uses: check-spelling/check-spelling@0.0.14-alpha
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         bucket: .github/actions


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
https://github.com/check-spelling/check-spelling/releases/tag/0.0.14-alpha

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

* https://github.com/jsoref/terminal/commit/d9d2bdeacb46507979222c0866daf10b41610248
* https://github.com/jsoref/terminal/runs/567983452#step:4:32
* https://github.com/jsoref/terminal/commit/ab6520c2f1a9c41640c3b9098be7c35a50268407

#### Items can be removed from the whitelist
Probably the main noticeable change is that for passing runs where whitelist entries are no longer necessary, you can now see that output in the logs, as seen here:
https://github.com/jsoref/terminal/runs/567983452#step:4:32

The output was always constructed (and is available to people who add `VERBOSE: 1` their branch's `.github/workflows/spelling.yml` in the `env:` section), but I had decided not to spam commits w/ such comments (it seemed too distracting/frustrating).

⚠️  The tool's definition of "no longer necessary" is a bit inaccurate, as it has opinions about different cases, and is a bit lazy (hence the iteration of commits to settle on this commit).

#### Validation / Reporting
There are now warnings for missing newlines in config files and there's a warning for corrupt regular expressions in the patterns file. -- These changes were based on feedback here.

#### Best practices (not specific to this update)

If your repository (e.g. microsoft/terminal or a fork) has actions enabled, then you can simply push a branch to your repository w/ the changes you want validated, and check spelling will run and comment on your commits. You don't need a pull request. This means you can avoid using other build resources / accumulating tiny iterative commits. (At some point I'll write this up, as well as provide instructions for using docker or running it manually w/o docker, but, probably not this month.)

-- I suppose something like this could be converted into a .md file and linked from `advice.txt` ...

#### Personal Availability
I'll be unavailable from this Wednesday night through Saturday night. The spell checker isn't critical and the changes here are minor and safe, plus if necessary, one can simply switch back to the older version. I'll check up on things next week.