### PR TITLE
Optimize booleans

### DIFF
--- a/samples/ReadConsoleInputStream/ReadConsoleInputStream.cs
+++ b/samples/ReadConsoleInputStream/ReadConsoleInputStream.cs
@@ -37,7 +37,7 @@ namespace Samples.Terminal
         internal ReadConsoleInputStream(HFILE handle,
             BlockingCollection<Kernel32.INPUT_RECORD> nonKeyEvents)
         {
-            Debug.Assert(handle.IsInvalid == false, "handle.IsInvalid == false");
+            Debug.Assert(!handle.IsInvalid, "handle.IsInvalid == false");
 
             _handle = handle.DangerousGetHandle();
             _nonKeyEvents = nonKeyEvents;
@@ -111,7 +111,7 @@ namespace Samples.Terminal
                             if (record.EventType == Kernel32.EVENT_TYPE.KEY_EVENT)
                             {
                                 // skip key up events - if not, every key will be duped in the stream
-                                if (record.Event.KeyEvent.bKeyDown == false) continue;
+                                if (!record.Event.KeyEvent.bKeyDown) continue;
 
                                 // pack ucs-2/utf-16le/unicode chars into position in our byte[] buffer.
                                 var glyph = (ushort) record.Event.KeyEvent.uChar;

--- a/src/cascadia/TerminalApp/WslDistroGenerator.cpp
+++ b/src/cascadia/TerminalApp/WslDistroGenerator.cpp
@@ -76,7 +76,7 @@ std::vector<TerminalApp::Profile> WslDistroGenerator::GenerateProfiles()
         THROW_HR(ERROR_UNHANDLED_EXCEPTION);
     }
     DWORD exitCode;
-    if (GetExitCodeProcess(pi.hProcess, &exitCode) == false)
+    if (!GetExitCodeProcess(pi.hProcess, &exitCode))
     {
         THROW_HR(E_INVALIDARG);
     }
@@ -116,7 +116,7 @@ std::vector<TerminalApp::Profile> WslDistroGenerator::GenerateProfiles()
                 continue;
             }
 
