### PR TITLE
Make Terminal look great in High Contrast

### DIFF
--- a/.github/actions/spell-check/dictionary/microsoft.txt
+++ b/.github/actions/spell-check/dictionary/microsoft.txt
@@ -1,4 +1,5 @@
 ACLs
+backplating
 DACL
 DACLs
 LKG

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -26,6 +26,10 @@ namespace winrt::TerminalApp::implementation
         }
 
         Initialize();
+
+        // Disable XAML's automatic backplating of text when in High Contrast
+        // mode: we want full control of and responsibility for the foreground
+        // and background colors that we draw in XAML.
         HighContrastAdjustment(::winrt::Windows::UI::Xaml::ApplicationHighContrastAdjustment::None);
     }
 

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -26,6 +26,7 @@ namespace winrt::TerminalApp::implementation
         }
 
         Initialize();
+        HighContrastAdjustment(::winrt::Windows::UI::Xaml::ApplicationHighContrastAdjustment::None);
     }
 
     AppLogic App::Logic()

--- a/src/cascadia/TerminalControl/SearchBoxControl.xaml
+++ b/src/cascadia/TerminalControl/SearchBoxControl.xaml
@@ -36,7 +36,6 @@
                     <Style x:Key="SearchBoxBackground" TargetType="StackPanel">
                         <Setter Property="Background" Value="#333333" />
                     </Style>
-                    <Style x:Key="PathStyle" TargetType="PathIcon" />
                     <!-- TextBox colors !-->
                     <SolidColorBrush x:Key="TextControlBackground" Color="#333333"/>
                     <SolidColorBrush x:Key="TextBoxPlaceholderTextThemeBrush" Color="#B5B5B5"/>
@@ -94,7 +93,6 @@
                     <Style x:Key="SearchBoxBackground" TargetType="StackPanel">
                         <Setter Property="Background" Value="#CCCCCC" />
                     </Style>
-                    <Style x:Key="PathStyle" TargetType="PathIcon" />
                     <!-- TextBox colors !-->
                     <SolidColorBrush x:Key="TextControlBackground" Color="#CCCCCC"/>
                     <SolidColorBrush x:Key="TextBoxPlaceholderTextThemeBrush" Color="#636363"/>
@@ -144,13 +142,9 @@
                 <ResourceDictionary x:Key="HighContrast">
                     <Style x:Key="FontIconStyle" TargetType="FontIcon">
                         <Setter Property="FontSize" Value="12" />
-                        <Setter Property="Foreground" Value="{ThemeResource SystemColorWindowTextColor}" />
                     </Style>
                     <Style x:Key="SearchBoxBackground" TargetType="StackPanel">
                         <Setter Property="Background" Value="{ThemeResource SystemColorWindowColor}" />
-                    </Style>
-                    <Style x:Key="PathStyle" TargetType="PathIcon">
-                        <Setter Property="Foreground" Value="{ThemeResource SystemColorWindowTextColor}" />
                     </Style>
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
@@ -188,8 +182,7 @@
         <ToggleButton x:Name="CaseSensitivityButton"
                       x:Uid="SearchBox_CaseSensitivity"
                       Style="{StaticResource ToggleButtonStyle}">
