### PR TITLE
WIP: Draw backgrounds separately from foregrounds

### DIFF
--- a/src/buffer/out/TextAttribute.hpp
+++ b/src/buffer/out/TextAttribute.hpp
@@ -154,22 +154,29 @@ public:
         return _foreground.IsRgb() || _background.IsRgb();
     }
 
-    // This returns whether this attribute, if printed directly next to another attribute, for the space
-    // character, would look identical to the other one.
-    bool HasIdenticalVisualRepresentationForBlankSpace(const TextAttribute& other, const bool inverted = false) const noexcept
+    bool HasIdenticalBackground(const TextAttribute& other, const bool inverted = false) const noexcept
     {
         // sneaky-sneaky: I'm using xor here
         // inverted is whether there's a global invert; Reverse is a local one.
         // global ^ local == true : the background attribute is actually the visible foreground, so we care about the foregrounds being identical
         // global ^ local == false: the foreground attribute is the visible foreground, so we care about the backgrounds being identical
         const auto checkForeground = (inverted != IsReverseVideo());
-        return !IsAnyGridLineEnabled() && // grid lines have a visual representation
+        return ((checkForeground && _foreground == other._foreground) ||
+                (!checkForeground && _background == other._background));
+    }
+
+    // This returns whether this attribute, if printed directly next to another attribute, for the space
+    // character, would look identical to the other one.
+    bool HasIdenticalForeground(const TextAttribute& other, const bool inverted = false) const noexcept
+    {
+        const auto checkBackground = (inverted != IsReverseVideo());
+        return ((checkBackground && _background == other._background) ||
+                (!checkBackground && _foreground == other._foreground)) &&
+               !IsAnyGridLineEnabled() && // grid lines have a visual representation
                // crossed out, doubly and singly underlined have a visual representation
                WI_AreAllFlagsClear(_extendedAttrs, ExtendedAttributes::CrossedOut | ExtendedAttributes::DoublyUnderlined | ExtendedAttributes::Underlined) &&
                // all other attributes do not have a visual representation
                (_wAttrLegacy & META_ATTRS) == (other._wAttrLegacy & META_ATTRS) &&
-               ((checkForeground && _foreground == other._foreground) ||
-                (!checkForeground && _background == other._background)) &&
                _extendedAttrs == other._extendedAttrs;
     }
 
@@ -195,6 +202,7 @@ private:
     template<typename TextAttribute>
     friend class WEX::TestExecution::VerifyOutputTraits;
 #endif
+    friend struct fmt::formatter<TextAttribute>;
 };
 
 #pragma pack(pop)

--- a/src/buffer/out/TextColor.h
+++ b/src/buffer/out/TextColor.h
@@ -120,6 +120,7 @@ private:
     template<typename TextColor>
     friend class WEX::TestExecution::VerifyOutputTraits;
 #endif
