### PR TITLE
Add actions missing in schema, descriptions for `toggleRetroEffect`

### DIFF
--- a/.github/actions/spell-check/expect/expect.txt
+++ b/.github/actions/spell-check/expect/expect.txt
@@ -1147,6 +1147,7 @@ IUI
 IUia
 IUnknown
 ivalid
+IValue
 IVector
 IWait
 iwch

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -55,9 +55,12 @@
         "splitPane",
         "switchToTab",
         "toggleFullscreen",
+        "toggleRetroEffect",
         "find",
         "setTabColor",
         "openTabColorPicker",
+        "renameTab",
+        "commandPalette",
         "unbound"
       ],
       "type": "string"

--- a/src/cascadia/TerminalApp/ActionAndArgs.cpp
+++ b/src/cascadia/TerminalApp/ActionAndArgs.cpp
@@ -251,6 +251,7 @@ namespace winrt::TerminalApp::implementation
                 { ShortcutAction::ResizePane, RS_(L"ResizePaneCommandKey") },
                 { ShortcutAction::MoveFocus, RS_(L"MoveFocusCommandKey") },
                 { ShortcutAction::OpenSettings, RS_(L"OpenSettingsCommandKey") },
+                { ShortcutAction::ToggleRetroEffect, RS_(L"ToggleRetroEffectCommandKey") },
                 { ShortcutAction::ToggleFullscreen, RS_(L"ToggleFullscreenCommandKey") },
                 { ShortcutAction::SplitPane, RS_(L"SplitPaneCommandKey") },
                 { ShortcutAction::Invalid, L"" },

--- a/src/cascadia/TerminalApp/CommandKeyChordVisibilityConverter.cpp
+++ b/src/cascadia/TerminalApp/CommandKeyChordVisibilityConverter.cpp
@@ -1,0 +1,38 @@
+#include "pch.h"
+#include "CommandKeyChordVisibilityConverter.h"
+#include "CommandKeyChordVisibilityConverter.g.cpp"
+
+using namespace winrt::Windows;
+using namespace winrt::Windows::UI::Xaml;
+
+namespace winrt::TerminalApp::implementation
+{
+    // Method Description:
+    // - Attempt to convert something into another type. For the
+    //   CommandKeyChordVisibilityConverter, we're gonna check if `value` is a
+    //   string, and try and convert it into a Visibility value. If the input
+    //   param wasn't a string, or was the empty string, we'll return
+    //   Visibility::Collapsed. Otherwise, we'll return Visible.
+
+    // Arguments:
+    // - value: the input object to attempt to convert into a Visibility.
+    // Return Value:
+    // - Visible if the object was a string and wasn't the empty string.
+    Foundation::IInspectable CommandKeyChordVisibilityConverter::Convert(Foundation::IInspectable const& value,
+                                                                         Windows::UI::Xaml::Interop::TypeName const& /* targetType */,
+                                                                         Foundation::IInspectable const& /* parameter */,
+                                                                         hstring const& /* language */)
+    {
+        const auto& name = winrt::unbox_value_or<hstring>(value, L"");
+        return winrt::box_value(name.empty() ? Visibility::Collapsed : Visibility::Visible);
+    }
+
+    // unused for one-way bindings
+    Foundation::IInspectable CommandKeyChordVisibilityConverter::ConvertBack(Foundation::IInspectable const& /* value */,
+                                                                             Windows::UI::Xaml::Interop::TypeName const& /* targetType */,
+                                                                             Foundation::IInspectable const& /* parameter */,
+                                                                             hstring const& /* language */)
+    {
+        throw hresult_not_implemented();
+    }
+}

