### PR TITLE
Don't abort early in VT reset operations if one of the steps fails

### DIFF
--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1763,56 +1763,30 @@ bool AdaptDispatch::SingleShift(const size_t gsetNumber)
 // True if handled successfully. False otherwise.
 bool AdaptDispatch::SoftReset()
 {
-    const bool isPty = _pConApi->IsConsolePty();
-
     bool success = CursorVisibility(true); // Cursor enabled.
-    if (success)
+    success = SetOriginMode(false) && success; // Absolute cursor addressing.
+    success = SetAutoWrapMode(true) && success; // Wrap at end of line.
+    success = SetCursorKeysMode(false) && success; // Normal characters.
+    success = SetKeypadMode(false) && success; // Numeric characters.
+
+    // Top margin = 1; bottom margin = page length.
+    success = _DoSetTopBottomScrollingMargins(0, 0) && success;
+
+    _termOutput = {}; // Reset all character set designations.
+    if (_initialCodePage.has_value())
     {
-        success = SetOriginMode(false); // Absolute cursor addressing.
+        // Restore initial code page if previously changed by a DOCS sequence.
+        success = _pConApi->SetConsoleOutputCP(_initialCodePage.value()) && success;
     }
-    if (success)
-    {
-        success = SetAutoWrapMode(true); // Wrap at end of line.
-    }
-    if (success)
-    {
-        success = SetCursorKeysMode(false); // Normal characters.
-    }
-    // SetCursorKeysMode will return false if we're in conpty mode, as to
-    // trigger a passthrough. If that's the case, just power through here.
-    if (success || isPty)
-    {
-        success = SetKeypadMode(false); // Numeric characters.
-    }
-    // SetKeypadMode will return false if we're in conpty mode, as to trigger a
-    // passthrough. If that's the case, just power through here.
-    if (success || isPty)
-    {
-        // Top margin = 1; bottom margin = page length.
-        success = _DoSetTopBottomScrollingMargins(0, 0);
-    }
-    if (success)
-    {
-        _termOutput = {}; // Reset all character set designations.
-        if (_initialCodePage.has_value())
-        {
-            // Restore initial code page if previously changed by a DOCS sequence.
-            success = _pConApi->SetConsoleOutputCP(_initialCodePage.value());
-        }
-    }
-    if (success)
-    {
-        const auto opt = DispatchTypes::GraphicsOptions::Off;
-        success = SetGraphicsRendition({ &opt, 1 }); // Normal rendition.
-    }
-    if (success)
-    {
-        // Reset the saved cursor state.
-        // Note that XTerm only resets the main buffer state, but that
-        // seems likely to be a bug. Most other terminals reset both.
-        _savedCursorState.at(0) = {}; // Main buffer
-        _savedCursorState.at(1) = {}; // Alt buffer
-    }
+
+    const auto opt = DispatchTypes::GraphicsOptions::Off;
+    success = SetGraphicsRendition({ &opt, 1 }) && success; // Normal rendition.
+
+    // Reset the saved cursor state.
+    // Note that XTerm only resets the main buffer state, but that
+    // seems likely to be a bug. Most other terminals reset both.
+    _savedCursorState.at(0) = {}; // Main buffer
+    _savedCursorState.at(1) = {}; // Alt buffer
 
     return success;
 }
@@ -1851,34 +1825,19 @@ bool AdaptDispatch::HardReset()
 
     // Sets the SGR state to normal - this must be done before EraseInDisplay
     //      to ensure that it clears with the default background color.
-    if (success)
-    {
-        success = SoftReset();
-    }
+    success = SoftReset() && success;
 
     // Clears the screen - Needs to be done in two operations.
-    if (success)
-    {
-        success = EraseInDisplay(DispatchTypes::EraseType::All);
-    }
-    if (success)
-    {
-        success = _EraseScrollback();
-    }
+    success = EraseInDisplay(DispatchTypes::EraseType::All) && success;
+    success = EraseInDisplay(DispatchTypes::EraseType::Scrollback) && success;
 
     // Set the DECSCNM screen mode back to normal.
-    if (success)
-    {
-        success = SetScreenMode(false);
-    }
+    success = SetScreenMode(false) && success;
 
     // Cursor to 1,1 - the Soft Reset guarantees this is absolute
-    if (success)
-    {
-        success = CursorPosition(1, 1);
-    }
+    success = CursorPosition(1, 1) && success;
 
-    // delete all current tab stops and reapply
+    // Delete all current tab stops and reapply
     _ResetTabStops();
 
     // GH#2715 - If all this succeeded, but we're in a conpty, return `false` to


### PR DESCRIPTION
The VT reset operations `RIS` and `DECSTR` are implemented as a series
of steps, each of which could potentially fail. Currently these
operations abort as soon as an error is detected, which is particularly
problematic in conpty mode, where some steps deliberately "fail" to
indicate that they need to be "passed through" to the conpty client. As
a result, the reset won't be fully executed. This PR changes that
behaviour, so the error state is recorded for any failures, but the
subsequent steps are still run.

Originally the structure of these operations was of the form:

    bool success = DoSomething();
    if (success)
    {
        success = DoSomethingElse();
    }

But I've now changed the code so it looks more like this:

    bool success = DoSomething();
    success = DoSomethingElse() && success;

This means that every one of the steps should execute, regardless of
whether previous steps were successful, but the final _success_ state
will only be true if none of the steps has failed.

While this is only really an issue in the conhost code, I've updated
both the `AdaptDispatch` and `TerminalDispatch` classes, since I thought
it would be best to have them in sync, and in general this seems like a
better way to handle multi-step operations anyway.

VALIDATION

I've manually tested the `RIS` escape sequence (`\ec`) in the Windows
Terminal, and confirmed that it now correctly resets the cursor
position, which it wasn't doing before.

Closes #6545