### PR TITLE
Fix #6079, allow pasting from Explorer's 'Copy Address'

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -11,6 +11,7 @@
 #include <LibraryResources.h>
 
 #include "TerminalPage.g.cpp"
+#include <winrt/Windows.Storage.h>
 #include <winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>
 
 #include "AzureCloudShellGenerator.h" // For AzureConnectionType
@@ -1467,6 +1468,16 @@ namespace winrt::TerminalApp::implementation
             if (data.Contains(StandardDataFormats::Text()))
             {
                 text = co_await data.GetTextAsync();
+            }
+            // Windows Explorer's "Copy address" menu item stores a StorageItem in the clipboard, and no text.
+            else if (data.Contains(StandardDataFormats::StorageItems()))
+            {
+                Windows::Foundation::Collections::IVectorView<Windows::Storage::IStorageItem> items = co_await data.GetStorageItemsAsync();
+                if (items.Size() > 0)
+                {
+                    Windows::Storage::IStorageItem item = items.GetAt(0);
+                    text = item.Path();
+                }
             }
             eventArgs.HandleClipboardData(text);
         }


### PR DESCRIPTION
Fixes #6079 by implementing support for IStorageItem clipboard contents. Manually tested, seems to work for both types of address-copying from Explorer (as well as normal text).

## PR Checklist
* [x] Closes #6079
* Not sure what tests would be useful here, it's mostly to do with what Explorer's doing

Not enormously familiar with C++ or this codebase, so happy to make changes as requested.

## Validation Steps Performed

Ran the terminal, pasted from several different sources (explorer's various copy functions + plaintext)