### PR TITLE
Add support for renderer backoff, don't FAIL_FAST on 3x failures, add UI

### DIFF
--- a/src/cascadia/TerminalControl/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalControl/Resources/en-US/Resources.resw
@@ -164,4 +164,10 @@
   <data name="SearchBox_Close.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Close Search Box</value>
   </data>
+  <data name="TermControl_RendererFailedTextBlock.Text" xml:space="preserve">
+    <value>This terminal has encountered an issue with the graphics driver and it could not recover in time. It has been suspended.</value>
+  </data>
+  <data name="TermControl_RendererRetryButton.Content" xml:space="preserve">
+    <value>Resume</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -79,6 +79,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         winrt::fire_and_forget RenderEngineSwapChainChanged();
         void _AttachDxgiSwapChainToXaml(IDXGISwapChain1* swapChain);
+        winrt::fire_and_forget _RendererEnteredErrorState();
+        void _RenderRetryButton_Click(IInspectable const& button, IInspectable const& args);
 
         void CreateSearchBoxControl();
 

--- a/src/cascadia/TerminalControl/TermControl.xaml
+++ b/src/cascadia/TerminalControl/TermControl.xaml
@@ -77,6 +77,23 @@
                                CurrentCursorPosition="_CurrentCursorPositionHandler"
                                CurrentFontInfo="_FontInfoHandler" />
 
+        <Grid x:Name="RendererFailedNotice"
+              x:Load="False"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center">
+            <Border Background="{ThemeResource SystemControlBackgroundAltHighBrush}"
+                    BorderBrush="{ThemeResource SystemAccentColor}"
+                    Margin="8,8,8,8"
+                    Padding="8,8,8,8"
+                    BorderThickness="2,2,2,2"
+                    CornerRadius="{ThemeResource OverlayCornerRadius}">
+                <StackPanel>
+                    <TextBlock HorizontalAlignment="Center" x:Uid="TermControl_RendererFailedTextBlock" TextWrapping="WrapWholeWords"/>
+                    <Button Click="_RenderRetryButton_Click" x:Uid="TermControl_RendererRetryButton" HorizontalAlignment="Right" />
+                </StackPanel>
+            </Border>
+        </Grid>
+
     </Grid>
 
 </UserControl>

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -86,6 +86,9 @@ Renderer::~Renderer()
                     {
                         _pfnRendererEnteredErrorState();
                     }
+                    // If there's no callback, we still don't want to FAIL_FAST: the renderer going black
+                    // isn't near as bad as the entire application aborting. We're a component. We shouldn't
+                    // abort applications that host us.
                     return S_FALSE;
                 }
                 // Add a bit of backoff.

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -11,6 +11,8 @@ using namespace Microsoft::Console::Render;
 using namespace Microsoft::Console::Types;
 
 static constexpr auto maxRetriesForRenderEngine = 3;
+// The renderer will wait this number of milliseconds * how many tries have elapsed before trying again.
+static constexpr auto renderBackoffBaseTimeMilliseconds{ 150 };
 
 // Routine Description:
 // - Creates a new renderer controller for a console.
@@ -88,7 +90,7 @@ Renderer::~Renderer()
                 }
                 // Add a bit of backoff.
                 // Sleep 150ms, 300ms, 450ms before failing out and disabling the renderer.
-                Sleep(150 * (maxRetriesForRenderEngine - tries));
+                Sleep(renderBackoffBaseTimeMilliseconds * (maxRetriesForRenderEngine - tries));
                 continue;
             }
             LOG_IF_FAILED(hr);

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -76,6 +76,9 @@ namespace Microsoft::Console::Render
 
         void AddRenderEngine(_In_ IRenderEngine* const pEngine) override;
 
+        void SetRendererEnteredErrorStateCallback(std::function<void()> pfn);
+        void ResetErrorStateAndResume();
+
     private:
         std::deque<IRenderEngine*> _rgpEngines;
 
@@ -127,6 +130,8 @@ namespace Microsoft::Console::Render
         // Helper functions to diagnose issues with painting and layout.
         // These are only actually effective/on in Debug builds when the flag is set using an attached debugger.
         bool _fDebug = false;
+
+        std::function<void()> _pfnRendererEnteredErrorState;
 
 #ifdef UNIT_TESTING
         friend class ConptyOutputTests;

--- a/src/renderer/base/thread.cpp
+++ b/src/renderer/base/thread.cpp
@@ -26,6 +26,7 @@ RenderThread::~RenderThread()
     if (_hThread)
     {
         _fKeepRunning = false; // stop loop after final run
+        EnablePainting(); // if we want to get the last frame out, we need to make sure it's enabled
         SignalObjectAndWait(_hEvent, _hThread, INFINITE, FALSE); // signal final paint and wait for thread to finish.
 
         CloseHandle(_hThread);
@@ -229,6 +230,11 @@ void RenderThread::NotifyPaint()
 void RenderThread::EnablePainting()
 {
     SetEvent(_hPaintEnabledEvent);
+}
+
+void RenderThread::DisablePainting()
+{
+    ResetEvent(_hPaintEnabledEvent);
 }
 
 void RenderThread::WaitForPaintCompletionAndDisable(const DWORD dwTimeoutMs)

--- a/src/renderer/base/thread.hpp
+++ b/src/renderer/base/thread.hpp
@@ -30,6 +30,7 @@ namespace Microsoft::Console::Render
         void NotifyPaint() override;
 
         void EnablePainting() override;
+        void DisablePainting() override;
         void WaitForPaintCompletionAndDisable(const DWORD dwTimeoutMs) override;
 
     private:

--- a/src/renderer/inc/IRenderThread.hpp
+++ b/src/renderer/inc/IRenderThread.hpp
@@ -26,6 +26,7 @@ namespace Microsoft::Console::Render
 
         virtual void NotifyPaint() = 0;
         virtual void EnablePainting() = 0;
+        virtual void DisablePainting() = 0;
         virtual void WaitForPaintCompletionAndDisable(const DWORD dwTimeoutMs) = 0;
 
     protected:


### PR DESCRIPTION
## Summary of the Pull Request
Renderer: Add support for backoff and auto-disable on failed retry

This commit introduces a backoff (150ms * number of tries) to the
renderer's retry logic (introduced in #2830). It also changes the
FAIL_FAST to a less globally-harmful render thread disable, so that we
stop blowing up any application hosting a terminal when the graphics
driver goes away.

In addition, it adds a callback that a Renderer consumer can use to
determine when the renderer _has_ failed, and a public method to kick it
back into life.

Fixes #5340.

This PR also wires up TermControl so that it shows some UI when the renderer tastes clay.

![image](https://user-images.githubusercontent.com/14316954/79266118-f073f680-7e4b-11ea-8b96-5588a13aff3b.png)

![image](https://user-images.githubusercontent.com/14316954/79266125-f36ee700-7e4b-11ea-9314-4280e9149461.png)

## PR Checklist
* [x] Closes #5340
* [x] cla
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already.

## Validation Steps Performed

I tested this by dropping the number of retries to 1 and forcing a TDR while doing `wsl cmatrix -u0`. It picked up exactly where it left off.

As a bonus, you can actually still type into the terminal when it's graphically suspended (and `exit` still works.). The block is _entirely graphical_.
