### PR TITLE
Fix sending a NUL on alt key up

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -725,7 +725,9 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         {
             // Manually generate an Alt KeyUp event into the key bindings or terminal.
             //   This is required as part of GH#6421.
-            (void)_TrySendKeyEvent(VK_MENU, 0, modifiers, false);
+            // GH#6513 - make sure to set the scancode too, otherwise conpty
+            // will think this is a NUL
+            (void)_TrySendKeyEvent(VK_MENU, LOWORD(MapVirtualKeyW(VK_MENU, MAPVK_VK_TO_VSC)), modifiers, false);
             handled = true;
         }
         else if (vkey == VK_F7 && down)


### PR DESCRIPTION
## Summary of the Pull Request

Make sure to set the scancode for the manual alt-up's we're sending. If you don't, then terminalInput in the conpty is going to treat that keypress as an actual NUL, and send that to the connected client.

## References
* regressed in #6421 

## PR Checklist
* [x] Closes #6513
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated

## Validation Steps Performed
Tested `showkeys -a`