### PR TITLE
wpf: port selection changes from TermControl, add multi-click selection

### DIFF
--- a/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
@@ -241,6 +241,8 @@ HRESULT HwndTerminal::Refresh(const SIZE windowSize, _Out_ COORD* dimensions)
 
     auto lock = _terminal->LockForWriting();
 
+    _terminal->ClearSelection();
+
     RETURN_IF_FAILED(_renderEngine->SetWindowSize(windowSize));
 
     // Invalidate everything
@@ -521,6 +523,10 @@ void _stdcall TerminalSetTheme(void* terminal, TerminalTheme theme, LPCWSTR font
 HRESULT _stdcall TerminalResize(void* terminal, COORD dimensions)
 {
     const auto publicTerminal = static_cast<const HwndTerminal*>(terminal);
+
+    auto lock = publicTerminal->_terminal->LockForWriting();
+    publicTerminal->_terminal->ClearSelection();
+    publicTerminal->_renderer->TriggerRedrawAll();
 
     return publicTerminal->_terminal->UserResize(dimensions);
 }

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
@@ -76,7 +76,7 @@ private:
     std::unique_ptr<::Microsoft::Console::Render::DxEngine> _renderEngine;
 
     std::chrono::milliseconds _multiClickTime;
-    unsigned int _multiClickCounter;
+    unsigned int _multiClickCounter{};
     std::chrono::steady_clock::time_point _lastMouseClickTimestamp{};
     std::optional<til::point> _lastMouseClickPos;
     std::optional<til::point> _singleClickTouchdownPos;
@@ -101,7 +101,7 @@ private:
     void _PasteTextFromClipboard() noexcept;
     void _StringPaste(const wchar_t* const pData) noexcept;
 
-    const unsigned int _NumberOfClicks(til::point clickPos, std::chrono::steady_clock::time_point clickTime);
+    const unsigned int _NumberOfClicks(til::point clickPos, std::chrono::steady_clock::time_point clickTime) noexcept;
     HRESULT _StartSelection(LPARAM lParam) noexcept;
     HRESULT _MoveSelection(LPARAM lParam) noexcept;
     IRawElementProviderSimple* _GetUiaProvider() noexcept;

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
@@ -75,6 +75,8 @@ private:
     std::unique_ptr<::Microsoft::Console::Render::Renderer> _renderer;
     std::unique_ptr<::Microsoft::Console::Render::DxEngine> _renderEngine;
 
+    std::optional<til::point> _singleClickTouchdownPos;
+
     friend HRESULT _stdcall CreateTerminal(HWND parentHwnd, _Out_ void** hwnd, _Out_ void** terminal);
     friend HRESULT _stdcall TerminalResize(void* terminal, COORD dimensions);
     friend void _stdcall TerminalDpiChanged(void* terminal, int newDpi);

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
@@ -75,6 +75,10 @@ private:
     std::unique_ptr<::Microsoft::Console::Render::Renderer> _renderer;
     std::unique_ptr<::Microsoft::Console::Render::DxEngine> _renderEngine;
 
+    std::chrono::milliseconds _multiClickTime;
+    unsigned int _multiClickCounter;
+    std::chrono::steady_clock::time_point _lastMouseClickTimestamp{};
+    std::optional<til::point> _lastMouseClickPos;
     std::optional<til::point> _singleClickTouchdownPos;
 
     friend HRESULT _stdcall CreateTerminal(HWND parentHwnd, _Out_ void** hwnd, _Out_ void** terminal);
@@ -97,6 +101,7 @@ private:
     void _PasteTextFromClipboard() noexcept;
     void _StringPaste(const wchar_t* const pData) noexcept;
 
+    const unsigned int _NumberOfClicks(til::point clickPos, std::chrono::steady_clock::time_point clickTime);
     HRESULT _StartSelection(LPARAM lParam) noexcept;
     HRESULT _MoveSelection(LPARAM lParam) noexcept;
     IRawElementProviderSimple* _GetUiaProvider() noexcept;

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -839,7 +839,11 @@ void Terminal::_NotifyTerminalCursorPositionChanged() noexcept
 {
     if (_pfnCursorPositionChanged)
     {
-        _pfnCursorPositionChanged();
+        try
+        {
+            _pfnCursorPositionChanged();
+        }
+        CATCH_LOG();
     }
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

This pull request ports #5096 to WpfTerminalControl, bringing it in line with the selection mechanics in Terminal. It also introduces double- and triple-click selection and makes sure we clear the selection when we resize.

Please read #5096 for more details.

## Detailed Description of the Pull Request / Additional comments

This code is, largely, copy-and-pasted from TermControl with some updates to use `std::chrono` and `til::point`. I love `til::point`. A lot.

## Validation Steps Performed
Lots of manual selection.
