### PR TITLE
Move to the TerminalDependencies NuGet feed

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -8,7 +8,7 @@
         <!--<add key="Static Package Dependencies" value="dep\packages" />-->
         
         <!-- Use our own NuGet Feed -->
-        <add key="Windows Terminal NuGet Feed" value="https://terminalnuget.blob.core.windows.net/feed/index.json" />
+        <add key="TerminalDependencies" value="https://pkgs.dev.azure.com/ms/terminal/_packaging/TerminalDependencies/nuget/v3/index.json" />
         
         <!-- Internal NuGet feeds that may not be accessible outside Microsoft corporate network -->
         <!--<add key="TAEF - internal" value="https://microsoft.pkgs.visualstudio.com/DefaultCollection/_packaging/Taef/nuget/v3/index.json" />


### PR DESCRIPTION
After we stood up our own NuGet feed in Azure blob storage, Azure DevOps
came out with a public artifact feed feature. I've migrated all our
packages over, and the only thing left to do is switch our project's
NuGet config to use it.

Fixes #6952