### PR TITLE
Remove parentheses from Preview and Dev build

### DIFF
--- a/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
@@ -20,7 +20,7 @@
     Version="0.0.1.0" />
 
   <Properties>
-    <DisplayName>ms-resource:AppNameDev</DisplayName>
+    <DisplayName>Windows Terminal Dev</DisplayName>
     <PublisherDisplayName>A Lone Developer</PublisherDisplayName>
     <Logo>Images\StoreLogo.png</Logo>
   </Properties>

--- a/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
@@ -21,7 +21,7 @@
     Version="0.5.0.0" />
 
   <Properties>
-    <DisplayName>Windows Terminal (Preview)</DisplayName>
+    <DisplayName>Windows Terminal Preview</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Images\StoreLogo.png</Logo>
   </Properties>

--- a/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
@@ -21,7 +21,7 @@
     Version="0.5.0.0" />
 
   <Properties>
-    <DisplayName>Windows Terminal Preview</DisplayName>
+    <DisplayName>ms-resource:AppNamePre</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Images\StoreLogo.png</Logo>
   </Properties>

--- a/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
@@ -21,7 +21,7 @@
     Version="0.5.0.0" />
 
   <Properties>
-    <DisplayName>ms-resource:AppNamePre</DisplayName>
+    <DisplayName>Windows Terminal Preview</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Images\StoreLogo.png</Logo>
   </Properties>

--- a/src/cascadia/CascadiaPackage/Package.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package.appxmanifest
@@ -21,7 +21,7 @@
     Version="1.0.0.0" />
 
   <Properties>
-    <DisplayName>ms-resource:AppName</DisplayName>
+    <DisplayName>Windows Terminal</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Images\StoreLogo.png</Logo>
   </Properties>

--- a/src/cascadia/CascadiaPackage/Package.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package.appxmanifest
@@ -21,7 +21,7 @@
     Version="1.0.0.0" />
 
   <Properties>
-    <DisplayName>Windows Terminal</DisplayName>
+    <DisplayName>ms-resource:AppName</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Images\StoreLogo.png</Logo>
   </Properties>

--- a/src/cascadia/CascadiaPackage/Resources/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/Resources.resw
@@ -121,7 +121,7 @@
     <value>Windows Terminal</value>
   </data>
   <data name="AppNameDev" xml:space="preserve">
-    <value>Windows Terminal (Dev Build)</value>
+    <value>Windows Terminal Dev Build</value>
   </data>
   <data name="AppNamePre" xml:space="preserve">
     <value>Windows Terminal Preview</value>
@@ -130,7 +130,7 @@
     <value>Terminal</value>
   </data>
   <data name="AppShortNameDev" xml:space="preserve">
-    <value>Terminal (Dev)</value>
+    <value>Terminal Dev</value>
   </data>
   <data name="AppShortNamePre" xml:space="preserve">
     <value>Terminal Preview</value>

--- a/src/cascadia/CascadiaPackage/Resources/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/Resources.resw
@@ -124,7 +124,7 @@
     <value>Windows Terminal (Dev Build)</value>
   </data>
   <data name="AppNamePre" xml:space="preserve">
-    <value>Windows Terminal (Preview)</value>
+    <value>Windows Terminal Preview</value>
   </data>
   <data name="AppShortName" xml:space="preserve">
     <value>Terminal</value>
@@ -133,6 +133,6 @@
     <value>Terminal (Dev)</value>
   </data>
   <data name="AppShortNamePre" xml:space="preserve">
-    <value>Terminal (Preview)</value>
+    <value>Terminal Preview</value>
   </data>
 </root>

--- a/src/cascadia/CascadiaPackage/Resources/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/Resources.resw
@@ -121,7 +121,7 @@
     <value>Windows Terminal</value>
   </data>
   <data name="AppNameDev" xml:space="preserve">
-    <value>Windows Terminal Dev Build</value>
+    <value>Windows Terminal Dev</value>
   </data>
   <data name="AppNamePre" xml:space="preserve">
     <value>Windows Terminal Preview</value>


### PR DESCRIPTION
## Summary of the Pull Request
Remove parentheses from the Preview and Dev build. Now they're called Windows Terminal Preview and Windows Terminal Dev Build respectively.

Also removed them from other identifiers of Terminal for consistency.

## PR Checklist
* [X] Closes #5974