### PR TITLE
Add Carlos Zamora to spell checker

### DIFF
--- a/.github/actions/spell-check/whitelist/whitelist.txt
+++ b/.github/actions/spell-check/whitelist/whitelist.txt
@@ -224,6 +224,8 @@ CARETBLINKINGENABLED
 CARRIAGERETURN
 cascadia
 catid
+carlos
+zamora
 cazamor
 CBash
 cbb


### PR DESCRIPTION
'carlos' 'zamora' exists. I swear. This was caught on a number of PRs...
