### PR TITLE
Make GlobalAppSettings a WinRT object

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/ColorSchemeTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/ColorSchemeTests.cpp
@@ -195,7 +195,7 @@ namespace TerminalAppLocalTests
 
         CascadiaSettings settings;
 
-        VERIFY_ARE_EQUAL(0u, settings._globals.GetColorSchemes().size());
+        VERIFY_ARE_EQUAL(0u, settings._globals.GetColorSchemes().Size());
         VERIFY_IS_NULL(settings._FindMatchingColorScheme(scheme0Json));
         VERIFY_IS_NULL(settings._FindMatchingColorScheme(scheme1Json));
         VERIFY_IS_NULL(settings._FindMatchingColorScheme(scheme2Json));
@@ -203,15 +203,15 @@ namespace TerminalAppLocalTests
 
         settings._LayerOrCreateColorScheme(scheme0Json);
         {
-            for (auto& kv : settings._globals._colorSchemes)
+            for (auto kv : settings._globals.GetColorSchemes())
             {
                 Log::Comment(NoThrowString().Format(
-                    L"kv:%s->%s", kv.first.data(), kv.second.Name().data()));
+                    L"kv:%s->%s", kv.Key().data(), kv.Value().Name().data()));
             }
-            VERIFY_ARE_EQUAL(1u, settings._globals.GetColorSchemes().size());
+            VERIFY_ARE_EQUAL(1u, settings._globals.GetColorSchemes().Size());
 
-            VERIFY_IS_TRUE(settings._globals._colorSchemes.find(L"scheme0") != settings._globals._colorSchemes.end());
-            auto scheme0Proj = settings._globals._colorSchemes.find(L"scheme0")->second;
+            VERIFY_IS_TRUE(settings._globals.GetColorSchemes().HasKey(L"scheme0"));
+            auto scheme0Proj = settings._globals.GetColorSchemes().Lookup(L"scheme0");
             auto scheme0 = winrt::get_self<ColorScheme>(scheme0Proj);
 
             VERIFY_IS_NOT_NULL(settings._FindMatchingColorScheme(scheme0Json));
@@ -225,13 +225,13 @@ namespace TerminalAppLocalTests
         settings._LayerOrCreateColorScheme(scheme1Json);
 
         {
-            VERIFY_ARE_EQUAL(2u, settings._globals.GetColorSchemes().size());
+            VERIFY_ARE_EQUAL(2u, settings._globals.GetColorSchemes().Size());
 
-            VERIFY_IS_TRUE(settings._globals._colorSchemes.find(L"scheme0") != settings._globals._colorSchemes.end());
-            auto scheme0Proj = settings._globals._colorSchemes.find(L"scheme0")->second;
+            VERIFY_IS_TRUE(settings._globals.GetColorSchemes().HasKey(L"scheme0"));
+            auto scheme0Proj = settings._globals.GetColorSchemes().Lookup(L"scheme0");
             auto scheme0 = winrt::get_self<ColorScheme>(scheme0Proj);
-            VERIFY_IS_TRUE(settings._globals._colorSchemes.find(L"scheme1") != settings._globals._colorSchemes.end());
-            auto scheme1Proj = settings._globals._colorSchemes.find(L"scheme1")->second;
+            VERIFY_IS_TRUE(settings._globals.GetColorSchemes().HasKey(L"scheme1"));
+            auto scheme1Proj = settings._globals.GetColorSchemes().Lookup(L"scheme1");
             auto scheme1 = winrt::get_self<ColorScheme>(scheme1Proj);
 
             VERIFY_IS_NOT_NULL(settings._FindMatchingColorScheme(scheme0Json));
@@ -246,13 +246,13 @@ namespace TerminalAppLocalTests
         settings._LayerOrCreateColorScheme(scheme2Json);
 
         {
-            VERIFY_ARE_EQUAL(2u, settings._globals.GetColorSchemes().size());
+            VERIFY_ARE_EQUAL(2u, settings._globals.GetColorSchemes().Size());
 
-            VERIFY_IS_TRUE(settings._globals._colorSchemes.find(L"scheme0") != settings._globals._colorSchemes.end());
-            auto scheme0Proj = settings._globals._colorSchemes.find(L"scheme0")->second;
+            VERIFY_IS_TRUE(settings._globals.GetColorSchemes().HasKey(L"scheme0"));
+            auto scheme0Proj = settings._globals.GetColorSchemes().Lookup(L"scheme0");
             auto scheme0 = winrt::get_self<ColorScheme>(scheme0Proj);
-            VERIFY_IS_TRUE(settings._globals._colorSchemes.find(L"scheme1") != settings._globals._colorSchemes.end());
-            auto scheme1Proj = settings._globals._colorSchemes.find(L"scheme1")->second;
+            VERIFY_IS_TRUE(settings._globals.GetColorSchemes().HasKey(L"scheme1"));
+            auto scheme1Proj = settings._globals.GetColorSchemes().Lookup(L"scheme1");
             auto scheme1 = winrt::get_self<ColorScheme>(scheme1Proj);
 
             VERIFY_IS_NOT_NULL(settings._FindMatchingColorScheme(scheme0Json));
@@ -267,16 +267,16 @@ namespace TerminalAppLocalTests
         settings._LayerOrCreateColorScheme(scheme3Json);
 
         {
-            VERIFY_ARE_EQUAL(3u, settings._globals.GetColorSchemes().size());
+            VERIFY_ARE_EQUAL(3u, settings._globals.GetColorSchemes().Size());
 
-            VERIFY_IS_TRUE(settings._globals._colorSchemes.find(L"scheme0") != settings._globals._colorSchemes.end());
-            auto scheme0Proj = settings._globals._colorSchemes.find(L"scheme0")->second;
+            VERIFY_IS_TRUE(settings._globals.GetColorSchemes().HasKey(L"scheme0"));
+            auto scheme0Proj = settings._globals.GetColorSchemes().Lookup(L"scheme0");
             auto scheme0 = winrt::get_self<ColorScheme>(scheme0Proj);
-            VERIFY_IS_TRUE(settings._globals._colorSchemes.find(L"scheme1") != settings._globals._colorSchemes.end());
-            auto scheme1Proj = settings._globals._colorSchemes.find(L"scheme1")->second;
+            VERIFY_IS_TRUE(settings._globals.GetColorSchemes().HasKey(L"scheme1"));
+            auto scheme1Proj = settings._globals.GetColorSchemes().Lookup(L"scheme1");
             auto scheme1 = winrt::get_self<ColorScheme>(scheme1Proj);
-            VERIFY_IS_TRUE(settings._globals._colorSchemes.find(L"") != settings._globals._colorSchemes.end());
-            auto scheme2Proj = settings._globals._colorSchemes.find(L"")->second;
+            VERIFY_IS_TRUE(settings._globals.GetColorSchemes().HasKey(L""));
+            auto scheme2Proj = settings._globals.GetColorSchemes().Lookup(L"");
             auto scheme2 = winrt::get_self<ColorScheme>(scheme2Proj);
 
             VERIFY_IS_NOT_NULL(settings._FindMatchingColorScheme(scheme0Json));

--- a/src/cascadia/LocalTests_TerminalApp/ColorSchemeTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/ColorSchemeTests.cpp
@@ -195,7 +195,7 @@ namespace TerminalAppLocalTests
 
         CascadiaSettings settings;
 
-        VERIFY_ARE_EQUAL(0u, settings._globals.GetColorSchemes().Size());
+        VERIFY_ARE_EQUAL(0u, settings._globals->GetColorSchemes().Size());
         VERIFY_IS_NULL(settings._FindMatchingColorScheme(scheme0Json));
         VERIFY_IS_NULL(settings._FindMatchingColorScheme(scheme1Json));
         VERIFY_IS_NULL(settings._FindMatchingColorScheme(scheme2Json));
@@ -203,15 +203,15 @@ namespace TerminalAppLocalTests
 
         settings._LayerOrCreateColorScheme(scheme0Json);
         {
-            for (auto kv : settings._globals.GetColorSchemes())
+            for (auto kv : settings._globals->GetColorSchemes())
             {
                 Log::Comment(NoThrowString().Format(
                     L"kv:%s->%s", kv.Key().data(), kv.Value().Name().data()));
             }
-            VERIFY_ARE_EQUAL(1u, settings._globals.GetColorSchemes().Size());
+            VERIFY_ARE_EQUAL(1u, settings._globals->GetColorSchemes().Size());
 
-            VERIFY_IS_TRUE(settings._globals.GetColorSchemes().HasKey(L"scheme0"));
-            auto scheme0Proj = settings._globals.GetColorSchemes().Lookup(L"scheme0");
+            VERIFY_IS_TRUE(settings._globals->GetColorSchemes().HasKey(L"scheme0"));
+            auto scheme0Proj = settings._globals->GetColorSchemes().Lookup(L"scheme0");
             auto scheme0 = winrt::get_self<ColorScheme>(scheme0Proj);
 
             VERIFY_IS_NOT_NULL(settings._FindMatchingColorScheme(scheme0Json));
@@ -225,13 +225,13 @@ namespace TerminalAppLocalTests
         settings._LayerOrCreateColorScheme(scheme1Json);
 
         {
-            VERIFY_ARE_EQUAL(2u, settings._globals.GetColorSchemes().Size());
+            VERIFY_ARE_EQUAL(2u, settings._globals->GetColorSchemes().Size());
 
-            VERIFY_IS_TRUE(settings._globals.GetColorSchemes().HasKey(L"scheme0"));
-            auto scheme0Proj = settings._globals.GetColorSchemes().Lookup(L"scheme0");
+            VERIFY_IS_TRUE(settings._globals->GetColorSchemes().HasKey(L"scheme0"));
+            auto scheme0Proj = settings._globals->GetColorSchemes().Lookup(L"scheme0");
             auto scheme0 = winrt::get_self<ColorScheme>(scheme0Proj);
-            VERIFY_IS_TRUE(settings._globals.GetColorSchemes().HasKey(L"scheme1"));
-            auto scheme1Proj = settings._globals.GetColorSchemes().Lookup(L"scheme1");
+            VERIFY_IS_TRUE(settings._globals->GetColorSchemes().HasKey(L"scheme1"));
+            auto scheme1Proj = settings._globals->GetColorSchemes().Lookup(L"scheme1");
             auto scheme1 = winrt::get_self<ColorScheme>(scheme1Proj);
 
             VERIFY_IS_NOT_NULL(settings._FindMatchingColorScheme(scheme0Json));
@@ -246,13 +246,13 @@ namespace TerminalAppLocalTests
         settings._LayerOrCreateColorScheme(scheme2Json);
 
         {
-            VERIFY_ARE_EQUAL(2u, settings._globals.GetColorSchemes().Size());
+            VERIFY_ARE_EQUAL(2u, settings._globals->GetColorSchemes().Size());
 
-            VERIFY_IS_TRUE(settings._globals.GetColorSchemes().HasKey(L"scheme0"));
-            auto scheme0Proj = settings._globals.GetColorSchemes().Lookup(L"scheme0");
+            VERIFY_IS_TRUE(settings._globals->GetColorSchemes().HasKey(L"scheme0"));
+            auto scheme0Proj = settings._globals->GetColorSchemes().Lookup(L"scheme0");
             auto scheme0 = winrt::get_self<ColorScheme>(scheme0Proj);
-            VERIFY_IS_TRUE(settings._globals.GetColorSchemes().HasKey(L"scheme1"));
-            auto scheme1Proj = settings._globals.GetColorSchemes().Lookup(L"scheme1");
+            VERIFY_IS_TRUE(settings._globals->GetColorSchemes().HasKey(L"scheme1"));
+            auto scheme1Proj = settings._globals->GetColorSchemes().Lookup(L"scheme1");
             auto scheme1 = winrt::get_self<ColorScheme>(scheme1Proj);
 
             VERIFY_IS_NOT_NULL(settings._FindMatchingColorScheme(scheme0Json));
@@ -267,16 +267,16 @@ namespace TerminalAppLocalTests
         settings._LayerOrCreateColorScheme(scheme3Json);
 
         {
-            VERIFY_ARE_EQUAL(3u, settings._globals.GetColorSchemes().Size());
+            VERIFY_ARE_EQUAL(3u, settings._globals->GetColorSchemes().Size());
 
-            VERIFY_IS_TRUE(settings._globals.GetColorSchemes().HasKey(L"scheme0"));
-            auto scheme0Proj = settings._globals.GetColorSchemes().Lookup(L"scheme0");
+            VERIFY_IS_TRUE(settings._globals->GetColorSchemes().HasKey(L"scheme0"));
+            auto scheme0Proj = settings._globals->GetColorSchemes().Lookup(L"scheme0");
             auto scheme0 = winrt::get_self<ColorScheme>(scheme0Proj);
-            VERIFY_IS_TRUE(settings._globals.GetColorSchemes().HasKey(L"scheme1"));
-            auto scheme1Proj = settings._globals.GetColorSchemes().Lookup(L"scheme1");
+            VERIFY_IS_TRUE(settings._globals->GetColorSchemes().HasKey(L"scheme1"));
+            auto scheme1Proj = settings._globals->GetColorSchemes().Lookup(L"scheme1");
             auto scheme1 = winrt::get_self<ColorScheme>(scheme1Proj);
-            VERIFY_IS_TRUE(settings._globals.GetColorSchemes().HasKey(L""));
-            auto scheme2Proj = settings._globals.GetColorSchemes().Lookup(L"");
+            VERIFY_IS_TRUE(settings._globals->GetColorSchemes().HasKey(L""));
+            auto scheme2Proj = settings._globals->GetColorSchemes().Lookup(L"");
             auto scheme2 = winrt::get_self<ColorScheme>(scheme2Proj);
 
             VERIFY_IS_NOT_NULL(settings._FindMatchingColorScheme(scheme0Json));

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -106,7 +106,7 @@ namespace TerminalAppLocalTests
         }
 
     private:
-        void _logCommandNames(winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::TerminalApp::Command>& commands, const int indentation = 1)
+        void _logCommandNames(winrt::Windows::Foundation::Collections::IMapView<winrt::hstring, winrt::TerminalApp::Command> commands, const int indentation = 1)
         {
             if (indentation == 1)
             {
@@ -125,7 +125,7 @@ namespace TerminalAppLocalTests
                 cmdImpl.copy_from(winrt::get_self<implementation::Command>(nameAndCommand.Value()));
                 if (cmdImpl->HasNestedCommands())
                 {
-                    _logCommandNames(cmdImpl->_subcommands, indentation + 2);
+                    _logCommandNames(cmdImpl->_subcommands.GetView(), indentation + 2);
                 }
             }
         }
@@ -522,16 +522,16 @@ namespace TerminalAppLocalTests
         CascadiaSettings settings;
 
         settings.LayerJson(settings0Json);
-        VERIFY_ARE_EQUAL(true, settings._globals._AlwaysShowTabs);
-        VERIFY_ARE_EQUAL(120, settings._globals._InitialCols);
-        VERIFY_ARE_EQUAL(30, settings._globals._InitialRows);
-        VERIFY_ARE_EQUAL(true, settings._globals._ShowTabsInTitlebar);
+        VERIFY_ARE_EQUAL(true, settings._globals.AlwaysShowTabs());
+        VERIFY_ARE_EQUAL(120, settings._globals.InitialCols());
+        VERIFY_ARE_EQUAL(30, settings._globals.InitialRows());
+        VERIFY_ARE_EQUAL(true, settings._globals.ShowTabsInTitlebar());
 
         settings.LayerJson(settings1Json);
-        VERIFY_ARE_EQUAL(true, settings._globals._AlwaysShowTabs);
-        VERIFY_ARE_EQUAL(240, settings._globals._InitialCols);
-        VERIFY_ARE_EQUAL(60, settings._globals._InitialRows);
-        VERIFY_ARE_EQUAL(false, settings._globals._ShowTabsInTitlebar);
+        VERIFY_ARE_EQUAL(true, settings._globals.AlwaysShowTabs());
+        VERIFY_ARE_EQUAL(240, settings._globals.InitialCols());
+        VERIFY_ARE_EQUAL(60, settings._globals.InitialRows());
+        VERIFY_ARE_EQUAL(false, settings._globals.ShowTabsInTitlebar());
     }
 
     void SettingsTests::ValidateProfileOrdering()
@@ -1330,7 +1330,7 @@ namespace TerminalAppLocalTests
         settings.LayerJson(settings._userSettings);
 
         VERIFY_ARE_EQUAL(3u, settings._profiles.size());
-        VERIFY_ARE_EQUAL(2u, settings._globals._colorSchemes.size());
+        VERIFY_ARE_EQUAL(2u, settings._globals.GetColorSchemes().Size());
 
         VERIFY_ARE_EQUAL(L"schemeOne", settings._profiles.at(0).ColorSchemeName());
         VERIFY_ARE_EQUAL(L"InvalidSchemeName", settings._profiles.at(1).ColorSchemeName());
@@ -1342,7 +1342,7 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::UnknownColorScheme, settings._warnings.at(0));
 
         VERIFY_ARE_EQUAL(3u, settings._profiles.size());
-        VERIFY_ARE_EQUAL(2u, settings._globals._colorSchemes.size());
+        VERIFY_ARE_EQUAL(2u, settings._globals.GetColorSchemes().Size());
 
         VERIFY_ARE_EQUAL(L"schemeOne", settings._profiles.at(0).ColorSchemeName());
         VERIFY_ARE_EQUAL(L"Campbell", settings._profiles.at(1).ColorSchemeName());
@@ -1554,7 +1554,7 @@ namespace TerminalAppLocalTests
             VERIFY_IS_FALSE(settings._userDefaultProfileSettings == Json::Value::null);
             settings.LayerJson(settings._userSettings);
 
-            VERIFY_ARE_EQUAL(guid1String, settings._globals._unparsedDefaultProfile);
+            VERIFY_ARE_EQUAL(guid1String, settings._globals.UnparsedDefaultProfile());
             VERIFY_ARE_EQUAL(2u, settings._profiles.size());
 
             VERIFY_ARE_EQUAL(2345, settings._profiles.at(0).HistorySize());
@@ -1612,7 +1612,7 @@ namespace TerminalAppLocalTests
 
             settings.LayerJson(settings._userSettings);
 
-            VERIFY_ARE_EQUAL(guid1String, settings._globals._unparsedDefaultProfile);
+            VERIFY_ARE_EQUAL(guid1String, settings._globals.UnparsedDefaultProfile());
             VERIFY_ARE_EQUAL(4u, settings._profiles.size());
 
             VERIFY_ARE_EQUAL(guid1, settings._profiles.at(2).Guid());
@@ -1794,12 +1794,13 @@ namespace TerminalAppLocalTests
         settings.LayerJson(settings._userSettings);
         settings._ValidateSettings();
 
-        auto appKeyBindings = settings._globals._keybindings;
+        auto appKeyBindingsProj = settings._globals.GetKeybindings();
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
         const auto profile2Guid = settings._profiles.at(2).Guid();
         VERIFY_ARE_NOT_EQUAL(winrt::guid{}, profile2Guid);
 
+        const auto appKeyBindings = winrt::get_self<implementation::AppKeyBindings>(appKeyBindingsProj);
         VERIFY_ARE_EQUAL(12u, appKeyBindings->_keyShortcuts.size());
 
         {
@@ -2241,14 +2242,14 @@ namespace TerminalAppLocalTests
         settings.LayerJson(settings._userSettings);
 
         VERIFY_ARE_EQUAL(6u, settings._profiles.size());
-        VERIFY_ARE_EQUAL(2u, settings._globals._colorSchemes.size());
+        VERIFY_ARE_EQUAL(2u, settings._globals.GetColorSchemes().Size());
 
-        auto terminalSettings0 = winrt::get_self<implementation::Profile>(settings._profiles[0])->CreateTerminalSettings(settings._globals._colorSchemes);
-        auto terminalSettings1 = winrt::get_self<implementation::Profile>(settings._profiles[1])->CreateTerminalSettings(settings._globals._colorSchemes);
-        auto terminalSettings2 = winrt::get_self<implementation::Profile>(settings._profiles[2])->CreateTerminalSettings(settings._globals._colorSchemes);
-        auto terminalSettings3 = winrt::get_self<implementation::Profile>(settings._profiles[3])->CreateTerminalSettings(settings._globals._colorSchemes);
-        auto terminalSettings4 = winrt::get_self<implementation::Profile>(settings._profiles[4])->CreateTerminalSettings(settings._globals._colorSchemes);
-        auto terminalSettings5 = winrt::get_self<implementation::Profile>(settings._profiles[5])->CreateTerminalSettings(settings._globals._colorSchemes);
+        auto terminalSettings0 = winrt::get_self<implementation::Profile>(settings._profiles[0])->CreateTerminalSettings(settings._globals.GetColorSchemes());
+        auto terminalSettings1 = winrt::get_self<implementation::Profile>(settings._profiles[1])->CreateTerminalSettings(settings._globals.GetColorSchemes());
+        auto terminalSettings2 = winrt::get_self<implementation::Profile>(settings._profiles[2])->CreateTerminalSettings(settings._globals.GetColorSchemes());
+        auto terminalSettings3 = winrt::get_self<implementation::Profile>(settings._profiles[3])->CreateTerminalSettings(settings._globals.GetColorSchemes());
+        auto terminalSettings4 = winrt::get_self<implementation::Profile>(settings._profiles[4])->CreateTerminalSettings(settings._globals.GetColorSchemes());
+        auto terminalSettings5 = winrt::get_self<implementation::Profile>(settings._profiles[5])->CreateTerminalSettings(settings._globals.GetColorSchemes());
 
         VERIFY_ARE_EQUAL(ARGB(0, 0x12, 0x34, 0x56), terminalSettings0.CursorColor()); // from color scheme
         VERIFY_ARE_EQUAL(DEFAULT_CURSOR_COLOR, terminalSettings1.CursorColor()); // default
@@ -2283,12 +2284,13 @@ namespace TerminalAppLocalTests
         const auto settingsObject = VerifyParseSucceeded(badSettings);
         auto settings = CascadiaSettings::FromJson(settingsObject);
 
-        VERIFY_ARE_EQUAL(0u, settings->_globals._keybindings->_keyShortcuts.size());
+        const auto globalsImpl = winrt::get_self<implementation::GlobalAppSettings>(settings->_globals);
+        VERIFY_ARE_EQUAL(0u, globalsImpl->_keybindings->_keyShortcuts.size());
 
-        VERIFY_ARE_EQUAL(3u, settings->_globals._keybindingsWarnings.size());
-        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::TooManyKeysForChord, settings->_globals._keybindingsWarnings.at(0));
-        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter, settings->_globals._keybindingsWarnings.at(1));
-        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter, settings->_globals._keybindingsWarnings.at(2));
+        VERIFY_ARE_EQUAL(3u, globalsImpl->_keybindingsWarnings.size());
+        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::TooManyKeysForChord, globalsImpl->_keybindingsWarnings.at(0));
+        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter, globalsImpl->_keybindingsWarnings.at(1));
+        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter, globalsImpl->_keybindingsWarnings.at(2));
 
         settings->_ValidateKeybindings();
 
