### PR TITLE
Dig directly into text buffer with render base for perf

### DIFF
--- a/src/buffer/out/AttrRow.cpp
+++ b/src/buffer/out/AttrRow.cpp
@@ -108,7 +108,12 @@ TextAttribute ATTR_ROW::GetAttrByColumn(const size_t column,
 {
     THROW_HR_IF(E_INVALIDARG, column >= _cchRowWidth);
     const auto runPos = FindAttrIndex(column, pApplies);
-    return _list.at(runPos).GetAttributes();
+    return GetAttrByIndex(runPos);
+}
+
+TextAttribute ATTR_ROW::GetAttrByIndex(const size_t index) const
+{
+    return _list.at(index).GetAttributes();
 }
 
 // Routine Description:

--- a/src/buffer/out/AttrRow.hpp
+++ b/src/buffer/out/AttrRow.hpp
@@ -36,6 +36,8 @@ public:
     TextAttribute GetAttrByColumn(const size_t column,
                                   size_t* const pApplies) const;
 
+    TextAttribute GetAttrByIndex(const size_t index) const;
+
     size_t GetNumberOfRuns() const noexcept;
 
     size_t FindAttrIndex(const size_t index,

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -29,7 +29,8 @@ Renderer::Renderer(IRenderData* pData,
     _pData(pData),
     _pThread{ std::move(thread) },
     _destructing{ false },
-    _clusterBuffer{}
+    _text{},
+    _clusterMap{}
 {
     _srViewportPrevious = { 0 };
 
@@ -375,7 +376,7 @@ bool Renderer::_CheckViewportAndScroll()
     // so they can prepare the buffers for changes to either preallocate memory at once
     // (instead of growing naturally) or shrink down to reduce usage as appropriate.
     const size_t lineLength = gsl::narrow_cast<size_t>(til::rectangle{ srNewViewport }.width());
-    til::manage_vector(_clusterBuffer, lineLength, _shrinkThreshold);
+    til::manage_vector(_clusterMap, lineLength, _shrinkThreshold);
 
     if (coordDelta.X != 0 || coordDelta.Y != 0)
     {
@@ -671,11 +672,11 @@ void Renderer::_PaintBufferOutput(_In_ IRenderEngine* const pEngine)
     }
 }
 
-static bool _IsAllSpaces(const std::wstring_view v)
-{
-    // first non-space char is not found (is npos)
-    return v.find_first_not_of(L" ") == decltype(v)::npos;
-}
+//static bool _IsAllSpaces(const std::wstring_view v)
+//{
+//    // first non-space char is not found (is npos)
+//    return v.find_first_not_of(L" ") == decltype(v)::npos;
+//}
 
 void Renderer::_PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine,
                                         const ROW& r,
@@ -729,7 +730,8 @@ void Renderer::_PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine,
             const auto currentRunTargetStart = screenPoint;
 
             // Ensure that our cluster vector is clear.
-            _clusterBuffer.clear();
+            _text.clear();
+            _clusterMap.clear();
 
             // Reset our flag to know when we're in the special circumstance
             // of attempting to draw only the right-half of a two-column character
@@ -768,7 +770,7 @@ void Renderer::_PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine,
 
                 // If we're on the first cluster to be added and it's marked as "trailing"
                 // (a.k.a. the right half of a two column character), then we need some special handling.
-                if (_clusterBuffer.empty() && dbcsAttr.IsTrailing())
+                if (_text.empty() && dbcsAttr.IsTrailing())
                 {
                     // If we have room to move to the left to start drawing...
                     if (screenPoint.X > 0)
@@ -780,7 +782,10 @@ void Renderer::_PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine,
                         // And add one to the number of columns we expect it to take as we insert it.
                         columnCount = 2;
                         //columnCount = it->Columns() + 1;
-                        _clusterBuffer.emplace_back(chars, columnCount);
+                        _text.append(chars);
+                        _clusterMap.push_back(2);
+                        _clusterMap.push_back(0);
+                        //_clusterBuffer.emplace_back(chars, columnCount);
                     }
                     else
                     {
@@ -793,7 +798,13 @@ void Renderer::_PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine,
                 else
                 {
                     columnCount = dbcsAttr.IsLeading() ? 2 : 1;
-                    _clusterBuffer.emplace_back(chars, columnCount);
+                    _text.append(chars);
+                    _clusterMap.push_back((UINT16)columnCount);
+                    if (columnCount > 1)
+                    {
+                        _clusterMap.push_back(0);
+                    }
+                    //_clusterBuffer.emplace_back(chars, columnCount);
                 }
 
                 if (columnCount > 1)
@@ -810,7 +821,7 @@ void Renderer::_PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine,
             } while (pos < limitRight);
 
             // Do the painting.
-            THROW_IF_FAILED(pEngine->PaintBufferLine({ _clusterBuffer.data(), _clusterBuffer.size() }, screenPoint, trimLeft, lineWrapped));
+            THROW_IF_FAILED(pEngine->PaintBufferLine(_text, { _clusterMap.data(), _clusterMap.size() }, screenPoint, trimLeft, lineWrapped));
 
             // If we're allowed to do grid drawing, draw that now too (since it will be coupled with the color data)
             // We're only allowed to draw the grid lines under certain circumstances.
@@ -836,161 +847,6 @@ void Renderer::_PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine,
                     for (auto colsPainted = 0u; colsPainted < cols; ++colsPainted, ++lineIt, ++lineTarget.X)
                     {
                         auto lines = attrRow.GetAttrByColumn(lineIt);
-                        _PaintBufferOutputGridLineHelper(pEngine, lines, 1, lineTarget);
-                    }
-                }
-                else
-                {
-                    // If nothing exciting is going on, draw the lines in bulk.
-                    _PaintBufferOutputGridLineHelper(pEngine, currentRunColor, cols, screenPoint);
-                }
-            }
-        }
-    }
-}
-
-
-void Renderer::_PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine,
-                                        TextBufferCellIterator it,
-                                        const COORD target,
-                                        const bool lineWrapped)
-{
-    auto globalInvert{ _pData->IsScreenReversed() };
-
-    // If we have valid data, let's figure out how to draw it.
-    if (it)
-    {
-        // TODO: MSFT: 20961091 -  This is a perf issue. Instead of rebuilding this and allocing memory to hold the reinterpretation,
-        // we should have an iterator/view adapter for the rendering.
-        // That would probably also eliminate the RenderData needing to give us the entire TextBuffer as well...
-        // Retrieve the iterator for one line of information.
-        size_t cols = 0;
-
-        // Retrieve the first color.
-        auto color = it->TextAttr();
-
-        // And hold the point where we should start drawing.
-        auto screenPoint = target;
-
-        // This outer loop will continue until we reach the end of the text we are trying to draw.
-        while (it)
-        {
-            // Hold onto the current run color right here for the length of the outer loop.
-            // We'll be changing the persistent one as we run through the inner loops to detect
-            // when a run changes, but we will still need to know this color at the bottom
-            // when we go to draw gridlines for the length of the run.
-            const auto currentRunColor = color;
-
-            // Update the drawing brushes with our color.
-            THROW_IF_FAILED(_UpdateDrawingBrushes(pEngine, currentRunColor, false));
-
-            // Advance the point by however many columns we've just outputted and reset the accumulator.
-            screenPoint.X += gsl::narrow<SHORT>(cols);
-            cols = 0;
-
-            // Hold onto the start of this run iterator and the target location where we started
-            // in case we need to do some special work to paint the line drawing characters.
-            const auto currentRunItStart = it;
-            const auto currentRunTargetStart = screenPoint;
-
-            // Ensure that our cluster vector is clear.
-            _clusterBuffer.clear();
-
-            // Reset our flag to know when we're in the special circumstance
-            // of attempting to draw only the right-half of a two-column character
-            // as the first item in our run.
-            bool trimLeft = false;
-
-            // Run contains wide character (>1 columns)
-            bool containsWideCharacter = false;
-
-            // This inner loop will accumulate clusters until the color changes.
-            // When the color changes, it will save the new color off and break.
-            do
-            {
-                if (color != it->TextAttr())
-                {
-                    auto newAttr{ it->TextAttr() };
-                    // foreground doesn't matter for runs of spaces (!)
-                    // if we trick it . . . we call Paint far fewer times for cmatrix
-                    if (!_IsAllSpaces(it->Chars()) || !newAttr.HasIdenticalVisualRepresentationForBlankSpace(color, globalInvert))
-                    {
-                        color = newAttr;
-                        break; // vend this run
-                    }
-                }
-
-                // Walk through the text data and turn it into rendering clusters.
-                // Keep the columnCount as we go to improve performance over digging it out of the vector at the end.
-                size_t columnCount = 0;
-
-                // If we're on the first cluster to be added and it's marked as "trailing"
-                // (a.k.a. the right half of a two column character), then we need some special handling.
-                if (_clusterBuffer.empty() && it->DbcsAttr().IsTrailing())
-                {
-                    // If we have room to move to the left to start drawing...
-                    if (screenPoint.X > 0)
-                    {
-                        // Move left to the one so the whole character can be struck correctly.
-                        --screenPoint.X;
-                        // And tell the next function to trim off the left half of it.
-                        trimLeft = true;
-                        // And add one to the number of columns we expect it to take as we insert it.
-                        columnCount = it->Columns() + 1;
-                        _clusterBuffer.emplace_back(it->Chars(), columnCount);
-                    }
-                    else
-                    {
-                        // If we didn't have room, move to the right one and just skip this one.
-                        screenPoint.X++;
-                        continue;
-                    }
-                }
-                // Otherwise if it's not a special case, just insert it as is.
-                else
-                {
-                    columnCount = it->Columns();
-                    _clusterBuffer.emplace_back(it->Chars(), columnCount);
-                }
-
-                if (columnCount > 1)
-                {
-                    containsWideCharacter = true;
-                }
-
-                // Advance the cluster and column counts.
-                it += columnCount > 0 ? columnCount : 1; // prevent infinite loop for no visible columns
-                cols += columnCount;
-
-            } while (it);
-
-            // Do the painting.
-            THROW_IF_FAILED(pEngine->PaintBufferLine({ _clusterBuffer.data(), _clusterBuffer.size() }, screenPoint, trimLeft, lineWrapped));
-
-            // If we're allowed to do grid drawing, draw that now too (since it will be coupled with the color data)
-            // We're only allowed to draw the grid lines under certain circumstances.
-            if (_pData->IsGridLineDrawingAllowed())
-            {
-                // See GH: 803
-                // If we found a wide character while we looped above, it's possible we skipped over the right half
-                // attribute that could have contained different line information than the left half.
-                if (containsWideCharacter)
-                {
-                    // Start from the original position in this run.
-                    auto lineIt = currentRunItStart;
-                    // Start from the original target in this run.
-                    auto lineTarget = currentRunTargetStart;
-
-                    // We need to go through the iterators again to ensure we get the lines associated with each
-                    // exact column. The code above will condense two-column characters into one, but it is possible
-                    // (like with the IME) that the line drawing characters will vary from the left to right half
-                    // of a wider character.
-                    // We could theoretically pre-pass for this in the loop above to be more efficient about walking
-                    // the iterator, but I fear it would make the code even more confusing than it already is.
-                    // Do that in the future if some WPR trace points you to this spot as super bad.
-                    for (auto colsPainted = 0u; colsPainted < cols; ++colsPainted, ++lineIt, ++lineTarget.X)
-                    {
-                        auto lines = lineIt->TextAttr();
                         _PaintBufferOutputGridLineHelper(pEngine, lines, 1, lineTarget);
                     }
                 }
@@ -1190,7 +1046,7 @@ void Renderer::_PaintOverlay(IRenderEngine& engine,
 
                     auto it = overlay.buffer.GetCellLineDataAt(source);
 
-                    _PaintBufferOutputHelper(&engine, it, target, false);
+                    //_PaintBufferOutputHelper(&engine, it, target, false);
                 }
             }
         }

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -104,10 +104,10 @@ namespace Microsoft::Console::Render
                                       const COORD target,
                                       const bool lineWrapped);
 
-        void _PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine,
-                                      TextBufferCellIterator it,
-                                      const COORD target,
-                                      const bool lineWrapped);
+        //void _PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine,
+        //                              TextBufferCellIterator it,
+        //                              const COORD target,
+        //                              const bool lineWrapped);
 
         static IRenderEngine::GridLines s_GetGridlines(const TextAttribute& textAttribute) noexcept;
 
