### PR TITLE
Smooth animation of command palette filtering

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -278,8 +278,10 @@ namespace winrt::TerminalApp::implementation
     // - A collection that will receive the filtered actions
     // Return Value:
     // - <none>
-    void CommandPalette::_collectFilteredActions(Windows::Foundation::Collections::IObservableVector<TerminalApp::Command>& actions)
+    std::vector<winrt::TerminalApp::Command> CommandPalette::_collectFilteredActions()
     {
+        std::vector<winrt::TerminalApp::Command> actions;
+
         auto searchText = _searchBox().Text();
         const bool addAll = searchText.empty();
 
@@ -302,10 +304,10 @@ namespace winrt::TerminalApp::implementation
 
             for (auto action : sortedCommands)
             {
-                actions.Append(action);
+                actions.push_back(action);
             }
 
-            return;
+            return actions;
         }
 
         // Here, there was some filter text.
@@ -342,8 +344,10 @@ namespace winrt::TerminalApp::implementation
         {
             auto top = heap.top();
             heap.pop();
-            actions.Append(top.command);
+            actions.push_back(top.command);
         }
+
+        return actions;
     }
 
     // Method Description:
@@ -356,17 +360,15 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     void CommandPalette::_updateFilteredActions()
     {
-        auto actions = winrt::single_threaded_observable_vector<winrt::TerminalApp::Command>();
-
-        _collectFilteredActions(actions);
+        auto actions = _collectFilteredActions();
 
         // Make _filteredActions look identical to actions, using only Insert and Remove.
         // This allows WinUI to nicely animate the ListView as it changes.
-        for (uint32_t i = 0; i < _filteredActions.Size() && i < actions.Size(); i++)
+        for (uint32_t i = 0; i < _filteredActions.Size() && i < actions.size(); i++)
         {
             for (uint32_t j = i; j < _filteredActions.Size(); j++)
             {
-                if (_filteredActions.GetAt(j) == actions.GetAt(i))
+                if (_filteredActions.GetAt(j) == actions[i])
                 {
                     for (uint32_t k = i; k < j; k++)
                     {
@@ -376,22 +378,22 @@ namespace winrt::TerminalApp::implementation
                 }
             }
 
-            if (_filteredActions.GetAt(i) != actions.GetAt(i))
+            if (_filteredActions.GetAt(i) != actions[i])
             {
-                _filteredActions.InsertAt(i, actions.GetAt(i));
+                _filteredActions.InsertAt(i, actions[i]);
             }
         }
 
         // Remove any extra trailing items from the destination
-        while (_filteredActions.Size() > actions.Size())
+        while (_filteredActions.Size() > actions.size())
         {
             _filteredActions.RemoveAtEnd();
         }
 
         // Add any extra trailing items from the source
-        while (_filteredActions.Size() < actions.Size())
+        while (_filteredActions.Size() < actions.size())
         {
-            _filteredActions.Append(actions.GetAt(_filteredActions.Size()));
+            _filteredActions.Append(actions[_filteredActions.Size()]);
         }
     }
 

--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -37,7 +37,7 @@ namespace winrt::TerminalApp::implementation
         void _selectNextItem(const bool moveDown);
 
         void _updateFilteredActions();
-        void _collectFilteredActions(Windows::Foundation::Collections::IObservableVector<TerminalApp::Command> &actions);
+        std::vector<winrt::TerminalApp::Command> _collectFilteredActions();
         static int _getWeight(const winrt::hstring& searchText, const winrt::hstring& name);
         void _close();
 

--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -37,6 +37,7 @@ namespace winrt::TerminalApp::implementation
         void _selectNextItem(const bool moveDown);
 
         void _updateFilteredActions();
+        void _collectFilteredActions(Windows::Foundation::Collections::IObservableVector<TerminalApp::Command> &actions);
         static int _getWeight(const winrt::hstring& searchText, const winrt::hstring& name);
         void _close();
 


### PR DESCRIPTION
The command palette is a ListView of commands.  As you type into the
search box, commands are added or removed from the ListView.  Currently,
each update is done by completely clearing the backing list, then adding
back any items that should be displayed.  However, this defeats the
ListView's built-in animations: upon every keystroke, ListView displays
its list-clearing animation, then animates the insertion of every item
that wasn't deleted.  This results in noticeable flickering.

This PR changes the update logic so that it updates the list using
(roughly) the minimum number of Insert and Remove calls, so the ListView
makes smoother transitions as you type.

## Detailed Description of the Pull Request / Additional comments
I implemented it by keeping the existing code that builds the filtered
list, but I changed it to build into a scratch list.  Then I grafted on
a generic delta algorithm to make the real list look like the scratch
list.

To verify the delta algorithm, I tested all 360,000 permutations of
pairs of up to 5 element lists in a toy C# app.

## Validation Steps Performed
I'm not sure if my screen capture tool really caught all the flickering
here, but the screencasts below should give a rough idea of the
difference.  (All the flickering was becoming a nuisance while I was
testing out the HC changes.)

Existing behavior:
![old](https://user-images.githubusercontent.com/10259764/87609408-53796180-c6b7-11ea-86b2-ab94f40c8ed0.gif)

New behavior:
![new](https://user-images.githubusercontent.com/10259764/87609416-56745200-c6b7-11ea-8415-fde870385485.gif)

