### PR TITLE
Add support for `--title` to the `wt.exe` commandline args

### DIFF
--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -315,6 +315,9 @@ void AppCommandlineArgs::_addNewTerminalArgs(AppCommandlineArgs::NewTerminalSubc
     subcommand.startingDirectoryOption = subcommand.subcommand->add_option("-d,--startingDirectory",
                                                                            _startingDirectory,
                                                                            RS_A(L"CmdStartingDirArgDesc"));
+    subcommand.titleOption = subcommand.subcommand->add_option("--title",
+                                                               _startingTitle,
+                                                               RS_A(L"CmdTitleArgDesc"));
 
     // Using positionals_at_end allows us to support "wt new-tab -d wsl -d Ubuntu"
     // without CLI11 thinking that we've specified -d twice.
@@ -372,6 +375,11 @@ NewTerminalArgs AppCommandlineArgs::_getNewTerminalArgs(AppCommandlineArgs::NewT
         args->StartingDirectory(winrt::to_hstring(_startingDirectory));
     }
 
+    if (*subcommand.titleOption)
+    {
+        args->TabTitle(winrt::to_hstring(_startingTitle));
+    }
+
     return *args;
 }
 
@@ -402,6 +410,7 @@ void AppCommandlineArgs::_resetStateToDefault()
 {
     _profileName.clear();
     _startingDirectory.clear();
+    _startingTitle.clear();
     _commandline.clear();
 
     _splitVertical = false;

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.h
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.h
@@ -51,6 +51,7 @@ private:
         CLI::Option* commandlineOption;
         CLI::Option* profileNameOption;
         CLI::Option* startingDirectoryOption;
+        CLI::Option* titleOption;
     };
 
     // --- Subcommands ---
@@ -64,6 +65,7 @@ private:
 
     std::string _profileName;
     std::string _startingDirectory;
+    std::string _startingTitle;
 
     // _commandline will contain the command line with which we'll be spawning a new terminal
     std::vector<std::string> _commandline;

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -256,6 +256,10 @@
     <value>Open in the given directory instead of the profile's set "startingDirectory"</value>
     <comment>{Locked="\"startingDirectory\""}</comment>
   </data>
+  <data name="CmdTitleArgDesc" xml:space="preserve">
+    <value>Open the terminal with the provided title instead of the profile's set "title"</value>
+    <comment>{Locked="\"title\""}</comment>
+  </data>
   <data name="CmdVersionDesc" xml:space="preserve">
     <value>Display the application version</value>
   </data>


### PR DESCRIPTION
## Summary of the Pull Request

Adds support for setting the terminal `title` with the commandline argument `--title <title>`.

## PR Checklist
* [x] Closes #6183
* [x] I work here
* [ ] Tests added/passed
* [ ] Requires documentation to be updated - probably does, yea

## Detailed Description of the Pull Request / Additional comments

* I wasn't sure how we felt about `-t` being the short version of this argument, so I left it out. If we're cool with that, adding it wouldn't be hard.

## Validation Steps Performed

![image](https://user-images.githubusercontent.com/18356694/83450866-afe03480-a41b-11ea-84e7-9134474fdd7a.png)