+    friend struct fmt::formatter<TextColor>;
 };
 
 #pragma pack(pop)

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -27,6 +27,20 @@ Author(s):
 
 namespace Microsoft::Console::Render
 {
+    struct ColorCluster
+    {
+        TextAttribute attribute;
+        size_t columns;
+        std::vector<Cluster> clusters;
+    };
+    struct Line
+    {
+        til::point origin;
+        bool wrapped;
+        bool trimLeft;
+        std::vector<BackgroundRun> backgrounds;
+        std::vector<ColorCluster> clusters;
+    };
     class Renderer sealed : public IRenderer
     {
     public:
@@ -94,6 +108,8 @@ namespace Microsoft::Console::Render
         bool _CheckViewportAndScroll();
 
         [[nodiscard]] HRESULT _PaintBackground(_In_ IRenderEngine* const pEngine);
+
+        std::vector<Line> _ProcessDirtyLines(_In_ IRenderEngine* const pEngine);
 
         void _PaintBufferBackground(IRenderEngine* const pEngine);
 

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -27,19 +27,19 @@ Author(s):
 
 namespace Microsoft::Console::Render
 {
-    struct ColorCluster
+    struct ForegroundRun
     {
         TextAttribute attribute;
         size_t columns;
         std::vector<Cluster> clusters;
     };
-    struct Line
+    struct PreparedDirtyRegion
     {
         til::point origin;
         bool wrapped;
         bool trimLeft;
         std::vector<BackgroundRun> backgrounds;
-        std::vector<ColorCluster> clusters;
+        std::vector<ForegroundRun> clusters;
     };
     class Renderer sealed : public IRenderer
     {
@@ -109,7 +109,7 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT _PaintBackground(_In_ IRenderEngine* const pEngine);
 
-        std::vector<Line> _ProcessDirtyLines(_In_ IRenderEngine* const pEngine);
+        std::vector<PreparedDirtyRegion> _ProcessDirtyLines(_In_ IRenderEngine* const pEngine);
 
         void _PaintBufferBackground(IRenderEngine* const pEngine);
 

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -95,6 +95,8 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT _PaintBackground(_In_ IRenderEngine* const pEngine);
 
+        void _PaintBufferBackground(IRenderEngine* const pEngine);
+
         void _PaintBufferOutput(_In_ IRenderEngine* const pEngine);
 
         void _PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine,

--- a/src/renderer/dx/CustomTextRenderer.cpp
+++ b/src/renderer/dx/CustomTextRenderer.cpp
@@ -290,8 +290,6 @@ using namespace Microsoft::Console::Render;
         d2dContext->PopAxisAlignedClip();
     });
 
-    d2dContext->FillRectangle(rect, drawingContext->backgroundBrush);
-
     // GH#5098: If we're rendering with cleartype text, we need to always render
     // onto an opaque background. If our background _isn't_ opaque, then we need
     // to use grayscale AA for this run of text.

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1235,6 +1235,11 @@ try
 }
 CATCH_RETURN()
 
+[[nodiscard]] HRESULT DxEngine::PaintBufferBackground(std::basic_string_view<BackgroundRun> backgrounds) {
+    (void)backgrounds;
+    return S_FALSE;
+}
+
 // Routine Description:
 // - Places one line of text onto the screen at the given position
 // Arguments:

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1236,8 +1236,15 @@ try
 CATCH_RETURN()
 
 [[nodiscard]] HRESULT DxEngine::PaintBufferBackground(std::basic_string_view<BackgroundRun> backgrounds) {
-    (void)backgrounds;
-    return S_FALSE;
+    WRL::ComPtr<ID2D1SolidColorBrush> solidBrush;
+    RETURN_IF_FAILED(_d2dBrushBackground.As(&solidBrush));
+    for (const auto& background : backgrounds)
+    {
+        const auto inflatedRect{ background.rect.scale_up(_glyphCell) };
+        solidBrush->SetColor(_ColorFFromColorRef(background.color));
+        _d2dRenderTarget->FillRectangle(inflatedRect, solidBrush.Get());
+    }
+    return S_OK;
 }
 
 // Routine Description:

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -78,6 +78,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT ScrollFrame() noexcept override;
 
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
+        [[nodiscard]] HRESULT PaintBufferBackground(std::basic_string_view<BackgroundRun>) override;
         [[nodiscard]] HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,
                                               COORD const coord,
                                               bool const fTrimLeft,

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -62,6 +62,8 @@ namespace Microsoft::Console::Render
         ::Microsoft::WRL::ComPtr<IDXGISwapChain1> GetSwapChain();
 
         // IRenderEngine Members
+        [[nodiscard]] RenderEngineFlags GetFlags() const noexcept override { return RenderEngineFlags::SupportsBackgroundAtlas; }
+
         [[nodiscard]] HRESULT Invalidate(const SMALL_RECT* const psrRegion) noexcept override;
         [[nodiscard]] HRESULT InvalidateCursor(const COORD* const pcoordCursor) noexcept override;
         [[nodiscard]] HRESULT InvalidateSystem(const RECT* const prcDirtyClient) noexcept override;

--- a/src/renderer/gdi/gdirenderer.hpp
+++ b/src/renderer/gdi/gdirenderer.hpp
@@ -42,6 +42,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT ScrollFrame() noexcept override;
 
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
+        [[nodiscard]] HRESULT PaintBufferBackground(std::basic_string_view<BackgroundRun>) override;
         [[nodiscard]] HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,
                                               const COORD coord,
                                               const bool trimLeft,

--- a/src/renderer/gdi/gdirenderer.hpp
+++ b/src/renderer/gdi/gdirenderer.hpp
@@ -26,6 +26,8 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT SetHwnd(const HWND hwnd) noexcept;
 
+        [[nodiscard]] RenderEngineFlags GetFlags() const noexcept override { return RenderEngineFlags::SupportsBackgroundAtlas; }
+
         [[nodiscard]] HRESULT InvalidateSelection(const std::vector<SMALL_RECT>& rectangles) noexcept override;
         [[nodiscard]] HRESULT InvalidateScroll(const COORD* const pcoordDelta) noexcept override;
         [[nodiscard]] HRESULT InvalidateSystem(const RECT* const prcDirtyClient) noexcept override;

--- a/src/renderer/gdi/paint.cpp
+++ b/src/renderer/gdi/paint.cpp
@@ -266,6 +266,10 @@ using namespace Microsoft::Console::Render;
     return S_OK;
 }
 
