### PR TITLE
Add a warning about using the `globals` property

### DIFF
--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -35,7 +35,8 @@ static const std::array<std::wstring_view, static_cast<uint32_t>(SettingsLoadWar
     USES_RESOURCE(L"InvalidIcon"),
     USES_RESOURCE(L"AtLeastOneKeybindingWarning"),
     USES_RESOURCE(L"TooManyKeysForChord"),
-    USES_RESOURCE(L"MissingRequiredParameter")
+    USES_RESOURCE(L"MissingRequiredParameter"),
+    USES_RESOURCE(L"LegacyGlobalsProperty")
 };
 static const std::array<std::wstring_view, static_cast<uint32_t>(SettingsLoadErrors::ERRORS_SIZE)> settingsLoadErrorsLabels {
     USES_RESOURCE(L"NoProfilesText"),
@@ -391,6 +392,27 @@ namespace winrt::TerminalApp::implementation
             if (!warningText.empty())
             {
                 warningsTextBlock.Inlines().Append(_BuildErrorRun(warningText, ::winrt::Windows::UI::Xaml::Application::Current().as<::winrt::TerminalApp::App>().Resources()));
+
+                // The "LegacyGlobalsProperty" warning is special - it has a URL
+                // that goes with it. So we need to manually construct a
+                // Hyperlink and insert it along with the warning text.
+                if (warning == SettingsLoadWarnings::LegacyGlobalsProperty)
+                {
+                    // Add the URL here too
+                    const auto legacyGlobalsLinkLabel = RS_(L"LegacyGlobalsPropertyHrefLabel");
+                    const auto legacyGlobalsLinkUriValue = RS_(L"LegacyGlobalsPropertyHrefUrl");
+
+                    winrt::Windows::UI::Xaml::Documents::Run legacyGlobalsLinkText;
+                    winrt::Windows::UI::Xaml::Documents::Hyperlink legacyGlobalsLink;
+                    winrt::Windows::Foundation::Uri legacyGlobalsLinkUri{ legacyGlobalsLinkUriValue };
+
+                    legacyGlobalsLinkText.Text(legacyGlobalsLinkLabel);
+                    legacyGlobalsLink.NavigateUri(legacyGlobalsLinkUri);
+                    legacyGlobalsLink.Inlines().Append(legacyGlobalsLinkText);
+
+                    warningsTextBlock.Inlines().Append(legacyGlobalsLink);
+                }
+
                 warningsTextBlock.Inlines().Append(Documents::LineBreak{});
             }
         }

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -211,6 +211,8 @@ void CascadiaSettings::_ValidateSettings()
     // warning if an action didn't have a required arg.
     // This will also catch other keybinding warnings, like from GH#4239
     _ValidateKeybindings();
+
+    _ValidateNoGlobalsKey();
 }
 
 // Method Description:
@@ -671,6 +673,25 @@ void CascadiaSettings::_ValidateKeybindings()
     {
         _warnings.push_back(::TerminalApp::SettingsLoadWarnings::AtLeastOneKeybindingWarning);
         _warnings.insert(_warnings.end(), keybindingWarnings.begin(), keybindingWarnings.end());
+    }
+}
+
+// Method Description:
+// - Checks for the presence of the legacy "globals" key in the user's
+//   settings.json. If this key is present, then they've probably got a pre-0.11
+//   settings file that won't work as expected anymore. We should warn them
+//   about that.
+// Arguments:
+// - <none>
+// Return Value:
+// - <none>
+// - Appends a SettingsLoadWarnings::LegacyGlobalsProperty to our list of warnings if
+//   we find any invalid background images.
+void CascadiaSettings::_ValidateNoGlobalsKey()
+{
+    if (auto oldGlobalsProperty{ _userSettings["globals"] })
+    {
+        _warnings.push_back(::TerminalApp::SettingsLoadWarnings::LegacyGlobalsProperty);
     }
 }
 

--- a/src/cascadia/TerminalApp/CascadiaSettings.h
+++ b/src/cascadia/TerminalApp/CascadiaSettings.h
@@ -119,6 +119,7 @@ private:
     void _ValidateAllSchemesExist();
     void _ValidateMediaResources();
     void _ValidateKeybindings();
