### PR TITLE
Draw the cursor underneath text, and above the background

### DIFF
--- a/src/host/ut_host/VtRendererTests.cpp
+++ b/src/host/ut_host/VtRendererTests.cpp
@@ -1492,7 +1492,7 @@ void VtRendererTest::TestCursorVisibility()
 
     VERIFY_ARE_NOT_EQUAL(origin, engine->_lastText);
 
-    IRenderEngine::CursorOptions options{};
+    CursorOptions options{};
     options.coordCursor = origin;
 
     // Frame 1: Paint the cursor at the home position. At the end of the frame,

--- a/src/interactivity/onecore/BgfxEngine.cpp
+++ b/src/interactivity/onecore/BgfxEngine.cpp
@@ -179,7 +179,7 @@ BgfxEngine::BgfxEngine(PVOID SharedViewBase, LONG DisplayHeight, LONG DisplayWid
     return S_OK;
 }
 
-[[nodiscard]] HRESULT BgfxEngine::PaintCursor(const IRenderEngine::CursorOptions& options) noexcept
+[[nodiscard]] HRESULT BgfxEngine::PaintCursor(const CursorOptions& options) noexcept
 {
     // TODO: MSFT: 11448021 - Modify BGFX to support rendering full-width
     // characters and a full-width cursor.

--- a/src/renderer/base/RenderEngineBase.cpp
+++ b/src/renderer/base/RenderEngineBase.cpp
@@ -35,3 +35,8 @@ HRESULT RenderEngineBase::UpdateTitle(const std::wstring& newTitle) noexcept
     }
     return hr;
 }
+
+HRESULT RenderEngineBase::PrepareRenderInfo(const RenderFrameInfo& /*info*/) noexcept
+{
+    return S_FALSE;
+}

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -139,7 +139,7 @@ try
     // B. Perform Scroll Operations
     RETURN_IF_FAILED(_PerformScrolling(pEngine));
 
-    // C.
+    // C. Prepare the engine with additional information before we start drawing.
     RETURN_IF_FAILED(_PrepareRenderInfo(pEngine));
 
     // 1. Paint Background
