### PR TITLE
Display meaningful errors when JSON types don't match

### DIFF
--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -632,9 +632,9 @@ namespace winrt::TerminalApp::implementation
             hr = E_INVALIDARG;
             _settingsLoadExceptionText = _GetErrorText(ex.Error());
         }
-        catch (const std::exception& e)
+        catch (const ::TerminalApp::SettingsTypedDeserializationException& e)
         {
-            hr = E_UNEXPECTED;
+            hr = E_INVALIDARG;
             std::string_view what{ e.what() };
             _settingsLoadExceptionText = til::u8u16(what);
         }

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -632,6 +632,12 @@ namespace winrt::TerminalApp::implementation
             hr = E_INVALIDARG;
             _settingsLoadExceptionText = _GetErrorText(ex.Error());
         }
+        catch (const std::exception& e)
+        {
+            hr = E_UNEXPECTED;
+            std::string_view what{ e.what() };
+            _settingsLoadExceptionText = til::u8u16(what);
+        }
         catch (...)
         {
             hr = wil::ResultFromCaughtException();

--- a/src/cascadia/TerminalApp/CascadiaSettings.h
+++ b/src/cascadia/TerminalApp/CascadiaSettings.h
@@ -39,7 +39,15 @@ namespace TerminalAppUnitTests
 
 namespace TerminalApp
 {
+    class SettingsTypedDeserializationException;
     class CascadiaSettings;
+};
+
+class TerminalApp::SettingsTypedDeserializationException final : public std::runtime_error
+{
+public:
+    SettingsTypedDeserializationException(const std::string_view description) :
+        runtime_error(description.data()) {}
 };
 
 class TerminalApp::CascadiaSettings final

--- a/src/cascadia/TerminalApp/JsonUtils.h
+++ b/src/cascadia/TerminalApp/JsonUtils.h
@@ -73,7 +73,8 @@ namespace TerminalApp::JsonUtils
     {
     public:
         DeserializationError(const Json::Value& value) :
-            runtime_error("failed to deserialize"), jsonValue{ value } {}
+            runtime_error("failed to deserialize"),
+            jsonValue{ value } {}
 
         void SetKey(std::string_view newKey)
         {

--- a/src/cascadia/TerminalApp/JsonUtils.h
+++ b/src/cascadia/TerminalApp/JsonUtils.h
@@ -96,7 +96,7 @@ namespace TerminalApp::JsonUtils
         T FromJson(const Json::Value&);
         bool CanConvert(const Json::Value& json);
 
-        std::string TypeName() const { return "<unknown>"; }
+        std::string TypeDescription() const { return "<unknown>"; }
     };
 
     template<>
@@ -112,7 +112,7 @@ namespace TerminalApp::JsonUtils
             return json.isString();
         }
 
-        std::string TypeName() const
+        std::string TypeDescription() const
         {
             return "string";
         }
@@ -131,7 +131,7 @@ namespace TerminalApp::JsonUtils
             return json.isString();
         }
 
-        std::string TypeName() const
+        std::string TypeDescription() const
         {
             return "string";
         }
@@ -162,7 +162,7 @@ namespace TerminalApp::JsonUtils
             return json.isBool();
         }
 
-        std::string TypeName() const
+        std::string TypeDescription() const
         {
             return "true | false";
         }
@@ -181,7 +181,7 @@ namespace TerminalApp::JsonUtils
             return json.isInt();
         }
 
-        std::string TypeName() const
+        std::string TypeDescription() const
         {
             return "number";
         }
@@ -200,7 +200,7 @@ namespace TerminalApp::JsonUtils
             return json.isUInt();
         }
 
-        std::string TypeName() const
+        std::string TypeDescription() const
         {
             return "number (>= 0)";
         }
@@ -219,7 +219,7 @@ namespace TerminalApp::JsonUtils
             return json.isNumeric();
         }
 
-        std::string TypeName() const
+        std::string TypeDescription() const
         {
             return "number";
         }
@@ -238,7 +238,7 @@ namespace TerminalApp::JsonUtils
             return json.isNumeric();
         }
 
