### PR TITLE
Localize the profile name for cmd, change it to Command Prompt

### DIFF
--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -11,6 +11,7 @@
 #include "../../inc/DefaultSettings.h"
 #include "AppLogic.h"
 #include "Utils.h"
+#include "LibraryResources.h"
 
 #include "PowershellCoreProfileGenerator.h"
 #include "WslDistroGenerator.h"
@@ -704,6 +705,8 @@ std::string CascadiaSettings::_ApplyFirstRunChangesToSettingsTemplate(std::strin
         replace(finalSettings, "%VERSION%", til::u16u8(appLogic->ApplicationVersion()));
         replace(finalSettings, "%PRODUCT%", til::u16u8(appLogic->ApplicationDisplayName()));
     }
+
+    replace(finalSettings, "%COMMAND_PROMPT_LOCALIZED_NAME%", RS_A(L"CommandPromptDisplayName"));
 
     return finalSettings;
 }

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -283,4 +283,8 @@ Temporarily using the Windows Terminal default settings.
   <data name="CloseAllDialog.Title" xml:space="preserve">
     <value>Do you want to close all tabs?</value>
   </data>
+  <data name="CommandPromptDisplayName" xml:space="preserve">
+    <value>Command Prompt</value>
+    <comment>This is the name of "Command Prompt", as localized in Windows. The localization here should match the one in the Windows product for "Command Prompt"</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/defaults.json
+++ b/src/cascadia/TerminalApp/defaults.json
@@ -34,7 +34,7 @@
         },
         {
             "guid": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
-            "name": "cmd",
+            "name": "Command Prompt",
             "commandline": "cmd.exe",
             "hidden": false,
             "startingDirectory": "%USERPROFILE%",

--- a/src/cascadia/TerminalApp/userDefaults.json
+++ b/src/cascadia/TerminalApp/userDefaults.json
@@ -26,7 +26,7 @@
             {
                 // Make changes here to the cmd.exe profile
                 "guid": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
-                "name": "cmd",
+                "name": "%COMMAND_PROMPT_LOCALIZED_NAME%",
                 "commandline": "cmd.exe",
                 "hidden": false
             }


### PR DESCRIPTION
This commit introduces another template replacement for the user's
default settings, COMMAND_PROMPT_LOCALIZED_NAME, which will be replaced
with the contents of the CommandPromptDisplayName resource.

By default, that will be "Command Prompt." This name change will apply
only for new users, and only on first launch. Changes in the system
locale after first launch will not impact the name of the profile.

If the user _removes_ the name from their command prompt profile, its
name will revert irrecoverably to "Command Prompt". They will not be
given a chance to regenerate a localized name.

Fixes #4476.

## References

Possibly rejected proposal for dynamic localized json strings: #5280 

## PR Checklist
* [x] Closes #4476
* [x] CLA signed
* [ ] Tests added/passed
* [x] Requires documentation to be updated
* [x] I've discussed this with core contributors already.

## Validation

Deleted my profiles.