### PR TITLE
Expose selection background and alpha through the WPF control

### DIFF
--- a/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
@@ -735,6 +735,7 @@ void _stdcall TerminalSetTheme(void* terminal, TerminalTheme theme, LPCWSTR font
 
         publicTerminal->_terminal->SetDefaultForeground(theme.DefaultForeground);
         publicTerminal->_terminal->SetDefaultBackground(theme.DefaultBackground);
+        publicTerminal->_renderEngine->SetSelectionBackground(theme.DefaultSelectionBackground, theme.SelectionBackgroundAlpha);
 
         // Set the font colors
         for (size_t tableIndex = 0; tableIndex < 16; tableIndex++)

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
@@ -12,10 +12,13 @@
 
 using namespace Microsoft::Console::VirtualTerminal;
 
+// Keep in sync with TerminalTheme.cs
 typedef struct _TerminalTheme
 {
     COLORREF DefaultBackground;
     COLORREF DefaultForeground;
+    COLORREF DefaultSelectionBackground;
+    float SelectionBackgroundAlpha;
     DispatchTypes::CursorStyle CursorStyle;
     COLORREF ColorTable[16];
 } TerminalTheme, *LPTerminalTheme;

--- a/src/cascadia/WpfTerminalControl/TerminalTheme.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalTheme.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Terminal.Wpf
     /// <summary>
     /// Structure for color handling in the terminal.
     /// </summary>
-    /// <remarks>Pack = 1 removes the padding added by some compilers/processors for optimization purposes.</remarks>
+    /// <remarks>Keep in sync with HwndTerminal.hpp.</remarks>
     [StructLayout(LayoutKind.Sequential)]
     public struct TerminalTheme
     {
@@ -65,6 +65,16 @@ namespace Microsoft.Terminal.Wpf
         /// The default foreground color of the terminal, represented in Win32 COLORREF format.
         /// </summary>
         public uint DefaultForeground;
+
+        /// <summary>
+        /// The default selection background color of the terminal, represented in Win32 COLORREF format.
+        /// </summary>
+        public uint DefaultSelectionBackground;
+
+        /// <summary>
+        /// The opacity alpha for the selection color of the terminal, must be between 1.0 and 0.0.
+        /// </summary>
+        public float SelectionBackgroundAlpha;
 
         /// <summary>
         /// The style of cursor to use in the terminal.

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -2354,12 +2354,12 @@ CATCH_RETURN();
 // - color - GDI Color
 // Return Value:
 // - N/A
-void DxEngine::SetSelectionBackground(const COLORREF color) noexcept
+void DxEngine::SetSelectionBackground(const COLORREF color, FLOAT alpha) noexcept
 {
     _selectionBackground = D2D1::ColorF(GetRValue(color) / 255.0f,
                                         GetGValue(color) / 255.0f,
                                         GetBValue(color) / 255.0f,
-                                        0.5f);
+                                        alpha);
 }
 
 // Routine Description:

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -2354,7 +2354,7 @@ CATCH_RETURN();
 // - color - GDI Color
 // Return Value:
 // - N/A
-void DxEngine::SetSelectionBackground(const COLORREF color, FLOAT alpha) noexcept
+void DxEngine::SetSelectionBackground(const COLORREF color, const float alpha) noexcept
 {
     _selectionBackground = D2D1::ColorF(GetRValue(color) / 255.0f,
                                         GetGValue(color) / 255.0f,

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -114,7 +114,7 @@ namespace Microsoft::Console::Render
 
         float GetScaling() const noexcept;
 
-        void SetSelectionBackground(const COLORREF color, FLOAT alpha = 0.5f) noexcept;
+        void SetSelectionBackground(const COLORREF color, const float alpha = 0.5f) noexcept;
         void SetAntialiasingMode(const D2D1_TEXT_ANTIALIAS_MODE antialiasingMode) noexcept;
         void SetDefaultTextBackgroundOpacity(const float opacity) noexcept;
 

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -114,7 +114,7 @@ namespace Microsoft::Console::Render
 
         float GetScaling() const noexcept;
 
-        void SetSelectionBackground(const COLORREF color) noexcept;
+        void SetSelectionBackground(const COLORREF color, FLOAT alpha = 0.5f) noexcept;
         void SetAntialiasingMode(const D2D1_TEXT_ANTIALIAS_MODE antialiasingMode) noexcept;
         void SetDefaultTextBackgroundOpacity(const float opacity) noexcept;
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds the ability to set the selection background opacity when setting the selection background. This also exposes the selection background and alpha through the terminal WPF container.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Patched VS and ran the terminal tool window with multiple selection background colors and alphas.