### PR TITLE
Fix the u8u16 test project?

### DIFF
--- a/src/tools/U8U16Test/U8U16Test.hpp
+++ b/src/tools/U8U16Test/U8U16Test.hpp
@@ -13,6 +13,7 @@
 #include <string_view>
 #include <array>
 #include <algorithm>
+#include <stdexcept>
 #include <windows.h>
 #include <intsafe.h>
 


### PR DESCRIPTION
I have no idea what's going on here.

I have a build failure that happened over in #6100 https://dev.azure.com/ms/Terminal/_build/results?buildId=83368&view=logs&jobId=6e3e7df0-e6f0-5f0c-c8d6-63e192049bc0 

It _looks_ like there's a missing header from the `U8U16Test` project, which I haven't touched at all.

Trying to build that locally on master, **I get the same error**. 

This header looks like it's the missing one. All I can find about it is [this obscure forum post](https://forum.zdoom.org/viewtopic.php?f=7&t=68641). So I have no idea what's really going on here, but this should fix the build?