@@ -846,7 +846,7 @@ void Renderer::_PaintBufferOutputGridLineHelper(_In_ IRenderEngine* const pEngin
 // - Retrieves information about the cursor, and pack it into a CursorOptions
 //   that the render engine can use for painting the cursor.
 // - If the cursor is "off", or the cursor is out of bounds of the viewport,
-//   this will return nullopt (indicating the cursor shoudln't be painted this
+//   this will return nullopt (indicating the cursor shouldn't be painted this
 //   frame)
 // Arguments:
 // - <none>

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -843,15 +843,15 @@ void Renderer::_PaintBufferOutputGridLineHelper(_In_ IRenderEngine* const pEngin
 }
 
 // Routine Description:
-// - Retrieves information about the cursor, and pack it into a CursorOptions
-//   that the render engine can use for painting the cursor.
+// - Retrieve information about the cursor, and pack it into a CursorOptions
+//   which the render engine can use for painting the cursor.
 // - If the cursor is "off", or the cursor is out of bounds of the viewport,
 //   this will return nullopt (indicating the cursor shouldn't be painted this
 //   frame)
 // Arguments:
 // - <none>
 // Return Value:
-// - nullopt if the cursor is off our out-of-frame, otherwise a CursorOptions
+// - nullopt if the cursor is off or out-of-frame, otherwise a CursorOptions
 [[nodiscard]] std::optional<CursorOptions> Renderer::_GetCursorInfo()
 {
     if (_pData->IsCursorVisible())

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -127,6 +127,8 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT _PaintTitle(IRenderEngine* const pEngine);
 
+        [[nodiscard]] HRESULT _PrepareRenderInfo(_In_ IRenderEngine* const pEngine);
+
         // Helper functions to diagnose issues with painting and layout.
         // These are only actually effective/on in Debug builds when the flag is set using an attached debugger.
         bool _fDebug = false;

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -127,6 +127,7 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT _PaintTitle(IRenderEngine* const pEngine);
 
+        [[nodiscard]] std::optional<CursorOptions> _GetCursorInfo();
         [[nodiscard]] HRESULT _PrepareRenderInfo(_In_ IRenderEngine* const pEngine);
 
         // Helper functions to diagnose issues with painting and layout.

--- a/src/renderer/dx/CustomTextRenderer.cpp
+++ b/src/renderer/dx/CustomTextRenderer.cpp
@@ -238,7 +238,7 @@ using namespace Microsoft::Console::Render;
 // - firstPass - true if we're being called before the text is drawn, false afterwards.
 // Return Value:
 // - S_FALSE if we did nothing, S_OK if we successfully painted, otherwise an appropriate HRESULT
-[[nodiscard]] HRESULT _drawCursor(ID2D1DeviceContext* d2dContext,
+[[nodiscard]] HRESULT _drawCursor(gsl::not_null<ID2D1DeviceContext*> d2dContext,
                                   D2D1_RECT_F textRunBounds,
                                   const DrawingContext& drawingContext,
                                   const bool firstPass)

--- a/src/renderer/dx/CustomTextRenderer.cpp
+++ b/src/renderer/dx/CustomTextRenderer.cpp
@@ -257,7 +257,7 @@ try
         return S_FALSE;
     }
 
-    // TODO GH#TODO: Add support for `"cursorTextColor": null` for letting the
+    // TODO GH#6338: Add support for `"cursorTextColor": null` for letting the
     // cursor draw on top again.
     if (!firstPass)
     {

--- a/src/renderer/dx/CustomTextRenderer.cpp
+++ b/src/renderer/dx/CustomTextRenderer.cpp
@@ -5,6 +5,8 @@
 
 #include "CustomTextRenderer.h"
 
+#include "../../inc/DefaultSettings.h"
+
 #include <wrl.h>
 #include <wrl/client.h>
 #include <VersionHelpers.h>
@@ -220,6 +222,106 @@ using namespace Microsoft::Console::Render;
                               clientDrawingEffect);
 }
 
+[[nodiscard]] HRESULT _DrawCursorHelper(::Microsoft::WRL::ComPtr<ID2D1DeviceContext> d2dContext,
+                                        const DrawingContext& drawingContext)
+try
+{
+    if (!drawingContext.cursorInfo.has_value())
+    {
+        return S_FALSE;
+    }
+
+    const auto& options = drawingContext.cursorInfo.value();
+    const til::size glyphSize{ til::math::flooring, drawingContext.cellSize.width, drawingContext.cellSize.height };
+    // const til::size glyphSize{ til::math::flooring, drawingContext.cellSize };
+    // if the cursor is off, do nothing - it should not be visible.
+    if (!options.isOn)
+    {
+        return S_FALSE;
+    }
+    // Create rectangular block representing where the cursor can fill.
+    D2D1_RECT_F rect = til::rectangle{ til::point{ options.coordCursor } }.scale_up(glyphSize);
+
+    // If we're double-width, make it one extra glyph wider
+    if (options.fIsDoubleWidth)
+    {
+        rect.right += glyphSize.width();
+    }
+
+    CursorPaintType paintType = CursorPaintType::Fill;
+
+    switch (options.cursorType)
+    {
+    case CursorType::Legacy:
+    {
+        // Enforce min/max cursor height
+        ULONG ulHeight = std::clamp(options.ulCursorHeightPercent, MinCursorHeightPercent, MaxCursorHeightPercent);
+        ulHeight = (glyphSize.height<ULONG>() * ulHeight) / 100;
+        rect.top = rect.bottom - ulHeight;
+        break;
+    }
+    case CursorType::VerticalBar:
+    {
+        // It can't be wider than one cell or we'll have problems in invalidation, so restrict here.
+        // It's either the left + the proposed width from the ease of access setting, or
+        // it's the right edge of the block cursor as a maximum.
+        rect.right = std::min(rect.right, rect.left + options.cursorPixelWidth);
+        break;
+    }
+    case CursorType::Underscore:
+    {
+        rect.top = rect.bottom - 1;
+        break;
+    }
+    case CursorType::EmptyBox:
+    {
+        paintType = CursorPaintType::Outline;
+        break;
+    }
+    case CursorType::FullBox:
+    {
+        break;
+    }
+    default:
+        return E_NOTIMPL;
+    }
+
+    Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> brush; // = _d2dBrushForeground;
+
+    if (options.fUseColor)
+    {
+        // Make sure to make the cursor opaque
+        RETURN_IF_FAILED(d2dContext->CreateSolidColorBrush(til::color{ OPACITY_OPAQUE | options.cursorColor },
+                                                           &brush));
+    }
+
+    switch (paintType)
+    {
+    case CursorPaintType::Fill:
+    {
+        d2dContext->FillRectangle(rect, brush.Get());
+        break;
+    }
+    case CursorPaintType::Outline:
+    {
+        // DrawRectangle in straddles physical pixels in an attempt to draw a line
+        // between them. To avoid this, bump the rectangle around by half the stroke width.
+        rect.top += 0.5f;
+        rect.left += 0.5f;
+        rect.bottom -= 0.5f;
+        rect.right -= 0.5f;
+
+        d2dContext->DrawRectangle(rect, brush.Get());
+        break;
+    }
+    default:
+        return E_NOTIMPL;
+    }
+
+    return S_OK;
+}
+CATCH_RETURN()
+
 // Routine Description:
 // - Implementation of IDWriteTextRenderer::DrawInlineObject
 // - Passes drawing control from the outer layout down into the context of an embedded object
@@ -291,6 +393,8 @@ using namespace Microsoft::Console::Render;
     });
 
     d2dContext->FillRectangle(rect, drawingContext->backgroundBrush);
