### PR TITLE
Remove last lingering references to profiles.json

### DIFF
--- a/doc/cascadia/SettingsSchema.md
+++ b/doc/cascadia/SettingsSchema.md
@@ -1,4 +1,4 @@
-# Profiles.json Documentation
+# Settings.json Documentation
 
 ## Globals
 Properties listed below affect the entire window, regardless of the profile settings.

--- a/doc/user-docs/UsingJsonSettings.md
+++ b/doc/user-docs/UsingJsonSettings.md
@@ -38,16 +38,17 @@ not affect a particular terminal instance.
 Example settings include
 
 ```json
+{
     "defaultProfile" : "{58ad8b0c-3ef8-5f4d-bc6f-13e4c00f2530}",
     "initialCols" : 120,
     "initialRows" : 50,
     "requestedTheme" : "system",
     "keybindings" : []
     ...
+}
 ```
 
-These global properties can exist either in the root json object, or in an
-object under a root property `"globals"`.
+These global properties can exist in the root json object.
 
 ## Key Bindings
 

--- a/doc/user-docs/UsingJsonSettings.md
+++ b/doc/user-docs/UsingJsonSettings.md
@@ -48,7 +48,7 @@ Example settings include
 }
 ```
 
-These global properties can exist in the root json object.
+These global properties should exist in the root json object.
 
 ## Key Bindings
 

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -672,7 +672,7 @@ namespace winrt::TerminalApp::implementation
                        wil::FolderChangeEvents::All,
                        [this, settingsPath](wil::FolderChangeEvent event, PCWSTR fileModified) {
                            // We want file modifications, AND when files are renamed to be
-                           // profiles.json. This second case will oftentimes happen with text
+                           // settings.json. This second case will oftentimes happen with text
                            // editors, who will write a temp file, then rename it to be the
                            // actual file you wrote. So listen for that too.
                            if (!(event == wil::FolderChangeEvent::Modified ||

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -889,7 +889,7 @@ bool Profile::IsHidden() const noexcept
 // Method Description:
 // - Helper function for expanding any environment variables in a user-supplied starting directory and validating the resulting path
 // Arguments:
-// - The value from the profiles.json file
+// - The value from the settings.json file
 // Return Value:
 // - The directory string with any environment variables expanded. If the resulting path is invalid,
 // - the function returns an evaluated version of %userprofile% to avoid blocking the session from starting.
@@ -920,7 +920,7 @@ std::wstring Profile::EvaluateStartingDirectory(const std::wstring& directory)
 // Method Description:
 // - Helper function for converting a user-specified closeOnExit value to its corresponding enum
 // Arguments:
-// - The value from the profiles.json file
+// - The value from the settings.json file
 // Return Value:
 // - The corresponding enum value which maps to the string provided by the user
 CloseOnExitMode Profile::ParseCloseOnExitMode(const Json::Value& json)
@@ -974,7 +974,7 @@ std::string_view Profile::_SerializeCloseOnExitMode(const CloseOnExitMode closeO
 // Method Description:
 // - Helper function for converting a user-specified scrollbar state to its corresponding enum
 // Arguments:
-// - The value from the profiles.json file
+// - The value from the settings.json file
 // Return Value:
 // - The corresponding enum value which maps to the string provided by the user
 ScrollbarState Profile::ParseScrollbarState(const std::wstring& scrollbarState)
@@ -997,7 +997,7 @@ ScrollbarState Profile::ParseScrollbarState(const std::wstring& scrollbarState)
 // - Helper function for converting a user-specified image stretch mode
 //   to the appropriate enum value
 // Arguments:
-// - The value from the profiles.json file
+// - The value from the settings.json file
 // Return Value:
 // - The corresponding enum value which maps to the string provided by the user
 Media::Stretch Profile::ParseImageStretchMode(const std::string_view imageStretchMode)
@@ -1047,7 +1047,7 @@ std::string_view Profile::SerializeImageStretchMode(const Media::Stretch imageSt
 // - Helper function for converting a user-specified image horizontal and vertical
 //   alignment to the appropriate enum values tuple
 // Arguments:
-// - The value from the profiles.json file
+// - The value from the settings.json file
 // Return Value:
 // - The corresponding enum values tuple which maps to the string provided by the user
 std::tuple<HorizontalAlignment, VerticalAlignment> Profile::ParseImageAlignment(const std::string_view imageAlignment)

--- a/src/cascadia/TerminalApp/lib/TerminalAppLib.vcxproj
+++ b/src/cascadia/TerminalApp/lib/TerminalAppLib.vcxproj
@@ -326,7 +326,7 @@
   <Target Name="_TerminalAppGenerateDefaultsUniversalH" Inputs="..\defaults-universal.json" Outputs="Generated Files\defaults-universal.h" BeforeTargets="BeforeClCompile">
     <Exec Command="powershell.exe -noprofile –ExecutionPolicy Unrestricted $(OpenConsoleDir)\tools\GenerateHeaderForJson.ps1 -JsonFile ..\defaults-universal.json -OutPath '&quot;Generated Files\defaults-universal.h&quot;' -VariableName DefaultUniversalJson" />
   </Target>
-  <!-- Same as above, but for the default profiles.json template -->
+  <!-- Same as above, but for the default settings.json template -->
   <Target Name="_TerminalAppGenerateUserSettingsH" Inputs="..\userDefaults.json" Outputs="Generated Files\userDefaults.h" BeforeTargets="BeforeClCompile">
     <Exec Command="powershell.exe -noprofile –ExecutionPolicy Unrestricted $(OpenConsoleDir)\tools\GenerateHeaderForJson.ps1 -JsonFile ..\userDefaults.json -OutPath '&quot;Generated Files\userDefaults.h&quot;' -VariableName UserSettingsJson" />
   </Target>

--- a/src/tools/ColorTool/ColorTool/ConsoleTargets/TerminalSchemeConsoleTarget.cs
+++ b/src/tools/ColorTool/ColorTool/ConsoleTargets/TerminalSchemeConsoleTarget.cs
@@ -10,7 +10,7 @@ namespace ColorTool.ConsoleTargets
     {
         public void ApplyColorScheme(ColorScheme colorScheme, bool quietMode)
         {
-            Console.WriteLine("Copy and paste the following text into the schemes array of your Windows Terminal profiles.json file to add this color scheme. (Don't forget to add a comma separator after the previous scheme.)");
+            Console.WriteLine("Copy and paste the following text into the schemes array of your Windows Terminal settings.json file to add this color scheme. (Don't forget to add a comma separator after the previous scheme.)");
             Console.WriteLine("{");
             Console.WriteLine($"    \"name\": \"{colorScheme.Name}\",");
 


### PR DESCRIPTION
Literally just <kbd>ctrl+f</kbd> find-and-replace all the old `profiles.json` that are sitting around in the repo with `settings.json`. I didn't touch the specs, since it seemed better to leave them in the state that they were originally authored in.

* [x] closes #5522
* [x] I work here.
* [x] This is docs.