-            <PathIcon Data="M8.87305 10H7.60156L6.5625 7.25195H2.40625L1.42871 10H0.150391L3.91016 0.197266H5.09961L8.87305 10ZM6.18652 6.21973L4.64844 2.04297C4.59831 1.90625 4.54818 1.6875 4.49805 1.38672H4.4707C4.42513 1.66471 4.37272 1.88346 4.31348 2.04297L2.78906 6.21973H6.18652ZM15.1826 10H14.0615V8.90625H14.0342C13.5465 9.74479 12.8288 10.1641 11.8809 10.1641C11.1836 10.1641 10.6367 9.97949 10.2402 9.61035C9.84831 9.24121 9.65234 8.7513 9.65234 8.14062C9.65234 6.83268 10.4225 6.07161 11.9629 5.85742L14.0615 5.56348C14.0615 4.37402 13.5807 3.7793 12.6191 3.7793C11.776 3.7793 11.015 4.06641 10.3359 4.64062V3.49219C11.0241 3.05469 11.8171 2.83594 12.7148 2.83594C14.36 2.83594 15.1826 3.70638 15.1826 5.44727V10ZM14.0615 6.45898L12.373 6.69141C11.8535 6.76432 11.4616 6.89421 11.1973 7.08105C10.9329 7.26335 10.8008 7.58919 10.8008 8.05859C10.8008 8.40039 10.9215 8.68066 11.1631 8.89941C11.4092 9.11361 11.735 9.2207 12.1406 9.2207C12.6966 9.2207 13.1546 9.02702 13.5146 8.63965C13.8792 8.24772 14.0615 7.75326 14.0615 7.15625V6.45898Z"
-                      Style="{ThemeResource PathStyle}" />
+            <PathIcon Data="M8.87305 10H7.60156L6.5625 7.25195H2.40625L1.42871 10H0.150391L3.91016 0.197266H5.09961L8.87305 10ZM6.18652 6.21973L4.64844 2.04297C4.59831 1.90625 4.54818 1.6875 4.49805 1.38672H4.4707C4.42513 1.66471 4.37272 1.88346 4.31348 2.04297L2.78906 6.21973H6.18652ZM15.1826 10H14.0615V8.90625H14.0342C13.5465 9.74479 12.8288 10.1641 11.8809 10.1641C11.1836 10.1641 10.6367 9.97949 10.2402 9.61035C9.84831 9.24121 9.65234 8.7513 9.65234 8.14062C9.65234 6.83268 10.4225 6.07161 11.9629 5.85742L14.0615 5.56348C14.0615 4.37402 13.5807 3.7793 12.6191 3.7793C11.776 3.7793 11.015 4.06641 10.3359 4.64062V3.49219C11.0241 3.05469 11.8171 2.83594 12.7148 2.83594C14.36 2.83594 15.1826 3.70638 15.1826 5.44727V10ZM14.0615 6.45898L12.373 6.69141C11.8535 6.76432 11.4616 6.89421 11.1973 7.08105C10.9329 7.26335 10.8008 7.58919 10.8008 8.05859C10.8008 8.40039 10.9215 8.68066 11.1631 8.89941C11.4092 9.11361 11.735 9.2207 12.1406 9.2207C12.6966 9.2207 13.1546 9.02702 13.5146 8.63965C13.8792 8.24772 14.0615 7.75326 14.0615 7.15625V6.45898Z"/>
         </ToggleButton>
 
         <Button x:Name="CloseButton"


### PR DESCRIPTION
## Summary of the Pull Request
This PR enables `ApplicationHighContrastAdjustment::None`.  Doing this disables a set of mitigations in XAML designed to band-aid apps that were never explicitly designed for High Contrast (HC) modes.  Terminal now has full control of and responsibility for its appearance in HC mode.  This allows Terminal to look a lot better.

## PR Checklist
* [X] Closes #5360 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments
On paper, we should be able to set `HighContrastAdjustment="None"` on the `<Application>` element.  But that doesn't have any effect.  I don't know if this is a bug in `<Toolkit:XamlApplication>` or somewhere else.  So instead I set the property in codebehind, which is not as ideal, but does at least work.  I'd love to a way to move this into App.xaml.

The Find box had a couple stray styles to override the ToggleButton's foreground color.  With backplating removed, these styles became actively harmful (white foreground on highlight color background), so I just removed them.  The built-in style for ToggleButton is perfect as-is.

## Validation Steps Performed
Vicariously validate via viewing various vivid videos.

High Contrast White:
![finalwhite](https://user-images.githubusercontent.com/10259764/86943563-732ee980-c0fb-11ea-94ea-2ef05ae6a6e2.gif)

High Contrast Dark:
![finalblack](https://user-images.githubusercontent.com/10259764/86943572-75914380-c0fb-11ea-8c3d-331d0aaa7dd4.gif)

The previous appearance, prior to this PR, for comparison purposes:
![finalold](https://user-images.githubusercontent.com/10259764/86943803-c143ed00-c0fb-11ea-8822-f1f914243bd8.gif)

@mimi89999 _this_ is the PR you've been waiting for ;)  Thanks for reporting the HC bugs, and please do keep leaning on apps to make them look great in HC mode.