### PR TITLE
Add stdexcept header explicitly to u8u16test tool

### DIFF
--- a/src/tools/U8U16Test/U8U16Test.hpp
+++ b/src/tools/U8U16Test/U8U16Test.hpp
@@ -9,6 +9,7 @@
 #undef WIN32_LEAN_AND_MEAN
 #undef NOMINMAX
 #define NOMINMAX
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <array>


### PR DESCRIPTION
## Summary of the Pull Request
Adds implicit stdexcept header include to u8u16test tool.

## PR Checklist
* [x] Closes regression introduced when moving from VS 16.5 to VS 16.6 (which the CI did of its own accord)
* [x] I work here.
* [x] Built it.
* [x] No doc.
* [x] Am core contributor.

## Detailed Description of the Pull Request / Additional comments
In VS 16.5, the <stdexcept> header was pulled in by `<string>` or  `<string_view>` or `<array>` or `<algorithm>` implicitly. In VS 16.6, that's gone. No one wrote it in the header because it was just automatically there in the past. Now I wrote it in the header.

## Validation Steps Performed
* [x] Built it on my machine after upgrading to VS `16.6.0`.
* [ ] Built it in CI.
