### PR TITLE
Update the virtual bottom location if the cursor moves below it

### DIFF
--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -1665,6 +1665,12 @@ void SCREEN_INFORMATION::SetCursorDBMode(const bool DoubleCursor)
 
     cursor.SetPosition(Position);
 
+    // If the cursor has moved below the virtual bottom, the bottom should be updated.
+    if (Position.Y > _virtualBottom)
+    {
+        _virtualBottom = Position.Y;
+    }
+
     // if we have the focus, adjust the cursor state
     if (gci.Flags & CONSOLE_HAS_FOCUS)
     {


### PR DESCRIPTION
## Summary of the Pull Request

If an application writes to the screen while not in VT mode, and the user has scrolled forward in the screen buffer, the _virtual bottom_ location is not updated to take that new content into account. As a result, the viewport can later jump back to the previous _virtual bottom_, making the content disappear off screen. This PR attempts to fix that issue by updating the _virtual bottom_ location whenever the cursor moves below that point.

## PR Checklist
* [x] Closes #5302
* [x] CLA signed. 
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've haven't discussed this with core contributors already. I'm ready to accept this work might be rejected in favor of a different grand plan.

## Detailed Description of the Pull Request / Additional comments

This simply adds a condition in the `SCREEN_INFORMATION::SetCursorPosition` to check if the new _Y_ coordinate is below the current _virtual bottom_, and if so, updates the _virtual bottom_ to that new value.

I considered trying to make it only update when something is actually written to the screen, but this seemed like a cleaner solution, and is less likely to miss out on a needed update.

## Validation Steps Performed

I've manually tested the case described in issue #5302, and confirmed that it now works as expected. I've also added a unit test that checks the virtual bottom is updated correctly under similar conditions.