### PR TITLE
Add ubuntu-specific background color

### DIFF
--- a/src/cascadia/TerminalApp/WslDistroGenerator.cpp
+++ b/src/cascadia/TerminalApp/WslDistroGenerator.cpp
@@ -126,7 +126,14 @@ std::vector<TerminalApp::Profile> WslDistroGenerator::GenerateProfiles()
             auto WSLDistro{ CreateDefaultProfile(distName) };
 
             WSLDistro.SetCommandline(L"wsl.exe -d " + distName);
-            WSLDistro.SetColorScheme({ L"Campbell" });
+
+            if (distName.rfind("Ubuntu", 0) == 0) {
+                WSLDistro.SetColorScheme({ L"Tango Dark" });
+                WSLDistro.SetDefaultBackground({ L"#300a24" });
+            } else {
+                WSLDistro.SetColorScheme({ L"Campbell" });
+            }
+
             WSLDistro.SetStartingDirectory(DEFAULT_STARTING_DIRECTORY);
             WSLDistro.SetIconPath(L"ms-appx:///ProfileIcons/{9acb9455-ca41-5af7-950f-6bca1bc9722f}.png");
             profiles.emplace_back(WSLDistro);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

`src\cascadia\TerminalApp\WslDistroGenerator.cpp` : 
```c++
if (distName.rfind("Ubuntu", 0) == 0) {
    WSLDistro.SetColorScheme({ L"Tango Dark" });
    WSLDistro.SetDefaultBackground({ L"#300a24" });
} else {
    WSLDistro.SetColorScheme({ L"Campbell" });
}
```

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #6085
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #6085

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

This changes WSL Ubuntu's default theme to match Ubuntu's theme, Tango Dark, and adds Ubuntu's background colour.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

I couldn't build the project to validate that it works. Maintainers are free to edit the PR.