### PR TITLE
Change Windows Powershell default scheme to Campbell

### DIFF
--- a/src/cascadia/TerminalApp/defaults.json
+++ b/src/cascadia/TerminalApp/defaults.json
@@ -30,7 +30,7 @@
             "name": "Windows PowerShell",
             "commandline": "powershell.exe",
             "icon": "ms-appx:///ProfileIcons/{61c54bbd-c2c6-5271-96e7-009a87ff44bf}.png",
-            "colorScheme": "Campbell Powershell",
+            "colorScheme": "Campbell",
             "antialiasingMode": "grayscale",
             "closeOnExit": "graceful",
             "cursorShape": "bar",


### PR DESCRIPTION
## Summary of the Pull Request
The "Campbell Powershell" color scheme does not have a high enough color contrast ratio. Campbell does, so we're changing it there.

## PR Checklist
* [X] Will close issue #5393 upon verification

## Validation Steps Performed
![Updated Accessibility Insights results for updated color scheme](https://user-images.githubusercontent.com/11050425/79806861-43ebb600-831e-11ea-812e-1a78ef9eaef6.png)