### PR TITLE
Reserve textClusterColumns vector for performance

### DIFF
--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -42,6 +42,8 @@ CustomTextLayout::CustomTextLayout(gsl::not_null<IDWriteFactory1*> const factory
     _localeName.resize(gsl::narrow_cast<size_t>(format->GetLocaleNameLength()) + 1); // +1 for null
     THROW_IF_FAILED(format->GetLocaleName(_localeName.data(), gsl::narrow<UINT32>(_localeName.size())));
 
+    _textClusterColumns.reserve(clusters.size());
+
     for (const auto& cluster : clusters)
     {
         const auto cols = gsl::narrow<UINT16>(cluster.GetColumns());


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

In tonight's episode of "Can we be even faster?", we will... you know what, just take a look at the code.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

It is actually a quite common technical among the codebase to first reserve the spaces before pushing something into vectors. I don't know why it is not used here.

Before:
![before](https://user-images.githubusercontent.com/4710575/80594408-84051400-8a55-11ea-9c04-c0a808061976.png)

After:

![after](https://user-images.githubusercontent.com/4710575/80594402-80718d00-8a55-11ea-8639-6c038b4bfcf8.png)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
