### PR TITLE
Replace basic_string_view<T> with span<const T>

### DIFF
--- a/src/buffer/out/AttrRow.cpp
+++ b/src/buffer/out/AttrRow.cpp
@@ -223,7 +223,7 @@ void ATTR_ROW::ReplaceAttrs(const TextAttribute& toBeReplacedAttr, const TextAtt
 // Return Value:
 // - STATUS_NO_MEMORY if there wasn't enough memory to insert the runs
 //   otherwise STATUS_SUCCESS if we were successful.
-[[nodiscard]] HRESULT ATTR_ROW::InsertAttrRuns(const std::basic_string_view<TextAttributeRun> newAttrs,
+[[nodiscard]] HRESULT ATTR_ROW::InsertAttrRuns(const gsl::span<const TextAttributeRun> newAttrs,
                                                const size_t iStart,
                                                const size_t iEnd,
                                                const size_t cBufferWidth)
@@ -250,7 +250,7 @@ void ATTR_ROW::ReplaceAttrs(const TextAttribute& toBeReplacedAttr, const TextAtt
     if (newAttrs.size() == 1)
     {
         // Get the new color attribute we're trying to apply
-        const TextAttribute NewAttr = newAttrs.at(0).GetAttributes();
+        const TextAttribute NewAttr = gsl::at(newAttrs, 0).GetAttributes();
 
         // If the existing run was only 1 element...
         // ...and the new color is the same as the old, we don't have to do anything and can exit quick.
@@ -372,7 +372,7 @@ void ATTR_ROW::ReplaceAttrs(const TextAttribute& toBeReplacedAttr, const TextAtt
     if (iStart == 0 && iEnd == iLastBufferCol)
     {
         // Just dump what we're given over what we have and call it a day.
-        _list.assign(newAttrs.cbegin(), newAttrs.cend());
+        _list.assign(newAttrs.begin(), newAttrs.end());
 
         return S_OK;
     }

--- a/src/buffer/out/AttrRow.hpp
+++ b/src/buffer/out/AttrRow.hpp
@@ -46,7 +46,7 @@ public:
 
     void Resize(const size_t newWidth);
 
-    [[nodiscard]] HRESULT InsertAttrRuns(const std::basic_string_view<TextAttributeRun> newAttrs,
+    [[nodiscard]] HRESULT InsertAttrRuns(const gsl::span<const TextAttributeRun> newAttrs,
                                          const size_t iStart,
                                          const size_t iEnd,
                                          const size_t cBufferWidth);

--- a/src/buffer/out/OutputCellIterator.cpp
+++ b/src/buffer/out/OutputCellIterator.cpp
@@ -112,9 +112,9 @@ OutputCellIterator::OutputCellIterator(const std::wstring_view utf16Text, const 
 // - This is an iterator over legacy colors only. The text is not modified.
 // Arguments:
 // - legacyAttrs - One legacy color item per cell
-OutputCellIterator::OutputCellIterator(const std::basic_string_view<WORD> legacyAttrs) noexcept :
+OutputCellIterator::OutputCellIterator(const gsl::span<const WORD> legacyAttrs) noexcept :
     _mode(Mode::LegacyAttr),
-    _currentView(s_GenerateViewLegacyAttr(legacyAttrs.at(0))),
+    _currentView(s_GenerateViewLegacyAttr(gsl::at(legacyAttrs, 0))),
     _run(legacyAttrs),
     _attr(InvalidTextAttribute),
     _distance(0),
@@ -127,9 +127,9 @@ OutputCellIterator::OutputCellIterator(const std::basic_string_view<WORD> legacy
 // - This is an iterator over legacy cell data. We will use the unicode text and the legacy color attribute.
 // Arguments:
 // - charInfos - Multiple cell with unicode text and legacy color data.
-OutputCellIterator::OutputCellIterator(const std::basic_string_view<CHAR_INFO> charInfos) noexcept :
+OutputCellIterator::OutputCellIterator(const gsl::span<const CHAR_INFO> charInfos) noexcept :
     _mode(Mode::CharInfo),
-    _currentView(s_GenerateView(charInfos.at(0))),
+    _currentView(s_GenerateView(gsl::at(charInfos, 0))),
     _run(charInfos),
     _attr(InvalidTextAttribute),
     _distance(0),
@@ -142,9 +142,9 @@ OutputCellIterator::OutputCellIterator(const std::basic_string_view<CHAR_INFO> c
 // - This is an iterator over existing OutputCells with full text and color data.
 // Arguments:
 // - cells - Multiple cells in a run
-OutputCellIterator::OutputCellIterator(const std::basic_string_view<OutputCell> cells) :
+OutputCellIterator::OutputCellIterator(const gsl::span<const OutputCell> cells) :
     _mode(Mode::Cell),
-    _currentView(s_GenerateView(cells.at(0))),
+    _currentView(s_GenerateView(gsl::at(cells, 0))),
     _run(cells),
     _attr(InvalidTextAttribute),
     _distance(0),
@@ -180,15 +180,15 @@ OutputCellIterator::operator bool() const noexcept
         }
         case Mode::Cell:
         {
-            return _pos < std::get<std::basic_string_view<OutputCell>>(_run).length();
+            return _pos < std::get<gsl::span<const OutputCell>>(_run).size();
         }
         case Mode::CharInfo:
         {
-            return _pos < std::get<std::basic_string_view<CHAR_INFO>>(_run).length();
+            return _pos < std::get<gsl::span<const CHAR_INFO>>(_run).size();
         }
         case Mode::LegacyAttr:
         {
-            return _pos < std::get<std::basic_string_view<WORD>>(_run).length();
+            return _pos < std::get<gsl::span<const WORD>>(_run).size();
         }
         default:
             FAIL_FAST_HR(E_NOTIMPL);
@@ -265,7 +265,7 @@ OutputCellIterator& OutputCellIterator::operator++()
         _pos++;
         if (operator bool())
         {
-            _currentView = s_GenerateView(std::get<std::basic_string_view<OutputCell>>(_run).at(_pos));
+            _currentView = s_GenerateView(gsl::at(std::get<gsl::span<const OutputCell>>(_run), _pos));
         }
         break;
     }
@@ -275,7 +275,7 @@ OutputCellIterator& OutputCellIterator::operator++()
         _pos++;
         if (operator bool())
         {
-            _currentView = s_GenerateView(std::get<std::basic_string_view<CHAR_INFO>>(_run).at(_pos));
+            _currentView = s_GenerateView(gsl::at(std::get<gsl::span<const CHAR_INFO>>(_run), _pos));
         }
         break;
     }
@@ -285,7 +285,7 @@ OutputCellIterator& OutputCellIterator::operator++()
         _pos++;
         if (operator bool())
         {
-            _currentView = s_GenerateViewLegacyAttr(std::get<std::basic_string_view<WORD>>(_run).at(_pos));
+            _currentView = s_GenerateViewLegacyAttr(gsl::at(std::get<gsl::span<const WORD>>(_run), _pos));
         }
         break;
     }

--- a/src/buffer/out/OutputCellIterator.hpp
+++ b/src/buffer/out/OutputCellIterator.hpp
@@ -39,9 +39,9 @@ public:
     OutputCellIterator(const CHAR_INFO& charInfo, const size_t fillLimit = 0) noexcept;
     OutputCellIterator(const std::wstring_view utf16Text);
     OutputCellIterator(const std::wstring_view utf16Text, const TextAttribute attribute);
-    OutputCellIterator(const std::basic_string_view<WORD> legacyAttributes) noexcept;
-    OutputCellIterator(const std::basic_string_view<CHAR_INFO> charInfos) noexcept;
-    OutputCellIterator(const std::basic_string_view<OutputCell> cells);
+    OutputCellIterator(const gsl::span<const WORD> legacyAttributes) noexcept;
+    OutputCellIterator(const gsl::span<const CHAR_INFO> charInfos) noexcept;
+    OutputCellIterator(const gsl::span<const OutputCell> cells);
     ~OutputCellIterator() = default;
 
     OutputCellIterator& operator=(const OutputCellIterator& it) = default;
@@ -86,13 +86,13 @@ private:
     };
     Mode _mode;
 
-    std::basic_string_view<WORD> _legacyAttrs;
+    gsl::span<const WORD> _legacyAttrs;
 
     std::variant<
         std::wstring_view,
-        std::basic_string_view<WORD>,
-        std::basic_string_view<CHAR_INFO>,
-        std::basic_string_view<OutputCell>,
+        gsl::span<const WORD>,
+        gsl::span<const CHAR_INFO>,
+        gsl::span<const OutputCell>,
         std::monostate>
         _run;
 

--- a/src/buffer/out/OutputCellRect.cpp
+++ b/src/buffer/out/OutputCellRect.cpp
@@ -50,7 +50,7 @@ gsl::span<OutputCell> OutputCellRect::GetRow(const size_t row)
 // - Read-only iterator of OutputCells
 OutputCellIterator OutputCellRect::GetRowIter(const size_t row) const
 {
-    const std::basic_string_view<OutputCell> view(_FindRowOffset(row), _cols);
+    const gsl::span<const OutputCell> view(_FindRowOffset(row), _cols);
 
     return OutputCellIterator(view);
 }

--- a/src/buffer/out/TextAttribute.cpp
+++ b/src/buffer/out/TextAttribute.cpp
@@ -90,7 +90,7 @@ bool TextAttribute::IsLegacy() const noexcept
 // - reverseScreenMode: true if the screen mode is reversed.
 // Return Value:
 // - the foreground and background colors that should be displayed.
-std::pair<COLORREF, COLORREF> TextAttribute::CalculateRgbColors(const std::basic_string_view<COLORREF> colorTable,
+std::pair<COLORREF, COLORREF> TextAttribute::CalculateRgbColors(const gsl::span<const COLORREF> colorTable,
                                                                 const COLORREF defaultFgColor,
                                                                 const COLORREF defaultBgColor,
                                                                 const bool reverseScreenMode) const noexcept

--- a/src/buffer/out/TextAttribute.hpp
+++ b/src/buffer/out/TextAttribute.hpp
@@ -63,7 +63,7 @@ public:
     static TextAttribute StripErroneousVT16VersionsOfLegacyDefaults(const TextAttribute& attribute) noexcept;
     WORD GetLegacyAttributes() const noexcept;
 
-    std::pair<COLORREF, COLORREF> CalculateRgbColors(const std::basic_string_view<COLORREF> colorTable,
+    std::pair<COLORREF, COLORREF> CalculateRgbColors(const gsl::span<const COLORREF> colorTable,
                                                      const COLORREF defaultFgColor,
                                                      const COLORREF defaultBgColor,
                                                      const bool reverseScreenMode = false) const noexcept;

--- a/src/buffer/out/TextColor.cpp
+++ b/src/buffer/out/TextColor.cpp
@@ -138,7 +138,7 @@ void TextColor::SetDefault() noexcept
 // - brighten: if true, we'll brighten a dark color table index.
 // Return Value:
 // - a COLORREF containing the real value of this TextColor.
-COLORREF TextColor::GetColor(std::basic_string_view<COLORREF> colorTable,
+COLORREF TextColor::GetColor(gsl::span<const COLORREF> colorTable,
                              const COLORREF defaultColor,
                              bool brighten) const noexcept
 {
@@ -158,9 +158,9 @@ COLORREF TextColor::GetColor(std::basic_string_view<COLORREF> colorTable,
             // If we find a match, return instead the bright version of this color
             for (size_t i = 0; i < 8; i++)
             {
-                if (colorTable.at(i) == defaultColor)
+                if (gsl::at(colorTable, i) == defaultColor)
                 {
-                    return colorTable.at(i + 8);
+                    return gsl::at(colorTable, i + 8);
                 }
             }
         }
@@ -173,11 +173,11 @@ COLORREF TextColor::GetColor(std::basic_string_view<COLORREF> colorTable,
     }
     else if (IsIndex16() && brighten)
     {
-        return colorTable.at(_index | 8);
+        return gsl::at(colorTable, _index | 8);
     }
     else
     {
-        return colorTable.at(_index);
+        return gsl::at(colorTable, _index);
     }
 }
 

--- a/src/buffer/out/TextColor.h
+++ b/src/buffer/out/TextColor.h
@@ -88,7 +88,7 @@ public:
     void SetIndex(const BYTE index, const bool isIndex256) noexcept;
     void SetDefault() noexcept;
 
-    COLORREF GetColor(std::basic_string_view<COLORREF> colorTable,
+    COLORREF GetColor(gsl::span<const COLORREF> colorTable,
                       const COLORREF defaultColor,
                       const bool brighten = false) const noexcept;
 

--- a/src/buffer/out/ut_textbuffer/TextAttributeTests.cpp
+++ b/src/buffer/out/ut_textbuffer/TextAttributeTests.cpp
@@ -27,7 +27,7 @@ class TextAttributeTests
     COLORREF _colorTable[COLOR_TABLE_SIZE];
     COLORREF _defaultFg = RGB(1, 2, 3);
     COLORREF _defaultBg = RGB(4, 5, 6);
-    std::basic_string_view<COLORREF> _GetTableView();
+    gsl::span<const COLORREF> _GetTableView();
 };
 
 bool TextAttributeTests::ClassSetup()
@@ -51,9 +51,9 @@ bool TextAttributeTests::ClassSetup()
     return true;
 }
 
-std::basic_string_view<COLORREF> TextAttributeTests::_GetTableView()
+gsl::span<const COLORREF> TextAttributeTests::_GetTableView()
 {
-    return std::basic_string_view<COLORREF>(&_colorTable[0], COLOR_TABLE_SIZE);
+    return gsl::span<const COLORREF>(&_colorTable[0], COLOR_TABLE_SIZE);
 }
 
 void TextAttributeTests::TestRoundtripLegacy()

--- a/src/buffer/out/ut_textbuffer/TextColorTests.cpp
+++ b/src/buffer/out/ut_textbuffer/TextColorTests.cpp
@@ -27,7 +27,7 @@ class TextColorTests
     COLORREF _colorTable[COLOR_TABLE_SIZE];
     COLORREF _defaultFg = RGB(1, 2, 3);
     COLORREF _defaultBg = RGB(4, 5, 6);
-    std::basic_string_view<COLORREF> _GetTableView();
+    gsl::span<const COLORREF> _GetTableView();
 };
 
 bool TextColorTests::ClassSetup()
@@ -51,9 +51,9 @@ bool TextColorTests::ClassSetup()
     return true;
 }
 
-std::basic_string_view<COLORREF> TextColorTests::_GetTableView()
+gsl::span<const COLORREF> TextColorTests::_GetTableView()
 {
-    return std::basic_string_view<COLORREF>(&_colorTable[0], COLOR_TABLE_SIZE);
+    return gsl::span<const COLORREF>(&_colorTable[0], COLOR_TABLE_SIZE);
 }
 
 void TextColorTests::TestDefaultColor()

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -93,7 +93,7 @@ const Profile* CascadiaSettings::FindProfile(GUID profileGuid) const noexcept
 // - <none>
 // Return Value:
 // - an iterable collection of all of our Profiles.
-std::basic_string_view<Profile> CascadiaSettings::GetProfiles() const noexcept
+gsl::span<const Profile> CascadiaSettings::GetProfiles() const noexcept
 {
     return { &_profiles[0], _profiles.size() };
 }

--- a/src/cascadia/TerminalApp/CascadiaSettings.h
+++ b/src/cascadia/TerminalApp/CascadiaSettings.h
@@ -59,7 +59,7 @@ public:
 
     GlobalAppSettings& GlobalSettings();
 
-    std::basic_string_view<Profile> GetProfiles() const noexcept;
+    gsl::span<const Profile> GetProfiles() const noexcept;
 
     winrt::TerminalApp::AppKeyBindings GetKeybindings() const noexcept;
 

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -354,12 +354,12 @@ bool TerminalDispatch::EnableAlternateScroll(const bool enabled) noexcept
     return true;
 }
 
-bool TerminalDispatch::SetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> params) noexcept
+bool TerminalDispatch::SetPrivateModes(const gsl::span<const DispatchTypes::PrivateModeParams> params) noexcept
 {
     return _SetResetPrivateModes(params, true);
 }
 
-bool TerminalDispatch::ResetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> params) noexcept
+bool TerminalDispatch::ResetPrivateModes(const gsl::span<const DispatchTypes::PrivateModeParams> params) noexcept
 {
     return _SetResetPrivateModes(params, false);
 }
@@ -374,7 +374,7 @@ bool TerminalDispatch::ResetPrivateModes(const std::basic_string_view<DispatchTy
 // - enable - True for set, false for unset.
 // Return Value:
 // - True if ALL params were handled successfully. False otherwise.
-bool TerminalDispatch::_SetResetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> params, const bool enable) noexcept
+bool TerminalDispatch::_SetResetPrivateModes(const gsl::span<const DispatchTypes::PrivateModeParams> params, const bool enable) noexcept
 {
     // because the user might chain together params we don't support with params we DO support, execute all
     // params in the sequence, and only return failure if we failed at least one of them

--- a/src/cascadia/TerminalCore/TerminalDispatch.hpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.hpp
@@ -13,7 +13,7 @@ public:
     void Print(const wchar_t wchPrintable) noexcept override;
     void PrintString(const std::wstring_view string) noexcept override;
 
-    bool SetGraphicsRendition(const std::basic_string_view<::Microsoft::Console::VirtualTerminal::DispatchTypes::GraphicsOptions> options) noexcept override;
+    bool SetGraphicsRendition(const gsl::span<const ::Microsoft::Console::VirtualTerminal::DispatchTypes::GraphicsOptions> options) noexcept override;
 
     bool CursorPosition(const size_t line,
                         const size_t column) noexcept override; // CUP
@@ -59,16 +59,16 @@ public:
     bool EnableAnyEventMouseMode(const bool enabled) noexcept override; // ?1003
     bool EnableAlternateScroll(const bool enabled) noexcept override; // ?1007
 
-    bool SetPrivateModes(const std::basic_string_view<::Microsoft::Console::VirtualTerminal::DispatchTypes::PrivateModeParams> /*params*/) noexcept override; // DECSET
-    bool ResetPrivateModes(const std::basic_string_view<::Microsoft::Console::VirtualTerminal::DispatchTypes::PrivateModeParams> /*params*/) noexcept override; // DECRST
+    bool SetPrivateModes(const gsl::span<const ::Microsoft::Console::VirtualTerminal::DispatchTypes::PrivateModeParams> /*params*/) noexcept override; // DECSET
+    bool ResetPrivateModes(const gsl::span<const ::Microsoft::Console::VirtualTerminal::DispatchTypes::PrivateModeParams> /*params*/) noexcept override; // DECRST
 
 private:
     ::Microsoft::Terminal::Core::ITerminalApi& _terminalApi;
 
-    size_t _SetRgbColorsHelper(const std::basic_string_view<::Microsoft::Console::VirtualTerminal::DispatchTypes::GraphicsOptions> options,
+    size_t _SetRgbColorsHelper(const gsl::span<const ::Microsoft::Console::VirtualTerminal::DispatchTypes::GraphicsOptions> options,
                                TextAttribute& attr,
                                const bool isForeground) noexcept;
 
-    bool _SetResetPrivateModes(const std::basic_string_view<::Microsoft::Console::VirtualTerminal::DispatchTypes::PrivateModeParams> params, const bool enable) noexcept;
+    bool _SetResetPrivateModes(const gsl::span<const ::Microsoft::Console::VirtualTerminal::DispatchTypes::PrivateModeParams> params, const bool enable) noexcept;
     bool _PrivateModeParamsHelper(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::PrivateModeParams param, const bool enable) noexcept;
 };

--- a/src/cascadia/TerminalCore/TerminalDispatchGraphics.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatchGraphics.cpp
@@ -41,7 +41,7 @@ const BYTE BRIGHT_WHITE   = BRIGHT_ATTR | RED_ATTR | GREEN_ATTR | BLUE_ATTR;
 // - isForeground - Whether or not the parsed color is for the foreground.
 // Return Value:
 // - The number of options consumed, not including the initial 38/48.
-size_t TerminalDispatch::_SetRgbColorsHelper(const std::basic_string_view<DispatchTypes::GraphicsOptions> options,
+size_t TerminalDispatch::_SetRgbColorsHelper(const gsl::span<const DispatchTypes::GraphicsOptions> options,
                                              TextAttribute& attr,
                                              const bool isForeground) noexcept
 {
@@ -94,7 +94,7 @@ size_t TerminalDispatch::_SetRgbColorsHelper(const std::basic_string_view<Dispat
 //   one at a time by setting or removing flags in the font style properties.
 // Return Value:
 // - True if handled successfully. False otherwise.
-bool TerminalDispatch::SetGraphicsRendition(const std::basic_string_view<DispatchTypes::GraphicsOptions> options) noexcept
+bool TerminalDispatch::SetGraphicsRendition(const gsl::span<const DispatchTypes::GraphicsOptions> options) noexcept
 {
     TextAttribute attr = _terminalApi.GetTextAttributes();
 
@@ -264,10 +264,10 @@ bool TerminalDispatch::SetGraphicsRendition(const std::basic_string_view<Dispatc
             attr.SetIndexedBackground(BRIGHT_WHITE);
             break;
         case ForegroundExtended:
-            i += _SetRgbColorsHelper(options.substr(i + 1), attr, true);
+            i += _SetRgbColorsHelper(options.subspan(i + 1), attr, true);
             break;
         case BackgroundExtended:
-            i += _SetRgbColorsHelper(options.substr(i + 1), attr, false);
+            i += _SetRgbColorsHelper(options.subspan(i + 1), attr, false);
             break;
         }
     }

--- a/src/host/ApiRoutines.h
+++ b/src/host/ApiRoutines.h
@@ -208,12 +208,12 @@ public:
                                                           size_t& written) noexcept override;
 
     [[nodiscard]] HRESULT WriteConsoleInputAImpl(InputBuffer& context,
-                                                 const std::basic_string_view<INPUT_RECORD> buffer,
+                                                 const gsl::span<const INPUT_RECORD> buffer,
                                                  size_t& written,
                                                  const bool append) noexcept override;
 
     [[nodiscard]] HRESULT WriteConsoleInputWImpl(InputBuffer& context,
-                                                 const std::basic_string_view<INPUT_RECORD> buffer,
+                                                 const gsl::span<const INPUT_RECORD> buffer,
                                                  size_t& written,
                                                  const bool append) noexcept override;
 
@@ -228,7 +228,7 @@ public:
                                                   Microsoft::Console::Types::Viewport& writtenRectangle) noexcept override;
 
     [[nodiscard]] HRESULT WriteConsoleOutputAttributeImpl(IConsoleOutputObject& OutContext,
-                                                          const std::basic_string_view<WORD> attrs,
+                                                          const gsl::span<const WORD> attrs,
                                                           const COORD target,
                                                           size_t& used) noexcept override;
 

--- a/src/host/_output.cpp
+++ b/src/host/_output.cpp
@@ -69,7 +69,7 @@ void WriteToScreen(SCREEN_INFORMATION& screenInfo, const Viewport& region)
 // Return Value:
 // - S_OK, E_INVALIDARG or similar HRESULT error.
 [[nodiscard]] HRESULT ApiRoutines::WriteConsoleOutputAttributeImpl(IConsoleOutputObject& OutContext,
-                                                                   const std::basic_string_view<WORD> attrs,
+                                                                   const gsl::span<const WORD> attrs,
                                                                    const COORD target,
                                                                    size_t& used) noexcept
 {

--- a/src/host/conareainfo.cpp
+++ b/src/host/conareainfo.cpp
@@ -112,7 +112,7 @@ void ConversionAreaInfo::SetAttributes(const TextAttribute& attr)
 void ConversionAreaInfo::WriteText(const std::vector<OutputCell>& text,
                                    const SHORT column)
 {
-    std::basic_string_view<OutputCell> view(text.data(), text.size());
+    gsl::span<const OutputCell> view(text.data(), text.size());
     _screenBuffer->Write(view, { column, 0 });
 }
 

--- a/src/host/conimeinfo.cpp
+++ b/src/host/conimeinfo.cpp
@@ -57,15 +57,15 @@ void ConsoleImeInfo::RedrawCompMessage()
 // - attributes - Encoded attributes including the cursor position and the color index (to the array)
 // - colorArray - An array of colors to use for the text
 void ConsoleImeInfo::WriteCompMessage(const std::wstring_view text,
-                                      const std::basic_string_view<BYTE> attributes,
-                                      const std::basic_string_view<WORD> colorArray)
+                                      const gsl::span<const BYTE> attributes,
+                                      const gsl::span<const WORD> colorArray)
 {
     ClearAllAreas();
 
     // Save copies of the composition message in case we need to redraw it as things scroll/resize
     _text = text;
-    _attributes = attributes;
-    _colorArray = colorArray;
+    _attributes.assign(attributes.begin(), attributes.end());
+    _colorArray.assign(colorArray.begin(), colorArray.end());
 
     _WriteUndeterminedChars(text, attributes, colorArray);
 }
@@ -177,8 +177,8 @@ void ConsoleImeInfo::ClearAllAreas()
 // Return Value:
 // - TextAttribute object with color and cursor and line drawing data.
 TextAttribute ConsoleImeInfo::s_RetrieveAttributeAt(const size_t pos,
-                                                    const std::basic_string_view<BYTE> attributes,
-                                                    const std::basic_string_view<WORD> colorArray)
+                                                    const gsl::span<const BYTE> attributes,
+                                                    const gsl::span<const WORD> colorArray)
 {
     // Encoded attribute is the shorthand information passed from the IME
     // that contains a cursor position packed in along with which color in the
@@ -214,8 +214,8 @@ TextAttribute ConsoleImeInfo::s_RetrieveAttributeAt(const size_t pos,
 // Return Value:
 // - Vector of OutputCells where each one represents one cell of the output buffer.
 std::vector<OutputCell> ConsoleImeInfo::s_ConvertToCells(const std::wstring_view text,
-                                                         const std::basic_string_view<BYTE> attributes,
-                                                         const std::basic_string_view<WORD> colorArray)
+                                                         const gsl::span<const BYTE> attributes,
+                                                         const gsl::span<const WORD> colorArray)
 {
     std::vector<OutputCell> cells;
 
@@ -389,8 +389,8 @@ std::vector<OutputCell>::const_iterator ConsoleImeInfo::_WriteConversionArea(con
 //                each text character. This view must be the same size as the text view.
 // - colorArray - 8 colors to be used to format the text for display
 void ConsoleImeInfo::_WriteUndeterminedChars(const std::wstring_view text,
-                                             const std::basic_string_view<BYTE> attributes,
-                                             const std::basic_string_view<WORD> colorArray)
+                                             const gsl::span<const BYTE> attributes,
+                                             const gsl::span<const WORD> colorArray)
 {
     CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     SCREEN_INFORMATION& screenInfo = gci.GetActiveOutputBuffer();

--- a/src/host/conimeinfo.h
+++ b/src/host/conimeinfo.h
@@ -48,8 +48,8 @@ public:
     [[nodiscard]] HRESULT ResizeAllAreas(const COORD newSize);
 
     void WriteCompMessage(const std::wstring_view text,
-                          const std::basic_string_view<BYTE> attributes,
-                          const std::basic_string_view<WORD> colorArray);
+                          const gsl::span<const BYTE> attributes,
+                          const gsl::span<const WORD> colorArray);
 
     void WriteResultMessage(const std::wstring_view text);
 
@@ -64,18 +64,18 @@ private:
     void _ClearComposition();
 
     void _WriteUndeterminedChars(const std::wstring_view text,
-                                 const std::basic_string_view<BYTE> attributes,
-                                 const std::basic_string_view<WORD> colorArray);
+                                 const gsl::span<const BYTE> attributes,
+                                 const gsl::span<const WORD> colorArray);
 
     void _InsertConvertedString(const std::wstring_view text);
 
     static TextAttribute s_RetrieveAttributeAt(const size_t pos,
-                                               const std::basic_string_view<BYTE> attributes,
-                                               const std::basic_string_view<WORD> colorArray);
+                                               const gsl::span<const BYTE> attributes,
+                                               const gsl::span<const WORD> colorArray);
 
     static std::vector<OutputCell> s_ConvertToCells(const std::wstring_view text,
-                                                    const std::basic_string_view<BYTE> attributes,
-                                                    const std::basic_string_view<WORD> colorArray);
+                                                    const gsl::span<const BYTE> attributes,
+                                                    const gsl::span<const WORD> colorArray);
 
     std::vector<OutputCell>::const_iterator _WriteConversionArea(const std::vector<OutputCell>::const_iterator begin,
                                                                  const std::vector<OutputCell>::const_iterator end,
@@ -86,6 +86,6 @@ private:
     bool _isSavedCursorVisible;
 
     std::wstring _text;
-    std::basic_string<BYTE> _attributes;
-    std::basic_string<WORD> _colorArray;
+    std::vector<BYTE> _attributes;
+    std::vector<WORD> _colorArray;
 };

--- a/src/host/convarea.cpp
+++ b/src/host/convarea.cpp
@@ -125,8 +125,8 @@ void WriteConvRegionToScreen(const SCREEN_INFORMATION& ScreenInfo,
 }
 
 [[nodiscard]] HRESULT ImeComposeData(std::wstring_view text,
-                                     std::basic_string_view<BYTE> attributes,
-                                     std::basic_string_view<WORD> colorArray)
+                                     gsl::span<const BYTE> attributes,
+                                     gsl::span<const WORD> colorArray)
 {
     try
     {

--- a/src/host/directio.cpp
+++ b/src/host/directio.cpp
@@ -472,7 +472,7 @@ void EventsToUnicode(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& inEvents,
 // Return Value:
 // - HRESULT indicating success or failure
 [[nodiscard]] HRESULT ApiRoutines::WriteConsoleInputAImpl(InputBuffer& context,
-                                                          const std::basic_string_view<INPUT_RECORD> buffer,
+                                                          const gsl::span<const INPUT_RECORD> buffer,
                                                           size_t& written,
                                                           const bool append) noexcept
 {
@@ -516,7 +516,7 @@ void EventsToUnicode(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& inEvents,
 // Return Value:
 // - HRESULT indicating success or failure
 [[nodiscard]] HRESULT ApiRoutines::WriteConsoleInputWImpl(InputBuffer& context,
-                                                          const std::basic_string_view<INPUT_RECORD> buffer,
+                                                          const gsl::span<const INPUT_RECORD> buffer,
                                                           size_t& written,
                                                           const bool append) noexcept
 {
@@ -1042,7 +1042,7 @@ void EventsToUnicode(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& inEvents,
             const auto subspan = buffer.subspan(totalOffset, writeRectangle.Width());
 
             // Convert to a CHAR_INFO view to fit into the iterator
-            const auto charInfos = std::basic_string_view<CHAR_INFO>(subspan.data(), subspan.size());
+            const auto charInfos = gsl::span<const CHAR_INFO>(subspan.data(), subspan.size());
 
             // Make the iterator and write to the target position.
             OutputCellIterator it(charInfos);

--- a/src/host/settings.cpp
+++ b/src/host/settings.cpp
@@ -726,12 +726,12 @@ void Settings::SetHistoryNoDup(const bool bHistoryNoDup)
     _bHistoryNoDup = bHistoryNoDup;
 }
 
-std::basic_string_view<COLORREF> Settings::Get16ColorTable() const
+gsl::span<const COLORREF> Settings::Get16ColorTable() const
 {
-    return Get256ColorTable().substr(0, 16);
+    return Get256ColorTable().subspan(0, 16);
 }
 
-std::basic_string_view<COLORREF> Settings::Get256ColorTable() const
+gsl::span<const COLORREF> Settings::Get256ColorTable() const
 {
     return { _colorTable.data(), _colorTable.size() };
 }

--- a/src/host/settings.hpp
+++ b/src/host/settings.hpp
@@ -159,8 +159,8 @@ public:
     bool GetHistoryNoDup() const;
     void SetHistoryNoDup(const bool fHistoryNoDup);
 
-    std::basic_string_view<COLORREF> Get16ColorTable() const;
-    std::basic_string_view<COLORREF> Get256ColorTable() const;
+    gsl::span<const COLORREF> Get16ColorTable() const;
+    gsl::span<const COLORREF> Get256ColorTable() const;
     void SetColorTableEntry(const size_t index, const COLORREF ColorValue);
     COLORREF GetColorTableEntry(const size_t index) const;
 

--- a/src/host/ut_host/OutputCellIteratorTests.cpp
+++ b/src/host/ut_host/OutputCellIteratorTests.cpp
@@ -367,7 +367,7 @@ class OutputCellIteratorTests
         SetVerifyOutput settings(VerifyOutputSettings::LogOnlyFailures);
 
         const std::vector<WORD> colors{ FOREGROUND_GREEN, FOREGROUND_RED | BACKGROUND_BLUE, FOREGROUND_BLUE | FOREGROUND_INTENSITY, BACKGROUND_GREEN };
-        const std::basic_string_view<WORD> view{ colors.data(), colors.size() };
+        const gsl::span<const WORD> view{ colors.data(), colors.size() };
 
         OutputCellIterator it(view);
 
@@ -401,7 +401,7 @@ class OutputCellIteratorTests
             charInfos.push_back(ci);
         }
 
-        const std::basic_string_view<CHAR_INFO> view{ charInfos.data(), charInfos.size() };
+        const gsl::span<const CHAR_INFO> view{ charInfos.data(), charInfos.size() };
 
         OutputCellIterator it(view);
 
@@ -433,7 +433,7 @@ class OutputCellIteratorTests
             cells.push_back(cell);
         }
 
-        const std::basic_string_view<OutputCell> view{ cells.data(), cells.size() };
+        const gsl::span<const OutputCell> view{ cells.data(), cells.size() };
 
         OutputCellIterator it(view);
 

--- a/src/inc/conime.h
+++ b/src/inc/conime.h
@@ -32,8 +32,8 @@ constexpr BYTE CONIME_CURSOR_LEFT = 0x20;
 [[nodiscard]] HRESULT ImeEndComposition();
 
 [[nodiscard]] HRESULT ImeComposeData(std::wstring_view text,
-                                     std::basic_string_view<BYTE> attributes,
-                                     std::basic_string_view<WORD> colorArray);
+                                     gsl::span<const BYTE> attributes,
+                                     gsl::span<const WORD> colorArray);
 
 [[nodiscard]] HRESULT ImeClearComposeData();
 

--- a/src/interactivity/onecore/BgfxEngine.cpp
+++ b/src/interactivity/onecore/BgfxEngine.cpp
@@ -145,7 +145,7 @@ BgfxEngine::BgfxEngine(PVOID SharedViewBase, LONG DisplayHeight, LONG DisplayWid
     return S_OK;
 }
 
-[[nodiscard]] HRESULT BgfxEngine::PaintBufferLine(const std::basic_string_view<Cluster> clusters,
+[[nodiscard]] HRESULT BgfxEngine::PaintBufferLine(const gsl::span<const Cluster> clusters,
                                                   const COORD coord,
                                                   const bool /*trimLeft*/,
                                                   const bool /*lineWrapped*/) noexcept

--- a/src/interactivity/onecore/BgfxEngine.hpp
+++ b/src/interactivity/onecore/BgfxEngine.hpp
@@ -49,7 +49,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT ScrollFrame() noexcept override;
 
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
-        [[nodiscard]] HRESULT PaintBufferLine(const std::basic_string_view<Cluster> clusters,
+        [[nodiscard]] HRESULT PaintBufferLine(const gsl::span<const Cluster> clusters,
                                               const COORD coord,
                                               const bool trimLeft,
                                               const bool lineWrapped) noexcept override;

--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -78,7 +78,7 @@ CATCH_RETURN()
 // - clusters - From the backing buffer, the text to be displayed clustered by the columns it should consume.
 // Return Value:
 // - S_OK or suitable memory management issue.
-[[nodiscard]] HRESULT STDMETHODCALLTYPE CustomTextLayout::AppendClusters(const std::basic_string_view<::Microsoft::Console::Render::Cluster> clusters)
+[[nodiscard]] HRESULT STDMETHODCALLTYPE CustomTextLayout::AppendClusters(const gsl::span<const ::Microsoft::Console::Render::Cluster> clusters)
 try
 {
     _textClusterColumns.reserve(_textClusterColumns.size() + clusters.size());

--- a/src/renderer/dx/CustomTextLayout.h
+++ b/src/renderer/dx/CustomTextLayout.h
@@ -27,7 +27,7 @@ namespace Microsoft::Console::Render
                          size_t const width,
                          IBoxDrawingEffect* const boxEffect);
 
-        [[nodiscard]] HRESULT STDMETHODCALLTYPE AppendClusters(const std::basic_string_view<::Microsoft::Console::Render::Cluster> clusters);
+        [[nodiscard]] HRESULT STDMETHODCALLTYPE AppendClusters(const gsl::span<const ::Microsoft::Console::Render::Cluster> clusters);
 
         [[nodiscard]] HRESULT STDMETHODCALLTYPE Reset() noexcept;
 

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1419,7 +1419,7 @@ CATCH_RETURN()
 // - fTrimLeft - Whether or not to trim off the left half of a double wide character
 // Return Value:
 // - S_OK or relevant DirectX error
-[[nodiscard]] HRESULT DxEngine::PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+[[nodiscard]] HRESULT DxEngine::PaintBufferLine(gsl::span<const Cluster> const clusters,
                                                 COORD const coord,
                                                 const bool /*trimLeft*/,
                                                 const bool /*lineWrapped*/) noexcept

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -86,7 +86,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT PrepareRenderInfo(const RenderFrameInfo& info) noexcept override;
 
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
-        [[nodiscard]] HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+        [[nodiscard]] HRESULT PaintBufferLine(gsl::span<const Cluster> const clusters,
                                               COORD const coord,
                                               bool const fTrimLeft,
                                               const bool lineWrapped) noexcept override;

--- a/src/renderer/gdi/gdirenderer.hpp
+++ b/src/renderer/gdi/gdirenderer.hpp
@@ -42,7 +42,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT ScrollFrame() noexcept override;
 
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
-        [[nodiscard]] HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+        [[nodiscard]] HRESULT PaintBufferLine(gsl::span<const Cluster> const clusters,
                                               const COORD coord,
                                               const bool trimLeft,
                                               const bool lineWrapped) noexcept override;

--- a/src/renderer/gdi/paint.cpp
+++ b/src/renderer/gdi/paint.cpp
@@ -284,7 +284,7 @@ using namespace Microsoft::Console::Render;
 // See: Win7: 390673, 447839 and then superseded by http://osgvsowi/638274 when FE/non-FE rendering condensed.
 //#define CONSOLE_EXTTEXTOUT_FLAGS ETO_OPAQUE | ETO_CLIPPED
 //#define MAX_POLY_LINES 80
-[[nodiscard]] HRESULT GdiEngine::PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+[[nodiscard]] HRESULT GdiEngine::PaintBufferLine(gsl::span<const Cluster> const clusters,
                                                  const COORD coord,
                                                  const bool trimLeft,
                                                  const bool /*lineWrapped*/) noexcept
@@ -316,7 +316,7 @@ using namespace Microsoft::Console::Render;
         // Convert data from clusters into the text array and the widths array.
         for (size_t i = 0; i < cchLine; i++)
         {
-            const auto& cluster = clusters.at(i);
+            const auto& cluster = gsl::at(clusters, i);
 
             // Our GDI renderer hasn't and isn't going to handle things above U+FFFF or sequences.
             // So replace anything complicated with a replacement character for drawing purposes.

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -71,7 +71,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] virtual HRESULT PrepareRenderInfo(const RenderFrameInfo& info) noexcept = 0;
 
         [[nodiscard]] virtual HRESULT PaintBackground() noexcept = 0;
-        [[nodiscard]] virtual HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+        [[nodiscard]] virtual HRESULT PaintBufferLine(gsl::span<const Cluster> const clusters,
                                                       const COORD coord,
                                                       const bool fTrimLeft,
                                                       const bool lineWrapped) noexcept = 0;

--- a/src/renderer/uia/UiaRenderer.cpp
+++ b/src/renderer/uia/UiaRenderer.cpp
@@ -305,7 +305,7 @@ CATCH_RETURN();
 // - fTrimLeft - Whether or not to trim off the left half of a double wide character
 // Return Value:
 // - S_FALSE
-[[nodiscard]] HRESULT UiaEngine::PaintBufferLine(std::basic_string_view<Cluster> const /*clusters*/,
+[[nodiscard]] HRESULT UiaEngine::PaintBufferLine(gsl::span<const Cluster> const /*clusters*/,
                                                  COORD const /*coord*/,
                                                  const bool /*trimLeft*/,
                                                  const bool /*lineWrapped*/) noexcept

--- a/src/renderer/uia/UiaRenderer.hpp
+++ b/src/renderer/uia/UiaRenderer.hpp
@@ -51,7 +51,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT InvalidateCircling(_Out_ bool* const pForcePaint) noexcept override;
 
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
-        [[nodiscard]] HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+        [[nodiscard]] HRESULT PaintBufferLine(gsl::span<const Cluster> const clusters,
                                               COORD const coord,
                                               bool const fTrimLeft,
                                               const bool lineWrapped) noexcept override;

--- a/src/renderer/vt/XtermEngine.cpp
+++ b/src/renderer/vt/XtermEngine.cpp
@@ -498,7 +498,7 @@ CATCH_RETURN();
 //   will be false.
 // Return Value:
 // - S_OK or suitable HRESULT error from writing pipe.
-[[nodiscard]] HRESULT XtermEngine::PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+[[nodiscard]] HRESULT XtermEngine::PaintBufferLine(gsl::span<const Cluster> const clusters,
                                                    const COORD coord,
                                                    const bool /*trimLeft*/,
                                                    const bool lineWrapped) noexcept

--- a/src/renderer/vt/XtermEngine.hpp
+++ b/src/renderer/vt/XtermEngine.hpp
@@ -41,7 +41,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] virtual HRESULT UpdateDrawingBrushes(const TextAttribute& textAttributes,
                                                            const gsl::not_null<IRenderData*> pData,
                                                            const bool isSettingDefaultBrushes) noexcept override;
-        [[nodiscard]] HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+        [[nodiscard]] HRESULT PaintBufferLine(gsl::span<const Cluster> const clusters,
                                               const COORD coord,
                                               const bool trimLeft,
                                               const bool lineWrapped) noexcept override;

--- a/src/renderer/vt/paint.cpp
+++ b/src/renderer/vt/paint.cpp
@@ -125,7 +125,7 @@ using namespace Microsoft::Console::Types;
 //   will be false.
 // Return Value:
 // - S_OK or suitable HRESULT error from writing pipe.
-[[nodiscard]] HRESULT VtEngine::PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+[[nodiscard]] HRESULT VtEngine::PaintBufferLine(gsl::span<const Cluster> const clusters,
                                                 const COORD coord,
                                                 const bool /*trimLeft*/,
                                                 const bool /*lineWrapped*/) noexcept
@@ -327,7 +327,7 @@ using namespace Microsoft::Console::Types;
 // - coord - character coordinate target to render within viewport
 // Return Value:
 // - S_OK or suitable HRESULT error from writing pipe.
-[[nodiscard]] HRESULT VtEngine::_PaintAsciiBufferLine(std::basic_string_view<Cluster> const clusters,
+[[nodiscard]] HRESULT VtEngine::_PaintAsciiBufferLine(gsl::span<const Cluster> const clusters,
                                                       const COORD coord) noexcept
 {
     try
@@ -362,7 +362,7 @@ using namespace Microsoft::Console::Types;
 // - coord - character coordinate target to render within viewport
 // Return Value:
 // - S_OK or suitable HRESULT error from writing pipe.
-[[nodiscard]] HRESULT VtEngine::_PaintUtf8BufferLine(std::basic_string_view<Cluster> const clusters,
+[[nodiscard]] HRESULT VtEngine::_PaintUtf8BufferLine(gsl::span<const Cluster> const clusters,
                                                      const COORD coord,
                                                      const bool lineWrapped) noexcept
 {

--- a/src/renderer/vt/vtrenderer.hpp
+++ b/src/renderer/vt/vtrenderer.hpp
@@ -61,7 +61,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] virtual HRESULT ScrollFrame() noexcept = 0;
 
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
-        [[nodiscard]] virtual HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+        [[nodiscard]] virtual HRESULT PaintBufferLine(gsl::span<const Cluster> const clusters,
                                                       const COORD coord,
                                                       const bool trimLeft,
                                                       const bool lineWrapped) noexcept override;
@@ -208,11 +208,11 @@ namespace Microsoft::Console::Render
         // buffer space for these two functions to build their lines
         // so they don't have to alloc/free in a tight loop
         std::wstring _bufferLine;
-        [[nodiscard]] HRESULT _PaintUtf8BufferLine(std::basic_string_view<Cluster> const clusters,
+        [[nodiscard]] HRESULT _PaintUtf8BufferLine(gsl::span<const Cluster> const clusters,
                                                    const COORD coord,
                                                    const bool lineWrapped) noexcept;
 
-        [[nodiscard]] HRESULT _PaintAsciiBufferLine(std::basic_string_view<Cluster> const clusters,
+        [[nodiscard]] HRESULT _PaintAsciiBufferLine(gsl::span<const Cluster> const clusters,
                                                     const COORD coord) noexcept;
 
         [[nodiscard]] HRESULT _WriteTerminalUtf8(const std::wstring_view str) noexcept;

--- a/src/renderer/wddmcon/WddmConRenderer.cpp
+++ b/src/renderer/wddmcon/WddmConRenderer.cpp
@@ -258,7 +258,7 @@ bool WddmConEngine::IsInitialized()
     return S_OK;
 }
 
-[[nodiscard]] HRESULT WddmConEngine::PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+[[nodiscard]] HRESULT WddmConEngine::PaintBufferLine(gsl::span<const Cluster> const clusters,
                                                      const COORD coord,
                                                      const bool /*trimLeft*/,
                                                      const bool /*lineWrapped*/) noexcept

--- a/src/renderer/wddmcon/WddmConRenderer.hpp
+++ b/src/renderer/wddmcon/WddmConRenderer.hpp
@@ -41,7 +41,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT ScrollFrame() noexcept override;
 
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
-        [[nodiscard]] HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+        [[nodiscard]] HRESULT PaintBufferLine(gsl::span<const Cluster> const clusters,
                                               const COORD coord,
                                               const bool trimLeft,
                                               const bool lineWrapped) noexcept override;

--- a/src/server/ApiDispatchers.cpp
+++ b/src/server/ApiDispatchers.cpp
@@ -881,7 +881,7 @@
     RETURN_IF_FAILED(pObjectHandle->GetInputBuffer(GENERIC_WRITE, &pInputBuffer));
 
     size_t written;
-    std::basic_string_view<INPUT_RECORD> buffer(reinterpret_cast<INPUT_RECORD*>(pvBuffer), cbSize / sizeof(INPUT_RECORD));
+    gsl::span<const INPUT_RECORD> buffer(reinterpret_cast<INPUT_RECORD*>(pvBuffer), cbSize / sizeof(INPUT_RECORD));
     if (!a->Unicode)
     {
         RETURN_IF_FAILED(m->_pApiRoutines->WriteConsoleInputAImpl(*pInputBuffer, buffer, written, !!a->Append));
@@ -1008,7 +1008,7 @@
     }
     case CONSOLE_ATTRIBUTE:
     {
-        const std::basic_string_view<WORD> text(reinterpret_cast<WORD*>(pvBuffer), cbBufferSize / sizeof(WORD));
+        const gsl::span<const WORD> text(reinterpret_cast<WORD*>(pvBuffer), cbBufferSize / sizeof(WORD));
 
         hr = m->_pApiRoutines->WriteConsoleOutputAttributeImpl(*pScreenInfo,
                                                                text,

--- a/src/server/IApiRoutines.h
+++ b/src/server/IApiRoutines.h
@@ -219,12 +219,12 @@ public:
                                                                   size_t& written) noexcept = 0;
 
     [[nodiscard]] virtual HRESULT WriteConsoleInputAImpl(IConsoleInputObject& context,
-                                                         const std::basic_string_view<INPUT_RECORD> buffer,
+                                                         const gsl::span<const INPUT_RECORD> buffer,
                                                          size_t& written,
                                                          const bool append) noexcept = 0;
 
     [[nodiscard]] virtual HRESULT WriteConsoleInputWImpl(IConsoleInputObject& context,
-                                                         const std::basic_string_view<INPUT_RECORD> buffer,
+                                                         const gsl::span<const INPUT_RECORD> buffer,
                                                          size_t& written,
                                                          const bool append) noexcept = 0;
 
@@ -239,7 +239,7 @@ public:
                                                           Microsoft::Console::Types::Viewport& writtenRectangle) noexcept = 0;
 
     [[nodiscard]] virtual HRESULT WriteConsoleOutputAttributeImpl(IConsoleOutputObject& OutContext,
-                                                                  const std::basic_string_view<WORD> attrs,
+                                                                  const gsl::span<const WORD> attrs,
                                                                   const COORD target,
                                                                   size_t& used) noexcept = 0;
 

--- a/src/terminal/adapter/IInteractDispatch.hpp
+++ b/src/terminal/adapter/IInteractDispatch.hpp
@@ -35,7 +35,7 @@ namespace Microsoft::Console::VirtualTerminal
         virtual bool WriteString(const std::wstring_view string) = 0;
 
         virtual bool WindowManipulation(const DispatchTypes::WindowManipulationType function,
-                                        const std::basic_string_view<size_t> parameters) = 0;
+                                        const gsl::span<const size_t> parameters) = 0;
 
         virtual bool MoveCursor(const size_t row,
                                 const size_t col) = 0;

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -86,11 +86,11 @@ public:
     virtual bool EraseInLine(const DispatchTypes::EraseType eraseType) = 0; // EL
     virtual bool EraseCharacters(const size_t numChars) = 0; // ECH
 
-    virtual bool SetGraphicsRendition(const std::basic_string_view<DispatchTypes::GraphicsOptions> options) = 0; // SGR
+    virtual bool SetGraphicsRendition(const gsl::span<const DispatchTypes::GraphicsOptions> options) = 0; // SGR
 
-    virtual bool SetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> params) = 0; // DECSET
+    virtual bool SetPrivateModes(const gsl::span<const DispatchTypes::PrivateModeParams> params) = 0; // DECSET
 
-    virtual bool ResetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> params) = 0; // DECRST
+    virtual bool ResetPrivateModes(const gsl::span<const DispatchTypes::PrivateModeParams> params) = 0; // DECRST
 
     virtual bool DeviceStatusReport(const DispatchTypes::AnsiStatusType statusType) = 0; // DSR, DSR-OS, DSR-CPR
     virtual bool DeviceAttributes() = 0; // DA1
@@ -116,7 +116,7 @@ public:
 
     // DTTERM_WindowManipulation
     virtual bool WindowManipulation(const DispatchTypes::WindowManipulationType function,
-                                    const std::basic_string_view<size_t> parameters) = 0;
+                                    const gsl::span<const size_t> parameters) = 0;
 };
 inline Microsoft::Console::VirtualTerminal::ITermDispatch::~ITermDispatch() {}
 #pragma warning(pop)

--- a/src/terminal/adapter/InteractDispatch.cpp
+++ b/src/terminal/adapter/InteractDispatch.cpp
@@ -96,7 +96,7 @@ bool InteractDispatch::WriteString(const std::wstring_view string)
 // Return value:
 // True if handled successfully. False otherwise.
 bool InteractDispatch::WindowManipulation(const DispatchTypes::WindowManipulationType function,
-                                          const std::basic_string_view<size_t> parameters)
+                                          const gsl::span<const size_t> parameters)
 {
     bool success = false;
     // Other Window Manipulation functions:

--- a/src/terminal/adapter/InteractDispatch.hpp
+++ b/src/terminal/adapter/InteractDispatch.hpp
@@ -29,7 +29,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool WriteCtrlKey(const KeyEvent& event) override;
         bool WriteString(const std::wstring_view string) override;
         bool WindowManipulation(const DispatchTypes::WindowManipulationType function,
-                                const std::basic_string_view<size_t> parameters) override; // DTTERM_WindowManipulation
+                                const gsl::span<const size_t> parameters) override; // DTTERM_WindowManipulation
         bool MoveCursor(const size_t row, const size_t col) override;
 
         bool IsVtInputEnabled() const override;

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1078,7 +1078,7 @@ bool AdaptDispatch::_PrivateModeParamsHelper(const DispatchTypes::PrivateModePar
 // - enable - True for set, false for unset.
 // Return Value:
 // - True if ALL params were handled successfully. False otherwise.
-bool AdaptDispatch::_SetResetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> params, const bool enable)
+bool AdaptDispatch::_SetResetPrivateModes(const gsl::span<const DispatchTypes::PrivateModeParams> params, const bool enable)
 {
     // because the user might chain together params we don't support with params we DO support, execute all
     // params in the sequence, and only return failure if we failed at least one of them
@@ -1096,7 +1096,7 @@ bool AdaptDispatch::_SetResetPrivateModes(const std::basic_string_view<DispatchT
 // - params - array of params to set
 // Return Value:
 // - True if handled successfully. False otherwise.
-bool AdaptDispatch::SetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> params)
+bool AdaptDispatch::SetPrivateModes(const gsl::span<const DispatchTypes::PrivateModeParams> params)
 {
     return _SetResetPrivateModes(params, true);
 }
@@ -1107,7 +1107,7 @@ bool AdaptDispatch::SetPrivateModes(const std::basic_string_view<DispatchTypes::
 // - params - array of params to reset
 // Return Value:
 // - True if handled successfully. False otherwise.
-bool AdaptDispatch::ResetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> params)
+bool AdaptDispatch::ResetPrivateModes(const gsl::span<const DispatchTypes::PrivateModeParams> params)
 {
     return _SetResetPrivateModes(params, false);
 }
@@ -2308,7 +2308,7 @@ bool Microsoft::Console::VirtualTerminal::AdaptDispatch::SetDefaultBackground(co
 // Return value:
 // True if handled successfully. False otherwise.
 bool AdaptDispatch::WindowManipulation(const DispatchTypes::WindowManipulationType function,
-                                       const std::basic_string_view<size_t> parameters)
+                                       const gsl::span<const size_t> parameters)
 {
     bool success = false;
     // Other Window Manipulation functions:

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -55,7 +55,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool EraseCharacters(const size_t numChars) override; // ECH
         bool InsertCharacter(const size_t count) override; // ICH
         bool DeleteCharacter(const size_t count) override; // DCH
-        bool SetGraphicsRendition(const std::basic_string_view<DispatchTypes::GraphicsOptions> options) override; // SGR
+        bool SetGraphicsRendition(const gsl::span<const DispatchTypes::GraphicsOptions> options) override; // SGR
         bool DeviceStatusReport(const DispatchTypes::AnsiStatusType statusType) override; // DSR, DSR-OS, DSR-CPR
         bool DeviceAttributes() override; // DA1
         bool SecondaryDeviceAttributes() override; // DA2
@@ -66,8 +66,8 @@ namespace Microsoft::Console::VirtualTerminal
         bool InsertLine(const size_t distance) override; // IL
         bool DeleteLine(const size_t distance) override; // DL
         bool SetColumns(const size_t columns) override; // DECCOLM
-        bool SetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> params) override; // DECSET
-        bool ResetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> params) override; // DECRST
+        bool SetPrivateModes(const gsl::span<const DispatchTypes::PrivateModeParams> params) override; // DECSET
+        bool ResetPrivateModes(const gsl::span<const DispatchTypes::PrivateModeParams> params) override; // DECRST
         bool SetCursorKeysMode(const bool applicationMode) override; // DECCKM
         bool SetKeypadMode(const bool applicationMode) override; // DECKPAM, DECKPNM
         bool EnableWin32InputMode(const bool win32InputMode) override; // win32-input-mode
@@ -116,7 +116,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool SetDefaultBackground(const DWORD color) override; // OSCDefaultBackground
 
         bool WindowManipulation(const DispatchTypes::WindowManipulationType function,
-                                const std::basic_string_view<size_t> parameters) override; // DTTERM_WindowManipulation
+                                const gsl::span<const size_t> parameters) override; // DTTERM_WindowManipulation
 
     private:
         enum class ScrollDirection
@@ -159,7 +159,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool _CursorPositionReport() const;
 
         bool _WriteResponse(const std::wstring_view reply) const;
-        bool _SetResetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> params, const bool enable);
+        bool _SetResetPrivateModes(const gsl::span<const DispatchTypes::PrivateModeParams> params, const bool enable);
         bool _PrivateModeParamsHelper(const DispatchTypes::PrivateModeParams param, const bool enable);
         bool _DoDECCOLMHelper(const size_t columns);
 
@@ -192,7 +192,7 @@ namespace Microsoft::Console::VirtualTerminal
 
         bool _isDECCOLMAllowed;
 
-        size_t _SetRgbColorsHelper(const std::basic_string_view<DispatchTypes::GraphicsOptions> options,
+        size_t _SetRgbColorsHelper(const gsl::span<const DispatchTypes::GraphicsOptions> options,
                                    TextAttribute& attr,
                                    const bool isForeground) noexcept;
     };

--- a/src/terminal/adapter/adaptDispatchGraphics.cpp
+++ b/src/terminal/adapter/adaptDispatchGraphics.cpp
@@ -47,7 +47,7 @@ const BYTE BRIGHT_WHITE   = BRIGHT_ATTR | RED_ATTR | GREEN_ATTR | BLUE_ATTR;
 // - isForeground - Whether or not the parsed color is for the foreground.
 // Return Value:
 // - The number of options consumed, not including the initial 38/48.
-size_t AdaptDispatch::_SetRgbColorsHelper(const std::basic_string_view<DispatchTypes::GraphicsOptions> options,
+size_t AdaptDispatch::_SetRgbColorsHelper(const gsl::span<const DispatchTypes::GraphicsOptions> options,
                                           TextAttribute& attr,
                                           const bool isForeground) noexcept
 {
@@ -100,7 +100,7 @@ size_t AdaptDispatch::_SetRgbColorsHelper(const std::basic_string_view<DispatchT
 //   one at a time by setting or removing flags in the font style properties.
 // Return Value:
 // - True if handled successfully. False otherwise.
-bool AdaptDispatch::SetGraphicsRendition(const std::basic_string_view<DispatchTypes::GraphicsOptions> options)
+bool AdaptDispatch::SetGraphicsRendition(const gsl::span<const DispatchTypes::GraphicsOptions> options)
 {
     TextAttribute attr;
     bool success = _pConApi->PrivateGetTextAttributes(attr);
@@ -273,10 +273,10 @@ bool AdaptDispatch::SetGraphicsRendition(const std::basic_string_view<DispatchTy
                 attr.SetIndexedBackground(BRIGHT_WHITE);
                 break;
             case ForegroundExtended:
-                i += _SetRgbColorsHelper(options.substr(i + 1), attr, true);
+                i += _SetRgbColorsHelper(options.subspan(i + 1), attr, true);
                 break;
             case BackgroundExtended:
-                i += _SetRgbColorsHelper(options.substr(i + 1), attr, false);
+                i += _SetRgbColorsHelper(options.subspan(i + 1), attr, false);
                 break;
             }
         }

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -80,11 +80,11 @@ public:
     bool EraseInLine(const DispatchTypes::EraseType /* eraseType*/) noexcept override { return false; } // EL
     bool EraseCharacters(const size_t /*numChars*/) noexcept override { return false; } // ECH
 
-    bool SetGraphicsRendition(const std::basic_string_view<DispatchTypes::GraphicsOptions> /*options*/) noexcept override { return false; } // SGR
+    bool SetGraphicsRendition(const gsl::span<const DispatchTypes::GraphicsOptions> /*options*/) noexcept override { return false; } // SGR
 
-    bool SetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> /*params*/) noexcept override { return false; } // DECSET
+    bool SetPrivateModes(const gsl::span<const DispatchTypes::PrivateModeParams> /*params*/) noexcept override { return false; } // DECSET
 
-    bool ResetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> /*params*/) noexcept override { return false; } // DECRST
+    bool ResetPrivateModes(const gsl::span<const DispatchTypes::PrivateModeParams> /*params*/) noexcept override { return false; } // DECRST
 
     bool DeviceStatusReport(const DispatchTypes::AnsiStatusType /*statusType*/) noexcept override { return false; } // DSR, DSR-OS, DSR-CPR
     bool DeviceAttributes() noexcept override { return false; } // DA1
@@ -110,5 +110,5 @@ public:
 
     // DTTERM_WindowManipulation
     bool WindowManipulation(const DispatchTypes::WindowManipulationType /*function*/,
-                            const std::basic_string_view<size_t> /*params*/) noexcept override { return false; }
+                            const gsl::span<const size_t> /*params*/) noexcept override { return false; }
 };

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -276,10 +276,10 @@ void TerminalInput::ForceDisableWin32InputMode(const bool win32InputMode) noexce
     _forceDisableWin32InputMode = win32InputMode;
 }
 
