### PR TITLE
Add and enforce minimum width

### DIFF
--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -179,17 +179,15 @@ LRESULT IslandWindow::_OnSizing(const WPARAM wParam, const LPARAM lParam)
     // If this fails, we'll use the default of 96.
     GetDpiForMonitor(hmon, MDT_EFFECTIVE_DPI, &dpix, &dpiy);
 
-    // X and Y are always the same DPI
     const auto widthScale = base::ClampedNumeric<float>(dpix) / USER_DEFAULT_SCREEN_DPI;
-    const auto minSizeScaled = minimumSize.scale(til::math::ceiling, widthScale);
+    const long minWidthScaled = minimumWidth * widthScale;
 
     const auto nonClientSize = GetTotalNonClientExclusiveSize(dpix);
-    
+
     auto clientWidth = winRect->right - winRect->left - nonClientSize.cx;
-    clientWidth = std::max(minSizeScaled.width<LONG>(), clientWidth);
+    clientWidth = std::max(minWidthScaled, clientWidth);
 
     auto clientHeight = winRect->bottom - winRect->top - nonClientSize.cy;
-    clientHeight = std::max(minSizeScaled.height<LONG>(), clientHeight);
 
     if (wParam != WMSZ_TOP && wParam != WMSZ_BOTTOM)
     {

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -179,8 +179,15 @@ LRESULT IslandWindow::_OnSizing(const WPARAM wParam, const LPARAM lParam)
     // If this fails, we'll use the default of 96.
     GetDpiForMonitor(hmon, MDT_EFFECTIVE_DPI, &dpix, &dpiy);
 
+    // The minimum client width that you can resize to.
+    // This lets the titlebar look good.
+    const auto minClientWidth = 420;
+    const auto scale = base::ClampedNumeric<float>(dpix) / USER_DEFAULT_SCREEN_DPI;
+    const long minClientWidthScaled = base::ClampMul(minClientWidth, scale);
+
     const auto nonClientSize = GetTotalNonClientExclusiveSize(dpix);
     auto clientWidth = winRect->right - winRect->left - nonClientSize.cx;
+    clientWidth = clientWidth < minClientWidthScaled ? minClientWidthScaled : clientWidth;
     auto clientHeight = winRect->bottom - winRect->top - nonClientSize.cy;
 
     if (wParam != WMSZ_TOP && wParam != WMSZ_BOTTOM)

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -179,24 +179,17 @@ LRESULT IslandWindow::_OnSizing(const WPARAM wParam, const LPARAM lParam)
     // If this fails, we'll use the default of 96.
     GetDpiForMonitor(hmon, MDT_EFFECTIVE_DPI, &dpix, &dpiy);
 
-    // The minimum client width that you can resize to.
-    // This lets the tabs fit.
-    const auto minClientWidth = 460;
+    // X and Y are always the same DPI
     const auto widthScale = base::ClampedNumeric<float>(dpix) / USER_DEFAULT_SCREEN_DPI;
-    const long minClientWidthScaled = base::ClampMul(minClientWidth, widthScale);
-
-    // The minimum client height that you can resize to.
-    // This lets the about menu fit.
-    const auto minClientHeight = 380;
-    const auto heightScale = base::ClampedNumeric<float>(dpiy) / USER_DEFAULT_SCREEN_DPI;
-    const long minClientHeightScaled = base::ClampMul(minClientHeight, heightScale);
+    const auto minSizeScaled = minimumSize.scale(til::math::ceiling, widthScale);
 
     const auto nonClientSize = GetTotalNonClientExclusiveSize(dpix);
+    
     auto clientWidth = winRect->right - winRect->left - nonClientSize.cx;
-    clientWidth = clientWidth < minClientWidthScaled ? minClientWidthScaled : clientWidth;
+    clientWidth = std::max(minSizeScaled.width<LONG>(), clientWidth);
 
     auto clientHeight = winRect->bottom - winRect->top - nonClientSize.cy;
-    clientHeight = clientHeight < minClientHeightScaled ? minClientHeightScaled : clientHeight;
+    clientHeight = std::max(minSizeScaled.height<LONG>(), clientHeight);
 
     if (wParam != WMSZ_TOP && wParam != WMSZ_BOTTOM)
     {

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -180,15 +180,23 @@ LRESULT IslandWindow::_OnSizing(const WPARAM wParam, const LPARAM lParam)
     GetDpiForMonitor(hmon, MDT_EFFECTIVE_DPI, &dpix, &dpiy);
 
     // The minimum client width that you can resize to.
-    // This lets the titlebar look good.
-    const auto minClientWidth = 420;
-    const auto scale = base::ClampedNumeric<float>(dpix) / USER_DEFAULT_SCREEN_DPI;
-    const long minClientWidthScaled = base::ClampMul(minClientWidth, scale);
+    // This lets the tabs fit.
+    const auto minClientWidth = 460;
+    const auto widthScale = base::ClampedNumeric<float>(dpix) / USER_DEFAULT_SCREEN_DPI;
+    const long minClientWidthScaled = base::ClampMul(minClientWidth, widthScale);
+
+    // The minimum client height that you can resize to.
+    // This lets the about menu fit.
+    const auto minClientHeight = 380;
+    const auto heightScale = base::ClampedNumeric<float>(dpiy) / USER_DEFAULT_SCREEN_DPI;
+    const long minClientHeightScaled = base::ClampMul(minClientHeight, heightScale);
 
     const auto nonClientSize = GetTotalNonClientExclusiveSize(dpix);
     auto clientWidth = winRect->right - winRect->left - nonClientSize.cx;
     clientWidth = clientWidth < minClientWidthScaled ? minClientWidthScaled : clientWidth;
+
     auto clientHeight = winRect->bottom - winRect->top - nonClientSize.cy;
+    clientHeight = clientHeight < minClientHeightScaled ? minClientHeightScaled : clientHeight;
 
     if (wParam != WMSZ_TOP && wParam != WMSZ_BOTTOM)
     {

--- a/src/cascadia/WindowsTerminal/IslandWindow.h
+++ b/src/cascadia/WindowsTerminal/IslandWindow.h
@@ -104,8 +104,6 @@ protected:
     void _ApplyWindowSize();
 
 private:
-    // This minimum size allows for...
-    //  - width: the tabs fit
-    //  - height: the about menu fits
-    static constexpr til::size minimumSize{ 460, 380 };
+    // This minimum width allows for width the tabs fit
+    static constexpr long minimumWidth = 460L;
 };

--- a/src/cascadia/WindowsTerminal/IslandWindow.h
+++ b/src/cascadia/WindowsTerminal/IslandWindow.h
@@ -102,4 +102,10 @@ protected:
     virtual void _SetIsFullscreen(const bool fullscreenEnabled);
     void _BackupWindowSizes(const bool currentIsInFullscreen);
     void _ApplyWindowSize();
+
+private:
+    // This minimum size allows for...
+    //  - width: the tabs fit
+    //  - height: the about menu fits
+    static constexpr til::size minimumSize{ 460, 380 };
 };


### PR DESCRIPTION
## Summary of the Pull Request
Enforces a minimum width of 460 wide. This allows tabs to always be seen (albeit partially).

NOTE: A minimum height was originally added to allow the About menu to be seen. This minimum height was removed from this PR because we don't foresee a circumstance where your Terminal is in that state, and you can't just resize it to make the content fit properly.

## References
#4990 may be fixed/affected by this?

## PR Checklist
* [X] Closes #4976 
* [X] Will close issue #5418 upon verification

## Validation Steps Performed
Here's some images of what the terminal looks like when it's at its minimum size:

### 100% scaling

#### 100% scaling: one tab
![100% scaling: one tab](https://user-images.githubusercontent.com/11050425/80408686-76e0fd00-887c-11ea-8283-35871d24652a.png)

#### 100% scaling: two tabs
![100% scaling: two tabs](https://user-images.githubusercontent.com/11050425/80408695-79435700-887c-11ea-9670-116cde320e07.png)

#### 100% scaling: 3 tabs (scrolling enabled)
![100% scaling: 3 tabs (scrolling enabled)](https://user-images.githubusercontent.com/11050425/80408701-7c3e4780-887c-11ea-8ede-8b69d20d6f66.png)


### 200% scaling

#### 200% scaling: one tab
![200% scaling: one tab](https://user-images.githubusercontent.com/11050425/80408783-9a0bac80-887c-11ea-8b62-bd064f89403d.png)

#### 200% scaling: two tabs
![200% scaling: two tabs](https://user-images.githubusercontent.com/11050425/80408793-9c6e0680-887c-11ea-9301-344189281006.png)

#### 200% scaling: 3 tabs (scrolling enabled)
![200% scaling: 3 tabs (scrolling enabled)](https://user-images.githubusercontent.com/11050425/80408799-9ed06080-887c-11ea-892a-ee8e329080c5.png)
