### PR TITLE
Make index in closeOtherTabs and closeTabsAfter optional

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -397,14 +397,16 @@
           "properties": {
             "action": { "type": "string", "pattern": "closeOtherTabs" },
             "index": {
-              "type": "integer",
+              "oneOf": [
+                { "type": "integer" },
+                { "type": null }
+              ],
               "default": "",
-              "description": "Close the tabs other than the one at this index."
+              "description": "Close the tabs other than the one at this index. If no index is provided, use the focused tab's index."
             }
           }
         }
-      ],
-      "required": [ "index" ]
+      ]
     },
     "CloseTabsAfterAction": {
       "description": "Arguments for a closeTabsAfter action",
@@ -414,14 +416,16 @@
           "properties": {
             "action": { "type": "string", "pattern": "closeTabsAfter" },
             "index": {
-              "type": "integer",
+              "oneOf": [
+                { "type": "integer" },
+                { "type": null }
+              ],
               "default": "",
-              "description": "Close the tabs following the tab at this index."
+              "description": "Close the tabs following the tab at this index. If no index is provided, use the focused tab's index."
             }
           }
         }
-      ],
-      "required": [ "index" ]
+      ]
     },
     "Keybinding": {
       "additionalProperties": false,

--- a/src/cascadia/TerminalApp/ActionArgs.cpp
+++ b/src/cascadia/TerminalApp/ActionArgs.cpp
@@ -339,19 +339,27 @@ namespace winrt::TerminalApp::implementation
 
     winrt::hstring CloseOtherTabsArgs::GenerateName() const
     {
-        // "Close tabs other than index {0}"
-        return winrt::hstring{
-            fmt::format(std::wstring_view(RS_(L"CloseOtherTabsCommandKey")),
-                        _Index)
-        };
+        if (_Index)
+        {
+            // "Close tabs other than index {0}"
+            return winrt::hstring{
+                fmt::format(std::wstring_view(RS_(L"CloseOtherTabsCommandKey")),
+                            _Index.Value())
+            };
+        }
+        return RS_(L"CloseOtherTabsDefaultCommandKey");
     }
 
     winrt::hstring CloseTabsAfterArgs::GenerateName() const
     {
-        // "Close tabs after index {0}"
-        return winrt::hstring{
-            fmt::format(std::wstring_view(RS_(L"CloseTabsAfterCommandKey")),
-                        _Index)
-        };
+        if (_Index)
+        {
+            // "Close tabs after index {0}"
+            return winrt::hstring{
+                fmt::format(std::wstring_view(RS_(L"CloseTabsAfterCommandKey")),
+                            _Index.Value())
+            };
+        }
+        return RS_(L"CloseTabsAfterDefaultCommandKey");
     }
 }

--- a/src/cascadia/TerminalApp/ActionArgs.h
+++ b/src/cascadia/TerminalApp/ActionArgs.h
@@ -495,7 +495,7 @@ namespace winrt::TerminalApp::implementation
     struct CloseOtherTabsArgs : public CloseOtherTabsArgsT<CloseOtherTabsArgs>
     {
         CloseOtherTabsArgs() = default;
-        GETSET_PROPERTY(uint32_t, Index, 0);
+        GETSET_PROPERTY(winrt::Windows::Foundation::IReference<uint32_t>, Index, nullptr);
 
         static constexpr std::string_view IndexKey{ "index" };
 
@@ -523,7 +523,7 @@ namespace winrt::TerminalApp::implementation
     struct CloseTabsAfterArgs : public CloseTabsAfterArgsT<CloseTabsAfterArgs>
     {
         CloseTabsAfterArgs() = default;
-        GETSET_PROPERTY(uint32_t, Index, 0);
+        GETSET_PROPERTY(winrt::Windows::Foundation::IReference<uint32_t>, Index, nullptr);
 
         static constexpr std::string_view IndexKey{ "index" };
 

--- a/src/cascadia/TerminalApp/ActionArgs.idl
+++ b/src/cascadia/TerminalApp/ActionArgs.idl
@@ -134,11 +134,11 @@ namespace TerminalApp
 
     [default_interface] runtimeclass CloseOtherTabsArgs : IActionArgs
     {
-        UInt32 Index { get; };
+        Windows.Foundation.IReference<UInt32> Index { get; };
     };
 
     [default_interface] runtimeclass CloseTabsAfterArgs : IActionArgs
     {
-        UInt32 Index { get; };
+        Windows.Foundation.IReference<UInt32> Index { get; };
     };
 }

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -426,7 +426,8 @@ namespace winrt::TerminalApp::implementation
             }
             else
             {
-                actionArgs.Handled(true);
+                // Do nothing
+                actionArgs.Handled(false);
                 return;
             }
 
