### PR TITLE
Fix openSettings misspelling in defaults

### DIFF
--- a/src/cascadia/TerminalApp/defaults.json
+++ b/src/cascadia/TerminalApp/defaults.json
@@ -279,7 +279,7 @@
         { "command": "toggleFullscreen", "keys": "f11" },
         { "command": "openNewTabDropdown", "keys": "ctrl+shift+space" },
         { "command": "openSettings", "keys": "ctrl+," },
-        { "command": { "action": "openSettings", "target": "defaultFile" }, "keys": "ctrl+alt+," },
+        { "command": { "action": "openSettings", "target": "defaultsFile" }, "keys": "ctrl+alt+," },
         { "command": "find", "keys": "ctrl+shift+f" },
 
         // Tab Management


### PR DESCRIPTION
## Summary of the Pull Request
Fixes a misspelling in defaults.json that made the new openSettings keybinding not actually work.

## References
#6299 - original PR

## PR Checklist
* [X] Closes #6486 

## Validation Steps Performed
pressed <kbd>ctrl+alt+,</kbd>