### PR TITLE
Muffle updates to the cursor position to 1/~100ms

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1861,8 +1861,12 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         auto weakThis{ get_weak() };
 
-        // Even with muffling, we dispatch this tens of times _per hundredth of a second_.
-        // Muffle it harder.
+        // Muffle 2: Muffle Harder
+        // If we're the lucky coroutine who gets through, we'll still wait 100ms to clog
+        // the atomic above so we don't service the cursor update too fast. If we get through
+        // and finish processing the update quickly but similar requests are still beating
+        // down the door above in the atomic, we may still update the cursor way more than
+        // is visible to anyone's eye, which is a waste of effort.
         static constexpr auto CursorUpdateQuiesceTime{ std::chrono::milliseconds(100) };
         co_await winrt::resume_after(CursorUpdateQuiesceTime);
 

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1847,6 +1847,15 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // - N/A
     winrt::fire_and_forget TermControl::_TerminalCursorPositionChanged()
     {
+        std::unique_lock muffleLock{ _stateUpdateMuffleMutex, std::defer_lock };
+        // ownership of the muffling lock moves into the coroutine
+        // and is only released when the coroutine is done
+        // this stops us from overwhelming the dispatcher with events.
+        if (!muffleLock.try_lock())
+        {
+            return;
+        }
+
         if (_closing.load())
         {
             return;

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -232,11 +232,11 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _CurrentCursorPositionHandler(const IInspectable& sender, const CursorPositionEventArgs& eventArgs);
         void _FontInfoHandler(const IInspectable& sender, const FontInfoEventArgs& eventArgs);
 
-        // this mutex is to be used as a guard against dispatching billions of coroutines for
+        // this atomic is to be used as a guard against dispatching billions of coroutines for
         // routine state changes that might happen millions of times a second.
         // Unbounded main dispatcher use leads to massive memory leaks and intense slowdowns
         // on the UI thread.
-        std::mutex _stateUpdateMuffleMutex;
+        std::atomic<bool> _coroutineDispatchStateUpdateInProgress{ false };
     };
 }
 

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -231,6 +231,12 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _CompositionCompleted(winrt::hstring text);
         void _CurrentCursorPositionHandler(const IInspectable& sender, const CursorPositionEventArgs& eventArgs);
         void _FontInfoHandler(const IInspectable& sender, const FontInfoEventArgs& eventArgs);
+
+        // this mutex is to be used as a guard against dispatching billions of coroutines for
+        // routine state changes that might happen millions of times a second.
+        // Unbounded main dispatcher use leads to massive memory leaks and intense slowdowns
+        // on the UI thread.
+        std::mutex _stateUpdateMuffleMutex;
     };
 }
 


### PR DESCRIPTION
This stops us from dispatching back-to-back terminal cursor position
updates to the TSF control before it has a chance to get back to us.

Fixes #5288 

This was tested live with the 6MB repro file from "Terminal Not Speed Enough".