### PR TITLE
Notify UIA when Search finds something

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1511,6 +1511,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         InputPane::GetForCurrentView().TryShow();
 
+        // GH#5421: Enable the UiaEngine before checking for the SearchBox
+        // That way, new selections are notified to automation clients.
         if (_uiaEngine.get())
         {
             THROW_IF_FAILED(_uiaEngine->Enable());

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1511,17 +1511,17 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         InputPane::GetForCurrentView().TryShow();
 
+        if (_uiaEngine.get())
+        {
+            THROW_IF_FAILED(_uiaEngine->Enable());
+        }
+
         // If the searchbox is focused, we don't want TSFInputControl to think
         // it has focus so it doesn't intercept IME input. We also don't want the
         // terminal's cursor to start blinking. So, we'll just return quickly here.
         if (_searchBox && _searchBox->ContainsFocus())
         {
             return;
-        }
-
-        if (_uiaEngine.get())
-        {
-            THROW_IF_FAILED(_uiaEngine->Enable());
         }
 
         if (TSFInputControl() != nullptr)


### PR DESCRIPTION
## Summary of the Pull Request
Before this, if the Search Box was open, new selections would not notify automation clients. This was because the UiaEngine (responsible for notifying automation clients) would remain disabled. Now we're enabling it before the early exit in TermControl's FocusHandler

## PR Checklist
* [X] Will close issue #5421 upon verification

## Validation Steps Performed
Verified using NVDA.
Narrator's behavior is not impacted, for some reason.  