-        std::string TypeName() const
+        std::string TypeDescription() const
         {
             return "number";
         }
@@ -263,7 +263,7 @@ namespace TerminalApp::JsonUtils
             return string.length() == 38 && string.front() == '{' && string.back() == '}';
         }
 
-        std::string TypeName() const
+        std::string TypeDescription() const
         {
             return "guid";
         }
@@ -294,7 +294,7 @@ namespace TerminalApp::JsonUtils
             return (string.length() == 7 || string.length() == 4) && string.front() == '#';
         }
 
-        std::string TypeName() const
+        std::string TypeDescription() const
         {
             return "color (#rrggbb, #rgb)";
         }
@@ -318,7 +318,7 @@ namespace TerminalApp::JsonUtils
             }
 
             DeserializationError e{ json };
-            e.expectedType = TypeName();
+            e.expectedType = TypeDescription();
             throw e;
         }
 
@@ -327,7 +327,7 @@ namespace TerminalApp::JsonUtils
             return json.isString();
         }
 
-        std::string TypeName() const
+        std::string TypeDescription() const
         {
             std::vector<std::string_view> names;
             std::transform(TBase::mappings.cbegin(), TBase::mappings.cend(), std::back_inserter(names), [](auto&& p) { return p.first; });
@@ -372,7 +372,7 @@ namespace TerminalApp::JsonUtils
                     {
                         // attempt to combine AllClear (explicitly) with anything else
                         DeserializationError e{ element };
-                        e.expectedType = TypeName();
+                        e.expectedType = TypeDescription();
                         throw e;
                     }
                     value |= newFlag;
@@ -408,7 +408,7 @@ namespace TerminalApp::JsonUtils
             return true;
         }
 
-        std::string TypeName() const
+        std::string TypeDescription() const
         {
             return "any";
         }
@@ -443,7 +443,7 @@ namespace TerminalApp::JsonUtils
             if (!conv.CanConvert(json))
             {
                 DeserializationError e{ json };
-                e.expectedType = conv.TypeName();
+                e.expectedType = conv.TypeDescription();
                 throw e;
             }
 

--- a/src/cascadia/TerminalApp/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalApp/TerminalSettingsSerializationHelpers.h
@@ -102,7 +102,7 @@ JSON_ENUM_MAPPER(::TerminalApp::CloseOnExitMode)
         return EnumMapper::CanConvert(json) || json.isBool();
     }
 
-    using EnumMapper::TypeName;
+    using EnumMapper::TypeDescription;
 };
 
 // This specialization isn't using JSON_ENUM_MAPPER because we need to have a different
@@ -154,7 +154,7 @@ struct ::TerminalApp::JsonUtils::ConversionTrait<::winrt::Windows::UI::Text::Fon
         return BaseEnumMapper::CanConvert(json) || json.isUInt();
     }
 
-    using EnumMapper::TypeName;
+    using EnumMapper::TypeDescription;
 };
 
 JSON_ENUM_MAPPER(::winrt::Windows::UI::Xaml::ElementTheme)
@@ -236,7 +236,7 @@ struct ::TerminalApp::JsonUtils::ConversionTrait<::TerminalApp::LaunchPosition>
         return json.isString();
     }
 
-    std::string TypeName() const
+    std::string TypeDescription() const
     {
         return "x, y";
     }

--- a/src/cascadia/TerminalApp/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalApp/TerminalSettingsSerializationHelpers.h
@@ -101,6 +101,8 @@ JSON_ENUM_MAPPER(::TerminalApp::CloseOnExitMode)
     {
         return EnumMapper::CanConvert(json) || json.isBool();
     }
+
+    using EnumMapper::TypeName;
 };
 
 // This specialization isn't using JSON_ENUM_MAPPER because we need to have a different
@@ -151,6 +153,8 @@ struct ::TerminalApp::JsonUtils::ConversionTrait<::winrt::Windows::UI::Text::Fon
     {
         return BaseEnumMapper::CanConvert(json) || json.isUInt();
     }
