### PR TITLE
Allow profile.padding to be an int (or any other type :|)

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -735,8 +735,15 @@
         "padding": {
           "default": "8, 8, 8, 8",
           "description": "Sets the padding around the text within the window. Can have three different formats:\n -\"#\" sets the same padding for all sides \n -\"#, #\" sets the same padding for left-right and top-bottom\n -\"#, #, #, #\" sets the padding individually for left, top, right, and bottom.",
-          "pattern": "^-?[0-9]+(\\.[0-9]+)?( *, *-?[0-9]+(\\.[0-9]+)?|( *, *-?[0-9]+(\\.[0-9]+)?){3})?$",
-          "type": "string"
+          "oneOf": [
+            {
+              "pattern": "^-?[0-9]+(\\.[0-9]+)?( *, *-?[0-9]+(\\.[0-9]+)?|( *, *-?[0-9]+(\\.[0-9]+)?){3})?$",
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ]
         },
         "scrollbarState": {
           "default": "visible",

--- a/src/cascadia/TerminalApp/JsonUtils.h
+++ b/src/cascadia/TerminalApp/JsonUtils.h
@@ -360,6 +360,25 @@ namespace TerminalApp::JsonUtils
         }
     };
 
+    template<typename T>
+    struct PermissiveStringConverter
+    {
+    };
+
+    template<>
+    struct PermissiveStringConverter<std::wstring>
+    {
+        std::wstring FromJson(const Json::Value& json)
+        {
+            return til::u8u16(json.asString());
+        }
+
+        bool CanConvert(const Json::Value& /*unused*/)
+        {
+            return true;
+        }
+    };
+
     // Method Description:
     // - Helper that will populate a reference with a value converted from a json object.
     // Arguments:

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -402,7 +402,11 @@ void Profile::LayerJson(const Json::Value& json)
     JsonUtils::GetValueForKey(json, UseAcrylicKey, _useAcrylic);
     JsonUtils::GetValueForKey(json, SuppressApplicationTitleKey, _suppressApplicationTitle);
     JsonUtils::GetValueForKey(json, CloseOnExitKey, _closeOnExitMode);
-    JsonUtils::GetValueForKey(json, PaddingKey, _padding);
+
+    // Padding was never specified as an integer, but it was a common working mistake.
+    // Allow it to be permissive.
+    JsonUtils::GetValueForKey(json, PaddingKey, _padding, JsonUtils::PermissiveStringConverter<std::wstring>{});
+
     JsonUtils::GetValueForKey(json, ScrollbarStateKey, _scrollbarState);
     JsonUtils::GetValueForKey(json, StartingDirectoryKey, _startingDirectory);
     JsonUtils::GetValueForKey(json, IconKey, _icon);


### PR DESCRIPTION
## Summary of the Pull Request

We're expecting that people have treated `padding` as an integer, and the type-based converter is too strict for that. This PR widens its scope and explicitly allows for it in the schema.

## PR Checklist
* [x] Closes #7234