### PR TITLE
Add rudimentary object model

### DIFF
--- a/src/TerminalSettings/TerminalSettings/AppSettings.cpp
+++ b/src/TerminalSettings/TerminalSettings/AppSettings.cpp
@@ -1,0 +1,2 @@
+#include "pch.h"
+#include "AppSettings.h"

--- a/src/TerminalSettings/TerminalSettings/AppSettings.h
+++ b/src/TerminalSettings/TerminalSettings/AppSettings.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "GlobalSettings.h"
+#include "ColorScheme.h"
+#include "Profile.h"
+
+namespace winrt::TerminalSettings::implementation
+{
+    enum class Modifiers
+    {
+        Shift = 0x1,
+        Alt = 0x2,
+        Ctrl = 0x4
+    };
+
+    enum class Key
+    {
+        TODO_FIX
+    };
+
+    class KeyChord
+    {
+        Modifiers Mods;
+        Key Button;
+    };
+
+    enum class Action
+    {
+        TODO_FIX
+    };
+
+    class AppSettings
+    {
+        AppSettings();
+
+        GlobalSettings Globals;
+        std::vector<Profile> Profiles;
+        std::map<hstring, ColorScheme> Schemes;
+        std::map<KeyChord, Action> Keybindings;
+    };
+}

--- a/src/TerminalSettings/TerminalSettings/ColorScheme.cpp
+++ b/src/TerminalSettings/TerminalSettings/ColorScheme.cpp
@@ -1,0 +1,2 @@
+#include "pch.h"
+#include "ColorScheme.h"

--- a/src/TerminalSettings/TerminalSettings/ColorScheme.h
+++ b/src/TerminalSettings/TerminalSettings/ColorScheme.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace winrt::TerminalSettings::implementation
+{
+    class ColorScheme
+    {
+        ColorScheme() = default;
+        ~ColorScheme() = default;
+
+        hstring Name;
+        unsigned int Foreground;
+        unsigned int Background;
+        unsigned int SelectionBackground;
+        unsigned int CursorColor;
+
+        std::array<unsigned int, 16> Table;
+    };
+}

--- a/src/TerminalSettings/TerminalSettings/GlobalSettings.cpp
+++ b/src/TerminalSettings/TerminalSettings/GlobalSettings.cpp
@@ -1,0 +1,2 @@
+#include "pch.h"
+#include "GlobalSettings.h"

--- a/src/TerminalSettings/TerminalSettings/GlobalSettings.h
+++ b/src/TerminalSettings/TerminalSettings/GlobalSettings.h
@@ -1,0 +1,55 @@
+#pragma once
+
+namespace winrt::TerminalSettings::implementation
+{
+    enum class ElementTheme
+    {
+        TODO_FIX
+    };
+
+    enum class TabViewWidthMode
+    {
+        TODO_FIX
+    };
+
+    struct LaunchPosition
+    {
+        int x;
+        int y;
+    };
+
+    enum class AppLaunchMode
+    {
+        TODO_FIX
+    };
+
+    class GlobalSettings
+    {
+        GlobalSettings() = default;
+        ~GlobalSettings() = default;
+
+        int InitialRows;
+        int InitialCols;
+        bool AlwaysShowTabs;
+        bool ShowTitleInTitlebar;
+        bool ConfirmCloseAllTabs;
+        ElementTheme Theme;
+        TabViewWidthMode TabWidthMode;
+        bool ShowTabsInTitlebar;
+        hstring WordDelimiters;
+        bool CopyOnSelect;
+        bool CopyFormatting;
+        bool WarnAboutLargePaste;
+        bool WarnAboutMultiLinePaste;
+        LaunchPosition InitialPosition;
+        AppLaunchMode LaunchMode;
+        bool SnapToGridOnResize;
+        bool ForceFullRepaintRendering;
+        bool SoftwareRendering;
+        bool ForceVTInput;
+        bool DebugFeaturesEnabled;
+        bool StartOnUserLogin;
+        bool AlwaysOnTop;
+    };
+
+}

--- a/src/TerminalSettings/TerminalSettings/Profile.cpp
+++ b/src/TerminalSettings/TerminalSettings/Profile.cpp
@@ -1,0 +1,2 @@
+#include "pch.h"
+#include "Profile.h"

