### PR TITLE
Reintroduce a color compatibility hack, but only for PowerShells

### DIFF
--- a/src/buffer/out/TextAttribute.cpp
+++ b/src/buffer/out/TextAttribute.cpp
@@ -24,7 +24,8 @@ void TextAttribute::SetLegacyDefaultAttributes(const WORD defaultAttributes) noe
 // - Returns whether the color passed in is an analogue of the default background color
 //   represented as a 16-color palette index.
 // - Do not use this function.
-bool TextAttribute::IsColorVT16VersionOfLegacyDefaultBackground(const TextColor& color) noexcept {
+bool TextAttribute::IsColorVT16VersionOfLegacyDefaultBackground(const TextColor& color) noexcept
+{
     return color.IsIndex16() && color.GetIndex() == s_legacyDefaultBackground;
 }
 

--- a/src/buffer/out/TextAttribute.cpp
+++ b/src/buffer/out/TextAttribute.cpp
@@ -21,6 +21,14 @@ void TextAttribute::SetLegacyDefaultAttributes(const WORD defaultAttributes) noe
 }
 
 // Routine Description:
+// - Returns whether the color passed in is an analogue of the default background color
+//   represented as a 16-color palette index.
+// - Do not use this function.
+bool TextAttribute::IsColorVT16VersionOfLegacyDefaultBackground(const TextColor& color) noexcept {
+    return color.IsIndex16() && color.GetIndex() == s_legacyDefaultBackground;
+}
+
+// Routine Description:
 // - Returns a WORD with legacy-style attributes for this textattribute.
 // Parameters:
 // - None

--- a/src/buffer/out/TextAttribute.cpp
+++ b/src/buffer/out/TextAttribute.cpp
@@ -47,8 +47,11 @@ TextAttribute TextAttribute::StripErroneousVT16VersionsOfLegacyDefaults(const Te
     const auto fg{ attribute.GetForeground() };
     const auto bg{ attribute.GetBackground() };
     auto copy{ attribute };
-    if (fg.IsIndex16() && fg.GetIndex() == s_legacyDefaultForeground)
+    if (fg.IsIndex16() &&
+        attribute.IsBold() == WI_IsFlagSet(s_legacyDefaultForeground, FOREGROUND_INTENSITY) &&
+        fg.GetIndex() == (s_legacyDefaultForeground & ~FOREGROUND_INTENSITY))
     {
+        // We don't want to turn 1;37m into 39m (or even 1;39m), as this was meant to mimic a legacy color.
         copy.SetDefaultForeground();
     }
     if (bg.IsIndex16() && bg.GetIndex() == s_legacyDefaultBackground)

--- a/src/buffer/out/TextAttribute.hpp
+++ b/src/buffer/out/TextAttribute.hpp
@@ -60,6 +60,7 @@ public:
     }
 
     static void SetLegacyDefaultAttributes(const WORD defaultAttributes) noexcept;
+    static bool IsColorVT16VersionOfLegacyDefaultBackground(const TextColor& textColor) noexcept;
     WORD GetLegacyAttributes() const noexcept;
 
     COLORREF CalculateRgbForeground(std::basic_string_view<COLORREF> colorTable,

--- a/src/buffer/out/TextAttribute.hpp
+++ b/src/buffer/out/TextAttribute.hpp
@@ -60,7 +60,7 @@ public:
     }
 
     static void SetLegacyDefaultAttributes(const WORD defaultAttributes) noexcept;