+
+    using EnumMapper::TypeName;
 };
 
 JSON_ENUM_MAPPER(::winrt::Windows::UI::Xaml::ElementTheme)
@@ -230,6 +234,11 @@ struct ::TerminalApp::JsonUtils::ConversionTrait<::TerminalApp::LaunchPosition>
     bool CanConvert(const Json::Value& json)
     {
         return json.isString();
+    }
+
+    std::string TypeName() const
+    {
+        return "x, y";
     }
 };
 

--- a/src/cascadia/ut_app/JsonUtilsTests.cpp
+++ b/src/cascadia/ut_app/JsonUtilsTests.cpp
@@ -33,6 +33,8 @@ struct ConversionTrait<StructWithConverterSpecialization>
     {
         return value.isInt();
     }
+
+    std::string TypeName() const { return ""; }
 };
 
 // Converts a JSON string value to an int and multiplies it by a specified factor
@@ -49,6 +51,8 @@ struct CustomConverter
     {
         return true;
     }
+
+    std::string TypeName() const { return ""; }
 };
 
 enum class JsonTestEnum : int
@@ -130,7 +134,7 @@ namespace TerminalAppUnitTests
 
         //// 1. Bare Value ////
         //// 1.a. Type Invalid - Exception ////
-        VERIFY_THROWS_SPECIFIC(GetValue<int>(object), TypeMismatchException, _ReturnTrueForException);
+        VERIFY_THROWS_SPECIFIC(GetValue<int>(object), DeserializationError, _ReturnTrueForException);
 
         //// 1.b. JSON NULL - Zero Value ////
         std::string zeroValueString{};
@@ -141,7 +145,7 @@ namespace TerminalAppUnitTests
 
         //// 2. Optional ////
         //// 2.a. Type Invalid - Exception ////
-        VERIFY_THROWS_SPECIFIC(GetValue<std::optional<int>>(object), TypeMismatchException, _ReturnTrueForException);
+        VERIFY_THROWS_SPECIFIC(GetValue<std::optional<int>>(object), DeserializationError, _ReturnTrueForException);
 
         //// 2.b. JSON NULL - nullopt ////
         VERIFY_ARE_EQUAL(std::nullopt, GetValue<std::optional<std::string>>(Json::Value::nullSingleton()));
@@ -160,7 +164,7 @@ namespace TerminalAppUnitTests
         std::string output{ "sentinel" }; // explicitly not the zero value
 
         //// 1.a. Type Invalid - Exception ////
-        VERIFY_THROWS_SPECIFIC(GetValue(object, outputRedHerring), TypeMismatchException, _ReturnTrueForException);
+        VERIFY_THROWS_SPECIFIC(GetValue(object, outputRedHerring), DeserializationError, _ReturnTrueForException);
         VERIFY_ARE_EQUAL(5, outputRedHerring); // unchanged
 
         //// 1.b. JSON NULL - Unchanged ////
@@ -176,7 +180,7 @@ namespace TerminalAppUnitTests
         std::optional<std::string> optionalOutput{ "sentinel2" }; // explicitly not nullopt
 
         //// 2.a. Type Invalid - Exception ////
-        VERIFY_THROWS_SPECIFIC(GetValue(object, optionalOutputRedHerring), TypeMismatchException, _ReturnTrueForException);
+        VERIFY_THROWS_SPECIFIC(GetValue(object, optionalOutputRedHerring), DeserializationError, _ReturnTrueForException);
         VERIFY_ARE_EQUAL(6, optionalOutputRedHerring); // unchanged
 
         //// 2.b. JSON NULL - nullopt ////
@@ -202,7 +206,7 @@ namespace TerminalAppUnitTests
 
         //// 1. Bare Value ////
         //// 1.a. Type Invalid - Exception ////
-        VERIFY_THROWS_SPECIFIC(GetValueForKey<int>(object, key), KeyedException, _ReturnTrueForException);
+        VERIFY_THROWS_SPECIFIC(GetValueForKey<int>(object, key), DeserializationError, _ReturnTrueForException);
 
         //// 1.b. JSON NULL - Zero Value ////
         std::string zeroValueString{};
