### PR TITLE
Update colors of our custom NewTab button to match MUX's TabView

### DIFF
--- a/src/cascadia/TerminalApp/TabRowControl.xaml
+++ b/src/cascadia/TerminalApp/TabRowControl.xaml
@@ -40,28 +40,28 @@ the MIT License. See LICENSE in the project root for license information. -->
                     <ResourceDictionary>
                         <ResourceDictionary.ThemeDictionaries>
                             <ResourceDictionary x:Key="Light">
-                                <StaticResource x:Key="SplitButtonBackground" ResourceKey="TabViewItemHeaderBackground" />
-                                <StaticResource x:Key="SplitButtonForeground" ResourceKey="SystemControlBackgroundBaseMediumBrush" />
+                                <StaticResource x:Key="SplitButtonBackground" ResourceKey="TabViewButtonBackground" />
+                                <StaticResource x:Key="SplitButtonForeground" ResourceKey="TabViewButtonForeground" />
                                 <StaticResource x:Key="SplitButtonBackgroundPressed" ResourceKey="TabViewItemHeaderBackgroundPressed" />
-                                <StaticResource x:Key="SplitButtonForegroundPressed" ResourceKey="SystemControlBackgroundBaseMediumHighBrush" />
+                                <StaticResource x:Key="SplitButtonForegroundPressed" ResourceKey="TabViewItemHeaderForegroundPressed" />
                                 <StaticResource x:Key="SplitButtonBackgroundPointerOver" ResourceKey="TabViewItemHeaderBackgroundPointerOver" />
-                                <StaticResource x:Key="SplitButtonForegroundPointerOver" ResourceKey="SystemControlBackgroundBaseMediumHighBrush" />
+                                <StaticResource x:Key="SplitButtonForegroundPointerOver" ResourceKey="TabViewItemHeaderForegroundPointerOver" />
                             </ResourceDictionary>
                             <ResourceDictionary x:Key="Dark">
-                                <StaticResource x:Key="SplitButtonBackground" ResourceKey="TabViewItemHeaderBackground" />
-                                <StaticResource x:Key="SplitButtonForeground" ResourceKey="SystemControlBackgroundBaseMediumBrush" />
+                                <StaticResource x:Key="SplitButtonBackground" ResourceKey="TabViewButtonBackground" />
+                                <StaticResource x:Key="SplitButtonForeground" ResourceKey="TabViewButtonForeground" />
                                 <StaticResource x:Key="SplitButtonBackgroundPressed" ResourceKey="TabViewItemHeaderBackgroundPressed" />
-                                <StaticResource x:Key="SplitButtonForegroundPressed" ResourceKey="SystemControlBackgroundBaseMediumHighBrush" />
+                                <StaticResource x:Key="SplitButtonForegroundPressed" ResourceKey="TabViewItemHeaderForegroundPressed" />
                                 <StaticResource x:Key="SplitButtonBackgroundPointerOver" ResourceKey="TabViewItemHeaderBackgroundPointerOver" />
-                                <StaticResource x:Key="SplitButtonForegroundPointerOver" ResourceKey="SystemControlBackgroundBaseMediumHighBrush" />
+                                <StaticResource x:Key="SplitButtonForegroundPointerOver" ResourceKey="TabViewItemHeaderForegroundPointerOver" />
                             </ResourceDictionary>
                             <ResourceDictionary x:Key="HighContrast">
-                                <StaticResource x:Key="SplitButtonBackground" ResourceKey="TabViewItemHeaderBackground" />
-                                <StaticResource x:Key="SplitButtonForeground" ResourceKey="SystemControlBackgroundBaseMediumBrush" />
+                                <StaticResource x:Key="SplitButtonBackground" ResourceKey="TabViewButtonBackground" />
+                                <StaticResource x:Key="SplitButtonForeground" ResourceKey="TabViewButtonForeground" />
                                 <StaticResource x:Key="SplitButtonBackgroundPressed" ResourceKey="TabViewItemHeaderBackgroundPressed" />
