### PR TITLE
Fix environment block creation

### DIFF
--- a/src/types/Environment.cpp
+++ b/src/types/Environment.cpp
@@ -3,6 +3,7 @@
 
 #include "precomp.h"
 #include "inc/Environment.hpp"
+#include "wil/token_helpers.h"
 
 using namespace ::Microsoft::Console::Utils;
 
@@ -14,7 +15,8 @@ using namespace ::Microsoft::Console::Utils;
 EnvironmentBlockPtr Microsoft::Console::Utils::CreateEnvironmentBlock()
 {
     void* newEnvironmentBlock{ nullptr };
-    if (!::CreateEnvironmentBlock(&newEnvironmentBlock, GetCurrentProcessToken(), FALSE))
+    auto processToken{ wil::open_current_access_token(TOKEN_QUERY | TOKEN_DUPLICATE) };
+    if (!::CreateEnvironmentBlock(&newEnvironmentBlock, processToken.get(), FALSE))
     {
         return nullptr;
     }


### PR DESCRIPTION
This fixes a regression in environment variable loading introduced as part
of the new environment block creation that prevents some system-defined,
volatile environment variables from being defined.

## References
https://github.com/microsoft/terminal/pull/7243#discussion_r476603599

## Validation Steps Performed
Manually verified locally.

Closes #7399