### PR TITLE
Add explicit identifier to some constructors

### DIFF
--- a/src/cascadia/TerminalApp/ActionArgs.h
+++ b/src/cascadia/TerminalApp/ActionArgs.h
@@ -32,7 +32,8 @@ namespace winrt::TerminalApp::implementation
     struct ActionEventArgs : public ActionEventArgsT<ActionEventArgs>
     {
         ActionEventArgs() = default;
-        ActionEventArgs(const TerminalApp::IActionArgs& args) :
+
+        explicit ActionEventArgs(const TerminalApp::IActionArgs& args) :
             _ActionArgs{ args } {};
         GETSET_PROPERTY(IActionArgs, ActionArgs, nullptr);
         GETSET_PROPERTY(bool, Handled, false);

--- a/src/cascadia/TerminalApp/CascadiaSettings.h
+++ b/src/cascadia/TerminalApp/CascadiaSettings.h
@@ -46,7 +46,7 @@ class TerminalApp::CascadiaSettings final
 {
 public:
     CascadiaSettings();
-    CascadiaSettings(const bool addDynamicProfiles);
+    explicit CascadiaSettings(const bool addDynamicProfiles);
 
     static std::unique_ptr<CascadiaSettings> LoadDefaults();
     static std::unique_ptr<CascadiaSettings> LoadAll();

--- a/src/cascadia/TerminalApp/DebugTapConnection.h
+++ b/src/cascadia/TerminalApp/DebugTapConnection.h
@@ -12,7 +12,7 @@ namespace winrt::Microsoft::TerminalApp::implementation
     class DebugTapConnection : public winrt::implements<DebugTapConnection, winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection>
     {
     public:
-        DebugTapConnection(Microsoft::Terminal::TerminalConnection::ITerminalConnection wrappedConnection);
+        explicit DebugTapConnection(Microsoft::Terminal::TerminalConnection::ITerminalConnection wrappedConnection);
         ~DebugTapConnection();
         void Start();
         void WriteInput(hstring const& data);

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -202,7 +202,7 @@ private:
         std::unique_ptr<LayoutSizeNode> nextFirstChild;
         std::unique_ptr<LayoutSizeNode> nextSecondChild;
 
-        LayoutSizeNode(const float minSize);
+        explicit LayoutSizeNode(const float minSize);
         LayoutSizeNode(const LayoutSizeNode& other);
 
         LayoutSizeNode& operator=(const LayoutSizeNode& other);

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -48,7 +48,7 @@ class TerminalApp::Profile final
 {
 public:
     Profile();
-    Profile(const std::optional<GUID>& guid);
+    explicit Profile(const std::optional<GUID>& guid);
 
     ~Profile();
 

--- a/src/cascadia/TerminalApp/TerminalWarnings.h
+++ b/src/cascadia/TerminalApp/TerminalWarnings.h
@@ -47,7 +47,7 @@ namespace TerminalApp
     class SettingsException : public std::runtime_error
     {
     public:
-        SettingsException(const SettingsLoadErrors& error) :
+        explicit SettingsException(const SettingsLoadErrors& error) :
             std::runtime_error{ nullptr },
             _error{ error } {};
 

--- a/src/cascadia/TerminalAzBridge/ConsoleInputReader.h
+++ b/src/cascadia/TerminalAzBridge/ConsoleInputReader.h
@@ -18,7 +18,7 @@ Abstract:
 class ConsoleInputReader
 {
 public:
-    ConsoleInputReader(HANDLE handle);
+    explicit ConsoleInputReader(HANDLE handle);
     void SetWindowSizeChangedCallback(std::function<void()> callback);
     std::optional<std::wstring_view> Read();
 

--- a/src/host/CommandNumberPopup.hpp
+++ b/src/host/CommandNumberPopup.hpp
@@ -20,7 +20,7 @@ Author:
 class CommandNumberPopup final : public Popup
 {
 public:
-    CommandNumberPopup(SCREEN_INFORMATION& screenInfo);
+    explicit CommandNumberPopup(SCREEN_INFORMATION& screenInfo);
 
     [[nodiscard]] NTSTATUS Process(COOKED_READ_DATA& cookedReadData) noexcept override;
 

--- a/src/host/CopyFromCharPopup.hpp
+++ b/src/host/CopyFromCharPopup.hpp
@@ -20,7 +20,7 @@ Author:
 class CopyFromCharPopup final : public Popup
 {
 public:
-    CopyFromCharPopup(SCREEN_INFORMATION& screenInfo);
+    explicit CopyFromCharPopup(SCREEN_INFORMATION& screenInfo);
 
     [[nodiscard]] NTSTATUS Process(COOKED_READ_DATA& cookedReadData) noexcept override;
 

--- a/src/host/conareainfo.h
+++ b/src/host/conareainfo.h
@@ -34,7 +34,7 @@ public:
     SMALL_RECT rcViewCaWindow;
     COORD coordConView;
 
-    ConversionAreaBufferInfo(const COORD coordBufferSize);
+    explicit ConversionAreaBufferInfo(const COORD coordBufferSize);
 };
 
 class ConversionAreaInfo final

--- a/src/host/conattrs.cpp
+++ b/src/host/conattrs.cpp
@@ -22,7 +22,7 @@ struct _HSL
     double h, s, l;
 
     // constructs an HSL color from a RGB Color.
-    _HSL(const COLORREF rgb)
+    explicit _HSL(const COLORREF rgb)
     {
         const double r = (double)GetRValue(rgb);
         const double g = (double)GetGValue(rgb);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
If a class has a constructor which can be called with a single argument, then this constructor becomes conversion constructor because such a constructor allows conversion of the single argument to the class being constructed. To ensure these constructors are passed the argument of its type, I labeled them explicit.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [X] Tests added/passed

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
In some header files, there were constructors that took a value that could involve implicit conversions, so I added explicit to ensure that does not happen.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Unit testing