-                                <StaticResource x:Key="SplitButtonForegroundPressed" ResourceKey="SystemControlBackgroundBaseMediumHighBrush" />
+                                <StaticResource x:Key="SplitButtonForegroundPressed" ResourceKey="TabViewItemHeaderForegroundPressed" />
                                 <StaticResource x:Key="SplitButtonBackgroundPointerOver" ResourceKey="TabViewItemHeaderBackgroundPointerOver" />
-                                <StaticResource x:Key="SplitButtonForegroundPointerOver" ResourceKey="SystemControlBackgroundBaseMediumHighBrush" />
+                                <StaticResource x:Key="SplitButtonForegroundPointerOver" ResourceKey="TabViewItemHeaderForegroundPointerOver" />
                             </ResourceDictionary>
                         </ResourceDictionary.ThemeDictionaries>
                     </ResourceDictionary>


### PR DESCRIPTION
Update colors of our custom NewTab button to match MUX's TabView button

MUX has a NewTab button, but Terminal uses a homemade lookalike.  The
version in Terminal doesn't use the same brush color resources as MUX's
button, so it looks very slightly different.  This PR updates Terminal's
button to use the exact same colors that MUX uses.  I literally copied
these brush names out of MUX source code.

## References
This is the color version of the layout fix #6766 
This is a prerequisite for fixing #5360

## PR Checklist
* [X] Closes #6812

## Detailed Description of the Pull Request / Additional comments
The real reason that this matters is that once you flip on
`ApplicationHighContrastAdjustment::None`, the existing colors will not
work at all.  The existing brushes are themed to black foreground on a
black background when High Contrast (HC) Black theme is enabled.  The
only thing that's saving you is
`ApplicationHighContrastAdjustment::Auto` is automatically backplating
the glyphs on the buttons, which (by design) hides the fact that the
colors are poor.  The backplates are those ugly squares inside the
buttons on the HC themes.

Before I can push a PR that disables automatic backplating (set
`ApplicationHighContrastAdjustment` to `None`), we'll need to select
better brushes that work in HC mode.  MUX has already selected brushes
that work great in all modes, so it just makes sense to use their
brushes.

If you want to hear some unsubstantiated speculation... read on.  I
speculate that when this Terminal code was originally written, the MUX
code was incomplete, so it wasn't possible to copy all of MUX's brushes.
It also may not have been obvious that MUX uses an inconsistent mix of
TabViewButtonXxx and TabViewItemHeaderXxx brushes for this widget, since
the latter is hidden in some styling override code.

## Validation Steps Performed
Screenshots!  Everybody loves screenshots!  These show the button in its
hover state (center button) and normal state (right button).

| Theme | Old | New |
| --------------- | --------------- | --------------- |
| Light | ![oldlight](https://user-images.githubusercontent.com/10259764/86686402-2ba04480-bfb9-11ea-8f42-1d3c3d820c11.png) | ![newlight](https://user-images.githubusercontent.com/10259764/86686418-2fcc6200-bfb9-11ea-8b97-43d84f2c3c26.png) |
| Dark | ![olddark](https://user-images.githubusercontent.com/10259764/86686451-365ad980-bfb9-11ea-8fbc-2f98e9bed942.png) | ![newdark](https://user-images.githubusercontent.com/10259764/86686463-38bd3380-bfb9-11ea-8376-f47c5fa48044.png) |
| HC White | ![oldwhite](https://user-images.githubusercontent.com/10259764/86686496-407cd800-bfb9-11ea-8aa8-c8684bf87a40.png) | ![newwhite](https://user-images.githubusercontent.com/10259764/86686529-470b4f80-bfb9-11ea-8def-df7345578674.png) |
| HC Black | ![oldblack](https://user-images.githubusercontent.com/10259764/86686556-4d99c700-bfb9-11ea-9483-a513501ac603.png) | ![newblack](https://user-images.githubusercontent.com/10259764/86686575-51c5e480-bfb9-11ea-98ac-c499c8841361.png) |

The one very subtle difference here is that, for non-HC themes, the
glyph's foreground has a bit more contrast when the button is in
hovered/pressed states.  Again this slight difference hardly matters
now, but using the correct brushes will become critical when we try to
remove the HC backplating.
