### PR TITLE
Revert some emoji back to narrow width

### DIFF
--- a/.github/actions/spell-check/whitelist/whitelist.txt
+++ b/.github/actions/spell-check/whitelist/whitelist.txt
@@ -2632,6 +2632,7 @@ wfdopen
 WFill
 wfopen
 wfstream
+WGL
 WHelper
 whitelisting
 WIDTHSCROLL

--- a/src/types/CodepointWidthDetector.cpp
+++ b/src/types/CodepointWidthDetector.cpp
@@ -38,6 +38,10 @@ namespace
         // 0x2666 0x2710,
         // 0x270E 0x2765 0x1f000 - 0x1f02b except 0x1f004 0x1f594
         //
+        // GH #5822 - Removed glyphs that appear inside of CP437 (https://en.wikipedia.org/wiki/Code_page_437)
+        // and WGL4 (https://en.wikipedia.org/wiki/Windows_Glyph_List_4) since they've been narrow since the
+        // beginning of time and changing it to wide would only cause destruction.
+        //
         // *** Codepoint ranges marked with "OVR" have their given width from EastAsianWidth.txt overridden.
         UnicodeRange{ 0xa1, 0xa1, CodepointWidth::Ambiguous },
         UnicodeRange{ 0xa4, 0xa4, CodepointWidth::Ambiguous },

--- a/src/types/CodepointWidthDetector.cpp
+++ b/src/types/CodepointWidthDetector.cpp
@@ -179,7 +179,6 @@ namespace
         UnicodeRange{ 0x2592, 0x2595, CodepointWidth::Ambiguous },
         UnicodeRange{ 0x25a0, 0x25a1, CodepointWidth::Ambiguous },
         UnicodeRange{ 0x25a3, 0x25a9, CodepointWidth::Ambiguous },
-        UnicodeRange{ 0x25aa, 0x25ab, CodepointWidth::Wide }, // OVR
         UnicodeRange{ 0x25b2, 0x25b3, CodepointWidth::Ambiguous },
         UnicodeRange{ 0x25b6, 0x25b7, CodepointWidth::Ambiguous },
         UnicodeRange{ 0x25bc, 0x25bd, CodepointWidth::Ambiguous },
@@ -204,13 +203,9 @@ namespace
         UnicodeRange{ 0x2626, 0x2626, CodepointWidth::Wide }, // OVR
         UnicodeRange{ 0x262a, 0x262a, CodepointWidth::Wide }, // OVR
         UnicodeRange{ 0x262e, 0x262f, CodepointWidth::Wide }, // OVR
-        UnicodeRange{ 0x2638, 0x263a, CodepointWidth::Wide }, // OVR
-        UnicodeRange{ 0x2640, 0x2640, CodepointWidth::Wide }, // OVR
-        UnicodeRange{ 0x2642, 0x2642, CodepointWidth::Wide }, // OVR
+        UnicodeRange{ 0x2638, 0x2639, CodepointWidth::Wide }, // OVR
         UnicodeRange{ 0x2648, 0x2653, CodepointWidth::Wide },
-        UnicodeRange{ 0x265f, 0x2660, CodepointWidth::Wide }, // OVR
-        UnicodeRange{ 0x2663, 0x2663, CodepointWidth::Wide }, // OVR
-        UnicodeRange{ 0x2665, 0x2666, CodepointWidth::Wide }, // OVR
+        UnicodeRange{ 0x265f, 0x265f, CodepointWidth::Wide }, // OVR
         UnicodeRange{ 0x2668, 0x2668, CodepointWidth::Wide }, // OVR
         UnicodeRange{ 0x2669, 0x266a, CodepointWidth::Ambiguous },
         UnicodeRange{ 0x266c, 0x266d, CodepointWidth::Ambiguous },


### PR DESCRIPTION
A couple of codepoints, namely the card suites, male and female signs,
and white and black smiling faces were changed to have a two-column
width as part of #5795 since they were specified as emoji in Unicode's
emoji list v13.0[1]. 

These particular glyphs also show up in some of the most fundamental
code pages, such as CP437[2] and WGL4[3]. We should
not be touching the width of the glyphs in these codepages, as suddenly
changing a long-time-running narrow glyph to use two-columns all of a
sudden will surely break (and has already broken) things.

[1] https://www.unicode.org/Public/13.0.0/ucd/emoji/emoji-data.txt
[2] https://en.wikipedia.org/wiki/Code_page_437
[3] https://en.wikipedia.org/wiki/Windows_Glyph_List_4

Closes #5822
