### PR TITLE
Resolve the default profile during defaults load, don't crash on launch

### DIFF
--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -225,9 +225,12 @@ void CascadiaSettings::_ValidateProfilesHaveGuid()
 void CascadiaSettings::_ResolveDefaultProfile()
 {
     const auto unparsedDefaultProfile{ GlobalSettings().UnparsedDefaultProfile() };
-    auto maybeParsedDefaultProfile{ _GetProfileGuidByName(unparsedDefaultProfile) };
-    auto defaultProfileGuid{ til::coalesce_value(maybeParsedDefaultProfile, GUID{}) };
-    GlobalSettings().DefaultProfile(defaultProfileGuid);
+    if (unparsedDefaultProfile)
+    {
+        auto maybeParsedDefaultProfile{ _GetProfileGuidByName(*unparsedDefaultProfile) };
+        auto defaultProfileGuid{ til::coalesce_value(maybeParsedDefaultProfile, GUID{}) };
+        GlobalSettings().DefaultProfile(defaultProfileGuid);
+    }
 }
 
 // Method Description:

--- a/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
@@ -61,7 +61,7 @@ std::unique_ptr<CascadiaSettings> CascadiaSettings::LoadAll()
     // GH 3588, we need this below to know if the user chose something that wasn't our default.
     // Collect it up here in case it gets modified by any of the other layers between now and when
     // the user's preferences are loaded and layered.
-    const auto hardcodedDefaultGuid = resultPtr->GlobalSettings().UnparsedDefaultProfile();
+    const auto hardcodedDefaultGuid = resultPtr->GlobalSettings().DefaultProfile();
 
     std::optional<std::string> fileData = _ReadUserSettings();
     const bool foundFile = fileData.has_value();
@@ -141,12 +141,11 @@ std::unique_ptr<CascadiaSettings> CascadiaSettings::LoadAll()
     // is a lot of computation we can skip if no one cares.
     if (TraceLoggingProviderEnabled(g_hTerminalAppProvider, 0, MICROSOFT_KEYWORD_MEASURES))
     {
-        const auto hardcodedDefaultGuidAsGuid = Utils::GuidFromString(hardcodedDefaultGuid);
         const auto guid = resultPtr->GlobalSettings().DefaultProfile();
 
         // Compare to the defaults.json one that we set on install.
         // If it's different, log what the user chose.
-        if (hardcodedDefaultGuidAsGuid != guid)
+        if (hardcodedDefaultGuid != guid)
         {
             TraceLoggingWrite(
                 g_hTerminalAppProvider, // handle to TerminalApp tracelogging provider
@@ -229,6 +228,7 @@ std::unique_ptr<CascadiaSettings> CascadiaSettings::LoadDefaults()
     // them from a file (and the potential that could fail)
     resultPtr->_ParseJsonString(DefaultJson, true);
     resultPtr->LayerJson(resultPtr->_defaultSettings);
+    resultPtr->_ResolveDefaultProfile();
 
     return resultPtr;
 }

--- a/src/cascadia/TerminalApp/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.cpp
@@ -89,9 +89,9 @@ GUID GlobalAppSettings::DefaultProfile() const
     return _defaultProfile;
 }
 
-std::wstring GlobalAppSettings::UnparsedDefaultProfile() const
+std::optional<std::wstring> GlobalAppSettings::UnparsedDefaultProfile() const
 {
-    return _unparsedDefaultProfile.value();
+    return _unparsedDefaultProfile;
 }
 
 AppKeyBindings GlobalAppSettings::GetKeybindings() const noexcept

--- a/src/cascadia/TerminalApp/GlobalAppSettings.h
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.h
@@ -56,7 +56,7 @@ public:
     // by higher layers in the app.
     void DefaultProfile(const GUID defaultProfile) noexcept;
     GUID DefaultProfile() const;
-    std::wstring UnparsedDefaultProfile() const;
+    std::optional<std::wstring> UnparsedDefaultProfile() const;
 
     GETSET_PROPERTY(int32_t, InitialRows); // default value set in constructor
     GETSET_PROPERTY(int32_t, InitialCols); // default value set in constructor


### PR DESCRIPTION
The "default profile as name" feature in 1.1 broke the loading of
default settings, as we would never get to the validation phase where
the default profile string was transformed into a guid.

I moved knowledge of the "unparsed default profile" optional to the
consumer so that we could make sure we only attempted to deserialize it
once (and only if it was present.)

Fixes #7236.

## PR Checklist
* [x] Closes #7236