### PR TITLE
Adjust TSFInputControl alignment

### DIFF
--- a/src/cascadia/TerminalControl/TSFInputControl.cpp
+++ b/src/cascadia/TerminalControl/TSFInputControl.cpp
@@ -202,9 +202,9 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         TextBlock().FontSize(unscaledFontSizePx);
         TextBlock().FontFamily(Media::FontFamily(fontArgs->FontFace()));
 
-        // TextBlock's dimensions before it's ever used ever used is 0w x 0h, causing
-        // any IME _not_ brought up as a result of text being typed (like Win+. for the emoji picker),
-        // to be placed approx. unscaledFontSizePx pixels higher than intended.
+        // TextBlock's actual dimensions right after initialization is 0w x 0h. So,
+        // if an IME is displayed before TextBlock has text (like showing the emoji picker
+        // using Win+.), it'll be placed higher than intended.
         TextBlock().MinWidth(unscaledFontSizePx);
         TextBlock().MinHeight(unscaledFontSizePx);
         _currentTextBlockHeight = std::max(unscaledFontSizePx, _currentTextBlockHeight);
@@ -444,13 +444,11 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         TextBlock().Text(L"");
 
-        // It turns out that setting the TextBlock's text to "" doesn't immediately
-        // update its ActualHeight. So, when a user just finishes a composition that
-        // involved text wrapping on the right edge of the terminal, the TextBlock's
-        // ActualHeight stays as tall as the TextBlock needed to be for the amount of
-        // wrapping that occurred. The next time a user brings up the Emoji IME with
-        // "Win+.", it'll show up at bottom pos of the previous text-wrapped TextBlock.
-        // So, let's force TextBlock to update when we reset it after a composition is completed.
+        // After we reset the TextBlock to empty string, we want to make sure
+        // ActualHeight reflects the respective height. It seems that ActualHeight
+        // isn't updated until there's new text in the TextBlock, so the next time a user
+        // invokes "Win+." for the emoji picker IME, it would end up
+        // using the pre-reset TextBlock().ActualHeight().
         TextBlock().UpdateLayout();
 
         // hide the controls until text input starts again

--- a/src/cascadia/TerminalControl/TSFInputControl.cpp
+++ b/src/cascadia/TerminalControl/TSFInputControl.cpp
@@ -202,12 +202,12 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         TextBlock().FontSize(unscaledFontSizePx);
         TextBlock().FontFamily(Media::FontFamily(fontArgs->FontFace()));
 
-        // TextBlock's dimensions before it gets a layout pass is 0w x 0h, causing
+        // TextBlock's dimensions before it's ever used ever used is 0w x 0h, causing
         // any IME _not_ brought up as a result of text being typed (like Win+. for the emoji picker),
-        // to be placed higher than intended. So, let's set the min width & height for this case.
+        // to be placed approx. unscaledFontSizePx pixels higher than intended.
         TextBlock().MinWidth(unscaledFontSizePx);
         TextBlock().MinHeight(unscaledFontSizePx);
-        _currentTextBlockHeight = std::max(fontSize.height<double>(), _currentTextBlockHeight);
+        _currentTextBlockHeight = std::max(unscaledFontSizePx, _currentTextBlockHeight);
 
         const auto widthToTerminalEnd = _currentCanvasWidth - clientCursorInDips.x<double>();
         // Make sure that we're setting the MaxWidth to a positive number - a

--- a/src/cascadia/TerminalControl/TSFInputControl.h
+++ b/src/cascadia/TerminalControl/TSFInputControl.h
@@ -82,6 +82,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         double _currentTextBlockHeight;
         winrt::Windows::Foundation::Rect _currentControlBounds;
         winrt::Windows::Foundation::Rect _currentTextBounds;
+        winrt::Windows::Foundation::Rect _currentWindowBounds;
     };
 }
 namespace winrt::Microsoft::Terminal::TerminalControl::factory_implementation


### PR DESCRIPTION
This PR fixes a couple of issues with TSFInputControl alignment:

1. The emoji picker IME in particular would show up overlapping the
   current buffer row because I stupidly didn't realize that
   `TextBlock.ActualHeight` is 0 right after initialization and before
   it has any text. So, the emoji picker will show up on the bottom of
   the 0 height TextBlock, which overlaps the current buffer row. This
   isn't a problem with CJK because inputting text _causes_ the IME to
   show up, so by the time the IME shows up, the TextBlock has text and
   accordingly has a height.
2. It turns out the emoji picker IME doesn't follow the `TextBlock`
   bottom, unlike Chinese and Japanese IME, so if a user were to compose
   near the edge of the screen and let the `TextBlock` start line
   wrapping, the emoji IME doesn't follow the bottom of the `TextBlock`
   as it grows. This means that the `TextBlock` position doesn't update
   in the middle of composition, and the `LayoutRequested` event that it
   fires at the beginning of composition is the only chance we get to
   tell the emoji IME where to place itself. It turns out when we reset
   `TextBlock.Text`, the ActualHeight doesn't get immediately reset back
   to the min size. So if a user were to bring up the emoji IME before
   `ActualHeight` is reset, the IME will show up way below the current
   buffer row.
3. We don't currently `TryRedrawCanvas` when the window position changes
   (resizing, dragging the window around), so sometimes dragging or
   resizing the Terminal doesn't update the position of the IME. Ideally
   it should be listening to some "window position changed" event, but
   alas we don't have that and it would be much harder than this
   incoming fix. We'll just track the window bounds as part of
   `TryRedrawCanvas` and redraw if it changes. For the most part, this
   will allow the IME to update to where the new window position is, but
   it'll only be called if we receive a `LayoutRequested` event.

## PR Checklist
* [x] Closes #5470
* [x] CLA signed.
* [x] Tests added/passed

## Validation Steps Performed
I play with it for quite a bit.