### PR TITLE
Replace "bindings" with "actions"

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -2440,7 +2440,7 @@ namespace TerminalAppLocalTests
                     "commandline": "wsl.exe"
                 }
             ],
-            "bindings": [
+            "actions": [
                 { "keys": "ctrl+a",                   "command": { "action": "splitPane", "split": "vertical" } },
                 {                   "name": "ctrl+b", "command": { "action": "splitPane", "split": "vertical" } },
                 { "keys": "ctrl+c", "name": "ctrl+c", "command": { "action": "splitPane", "split": "vertical" } },
@@ -2642,7 +2642,7 @@ namespace TerminalAppLocalTests
                     "commandline": "wsl.exe"
                 }
             ],
-            "bindings": [
+            "actions": [
                 {
                     "name": "iterable command ${profile.name}",
                     "iterateOn": "profiles",
@@ -2773,7 +2773,7 @@ namespace TerminalAppLocalTests
                     "commandline": "wsl.exe"
                 }
             ],
-            "bindings": [
+            "actions": [
                 {
                     "iterateOn": "profiles",
                     "command": { "action": "splitPane", "profile": "${profile.name}" }
@@ -2904,7 +2904,7 @@ namespace TerminalAppLocalTests
                     "commandline": "wsl.exe"
                 }
             ],
-            "bindings": [
+            "actions": [
                 {
                     "name": "iterable command ${profile.name}",
                     "iterateOn": "profiles",
@@ -3041,7 +3041,7 @@ namespace TerminalAppLocalTests
                     "commandline": "wsl.exe"
                 }
             ],
-            "bindings": [
+            "actions": [
                 {
                     "name": "Connect to ssh...",
                     "commands": [
@@ -3144,7 +3144,7 @@ namespace TerminalAppLocalTests
                     "commandline": "wsl.exe"
                 }
             ],
-            "bindings": [
+            "actions": [
                 {
                     "name": "grandparent",
                     "commands": [
@@ -3292,7 +3292,7 @@ namespace TerminalAppLocalTests
                     "commandline": "wsl.exe"
                 }
             ],
-            "bindings": [
+            "actions": [
                 {
                     "iterateOn": "profiles",
                     "name": "${profile.name}...",
@@ -3445,7 +3445,7 @@ namespace TerminalAppLocalTests
                     "commandline": "wsl.exe"
                 }
             ],
-            "bindings": [
+            "actions": [
                 {
                     "name": "New Tab With Profile...",
                     "commands": [
@@ -3553,7 +3553,7 @@ namespace TerminalAppLocalTests
                     "commandline": "wsl.exe"
                 }
             ],
-            "bindings": [
+            "actions": [
                 {
                     "name": "New Pane...",
                     "commands": [
@@ -3716,7 +3716,7 @@ namespace TerminalAppLocalTests
                     "commandline": "wsl.exe"
                 }
             ],
-            "bindings": [
+            "actions": [
                 {
                     "commands": [
                         {
@@ -3779,7 +3779,7 @@ namespace TerminalAppLocalTests
                     "commandline": "wsl.exe"
                 }
             ],
-            "bindings": [
+            "actions": [
                 {
                     "name": "parent",
                     "commands": [
@@ -3800,7 +3800,7 @@ namespace TerminalAppLocalTests
         const std::string settings1Json{ R"(
         {
             "defaultProfile": "{6239a42c-0000-49a3-80bd-e8fdd045185c}",
-            "bindings": [
+            "actions": [
                 {
                     "name": "parent",
                     "commands": null
@@ -3862,7 +3862,7 @@ namespace TerminalAppLocalTests
                     "commandline": "wsl.exe"
                 }
             ],
-            "bindings": [
+            "actions": [
                 {
                     "name": "parent",
                     "commands": [
@@ -3883,7 +3883,7 @@ namespace TerminalAppLocalTests
         const std::string settings1Json{ R"(
         {
             "defaultProfile": "{6239a42c-0000-49a3-80bd-e8fdd045185c}",
-            "bindings": [
+            "actions": [
                 {
                     "name": "parent",
                     "command": "newTab"

--- a/src/cascadia/TerminalApp/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.cpp
@@ -16,7 +16,7 @@ using namespace ::Microsoft::Console;
 using namespace winrt::Microsoft::UI::Xaml::Controls;
 
 static constexpr std::string_view LegacyKeybindingsKey{ "keybindings" };
-static constexpr std::string_view BindingsKey{ "bindings" };
+static constexpr std::string_view ActionsKey{ "actions" };
 static constexpr std::string_view DefaultProfileKey{ "defaultProfile" };
 static constexpr std::string_view AlwaysShowTabsKey{ "alwaysShowTabs" };
 static constexpr std::string_view InitialRowsKey{ "initialRows" };
@@ -202,7 +202,7 @@ void GlobalAppSettings::LayerJson(const Json::Value& json)
         }
     };
     parseBindings(LegacyKeybindingsKey);
-    parseBindings(BindingsKey);
+    parseBindings(ActionsKey);
 }
 
 // Method Description:

--- a/src/cascadia/TerminalApp/defaults-universal.json
+++ b/src/cascadia/TerminalApp/defaults-universal.json
@@ -72,7 +72,7 @@
             "brightWhite": "#FFFFFF"
         }
     ],
-    "keybindings":
+    "actions":
     [
         // Application-level Keys
         { "command": "closeWindow", "keys": "alt+f4" },

--- a/src/cascadia/TerminalApp/defaults.json
+++ b/src/cascadia/TerminalApp/defaults.json
@@ -271,7 +271,7 @@
             "brightWhite": "#EEEEEC"
         }
     ],
-    "bindings":
+    "actions":
     [
         // Application-level Keys
         { "command": "closeWindow", "keys": "alt+f4" },


### PR DESCRIPTION
In #6532, we thought it would be a good idea to add "bindings" as an
overload for "keybindings", as we were no longer going to use the
keybindings array for just keybindings. We were going to add commands.
So we started secretly treating `"bindings"` the same as
`"keybindings"`.

Then, in #7175, we discussed using "actions" as the key for the list of
commands/keybindings/global actions, instead of using "bindings". We're
going to be using this array as the global list of all actions, so it
makes sense to just call it `"actions"`. 

This PR renames "bindings" to "actions". Fortunately, we never
documented the "bindings" overload in the first place, so we can get
away with this safely, and preferably before we ship "bindings" for too
long.

References #6899