### PR TITLE
Allow starting selections from padding area

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2332,7 +2332,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         }
 
         // Account for the size of any padding
-        const auto padding = SwapChainPanel().Margin();
+        const auto padding = GetPadding();
         width += padding.Left + padding.Right;
         height += padding.Top + padding.Bottom;
 
@@ -2352,7 +2352,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         const auto fontSize = _actualFont.GetSize();
         const auto fontDimension = widthOrHeight ? fontSize.X : fontSize.Y;
 
-        const auto padding = SwapChainPanel().Margin();
+        const auto padding = GetPadding();
         auto nonTerminalArea = gsl::narrow_cast<float>(widthOrHeight ?
                                                            padding.Left + padding.Right :
                                                            padding.Top + padding.Bottom);
@@ -2484,7 +2484,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     {
         // cursorPosition is DIPs, relative to SwapChainPanel origin
         const til::point cursorPosInDIPs{ til::math::rounding, cursorPosition };
-        const til::size marginsInDips{ til::math::rounding, SwapChainPanel().Margin().Left, SwapChainPanel().Margin().Top };
+        const til::size marginsInDips{ til::math::rounding, GetPadding().Left, GetPadding().Top };
 
         // This point is the location of the cursor within the actual grid of characters, in DIPs
         const til::point relativeToMarginInDIPs = cursorPosInDIPs - marginsInDips;

--- a/src/cascadia/TerminalControl/TermControl.xaml
+++ b/src/cascadia/TerminalControl/TermControl.xaml
@@ -38,13 +38,17 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
-            <Grid Grid.Column="0">
+            <Grid x:Name="TerminalArea"
+                  Grid.Column="0"
+                  Visibility="Visible"
+                  Background="Transparent"
+                  PointerPressed="_PointerPressedHandler"
+                  PointerMoved="_PointerMovedHandler"
+                  PointerReleased="_PointerReleasedHandler">
+
                 <SwapChainPanel x:Name="SwapChainPanel"
                                 SizeChanged="_SwapChainSizeChanged"
-                                CompositionScaleChanged="_SwapChainScaleChanged"
-                                PointerPressed="_PointerPressedHandler"
-                                PointerMoved="_PointerMovedHandler"
-                                PointerReleased="_PointerReleasedHandler" />
+                                CompositionScaleChanged="_SwapChainScaleChanged" />
 
                 <!-- Putting this in a grid w/ the SwapChainPanel
                 ensures that it's always aligned w/ the scrollbar -->

--- a/src/cascadia/TerminalControl/TermControl.xaml
+++ b/src/cascadia/TerminalControl/TermControl.xaml
@@ -38,8 +38,7 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
-            <Grid x:Name="TerminalArea"
-                  Grid.Column="0"
+            <Grid Grid.Column="0"
                   Visibility="Visible"
                   Background="Transparent"
                   PointerPressed="_PointerPressedHandler"


### PR DESCRIPTION
WinUI's `Margin` and `Padding` work very similarly. `Margin` distances
ourselves from our parent. Whereas `Padding` distances our children from
ourselves.

Terminal's `padding` setting is actually implemented by defining
`Margin` on the SwapChainPanel. This means that the "padding" that is
created is actually belongs to SwapChainPanel's parent: Grid (not to be
confused with its parent, "RootGrid").

When a user clicks on the padded area, input goes to Grid. But there's a
twist: you can't actually hit Grid. To be able to hit Grid, you can't
just set IsHitTestVisible. You need to set it's Visibility to Visible,
and it's Background to Transparent (not null) [2].

## Validation Steps Performed

- [X] Start a selection from the padding area
- [X] Click on a SearchBox if one is available
   - The SearchBox gets first dibs on the hit test so none gets through
     to the SwapChainPanel

## References
[1] https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.uielement.ishittestvisible
[2] https://docs.microsoft.com/en-us/windows/uwp/xaml-platform/events-and-routed-events-overview#hit-testing-and-input-events

Closes #5626