### PR TITLE
Make bcz not run personal PowerShell profile script (-NoProfile)

### DIFF
--- a/tools/bcz.cmd
+++ b/tools/bcz.cmd
@@ -97,9 +97,8 @@ set MSBuildEmitSolution=1
 set MSBuildEmitSolution=
 
 rem Use bx.ps1 to figure out which target we're looking at
-set _BX_SCRIPT=powershell bx.ps1
 set _OUTPUT=
-FOR /F "tokens=* USEBACKQ" %%F IN (`powershell bx.ps1 2^> NUL`) DO (
+FOR /F "tokens=* USEBACKQ" %%F IN (`powershell -NoProfile -ExecutionPolicy Bypass -NonInteractive bx.ps1 2^> NUL`) DO (
     set _OUTPUT=%%F
 )
 if "!_OUTPUT!" == "" (


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The `bcz.cmd` script calls a powershell helper script (bx.ps1), but (previous to this change) did not pass `-NoProfile`, which means that powershell.exe would load and run one's personal profile script, which can only slow things down, and worse, can change default behaviors (such as turning on strict mode by default, which will cause scripts that don't run cleanly with strict mode to generate lots of errors--such as bx.ps1).

This change amends the powershell.exe command line to pass -NoProfile, as well as to set the execution policy and ensure that interactive prompts can't inadvertently show up (normal best practices for use of powershell in build scripts).

This change will speed things up (probably negligibly, but still) and (more importantly) prevent non-determinism and errors that could result from running people's profile scripts when running the helper bx.ps1.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

