### PR TITLE
Disable incremental rendering.

### DIFF
--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -885,21 +885,26 @@ try
 {
     RETURN_HR_IF(E_NOT_VALID_STATE, _isPainting); // invalid to start a paint while painting.
 
-    // If retro terminal effects are on, we must invalidate everything for them to draw correctly.
-    // Yes, this will further impact the performance of retro terminal effects.
-    // But we're talking about running the entire display pipeline through a shader for
-    // cosmetic effect, so performance isn't likely the top concern with this feature.
-    if (_retroTerminalEffects)
-    {
-        _invalidMap.set_all();
-    }
+    //// If retro terminal effects are on, we must invalidate everything for them to draw correctly.
+    //// Yes, this will further impact the performance of retro terminal effects.
+    //// But we're talking about running the entire display pipeline through a shader for
+    //// cosmetic effect, so performance isn't likely the top concern with this feature.
+    //if (_retroTerminalEffects)
+    //{
+    //    _invalidMap.set_all();
+    //}
 
-    // If we're doing High DPI, we must invalidate everything for it to draw correctly.
-    // TODO: GH: 5320 - Remove implicit DPI scaling in D2D target to enable pixel perfect High DPI
-    if (_scale != 1.0f)
-    {
-        _invalidMap.set_all();
-    }
+    //// If we're doing High DPI, we must invalidate everything for it to draw correctly.
+    //// TODO: GH: 5320 - Remove implicit DPI scaling in D2D target to enable pixel perfect High DPI
+    //if (_scale != 1.0f)
+    //{
+    //    _invalidMap.set_all();
+    //}
+
+    // TODO: GH: 778, 5345 - There are too many issues with incremental rendering for 1.0. This disables it by going back
+    // to redrawing everything.
+    // The above lines are left in and commented out for when we turn this back on post 1.0.
+    _invalidMap.set_all();
 
     if (TraceLoggingProviderEnabled(g_hDxRenderProvider, WINEVENT_LEVEL_VERBOSE, 0))
     {


### PR DESCRIPTION
## Summary of the Pull Request
Disables incremental rendering as we cannot reach parity between normal and High DPI by 1.0 ship, there are some outstanding longtail issues with the incremental rendering around fonts and certain applications, and the solutions to these problems require broad architectural change to resolve.

## PR Checklist
* [x] Reopens #778, closes part of a vim issue and many of the issues revealed in #5345
* [x] I work here.
* [x] Manual testing of me and everyone else.
* [x] No doc.
* [x] Dustin and I discussed this.

## Validation Steps Performed
- [x] - Ran it and dragged it between two DPI monitors
- [x] - Ran some commands outputting a bunch of text, including to the bottom of the circular buffer.
- [x] - Tried vim in ubuntu via WSL