+    void _ValidateNoGlobalsKey();
 
     friend class TerminalAppLocalTests::SettingsTests;
     friend class TerminalAppLocalTests::ProfileTests;

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -192,7 +192,7 @@
     <comment>{Locked="\"globals\""} </comment>
   </data>
   <data name="LegacyGlobalsPropertyHrefUrl" xml:space="preserve">
-    <value>https://go.microsoft.com/fwlink/?linkid=TODO:GENERATE_ME</value>
+    <value>https://go.microsoft.com/fwlink/?linkid=2128258</value>
     <comment>{Locked}This is a FWLink, so it will be localized with the fwlink tool</comment>
   </data>
   <data name="LegacyGlobalsPropertyHrefLabel" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -186,6 +186,17 @@
   <data name="MissingRequiredParameter" xml:space="preserve">
     <value>&#x2022; Found a keybinding that was missing a required parameter value. This keybinding will be ignored.</value>
     <comment>{Locked="&#x2022;"} This glyph is a bullet, used in a bulleted list.</comment>
+  </data>
+  <data name="LegacyGlobalsProperty" xml:space="preserve">
+    <value>The "globals" property is deprecated - your settings might need updating. For more info, see: </value>
+    <comment>{Locked="\"globals\""} </comment>
+  </data>
+  <data name="LegacyGlobalsPropertyHrefUrl" xml:space="preserve">
+    <value>https://go.microsoft.com/fwlink/?linkid=TODO:GENERATE_ME</value>
+    <comment>{Locked}This is a FWLink, so it will be localized with the fwlink tool</comment>
+  </data>
+  <data name="LegacyGlobalsPropertyHrefLabel" xml:space="preserve">
+    <value>this web page</value>
   </data>
   <data name="CmdCommandArgDesc" xml:space="preserve">
     <value>An optional command, with arguments, to be spawned in the new tab or pane</value>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -188,7 +188,7 @@
     <comment>{Locked="&#x2022;"} This glyph is a bullet, used in a bulleted list.</comment>
   </data>
   <data name="LegacyGlobalsProperty" xml:space="preserve">
-    <value>The "globals" property is deprecated - your settings might need updating. For more info, see: </value>
+    <value>The "globals" property is deprecated - your settings might need updating. </value>
     <comment>{Locked="\"globals\""} </comment>
   </data>
   <data name="LegacyGlobalsPropertyHrefUrl" xml:space="preserve">
@@ -196,7 +196,7 @@
     <comment>{Locked}This is a FWLink, so it will be localized with the fwlink tool</comment>
   </data>
   <data name="LegacyGlobalsPropertyHrefLabel" xml:space="preserve">
-    <value>this web page</value>
+    <value>For more info, see this web page.</value>
   </data>
   <data name="CmdCommandArgDesc" xml:space="preserve">
     <value>An optional command, with arguments, to be spawned in the new tab or pane</value>

--- a/src/cascadia/TerminalApp/TerminalWarnings.h
+++ b/src/cascadia/TerminalApp/TerminalWarnings.h
@@ -29,6 +29,7 @@ namespace TerminalApp
         AtLeastOneKeybindingWarning = 5,
         TooManyKeysForChord = 6,
         MissingRequiredParameter = 7,
+        LegacyGlobalsProperty = 8,
         WARNINGS_SIZE // IMPORTANT: This MUST be the last value in this enum. It's an unused placeholder.
     };
 


### PR DESCRIPTION
This property was deprecated in 0.11. We probably should have also added a warning
message to help the community figure out that this property is gone and won't work
anymore.

This PR adds that warning.

* I'm not going to list the enormous number of duped threads _wait yes I am_
    * #5581
    * #5547
    * #5555
    * #5557
    * #5573 
    * #5532
    * #5527
    * #5535 
    * #5510
    * #5511
    * #5512
    * #5513
    * #5516
    * #5515
    * #5521 
    * This literally isn't even all of them 

* [x] Also mainly related to #5458
* [x] I work here
* [x] Tests added/passed