--- a/src/cascadia/TerminalApp/CommandKeyChordVisibilityConverter.h
+++ b/src/cascadia/TerminalApp/CommandKeyChordVisibilityConverter.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "CommandKeyChordVisibilityConverter.g.h"
+#include "..\inc\cppwinrt_utils.h"
+
+namespace winrt::TerminalApp::implementation
+{
+    struct CommandKeyChordVisibilityConverter : CommandKeyChordVisibilityConverterT<CommandKeyChordVisibilityConverter>
+    {
+        CommandKeyChordVisibilityConverter() = default;
+
+        Windows::Foundation::IInspectable Convert(Windows::Foundation::IInspectable const& value,
+                                                  Windows::UI::Xaml::Interop::TypeName const& targetType,
+                                                  Windows::Foundation::IInspectable const& parameter,
+                                                  hstring const& language);
+
+        Windows::Foundation::IInspectable ConvertBack(Windows::Foundation::IInspectable const& value,
+                                                      Windows::UI::Xaml::Interop::TypeName const& targetType,
+                                                      Windows::Foundation::IInspectable const& parameter,
+                                                      hstring const& language);
+    };
+}
+
+namespace winrt::TerminalApp::factory_implementation
+{
+    BASIC_FACTORY(CommandKeyChordVisibilityConverter);
+}

--- a/src/cascadia/TerminalApp/CommandKeyChordVisibilityConverter.idl
+++ b/src/cascadia/TerminalApp/CommandKeyChordVisibilityConverter.idl
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+namespace TerminalApp
+{
+    // See https://docs.microsoft.com/en-us/windows/uwp/data-binding/data-binding-quickstart
+
+    // We use the default attribute to declare IValueConverter as the default
+    // interface. In the listing, CommandKeyChordVisibilityConverter has only a
+    // constructor, and no methods, so no default interface is generated for it.
+    // The default attribute is optimal if you won't be adding instance members
+    // to CommandKeyChordVisibilityConverter, because no QueryInterface will be
+    // required to call the IValueConverter methods
+    runtimeclass CommandKeyChordVisibilityConverter : [default] Windows.UI.Xaml.Data.IValueConverter
+    {
+        CommandKeyChordVisibilityConverter();
+    };
+
+}

--- a/src/cascadia/TerminalApp/CommandPalette.xaml
+++ b/src/cascadia/TerminalApp/CommandPalette.xaml
@@ -19,6 +19,9 @@ the MIT License. See LICENSE in the project root for license information. -->
             adds it conditionally -->
             <Windows10version1903:ThemeShadow x:Name="CommandPaletteShadow" />
 
+            <!-- This creates an instance of our CommandKeyChordVisibilityConverter we can reference below -->
+            <local:CommandKeyChordVisibilityConverter x:Key="CommandKeyChordVisibilityConverter"/>
+
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Dark">
                     <Style x:Key="CommandPaletteBackground" TargetType="Grid">
@@ -176,8 +179,14 @@ the MIT License. See LICENSE in the project root for license information. -->
                                        HorizontalAlignment="Left"
                                        Text="{x:Bind Name, Mode=OneWay}" />
 
+                            <!-- The block for the key chord is only visible
+                            when there's actual text set as the label. See
+                            CommandKeyChordVisibilityConverter for details. -->
                             <Border
                                 Grid.Column="2"
+                                Visibility="{x:Bind KeyChordText,
+                                             Mode=OneWay,
+                                             Converter={StaticResource CommandKeyChordVisibilityConverter}}"
                                 BorderBrush="{ThemeResource SystemControlForegroundBaseMediumBrush}"
                                 Background="{ThemeResource SystemControlForegroundBaseLowBrush}"
                                 BorderThickness="1"

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -501,6 +501,9 @@
   <data name="ResetFontSizeCommandKey" xml:space="preserve">
     <value>Reset font size</value>
   </data>
+  <data name="ToggleRetroEffectCommandKey" xml:space="preserve">
+    <value>Toggle retro terminal effect</value>
+  </data>
   <data name="ToggleCommandPaletteCommandKey" xml:space="preserve">
     <value>Toggle command palette</value>
   </data>
