### PR TITLE
Fix Ctrl+Alt not being treated as a substitute for AltGr anymore

### DIFF
--- a/src/terminal/adapter/ut_adapter/inputTest.cpp
+++ b/src/terminal/adapter/ut_adapter/inputTest.cpp
@@ -482,7 +482,7 @@ void InputTest::TerminalInputModifierKeyTests()
             // Alt+Key generates [0x1b, Ctrl+key] into the stream
             // Pressing the control key causes all bits but the 5 least
             // significant ones to be zeroed out (when using ASCII).
-            if (AltPressed(uiKeystate) && ControlPressed(uiKeystate) && ch >= 0x40 && ch < 0x7F)
+            if (AltPressed(uiKeystate) && ControlPressed(uiKeystate) && ch > 0x40 && ch <= 0x5A)
             {
                 s_expectedInput.clear();
                 s_expectedInput.push_back(L'\x1b');
@@ -491,7 +491,7 @@ void InputTest::TerminalInputModifierKeyTests()
             }
 
             // Alt+Key generates [0x1b, key] into the stream
-            if (AltPressed(uiKeystate) && ch != 0)
+            if (AltPressed(uiKeystate) && !ControlPressed(uiKeystate) && ch != 0)
             {
                 s_expectedInput.clear();
                 s_expectedInput.push_back(L'\x1b');


### PR DESCRIPTION
## Summary of the Pull Request

This PR fixes #5525 by re-adding range checks that where erroneously removed in a9c9714.

## PR Checklist
* [x] Closes #5525
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #5525

## Validation Steps Performed

* Enabled a German keyboard layout
* Entered `<`, `+`, `7`, `8`, `9`, `0` while holding either Alt+Ctrl or AltGr and...
* Ensuring that both produce `|`, `~`, `{`, `[`, `]`, `}`