-static const std::basic_string_view<TermKeyMap> _getKeyMapping(const KeyEvent& keyEvent,
-                                                               const bool ansiMode,
-                                                               const bool cursorApplicationMode,
-                                                               const bool keypadApplicationMode) noexcept
+static const gsl::span<const TermKeyMap> _getKeyMapping(const KeyEvent& keyEvent,
+                                                        const bool ansiMode,
+                                                        const bool cursorApplicationMode,
+                                                        const bool keypadApplicationMode) noexcept
 {
     if (ansiMode)
     {
@@ -327,7 +327,7 @@ static const std::basic_string_view<TermKeyMap> _getKeyMapping(const KeyEvent& k
 // Return Value:
 // - Has value if there was a match to a key translation.
 static std::optional<const TermKeyMap> _searchKeyMapping(const KeyEvent& keyEvent,
-                                                         std::basic_string_view<TermKeyMap> keyMapping) noexcept
+                                                         gsl::span<const TermKeyMap> keyMapping) noexcept
 {
     for (auto& map : keyMapping)
     {
@@ -490,7 +490,7 @@ static bool _searchWithModifier(const KeyEvent& keyEvent, InputSender sender)
 // Return Value:
 // - True if there was a match to a key translation, and we successfully sent it to the input
 static bool _translateDefaultMapping(const KeyEvent& keyEvent,
-                                     const std::basic_string_view<TermKeyMap> keyMapping,
+                                     const gsl::span<const TermKeyMap> keyMapping,
                                      InputSender sender)
 {
     const auto match = _searchKeyMapping(keyEvent, keyMapping);

--- a/src/terminal/parser/IStateMachineEngine.hpp
+++ b/src/terminal/parser/IStateMachineEngine.hpp
@@ -31,13 +31,13 @@ namespace Microsoft::Console::VirtualTerminal
         virtual bool ActionPassThroughString(const std::wstring_view string) = 0;
 
         virtual bool ActionEscDispatch(const wchar_t wch,
-                                       const std::basic_string_view<wchar_t> intermediates) = 0;
+                                       const gsl::span<const wchar_t> intermediates) = 0;
         virtual bool ActionVt52EscDispatch(const wchar_t wch,
-                                           const std::basic_string_view<wchar_t> intermediates,
-                                           const std::basic_string_view<size_t> parameters) = 0;
+                                           const gsl::span<const wchar_t> intermediates,
+                                           const gsl::span<const size_t> parameters) = 0;
         virtual bool ActionCsiDispatch(const wchar_t wch,
-                                       const std::basic_string_view<wchar_t> intermediates,
-                                       const std::basic_string_view<size_t> parameters) = 0;
+                                       const gsl::span<const wchar_t> intermediates,
+                                       const gsl::span<const size_t> parameters) = 0;
 
         virtual bool ActionClear() = 0;
 
@@ -48,7 +48,7 @@ namespace Microsoft::Console::VirtualTerminal
                                        const std::wstring_view string) = 0;
 
         virtual bool ActionSs3Dispatch(const wchar_t wch,
-                                       const std::basic_string_view<size_t> parameters) = 0;
+                                       const gsl::span<const size_t> parameters) = 0;
 
         virtual bool ParseControlSequenceAfterSs3() const = 0;
         virtual bool FlushAtEndOfString() const = 0;

