### PR TITLE
Update to point to live docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains the source code for:
 
 Related repositories include:
 
-* [Windows Terminal Documentation](https://github.com/MicrosoftDocs/terminal)
+* [Windows Terminal Documentation](https://docs.microsoft.com/windows/terminal) ([Repo: Contribute to the docs](https://github.com/MicrosoftDocs/terminal))
 * [Console API Documentation](https://github.com/MicrosoftDocs/Console-Docs)
 * [Cascadia Code Font](https://github.com/Microsoft/Cascadia-Code)
 


### PR DESCRIPTION
included a link to the repo, but live docs is a better reading experience

## Summary of the Pull Request

Recommend pointing to the docs.microsoft.com/windows/terminal live documentation in this ReadMe so users get a good reading experience. I left the link to the docs source code in case folks want to contribute.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ x] Closes #xxx
* [ x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ na] Tests added/passed
* [ na] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
