### PR TITLE
Manually close tabs when they're closed while dragging them

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -854,12 +854,16 @@ namespace winrt::TerminalApp::implementation
         {
             _lastTabClosedHandlers(*this, nullptr);
         }
-        else if (_isFullscreen)
+        else if (_isFullscreen || _rearranging)
         {
             // GH#5799 - If we're fullscreen, the TabView isn't visible. If it's
             // not Visible, it's _not_ going to raise a SelectionChanged event,
             // which is what we usually use to focus another tab. Instead, we'll
             // have to do it manually here.
+            //
+            // GH#5559 Similarly, we suppress _OnTabItemsChanged events during a
+            // rearrange, so if a tab is closed while we're rearranging tabs, do
+            // this manually.
             //
             // We can't use
             //   auto selectedIndex = _tabView.SelectedIndex();
@@ -884,6 +888,15 @@ namespace winrt::TerminalApp::implementation
             // work correctly.
             auto newSelectedTab{ _GetStrongTabImpl(newSelectedIndex) };
             _tabView.SelectedItem(newSelectedTab->GetTabViewItem());
+        }
+
+        // GH#5559 - If we were in the middle of a drag/drop, end it by clearing
+        // out our state.
+        if (_rearranging)
+        {
+            _rearranging = false;
+            _rearrangeFrom = std::nullopt;
+            _rearrangeTo = std::nullopt;
         }
     }
 


### PR DESCRIPTION
## Summary of the Pull Request

When we're dragging the tab around, if you execute a `ClosePane`/`CloseTab`, then we should make sure to actually activate a new tab, so that focus doesn't just fall into the void.

## References

* This is almost exactly #5799, but with rearranging tabs

## PR Checklist
* [x] Closes #5559
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated

## Detailed Description of the Pull Request / Additional comments
We suppress `_OnTabItemsChanged` events during a rearrange, so if a tab is closed while we're rearranging tabs, the we don't fire the `SelectionChanged` event that we usually do during a close that would select the new tab.

## Validation Steps Performed
* Tested manually
  - Confirmed that tragging a tab out, closing it, then dragging it back in does nothing.