### PR TITLE
Don't set the new tab button colors for now

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -911,8 +911,12 @@ namespace winrt::TerminalApp::implementation
             }
         });
 
+        // TODO GH#3327: Once we support colorizing the NewTab button based on
+        // the color of the tab, we'll want to make sure to call
+        // _ClearNewTabButtonColor here, to reset it to the default (for the
+        // newly created tab).
         // remove any colors left by other colored tabs
-        _ClearNewTabButtonColor();
+        // _ClearNewTabButtonColor();
     }
 
     // Method Description:
@@ -1929,6 +1933,11 @@ namespace winrt::TerminalApp::implementation
         winrt::Windows::UI::Xaml::Media::SolidColorBrush backgroundBrush;
         winrt::Windows::UI::Xaml::Media::SolidColorBrush foregroundBrush;
 
+        // TODO: Related to GH#3917 - I think if the system is set to "Dark"
+        // theme, but the app is set to light theme, then this lookup still
+        // returns to us the dark theme brushes. There's gotta be a way to get
+        // the right brushes...
+        // See also GH#5741
         if (res.HasKey(defaultBackgroundKey))
         {
             winrt::Windows::Foundation::IInspectable obj = res.Lookup(defaultBackgroundKey);


### PR DESCRIPTION
## Summary of the Pull Request

This is actually related to another issue we have, #3917. I think if the system is set to "Dark" theme, but the app is set to light theme, then the brush lookup in `_ClearNewTabButtonColor` still returns to us the dark theme brushes.

Fortunately, since we're not actually setting the color of the new tab button anymore, we can just remove the call to that method now, and loop back on it later.

## References
* regressed in #3789 
* related to #3917

## PR Checklist
* [x] Closes #5741
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated

## Validation Steps Performed
![image](https://user-images.githubusercontent.com/18356694/81070631-20417780-8ea9-11ea-9e86-1ee39e291e06.png)


