### PR TITLE
Reintroduce the check for VT_INPUT_MODE in AdaptDispatch

### DIFF
--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1096,8 +1096,7 @@ bool AdaptDispatch::SetKeypadMode(const bool fApplicationMode)
     bool success = true;
     success = _pConApi->PrivateSetKeypadMode(fApplicationMode);
 
-    // If we're a conpty, always return false
-    if (_pConApi->IsConsolePty())
+    if (_ShouldPassThroughInputModeChange())
     {
         return false;
     }
@@ -1117,8 +1116,7 @@ bool AdaptDispatch::EnableWin32InputMode(const bool win32InputMode)
     bool success = true;
     success = _pConApi->PrivateEnableWin32InputMode(win32InputMode);
 
-    // If we're a conpty, always return false
-    if (_pConApi->IsConsolePty())
+    if (_ShouldPassThroughInputModeChange())
     {
         return false;
     }
@@ -1136,8 +1134,7 @@ bool AdaptDispatch::SetCursorKeysMode(const bool applicationMode)
     bool success = true;
     success = _pConApi->PrivateSetCursorKeysMode(applicationMode);
 
-    // If we're a conpty, always return false
-    if (_pConApi->IsConsolePty())
+    if (_ShouldPassThroughInputModeChange())
     {
         return false;
     }
@@ -2045,8 +2042,7 @@ bool AdaptDispatch::EnableVT200MouseMode(const bool enabled)
     bool success = true;
     success = _pConApi->PrivateEnableVT200MouseMode(enabled);
 
-    // If we're a conpty, always return false
-    if (_pConApi->IsConsolePty())
+    if (_ShouldPassThroughInputModeChange())
     {
         return false;
     }
@@ -2066,8 +2062,7 @@ bool AdaptDispatch::EnableUTF8ExtendedMouseMode(const bool enabled)
     bool success = true;
     success = _pConApi->PrivateEnableUTF8ExtendedMouseMode(enabled);
 
-    // If we're a conpty, always return false
-    if (_pConApi->IsConsolePty())
+    if (_ShouldPassThroughInputModeChange())
     {
         return false;
     }
@@ -2087,8 +2082,7 @@ bool AdaptDispatch::EnableSGRExtendedMouseMode(const bool enabled)
     bool success = true;
     success = _pConApi->PrivateEnableSGRExtendedMouseMode(enabled);
 
-    // If we're a conpty, always return false
-    if (_pConApi->IsConsolePty())
+    if (_ShouldPassThroughInputModeChange())
     {
         return false;
     }
@@ -2107,8 +2101,7 @@ bool AdaptDispatch::EnableButtonEventMouseMode(const bool enabled)
     bool success = true;
     success = _pConApi->PrivateEnableButtonEventMouseMode(enabled);
 
-    // If we're a conpty, always return false
-    if (_pConApi->IsConsolePty())
+    if (_ShouldPassThroughInputModeChange())
     {
         return false;
     }
@@ -2128,8 +2121,7 @@ bool AdaptDispatch::EnableAnyEventMouseMode(const bool enabled)
     bool success = true;
     success = _pConApi->PrivateEnableAnyEventMouseMode(enabled);
 
-    // If we're a conpty, always return false
-    if (_pConApi->IsConsolePty())
+    if (_ShouldPassThroughInputModeChange())
     {
         return false;
     }
@@ -2149,8 +2141,7 @@ bool AdaptDispatch::EnableAlternateScroll(const bool enabled)
     bool success = true;
     success = _pConApi->PrivateEnableAlternateScroll(enabled);
 
-    // If we're a conpty, always return false
-    if (_pConApi->IsConsolePty())
+    if (_ShouldPassThroughInputModeChange())
     {
         return false;
     }
@@ -2340,4 +2331,23 @@ bool AdaptDispatch::WindowManipulation(const DispatchTypes::WindowManipulationTy
     }
 
     return success;
+}
+
+// Routine Description:
+// - Determines whether we should pass any sequence that manipulates
+//   TerminalInput's input generator through the PTY. It encapsulates
+//   a check for whether the PTY is in use.
+// Return value:
+// True if the request should be passed.
+bool AdaptDispatch::_ShouldPassThroughInputModeChange() noexcept
+{
+    // If we're a conpty, AND WE'RE IN VT INPUT MODE, always pass input mode requests
+    // The VT Input mode check is to work around ssh.exe v7.7, which uses VT
+    // output, but not Input.
+    // The original comment said, "Once the conpty supports these types of input,
+    // this check can be removed. See GH#4911". Unfortunately, time has shown
+    // us that SSH 7.7 _also_ requests mouse input and that can have a user interface
+    // impact on the actual connected terminal. We can't remove this check,
+    // because SSH <=7.7 is out in the wild on all versions of Windows <=2004.
+    return _pConApi->IsConsolePty() && _pConApi->PrivateIsVtInputEnabled();
 }

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -2339,7 +2339,7 @@ bool AdaptDispatch::WindowManipulation(const DispatchTypes::WindowManipulationTy
 //   a check for whether the PTY is in use.
 // Return value:
 // True if the request should be passed.
-bool AdaptDispatch::_ShouldPassThroughInputModeChange() noexcept
+bool AdaptDispatch::_ShouldPassThroughInputModeChange() const
 {
     // If we're a conpty, AND WE'RE IN VT INPUT MODE, always pass input mode requests
     // The VT Input mode check is to work around ssh.exe v7.7, which uses VT

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -164,6 +164,8 @@ namespace Microsoft::Console::VirtualTerminal
         void _ResetTabStops() noexcept;
         void _InitTabStopsForWidth(const size_t width);
 
+        bool _ShouldPassThroughInputModeChange() noexcept;
+
         std::vector<bool> _tabStopColumns;
         bool _initDefaultTabStops = true;
 

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -164,7 +164,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _ResetTabStops() noexcept;
         void _InitTabStopsForWidth(const size_t width);
 
-        bool _ShouldPassThroughInputModeChange() noexcept;
+        bool _ShouldPassThroughInputModeChange() const;
 
         std::vector<bool> _tabStopColumns;
         bool _initDefaultTabStops = true;


### PR DESCRIPTION
This commit reverts the removal of the "SSH hack" in #5383. It was
originally added as a solution to #4911, when we realized that SSH would
request the SS3 cursor key encoding but we weren't equipped to handle
it.

A number of folks have filed issues that, in summary, say "when I use
SSH, I can't select/copy/paste text". It turns out that SSH will _also_
pass through requests for mouse input. Terminal dutifully responds to
those requests, of course, by disabling mouse selection/copy/paste. SSH
is **NOT** actually in VT_INPUT_MODE, so it will never receive the mouse
messages.

It's important to note that even with #376 fixed, we are still required
to keep this check. With the closure of #376, we'll be able to convert
VT mouse input back into Win32 mouse input for Win32 applications . . .
but SSH also doesn't know how to handle Win32 mouse input.

Fixes #6476.
Fixes #6196.
Fixes #5704.
Fixes #5608.