### PR TITLE
Control: Start the connection outside of lock

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -632,11 +632,15 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             //      becomes a no-op.
             this->Focus(FocusState::Programmatic);
 
-            _connection.Start();
             _initializedTerminal = true;
         } // scope for TerminalLock
-        // call this event dispatcher outside of lock
 
+        // Start the connection outside of lock, because it could
+        // start writing output immediately.
+        _connection.Start();
+
+        // Likewise, run the event handlers outside of lock (they could
+        // be reentrant)
         _InitializedHandlers(*this, nullptr);
         return true;
     }


### PR DESCRIPTION
When the connection printed text immediately, synchronously, as part of
Start() it would cause terminal to deadlock. We should start the
connection outside of lock.

The ConptyConnection would do this when it failed to launch something
(trivial repro: `wt -- xyz`).

The TelnetConnection would do this all the time, because local loopback
telnet is fast and easy.

## References

## PR Checklist
* [x] Closes a crash I ran into today
* [x] work here
* [x] tested
* [ ] Requires documentation to be updated
* [x] C O R E

## Validation

Attempted to run the failing scenario.