@@ -2325,17 +2327,18 @@ namespace TerminalAppLocalTests
 
         auto settings = CascadiaSettings::FromJson(settingsObject);
 
-        VERIFY_ARE_EQUAL(0u, settings->_globals._keybindings->_keyShortcuts.size());
+        auto globalsImpl = winrt::get_self<implementation::GlobalAppSettings>(settings->_globals);
+        VERIFY_ARE_EQUAL(0u, globalsImpl->_keybindings->_keyShortcuts.size());
 
-        for (const auto& warning : settings->_globals._keybindingsWarnings)
+        for (const auto& warning : globalsImpl->_keybindingsWarnings)
         {
             Log::Comment(NoThrowString().Format(
                 L"warning:%d", warning));
         }
-        VERIFY_ARE_EQUAL(3u, settings->_globals._keybindingsWarnings.size());
-        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter, settings->_globals._keybindingsWarnings.at(0));
-        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter, settings->_globals._keybindingsWarnings.at(1));
-        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter, settings->_globals._keybindingsWarnings.at(2));
+        VERIFY_ARE_EQUAL(3u, globalsImpl->_keybindingsWarnings.size());
+        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter, globalsImpl->_keybindingsWarnings.at(0));
+        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter, globalsImpl->_keybindingsWarnings.at(1));
+        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter, globalsImpl->_keybindingsWarnings.at(2));
 
         settings->_ValidateKeybindings();
 
@@ -2465,7 +2468,7 @@ namespace TerminalAppLocalTests
         const auto profile2Guid = settings._profiles.at(2).Guid();
         VERIFY_ARE_NOT_EQUAL(winrt::guid{}, profile2Guid);
 
-        auto appKeyBindings = settings._globals._keybindings;
+        auto appKeyBindings = winrt::get_self<implementation::AppKeyBindings>(settings._globals.GetKeybindings());
         VERIFY_ARE_EQUAL(5u, appKeyBindings->_keyShortcuts.size());
 
         // A/D, B, C, E will be in the list of commands, for 4 total.
@@ -2665,7 +2668,7 @@ namespace TerminalAppLocalTests
 
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto& commands = settings._globals.GetCommands();
+        auto commands = settings._globals.GetCommands();
         VERIFY_ARE_EQUAL(1u, commands.Size());
 
         {
@@ -2686,8 +2689,8 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"${profile.name}", realArgs.TerminalArgs().Profile());
         }
 
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands.GetView(), settings.GetProfiles(), settings._globals.GetColorSchemes());
-        _logCommandNames(expandedCommands);
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals.GetColorSchemes());
+        _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(3u, expandedCommands.Size());
@@ -2795,7 +2798,7 @@ namespace TerminalAppLocalTests
 
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto& commands = settings._globals.GetCommands();
+        auto commands = settings._globals.GetCommands();
         VERIFY_ARE_EQUAL(1u, commands.Size());
 
         {
@@ -2816,8 +2819,8 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"${profile.name}", realArgs.TerminalArgs().Profile());
         }
 
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands.GetView(), settings.GetProfiles(), settings._globals.GetColorSchemes());
-        _logCommandNames(expandedCommands);
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals.GetColorSchemes());
+        _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(3u, expandedCommands.Size());
@@ -2927,7 +2930,7 @@ namespace TerminalAppLocalTests
 
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto& commands = settings._globals.GetCommands();
+        auto commands = settings._globals.GetCommands();
         VERIFY_ARE_EQUAL(1u, commands.Size());
 
         {
@@ -2949,8 +2952,8 @@ namespace TerminalAppLocalTests
         }
 
         settings._ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands.GetView(), settings.GetProfiles(), settings._globals.GetColorSchemes());
-        _logCommandNames(expandedCommands);
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals.GetColorSchemes());
+        _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(3u, expandedCommands.Size());
@@ -3068,10 +3071,10 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto& commands = settings._globals.GetCommands();
+        auto commands = settings._globals.GetCommands();
         settings._ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands.GetView(), settings.GetProfiles(), settings._globals.GetColorSchemes());
-        _logCommandNames(expandedCommands);
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals.GetColorSchemes());
+        _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(1u, expandedCommands.Size());
@@ -3176,10 +3179,10 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto& commands = settings._globals.GetCommands();
+        auto commands = settings._globals.GetCommands();
         settings._ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands.GetView(), settings.GetProfiles(), settings._globals.GetColorSchemes());
-        _logCommandNames(expandedCommands);
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals.GetColorSchemes());
+        _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(1u, expandedCommands.Size());
@@ -3315,10 +3318,10 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto& commands = settings._globals.GetCommands();
+        auto commands = settings._globals.GetCommands();
         settings._ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands.GetView(), settings.GetProfiles(), settings._globals.GetColorSchemes());
-        _logCommandNames(expandedCommands);
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals.GetColorSchemes());
+        _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
 
