### PR TITLE
Cache the viewport to make invalidation faster

### DIFF
--- a/src/host/ut_host/VtIoTests.cpp
+++ b/src/host/ut_host/VtIoTests.cpp
@@ -284,12 +284,10 @@ public:
 
     void LockConsole() noexcept override
     {
-
     }
 
     void UnlockConsole() noexcept override
     {
-
     }
 
     const TextAttribute GetDefaultBrushColors() noexcept override
@@ -374,12 +372,10 @@ public:
 
     void ClearSelection() override
     {
-
     }
 
     void SelectNewRegion(const COORD /*coordStart*/, const COORD /*coordEnd*/) override
     {
-
     }
 
     const COORD GetSelectionAnchor() const noexcept
@@ -394,7 +390,6 @@ public:
 
     void ColorSelection(const COORD /*coordSelectionStart*/, const COORD /*coordSelectionEnd*/, const TextAttribute /*attr*/)
     {
-
     }
 };
 

--- a/src/host/ut_host/VtIoTests.cpp
+++ b/src/host/ut_host/VtIoTests.cpp
@@ -254,6 +254,150 @@ void VtIoTests::DtorTestStackAllocMany()
     }
 }
 
+class MockRenderData : public IRenderData, IUiaData
+{
+public:
+    Microsoft::Console::Types::Viewport GetViewport() noexcept override
+    {
+        return Microsoft::Console::Types::Viewport{};
+    }
+
+    COORD GetTextBufferEndPosition() const noexcept override
+    {
+        return COORD{};
+    }
+
+    const TextBuffer& GetTextBuffer() noexcept override
+    {
+        FAIL_FAST_HR(E_NOTIMPL);
+    }
+
+    const FontInfo& GetFontInfo() noexcept override
+    {
+        FAIL_FAST_HR(E_NOTIMPL);
+    }
+
+    std::vector<Microsoft::Console::Types::Viewport> GetSelectionRects() noexcept override
+    {
+        return std::vector<Microsoft::Console::Types::Viewport>{};
+    }
+
+    void LockConsole() noexcept override
+    {
+
+    }
+
+    void UnlockConsole() noexcept override
+    {
+
+    }
+
+    const TextAttribute GetDefaultBrushColors() noexcept override
+    {
+        return TextAttribute{};
+    }
+
+    std::pair<COLORREF, COLORREF> GetAttributeColors(const TextAttribute& /*attr*/) const noexcept override
+    {
+        return std::make_pair(COLORREF{}, COLORREF{});
+    }
+
+    COORD GetCursorPosition() const noexcept override
+    {
+        return COORD{};
+    }
+
+    bool IsCursorVisible() const noexcept override
+    {
+        return false;
+    }
+
+    bool IsCursorOn() const noexcept override
+    {
+        return false;
+    }
+
+    ULONG GetCursorHeight() const noexcept override
+    {
+        return 42ul;
+    }
+
+    CursorType GetCursorStyle() const noexcept override
+    {
+        return CursorType::FullBox;
+    }
+
+    ULONG GetCursorPixelWidth() const noexcept override
+    {
+        return 12ul;
+    }
+
+    COLORREF GetCursorColor() const noexcept override
+    {
+        return COLORREF{};
+    }
+
+    bool IsCursorDoubleWidth() const override
+    {
+        return false;
+    }
+
+    bool IsScreenReversed() const noexcept override
+    {
+        return false;
+    }
+
+    const std::vector<RenderOverlay> GetOverlays() const noexcept override
+    {
+        return std::vector<RenderOverlay>{};
+    }
+
+    const bool IsGridLineDrawingAllowed() noexcept override
+    {
+        return false;
+    }
+
+    const std::wstring GetConsoleTitle() const noexcept override
+    {
+        return std::wstring{};
+    }
+
+    const bool IsSelectionActive() const override
+    {
+        return false;
+    }
+
+    const bool IsBlockSelection() const noexcept override
+    {
+        return false;
+    }
+
+    void ClearSelection() override
+    {
+
+    }
+
+    void SelectNewRegion(const COORD /*coordStart*/, const COORD /*coordEnd*/) override
+    {
+
+    }
+
+    const COORD GetSelectionAnchor() const noexcept
+    {
+        return COORD{};
+    }
+
+    const COORD GetSelectionEnd() const noexcept
+    {
+        return COORD{};
+    }
+
+    void ColorSelection(const COORD /*coordSelectionStart*/, const COORD /*coordSelectionEnd*/, const TextAttribute /*attr*/)
+    {
+
+    }
+};
+
 void VtIoTests::RendererDtorAndThread()
 {
     Log::Comment(NoThrowString().Format(
@@ -261,9 +405,10 @@ void VtIoTests::RendererDtorAndThread()
 
     for (int i = 0; i < 16; ++i)
     {
+        auto data = std::make_unique<MockRenderData>();
         auto thread = std::make_unique<Microsoft::Console::Render::RenderThread>();
         auto* pThread = thread.get();
-        auto pRenderer = std::make_unique<Microsoft::Console::Render::Renderer>(nullptr, nullptr, 0, std::move(thread));
+        auto pRenderer = std::make_unique<Microsoft::Console::Render::Renderer>(data.get(), nullptr, 0, std::move(thread));
         VERIFY_SUCCEEDED(pThread->Initialize(pRenderer.get()));
         // Sleep for a hot sec to make sure the thread starts before we enable painting
         // If you don't, the thread might wait on the paint enabled event AFTER
@@ -286,9 +431,10 @@ void VtIoTests::RendererDtorAndThreadAndDx()
 
     for (int i = 0; i < 16; ++i)
     {
+        auto data = std::make_unique<MockRenderData>();
         auto thread = std::make_unique<Microsoft::Console::Render::RenderThread>();
         auto* pThread = thread.get();
-        auto pRenderer = std::make_unique<Microsoft::Console::Render::Renderer>(nullptr, nullptr, 0, std::move(thread));
+        auto pRenderer = std::make_unique<Microsoft::Console::Render::Renderer>(data.get(), nullptr, 0, std::move(thread));
         VERIFY_SUCCEEDED(pThread->Initialize(pRenderer.get()));
 
         auto dxEngine = std::make_unique<::Microsoft::Console::Render::DxEngine>();

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -30,7 +30,7 @@ Renderer::Renderer(IRenderData* pData,
     _pThread{ std::move(thread) },
     _destructing{ false },
     _clusterBuffer{},
-    _viewport{Viewport::Empty()}
+    _viewport{ Viewport::Empty() }
 {
     for (size_t i = 0; i < cEngines; i++)
     {

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -30,7 +30,7 @@ Renderer::Renderer(IRenderData* pData,
     _pThread{ std::move(thread) },
     _destructing{ false },
     _clusterBuffer{},
-    _viewport{ Viewport::Empty() }
+    _viewport{ pData->GetViewport() }
 {
     for (size_t i = 0; i < cEngines; i++)
     {

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -29,10 +29,9 @@ Renderer::Renderer(IRenderData* pData,
     _pData(pData),
     _pThread{ std::move(thread) },
     _destructing{ false },
-    _clusterBuffer{}
+    _clusterBuffer{},
+    _viewport{Viewport::Empty()}
 {
-    _srViewportPrevious = { 0 };
-
     for (size_t i = 0; i < cEngines; i++)
     {
         IRenderEngine* engine = rgpEngines[i];
@@ -208,7 +207,7 @@ void Renderer::TriggerSystemRedraw(const RECT* const prcDirtyClient)
 // - <none>
 void Renderer::TriggerRedraw(const Viewport& region)
 {
-    Viewport view = _pData->GetViewport();
+    Viewport view = _viewport;
     SMALL_RECT srUpdateRegion = region.ToExclusive();
 
     if (view.TrimToViewport(&srUpdateRegion))
@@ -357,7 +356,7 @@ void Renderer::TriggerSelection()
 // - True if something changed and we scrolled. False otherwise.
 bool Renderer::_CheckViewportAndScroll()
 {
-    SMALL_RECT const srOldViewport = _srViewportPrevious;
+    SMALL_RECT const srOldViewport = _viewport.ToInclusive();
     SMALL_RECT const srNewViewport = _pData->GetViewport().ToInclusive();
 
     COORD coordDelta;
@@ -369,7 +368,7 @@ bool Renderer::_CheckViewportAndScroll()
         LOG_IF_FAILED(engine->UpdateViewport(srNewViewport));
     }
 
-    _srViewportPrevious = srNewViewport;
+    _viewport = Viewport::FromInclusive(srNewViewport);
 
     // If we're keeping some buffers between calls, let them know about the viewport size
     // so they can prepare the buffers for changes to either preallocate memory at once

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -26,7 +26,7 @@ Renderer::Renderer(IRenderData* pData,
                    _In_reads_(cEngines) IRenderEngine** const rgpEngines,
                    const size_t cEngines,
                    std::unique_ptr<IRenderThread> thread) :
-    _pData(pData),
+    _pData(THROW_HR_IF_NULL(E_INVALIDARG, pData)),
     _pThread{ std::move(thread) },
     _destructing{ false },
     _clusterBuffer{},

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -120,7 +120,7 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT _PerformScrolling(_In_ IRenderEngine* const pEngine);
 
-        SMALL_RECT _srViewportPrevious;
+        Microsoft::Console::Types::Viewport _viewport;
 
         static constexpr float _shrinkThreshold = 0.8f;
         std::vector<Cluster> _clusterBuffer;


### PR DESCRIPTION
In `Renderer::TriggerRedraw`, the act of fetching the viewport from the
`pData` over and over is wasted time. We already have a cached variable
of the viewport that is updated on every scroll check (on
`TriggerScroll` and on `PaintFrame`.) Scrolling wouldn't be working
correctly if the clients weren't already notifying us that the viewport
has changed for scroll purposes, so we can just keep using that cached
value for the invalidation restriction to speed things up over fetching
it again.

## Validation Steps Performed
- Run `time cat big.txt`. Checked average time before/after, WPR traces
  before/after.

## PR Checklist
* [x] Closes perf itch
* [x] I work here
* [x] Manual test
* [x] Documentation irrelevant.
* [x] Schema irrelevant.
* [x] Am core contributor.