### PR TITLE
Clear cached runs after translate_y

### DIFF
--- a/src/inc/til/bitmap.h
+++ b/src/inc/til/bitmap.h
@@ -440,6 +440,8 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
                     _bits.set(_bits.size() - newBits, newBits, true);
                 }
             }
+
+            _runs.reset(); // reset cached runs on any non-const method
         }
 
         til::size _sz;

--- a/src/inc/til/bitmap.h
+++ b/src/inc/til/bitmap.h
@@ -398,7 +398,11 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
 
             const auto bitShift = delta_y * _sz.width();
 
+#pragma warning(push)
+            // we can't depend on GSL here (some libraries use BLOCK_GSL), so we use static_cast for explicit narrowing
+#pragma warning(disable : 26472)
             const auto newBits = static_cast<size_t>(std::abs(bitShift));
+#pragma warning(pop)
             const bool isLeftShift = bitShift > 0;
 
             if (newBits >= _bits.size())

--- a/src/inc/til/bitmap.h
+++ b/src/inc/til/bitmap.h
@@ -194,6 +194,13 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
         // optional fill the uncovered area with bits.
         void translate(const til::point delta, bool fill = false)
         {
+            if (delta.x() == 0)
+            {
+                // fast path by using bit shifting
+                translate_y(delta.y(), fill);
+                return;
+            }
+
             // FUTURE: PERF: GH #4015: This could use in-place walk semantics instead of a temporary.
             til::bitmap other{ _sz };
 
@@ -382,6 +389,55 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
         }
 
     private:
+        void translate_y(ptrdiff_t delta_y, bool fill)
+        {
+            if (delta_y == 0)
+            {
+                return;
+            }
+
+            const auto bitShift = delta_y * _sz.width();
+
+            const auto newBits = static_cast<size_t>(std::abs(bitShift));
+            const bool isLeftShift = bitShift > 0;
+
+            if (newBits >= _bits.size())
+            {
+                if (fill)
+                {
+                    set_all();
+                }
+                else
+                {
+                    reset_all();
+                }
+                return;
+            }
+
+            if (isLeftShift)
+            {
+                // This operator doesn't modify the size of `_bits`: the
+                // new bits are set to 0.
+                _bits <<= newBits;
+            }
+            else
+            {
+                _bits >>= newBits;
+            }
+
+            if (fill)
+            {
+                if (isLeftShift)
+                {
+                    _bits.set(0, newBits, true);
+                }
+                else
+                {
+                    _bits.set(_bits.size() - newBits, newBits, true);
+                }
+            }
+        }
+
         til::size _sz;
         til::rectangle _rc;
         dynamic_bitset<> _bits;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

While re-reading the code, I found out that I forgot to do clear cached runs after translate_y in my previous PR.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
