### PR TITLE
InteractivityWin32: Add a dependency on Dx

### DIFF
--- a/src/interactivity/win32/lib/win32.LIB.vcxproj
+++ b/src/interactivity/win32/lib/win32.LIB.vcxproj
@@ -60,6 +60,11 @@
     <ClInclude Include="..\WindowIo.hpp" />
     <ClInclude Include="..\windowUiaProvider.hpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\renderer\dx\lib\dx.vcxproj">
+      <Project>{48d21369-3d7b-4431-9967-24e81292cf62}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\..\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>


### PR DESCRIPTION
#5743 introduced a dependency from _any consumer of the DX header_ to a header generated from an IDL file.

I hope this fixes #5819. I'm going to run builds to find out.