### PR TITLE
Remove singleLine copy from Shift+Click, CopyOnSelect 

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1146,17 +1146,9 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
             // Only a left click release when copy on select is active should perform a copy.
             // Right clicks and middle clicks should not need to do anything when released.
-            if (_settings.CopyOnSelect() && point.Properties().PointerUpdateKind() == Windows::UI::Input::PointerUpdateKind::LeftButtonReleased)
+            if (_settings.CopyOnSelect() && point.Properties().PointerUpdateKind() == Windows::UI::Input::PointerUpdateKind::LeftButtonReleased && _selectionNeedsToBeCopied)
             {
-                const auto modifiers = static_cast<uint32_t>(args.KeyModifiers());
-                // static_cast to a uint32_t because we can't use the WI_IsFlagSet
-                // macro directly with a VirtualKeyModifiers
-                const auto shiftEnabled = WI_IsFlagSet(modifiers, static_cast<uint32_t>(VirtualKeyModifiers::Shift));
-
-                if (_selectionNeedsToBeCopied)
-                {
-                    CopySelectionToClipboard(shiftEnabled);
-                }
+                CopySelectionToClipboard();
             }
         }
         else if (ptr.PointerDeviceType() == Windows::Devices::Input::PointerDeviceType::Touch)

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -63,7 +63,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         hstring Title();
         hstring GetProfileName() const;
 
-        bool CopySelectionToClipboard(bool collapseText);
+        bool CopySelectionToClipboard(bool collapseText = false);
         void PasteTextFromClipboard();
         void Close();
         Windows::Foundation::Size CharacterDimensions() const;


### PR DESCRIPTION
## Summary of the Pull Request
This fixes an issue where a shift+click selection with `copyOnSelect` enabled would result in copying the content as a single line.

## PR Checklist
* [X] Closes #4737

## Detailed Description of the Pull Request / Additional comments
I've been thinking a lot about this issue and how it relates to the copy/paste discussions we've been having over the past few weeks. Considering that the majority of users want regular copy, it makes sense to default to that in this case too.

If a user wants to perform a special form of copy, it makes sense that they should use their custom keybinding to accomplish that. This kind of behavior aligns with that kind of philosophy.

## Validation Steps Performed

The following scenarios were tested with `copyOnSelect` enabled.
| scenario | behavior |
|--|--|
| Perform a shift+click selection | content copied w/ newlines |
| right-click | clipboard paste |
| copy keybinding (`singleLine` disabled) | content copied w/ newlines |
| copy keybinding (`singleLine` enabled) | content copied as single line |