### PR TITLE
Set tab title as early as possible

### DIFF
--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -45,6 +45,7 @@ namespace winrt::TerminalApp::implementation
     void Tab::_MakeTabViewItem()
     {
         _tabViewItem = ::winrt::MUX::Controls::TabViewItem{};
+        _UpdateTitle();
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -98,6 +98,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         auto inputFn = std::bind(&TermControl::_SendInputToConnection, this, std::placeholders::_1);
         _terminal->SetWriteInputCallback(inputFn);
 
+        _terminal->UpdateSettings(settings);
+
         // Subscribe to the connection's disconnected event and call our connection closed handlers.
         _connectionStateChangedRevoker = _connection.StateChanged(winrt::auto_revoke, [this](auto&& /*s*/, auto&& /*v*/) {
             _ConnectionStateChangedHandlers(*this, nullptr);

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -92,11 +92,6 @@ void Terminal::CreateFromSettings(winrt::Microsoft::Terminal::Settings::ICoreSet
     Create(viewportSize, Utils::ClampToShortMax(settings.HistorySize(), 0), renderTarget);
 
     UpdateSettings(settings);
-
-    if (_suppressApplicationTitle)
-    {
-        _title = _startingTitle;
-    }
 }
 
 // Method Description:
@@ -130,9 +125,12 @@ void Terminal::UpdateSettings(winrt::Microsoft::Terminal::Settings::ICoreSetting
         break;
     }
 
-    _buffer->GetCursor().SetStyle(settings.CursorHeight(),
-                                  settings.CursorColor(),
-                                  cursorShape);
+    if (_buffer)
+    {
+        _buffer->GetCursor().SetStyle(settings.CursorHeight(),
+                                      settings.CursorColor(),
+                                      cursorShape);
+    }
 
     for (int i = 0; i < 16; i++)
     {

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -205,7 +205,7 @@ private:
     std::unique_ptr<::Microsoft::Console::VirtualTerminal::StateMachine> _stateMachine;
     std::unique_ptr<::Microsoft::Console::VirtualTerminal::TerminalInput> _terminalInput;
 
-    std::wstring _title;
+    std::optional<std::wstring> _title;
     std::wstring _startingTitle;
 
     std::array<COLORREF, XTERM_COLOR_TABLE_SIZE> _colorTable;

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -409,10 +409,11 @@ CATCH_LOG_RETURN_FALSE()
 bool Terminal::SetWindowTitle(std::wstring_view title) noexcept
 try
 {
-    _title = _suppressApplicationTitle ? _startingTitle : title;
-
-    _pfnTitleChanged(_title);
-
+    if (!_suppressApplicationTitle)
+    {
+        _title.emplace(title);
+        _pfnTitleChanged(_title.value());
+    }
     return true;
 }
 CATCH_LOG_RETURN_FALSE()

--- a/src/cascadia/TerminalCore/terminalrenderdata.cpp
+++ b/src/cascadia/TerminalCore/terminalrenderdata.cpp
@@ -181,7 +181,11 @@ void Terminal::SelectNewRegion(const COORD coordStart, const COORD coordEnd)
 const std::wstring Terminal::GetConsoleTitle() const noexcept
 try
 {
-    return _title;
+    if (_title.has_value())
+    {
+        return _title.value();
+    }
+    return _startingTitle;
 }
 catch (...)
 {


### PR DESCRIPTION
When opening a new tab, it takes a few milliseconds before title to
appears. This PR makes it instantaneous.

* Updated the Terminal so that it can load the title from the settings
  before it is initialized.
* Load terminal settings in TermControl constructor before the terminal
  is initialized (see above).
* Update Tab so that it sets the TabViewItem's title in the constructor
  (in Tab::_MakeTabViewItem) instead of waiting for the VT sequence to
  set the title (from what I understand).

NOTE 1: there is a similar problem with the tabview icon which is not
fixed by this PR.

NOTE 2: This is only a problem with animations disabled because
otherwise the title fades in so there is enough time for it to be set
when it becomes visible.

## Validation

I ran the terminal and opened a new tab. The title appears instantly.