-    static bool IsColorVT16VersionOfLegacyDefaultBackground(const TextColor& textColor) noexcept;
+    static TextAttribute StripErroneousVT16VersionsOfLegacyDefaults(const TextAttribute& attribute) noexcept;
     WORD GetLegacyAttributes() const noexcept;
 
     COLORREF CalculateRgbForeground(std::basic_string_view<COLORREF> colorTable,

--- a/src/host/ApiRoutines.h
+++ b/src/host/ApiRoutines.h
@@ -98,11 +98,13 @@ public:
     [[nodiscard]] HRESULT WriteConsoleAImpl(IConsoleOutputObject& context,
                                             const std::string_view buffer,
                                             size_t& read,
+                                            bool requiresVtQuirk,
                                             std::unique_ptr<IWaitRoutine>& waiter) noexcept override;
 
     [[nodiscard]] HRESULT WriteConsoleWImpl(IConsoleOutputObject& context,
                                             const std::wstring_view buffer,
                                             size_t& read,
+                                            bool requiresVtQuirk,
                                             std::unique_ptr<IWaitRoutine>& waiter) noexcept override;
 
 #pragma region ThreadCreationInfo

--- a/src/host/_stream.h
+++ b/src/host/_stream.h
@@ -93,4 +93,5 @@ Note:
 [[nodiscard]] NTSTATUS DoWriteConsole(_In_reads_bytes_(*pcbBuffer) PWCHAR pwchBuffer,
                                       _Inout_ size_t* const pcbBuffer,
                                       SCREEN_INFORMATION& screenInfo,
+                                      bool requiresVtQuirk,
                                       std::unique_ptr<WriteData>& waiter);

--- a/src/host/screenInfo.hpp
+++ b/src/host/screenInfo.hpp
@@ -238,6 +238,9 @@ public:
 
     void InitializeCursorRowAttributes();
 
+    void SetIgnoreLegacyEquivalentVTAttributes() noexcept;
+    void ResetIgnoreLegacyEquivalentVTAttributes() noexcept;
+
 private:
     SCREEN_INFORMATION(_In_ Microsoft::Console::Interactivity::IWindowMetrics* pMetrics,
                        _In_ Microsoft::Console::Interactivity::IAccessibilityNotifier* pNotifier,
@@ -299,6 +302,8 @@ private:
     short _virtualBottom;
 
     ScreenBufferRenderTarget _renderTarget;
+
+    bool _ignoreLegacyEquivalentVTAttributes;
 
 #ifdef UNIT_TESTING
     friend class TextBufferIteratorTests;

--- a/src/host/ut_host/ApiRoutinesTests.cpp
+++ b/src/host/ut_host/ApiRoutinesTests.cpp
@@ -386,7 +386,7 @@ class ApiRoutinesTests
             const size_t cchWriteLength = std::min(cchIncrement, cchTestText - i);
 
             // Run the test method
-            const HRESULT hr = _pApiRoutines->WriteConsoleAImpl(si, { pszTestText + i, cchWriteLength }, cchRead, waiter);
+            const HRESULT hr = _pApiRoutines->WriteConsoleAImpl(si, { pszTestText + i, cchWriteLength }, cchRead, false, waiter);
 
             VERIFY_ARE_EQUAL(S_OK, hr, L"Successful result code from writing.");
             if (!fInduceWait)
@@ -442,7 +442,7 @@ class ApiRoutinesTests
 
         size_t cchRead = 0;
         std::unique_ptr<IWaitRoutine> waiter;
-        const HRESULT hr = _pApiRoutines->WriteConsoleWImpl(si, testText, cchRead, waiter);
+        const HRESULT hr = _pApiRoutines->WriteConsoleWImpl(si, testText, cchRead, false, waiter);
 
         VERIFY_ARE_EQUAL(S_OK, hr, L"Successful result code from writing.");
         if (!fInduceWait)

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -2115,7 +2115,7 @@ void ScreenBufferTests::TestAltBufferVtDispatching()
         std::unique_ptr<WriteData> waiter;
         std::wstring seq = L"\x1b[5;6H";
         size_t seqCb = 2 * seq.size();
-        VERIFY_SUCCEEDED(DoWriteConsole(&seq[0], &seqCb, mainBuffer, waiter));
+        VERIFY_SUCCEEDED(DoWriteConsole(&seq[0], &seqCb, mainBuffer, false, waiter));
 
         VERIFY_ARE_EQUAL(COORD({ 0, 0 }), mainCursor.GetPosition());
         // recall: vt coordinates are (row, column), 1-indexed
@@ -2130,14 +2130,14 @@ void ScreenBufferTests::TestAltBufferVtDispatching()
 
         seq = L"\x1b[48;2;255;0;255m";
         seqCb = 2 * seq.size();
-        VERIFY_SUCCEEDED(DoWriteConsole(&seq[0], &seqCb, mainBuffer, waiter));
+        VERIFY_SUCCEEDED(DoWriteConsole(&seq[0], &seqCb, mainBuffer, false, waiter));
 
         VERIFY_ARE_EQUAL(expectedDefaults, mainBuffer.GetAttributes());
         VERIFY_ARE_EQUAL(expectedRgb, alternate.GetAttributes());
 
         seq = L"X";
         seqCb = 2 * seq.size();
-        VERIFY_SUCCEEDED(DoWriteConsole(&seq[0], &seqCb, mainBuffer, waiter));
+        VERIFY_SUCCEEDED(DoWriteConsole(&seq[0], &seqCb, mainBuffer, false, waiter));
 
         VERIFY_ARE_EQUAL(COORD({ 0, 0 }), mainCursor.GetPosition());
         VERIFY_ARE_EQUAL(COORD({ 6, 4 }), altCursor.GetPosition());

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -5948,16 +5948,6 @@ void ScreenBufferTests::TestWriteConsoleVTQuirkMode()
     // Otherwise they could be polluted from a previous test.
     mainBuffer.SetAttributes(defaultAttribute);
 
-    TextAttribute vtRedOnBlueAttribute{};
-    vtRedOnBlueAttribute.SetForeground(TextColor{ gsl::narrow_cast<BYTE>(XtermToWindowsIndex(1)), false });
-    vtRedOnBlueAttribute.SetBackground(TextColor{ gsl::narrow_cast<BYTE>(XtermToWindowsIndex(4)), false });
-
-    TextAttribute vtWhiteOnBlackAttribute{};
-    vtWhiteOnBlackAttribute.SetForeground(TextColor{ gsl::narrow_cast<BYTE>(XtermToWindowsIndex(7)), false });
-    vtWhiteOnBlackAttribute.SetBackground(TextColor{ gsl::narrow_cast<BYTE>(XtermToWindowsIndex(0)), false });
-
-    const TextAttribute quirkExpectedAttribute{ useQuirk ? defaultAttribute : vtWhiteOnBlackAttribute };
-
     const auto verifyLastAttribute = [&](const TextAttribute& expected) {
         const ROW& row = mainBuffer.GetTextBuffer().GetRowByOffset(cursor.GetPosition().Y);
         const auto attrRow = &row.GetAttrRow();
@@ -5968,27 +5958,91 @@ void ScreenBufferTests::TestWriteConsoleVTQuirkMode()
 
     std::unique_ptr<WriteData> waiter;
 
-    std::wstring seq = L"\x1b[31;44m";
-    size_t seqCb = 2 * seq.size();
-    VERIFY_SUCCEEDED(DoWriteConsole(&seq[0], &seqCb, mainBuffer, useQuirk, waiter));
+    std::wstring seq{};
+    size_t seqCb{ 0 };
 
-    VERIFY_ARE_EQUAL(vtRedOnBlueAttribute, mainBuffer.GetAttributes());
+    /* Write red on blue, verify that it comes through */
+    {
+        TextAttribute vtRedOnBlueAttribute{};
+        vtRedOnBlueAttribute.SetForeground(TextColor{ gsl::narrow_cast<BYTE>(XtermToWindowsIndex(1)), false });
+        vtRedOnBlueAttribute.SetBackground(TextColor{ gsl::narrow_cast<BYTE>(XtermToWindowsIndex(4)), false });
 
-    seq = L"X";
-    seqCb = 2 * seq.size();
-    VERIFY_SUCCEEDED(DoWriteConsole(&seq[0], &seqCb, mainBuffer, useQuirk, waiter));
+        seq = L"\x1b[31;44m";
+        seqCb = 2 * seq.size();
+        VERIFY_SUCCEEDED(DoWriteConsole(&seq[0], &seqCb, mainBuffer, useQuirk, waiter));
 
-    verifyLastAttribute(vtRedOnBlueAttribute);
+        VERIFY_ARE_EQUAL(vtRedOnBlueAttribute, mainBuffer.GetAttributes());
 
-    seq = L"\x1b[37;40m"; // the quirk should suppress this, turning it into "defaults"
-    seqCb = 2 * seq.size();
-    VERIFY_SUCCEEDED(DoWriteConsole(&seq[0], &seqCb, mainBuffer, useQuirk, waiter));
+        seq = L"X";
+        seqCb = 2 * seq.size();
+        VERIFY_SUCCEEDED(DoWriteConsole(&seq[0], &seqCb, mainBuffer, useQuirk, waiter));
 
-    VERIFY_ARE_EQUAL(quirkExpectedAttribute, mainBuffer.GetAttributes());
+        verifyLastAttribute(vtRedOnBlueAttribute);
+    }
 
-    seq = L"X";
-    seqCb = 2 * seq.size();
-    VERIFY_SUCCEEDED(DoWriteConsole(&seq[0], &seqCb, mainBuffer, useQuirk, waiter));
+    /* Write white on black, verify that it acts as expected for the quirk mode */
+    {
+        TextAttribute vtWhiteOnBlackAttribute{};
+        vtWhiteOnBlackAttribute.SetForeground(TextColor{ gsl::narrow_cast<BYTE>(XtermToWindowsIndex(7)), false });
+        vtWhiteOnBlackAttribute.SetBackground(TextColor{ gsl::narrow_cast<BYTE>(XtermToWindowsIndex(0)), false });
 
-    verifyLastAttribute(quirkExpectedAttribute);
+        const TextAttribute quirkExpectedAttribute{ useQuirk ? defaultAttribute : vtWhiteOnBlackAttribute };
+
+        seq = L"\x1b[37;40m"; // the quirk should suppress this, turning it into "defaults"
+        seqCb = 2 * seq.size();
+        VERIFY_SUCCEEDED(DoWriteConsole(&seq[0], &seqCb, mainBuffer, useQuirk, waiter));
+
+        VERIFY_ARE_EQUAL(quirkExpectedAttribute, mainBuffer.GetAttributes());
+
+        seq = L"X";
+        seqCb = 2 * seq.size();
+        VERIFY_SUCCEEDED(DoWriteConsole(&seq[0], &seqCb, mainBuffer, useQuirk, waiter));
+
+        verifyLastAttribute(quirkExpectedAttribute);
+    }
+
+    /* Write bright white on black, verify that it acts as expected for the quirk mode */
+    {
+        TextAttribute vtBrightWhiteOnBlackAttribute{};
+        vtBrightWhiteOnBlackAttribute.SetForeground(TextColor{ gsl::narrow_cast<BYTE>(XtermToWindowsIndex(7)), false });
+        vtBrightWhiteOnBlackAttribute.SetBackground(TextColor{ gsl::narrow_cast<BYTE>(XtermToWindowsIndex(0)), false });
+        vtBrightWhiteOnBlackAttribute.SetBold(true);
+
+        TextAttribute vtBrightWhiteOnDefaultAttribute{ vtBrightWhiteOnBlackAttribute }; // copy the above attribute
+        vtBrightWhiteOnDefaultAttribute.SetDefaultBackground();
+
+        const TextAttribute quirkExpectedAttribute{ useQuirk ? vtBrightWhiteOnDefaultAttribute : vtBrightWhiteOnBlackAttribute };
+
+        seq = L"\x1b[1;37;40m"; // the quirk should suppress black only, turning it into "default background"
+        seqCb = 2 * seq.size();
+        VERIFY_SUCCEEDED(DoWriteConsole(&seq[0], &seqCb, mainBuffer, useQuirk, waiter));
+
+        VERIFY_ARE_EQUAL(quirkExpectedAttribute, mainBuffer.GetAttributes());
+
+        seq = L"X";
+        seqCb = 2 * seq.size();
+        VERIFY_SUCCEEDED(DoWriteConsole(&seq[0], &seqCb, mainBuffer, useQuirk, waiter));
+
+        verifyLastAttribute(quirkExpectedAttribute);
+    }
+
+    /* Write a 256-color white on a 256-color black, make sure the quirk does not suppress it */
+    {
+        TextAttribute vtWhiteOnBlack256Attribute{};
+        vtWhiteOnBlack256Attribute.SetForeground(TextColor{ gsl::narrow_cast<BYTE>(XtermToWindowsIndex(7)), true });
+        vtWhiteOnBlack256Attribute.SetBackground(TextColor{ gsl::narrow_cast<BYTE>(XtermToWindowsIndex(0)), true });
+
+        // reset (disable bold from the last test) before setting both colors
+        seq = L"\x1b[m\x1b[38;5;7;48;5;0m"; // the quirk should *not* suppress this (!)
+        seqCb = 2 * seq.size();
+        VERIFY_SUCCEEDED(DoWriteConsole(&seq[0], &seqCb, mainBuffer, useQuirk, waiter));
+
+        VERIFY_ARE_EQUAL(vtWhiteOnBlack256Attribute, mainBuffer.GetAttributes());
+
+        seq = L"X";
+        seqCb = 2 * seq.size();
+        VERIFY_SUCCEEDED(DoWriteConsole(&seq[0], &seqCb, mainBuffer, useQuirk, waiter));
+
+        verifyLastAttribute(vtWhiteOnBlack256Attribute);
+    }
 }

--- a/src/host/ut_host/TextBufferTests.cpp
+++ b/src/host/ut_host/TextBufferTests.cpp
@@ -1573,7 +1573,7 @@ void TextBufferTests::TestBackspaceStringsAPI()
     std::unique_ptr<WriteData> waiter;
 
     size_t aCb = 2;
-    VERIFY_SUCCEEDED(DoWriteConsole(L"a", &aCb, si, waiter));
+    VERIFY_SUCCEEDED(DoWriteConsole(L"a", &aCb, si, false, waiter));
 
     size_t seqCb = 6;
     Log::Comment(NoThrowString().Format(
@@ -1587,9 +1587,9 @@ void TextBufferTests::TestBackspaceStringsAPI()
 
         Log::Comment(NoThrowString().Format(
             L"Using DoWriteConsole, write \\b \\b as a single string."));
-        VERIFY_SUCCEEDED(DoWriteConsole(L"a", &aCb, si, waiter));
+        VERIFY_SUCCEEDED(DoWriteConsole(L"a", &aCb, si, false, waiter));
 
-        VERIFY_SUCCEEDED(DoWriteConsole(str, &seqCb, si, waiter));
+        VERIFY_SUCCEEDED(DoWriteConsole(str, &seqCb, si, false, waiter));
         VERIFY_ARE_EQUAL(cursor.GetPosition().X, x0);
         VERIFY_ARE_EQUAL(cursor.GetPosition().Y, y0);
     }
@@ -1599,10 +1599,10 @@ void TextBufferTests::TestBackspaceStringsAPI()
     Log::Comment(NoThrowString().Format(
         L"Using DoWriteConsole, write \\b \\b as separate strings."));
 
-    VERIFY_SUCCEEDED(DoWriteConsole(L"a", &seqCb, si, waiter));
-    VERIFY_SUCCEEDED(DoWriteConsole(L"\b", &seqCb, si, waiter));
-    VERIFY_SUCCEEDED(DoWriteConsole(L" ", &seqCb, si, waiter));
-    VERIFY_SUCCEEDED(DoWriteConsole(L"\b", &seqCb, si, waiter));
+    VERIFY_SUCCEEDED(DoWriteConsole(L"a", &seqCb, si, false, waiter));
+    VERIFY_SUCCEEDED(DoWriteConsole(L"\b", &seqCb, si, false, waiter));
+    VERIFY_SUCCEEDED(DoWriteConsole(L" ", &seqCb, si, false, waiter));
+    VERIFY_SUCCEEDED(DoWriteConsole(L"\b", &seqCb, si, false, waiter));
 
     VERIFY_ARE_EQUAL(cursor.GetPosition().X, x0);
     VERIFY_ARE_EQUAL(cursor.GetPosition().Y, y0);

--- a/src/host/writeData.cpp
+++ b/src/host/writeData.cpp
@@ -24,12 +24,14 @@
 WriteData::WriteData(SCREEN_INFORMATION& siContext,
                      _In_reads_bytes_(cbContext) wchar_t* const pwchContext,
                      const size_t cbContext,
-                     const UINT uiOutputCodepage) :
+                     const UINT uiOutputCodepage,
+                     const bool requiresVtQuirk) :
     IWaitRoutine(ReplyDataType::Write),
     _siContext(siContext),
     _pwchContext(THROW_IF_NULL_ALLOC(reinterpret_cast<wchar_t*>(new byte[cbContext]))),
     _cbContext(cbContext),
     _uiOutputCodepage(uiOutputCodepage),
+    _requiresVtQuirk(requiresVtQuirk),
     _fLeadByteCaptured(false),
     _fLeadByteConsumed(false),
     _cchUtf8Consumed(0)
@@ -124,6 +126,7 @@ bool WriteData::Notify(const WaitTerminationReason TerminationReason,
     NTSTATUS Status = DoWriteConsole(_pwchContext,
                                      &cbContext,
                                      _siContext,
+                                     _requiresVtQuirk,
                                      waiter);
 
     if (Status == CONSOLE_STATUS_WAIT)

--- a/src/host/writeData.hpp
+++ b/src/host/writeData.hpp
@@ -27,7 +27,8 @@ public:
     WriteData(SCREEN_INFORMATION& siContext,
               _In_reads_bytes_(cbContext) wchar_t* const pwchContext,
               const size_t cbContext,
-              const UINT uiOutputCodepage);
+              const UINT uiOutputCodepage,
+              const bool requiresVtQuirk);
     ~WriteData();
 
     void SetLeadByteAdjustmentStatus(const bool fLeadByteCaptured,
@@ -47,6 +48,7 @@ private:
     wchar_t* const _pwchContext;
     size_t const _cbContext;
     UINT const _uiOutputCodepage;
+    bool _requiresVtQuirk;
     bool _fLeadByteCaptured;
     bool _fLeadByteConsumed;
     size_t _cchUtf8Consumed;

--- a/src/renderer/vt/paint.cpp
+++ b/src/renderer/vt/paint.cpp
@@ -191,33 +191,9 @@ using namespace Microsoft::Console::Types;
 [[nodiscard]] HRESULT VtEngine::_RgbUpdateDrawingBrushes(const TextAttribute& textAttributes) noexcept
 {
     const auto fg = textAttributes.GetForeground();
-    auto bg = textAttributes.GetBackground();
+    const auto bg = textAttributes.GetBackground();
     auto lastFg = _lastTextAttributes.GetForeground();
     auto lastBg = _lastTextAttributes.GetBackground();
-
-    // GH#6807
-    // Replace a background color that explicitly matches the console host's
-    // active background with the "default" background.
-    //
-    // There is going to be a very long tail of applications that will
-    // explicitly request VT SGR 40 when what they really want is to
-    // SetConsoleTextAttribute() with a black background. Instead of making
-    // those applications look bad (and therefore making us look bad, because
-    // we're releasing this as an update to something that "looks good"
-    // already), we're introducing this compatibility hack. Before the color
-    // reckoning in GH#6698 + GH#6506, *every* color was subject to being
-    // spontaneously and erroneously turned into the default color. Now, only
-    // the 16-color palette value that matches the active console background
-    // color will be destroyed.
-    // This is not intended to be a long-term solution. This comment will be
-    // discovered in forty years(*) time and people will laugh at our hubris.
-    //
-    // *it doesn't matter when you're reading this, it will always be 40 years
-    // from now.
-    if (TextAttribute::IsColorVT16VersionOfLegacyDefaultBackground(bg))
-    {
-        bg = {};
-    }
 
     // If both the FG and BG should be the defaults, emit a SGR reset.
     if (fg.IsDefault() && bg.IsDefault() && !(lastFg.IsDefault() && lastBg.IsDefault()))
@@ -285,15 +261,9 @@ using namespace Microsoft::Console::Types;
 [[nodiscard]] HRESULT VtEngine::_16ColorUpdateDrawingBrushes(const TextAttribute& textAttributes) noexcept
 {
     const auto fg = textAttributes.GetForeground();
-    auto bg = textAttributes.GetBackground();
+    const auto bg = textAttributes.GetBackground();
     auto lastFg = _lastTextAttributes.GetForeground();
     auto lastBg = _lastTextAttributes.GetBackground();
-
-    // As above in _RgbUpdateDrawingBrushes; see GH#6807 for details.
-    if (TextAttribute::IsColorVT16VersionOfLegacyDefaultBackground(bg))
-    {
-        bg = {};
-    }
 
     // If either FG or BG have changed to default, emit a SGR reset.
     // We can't reset FG and BG to default individually.

--- a/src/renderer/vt/paint.cpp
+++ b/src/renderer/vt/paint.cpp
@@ -191,9 +191,33 @@ using namespace Microsoft::Console::Types;
 [[nodiscard]] HRESULT VtEngine::_RgbUpdateDrawingBrushes(const TextAttribute& textAttributes) noexcept
 {
     const auto fg = textAttributes.GetForeground();
-    const auto bg = textAttributes.GetBackground();
+    auto bg = textAttributes.GetBackground();
     auto lastFg = _lastTextAttributes.GetForeground();
     auto lastBg = _lastTextAttributes.GetBackground();
+
+    // GH#6807
+    // Replace a background color that explicitly matches the console host's
+    // active background with the "default" background.
+    //
+    // There is going to be a very long tail of applications that will
+    // explicitly request VT SGR 40 when what they really want is to
+    // SetConsoleTextAttribute() with a black background. Instead of making
+    // those applications look bad (and therefore making us look bad, because
+    // we're releasing this as an update to something that "looks good"
+    // already), we're introducing this compatibility hack. Before the color
+    // reckoning in GH#6698 + GH#6506, *every* color was subject to being
+    // spontaneously and erroneously turned into the default color. Now, only
+    // the 16-color palette value that matches the active console background
+    // color will be destroyed.
+    // This is not intended to be a long-term solution. This comment will be
+    // discovered in forty years(*) time and people will laugh at our hubris.
+    //
+    // *it doesn't matter when you're reading this, it will always be 40 years
+    // from now.
+    if (TextAttribute::IsColorVT16VersionOfLegacyDefaultBackground(bg))
+    {
+        bg = {};
+    }
 
     // If both the FG and BG should be the defaults, emit a SGR reset.
     if (fg.IsDefault() && bg.IsDefault() && !(lastFg.IsDefault() && lastBg.IsDefault()))
@@ -261,9 +285,15 @@ using namespace Microsoft::Console::Types;
 [[nodiscard]] HRESULT VtEngine::_16ColorUpdateDrawingBrushes(const TextAttribute& textAttributes) noexcept
 {
     const auto fg = textAttributes.GetForeground();
-    const auto bg = textAttributes.GetBackground();
+    auto bg = textAttributes.GetBackground();
     auto lastFg = _lastTextAttributes.GetForeground();
     auto lastBg = _lastTextAttributes.GetBackground();
+
+    // As above in _RgbUpdateDrawingBrushes; see GH#6807 for details.
+    if (TextAttribute::IsColorVT16VersionOfLegacyDefaultBackground(bg))
+    {
+        bg = {};
+    }
 
     // If either FG or BG have changed to default, emit a SGR reset.
     // We can't reset FG and BG to default individually.

--- a/src/server/ApiDispatchers.cpp
+++ b/src/server/ApiDispatchers.cpp
@@ -408,7 +408,7 @@
     std::unique_ptr<IWaitRoutine> waiter;
     size_t cbRead;
 
-    const auto requiresVtQuirk{ m->GetProcessHandle()->GetShimPolicy().ApplicationMishandlesVTColors() };
+    const auto requiresVtQuirk{ m->GetProcessHandle()->GetShimPolicy().IsVtColorQuirkRequired() };
 
     // We have to hold onto the HR from the call and return it.
     // We can't return some other error after the actual API call.

--- a/src/server/ApiDispatchers.cpp
+++ b/src/server/ApiDispatchers.cpp
@@ -408,6 +408,8 @@
     std::unique_ptr<IWaitRoutine> waiter;
     size_t cbRead;
 
+    const auto requiresVtQuirk{ m->GetProcessHandle()->GetShimPolicy().ApplicationMishandlesVTColors() };
+
     // We have to hold onto the HR from the call and return it.
     // We can't return some other error after the actual API call.
     // This is because the write console function is allowed to write part of the string and then return an error.
@@ -418,7 +420,7 @@
         const std::wstring_view buffer(reinterpret_cast<wchar_t*>(pvBuffer), cbBufferSize / sizeof(wchar_t));
         size_t cchInputRead;
 
-        hr = m->_pApiRoutines->WriteConsoleWImpl(*pScreenInfo, buffer, cchInputRead, waiter);
+        hr = m->_pApiRoutines->WriteConsoleWImpl(*pScreenInfo, buffer, cchInputRead, requiresVtQuirk, waiter);
 
         // We must set the reply length in bytes. Convert back from characters.
         LOG_IF_FAILED(SizeTMult(cchInputRead, sizeof(wchar_t), &cbRead));
@@ -428,7 +430,7 @@
         const std::string_view buffer(reinterpret_cast<char*>(pvBuffer), cbBufferSize);
         size_t cchInputRead;
 
-        hr = m->_pApiRoutines->WriteConsoleAImpl(*pScreenInfo, buffer, cchInputRead, waiter);
+        hr = m->_pApiRoutines->WriteConsoleAImpl(*pScreenInfo, buffer, cchInputRead, requiresVtQuirk, waiter);
 
         // Reply length is already in bytes (chars), don't need to convert.
         cbRead = cchInputRead;

--- a/src/server/ConsoleShimPolicy.cpp
+++ b/src/server/ConsoleShimPolicy.cpp
@@ -80,3 +80,16 @@ bool ConsoleShimPolicy::IsPowershellExe() const noexcept
 {
     return _isPowershell;
 }
+
+// Method Description:
+// - Returns true if the connected client application is known to
+//   attempt VT color promotion of legacy colors. See GH#6807 for more.
+// Arguments:
+// - <none>
+// Return Value:
+// - True as laid out above.
+bool ConsoleShimPolicy::ApplicationMishandlesVTColors() const noexcept
+{
+    // Right now, the only client we're shimming is powershell.
+    return IsPowershellExe();
+}

--- a/src/server/ConsoleShimPolicy.cpp
+++ b/src/server/ConsoleShimPolicy.cpp
@@ -88,7 +88,7 @@ bool ConsoleShimPolicy::IsPowershellExe() const noexcept
 // - <none>
 // Return Value:
 // - True as laid out above.
-bool ConsoleShimPolicy::ApplicationMishandlesVTColors() const noexcept
+bool ConsoleShimPolicy::IsVtColorQuirkRequired() const noexcept
 {
     // Right now, the only client we're shimming is powershell.
     return IsPowershellExe();

--- a/src/server/ConsoleShimPolicy.h
+++ b/src/server/ConsoleShimPolicy.h
@@ -25,7 +25,7 @@ public:
 
     bool IsCmdExe() const noexcept;
     bool IsPowershellExe() const noexcept;
-    bool ApplicationMishandlesVTColors() const noexcept;
+    bool IsVtColorQuirkRequired() const noexcept;
 
 private:
     ConsoleShimPolicy(const bool isCmd,

--- a/src/server/ConsoleShimPolicy.h
+++ b/src/server/ConsoleShimPolicy.h
@@ -25,6 +25,7 @@ public:
 
     bool IsCmdExe() const noexcept;
     bool IsPowershellExe() const noexcept;
+    bool ApplicationMishandlesVTColors() const noexcept;
 
 private:
     ConsoleShimPolicy(const bool isCmd,

--- a/src/server/IApiRoutines.h
+++ b/src/server/IApiRoutines.h
@@ -113,11 +113,13 @@ public:
     [[nodiscard]] virtual HRESULT WriteConsoleAImpl(IConsoleOutputObject& context,
                                                     const std::string_view buffer,
                                                     size_t& read,
+                                                    bool requiresVtQuirk,
                                                     std::unique_ptr<IWaitRoutine>& waiter) noexcept = 0;
 
     [[nodiscard]] virtual HRESULT WriteConsoleWImpl(IConsoleOutputObject& context,
                                                     const std::wstring_view buffer,
                                                     size_t& read,
+                                                    bool requiresVtQuirk,
                                                     std::unique_ptr<IWaitRoutine>& waiter) noexcept = 0;
 
 #pragma region Thread Creation Info


### PR DESCRIPTION
There is going to be a very long tail of applications that will
explicitly request VT SGR 40/37 when what they really want is to
SetConsoleTextAttribute() with a black background/white foreground.
Instead of making those applications look bad (and therefore making us
look bad, because we're releasing this as an update to something that
"looks good" already), we're introducing this compatibility quirk.
Before the color reckoning in #6698 + #6506, *every* color was subject
to being spontaneously and erroneously turned into the default color.
Now, only the 16-color palette value that matches the active console
background/foreground color will be destroyed, and only when received
from specific applications.

Removal will be tracked by #6807.

Michael and I discussed what layer this quirk really belonged in. I
originally believed it would be sufficient to detect a background color
that matched the legacy default background, but @j4james provided an
example of where that wouldn't work out (powershell setting the
foreground color to white/gray). In addition, it was too heavyhanded: it
re-broke black backgrounds for every application.

Michael thought that it should live in the server, as a small VT parser
that righted the wrongs coming directly out of the application. On
further investigation, however, I realized that we'd need to push more
information up into the server (so that it could make the decision about
which VT was wrong and which was right) than should be strictly
necessary.

The host knows which colors are right and wrong, and it gets final say
in what ends up in the buffer.

Because of that, I chose to push the quirk state down through
WriteConsole to DoWriteConsole and toggle state on the
SCREEN_INFORMATION that indicates whether the colors coming out of the
application are to be distrusted. This quirk _only applies to pwsh.exe
and powershell.exe._

**NOTE**: This doesn't work for PowerShell the .NET Global tool,
because it is run as an assembly through dotnet.exe. I have no opinion
on how to fix this, or whether it is worth fixing.

## PR Checklist
* [x] Closes #6767 
* [x] CLA signed
* [x] Tests added/passed
* [x] Documentation updated
* [x] Schema updated.
* [x] I've discussed this with core contributors already

## Validation

I've configured my terminals to have an incredibly garish color scheme
to show exactly what's going to happen as a result of this. The _default
terminal background_ is purple or red, and the foreground green. I've
printed out a heap of test colors to see how black interacts with them.

One the left, Terminal Preview without this fix. On the right, Terminal
Dev _with_ this fix.


* `DEFAULT` = `39` or `49`
* `WHITE` = `37` or `47`
* `BLACK` = `30` or `40`
* `AIX WHT` = `97` or `107`
* `AIX BLK` = `90` or `100`
* `INT` = `1`

![image](https://user-images.githubusercontent.com/189190/86836209-03b0ef80-c052-11ea-90d3-a0dc3e67e165.png)

The only color lines that change are the ones where black as a
background or white as a foreground is selected out of the 16-color
palette explicitly. Reverse video still works fine (because black is in
the foreground!), and it's even possible to represent "black on default"
and reverse it into "default on black", despite the black in question
having been `40`.