### PR TITLE
Add option to strip tabs on paste

### DIFF
--- a/src/cascadia/TerminalApp/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.cpp
@@ -34,7 +34,7 @@ static constexpr std::string_view CopyFormattingKey{ "copyFormatting" };
 static constexpr std::string_view LaunchModeKey{ "launchMode" };
 static constexpr std::string_view ConfirmCloseAllKey{ "confirmCloseAllTabs" };
 static constexpr std::string_view SnapToGridOnResizeKey{ "snapToGridOnResize" };
-static constexpr std::string_view RemoveTabsOnPasteKey{ "removeTabsOnPaste" };
+static constexpr std::string_view ReplaceTabsWithSpacesOnPasteKey{ "replaceTabsWithSpacesOnPaste" };
 
 static constexpr std::string_view DebugFeaturesKey{ "debugFeatures" };
 
@@ -227,7 +227,7 @@ void GlobalAppSettings::LayerJson(const Json::Value& json)
 
     JsonUtils::GetBool(json, EnableStartupTaskKey, _StartOnUserLogin);
 
-    JsonUtils::GetBool(json, RemoveTabsOnPasteKey, _RemoveTabsOnPaste);
+    JsonUtils::GetOptionalInt(json, ReplaceTabsWithSpacesOnPasteKey, _ReplaceTabsWithSpacesOnPaste);
 }
 
 // Method Description:

--- a/src/cascadia/TerminalApp/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.cpp
@@ -34,6 +34,7 @@ static constexpr std::string_view CopyFormattingKey{ "copyFormatting" };
 static constexpr std::string_view LaunchModeKey{ "launchMode" };
 static constexpr std::string_view ConfirmCloseAllKey{ "confirmCloseAllTabs" };
 static constexpr std::string_view SnapToGridOnResizeKey{ "snapToGridOnResize" };
+static constexpr std::string_view RemoveTabsOnPasteKey{ "removeTabsOnPaste" };
 
 static constexpr std::string_view DebugFeaturesKey{ "debugFeatures" };
 
@@ -225,6 +226,8 @@ void GlobalAppSettings::LayerJson(const Json::Value& json)
     JsonUtils::GetBool(json, DebugFeaturesKey, _DebugFeaturesEnabled);
 
     JsonUtils::GetBool(json, EnableStartupTaskKey, _StartOnUserLogin);
+
+    JsonUtils::GetBool(json, RemoveTabsOnPasteKey, _RemoveTabsOnPaste);
 }
 
 // Method Description:

--- a/src/cascadia/TerminalApp/GlobalAppSettings.h
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.h
@@ -78,6 +78,7 @@ public:
     GETSET_PROPERTY(bool, ForceFullRepaintRendering, false);
     GETSET_PROPERTY(bool, SoftwareRendering, false);
     GETSET_PROPERTY(bool, DebugFeaturesEnabled); // default value set in constructor
+    GETSET_PROPERTY(bool, RemoveTabsOnPaste, false);
 
     GETSET_PROPERTY(bool, StartOnUserLogin, false);
 

--- a/src/cascadia/TerminalApp/GlobalAppSettings.h
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.h
@@ -78,7 +78,7 @@ public:
     GETSET_PROPERTY(bool, ForceFullRepaintRendering, false);
     GETSET_PROPERTY(bool, SoftwareRendering, false);
     GETSET_PROPERTY(bool, DebugFeaturesEnabled); // default value set in constructor
-    GETSET_PROPERTY(bool, RemoveTabsOnPaste, false);
+    GETSET_PROPERTY(std::optional<int>, ReplaceTabsWithSpacesOnPaste, std::nullopt);
 
     GETSET_PROPERTY(bool, StartOnUserLogin, false);
 

--- a/src/cascadia/TerminalApp/JsonUtils.cpp
+++ b/src/cascadia/TerminalApp/JsonUtils.cpp
@@ -62,6 +62,23 @@ void TerminalApp::JsonUtils::GetOptionalDouble(const Json::Value& json,
                      validationFn);
 }
 
