### PR TITLE
Adds Alt+Click to auto split pane

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -349,7 +349,12 @@ namespace winrt::TerminalApp::implementation
                     const bool altPressed = WI_IsFlagSet(lAltState, CoreVirtualKeyStates::Down) ||
                                             WI_IsFlagSet(rAltState, CoreVirtualKeyStates::Down);
 
-                    if (altPressed)
+                    // Check for DebugTap
+                    bool debugTap = _settings->GlobalSettings().DebugFeaturesEnabled() &&
+                                    WI_IsFlagSet(lAltState, CoreVirtualKeyStates::Down) &&
+                                    WI_IsFlagSet(rAltState, CoreVirtualKeyStates::Down);
+
+                    if (altPressed && !debugTap)
                     {
                         page->_SplitPane(TerminalApp::SplitState::Automatic,
                                          TerminalApp::SplitType::Manual,

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -341,7 +341,24 @@ namespace winrt::TerminalApp::implementation
                 {
                     auto newTerminalArgs = winrt::make_self<winrt::TerminalApp::implementation::NewTerminalArgs>();
                     newTerminalArgs->ProfileIndex(profileIndex);
-                    page->_OpenNewTab(*newTerminalArgs);
+
+                    // if alt is pressed, open a pane
+                    const CoreWindow window = CoreWindow::GetForCurrentThread();
+                    const auto rAltState = window.GetKeyState(VirtualKey::RightMenu);
+                    const auto lAltState = window.GetKeyState(VirtualKey::LeftMenu);
+                    const bool altPressed = WI_IsFlagSet(lAltState, CoreVirtualKeyStates::Down) ||
+                                            WI_IsFlagSet(rAltState, CoreVirtualKeyStates::Down);
+
+                    if (altPressed)
+                    {
+                        page->_SplitPane(TerminalApp::SplitState::Automatic,
+                                         TerminalApp::SplitType::Manual,
+                                         *newTerminalArgs);
+                    }
+                    else
+                    {
+                        page->_OpenNewTab(*newTerminalArgs);
+                    }
                 }
             });
             newTabFlyout.Items().Append(profileMenuItem);

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -350,7 +350,7 @@ namespace winrt::TerminalApp::implementation
                                             WI_IsFlagSet(rAltState, CoreVirtualKeyStates::Down);
 
                     // Check for DebugTap
-                    bool debugTap = _settings->GlobalSettings().DebugFeaturesEnabled() &&
+                    bool debugTap = page->_settings->GlobalSettings().DebugFeaturesEnabled() &&
                                     WI_IsFlagSet(lAltState, CoreVirtualKeyStates::Down) &&
                                     WI_IsFlagSet(rAltState, CoreVirtualKeyStates::Down);
 


### PR DESCRIPTION
## Summary of the Pull Request
Users can now open an auto split pane with the mouse.
When opening the dropdown, alt+invoke the profile of choice and it should open in an auto sized pane.

## References
#5025 - further discussion there as to whether this actually closes it.

## Detailed Description of the Pull Request / Additional comments
Had to do a special check for debugTap because that's triggered by holding both alts.

## Validation Steps Performed
alt+click/enter on a new profile. Looks great!