@@ -462,7 +463,8 @@ namespace winrt::TerminalApp::implementation
             }
             else
             {
-                actionArgs.Handled(true);
+                // Do nothing
+                actionArgs.Handled(false);
                 return;
             }
 

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -415,7 +415,20 @@ namespace winrt::TerminalApp::implementation
     {
         if (const auto& realArgs = actionArgs.ActionArgs().try_as<TerminalApp::CloseOtherTabsArgs>())
         {
-            uint32_t index = realArgs.Index();
+            uint32_t index;
+            if (realArgs.Index())
+            {
+                index = realArgs.Index().Value();
+            }
+            else if (auto focusedTabIndex = _GetFocusedTabIndex())
+            {
+                index = *focusedTabIndex;
+            }
+            else
+            {
+                actionArgs.Handled(true);
+                return;
+            }
 
             // Remove tabs after the current one
             while (_tabs.Size() > index + 1)
@@ -438,7 +451,20 @@ namespace winrt::TerminalApp::implementation
     {
         if (const auto& realArgs = actionArgs.ActionArgs().try_as<TerminalApp::CloseTabsAfterArgs>())
         {
-            uint32_t index = realArgs.Index();
+            uint32_t index;
+            if (realArgs.Index())
+            {
+                index = realArgs.Index().Value();
+            }
+            else if (auto focusedTabIndex = _GetFocusedTabIndex())
+            {
+                index = *focusedTabIndex;
+            }
+            else
+            {
+                actionArgs.Handled(true);
+                return;
+            }
 
             // Remove tabs after the current one
             while (_tabs.Size() > index + 1)

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -650,6 +650,6 @@
     <value>Close all other tabs</value>
   </data>
   <data name="CloseTabsAfterDefaultCommandKey" xml:space="preserve">
-    <value>Close all tabs after</value>
+    <value>Close all tabs after the current tab</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -646,4 +646,10 @@
   <data name="DarkGrayColorButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Dark Gray</value>
   </data>
+  <data name="CloseOtherTabsDefaultCommandKey" xml:space="preserve">
+    <value>Close all other tabs</value>
+  </data>
+  <data name="CloseTabsAfterDefaultCommandKey" xml:space="preserve">
+    <value>Close all tabs after</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1304,7 +1304,7 @@ namespace winrt::TerminalApp::implementation
 
     // Method Description:
     // - Returns the index in our list of tabs of the currently focused tab. If
-    //      no tab is currently selected, returns -1.
+    //      no tab is currently selected, returns nullopt.
     // Return Value:
     // - the index of the currently focused tab if there is one, else -1
     std::optional<uint32_t> TerminalPage::_GetFocusedTabIndex() const noexcept

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1306,7 +1306,7 @@ namespace winrt::TerminalApp::implementation
     // - Returns the index in our list of tabs of the currently focused tab. If
     //      no tab is currently selected, returns nullopt.
     // Return Value:
-    // - the index of the currently focused tab if there is one, else -1
+    // - the index of the currently focused tab if there is one, else nullopt
     std::optional<uint32_t> TerminalPage::_GetFocusedTabIndex() const noexcept
     {
         // GH#1117: This is a workaround because _tabView.SelectedIndex()

--- a/src/cascadia/TerminalApp/defaults.json
+++ b/src/cascadia/TerminalApp/defaults.json
@@ -291,6 +291,8 @@
         // Tab Management
         // "command": "closeTab" is unbound by default.
         //   The closeTab command closes a tab without confirmation, even if it has multiple panes.
+        { "command": "closeOtherTabs" },
+        { "command": "closeTabsAfter" },
         { "command": "newTab", "keys": "ctrl+shift+t" },
         { "command": { "action": "newTab", "index": 0 }, "keys": "ctrl+shift+1" },
         { "command": { "action": "newTab", "index": 1 }, "keys": "ctrl+shift+2" },


### PR DESCRIPTION
## Summary of the Pull Request
The `index` action argument is now optional for `closeOtherTabs` and `closeTabsAfter`. When `index` is not defined, `index` is set to the focused tab's index.

Also, adds the non-index version of these actions to defaults.json.

## PR Checklist
* [X] Closes #7181 
* [X] CLA signed
* [X] Tests passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [X] Schema updated.

## Validation Steps Performed
Opened 4 tabs and ran closeOtherTabs/closeTabsAfter from command palette.