+void TerminalApp::JsonUtils::GetOptionalInt(const Json::Value& json,
+                                            std::string_view key,
+                                            std::optional<int>& target)
+{
+    const auto conversionFn = [](const Json::Value& value) -> int {
+        return value.asInt();
+    };
+    const auto validationFn = [](const Json::Value& value) -> bool {
+        return value.isInt();
+    };
+    GetOptionalValue(json,
+                     key,
+                     target,
+                     conversionFn,
+                     validationFn);
+}
+
 void TerminalApp::JsonUtils::GetInt(const Json::Value& json,
                                     std::string_view key,
                                     int& target)

--- a/src/cascadia/TerminalApp/JsonUtils.h
+++ b/src/cascadia/TerminalApp/JsonUtils.h
@@ -31,6 +31,10 @@ namespace TerminalApp::JsonUtils
                            std::string_view key,
                            std::optional<double>& target);
 
+    void GetOptionalInt(const Json::Value& json,
+                           std::string_view key,
+                           std::optional<int>& target);
+
     // Method Description:
     // - Helper that can be used for retrieving an optional value from a json
     //   object, and parsing it's value to layer on a given target object.

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -20,6 +20,8 @@
 #include "ColorHelper.h"
 #include "DebugTapConnection.h"
 
+#include <algorithm>
+
 using namespace winrt;
 using namespace winrt::Windows::Foundation::Collections;
 using namespace winrt::Windows::UI::Xaml;
@@ -1516,7 +1518,13 @@ namespace winrt::TerminalApp::implementation
                     text = item.Path();
                 }
             }
+            hstring::value_type* temporary = new hstring::value_type[text.size()+1];
+            wcscpy_s(temporary, text.size() + 1, text.c_str());
+            auto trash = std::remove(temporary, temporary + text.size() + 1, L'\t');
+            text = hstring(temporary);
+            trash = trash; //Know your place
             eventArgs.HandleClipboardData(text);
+            delete[] temporary;
         }
         CATCH_LOG();
     }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1518,11 +1518,12 @@ namespace winrt::TerminalApp::implementation
                     text = item.Path();
                 }
             }
+            //The following removes all tab characters when pasting from clipboard.
+            //TODO: Include an option to toggle this setting on and off.
             hstring::value_type* temporary = new hstring::value_type[text.size()+1];
             wcscpy_s(temporary, text.size() + 1, text.c_str());
-            auto trash = std::remove(temporary, temporary + text.size() + 1, L'\t');
-            text = hstring(temporary);
-            trash = trash; //Know your place
+            auto endIt = std::remove(temporary, temporary + text.size() + 1, L'\t');
+            text = hstring(temporary, endIt - temporary);
             eventArgs.HandleClipboardData(text);
             delete[] temporary;
         }

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -149,7 +149,7 @@ namespace winrt::TerminalApp::implementation
                                                           const Microsoft::Terminal::TerminalControl::PasteFromClipboardEventArgs eventArgs);
         bool _CopyText(const bool trimTrailingWhitespace);
         void _PasteText();
-        static fire_and_forget PasteFromClipboard(winrt::Microsoft::Terminal::TerminalControl::PasteFromClipboardEventArgs eventArgs, bool removeTabs);
+        static fire_and_forget PasteFromClipboard(winrt::Microsoft::Terminal::TerminalControl::PasteFromClipboardEventArgs eventArgs, std::optional<int> numSpacesToReplaceTab);
 
         fire_and_forget _LaunchSettings(const bool openDefaults);
 

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -149,7 +149,7 @@ namespace winrt::TerminalApp::implementation
                                                           const Microsoft::Terminal::TerminalControl::PasteFromClipboardEventArgs eventArgs);
         bool _CopyText(const bool trimTrailingWhitespace);
         void _PasteText();
-        static fire_and_forget PasteFromClipboard(winrt::Microsoft::Terminal::TerminalControl::PasteFromClipboardEventArgs eventArgs);
+        static fire_and_forget PasteFromClipboard(winrt::Microsoft::Terminal::TerminalControl::PasteFromClipboardEventArgs eventArgs, bool removeTabs);
 
         fire_and_forget _LaunchSettings(const bool openDefaults);
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Add option to remove tabs that are pasted in (similar to cmd)
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
None, as far as I know
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #6134
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [x] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
I built and loaded the terminal and disabled and enabled the option to see if it worked. 