### PR TITLE
Tweak the Palette's KeyChord for High Contrast mode

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.xaml
+++ b/src/cascadia/TerminalApp/CommandPalette.xaml
@@ -45,6 +45,17 @@ the MIT License. See LICENSE in the project root for license information. -->
                     <SolidColorBrush x:Key="TextControlButtonForegroundPressed" Color="#FFFFFF"/>
                     <SolidColorBrush x:Key="TextControlButtonBackgroundPressed" Color="#FF4343"/>
 
+                    <!--  KeyChordText styles  -->
+                    <Style x:Key="KeyChordBorderStyle" TargetType="Border">
+                        <Setter Property="BorderThickness" Value="1" />
+                        <Setter Property="CornerRadius" Value="1" />
+                        <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
+                        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+                    </Style>
+                    <Style x:Key="KeyChordTextBlockStyle" TargetType="TextBlock">
+                        <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+                    </Style>
+
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Light">
                     <Style x:Key="CommandPaletteBackground" TargetType="Grid">
@@ -65,11 +76,27 @@ the MIT License. See LICENSE in the project root for license information. -->
                     <SolidColorBrush x:Key="TextControlButtonForegroundPressed" Color="#FFFFFF"/>
                     <SolidColorBrush x:Key="TextControlButtonBackgroundPressed" Color="#FF4343"/>
 
+                    <!--  KeyChordText styles  -->
+                    <Style x:Key="KeyChordBorderStyle" TargetType="Border">
+                        <Setter Property="BorderThickness" Value="1" />
+                        <Setter Property="CornerRadius" Value="1" />
+                        <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
+                        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+                    </Style>
+                    <Style x:Key="KeyChordTextBlockStyle" TargetType="TextBlock">
+                        <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+                    </Style>
+
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="HighContrast">
                     <Style x:Key="CommandPaletteBackground" TargetType="Grid">
                         <Setter Property="Background" Value="{ThemeResource SystemColorWindowColor}" />
                     </Style>
+
+                    <!--  KeyChordText styles (use XAML defaults for High Contrast theme) -->
+                    <Style x:Key="KeyChordBorderStyle" TargetType="Border"/>
+                    <Style x:Key="KeyChordTextBlockStyle" TargetType="TextBlock"/>
+
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>
@@ -187,16 +214,13 @@ the MIT License. See LICENSE in the project root for license information. -->
                                 Visibility="{x:Bind KeyChordText,
                                              Mode=OneWay,
                                              Converter={StaticResource CommandKeyChordVisibilityConverter}}"
-                                BorderBrush="{ThemeResource SystemControlForegroundBaseMediumBrush}"
-                                Background="{ThemeResource SystemControlForegroundBaseLowBrush}"
-                                BorderThickness="1"
-                                CornerRadius="1"
+                                Style="{ThemeResource KeyChordBorderStyle}"
                                 Padding="2,0,2,0"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Center">
 
                                 <TextBlock
-                                    Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
+                                    Style="{ThemeResource KeyChordTextBlockStyle}"
                                     FontSize="12"
                                     Text="{x:Bind KeyChordText, Mode=OneWay}" />
                             </Border>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Update the Palette to be readable under High Contrast mode

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
Regressed in #6833

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #6892
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #6892

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
I pulled the styling of the KeyChord text into a Style, so we can give it a different style under High Contrast.  Under HC, I just left all the colors at their default, so ListView can do its thing.  (IMHO, the HC style now looks better than the non-HC mode, but maybe I'm biased ;) )

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
| | Old | New |
|---|:---:|:---:|
| Light | ![light](https://user-images.githubusercontent.com/10259764/87398203-6b8f9a80-c56a-11ea-99d0-2eeefcfea269.png) | ![newlight](https://user-images.githubusercontent.com/10259764/87399212-e3aa9000-c56b-11ea-9e94-c8fae8825cd1.png) |
| Dark | ![dark](https://user-images.githubusercontent.com/10259764/87398269-819d5b00-c56a-11ea-9180-5c6ec1071b95.png) | ![newdark](https://user-images.githubusercontent.com/10259764/87399227-ead19e00-c56b-11ea-996d-ad52bc2dcbf3.png) |
| HC White | ![oldwhite](https://user-images.githubusercontent.com/10259764/87398320-92e66780-c56a-11ea-9d52-e2f6e31ae487.png) | ![newwhite](https://user-images.githubusercontent.com/10259764/87398340-98dc4880-c56a-11ea-87e2-ed257ad89c4a.png) |
| HC Black | ![oldblack](https://user-images.githubusercontent.com/10259764/87398357-9f6ac000-c56a-11ea-848c-1ccef6a65442.png) | ![newblack](https://user-images.githubusercontent.com/10259764/87398370-a396dd80-c56a-11ea-9540-8aa9bb934791.png) |




