### PR TITLE
Replace std::map with std::unordered_map

### DIFF
--- a/src/buffer/out/UnicodeStorage.cpp
+++ b/src/buffer/out/UnicodeStorage.cpp
@@ -47,7 +47,7 @@ void UnicodeStorage::Erase(const key_type key)
 // - rowMap - A map of the old row IDs to the new row IDs.
 // - width - The width of the new row. Remove any items that are beyond the row width.
 //         - Use nullopt if we're not resizing the width of the row, just renumbering the rows.
-void UnicodeStorage::Remap(const std::map<SHORT, SHORT>& rowMap, const std::optional<SHORT> width)
+void UnicodeStorage::Remap(const std::unordered_map<SHORT, SHORT>& rowMap, const std::optional<SHORT> width)
 {
     // Make a temporary map to hold all the new row positioning
     std::unordered_map<key_type, mapped_type> newMap;

--- a/src/buffer/out/UnicodeStorage.hpp
+++ b/src/buffer/out/UnicodeStorage.hpp
@@ -55,7 +55,7 @@ public:
 
     void Erase(const key_type key);
 
-    void Remap(const std::map<SHORT, SHORT>& rowMap, const std::optional<SHORT> width);
+    void Remap(const std::unordered_map<SHORT, SHORT>& rowMap, const std::optional<SHORT> width);
 
 private:
     std::unordered_map<key_type, mapped_type> _map;

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -872,7 +872,7 @@ UnicodeStorage& TextBuffer::GetUnicodeStorage() noexcept
 // - newRowWidth - Optional new value for the row width.
 void TextBuffer::_RefreshRowIDs(std::optional<SHORT> newRowWidth)
 {
-    std::map<SHORT, SHORT> rowMap;
+    std::unordered_map<SHORT, SHORT> rowMap;
     SHORT i = 0;
     for (auto& it : _storage)
     {

--- a/src/cascadia/WpfTerminalControl/NativeMethods.cs
+++ b/src/cascadia/WpfTerminalControl/NativeMethods.cs
@@ -37,6 +37,9 @@ namespace Microsoft.Terminal.Wpf
             /// </summary>
             WM_MOUSEACTIVATE = 0x0021,
 
+            /// <summary>
+            /// The WM_GETOBJECT message is sent by Active Accessibility when a client calls AccessibleObjectFromWindow or any of the other AccessibleObjectFromX APIs that retrieve an interface to an object.
+            /// </summary>
             WM_GETOBJECT = 0x003D,
 
             /// <summary>

--- a/src/cascadia/WpfTerminalControl/TerminalContainer.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalContainer.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Terminal.Wpf
         internal int Columns { get; private set; }
 
         /// <summary>
-        /// Stores the window handle of the terminal.
+        /// Gets the window handle of the terminal.
         /// </summary>
         internal IntPtr Hwnd => this.hwnd;
 

--- a/src/cascadia/WpfTerminalControl/TerminalContainer.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalContainer.cs
@@ -72,6 +72,9 @@ namespace Microsoft.Terminal.Wpf
         /// </summary>
         internal int Columns { get; private set; }
 
+        /// <summary>
+        /// Stores the window handle of the terminal.
+        /// </summary>
         internal IntPtr Hwnd => this.hwnd;
 
         /// <summary>
@@ -238,7 +241,7 @@ namespace Microsoft.Terminal.Wpf
                             NativeMethods.TerminalSetCursorVisible(this.terminal, true);
                             ulong scanCode = (((ulong)lParam) & 0x00FF0000) >> 16;
 
-                            NativeMethods.TerminalSendKeyEvent(this.terminal, (ushort)wParam, (ushort)(scanCode), true);
+                            NativeMethods.TerminalSendKeyEvent(this.terminal, (ushort)wParam, (ushort)scanCode, true);
                             this.blinkTimer?.Start();
                             break;
                         }
@@ -247,7 +250,7 @@ namespace Microsoft.Terminal.Wpf
                         {
                             // WM_KEYUP lParam layout documentation: https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-keyup
                             ulong scanCode = (((ulong)lParam) & 0x00FF0000) >> 16;
-                            NativeMethods.TerminalSendKeyEvent(this.terminal, (ushort)wParam, (ushort)(scanCode), false);
+                            NativeMethods.TerminalSendKeyEvent(this.terminal, (ushort)wParam, (ushort)scanCode, false);
                             break;
                         }
 

--- a/src/interactivity/win32/windowUiaProvider.hpp
+++ b/src/interactivity/win32/windowUiaProvider.hpp
@@ -89,7 +89,7 @@ namespace Microsoft::Console::Interactivity::Win32
         // eventually overflowing the stack.
         // We aren't using this as a cheap locking
         // mechanism for multi-threaded code.
-        std::map<EVENTID, bool> _signalEventFiring;
+        std::unordered_map<EVENTID, bool> _signalEventFiring;
 
         [[nodiscard]] HRESULT _EnsureValidHwnd() const;
 

--- a/src/types/ScreenInfoUiaProviderBase.h
+++ b/src/types/ScreenInfoUiaProviderBase.h
@@ -121,7 +121,7 @@ namespace Microsoft::Console::Types
         // eventually overflowing the stack.
         // We aren't using this as a cheap locking
         // mechanism for multi-threaded code.
-        std::map<EVENTID, bool> _signalFiringMapping{};
+        std::unordered_map<EVENTID, bool> _signalFiringMapping{};
 
         const COORD _getScreenBufferCoords() const;
         const TextBuffer& _getTextBuffer() const noexcept;

--- a/src/types/inc/CodepointWidthDetector.hpp
+++ b/src/types/inc/CodepointWidthDetector.hpp
@@ -46,6 +46,6 @@ private:
     bool _checkFallbackViaCache(const std::wstring_view glyph) const;
     static unsigned int _extractCodepoint(const std::wstring_view glyph) noexcept;
 
-    mutable std::map<std::wstring, bool> _fallbackCache;
+    mutable std::unordered_map<std::wstring, bool> _fallbackCache;
     std::function<bool(std::wstring_view)> _pfnFallbackMethod;
 };


### PR DESCRIPTION
Replace std::map with std::unordered_map when the order doesn't matter
and hash functions are provided. Simple optimizations, but I expect the
performance should be strictly better, especially for
CodepointWidthDetector.hpp.