### PR TITLE
Don't zoom when there's only one pane

### DIFF
--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -107,7 +107,9 @@ namespace winrt::TerminalApp::implementation
                                              const TerminalApp::ActionEventArgs& args)
     {
         auto activeTab = _GetFocusedTab();
-        if (activeTab)
+
+        // Don't do anything if there's only one pane. It's already zoomed.
+        if (activeTab && activeTab->GetLeafPaneCount() > 1)
         {
             // First thing's first, remove the current content from the UI
             // tree. This is important, because we might be leaving zoom, and if

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -960,7 +960,7 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     // Return Value:
     // - The total number of leaf panes hosted by this tab.
-    int Tab::_GetLeafPaneCount() const noexcept
+    int Tab::GetLeafPaneCount() const noexcept
     {
         return _rootPane->GetLeafPaneCount();
     }

--- a/src/cascadia/TerminalApp/Tab.h
+++ b/src/cascadia/TerminalApp/Tab.h
@@ -66,6 +66,8 @@ namespace winrt::TerminalApp::implementation
         void EnterZoom();
         void ExitZoom();
 
+        int GetLeafPaneCount() const noexcept;
+
         WINRT_CALLBACK(Closed, winrt::Windows::Foundation::EventHandler<winrt::Windows::Foundation::IInspectable>);
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
         DECLARE_EVENT(ActivePaneChanged, _ActivePaneChangedHandlers, winrt::delegate<>);
@@ -102,7 +104,6 @@ namespace winrt::TerminalApp::implementation
         void _AttachEventHandlersToControl(const winrt::Microsoft::Terminal::TerminalControl::TermControl& control);
         void _AttachEventHandlersToPane(std::shared_ptr<Pane> pane);
 
-        int _GetLeafPaneCount() const noexcept;
         void _UpdateActivePane(std::shared_ptr<Pane> pane);
 
         void _UpdateTabHeader();


### PR DESCRIPTION
This is a minor fix from #6989. If there's only one pane in the
Terminal, then we'd still "zoom" it and give it a border, but all the
borders would be black. 

A single pane is already "zoomed", so it doesn't really make sense to
try and zoom if there's only one. 