+[[nodiscard]] HRESULT GdiEngine::PaintBufferBackground(std::basic_string_view<BackgroundRun> /*backgrounds*/) {
+    return S_FALSE;
+}
+
 // Routine Description:
 // - Draws one line of the buffer to the screen.
 // - This will now be cached in a PolyText buffer and flushed periodically instead of drawing every individual segment. Note this means that the PolyText buffer must be flushed before some operations (changing the brush color, drawing lines on top of the characters, inverting for cursor/selection, etc.)

--- a/src/renderer/gdi/paint.cpp
+++ b/src/renderer/gdi/paint.cpp
@@ -271,10 +271,10 @@ using namespace Microsoft::Console::Render;
 [[nodiscard]] HRESULT GdiEngine::PaintBufferBackground(std::basic_string_view<BackgroundRun> backgrounds) {
     for (const auto& brun : backgrounds)
     {
-        wil::unique_hbrush hbr{ CreateSolidBrush(brun.col) };
+        wil::unique_hbrush hbr{ CreateSolidBrush(brun.color) };
         COORD const coordFontSize = _GetFontSize();
         til::size fsz{ coordFontSize.X, coordFontSize.Y };
-        RECT rect{ static_cast<RECT>(brun.pos.scale_up(fsz)) };
+        RECT rect{ static_cast<RECT>(brun.rect.scale_up(fsz)) };
         FillRect(_hdcMemoryContext, &rect, hbr.get());
     }
     return S_OK;

--- a/src/renderer/gdi/state.cpp
+++ b/src/renderer/gdi/state.cpp
@@ -199,7 +199,8 @@ GdiEngine::~GdiEngine()
     }
     if (colorBackground != _lastBg)
     {
-        RETURN_HR_IF(E_FAIL, CLR_INVALID == SetBkColor(_hdcMemoryContext, colorBackground));
+        //RETURN_HR_IF(E_FAIL, CLR_INVALID == SetBkColor(_hdcMemoryContext, colorBackground));
+        // try to hork it up
         _lastBg = colorBackground;
     }
 

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -20,6 +20,12 @@ Author(s):
 
 namespace Microsoft::Console::Render
 {
+    struct BackgroundRun
+    {
+        til::rectangle pos;
+        COLORREF color;
+    };
+
     class IRenderEngine
     {
     public:
@@ -91,6 +97,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] virtual HRESULT InvalidateTitle(const std::wstring& proposedTitle) noexcept = 0;
 
         [[nodiscard]] virtual HRESULT PaintBackground() noexcept = 0;
+        [[nodiscard]] virtual HRESULT PaintBufferBackground(std::basic_string_view<BackgroundRun> const backgrounds) = 0;
         [[nodiscard]] virtual HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,
                                                       const COORD coord,
                                                       const bool fTrimLeft,

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -23,9 +23,15 @@ namespace Microsoft::Console::Render
 {
     struct BackgroundRun
     {
-        til::rectangle pos;
-        TextAttribute attr;
-        COLORREF col;
+        til::rectangle rect;
+        TextAttribute attribute;
+        COLORREF color;
+    };
+
+    enum class RenderEngineFlags : uint32_t
+    {
+        None = 0,
+        SupportsBackgroundAtlas = 1u << 0,
     };
 
     class IRenderEngine
@@ -80,6 +86,8 @@ namespace Microsoft::Console::Render
         IRenderEngine& operator=(IRenderEngine&&) = default;
 
     public:
+        [[nodiscard]] virtual RenderEngineFlags GetFlags() const noexcept { return RenderEngineFlags::None; }
+
         [[nodiscard]] virtual HRESULT StartPaint() noexcept = 0;
         [[nodiscard]] virtual HRESULT EndPaint() noexcept = 0;
         [[nodiscard]] virtual HRESULT Present() noexcept = 0;
@@ -136,3 +144,4 @@ namespace Microsoft::Console::Render
 }
 
 DEFINE_ENUM_FLAG_OPERATORS(Microsoft::Console::Render::IRenderEngine::GridLines)
+DEFINE_ENUM_FLAG_OPERATORS(Microsoft::Console::Render::RenderEngineFlags);

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -17,13 +17,15 @@ Author(s):
 #include "../../inc/conattrs.hpp"
 #include "Cluster.hpp"
 #include "FontInfoDesired.hpp"
+#include "../buffer/out/TextAttribute.hpp"
 
 namespace Microsoft::Console::Render
 {
     struct BackgroundRun
     {
         til::rectangle pos;
-        COLORREF color;
+        TextAttribute attr;
+        COLORREF col;
     };
 
     class IRenderEngine

--- a/src/renderer/uia/UiaRenderer.cpp
+++ b/src/renderer/uia/UiaRenderer.cpp
@@ -296,6 +296,11 @@ CATCH_RETURN();
     return S_FALSE;
 }
 
+[[nodiscard]] HRESULT UiaEngine::PaintBufferBackground(std::basic_string_view<BackgroundRun>)
+{
+    return S_FALSE;
+}
+
 // Routine Description:
 // - Places one line of text onto the screen at the given position
 //  For UIA, this doesn't mean anything. So do nothing.

--- a/src/renderer/uia/UiaRenderer.hpp
+++ b/src/renderer/uia/UiaRenderer.hpp
@@ -51,6 +51,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT InvalidateCircling(_Out_ bool* const pForcePaint) noexcept override;
 
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
+        [[nodiscard]] HRESULT PaintBufferBackground(std::basic_string_view<BackgroundRun>) override;
         [[nodiscard]] HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,
                                               COORD const coord,
                                               bool const fTrimLeft,

--- a/src/renderer/vt/paint.cpp
+++ b/src/renderer/vt/paint.cpp
@@ -111,6 +111,10 @@ using namespace Microsoft::Console::Types;
     return S_OK;
 }
 
