### PR TITLE
wpf: only dismiss selection for real chars, not modifiers

### DIFF
--- a/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
@@ -115,6 +115,9 @@ private:
     bool _CanSendVTMouseInput() const noexcept;
     bool _SendMouseEvent(UINT uMsg, WPARAM wParam, LPARAM lParam) noexcept;
 
+    void _SendKeyEvent(WORD vkey, WORD scanCode) noexcept;
+    void _SendCharEvent(wchar_t ch, WORD scanCode) noexcept;
+
     // Inherited via IControlAccessibilityInfo
     COORD GetFontSize() const override;
     RECT GetBounds() const noexcept override;

--- a/src/cascadia/WpfTerminalControl/TerminalContainer.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalContainer.cs
@@ -235,7 +235,6 @@ namespace Microsoft.Terminal.Wpf
                     case NativeMethods.WindowMessage.WM_KEYDOWN:
                         // WM_KEYDOWN lParam layout documentation: https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-keydown
                         NativeMethods.TerminalSetCursorVisible(this.terminal, true);
-                        NativeMethods.TerminalClearSelection(this.terminal);
                         NativeMethods.TerminalSendKeyEvent(this.terminal, (ushort)wParam, (ushort)((uint)lParam >> 16));
                         this.blinkTimer?.Start();
                         break;


### PR DESCRIPTION
Selection would act up when you were using shift to ignore VT mouse
mode: we would get hundreds of WM_KEYDOWN for VK_SHIFT and dismiss the
selection every time.

I took the opportunity to move the actual responsibility for key event
dispatch into HwndTerminal. In the future, I'd like to make more of the
TerminalXxx calls just call impl methods on HwndTerminal.

## PR Checklist
* [ ] Closes #xxx
* [x] CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] Core Contributor Discussion

## Validation Steps Performed
Selection now works in VT mouse mode.