### PR TITLE
When the tab receives focus, immediately move focus to the active control

### DIFF
--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -49,6 +49,8 @@ namespace winrt::TerminalApp::implementation
         // If the tab _itself_ gains focus, instead pass it straight on through
         // to the focused control. We don't want focus to silently land on the
         // tab.
+        // TerminalPage will handle RequestFocusActiveControl to pass focus to
+        // the active control in the active tab.
         auto weakThis{ get_weak() };
         _tabViewItem.GotFocus([weakThis](Windows::Foundation::IInspectable const& sender,
                                          RoutedEventArgs const& /*args*/) {
@@ -56,13 +58,9 @@ namespace winrt::TerminalApp::implementation
             auto c = sender.try_as<winrt::Windows::UI::Xaml::Controls::Control>();
             if (c && tab)
             {
-                if (c.FocusState() != FocusState::Unfocused && tab->_focused)
+                if (c.FocusState() != FocusState::Unfocused)
                 {
-                    auto lastFocusedControl = tab->GetActiveTerminalControl();
-                    if (lastFocusedControl)
-                    {
-                        lastFocusedControl.Focus(FocusState::Programmatic);
-                    }
+                    tab->_RequestFocusActiveControlHandlers(*tab, nullptr);
                 }
             }
         });
@@ -680,14 +678,9 @@ namespace winrt::TerminalApp::implementation
                     // Manually pass the focus on to our focused control.
                     // Otherwise, the focus will just be lost when we're removed
                     // from the tree.
-                    if (tab->_focused)
-                    {
-                        auto lastFocusedControl = tab->GetActiveTerminalControl();
-                        if (lastFocusedControl)
-                        {
-                            lastFocusedControl.Focus(FocusState::Programmatic);
-                        }
-                    }
+                    // TerminalPage will handle RequestFocusActiveControl to
+                    // pass focus to the active control in the active tab.
+                    tab->_RequestFocusActiveControlHandlers(*tab, nullptr);
                     break;
                 }
             }

--- a/src/cascadia/TerminalApp/Tab.h
+++ b/src/cascadia/TerminalApp/Tab.h
@@ -53,6 +53,7 @@ namespace winrt::TerminalApp::implementation
 
         std::optional<winrt::Windows::UI::Color> GetTabColor();
 
+        TYPED_EVENT(RequestFocusActiveControl, winrt::Windows::Foundation::IInspectable, winrt::Windows::UI::Xaml::RoutedEventArgs);
         WINRT_CALLBACK(Closed, winrt::Windows::Foundation::EventHandler<winrt::Windows::Foundation::IInspectable>);
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
         DECLARE_EVENT(ActivePaneChanged, _ActivePaneChangedHandlers, winrt::delegate<>);

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -988,6 +988,17 @@ namespace winrt::TerminalApp::implementation
         // newly created tab).
         // remove any colors left by other colored tabs
         // _ClearNewTabButtonColor();
+
+        hostingTab.RequestFocusActiveControl([weakThis{ get_weak() }](auto&&, auto&&) {
+            if (auto page{ weakThis.get() })
+            {
+                // Return focus to the active control
+                if (auto index{ page->_GetFocusedTabIndex() })
+                {
+                    page->_GetStrongTabImpl(index.value())->SetFocused(true);
+                }
+            }
+        });
     }
 
     // Method Description:


### PR DESCRIPTION
I'm mostly just putting the PR out there for comments. I'm worried that this might have horrifying unintentional side-effects for accessibility, which I'm not loving. 

This PR makes the `Tab` immediately toss focus to the active control, whenever the `Tab` receives focus, for any reason. 
* Left-click on the tab to focus the window? Focus the control. #3609
* Close the color picker? Focus the control.
* Hit esc to dismiss the menuflyout from the New Tab menu, the tab context menu? Focus the control. #5750
* Hit esc to dismiss the tab rename? Focus the control. 

@carlos-zamora will this horribly break accessibility?

My other theory here is to pre-emptively prevent the tab from receiving focus. That would probably involve
* Focusing the control when a tab is left clicked
* Manually passing focus to the control when any flyout is closed
* Manually passing focus to the control when the color picker is closed
* Manually passing focus to the control when the tab renamer is dismissed
* Manually passing focus to the control when the command palette is closed
* Manually passing focus to the control when \<any future UI> is closed

So that might not scale as well, but that might be the more _correct_ solution. 

* [x] I work here
* [ ] This is UI so it doesn't have tests
* [x] Closes #3609
* [x] Closes #5750
