### PR TITLE
Skip validations on some text buffer methods

### DIFF
--- a/src/buffer/out/AttrRow.cpp
+++ b/src/buffer/out/AttrRow.cpp
@@ -250,11 +250,11 @@ void ATTR_ROW::ReplaceAttrs(const TextAttribute& toBeReplacedAttr, const TextAtt
     if (newAttrs.size() == 1)
     {
         // Get the new color attribute we're trying to apply
-        const TextAttribute NewAttr = newAttrs.at(0).GetAttributes();
+        const TextAttribute NewAttr = newAttrs[0].GetAttributes();
 
         // If the existing run was only 1 element...
         // ...and the new color is the same as the old, we don't have to do anything and can exit quick.
-        if (_list.size() == 1 && _list.at(0).GetAttributes() == NewAttr)
+        if (_list.size() == 1 && _list[0].GetAttributes() == NewAttr)
         {
             return S_OK;
         }

--- a/src/buffer/out/CharRow.cpp
+++ b/src/buffer/out/CharRow.cpp
@@ -233,7 +233,9 @@ void CharRow::ClearGlyph(const size_t column)
 // - Note: will throw exception if column is out of bounds
 const CharRow::reference CharRow::GlyphAt(const size_t column) const
 {
+#ifdef DBG
     THROW_HR_IF(E_INVALIDARG, column >= _data.size());
+#endif
     return { const_cast<CharRow&>(*this), column };
 }
 
@@ -246,7 +248,9 @@ const CharRow::reference CharRow::GlyphAt(const size_t column) const
 // - Note: will throw exception if column is out of bounds
 CharRow::reference CharRow::GlyphAt(const size_t column)
 {
+#ifdef DBG
     THROW_HR_IF(E_INVALIDARG, column >= _data.size());
+#endif
     return { *this, column };
 }
 

--- a/src/buffer/out/CharRowCellReference.cpp
+++ b/src/buffer/out/CharRowCellReference.cpp
@@ -41,7 +41,7 @@ CharRowCellReference::operator std::wstring_view() const
 // - ref to the CharRowCell
 CharRowCell& CharRowCellReference::_cellData()
 {
-    return _parent._data.at(_index);
+    return _parent._data[_index];
 }
 
 // Routine Description:
@@ -50,7 +50,7 @@ CharRowCell& CharRowCellReference::_cellData()
 // - ref to the CharRowCell
 const CharRowCell& CharRowCellReference::_cellData() const
 {
-    return _parent._data.at(_index);
+    return _parent._data[_index];
 }
 
 // Routine Description:

--- a/src/buffer/out/OutputCellIterator.cpp
+++ b/src/buffer/out/OutputCellIterator.cpp
@@ -159,42 +159,33 @@ OutputCellIterator::OutputCellIterator(const std::basic_string_view<OutputCell> 
 // - True if the views on dereference are valid. False if it shouldn't be dereferenced.
 OutputCellIterator::operator bool() const noexcept
 {
-    try
+    switch (_mode)
     {
-        switch (_mode)
-        {
-        case Mode::Loose:
-        case Mode::LooseTextOnly:
-        {
-            // In lieu of using start and end, this custom iterator type simply becomes bool false
-            // when we run out of items to iterate over.
-            return _pos < std::get<std::wstring_view>(_run).length();
-        }
-        case Mode::Fill:
-        {
-            if (_fillLimit > 0)
-            {
-                return _pos < _fillLimit;
-            }
-            return true;
-        }
-        case Mode::Cell:
-        {
-            return _pos < std::get<std::basic_string_view<OutputCell>>(_run).length();
-        }
-        case Mode::CharInfo:
-        {
-            return _pos < std::get<std::basic_string_view<CHAR_INFO>>(_run).length();
-        }
-        case Mode::LegacyAttr:
-        {
-            return _pos < std::get<std::basic_string_view<WORD>>(_run).length();
-        }
-        default:
-            FAIL_FAST_HR(E_NOTIMPL);
-        }
+    case Mode::Loose:
+    case Mode::LooseTextOnly: {
+        // In lieu of using start and end, this custom iterator type simply becomes bool false
+        // when we run out of items to iterate over.
+        return _pos < std::get<std::wstring_view>(_run).length();
     }
-    CATCH_FAIL_FAST();
+    case Mode::Fill: {
+        if (_fillLimit > 0)
+        {
+            return _pos < _fillLimit;
+        }
+        return true;
+    }
+    case Mode::Cell: {
+        return _pos < std::get<std::basic_string_view<OutputCell>>(_run).length();
+    }
+    case Mode::CharInfo: {
+        return _pos < std::get<std::basic_string_view<CHAR_INFO>>(_run).length();
+    }
+    case Mode::LegacyAttr: {
+        return _pos < std::get<std::wstring_view>(_run).length();
+    }
+    default:
+        FAIL_FAST_HR(E_NOTIMPL);
+    }
 }
 
 // Routine Description:
@@ -208,8 +199,7 @@ OutputCellIterator& OutputCellIterator::operator++()
 
     switch (_mode)
     {
-    case Mode::Loose:
-    {
+    case Mode::Loose: {
         if (!_TryMoveTrailing())
         {
             // When walking through a text sequence, we need to move forward by the number of wchar_ts consumed in the previous view
@@ -222,8 +212,7 @@ OutputCellIterator& OutputCellIterator::operator++()
         }
         break;
     }
-    case Mode::LooseTextOnly:
-    {
+    case Mode::LooseTextOnly: {
         if (!_TryMoveTrailing())
         {
             // When walking through a text sequence, we need to move forward by the number of wchar_ts consumed in the previous view
@@ -236,8 +225,7 @@ OutputCellIterator& OutputCellIterator::operator++()
         }
         break;
     }
-    case Mode::Fill:
-    {
+    case Mode::Fill: {
         if (!_TryMoveTrailing())
         {
             if (_currentView.DbcsAttr().IsTrailing())
@@ -259,8 +247,7 @@ OutputCellIterator& OutputCellIterator::operator++()
         }
         break;
     }
-    case Mode::Cell:
-    {
+    case Mode::Cell: {
         // Walk forward by one because cells are assumed to be in the form they needed to be
         _pos++;
         if (operator bool())
@@ -269,8 +256,7 @@ OutputCellIterator& OutputCellIterator::operator++()
         }
         break;
     }
-    case Mode::CharInfo:
-    {
+    case Mode::CharInfo: {
         // Walk forward by one because charinfos are just the legacy version of cells and prealigned to columns
         _pos++;
         if (operator bool())
@@ -279,8 +265,7 @@ OutputCellIterator& OutputCellIterator::operator++()
         }
         break;
     }
-    case Mode::LegacyAttr:
-    {
+    case Mode::LegacyAttr: {
         // Walk forward by one because color attributes apply cell by cell (no complex text information)
         _pos++;
         if (operator bool())

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -81,7 +81,7 @@ const ROW& TextBuffer::GetRowByOffset(const size_t index) const
 
     // Rows are stored circularly, so the index you ask for is offset by the start position and mod the total of rows.
     const size_t offsetIndex = (_firstRow + index) % totalRows;
-    return _storage.at(offsetIndex);
+    return _storage[offsetIndex];
 }
 
 // Routine Description:
@@ -97,7 +97,7 @@ ROW& TextBuffer::GetRowByOffset(const size_t index)
 
     // Rows are stored circularly, so the index you ask for is offset by the start position and mod the total of rows.
     const size_t offsetIndex = (_firstRow + index) % totalRows;
-    return _storage.at(offsetIndex);
+    return _storage[offsetIndex];
 }
 
 // Routine Description:

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -214,9 +214,10 @@ void Renderer::TriggerRedraw(const Viewport& region)
     if (view.TrimToViewport(&srUpdateRegion))
     {
         view.ConvertToOrigin(&srUpdateRegion);
-        std::for_each(_rgpEngines.begin(), _rgpEngines.end(), [&](IRenderEngine* const pEngine) {
+        for (auto pEngine : _rgpEngines)
+        {
             LOG_IF_FAILED(pEngine->Invalidate(&srUpdateRegion));
-        });
+        }
 
         _NotifyPaintFrame();
     }


### PR DESCRIPTION
This is a selection of top hitters when running massive outputs by `cat`. They're assorted checks on pieces of the text buffer to ensure things aren't out of range. Generally speaking, I want to have these still hit in debug mode, just not in release mode. We check and double check and triple check a lot of these parameters (or pull things into bounds with Viewport/rectangle classes) so for the final release perf, we may as well toast a handful of them for the sake of zoom.

## Validation Steps Performed
- Run `time cat big.txt`. Checked average time before/after, WPR traces
  before/after.

## PR Checklist
* [x] Closes perf itch
* [x] I work here
* [x] Manual test
* [x] Documentation irrelevant.
* [x] Schema irrelevant.
* [x] Am core contributor.