--- a/src/terminal/parser/InputStateMachineEngine.hpp
+++ b/src/terminal/parser/InputStateMachineEngine.hpp
@@ -146,15 +146,15 @@ namespace Microsoft::Console::VirtualTerminal
         bool ActionPassThroughString(const std::wstring_view string) override;
 
         bool ActionEscDispatch(const wchar_t wch,
-                               const std::basic_string_view<wchar_t> intermediates) override;
+                               const gsl::span<const wchar_t> intermediates) override;
 
         bool ActionVt52EscDispatch(const wchar_t wch,
-                                   const std::basic_string_view<wchar_t> intermediates,
-                                   const std::basic_string_view<size_t> parameters) noexcept override;
+                                   const gsl::span<const wchar_t> intermediates,
+                                   const gsl::span<const size_t> parameters) noexcept override;
 
         bool ActionCsiDispatch(const wchar_t wch,
-                               const std::basic_string_view<wchar_t> intermediates,
-                               const std::basic_string_view<size_t> parameters) override;
+                               const gsl::span<const wchar_t> intermediates,
+                               const gsl::span<const size_t> parameters) override;
 
         bool ActionClear() noexcept override;
 
@@ -165,7 +165,7 @@ namespace Microsoft::Console::VirtualTerminal
                                const std::wstring_view string) noexcept override;
 
         bool ActionSs3Dispatch(const wchar_t wch,
-                               const std::basic_string_view<size_t> parameters) override;
+                               const gsl::span<const size_t> parameters) override;
 
         bool ParseControlSequenceAfterSs3() const noexcept override;
         bool FlushAtEndOfString() const noexcept override;