@@ -129,7 +129,9 @@ namespace Microsoft::Console::Render
         SMALL_RECT _srViewportPrevious;
 
         static constexpr float _shrinkThreshold = 0.8f;
-        std::vector<Cluster> _clusterBuffer;
+        std::wstring _text;
+        std::vector<UINT16> _clusterMap;
+        //std::vector<Cluster> _clusterBuffer;
 
         std::vector<SMALL_RECT> _GetSelectionRects() const;
         void _ScrollPreviousSelection(const til::point delta);

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -99,6 +99,12 @@ namespace Microsoft::Console::Render
         void _PaintBufferOutput(_In_ IRenderEngine* const pEngine);
 
         void _PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine,
+                                      const ROW& r,
+                                      const SHORT limitRight,
+                                      const COORD target,
+                                      const bool lineWrapped);
+
+        void _PaintBufferOutputHelper(_In_ IRenderEngine* const pEngine,
                                       TextBufferCellIterator it,
                                       const COORD target,
                                       const bool lineWrapped);

--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -78,25 +78,27 @@ CATCH_RETURN()
 // - clusters - From the backing buffer, the text to be displayed clustered by the columns it should consume.
 // Return Value:
 // - S_OK or suitable memory management issue.
-[[nodiscard]] HRESULT STDMETHODCALLTYPE CustomTextLayout::AppendClusters(const std::basic_string_view<::Microsoft::Console::Render::Cluster> clusters)
+[[nodiscard]] HRESULT STDMETHODCALLTYPE CustomTextLayout::AppendClusters(std::wstring_view text,
+                                                                         std::basic_string_view<UINT16> clusterMap)
 try
 {
-    _textClusterColumns.reserve(_textClusterColumns.size() + clusters.size());
+    _text.append(text);
+    _textClusterColumns.insert(_textClusterColumns.end(), clusterMap.cbegin(), clusterMap.cend());
 
-    for (const auto& cluster : clusters)
-    {
-        const auto cols = gsl::narrow<UINT16>(cluster.GetColumns());
-        const auto text = cluster.GetText();
+    //for (const auto& cluster : clusters)
+    //{
+    //    const auto cols = gsl::narrow<UINT16>(cluster.GetColumns());
+    //    const auto text = cluster.GetText();
 
-        // Push back the number of columns for this bit of text.
-        _textClusterColumns.push_back(cols);
+    //    // Push back the number of columns for this bit of text.
+    //    _textClusterColumns.push_back(cols);
 
-        // If there is more than one text character here, push 0s for the rest of the columns
-        // of the text run.
-        _textClusterColumns.resize(_textClusterColumns.size() + base::ClampSub(text.size(), 1u), gsl::narrow_cast<UINT16>(0u));
+    //    // If there is more than one text character here, push 0s for the rest of the columns
+    //    // of the text run.
+    //    _textClusterColumns.resize(_textClusterColumns.size() + base::ClampSub(text.size(), 1u), gsl::narrow_cast<UINT16>(0u));
 
-        _text += text;
-    }
+    //    _text += text;
+    //}
 
     return S_OK;
 }

