### PR TITLE
Add a new appxmanifest for preview

### DIFF
--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -15,6 +15,14 @@ variables:
 # store publication machinery happy.
 name: 'Terminal_$(date:yyMM).$(date:dd)$(rev:rrr)'
 
+# Build Arguments:
+#   WindowsTerminalOfficialBuild=[true,false]
+#     true - this is running on our build agent
+#     false - running locally
+#   WindowsTerminalBranding=[Dev,Preview,Release]
+#     Dev - Development build resources
+#     Preview - Preview build resources
+#     Release - regular build resources
 jobs:
   - template: ./templates/build-console-audit-job.yml
     parameters:
@@ -23,17 +31,17 @@ jobs:
   - template: ./templates/build-console-int.yml
     parameters:
       platform: x64
-      additionalBuildArguments: /p:WindowsTerminalReleaseBuild=true
+      additionalBuildArguments: /p:WindowsTerminalOfficialBuild=true;WindowsTerminalBranding=Preview
 
   - template: ./templates/build-console-int.yml
     parameters:
       platform: x86
-      additionalBuildArguments: /p:WindowsTerminalReleaseBuild=true
+      additionalBuildArguments: /p:WindowsTerminalOfficialBuild=true;WindowsTerminalBranding=Preview
 
   - template: ./templates/build-console-int.yml
     parameters:
       platform: arm64
-      additionalBuildArguments: /p:WindowsTerminalReleaseBuild=true
+      additionalBuildArguments: /p:WindowsTerminalOfficialBuild=true;WindowsTerminalBranding=Preview
 
   - template: ./templates/check-formatting.yml
 

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -20,7 +20,7 @@ name: 'Terminal_$(date:yyMM).$(date:dd)$(rev:rrr)'
 #     true - this is running on our build agent
 #     false - running locally
 #   WindowsTerminalBranding=[Dev,Preview,Release]
-#     Dev - Development build resources
+#     <none>  - Development build resources (default)
 #     Preview - Preview build resources
 #     Release - regular build resources
 jobs:

--- a/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
+++ b/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
@@ -35,10 +35,10 @@
     <AppxManifest Include="Package.appxmanifest" Condition="'$(WindowsTerminalBranding)'=='Release'">
       <SubType>Designer</SubType>
     </AppxManifest>
-        <AppxManifest Include="Package-Pre.appxmanifest" Condition="'$(WindowsTerminalBranding)'=='Preview'">
+    <AppxManifest Include="Package-Pre.appxmanifest" Condition="'$(WindowsTerminalBranding)'=='Preview'">
       <SubType>Designer</SubType>
     </AppxManifest>
-    <AppxManifest Include="Package-Dev.appxmanifest" Condition="'$(WindowsTerminalBranding)'=='Dev'">
+    <AppxManifest Include="Package-Dev.appxmanifest" Condition="'$(WindowsTerminalBranding)'==''">
       <SubType>Designer</SubType>
     </AppxManifest>
   </ItemGroup>
@@ -51,7 +51,7 @@
   </ItemGroup>
 
   <!-- This is picked up by CascadiaResources.build.items. -->
-  <PropertyGroup Condition="'$(WindowsTerminalBranding)'=='Dev'">
+  <PropertyGroup Condition="'$(WindowsTerminalBranding)'==''">
     <WindowsTerminalAssetSuffix>-Dev</WindowsTerminalAssetSuffix>
   </PropertyGroup>
   <PropertyGroup Condition="'$(WindowsTerminalBranding)'=='Preview'">

--- a/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
+++ b/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
@@ -32,10 +32,13 @@
     <None Include="CascadiaPackage_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>
-    <AppxManifest Include="Package.appxmanifest" Condition="'$(WindowsTerminalReleaseBuild)'=='true'">
+    <AppxManifest Include="Package.appxmanifest" Condition="'$(WindowsTerminalBranding)'=='Release'">
       <SubType>Designer</SubType>
     </AppxManifest>
-    <AppxManifest Include="Package-Dev.appxmanifest" Condition="'$(WindowsTerminalReleaseBuild)'!='true'">
+        <AppxManifest Include="Package-Pre.appxmanifest" Condition="'$(WindowsTerminalBranding)'=='Preview'">
+      <SubType>Designer</SubType>
+    </AppxManifest>
+    <AppxManifest Include="Package-Dev.appxmanifest" Condition="'$(WindowsTerminalBranding)'=='Dev'">
       <SubType>Designer</SubType>
     </AppxManifest>
   </ItemGroup>
@@ -46,10 +49,15 @@
     <PRIResource Include="Resources\*\Resources.resw" />
     <PRIResource Include="Resources\Resources.resw" />
   </ItemGroup>
-  <PropertyGroup Condition="'$(WindowsTerminalReleaseBuild)'!='true'">
-    <!-- This is picked up by CascadiaResources.build.items. -->
+
+  <!-- This is picked up by CascadiaResources.build.items. -->
+  <PropertyGroup Condition="'$(WindowsTerminalBranding)'=='Dev'">
     <WindowsTerminalAssetSuffix>-Dev</WindowsTerminalAssetSuffix>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(WindowsTerminalBranding)'=='Preview'">
