### PR TITLE
Send a Ctrl-C KeyUp event

### DIFF
--- a/src/terminal/adapter/InteractDispatch.cpp
+++ b/src/terminal/adapter/InteractDispatch.cpp
@@ -46,9 +46,9 @@ bool InteractDispatch::WriteInput(std::deque<std::unique_ptr<IInputEvent>>& inpu
 // True if handled successfully. False otherwise.
 bool InteractDispatch::WriteCtrlC()
 {
-    KeyEvent keyUp = KeyEvent(true, 1, 'C', 0, UNICODE_ETX, LEFT_CTRL_PRESSED);
-    KeyEvent keyDown = KeyEvent(false, 1, 'C', 0, UNICODE_ETX, LEFT_CTRL_PRESSED);
-    return _pConApi->PrivateWriteConsoleControlInput(keyUp) && _pConApi->PrivateWriteConsoleControlInput(keyDown);
+    KeyEvent keyDown = KeyEvent(true, 1, 'C', 0, UNICODE_ETX, LEFT_CTRL_PRESSED);
+    KeyEvent keyUp = KeyEvent(false, 1, 'C', 0, UNICODE_ETX, LEFT_CTRL_PRESSED);
+    return _pConApi->PrivateWriteConsoleControlInput(keyDown) && _pConApi->PrivateWriteConsoleControlInput(keyUp);
 }
 
 // Method Description:

--- a/src/terminal/adapter/InteractDispatch.cpp
+++ b/src/terminal/adapter/InteractDispatch.cpp
@@ -46,8 +46,9 @@ bool InteractDispatch::WriteInput(std::deque<std::unique_ptr<IInputEvent>>& inpu
 // True if handled successfully. False otherwise.
 bool InteractDispatch::WriteCtrlC()
 {
-    KeyEvent key = KeyEvent(true, 1, 'C', 0, UNICODE_ETX, LEFT_CTRL_PRESSED);
-    return _pConApi->PrivateWriteConsoleControlInput(key);
+    KeyEvent keyUp = KeyEvent(true, 1, 'C', 0, UNICODE_ETX, LEFT_CTRL_PRESSED);
+    KeyEvent keyDown = KeyEvent(false, 1, 'C', 0, UNICODE_ETX, LEFT_CTRL_PRESSED);
+    return _pConApi->PrivateWriteConsoleControlInput(keyUp) && _pConApi->PrivateWriteConsoleControlInput(keyDown);
 }
 
 // Method Description:

--- a/src/terminal/parser/ut_parser/InputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/InputEngineTest.cpp
@@ -336,9 +336,11 @@ bool TestInteractDispatch::WriteInput(_In_ std::deque<std::unique_ptr<IInputEven
 bool TestInteractDispatch::WriteCtrlC()
 {
     VERIFY_IS_TRUE(_testState->_expectSendCtrlC);
-    KeyEvent key = KeyEvent(true, 1, 'C', 0, UNICODE_ETX, LEFT_CTRL_PRESSED);
+    KeyEvent keyDown = KeyEvent(true, 1, 'C', 0, UNICODE_ETX, LEFT_CTRL_PRESSED);
+    KeyEvent keyUp = KeyEvent(false, 1, 'C', 0, UNICODE_ETX, LEFT_CTRL_PRESSED);
     std::deque<std::unique_ptr<IInputEvent>> inputEvents;
-    inputEvents.push_back(std::make_unique<KeyEvent>(key));
+    inputEvents.push_back(std::make_unique<KeyEvent>(keyDown));
+    inputEvents.push_back(std::make_unique<KeyEvent>(keyUp));
     return WriteInput(inputEvents);
 }
 


### PR DESCRIPTION
## Summary of the Pull Request
Users were not able to intercept Ctrl-C input using `$Host.UI.RawUI.ReadKey("IncludeKeyUp")`, because we weren't sending a Ctrl-C KeyUp event. This PR simply adds a KeyUp event alongside the existing KeyDown.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #1894
* [x] CLA signed.
* [x] Tests added/passed

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
The repro script in #1894 now works, both options for `ReadKey`: `IncludeKeyUp` and `IncludeKeyDown` work fine.
