### PR TITLE
Don't send a manual F7 keyup

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -706,7 +706,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         {
             // _TrySendKeyEvent pretends it didn't handle F7 for some unknown reason.
             (void)_TrySendKeyEvent(VK_F7, 0, modifiers, true);
-            (void)_TrySendKeyEvent(VK_F7, 0, modifiers, false);
+            // GH#6438: Note that we're _not_ sending the key up here - that'll
+            // get passed through XAML to our KeyUp handler normally.
             handled = true;
         }
 


### PR DESCRIPTION
## Summary of the Pull Request

When someone asked "Do we need to send a F7 keyup too" in #6309, the right answer was actually _no_. Turns out that while XAML will eat the F7 key**down**, it _won't_ eat the F7 key**up**. 

## References

* regressed in #6309

## PR Checklist
* [x] Closes #6438 
* [x] I work here
* [ ] Tested manually
* [n/a] Requires documentation to be updated

## Validation Steps Performed

* Checked this with the debug tap