--- a/src/TerminalSettings/TerminalSettings/Profile.h
+++ b/src/TerminalSettings/TerminalSettings/Profile.h
@@ -1,0 +1,99 @@
+#pragma once
+
+namespace winrt::TerminalSettings::implementation
+{
+    enum class CloseOnExitMode
+    {
+        TODO_FIX
+    };
+
+    enum class ScrollbarState
+    {
+        TODO_FIX
+    };
+
+    enum class FontWeight
+    {
+        TODO_FIX
+    };
+
+    enum class Stretch
+    {
+        TODO_FIX
+    };
+
+    enum class HorizontalAlignment
+    {
+        TODO_FIX
+    };
+
+    enum class VerticalAlignment
+    {
+        TODO_FIX
+    };
+
+    enum class TextAntialiasingMode
+    {
+        TODO_FIX
+    };
+
+    enum class CursorStyle
+    {
+        TODO_FIX
+    };
+
+    class Profile
+    {
+        Profile() = default;
+        ~Profile() = default;
+
+        std::optional<guid> Guid;
+        hstring Name;
+        std::optional<hstring> Source;
+        std::optional<hstring> ConnectionType;
+        std::optional<hstring> Icon;
+        bool Hidden;
+        CloseOnExitMode CloseOnExit;
+        hstring TabTitle;
+
+        // Terminal Control Settings
+        bool UseAcrylic;
+        double AcrylicOpacity;
+        ScrollbarState ScrollState;
+        hstring FontFace;
+        int FontSize;
+        FontWeight FontWeight;
+        hstring Padding;
+        bool CopyOnSelect;
+        hstring Commandline;
+        hstring StartingDirectory;
+        hstring EnvironmentVariables;
+        hstring BackgroundImage;
+        double BackgroundImageOpacity;
+        Stretch BackgroundImageStretchMode;
+        // BackgroundImageAlignment is weird. It's 1 settings saved as 2 separate values
+        HorizontalAlignment BackgroundImageHorizontalAlignment;
+        VerticalAlignment BackgroundImageVerticalAlignment;
+        unsigned int SelectionBackground;
+        TextAntialiasingMode AntialiasingMode;
+        bool RetroTerminalEffect;
+        bool ForceFullRepaintRendering;
+        bool SoftwareRendering;
+
+        // Terminal Core Settings
+        unsigned int DefaultForeground;
+        unsigned int DefaultBackground;
+        hstring ColorScheme ;
+        int HistorySize ;
+        int InitialRows;
+        int InitialCols;
+        bool SnapOnInput ;
+        bool AltGrAliasing ;
+        unsigned int CursorColor;
+        CursorStyle CursorShape ;
+        unsigned int CursorHeight ;
+        hstring StartingTitle;
+        bool SuppressApplicationTitle;
+        bool ForceVTInput;
+    };
+}

--- a/src/TerminalSettings/TerminalSettings/TerminalSettings.vcxproj
+++ b/src/TerminalSettings/TerminalSettings/TerminalSettings.vcxproj
@@ -103,6 +103,8 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="AppSettings.h" />
+    <ClInclude Include="ColorScheme.h" />
     <ClInclude Include="ColorSchemes.h">
       <DependentUpon>ColorSchemes.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -111,6 +113,7 @@
       <DependentUpon>Globals.xaml</DependentUpon>
       <SubType>Code</SubType>
     </ClInclude>
+    <ClInclude Include="GlobalSettings.h" />
     <ClInclude Include="Keybindings.h">
       <DependentUpon>Keybindings.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -122,6 +125,7 @@
     <ClInclude Include="MainPage.h">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="Profile.h" />
     <ClInclude Include="Profiles.h">
       <DependentUpon>Profiles.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -174,6 +178,8 @@
     <Image Include="Assets\Wide310x150Logo.scale-200.png" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="AppSettings.cpp" />
+    <ClCompile Include="ColorScheme.cpp" />
     <ClCompile Include="ColorSchemes.cpp">
       <DependentUpon>ColorSchemes.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -182,6 +188,7 @@
       <DependentUpon>Globals.xaml</DependentUpon>
       <SubType>Code</SubType>
     </ClCompile>
+    <ClCompile Include="GlobalSettings.cpp" />
     <ClCompile Include="Keybindings.cpp">
       <DependentUpon>Keybindings.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -196,6 +203,7 @@
       <DependentUpon>MainPage.xaml</DependentUpon>
     </ClCompile>
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="Profile.cpp" />
     <ClCompile Include="Profiles.cpp">
       <DependentUpon>Profiles.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/src/TerminalSettings/TerminalSettings/TerminalSettings.vcxproj.filters
+++ b/src/TerminalSettings/TerminalSettings/TerminalSettings.vcxproj.filters
@@ -19,9 +19,29 @@
     <ClCompile Include="App.cpp" />
     <ClCompile Include="MainPage.cpp" />
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="AppSettings.cpp">
+      <Filter>ObjectModel</Filter>
+    </ClCompile>
+    <ClCompile Include="GlobalSettings.cpp">
+      <Filter>ObjectModel</Filter>
+    </ClCompile>
+    <ClCompile Include="ColorScheme.cpp" />
+    <ClCompile Include="Profile.cpp">
+      <Filter>ObjectModel</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
+    <ClInclude Include="AppSettings.h">
+      <Filter>ObjectModel</Filter>
+    </ClInclude>
+    <ClInclude Include="GlobalSettings.h">
+      <Filter>ObjectModel</Filter>
+    </ClInclude>
+    <ClInclude Include="ColorScheme.h" />
+    <ClInclude Include="Profile.h">
+      <Filter>ObjectModel</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="Assets\Wide310x150Logo.scale-200.png">
@@ -88,6 +108,9 @@
   <ItemGroup>
     <Filter Include="Assets">
       <UniqueIdentifier>{e48dc53e-40b1-40cb-970a-f89935452892}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ObjectModel">
+      <UniqueIdentifier>{82df4a65-69a2-4d4a-bd7f-3eb55c6b2533}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I added some objects under an "ObjectModel" folder. This is _far_ from ideal. But it's a _hack_.

Using these objects, you should be able to do XAML Data Binding. `AppSettings` is the top-level settings object. All of the XAML should be able to retrieve the relevant parts of the `AppSettings` and update it's innards.

In my other branch, I'm actually hooking up these similar objects to the JSON and Windows Terminal. Once I can get that working, I'll handle moving the Settings UI project over to the main .sln file, then we can actually consume a real `AppSettings.

NOTE: I didn't really define any of the enums. I'm a bit too lazy. You could just populate them as you go with the XAML for now.