+
+    RETURN_IF_FAILED(_DrawCursorHelper(d2dContext, *drawingContext));
 
     // GH#5098: If we're rendering with cleartype text, we need to always render
     // onto an opaque background. If our background _isn't_ opaque, then we need

--- a/src/renderer/dx/CustomTextRenderer.h
+++ b/src/renderer/dx/CustomTextRenderer.h
@@ -18,7 +18,7 @@ namespace Microsoft::Console::Render
                        IDWriteFactory* dwriteFactory,
                        const DWRITE_LINE_SPACING spacing,
                        const D2D_SIZE_F cellSize,
-                       const std::optional<CursorOptions> cursorInfo,
+                       const std::optional<CursorOptions>& cursorInfo,
                        const D2D1_DRAW_TEXT_OPTIONS options = D2D1_DRAW_TEXT_OPTIONS_NONE) noexcept
         {
             this->renderTarget = renderTarget;

--- a/src/renderer/dx/CustomTextRenderer.h
+++ b/src/renderer/dx/CustomTextRenderer.h
@@ -18,7 +18,7 @@ namespace Microsoft::Console::Render
                        IDWriteFactory* dwriteFactory,
                        const DWRITE_LINE_SPACING spacing,
                        const D2D_SIZE_F cellSize,
-                       const CursorOptions cursorInfo,
+                       const std::optional<CursorOptions> cursorInfo,
                        const D2D1_DRAW_TEXT_OPTIONS options = D2D1_DRAW_TEXT_OPTIONS_NONE) noexcept
         {
             this->renderTarget = renderTarget;
@@ -39,9 +39,19 @@ namespace Microsoft::Console::Render
         IDWriteFactory* dwriteFactory;
         DWRITE_LINE_SPACING spacing;
         D2D_SIZE_F cellSize;
-        CursorOptions cursorInfo;
+        std::optional<CursorOptions> cursorInfo;
         D2D1_DRAW_TEXT_OPTIONS options;
     };
+
+    // Helper to choose which Direct2D method to use when drawing the cursor rectangle
+    enum class CursorPaintType
+    {
+        Fill,
+        Outline
+    };
+
+    constexpr const ULONG MinCursorHeightPercent = 25;
+    constexpr const ULONG MaxCursorHeightPercent = 100;
 
     class CustomTextRenderer : public ::Microsoft::WRL::RuntimeClass<::Microsoft::WRL::RuntimeClassFlags<::Microsoft::WRL::ClassicCom | ::Microsoft::WRL::InhibitFtmBase>, IDWriteTextRenderer>
     {

--- a/src/renderer/dx/CustomTextRenderer.h
+++ b/src/renderer/dx/CustomTextRenderer.h
@@ -5,6 +5,7 @@
 
 #include <wrl/implements.h>
 #include "BoxDrawingEffect.h"
+#include "../../renderer/inc/CursorOptions.h"
 
 namespace Microsoft::Console::Render
 {
@@ -17,6 +18,7 @@ namespace Microsoft::Console::Render
                        IDWriteFactory* dwriteFactory,
                        const DWRITE_LINE_SPACING spacing,
                        const D2D_SIZE_F cellSize,
+                       const CursorOptions cursorInfo,
                        const D2D1_DRAW_TEXT_OPTIONS options = D2D1_DRAW_TEXT_OPTIONS_NONE) noexcept
         {
             this->renderTarget = renderTarget;
@@ -26,6 +28,7 @@ namespace Microsoft::Console::Render
             this->dwriteFactory = dwriteFactory;
             this->spacing = spacing;
             this->cellSize = cellSize;
+            this->cursorInfo = cursorInfo;
             this->options = options;
         }
 
@@ -36,6 +39,7 @@ namespace Microsoft::Console::Render
         IDWriteFactory* dwriteFactory;
         DWRITE_LINE_SPACING spacing;
         D2D_SIZE_F cellSize;
+        CursorOptions cursorInfo;
         D2D1_DRAW_TEXT_OPTIONS options;
     };
 

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1298,7 +1298,7 @@ try
                            _dwriteFactory.Get(),
                            spacing,
                            _glyphCell,
-                           {},
+                           _frameInfo.cursorInfo,
                            D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT);
 
     // Layout then render the text
@@ -1414,109 +1414,107 @@ try
 }
 CATCH_RETURN()
 
