### PR TITLE
Pass the scancode in our tunneled DirectKey event

### DIFF
--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -917,7 +917,7 @@ namespace winrt::TerminalApp::implementation
     // - Implements the Alt handler (per GH#6421)
     // Return value:
     // - whether the key was handled
-    bool AppLogic::OnDirectKeyEvent(const uint32_t vkey, const bool down)
+    bool AppLogic::OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool down)
     {
         if (_root)
         {
@@ -928,7 +928,7 @@ namespace winrt::TerminalApp::implementation
             {
                 if (auto keyListener{ focusedObject.try_as<IDirectKeyListener>() })
                 {
-                    if (keyListener.OnDirectKeyEvent(vkey, down))
+                    if (keyListener.OnDirectKeyEvent(vkey, scanCode, down))
                     {
                         return true;
                     }

--- a/src/cascadia/TerminalApp/AppLogic.h
+++ b/src/cascadia/TerminalApp/AppLogic.h
@@ -48,7 +48,7 @@ namespace winrt::TerminalApp::implementation
 
         hstring Title();
         void TitlebarClicked();
-        bool OnDirectKeyEvent(const uint32_t vkey, const bool down);
+        bool OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool down);
 
         void WindowCloseButtonClicked();
 

--- a/src/cascadia/TerminalApp/IDirectKeyListener.idl
+++ b/src/cascadia/TerminalApp/IDirectKeyListener.idl
@@ -8,7 +8,7 @@ namespace TerminalApp
     // If you update this one, please update the one in TerminalControl\TermControl.idl
     // If you change this interface, please update the guid.
     // If you press F7 or Alt and get a runtime error, go make sure both copies are the same.
-    [uuid("339e1a87-5315-4da6-96f0-565549b6472b")] interface IDirectKeyListener {
-        Boolean OnDirectKeyEvent(UInt32 vkey, Boolean down);
+    [uuid("0ddf4edc-3fda-4dee-97ca-a417ee3dd510")] interface IDirectKeyListener {
+        Boolean OnDirectKeyEvent(UInt32 vkey, UInt8 scanCode, Boolean down);
     }
 }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -771,9 +771,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         {
             // Manually generate an Alt KeyUp event into the key bindings or terminal.
             //   This is required as part of GH#6421.
-            // GH#6513 - make sure to set the scancode too, otherwise conpty
-            // will think this is a NUL
-            (void)_TrySendKeyEvent(VK_MENU, LOWORD(MapVirtualKeyW(VK_MENU, MAPVK_VK_TO_VSC)), modifiers, false);
+            (void)_TrySendKeyEvent(VK_MENU, scanCode, modifiers, false);
             handled = true;
         }
         else if (vkey == VK_F7 && down)

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -763,7 +763,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     //   normally. Namely, the keys we're concerned with are F7 down and Alt up.
     // Return value:
     // - Whether the key was handled.
-    bool TermControl::OnDirectKeyEvent(const uint32_t vkey, const bool down)
+    bool TermControl::OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool down)
     {
         const auto modifiers{ _GetPressedModifierKeys() };
         auto handled = false;
@@ -795,7 +795,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             if (!handled)
             {
                 // _TrySendKeyEvent pretends it didn't handle F7 for some unknown reason.
-                (void)_TrySendKeyEvent(VK_F7, 0, modifiers, true);
+                (void)_TrySendKeyEvent(VK_F7, scanCode, modifiers, true);
                 // GH#6438: Note that we're _not_ sending the key up here - that'll
                 // get passed through XAML to our KeyUp handler normally.
                 handled = true;

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -91,7 +91,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         void CreateSearchBoxControl();
 
-        bool OnDirectKeyEvent(const uint32_t vkey, const bool down);
+        bool OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool down);
 
         bool OnMouseWheel(const Windows::Foundation::Point location, const int32_t delta, const bool leftButtonDown, const bool midButtonDown, const bool rightButtonDown);
 

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -15,8 +15,8 @@ namespace Microsoft.Terminal.TerminalControl
     // If you update this one, please update TerminalApp\IDirectKeyListener.idl.
     // If you change this interface, please update the guid.
     // If you press F7 or Alt and get a runtime error, go make sure both copies are the same.
-    [uuid("339e1a87-5315-4da6-96f0-565549b6472b")] interface IDirectKeyListener {
-        Boolean OnDirectKeyEvent(UInt32 vkey, Boolean down);
+    [uuid("0ddf4edc-3fda-4dee-97ca-a417ee3dd510")] interface IDirectKeyListener {
+        Boolean OnDirectKeyEvent(UInt32 vkey, UInt8 scanCode, Boolean down);
     }
 
     runtimeclass CopyToClipboardEventArgs

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -69,11 +69,11 @@ AppHost::~AppHost()
     _app = nullptr;
 }
 
-bool AppHost::OnDirectKeyEvent(const uint32_t vkey, const bool down)
+bool AppHost::OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool down)
 {
     if (_logic)
     {
-        return _logic.OnDirectKeyEvent(vkey, down);
+        return _logic.OnDirectKeyEvent(vkey, scanCode, down);
     }
     return false;
 }

--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -16,7 +16,7 @@ public:
     void AppTitleChanged(const winrt::Windows::Foundation::IInspectable& sender, winrt::hstring newTitle);
     void LastTabClosed(const winrt::Windows::Foundation::IInspectable& sender, const winrt::TerminalApp::LastTabClosedEventArgs& args);
     void Initialize();
-    bool OnDirectKeyEvent(const uint32_t vkey, const bool down);
+    bool OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool down);
 
 private:
     bool _useNonClientArea;

--- a/src/cascadia/WindowsTerminal/main.cpp
+++ b/src/cascadia/WindowsTerminal/main.cpp
@@ -141,7 +141,7 @@ int __stdcall wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int)
         // been handled we can discard the message before we even translate it.
         if (_messageIsF7Keypress(message))
         {
-            if (host.OnDirectKeyEvent(VK_F7, true))
+            if (host.OnDirectKeyEvent(VK_F7, LOBYTE(HIWORD(message.lParam)), true))
             {
                 // The application consumed the F7. Don't let Xaml get it.
                 continue;
@@ -154,7 +154,7 @@ int __stdcall wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int)
         if (_messageIsAltKeyup(message))
         {
             // Let's pass <Alt> to the application
-            if (host.OnDirectKeyEvent(VK_MENU, false))
+            if (host.OnDirectKeyEvent(VK_MENU, LOBYTE(HIWORD(message.lParam)), false))
             {
                 // The application consumed the Alt. Don't let Xaml get it.
                 continue;


### PR DESCRIPTION
#7145 introduced a check so that we wouldn't dispatch keys unless they
actually had a scancode. Our synthetic events actually _didn't_ have
scancodes. Not because they couldn't--just because they didn't.

Fixes #7297