@@ -3337,7 +3340,7 @@ namespace TerminalAppLocalTests
 
             VERIFY_IS_TRUE(commandImpl->HasNestedCommands());
             VERIFY_ARE_EQUAL(3u, commandImpl->_subcommands.Size());
-            _logCommandNames(commandImpl->_subcommands);
+            _logCommandNames(commandImpl->_subcommands.GetView());
             {
                 winrt::hstring childCommandName{ fmt::format(L"Split pane, profile: {}", name) };
                 auto childCommandProj = commandImpl->_subcommands.Lookup(childCommandName);
@@ -3468,10 +3471,10 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto& commands = settings._globals.GetCommands();
+        auto commands = settings._globals.GetCommands();
         settings._ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands.GetView(), settings.GetProfiles(), settings._globals.GetColorSchemes());
-        _logCommandNames(expandedCommands);
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals.GetColorSchemes());
+        _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(1u, expandedCommands.Size());
@@ -3581,10 +3584,10 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto& commands = settings._globals.GetCommands();
+        auto commands = settings._globals.GetCommands();
         settings._ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands.GetView(), settings.GetProfiles(), settings._globals.GetColorSchemes());
-        _logCommandNames(expandedCommands);
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals.GetColorSchemes());
+        _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(1u, expandedCommands.Size());
@@ -3613,7 +3616,7 @@ namespace TerminalAppLocalTests
             VERIFY_IS_TRUE(commandImpl->HasNestedCommands());
             VERIFY_ARE_EQUAL(3u, commandImpl->_subcommands.Size());
 
-            _logCommandNames(commandImpl->_subcommands);
+            _logCommandNames(commandImpl->_subcommands.GetView());
             {
                 winrt::hstring childCommandName{ fmt::format(L"Split pane, profile: {}", name) };
                 auto childCommandProj = commandImpl->_subcommands.Lookup(childCommandName);
@@ -3742,7 +3745,7 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto& commands = settings._globals.GetCommands();
+        auto commands = settings._globals.GetCommands();
         settings._ValidateSettings();
         _logCommandNames(commands);
 
@@ -3819,7 +3822,7 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto& commands = settings._globals.GetCommands();
+        auto commands = settings._globals.GetCommands();
         settings._ValidateSettings();
         _logCommandNames(commands);
 
@@ -3902,7 +3905,7 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto& commands = settings._globals.GetCommands();
+        auto commands = settings._globals.GetCommands();
         settings._ValidateSettings();
         _logCommandNames(commands);
 
@@ -3998,7 +4001,7 @@ namespace TerminalAppLocalTests
 
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto& commands = settings._globals.GetCommands();
+        auto commands = settings._globals.GetCommands();
         VERIFY_ARE_EQUAL(1u, commands.Size());
 
         {
@@ -4019,8 +4022,8 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"${scheme.name}", realArgs.TerminalArgs().Profile());
         }
 
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands.GetView(), settings.GetProfiles(), settings._globals.GetColorSchemes());
-        _logCommandNames(expandedCommands);
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals.GetColorSchemes());
+        _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(3u, expandedCommands.Size());

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -274,7 +274,7 @@ namespace TerminalAppLocalTests
             settings->_ValidateDefaultProfileExists();
             VERIFY_ARE_EQUAL(static_cast<size_t>(0), settings->_warnings.size());
             VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_profiles.size());
-            VERIFY_ARE_EQUAL(winrt::guid{ settings->_globals.DefaultProfile() }, settings->_profiles.at(0).Guid());
+            VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.at(0).Guid());
         }
         {
             // Case 2: Bad settings
@@ -288,7 +288,7 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingDefaultProfile, settings->_warnings.at(0));
 
             VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_profiles.size());
-            VERIFY_ARE_EQUAL(winrt::guid{ settings->_globals.DefaultProfile() }, settings->_profiles.at(0).Guid());
+            VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.at(0).Guid());
         }
         {
             // Case 2: Bad settings
@@ -302,7 +302,7 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingDefaultProfile, settings->_warnings.at(0));
 
             VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_profiles.size());
-            VERIFY_ARE_EQUAL(winrt::guid{ settings->_globals.DefaultProfile() }, settings->_profiles.at(0).Guid());
+            VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.at(0).Guid());
         }
         {
             // Case 4: Good settings, default profile is a string
@@ -314,7 +314,7 @@ namespace TerminalAppLocalTests
             settings->_ValidateDefaultProfileExists();
             VERIFY_ARE_EQUAL(static_cast<size_t>(0), settings->_warnings.size());
             VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_profiles.size());
-            VERIFY_ARE_EQUAL(winrt::guid{ settings->_globals.DefaultProfile() }, settings->_profiles.at(1).Guid());
+            VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.at(1).Guid());
         }
     }
 
@@ -381,19 +381,19 @@ namespace TerminalAppLocalTests
                 }
             ]
         })" };
-        Profile profile0 = winrt::make<implementation::Profile>(winrt::guid{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-4444-49a3-80bd-e8fdd045185c}") });
+        Profile profile0 = winrt::make<implementation::Profile>(::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-4444-49a3-80bd-e8fdd045185c}"));
         profile0.Name(L"profile0");
-        Profile profile1 = winrt::make<implementation::Profile>(winrt::guid{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-5555-49a3-80bd-e8fdd045185c}") });
+        Profile profile1 = winrt::make<implementation::Profile>(::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-5555-49a3-80bd-e8fdd045185c}"));
         profile1.Name(L"profile1");
-        Profile profile2 = winrt::make<implementation::Profile>(winrt::guid{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-4444-49a3-80bd-e8fdd045185c}") });
+        Profile profile2 = winrt::make<implementation::Profile>(::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-4444-49a3-80bd-e8fdd045185c}"));
         profile2.Name(L"profile2");
-        Profile profile3 = winrt::make<implementation::Profile>(winrt::guid{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-4444-49a3-80bd-e8fdd045185c}") });
+        Profile profile3 = winrt::make<implementation::Profile>(::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-4444-49a3-80bd-e8fdd045185c}"));
         profile3.Name(L"profile3");
-        Profile profile4 = winrt::make<implementation::Profile>(winrt::guid{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-6666-49a3-80bd-e8fdd045185c}") });
+        Profile profile4 = winrt::make<implementation::Profile>(::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-6666-49a3-80bd-e8fdd045185c}"));
         profile4.Name(L"profile4");
-        Profile profile5 = winrt::make<implementation::Profile>(winrt::guid{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-5555-49a3-80bd-e8fdd045185c}") });
+        Profile profile5 = winrt::make<implementation::Profile>(::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-5555-49a3-80bd-e8fdd045185c}"));
         profile5.Name(L"profile5");
-        Profile profile6 = winrt::make<implementation::Profile>(winrt::guid{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-7777-49a3-80bd-e8fdd045185c}") });
+        Profile profile6 = winrt::make<implementation::Profile>(::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-7777-49a3-80bd-e8fdd045185c}"));
         profile6.Name(L"profile6");
 
         {
@@ -474,9 +474,9 @@ namespace TerminalAppLocalTests
                 }
             ]
         })" };
-        Profile profile4 = winrt::make<implementation::Profile>(winrt::guid{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-4444-49a3-80bd-e8fdd045185c}") });
+        Profile profile4 = winrt::make<implementation::Profile>(::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-4444-49a3-80bd-e8fdd045185c}"));
         profile4.Name(L"profile4");
-        Profile profile5 = winrt::make<implementation::Profile>(winrt::guid{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-4444-49a3-80bd-e8fdd045185c}") });
+        Profile profile5 = winrt::make<implementation::Profile>(::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-4444-49a3-80bd-e8fdd045185c}"));
         profile5.Name(L"profile5");
 
         // Case 2: Bad settings
@@ -496,7 +496,7 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::UnknownColorScheme, settings->_warnings.at(2));
 
         VERIFY_ARE_EQUAL(3u, settings->_profiles.size());
-        VERIFY_ARE_EQUAL(winrt::guid{ settings->_globals.DefaultProfile() }, settings->_profiles.at(0).Guid());
+        VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.at(0).Guid());
         VERIFY_IS_TRUE(settings->_profiles.at(0).HasGuid());
         VERIFY_IS_TRUE(settings->_profiles.at(1).HasGuid());
         VERIFY_IS_TRUE(settings->_profiles.at(2).HasGuid());
@@ -522,16 +522,16 @@ namespace TerminalAppLocalTests
         CascadiaSettings settings;
 
         settings.LayerJson(settings0Json);
-        VERIFY_ARE_EQUAL(true, settings._globals.AlwaysShowTabs());
-        VERIFY_ARE_EQUAL(120, settings._globals.InitialCols());
-        VERIFY_ARE_EQUAL(30, settings._globals.InitialRows());
-        VERIFY_ARE_EQUAL(true, settings._globals.ShowTabsInTitlebar());
+        VERIFY_ARE_EQUAL(true, settings._globals->AlwaysShowTabs());
+        VERIFY_ARE_EQUAL(120, settings._globals->InitialCols());
+        VERIFY_ARE_EQUAL(30, settings._globals->InitialRows());
+        VERIFY_ARE_EQUAL(true, settings._globals->ShowTabsInTitlebar());
 
         settings.LayerJson(settings1Json);
-        VERIFY_ARE_EQUAL(true, settings._globals.AlwaysShowTabs());
-        VERIFY_ARE_EQUAL(240, settings._globals.InitialCols());
-        VERIFY_ARE_EQUAL(60, settings._globals.InitialRows());
-        VERIFY_ARE_EQUAL(false, settings._globals.ShowTabsInTitlebar());
+        VERIFY_ARE_EQUAL(true, settings._globals->AlwaysShowTabs());
+        VERIFY_ARE_EQUAL(240, settings._globals->InitialCols());
+        VERIFY_ARE_EQUAL(60, settings._globals->InitialRows());
+        VERIFY_ARE_EQUAL(false, settings._globals->ShowTabsInTitlebar());
     }
 
     void SettingsTests::ValidateProfileOrdering()
@@ -1330,7 +1330,7 @@ namespace TerminalAppLocalTests
         settings.LayerJson(settings._userSettings);
 
         VERIFY_ARE_EQUAL(3u, settings._profiles.size());
-        VERIFY_ARE_EQUAL(2u, settings._globals.GetColorSchemes().Size());
+        VERIFY_ARE_EQUAL(2u, settings._globals->GetColorSchemes().Size());
 
         VERIFY_ARE_EQUAL(L"schemeOne", settings._profiles.at(0).ColorSchemeName());
         VERIFY_ARE_EQUAL(L"InvalidSchemeName", settings._profiles.at(1).ColorSchemeName());
@@ -1342,7 +1342,7 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::UnknownColorScheme, settings._warnings.at(0));
 
         VERIFY_ARE_EQUAL(3u, settings._profiles.size());
-        VERIFY_ARE_EQUAL(2u, settings._globals.GetColorSchemes().Size());
+        VERIFY_ARE_EQUAL(2u, settings._globals->GetColorSchemes().Size());
 
         VERIFY_ARE_EQUAL(L"schemeOne", settings._profiles.at(0).ColorSchemeName());
         VERIFY_ARE_EQUAL(L"Campbell", settings._profiles.at(1).ColorSchemeName());
@@ -1379,11 +1379,11 @@ namespace TerminalAppLocalTests
         auto name3{ L"ThisProfileShouldNotThrow" };
         auto badName{ L"DoesNotExist" };
 
-        winrt::guid guid0{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-5555-49a3-80bd-e8fdd045185c}") };
-        winrt::guid guid1{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-6666-49a3-80bd-e8fdd045185c}") };
-        winrt::guid guid2{ ::Microsoft::Console::Utils::GuidFromString(L"{2C4DE342-38B7-51CF-B940-2309A097F518}") };
-        winrt::guid fakeGuid{ ::Microsoft::Console::Utils::GuidFromString(L"{FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF}") };
-        std::optional<winrt::guid> badGuid{};
+        const winrt::guid guid0{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-5555-49a3-80bd-e8fdd045185c}") };
+        const winrt::guid guid1{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-6666-49a3-80bd-e8fdd045185c}") };
+        const winrt::guid guid2{ ::Microsoft::Console::Utils::GuidFromString(L"{2C4DE342-38B7-51CF-B940-2309A097F518}") };
+        const winrt::guid fakeGuid{ ::Microsoft::Console::Utils::GuidFromString(L"{FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF}") };
+        const std::optional<winrt::guid> badGuid{};
 
         VerifyParseSucceeded(settings0String);
 
@@ -1450,7 +1450,7 @@ namespace TerminalAppLocalTests
         settings.LayerJson(settings._userSettings);
         VERIFY_IS_FALSE(settings._profiles.empty());
 
-        GlobalAppSettings globalSettings{};
+        auto globalSettings{ winrt::make<implementation::GlobalAppSettings>() };
         const auto profileImpl = winrt::get_self<implementation::Profile>(settings._profiles[0]);
         auto terminalSettings = profileImpl->CreateTerminalSettings(globalSettings.GetColorSchemes());
         VERIFY_ARE_EQUAL(expectedPath, terminalSettings.BackgroundImage());
@@ -1554,7 +1554,7 @@ namespace TerminalAppLocalTests
             VERIFY_IS_FALSE(settings._userDefaultProfileSettings == Json::Value::null);
             settings.LayerJson(settings._userSettings);
 
-            VERIFY_ARE_EQUAL(guid1String, settings._globals.UnparsedDefaultProfile());
+            VERIFY_ARE_EQUAL(guid1String, settings._globals->UnparsedDefaultProfile());
             VERIFY_ARE_EQUAL(2u, settings._profiles.size());
 
             VERIFY_ARE_EQUAL(2345, settings._profiles.at(0).HistorySize());
@@ -1612,7 +1612,7 @@ namespace TerminalAppLocalTests
 
             settings.LayerJson(settings._userSettings);
 
-            VERIFY_ARE_EQUAL(guid1String, settings._globals.UnparsedDefaultProfile());
+            VERIFY_ARE_EQUAL(guid1String, settings._globals->UnparsedDefaultProfile());
             VERIFY_ARE_EQUAL(4u, settings._profiles.size());
 
             VERIFY_ARE_EQUAL(guid1, settings._profiles.at(2).Guid());
@@ -1629,9 +1629,9 @@ namespace TerminalAppLocalTests
         // settings in defaultSettings should apply _on top_ of settings from
         // dynamic profiles.
 
-        winrt::guid guid1{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-1111-49a3-80bd-e8fdd045185c}") };
-        winrt::guid guid2{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-2222-49a3-80bd-e8fdd045185c}") };
-        winrt::guid guid3{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-3333-49a3-80bd-e8fdd045185c}") };
+        const winrt::guid guid1{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-1111-49a3-80bd-e8fdd045185c}") };
+        const winrt::guid guid2{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-2222-49a3-80bd-e8fdd045185c}") };
+        const winrt::guid guid3{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-3333-49a3-80bd-e8fdd045185c}") };
 
         const std::string userProfiles{ R"(
         {
@@ -1794,7 +1794,7 @@ namespace TerminalAppLocalTests
         settings.LayerJson(settings._userSettings);
         settings._ValidateSettings();
 
-        auto appKeyBindingsProj = settings._globals.GetKeybindings();
+        auto appKeyBindingsProj = settings._globals->GetKeybindings();
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
         const auto profile2Guid = settings._profiles.at(2).Guid();
@@ -2177,7 +2177,7 @@ namespace TerminalAppLocalTests
 
         VERIFY_ARE_EQUAL(2u, settings->_warnings.size());
         VERIFY_ARE_EQUAL(2u, settings->_profiles.size());
-        VERIFY_ARE_EQUAL(winrt::guid{ settings->_globals.DefaultProfile() }, settings->_profiles.at(0).Guid());
+        VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.at(0).Guid());
         try
         {
             const auto [guid, termSettings] = settings->BuildSettings(nullptr);
@@ -2242,14 +2242,14 @@ namespace TerminalAppLocalTests
         settings.LayerJson(settings._userSettings);
 
         VERIFY_ARE_EQUAL(6u, settings._profiles.size());
-        VERIFY_ARE_EQUAL(2u, settings._globals.GetColorSchemes().Size());
+        VERIFY_ARE_EQUAL(2u, settings._globals->GetColorSchemes().Size());
 
-        auto terminalSettings0 = winrt::get_self<implementation::Profile>(settings._profiles[0])->CreateTerminalSettings(settings._globals.GetColorSchemes());
-        auto terminalSettings1 = winrt::get_self<implementation::Profile>(settings._profiles[1])->CreateTerminalSettings(settings._globals.GetColorSchemes());
-        auto terminalSettings2 = winrt::get_self<implementation::Profile>(settings._profiles[2])->CreateTerminalSettings(settings._globals.GetColorSchemes());
-        auto terminalSettings3 = winrt::get_self<implementation::Profile>(settings._profiles[3])->CreateTerminalSettings(settings._globals.GetColorSchemes());
-        auto terminalSettings4 = winrt::get_self<implementation::Profile>(settings._profiles[4])->CreateTerminalSettings(settings._globals.GetColorSchemes());
-        auto terminalSettings5 = winrt::get_self<implementation::Profile>(settings._profiles[5])->CreateTerminalSettings(settings._globals.GetColorSchemes());
+        auto terminalSettings0 = winrt::get_self<implementation::Profile>(settings._profiles[0])->CreateTerminalSettings(settings._globals->GetColorSchemes());
+        auto terminalSettings1 = winrt::get_self<implementation::Profile>(settings._profiles[1])->CreateTerminalSettings(settings._globals->GetColorSchemes());
+        auto terminalSettings2 = winrt::get_self<implementation::Profile>(settings._profiles[2])->CreateTerminalSettings(settings._globals->GetColorSchemes());
+        auto terminalSettings3 = winrt::get_self<implementation::Profile>(settings._profiles[3])->CreateTerminalSettings(settings._globals->GetColorSchemes());
+        auto terminalSettings4 = winrt::get_self<implementation::Profile>(settings._profiles[4])->CreateTerminalSettings(settings._globals->GetColorSchemes());
+        auto terminalSettings5 = winrt::get_self<implementation::Profile>(settings._profiles[5])->CreateTerminalSettings(settings._globals->GetColorSchemes());
 
         VERIFY_ARE_EQUAL(ARGB(0, 0x12, 0x34, 0x56), terminalSettings0.CursorColor()); // from color scheme
         VERIFY_ARE_EQUAL(DEFAULT_CURSOR_COLOR, terminalSettings1.CursorColor()); // default
@@ -2284,13 +2284,12 @@ namespace TerminalAppLocalTests
         const auto settingsObject = VerifyParseSucceeded(badSettings);
         auto settings = CascadiaSettings::FromJson(settingsObject);
 
-        const auto globalsImpl = winrt::get_self<implementation::GlobalAppSettings>(settings->_globals);
-        VERIFY_ARE_EQUAL(0u, globalsImpl->_keybindings->_keyShortcuts.size());
+        VERIFY_ARE_EQUAL(0u, settings->_globals->_keybindings->_keyShortcuts.size());
 
-        VERIFY_ARE_EQUAL(3u, globalsImpl->_keybindingsWarnings.size());
-        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::TooManyKeysForChord, globalsImpl->_keybindingsWarnings.at(0));
-        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter, globalsImpl->_keybindingsWarnings.at(1));
-        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter, globalsImpl->_keybindingsWarnings.at(2));
+        VERIFY_ARE_EQUAL(3u, settings->_globals->_keybindingsWarnings.size());
+        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::TooManyKeysForChord, settings->_globals->_keybindingsWarnings.at(0));
+        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter, settings->_globals->_keybindingsWarnings.at(1));
+        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter, settings->_globals->_keybindingsWarnings.at(2));
 
         settings->_ValidateKeybindings();
 