+    <WindowsTerminalAssetSuffix>-Pre</WindowsTerminalAssetSuffix>
+  </PropertyGroup>
+
   <Import Project="$(MSBuildThisFileDirectory)..\CascadiaResources.build.items" />
   <Import Project="$(OpenConsoleDir)src\wap-common.build.post.props" />
   <ItemGroup>
@@ -117,14 +125,14 @@
   <!-- This target removes the FrameworkSdkReferences from before the AppX package targets manifest generation happens.
        This is part of the generic machinery that applies to every AppX. -->
   <Target Name="_OpenConsoleStripAllDependenciesFromPackageFirstManifest" BeforeTargets="_GenerateCurrentProjectAppxManifest">
-    <ItemGroup Condition="'$(WindowsTerminalReleaseBuild)'=='true'">
+    <ItemGroup Condition="'$(WindowsTerminalOfficialBuild)'=='true'">
       <FrameworkSdkReference Remove="@(FrameworkSdkReference)" />
     </ItemGroup>
   </Target>
 
   <!-- This target removes the FrameworkSdkPackages from before the *desktop bridge* manifest generation happens. -->
   <Target Name="_OpenConsoleStripAllDependenciesFromPackageSecondManifest" BeforeTargets="_GenerateDesktopBridgeAppxManifest" DependsOnTargets="_ResolveVCLibDependencies">
-    <ItemGroup Condition="'$(WindowsTerminalReleaseBuild)'=='true'">
+    <ItemGroup Condition="'$(WindowsTerminalOfficialBuild)'=='true'">
       <FrameworkSdkPackage Remove="@(FrameworkSdkPackage)" />
     </ItemGroup>
   </Target>

--- a/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
+  xmlns:uap4="http://schemas.microsoft.com/appx/manifest/uap/windows10/4"
+  xmlns:uap7="http://schemas.microsoft.com/appx/manifest/uap/windows10/7"
+  xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap mp rescap">
+
+  <Identity
+    Name="Microsoft.WindowsTerminal.Preview"
+    Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
+    Version="1.0.0.0" />
+
+  <Properties>
+    <DisplayName>Windows Terminal (Preview)</DisplayName>
+    <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
+    <Logo>Images\StoreLogo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.18362.0" MaxVersionTested="10.0.18362.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="x-generate"/>
+  </Resources>
+
+  <Applications>
+    <Application Id="App"
+      Executable="$targetnametoken$.exe"
+      EntryPoint="$targetentrypoint$">
+      <uap:VisualElements
+        DisplayName="ms-resource:AppNamePre"
+        Description="ms-resource:AppDescriptionPre"
+        BackgroundColor="transparent"
+        Square150x150Logo="Images\Square150x150Logo.png"
+        Square44x44Logo="Images\Square44x44Logo.png">
+        <uap:DefaultTile
+          Wide310x150Logo="Images\Wide310x150Logo.png" 
+          Square71x71Logo="Images\SmallTile.png"
+          Square310x310Logo="Images\LargeTile.png"
+          ShortName="ms-resource:AppShortNamePre">
+          <uap:ShowNameOnTiles>
+            <uap:ShowOn Tile="square150x150Logo"/>
+	    <uap:ShowOn Tile="wide310x150Logo"/>
+            <uap:ShowOn Tile="square310x310Logo"/>
+          </uap:ShowNameOnTiles>
+        </uap:DefaultTile>
+        <uap:SplashScreen Image="Images\SplashScreen.png"/>
+      </uap:VisualElements>
+
+      <Extensions>
+        <uap3:Extension Category="windows.appExecutionAlias" Executable="WindowsTerminal.exe" EntryPoint="Windows.FullTrustApplication">
+          <uap3:AppExecutionAlias>
+            <desktop:ExecutionAlias Alias="wt.exe" />
+          </uap3:AppExecutionAlias>
+        </uap3:Extension>
+      </Extensions>
+
+    </Application>
+  </Applications>
+
+  <Capabilities>
+    <Capability Name="internetClient" />
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+
+  <Extensions>
+    <uap7:Extension Category="windows.sharedFonts">
+      <uap7:SharedFonts>
+        <uap4:Font File="Cascadia.ttf" />
+        <uap4:Font File="CascadiaMono.ttf" />
+      </uap7:SharedFonts>
+    </uap7:Extension>
+  </Extensions>
+</Package>

--- a/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
@@ -12,9 +12,9 @@
   IgnorableNamespaces="uap mp rescap">
 
   <Identity
-    Name="Microsoft.WindowsTerminal.Preview"
+    Name="Microsoft.WindowsTerminalPreview"
     Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
-    Version="1.0.0.0" />
+    Version="0.5.0.0" />
 
   <Properties>
     <DisplayName>Windows Terminal (Preview)</DisplayName>

