### PR TITLE
Move TerminalSettings object to TermApp Project

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -16,6 +16,7 @@ using namespace WEX::Logging;
 using namespace WEX::TestExecution;
 using namespace WEX::Common;
 using namespace winrt::TerminalApp;
+using namespace winrt::Microsoft::Terminal::Settings;
 
 namespace TerminalAppLocalTests
 {

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -16,7 +16,6 @@ using namespace WEX::Logging;
 using namespace WEX::TestExecution;
 using namespace WEX::Common;
 using namespace winrt::TerminalApp;
-using namespace winrt::Microsoft::Terminal::Settings;
 
 namespace TerminalAppLocalTests
 {
@@ -93,7 +92,7 @@ namespace TerminalAppLocalTests
 
     void SettingsTests::TryCreateWinRTType()
     {
-        winrt::Microsoft::Terminal::Settings::TerminalSettings settings;
+        TerminalSettings settings;
         VERIFY_IS_NOT_NULL(settings);
         auto oldFontSize = settings.FontSize();
         settings.FontSize(oldFontSize + 5);

--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -84,7 +84,7 @@ namespace TerminalAppLocalTests
     {
         // Verify we can create a WinRT type we authored
         // Just creating it is enough to know that everything is working.
-        winrt::Microsoft::Terminal::Settings::TerminalSettings settings;
+        TerminalSettings settings;
         VERIFY_IS_NOT_NULL(settings);
         auto oldFontSize = settings.FontSize();
         settings.FontSize(oldFontSize + 5);
@@ -140,7 +140,7 @@ namespace TerminalAppLocalTests
             // 4. one of our types that uses MUX/Xaml in this dll (Tab).
             // Just creating all of them is enough to know that everything is working.
             const auto profileGuid{ Utils::CreateGuid() };
-            winrt::Microsoft::Terminal::Settings::TerminalSettings settings{};
+            TerminalSettings settings{};
             VERIFY_IS_NOT_NULL(settings);
             winrt::Microsoft::Terminal::TerminalConnection::EchoConnection conn{};
             VERIFY_IS_NOT_NULL(conn);

--- a/src/cascadia/TerminalApp/CascadiaSettings.h
+++ b/src/cascadia/TerminalApp/CascadiaSettings.h
@@ -54,8 +54,8 @@ public:
 
     static const CascadiaSettings& GetCurrentAppSettings();
 
-    std::tuple<GUID, winrt::Microsoft::Terminal::Settings::TerminalSettings> BuildSettings(const winrt::TerminalApp::NewTerminalArgs& newTerminalArgs) const;
-    winrt::Microsoft::Terminal::Settings::TerminalSettings BuildSettings(GUID profileGuid) const;
+    std::tuple<GUID, winrt::TerminalApp::TerminalSettings> BuildSettings(const winrt::TerminalApp::NewTerminalArgs& newTerminalArgs) const;
+    winrt::TerminalApp::TerminalSettings BuildSettings(GUID profileGuid) const;
 
     GlobalAppSettings& GlobalSettings();
 

--- a/src/cascadia/TerminalApp/ColorScheme.cpp
+++ b/src/cascadia/TerminalApp/ColorScheme.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 #include "pch.h"
+#include <winrt/Microsoft.Terminal.Settings.h>
 #include "ColorScheme.h"
 #include "DefaultSettings.h"
 #include "../../types/inc/Utils.hpp"
@@ -10,8 +11,7 @@
 
 using namespace ::Microsoft::Console;
 using namespace TerminalApp;
-using namespace winrt::Microsoft::Terminal::Settings;
-using namespace winrt::Microsoft::Terminal::TerminalControl;
+using namespace winrt::TerminalApp;
 
 static constexpr std::string_view NameKey{ "name" };
 static constexpr std::string_view ForegroundKey{ "foreground" };

--- a/src/cascadia/TerminalApp/ColorScheme.h
+++ b/src/cascadia/TerminalApp/ColorScheme.h
@@ -15,7 +15,7 @@ Author(s):
 
 --*/
 #pragma once
-#include <winrt/Microsoft.Terminal.Settings.h>
+#include <winrt/TerminalApp.h>
 #include <winrt/Microsoft.Terminal.TerminalControl.h>
 #include "../../inc/conattrs.hpp"
 
@@ -38,7 +38,7 @@ public:
     ColorScheme(std::wstring name, til::color defaultFg, til::color defaultBg, til::color cursorColor);
     ~ColorScheme();
 
-    void ApplyScheme(winrt::Microsoft::Terminal::Settings::TerminalSettings terminalSettings) const;
+    void ApplyScheme(winrt::TerminalApp::TerminalSettings terminalSettings) const;
 
     static ColorScheme FromJson(const Json::Value& json);
     bool ShouldBeLayered(const Json::Value& json) const;

--- a/src/cascadia/TerminalApp/ColorScheme.h
+++ b/src/cascadia/TerminalApp/ColorScheme.h
@@ -15,8 +15,8 @@ Author(s):
 
 --*/
 #pragma once
-#include <winrt/TerminalApp.h>
 #include <winrt/Microsoft.Terminal.TerminalControl.h>
+#include "TerminalSettings.h"
 #include "../../inc/conattrs.hpp"
 
 // fwdecl unittest classes

--- a/src/cascadia/TerminalApp/GlobalAppSettings.h
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.h
@@ -46,7 +46,7 @@ public:
     static GlobalAppSettings FromJson(const Json::Value& json);
     void LayerJson(const Json::Value& json);
 
-    void ApplyToSettings(winrt::Microsoft::Terminal::Settings::TerminalSettings& settings) const noexcept;
+    void ApplyToSettings(winrt::TerminalApp::TerminalSettings& settings) const noexcept;
 
     std::vector<TerminalApp::SettingsLoadWarnings> GetKeybindingsWarnings() const;
 

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -51,7 +51,7 @@ public:
     void ClearActive();
     void SetActive();
 
-    void UpdateSettings(const winrt::Microsoft::Terminal::Settings::TerminalSettings& settings,
+    void UpdateSettings(const winrt::TerminalApp::TerminalSettings& settings,
                         const GUID& profile);
     void ResizeContent(const winrt::Windows::Foundation::Size& newSize);
     void Relayout();

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -12,6 +12,7 @@
 #include "TerminalSettingsSerializationHelpers.h"
 
 using namespace TerminalApp;
+using namespace winrt::TerminalApp;
 using namespace winrt::Microsoft::Terminal::Settings;
 using namespace winrt::Windows::UI::Xaml;
 using namespace ::Microsoft::Console;

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -46,7 +46,7 @@ public:
 
     ~Profile();
 
-    winrt::Microsoft::Terminal::Settings::TerminalSettings CreateTerminalSettings(const std::unordered_map<std::wstring, ColorScheme>& schemes) const;
+    winrt::TerminalApp::TerminalSettings CreateTerminalSettings(const std::unordered_map<std::wstring, ColorScheme>& schemes) const;
 
     Json::Value GenerateStub() const;
     static Profile FromJson(const Json::Value& json);

--- a/src/cascadia/TerminalApp/Tab.h
+++ b/src/cascadia/TerminalApp/Tab.h
@@ -46,7 +46,7 @@ namespace winrt::TerminalApp::implementation
         void ResizePane(const winrt::TerminalApp::Direction& direction);
         void NavigateFocus(const winrt::TerminalApp::Direction& direction);
 
-        void UpdateSettings(const winrt::Microsoft::Terminal::Settings::TerminalSettings& settings, const GUID& profile);
+        void UpdateSettings(const winrt::TerminalApp::TerminalSettings& settings, const GUID& profile);
         winrt::hstring GetActiveTitle() const;
 
         void Shutdown();

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -32,7 +32,6 @@ using namespace winrt::Windows::UI::Text;
 using namespace winrt::Microsoft::Terminal;
 using namespace winrt::Microsoft::Terminal::TerminalControl;
 using namespace winrt::Microsoft::Terminal::TerminalConnection;
-using namespace winrt::Microsoft::Terminal::Settings;
 using namespace ::TerminalApp;
 using namespace ::Microsoft::Console;
 
@@ -727,7 +726,7 @@ namespace winrt::TerminalApp::implementation
     // Return value:
     // - the desired connection
     TerminalConnection::ITerminalConnection TerminalPage::_CreateConnectionFromSettings(GUID profileGuid,
-                                                                                        winrt::Microsoft::Terminal::Settings::TerminalSettings settings)
+                                                                                        TerminalSettings settings)
     {
         const auto* const profile = _settings->FindProfile(profileGuid);
 
@@ -1368,7 +1367,7 @@ namespace winrt::TerminalApp::implementation
         try
         {
             auto focusedTab = _GetStrongTabImpl(*indexOpt);
-            winrt::Microsoft::Terminal::Settings::TerminalSettings controlSettings;
+            TerminalSettings controlSettings;
             GUID realGuid;
             bool profileFound = false;
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -625,7 +625,7 @@ namespace winrt::TerminalApp::implementation
     //      currently displayed, it will be shown.
     // Arguments:
     // - settings: the TerminalSettings object to use to create the TerminalControl with.
-    void TerminalPage::_CreateNewTabFromSettings(GUID profileGuid, TerminalSettings settings)
+    void TerminalPage::_CreateNewTabFromSettings(GUID profileGuid, TerminalApp::TerminalSettings settings)
     {
         // Initialize the new tab
 
@@ -726,7 +726,7 @@ namespace winrt::TerminalApp::implementation
     // Return value:
     // - the desired connection
     TerminalConnection::ITerminalConnection TerminalPage::_CreateConnectionFromSettings(GUID profileGuid,
-                                                                                        TerminalSettings settings)
+                                                                                        TerminalApp::TerminalSettings settings)
     {
         const auto* const profile = _settings->FindProfile(profileGuid);
 
@@ -1367,7 +1367,7 @@ namespace winrt::TerminalApp::implementation
         try
         {
             auto focusedTab = _GetStrongTabImpl(*indexOpt);
-            TerminalSettings controlSettings;
+            TerminalApp::TerminalSettings controlSettings;
             GUID realGuid;
             bool profileFound = false;
 

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -118,8 +118,8 @@ namespace winrt::TerminalApp::implementation
         void _CreateNewTabFlyout();
         void _OpenNewTabDropdown();
         void _OpenNewTab(const winrt::TerminalApp::NewTerminalArgs& newTerminalArgs);
-        void _CreateNewTabFromSettings(GUID profileGuid, TerminalSettings settings);
-        winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection _CreateConnectionFromSettings(GUID profileGuid, TerminalSettings settings);
+        void _CreateNewTabFromSettings(GUID profileGuid, TerminalApp::TerminalSettings settings);
+        winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection _CreateConnectionFromSettings(GUID profileGuid, TerminalApp::TerminalSettings settings);
 
         void _SettingsButtonOnClick(const IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& eventArgs);
         void _FeedbackButtonOnClick(const IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& eventArgs);

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -118,8 +118,8 @@ namespace winrt::TerminalApp::implementation
         void _CreateNewTabFlyout();
         void _OpenNewTabDropdown();
         void _OpenNewTab(const winrt::TerminalApp::NewTerminalArgs& newTerminalArgs);
-        void _CreateNewTabFromSettings(GUID profileGuid, winrt::Microsoft::Terminal::Settings::TerminalSettings settings);
-        winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection _CreateConnectionFromSettings(GUID profileGuid, winrt::Microsoft::Terminal::Settings::TerminalSettings settings);
+        void _CreateNewTabFromSettings(GUID profileGuid, TerminalSettings settings);
+        winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection _CreateConnectionFromSettings(GUID profileGuid, TerminalSettings settings);
 
         void _SettingsButtonOnClick(const IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& eventArgs);
         void _FeedbackButtonOnClick(const IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& eventArgs);

--- a/src/cascadia/TerminalApp/TerminalSettings.cpp
+++ b/src/cascadia/TerminalApp/TerminalSettings.cpp
@@ -6,7 +6,7 @@
 
 #include "TerminalSettings.g.cpp"
 
-namespace winrt::Microsoft::Terminal::Settings::implementation
+namespace winrt::TerminalApp::implementation
 {
     uint32_t TerminalSettings::GetColorTableEntry(int32_t index) const noexcept
     {

--- a/src/cascadia/TerminalApp/TerminalSettings.h
+++ b/src/cascadia/TerminalApp/TerminalSettings.h
@@ -19,7 +19,7 @@ Author(s):
 #include <DefaultSettings.h>
 #include <conattrs.hpp>
 
-namespace winrt::Microsoft::Terminal::Settings::implementation
+namespace winrt::TerminalApp::implementation
 {
     struct TerminalSettings : TerminalSettingsT<TerminalSettings>
     {
@@ -49,7 +49,7 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         GETSET_PROPERTY(bool, SnapOnInput, true);
         GETSET_PROPERTY(bool, AltGrAliasing, true);
         GETSET_PROPERTY(uint32_t, CursorColor, DEFAULT_CURSOR_COLOR);
-        GETSET_PROPERTY(CursorStyle, CursorShape, CursorStyle::Vintage);
+        GETSET_PROPERTY(Microsoft::Terminal::Settings::CursorStyle, CursorShape, Microsoft::Terminal::Settings::CursorStyle::Vintage);
         GETSET_PROPERTY(uint32_t, CursorHeight, DEFAULT_CURSOR_HEIGHT);
         GETSET_PROPERTY(hstring, WordDelimiters, DEFAULT_WORD_DELIMITERS);
         GETSET_PROPERTY(bool, CopyOnSelect, false);
@@ -78,7 +78,7 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
                         BackgroundImageVerticalAlignment,
                         winrt::Windows::UI::Xaml::VerticalAlignment::Center);
 
-        GETSET_PROPERTY(IKeyBindings, KeyBindings, nullptr);
+        GETSET_PROPERTY(Microsoft::Terminal::Settings::IKeyBindings, KeyBindings, nullptr);
 
         GETSET_PROPERTY(hstring, Commandline);
         GETSET_PROPERTY(hstring, StartingDirectory);
@@ -86,9 +86,9 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
         GETSET_PROPERTY(bool, SuppressApplicationTitle);
         GETSET_PROPERTY(hstring, EnvironmentVariables);
 
-        GETSET_PROPERTY(ScrollbarState, ScrollState, ScrollbarState::Visible);
+        GETSET_PROPERTY(Microsoft::Terminal::Settings::ScrollbarState, ScrollState, Microsoft::Terminal::Settings::ScrollbarState::Visible);
 
-        GETSET_PROPERTY(TextAntialiasingMode, AntialiasingMode, TextAntialiasingMode::Grayscale);
+        GETSET_PROPERTY(Microsoft::Terminal::Settings::TextAntialiasingMode, AntialiasingMode, Microsoft::Terminal::Settings::TextAntialiasingMode::Grayscale);
 
         GETSET_PROPERTY(bool, RetroTerminalEffect, false);
         GETSET_PROPERTY(bool, ForceFullRepaintRendering, false);
@@ -102,7 +102,7 @@ namespace winrt::Microsoft::Terminal::Settings::implementation
     };
 }
 
-namespace winrt::Microsoft::Terminal::Settings::factory_implementation
+namespace winrt::TerminalApp::factory_implementation
 {
     BASIC_FACTORY(TerminalSettings);
 }

--- a/src/cascadia/TerminalApp/TerminalSettings.idl
+++ b/src/cascadia/TerminalApp/TerminalSettings.idl
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import "ICoreSettings.idl";
-import "IControlSettings.idl";
-
-namespace Microsoft.Terminal.Settings
+namespace TerminalApp
 {
     // Class Description:
     // TerminalSettings encapsulates all settings that control the
@@ -15,8 +12,8 @@ namespace Microsoft.Terminal.Settings
     // The TerminalControl will pull settings it requires from this object,
     //      and pass along the Core properties to the terminal core.
     [default_interface]
-    runtimeclass TerminalSettings : ICoreSettings,
-                                    IControlSettings
+    runtimeclass TerminalSettings : Microsoft.Terminal.Settings.ICoreSettings,
+                                    Microsoft.Terminal.Settings.IControlSettings
     {
         TerminalSettings();
     };

--- a/src/cascadia/TerminalApp/lib/TerminalAppLib.vcxproj
+++ b/src/cascadia/TerminalApp/lib/TerminalAppLib.vcxproj
@@ -117,7 +117,7 @@
     <ClInclude Include="../AzureCloudShellGenerator.h" />
     <ClInclude Include="../TelnetGenerator.h" />
     <ClInclude Include="../ColorHelper.h" />
-    <ClInclude Include="..\TerminalSettings.h">
+    <ClInclude Include="../TerminalSettings.h">
       <DependentUpon>../TerminalSettings.idl</DependentUpon>
     </ClInclude>
     <ClInclude Include="pch.h" />
@@ -189,7 +189,7 @@
     <ClCompile Include="../Pane.LayoutSizeNode.cpp" />
     <ClCompile Include="../ColorHelper.cpp" />
     <ClCompile Include="../DebugTapConnection.cpp" />
-    <ClCompile Include="..\TerminalSettings.cpp">
+    <ClCompile Include="../TerminalSettings.cpp">
       <DependentUpon>../TerminalSettings.idl</DependentUpon>
     </ClCompile>
     <ClCompile Include="pch.cpp">
@@ -262,7 +262,7 @@
     <Midl Include="../Command.idl" />
     <Midl Include="../CommandKeyChordVisibilityConverter.idl" />
     <Midl Include="../Tab.idl" />
-    <Midl Include="..\TerminalSettings.idl" />
+    <Midl Include="../TerminalSettings.idl" />
   </ItemGroup>
   <!-- ========================= Misc Files ======================== -->
   <ItemGroup>

--- a/src/cascadia/TerminalApp/lib/TerminalAppLib.vcxproj
+++ b/src/cascadia/TerminalApp/lib/TerminalAppLib.vcxproj
@@ -117,6 +117,9 @@
     <ClInclude Include="../AzureCloudShellGenerator.h" />
     <ClInclude Include="../TelnetGenerator.h" />
     <ClInclude Include="../ColorHelper.h" />
+    <ClInclude Include="..\TerminalSettings.h">
+      <DependentUpon>../TerminalSettings.idl</DependentUpon>
+    </ClInclude>
     <ClInclude Include="pch.h" />
     <ClInclude Include="../ShortcutActionDispatch.h">
       <DependentUpon>../ShortcutActionDispatch.idl</DependentUpon>
@@ -186,6 +189,9 @@
     <ClCompile Include="../Pane.LayoutSizeNode.cpp" />
     <ClCompile Include="../ColorHelper.cpp" />
     <ClCompile Include="../DebugTapConnection.cpp" />
+    <ClCompile Include="..\TerminalSettings.cpp">
+      <DependentUpon>../TerminalSettings.idl</DependentUpon>
+    </ClCompile>
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
@@ -256,6 +262,7 @@
     <Midl Include="../Command.idl" />
     <Midl Include="../CommandKeyChordVisibilityConverter.idl" />
     <Midl Include="../Tab.idl" />
+    <Midl Include="..\TerminalSettings.idl" />
   </ItemGroup>
   <!-- ========================= Misc Files ======================== -->
   <ItemGroup>

--- a/src/cascadia/TerminalApp/lib/TerminalAppLib.vcxproj.filters
+++ b/src/cascadia/TerminalApp/lib/TerminalAppLib.vcxproj.filters
@@ -59,7 +59,7 @@
     <ClCompile Include="../Commandline.cpp" />
     <ClCompile Include="../ColorHelper.cpp" />
     <ClCompile Include="../DebugTapConnection.cpp" />
-    <ClCompile Include="..\TerminalSettings.cpp">
+    <ClCompile Include="../TerminalSettings.cpp">
       <Filter>settings</Filter>
     </ClCompile>
   </ItemGroup>
@@ -119,7 +119,7 @@
     <ClInclude Include="../TelnetGenerator.h">
       <Filter>profileGeneration</Filter>
     </ClInclude>
-    <ClInclude Include="..\TerminalSettings.h">
+    <ClInclude Include="../TerminalSettings.h">
       <Filter>settings</Filter>
     </ClInclude>
   </ItemGroup>
@@ -144,7 +144,7 @@
     </Midl>
     <Midl Include="../IDirectKeyListener.idl" />
     <Midl Include="../CommandKeyChordVisibilityConverter.idl" />
-    <Midl Include="..\TerminalSettings.idl">
+    <Midl Include="../TerminalSettings.idl">
       <Filter>settings</Filter>
     </Midl>
   </ItemGroup>

--- a/src/cascadia/TerminalApp/lib/TerminalAppLib.vcxproj.filters
+++ b/src/cascadia/TerminalApp/lib/TerminalAppLib.vcxproj.filters
@@ -59,7 +59,7 @@
     <ClCompile Include="../Commandline.cpp" />
     <ClCompile Include="../ColorHelper.cpp" />
     <ClCompile Include="../DebugTapConnection.cpp" />
-    <ClCompile Include="../CommandSerialization.cpp">
+    <ClCompile Include="..\TerminalSettings.cpp">
       <Filter>settings</Filter>
     </ClCompile>
   </ItemGroup>
@@ -119,7 +119,7 @@
     <ClInclude Include="../TelnetGenerator.h">
       <Filter>profileGeneration</Filter>
     </ClInclude>
-    <ClInclude Include="../CommandSerialization.h">
+    <ClInclude Include="..\TerminalSettings.h">
       <Filter>settings</Filter>
     </ClInclude>
   </ItemGroup>
@@ -139,9 +139,13 @@
     <Midl Include="../Tab.idl">
       <Filter>tab</Filter>
     </Midl>
-    <Midl Include="../IF7Listener.idl" />
     <Midl Include="../Command.idl">
       <Filter>commandPalette</Filter>
+    </Midl>
+    <Midl Include="../IDirectKeyListener.idl" />
+    <Midl Include="../CommandKeyChordVisibilityConverter.idl" />
+    <Midl Include="..\TerminalSettings.idl">
+      <Filter>settings</Filter>
     </Midl>
   </ItemGroup>
   <ItemGroup>

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -56,11 +56,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         return initialized;
     }
 
-    TermControl::TermControl() :
-        TermControl(Settings::IControlSettings{ nullptr }, TerminalConnection::ITerminalConnection{ nullptr })
-    {
-    }
-
     TermControl::TermControl(Settings::IControlSettings settings, TerminalConnection::ITerminalConnection connection) :
         _connection{ connection },
         _initializedTerminal{ false },

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -57,7 +57,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     }
 
     TermControl::TermControl() :
-        TermControl(Settings::TerminalSettings{}, TerminalConnection::ITerminalConnection{ nullptr })
+        TermControl(Settings::IControlSettings{ nullptr }, TerminalConnection::ITerminalConnection{ nullptr })
     {
     }
 

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -56,7 +56,6 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
     struct TermControl : TermControlT<TermControl>
     {
-        TermControl();
         TermControl(Settings::IControlSettings settings, TerminalConnection::ITerminalConnection connection);
 
         winrt::fire_and_forget UpdateSettings(Settings::IControlSettings newSettings);

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -32,7 +32,6 @@ namespace Microsoft.Terminal.TerminalControl
 
     [default_interface] runtimeclass TermControl : Windows.UI.Xaml.Controls.UserControl, IDirectKeyListener, IMouseWheelListener
     {
-        TermControl();
         TermControl(Microsoft.Terminal.Settings.IControlSettings settings, Microsoft.Terminal.TerminalConnection.ITerminalConnection connection);
 
         static Windows.Foundation.Size GetProposedDimensions(Microsoft.Terminal.Settings.IControlSettings settings, UInt32 dpi);

--- a/src/cascadia/TerminalSettings/TerminalSettings.vcxproj
+++ b/src/cascadia/TerminalSettings/TerminalSettings.vcxproj
@@ -17,17 +17,12 @@
      -->
     <NoOutputRedirection>true</NoOutputRedirection>
   </PropertyGroup>
-
   <Import Project="..\..\..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.pre.props" />
-
   <ItemGroup>
     <ClInclude Include="pch.h" />
     <ClInclude Include="KeyChord.h">
       <DependentUpon>KeyChord.idl</DependentUpon>
-    </ClInclude>
-    <ClInclude Include="TerminalSettings.h">
-      <DependentUpon>TerminalSettings.idl</DependentUpon>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -37,13 +32,9 @@
     <ClCompile Include="KeyChord.cpp">
       <DependentUpon>KeyChord.idl</DependentUpon>
     </ClCompile>
-    <ClCompile Include="TerminalSettings.cpp">
-      <DependentUpon>TerminalSettings.idl</DependentUpon>
-    </ClCompile>
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <Midl Include="TerminalSettings.idl" />
     <Midl Include="ICoreSettings.idl" />
     <Midl Include="IControlSettings.idl" />
     <Midl Include="KeyChord.idl" />
@@ -53,6 +44,5 @@
     <None Include="packages.config" />
     <None Include="TerminalSettings.def" />
   </ItemGroup>
-
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.post.props" />
 </Project>


### PR DESCRIPTION
Move TerminalSettings object from TerminalSettings project
(Microsoft.Terminal.Settings) to TerminalApp project. `TerminalSettings`
specifically operates as a bridge that exposes any necessary information
to a TerminalControl.

Closes #7139 
Related Epic: #885
Related Spec: #6904

## PR Checklist
* [X] Closes #7139 
* [X] CLA signed
* [X] Tests ~added~/passed (no additional tests necessary)
* [X] ~Documentation updated~
* [X] ~Schema updated~

## Validation Steps Performed
Deployed Windows Terminal and opened a few new tabs.