### PR TITLE
Remove a stray __stdcall that was breaking the x86 build

### DIFF
--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -89,7 +89,7 @@ void NonClientIslandWindow::MakeWindow() noexcept
 
 // Function Description:
 // - The window procedure for the drag bar forwards clicks on its client area to its parent as non-client clicks.
-LRESULT __stdcall NonClientIslandWindow::_InputSinkMessageHandler(UINT const message, WPARAM const wparam, LPARAM const lparam) noexcept
+LRESULT NonClientIslandWindow::_InputSinkMessageHandler(UINT const message, WPARAM const wparam, LPARAM const lparam) noexcept
 {
     std::optional<UINT> nonClientMessage{ std::nullopt };
 


### PR DESCRIPTION
This is one of the downsides of not running the x86 build in CI.