### PR TITLE
Fixed window title not updating with tab rename

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1465,7 +1465,9 @@ namespace winrt::TerminalApp::implementation
                 {
                     if (auto focusedControl{ _GetActiveControl() })
                     {
-                        return focusedControl.Title();
+                        auto indexOpt = _GetFocusedTabIndex();
+                        auto focusedTab{ _GetStrongTabImpl(*indexOpt) };
+                        return focusedTab->GetActiveTitle();
                     }
                 }
                 CATCH_LOG();

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1465,9 +1465,7 @@ namespace winrt::TerminalApp::implementation
                 {
                     if (auto focusedControl{ _GetActiveControl() })
                     {
-                        auto indexOpt = _GetFocusedTabIndex();
-                        auto focusedTab{ _GetStrongTabImpl(*indexOpt) };
-                        return focusedTab->GetActiveTitle();
+                        return focusedControl.Title();
                     }
                 }
                 CATCH_LOG();
@@ -1797,7 +1795,7 @@ namespace winrt::TerminalApp::implementation
                 tab->SetFocused(true);
 
                 // Raise an event that our title changed
-                _titleChangeHandlers(*this, Title());
+                _titleChangeHandlers(*this, tab->GetActiveTitle());
 
                 // Raise an event that our titlebar color changed
                 std::optional<Windows::UI::Color> color = tab->GetTabColor();


### PR DESCRIPTION
## Brief description of PR

The outer window title was not updating correctly with tab renames, this change fixes that

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #6814 
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## More detailed description

Previously, upon changing tabs we would send up the title of the focused control, this change makes it so we send up the title of the focused tab instead.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation steps

Cannot reproduce the bug after this change. 
