### PR TITLE
When we add a new tab in compact mode, re-enforce Compact mode

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -557,6 +557,16 @@ namespace winrt::TerminalApp::implementation
 
         auto tabViewItem = newTabImpl->GetTabViewItem();
         _tabView.TabItems().Append(tabViewItem);
+        // GH#6570
+        // The TabView does not apply compact sizing to items added after Compact is enabled.
+        // By forcibly reapplying compact sizing every time we add a new tab, we'll make sure
+        // that it works.
+        // Workaround from https://github.com/microsoft/microsoft-ui-xaml/issues/2711
+        if (_tabView.TabWidthMode() == MUX::Controls::TabViewWidthMode::Compact)
+        {
+            _tabView.UpdateLayout();
+            _tabView.TabWidthMode(MUX::Controls::TabViewWidthMode::Compact);
+        }
 
         // Set this tab's icon to the icon from the user's profile
         const auto* const profile = _settings->FindProfile(profileGuid);


### PR DESCRIPTION
This workaround was suggested by @chingucoding in
microsoft/microsoft-ui-xaml#2711

Fixes #6570

## References

microsoft/microsoft-ui-xaml#2711
#6570

## PR Checklist
* [x] Closes an issue
* [x] CLA
* [x] Tested
* [x] Docs not required
* [x] Schema not required