### PR TITLE
Avoid copying the bitmap on the way into the tracing function

### DIFF
--- a/src/renderer/vt/tracing.cpp
+++ b/src/renderer/vt/tracing.cpp
@@ -145,7 +145,7 @@ void RenderTracing::TraceInvalidateScroll(const til::point scroll) const
 }
 
 void RenderTracing::TraceStartPaint(const bool quickReturn,
-                                    const til::bitmap invalidMap,
+                                    const til::bitmap& invalidMap,
                                     const til::rectangle lastViewport,
                                     const til::point scrollDelt,
                                     const bool cursorMoved,

--- a/src/renderer/vt/tracing.hpp
+++ b/src/renderer/vt/tracing.hpp
@@ -39,7 +39,7 @@ namespace Microsoft::Console::VirtualTerminal
         void TraceTriggerCircling(const bool newFrame) const;
         void TraceInvalidateScroll(const til::point scroll) const;
         void TraceStartPaint(const bool quickReturn,
-                             const til::bitmap invalidMap,
+                             const til::bitmap& invalidMap,
                              const til::rectangle lastViewport,
                              const til::point scrollDelta,
                              const bool cursorMoved,


### PR DESCRIPTION
## PR Checklist
* [x] Closes perf itch.
* [x] I work here.
* [x] Manual perf test.
* [x] Documentation irrelevant.
* [x] Schema irrelevant.
* [x] Am core contributor.

## Detailed Description of the Pull Request / Additional comments
Passes the bitmap by ref into the tracing function instead of making a copy on the way in. It's only read anyway for tracing (if enabled) so the copy was a pointless oversight.

## Validation Steps Performed
- Observed WPR trace before and after with `time cat big.txt` in WSL.
