### PR TITLE
Grab the write lock before updating the font

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1840,7 +1840,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     //   swapchain size. This helper will call _DoResize with the current size
     //   of the swapchain, accounting for scaling due to DPI.
     // - Note that a DPI change will also trigger a font size change, and will call into here.
-    // - The write lock should be held when calling this method. We might be changing the buffer size here.
+    // - The write lock should be held when calling this method, we might be changing the buffer size in _DoResize.
     // Arguments:
     // - <none>
     // Return Value:

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -197,8 +197,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _SendPastedTextToConnection(const std::wstring& wstr);
         void _SwapChainSizeChanged(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::SizeChangedEventArgs const& e);
         void _SwapChainScaleChanged(Windows::UI::Xaml::Controls::SwapChainPanel const& sender, Windows::Foundation::IInspectable const& args);
-        void _DoResize(const double newWidth, const double newHeight);
-        void _RefreshSize();
+        void _DoResizeUnderLock(const double newWidth, const double newHeight);
+        void _RefreshSizeUnderLock();
         void _TerminalTitleChanged(const std::wstring_view& wstr);
         winrt::fire_and_forget _TerminalScrollPositionChanged(const int viewTop, const int viewHeight, const int bufferSize);
         winrt::fire_and_forget _TerminalCursorPositionChanged();


### PR DESCRIPTION
## Summary of the Pull Request
Based on the discussion in #5479, it seems that the crash is caused by a race condition due to not obtaining the write lock before calling `TriggerFontChange`.

I'm not totally sure if my approach is the right one, but I've taken the lock out of `_RefreshSize` since it seems like all calls of `_RefreshSize` come after a `TriggerFontChange`/`UpdateFont`. Then I just 
made sure all calls of `TriggerFontChange`/`UpdateFont` are preceded with a `LockForWriting`.

## PR Checklist
* [x] Closes #5479
* [x] CLA signed.
* [x] Tests added/passed

## Validation Steps Performed
Scrolling to change my font size does not kill the Terminal anymore! 🙌 