-// Helper to choose which Direct2D method to use when drawing the cursor rectangle
-enum class CursorPaintType
+[[nodiscard]] HRESULT DxEngine::PaintCursor(const CursorOptions& /*options*/) noexcept
 {
-    Fill,
-    Outline
-};
-
-// Routine Description:
-// - Draws a block at the given position to represent the cursor
-// - May be a styled cursor at the character cell location that is less than a full block
-// Arguments:
-// - options - Packed options relevant to how to draw the cursor
-// Return Value:
-// - S_OK or relevant DirectX error.
-[[nodiscard]] HRESULT DxEngine::PaintCursor(const CursorOptions& options) noexcept
-try
-{
-    // if the cursor is off, do nothing - it should not be visible.
-    if (!options.isOn)
-    {
-        return S_FALSE;
-    }
-    // Create rectangular block representing where the cursor can fill.
-    D2D1_RECT_F rect = til::rectangle{ til::point{ options.coordCursor } }.scale_up(_glyphCell);
-
-    // If we're double-width, make it one extra glyph wider
-    if (options.fIsDoubleWidth)
-    {
-        rect.right += _glyphCell.width();
-    }
-
-    CursorPaintType paintType = CursorPaintType::Fill;
-
-    switch (options.cursorType)
-    {
-    case CursorType::Legacy:
-    {
-        // Enforce min/max cursor height
-        ULONG ulHeight = std::clamp(options.ulCursorHeightPercent, s_ulMinCursorHeightPercent, s_ulMaxCursorHeightPercent);
-        ulHeight = (_glyphCell.height<ULONG>() * ulHeight) / 100;
-        rect.top = rect.bottom - ulHeight;
-        break;
-    }
-    case CursorType::VerticalBar:
-    {
-        // It can't be wider than one cell or we'll have problems in invalidation, so restrict here.
-        // It's either the left + the proposed width from the ease of access setting, or
-        // it's the right edge of the block cursor as a maximum.
-        rect.right = std::min(rect.right, rect.left + options.cursorPixelWidth);
-        break;
-    }
-    case CursorType::Underscore:
-    {
-        rect.top = rect.bottom - 1;
-        break;
-    }
-    case CursorType::EmptyBox:
-    {
-        paintType = CursorPaintType::Outline;
-        break;
-    }
-    case CursorType::FullBox:
-    {
-        break;
-    }
-    default:
-        return E_NOTIMPL;
-    }
-
-    Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> brush = _d2dBrushForeground;
-
-    if (options.fUseColor)
-    {
-        // Make sure to make the cursor opaque
-        RETURN_IF_FAILED(_d2dRenderTarget->CreateSolidColorBrush(_ColorFFromColorRef(OPACITY_OPAQUE | options.cursorColor), &brush));
-    }
-
-    switch (paintType)
-    {
-    case CursorPaintType::Fill:
-    {
-        _d2dRenderTarget->FillRectangle(rect, brush.Get());
-        break;
-    }
-    case CursorPaintType::Outline:
-    {
-        // DrawRectangle in straddles physical pixels in an attempt to draw a line
-        // between them. To avoid this, bump the rectangle around by half the stroke width.
-        rect.top += 0.5f;
-        rect.left += 0.5f;
-        rect.bottom -= 0.5f;
-        rect.right -= 0.5f;
-
-        _d2dRenderTarget->DrawRectangle(rect, brush.Get());
-        break;
-    }
-    default:
-        return E_NOTIMPL;
-    }
-
     return S_OK;
 }
