### PR TITLE
Add explicit casting to ColorScheme

### DIFF
--- a/src/cascadia/TerminalApp/ColorScheme.cpp
+++ b/src/cascadia/TerminalApp/ColorScheme.cpp
@@ -75,8 +75,8 @@ void ColorScheme::ApplyScheme(TerminalSettings terminalSettings) const
     terminalSettings.SelectionBackground(static_cast<COLORREF>(_selectionBackground));
     terminalSettings.CursorColor(static_cast<COLORREF>(_cursorColor));
 
-    auto const tableCount = gsl::narrow_cast<int>(_table.size());
-    for (int i = 0; i < tableCount; i++)
+    const auto tableCount = _table.size();
+    for (size_t i = 0; i < _table.size(); i++)
     {
         terminalSettings.SetColorTableEntry(i, static_cast<COLORREF>(_table[i]));
     }
@@ -131,7 +131,7 @@ void ColorScheme::LayerJson(const Json::Value& json)
     JsonUtils::GetValueForKey(json, SelectionBackgroundKey, _selectionBackground);
     JsonUtils::GetValueForKey(json, CursorColorKey, _cursorColor);
 
-    int i = 0;
+    unsigned int i = 0;
     for (const auto& current : TableColors)
     {
         JsonUtils::GetValueForKey(json, current, _table.at(i));

--- a/src/cascadia/TerminalApp/ColorScheme.cpp
+++ b/src/cascadia/TerminalApp/ColorScheme.cpp
@@ -75,8 +75,8 @@ void ColorScheme::ApplyScheme(TerminalSettings terminalSettings) const
     terminalSettings.SelectionBackground(static_cast<COLORREF>(_selectionBackground));
     terminalSettings.CursorColor(static_cast<COLORREF>(_cursorColor));
 
-    const auto tableCount = _table.size();
-    for (size_t i = 0; i < _table.size(); i++)
+    auto const tableCount = _table.size();
+    for (size_t i = 0; i < tableCount; i++)
     {
         terminalSettings.SetColorTableEntry(i, static_cast<COLORREF>(_table[i]));
     }
@@ -131,7 +131,7 @@ void ColorScheme::LayerJson(const Json::Value& json)
     JsonUtils::GetValueForKey(json, SelectionBackgroundKey, _selectionBackground);
     JsonUtils::GetValueForKey(json, CursorColorKey, _cursorColor);
 
-    unsigned int i = 0;
+    size_t i = 0;
     for (const auto& current : TableColors)
     {
         JsonUtils::GetValueForKey(json, current, _table.at(i));

--- a/src/cascadia/TerminalApp/ColorScheme.cpp
+++ b/src/cascadia/TerminalApp/ColorScheme.cpp
@@ -78,7 +78,7 @@ void ColorScheme::ApplyScheme(TerminalSettings terminalSettings) const
     auto const tableCount = gsl::narrow_cast<unsigned int>(_table.size());
     for (unsigned int i = 0; i < tableCount; i++)
     {
-        terminalSettings.SetColorTableEntry((size_t)i, static_cast<COLORREF>(_table[i]));
+        terminalSettings.SetColorTableEntry(static_cast<size_t>i, static_cast<COLORREF>(_table[i]));
     }
 }
 
@@ -134,7 +134,7 @@ void ColorScheme::LayerJson(const Json::Value& json)
     unsigned int i = 0;
     for (const auto& current : TableColors)
     {
-        JsonUtils::GetValueForKey(json, current, _table.at((size_t)i));
+        JsonUtils::GetValueForKey(json, current, _table.at(static_cast<size_t>i));
         i++;
     }
 }

--- a/src/cascadia/TerminalApp/ColorScheme.cpp
+++ b/src/cascadia/TerminalApp/ColorScheme.cpp
@@ -78,7 +78,7 @@ void ColorScheme::ApplyScheme(TerminalSettings terminalSettings) const
     auto const tableCount = gsl::narrow_cast<unsigned int>(_table.size());
     for (unsigned int i = 0; i < tableCount; i++)
     {
-        terminalSettings.SetColorTableEntry(static_cast<size_t> i, static_cast<COLORREF>(_table[i]));
+        terminalSettings.SetColorTableEntry(static_cast<size_t>(i), static_cast<COLORREF>(_table[i]));
     }
 }
 
@@ -134,7 +134,7 @@ void ColorScheme::LayerJson(const Json::Value& json)
     unsigned int i = 0;
     for (const auto& current : TableColors)
     {
-        JsonUtils::GetValueForKey(json, current, _table.at(static_cast<size_t> i));
+        JsonUtils::GetValueForKey(json, current, _table.at(static_cast<size_t>(i)));
         i++;
     }
 }

--- a/src/cascadia/TerminalApp/ColorScheme.cpp
+++ b/src/cascadia/TerminalApp/ColorScheme.cpp
@@ -75,8 +75,8 @@ void ColorScheme::ApplyScheme(TerminalSettings terminalSettings) const
     terminalSettings.SelectionBackground(static_cast<COLORREF>(_selectionBackground));
     terminalSettings.CursorColor(static_cast<COLORREF>(_cursorColor));
 
