### PR TITLE
dx: fix a missing stdcall that was blowing up the x86 build

### DIFF
--- a/src/renderer/dx/CustomTextLayout.h
+++ b/src/renderer/dx/CustomTextLayout.h
@@ -139,7 +139,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT _ShapeGlyphRun(const UINT32 runIndex, UINT32& glyphStart) noexcept;
         [[nodiscard]] HRESULT _CorrectGlyphRuns() noexcept;
         [[nodiscard]] HRESULT _CorrectGlyphRun(const UINT32 runIndex) noexcept;
-        [[nodiscard]] HRESULT _CorrectBoxDrawing() noexcept;
+        [[nodiscard]] HRESULT STDMETHODCALLTYPE _CorrectBoxDrawing() noexcept;
         [[nodiscard]] HRESULT _DrawGlyphRuns(_In_opt_ void* clientDrawingContext,
                                              IDWriteTextRenderer* renderer,
                                              const D2D_POINT_2F origin) noexcept;


### PR DESCRIPTION
One of the downsides of not having x86 in CI.