--- a/src/renderer/dx/CustomTextLayout.h
+++ b/src/renderer/dx/CustomTextLayout.h
@@ -27,7 +27,8 @@ namespace Microsoft::Console::Render
                          size_t const width,
                          IBoxDrawingEffect* const boxEffect);
 
-        [[nodiscard]] HRESULT STDMETHODCALLTYPE AppendClusters(const std::basic_string_view<::Microsoft::Console::Render::Cluster> clusters);
+        [[nodiscard]] HRESULT STDMETHODCALLTYPE AppendClusters(std::wstring_view text,
+                                                               std::basic_string_view<UINT16> clusterMap);
 
         [[nodiscard]] HRESULT STDMETHODCALLTYPE Reset() noexcept;
 

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1419,7 +1419,8 @@ CATCH_RETURN()
 // - fTrimLeft - Whether or not to trim off the left half of a double wide character
 // Return Value:
 // - S_OK or relevant DirectX error
-[[nodiscard]] HRESULT DxEngine::PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+[[nodiscard]] HRESULT DxEngine::PaintBufferLine(std::wstring_view text,
+                                                std::basic_string_view<UINT16> clusterMap,
                                                 COORD const coord,
                                                 const bool /*trimLeft*/,
                                                 const bool /*lineWrapped*/) noexcept