--- a/src/cascadia/CascadiaPackage/Resources/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/Resources.resw
@@ -1,5 +1,64 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -64,10 +123,16 @@
   <data name="AppNameDev" xml:space="preserve">
     <value>Windows Terminal (Dev Build)</value>
   </data>
+  <data name="AppNamePre" xml:space="preserve">
+    <value>Windows Terminal (Preview)</value>
+  </data>
   <data name="AppShortName" xml:space="preserve">
     <value>Terminal</value>
   </data>
   <data name="AppShortNameDev" xml:space="preserve">
     <value>Terminal (Dev)</value>
+  </data>
+  <data name="AppShortNamePre" xml:space="preserve">
+    <value>Terminal (Preview)</value>
   </data>
 </root>

--- a/src/cascadia/CascadiaResources.build.items
+++ b/src/cascadia/CascadiaResources.build.items
@@ -12,11 +12,11 @@
       <Link>Images\%(RecursiveDir)%(FileName)%(Extension)</Link>
     </Content>
     <!-- Fonts -->
-    <Content Include="$(OpenConsoleDir)res\Cascadia.ttf" Condition="'$(WindowsTerminalReleaseBuild)'=='true'">
+    <Content Include="$(OpenConsoleDir)res\Cascadia.ttf" Condition="'$(WindowsTerminalOfficialBuild)'=='true'">
       <DeploymentContent>true</DeploymentContent>
       <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>
     </Content>
-    <Content Include="$(OpenConsoleDir)res\CascadiaMono.ttf" Condition="'$(WindowsTerminalReleaseBuild)'=='true'">
+    <Content Include="$(OpenConsoleDir)res\CascadiaMono.ttf" Condition="'$(WindowsTerminalOfficialBuild)'=='true'">
       <DeploymentContent>true</DeploymentContent>
       <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>
     </Content>

--- a/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
+++ b/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
@@ -121,7 +121,7 @@
     <ReasonablePlatform Condition="'$(ReasonablePlatform)'==''">$(Platform)</ReasonablePlatform>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(WindowsTerminalReleaseBuild)'=='true'">
+  <ItemGroup Condition="'$(WindowsTerminalOfficialBuild)'=='true'">
     <!-- Add all the CRT libs as content -->
     <_OpenConsoleVCLibToCopy Include="$(VCToolsRedistInstallDir)\$(ReasonablePlatform)\Microsoft.VC142.CRT\*.dll">
       <TargetPath>%(Filename)%(Extension)</TargetPath>
@@ -165,4 +165,5 @@
 
   <Import Project="$(OpenConsoleDir)\build\rules\GenerateSxsManifestsFromWinmds.targets" />
   <Import Project="..\..\..\packages\Terminal.ThemeHelpers.0.2.200324001\build\native\Terminal.ThemeHelpers.targets" Condition="Exists('..\..\..\packages\Terminal.ThemeHelpers.0.2.200324001\build\native\Terminal.ThemeHelpers.targets')" />
-</Project>
+</Project>
+

--- a/src/cascadia/WindowsTerminalUniversal/WindowsTerminalUniversal.vcxproj
+++ b/src/cascadia/WindowsTerminalUniversal/WindowsTerminalUniversal.vcxproj
@@ -112,10 +112,10 @@
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>
-    <AppxManifest Include="Package.appxmanifest" Condition="'$(WindowsTerminalReleaseBuild)'=='true'">
+    <AppxManifest Include="Package.appxmanifest" Condition="'$(WindowsTerminalOfficialBuild)'=='true'">
       <SubType>Designer</SubType>
     </AppxManifest>
-    <AppxManifest Include="Package-Dev.appxmanifest" Condition="'$(WindowsTerminalReleaseBuild)'!='true'">
+    <AppxManifest Include="Package-Dev.appxmanifest" Condition="'$(WindowsTerminalOfficialBuild)'!='true'">
       <SubType>Designer</SubType>
     </AppxManifest>
   </ItemGroup>
@@ -131,7 +131,7 @@
     <!-- This is picked up by CascadiaResources.build.items. -->
     <WindowsTerminalAssetSuffix>-Universal</WindowsTerminalAssetSuffix>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(WindowsTerminalReleaseBuild)'!='true'">
+  <PropertyGroup Condition="'$(WindowsTerminalOfficialBuild)'!='true'">
     <!-- This is picked up by CascadiaResources.build.items. -->
     <WindowsTerminalAssetSuffix>$(WindowsTerminalAssetSuffix)Dev</WindowsTerminalAssetSuffix>
   </PropertyGroup>


### PR DESCRIPTION
## Summary of the Pull Request
This adds a new appxmanifest for 'Windows Terminal (Preview)' and links the resources.

Code-wise, split up `WindowsTerminalReleaseBuild` into...
- WindowsTerminalOfficialBuild: [true, false]
- WindowsTerminalBranding: [Dev, Preview, Release]

Added a comment about that in release.yml

## Validation Steps Performed
used msbuild to build...
- [X] Dev
- [X] Preview
- [X] Release
then checked the msix for the correct name/icon.
