### PR TITLE
Disable parallel build (again) and keep TerminalApp PCHs

### DIFF
--- a/build/pipelines/templates/build-console-steps.yml
+++ b/build/pipelines/templates/build-console-steps.yml
@@ -34,7 +34,7 @@ steps:
     configuration: '$(BuildConfiguration)'
     msbuildArgs: "${{ parameters.additionalBuildArguments }}"
     clean: true
-    maximumCpuCount: true
+    maximumCpuCount: false
 
 - task: PowerShell@2
   displayName: 'Check MSIX for common regressions'

--- a/src/common.build.post.props
+++ b/src/common.build.post.props
@@ -54,7 +54,7 @@
   <Target Name="CleanUpPrecompForSmallCIAgents"
           DependsOnTargets="_ComputePrecompToCleanUp"
           AfterTargets="AfterBuild"
-          Condition="'$(AGENT_ID)' != ''">
+          Condition="'$(AGENT_ID)' != '' and !$(ProjectName.Contains('TerminalApp'))">
     <!-- We just need to keep *TerminalApp*'s PCHs because they get rebuilt more often. -->
     <Delete Files="@(_PCHFileToCleanWithTimestamp)"/>
     <Touch Files="@(_PCHFileToCleanWithTimestamp)" Time="%(LastWriteTime)" AlwaysCreate="true" />


### PR DESCRIPTION
The build now builds every project multiple times, so I figure, why not
try to fix it.