### PR TITLE
Use D2DDeviceContext and friends over D2DRenderTarget

### DIFF
--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -558,7 +558,7 @@ try
 }
 CATCH_RETURN();
 
-D2D1_ALPHA_MODE _dxgiAlphaToD2d1Alpha(DXGI_ALPHA_MODE mode)
+D2D1_ALPHA_MODE _dxgiAlphaToD2d1Alpha(DXGI_ALPHA_MODE mode) noexcept
 {
     switch (mode)
     {

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -450,7 +450,8 @@ try
 
         switch (_chainMode)
         {
-        case SwapChainMode::ForHwnd: {
+        case SwapChainMode::ForHwnd:
+        {
             // use the HWND's dimensions for the swap chain dimensions.
             RECT rect = { 0 };
             RETURN_IF_WIN32_BOOL_FALSE(GetClientRect(_hwndTarget, &rect));
@@ -479,7 +480,8 @@ try
 
             break;
         }
-        case SwapChainMode::ForComposition: {
+        case SwapChainMode::ForComposition:
+        {
             // Use the given target size for compositions.
             _swapChainDesc.Width = _displaySizePixels.width<UINT>();
             _swapChainDesc.Height = _displaySizePixels.height<UINT>();
@@ -915,13 +917,15 @@ CATCH_RETURN();
 {
     switch (_chainMode)
     {
-    case SwapChainMode::ForHwnd: {
+    case SwapChainMode::ForHwnd:
+    {
         RECT clientRect = { 0 };
         LOG_IF_WIN32_BOOL_FALSE(GetClientRect(_hwndTarget, &clientRect));
 
         return til::rectangle{ clientRect }.size();
     }
-    case SwapChainMode::ForComposition: {
+    case SwapChainMode::ForComposition:
+    {
         return _sizeTarget;
     }
     default:
@@ -2164,10 +2168,12 @@ CATCH_RETURN();
 
     switch (_chainMode)
     {
-    case SwapChainMode::ForHwnd: {
+    case SwapChainMode::ForHwnd:
+    {
         return D2D1::ColorF(rgb);
     }
-    case SwapChainMode::ForComposition: {
+    case SwapChainMode::ForComposition:
+    {
         // Get the A value we've snuck into the highest byte
         const BYTE a = ((color >> 24) & 0xFF);
         const float aFloat = a / 255.0f;

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -83,6 +83,7 @@ DxEngine::DxEngine() :
     _glyphCell{},
     _boxDrawingEffect{},
     _haveDeviceResources{ false },
+    _swapChainDesc{ 0 },
     _swapChainFrameLatencyWaitableObject{ INVALID_HANDLE_VALUE },
     _retroTerminalEffects{ false },
     _forceFullRepaintRendering{ false },
@@ -435,6 +436,7 @@ try
 
     if (createSwapChain)
     {
+        _swapChainDesc = { 0 };
         _swapChainDesc.Flags = 0;
 
         // requires DXGI 1.3 which was introduced in Windows 8.1
@@ -558,7 +560,7 @@ try
 }
 CATCH_RETURN();
 
-D2D1_ALPHA_MODE _dxgiAlphaToD2d1Alpha(DXGI_ALPHA_MODE mode) noexcept
+static constexpr D2D1_ALPHA_MODE _dxgiAlphaToD2d1Alpha(DXGI_ALPHA_MODE mode) noexcept
 {
     switch (mode)
     {

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -13,6 +13,7 @@
 
 #include <d3d11.h>
 #include <d2d1.h>
+#include <d2d1_1.h>
 #include <d2d1helper.h>
 #include <dwrite.h>
 #include <dwrite_1.h>
@@ -166,7 +167,8 @@ namespace Microsoft::Console::Render
         static std::atomic<size_t> _tracelogCount;
 
         // Device-Independent Resources
-        ::Microsoft::WRL::ComPtr<ID2D1Factory> _d2dFactory;
+        ::Microsoft::WRL::ComPtr<ID2D1Factory1> _d2dFactory;
+
         ::Microsoft::WRL::ComPtr<IDWriteFactory1> _dwriteFactory;
         ::Microsoft::WRL::ComPtr<IDWriteTextFormat> _dwriteTextFormat;
         ::Microsoft::WRL::ComPtr<IDWriteFontFace1> _dwriteFontFace;
@@ -178,12 +180,18 @@ namespace Microsoft::Console::Render
         bool _haveDeviceResources;
         ::Microsoft::WRL::ComPtr<ID3D11Device> _d3dDevice;
         ::Microsoft::WRL::ComPtr<ID3D11DeviceContext> _d3dDeviceContext;
-        ::Microsoft::WRL::ComPtr<IDXGIFactory2> _dxgiFactory2;
-        ::Microsoft::WRL::ComPtr<IDXGISurface> _dxgiSurface;
-        ::Microsoft::WRL::ComPtr<ID2D1RenderTarget> _d2dRenderTarget;
+
+        ::Microsoft::WRL::ComPtr<ID2D1Device> _d2dDevice;
+        ::Microsoft::WRL::ComPtr<ID2D1DeviceContext> _d2dDeviceContext;
+        ::Microsoft::WRL::ComPtr<ID2D1Bitmap1> _d2dBitmap;
         ::Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> _d2dBrushForeground;
         ::Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> _d2dBrushBackground;
-        UINT _swapChainFlags;
+
+        ::Microsoft::WRL::ComPtr<IDXGIFactory2> _dxgiFactory2;
+        ::Microsoft::WRL::ComPtr<IDXGIDevice> _dxgiDevice;
+        ::Microsoft::WRL::ComPtr<IDXGISurface> _dxgiSurface;
+
+        DXGI_SWAP_CHAIN_DESC1 _swapChainDesc;
         ::Microsoft::WRL::ComPtr<IDXGISwapChain1> _dxgiSwapChain;
         wil::unique_handle _swapChainFrameLatencyWaitableObject;
 


### PR DESCRIPTION
I was told that the DeviceContext version supercedes the RenderTarget
one. This moves us to it so we can gain access to a higher level of
control over the various pieces in our pipeline as we continue to evolve
the renderer.

The underlying motivation here is to potentially use a
`ID2D1CommandList` to batch our commands and run them all later outside
the lock. That can only really be done with this more granular level of
control over the pipeline. So this moves to that in a single step that
is easily findable in history should we have problems

I discussed this with @NiklasBorson of the Direct2D/DirectWrite team as
well as with @DHowett before doing it.

## Validation
- [x] Checked docs to make sure that these work on Windows 7 with
  Platform Update
- [x] Manual smoke test real quick
- [ ] Try running on Win7 + Platform Update after change
- [x] Probably do more than just a smoke test manually or otherwise

Closes #6525