### PR TITLE
Improve default foregrounds for Tango schemes

### DIFF
--- a/src/cascadia/TerminalApp/defaults.json
+++ b/src/cascadia/TerminalApp/defaults.json
@@ -225,7 +225,7 @@
         },
         {
             "name": "Tango Dark",
-            "foreground": "#FFFFFF",
+            "foreground": "#D3D7CF",
             "background": "#000000",
             "cursorColor": "#FFFFFF",
             "black": "#000000",
@@ -247,7 +247,7 @@
         },
         {
             "name": "Tango Light",
-            "foreground": "#000000",
+            "foreground": "#555753",
             "background": "#FFFFFF",
             "cursorColor": "#000000",
             "black": "#000000",

--- a/src/tools/ColorTool/schemes/tango_dark.itermcolors
+++ b/src/tools/ColorTool/schemes/tango_dark.itermcolors
@@ -196,11 +196,11 @@
         <key>Foreground Color</key>
         <dict>
             <key>Blue Component</key>
-            <string>1</string>
+            <string>0.8117647</string>
             <key>Green Component</key>
-            <string>1</string>
+            <string>0.8431373</string>
             <key>Red Component</key>
-            <string>1</string>
+            <string>0.827451</string>
         </dict>
         <key>Selected Text Color</key>
         <dict>

--- a/src/tools/ColorTool/schemes/tango_light.itermcolors
+++ b/src/tools/ColorTool/schemes/tango_light.itermcolors
@@ -196,11 +196,11 @@
         <key>Foreground Color</key>
         <dict>
             <key>Blue Component</key>
-            <string>0</string>
+            <string>0.3254902</string>
             <key>Green Component</key>
-            <string>0</string>
+            <string>0.3411765</string>
             <key>Red Component</key>
-            <string>0</string>
+            <string>0.3333333</string>
         </dict>
         <key>Selected Text Color</key>
         <dict>


### PR DESCRIPTION
Followup on ea61aa3b.

The default foreground in the iTerm2 defaults for the Tango Dark color
scheme is too bright, use the value for ANSI 7 (white) instead.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>

## References

#5305

## PR Checklist
* [ ] Closes #xxx
* [x ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

Sorry, I should have really done this in the original PR.