### PR TITLE
Rework error handling and state flow in the Azure connection

### DIFF
--- a/src/cascadia/TerminalConnection/AzureClient.h
+++ b/src/cascadia/TerminalConnection/AzureClient.h
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+#include "cpprest/json.h"
+
+namespace Microsoft::Terminal::Azure
+{
+    class AzureException : public std::runtime_error
+    {
+        std::wstring _code;
+
+    public:
+        static bool IsErrorPayload(const web::json::value& errorObject)
+        {
+            return errorObject.has_string_field(L"error");
+        }
+
+        AzureException(const web::json::value& errorObject) :
+            runtime_error(til::u16u8(errorObject.at(L"error_description").as_string())), // surface the human-readable description as .what()
+            _code(errorObject.at(L"error").as_string())
+        {
+        }
+
+        std::wstring_view GetCode() const noexcept
+        {
+            return _code;
+        }
+    };
+
+    namespace ErrorCodes
+    {
+        static constexpr std::wstring_view AuthorizationPending{ L"authorization_pending" };
+        static constexpr std::wstring_view InvalidGrant{ L"invalid_grant" };
+    }
+}
+
+#define THROW_IF_AZURE_ERROR(payload)                  \
+    do                                                 \
+    {                                                  \
+        if (AzureException::IsErrorPayload((payload))) \
+        {                                              \
+            throw AzureException((payload));           \
+        }                                              \
+    } while (0)

--- a/src/cascadia/TerminalConnection/AzureClient.h
+++ b/src/cascadia/TerminalConnection/AzureClient.h
@@ -34,6 +34,13 @@ namespace Microsoft::Terminal::Azure
         static constexpr std::wstring_view AuthorizationPending{ L"authorization_pending" };
         static constexpr std::wstring_view InvalidGrant{ L"invalid_grant" };
     }
+
+    struct Tenant
+    {
+        std::wstring ID;
+        std::optional<std::wstring> DisplayName;
+        std::optional<std::wstring> DefaultDomain;
+    };
 }
 
 #define THROW_IF_AZURE_ERROR(payload)                  \

--- a/src/cascadia/TerminalConnection/AzureConnection.cpp
+++ b/src/cascadia/TerminalConnection/AzureConnection.cpp
@@ -321,32 +321,32 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
                 // or allow them to login with a different account or allow them to remove the saved settings
                 case AzureState::AccessStored:
                 {
-                    RETURN_IF_FAILED(_AccessHelper());
+                    RETURN_IF_FAILED(_RunAccessState());
                     break;
                 }
                 // User has no saved connection settings or has opted to login with a different account
                 // Azure authentication happens here
                 case AzureState::DeviceFlow:
                 {
-                    RETURN_IF_FAILED(_DeviceFlowHelper());
+                    RETURN_IF_FAILED(_RunDeviceFlowState());
                     break;
                 }
                 // User has multiple tenants in their Azure account, they need to choose which one to connect to
                 case AzureState::TenantChoice:
                 {
-                    RETURN_IF_FAILED(_TenantChoiceHelper());
+                    RETURN_IF_FAILED(_RunTenantChoiceState());
                     break;
                 }
                 // Ask the user if they want to save these connection settings for future logins
                 case AzureState::StoreTokens:
                 {
-                    RETURN_IF_FAILED(_StoreHelper());
+                    RETURN_IF_FAILED(_RunStoreState());
                     break;
                 }
                 // Connect to Azure, we only get here once we have everything we need (tenantID, accessToken, refreshToken)
                 case AzureState::TermConnecting:
                 {
-                    RETURN_IF_FAILED(_ConnectHelper());
+                    RETURN_IF_FAILED(_RunConnectState());
                     break;
                 }
                 // We are connected, continuously read from the websocket until its closed
@@ -402,7 +402,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
     // - S_FALSE if there are no stored credentials
     // - S_OK if the user opts to login with a stored set of credentials or login with a different account
     // - E_FAIL if the user closes the tab