@@ -1430,7 +1431,7 @@ try
 
     // Create the text layout
     RETURN_IF_FAILED(_customLayout->Reset());
-    RETURN_IF_FAILED(_customLayout->AppendClusters(clusters));
+    RETURN_IF_FAILED(_customLayout->AppendClusters(text, clusterMap));
 
     // Layout then render the text
     RETURN_IF_FAILED(_customLayout->Draw(_drawingContext.get(), _customRenderer.Get(), origin.x, origin.y));
@@ -1818,10 +1819,12 @@ try
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, pResult);
 
-    const Cluster cluster(glyph, 0); // columns don't matter, we're doing analysis not layout.
+    //const Cluster cluster(glyph, 0); // columns don't matter, we're doing analysis not layout.
+
+    UINT16 col = 0;
 
     RETURN_IF_FAILED(_customLayout->Reset());
-    RETURN_IF_FAILED(_customLayout->AppendClusters({ &cluster, 1 }));
+    RETURN_IF_FAILED(_customLayout->AppendClusters(glyph, { &col, 1 }));
 
     UINT32 columns = 0;
     RETURN_IF_FAILED(_customLayout->GetColumns(&columns));

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -86,7 +86,8 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT PrepareRenderInfo(const RenderFrameInfo& info) noexcept override;
 
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
-        [[nodiscard]] HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+        [[nodiscard]] HRESULT PaintBufferLine(std::wstring_view text,
+                                              std::basic_string_view<UINT16> clusterMap,
                                               COORD const coord,
                                               bool const fTrimLeft,
                                               const bool lineWrapped) noexcept override;