@@ -2327,18 +2326,17 @@ namespace TerminalAppLocalTests
 
         auto settings = CascadiaSettings::FromJson(settingsObject);
 
-        auto globalsImpl = winrt::get_self<implementation::GlobalAppSettings>(settings->_globals);
-        VERIFY_ARE_EQUAL(0u, globalsImpl->_keybindings->_keyShortcuts.size());
+        VERIFY_ARE_EQUAL(0u, settings->_globals->_keybindings->_keyShortcuts.size());
 
-        for (const auto& warning : globalsImpl->_keybindingsWarnings)
+        for (const auto& warning : settings->_globals->_keybindingsWarnings)
         {
             Log::Comment(NoThrowString().Format(
                 L"warning:%d", warning));
         }
-        VERIFY_ARE_EQUAL(3u, globalsImpl->_keybindingsWarnings.size());
-        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter, globalsImpl->_keybindingsWarnings.at(0));
-        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter, globalsImpl->_keybindingsWarnings.at(1));
-        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter, globalsImpl->_keybindingsWarnings.at(2));
+        VERIFY_ARE_EQUAL(3u, settings->_globals->_keybindingsWarnings.size());
+        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter, settings->_globals->_keybindingsWarnings.at(0));
+        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter, settings->_globals->_keybindingsWarnings.at(1));
+        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingRequiredParameter, settings->_globals->_keybindingsWarnings.at(2));
 
         settings->_ValidateKeybindings();
 
@@ -2468,13 +2466,13 @@ namespace TerminalAppLocalTests
         const auto profile2Guid = settings._profiles.at(2).Guid();
         VERIFY_ARE_NOT_EQUAL(winrt::guid{}, profile2Guid);
 
-        auto appKeyBindings = winrt::get_self<implementation::AppKeyBindings>(settings._globals.GetKeybindings());
+        auto appKeyBindings = winrt::get_self<implementation::AppKeyBindings>(settings._globals->GetKeybindings());
         VERIFY_ARE_EQUAL(5u, appKeyBindings->_keyShortcuts.size());
 
         // A/D, B, C, E will be in the list of commands, for 4 total.
         // * A and D share the same name, so they'll only generate a single action.
         // * F's name is set manually to `null`
-        auto commands = settings._globals.GetCommands();
+        auto commands = settings._globals->GetCommands();
         VERIFY_ARE_EQUAL(4u, commands.Size());
 
         {
@@ -2668,7 +2666,7 @@ namespace TerminalAppLocalTests
 
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto commands = settings._globals.GetCommands();
+        auto commands = settings._globals->GetCommands();
         VERIFY_ARE_EQUAL(1u, commands.Size());
 
         {
@@ -2689,7 +2687,7 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"${profile.name}", realArgs.TerminalArgs().Profile());
         }
 
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals.GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
@@ -2798,7 +2796,7 @@ namespace TerminalAppLocalTests
 
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto commands = settings._globals.GetCommands();
+        auto commands = settings._globals->GetCommands();
         VERIFY_ARE_EQUAL(1u, commands.Size());
 
         {
@@ -2819,7 +2817,7 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"${profile.name}", realArgs.TerminalArgs().Profile());
         }
 
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals.GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
@@ -2930,7 +2928,7 @@ namespace TerminalAppLocalTests
 
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto commands = settings._globals.GetCommands();
+        auto commands = settings._globals->GetCommands();
         VERIFY_ARE_EQUAL(1u, commands.Size());
 
         {
@@ -2952,7 +2950,7 @@ namespace TerminalAppLocalTests
         }
 
         settings._ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals.GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
@@ -3071,9 +3069,9 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto commands = settings._globals.GetCommands();
+        auto commands = settings._globals->GetCommands();
         settings._ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals.GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
@@ -3179,9 +3177,9 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto commands = settings._globals.GetCommands();
+        auto commands = settings._globals->GetCommands();
         settings._ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals.GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
@@ -3318,9 +3316,9 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto commands = settings._globals.GetCommands();
+        auto commands = settings._globals->GetCommands();
         settings._ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals.GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
@@ -3471,9 +3469,9 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto commands = settings._globals.GetCommands();
+        auto commands = settings._globals->GetCommands();
         settings._ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals.GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
@@ -3584,9 +3582,9 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto commands = settings._globals.GetCommands();
+        auto commands = settings._globals->GetCommands();
         settings._ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals.GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
@@ -3745,7 +3743,7 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto commands = settings._globals.GetCommands();
+        auto commands = settings._globals->GetCommands();
         settings._ValidateSettings();
         _logCommandNames(commands);
 
@@ -3822,7 +3820,7 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto commands = settings._globals.GetCommands();
+        auto commands = settings._globals->GetCommands();
         settings._ValidateSettings();
         _logCommandNames(commands);
 
@@ -3905,7 +3903,7 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto commands = settings._globals.GetCommands();
+        auto commands = settings._globals->GetCommands();
         settings._ValidateSettings();
         _logCommandNames(commands);
 
@@ -4001,7 +3999,7 @@ namespace TerminalAppLocalTests
 
         VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
 
-        auto commands = settings._globals.GetCommands();
+        auto commands = settings._globals->GetCommands();
         VERIFY_ARE_EQUAL(1u, commands.Size());
 
         {
@@ -4022,7 +4020,7 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"${scheme.name}", realArgs.TerminalArgs().Profile());
         }
 
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals.GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings._warnings.size());

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -561,7 +561,7 @@ namespace winrt::TerminalApp::implementation
     // - defaultInitialY: the system default y coordinate value
     // Return Value:
     // - a point containing the requested initial position in pixels.
-    winrt::Windows::Foundation::Point AppLogic::GetLaunchInitialPositions(int32_t defaultInitialX, int32_t defaultInitialY)
+    TerminalApp::InitialPosition AppLogic::GetInitialPosition(int64_t defaultInitialX, int64_t defaultInitialY)
     {
         if (!_loadedInitialSettings)
         {
@@ -569,13 +569,11 @@ namespace winrt::TerminalApp::implementation
             LoadSettings();
         }
 
-        const auto globals{ _settings->GlobalSettings() };
-        winrt::Windows::Foundation::Point point{
-            /* X */ gsl::narrow_cast<float>(globals.HasInitialPositionX() ? globals.InitialPositionX() : defaultInitialX),
-            /* Y */ gsl::narrow_cast<float>(globals.HasInitialPositionY() ? globals.InitialPositionY() : defaultInitialY)
+        const auto initialPosition{ _settings->GlobalSettings().InitialPosition() };
+        return {
+            initialPosition.X ? initialPosition.X.Value() : defaultInitialX,
+            initialPosition.Y ? initialPosition.Y.Value() : defaultInitialY
         };
-
-        return point;
     }
 
     winrt::Windows::UI::Xaml::ElementTheme AppLogic::GetRequestedTheme()

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -569,10 +569,10 @@ namespace winrt::TerminalApp::implementation
             LoadSettings();
         }
 
-        const auto initialPosition{ _settings->GlobalSettings().InitialPosition() };
+        const auto globals{ _settings->GlobalSettings() };
         winrt::Windows::Foundation::Point point{
-            /* X */ gsl::narrow_cast<float>(initialPosition.x.value_or(defaultInitialX)),
-            /* Y */ gsl::narrow_cast<float>(initialPosition.y.value_or(defaultInitialY))
+            /* X */ gsl::narrow_cast<float>(globals.HasInitialPositionX() ? globals.InitialPositionX() : defaultInitialX),
+            /* Y */ gsl::narrow_cast<float>(globals.HasInitialPositionY() ? globals.InitialPositionY() : defaultInitialY)
         };
 
         return point;

--- a/src/cascadia/TerminalApp/AppLogic.h
+++ b/src/cascadia/TerminalApp/AppLogic.h
@@ -38,7 +38,7 @@ namespace winrt::TerminalApp::implementation
         bool AlwaysOnTop() const;
 
         Windows::Foundation::Size GetLaunchDimensions(uint32_t dpi);
-        winrt::Windows::Foundation::Point GetLaunchInitialPositions(int32_t defaultInitialX, int32_t defaultInitialY);
+        TerminalApp::InitialPosition GetInitialPosition(int64_t defaultInitialX, int64_t defaultInitialY);
         winrt::Windows::UI::Xaml::ElementTheme GetRequestedTheme();
         LaunchMode GetLaunchMode();
         bool GetShowTabsInTitlebar();

