### PR TITLE
Prevent DXRenderer from using invalid properties

### DIFF
--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1221,6 +1221,13 @@ CATCH_RETURN()
                                                 const bool /*lineWrapped*/) noexcept
 try
 {
+    if (nullptr == _dwriteTextAnalyzer.Get() ||
+        nullptr == _dwriteTextFormat.Get() ||
+        nullptr == _dwriteFontFace.Get())
+    {
+        return S_OK;
+    }
+
     // Calculate positioning of our origin.
     const D2D1_POINT_2F origin = til::point{ coord } * _glyphCell;
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The working fix, in case you needed it.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #5479
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Manually validated.