### PR TITLE
Revert "Skip ... analysis when the ... text is simple (6206)"

### DIFF
--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -39,8 +39,7 @@ CustomTextLayout::CustomTextLayout(gsl::not_null<IDWriteFactory1*> const factory
     _runs{},
     _breakpoints{},
     _runIndex{ 0 },
-    _width{ width },
-    _isEntireTextSimple{ false }
+    _width{ width }
 {
     // Fetch the locale name out once now from the format
     _localeName.resize(gsl::narrow_cast<size_t>(format->GetLocaleNameLength()) + 1); // +1 for null
@@ -59,7 +58,6 @@ try
     _runs.clear();
     _breakpoints.clear();
     _runIndex = 0;
-    _isEntireTextSimple = false;
     _textClusterColumns.clear();
     _text.clear();
     return S_OK;
@@ -107,7 +105,6 @@ CATCH_RETURN()
     RETURN_HR_IF_NULL(E_INVALIDARG, columns);
     *columns = 0;
 
-    RETURN_IF_FAILED(_AnalyzeTextComplexity());
     RETURN_IF_FAILED(_AnalyzeRuns());
     RETURN_IF_FAILED(_ShapeGlyphRuns());
 
@@ -138,7 +135,6 @@ CATCH_RETURN()
                                                                FLOAT originX,
                                                                FLOAT originY) noexcept
 {
-    RETURN_IF_FAILED(_AnalyzeTextComplexity());
     RETURN_IF_FAILED(_AnalyzeRuns());
     RETURN_IF_FAILED(_ShapeGlyphRuns());
     RETURN_IF_FAILED(_CorrectGlyphRuns());
@@ -149,44 +145,6 @@ CATCH_RETURN()
 
     RETURN_IF_FAILED(_DrawGlyphRuns(clientDrawingContext, renderer, { originX, originY }));
 
-    return S_OK;
-}
-
-// Routine Description:
-// - Uses the internal text information and the analyzers/font information from construction
-//   to determine the complexity of the text. If the text is determined to be entirely simple,
-//   we'll have more chances to optimize the layout process.
-// Arguments:
-// - <none> - Uses internal state
-// Return Value:
-// - S_OK or suitable DirectWrite or STL error code
-[[nodiscard]] HRESULT CustomTextLayout::_AnalyzeTextComplexity() noexcept
-{
-    try
-    {
-        const auto textLength = gsl::narrow<UINT32>(_text.size());
-
-        BOOL isTextSimple = FALSE;
-        UINT32 uiLengthRead = 0;
-
-        // Start from the beginning.
-        const UINT32 glyphStart = 0;
-
-        _glyphIndices.resize(textLength);
-
-        const HRESULT hr = _analyzer->GetTextComplexity(
-            _text.c_str(),
-            textLength,
-            _font.Get(),
-            &isTextSimple,
-            &uiLengthRead,
-            &_glyphIndices.at(glyphStart));
-
-        RETURN_IF_FAILED(hr);
-
-        _isEntireTextSimple = isTextSimple && uiLengthRead == textLength;
-    }
-    CATCH_RETURN();
     return S_OK;
 }
 
@@ -220,7 +178,11 @@ CATCH_RETURN()
         // Allocate enough room to have one breakpoint per code unit.
         _breakpoints.resize(_text.size());
 
-        if (!_isEntireTextSimple)
+        BOOL isTextSimple = FALSE;
+        UINT32 uiLengthRead = 0;
+        RETURN_IF_FAILED(_analyzer->GetTextComplexity(_text.c_str(), textLength, _font.Get(), &isTextSimple, &uiLengthRead, NULL));
+
+        if (!(isTextSimple && uiLengthRead == _text.size()))
         {
             // Call each of the analyzers in sequence, recording their results.
             RETURN_IF_FAILED(_analyzer->AnalyzeLineBreakpoints(this, 0, textLength, this));
@@ -341,39 +303,6 @@ CATCH_RETURN()
             _glyphIndices.resize(totalGlyphsArrayCount);
         }
 
-        if (_isEntireTextSimple)
-        {
-            // When the entire text is simple, we can skip GetGlyphs and directly retrieve glyph indices and
-            // advances(in font design unit). With the help of font metrics, we can calculate the actual glyph
-            // advances without the need of GetGlyphPlacements. This shortcut will significantly reduce the time
-            // needed for text analysis.
-            DWRITE_FONT_METRICS1 metrics;
-            run.fontFace->GetMetrics(&metrics);
-
-            // With simple text, there's only one run. The actual glyph count is the same as textLength.
-            _glyphDesignUnitAdvances.resize(textLength);
-            _glyphAdvances.resize(textLength);
-            _glyphOffsets.resize(textLength);
-
-            USHORT designUnitsPerEm = metrics.designUnitsPerEm;
-
-            RETURN_IF_FAILED(_font->GetDesignGlyphAdvances(
-                textLength,
-                &_glyphIndices.at(glyphStart),
-                &_glyphDesignUnitAdvances.at(glyphStart),
-                run.isSideways));
-
-            for (size_t i = glyphStart; i < _glyphAdvances.size(); i++)
-            {
-                _glyphAdvances.at(i) = (float)_glyphDesignUnitAdvances.at(i) / designUnitsPerEm * _format->GetFontSize() * run.fontScale;
-            }
-
-            run.glyphCount = textLength;
-            glyphStart += textLength;
-
-            return S_OK;
-        }
-
         std::vector<DWRITE_SHAPING_TEXT_PROPERTIES> textProps(textLength);
         std::vector<DWRITE_SHAPING_GLYPH_PROPERTIES> glyphProps(maxGlyphCount);
 
@@ -471,12 +400,6 @@ CATCH_RETURN()
 {
     try
     {
-        // For simple text, there is no need to correct runs.
-        if (_isEntireTextSimple)
-        {
-            return S_OK;
-        }
-
         // Correct each run separately. This is needed whenever script, locale,
         // or reading direction changes.
         for (UINT32 runIndex = 0; runIndex < _runs.size(); ++runIndex)
@@ -613,6 +536,9 @@ try
     }
 
     // We're going to walk through and check for advances that don't match the space that we expect to give out.
+
+    DWRITE_FONT_METRICS1 metrics;
+    run.fontFace->GetMetrics(&metrics);
 
     // Glyph Indices represents the number inside the selected font where the glyph image/paths are found.
     // Text represents the original text we gave in.

--- a/src/renderer/dx/CustomTextLayout.h
+++ b/src/renderer/dx/CustomTextLayout.h
@@ -137,7 +137,6 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT STDMETHODCALLTYPE _AnalyzeBoxDrawing(gsl::not_null<IDWriteTextAnalysisSource*> const source, UINT32 textPosition, UINT32 textLength);
         [[nodiscard]] HRESULT STDMETHODCALLTYPE _SetBoxEffect(UINT32 textPosition, UINT32 textLength);
 
-        [[nodiscard]] HRESULT _AnalyzeTextComplexity() noexcept;
         [[nodiscard]] HRESULT _AnalyzeRuns() noexcept;
         [[nodiscard]] HRESULT _ShapeGlyphRuns() noexcept;
         [[nodiscard]] HRESULT _ShapeGlyphRun(const UINT32 runIndex, UINT32& glyphStart) noexcept;
@@ -184,9 +183,6 @@ namespace Microsoft::Console::Render
 
         // Glyph shaping results
 
-        // Whether the entire text is determined to be simple and does not require full script shaping.
-        bool _isEntireTextSimple;
-
         std::vector<DWRITE_GLYPH_OFFSET> _glyphOffsets;
 
         // Clusters are complicated. They're in respect to each individual run.
@@ -197,9 +193,6 @@ namespace Microsoft::Console::Render
 
         // This appears to be the index of the glyph inside each font.
         std::vector<UINT16> _glyphIndices;
-
-        // This is for calculating glyph advances when the entire text is simple.
-        std::vector<INT32> _glyphDesignUnitAdvances;
 
         std::vector<float> _glyphAdvances;
 


### PR DESCRIPTION
This reverts commit 94eab6e391a099814ce8f9a08c8cccf9f588b7d1.

We'll reintroduce this again after making sure it plays nicely with
recycling and box drawing glyphs.

Fixes #6488
Fixes #6664