### PR TITLE
Update the tab's close button color to match the tab text color

### DIFF
--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -586,6 +586,7 @@ namespace winrt::TerminalApp::implementation
             tab->_tabViewItem.Resources().Insert(winrt::box_value(L"TabViewItemHeaderForegroundSelected"), fontBrush);
             tab->_tabViewItem.Resources().Insert(winrt::box_value(L"TabViewItemHeaderForegroundPointerOver"), fontBrush);
             tab->_tabViewItem.Resources().Insert(winrt::box_value(L"TabViewItemHeaderForegroundPressed"), fontBrush);
+            tab->_tabViewItem.Resources().Insert(winrt::box_value(L"TabViewButtonForegroundActiveTab"), fontBrush);
 
             tab->_RefreshVisualState();
 
@@ -619,7 +620,8 @@ namespace winrt::TerminalApp::implementation
                 L"TabViewItemHeaderForegroundSelected",
                 L"TabViewItemHeaderForegroundPointerOver",
                 L"TabViewItemHeaderBackgroundPressed",
-                L"TabViewItemHeaderForegroundPressed"
+                L"TabViewItemHeaderForegroundPressed",
+                L"TabViewButtonForegroundActiveTab"
             };
 
             // simply clear any of the colors in the tab's dict


### PR DESCRIPTION
## Summary of the Pull Request

When we select a color for the tab, we update the foreground color of the text so that it maintains acceptable contrast with the new tab color. However, we weren't also updating the foreground color of the close button.

This is understandable though, because apparently this wasn't fixable until MUX 2.4 arrived. I'm not a XAML expert, but I know that setting this key only works when we're using MUX 2.4, so I'm assuming something about the TabView implementation changed in that release. _This PR is marked as a draft until #5778 is merged, then I'll re-target to master._

## References
* #5778 - PR to move to MUX 2.4
* This bug was introduced with the tab color picker in #3789

## PR Checklist
* [x] Closes #5780
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated

## Validation Steps Performed
A light tab color:
![image](https://user-images.githubusercontent.com/18356694/81303943-00918700-9042-11ea-86e6-7bdfe343c4ca.png)

A dark tab color:
![image](https://user-images.githubusercontent.com/18356694/81303953-04250e00-9042-11ea-8db2-be97af519fae.png)
