### PR TITLE
Hide the commandline on a resize to prevent a crash when snapping the window

### DIFF
--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -589,7 +589,15 @@ void ApiRoutines::GetLargestConsoleWindowSizeImpl(const SCREEN_INFORMATION& cont
         if (NewSize.X != context.GetViewport().Width() ||
             NewSize.Y != context.GetViewport().Height())
         {
+            // GH#1856 - make sure to hide the commandline _before_ we execute
+            // the resize, and the re-display it after the resize. If we leave
+            // it displayed, we'll crash during the resize when we try to figure
+            // out if the bounds of the old commandline fit within the new
+            // window (it might not).
+            CommandLine& commandLine = CommandLine::Instance();
+            commandLine.Hide(FALSE);
             context.SetViewportSize(&NewSize);
+            commandLine.Show();
 
             IConsoleWindow* const pWindow = ServiceLocator::LocateConsoleWindow();
             if (pWindow != nullptr)

--- a/src/inc/test/CommonState.hpp
+++ b/src/inc/test/CommonState.hpp
@@ -124,7 +124,7 @@ public:
         delete gci.pInputBuffer;
     }
 
-    void PrepareCookedReadData()
+    void PrepareCookedReadData(const std::string_view initialData = {})
     {
         CONSOLE_INFORMATION& gci = Microsoft::Console::Interactivity::ServiceLocator::LocateGlobals().getConsoleInformation();
         auto* readData = new COOKED_READ_DATA(gci.pInputBuffer,
@@ -135,7 +135,7 @@ public:
                                               0,
                                               nullptr,
                                               L"",
-                                              {});
+                                              initialData);
         gci.SetCookedReadData(readData);
     }
 


### PR DESCRIPTION
Hide any commandline (cooked read) we have before we begin a resize, and
show it again after the resize. 

## References

* I found #5618 while I was working on this.

## PR Checklist
* [x] Closes #1856
* [x] I work here
* [x] Tests added/passed
* [n/a] Requires documentation to be updated

## Detailed Description of the Pull Request / Additional comments

Basically, during a resize, we try to restore the viewport position
correctly, and part of that checks where the current commandline ends.
However, when we do that, the commandline's _current_ state still
reflects the _old_ buffer size, so resizing to be smaller can cause us
to throw an exception, when we find that the commandline doesn't fit in
the new viewport cleanly.

By hiding it, then redrawing it, we avoid this problem entirely. We
don't need to perform the check on the old commandline contents (since
they'll be empty), and we'll redraw it just fine for the new buffer size

## Validation Steps Performed
* ran tests
* checked resizing, snapping in conhost with a cooked read
* checked resizing, snapping in the Terminal with a cooked read