--- a/src/cascadia/TerminalApp/AppLogic.idl
+++ b/src/cascadia/TerminalApp/AppLogic.idl
@@ -7,6 +7,12 @@ import "IDirectKeyListener.idl";
 
 namespace TerminalApp
 {
+    struct InitialPosition
+    {
+        Int64 X;
+        Int64 Y;
+    };
+
     enum LaunchMode
     {
         DefaultMode,
@@ -47,7 +53,7 @@ namespace TerminalApp
 
         Windows.Foundation.Size GetLaunchDimensions(UInt32 dpi);
 
-        Windows.Foundation.Point GetLaunchInitialPositions(Int32 defaultInitialX, Int32 defaultInitialY);
+        InitialPosition GetInitialPosition(Int64 defaultInitialX, Int64 defaultInitialY);
         Windows.UI.Xaml.ElementTheme GetRequestedTheme();
         LaunchMode GetLaunchMode();
         Boolean GetShowTabsInTitlebar();

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -53,7 +53,7 @@ CascadiaSettings::CascadiaSettings() :
 // Arguments:
 // - addDynamicProfiles: if true, we'll add the built-in DPGs.
 CascadiaSettings::CascadiaSettings(const bool addDynamicProfiles) :
-    _globals(winrt::make_self<winrt::TerminalApp::implementation::GlobalAppSettings>())
+    _globals{ winrt::make_self<winrt::TerminalApp::implementation::GlobalAppSettings>() }
 {
     if (addDynamicProfiles)
     {

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -52,7 +52,8 @@ CascadiaSettings::CascadiaSettings() :
 //   generators. Set this to `false` for unit testing.
 // Arguments:
 // - addDynamicProfiles: if true, we'll add the built-in DPGs.
-CascadiaSettings::CascadiaSettings(const bool addDynamicProfiles)
+CascadiaSettings::CascadiaSettings(const bool addDynamicProfiles) :
+    _globals(winrt::make_self<winrt::TerminalApp::implementation::GlobalAppSettings>())
 {
     if (addDynamicProfiles)
     {

--- a/src/cascadia/TerminalApp/CascadiaSettings.h
+++ b/src/cascadia/TerminalApp/CascadiaSettings.h
@@ -87,7 +87,7 @@ public:
     bool ApplyColorScheme(winrt::Microsoft::Terminal::TerminalControl::IControlSettings& settings, winrt::hstring schemeName);
 
 private:
-    winrt::TerminalApp::GlobalAppSettings _globals;
+    winrt::com_ptr<winrt::TerminalApp::implementation::GlobalAppSettings> _globals;
     std::vector<winrt::TerminalApp::Profile> _profiles;
     std::vector<TerminalApp::SettingsLoadWarnings> _warnings;
 

--- a/src/cascadia/TerminalApp/CascadiaSettings.h
+++ b/src/cascadia/TerminalApp/CascadiaSettings.h
@@ -67,7 +67,7 @@ public:
     std::tuple<winrt::guid, winrt::TerminalApp::TerminalSettings> BuildSettings(const winrt::TerminalApp::NewTerminalArgs& newTerminalArgs) const;
     winrt::TerminalApp::TerminalSettings BuildSettings(winrt::guid profileGuid) const;
 
-    GlobalAppSettings& GlobalSettings();
+    winrt::TerminalApp::GlobalAppSettings GlobalSettings();
 
     gsl::span<const winrt::TerminalApp::Profile> GetProfiles() const noexcept;
 
@@ -84,10 +84,10 @@ public:
 
     std::vector<TerminalApp::SettingsLoadWarnings>& GetWarnings();
 
-    bool ApplyColorScheme(winrt::Microsoft::Terminal::TerminalControl::IControlSettings& settings, std::wstring_view schemeName);
+    bool ApplyColorScheme(winrt::Microsoft::Terminal::TerminalControl::IControlSettings& settings, winrt::hstring schemeName);
 
 private:
-    GlobalAppSettings _globals;
+    winrt::TerminalApp::GlobalAppSettings _globals;
     std::vector<winrt::TerminalApp::Profile> _profiles;
     std::vector<TerminalApp::SettingsLoadWarnings> _warnings;
 

--- a/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
@@ -560,7 +560,8 @@ std::unique_ptr<CascadiaSettings> CascadiaSettings::FromJson(const Json::Value& 
 // <none>
 void CascadiaSettings::LayerJson(const Json::Value& json)
 {
-    _globals.LayerJson(json);
+    auto globals = winrt::get_self<implementation::GlobalAppSettings>(_globals);
+    globals->LayerJson(json);
 
     if (auto schemes{ json[SchemesKey.data()] })
     {
@@ -728,11 +729,9 @@ winrt::com_ptr<implementation::ColorScheme> CascadiaSettings::_FindMatchingColor
 {
     if (auto schemeName = implementation::ColorScheme::GetNameFromJson(schemeJson))
     {
-        auto& schemes = _globals.GetColorSchemes();
-        auto iterator = schemes.find(*schemeName);
-        if (iterator != schemes.end())
+        if (auto scheme{ _globals.GetColorSchemes().TryLookup(*schemeName) })
         {
-            return winrt::get_self<implementation::ColorScheme>(iterator->second)->get_strong();
+            return winrt::get_self<implementation::ColorScheme>(scheme)->get_strong();
         }
     }
     return nullptr;

--- a/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
@@ -560,8 +560,7 @@ std::unique_ptr<CascadiaSettings> CascadiaSettings::FromJson(const Json::Value& 
 // <none>
 void CascadiaSettings::LayerJson(const Json::Value& json)
 {
-    auto globals = winrt::get_self<implementation::GlobalAppSettings>(_globals);
-    globals->LayerJson(json);
+    _globals->LayerJson(json);
 
     if (auto schemes{ json[SchemesKey.data()] })
     {
@@ -710,7 +709,7 @@ void CascadiaSettings::_LayerOrCreateColorScheme(const Json::Value& schemeJson)
     else
     {
         const auto scheme = implementation::ColorScheme::FromJson(schemeJson);
-        _globals.AddColorScheme(*scheme);
+        _globals->AddColorScheme(*scheme);
     }
 }
 
@@ -729,7 +728,7 @@ winrt::com_ptr<implementation::ColorScheme> CascadiaSettings::_FindMatchingColor
 {
     if (auto schemeName = implementation::ColorScheme::GetNameFromJson(schemeJson))
     {
-        if (auto scheme{ _globals.GetColorSchemes().TryLookup(*schemeName) })
+        if (auto scheme{ _globals->GetColorSchemes().TryLookup(*schemeName) })
         {
             return winrt::get_self<implementation::ColorScheme>(scheme)->get_strong();
         }

--- a/src/cascadia/TerminalApp/Command.h
+++ b/src/cascadia/TerminalApp/Command.h
@@ -60,7 +60,7 @@ namespace winrt::TerminalApp::implementation
         OBSERVABLE_GETSET_PROPERTY(winrt::hstring, KeyChordText, _PropertyChangedHandlers);
         OBSERVABLE_GETSET_PROPERTY(winrt::Windows::UI::Xaml::Controls::IconSource, IconSource, _PropertyChangedHandlers, nullptr);
 
-        GETSET_PROPERTY(::TerminalApp::ExpandCommandType, IterateOn, ::TerminalApp::ExpandCommandType::None);
+        GETSET_PROPERTY(ExpandCommandType, IterateOn, ExpandCommandType::None);
 
     private:
         Json::Value _originalJson;

--- a/src/cascadia/TerminalApp/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.cpp
@@ -75,7 +75,7 @@ winrt::Windows::Foundation::Collections::IMapView<winrt::hstring, winrt::Termina
     return _colorSchemes.GetView();
 }
 
-void GlobalAppSettings::DefaultProfile(const winrt::guid defaultProfile) noexcept
+void GlobalAppSettings::DefaultProfile(const winrt::guid& defaultProfile) noexcept
 {
     _unparsedDefaultProfile.clear();
     _defaultProfile = defaultProfile;
@@ -104,7 +104,7 @@ winrt::TerminalApp::AppKeyBindings GlobalAppSettings::GetKeybindings() const noe
 // - settings: a TerminalSettings object to add global property values to.
 // Return Value:
 // - <none>
-void GlobalAppSettings::ApplyToSettings(TerminalApp::TerminalSettings settings) const noexcept
+void GlobalAppSettings::ApplyToSettings(const TerminalApp::TerminalSettings& settings) const noexcept
 {
     settings.KeyBindings(GetKeybindings());
     settings.InitialRows(_InitialRows);
@@ -211,7 +211,7 @@ void GlobalAppSettings::LayerJson(const Json::Value& json)
 // - scheme: the color scheme to add
 // Return Value:
 // - <none>
-void GlobalAppSettings::AddColorScheme(winrt::TerminalApp::ColorScheme scheme)
+void GlobalAppSettings::AddColorScheme(const winrt::TerminalApp::ColorScheme& scheme)
 {
     _colorSchemes.Insert(scheme.Name(), scheme);
 }

--- a/src/cascadia/TerminalApp/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.cpp
@@ -9,8 +9,10 @@
 #include "JsonUtils.h"
 #include "TerminalSettingsSerializationHelpers.h"
 
+#include "GlobalAppSettings.g.cpp"
+
 using namespace TerminalApp;
-using namespace winrt::TerminalApp;
+using namespace winrt::TerminalApp::implementation;
 using namespace winrt::Windows::UI::Xaml;
 using namespace ::Microsoft::Console;
 using namespace winrt::Microsoft::UI::Xaml::Controls;
@@ -51,10 +53,9 @@ static constexpr bool debugFeaturesDefault{ false };
 #endif
 
 GlobalAppSettings::GlobalAppSettings() :
-    _keybindings{ winrt::make_self<winrt::TerminalApp::implementation::AppKeyBindings>() },
+    _keybindings{ winrt::make_self<AppKeyBindings>() },
     _keybindingsWarnings{},
-    _colorSchemes{},
-    _unparsedDefaultProfile{ std::nullopt },
+    _unparsedDefaultProfile{ },
     _defaultProfile{},
     _InitialRows{ DEFAULT_ROWS },
     _InitialCols{ DEFAULT_COLS },
@@ -62,41 +63,37 @@ GlobalAppSettings::GlobalAppSettings() :
     _DebugFeaturesEnabled{ debugFeaturesDefault }
 {
     _commands = winrt::single_threaded_map<winrt::hstring, winrt::TerminalApp::Command>();
+    _colorSchemes = winrt::single_threaded_map<winrt::hstring, winrt::TerminalApp::ColorScheme>();
 }
 
 GlobalAppSettings::~GlobalAppSettings()
 {
 }
 
-std::unordered_map<std::wstring, ColorScheme>& GlobalAppSettings::GetColorSchemes() noexcept
+winrt::Windows::Foundation::Collections::IMapView<winrt::hstring, winrt::TerminalApp::ColorScheme> GlobalAppSettings::GetColorSchemes() noexcept
 {
-    return _colorSchemes;
+    return _colorSchemes.GetView();
 }
 
-const std::unordered_map<std::wstring, ColorScheme>& GlobalAppSettings::GetColorSchemes() const noexcept
+void GlobalAppSettings::DefaultProfile(const winrt::guid defaultProfile) noexcept
 {
-    return _colorSchemes;
-}
-
-void GlobalAppSettings::DefaultProfile(const GUID defaultProfile) noexcept
-{
-    _unparsedDefaultProfile.reset();
+    _unparsedDefaultProfile.clear();
     _defaultProfile = defaultProfile;
 }
 
-GUID GlobalAppSettings::DefaultProfile() const
+winrt::guid GlobalAppSettings::DefaultProfile() const
 {
     // If we have an unresolved default profile, we should likely explode.
-    THROW_HR_IF(E_INVALIDARG, _unparsedDefaultProfile.has_value());
+    THROW_HR_IF(E_INVALIDARG, !_unparsedDefaultProfile.empty());
     return _defaultProfile;
 }
 
-std::optional<std::wstring> GlobalAppSettings::UnparsedDefaultProfile() const
+winrt::hstring GlobalAppSettings::UnparsedDefaultProfile() const
 {
     return _unparsedDefaultProfile;
 }
 
-AppKeyBindings GlobalAppSettings::GetKeybindings() const noexcept
+winrt::TerminalApp::AppKeyBindings GlobalAppSettings::GetKeybindings() const noexcept
 {
     return *_keybindings;
 }
@@ -107,7 +104,7 @@ AppKeyBindings GlobalAppSettings::GetKeybindings() const noexcept
 // - settings: a TerminalSettings object to add global property values to.
 // Return Value:
 // - <none>
-void GlobalAppSettings::ApplyToSettings(TerminalSettings& settings) const noexcept
+void GlobalAppSettings::ApplyToSettings(TerminalApp::TerminalSettings settings) const noexcept
 {
     settings.KeyBindings(GetKeybindings());
     settings.InitialRows(_InitialRows);
@@ -126,10 +123,10 @@ void GlobalAppSettings::ApplyToSettings(TerminalSettings& settings) const noexce
 // - json: an object which should be a serialization of a GlobalAppSettings object.
 // Return Value:
 // - a new GlobalAppSettings instance created from the values in `json`
-GlobalAppSettings GlobalAppSettings::FromJson(const Json::Value& json)
+winrt::com_ptr<GlobalAppSettings> GlobalAppSettings::FromJson(const Json::Value& json)
 {
-    GlobalAppSettings result;
-    result.LayerJson(json);
+    auto result = winrt::make_self<GlobalAppSettings>();
+    result->LayerJson(json);
     return result;
 }
 
@@ -145,7 +142,7 @@ void GlobalAppSettings::LayerJson(const Json::Value& json)
 
     JsonUtils::GetValueForKey(json, InitialColsKey, _InitialCols);
 
-    JsonUtils::GetValueForKey(json, InitialPositionKey, _InitialPosition);
+    JsonUtils::GetValueForKey(json, InitialPositionKey, _initialPosition);
 
     JsonUtils::GetValueForKey(json, ShowTitleInTitlebarKey, _ShowTitleInTitlebar);
 
@@ -214,10 +211,9 @@ void GlobalAppSettings::LayerJson(const Json::Value& json)
 // - scheme: the color scheme to add
 // Return Value:
 // - <none>
-void GlobalAppSettings::AddColorScheme(ColorScheme scheme)
+void GlobalAppSettings::AddColorScheme(winrt::TerminalApp::ColorScheme scheme)
 {
-    std::wstring name{ scheme.Name() };
-    _colorSchemes[name] = std::move(scheme);
+    _colorSchemes.Insert(scheme.Name(), scheme);
 }
 
 // Method Description:
@@ -234,12 +230,27 @@ std::vector<TerminalApp::SettingsLoadWarnings> GlobalAppSettings::GetKeybindings
     return _keybindingsWarnings;
 }
 
-const winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::TerminalApp::Command>& GlobalAppSettings::GetCommands() const noexcept
+winrt::Windows::Foundation::Collections::IMapView<winrt::hstring, winrt::TerminalApp::Command> GlobalAppSettings::GetCommands() noexcept
 {
-    return _commands;
+    return _commands.GetView();
 }
 
-winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::TerminalApp::Command>& GlobalAppSettings::GetCommands() noexcept
+bool GlobalAppSettings::HasInitialPositionX() const
 {
-    return _commands;
+    return _initialPosition.x.has_value();
+}
+
+bool GlobalAppSettings::HasInitialPositionY() const
+{
+    return _initialPosition.y.has_value();
+}
+
+int32_t GlobalAppSettings::InitialPositionX() const
+{
+    return _initialPosition.x.value();
+}
+
+int32_t GlobalAppSettings::InitialPositionY() const
+{
+    return _initialPosition.y.value();
 }

--- a/src/cascadia/TerminalApp/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.cpp
@@ -142,7 +142,7 @@ void GlobalAppSettings::LayerJson(const Json::Value& json)
 
     JsonUtils::GetValueForKey(json, InitialColsKey, _InitialCols);
 
-    JsonUtils::GetValueForKey(json, InitialPositionKey, _initialPosition);
+    JsonUtils::GetValueForKey(json, InitialPositionKey, _InitialPosition);
 
     JsonUtils::GetValueForKey(json, ShowTitleInTitlebarKey, _ShowTitleInTitlebar);
 
@@ -233,24 +233,4 @@ std::vector<TerminalApp::SettingsLoadWarnings> GlobalAppSettings::GetKeybindings
 winrt::Windows::Foundation::Collections::IMapView<winrt::hstring, winrt::TerminalApp::Command> GlobalAppSettings::GetCommands() noexcept
 {
     return _commands.GetView();
-}
-
-bool GlobalAppSettings::HasInitialPositionX() const
-{
-    return _initialPosition.x.has_value();
-}
-
-bool GlobalAppSettings::HasInitialPositionY() const
-{
-    return _initialPosition.y.has_value();
-}
-
-int32_t GlobalAppSettings::InitialPositionX() const
-{
-    return _initialPosition.x.value();
-}
-
-int32_t GlobalAppSettings::InitialPositionY() const
-{
-    return _initialPosition.y.value();
 }

--- a/src/cascadia/TerminalApp/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.cpp
@@ -46,28 +46,14 @@ static constexpr std::string_view ForceFullRepaintRenderingKey{ "experimental.re
 static constexpr std::string_view SoftwareRenderingKey{ "experimental.rendering.software" };
 static constexpr std::string_view ForceVTInputKey{ "experimental.input.forceVT" };
 
-#ifdef _DEBUG
-static constexpr bool debugFeaturesDefault{ true };
-#else
-static constexpr bool debugFeaturesDefault{ false };
-#endif
-
 GlobalAppSettings::GlobalAppSettings() :
     _keybindings{ winrt::make_self<AppKeyBindings>() },
     _keybindingsWarnings{},
-    _unparsedDefaultProfile{ },
-    _defaultProfile{},
-    _InitialRows{ DEFAULT_ROWS },
-    _InitialCols{ DEFAULT_COLS },
-    _WordDelimiters{ DEFAULT_WORD_DELIMITERS },
-    _DebugFeaturesEnabled{ debugFeaturesDefault }
+    _unparsedDefaultProfile{},
+    _defaultProfile{}
 {
     _commands = winrt::single_threaded_map<winrt::hstring, winrt::TerminalApp::Command>();
     _colorSchemes = winrt::single_threaded_map<winrt::hstring, winrt::TerminalApp::ColorScheme>();
-}
-
-GlobalAppSettings::~GlobalAppSettings()
-{
 }
 
 winrt::Windows::Foundation::Collections::IMapView<winrt::hstring, winrt::TerminalApp::ColorScheme> GlobalAppSettings::GetColorSchemes() noexcept

--- a/src/cascadia/TerminalApp/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.cpp
@@ -46,11 +46,18 @@ static constexpr std::string_view ForceFullRepaintRenderingKey{ "experimental.re
 static constexpr std::string_view SoftwareRenderingKey{ "experimental.rendering.software" };
 static constexpr std::string_view ForceVTInputKey{ "experimental.input.forceVT" };
 
+#ifdef _DEBUG
+static constexpr bool debugFeaturesDefault{ true };
+#else
+static constexpr bool debugFeaturesDefault{ false };
+#endif
+
 GlobalAppSettings::GlobalAppSettings() :
     _keybindings{ winrt::make_self<AppKeyBindings>() },
     _keybindingsWarnings{},
     _unparsedDefaultProfile{},
-    _defaultProfile{}
+    _defaultProfile{},
+    _DebugFeaturesEnabled{ debugFeaturesDefault }
 {
     _commands = winrt::single_threaded_map<winrt::hstring, winrt::TerminalApp::Command>();
     _colorSchemes = winrt::single_threaded_map<winrt::hstring, winrt::TerminalApp::ColorScheme>();

--- a/src/cascadia/TerminalApp/GlobalAppSettings.h
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.h
@@ -14,11 +14,13 @@ Author(s):
 
 --*/
 #pragma once
-#include "AppKeyBindings.h"
-#include "Command.h"
+
+#include "GlobalAppSettings.g.h"
 #include "SettingsTypes.h"
 
-#include "ColorScheme.g.h"
+#include "AppKeyBindings.h"
+#include "Command.h"
+#include "ColorScheme.h"
 
 // fwdecl unittest classes
 namespace TerminalAppLocalTests
@@ -27,73 +29,79 @@ namespace TerminalAppLocalTests
     class ColorSchemeTests;
 };
 
-namespace TerminalApp
+namespace winrt::TerminalApp::implementation
 {
-    class GlobalAppSettings;
-};
+    struct GlobalAppSettings : GlobalAppSettingsT<GlobalAppSettings>
+    {
+    public:
+        GlobalAppSettings();
+        ~GlobalAppSettings();
 
-class TerminalApp::GlobalAppSettings final
+        Windows::Foundation::Collections::IMapView<hstring, TerminalApp::ColorScheme> GetColorSchemes() noexcept;
+        void AddColorScheme(TerminalApp::ColorScheme scheme);
+
+        TerminalApp::AppKeyBindings GetKeybindings() const noexcept;
+
+        static com_ptr<GlobalAppSettings> FromJson(const Json::Value& json);
+        void LayerJson(const Json::Value& json);
+
+        void ApplyToSettings(TerminalApp::TerminalSettings settings) const noexcept;
+
+        std::vector<::TerminalApp::SettingsLoadWarnings> GetKeybindingsWarnings() const;
+
+        Windows::Foundation::Collections::IMapView<hstring, TerminalApp::Command> GetCommands() noexcept;
+
+        // These are implemented manually to handle the string/GUID exchange
+        // by higher layers in the app.
+        void DefaultProfile(const guid defaultProfile) noexcept;
+        guid DefaultProfile() const;
+        hstring UnparsedDefaultProfile() const;
+
+        bool HasInitialPositionX() const;
+        bool HasInitialPositionY() const;
+        int32_t InitialPositionX() const;
+        int32_t InitialPositionY() const;
+
+        GETSET_PROPERTY(int32_t, InitialRows); // default value set in constructor
+        GETSET_PROPERTY(int32_t, InitialCols); // default value set in constructor
+        GETSET_PROPERTY(bool, AlwaysShowTabs, true);
+        GETSET_PROPERTY(bool, ShowTitleInTitlebar, true);
+        GETSET_PROPERTY(bool, ConfirmCloseAllTabs, true);
+        GETSET_PROPERTY(winrt::Windows::UI::Xaml::ElementTheme, Theme, winrt::Windows::UI::Xaml::ElementTheme::Default);
+        GETSET_PROPERTY(winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode, TabWidthMode, winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode::Equal);
+        GETSET_PROPERTY(bool, ShowTabsInTitlebar, true);
+        GETSET_PROPERTY(hstring, WordDelimiters); // default value set in constructor
+        GETSET_PROPERTY(bool, CopyOnSelect, false);
+        GETSET_PROPERTY(winrt::Microsoft::Terminal::TerminalControl::CopyFormat, CopyFormatting, 0);
+        GETSET_PROPERTY(bool, WarnAboutLargePaste, true);
+        GETSET_PROPERTY(bool, WarnAboutMultiLinePaste, true);
+        GETSET_PROPERTY(winrt::TerminalApp::LaunchMode, LaunchMode, winrt::TerminalApp::LaunchMode::DefaultMode);
+        GETSET_PROPERTY(bool, SnapToGridOnResize, true);
+        GETSET_PROPERTY(bool, ForceFullRepaintRendering, false);
+        GETSET_PROPERTY(bool, SoftwareRendering, false);
+        GETSET_PROPERTY(bool, ForceVTInput, false);
+        GETSET_PROPERTY(bool, DebugFeaturesEnabled); // default value set in constructor
+        GETSET_PROPERTY(bool, StartOnUserLogin, false);
+        GETSET_PROPERTY(bool, AlwaysOnTop, false);
+        GETSET_PROPERTY(bool, UseTabSwitcher, true);
+
+    private:
+        hstring _unparsedDefaultProfile;
+        guid _defaultProfile;
+        LaunchPosition _initialPosition;
+
+        com_ptr<AppKeyBindings> _keybindings;
+        std::vector<::TerminalApp::SettingsLoadWarnings> _keybindingsWarnings;
+
+        Windows::Foundation::Collections::IMap<hstring, TerminalApp::ColorScheme> _colorSchemes;
+        Windows::Foundation::Collections::IMap<hstring, TerminalApp::Command> _commands;
+
+        friend class TerminalAppLocalTests::SettingsTests;
+        friend class TerminalAppLocalTests::ColorSchemeTests;
+    };
+}
+
+namespace winrt::TerminalApp::factory_implementation
 {
-public:
-    GlobalAppSettings();
-    ~GlobalAppSettings();
-
-    std::unordered_map<std::wstring, winrt::TerminalApp::ColorScheme>& GetColorSchemes() noexcept;
-    const std::unordered_map<std::wstring, winrt::TerminalApp::ColorScheme>& GetColorSchemes() const noexcept;
-    void AddColorScheme(winrt::TerminalApp::ColorScheme scheme);
-
-    winrt::TerminalApp::AppKeyBindings GetKeybindings() const noexcept;
-
-    static GlobalAppSettings FromJson(const Json::Value& json);
-    void LayerJson(const Json::Value& json);
-
-    void ApplyToSettings(winrt::TerminalApp::TerminalSettings& settings) const noexcept;
-
-    std::vector<TerminalApp::SettingsLoadWarnings> GetKeybindingsWarnings() const;
-
-    const winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::TerminalApp::Command>& GetCommands() const noexcept;
-    winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::TerminalApp::Command>& GetCommands() noexcept;
-
-    // These are implemented manually to handle the string/GUID exchange
-    // by higher layers in the app.
-    void DefaultProfile(const GUID defaultProfile) noexcept;
-    GUID DefaultProfile() const;
-    std::optional<std::wstring> UnparsedDefaultProfile() const;
-
-    GETSET_PROPERTY(int32_t, InitialRows); // default value set in constructor
-    GETSET_PROPERTY(int32_t, InitialCols); // default value set in constructor
-    GETSET_PROPERTY(bool, AlwaysShowTabs, true);
-    GETSET_PROPERTY(bool, ShowTitleInTitlebar, true);
-    GETSET_PROPERTY(bool, ConfirmCloseAllTabs, true);
-    GETSET_PROPERTY(winrt::Windows::UI::Xaml::ElementTheme, Theme, winrt::Windows::UI::Xaml::ElementTheme::Default);
-    GETSET_PROPERTY(winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode, TabWidthMode, winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode::Equal);
-    GETSET_PROPERTY(bool, ShowTabsInTitlebar, true);
-    GETSET_PROPERTY(std::wstring, WordDelimiters); // default value set in constructor
-    GETSET_PROPERTY(bool, CopyOnSelect, false);
-    GETSET_PROPERTY(winrt::Microsoft::Terminal::TerminalControl::CopyFormat, CopyFormatting, 0);
-    GETSET_PROPERTY(bool, WarnAboutLargePaste, true);
-    GETSET_PROPERTY(bool, WarnAboutMultiLinePaste, true);
-    GETSET_PROPERTY(LaunchPosition, InitialPosition);
-    GETSET_PROPERTY(winrt::TerminalApp::LaunchMode, LaunchMode, winrt::TerminalApp::LaunchMode::DefaultMode);
-    GETSET_PROPERTY(bool, SnapToGridOnResize, true);
-    GETSET_PROPERTY(bool, ForceFullRepaintRendering, false);
-    GETSET_PROPERTY(bool, SoftwareRendering, false);
-    GETSET_PROPERTY(bool, ForceVTInput, false);
-    GETSET_PROPERTY(bool, DebugFeaturesEnabled); // default value set in constructor
-    GETSET_PROPERTY(bool, StartOnUserLogin, false);
-    GETSET_PROPERTY(bool, AlwaysOnTop, false);
-    GETSET_PROPERTY(bool, UseTabSwitcher, true);
-
-private:
-    std::optional<std::wstring> _unparsedDefaultProfile;
-    GUID _defaultProfile;
-
-    winrt::com_ptr<winrt::TerminalApp::implementation::AppKeyBindings> _keybindings;
-    std::vector<::TerminalApp::SettingsLoadWarnings> _keybindingsWarnings;
-
-    std::unordered_map<std::wstring, winrt::TerminalApp::ColorScheme> _colorSchemes;
-    winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::TerminalApp::Command> _commands;
-
-    friend class TerminalAppLocalTests::SettingsTests;
-    friend class TerminalAppLocalTests::ColorSchemeTests;
-};
+    BASIC_FACTORY(GlobalAppSettings);
+}

--- a/src/cascadia/TerminalApp/GlobalAppSettings.h
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.h
@@ -37,14 +37,14 @@ namespace winrt::TerminalApp::implementation
         ~GlobalAppSettings();
 
         Windows::Foundation::Collections::IMapView<hstring, TerminalApp::ColorScheme> GetColorSchemes() noexcept;
-        void AddColorScheme(TerminalApp::ColorScheme scheme);
+        void AddColorScheme(const TerminalApp::ColorScheme& scheme);
 
         TerminalApp::AppKeyBindings GetKeybindings() const noexcept;
 
         static com_ptr<GlobalAppSettings> FromJson(const Json::Value& json);
         void LayerJson(const Json::Value& json);
 
-        void ApplyToSettings(TerminalApp::TerminalSettings settings) const noexcept;
+        void ApplyToSettings(const TerminalApp::TerminalSettings& settings) const noexcept;
 
         std::vector<::TerminalApp::SettingsLoadWarnings> GetKeybindingsWarnings() const;
 
@@ -52,7 +52,7 @@ namespace winrt::TerminalApp::implementation
 
         // These are implemented manually to handle the string/GUID exchange
         // by higher layers in the app.
-        void DefaultProfile(const guid defaultProfile) noexcept;
+        void DefaultProfile(const guid& defaultProfile) noexcept;
         guid DefaultProfile() const;
         hstring UnparsedDefaultProfile() const;
 

--- a/src/cascadia/TerminalApp/GlobalAppSettings.h
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.h
@@ -16,7 +16,6 @@ Author(s):
 #pragma once
 
 #include "GlobalAppSettings.g.h"
-#include "SettingsTypes.h"
 
 #include "AppKeyBindings.h"
 #include "Command.h"
@@ -57,11 +56,6 @@ namespace winrt::TerminalApp::implementation
         guid DefaultProfile() const;
         hstring UnparsedDefaultProfile() const;
 
-        bool HasInitialPositionX() const;
-        bool HasInitialPositionY() const;
-        int32_t InitialPositionX() const;
-        int32_t InitialPositionY() const;
-
         GETSET_PROPERTY(int32_t, InitialRows); // default value set in constructor
         GETSET_PROPERTY(int32_t, InitialCols); // default value set in constructor
         GETSET_PROPERTY(bool, AlwaysShowTabs, true);
@@ -75,6 +69,7 @@ namespace winrt::TerminalApp::implementation
         GETSET_PROPERTY(winrt::Microsoft::Terminal::TerminalControl::CopyFormat, CopyFormatting, 0);
         GETSET_PROPERTY(bool, WarnAboutLargePaste, true);
         GETSET_PROPERTY(bool, WarnAboutMultiLinePaste, true);
+        GETSET_PROPERTY(winrt::TerminalApp::LaunchPosition, InitialPosition, nullptr, nullptr);
         GETSET_PROPERTY(winrt::TerminalApp::LaunchMode, LaunchMode, winrt::TerminalApp::LaunchMode::DefaultMode);
         GETSET_PROPERTY(bool, SnapToGridOnResize, true);
         GETSET_PROPERTY(bool, ForceFullRepaintRendering, false);
@@ -88,7 +83,6 @@ namespace winrt::TerminalApp::implementation
     private:
         hstring _unparsedDefaultProfile;
         guid _defaultProfile;
-        LaunchPosition _initialPosition;
 
         com_ptr<AppKeyBindings> _keybindings;
         std::vector<::TerminalApp::SettingsLoadWarnings> _keybindingsWarnings;

--- a/src/cascadia/TerminalApp/GlobalAppSettings.h
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.h
@@ -21,12 +21,6 @@ Author(s):
 #include "Command.h"
 #include "ColorScheme.h"
 
-#ifdef _DEBUG
-static constexpr bool debugFeaturesDefault{ true };
-#else
-static constexpr bool debugFeaturesDefault{ false };
-#endif
-
 // fwdecl unittest classes
 namespace TerminalAppLocalTests
 {
@@ -80,7 +74,7 @@ namespace winrt::TerminalApp::implementation
         GETSET_PROPERTY(bool, ForceFullRepaintRendering, false);
         GETSET_PROPERTY(bool, SoftwareRendering, false);
         GETSET_PROPERTY(bool, ForceVTInput, false);
-        GETSET_PROPERTY(bool, DebugFeaturesEnabled, debugFeaturesDefault);
+        GETSET_PROPERTY(bool, DebugFeaturesEnabled); // default value set in constructor
         GETSET_PROPERTY(bool, StartOnUserLogin, false);
         GETSET_PROPERTY(bool, AlwaysOnTop, false);
         GETSET_PROPERTY(bool, UseTabSwitcher, true);

--- a/src/cascadia/TerminalApp/GlobalAppSettings.h
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.h
@@ -21,6 +21,12 @@ Author(s):
 #include "Command.h"
 #include "ColorScheme.h"
 
+#ifdef _DEBUG
+static constexpr bool debugFeaturesDefault{ true };
+#else
+static constexpr bool debugFeaturesDefault{ false };
+#endif
+
 // fwdecl unittest classes
 namespace TerminalAppLocalTests
 {
@@ -34,7 +40,6 @@ namespace winrt::TerminalApp::implementation
     {
     public:
         GlobalAppSettings();
-        ~GlobalAppSettings();
 
         Windows::Foundation::Collections::IMapView<hstring, TerminalApp::ColorScheme> GetColorSchemes() noexcept;
         void AddColorScheme(const TerminalApp::ColorScheme& scheme);
@@ -56,15 +61,15 @@ namespace winrt::TerminalApp::implementation
         guid DefaultProfile() const;
         hstring UnparsedDefaultProfile() const;
 
-        GETSET_PROPERTY(int32_t, InitialRows); // default value set in constructor
-        GETSET_PROPERTY(int32_t, InitialCols); // default value set in constructor
+        GETSET_PROPERTY(int32_t, InitialRows, DEFAULT_ROWS);
+        GETSET_PROPERTY(int32_t, InitialCols, DEFAULT_COLS);
         GETSET_PROPERTY(bool, AlwaysShowTabs, true);
         GETSET_PROPERTY(bool, ShowTitleInTitlebar, true);
         GETSET_PROPERTY(bool, ConfirmCloseAllTabs, true);
         GETSET_PROPERTY(winrt::Windows::UI::Xaml::ElementTheme, Theme, winrt::Windows::UI::Xaml::ElementTheme::Default);
         GETSET_PROPERTY(winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode, TabWidthMode, winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode::Equal);
         GETSET_PROPERTY(bool, ShowTabsInTitlebar, true);
-        GETSET_PROPERTY(hstring, WordDelimiters); // default value set in constructor
+        GETSET_PROPERTY(hstring, WordDelimiters, DEFAULT_WORD_DELIMITERS);
         GETSET_PROPERTY(bool, CopyOnSelect, false);
         GETSET_PROPERTY(winrt::Microsoft::Terminal::TerminalControl::CopyFormat, CopyFormatting, 0);
         GETSET_PROPERTY(bool, WarnAboutLargePaste, true);
@@ -75,7 +80,7 @@ namespace winrt::TerminalApp::implementation
         GETSET_PROPERTY(bool, ForceFullRepaintRendering, false);
         GETSET_PROPERTY(bool, SoftwareRendering, false);
         GETSET_PROPERTY(bool, ForceVTInput, false);
-        GETSET_PROPERTY(bool, DebugFeaturesEnabled); // default value set in constructor
+        GETSET_PROPERTY(bool, DebugFeaturesEnabled, debugFeaturesDefault);
         GETSET_PROPERTY(bool, StartOnUserLogin, false);
         GETSET_PROPERTY(bool, AlwaysOnTop, false);
         GETSET_PROPERTY(bool, UseTabSwitcher, true);

--- a/src/cascadia/TerminalApp/GlobalAppSettings.h
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.h
@@ -93,8 +93,3 @@ namespace winrt::TerminalApp::implementation
         friend class TerminalAppLocalTests::ColorSchemeTests;
     };
 }
-
-namespace winrt::TerminalApp::factory_implementation
-{
-    BASIC_FACTORY(GlobalAppSettings);
-}

--- a/src/cascadia/TerminalApp/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.idl
@@ -9,6 +9,12 @@ import "TerminalSettings.idl";
 
 namespace TerminalApp
 {
+    struct LaunchPosition
+    {
+        Windows.Foundation.IReference<Int64> X;
+        Windows.Foundation.IReference<Int64> Y;
+    };
+
     [default_interface] runtimeclass GlobalAppSettings {
         GlobalAppSettings();
 
@@ -28,6 +34,7 @@ namespace TerminalApp
         Microsoft.Terminal.TerminalControl.CopyFormat CopyFormatting;
         Boolean WarnAboutLargePaste;
         Boolean WarnAboutMultiLinePaste;
+        LaunchPosition InitialPosition;
         LaunchMode LaunchMode;
         Boolean SnapToGridOnResize;
         Boolean ForceFullRepaintRendering;
@@ -37,12 +44,6 @@ namespace TerminalApp
         Boolean StartOnUserLogin;
         Boolean AlwaysOnTop;
         Boolean UseTabSwitcher;
-
-        Boolean HasInitialPositionX();
-        Boolean HasInitialPositionY();
-        Int32 InitialPositionX { get; };
-        Int32 InitialPositionY { get; };
-
 
         Windows.Foundation.Collections.IMapView<String, ColorScheme> GetColorSchemes();
         void AddColorScheme(ColorScheme scheme);

--- a/src/cascadia/TerminalApp/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.idl
@@ -9,6 +9,10 @@ import "TerminalSettings.idl";
 
 namespace TerminalApp
 {
+    // MIDL 3 allows for structs to hold nullable types
+    // Though IReference is a WinRT object, MIDL 3
+    // handles all of the ownership logic for us.
+    // Docs: https://docs.microsoft.com/en-us/uwp/midl-3/intro#types
     struct LaunchPosition
     {
         Windows.Foundation.IReference<Int64> X;

--- a/src/cascadia/TerminalApp/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.idl
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "AppLogic.idl";
+import "ColorScheme.idl";
+import "AppKeybindings.idl";
+import "Command.idl";
+import "TerminalSettings.idl";
+
+namespace TerminalApp
+{
+    [default_interface] runtimeclass GlobalAppSettings {
+        GlobalAppSettings();
+
+        Guid DefaultProfile;
+        String UnparsedDefaultProfile();
+
+        Int32 InitialRows;
+        Int32 InitialCols;
+        Boolean AlwaysShowTabs;
+        Boolean ShowTitleInTitlebar;
+        Boolean ConfirmCloseAllTabs;
+        Windows.UI.Xaml.ElementTheme Theme;
+        Microsoft.UI.Xaml.Controls.TabViewWidthMode TabWidthMode;
+        Boolean ShowTabsInTitlebar;
+        String WordDelimiters;
+        Boolean CopyOnSelect;
+        Microsoft.Terminal.TerminalControl.CopyFormat CopyFormatting;
+        Boolean WarnAboutLargePaste;
+        Boolean WarnAboutMultiLinePaste;
+        LaunchMode LaunchMode;
+        Boolean SnapToGridOnResize;
+        Boolean ForceFullRepaintRendering;
+        Boolean SoftwareRendering;
+        Boolean ForceVTInput;
+        Boolean DebugFeaturesEnabled;
+        Boolean StartOnUserLogin;
+        Boolean AlwaysOnTop;
+        Boolean UseTabSwitcher;
+
+        Boolean HasInitialPositionX();
+        Boolean HasInitialPositionY();
+        Int32 InitialPositionX { get; };
+        Int32 InitialPositionY { get; };
+
+
+        Windows.Foundation.Collections.IMapView<String, ColorScheme> GetColorSchemes();
+        void AddColorScheme(ColorScheme scheme);
+
+        AppKeyBindings GetKeybindings();
+
+        Windows.Foundation.Collections.IMapView<String, Command> GetCommands();
+
+        void ApplyToSettings(TerminalSettings settings);
+    }
+}

--- a/src/cascadia/TerminalApp/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.idl
@@ -20,8 +20,6 @@ namespace TerminalApp
     };
 
     [default_interface] runtimeclass GlobalAppSettings {
-        GlobalAppSettings();
-
         Guid DefaultProfile;
         String UnparsedDefaultProfile();
 

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -508,7 +508,7 @@ bool Profile::HasGuid() const noexcept
     return _Guid.has_value();
 }
 
-winrt::guid Profile::Guid() const noexcept
+winrt::guid Profile::Guid() const
 {
     // This can throw if we never had our guid set to a legitimate value.
     THROW_HR_IF_MSG(E_FAIL, !_Guid.has_value(), "Profile._guid always expected to have a value");

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -75,9 +75,9 @@ Profile::Profile(guid guid) :
 // - schemes: a list of schemes to look for our color scheme in, if we have one.
 // Return Value:
 // - a new TerminalSettings object with our settings in it.
-winrt::TerminalApp::TerminalSettings Profile::CreateTerminalSettings(const std::unordered_map<std::wstring, ColorScheme>& schemes) const
+winrt::TerminalApp::TerminalSettings Profile::CreateTerminalSettings(const Collections::IMapView<winrt::hstring, TerminalApp::ColorScheme>& schemes) const
 {
-    winrt::TerminalApp::TerminalSettings terminalSettings{};
+    auto terminalSettings = winrt::make<TerminalSettings>();
 
     // Fill in the Terminal Setting's CoreSettings from the profile
     terminalSettings.HistorySize(_HistorySize);
@@ -115,10 +115,9 @@ winrt::TerminalApp::TerminalSettings Profile::CreateTerminalSettings(const std::
 
     if (!_ColorSchemeName.empty())
     {
-        const auto found = schemes.find(_ColorSchemeName.c_str());
-        if (found != schemes.end())
+        if (const auto found{ schemes.TryLookup(_ColorSchemeName) })
         {
-            found->second.ApplyScheme(terminalSettings);
+            found.ApplyScheme(terminalSettings);
         }
     }
     if (_Foreground)

--- a/src/cascadia/TerminalApp/Profile.cpp
+++ b/src/cascadia/TerminalApp/Profile.cpp
@@ -508,14 +508,14 @@ bool Profile::HasGuid() const noexcept
     return _Guid.has_value();
 }
 
-winrt::guid Profile::Guid() const
+winrt::guid Profile::Guid() const noexcept
 {
     // This can throw if we never had our guid set to a legitimate value.
     THROW_HR_IF_MSG(E_FAIL, !_Guid.has_value(), "Profile._guid always expected to have a value");
     return *_Guid;
 }
 
-void Profile::Guid(winrt::guid guid) noexcept
+void Profile::Guid(const winrt::guid& guid) noexcept
 {
     _Guid = guid;
 }
@@ -530,7 +530,7 @@ winrt::guid Profile::ConnectionType() const noexcept
     return *_ConnectionType;
 }
 
-void Profile::ConnectionType(winrt::guid conType) noexcept
+void Profile::ConnectionType(const winrt::guid& conType) noexcept
 {
     _ConnectionType = conType;
 }

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -60,7 +60,7 @@ namespace winrt::TerminalApp::implementation
         static guid GetGuidOrGenerateForJson(const Json::Value& json) noexcept;
 
         bool HasGuid() const noexcept;
-        winrt::guid Guid() const noexcept;
+        winrt::guid Guid() const;
         void Guid(const winrt::guid& guid) noexcept;
 
         bool HasConnectionType() const noexcept;

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -60,12 +60,12 @@ namespace winrt::TerminalApp::implementation
         static guid GetGuidOrGenerateForJson(const Json::Value& json) noexcept;
 
         bool HasGuid() const noexcept;
-        winrt::guid Guid() const;
-        void Guid(winrt::guid guid) noexcept;
+        winrt::guid Guid() const noexcept;
+        void Guid(const winrt::guid& guid) noexcept;
 
         bool HasConnectionType() const noexcept;
         winrt::guid ConnectionType() const noexcept;
-        void ConnectionType(winrt::guid conType) noexcept;
+        void ConnectionType(const winrt::guid& conType) noexcept;
 
         // BackgroundImageAlignment is 1 setting saved as 2 separate values
         const Windows::UI::Xaml::HorizontalAlignment BackgroundImageHorizontalAlignment() const noexcept;

--- a/src/cascadia/TerminalApp/Profile.h
+++ b/src/cascadia/TerminalApp/Profile.h
@@ -16,7 +16,7 @@ Author(s):
 #pragma once
 
 #include "Profile.g.h"
-#include "ColorScheme.g.h"
+#include "TerminalSettings.h"
 
 #include "../inc/cppwinrt_utils.h"
 #include "JsonUtils.h"
@@ -46,7 +46,7 @@ namespace winrt::TerminalApp::implementation
         Profile();
         Profile(guid guid);
 
-        TerminalApp::TerminalSettings CreateTerminalSettings(const std::unordered_map<std::wstring, winrt::TerminalApp::ColorScheme>& schemes) const;
+        TerminalApp::TerminalSettings CreateTerminalSettings(const Windows::Foundation::Collections::IMapView<hstring, TerminalApp::ColorScheme>& schemes) const;
 
         Json::Value GenerateStub() const;
         static com_ptr<Profile> FromJson(const Json::Value& json);

--- a/src/cascadia/TerminalApp/Profile.idl
+++ b/src/cascadia/TerminalApp/Profile.idl
@@ -17,8 +17,6 @@ namespace TerminalApp
         Profile();
         Profile(Guid guid);
 
-        TerminalSettings CreateTerminalSettings(Windows.Foundation.Collections.IMapView<String, ColorScheme> schemes);
-
         String Name;
         Boolean HasGuid();
         Guid Guid;

--- a/src/cascadia/TerminalApp/Profile.idl
+++ b/src/cascadia/TerminalApp/Profile.idl
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import "TerminalSettings.idl";
+import "ColorScheme.idl";
+
 namespace TerminalApp
 {
     enum CloseOnExitMode
@@ -13,6 +16,8 @@ namespace TerminalApp
     [default_interface] runtimeclass Profile {
         Profile();
         Profile(Guid guid);
+
+        TerminalSettings CreateTerminalSettings(Windows.Foundation.Collections.IMapView<String, ColorScheme> schemes);
 
         String Name;
         Boolean HasGuid();

--- a/src/cascadia/TerminalApp/Profile.idl
+++ b/src/cascadia/TerminalApp/Profile.idl
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import "TerminalSettings.idl";
-import "ColorScheme.idl";
-
 namespace TerminalApp
 {
     enum CloseOnExitMode

--- a/src/cascadia/TerminalApp/SettingsTypes.h
+++ b/src/cascadia/TerminalApp/SettingsTypes.h
@@ -13,12 +13,6 @@ Abstract:
 
 namespace winrt::TerminalApp
 {
-    struct LaunchPosition
-    {
-        std::optional<int> x;
-        std::optional<int> y;
-    };
-
     enum class ExpandCommandType : uint32_t
     {
         None = 0,

--- a/src/cascadia/TerminalApp/SettingsTypes.h
+++ b/src/cascadia/TerminalApp/SettingsTypes.h
@@ -11,7 +11,7 @@ Abstract:
 
 #pragma once
 
-namespace TerminalApp
+namespace winrt::TerminalApp
 {
     struct LaunchPosition
     {

--- a/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
@@ -107,7 +107,9 @@
     <ClInclude Include="ColorScheme.h">
       <DependentUpon>ColorScheme.idl</DependentUpon>
     </ClInclude>
-    <ClInclude Include="GlobalAppSettings.h" />
+    <ClInclude Include="GlobalAppSettings.h">
+      <DependentUpon>GlobalAppSettings.idl</DependentUpon>
+    </ClInclude>
     <ClInclude Include="Profile.h">
       <DependentUpon>Profile.idl</DependentUpon>
     </ClInclude>
@@ -188,7 +190,9 @@
     <ClCompile Include="ColorScheme.cpp">
       <DependentUpon>ColorScheme.idl</DependentUpon>
     </ClCompile>
-    <ClCompile Include="GlobalAppSettings.cpp" />
+    <ClCompile Include="GlobalAppSettings.cpp">
+      <DependentUpon>GlobalAppSettings.idl</DependentUpon>
+    </ClCompile>
     <ClCompile Include="Profile.cpp">
       <DependentUpon>Profile.idl</DependentUpon>
     </ClCompile>
@@ -281,6 +285,7 @@
     <Midl Include="TerminalSettings.idl" />
     <Midl Include="ColorScheme.idl" />
     <Midl Include="Profile.idl" />
+    <Midl Include="GlobalAppSettings.idl" />
   </ItemGroup>
   <!-- ========================= Misc Files ======================== -->
   <ItemGroup>

--- a/src/cascadia/TerminalApp/TerminalAppLib.vcxproj.filters
+++ b/src/cascadia/TerminalApp/TerminalAppLib.vcxproj.filters
@@ -154,6 +154,9 @@
     <Midl Include="../Profile.idl">
       <Filter>settings</Filter>
     </Midl>
+    <Midl Include="../GlobalAppSettings.idl">
+      <Filter>settings</Filter>
+    </Midl>
   </ItemGroup>
   <ItemGroup>
     <None Include="../packages.config" />

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2070,16 +2070,16 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     IMap<winrt::hstring, winrt::TerminalApp::Command> TerminalPage::_ExpandCommands(IMapView<winrt::hstring, winrt::TerminalApp::Command> commandsToExpand,
                                                                                     gsl::span<const winrt::TerminalApp::Profile> profiles,
-                                                                                    const std::unordered_map<std::wstring, winrt::TerminalApp::ColorScheme>& schemes)
+                                                                                    IMapView<winrt::hstring, winrt::TerminalApp::ColorScheme> schemes)
     {
         std::vector<::TerminalApp::SettingsLoadWarnings> warnings;
 
         std::vector<winrt::TerminalApp::ColorScheme> sortedSchemes;
-        sortedSchemes.reserve(schemes.size());
+        sortedSchemes.reserve(schemes.Size());
 
         for (const auto& nameAndScheme : schemes)
         {
-            sortedSchemes.push_back(nameAndScheme.second);
+            sortedSchemes.push_back(nameAndScheme.Value());
         }
         std::sort(sortedSchemes.begin(),
                   sortedSchemes.end(),
@@ -2108,7 +2108,7 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     void TerminalPage::_UpdateCommandsForPalette()
     {
-        IMap<winrt::hstring, winrt::TerminalApp::Command> copyOfCommands = _ExpandCommands(_settings->GlobalSettings().GetCommands().GetView(),
+        IMap<winrt::hstring, winrt::TerminalApp::Command> copyOfCommands = _ExpandCommands(_settings->GlobalSettings().GetCommands(),
                                                                                            _settings->GetProfiles(),
                                                                                            _settings->GlobalSettings().GetColorSchemes());
 

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -138,7 +138,7 @@ namespace winrt::TerminalApp::implementation
         void _UpdateCommandsForPalette();
         static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::TerminalApp::Command> _ExpandCommands(Windows::Foundation::Collections::IMapView<winrt::hstring, winrt::TerminalApp::Command> commandsToExpand,
                                                                                                                           gsl::span<const winrt::TerminalApp::Profile> profiles,
-                                                                                                                          const std::unordered_map<std::wstring, winrt::TerminalApp::ColorScheme>& schemes);
+                                                                                                                          Windows::Foundation::Collections::IMapView<winrt::hstring, winrt::TerminalApp::ColorScheme> schemes);
 
         void _DuplicateTabViewItem();
         void _RemoveTabViewItem(const Microsoft::UI::Xaml::Controls::TabViewItem& tabViewItem);

--- a/src/cascadia/TerminalApp/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalApp/TerminalSettingsSerializationHelpers.h
@@ -184,7 +184,7 @@ JSON_ENUM_MAPPER(::winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode)
     };
 };
 
-JSON_ENUM_MAPPER(::TerminalApp::ExpandCommandType)
+JSON_ENUM_MAPPER(winrt::TerminalApp::ExpandCommandType)
 {
     JSON_MAPPINGS(2) = {
         pair_type{ "profiles", ValueType::Profiles },
@@ -226,11 +226,11 @@ JSON_FLAG_MAPPER(::winrt::Microsoft::Terminal::TerminalControl::CopyFormat)
 //   (abc, 100): if a value is not valid, we treat it as default
 //   (100, 100, 100): we only read the first two values, this is equivalent to (100, 100)
 template<>
-struct ::TerminalApp::JsonUtils::ConversionTrait<::TerminalApp::LaunchPosition>
+struct ::TerminalApp::JsonUtils::ConversionTrait<::winrt::TerminalApp::LaunchPosition>
 {
-    ::TerminalApp::LaunchPosition FromJson(const Json::Value& json)
+    ::winrt::TerminalApp::LaunchPosition FromJson(const Json::Value& json)
     {
-        ::TerminalApp::LaunchPosition ret;
+        ::winrt::TerminalApp::LaunchPosition ret;
         std::string initialPosition{ json.asString() };
         static constexpr char singleCharDelim = ',';
         std::stringstream tokenStream(initialPosition);

--- a/src/cascadia/TerminalApp/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalApp/TerminalSettingsSerializationHelpers.h
@@ -244,15 +244,15 @@ struct ::TerminalApp::JsonUtils::ConversionTrait<::winrt::TerminalApp::LaunchPos
         {
             try
             {
-                int32_t position = std::stoi(token);
+                int64_t position = std::stol(token);
                 if (initialPosIndex == 0)
                 {
-                    ret.x.emplace(position);
+                    ret.X = position;
                 }
 
                 if (initialPosIndex == 1)
                 {
-                    ret.y.emplace(position);
+                    ret.Y = position;
                 }
             }
             catch (...)

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -241,9 +241,9 @@ void AppHost::_HandleCreateWindow(const HWND hwnd, RECT proposedRect, winrt::Ter
     launchMode = _logic.GetLaunchMode();
 
     // Acquire the actual initial position
-    winrt::Windows::Foundation::Point initialPosition = _logic.GetLaunchInitialPositions(proposedRect.left, proposedRect.top);
-    proposedRect.left = gsl::narrow_cast<long>(initialPosition.X);
-    proposedRect.top = gsl::narrow_cast<long>(initialPosition.Y);
+    auto initialPos = _logic.GetInitialPosition(proposedRect.left, proposedRect.top);
+    proposedRect.left = static_cast<long>(initialPos.X);
+    proposedRect.top = static_cast<long>(initialPos.Y);
 
     long adjustedHeight = 0;
     long adjustedWidth = 0;


### PR DESCRIPTION
GlobalAppSettings is now a WinRT object in the TerminalApp project.

## References
#7141 - GlobalAppSettings is a settings object
#885 - this new settings object will be moved to a new TerminalSettingsModel project

## PR Checklist
* [x] Tests passed

## Detailed Description of the Pull Request / Additional comments
This one was probably the easiest thus far.

The only weird thing is how we handle InitialPosition. Today, we lose a
little bit of fidelity when we convert from LaunchPosition (int) -->
Point (float) --> RECT (long). The current change converts
LaunchPosition (optional<long>) --> InitialPosition (long) --> RECT
(long).

NOTE: Though I could use LaunchPosition to go directly from TermApp to
AppHost, I decided to introduce InitialPosition because LaunchPosition
will be a part of TerminalSettingsModel soon.

## Validation Steps Performed
- [x] Tests passed
- [x] Deployment succeeded