### PR TITLE
Add support for the "crossed-out" graphic rendition attribute

### DIFF
--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -860,6 +860,11 @@ IRenderEngine::GridLines Renderer::s_GetGridlines(const TextAttribute& textAttri
     {
         lines |= IRenderEngine::GridLines::Right;
     }
+
+    if (textAttribute.IsCrossedOut())
+    {
+        lines |= IRenderEngine::GridLines::Strikethrough;
+    }
     return lines;
 }
 

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -1260,7 +1260,7 @@ public:
     TEST_METHOD(GraphicsSingleTests)
     {
         BEGIN_TEST_METHOD_PROPERTIES()
-            TEST_METHOD_PROPERTY(L"Data:uiGraphicsOptions", L"{0, 1, 2, 4, 7, 8, 22, 24, 27, 28, 30, 31, 32, 33, 34, 35, 36, 37, 39, 40, 41, 42, 43, 44, 45, 46, 47, 49, 53, 55, 90, 91, 92, 93, 94, 95, 96, 97, 100, 101, 102, 103, 104, 105, 106, 107}") // corresponds to options in DispatchTypes::GraphicsOptions
+            TEST_METHOD_PROPERTY(L"Data:uiGraphicsOptions", L"{0, 1, 2, 4, 7, 8, 9, 22, 24, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 39, 40, 41, 42, 43, 44, 45, 46, 47, 49, 53, 55, 90, 91, 92, 93, 94, 95, 96, 97, 100, 101, 102, 103, 104, 105, 106, 107}") // corresponds to options in DispatchTypes::GraphicsOptions
         END_TEST_METHOD_PROPERTIES()
 
         Log::Comment(L"Starting test...");
@@ -1316,6 +1316,12 @@ public:
             _testGetSet->_expectedAttribute = TextAttribute{ 0 };
             _testGetSet->_expectedAttribute.SetInvisible(true);
             break;
+        case DispatchTypes::GraphicsOptions::CrossedOut:
+            Log::Comment(L"Testing graphics 'Crossed Out'");
+            _testGetSet->_attribute = TextAttribute{ 0 };
+            _testGetSet->_expectedAttribute = TextAttribute{ 0 };
+            _testGetSet->_expectedAttribute.SetCrossedOut(true);
+            break;
         case DispatchTypes::GraphicsOptions::NotBoldOrFaint:
             Log::Comment(L"Testing graphics 'No Bold or Faint'");
             _testGetSet->_attribute = TextAttribute{ 0 };
@@ -1342,6 +1348,12 @@ public:
             Log::Comment(L"Testing graphics 'Visible'");
             _testGetSet->_attribute = TextAttribute{ 0 };
             _testGetSet->_attribute.SetInvisible(true);
+            _testGetSet->_expectedAttribute = TextAttribute{ 0 };
+            break;
+        case DispatchTypes::GraphicsOptions::NotCrossedOut:
+            Log::Comment(L"Testing graphics 'Not Crossed Out'");
+            _testGetSet->_attribute = TextAttribute{ 0 };
+            _testGetSet->_attribute.SetCrossedOut(true);
             _testGetSet->_expectedAttribute = TextAttribute{ 0 };
             break;
         case DispatchTypes::GraphicsOptions::ForegroundBlack:


### PR DESCRIPTION
This PR adds support for the ANSI _crossed-out_ graphic rendition
attribute, which is enabled by the `SGR 9` escape sequence.

* Support for the escape sequences and storage of the attribute was
  originally added in #2917.
* Support for drawing the strikethrough effect in the grid line renderer
  was added in #7107.

Since the majority of the code required for this attribute had already
been implemented, it was just a matter of activating the
`GridLines::Strikethrough` style in the `Renderer::s_GetGridlines`
method when the `CrossedOut` attribute was set.

VALIDATION

There were already some unit tests in place in `VtRendererTest` and the
`ScreenBufferTests`, but I've also now extended the SGR tests in
`AdapterTest` to cover this attribute.

I've manually confirmed the first test case from #6205 now works as
expected in both conhost and Terminal.

Closes #6205