+[[nodiscard]] HRESULT VtEngine::PaintBufferBackground(std::basic_string_view<BackgroundRun> /*backgrounds*/) {
+    return S_FALSE;
+}
+
 // Routine Description:
 // - Draws one line of the buffer to the screen. Writes the characters to the
 //      pipe. If the characters are outside the ASCII range (0-0x7f), then

--- a/src/renderer/vt/vtrenderer.hpp
+++ b/src/renderer/vt/vtrenderer.hpp
@@ -63,6 +63,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] virtual HRESULT ScrollFrame() noexcept = 0;
 
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
+        [[nodiscard]] HRESULT PaintBufferBackground(std::basic_string_view<BackgroundRun>) override;
         [[nodiscard]] virtual HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,
                                                       const COORD coord,
                                                       const bool trimLeft,


### PR DESCRIPTION
This implements #6193. It's a WIP.

## Summary of the Pull Request

---

Alright, I've got this down to a single function that takes each dirty region and produces...

* A list of damaged backgrounds to repaint
* A list of colored cluster lists to repaint

I don't like the number of vectors here, but... we're saving money by invalidating narrowly whenever possible.

```
Dirty Region [1..n]
- Origin (SCREEN CHAR COORDS)
- At line wrap point
- Region intersected right half of DBCS char (left trim)
- Background Run [1..n]
  - Attribute
  - Rect Covered (SCREEN CHAR COORDS)
- Colored Foreground Run [1..n]
  - Attribute
  - Columns
  - Cluster [1..n]
```

Right now, because of some minor issues (#2661), backgrounds are attributes _and_ actual final colors. It's not pleasant!

To fix:

* [ ] reverse is occasionally (!) broken
* [x] render engines need flags to say "plz no background splitting" (vt engine needs to update drawing brushes per text run, foreground _and_ background)
* [ ] need to re-enable space optimization (if the cell is non-printing (and has no underline, etc.), no point in forwarding it to the cluster renderer!)

---

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
