### PR TITLE
Remove the shell extension from directory backgrounds

### DIFF
--- a/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
@@ -82,9 +82,14 @@
                 <desktop5:ItemType Type="Directory">
                     <desktop5:Verb Id="Command1" Clsid="9f156763-7844-4dc4-b2b1-901f640f5155" />
                 </desktop5:ItemType>
+                <!-- Due to a bug in the OS, this doesn't actually work right -
+                we'll get a nullptr in our implementation. So this is disabled
+                temporarily. See MSFT:24623699 for more details.
+
                 <desktop5:ItemType Type="Directory\Background">
                     <desktop5:Verb Id="Command2" Clsid="9f156763-7844-4dc4-b2b1-901f640f5155" />
                 </desktop5:ItemType>
+                -->
             </desktop4:FileExplorerContextMenus>
         </desktop4:Extension>
 

--- a/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
@@ -82,9 +82,15 @@
                 <desktop5:ItemType Type="Directory">
                     <desktop5:Verb Id="Command1" Clsid="9f156763-7844-4dc4-b2b1-901f640f5155" />
                 </desktop5:ItemType>
+                <!-- Due to a bug in the OS, this doesn't actually work right -
+                we'll get a nullptr in our implementation. So this is disabled
+                temporarily. See MSFT:24623699 for more details.
+
                 <desktop5:ItemType Type="Directory\Background">
                     <desktop5:Verb Id="Command2" Clsid="9f156763-7844-4dc4-b2b1-901f640f5155" />
                 </desktop5:ItemType>
+                -->
+
             </desktop4:FileExplorerContextMenus>
         </desktop4:Extension>
 

--- a/src/cascadia/CascadiaPackage/Package.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package.appxmanifest
@@ -83,9 +83,14 @@
                 <desktop5:ItemType Type="Directory">
                     <desktop5:Verb Id="Command1" Clsid="9f156763-7844-4dc4-b2b1-901f640f5155" />
                 </desktop5:ItemType>
+                <!-- Due to a bug in the OS, this doesn't actually work right -
+                we'll get a nullptr in our implementation. So this is disabled
+                temporarily. See MSFT:24623699 for more details.
+
                 <desktop5:ItemType Type="Directory\Background">
                     <desktop5:Verb Id="Command2" Clsid="9f156763-7844-4dc4-b2b1-901f640f5155" />
                 </desktop5:ItemType>
+                -->
             </desktop4:FileExplorerContextMenus>
         </desktop4:Extension>
 


### PR DESCRIPTION
We're removing this because of MSFT:24623699, which prevents us from being able to do the right thing when we're called on the background of a directory for a range of OS builds. 

#6414 will track re-adding this to the Terminal when the original issue is closed.

* [x] closes #6245
* I work here