### PR TITLE
TermControl: set the scrollbar jump distance to one screenful

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -156,6 +156,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                     scrollBar.Maximum(update.newMaximum);
                     scrollBar.Minimum(update.newMinimum);
                     scrollBar.ViewportSize(update.newViewportSize);
+                    scrollBar.LargeChange(std::max(update.newViewportSize - 1, 0.)); // scroll one "screenful" at a time when the scroll bar is clicked
 
                     control->_isInternalScrollBarUpdate = false;
                 }
@@ -699,6 +700,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             ScrollBar().Minimum(0);
             ScrollBar().Value(0);
             ScrollBar().ViewportSize(bufferHeight);
+            ScrollBar().LargeChange(std::max<SHORT>(bufferHeight - 1, 0)); // scroll one "screenful" at a time when the scroll bar is clicked
 
             localPointerToThread->EnablePainting();
 


### PR DESCRIPTION
Most applications with scrollable content seem to define the "large
jump" distance as about a screenful of content. You can see this in long
pages in Settings and documents in Notepad.

We just weren't configuring ScrollBar here.

Fixes #7367

## PR Checklist
* [x] Closes #7367
* [x] CLA'd
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