@@ -216,7 +220,7 @@ namespace TerminalAppUnitTests
 
         //// 2. Optional ////
         //// 2.a. Type Invalid - Exception ////
-        VERIFY_THROWS_SPECIFIC(GetValueForKey<std::optional<int>>(object, key), KeyedException, _ReturnTrueForException);
+        VERIFY_THROWS_SPECIFIC(GetValueForKey<std::optional<int>>(object, key), DeserializationError, _ReturnTrueForException);
 
         //// 2.b. JSON NULL - nullopt ////
         VERIFY_ARE_EQUAL(std::nullopt, GetValueForKey<std::optional<std::string>>(object, nullKey));
@@ -245,7 +249,7 @@ namespace TerminalAppUnitTests
         std::string output{ "sentinel" }; // explicitly not the zero value
 
         //// 1.a. Type Invalid - Exception ////
-        VERIFY_THROWS_SPECIFIC(GetValueForKey(object, key, outputRedHerring), KeyedException, _ReturnTrueForException);
+        VERIFY_THROWS_SPECIFIC(GetValueForKey(object, key, outputRedHerring), DeserializationError, _ReturnTrueForException);
         VERIFY_ARE_EQUAL(5, outputRedHerring); // unchanged
 
         //// 1.b. JSON NULL - Unchanged ////
@@ -267,7 +271,7 @@ namespace TerminalAppUnitTests
         std::optional<std::string> optionalOutput{ "sentinel2" }; // explicitly not nullopt
 
         //// 2.a. Type Invalid - Exception ////
-        VERIFY_THROWS_SPECIFIC(GetValueForKey(object, key, optionalOutputRedHerring), KeyedException, _ReturnTrueForException);
+        VERIFY_THROWS_SPECIFIC(GetValueForKey(object, key, optionalOutputRedHerring), DeserializationError, _ReturnTrueForException);
         VERIFY_ARE_EQUAL(6, optionalOutputRedHerring); // unchanged
 
         //// 2.b. JSON NULL - nullopt ////
@@ -321,12 +325,12 @@ namespace TerminalAppUnitTests
 
         TryBasicType(testGuid, testGuidString);
 
-        VERIFY_THROWS_SPECIFIC(GetValue<GUID>({ "NOT_A_GUID" }), TypeMismatchException, _ReturnTrueForException);
-        VERIFY_THROWS_SPECIFIC(GetValue<GUID>({ "{too short for a guid but just a bit}" }), TypeMismatchException, _ReturnTrueForException);
+        VERIFY_THROWS_SPECIFIC(GetValue<GUID>({ "NOT_A_GUID" }), DeserializationError, _ReturnTrueForException);
+        VERIFY_THROWS_SPECIFIC(GetValue<GUID>({ "{too short for a guid but just a bit}" }), DeserializationError, _ReturnTrueForException);
         VERIFY_THROWS_SPECIFIC(GetValue<GUID>({ "{proper length string not a guid tho?}" }), std::exception, _ReturnTrueForException);
 
-        VERIFY_THROWS_SPECIFIC(GetValue<til::color>({ "#" }), TypeMismatchException, _ReturnTrueForException);
-        VERIFY_THROWS_SPECIFIC(GetValue<til::color>({ "#1234567890" }), TypeMismatchException, _ReturnTrueForException);
+        VERIFY_THROWS_SPECIFIC(GetValue<til::color>({ "#" }), DeserializationError, _ReturnTrueForException);
+        VERIFY_THROWS_SPECIFIC(GetValue<til::color>({ "#1234567890" }), DeserializationError, _ReturnTrueForException);
     }
 
     void JsonUtilsTests::BasicTypeWithCustomConverter()
@@ -366,7 +370,7 @@ namespace TerminalAppUnitTests
 
         // Unknown value should produce something?
         Json::Value stringUnknown{ "unknown" };