--- a/src/renderer/gdi/gdirenderer.hpp
+++ b/src/renderer/gdi/gdirenderer.hpp
@@ -42,7 +42,8 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT ScrollFrame() noexcept override;
 
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
-        [[nodiscard]] HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+        [[nodiscard]] HRESULT PaintBufferLine(std::wstring_view text,
+                                              std::basic_string_view<UINT16> clusterMap,
                                               const COORD coord,
                                               const bool trimLeft,
                                               const bool lineWrapped) noexcept override;

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -71,7 +71,8 @@ namespace Microsoft::Console::Render
         [[nodiscard]] virtual HRESULT PrepareRenderInfo(const RenderFrameInfo& info) noexcept = 0;
 
         [[nodiscard]] virtual HRESULT PaintBackground() noexcept = 0;
-        [[nodiscard]] virtual HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+        [[nodiscard]] virtual HRESULT PaintBufferLine(std::wstring_view text,
+                                                      std::basic_string_view<UINT16> clusterMap,
                                                       const COORD coord,
                                                       const bool fTrimLeft,
                                                       const bool lineWrapped) noexcept = 0;

--- a/src/renderer/uia/UiaRenderer.cpp
+++ b/src/renderer/uia/UiaRenderer.cpp
@@ -305,7 +305,8 @@ CATCH_RETURN();
 // - fTrimLeft - Whether or not to trim off the left half of a double wide character
 // Return Value:
 // - S_FALSE