-CATCH_RETURN()
+
+// // Routine Description:
+// // - Draws a block at the given position to represent the cursor
+// // - May be a styled cursor at the character cell location that is less than a full block
+// // Arguments:
+// // - options - Packed options relevant to how to draw the cursor
+// // Return Value:
+// // - S_OK or relevant DirectX error.
+// [[nodiscard]] HRESULT DxEngine::PaintCursor(const CursorOptions& options) noexcept
+// try
+// {
+//     // if the cursor is off, do nothing - it should not be visible.
+//     if (!options.isOn)
+//     {
+//         return S_FALSE;
+//     }
+//     // Create rectangular block representing where the cursor can fill.
+//     D2D1_RECT_F rect = til::rectangle{ til::point{ options.coordCursor } }.scale_up(_glyphCell);
+
+//     // If we're double-width, make it one extra glyph wider
+//     if (options.fIsDoubleWidth)
+//     {
+//         rect.right += _glyphCell.width();
+//     }
+
+//     CursorPaintType paintType = CursorPaintType::Fill;
+
+//     switch (options.cursorType)
+//     {
+//     case CursorType::Legacy:
+//     {
+//         // Enforce min/max cursor height
+//         ULONG ulHeight = std::clamp(options.ulCursorHeightPercent, s_ulMinCursorHeightPercent, s_ulMaxCursorHeightPercent);
+//         ulHeight = (_glyphCell.height<ULONG>() * ulHeight) / 100;
+//         rect.top = rect.bottom - ulHeight;
+//         break;
+//     }
+//     case CursorType::VerticalBar:
+//     {
+//         // It can't be wider than one cell or we'll have problems in invalidation, so restrict here.
+//         // It's either the left + the proposed width from the ease of access setting, or
+//         // it's the right edge of the block cursor as a maximum.
+//         rect.right = std::min(rect.right, rect.left + options.cursorPixelWidth);
+//         break;
+//     }
+//     case CursorType::Underscore:
+//     {
+//         rect.top = rect.bottom - 1;
+//         break;
+//     }
+//     case CursorType::EmptyBox:
+//     {
+//         paintType = CursorPaintType::Outline;
+//         break;
+//     }
+//     case CursorType::FullBox:
+//     {
+//         break;
+//     }
+//     default:
+//         return E_NOTIMPL;
+//     }
+
+//     Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> brush = _d2dBrushForeground;
+
+//     if (options.fUseColor)
+//     {
+//         // Make sure to make the cursor opaque
+//         RETURN_IF_FAILED(_d2dRenderTarget->CreateSolidColorBrush(_ColorFFromColorRef(OPACITY_OPAQUE | options.cursorColor), &brush));
+//     }
+
+//     switch (paintType)
+//     {
+//     case CursorPaintType::Fill:
+//     {
+//         _d2dRenderTarget->FillRectangle(rect, brush.Get());
+//         break;
+//     }
+//     case CursorPaintType::Outline:
+//     {
+//         // DrawRectangle in straddles physical pixels in an attempt to draw a line
+//         // between them. To avoid this, bump the rectangle around by half the stroke width.
+//         rect.top += 0.5f;
+//         rect.left += 0.5f;
+//         rect.bottom -= 0.5f;
+//         rect.right -= 0.5f;
+
+//         _d2dRenderTarget->DrawRectangle(rect, brush.Get());
+//         break;
+//     }
+//     default:
+//         return E_NOTIMPL;
+//     }
+
+//     return S_OK;
+// }
+// CATCH_RETURN()
 
 // Routine Description:
 // - Paint terminal effects.
@@ -2247,3 +2245,9 @@ try
     LOG_IF_FAILED(InvalidateAll());
 }
 CATCH_LOG()
+
+[[nodiscard]] HRESULT DxEngine::PrepareRenderInfo(const RenderFrameInfo& info) noexcept
+{
+    _frameInfo = info;
+    return S_OK;
+}

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1414,107 +1414,17 @@ try
 }
 CATCH_RETURN()
 
+// Routine Description:
+// - Does nothing. Our cursor is drawn in CustomTextRenderer::DrawGlyphRun,
+//   either above or below the text.
+// Arguments:
+// - options - unused
+// Return Value:
+// - S_OK
 [[nodiscard]] HRESULT DxEngine::PaintCursor(const CursorOptions& /*options*/) noexcept
 {
     return S_OK;
 }