-        VERIFY_THROWS_SPECIFIC(GetValue<JsonTestEnum>(stringUnknown), UnexpectedValueException, _ReturnTrueForException);
+        VERIFY_THROWS_SPECIFIC(GetValue<JsonTestEnum>(stringUnknown), DeserializationError, _ReturnTrueForException);
     }
 
     void JsonUtilsTests::FlagMapper()
@@ -401,17 +405,17 @@ namespace TerminalAppUnitTests
         Json::Value arrayNoneFirst{ Json::arrayValue };
         arrayNoneFirst.append({ "none" });
         arrayNoneFirst.append({ "first" });
-        VERIFY_THROWS_SPECIFIC(GetValue<JsonTestFlags>(arrayNoneFirst), UnexpectedValueException, _ReturnTrueForException);
+        VERIFY_THROWS_SPECIFIC(GetValue<JsonTestFlags>(arrayNoneFirst), DeserializationError, _ReturnTrueForException);
 
         // Stacking Any + None (Exception; same as above, different order)
         Json::Value arrayFirstNone{ Json::arrayValue };
         arrayFirstNone.append({ "first" });
         arrayFirstNone.append({ "none" });
-        VERIFY_THROWS_SPECIFIC(GetValue<JsonTestFlags>(arrayFirstNone), UnexpectedValueException, _ReturnTrueForException);
+        VERIFY_THROWS_SPECIFIC(GetValue<JsonTestFlags>(arrayFirstNone), DeserializationError, _ReturnTrueForException);
 
         // Unknown flag value?
         Json::Value stringUnknown{ "unknown" };
-        VERIFY_THROWS_SPECIFIC(GetValue<JsonTestFlags>(stringUnknown), UnexpectedValueException, _ReturnTrueForException);
+        VERIFY_THROWS_SPECIFIC(GetValue<JsonTestFlags>(stringUnknown), DeserializationError, _ReturnTrueForException);
     }
 
     void JsonUtilsTests::NestedExceptionDuringKeyParse()
@@ -420,20 +424,10 @@ namespace TerminalAppUnitTests
         Json::Value object{ Json::objectValue };
         object[key] = Json::Value{ "string" };
 
-        auto CheckKeyedException = [](const KeyedException& k) {
-            try
-            {
-                k.RethrowInner();
-            }
-            catch (TypeMismatchException&)
-            {
-                // This Keyed exception contained the correct inner.
-                return true;
-            }
-            // This Keyed exception did not contain the correct inner.
-            return false;
+        auto CheckKeyInException = [](const DeserializationError& k) {
+            return k.key.has_value();
         };
-        VERIFY_THROWS_SPECIFIC(GetValueForKey<int>(object, key), KeyedException, CheckKeyedException);
+        VERIFY_THROWS_SPECIFIC(GetValueForKey<int>(object, key), DeserializationError, CheckKeyInException);
     }
 
 }

--- a/src/cascadia/ut_app/JsonUtilsTests.cpp
+++ b/src/cascadia/ut_app/JsonUtilsTests.cpp
@@ -34,7 +34,7 @@ struct ConversionTrait<StructWithConverterSpecialization>
         return value.isInt();
     }
 
-    std::string TypeName() const { return ""; }
+    std::string TypeDescription() const { return ""; }
 };
 
 // Converts a JSON string value to an int and multiplies it by a specified factor
@@ -52,7 +52,7 @@ struct CustomConverter
         return true;
     }
 
-    std::string TypeName() const { return ""; }
+    std::string TypeDescription() const { return ""; }
 };
 
 enum class JsonTestEnum : int


### PR DESCRIPTION
This pull request completes (and somewhat rewrites) the JsonUtils error
handling arc. Deserialization errors, no longer represented by trees of
exceptions that must be rethrown and caught, are now transformed at
catch time into a message explaining what we expected and where we
expected it.

Instead of exception trees, a deserialization failure will result in a
single type of exception with the originating JSON object from which we
can determine the contents and location of the failure.

Because most of the error message actually comes from the JSON schema
or the actual supported types, and the other jsoncpp errors are not
localized I've made the decision to **not** localize these messages.