-    auto const tableCount = _table.size();
-    for (size_t i = 0; i < tableCount; i++)
+    auto const tableCount = gsl::narrow_cast<int32_t>(_table.size());
+    for (int32_t i = 0; i < tableCount; i++)
     {
         terminalSettings.SetColorTableEntry(i, static_cast<COLORREF>(_table[i]));
     }
@@ -131,10 +131,10 @@ void ColorScheme::LayerJson(const Json::Value& json)
     JsonUtils::GetValueForKey(json, SelectionBackgroundKey, _selectionBackground);
     JsonUtils::GetValueForKey(json, CursorColorKey, _cursorColor);
 
-    size_t i = 0;
+    unsigned int i = 0;
     for (const auto& current : TableColors)
     {
-        JsonUtils::GetValueForKey(json, current, _table.at(i));
+        JsonUtils::GetValueForKey(json, current, _table.at(static_cast<size_t>(i)));
         i++;
     }
 }

--- a/src/cascadia/TerminalApp/ColorScheme.cpp
+++ b/src/cascadia/TerminalApp/ColorScheme.cpp
@@ -75,10 +75,10 @@ void ColorScheme::ApplyScheme(TerminalSettings terminalSettings) const
     terminalSettings.SelectionBackground(static_cast<COLORREF>(_selectionBackground));
     terminalSettings.CursorColor(static_cast<COLORREF>(_cursorColor));
 
-    auto const tableCount = gsl::narrow_cast<unsigned int>(_table.size());
-    for (unsigned int i = 0; i < tableCount; i++)
+    auto const tableCount = _table.size();
+    for (size_t i = 0; i < tableCount; i++)
     {
-        terminalSettings.SetColorTableEntry(static_cast<size_t>(i), static_cast<COLORREF>(_table[i]));
+        terminalSettings.SetColorTableEntry(i, static_cast<COLORREF>(_table[i]));
     }
 }
 
@@ -131,10 +131,10 @@ void ColorScheme::LayerJson(const Json::Value& json)
     JsonUtils::GetValueForKey(json, SelectionBackgroundKey, _selectionBackground);
     JsonUtils::GetValueForKey(json, CursorColorKey, _cursorColor);
 
-    unsigned int i = 0;
+    size_t i = 0;
     for (const auto& current : TableColors)
     {
-        JsonUtils::GetValueForKey(json, current, _table.at(static_cast<size_t>(i)));
+        JsonUtils::GetValueForKey(json, current, _table.at(i));
         i++;
     }
 }

--- a/src/cascadia/TerminalApp/ColorScheme.cpp
+++ b/src/cascadia/TerminalApp/ColorScheme.cpp
@@ -75,10 +75,10 @@ void ColorScheme::ApplyScheme(TerminalSettings terminalSettings) const
     terminalSettings.SelectionBackground(static_cast<COLORREF>(_selectionBackground));
     terminalSettings.CursorColor(static_cast<COLORREF>(_cursorColor));
 
-    auto const tableCount = _table.size();
-    for (size_t i = 0; i < tableCount; i++)
+    auto const tableCount = gsl::narrow_cast<unsigned int>(_table.size());
+    for (unsigned int i = 0; i < tableCount; i++)
     {
-        terminalSettings.SetColorTableEntry(i, static_cast<COLORREF>(_table[i]));
+        terminalSettings.SetColorTableEntry((size_t)i, static_cast<COLORREF>(_table[i]));
     }
 }
 
@@ -131,10 +131,10 @@ void ColorScheme::LayerJson(const Json::Value& json)
     JsonUtils::GetValueForKey(json, SelectionBackgroundKey, _selectionBackground);
     JsonUtils::GetValueForKey(json, CursorColorKey, _cursorColor);
 
-    size_t i = 0;
+    unsigned int i = 0;
     for (const auto& current : TableColors)
     {
-        JsonUtils::GetValueForKey(json, current, _table.at(i));
+        JsonUtils::GetValueForKey(json, current, _table.at((size_t)i));
         i++;
     }
 }

--- a/src/cascadia/TerminalApp/ColorScheme.cpp
+++ b/src/cascadia/TerminalApp/ColorScheme.cpp
@@ -78,7 +78,7 @@ void ColorScheme::ApplyScheme(TerminalSettings terminalSettings) const
     auto const tableCount = gsl::narrow_cast<unsigned int>(_table.size());
     for (unsigned int i = 0; i < tableCount; i++)
     {
-        terminalSettings.SetColorTableEntry(static_cast<size_t>i, static_cast<COLORREF>(_table[i]));
+        terminalSettings.SetColorTableEntry(static_cast<size_t> i, static_cast<COLORREF>(_table[i]));
     }
 }
 
@@ -134,7 +134,7 @@ void ColorScheme::LayerJson(const Json::Value& json)
     unsigned int i = 0;
     for (const auto& current : TableColors)
     {
-        JsonUtils::GetValueForKey(json, current, _table.at(static_cast<size_t>i));
+        JsonUtils::GetValueForKey(json, current, _table.at(static_cast<size_t> i));
         i++;
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Basically, since i is never below zero, and the program implicitly casts i to size_t - an unsigned long - making i unsigned to aid in static casting to the table.at() argument type would be the right step.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [X] Tests added/passed
* [X] Schema updated.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
