### PR TITLE
Fix RTL regression (fixes #4779)

### DIFF
--- a/src/renderer/dx/CustomTextRenderer.cpp
+++ b/src/renderer/dx/CustomTextRenderer.cpp
@@ -400,7 +400,8 @@ using namespace Microsoft::Console::Render;
                 case DWRITE_GLYPH_IMAGE_FORMATS_PNG:
                 case DWRITE_GLYPH_IMAGE_FORMATS_JPEG:
                 case DWRITE_GLYPH_IMAGE_FORMATS_TIFF:
-                case DWRITE_GLYPH_IMAGE_FORMATS_PREMULTIPLIED_B8G8R8A8: {
+                case DWRITE_GLYPH_IMAGE_FORMATS_PREMULTIPLIED_B8G8R8A8: 
+                {
                     // This run is bitmap glyphs. Use Direct2D to draw them.
                     d2dContext4->DrawColorBitmapGlyphRun(colorRun->glyphImageFormat,
                                                          currentBaselineOrigin,
@@ -409,7 +410,8 @@ using namespace Microsoft::Console::Render;
                 }
                 break;
 
-                case DWRITE_GLYPH_IMAGE_FORMATS_SVG: {
+                case DWRITE_GLYPH_IMAGE_FORMATS_SVG: 
+                {
                     // This run is SVG glyphs. Use Direct2D to draw them.
                     d2dContext4->DrawSvgGlyphRun(currentBaselineOrigin,
                                                  &colorRun->glyphRun,

--- a/src/renderer/dx/CustomTextRenderer.cpp
+++ b/src/renderer/dx/CustomTextRenderer.cpp
@@ -400,7 +400,7 @@ using namespace Microsoft::Console::Render;
                 case DWRITE_GLYPH_IMAGE_FORMATS_PNG:
                 case DWRITE_GLYPH_IMAGE_FORMATS_JPEG:
                 case DWRITE_GLYPH_IMAGE_FORMATS_TIFF:
-                case DWRITE_GLYPH_IMAGE_FORMATS_PREMULTIPLIED_B8G8R8A8: 
+                case DWRITE_GLYPH_IMAGE_FORMATS_PREMULTIPLIED_B8G8R8A8:
                 {
                     // This run is bitmap glyphs. Use Direct2D to draw them.
                     d2dContext4->DrawColorBitmapGlyphRun(colorRun->glyphImageFormat,
@@ -410,7 +410,7 @@ using namespace Microsoft::Console::Render;
                 }
                 break;
 
-                case DWRITE_GLYPH_IMAGE_FORMATS_SVG: 
+                case DWRITE_GLYPH_IMAGE_FORMATS_SVG:
                 {
                     // This run is SVG glyphs. Use Direct2D to draw them.
                     d2dContext4->DrawSvgGlyphRun(currentBaselineOrigin,


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This fixes the RTL regression caused in #4747. We create the rectangle taking the direction (through the BiDi Level) into account, and then the rendering works again. The GlyphRun shaping could still probably use some work to be a polished thingy, and there are still issues with RTL getting chopped up a lot when there's font fallback going on, but this fixes the regression, and it's now functional again.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
#4779 #4747 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #4779
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The baseline is actually direction dependent. So when it was being initialized, the unconditional baseline as left broke it, setting the box off to right of the text. We just check if the `GlyphRun->bidiLevel` is set, and if so, we adjust it so that the baseline lines up with the right, not with the left.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
![image](https://user-images.githubusercontent.com/16987694/80968891-681cbc00-8e21-11ea-9e5c-9b7cf6d78d53.png)
