### PR TITLE
Compensate for new warnings and STL changes in VS 16.7

### DIFF
--- a/src/buffer/out/UnicodeStorage.cpp
+++ b/src/buffer/out/UnicodeStorage.cpp
@@ -35,7 +35,7 @@ void UnicodeStorage::StoreGlyph(const key_type key, const mapped_type& glyph)
 // - erases key and its associated data from the storage
 // Arguments:
 // - key - the key to remove
-void UnicodeStorage::Erase(const key_type key)
+void UnicodeStorage::Erase(const key_type key) noexcept
 {
     _map.erase(key);
 }

--- a/src/buffer/out/UnicodeStorage.cpp
+++ b/src/buffer/out/UnicodeStorage.cpp
@@ -35,7 +35,12 @@ void UnicodeStorage::StoreGlyph(const key_type key, const mapped_type& glyph)
 // - erases key and its associated data from the storage
 // Arguments:
 // - key - the key to remove
-void UnicodeStorage::Erase(const key_type key) noexcept
+// ~~~~~~~~~~~~~~
+// NOTE: VS 16.7 changes std::map::erase to noexcept, but the build agents are still 16.6.5.
+// Ignore this audit warning on your dev box until the build starts failing. Then fix it
+// and remove this comment.
+// ~~~~~~~~~~~~~
+void UnicodeStorage::Erase(const key_type key)
 {
     _map.erase(key);
 }

--- a/src/buffer/out/UnicodeStorage.hpp
+++ b/src/buffer/out/UnicodeStorage.hpp
@@ -53,7 +53,7 @@ public:
 
     void StoreGlyph(const key_type key, const mapped_type& glyph);
 
-    void Erase(const key_type key);
+    void Erase(const key_type key) noexcept;
 
     void Remap(const std::unordered_map<SHORT, SHORT>& rowMap, const std::optional<SHORT> width);
 

--- a/src/buffer/out/UnicodeStorage.hpp
+++ b/src/buffer/out/UnicodeStorage.hpp
@@ -53,7 +53,7 @@ public:
 
     void StoreGlyph(const key_type key, const mapped_type& glyph);
 
-    void Erase(const key_type key) noexcept;
+    void Erase(const key_type key);
 
     void Remap(const std::unordered_map<SHORT, SHORT>& rowMap, const std::optional<SHORT> width);
 

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
@@ -79,6 +79,8 @@ try
                 case WM_RBUTTONUP:
                     ReleaseCapture();
                     break;
+                default:
+                    break;
                 }
 
                 // Suppress all mouse events that made it into the terminal.
@@ -132,6 +134,8 @@ try
             terminal->_hwnd.release();
             terminal->Teardown();
             return 0;
+        default:
+            break;
         }
     }
     return DefWindowProc(hwnd, uMsg, wParam, lParam);

--- a/src/cascadia/TerminalConnection/init.cpp
+++ b/src/cascadia/TerminalConnection/init.cpp
@@ -28,6 +28,8 @@ BOOL WINAPI DllMain(HINSTANCE hInstDll, DWORD reason, LPVOID /*reserved*/)
             TraceLoggingUnregister(g_hTerminalConnectionProvider);
         }
         break;
+    default:
+        break;
     }
 
     return TRUE;

--- a/src/inc/til/bitmap.h
+++ b/src/inc/til/bitmap.h
@@ -315,7 +315,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
 
                 // Copy any regions that overlap from this map to the new one.
                 // Just iterate our runs...
-                for (const auto run : *this)
+                for (const auto& run : *this)
                 {
                     // intersect them with the new map
                     // so we don't attempt to set bits that fit outside

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1417,7 +1417,7 @@ try
         // Use a transform by the size of one cell to convert cells-to-pixels
         // as we clear.
         _d2dDeviceContext->SetTransform(D2D1::Matrix3x2F::Scale(_glyphCell));
-        for (const auto rect : _invalidMap.runs())
+        for (const auto& rect : _invalidMap.runs())
         {
             // Use aliased.
             // For graphics reasons, it'll look better because it will ensure that

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1578,6 +1578,9 @@ bool AdaptDispatch::TabClear(const size_t clearType)
     case DispatchTypes::TabClearType::ClearAllColumns:
         success = _ClearAllTabStops();
         break;
+    default:
+        success = false;
+        break;
     }
     return success;
 }
