### PR TITLE
Stop trying to set selection endpoints when there's no selection

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1822,6 +1822,11 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // - cursorPosition: in pixels, relative to the origin of the control
     void TermControl::_SetEndSelectionPointAtCursor(Windows::Foundation::Point const& cursorPosition)
     {
+        if (!_terminal->IsSelectionActive())
+        {
+            return;
+        }
+
         auto terminalPosition = _GetTerminalPosition(cursorPosition);
 
         const short lastVisibleRow = std::max<short>(_terminal->GetViewport().Height() - 1, 0);

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -138,6 +138,13 @@ void Terminal::SetSelectionAnchor(const COORD viewportPos)
 // - newExpansionMode: overwrites the _multiClickSelectionMode for this function call. Used for ShiftClick
 void Terminal::SetSelectionEnd(const COORD viewportPos, std::optional<SelectionExpansionMode> newExpansionMode)
 {
+    if (!_selection.has_value())
+    {
+        // capture a log for spurious endpoint sets without an active selection
+        LOG_HR(E_ILLEGAL_STATE_CHANGE);
+        return;
+    }
+
     const auto textBufferPos = _ConvertToBufferCell(viewportPos);
 
     // if this is a shiftClick action, we need to overwrite the _multiClickSelectionMode value (even if it's the same)


### PR DESCRIPTION
Apparently, this accounts for somewhere between 7% and 14% of our
crashes on 1.0RC1.

## Summary of the Pull Request
It turns out that we weren't really adequately guarding calls to SetSelectionEnd and friends.

## PR Checklist
* [x] Closes internal crash report
* [x] CLA
* [x] Tests passed
* [ ] Requires documentation to be updated
* [x] One with the corefolk

## Detailed Description of the Pull Request / Additional comments

I decided that it would be prudent to add a WIL log.

## Validation Steps Performed

First, I figured out how the heck to repro this. Snap the window, begin a selection, then use <kbd>Win+Up</kbd> to resize it. Then, I fixed it and tried the repro again.
