### PR TITLE
Add a pair of nested, iterable default commands

### DIFF
--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -576,6 +576,12 @@
   <data name="SetColorSchemeParentCommandName" xml:space="preserve">
     <value>Select color scheme...</value>
   </data>
+  <data name="NewTabParentCommandName" xml:space="preserve">
+    <value>New Tab...</value>
+  </data>
+  <data name="SplitPaneParentCommandName" xml:space="preserve">
+    <value>Split Pane...</value>
+  </data>
   <data name="TabSwitcherControlName" xml:space="preserve">
     <value>Tab Switcher</value>
   </data>

--- a/src/cascadia/TerminalApp/defaults.json
+++ b/src/cascadia/TerminalApp/defaults.json
@@ -342,7 +342,9 @@
         { "command": { "action": "adjustFontSize", "delta": -1 }, "keys": "ctrl+-" },
         { "command": "resetFontSize", "keys": "ctrl+0" },
 
+        // Other commands
         {
+            // Select color scheme...
             "name": { "key": "SetColorSchemeParentCommandName" },
             "commands": [
                 {
@@ -352,5 +354,39 @@
                 }
             ]
         },
+        {
+            // New tab...
+            "name": { "key": "NewTabParentCommandName" },
+            "commands": [
+                {
+                    "iterateOn": "profiles",
+                    "icon": "${profile.icon}",
+                    "name": "${profile.name}",
+                    "command": { "action": "newTab", "profile": "${profile.name}" }
+                }
+            ]
+        },
+        {
+            // Split pane...
+            "name": { "key": "SplitPaneParentCommandName" },
+            "commands": [
+                {
+                    "iterateOn": "profiles",
+                    "icon": "${profile.icon}",
+                    "name": "${profile.name}...",
+                    "commands": [
+                        {
+                            "command": { "action": "splitPane", "profile": "${profile.name}", "split": "auto" }
+                        },
+                        {
+                            "command": { "action": "splitPane", "profile": "${profile.name}", "split": "vertical" }
+                        },
+                        {
+                            "command": { "action": "splitPane", "profile": "${profile.name}", "split": "horizontal" }
+                        }
+                    ]
+                }
+            ]
+        }
     ]
 }


### PR DESCRIPTION
## Summary of the Pull Request
![cmdpal-default-nested-commands](https://user-images.githubusercontent.com/18356694/90684483-e6b13400-e22d-11ea-8ca6-fe90ca8d9e82.gif)

Adds a pair of top-level commands that both have nested, iterable sub-commands. The "New Tab..." command has one child for each profile, and will open a new tab for that profile. The "Split Pane..." command similarly has a nested command for each profile, and also has a nested command for split auto/horizontal/vertical.

## References

* megathread: #5400 
* Would look better with icons from  #6644

## PR Checklist
* [x] Closes #7174 
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated
