### PR TITLE
Lower case modifiers in doc

### DIFF
--- a/doc/cascadia/SettingsSchema.md
+++ b/doc/cascadia/SettingsSchema.md
@@ -139,7 +139,7 @@ For commands with arguments:
 ### Accepted Modifiers and Keys
 
 #### Modifiers
-`Ctrl+`, `Shift+`, `Alt+`
+`ctrl+`, `shift+`, `alt+`
 
 #### Keys
 | Type | Keys |


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR aligns documentation with actual implementation.

The modifiers, `ctrl+`, `shift+` and `alt+` were capitalized but *terminal* does **not** accept capitalized modifiers, e.g. `Ctrl+` is an **invalid** modifier.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
