### PR TITLE
Add docs: Multiple Panes Within a Tab; fix link

### DIFF
--- a/doc/user-docs/index.md
+++ b/doc/user-docs/index.md
@@ -36,6 +36,11 @@ default shell is displayed (default shortcut: <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<
 
 Additional shells (panes) within the active tab can be created, sharing the area previously taken up by the active pane. On the creation of a pane, the active pane's area will be split into two equal parts, spawning a new session using the active pane's profile by default. Press <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>+</kbd> to create a vertical split, and <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>-</kbd> to create a horizontal one. Additionally, a default example keybinding of <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>d</kbd> is included in the configuration with the `auto` split type; an alternative to `vertical` or `horizontal` which always splits the longest axis.
 
+Focus can be moved from the active pane to an adjacent one with <kbd>Alt</kbd> in combination with the arrow keys, e.g. <kbd>Alt</kbd>+<kbd>Up</kbd> to move focus up. The size of the active pane can be altered using <kbd>Alt</kbd>+<kbd>Shift</kbd> in combination with the arrow keys, e.g. <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>Right</kbd>, expanding or contracting based on context.
+
+<!-- Whether a pane expands or contracts is intuitive but difficult to describe. Here are 3 options I _think_ are all equivelant (and fit my tests): A binary-tree-esq hirarchy exists of pane creation order and panes are expanded only in the direction of adjacent panes of equal or greater depth in such a tree; panes are expanded preferentially to the right and down, unless the edge in that direction is shared by a pane with a longer corresponding edge; a pane is expanded such that the change to total perimeter length is minimised. -->
+<!-- I've the above paragraph commented because I'm not sure which, if any, options are accurate, but mostly: it's prolix. -->
+
 ## Running a Different Shell
 
 Note: This section assumes you already have _Windows Subsystem for Linux_ (WSL) installed. For more information, see [the installation guide](https://docs.microsoft.com/en-us/windows/wsl/install-win10).

--- a/doc/user-docs/index.md
+++ b/doc/user-docs/index.md
@@ -38,9 +38,6 @@ Additional shells (panes) within the active tab can be created, sharing the area
 
 Focus can be moved from the active pane to an adjacent one with <kbd>Alt</kbd> in combination with the arrow keys, e.g. <kbd>Alt</kbd>+<kbd>Up</kbd> to move focus up. The size of the active pane can be altered using <kbd>Alt</kbd>+<kbd>Shift</kbd> in combination with the arrow keys, e.g. <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>Right</kbd>, expanding or contracting based on context.
 
-<!-- Whether a pane expands or contracts is intuitive but difficult to describe. Here are 3 options I _think_ are all equivelant (and fit my tests): A binary-tree-esq hirarchy exists of pane creation order and panes are expanded only in the direction of adjacent panes of equal or greater depth in such a tree; panes are expanded preferentially to the right and down, unless the edge in that direction is shared by a pane with a longer corresponding edge; a pane is expanded such that the change to total perimeter length is minimised. -->
-<!-- I've commented the above paragraph commented because I'm not sure which, if any, options are accurate, but mostly: it's prolix. -->
-
 ## Running a Different Shell
 
 Note: This section assumes you already have _Windows Subsystem for Linux_ (WSL) installed. For more information, see [the installation guide](https://docs.microsoft.com/en-us/windows/wsl/install-win10).

--- a/doc/user-docs/index.md
+++ b/doc/user-docs/index.md
@@ -32,6 +32,10 @@ Windows Terminal has implemented a rich set of command-line options in part as r
 Additional shells can be started by hitting the `+` button from the tab bar -- a new instance of the
 default shell is displayed (default shortcut: <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>1</kbd>).
 
+## Multiple Panes Within a Tab
+
+Additional shells (panes) within the active tab can be created, sharing the area previously taken up by the active pane. On the creation of a pane, the active pane's area will be split into two equal parts, spawning a new session using the active pane's profile by default. Press <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>+</kbd> to create a vertical split, and <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>-</kbd> to create a horizontal one. Additionally, a default example keybinding of <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>d</kbd> is included in the configuration with the `auto` split type; an alternative to `vertical` or `horizontal` which always splits the longest axis.
+
 ## Running a Different Shell
 
 Note: This section assumes you already have _Windows Subsystem for Linux_ (WSL) installed. For more information, see [the installation guide](https://docs.microsoft.com/en-us/windows/wsl/install-win10).

--- a/doc/user-docs/index.md
+++ b/doc/user-docs/index.md
@@ -39,7 +39,7 @@ Additional shells (panes) within the active tab can be created, sharing the area
 Focus can be moved from the active pane to an adjacent one with <kbd>Alt</kbd> in combination with the arrow keys, e.g. <kbd>Alt</kbd>+<kbd>Up</kbd> to move focus up. The size of the active pane can be altered using <kbd>Alt</kbd>+<kbd>Shift</kbd> in combination with the arrow keys, e.g. <kbd>Alt</kbd>+<kbd>Shift</kbd>+<kbd>Right</kbd>, expanding or contracting based on context.
 
 <!-- Whether a pane expands or contracts is intuitive but difficult to describe. Here are 3 options I _think_ are all equivelant (and fit my tests): A binary-tree-esq hirarchy exists of pane creation order and panes are expanded only in the direction of adjacent panes of equal or greater depth in such a tree; panes are expanded preferentially to the right and down, unless the edge in that direction is shared by a pane with a longer corresponding edge; a pane is expanded such that the change to total perimeter length is minimised. -->
-<!-- I've the above paragraph commented because I'm not sure which, if any, options are accurate, but mostly: it's prolix. -->
+<!-- I've commented the above paragraph commented because I'm not sure which, if any, options are accurate, but mostly: it's prolix. -->
 
 ## Running a Different Shell
 

--- a/src/cascadia/TerminalApp/userDefaults.json
+++ b/src/cascadia/TerminalApp/userDefaults.json
@@ -67,7 +67,7 @@
         { "command": "find", "keys": "ctrl+shift+f" },
 
         // Press Alt+Shift+D to open a new pane.
-        // - "split": "auto" makes this pane open in the direction that provides the most surface area.
+        // - "split": "auto" bisects the active pane along the shorter perpendicular segment.
         // - "splitMode": "duplicate" makes the new pane use the focused pane's profile.
         // To learn more about panes, visit https://aka.ms/terminal-panes
         { "command": { "action": "splitPane", "split": "auto", "splitMode": "duplicate" }, "keys": "alt+shift+d" }


### PR DESCRIPTION
Add docs covering what panes are, how to create them, and their keyboard shortcuts.

Additionally: <https://aka.ms/terminal-panes> directs to this page, but there are no docs about panes here 😥 ... YET!

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## PR Checklist
<!-- * [ ] Closes #xxx -->
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
<!-- * [ ] Tests added/passed
* [ ] Requires documentation to be updated -->
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work 
might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

(omitted items not applicable)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

`auto` split behaviour based on the comment immediately before the keyboard shortcut entry in default config. `horizontal` and `vertical` properties guessed but they work - not sure if there are any other options.

Can't remember where I heard the default shortcuts (a video of some kind published recently, maybe?) Anyway splitting panes is _literally_ the _single_ feature I thought `terminal` was missing. 👍🚀