### PR TITLE
Reduce latency with DXGI 1.3 swap chains

### DIFF
--- a/src/renderer/base/RenderEngineBase.cpp
+++ b/src/renderer/base/RenderEngineBase.cpp
@@ -40,3 +40,10 @@ HRESULT RenderEngineBase::PrepareRenderInfo(const RenderFrameInfo& /*info*/) noe
 {
     return S_FALSE;
 }
+
+// Method Description:
+// - Blocks until the engine is able to render without blocking.
+void RenderEngineBase::WaitUntilCanRender() noexcept
+{
+    // do nothing by default
+}

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -1194,3 +1194,13 @@ void Renderer::ResetErrorStateAndResume()
     // because we're not stateful (we could be in the future), all we want to do is reenable painting.
     EnablePainting();
 }
+
+// Method Description:
+// - Blocks until the engines are able to render without blocking.
+void Renderer::WaitUntilCanRender()
+{
+    for (const auto pEngine : _rgpEngines)
+    {
+        pEngine->WaitUntilCanRender();
+    }
+}

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -73,6 +73,7 @@ namespace Microsoft::Console::Render
 
         void EnablePainting() override;
         void WaitForPaintCompletionAndDisable(const DWORD dwTimeoutMs) override;
+        void WaitUntilCanRender() override;
 
         void AddRenderEngine(_In_ IRenderEngine* const pEngine) override;
 

--- a/src/renderer/base/thread.cpp
+++ b/src/renderer/base/thread.cpp
@@ -201,6 +201,7 @@ DWORD WINAPI RenderThread::_ThreadProc()
 
         ResetEvent(_hPaintCompletedEvent);
 
+        _pRenderer->WaitUntilCanRender();
         LOG_IF_FAILED(_pRenderer->PaintFrame());
 
         SetEvent(_hPaintCompletedEvent);

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -9,6 +9,7 @@
 
 #include <dxgi.h>
 #include <dxgi1_2.h>
+#include <dxgi1_3.h>
 
 #include <d3d11.h>
 #include <d2d1.h>
@@ -73,6 +74,8 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT StartPaint() noexcept override;
         [[nodiscard]] HRESULT EndPaint() noexcept override;
+
+        void WaitUntilCanRender() noexcept override;
         [[nodiscard]] HRESULT Present() noexcept override;
 
         [[nodiscard]] HRESULT ScrollFrame() noexcept override;
@@ -181,6 +184,7 @@ namespace Microsoft::Console::Render
         ::Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> _d2dBrushForeground;
         ::Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> _d2dBrushBackground;
         ::Microsoft::WRL::ComPtr<IDXGISwapChain1> _dxgiSwapChain;
+        HANDLE _swapChainFrameLatencyWaitableObject;
 
         // Terminal effects resources.
         bool _retroTerminalEffects;

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -49,6 +49,8 @@ namespace Microsoft::Console::Render
     public:
         [[nodiscard]] virtual HRESULT StartPaint() noexcept = 0;
         [[nodiscard]] virtual HRESULT EndPaint() noexcept = 0;
+
+        virtual void WaitUntilCanRender() noexcept = 0;
         [[nodiscard]] virtual HRESULT Present() noexcept = 0;
 
         [[nodiscard]] virtual HRESULT PrepareForTeardown(_Out_ bool* const pForcePaint) noexcept = 0;

--- a/src/renderer/inc/IRenderer.hpp
+++ b/src/renderer/inc/IRenderer.hpp
@@ -58,6 +58,7 @@ namespace Microsoft::Console::Render
 
         virtual void EnablePainting() = 0;
         virtual void WaitForPaintCompletionAndDisable(const DWORD dwTimeoutMs) = 0;
+        virtual void WaitUntilCanRender() = 0;
 
         virtual void AddRenderEngine(_In_ IRenderEngine* const pEngine) = 0;
 

--- a/src/renderer/inc/RenderEngineBase.hpp
+++ b/src/renderer/inc/RenderEngineBase.hpp
@@ -40,6 +40,8 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT PrepareRenderInfo(const RenderFrameInfo& info) noexcept override;
 
+        void WaitUntilCanRender() noexcept override;
+
     protected:
         [[nodiscard]] virtual HRESULT _DoUpdateTitle(const std::wstring& newTitle) noexcept = 0;
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Reduce input lag, especially with selection, by using `IDXGISwapChain2::GetFrameLatencyWaitableObject`.

I hope that it's visible on these GIFs: 

Before:
![before](https://user-images.githubusercontent.com/56923875/84176001-0cc59580-aa81-11ea-9eca-b4ff5eeebb4c.gif)

After:
![after](https://user-images.githubusercontent.com/56923875/84176011-118a4980-aa81-11ea-9e85-6fa3cb6e82b9.gif)

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

I used the documenation from:
https://docs.microsoft.com/en-us/windows/uwp/gaming/reduce-latency-with-dxgi-1-3-swap-chains

From https://docs.microsoft.com/en-us/windows/win32/direct3ddxgi/dxgi-1-3-improvements:
> The following functionality has been added in Microsoft DirectX Graphics Infrastructure (DXGI) 1.3, which is included starting in Windows 8.1.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Before, during rendering:
1. render frame
1. call `Present` on swap chain:
   1. blocks until it can present
   1. meanwhile, selection/text in terminal might have changed, but we're still using the frame that we rendered before blocking
   1. presents

After, during rendering:
1. block until we can present
1. render frame with latest data
1. call `Present` on swap chain:
  1. present without blocking

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
