### PR TITLE
Enable partial rebuilds of the TerminalControl project again

### DIFF
--- a/src/cascadia/TerminalCore/lib/terminalcore-lib.vcxproj
+++ b/src/cascadia/TerminalCore/lib/terminalcore-lib.vcxproj
@@ -8,6 +8,10 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <RootNamespace>Microsoft.Terminal.TerminalControl</RootNamespace>
+
+    <!-- sets a bunch of Windows Universal properties -->
+    <OpenConsoleUniversalApp>true</OpenConsoleUniversalApp>
+
     <!--
       DON'T REDIRECT OUR OUTPUT.
       Setting this will tell cppwinrt.build.post.props to copy our output from


### PR DESCRIPTION
This regressed around the #7163 timeframe.

We're discussing this on chat currently. It might break the intellisense
on the `#include <winrt/Microsoft.Terminal.TerminalControl.h>` line in
VS 16.7, but we're not _really_ sure? Intellisense has been notoriously
flaky for us.

I'm running 16.6.5, and it works for me. @lhecker is running 16.7 and
confirmed it worked there. If the CI build passes, then this definitely
will work for 16.7.