### PR TITLE
Teach TerminalPage to handle exceptions that happen during paste

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1448,12 +1448,16 @@ namespace winrt::TerminalApp::implementation
         // will crash on the UI thread, because the main thread is a STA.
         co_await winrt::resume_background();
 
-        hstring text = L"";
-        if (data.Contains(StandardDataFormats::Text()))
+        try
         {
-            text = co_await data.GetTextAsync();
+            hstring text = L"";
+            if (data.Contains(StandardDataFormats::Text()))
+            {
+                text = co_await data.GetTextAsync();
+            }
+            eventArgs.HandleClipboardData(text);
         }
-        eventArgs.HandleClipboardData(text);
+        CATCH_LOG();
     }
 
     // Method Description:


### PR DESCRIPTION
## Summary of the Pull Request

Terminal should try not to join the choir invisible when the clipboard
API straight up horks it.

This accounts for ~3% of the crashes seen in 1.0RC1 and ~1% of the crashes
seen all-up in the last 14 days.

Fixes #4906.

## PR Checklist
* [x] Closes #4906
* [x] CLA'd
* [ ] Tests passed/do not exist
* [ ] Requires documentation to be updated
* [x] Meh

## Validation Steps Performed

Found out a surefire way to repro it!

`"copyOnSelect": true`

Copy something small.

Hold down <kbd>Ctrl+Shift+V</kbd>

Double-click like your life depends on it. Double-click like you're
playing cookie clicker again. 2013 called, it wants its cookies back.
