### PR TITLE
Don't snap on input nor dismiss selection for just a modifier key

### DIFF
--- a/.github/actions/spell-check/dictionary/apis.txt
+++ b/.github/actions/spell-check/dictionary/apis.txt
@@ -17,6 +17,7 @@ IMap
 IObject
 IStorage
 LCID
+LSHIFT
 NCHITTEST
 NCLBUTTONDBLCLK
 NCRBUTTONDBLCLK
@@ -26,5 +27,6 @@ oaidl
 ocidl
 rfind
 roundf
+RSHIFT
 SIZENS
 tmp

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -824,7 +824,10 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         // When there is a selection active, escape should clear it and NOT flow through
         // to the terminal. With any other keypress, it should clear the selection AND
         // flow through to the terminal.
-        if (_terminal->IsSelectionActive())
+        // GH#6423 - don't dismiss selection if the key that was pressed was a
+        // modifier key. We'll wait for a real keystroke to dismiss the
+        // selection.
+        if (_terminal->IsSelectionActive() && !KeyEvent::IsModifierKey(vkey))
         {
             _terminal->ClearSelection();
             _renderer->TriggerSelection();

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -419,7 +419,13 @@ bool Terminal::SendKeyEvent(const WORD vkey,
                             const ControlKeyStates states,
                             const bool keyDown)
 {
-    TrySnapOnInput();
+    // GH#6423 - don't snap on this key if the key that was pressed was a
+    // modifier key. We'll wait for a real keystroke to snap to the bottom.
+    if (!KeyEvent::IsModifierKey(vkey))
+    {
+        TrySnapOnInput();
+    }
+
     _StoreKeyEvent(vkey, scanCode);
 
     const auto isAltOnlyPressed = states.IsAltPressed() && !states.IsCtrlPressed();

--- a/src/types/inc/IInputEvent.hpp
+++ b/src/types/inc/IInputEvent.hpp
@@ -301,6 +301,29 @@ public:
     bool IsCommandLineEditingKey() const noexcept;
     bool IsPopupKey() const noexcept;
 
+    // Function Description:
+    // - Returns true if the given VKey represents a modifier key - shift, alt,
+    //   control or the Win key.
+    // Arguments:
+    // - vkey: the VKEY to check
+    // Return Value:
+    // - true iff the key is a modifier key.
+    constexpr static bool IsModifierKey(const WORD vkey)
+    {
+        return (vkey == VK_CONTROL) ||
+               (vkey == VK_LCONTROL) ||
+               (vkey == VK_RCONTROL) ||
+               (vkey == VK_MENU) ||
+               (vkey == VK_LMENU) ||
+               (vkey == VK_RMENU) ||
+               (vkey == VK_SHIFT) ||
+               (vkey == VK_LSHIFT) ||
+               (vkey == VK_RSHIFT) ||
+               // There is no VK_WIN
+               (vkey == VK_LWIN) ||
+               (vkey == VK_RWIN);
+    };
+
 private:
     bool _keyDown;
     WORD _repeatCount;


### PR DESCRIPTION
Does what it says on the label. Pure modifier keys weren't making it
this far at all prior to #6309. This PR changes these methods to make
sure that we only dismiss a selection or snap on input when the key
pressed isn't a modifier key.

## References

* regressed in #6309

## PR Checklist
* [x] Closes #6423
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated

## Validation Steps Performed

* Tried to repro this in the Terminal, couldn't anymore.