### PR TITLE
Remove unnecessary check when updating ATS indices

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -772,14 +772,11 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     void CommandPalette::UpdateTabIndices(const uint32_t startIdx)
     {
-        if (startIdx != _allTabActions.Size() - 1)
+        for (auto i = startIdx; i < _allTabActions.Size(); ++i)
         {
-            for (auto i = startIdx; i < _allTabActions.Size(); ++i)
-            {
-                auto command = _allTabActions.GetAt(i);
+            auto command = _allTabActions.GetAt(i);
 
-                command.Action().Args().as<implementation::SwitchToTabArgs>()->TabIndex(i);
-            }
+            command.Action().Args().as<implementation::SwitchToTabArgs>()->TabIndex(i);
         }
     }
 


### PR DESCRIPTION
Removes the if-statement in `UpdateTabIndices` that blocks all scenarios where you delete the second to last tab. This fixes the issue where the ATS gets confused about which item in the ListView is associated with which tab.

Closes #7278