-[[nodiscard]] HRESULT UiaEngine::PaintBufferLine(std::basic_string_view<Cluster> const /*clusters*/,
+[[nodiscard]] HRESULT UiaEngine::PaintBufferLine(std::wstring_view /*text*/,
+                                                 std::basic_string_view<UINT16> /*clusterMap*/,
                                                  COORD const /*coord*/,
                                                  const bool /*trimLeft*/,
                                                  const bool /*lineWrapped*/) noexcept

--- a/src/renderer/uia/UiaRenderer.hpp
+++ b/src/renderer/uia/UiaRenderer.hpp
@@ -51,7 +51,8 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT InvalidateCircling(_Out_ bool* const pForcePaint) noexcept override;
 
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
-        [[nodiscard]] HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+        [[nodiscard]] HRESULT PaintBufferLine(std::wstring_view text,
+                                              std::basic_string_view<UINT16> clusterMap,
                                               COORD const coord,
                                               bool const fTrimLeft,
                                               const bool lineWrapped) noexcept override;

--- a/src/renderer/vt/XtermEngine.cpp
+++ b/src/renderer/vt/XtermEngine.cpp
@@ -498,14 +498,15 @@ CATCH_RETURN();
 //   will be false.
 // Return Value:
 // - S_OK or suitable HRESULT error from writing pipe.
-[[nodiscard]] HRESULT XtermEngine::PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+[[nodiscard]] HRESULT XtermEngine::PaintBufferLine(std::wstring_view text,
+                                                   std::basic_string_view<UINT16> clusterMap,
                                                    const COORD coord,
                                                    const bool /*trimLeft*/,
                                                    const bool lineWrapped) noexcept
 {
     return _fUseAsciiOnly ?
-               VtEngine::_PaintAsciiBufferLine(clusters, coord) :
-               VtEngine::_PaintUtf8BufferLine(clusters, coord, lineWrapped);
+               VtEngine::_PaintAsciiBufferLine(text, clusterMap, coord) :
+               VtEngine::_PaintUtf8BufferLine(text, clusterMap, coord, lineWrapped);
 }
 
 // Method Description:

--- a/src/renderer/vt/XtermEngine.hpp
+++ b/src/renderer/vt/XtermEngine.hpp
@@ -41,7 +41,8 @@ namespace Microsoft::Console::Render
         [[nodiscard]] virtual HRESULT UpdateDrawingBrushes(const TextAttribute& textAttributes,
                                                            const gsl::not_null<IRenderData*> pData,
                                                            const bool isSettingDefaultBrushes) noexcept override;
-        [[nodiscard]] HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+        [[nodiscard]] HRESULT PaintBufferLine(std::wstring_view text,
+                                              std::basic_string_view<UINT16> clusterMap,
                                               const COORD coord,
                                               const bool trimLeft,
                                               const bool lineWrapped) noexcept override;

--- a/src/renderer/vt/paint.cpp
+++ b/src/renderer/vt/paint.cpp
@@ -3,6 +3,9 @@
 
 #include "precomp.h"
 
+#include <algorithm>
+#include <numeric>
+
 #include "vtrenderer.hpp"
 #include "../../inc/conattrs.hpp"
 #include "../../types/inc/convert.hpp"
@@ -125,12 +128,13 @@ using namespace Microsoft::Console::Types;
 //   will be false.
 // Return Value:
 // - S_OK or suitable HRESULT error from writing pipe.
-[[nodiscard]] HRESULT VtEngine::PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+[[nodiscard]] HRESULT VtEngine::PaintBufferLine(std::wstring_view text,
+                                                std::basic_string_view<UINT16> clusterMap,
                                                 const COORD coord,
                                                 const bool /*trimLeft*/,
                                                 const bool /*lineWrapped*/) noexcept
 {
-    return VtEngine::_PaintAsciiBufferLine(clusters, coord);
+    return VtEngine::_PaintAsciiBufferLine(text, clusterMap, coord);
 }
 
 // Method Description:
@@ -327,27 +331,28 @@ using namespace Microsoft::Console::Types;
 // - coord - character coordinate target to render within viewport
 // Return Value:
 // - S_OK or suitable HRESULT error from writing pipe.
-[[nodiscard]] HRESULT VtEngine::_PaintAsciiBufferLine(std::basic_string_view<Cluster> const clusters,
+[[nodiscard]] HRESULT VtEngine::_PaintAsciiBufferLine(std::wstring_view text,
+                                                      std::basic_string_view<UINT16> clusterMap,
                                                       const COORD coord) noexcept
 {
     try
     {
         RETURN_IF_FAILED(_MoveCursor(coord));
 
-        _bufferLine.clear();
-        _bufferLine.reserve(clusters.size());
+        /*_bufferLine.clear();*/
+        //_bufferLine.reserve(clusters.size());
 
-        short totalWidth = 0;
+        /*short totalWidth = 0;
         for (const auto& cluster : clusters)
         {
             _bufferLine.append(cluster.GetText());
             RETURN_IF_FAILED(ShortAdd(totalWidth, gsl::narrow<short>(cluster.GetColumns()), &totalWidth));
-        }
+        }*/
 
-        RETURN_IF_FAILED(VtEngine::_WriteTerminalAscii(_bufferLine));
+        RETURN_IF_FAILED(VtEngine::_WriteTerminalAscii(text));
 
         // Update our internal tracker of the cursor's position
-        _lastText.X += totalWidth;
+        _lastText.X += (SHORT)std::accumulate(clusterMap.begin(), clusterMap.end(), 0);
 
         return S_OK;
     }
@@ -362,7 +367,8 @@ using namespace Microsoft::Console::Types;
 // - coord - character coordinate target to render within viewport
 // Return Value:
 // - S_OK or suitable HRESULT error from writing pipe.
-[[nodiscard]] HRESULT VtEngine::_PaintUtf8BufferLine(std::basic_string_view<Cluster> const clusters,
+[[nodiscard]] HRESULT VtEngine::_PaintUtf8BufferLine(std::wstring_view text,
+                                                     std::basic_string_view<UINT16> clusterMap,
                                                      const COORD coord,
                                                      const bool lineWrapped) noexcept
 {
@@ -371,21 +377,21 @@ using namespace Microsoft::Console::Types;
         return S_OK;
     }
 
-    _bufferLine.clear();
-    _bufferLine.reserve(clusters.size());
-    short totalWidth = 0;
-    for (const auto& cluster : clusters)
+    /*_bufferLine.clear();
+    _bufferLine.reserve(clusters.size());*/
+    short totalWidth = (SHORT)std::accumulate(clusterMap.begin(), clusterMap.end(), 0);
+    /*for (const auto& cluster : clusters)
     {
         _bufferLine.append(cluster.GetText());
         RETURN_IF_FAILED(ShortAdd(totalWidth, static_cast<short>(cluster.GetColumns()), &totalWidth));
-    }
-    const size_t cchLine = _bufferLine.size();
+    }*/
+    const size_t cchLine = text.size();
 
     bool foundNonspace = false;
     size_t lastNonSpace = 0;
     for (size_t i = 0; i < cchLine; i++)
     {
-        if (_bufferLine.at(i) != L'\x20')
+        if (text.at(i) != L'\x20')
         {
             lastNonSpace = i;
             foundNonspace = true;
@@ -479,7 +485,7 @@ using namespace Microsoft::Console::Types;
     RETURN_IF_FAILED(_MoveCursor(coord));
 
     // Write the actual text string
-    RETURN_IF_FAILED(VtEngine::_WriteTerminalUtf8({ _bufferLine.data(), cchActual }));
+    RETURN_IF_FAILED(VtEngine::_WriteTerminalUtf8({ text.data(), cchActual }));
 
     // GH#4415, GH#5181
     // If the renderer told us that this was a wrapped line, then mark

--- a/src/renderer/vt/state.cpp
+++ b/src/renderer/vt/state.cpp
@@ -49,8 +49,7 @@ VtEngine::VtEngine(_In_ wil::unique_hfile pipe,
     _newBottomLine{ false },
     _deferredCursorPos{ INVALID_COORDS },
     _inResizeRequest{ false },
-    _trace{},
-    _bufferLine{}
+    _trace{}
 {
 #ifndef UNIT_TESTING
     // When unit testing, we can instantiate a VtEngine without a pipe.

--- a/src/renderer/vt/vtrenderer.hpp
+++ b/src/renderer/vt/vtrenderer.hpp
@@ -61,7 +61,8 @@ namespace Microsoft::Console::Render
         [[nodiscard]] virtual HRESULT ScrollFrame() noexcept = 0;
 
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
-        [[nodiscard]] virtual HRESULT PaintBufferLine(std::basic_string_view<Cluster> const clusters,
+        [[nodiscard]] virtual HRESULT PaintBufferLine(std::wstring_view text,
+                                                      std::basic_string_view<UINT16> clusterMap,
                                                       const COORD coord,
                                                       const bool trimLeft,
                                                       const bool lineWrapped) noexcept override;
@@ -207,12 +208,14 @@ namespace Microsoft::Console::Render
 
         // buffer space for these two functions to build their lines
         // so they don't have to alloc/free in a tight loop
-        std::wstring _bufferLine;
-        [[nodiscard]] HRESULT _PaintUtf8BufferLine(std::basic_string_view<Cluster> const clusters,
+        //std::wstring _bufferLine;
+        [[nodiscard]] HRESULT _PaintUtf8BufferLine(std::wstring_view text,
+                                                   std::basic_string_view<UINT16> clusterMap,
                                                    const COORD coord,
                                                    const bool lineWrapped) noexcept;
 
-        [[nodiscard]] HRESULT _PaintAsciiBufferLine(std::basic_string_view<Cluster> const clusters,
+        [[nodiscard]] HRESULT _PaintAsciiBufferLine(std::wstring_view text,
+                                                    std::basic_string_view<UINT16> clusterMap,
                                                     const COORD coord) noexcept;
 
         [[nodiscard]] HRESULT _WriteTerminalUtf8(const std::wstring_view str) noexcept;


### PR DESCRIPTION
The act of working with `Cluster`s creates a lot of overhead for the assorted engines when they really treat things rather similarly in terms of a string and a "cluster map" of sorts of which characters belong to which columns. The inspiration for this comes from how DirectWrite gives us this information when we do an analysis as it turns out to be rather efficient.

I'm still not sold on this as the location where this will happen. I'm thinking of moving it up even further such that the `TextBuffer` can either store the information in this order (to be able to NxM at its own level more easily). Or perhaps just making the `IRenderData` generate this into a copy location so it can happen under lock then unlock and let the render thread do the layout work while the IO thread can keep capturing.

Bunch of cleanup left to do here.

## Validation Steps Performed
- Run `time cat big.txt`. Checked average time before/after, WPR traces
  before/after.

## PR Checklist
* [x] Closes perf itch
* [x] I work here
* [x] Manual test
* [x] Documentation irrelevant.
* [x] Schema irrelevant.
* [x] Am core contributor.