-            size_t firstChar = distName.find_first_of(L"( ");
+            const size_t firstChar = distName.find_first_of(L"( ");
             // Some localizations don't have a space between the name and "(Default)"
             // https://github.com/microsoft/terminal/issues/1168#issuecomment-500187109
             if (firstChar < distName.size())

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -403,7 +403,7 @@ int NonClientIslandWindow::_GetResizeHandleHeight() const noexcept
 //   window frame.
 [[nodiscard]] LRESULT NonClientIslandWindow::_OnNcCalcSize(const WPARAM wParam, const LPARAM lParam) noexcept
 {
-    if (wParam == false)
+    if (!wParam)
     {
         return 0;
     }
@@ -417,7 +417,7 @@ int NonClientIslandWindow::_GetResizeHandleHeight() const noexcept
     const auto originalSize = params->rgrc[0];
 
     // apply the default frame
-    auto ret = DefWindowProc(_window.get(), WM_NCCALCSIZE, wParam, lParam);
+    const auto ret = DefWindowProc(_window.get(), WM_NCCALCSIZE, wParam, lParam);
     if (ret != 0)
     {
         return ret;
@@ -783,9 +783,9 @@ void NonClientIslandWindow::_UpdateFrameMargins() const noexcept
 [[nodiscard]] LRESULT NonClientIslandWindow::_OnNcCreate(WPARAM wParam, LPARAM lParam) noexcept
 {
     const auto ret = IslandWindow::_OnNcCreate(wParam, lParam);
-    if (ret == FALSE)
+    if (!ret)
     {
-        return ret;
+        return FALSE;
     }
 
     // Set the frame's theme before it is rendered (WM_NCPAINT) so that it is

--- a/src/host/CursorBlinker.cpp
+++ b/src/host/CursorBlinker.cpp
@@ -218,7 +218,7 @@ void CursorBlinker::KillCaretTimer()
         // A failure to delete the timer with the LastError being ERROR_IO_PENDING means that the timer is
         // currently in use and will get cleaned up when released. Delete should not be called again.
         // We treat that case as a success.
-        if (bRet == false && GetLastError() != ERROR_IO_PENDING)
+        if (!bRet && GetLastError() != ERROR_IO_PENDING)
         {
             LOG_LAST_ERROR();
         }

--- a/src/interactivity/onecore/ConIoSrvComm.cpp
+++ b/src/interactivity/onecore/ConIoSrvComm.cpp
@@ -100,7 +100,7 @@ ConIoSrvComm::~ConIoSrvComm()
 
     // Initialize the server port name.
     Ret = RtlCreateUnicodeString(&PortName, CIS_ALPC_PORT_NAME);
-    if (Ret == FALSE)
+    if (!Ret)
     {
         return STATUS_NO_MEMORY;
     }

--- a/src/tools/U8U16Test/U8U16Test.cpp
+++ b/src/tools/U8U16Test/U8U16Test.cpp
@@ -303,7 +303,7 @@ void u16state::reset() noexcept
                 }
 
                 // *** convert the code point to UTF-16 ***
-                if (codePoint != unicodeReplacementChar || discardInvalids == false)
+                if (codePoint != unicodeReplacementChar || !discardInvalids)
                 {
                     if (codePoint < 0x00010000u)
                     {
@@ -471,7 +471,7 @@ void u16state::reset() noexcept
                 }
 
                 // *** convert the code point to UTF-16 ***
-                if (codePoint != unicodeReplacementChar || discardInvalids == false)
+                if (codePoint != unicodeReplacementChar || !discardInvalids)
                 {
                     if (codePoint < 0x00010000u)
                     {
@@ -562,7 +562,7 @@ void u16state::reset() noexcept
                 }
 
                 // *** convert the code point to UTF-8 ***
-                if (codePoint != unicodeReplacementChar || discardInvalids == false)
+                if (codePoint != unicodeReplacementChar || !discardInvalids)
                 {
                     // the outcome of performance tests is that subsequent calls of push_back
                     // perform much better than appending a single initializer_list
@@ -664,7 +664,7 @@ void u16state::reset() noexcept
                 }
 
                 // *** convert the code point to UTF-8 ***
-                if (codePoint != unicodeReplacementChar || discardInvalids == false)
+                if (codePoint != unicodeReplacementChar || !discardInvalids)
                 {
                     // the outcome of further performance tests is that using pointers
                     // perform even better than subsequent calls of push_back

--- a/src/tools/U8U16Test/main.cpp
+++ b/src/tools/U8U16Test/main.cpp
@@ -538,7 +538,7 @@ ptrdiff_t RandomIndex(ptrdiff_t length)
 {
     static bool generatorInitialized{ false };
     static std::default_random_engine generator;
-    if (generatorInitialized == false)
+    if (!generatorInitialized)
     {
         generator.seed(static_cast<unsigned>(std::chrono::system_clock::now().time_since_epoch().count()));
         generatorInitialized = true;

--- a/src/tools/pixels/main.cpp
+++ b/src/tools/pixels/main.cpp
@@ -222,9 +222,7 @@ int __cdecl wmain(int /*argc*/, WCHAR* /*argv*/[])
     CONSOLE_SCREEN_BUFFER_INFOEX csbiex = { 0 };
     csbiex.cbSize = sizeof(csbiex);
 
-    BOOL b = GetConsoleScreenBufferInfoEx(hOut, &csbiex);
-
-    if (b == FALSE)
+    if (!GetConsoleScreenBufferInfoEx(hOut, &csbiex))
     {
         wcout << GetLastError() << endl;
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Many places in this codebase has an equality comparison to the boolean FALSE. This adds unneeded complexity as C and C++ has a NOT operand for use of these in if statements. This makes the code more readable in those areas.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [X] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
One boolean being compared to FALSE was only used once, with the boolean name being "b", so it is better off not existing at all.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Unit Testing passed, compiler refactoring