### PR TITLE
Disable MinimalCoreWin when OpenConsoleUniversalApp is false

### DIFF
--- a/src/cppwinrt.build.pre.props
+++ b/src/cppwinrt.build.pre.props
@@ -29,7 +29,7 @@
     <ApplicationType>Windows Store</ApplicationType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(OpenConsoleUniversalApp)'!='true'">
-	  <!-- Some of our projects include the cppwinrt build options to
+    <!-- Some of our projects include the cppwinrt build options to
          just build cppwinrt things, but don't want the store bits
          in full swing. MinimalCoreWin != false means "don't let me
          use win32 APIs"

--- a/src/cppwinrt.build.pre.props
+++ b/src/cppwinrt.build.pre.props
@@ -22,11 +22,19 @@
        at the winmd we build to generate type info.
        In general, cppwinrt projects all want this.
   -->
-  <PropertyGroup Condition="'$(OpenConsoleUniversalApp)'!='false'">
+  <PropertyGroup Condition="'$(OpenConsoleUniversalApp)'=='true'">
     <MinimalCoreWin>true</MinimalCoreWin>
     <AppContainerApplication>true</AppContainerApplication>
     <WindowsStoreApp>true</WindowsStoreApp>
     <ApplicationType>Windows Store</ApplicationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OpenConsoleUniversalApp)'!='true'">
+	  <!-- Some of our projects include the cppwinrt build options to
+         just build cppwinrt things, but don't want the store bits
+         in full swing. MinimalCoreWin != false means "don't let me
+         use win32 APIs"
+    -->
+    <MinimalCoreWin>false</MinimalCoreWin>
   </PropertyGroup>
 
   <!-- This is magic that tells msbuild to link against the Desktop platform


### PR DESCRIPTION
This fixes the build the rest of the way in VS 16.7. Something about the
way we were using the Store/Container flags caused some of our projects
to end up linking kernel32.lib only (MinimalCoreWin==KernelOnly).
The best way to solve it once and for all is to make sure MinimalCoreWin
is always set.

References 313568d0e5c.