### PR TITLE
Fix a crash with this method when running unpackaged

### DIFF
--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -776,7 +776,16 @@ namespace winrt::TerminalApp::implementation
     }
 
     fire_and_forget AppLogic::_ApplyStartupTaskStateChange()
+    try
     {
+        // First, make sure we're running in a packaged context. This method
+        // won't work, and will crash mysteriously if we're running unpackaged.
+        const auto package{ winrt::Windows::ApplicationModel::Package::Current() };
+        if (package == nullptr)
+        {
+            return;
+        }
+
         auto weakThis{ get_weak() };
         co_await winrt::resume_foreground(_root->Dispatcher(), CoreDispatcherPriority::Normal);
         if (auto page{ weakThis.get() })
@@ -812,6 +821,8 @@ namespace winrt::TerminalApp::implementation
             }
         }
     }
+    CATCH_LOG();
+
     // Method Description:
     // - Reloads the settings from the profile.json.
     void AppLogic::_ReloadSettings()


### PR DESCRIPTION
## Summary of the Pull Request

I was debugging the terminal unpackaged, and noticed that this method crashes immediately. I'm gonna bet that this functionality only works when the app is installed as a package. Wrapping this whole method up in one big ol' `try/catch` seems to fix the immediate crash.

## References

* Introduced in #4908 

## PR Checklist
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated

## Detailed Description of the Pull Request / Additional comments

We _could_ display a warning if the user has this property set and is running the terminal unpackaged, to clue them in that it won't work? I'm willing to file a follow-up for that, but I think we should fix the crash _now_.

## Validation Steps Performed
* Ran the terminal successfully unpackaged.