### PR TITLE
spelling: COLOREREF -> COLORREF

### DIFF
--- a/.github/actions/spell-check/whitelist/whitelist.txt
+++ b/.github/actions/spell-check/whitelist/whitelist.txt
@@ -323,7 +323,6 @@ codepage
 codepoint
 COINIT
 colo
-COLOREREF
 colorizing
 colororacle
 colorref

--- a/src/til/ut_til/ColorTests.cpp
+++ b/src/til/ut_til/ColorTests.cpp
@@ -61,7 +61,7 @@ class ColorTests
     {
         til::color rgb{ 0xf0, 0x0d, 0xca, 0xfe };
 
-        VERIFY_ARE_EQUAL(0x00CA0DF0u, static_cast<COLORREF>(rgb)); // alpha is dropped, COLOREREF is 0BGR
+        VERIFY_ARE_EQUAL(0x00CA0DF0u, static_cast<COLORREF>(rgb)); // alpha is dropped, COLORREF is 0BGR
     }
 
     template<typename T>


### PR DESCRIPTION
## Summary of the Pull Request

## References

## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed
Spell check passed on my fork :-)

I saw this when I was looking at someone else's PR and realized that it's just a typo.