### PR TITLE
Update New Tab Button styling for consistency

### DIFF
--- a/src/cascadia/TerminalApp/TabRowControl.xaml
+++ b/src/cascadia/TerminalApp/TabRowControl.xaml
@@ -30,7 +30,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                 UseLayoutRounding="true"
                 FontFamily="Segoe MDL2 Assets"
                 FontWeight="SemiLight"
-                FontSize="12"
+                FontSize="11"
                 AutomationProperties.AccessibilityView="Control">
                 <!-- U+E710 is the fancy plus icon. -->
                 <mux:SplitButton.Resources>


### PR DESCRIPTION
## Summary of the Pull Request
This is a _huge_ nit, but the styling of WinUI's TabView's NewTabButton is slightly different from ours. This PR manually aligns them to be more consistent.

## References
WinUI's Styling: https://github.com/microsoft/microsoft-ui-xaml/blob/0d4065ff2392048a4fd0ff5036fe2b73b09ad7cf/dev/TabView/TabView.xaml#L304

## Detailed Description of the Pull Request / Additional comments
Before: \<Image Coming Soon\>
After: ![updated button](https://user-images.githubusercontent.com/11050425/80769707-f4b63a00-8b02-11ea-83c3-d882d6ce8f3b.png)