-
-// // Routine Description:
-// // - Draws a block at the given position to represent the cursor
-// // - May be a styled cursor at the character cell location that is less than a full block
-// // Arguments:
-// // - options - Packed options relevant to how to draw the cursor
-// // Return Value:
-// // - S_OK or relevant DirectX error.
-// [[nodiscard]] HRESULT DxEngine::PaintCursor(const CursorOptions& options) noexcept
-// try
-// {
-//     // if the cursor is off, do nothing - it should not be visible.
-//     if (!options.isOn)
-//     {
-//         return S_FALSE;
-//     }
-//     // Create rectangular block representing where the cursor can fill.
-//     D2D1_RECT_F rect = til::rectangle{ til::point{ options.coordCursor } }.scale_up(_glyphCell);
-
-//     // If we're double-width, make it one extra glyph wider
-//     if (options.fIsDoubleWidth)
-//     {
-//         rect.right += _glyphCell.width();
-//     }
-
-//     CursorPaintType paintType = CursorPaintType::Fill;
-
-//     switch (options.cursorType)
-//     {
-//     case CursorType::Legacy:
-//     {
-//         // Enforce min/max cursor height
-//         ULONG ulHeight = std::clamp(options.ulCursorHeightPercent, s_ulMinCursorHeightPercent, s_ulMaxCursorHeightPercent);
-//         ulHeight = (_glyphCell.height<ULONG>() * ulHeight) / 100;
-//         rect.top = rect.bottom - ulHeight;
-//         break;
-//     }
-//     case CursorType::VerticalBar:
-//     {
-//         // It can't be wider than one cell or we'll have problems in invalidation, so restrict here.
-//         // It's either the left + the proposed width from the ease of access setting, or
-//         // it's the right edge of the block cursor as a maximum.
-//         rect.right = std::min(rect.right, rect.left + options.cursorPixelWidth);
-//         break;
-//     }
-//     case CursorType::Underscore:
-//     {
-//         rect.top = rect.bottom - 1;
-//         break;
-//     }
-//     case CursorType::EmptyBox:
-//     {
-//         paintType = CursorPaintType::Outline;
-//         break;
-//     }
-//     case CursorType::FullBox:
-//     {
-//         break;
-//     }
-//     default:
-//         return E_NOTIMPL;
-//     }
-
-//     Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> brush = _d2dBrushForeground;
-
-//     if (options.fUseColor)
-//     {
-//         // Make sure to make the cursor opaque
-//         RETURN_IF_FAILED(_d2dRenderTarget->CreateSolidColorBrush(_ColorFFromColorRef(OPACITY_OPAQUE | options.cursorColor), &brush));
-//     }
-
-//     switch (paintType)
-//     {
-//     case CursorPaintType::Fill:
-//     {
-//         _d2dRenderTarget->FillRectangle(rect, brush.Get());
-//         break;
-//     }
-//     case CursorPaintType::Outline:
-//     {
-//         // DrawRectangle in straddles physical pixels in an attempt to draw a line
-//         // between them. To avoid this, bump the rectangle around by half the stroke width.
-//         rect.top += 0.5f;
-//         rect.left += 0.5f;
-//         rect.bottom -= 0.5f;
-//         rect.right -= 0.5f;
-
-//         _d2dRenderTarget->DrawRectangle(rect, brush.Get());
-//         break;
-//     }
-//     default:
-//         return E_NOTIMPL;
-//     }
-
-//     return S_OK;
-// }
-// CATCH_RETURN()
 
 // Routine Description:
 // - Paint terminal effects.
@@ -2246,6 +2156,17 @@ try
 }
 CATCH_LOG()
 
+// Method Description:
+// - Informs this render engine about certain state for this frame at the
+//   beginning of this frame. We'll use it to get information about the cursor
+//   before PaintCursor is called. This enables the DX renderer to draw the
+//   cursor underneath the text.
+// - This is called every frame. When the cursor is Off or out of frame, the
+//   info's cursorInfo will be set to std::nullopt;
+// Arguments:
+// - info - a RenderFrameInfo with information about the state of the cursor in this frame.
+// Return Value:
+// - S_OK
 [[nodiscard]] HRESULT DxEngine::PrepareRenderInfo(const RenderFrameInfo& info) noexcept
 {
     _frameInfo = info;

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1298,6 +1298,7 @@ try
                            _dwriteFactory.Get(),
                            spacing,
                            _glyphCell,
+                           {},
                            D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT);
 
     // Layout then render the text
@@ -1427,7 +1428,7 @@ enum class CursorPaintType
 // - options - Packed options relevant to how to draw the cursor
 // Return Value:
 // - S_OK or relevant DirectX error.
