### PR TITLE
tools: add Get-OSSConhostLog

### DIFF
--- a/.github/actions/spell-check/expect/expect.txt
+++ b/.github/actions/spell-check/expect/expect.txt
@@ -352,6 +352,7 @@ conserv
 consoleapi
 CONSOLECONTROL
 CONSOLEENDTASK
+consolegit
 CONSOLEIME
 consoleinternal
 Consoleroot
@@ -422,6 +423,7 @@ cstdlib
 cstr
 cstring
 cstyle
+CSV
 CSwitch
 CText
 ctime
@@ -886,6 +888,7 @@ getwriter
 Gfun
 gfx
 gh
+gitfilters
 github
 gitlab
 gle
@@ -1056,6 +1059,8 @@ IInteract
 IInteractivity
 IIo
 IList
+imagemagick
+Imatch
 ime
 Imm
 IMouse
@@ -1072,7 +1077,6 @@ INITCOMMONCONTROLSEX
 INITDIALOG
 initguid
 INITMENU
-imagemagick
 inkscape
 inl
 INLINEPREFIX
@@ -1520,8 +1524,8 @@ nothrow
 NOTICKS
 NOTIMPL
 notin
-NOTOPMOST
 NOTNULL
+NOTOPMOST
 NOTRACK
 NOTSUPPORTED
 notypeopt
@@ -1610,8 +1614,8 @@ OSCBG
 OSCCT
 OSCFG
 OSCRCC
-OSCSCC
 OSCSCB
+OSCSCC
 OSCWT
 OSDEPENDSROOT
 osfhandle
@@ -2337,6 +2341,7 @@ Toolset
 tooltip
 TOPDOWNDIB
 TOPLEFT
+toplevel
 TOPRIGHT
 TOpt
 tosign

--- a/tools/Get-OSSConhostLog.ps1
+++ b/tools/Get-OSSConhostLog.ps1
@@ -1,0 +1,65 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+################################
+# This script takes a range of commits and generates
+# a commit log with the git2git-excluded file changes
+# filtered out.
+#
+# It also replaces GitHub issue numbers with GH-XXX so
+# as to not confuse Git2Git or Azure DevOps.
+# Community contributions are tagged with CC- so they
+# can be detected later.
+
+[CmdletBinding()]
+Param(
+    [string]$RevisionRange
+)
+
+Function Test-MicrosoftPerson($email) {
+    Return $email -like "*@microsoft.com"
+}
+
+# Replaces github PR numbers with GH-XXX or CC-XXX (community contribution)
+# and issue numbers with GH-XXX
+Function Mangle-CommitMessage($object) {
+    $Prefix = "GH-"
+    If (-Not (Test-MicrosoftPerson $object.Email)) {
+        $Prefix = "CC-"
+    }
+
+    $s = $object.Subject -Replace "\(#(\d+)\)", "(${Prefix}`$1)"
+    $s = $s -Replace "#(\d+)","GH-`$1"
+    $s
+}
+
+Function Get-Git2GitIgnoresAsExcludes() {
+    $filters = (Get-Content (Join-Path (& git rev-parse --show-toplevel) consolegit2gitfilters.json) | ConvertFrom-Json)
+    $excludes = $filters.ContainsFilters | ? { $_ -Ne "/." } | % { $_ -Replace "^/","" }
+    $excludes += $filters.SuffixFilters | % { "**/*$_"; "*$_" }
+    $excludes += $filters.PrefixFilters | % { "**/$_*"; "$_*" }
+    $excludes | % { ":(top,exclude)$_" }
+}
+
+$Excludes = Get-Git2GitIgnoresAsExcludes
+Write-Verbose "IGNORING: $Excludes"
+$Entries = & git log $RevisionRange "--pretty=format:%an%x1C%ae%x1C%s" -- $Excludes |
+    ConvertFrom-CSV -Delimiter "`u{001C}" -Header Author,Email,Subject
+
+Write-Verbose ("{0} unfiltered log entries" -f $Entries.Count)
+
+$Grouped = $Entries | Group Email
+$Grouped | % {
+    $e = $_.Group[0].Email
+    $p = $_.Group[0].Author
+    "$p ($($_.Group.Count))"
+    $_.Group | % {
+        If ($_.Subject -Imatch "^Merge") {
+            # Skip merge commits
+            Return
+        }
+        $cm = Mangle-CommitMessage $_
+        "* $cm"
+    }
+    ""
+}


### PR DESCRIPTION
This script takes a range of commits and generates a commit log with the
git2git-excluded file changes filtered out.

It also replaces GitHub issue numbers with GH-XXX so as to not confuse
Git2Git or Azure DevOps.  Community contributions are tagged with CC- so
they can be detected later.

The output looks like this:

```
Carlos Zamora (2)
* Pass mouse button state into HandleMouse instead of asking win32 (GH-6765)

Dustin L. Howett (6)
* Disable MinimalCoreWin when OpenConsoleUniversalApp is false (GH-7203)

James Holderness (1)
* Add support for the "doubly underlined" graphic rendition attribute (CC-7223)
```

Yes, the numbers are wrong. No, it doesn't really matter.