-    HRESULT AzureConnection::_AccessHelper()
+    HRESULT AzureConnection::_RunAccessState()
     {
         bool oldVersionEncountered = false;
         auto vault = PasswordVault();
@@ -545,7 +545,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
     // Return value:
     // - E_FAIL if the user closes the tab, does not authenticate in time or has no tenants in their Azure account
     // - S_OK otherwise
-    HRESULT AzureConnection::_DeviceFlowHelper()
+    HRESULT AzureConnection::_RunDeviceFlowState()
     {
         // Initiate device code flow
         const auto deviceCodeResponse = _GetDeviceCode();
@@ -594,7 +594,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
     // Return value:
     // - E_FAIL if the user closes the tab
     // - S_OK otherwise
-    HRESULT AzureConnection::_TenantChoiceHelper()
+    HRESULT AzureConnection::_RunTenantChoiceState()
     {
         try
         {
@@ -651,7 +651,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
     // Return value:
     // - E_FAIL if the user closes the tab
     // - S_OK otherwise
-    HRESULT AzureConnection::_StoreHelper()
+    HRESULT AzureConnection::_RunStoreState()
     {
         _WriteStringWithNewline(_formatResWithColoredUserInputOptions(USES_RESOURCE(L"AzureStorePrompt"), USES_RESOURCE(L"AzureUserEntry_Yes"), USES_RESOURCE(L"AzureUserEntry_No")));
         // Wait for user input
@@ -685,7 +685,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
     // Return value:
     // - E_FAIL if the user has not set up their cloud shell yet
     // - S_OK after successful connection
-    HRESULT AzureConnection::_ConnectHelper()
+    HRESULT AzureConnection::_RunConnectState()
     {
         // Get user's cloud shell settings
         const auto settingsResponse = _GetCloudShellUserSettings();

--- a/src/cascadia/TerminalConnection/AzureConnection.cpp
+++ b/src/cascadia/TerminalConnection/AzureConnection.cpp
@@ -284,7 +284,21 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
     static std::tuple<utility::string_t, utility::string_t> _crackTenant(const json::value& tenant)
     {
         auto tenantId{ tenant.at(L"tenantId").as_string() };
-        std::wstring displayName{ tenant.has_string_field(L"displayName") ? tenant.at(L"displayName").as_string() : static_cast<std::wstring>(RS_(L"AzureUnknownTenantName")) };
+        std::wstring displayName{};
+        if (tenant.has_string_field(L"displayName"))
+        {
+            displayName = tenant.at(L"displayName").as_string();
+        }
+        else
+        {
+            displayName = std::wstring{ RS_(L"AzureUnknownTenantName") };
+        }
+
+        if (tenant.has_string_field(L"defaultDomain"))
+        {
+            auto defaultDomain{ tenant.at(L"defaultDomain").as_string() };
+            displayName = wil::str_printf<std::wstring>(L"%.*s, %.*s", displayName.size(), displayName.data(), defaultDomain.size(), defaultDomain.data());
+        }
         return { tenantId, displayName };
     }
 
@@ -832,7 +846,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 
         // Initialize the request
         http_request tenantRequest(L"GET");
-        tenantRequest.set_request_uri(L"tenants?api-version=2018-01-01");
+        tenantRequest.set_request_uri(L"tenants?api-version=2020-01-01");
         _HeaderHelper(tenantRequest);
 
         // Send the request and return the response as a json value

--- a/src/cascadia/TerminalConnection/AzureConnection.cpp
+++ b/src/cascadia/TerminalConnection/AzureConnection.cpp
@@ -526,7 +526,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         auto desiredCredential = credList.GetAt(selectedTenant);
         desiredCredential.RetrievePassword();
         auto passWordJson = json::value::parse(desiredCredential.Password().c_str());
-        _currentTenant = _tenantList[selectedTenant]; // we already unpacked the name info, so we should just use it
+        _currentTenant = til::at(_tenantList, selectedTenant); // we already unpacked the name info, so we should just use it
         _accessToken = passWordJson.at(L"accessToken").as_string();
         _refreshToken = passWordJson.at(L"refreshToken").as_string();
         _expiry = std::stoi(passWordJson.at(L"expiry").as_string());
@@ -610,7 +610,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         auto numTenants = gsl::narrow<int>(_tenantList.size());
         for (int i = 0; i < numTenants; i++)
         {
-            _WriteStringWithNewline(_formatTenant(i, _tenantList[i]));
+            _WriteStringWithNewline(_formatTenant(i, til::at(_tenantList, i)));
         }
         _WriteStringWithNewline(RS_(L"AzureEnterTenant"));
 
@@ -644,7 +644,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             _WriteStringWithNewline(RS_(L"AzureNonNumberError"));
         } while (true);
 
-        _currentTenant = _tenantList[selectedTenant];
+        _currentTenant = til::at(_tenantList, selectedTenant);
 
         // We have to refresh now that we have the tenantID
         _RefreshTokens();

--- a/src/cascadia/TerminalConnection/AzureConnection.cpp
+++ b/src/cascadia/TerminalConnection/AzureConnection.cpp
@@ -235,7 +235,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 
             // Initialize the request
             http_request terminalRequest(L"POST");
-            terminalRequest.set_request_uri(L"terminals/" + _terminalID + L"/size?cols=" + std::to_wstring(columns) + L"&rows=" + std::to_wstring(rows) + L"&version=2019-01-01");
+            terminalRequest.set_request_uri(fmt::format(L"terminals/{}/size?cols={}&rows={}&version=2019-01-01", _terminalID, columns, rows));
             terminalRequest.set_body(json::value::null());
 
             // Send the request (don't care about the response)
@@ -757,7 +757,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         // Initialize the request
         http_request commonRequest(L"POST");
         commonRequest.set_request_uri(L"common/oauth2/devicecode");
-        const auto body = L"client_id=" + AzureClientID + L"&resource=" + _wantedResource;
+        const auto body{ fmt::format(L"client_id={}&resource={}", AzureClientID, _wantedResource) };
         commonRequest.set_body(body.c_str(), L"application/x-www-form-urlencoded");
 
         // Send the request and receive the response as a json value
@@ -779,7 +779,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         http_client pollingClient(_loginUri);
 
         // Continuously send a poll request until the user authenticates
-        const auto body = L"grant_type=device_code&resource=" + _wantedResource + L"&client_id=" + AzureClientID + L"&code=" + deviceCode;
+        const auto body{ fmt::format(L"grant_type=device_code&resource={}&client_id={}&code={}", _wantedResource, AzureClientID, deviceCode) };
         const auto requestUri = L"common/oauth2/token";
 
         // use a steady clock here so it's not impacted by local time discontinuities
@@ -849,7 +849,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         // Initialize the request
         http_request refreshRequest(L"POST");
         refreshRequest.set_request_uri(_tenantID + L"/oauth2/token");
-        const auto body = L"client_id=" + AzureClientID + L"&resource=" + _wantedResource + L"&grant_type=refresh_token" + L"&refresh_token=" + _refreshToken;
+        const auto body{ fmt::format(L"client_id={}&resource={}&grant_type=refresh_token&refresh_token={}", AzureClientID, _wantedResource, _refreshToken) };
         refreshRequest.set_body(body.c_str(), L"application/x-www-form-urlencoded");
 
         // Send the request and return the response as a json value
@@ -909,7 +909,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 
         // Initialize the request
         http_request terminalRequest(L"POST");
-        terminalRequest.set_request_uri(L"terminals?cols=" + std::to_wstring(_initialCols) + L"&rows=" + std::to_wstring(_initialRows) + L"&version=2019-01-01&shell=" + shellType);
+        terminalRequest.set_request_uri(fmt::format(L"terminals?cols={}&rows={}&version=2019-01-01&shell={}", _initialCols, _initialRows, shellType));
         // LOAD-BEARING. the API returns "'content-type' should be 'application/json' or 'multipart/form-data'"
         terminalRequest.set_body(json::value::null());
 

--- a/src/cascadia/TerminalConnection/AzureConnection.h
+++ b/src/cascadia/TerminalConnection/AzureConnection.h
@@ -40,7 +40,6 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             StoreTokens,
             TermConnecting,
             TermConnected,
-            NoConnect
         };
 
         AzureState _state{ AzureState::AccessStored };
@@ -69,11 +68,12 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         utility::string_t _terminalID;
 
         void _WriteStringWithNewline(const std::wstring_view str);
+        void _WriteCaughtExceptionRecord();
         web::json::value _RequestHelper(web::http::client::http_client theClient, web::http::http_request theRequest);
         web::json::value _GetDeviceCode();
         web::json::value _WaitForUser(utility::string_t deviceCode, int pollInterval, int expiresIn);
         web::json::value _GetTenants();
-        web::json::value _RefreshTokens();
+        void _RefreshTokens();
         web::json::value _GetCloudShellUserSettings();
         utility::string_t _GetCloudShell();
         utility::string_t _GetTerminal(utility::string_t shellType);

--- a/src/cascadia/TerminalConnection/AzureConnection.h
+++ b/src/cascadia/TerminalConnection/AzureConnection.h
@@ -13,6 +13,7 @@
 
 #include "../cascadia/inc/cppwinrt_utils.h"
 #include "ConnectionStateHolder.h"
+#include "AzureClient.h"
 
 namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 {
@@ -57,14 +58,14 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         const utility::string_t _resourceUri{ U("https://management.azure.com/") };
         const utility::string_t _wantedResource{ U("https://management.core.windows.net/") };
         const int _expireLimit{ 2700 };
-        web::json::value _tenantList;
-        utility::string_t _displayName;
-        utility::string_t _tenantID;
         utility::string_t _accessToken;
         utility::string_t _refreshToken;
         int _expiry{ 0 };
         utility::string_t _cloudShellUri;
         utility::string_t _terminalID;
+
+        std::vector<::Microsoft::Terminal::Azure::Tenant> _tenantList;
+        std::optional<::Microsoft::Terminal::Azure::Tenant> _currentTenant;
 
         void _WriteStringWithNewline(const std::wstring_view str);
         void _WriteCaughtExceptionRecord();
@@ -72,7 +73,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         web::json::value _SendAuthenticatedRequestReturningJson(web::http::client::http_client& theClient, web::http::http_request theRequest);
         web::json::value _GetDeviceCode();
         web::json::value _WaitForUser(utility::string_t deviceCode, int pollInterval, int expiresIn);
-        web::json::value _GetTenants();
+        void _PopulateTenantList();
         void _RefreshTokens();
         web::json::value _GetCloudShellUserSettings();
         utility::string_t _GetCloudShell();

--- a/src/cascadia/TerminalConnection/AzureConnection.h
+++ b/src/cascadia/TerminalConnection/AzureConnection.h
@@ -47,11 +47,11 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         wil::unique_handle _hOutputThread;
 
         DWORD _OutputThread();
-        HRESULT _RunAccessState();
-        HRESULT _RunDeviceFlowState();
-        HRESULT _RunTenantChoiceState();
-        HRESULT _RunStoreState();
-        HRESULT _RunConnectState();
+        void _RunAccessState();
+        void _RunDeviceFlowState();
+        void _RunTenantChoiceState();
+        void _RunStoreState();
+        void _RunConnectState();
 
         const utility::string_t _loginUri{ U("https://login.microsoftonline.com/") };
         const utility::string_t _resourceUri{ U("https://management.azure.com/") };

--- a/src/cascadia/TerminalConnection/AzureConnection.h
+++ b/src/cascadia/TerminalConnection/AzureConnection.h
@@ -47,11 +47,11 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         wil::unique_handle _hOutputThread;
 
         DWORD _OutputThread();
-        HRESULT _AccessHelper();
-        HRESULT _DeviceFlowHelper();
-        HRESULT _TenantChoiceHelper();
-        HRESULT _StoreHelper();
-        HRESULT _ConnectHelper();
+        HRESULT _RunAccessState();
+        HRESULT _RunDeviceFlowState();
+        HRESULT _RunTenantChoiceState();
+        HRESULT _RunStoreState();
+        HRESULT _RunConnectState();
 
         const utility::string_t _loginUri{ U("https://login.microsoftonline.com/") };
         const utility::string_t _resourceUri{ U("https://management.azure.com/") };

--- a/src/cascadia/TerminalConnection/AzureConnection.h
+++ b/src/cascadia/TerminalConnection/AzureConnection.h
@@ -46,7 +46,6 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 
         wil::unique_handle _hOutputThread;
 
-        static DWORD WINAPI StaticOutputThreadProc(LPVOID lpParameter);
         DWORD _OutputThread();
         HRESULT _AccessHelper();
         HRESULT _DeviceFlowHelper();

--- a/src/cascadia/TerminalConnection/AzureConnection.h
+++ b/src/cascadia/TerminalConnection/AzureConnection.h
@@ -68,7 +68,8 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 
         void _WriteStringWithNewline(const std::wstring_view str);
         void _WriteCaughtExceptionRecord();
-        web::json::value _RequestHelper(web::http::client::http_client theClient, web::http::http_request theRequest);
+        web::json::value _SendRequestReturningJson(web::http::client::http_client& theClient, web::http::http_request theRequest);
+        web::json::value _SendAuthenticatedRequestReturningJson(web::http::client::http_client& theClient, web::http::http_request theRequest);
         web::json::value _GetDeviceCode();
         web::json::value _WaitForUser(utility::string_t deviceCode, int pollInterval, int expiresIn);
         web::json::value _GetTenants();
@@ -76,7 +77,6 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         web::json::value _GetCloudShellUserSettings();
         utility::string_t _GetCloudShell();
         utility::string_t _GetTerminal(utility::string_t shellType);
-        void _HeaderHelper(web::http::http_request theRequest);
         void _StoreCredential();
         void _RemoveCredentials();
 

--- a/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
@@ -123,15 +123,15 @@
   <data name="AzureEnterTenant" xml:space="preserve">
     <value>Please enter the desired tenant number.</value>
   </data>
-  <data name="AzureNewLogin" xml:space="default">
+  <data name="AzureNewLogin" xml:space="preserve">
     <value>Enter {0} to login with a new account</value>
     <comment>{0} will be replaced with the resource from AzureUserEntry_NewLogin; it is intended to be a single-character shorthand for "new account"</comment>
   </data>
-  <data name="AzureRemoveStored" xml:space="default">
+  <data name="AzureRemoveStored" xml:space="preserve">
     <value>Enter {0} to remove the above saved connection settings.</value>
     <comment>{0} will be replaced with the resource from AzureUserEntry_RemoveStored; it is intended to be a single-character shorthand for "remove stored"</comment>
   </data>
-  <data name="AzureInvalidAccessInput" xml:space="default">
+  <data name="AzureInvalidAccessInput" xml:space="preserve">
     <value>Please enter a valid number to access the stored connection settings, {0} to log in with a new account, or {1} to remove the saved connection settings.</value>
     <comment>{0} will be replaced with the resource from AzureUserEntry_NewLogin, and {1} will be replaced with AzureUserEntry_RemoveStored. This is an error message, used after AzureNewLogin/AzureRemoveStored if the user enters an invalid value.</comment>
   </data>
@@ -148,11 +148,11 @@
     <value>You have not set up your cloud shell account yet. Please go to https://shell.azure.com to set it up.</value>
     <comment>{Locked="https://shell.azure.com"} This URL should not be localized. Everything else should.</comment>
   </data>
-  <data name="AzureStorePrompt" xml:space="default">
+  <data name="AzureStorePrompt" xml:space="preserve">
     <value>Do you want to save these connection settings for future logins? [{0}/{1}]</value>
     <comment>{0} and {1} will be replaced with AzureUserEntry_Yes and AzureUserEntry_No. They are single-character shorthands for "yes" and "no" in this language.</comment>
   </data>
-  <data name="AzureInvalidStoreInput" xml:space="default">
+  <data name="AzureInvalidStoreInput" xml:space="preserve">
     <value>Please enter {0} or {1}</value>
     <comment>{0} and {1} will be replaced with AzureUserEntry_Yes and AzureUserEntry_No. This resource will be used as an error response after AzureStorePrompt.</comment>
   </data>
@@ -180,16 +180,13 @@
   <data name="AzureAuthString" xml:space="preserve">
     <value>Authenticated.</value>
   </data>
-  <data name="AzureInternetOrServerIssue" xml:space="preserve">
-    <value>Could not connect to Azure. You may not have internet or the server might be down.</value>
-  </data>
   <data name="AzureOldCredentialsFlushedMessage" xml:space="preserve">
     <value>Authentication parameters changed. You'll need to log in again.</value>
   </data>
   <data name="AzureUnknownTenantName" xml:space="preserve">
     <value>&lt;unknown tenant name&gt;</value>
   </data>
-  <data name="AzureIthTenant" xml:space="default">
+  <data name="AzureIthTenant" xml:space="preserve">
     <value>Tenant {0}: {1} ({2})</value>
     <comment>{0} is the tenant's number, which the user will enter to connect to the tenant. {1} is the tenant's display name, which will be meaningful for the user. {2} is the tenant's internal ID number.</comment>
   </data>

--- a/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
@@ -174,12 +174,6 @@
   <data name="AzureTokensRemoved" xml:space="preserve">
     <value>Saved connection settings removed.</value>
   </data>
-  <data name="AzureExitStr" xml:space="preserve">
-    <value>Exit.</value>
-  </data>
-  <data name="AzureAuthString" xml:space="preserve">
-    <value>Authenticated.</value>
-  </data>
   <data name="AzureOldCredentialsFlushedMessage" xml:space="preserve">
     <value>Authentication parameters changed. You'll need to log in again.</value>
   </data>


### PR DESCRIPTION
### 38429b56c - az: rework tenant/tenant storage and fix display names
Instead of passing around four loose variables, create a Tenant class
and use that for packing/unpacking into/out of json (and the windows
credential store, where we "cleverly" used json for the tenant info
there too).

When displaying a tenant, use its display name if there is one, the
unknown resource string if there isn't, and the default domain if there
is one and the ID if there isn't.

Fixes #5325.

### 9f6ebcb67 - az: use {fmt} for formatting request bodies

### 8a54e098d - az: remove dead strings

### 8985c3831 - az: rework Request/HeaderHelper to Send(Authenticated?)ReqReturningJson

### 7ad9e8827 - az: rewrite polling to use std::chrono

### 69b59cb3f - az: remove HR returns from state machine

### 2fe5f66ea - az: rename state handlers from _XHelper to _RunXState

### a1de8c37b - az: cleanup, prefix user input with >, remove namespaces

### b5e16c27c - az: show more tenant info
Switch to 2020 tenant API; use defaultDomain; put defaultDomain into the
display name.

Consider: not showing the tenant GUID at all?

### 61f06e7aa - az: rework error handling
* _RequestHelper no longer eats exceptions.
* Delete the "no internet" error message.
* Wrap exceptions coming out of Azure API in a well-known type.
* Catch by type.
* Extract error codes for known failures (keep polling, invalid grant).
* When we get an Invalid Grant, dispose of the cached refresh token and force the user to log in again.
* Catch all printable exceptions and print them.
* Remove the NoConnect state completely -- just bail out when an exception hits the toplevel of the output thread.
* Move 3x logic into _RefreshTokens and pop exceptions out of it.
* Begin abstracting into AzureClient


## Summary of the Pull Request

This is a tidying-up of the azure connection. It improves error logging (like: it actually emits error logs...) and retry logic and the state machine and it audits the exit points of the state machine for exceptions and removes the HRESULT returns (so they either succeed and transition to a new state or throw an exception or are going down anyway).

There's also a change in here that changes how we display tenants. It adds the "default domain" to the name, so that instead of seeing this:

```
Conhost (aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)
Default Directory (bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb)
```

you see this

```
Conhost (conhost.onmicrosoft.com)
Default Directory (dustinhowett.onmicrosoft.com)
```

# References

Fixes #5325 (by addressing its chief complaint).
Fixes #4803.
Adds diagnosability for #4575.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #5325. Closes #4803.
* [x] CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] Core contributor

## Detailed Description of the Pull Request / Additional comments
As above.

## Validation Steps Performed
Logged in, out, around a good number of times.
