### PR TITLE
Default initialize a CmdPal mode

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -22,7 +22,8 @@ using namespace winrt::Windows::Foundation::Collections;
 namespace winrt::TerminalApp::implementation
 {
     CommandPalette::CommandPalette() :
-        _switcherStartIdx{ 0 }
+        _switcherStartIdx{ 0 },
+        _anchorKey{ VirtualKey::None }
     {
         InitializeComponent();
 

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -30,6 +30,12 @@ namespace winrt::TerminalApp::implementation
         _allCommands = winrt::single_threaded_vector<winrt::TerminalApp::Command>();
         _allTabActions = winrt::single_threaded_vector<winrt::TerminalApp::Command>();
 
+        // GH#7254 - default initialize a mode
+        _currentMode = CommandPaletteMode::ActionMode;
+        SearchBoxText(RS_(L"CommandPalette_SearchBox/PlaceholderText"));
+        NoMatchesText(RS_(L"CommandPalette_NoMatchesText/Text"));
+        ControlName(RS_(L"CommandPaletteControlName"));
+
         if (CommandPaletteShadow())
         {
             // Hook up the shadow on the command palette to the backdrop that

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -22,8 +22,8 @@ using namespace winrt::Windows::Foundation::Collections;
 namespace winrt::TerminalApp::implementation
 {
     CommandPalette::CommandPalette() :
-        _switcherStartIdx{ 0 },
-        _anchorKey{ VirtualKey::None }
+        _anchorKey{ VirtualKey::None },
+        _switcherStartIdx{ 0 }
     {
         InitializeComponent();
 
@@ -31,11 +31,7 @@ namespace winrt::TerminalApp::implementation
         _allCommands = winrt::single_threaded_vector<winrt::TerminalApp::Command>();
         _allTabActions = winrt::single_threaded_vector<winrt::TerminalApp::Command>();
 
-        // GH#7254 - default initialize a mode
-        _currentMode = CommandPaletteMode::ActionMode;
-        SearchBoxText(RS_(L"CommandPalette_SearchBox/PlaceholderText"));
-        NoMatchesText(RS_(L"CommandPalette_NoMatchesText/Text"));
-        ControlName(RS_(L"CommandPaletteControlName"));
+        _switchToMode(CommandPaletteMode::ActionMode);
 
         if (CommandPaletteShadow())
         {
@@ -396,23 +392,26 @@ namespace winrt::TerminalApp::implementation
             {
                 _filteredActions.Append(action);
             }
+        }
 
-            switch (_currentMode)
-            {
-            case CommandPaletteMode::TabSwitcherMode:
-            {
-                SearchBoxText(RS_(L"TabSwitcher_SearchBoxText"));
-                NoMatchesText(RS_(L"TabSwitcher_NoMatchesText"));
-                ControlName(RS_(L"TabSwitcherControlName"));
-                break;
-            }
-            case CommandPaletteMode::ActionMode:
-            default:
-                SearchBoxText(RS_(L"CommandPalette_SearchBox/PlaceholderText"));
-                NoMatchesText(RS_(L"CommandPalette_NoMatchesText/Text"));
-                ControlName(RS_(L"CommandPaletteControlName"));
-                break;
-            }
+        // Leaving this block of code outside the above if-statement
+        // guarantees that the correct text is shown for the mode
+        // whenever _switchToMode is called.
+        switch (_currentMode)
+        {
+        case CommandPaletteMode::TabSwitcherMode:
+        {
+            SearchBoxText(RS_(L"TabSwitcher_SearchBoxText"));
+            NoMatchesText(RS_(L"TabSwitcher_NoMatchesText"));
+            ControlName(RS_(L"TabSwitcherControlName"));
+            break;
+        }
+        case CommandPaletteMode::ActionMode:
+        default:
+            SearchBoxText(RS_(L"CommandPalette_SearchBox/PlaceholderText"));
+            NoMatchesText(RS_(L"CommandPalette_NoMatchesText/Text"));
+            ControlName(RS_(L"CommandPaletteControlName"));
+            break;
         }
     }
 


### PR DESCRIPTION
Whoops, members are zero initialized in Debug builds but most likely not
in Release builds So, this PR adds a couple of default values to
`_currentMode` and its associated XAML strings to make cmdpal/ats work
deterministically on first use.  I also added a default value to
`_anchorKey` just to be safe.

Closes #7254