### PR TITLE
Fix syntax errors in font weight options

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -534,7 +534,7 @@
         "fontWeight": {
           "default": "normal",
           "description": "Sets the weight (lightness or heaviness of the strokes) for the given font. Possible values:\n -\"thin\"\n -\"extra-light\"\n -\"light\"\n -\"semi-light\"\n -\"normal\" (default)\n -\"medium\"\n -\"semi-bold\"\n -\"bold\"\n -\"extra-bold\"\n -\"black\"\n -\"extra-black\" or the corresponding numeric representation of OpenType font weight.",
-           "oneOf": [
+          "oneOf": [
             {
               "enum": [
                 "thin",
@@ -556,7 +556,8 @@
               "minimum": 100,
               "type": "integer"
             }
-        }
+          ]
+        },
         "foreground": {
           "$ref": "#/definitions/Color",
           "default": "#cccccc",


### PR DESCRIPTION
## Summary of the Pull Request
Fix some simple syntax errors in font weight options.

## References

## PR Checklist

## Detailed Description of the Pull Request / Additional comments
Existing syntax errors in file [profiles.schema.json](https://github.com/microsoft/terminal/blob/master/doc/cascadia/profiles.schema.json):
1. Line 537: indentation error
2. Line 559: "]" for closing "one of" is mising; "," after "}" is mising

## Validation Steps Performed
1. Open the settings file for Windows Terminal, `$schema` will display as "unable to parse content".
2. Modify `$schema` to new file.
```json
  "$schema": "https://raw.githubusercontent.com/alexzshl/terminal/patch-2/doc/cascadia/profiles.schema.json",
```