-[[nodiscard]] HRESULT DxEngine::PaintCursor(const IRenderEngine::CursorOptions& options) noexcept
+[[nodiscard]] HRESULT DxEngine::PaintCursor(const CursorOptions& options) noexcept
 try
 {
     // if the cursor is off, do nothing - it should not be visible.

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -77,6 +77,8 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT ScrollFrame() noexcept override;
 
+        [[nodiscard]] HRESULT PrepareRenderInfo(const RenderFrameInfo& info) noexcept override;
+
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
         [[nodiscard]] HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,
                                               COORD const coord,
@@ -201,6 +203,8 @@ namespace Microsoft::Console::Render
         D2D1_TEXT_ANTIALIAS_MODE _antialiasingMode;
 
         float _defaultTextBackgroundOpacity;
+
+        RenderFrameInfo _frameInfo;
 
         // DirectX constant buffers need to be a multiple of 16; align to pad the size.
         __declspec(align(16)) struct

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -162,9 +162,6 @@ namespace Microsoft::Console::Render
 
         static std::atomic<size_t> _tracelogCount;
 
-        static const ULONG s_ulMinCursorHeightPercent = 25;
-        static const ULONG s_ulMaxCursorHeightPercent = 100;
-
         // Device-Independent Resources
         ::Microsoft::WRL::ComPtr<ID2D1Factory> _d2dFactory;
         ::Microsoft::WRL::ComPtr<IDWriteFactory1> _dwriteFactory;

--- a/src/renderer/gdi/paint.cpp
+++ b/src/renderer/gdi/paint.cpp
@@ -507,7 +507,7 @@ using namespace Microsoft::Console::Render;
 // - options - Parameters that affect the way that the cursor is drawn
 // Return Value:
 // - S_OK, suitable GDI HRESULT error, or safemath error, or E_FAIL in a GDI error where a specific error isn't set.
-[[nodiscard]] HRESULT GdiEngine::PaintCursor(const IRenderEngine::CursorOptions& options) noexcept
+[[nodiscard]] HRESULT GdiEngine::PaintCursor(const CursorOptions& options) noexcept
 {
     // if the cursor is off, do nothing - it should not be visible.
     if (!options.isOn)

--- a/src/renderer/inc/CursorOptions.h
+++ b/src/renderer/inc/CursorOptions.h
@@ -1,0 +1,50 @@
+/*++
+Copyright (c) Microsoft Corporation
+Licensed under the MIT license.
+
+Module Name:
+- CursorOptions.h
+
+Abstract:
+- A collection of state about the cursor that a render engine might need to display the cursor correctly.
+
+Author(s):
+- Mike Griese, 03-Jun-2020
+--*/
+
+#pragma once
+
+#include "../../inc/conattrs.hpp"
+
+namespace Microsoft::Console::Render
+{
+    struct CursorOptions
+    {
+        // Character cell in the grid to draw at
+        // This is relative to the viewport, not the buffer.
+        COORD coordCursor;
+
+        // For an underscore type _ cursor, how tall it should be as a % of cell height
+        ULONG ulCursorHeightPercent;
+
+        // For a vertical bar type | cursor, how many pixels wide it should be per ease of access preferences
+        ULONG cursorPixelWidth;
+
+        // Whether to draw the cursor 2 cells wide (+X from the coordinate given)
+        bool fIsDoubleWidth;
+
+        // Chooses a special cursor type like a full box, a vertical bar, etc.
+        CursorType cursorType;
+
+        // Specifies to use the color below instead of the default color
+        bool fUseColor;
+
+        // Color to use for drawing instead of the default
+        COLORREF cursorColor;
+
+        // Is the cursor currently visually visible?
+        // If the cursor has blinked off, this is false.
+        // if the cursor has blinked on, this is true.
+        bool isOn;
+    };
+}

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -14,7 +14,7 @@ Author(s):
 
 #pragma once
 
-#include "../../inc/conattrs.hpp"
+#include "CursorOptions.h"
 #include "Cluster.hpp"
 #include "FontInfoDesired.hpp"
 
@@ -30,36 +30,6 @@ namespace Microsoft::Console::Render
             Bottom = 0x2,
             Left = 0x4,
             Right = 0x8
-        };
-
-        struct CursorOptions
-        {
-            // Character cell in the grid to draw at
-            // This is relative to the viewport, not the buffer.
-            COORD coordCursor;
-
-            // For an underscore type _ cursor, how tall it should be as a % of cell height
-            ULONG ulCursorHeightPercent;
-
-            // For a vertical bar type | cursor, how many pixels wide it should be per ease of access preferences
-            ULONG cursorPixelWidth;
-
-            // Whether to draw the cursor 2 cells wide (+X from the coordinate given)
-            bool fIsDoubleWidth;
-
-            // Chooses a special cursor type like a full box, a vertical bar, etc.
-            CursorType cursorType;
-
-            // Specifies to use the color below instead of the default color
-            bool fUseColor;
-
-            // Color to use for drawing instead of the default
-            COLORREF cursorColor;
-
-            // Is the cursor currently visually visible?
-            // If the cursor has blinked off, this is false.
-            // if the cursor has blinked on, this is true.
-            bool isOn;
         };
 
         virtual ~IRenderEngine() = 0;

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -20,6 +20,11 @@ Author(s):
 
 namespace Microsoft::Console::Render
 {
+    struct RenderFrameInfo
+    {
+        std::optional<CursorOptions> cursorInfo;
+    };
+
     class IRenderEngine
     {
     public:
@@ -59,6 +64,8 @@ namespace Microsoft::Console::Render
         [[nodiscard]] virtual HRESULT InvalidateCircling(_Out_ bool* const pForcePaint) noexcept = 0;
 
         [[nodiscard]] virtual HRESULT InvalidateTitle(const std::wstring& proposedTitle) noexcept = 0;
+
+        [[nodiscard]] virtual HRESULT PrepareRenderInfo(const RenderFrameInfo& /*info*/) noexcept { return S_FALSE; };
 
         [[nodiscard]] virtual HRESULT PaintBackground() noexcept = 0;
         [[nodiscard]] virtual HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -65,7 +65,7 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] virtual HRESULT InvalidateTitle(const std::wstring& proposedTitle) noexcept = 0;
 
-        [[nodiscard]] virtual HRESULT PrepareRenderInfo(const RenderFrameInfo& /*info*/) noexcept { return S_FALSE; };
+        [[nodiscard]] virtual HRESULT PrepareRenderInfo(const RenderFrameInfo& info) noexcept = 0;
 
         [[nodiscard]] virtual HRESULT PaintBackground() noexcept = 0;
         [[nodiscard]] virtual HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,

--- a/src/renderer/inc/RenderEngineBase.hpp
+++ b/src/renderer/inc/RenderEngineBase.hpp
@@ -38,6 +38,8 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT UpdateTitle(const std::wstring& newTitle) noexcept override;
 
+        [[nodiscard]] HRESULT PrepareRenderInfo(const RenderFrameInfo& info) noexcept override;
+
     protected:
         [[nodiscard]] virtual HRESULT _DoUpdateTitle(const std::wstring& newTitle) noexcept = 0;
 

--- a/src/renderer/uia/UiaRenderer.cpp
+++ b/src/renderer/uia/UiaRenderer.cpp
@@ -352,7 +352,7 @@ CATCH_RETURN();
 // - options - Packed options relevant to how to draw the cursor
 // Return Value:
 // - S_FALSE
-[[nodiscard]] HRESULT UiaEngine::PaintCursor(const IRenderEngine::CursorOptions& /*options*/) noexcept
+[[nodiscard]] HRESULT UiaEngine::PaintCursor(const CursorOptions& /*options*/) noexcept
 {
     return S_FALSE;
 }

--- a/src/renderer/vt/XtermEngine.cpp
+++ b/src/renderer/vt/XtermEngine.cpp
@@ -199,7 +199,7 @@ XtermEngine::XtermEngine(_In_ wil::unique_hfile hPipe,
 // - options - Options that affect the presentation of the cursor
 // Return Value:
 // - S_OK or suitable HRESULT error from writing pipe.
-[[nodiscard]] HRESULT XtermEngine::PaintCursor(const IRenderEngine::CursorOptions& options) noexcept
+[[nodiscard]] HRESULT XtermEngine::PaintCursor(const CursorOptions& options) noexcept
 {
     // PaintCursor is only called when the cursor is in fact visible in a single
     // frame. When this is called, mark _nextCursorIsVisible as true. At the end

--- a/src/renderer/vt/paint.cpp
+++ b/src/renderer/vt/paint.cpp
@@ -156,7 +156,7 @@ using namespace Microsoft::Console::Types;
 // - options - Options that affect the presentation of the cursor
 // Return Value:
 // - S_OK or suitable HRESULT error from writing pipe.
-[[nodiscard]] HRESULT VtEngine::PaintCursor(const IRenderEngine::CursorOptions& options) noexcept
+[[nodiscard]] HRESULT VtEngine::PaintCursor(const CursorOptions& options) noexcept
 {
     _trace.TracePaintCursor(options.coordCursor);
 

--- a/src/renderer/wddmcon/WddmConRenderer.cpp
+++ b/src/renderer/wddmcon/WddmConRenderer.cpp
@@ -300,7 +300,7 @@ bool WddmConEngine::IsInitialized()
     return S_OK;
 }
 
-[[nodiscard]] HRESULT WddmConEngine::PaintCursor(const IRenderEngine::CursorOptions& /*options*/) noexcept
+[[nodiscard]] HRESULT WddmConEngine::PaintCursor(const CursorOptions& /*options*/) noexcept
 {
     return S_OK;
 }


### PR DESCRIPTION
## Summary of the Pull Request

![textAboveCursor003](https://user-images.githubusercontent.com/18356694/83681722-67a24d00-a5a8-11ea-8d9b-2d294065e4e4.gif)

This is the plan that @miniksa suggested to me. Instead of trying to do lots of work in all the renderers to do backgrounds as one pass, and foregrounds as another, we can localize this change to basically just the DX renderer. 
1. First, we give the DX engine a "heads up" on where the cursor is going to be drawn during the frame, in `PrepareRenderInfo`.
  - This function is left unimplemented in the other render engines.
2. While printing runs of text, the DX renderer will try to paint the cursor in `CustomTextRenderer::DrawGlyphRun` INSTEAD of `DxEngine::PaintCursor`. This lets us weave the cursor background between the text background and the text. 

## References

* #6151 was a spec in this general area. I should probably go back and update it, and we should probably approve that first.
* #6193 is also right up in this mess

## PR Checklist
* [x] Closes #1203
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated

## Detailed Description of the Pull Request / Additional comments

* This is essentially `"cursorTextColor": "textForeground"` from #6151.
* A follow up work item is needed to add support for the current behavior, (`"cursorTextColor": null`), and hooking up that setting to the renderer.

