### PR TITLE
Add some logging regarding command palette usage

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -39,6 +39,10 @@ namespace winrt::TerminalApp::implementation
         void _updateFilteredActions();
         static int _getWeight(const winrt::hstring& searchText, const winrt::hstring& name);
         void _close();
+
+        void _dispatchCommand(const TerminalApp::Command& command);
+
+        void _dismissPalette();
     };
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

Pretty straightforward. Logs three scenarios:
* The user opened the command palette (and which mode it was opened in)
* The user ran a command from the palette
* The user dismissed the palette without running an action.

We discussed this in team sync yesterday.

## PR Checklist
* [x] I work here
* [n/a] Requires documentation to be updated

