### PR TITLE
Make sure to update the maximize button's visual state on launch

### DIFF
--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -205,6 +205,11 @@ void NonClientIslandWindow::Initialize()
     _rootGrid.Children().Append(_titlebar);
 
     Controls::Grid::SetRow(_titlebar, 0);
+
+    // GH#3440 - When the titlebar is loaded (officially added to our UI tree),
+    // then make sure to update it's visual state to reflect if we're in the
+    // maximized state on launch.
+    _titlebar.Loaded([this](auto&&, auto&&) { _OnMaximizeChange(); });
 }
 
 // Method Description:


### PR DESCRIPTION
## Summary of the Pull Request
This is an enormously trivial nit - when we launch maximized, we don't draw the maximize button in the "restore" state.

This PR changes the terminal to manually update the Maximize button on launch, once the titlebar is added to the UI tree.

## PR Checklist
* [x] Closes #3440
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated
