### PR TITLE
Make the conversion from WORD to TextAttribute explicit

### DIFF
--- a/src/buffer/out/TextAttribute.hpp
+++ b/src/buffer/out/TextAttribute.hpp
@@ -40,7 +40,7 @@ public:
     {
     }
 
-    constexpr TextAttribute(const WORD wLegacyAttr) noexcept :
+    explicit constexpr TextAttribute(const WORD wLegacyAttr) noexcept :
         _wAttrLegacy{ gsl::narrow_cast<WORD>(wLegacyAttr & META_ATTRS) },
         _foreground{ gsl::narrow_cast<BYTE>(wLegacyAttr & FG_ATTRS), true },
         _background{ gsl::narrow_cast<BYTE>((wLegacyAttr & BG_ATTRS) >> 4), true },

--- a/src/host/conareainfo.cpp
+++ b/src/host/conareainfo.cpp
@@ -37,8 +37,8 @@ ConversionAreaInfo::ConversionAreaInfo(const COORD bufferSize,
     THROW_IF_NTSTATUS_FAILED(SCREEN_INFORMATION::CreateInstance(windowSize,
                                                                 fontInfo,
                                                                 bufferSize,
-                                                                { fill.Attributes },
-                                                                { popupFill.Attributes },
+                                                                TextAttribute{ fill.Attributes },
+                                                                TextAttribute{ popupFill.Attributes },
                                                                 0,
                                                                 &pNewScreen));
 

--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -577,7 +577,7 @@ void ApiRoutines::GetLargestConsoleWindowSizeImpl(const SCREEN_INFORMATION& cont
             gci.SetColorTableEntry(i, data.ColorTable[i]);
         }
 
-        context.SetDefaultAttributes({ data.wAttributes }, { data.wPopupAttributes });
+        context.SetDefaultAttributes(TextAttribute{ data.wAttributes }, TextAttribute{ data.wPopupAttributes });
 
         const Viewport requestedViewport = Viewport::FromExclusive(data.srWindow);
 

--- a/src/host/popup.cpp
+++ b/src/host/popup.cpp
@@ -32,7 +32,7 @@ Popup::Popup(SCREEN_INFORMATION& screenInfo, const COORD proposedSize) :
     _screenInfo(screenInfo),
     _userInputFunction(&Popup::_getUserInputInternal)
 {
-    _attributes = screenInfo.GetPopupAttributes()->GetLegacyAttributes();
+    _attributes = *screenInfo.GetPopupAttributes();
 
     const COORD size = _CalculateSize(screenInfo, proposedSize);
     const COORD origin = _CalculateOrigin(screenInfo, size);

--- a/src/host/ut_host/AttrRowTests.cpp
+++ b/src/host/ut_host/AttrRowTests.cpp
@@ -110,7 +110,7 @@ class AttrRowTests
         {
             TextAttributeRun* pRun = &pChain->_list[iChain];
 
-            pRun->SetAttributes(iChain); // Just use the chain position as the value
+            pRun->SetAttributes(TextAttribute{ gsl::narrow_cast<WORD>(iChain) }); // Just use the chain position as the value
             pRun->SetLength(sChainSegLength);
         }
 
@@ -269,11 +269,11 @@ class AttrRowTests
         ATTR_ROW originalRow{ static_cast<UINT>(_sDefaultLength), _DefaultAttr };
         originalRow._list.resize(3);
         originalRow._cchRowWidth = 10;
-        originalRow._list[0].SetAttributes('R');
+        originalRow._list[0].SetAttributes(TextAttribute{ 'R' });
         originalRow._list[0].SetLength(3);
-        originalRow._list[1].SetAttributes('B');
+        originalRow._list[1].SetAttributes(TextAttribute{ 'B' });
         originalRow._list[1].SetLength(5);
-        originalRow._list[2].SetAttributes('G');
+        originalRow._list[2].SetAttributes(TextAttribute{ 'G' });
         originalRow._list[2].SetLength(2);
         LogChain(L"Original: ", originalRow._list);
 
@@ -286,11 +286,11 @@ class AttrRowTests
 
         std::vector<TextAttributeRun> insertRow;
         insertRow.resize(cInsertRow);
-        insertRow[0].SetAttributes(ch1);
+        insertRow[0].SetAttributes(TextAttribute{ ch1 });
         insertRow[0].SetLength(uiChar1Length);
         if (fUseStr2)
         {
-            insertRow[1].SetAttributes(ch2);
+            insertRow[1].SetAttributes(TextAttribute{ ch2 });
             insertRow[1].SetLength(uiChar2Length);
         }
 

--- a/src/host/ut_host/OutputCellIteratorTests.cpp
+++ b/src/host/ut_host/OutputCellIteratorTests.cpp
@@ -375,7 +375,7 @@ class OutputCellIteratorTests
         {
             auto expected = OutputCellView({},
                                            {},
-                                           { color },
+                                           TextAttribute{ color },
                                            TextAttributeBehavior::StoredOnly);
 
             VERIFY_IS_TRUE(it);
@@ -409,7 +409,7 @@ class OutputCellIteratorTests
         {
             auto expected = OutputCellView({ &ci.Char.UnicodeChar, 1 },
                                            {},
-                                           { ci.Attributes },
+                                           TextAttribute{ ci.Attributes },
                                            TextAttributeBehavior::Stored);
 
             VERIFY_IS_TRUE(it);
@@ -429,7 +429,7 @@ class OutputCellIteratorTests
         for (auto i = 0; i < 5; i++)
         {
             const std::wstring pair(L"\xd834\xdd1e");
-            OutputCell cell(pair, {}, gsl::narrow<WORD>(i));
+            OutputCell cell(pair, {}, TextAttribute{ gsl::narrow<WORD>(i) });
             cells.push_back(cell);
         }
 

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -2194,7 +2194,7 @@ void ScreenBufferTests::SetDefaultsIndividuallyBothDefault()
 
     gci.SetDefaultForegroundColor(yellow);
     gci.SetDefaultBackgroundColor(magenta);
-    si.SetDefaultAttributes(gci.GetDefaultAttributes(), { gci.GetPopupFillAttribute() });
+    si.SetDefaultAttributes(gci.GetDefaultAttributes(), TextAttribute{ gci.GetPopupFillAttribute() });
 
     Log::Comment(NoThrowString().Format(L"Write 6 X's:"));
     Log::Comment(NoThrowString().Format(L"  The first in default-fg on default-bg (yellow on magenta)"));
@@ -2303,7 +2303,7 @@ void ScreenBufferTests::SetDefaultsTogether()
 
     gci.SetDefaultForegroundColor(yellow);
     gci.SetDefaultBackgroundColor(magenta);
-    si.SetDefaultAttributes(gci.GetDefaultAttributes(), { gci.GetPopupFillAttribute() });
+    si.SetDefaultAttributes(gci.GetDefaultAttributes(), TextAttribute{ gci.GetPopupFillAttribute() });
 
     Log::Comment(NoThrowString().Format(L"Write 6 X's:"));
     Log::Comment(NoThrowString().Format(L"  The first in default-fg on default-bg (yellow on magenta)"));
@@ -2378,7 +2378,7 @@ void ScreenBufferTests::ReverseResetWithDefaultBackground()
 
     gci.SetDefaultForegroundColor(INVALID_COLOR);
     gci.SetDefaultBackgroundColor(magenta);
-    si.SetDefaultAttributes(gci.GetDefaultAttributes(), { gci.GetPopupFillAttribute() });
+    si.SetDefaultAttributes(gci.GetDefaultAttributes(), TextAttribute{ gci.GetPopupFillAttribute() });
 
     Log::Comment(NoThrowString().Format(L"Write 3 X's:"));
     Log::Comment(NoThrowString().Format(L"  The first in default-attr on default color (magenta)"));
@@ -2446,7 +2446,7 @@ void ScreenBufferTests::BackspaceDefaultAttrs()
     COLORREF magenta = RGB(255, 0, 255);
 
     gci.SetDefaultBackgroundColor(magenta);
-    si.SetDefaultAttributes(gci.GetDefaultAttributes(), { gci.GetPopupFillAttribute() });
+    si.SetDefaultAttributes(gci.GetDefaultAttributes(), TextAttribute{ gci.GetPopupFillAttribute() });
 
     Log::Comment(NoThrowString().Format(L"Write 2 X's, then backspace one."));
 
@@ -2509,7 +2509,7 @@ void ScreenBufferTests::BackspaceDefaultAttrsWriteCharsLegacy()
     COLORREF magenta = RGB(255, 0, 255);
 
     gci.SetDefaultBackgroundColor(magenta);
-    si.SetDefaultAttributes(gci.GetDefaultAttributes(), { gci.GetPopupFillAttribute() });
+    si.SetDefaultAttributes(gci.GetDefaultAttributes(), TextAttribute{ gci.GetPopupFillAttribute() });
 
     Log::Comment(NoThrowString().Format(L"Write 2 X's, then backspace one."));
 
@@ -2577,7 +2577,7 @@ void ScreenBufferTests::BackspaceDefaultAttrsInPrompt()
     COLORREF magenta = RGB(255, 0, 255);
 
     gci.SetDefaultBackgroundColor(magenta);
-    si.SetDefaultAttributes(gci.GetDefaultAttributes(), { gci.GetPopupFillAttribute() });
+    si.SetDefaultAttributes(gci.GetDefaultAttributes(), TextAttribute{ gci.GetPopupFillAttribute() });
     TextAttribute expectedDefaults{};
 
     Log::Comment(NoThrowString().Format(L"Write 3 X's, move to the left, then delete-char the second."));
@@ -3811,7 +3811,7 @@ void ScreenBufferTests::EraseScrollbackTests()
     }
 
     // Set the colors to Green on Red. This should have no effect on the results.
-    si.SetAttributes({ FOREGROUND_GREEN | BACKGROUND_RED });
+    si.SetAttributes(TextAttribute{ FOREGROUND_GREEN | BACKGROUND_RED });
 
     // Place the cursor in the center.
     const short centerX = bufferWidth / 2;

--- a/src/interactivity/win32/menu.cpp
+++ b/src/interactivity/win32/menu.cpp
@@ -584,7 +584,7 @@ void Menu::s_PropertiesUpdate(PCONSOLE_STATE_INFO pStateInfo)
     gci.SetDefaultBackgroundColor(pStateInfo->DefaultBackground);
 
     // Set the screen info's default text attributes to defaults -
-    ScreenInfo.SetDefaultAttributes(gci.GetDefaultAttributes(), { gci.GetPopupFillAttribute() });
+    ScreenInfo.SetDefaultAttributes(gci.GetDefaultAttributes(), TextAttribute{ gci.GetPopupFillAttribute() });
 
     CommandHistory::s_ResizeAll(pStateInfo->HistoryBufferSize);
     gci.SetNumberOfHistoryBuffers(pStateInfo->NumberOfHistoryBuffers);

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -630,7 +630,7 @@ public:
         _expectedCursorVisible = _cursorVisible;
 
         // Attribute default is gray on black.
-        _attribute = FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED;
+        _attribute = TextAttribute{ FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED };
         _expectedAttribute = _attribute;
     }
 
@@ -1274,238 +1274,238 @@ public:
         {
         case DispatchTypes::GraphicsOptions::Off:
             Log::Comment(L"Testing graphics 'Off/Reset'");
-            _testGetSet->_attribute = (WORD)~_testGetSet->s_defaultFill;
-            _testGetSet->_expectedAttribute = {};
+            _testGetSet->_attribute = TextAttribute{ (WORD)~_testGetSet->s_defaultFill };
+            _testGetSet->_expectedAttribute = TextAttribute{};
             break;
         case DispatchTypes::GraphicsOptions::BoldBright:
             Log::Comment(L"Testing graphics 'Bold/Bright'");
-            _testGetSet->_attribute = 0;
-            _testGetSet->_expectedAttribute = 0;
+            _testGetSet->_attribute = TextAttribute{ 0 };
+            _testGetSet->_expectedAttribute = TextAttribute{ 0 };
             _testGetSet->_expectedAttribute.SetBold(true);
             break;
         case DispatchTypes::GraphicsOptions::Underline:
             Log::Comment(L"Testing graphics 'Underline'");
-            _testGetSet->_attribute = 0;
-            _testGetSet->_expectedAttribute = COMMON_LVB_UNDERSCORE;
+            _testGetSet->_attribute = TextAttribute{ 0 };
+            _testGetSet->_expectedAttribute = TextAttribute{ COMMON_LVB_UNDERSCORE };
             break;
         case DispatchTypes::GraphicsOptions::Negative:
             Log::Comment(L"Testing graphics 'Negative'");
-            _testGetSet->_attribute = 0;
-            _testGetSet->_expectedAttribute = COMMON_LVB_REVERSE_VIDEO;
+            _testGetSet->_attribute = TextAttribute{ 0 };
+            _testGetSet->_expectedAttribute = TextAttribute{ COMMON_LVB_REVERSE_VIDEO };
             break;
         case DispatchTypes::GraphicsOptions::NoUnderline:
             Log::Comment(L"Testing graphics 'No Underline'");
-            _testGetSet->_attribute = COMMON_LVB_UNDERSCORE;
-            _testGetSet->_expectedAttribute = 0;
+            _testGetSet->_attribute = TextAttribute{ COMMON_LVB_UNDERSCORE };
+            _testGetSet->_expectedAttribute = TextAttribute{ 0 };
             break;
         case DispatchTypes::GraphicsOptions::Positive:
             Log::Comment(L"Testing graphics 'Positive'");
-            _testGetSet->_attribute = COMMON_LVB_REVERSE_VIDEO;
-            _testGetSet->_expectedAttribute = 0;
+            _testGetSet->_attribute = TextAttribute{ COMMON_LVB_REVERSE_VIDEO };
+            _testGetSet->_expectedAttribute = TextAttribute{ 0 };
             break;
         case DispatchTypes::GraphicsOptions::ForegroundBlack:
             Log::Comment(L"Testing graphics 'Foreground Color Black'");
-            _testGetSet->_attribute = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY;
+            _testGetSet->_attribute = TextAttribute{ FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedForeground(0);
             break;
         case DispatchTypes::GraphicsOptions::ForegroundBlue:
             Log::Comment(L"Testing graphics 'Foreground Color Blue'");
-            _testGetSet->_attribute = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY;
+            _testGetSet->_attribute = TextAttribute{ FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedForeground(FOREGROUND_BLUE);
             break;
         case DispatchTypes::GraphicsOptions::ForegroundGreen:
             Log::Comment(L"Testing graphics 'Foreground Color Green'");
-            _testGetSet->_attribute = FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY;
+            _testGetSet->_attribute = TextAttribute{ FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedForeground(FOREGROUND_GREEN);
             break;
         case DispatchTypes::GraphicsOptions::ForegroundCyan:
             Log::Comment(L"Testing graphics 'Foreground Color Cyan'");
-            _testGetSet->_attribute = FOREGROUND_RED | FOREGROUND_INTENSITY;
+            _testGetSet->_attribute = TextAttribute{ FOREGROUND_RED | FOREGROUND_INTENSITY };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedForeground(FOREGROUND_BLUE | FOREGROUND_GREEN);
             break;
         case DispatchTypes::GraphicsOptions::ForegroundRed:
             Log::Comment(L"Testing graphics 'Foreground Color Red'");
-            _testGetSet->_attribute = FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_INTENSITY;
+            _testGetSet->_attribute = TextAttribute{ FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_INTENSITY };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedForeground(FOREGROUND_RED);
             break;
         case DispatchTypes::GraphicsOptions::ForegroundMagenta:
             Log::Comment(L"Testing graphics 'Foreground Color Magenta'");
-            _testGetSet->_attribute = FOREGROUND_GREEN | FOREGROUND_INTENSITY;
+            _testGetSet->_attribute = TextAttribute{ FOREGROUND_GREEN | FOREGROUND_INTENSITY };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedForeground(FOREGROUND_BLUE | FOREGROUND_RED);
             break;
         case DispatchTypes::GraphicsOptions::ForegroundYellow:
             Log::Comment(L"Testing graphics 'Foreground Color Yellow'");
-            _testGetSet->_attribute = FOREGROUND_BLUE | FOREGROUND_INTENSITY;
+            _testGetSet->_attribute = TextAttribute{ FOREGROUND_BLUE | FOREGROUND_INTENSITY };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedForeground(FOREGROUND_GREEN | FOREGROUND_RED);
             break;
         case DispatchTypes::GraphicsOptions::ForegroundWhite:
             Log::Comment(L"Testing graphics 'Foreground Color White'");
-            _testGetSet->_attribute = FOREGROUND_INTENSITY;
+            _testGetSet->_attribute = TextAttribute{ FOREGROUND_INTENSITY };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedForeground(FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED);
             break;
         case DispatchTypes::GraphicsOptions::ForegroundDefault:
             Log::Comment(L"Testing graphics 'Foreground Color Default'");
-            _testGetSet->_attribute = (WORD)~_testGetSet->s_wDefaultAttribute; // set the current attribute to the opposite of default so we can ensure all relevant bits flip.
+            _testGetSet->_attribute = TextAttribute{ (WORD)~_testGetSet->s_wDefaultAttribute }; // set the current attribute to the opposite of default so we can ensure all relevant bits flip.
             // To get expected value, take what we started with and change ONLY the background series of bits to what the Default says.
             _testGetSet->_expectedAttribute = _testGetSet->_attribute; // expect = starting
             _testGetSet->_expectedAttribute.SetDefaultForeground(); // set the foreground as default
             break;
         case DispatchTypes::GraphicsOptions::BackgroundBlack:
             Log::Comment(L"Testing graphics 'Background Color Black'");
-            _testGetSet->_attribute = BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE | BACKGROUND_INTENSITY;
+            _testGetSet->_attribute = TextAttribute{ BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE | BACKGROUND_INTENSITY };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedBackground(0);
             break;
         case DispatchTypes::GraphicsOptions::BackgroundBlue:
             Log::Comment(L"Testing graphics 'Background Color Blue'");
-            _testGetSet->_attribute = BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_INTENSITY;
+            _testGetSet->_attribute = TextAttribute{ BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_INTENSITY };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedBackground(BACKGROUND_BLUE >> 4);
             break;
         case DispatchTypes::GraphicsOptions::BackgroundGreen:
             Log::Comment(L"Testing graphics 'Background Color Green'");
-            _testGetSet->_attribute = BACKGROUND_RED | BACKGROUND_BLUE | BACKGROUND_INTENSITY;
+            _testGetSet->_attribute = TextAttribute{ BACKGROUND_RED | BACKGROUND_BLUE | BACKGROUND_INTENSITY };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedBackground(BACKGROUND_GREEN >> 4);
             break;
         case DispatchTypes::GraphicsOptions::BackgroundCyan:
             Log::Comment(L"Testing graphics 'Background Color Cyan'");
-            _testGetSet->_attribute = BACKGROUND_RED | BACKGROUND_INTENSITY;
+            _testGetSet->_attribute = TextAttribute{ BACKGROUND_RED | BACKGROUND_INTENSITY };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedBackground((BACKGROUND_BLUE | BACKGROUND_GREEN) >> 4);
             break;
         case DispatchTypes::GraphicsOptions::BackgroundRed:
             Log::Comment(L"Testing graphics 'Background Color Red'");
-            _testGetSet->_attribute = BACKGROUND_BLUE | BACKGROUND_GREEN | BACKGROUND_INTENSITY;
+            _testGetSet->_attribute = TextAttribute{ BACKGROUND_BLUE | BACKGROUND_GREEN | BACKGROUND_INTENSITY };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedBackground(BACKGROUND_RED >> 4);
             break;
         case DispatchTypes::GraphicsOptions::BackgroundMagenta:
             Log::Comment(L"Testing graphics 'Background Color Magenta'");
-            _testGetSet->_attribute = BACKGROUND_GREEN | BACKGROUND_INTENSITY;
+            _testGetSet->_attribute = TextAttribute{ BACKGROUND_GREEN | BACKGROUND_INTENSITY };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedBackground((BACKGROUND_BLUE | BACKGROUND_RED) >> 4);
             break;
         case DispatchTypes::GraphicsOptions::BackgroundYellow:
             Log::Comment(L"Testing graphics 'Background Color Yellow'");
-            _testGetSet->_attribute = BACKGROUND_BLUE | BACKGROUND_INTENSITY;
+            _testGetSet->_attribute = TextAttribute{ BACKGROUND_BLUE | BACKGROUND_INTENSITY };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedBackground((BACKGROUND_GREEN | BACKGROUND_RED) >> 4);
             break;
         case DispatchTypes::GraphicsOptions::BackgroundWhite:
             Log::Comment(L"Testing graphics 'Background Color White'");
-            _testGetSet->_attribute = BACKGROUND_INTENSITY;
+            _testGetSet->_attribute = TextAttribute{ BACKGROUND_INTENSITY };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedBackground((BACKGROUND_BLUE | BACKGROUND_GREEN | BACKGROUND_RED) >> 4);
             break;
         case DispatchTypes::GraphicsOptions::BackgroundDefault:
             Log::Comment(L"Testing graphics 'Background Color Default'");
-            _testGetSet->_attribute = (WORD)~_testGetSet->s_wDefaultAttribute; // set the current attribute to the opposite of default so we can ensure all relevant bits flip.
+            _testGetSet->_attribute = TextAttribute{ (WORD)~_testGetSet->s_wDefaultAttribute }; // set the current attribute to the opposite of default so we can ensure all relevant bits flip.
             // To get expected value, take what we started with and change ONLY the background series of bits to what the Default says.
             _testGetSet->_expectedAttribute = _testGetSet->_attribute; // expect = starting
             _testGetSet->_expectedAttribute.SetDefaultBackground(); // set the background as default
             break;
         case DispatchTypes::GraphicsOptions::BrightForegroundBlack:
             Log::Comment(L"Testing graphics 'Bright Foreground Color Black'");
-            _testGetSet->_attribute = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
+            _testGetSet->_attribute = TextAttribute{ FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedForeground(FOREGROUND_INTENSITY);
             break;
         case DispatchTypes::GraphicsOptions::BrightForegroundBlue:
             Log::Comment(L"Testing graphics 'Bright Foreground Color Blue'");
-            _testGetSet->_attribute = FOREGROUND_RED | FOREGROUND_GREEN;
+            _testGetSet->_attribute = TextAttribute{ FOREGROUND_RED | FOREGROUND_GREEN };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedForeground(FOREGROUND_INTENSITY | FOREGROUND_BLUE);
             break;
         case DispatchTypes::GraphicsOptions::BrightForegroundGreen:
             Log::Comment(L"Testing graphics 'Bright Foreground Color Green'");
-            _testGetSet->_attribute = FOREGROUND_RED | FOREGROUND_BLUE;
+            _testGetSet->_attribute = TextAttribute{ FOREGROUND_RED | FOREGROUND_BLUE };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedForeground(FOREGROUND_INTENSITY | FOREGROUND_GREEN);
             break;
         case DispatchTypes::GraphicsOptions::BrightForegroundCyan:
             Log::Comment(L"Testing graphics 'Bright Foreground Color Cyan'");
-            _testGetSet->_attribute = FOREGROUND_RED;
+            _testGetSet->_attribute = TextAttribute{ FOREGROUND_RED };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedForeground(FOREGROUND_INTENSITY | FOREGROUND_BLUE | FOREGROUND_GREEN);
             break;
         case DispatchTypes::GraphicsOptions::BrightForegroundRed:
             Log::Comment(L"Testing graphics 'Bright Foreground Color Red'");
-            _testGetSet->_attribute = FOREGROUND_BLUE | FOREGROUND_GREEN;
+            _testGetSet->_attribute = TextAttribute{ FOREGROUND_BLUE | FOREGROUND_GREEN };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedForeground(FOREGROUND_INTENSITY | FOREGROUND_RED);
             break;
         case DispatchTypes::GraphicsOptions::BrightForegroundMagenta:
             Log::Comment(L"Testing graphics 'Bright Foreground Color Magenta'");
-            _testGetSet->_attribute = FOREGROUND_GREEN;
+            _testGetSet->_attribute = TextAttribute{ FOREGROUND_GREEN };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedForeground(FOREGROUND_INTENSITY | FOREGROUND_BLUE | FOREGROUND_RED);
             break;
         case DispatchTypes::GraphicsOptions::BrightForegroundYellow:
             Log::Comment(L"Testing graphics 'Bright Foreground Color Yellow'");
-            _testGetSet->_attribute = FOREGROUND_BLUE;
+            _testGetSet->_attribute = TextAttribute{ FOREGROUND_BLUE };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedForeground(FOREGROUND_INTENSITY | FOREGROUND_GREEN | FOREGROUND_RED);
             break;
         case DispatchTypes::GraphicsOptions::BrightForegroundWhite:
             Log::Comment(L"Testing graphics 'Bright Foreground Color White'");
-            _testGetSet->_attribute = 0;
+            _testGetSet->_attribute = TextAttribute{ 0 };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedForeground(FOREGROUND_INTENSITY | FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED);
             break;
         case DispatchTypes::GraphicsOptions::BrightBackgroundBlack:
             Log::Comment(L"Testing graphics 'Bright Background Color Black'");
-            _testGetSet->_attribute = BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE;
+            _testGetSet->_attribute = TextAttribute{ BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedBackground(BACKGROUND_INTENSITY >> 4);
             break;
         case DispatchTypes::GraphicsOptions::BrightBackgroundBlue:
             Log::Comment(L"Testing graphics 'Bright Background Color Blue'");
-            _testGetSet->_attribute = BACKGROUND_RED | BACKGROUND_GREEN;
+            _testGetSet->_attribute = TextAttribute{ BACKGROUND_RED | BACKGROUND_GREEN };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedBackground((BACKGROUND_INTENSITY | BACKGROUND_BLUE) >> 4);
             break;
         case DispatchTypes::GraphicsOptions::BrightBackgroundGreen:
             Log::Comment(L"Testing graphics 'Bright Background Color Green'");
-            _testGetSet->_attribute = BACKGROUND_RED | BACKGROUND_BLUE;
+            _testGetSet->_attribute = TextAttribute{ BACKGROUND_RED | BACKGROUND_BLUE };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedBackground((BACKGROUND_INTENSITY | BACKGROUND_GREEN) >> 4);
             break;
         case DispatchTypes::GraphicsOptions::BrightBackgroundCyan:
             Log::Comment(L"Testing graphics 'Bright Background Color Cyan'");
-            _testGetSet->_attribute = BACKGROUND_RED;
+            _testGetSet->_attribute = TextAttribute{ BACKGROUND_RED };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedBackground((BACKGROUND_INTENSITY | BACKGROUND_BLUE | BACKGROUND_GREEN) >> 4);
             break;
         case DispatchTypes::GraphicsOptions::BrightBackgroundRed:
             Log::Comment(L"Testing graphics 'Bright Background Color Red'");
-            _testGetSet->_attribute = BACKGROUND_BLUE | BACKGROUND_GREEN;
+            _testGetSet->_attribute = TextAttribute{ BACKGROUND_BLUE | BACKGROUND_GREEN };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedBackground((BACKGROUND_INTENSITY | BACKGROUND_RED) >> 4);
             break;
         case DispatchTypes::GraphicsOptions::BrightBackgroundMagenta:
             Log::Comment(L"Testing graphics 'Bright Background Color Magenta'");
-            _testGetSet->_attribute = BACKGROUND_GREEN;
+            _testGetSet->_attribute = TextAttribute{ BACKGROUND_GREEN };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedBackground((BACKGROUND_INTENSITY | BACKGROUND_BLUE | BACKGROUND_RED) >> 4);
             break;
         case DispatchTypes::GraphicsOptions::BrightBackgroundYellow:
             Log::Comment(L"Testing graphics 'Bright Background Color Yellow'");
-            _testGetSet->_attribute = BACKGROUND_BLUE;
+            _testGetSet->_attribute = TextAttribute{ BACKGROUND_BLUE };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedBackground((BACKGROUND_INTENSITY | BACKGROUND_GREEN | BACKGROUND_RED) >> 4);
             break;
         case DispatchTypes::GraphicsOptions::BrightBackgroundWhite:
             Log::Comment(L"Testing graphics 'Bright Background Color White'");
-            _testGetSet->_attribute = 0;
+            _testGetSet->_attribute = TextAttribute{ 0 };
             _testGetSet->_expectedAttribute = _testGetSet->_attribute;
             _testGetSet->_expectedAttribute.SetIndexedBackground((BACKGROUND_INTENSITY | BACKGROUND_BLUE | BACKGROUND_GREEN | BACKGROUND_RED) >> 4);
             break;


### PR DESCRIPTION
In Windows, we build with /Zc:wchar_t- (which makes wchar_t an unsigned
short typedef.) This causes build breaks when we compare two wchar_t
values (or a wchar_t and an enum class that's of type wchar_t) and the
compiler decides that it might want to _promote them to TextAttribute_
before doing the comparison.