### PR TITLE
Bind the command palette by default

### DIFF
--- a/src/cascadia/TerminalApp/defaults-universal.json
+++ b/src/cascadia/TerminalApp/defaults-universal.json
@@ -81,6 +81,7 @@
         { "command": "openNewTabDropdown", "keys": "ctrl+shift+space" },
         { "command": "openSettings", "keys": "ctrl+," },
         { "command": "find", "keys": "ctrl+shift+f" },
+        { "command": "commandPalette", "keys":"ctrl+shift+p" },
 
         // Tab Management
         // "command": "closeTab" is unbound by default.

--- a/src/cascadia/TerminalApp/defaults.json
+++ b/src/cascadia/TerminalApp/defaults.json
@@ -286,6 +286,7 @@
         { "command": "find", "keys": "ctrl+shift+f" },
         { "command": "toggleRetroEffect" },
         { "command": "openTabColorPicker" },
+        { "command": "commandPalette", "keys":"ctrl+shift+p" },
 
         // Tab Management
         // "command": "closeTab" is unbound by default.


### PR DESCRIPTION
Bind the command palette to <kbd>Ctrl+Shift+P</kbd> by default, to enable it for all users in v1.3