### PR TITLE
Cache VT buffer line string to avoid (de)alloc on every paint

### DIFF
--- a/src/renderer/vt/state.cpp
+++ b/src/renderer/vt/state.cpp
@@ -49,7 +49,8 @@ VtEngine::VtEngine(_In_ wil::unique_hfile pipe,
     _newBottomLine{ false },
     _deferredCursorPos{ INVALID_COORDS },
     _inResizeRequest{ false },
-    _trace{}
+    _trace{},
+    _bufferLine{}
 {
 #ifndef UNIT_TESTING
     // When unit testing, we can instantiate a VtEngine without a pipe.

--- a/src/renderer/vt/vtrenderer.hpp
+++ b/src/renderer/vt/vtrenderer.hpp
@@ -206,7 +206,7 @@ namespace Microsoft::Console::Render
 
         // buffer space for these two functions to build their lines
         // so they don't have to alloc/free in a tight loop
-        std::wstring _bufferLine; 
+        std::wstring _bufferLine;
         [[nodiscard]] HRESULT _PaintUtf8BufferLine(std::basic_string_view<Cluster> const clusters,
                                                    const COORD coord,
                                                    const bool lineWrapped) noexcept;

--- a/src/renderer/vt/vtrenderer.hpp
+++ b/src/renderer/vt/vtrenderer.hpp
@@ -204,6 +204,9 @@ namespace Microsoft::Console::Render
 
         bool _WillWriteSingleChar() const;
 
+        // buffer space for these two functions to build their lines
+        // so they don't have to alloc/free in a tight loop
+        std::wstring _bufferLine; 
         [[nodiscard]] HRESULT _PaintUtf8BufferLine(std::basic_string_view<Cluster> const clusters,
                                                    const COORD coord,
                                                    const bool lineWrapped) noexcept;


### PR DESCRIPTION
## PR Checklist
* [x] Closes perf itch
* [x] I work here
* [x] Manual test
* [x] Documentation irrelevant.
* [x] Schema irrelevant.
* [x] Am core contributor.

## Detailed Description of the Pull Request / Additional comments
A lot of time was spent between each individual line in the VT paint engine in allocating some scratch space to assemble the clusters then deallocating it only to have the next line do that again. Now we just hold onto that memory space since it should be approximately the size of a single line wide and will be used over and over and over as painting continues.

## Validation Steps Performed
- Run `time cat big.txt` under WPR. Checked before and after perf metrics.
