### PR TITLE
Fix line drawing during IME operations.

### DIFF
--- a/.github/actions/spell-check/dictionary/apis.txt
+++ b/.github/actions/spell-check/dictionary/apis.txt
@@ -5,6 +5,7 @@ IBox
 ICustom
 IMap
 IObject
+IStorage
 LCID
 NCHITTEST
 NCLBUTTONDBLCLK

--- a/src/host/conimeinfo.cpp
+++ b/src/host/conimeinfo.cpp
@@ -263,6 +263,7 @@ std::vector<OutputCell> ConsoleImeInfo::s_ConvertToCells(const std::wstring_view
         if (IsGlyphFullWidth(glyph))
         {
             auto leftHalfAttr = drawingAttr;
+            auto rightHalfAttr = drawingAttr;
 
             // Don't draw lines in the middle of full width glyphs.
             // If we need a right vertical, don't apply it to the left side of the character
@@ -276,12 +277,16 @@ std::vector<OutputCell> ConsoleImeInfo::s_ConvertToCells(const std::wstring_view
             dbcsAttr.SetTrailing();
 
             // If we need a left vertical, don't apply it to the right side of the character
-            if (drawingAttr.IsLeftVerticalDisplayed())
+            if (rightHalfAttr.IsLeftVerticalDisplayed())
             {
-                drawingAttr.SetLeftVerticalDisplayed(false);
+                rightHalfAttr.SetLeftVerticalDisplayed(false);
             }
+            cells.emplace_back(glyph, dbcsAttr, rightHalfAttr);
         }
-        cells.emplace_back(glyph, dbcsAttr, drawingAttr);
+        else
+        {
+            cells.emplace_back(glyph, dbcsAttr, drawingAttr);
+        }
     }
 
     return cells;

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -783,8 +783,10 @@ void Renderer::_PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine,
             THROW_IF_FAILED(pEngine->PaintBufferLine({ clusters.data(), clusters.size() }, screenPoint, trimLeft, lineWrapped));
 
             // If we're allowed to do grid drawing, draw that now too (since it will be coupled with the color data)
+            // We're only allowed to draw the grid lines under certain circumstances.
             if (_pData->IsGridLineDrawingAllowed())
             {
+                // See GH: 803
                 // If we found a wide character while we looped above, it's possible we skipped over the right half
                 // attribute that could have contained different line information than the left half.
                 if (containsWideCharacter)
@@ -805,7 +807,6 @@ void Renderer::_PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine,
                     {
                         auto lines = lineIt->TextAttr();
 
-                        // We're only allowed to draw the grid lines under certain circumstances.
                         _PaintBufferOutputGridLineHelper(pEngine, lines, 1, lineTarget);
                     }
                 }


### PR DESCRIPTION
## Summary of the Pull Request
Restores proper line drawing during IME operations in `conhost`

## PR Checklist
* [x] Closes #803
* [x] I work here.
* [x] Tested manually.
* [x] Check the performance of this and see if it's worse-enough to merit a more confusing algorithm. It was worse for the majority case so I scoped it.
* [x] No doc, it should have worked this way.
* [x] Am core contributor.

## Detailed Description of the Pull Request / Additional comments
- Changed `ConsoleImeInfo::s_ConvertToCells` to be less confusing. It's doing about the same thing, but it's way easier to read now and the compiler/linker/optimizer should just be the same.
- Edited `Renderer::_PaintBufferOutputHelper` to check each attribute for line drawing characters as the right half of a two-col character might have different line drawing characters than the left-half.

## Validation Steps Performed
- [x] Manual operation of IME in conhost with Japanese IME.
- [x] Manual operation of IME in conhost with Chinese IME.
- [x] Manual operation of IME in conhost with Chinese (Traditional) IME.
- [x] Manual operation of IME in conhost with and Korean IME. - @leonMSFT says Korean doesn't work this way. But Korean is broken worse in that it's not showing suggestions at all. Filing new bug. #6227 
- [x] Validated against API-filling calls through `SetConsoleTextAttribute` per @j4james's sample code
