### PR TITLE
Set ProcessTestResults job to use conditions specified in parent

### DIFF
--- a/build/pipelines/templates/build-console-ci.yml
+++ b/build/pipelines/templates/build-console-ci.yml
@@ -30,6 +30,6 @@ jobs:
   parameters:
     dependsOn:
     - RunTestsInHelix
-    condition: and(succeeded(), and(eq('${{ parameters.platform }}', 'x64'), not(eq(variables['Build.Reason'], 'PullRequest')))) 
+    condition: and(succeededOrFailed(), and(eq('${{ parameters.platform }}', 'x64'), not(eq(variables['Build.Reason'], 'PullRequest')))) 
     rerunPassesRequiredToAvoidFailure: ${{ parameters.rerunPassesRequiredToAvoidFailure }}
     minimumExpectedTestsExecutedCount: ${{ parameters.minimumExpectedTestsExecutedCount }}

--- a/build/pipelines/templates/helix-processtestresults-job.yml
+++ b/build/pipelines/templates/helix-processtestresults-job.yml
@@ -1,4 +1,5 @@
 parameters:
+  condition: 'succeededOrFailed()'
   dependsOn: ''
   rerunPassesRequiredToAvoidFailure: 5
   minimumExpectedTestsExecutedCount: 10

--- a/build/pipelines/templates/helix-processtestresults-job.yml
+++ b/build/pipelines/templates/helix-processtestresults-job.yml
@@ -7,7 +7,7 @@ parameters:
 
 jobs:
 - job: ProcessTestResults
-  condition: succeededOrFailed()
+  condition: ${{ parameters.condition }}
   dependsOn: ${{ parameters.dependsOn }}
   pool:
     vmImage: 'windows-2019'


### PR DESCRIPTION
Activating a template doesn't actually process conditions. Only jobs, stages, and tasks can process a condition. So specify the full condition in the parent template call as a parameter and ask the child job (who can actually evaluate the condition) to use that parameter to determine if it should run.