@@ -1694,6 +1697,9 @@ bool AdaptDispatch::DesignateCodingSystem(const wchar_t codingSystem)
         {
             _termOutput.EnableGrTranslation(false);
         }
+        break;
+    default:
+        success = false;
         break;
     }
     return success;

--- a/src/terminal/adapter/terminalOutput.cpp
+++ b/src/terminal/adapter/terminalOutput.cpp
@@ -66,8 +66,9 @@ bool TerminalOutput::Designate94Charset(size_t gsetNumber, const std::pair<wchar
             return _SetTranslationTable(gsetNumber, DecCyrillic);
         case L'5': // Russian NRCS
             return _SetTranslationTable(gsetNumber, RussianNrcs);
+        default:
+            return false;
         }
-        return false;
     case L'"':
         switch (charset.second)
         {
@@ -77,8 +78,9 @@ bool TerminalOutput::Designate94Charset(size_t gsetNumber, const std::pair<wchar
             return _SetTranslationTable(gsetNumber, GreekNrcs);
         case L'4': // DEC Hebrew
             return _SetTranslationTable(gsetNumber, DecHebrew);
+        default:
+            return false;
         }
-        return false;
     case L'%':
         switch (charset.second)
         {
@@ -92,8 +94,9 @@ bool TerminalOutput::Designate94Charset(size_t gsetNumber, const std::pair<wchar
             return _SetTranslationTable(gsetNumber, DecSupplemental);
         case L'6': // Portuguese NRCS
             return _SetTranslationTable(gsetNumber, PortugueseNrcs);
+        default:
+            return false;
         }
-        return false;
     default:
         return false;
     }

--- a/src/terminal/input/mouseInput.cpp
+++ b/src/terminal/input/mouseInput.cpp
@@ -29,7 +29,6 @@ static constexpr std::wstring_view ApplicationDownSequence{ L"\x1bOB" };
 // - true iff button is a button message to translate
 static constexpr bool _isButtonMsg(const unsigned int button) noexcept
 {
-    bool isButton = false;
     switch (button)
     {
     case WM_LBUTTONDBLCLK:
@@ -43,10 +42,10 @@ static constexpr bool _isButtonMsg(const unsigned int button) noexcept
     case WM_MBUTTONDBLCLK:
     case WM_MOUSEWHEEL:
     case WM_MOUSEHWHEEL:
-        isButton = true;
-        break;
+        return true;
+    default:
+        return false;
     }
-    return isButton;
 }
 
 // Routine Description:
@@ -80,7 +79,6 @@ static constexpr bool _isWheelMsg(const unsigned int buttonCode) noexcept
 // - true iff button is a button down event
 static constexpr bool _isButtonDown(const unsigned int button) noexcept
 {
-    bool isButtonDown = false;
     switch (button)
     {
     case WM_LBUTTONDBLCLK:
@@ -91,10 +89,10 @@ static constexpr bool _isButtonDown(const unsigned int button) noexcept
     case WM_MBUTTONDBLCLK:
     case WM_MOUSEWHEEL:
     case WM_MOUSEHWHEEL:
-        isButtonDown = true;
-        break;
+        return true;
+    default:
+        return false;
     }
-    return isButtonDown;
 }
 
 // Routine Description:
@@ -180,6 +178,10 @@ static constexpr int _windowsButtonToXEncoding(const unsigned int button,
     case WM_MOUSEWHEEL:
     case WM_MOUSEHWHEEL:
         xvalue = delta > 0 ? 0x40 : 0x41;
+        break;
+    default:
+        xvalue = 0;
+        break;
     }
     if (isHover)
     {
@@ -235,6 +237,10 @@ static constexpr int _windowsButtonToSGREncoding(const unsigned int button,
     case WM_MOUSEWHEEL:
     case WM_MOUSEHWHEEL:
         xvalue = delta > 0 ? 0x40 : 0x41;
+        break;
+    default:
+        xvalue = 0;
+        break;
     }
     if (isHover)
     {

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -378,7 +378,7 @@ static bool _searchWithModifier(const KeyEvent& keyEvent, InputSender sender)
                                          { s_modifierKeyMapping.data(), s_modifierKeyMapping.size() });
     if (match)
     {
-        const auto v = match.value();
+        const auto& v = match.value();
         if (!v.sequence.empty())
         {
             std::wstring modified{ v.sequence }; // Make a copy so we can modify it.

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -408,6 +408,7 @@ bool InputStateMachineEngine::ActionCsiDispatch(const wchar_t wch,
             // even if we failed to parse a portion of this sequence.
             success = _UpdateSGRMouseButtonState(wch, parameters, buttonState, eventFlags) && success;
             success = success && _WriteMouseEvent(col, row, buttonState, modifierState, eventFlags);
+            break;
         }
         default:
             success = false;
@@ -432,6 +433,7 @@ bool InputStateMachineEngine::ActionCsiDispatch(const wchar_t wch,
             success = _GetXYPosition(parameters, row, col);
             break;
         }
+        [[fallthrough]];
     case CsiActionCodes::ArrowUp:
     case CsiActionCodes::ArrowDown:
     case CsiActionCodes::ArrowRight:
@@ -477,7 +479,7 @@ bool InputStateMachineEngine::ActionCsiDispatch(const wchar_t wch,
                 _lookingForDSR = false;
                 break;
             }
-            __fallthrough;
+            [[fallthrough]];
         case CsiActionCodes::Generic:
         case CsiActionCodes::ArrowUp:
         case CsiActionCodes::ArrowDown:
@@ -1363,6 +1365,8 @@ bool InputStateMachineEngine::_GenerateWin32Key(const gsl::span<const size_t> pa
         [[fallthrough]];
     case 1:
         key.SetVirtualKeyCode(::base::saturated_cast<WORD>(til::at(parameters, 0)));
+        break;
+    default:
         break;
     }
 

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -435,6 +435,9 @@ bool OutputStateMachineEngine::_IntermediateScsDispatch(const wchar_t wch,
         success = _dispatch->Designate96Charset(3, charset);
         TermTelemetry::Instance().Log(TermTelemetry::Codes::DesignateG3);
         break;
+    default:
+        success = false;
+        break;
     }
 
     return success;
@@ -806,8 +809,14 @@ bool OutputStateMachineEngine::_IntermediateGreaterThanOrEqualDispatch(const wch
                 success = _dispatch->TertiaryDeviceAttributes();
                 TermTelemetry::Instance().Log(TermTelemetry::Codes::DA3);
                 break;
+            default:
+                success = false;
+                break;
             }
         }
+        break;
+    default:
+        success = false;
         break;
     }
 
@@ -1329,6 +1338,9 @@ bool OutputStateMachineEngine::_GetDeviceStatusOperation(const gsl::span<const s
         case (unsigned short)DispatchTypes::AnsiStatusType::CPR_CursorPositionReport:
             statusType = DispatchTypes::AnsiStatusType::CPR_CursorPositionReport;
             success = true;
+            break;
+        default:
+            success = false;
             break;
         }
     }

--- a/src/terminal/parser/base64.cpp
+++ b/src/terminal/parser/base64.cpp
@@ -128,6 +128,8 @@ bool Base64::s_Decode(const std::wstring_view src, std::wstring& dst) noexcept
             dst.push_back(tmp);
             state = 0;
             break;
+        default:
+            break;
         }
 
         iter++;
@@ -154,6 +156,7 @@ bool Base64::s_Decode(const std::wstring_view src, std::wstring& dst) noexcept
                 return false;
             }
             iter++; // Skip the padding character and fallthrough to "single trailing padding character" case.
+            [[fallthrough]];
         case 3:
             while (iter < src.cend())
             {
@@ -163,6 +166,9 @@ bool Base64::s_Decode(const std::wstring_view src, std::wstring& dst) noexcept
                 }
                 iter++;
             }
+            break;
+        default:
+            break;
         }
     }
     else if (state != 0) // When no padding, we must be in state 0.


### PR DESCRIPTION
New warnings were added in VS 16.7 and `std::map::erase` is now `noexcept`.
Update our code to be compatible with the new enforcement.

## PR Checklist
* [x] Closes broken audit in main after Agents updated over the weekend.
* [x] I work here.
* [x] Audit mode passes now
* [x] Am core contributor.

## Validation Steps Performed
* [x] Ran audit mode locally
