### PR TITLE
Find icon from shortcut target if shortcut doesn't specify it

### DIFF
--- a/src/propsheet/PropSheetHandler.cpp
+++ b/src/propsheet/PropSheetHandler.cpp
@@ -118,7 +118,7 @@ private:
                 // Not all console shortcuts have console-specific properties. We just take the registry defaults in
                 // those cases.
                 BOOL readSettings = FALSE;
-                NTSTATUS s = ShortcutSerialization::s_GetLinkValues(gpStateInfo, &readSettings, nullptr, 0, nullptr, 0, nullptr, nullptr, nullptr);
+                NTSTATUS s = ShortcutSerialization::s_GetLinkValues(gpStateInfo, &readSettings, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, nullptr, nullptr);
                 hr = HRESULT_FROM_NT(s);
             }
             else

--- a/src/propslib/ShortcutSerialization.cpp
+++ b/src/propslib/ShortcutSerialization.cpp
@@ -344,6 +344,8 @@ void ShortcutSerialization::s_GetLinkTitle(_In_ PCWSTR pwszShortcutFilename,
                                                               _Out_ BOOL* const pfReadConsoleProperties,
                                                               _Out_writes_opt_(cchShortcutTitle) PWSTR pwszShortcutTitle,
                                                               const size_t cchShortcutTitle,
+                                                              _Out_writes_opt_(cchLinkTarget) PWSTR pwszLinkTarget,
+                                                              const size_t cchLinkTarget,
                                                               _Out_writes_opt_(cchIconLocation) PWSTR pwszIconLocation,
                                                               const size_t cchIconLocation,
                                                               _Out_opt_ int* const piIcon,
@@ -355,6 +357,11 @@ void ShortcutSerialization::s_GetLinkTitle(_In_ PCWSTR pwszShortcutFilename,
     if (pwszShortcutTitle && cchShortcutTitle > 0)
     {
         pwszShortcutTitle[0] = L'\0';
+    }
+
+    if (pwszLinkTarget && cchLinkTarget > 0)
+    {
+        pwszLinkTarget[0] = L'\0';
     }
 
     if (pwszIconLocation && cchIconLocation > 0)
@@ -374,7 +381,12 @@ void ShortcutSerialization::s_GetLinkTitle(_In_ PCWSTR pwszShortcutFilename,
             s_GetLinkTitle(pStateInfo->LinkTitle, pwszShortcutTitle, cchShortcutTitle);
         }
 
-        if (pwszIconLocation && piIcon)
+        if (pwszLinkTarget)
+        {
+            hr = psl->GetPath(pwszLinkTarget, static_cast<int>(cchLinkTarget), NULL, 0);
+        }
+
+        if (SUCCEEDED(hr) && pwszIconLocation && piIcon)
         {
             hr = psl->GetIconLocation(pwszIconLocation, static_cast<int>(cchIconLocation), piIcon);
         }

--- a/src/propslib/ShortcutSerialization.hpp
+++ b/src/propslib/ShortcutSerialization.hpp
@@ -30,6 +30,8 @@ public:
                                                   _Out_ BOOL* const pfReadConsoleProperties,
                                                   _Out_writes_opt_(cchShortcutTitle) PWSTR pwszShortcutTitle,
                                                   const size_t cchShortcutTitle,
+                                                  _Out_writes_opt_(cchLinkTarget) PWSTR pwszLinkTarget,
+                                                  const size_t cchLinkTarget,
                                                   _Out_writes_opt_(cchIconLocation) PWSTR pwszIconLocation,
                                                   const size_t cchIconLocation,
                                                   _Out_opt_ int* const piIcon,


### PR DESCRIPTION
Implements what I was suggesting in #6266 where if a shortcut doesn't
specify an icon, the shortcut target full path is used before searching
for a matching executable in the path.

## References

Found due to not getting the right icon in conhost from the Yori
installer.  It's fixed in the installer from
https://github.com/malxau/yori/commit/5af366b6a5ea4c92dce3940abb8616ab5bd300a6
for all current users of conhost though, so this PR is just trying to
minimize surprises for the next guy.

## Detailed Description of the Pull Request / Additional comments

I know conhost and shortcut settings aren't really the team's focus
which is why I'm doing this.  I understand though if there's a better
way or there are factors that I hadn't considered.  Note that the path
searching code is used when programs are launched without using a
shortcut, and it will match if the working directory of the shortcut is
the directory containing the executable.

## Validation Steps Performed

Created a shortcut that didn't specify an icon to a binary that wasn't
in the path, and verified that the icon in the upper left of the console
window could resolve correctly when opening the shortcut.  I'm not aware
of a way to get into this path (of launching via a shortcut to a command
line process) without replacing the system conhost, which is what I did
to verify it.  In order to diagnose it, I used hardcoded DebugBreak()
since even ImageFileExecutionOptions didn't like running against conhost-
is there are better way to debug and test these cases without being so
invasive on the system?

Closes #6266