### PR TITLE
Add a git submodules sanity check step to the build

### DIFF
--- a/src/common.build.pre.props
+++ b/src/common.build.pre.props
@@ -156,4 +156,12 @@
       <EnablePREfast>true</EnablePREfast>
     </ClCompile>
   </ItemDefinitionGroup>
+
+  <!-- Sanity check: Make sure the user followed the README and initialized git submodules. -->
+  <Target Name="EnsureSubmodulesExist" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references git submodule(s) that are missing on this computer. Use `git submodule update --init --recursive` to download them.  For more information, see https://github.com/microsoft/terminal#building-the-code. </ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\dep\wil') Or !Exists('$(SolutionDir)\dep\gsl')" Text="$([System.String]::Format('$(ErrorText)'))" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary of the Pull Request

Add a specific error message to the build that tells people to restore git submodules if they forgot to read the README.

![image](https://user-images.githubusercontent.com/18356694/79750779-27785b00-82d7-11ea-84fb-8d448a532609.png)

## References

#5416 was the straw that broke the camels back

## PR Checklist

* [x] I work here