@@ -180,19 +180,19 @@ namespace Microsoft::Console::VirtualTerminal
         bool _lookingForDSR;
         DWORD _mouseButtonState = 0;
 
-        DWORD _GetCursorKeysModifierState(const std::basic_string_view<size_t> parameters, const CsiActionCodes actionCode) noexcept;
-        DWORD _GetGenericKeysModifierState(const std::basic_string_view<size_t> parameters) noexcept;
-        DWORD _GetSGRMouseModifierState(const std::basic_string_view<size_t> parameters) noexcept;
+        DWORD _GetCursorKeysModifierState(const gsl::span<const size_t> parameters, const CsiActionCodes actionCode) noexcept;
+        DWORD _GetGenericKeysModifierState(const gsl::span<const size_t> parameters) noexcept;
+        DWORD _GetSGRMouseModifierState(const gsl::span<const size_t> parameters) noexcept;
         bool _GenerateKeyFromChar(const wchar_t wch, short& vkey, DWORD& modifierState) noexcept;
 
         bool _IsModified(const size_t paramCount) noexcept;
         DWORD _GetModifier(const size_t parameter) noexcept;
 
         bool _UpdateSGRMouseButtonState(const wchar_t wch,
-                                        const std::basic_string_view<size_t> parameters,
+                                        const gsl::span<const size_t> parameters,
                                         DWORD& buttonState,
                                         DWORD& eventFlags) noexcept;
