### PR TITLE
Add a helper to skip nuget restore during local builds

### DIFF
--- a/tools/bcz.cmd
+++ b/tools/bcz.cmd
@@ -65,8 +65,12 @@ if "%_EXCLUSIVE%" == "1" (
     if "%PROJECT_NAME%" == "" ( goto :eof ) else echo Building only %PROJECT_NAME%
 )
 
-echo Performing nuget restore...
-nuget.exe restore %OPENCON%\OpenConsole.sln
+if "%_SKIP_NUGET_RESTORE%" == "1" (
+    echo Skipped nuget restore
+) else (
+    echo Performing nuget restore...
+    nuget.exe restore %OPENCON%\OpenConsole.sln
+)
 
 set _BUILD_CMDLINE="%MSBUILD%" %OPENCON%\OpenConsole.sln /t:"%_MSBUILD_TARGET%" /m /p:Configuration=%_LAST_BUILD_CONF% /p:Platform=%ARCH% %_APPX_ARGS%
 


### PR DESCRIPTION
Running `nuget restore` on every build is pretty unnecessary - usually, you _know_ when you need to run it. For the inner dev loop, this is a few seconds on every `bx` build. 

This adds a environment variable you can set to skip the `nuget restore` part of a `bcz` build.

Add the following to your `.razzlerc.cmd`:
```cmd
set _SKIP_NUGET_RESTORE=1
```

and `bcz` (and the other helpers) _won't_ perform a nuget restore on every build.

