### PR TITLE
Fall back to TerminalApp.dll's version when we're unpackaged

### DIFF
--- a/.github/actions/spell-check/dictionary/apis.txt
+++ b/.github/actions/spell-check/dictionary/apis.txt
@@ -1,1 +1,2 @@
+LCID
 rfind

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -913,7 +913,7 @@ namespace winrt::TerminalApp::implementation
         {
             struct LocalizationInfo
             {
-                WORD lcid, codepage;
+                WORD language, codepage;
             };
             // Use the current module instance handle for TerminalApp.dll, nullptr for WindowsTerminal.exe
             auto filename{ wil::GetModuleFileNameW<std::wstring>(wil::GetCurrentModuleHandleW()) };

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -911,22 +911,33 @@ namespace winrt::TerminalApp::implementation
         // Try to get the version the old-fashioned way
         try
         {
+            struct LocalizationInfo
+            {
+                WORD lcid, codepage;
+            };
             // Use the current module instance handle for TerminalApp.dll, nullptr for WindowsTerminal.exe
-            auto filename{ wil::GetModuleFileNameW<std::wstring>(nullptr /* wil::GetModuleInstanceHandle() */) };
+            auto filename{ wil::GetModuleFileNameW<std::wstring>(wil::GetCurrentModuleHandleW()) };
             auto size{ GetFileVersionInfoSizeExW(0, filename.c_str(), nullptr) };
             THROW_LAST_ERROR_IF(size == 0);
             auto versionBuffer{ std::make_unique<std::byte[]>(size) };
             THROW_IF_WIN32_BOOL_FALSE(GetFileVersionInfoExW(0, filename.c_str(), 0, size, versionBuffer.get()));
-            void* pFixedFileInfoUntyped{ nullptr }; // points into versionBuffer; do not delete
-            UINT fixedFileInfoLen{ 0 };
-            THROW_IF_WIN32_BOOL_FALSE(VerQueryValueW(versionBuffer.get(), L"\\", &pFixedFileInfoUntyped, &fixedFileInfoLen));
-            auto pFixedFileInfo{ static_cast<VS_FIXEDFILEINFO*>(pFixedFileInfoUntyped) };
-            winrt::hstring formatted{ wil::str_printf<std::wstring>(L"%u.%u.%u.%u",
-                                                                    HIWORD(pFixedFileInfo->dwProductVersionMS),
-                                                                    LOWORD(pFixedFileInfo->dwProductVersionMS),
-                                                                    HIWORD(pFixedFileInfo->dwProductVersionLS),
-                                                                    LOWORD(pFixedFileInfo->dwProductVersionLS)) };
-            return formatted;
+
+            // Get the list of Version localizations
+            LocalizationInfo* pVarLocalization{ nullptr };
+            UINT varLen{ 0 };
+            THROW_IF_WIN32_BOOL_FALSE(VerQueryValueW(versionBuffer.get(), L"\\VarFileInfo\\Translation", reinterpret_cast<void**>(&pVarLocalization), &varLen));
+            THROW_HR_IF(E_UNEXPECTED, varLen < sizeof(*pVarLocalization)); // there must be at least one translation
+
+            // Get the product version from the localized version compartment
+            // We're using String/ProductVersion here because our build pipeline puts more rich information in it (like the branch name)
+            // than in the unlocalized numeric version fields.
+            WCHAR* pProductVersion{ nullptr };
+            UINT versionLen{ 0 };
+            const auto localizedVersionName{ wil::str_printf<std::wstring>(L"\\StringFileInfo\\%04x%04x\\ProductVersion",
+                                                                           pVarLocalization->language ? pVarLocalization->language : 0x0409, // well-known en-US LCID
+                                                                           pVarLocalization->codepage) };
+            THROW_IF_WIN32_BOOL_FALSE(VerQueryValueW(versionBuffer.get(), localizedVersionName.c_str(), reinterpret_cast<void**>(&pProductVersion), &versionLen));
+            return { pProductVersion };
         }
         CATCH_LOG();
 

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -916,7 +916,7 @@ namespace winrt::TerminalApp::implementation
                 WORD language, codepage;
             };
             // Use the current module instance handle for TerminalApp.dll, nullptr for WindowsTerminal.exe
-            auto filename{ wil::GetModuleFileNameW<std::wstring>(wil::GetCurrentModuleHandleW()) };
+            auto filename{ wil::GetModuleFileNameW<std::wstring>(wil::GetModuleInstanceHandle()) };
             auto size{ GetFileVersionInfoSizeExW(0, filename.c_str(), nullptr) };
             THROW_LAST_ERROR_IF(size == 0);
             auto versionBuffer{ std::make_unique<std::byte[]>(size) };


### PR DESCRIPTION
## Summary of the Pull Request

This pull request makes sure we still get a usable (for troubleshooting purposes) version number in the about dialog and settings file when the user is running unpackaged.

![image](https://user-images.githubusercontent.com/14316954/78717232-29a0e980-78d5-11ea-9555-4df6c5c1656f.png)

![image](https://user-images.githubusercontent.com/14316954/78717279-3b828c80-78d5-11ea-9238-a69d25e5be8d.png)

I've had this laying around since I reworked the about dialog.

## PR Checklist
* [ ] Closes nothing.
* [x] work here
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] work here!

## Detailed Description of the Pull Request / Additional comments

The code looks hairy, and we could pull it out into a helper. It's straightforward except for the magic LCID constant.

The story behind that constant: by default, Package ES emits version resource information that says we're localized to ... language zero.
It also emits a language-coded version block for 0x0409 (en-US).

These two things cannot both be true.