-        bool _GetGenericVkey(const std::basic_string_view<size_t> parameters,
+        bool _GetGenericVkey(const gsl::span<const size_t> parameters,
                              short& vkey) const;
         bool _GetCursorKeysVkey(const wchar_t wch, short& vkey) const;
         bool _GetSs3KeysVkey(const wchar_t wch, short& vkey) const;
@@ -212,17 +212,17 @@ namespace Microsoft::Console::VirtualTerminal
                                 const DWORD modifierState,
                                 std::vector<INPUT_RECORD>& input);
 
-        bool _GetWindowManipulationType(const std::basic_string_view<size_t> parameters,
+        bool _GetWindowManipulationType(const gsl::span<const size_t> parameters,
                                         unsigned int& function) const noexcept;
 
-        bool _GenerateWin32Key(const std::basic_string_view<size_t> parameters, KeyEvent& key);
+        bool _GenerateWin32Key(const gsl::span<const size_t> parameters, KeyEvent& key);
 
         static constexpr size_t DefaultLine = 1;
         static constexpr size_t DefaultColumn = 1;
-        bool _GetXYPosition(const std::basic_string_view<size_t> parameters,
+        bool _GetXYPosition(const gsl::span<const size_t> parameters,
                             size_t& line,
                             size_t& column) const noexcept;
-        bool _GetSGRXYPosition(const std::basic_string_view<size_t> parameters,
+        bool _GetSGRXYPosition(const gsl::span<const size_t> parameters,
                                size_t& line,
                                size_t& column) const noexcept;
 

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -184,7 +184,7 @@ bool OutputStateMachineEngine::ActionPassThroughString(const std::wstring_view s
 // Return Value:
 // - true iff we successfully dispatched the sequence.
 bool OutputStateMachineEngine::ActionEscDispatch(const wchar_t wch,
-                                                 const std::basic_string_view<wchar_t> intermediates)
+                                                 const gsl::span<const wchar_t> intermediates)
 {
     bool success = false;
 
@@ -317,8 +317,8 @@ bool OutputStateMachineEngine::ActionEscDispatch(const wchar_t wch,
 // Return Value:
 // - true iff we successfully dispatched the sequence.
 bool OutputStateMachineEngine::ActionVt52EscDispatch(const wchar_t wch,
-                                                     const std::basic_string_view<wchar_t> intermediates,
-                                                     const std::basic_string_view<size_t> parameters)
+                                                     const gsl::span<const wchar_t> intermediates,
+                                                     const gsl::span<const size_t> parameters)
 {
     bool success = false;
 
@@ -360,7 +360,7 @@ bool OutputStateMachineEngine::ActionVt52EscDispatch(const wchar_t wch,
         case Vt52ActionCodes::DirectCursorAddress:
             // VT52 cursor addresses are provided as ASCII characters, with
             // the lowest value being a space, representing an address of 1.
-            success = _dispatch->CursorPosition(parameters.at(0) - ' ' + 1, parameters.at(1) - ' ' + 1);
+            success = _dispatch->CursorPosition(gsl::at(parameters, 0) - ' ' + 1, gsl::at(parameters, 1) - ' ' + 1);
             break;
         case Vt52ActionCodes::Identify:
             success = _dispatch->Vt52DeviceAttributes();
@@ -397,15 +397,15 @@ bool OutputStateMachineEngine::ActionVt52EscDispatch(const wchar_t wch,
 // Return Value:
 // - True if handled successfully. False otherwise.
 bool OutputStateMachineEngine::_IntermediateScsDispatch(const wchar_t wch,
-                                                        const std::basic_string_view<wchar_t> intermediates)
+                                                        const gsl::span<const wchar_t> intermediates)
 {
     bool success = false;
 
     // If we have more than one intermediate, the second intermediate forms part of
     // the charset identifier. Otherwise it's identified by just the final character.
-    const auto charset = intermediates.size() > 1 ? std::make_pair(intermediates.at(1), wch) : std::make_pair(wch, L'\0');
+    const auto charset = intermediates.size() > 1 ? std::make_pair(gsl::at(intermediates, 1), wch) : std::make_pair(wch, L'\0');
 
-    switch (intermediates.at(0))
+    switch (gsl::at(intermediates, 0))
     {
     case L'(':
         success = _dispatch->Designate94Charset(0, charset);
@@ -451,8 +451,8 @@ bool OutputStateMachineEngine::_IntermediateScsDispatch(const wchar_t wch,
 // Return Value:
 // - true iff we successfully dispatched the sequence.
 bool OutputStateMachineEngine::ActionCsiDispatch(const wchar_t wch,
-                                                 const std::basic_string_view<wchar_t> intermediates,
-                                                 std::basic_string_view<size_t> parameters)
+                                                 const gsl::span<const wchar_t> intermediates,
+                                                 gsl::span<const size_t> parameters)
 {
     bool success = false;
     size_t distance = 0;
@@ -470,7 +470,7 @@ bool OutputStateMachineEngine::ActionCsiDispatch(const wchar_t wch,
     DispatchTypes::AnsiStatusType deviceStatusType = static_cast<DispatchTypes::AnsiStatusType>(0); // there is no default status type.
     size_t repeatCount = 0;
     // This is all the args after the first arg, and the count of args not including the first one.
-    const auto remainingParams = parameters.size() > 1 ? parameters.substr(1) : std::basic_string_view<size_t>{};
+    const auto remainingParams = parameters.size() > 1 ? parameters.subspan(1) : gsl::span<const size_t>{};
 
     if (intermediates.empty())
     {
@@ -737,7 +737,7 @@ bool OutputStateMachineEngine::ActionCsiDispatch(const wchar_t wch,
 // Return Value:
 // - True if handled successfully. False otherwise.
 bool OutputStateMachineEngine::_IntermediateQuestionMarkDispatch(const wchar_t wchAction,
-                                                                 const std::basic_string_view<size_t> parameters)
+                                                                 const gsl::span<const size_t> parameters)
 {
     bool success = false;
 
@@ -787,7 +787,7 @@ bool OutputStateMachineEngine::_IntermediateQuestionMarkDispatch(const wchar_t w
 // - True if handled successfully. False otherwise.
 bool OutputStateMachineEngine::_IntermediateGreaterThanOrEqualDispatch(const wchar_t wch,
                                                                        const wchar_t intermediate,
-                                                                       const std::basic_string_view<size_t> parameters)
+                                                                       const gsl::span<const size_t> parameters)
 {
     bool success = false;
 
@@ -846,7 +846,7 @@ bool OutputStateMachineEngine::_IntermediateExclamationDispatch(const wchar_t wc
 // Return Value:
 // - True if handled successfully. False otherwise.
 bool OutputStateMachineEngine::_IntermediateSpaceDispatch(const wchar_t wchAction,
-                                                          const std::basic_string_view<size_t> parameters)
+                                                          const gsl::span<const size_t> parameters)
 {
     bool success = false;
     DispatchTypes::CursorStyle cursorStyle = DefaultCursorStyle;
@@ -1022,7 +1022,7 @@ bool OutputStateMachineEngine::ActionOscDispatch(const wchar_t /*wch*/,
 // Return Value:
 // - true iff we successfully dispatched the sequence.
 bool OutputStateMachineEngine::ActionSs3Dispatch(const wchar_t /*wch*/,
-                                                 const std::basic_string_view<size_t> /*parameters*/) noexcept
+                                                 const gsl::span<const size_t> /*parameters*/) noexcept
 {
     // The output engine doesn't handle any SS3 sequences.
     _ClearLastChar();
@@ -1036,7 +1036,7 @@ bool OutputStateMachineEngine::ActionSs3Dispatch(const wchar_t /*wch*/,
 // - options - Space that will be filled with valid options from the GraphicsOptions enum
 // Return Value:
 // - True if we successfully retrieved an array of valid graphics options from the parameters we've stored. False otherwise.
-bool OutputStateMachineEngine::_GetGraphicsOptions(const std::basic_string_view<size_t> parameters,
+bool OutputStateMachineEngine::_GetGraphicsOptions(const gsl::span<const size_t> parameters,
                                                    std::vector<DispatchTypes::GraphicsOptions>& options) const
 {
     bool success = false;
@@ -1072,7 +1072,7 @@ bool OutputStateMachineEngine::_GetGraphicsOptions(const std::basic_string_view<
 // - eraseType - Receives the erase type parameter
 // Return Value:
 // - True if we successfully pulled an erase type from the parameters we've stored. False otherwise.
-bool OutputStateMachineEngine::_GetEraseOperation(const std::basic_string_view<size_t> parameters,
+bool OutputStateMachineEngine::_GetEraseOperation(const gsl::span<const size_t> parameters,
                                                   DispatchTypes::EraseType& eraseType) const noexcept
 {
     bool success = false; // If we have too many parameters or don't know what to do with the given value, return false.
@@ -1111,7 +1111,7 @@ bool OutputStateMachineEngine::_GetEraseOperation(const std::basic_string_view<s
 // - distance - Receives the distance
 // Return Value:
 // - True if we successfully pulled the cursor distance from the parameters we've stored. False otherwise.
-bool OutputStateMachineEngine::_GetCursorDistance(const std::basic_string_view<size_t> parameters,
+bool OutputStateMachineEngine::_GetCursorDistance(const gsl::span<const size_t> parameters,
                                                   size_t& distance) const noexcept
 {
     bool success = false;
@@ -1145,7 +1145,7 @@ bool OutputStateMachineEngine::_GetCursorDistance(const std::basic_string_view<s
 // - distance - Receives the distance
 // Return Value:
 // - True if we successfully pulled the scroll distance from the parameters we've stored. False otherwise.
-bool OutputStateMachineEngine::_GetScrollDistance(const std::basic_string_view<size_t> parameters,
+bool OutputStateMachineEngine::_GetScrollDistance(const gsl::span<const size_t> parameters,
                                                   size_t& distance) const noexcept
 {
     bool success = false;
@@ -1179,7 +1179,7 @@ bool OutputStateMachineEngine::_GetScrollDistance(const std::basic_string_view<s
 // - consoleWidth - Receives the width
 // Return Value:
 // - True if we successfully pulled the width from the parameters we've stored. False otherwise.
-bool OutputStateMachineEngine::_GetConsoleWidth(const std::basic_string_view<size_t> parameters,
+bool OutputStateMachineEngine::_GetConsoleWidth(const gsl::span<const size_t> parameters,
                                                 size_t& consoleWidth) const noexcept
 {
     bool success = false;
@@ -1214,7 +1214,7 @@ bool OutputStateMachineEngine::_GetConsoleWidth(const std::basic_string_view<siz
 // - column - Receives the X/Column position
 // Return Value:
 // - True if we successfully pulled the cursor coordinates from the parameters we've stored. False otherwise.
-bool OutputStateMachineEngine::_GetXYPosition(const std::basic_string_view<size_t> parameters,
+bool OutputStateMachineEngine::_GetXYPosition(const gsl::span<const size_t> parameters,
                                               size_t& line,
                                               size_t& column) const noexcept
 {
@@ -1263,7 +1263,7 @@ bool OutputStateMachineEngine::_GetXYPosition(const std::basic_string_view<size_
 // - bottomMargin - Receives the bottom margin
 // Return Value:
 // - True if we successfully pulled the margin settings from the parameters we've stored. False otherwise.
-bool OutputStateMachineEngine::_GetTopBottomMargins(const std::basic_string_view<size_t> parameters,
+bool OutputStateMachineEngine::_GetTopBottomMargins(const gsl::span<const size_t> parameters,
                                                     size_t& topMargin,
                                                     size_t& bottomMargin) const noexcept
 {
@@ -1308,7 +1308,7 @@ bool OutputStateMachineEngine::_GetTopBottomMargins(const std::basic_string_view
 // - statusType - Receives the Status Type parameter
 // Return Value:
 // - True if we successfully found a device operation in the parameters stored. False otherwise.
-bool OutputStateMachineEngine::_GetDeviceStatusOperation(const std::basic_string_view<size_t> parameters,
+bool OutputStateMachineEngine::_GetDeviceStatusOperation(const gsl::span<const size_t> parameters,
                                                          DispatchTypes::AnsiStatusType& statusType) const noexcept
 {
     bool success = false;
@@ -1343,7 +1343,7 @@ bool OutputStateMachineEngine::_GetDeviceStatusOperation(const std::basic_string
 // - privateModes - Space that will be filled with valid params from the PrivateModeParams enum
 // Return Value:
 // - True if we successfully retrieved an array of private mode params from the parameters we've stored. False otherwise.
-bool OutputStateMachineEngine::_GetPrivateModeParams(const std::basic_string_view<size_t> parameters,
+bool OutputStateMachineEngine::_GetPrivateModeParams(const gsl::span<const size_t> parameters,
                                                      std::vector<DispatchTypes::PrivateModeParams>& privateModes) const
 {
     bool success = false;
@@ -1364,7 +1364,7 @@ bool OutputStateMachineEngine::_GetPrivateModeParams(const std::basic_string_vie
 // - parameters - The parameters to parse
 // Return Value:
 // - True if there were no parameters. False otherwise.
-bool OutputStateMachineEngine::_VerifyHasNoParameters(const std::basic_string_view<size_t> parameters) const noexcept
+bool OutputStateMachineEngine::_VerifyHasNoParameters(const gsl::span<const size_t> parameters) const noexcept
 {
     return parameters.empty();
 }
@@ -1376,7 +1376,7 @@ bool OutputStateMachineEngine::_VerifyHasNoParameters(const std::basic_string_vi
 // - parameters - The parameters to parse
 // Return Value:
 // - True if the DA params were valid. False otherwise.
-bool OutputStateMachineEngine::_VerifyDeviceAttributesParams(const std::basic_string_view<size_t> parameters) const noexcept
+bool OutputStateMachineEngine::_VerifyDeviceAttributesParams(const gsl::span<const size_t> parameters) const noexcept
 {
     bool success = false;
 
@@ -1417,7 +1417,7 @@ bool OutputStateMachineEngine::_GetOscTitle(const std::wstring_view string,
 // - distance - Receives the distance
 // Return Value:
 // - True if we successfully pulled the tab distance from the parameters we've stored. False otherwise.
-bool OutputStateMachineEngine::_GetTabDistance(const std::basic_string_view<size_t> parameters,
+bool OutputStateMachineEngine::_GetTabDistance(const gsl::span<const size_t> parameters,
                                                size_t& distance) const noexcept
 {
     bool success = false;
@@ -1451,7 +1451,7 @@ bool OutputStateMachineEngine::_GetTabDistance(const std::basic_string_view<size
 // - clearType - Receives the clear type
 // Return Value:
 // - True if we successfully pulled the tab clear type from the parameters we've stored. False otherwise.
-bool OutputStateMachineEngine::_GetTabClearType(const std::basic_string_view<size_t> parameters,
+bool OutputStateMachineEngine::_GetTabClearType(const gsl::span<const size_t> parameters,
                                                 size_t& clearType) const noexcept
 {
     bool success = false;
@@ -1628,7 +1628,7 @@ bool OutputStateMachineEngine::s_ParseColorSpec(const std::wstring_view string,
         for (size_t component = 0; component < 3; component++)
         {
             bool foundColor = false;
-            auto& value = colorValues.at(component);
+            auto& value = gsl::at(colorValues, component);
             for (size_t i = 0; i < 3; i++)
             {
                 const wchar_t wch = *curr++;
@@ -1803,7 +1803,7 @@ bool OutputStateMachineEngine::_GetOscSetColor(const std::wstring_view string,
 // - function - Receives the function type
 // Return Value:
 // - True iff we successfully pulled the function type from the parameters
-bool OutputStateMachineEngine::_GetWindowManipulationType(const std::basic_string_view<size_t> parameters,
+bool OutputStateMachineEngine::_GetWindowManipulationType(const gsl::span<const size_t> parameters,
                                                           unsigned int& function) const noexcept
 {
     bool success = false;
@@ -1837,7 +1837,7 @@ bool OutputStateMachineEngine::_GetWindowManipulationType(const std::basic_strin
 // - cursorStyle - Receives the cursorStyle
 // Return Value:
 // - True if we successfully pulled the cursor style from the parameters we've stored. False otherwise.
-bool OutputStateMachineEngine::_GetCursorStyle(const std::basic_string_view<size_t> parameters,
+bool OutputStateMachineEngine::_GetCursorStyle(const gsl::span<const size_t> parameters,
                                                DispatchTypes::CursorStyle& cursorStyle) const noexcept
 {
     bool success = false;
@@ -1886,7 +1886,7 @@ void OutputStateMachineEngine::SetTerminalConnection(ITerminalOutputConnection* 
 // Return Value:
 // - True if we successfully pulled the repeat count from the parameters.
 //   False otherwise.
-bool OutputStateMachineEngine::_GetRepeatCount(std::basic_string_view<size_t> parameters,
+bool OutputStateMachineEngine::_GetRepeatCount(gsl::span<const size_t> parameters,
                                                size_t& repeatCount) const noexcept
 {
     bool success = false;

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -34,15 +34,15 @@ namespace Microsoft::Console::VirtualTerminal
         bool ActionPassThroughString(const std::wstring_view string) override;
 
         bool ActionEscDispatch(const wchar_t wch,
-                               const std::basic_string_view<wchar_t> intermediates) override;
+                               const gsl::span<const wchar_t> intermediates) override;
 
         bool ActionVt52EscDispatch(const wchar_t wch,
-                                   const std::basic_string_view<wchar_t> intermediates,
-                                   const std::basic_string_view<size_t> parameters) override;
+                                   const gsl::span<const wchar_t> intermediates,
+                                   const gsl::span<const size_t> parameters) override;
 
         bool ActionCsiDispatch(const wchar_t wch,
-                               const std::basic_string_view<wchar_t> intermediates,
-                               const std::basic_string_view<size_t> parameters) override;
+                               const gsl::span<const wchar_t> intermediates,
+                               const gsl::span<const size_t> parameters) override;
 
         bool ActionClear() noexcept override;
 
@@ -53,7 +53,7 @@ namespace Microsoft::Console::VirtualTerminal
                                const std::wstring_view string) override;
 
         bool ActionSs3Dispatch(const wchar_t wch,
-                               const std::basic_string_view<size_t> parameters) noexcept override;
+                               const gsl::span<const size_t> parameters) noexcept override;
 
         bool ParseControlSequenceAfterSs3() const noexcept override;
         bool FlushAtEndOfString() const noexcept override;
@@ -74,15 +74,15 @@ namespace Microsoft::Console::VirtualTerminal
         std::vector<DispatchTypes::GraphicsOptions> _graphicsOptions;
 
         bool _IntermediateScsDispatch(const wchar_t wch,
-                                      const std::basic_string_view<wchar_t> intermediates);
+                                      const gsl::span<const wchar_t> intermediates);
         bool _IntermediateQuestionMarkDispatch(const wchar_t wchAction,
-                                               const std::basic_string_view<size_t> parameters);
+                                               const gsl::span<const size_t> parameters);
         bool _IntermediateGreaterThanOrEqualDispatch(const wchar_t wch,
                                                      const wchar_t intermediate,
-                                                     const std::basic_string_view<size_t> parameters);
+                                                     const gsl::span<const size_t> parameters);
         bool _IntermediateExclamationDispatch(const wchar_t wch);
         bool _IntermediateSpaceDispatch(const wchar_t wchAction,
-                                        const std::basic_string_view<size_t> parameters);
+                                        const gsl::span<const size_t> parameters);
 
         enum VTActionCodes : wchar_t
         {
@@ -180,44 +180,44 @@ namespace Microsoft::Console::VirtualTerminal
         };
 
         static constexpr DispatchTypes::GraphicsOptions DefaultGraphicsOption = DispatchTypes::GraphicsOptions::Off;
-        bool _GetGraphicsOptions(const std::basic_string_view<size_t> parameters,
+        bool _GetGraphicsOptions(const gsl::span<const size_t> parameters,
                                  std::vector<DispatchTypes::GraphicsOptions>& options) const;
 
         static constexpr DispatchTypes::EraseType DefaultEraseType = DispatchTypes::EraseType::ToEnd;
-        bool _GetEraseOperation(const std::basic_string_view<size_t> parameters,
+        bool _GetEraseOperation(const gsl::span<const size_t> parameters,
                                 DispatchTypes::EraseType& eraseType) const noexcept;
 
         static constexpr size_t DefaultCursorDistance = 1;
-        bool _GetCursorDistance(const std::basic_string_view<size_t> parameters,
+        bool _GetCursorDistance(const gsl::span<const size_t> parameters,
                                 size_t& distance) const noexcept;
 
         static constexpr size_t DefaultScrollDistance = 1;
-        bool _GetScrollDistance(const std::basic_string_view<size_t> parameters,
+        bool _GetScrollDistance(const gsl::span<const size_t> parameters,
                                 size_t& distance) const noexcept;
 
         static constexpr size_t DefaultConsoleWidth = 80;
-        bool _GetConsoleWidth(const std::basic_string_view<size_t> parameters,
+        bool _GetConsoleWidth(const gsl::span<const size_t> parameters,
                               size_t& consoleWidth) const noexcept;
 
         static constexpr size_t DefaultLine = 1;
         static constexpr size_t DefaultColumn = 1;
-        bool _GetXYPosition(const std::basic_string_view<size_t> parameters,
+        bool _GetXYPosition(const gsl::span<const size_t> parameters,
                             size_t& line,
                             size_t& column) const noexcept;
 
-        bool _GetDeviceStatusOperation(const std::basic_string_view<size_t> parameters,
+        bool _GetDeviceStatusOperation(const gsl::span<const size_t> parameters,
                                        DispatchTypes::AnsiStatusType& statusType) const noexcept;
 
-        bool _VerifyHasNoParameters(const std::basic_string_view<size_t> parameters) const noexcept;
+        bool _VerifyHasNoParameters(const gsl::span<const size_t> parameters) const noexcept;
 
-        bool _VerifyDeviceAttributesParams(const std::basic_string_view<size_t> parameters) const noexcept;
+        bool _VerifyDeviceAttributesParams(const gsl::span<const size_t> parameters) const noexcept;
 
-        bool _GetPrivateModeParams(const std::basic_string_view<size_t> parameters,
+        bool _GetPrivateModeParams(const gsl::span<const size_t> parameters,
                                    std::vector<DispatchTypes::PrivateModeParams>& privateModes) const;
 
         static constexpr size_t DefaultTopMargin = 0;
         static constexpr size_t DefaultBottomMargin = 0;
-        bool _GetTopBottomMargins(const std::basic_string_view<size_t> parameters,
+        bool _GetTopBottomMargins(const gsl::span<const size_t> parameters,
                                   size_t& topMargin,
                                   size_t& bottomMargin) const noexcept;
 
@@ -225,15 +225,15 @@ namespace Microsoft::Console::VirtualTerminal
                           std::wstring& title) const;
 
         static constexpr size_t DefaultTabDistance = 1;
-        bool _GetTabDistance(const std::basic_string_view<size_t> parameters,
+        bool _GetTabDistance(const gsl::span<const size_t> parameters,
                              size_t& distance) const noexcept;
 
         static constexpr size_t DefaultTabClearType = 0;
-        bool _GetTabClearType(const std::basic_string_view<size_t> parameters,
+        bool _GetTabClearType(const gsl::span<const size_t> parameters,
                               size_t& clearType) const noexcept;
 
         static constexpr DispatchTypes::WindowManipulationType DefaultWindowManipulationType = DispatchTypes::WindowManipulationType::Invalid;
-        bool _GetWindowManipulationType(const std::basic_string_view<size_t> parameters,
+        bool _GetWindowManipulationType(const gsl::span<const size_t> parameters,
                                         unsigned int& function) const noexcept;
 
         static bool s_HexToUint(const wchar_t wch,
@@ -249,11 +249,11 @@ namespace Microsoft::Console::VirtualTerminal
                              DWORD& rgb) const noexcept;
 
         static constexpr DispatchTypes::CursorStyle DefaultCursorStyle = DispatchTypes::CursorStyle::BlinkingBlockDefault;
-        bool _GetCursorStyle(const std::basic_string_view<size_t> parameters,
+        bool _GetCursorStyle(const gsl::span<const size_t> parameters,
                              DispatchTypes::CursorStyle& cursorStyle) const noexcept;
 
         static constexpr size_t DefaultRepeatCount = 1;
-        bool _GetRepeatCount(const std::basic_string_view<size_t> parameters,
+        bool _GetRepeatCount(const gsl::span<const size_t> parameters,
                              size_t& repeatCount) const noexcept;
 
         bool _GetOscSetClipboard(const std::wstring_view string,

--- a/src/terminal/parser/ut_parser/InputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/InputEngineTest.cpp
@@ -327,7 +327,7 @@ public:
 
     virtual bool WriteCtrlKey(const KeyEvent& event) override;
     virtual bool WindowManipulation(const DispatchTypes::WindowManipulationType function,
-                                    const std::basic_string_view<size_t> parameters) override; // DTTERM_WindowManipulation
+                                    const gsl::span<const size_t> parameters) override; // DTTERM_WindowManipulation
     virtual bool WriteString(const std::wstring_view string) override;
 
     virtual bool MoveCursor(const size_t row,
@@ -362,14 +362,14 @@ bool TestInteractDispatch::WriteCtrlKey(const KeyEvent& event)
 }
 
 bool TestInteractDispatch::WindowManipulation(const DispatchTypes::WindowManipulationType function,
-                                              const std::basic_string_view<size_t> parameters)
+                                              const gsl::span<const size_t> parameters)
 {
     VERIFY_ARE_EQUAL(true, _testState->_expectedToCallWindowManipulation);
     VERIFY_ARE_EQUAL(_testState->_expectedWindowManipulation, function);
     for (size_t i = 0; i < parameters.size(); i++)
     {
         unsigned short actual;
-        VERIFY_SUCCEEDED(SizeTToUShort(parameters.at(i), &actual));
+        VERIFY_SUCCEEDED(SizeTToUShort(gsl::at(parameters, i), &actual));
         VERIFY_ARE_EQUAL(_testState->_expectedParams[i], actual);
     }
     return true;

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -748,10 +748,10 @@ public:
         return true;
     }
 
-    bool SetGraphicsRendition(const std::basic_string_view<DispatchTypes::GraphicsOptions> options) noexcept override
+    bool SetGraphicsRendition(const gsl::span<const DispatchTypes::GraphicsOptions> options) noexcept override
     try
     {
-        _options.assign(options.cbegin(), options.cend());
+        _options.assign(options.begin(), options.end());
         _setGraphics = true;
         return true;
     }
@@ -841,7 +841,7 @@ public:
         return fSuccess;
     }
 
-    bool _SetResetPrivateModesHelper(const std::basic_string_view<DispatchTypes::PrivateModeParams> params,
+    bool _SetResetPrivateModesHelper(const gsl::span<const DispatchTypes::PrivateModeParams> params,
                                      const bool enable)
     {
         size_t cFailures = 0;
@@ -852,12 +852,12 @@ public:
         return cFailures == 0;
     }
 
-    bool SetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> params) noexcept override
+    bool SetPrivateModes(const gsl::span<const DispatchTypes::PrivateModeParams> params) noexcept override
     {
         return _SetResetPrivateModesHelper(params, true);
     }
 
-    bool ResetPrivateModes(const std::basic_string_view<DispatchTypes::PrivateModeParams> params) noexcept override
+    bool ResetPrivateModes(const gsl::span<const DispatchTypes::PrivateModeParams> params) noexcept override
     {
         return _SetResetPrivateModesHelper(params, false);
     }
@@ -1545,7 +1545,7 @@ class StateMachineExternalTest final
         VERIFY_ARE_EQUAL(expectedDispatchTypes, pDispatch->_eraseType);
     }
 
-    void VerifyDispatchTypes(const std::basic_string_view<DispatchTypes::GraphicsOptions> expectedOptions,
+    void VerifyDispatchTypes(const gsl::span<const DispatchTypes::GraphicsOptions> expectedOptions,
                              const StatefulDispatch& dispatch)
     {
         VERIFY_ARE_EQUAL(expectedOptions.size(), dispatch._options.size());
@@ -1557,14 +1557,14 @@ class StateMachineExternalTest final
 
             if (i < expectedOptions.size())
             {
-                expectedOption = expectedOptions.at(i);
+                expectedOption = gsl::at(expectedOptions, i);
             }
 
-            optionsValid = expectedOption == dispatch._options.at(i);
+            optionsValid = expectedOption == gsl::at(dispatch._options, i);
 
             if (!optionsValid)
             {
-                Log::Comment(NoThrowString().Format(L"Graphics option match failed, index [%zu]. Expected: '%d' Actual: '%d'", i, expectedOption, dispatch._options.at(i)));
+                Log::Comment(NoThrowString().Format(L"Graphics option match failed, index [%zu]. Expected: '%d' Actual: '%d'", i, expectedOption, gsl::at(dispatch._options, i)));
                 break;
             }
         }

--- a/src/terminal/parser/ut_parser/StateMachineTest.cpp
+++ b/src/terminal/parser/ut_parser/StateMachineTest.cpp
@@ -51,11 +51,11 @@ public:
     };
 
     bool ActionEscDispatch(const wchar_t /* wch */,
-                           const std::basic_string_view<wchar_t> /* intermediates */) override { return true; };
+                           const gsl::span<const wchar_t> /* intermediates */) override { return true; };
 
     bool ActionVt52EscDispatch(const wchar_t /*wch*/,
-                               const std::basic_string_view<wchar_t> /*intermediates*/,
-                               const std::basic_string_view<size_t> /*parameters*/) override { return true; };
+                               const gsl::span<const wchar_t> /*intermediates*/,
+                               const gsl::span<const size_t> /*parameters*/) override { return true; };
 
     bool ActionClear() override { return true; };
 
@@ -74,7 +74,7 @@ public:
     };
 
     bool ActionSs3Dispatch(const wchar_t /* wch */,
-                           const std::basic_string_view<size_t> /* parameters */) override { return true; };
+                           const gsl::span<const size_t> /* parameters */) override { return true; };
 
     bool ParseControlSequenceAfterSs3() const override { return false; }
     bool FlushAtEndOfString() const override { return false; };
@@ -83,8 +83,8 @@ public:
 
     // ActionCsiDispatch is the only method that's actually implemented.
     bool ActionCsiDispatch(const wchar_t /*wch*/,
-                           const std::basic_string_view<wchar_t> /*intermediates*/,
-                           const std::basic_string_view<size_t> parameters) override
+                           const gsl::span<const wchar_t> /*intermediates*/,
+                           const gsl::span<const size_t> parameters) override
     {
         // If flush to terminal is registered for a test, then use it.
         if (pfnFlushToTerminal)
@@ -94,7 +94,7 @@ public:
         }
         else
         {
-            csiParams.emplace(parameters.cbegin(), parameters.cend());
+            csiParams.emplace(parameters.begin(), parameters.end());
             return true;
         }
     }

--- a/src/tsf/TfConvArea.cpp
+++ b/src/tsf/TfConvArea.cpp
@@ -45,8 +45,8 @@ Notes:
     const auto encodedAttributes = _DisplayAttributesToEncodedAttributes(DisplayAttributes,
                                                                          CompCursorPos);
 
-    std::basic_string_view<BYTE> attributes(encodedAttributes.data(), encodedAttributes.size());
-    std::basic_string_view<WORD> colorArray(colors.data(), colors.size());
+    gsl::span<const BYTE> attributes(encodedAttributes.data(), encodedAttributes.size());
+    gsl::span<const WORD> colorArray(colors.data(), colors.size());
 
     return ImeComposeData(CompStr, attributes, colorArray);
 }

--- a/src/types/ScreenInfoUiaProviderBase.cpp
+++ b/src/types/ScreenInfoUiaProviderBase.cpp
@@ -9,21 +9,21 @@
 using namespace Microsoft::Console::Types;
 
 // A helper function to create a SafeArray Version of an int array of a specified length
-SAFEARRAY* BuildIntSafeArray(std::basic_string_view<int> data)
+SAFEARRAY* BuildIntSafeArray(gsl::span<const int> data)
 {
     SAFEARRAY* psa = SafeArrayCreateVector(VT_I4, 0, gsl::narrow<ULONG>(data.size()));
     if (psa != nullptr)
     {
-        for (size_t i = 0; i < data.size(); i++)
+        LONG lIndex{ 0 };
+        for (auto val : data)
         {
-            LONG lIndex = 0;
-            if (FAILED(SizeTToLong(i, &lIndex)) ||
-                FAILED(SafeArrayPutElement(psa, &lIndex, (void*)&(data.at(i)))))
+            if (FAILED(SafeArrayPutElement(psa, &lIndex, (void*)&val)))
             {
                 SafeArrayDestroy(psa);
                 psa = nullptr;
                 break;
             }
+            ++lIndex;
         }
     }
 
@@ -191,7 +191,7 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::GetRuntimeId(_Outptr_result_maybenull_
     // AppendRuntimeId is a magic Number that tells UIAutomation to Append its own Runtime ID(From the HWND)
     const std::array<int, 2> rId{ UiaAppendRuntimeId, -1 };
 
-    const std::basic_string_view<int> span{ rId.data(), rId.size() };
+    const gsl::span<const int> span{ rId.data(), rId.size() };
     // BuildIntSafeArray is a custom function to hide the SafeArray creation
     *ppRuntimeId = BuildIntSafeArray(span);
     RETURN_IF_NULL_ALLOC(*ppRuntimeId);


### PR DESCRIPTION
We were using std::basic_string_view as a stand-in for std::span so that
we could change over all at once when C++20 dropped with full span
support. That day's not here yet, but as of 54a7fce3e we're using GSL 3,
whose span is C++20-compliant.

This commit replaces every instance of basic_string_view that was not
referring to an actual string with a span of the appropriate type.

I moved the `const` qualifier into span's `T` because while
`basic_string_view.at()` returns `const T&`, `span.at()` returns `T&`
(without the const). I wanted to maintain the invariant that members of
the span were immutable.

* Mechanical Changes
   * `sv.at(x)` -> `gsl::at(sp, x)`
   * `sv.c{begin,end}` -> `sp.{begin,end}` (span's iterators are const)

I had to replace a `std::basic_string<>` with a `std::vector<>` in
ConImeInfo, and I chose to replace a manual array walk in
ScreenInfoUiaProviderBase with a ranged-for. Please review those
specifically.

This will almost certainly cause a code size regression in Windows
because I'm blowing out all the PGO counts. Whoops.

Related: #3956, #975.