### PR TITLE
Research how many characters users are typing before dismissing the cmdpal

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -187,15 +187,16 @@ namespace winrt::TerminalApp::implementation
         {
             const auto actionAndArgs = command.Action();
             _dispatch.DoAction(actionAndArgs);
-            _close();
 
             TraceLoggingWrite(
                 g_hTerminalAppProvider, // handle to TerminalApp tracelogging provider
                 "CommandPaletteDispatchedAction",
                 TraceLoggingDescription("Event emitted when the user selects an action in the Command Palette"),
-                TraceLoggingUInt32(_searchBox().Text().size(), "Number of characters in the search string"),
+                TraceLoggingUInt32(_searchBox().Text().size(), "SearchTextLength", "Number of characters in the search string"),
                 TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
                 TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
+
+            _close();
         }
     }
 


### PR DESCRIPTION
Add some user research to determine what the average number of characters a user types before executing a cmdpal action.

This might need to be modified when it merges with #6732 