@@ -529,13 +532,13 @@
   </data>
   <data name="MediumSeaGreenColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Medium Sea Green</value>
-  </data>  
+  </data>
   <data name="DarkOrangeColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Dark Orange</value>
   </data>
   <data name="MediumVioletRedColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Medium Violet Red</value>
-  </data>  
+  </data>
   <data name="DodgerBlueColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Dodger Blue</value>
   </data>

--- a/src/cascadia/TerminalApp/defaults.json
+++ b/src/cascadia/TerminalApp/defaults.json
@@ -271,7 +271,7 @@
             "brightWhite": "#EEEEEC"
         }
     ],
-    "keybindings":
+    "bindings":
     [
         // Application-level Keys
         { "command": "closeWindow", "keys": "alt+f4" },
@@ -281,6 +281,8 @@
         { "command": "openSettings", "keys": "ctrl+," },
         { "command": { "action": "openSettings", "target": "defaultsFile" }, "keys": "ctrl+alt+," },
         { "command": "find", "keys": "ctrl+shift+f" },
+        { "command": "toggleRetroEffect" },
+        { "command": "openTabColorPicker" },
 
         // Tab Management
         // "command": "closeTab" is unbound by default.

--- a/src/cascadia/TerminalApp/lib/TerminalAppLib.vcxproj
+++ b/src/cascadia/TerminalApp/lib/TerminalAppLib.vcxproj
@@ -94,6 +94,9 @@
     <ClInclude Include="../Command.h">
       <DependentUpon>../Command.idl</DependentUpon>
     </ClInclude>
+    <ClInclude Include="../CommandKeyChordVisibilityConverter.h">
+      <DependentUpon>../CommandKeyChordVisibilityConverter.idl</DependentUpon>
+    </ClInclude>
     <ClInclude Include="../Tab.h">
       <DependentUpon>../Tab.idl</DependentUpon>
     </ClInclude>
@@ -160,6 +163,9 @@
     </ClCompile>
     <ClCompile Include="../Command.cpp">
       <DependentUpon>../Command.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="../CommandKeyChordVisibilityConverter.cpp">
+      <DependentUpon>../CommandKeyChordVisibilityConverter.idl</DependentUpon>
     </ClCompile>
     <ClCompile Include="../Tab.cpp">
       <DependentUpon>../Tab.idl</DependentUpon>
@@ -249,6 +255,7 @@
       <SubType>Code</SubType>
     </Midl>
     <Midl Include="../Command.idl" />
+    <Midl Include="../CommandKeyChordVisibilityConverter.idl" />
     <Midl Include="../Tab.idl" />
   </ItemGroup>
   <!-- ========================= Misc Files ======================== -->


### PR DESCRIPTION
## Summary of the Pull Request

In the wake of #6635, a couple things got missed in merges:
* `toggleRetroEffect` didn't get into the schema, nor did `renameTab` or
  `commandPalette`.
* `toggleRetroEffect` also didn't get a name

Furthermore, I thought it might be a good idea to start sticking
commands into `bindings` even without `keys`. So I tried doing that for
`opentabColorPicker` and `toggleRetroEffect`, and found immediately that
the labels for the key chord still appear even when the text is empty.
So I added some XAML magic to hide those when the text is empty.

## References
* #6762 
* #6691
* #6557 
* #6635 

## PR Checklist
* [x] Closes #6762
* [x] I work here
* [x] Tests added/passed
* [n/a] Requires documentation to be updated

## Detailed Description of the Pull Request / Additional comments

* See also: https://docs.microsoft.com/en-us/windows/uwp/data-binding/data-binding-quickstart#formatting-or-converting-data-values-for-display
  - make sure to switch to C++/WinRT at the top!

## Validation Steps Performed
Removed all my manual actions, ran the Terminal:
![image](https://user-images.githubusercontent.com/18356694/86652356-f5a79400-bfa9-11ea-9131-5b7d3e835e19.png)

