### PR TITLE
build: merge the signing steps and wildcard them

### DIFF
--- a/build/config/SignConfig.WindowsTerminal.xml
+++ b/build/config/SignConfig.WindowsTerminal.xml
@@ -1,6 +1,5 @@
 <SignConfigXML>
   <job platform="" configuration="" certSubject="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" jobname="EngFunSimpleSign" approvers="">
-   <file src="__INPATHROOT__\Microsoft.WindowsTerminal_8wekyb3d8bbwe.msixbundle" signType="136020001" dest="__OUTPATHROOT__\Microsoft.WindowsTerminal_8wekyb3d8bbwe.msixbundle" /> 
-   <file src="__INPATHROOT__\Microsoft.WindowsTerminalUniversal_8wekyb3d8bbwe.msixbundle" signType="136020001" dest="__OUTPATHROOT__\Microsoft.WindowsTerminalUniversal_8wekyb3d8bbwe.msixbundle" /> 
+   <file src="__INPATHROOT__\Microsoft.WindowsTerminal*.msixbundle" signType="136020001" />
   </job>
 </SignConfigXML>


### PR DESCRIPTION
This allows me to make the build pipeline, instead of the release
engineer, put the version number in the package name.

It also lets us sign _multiple packages_ (if we ever produce more than
one.)