### PR TITLE
Render hyperlinks with a dashed underline

### DIFF
--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -875,6 +875,11 @@ IRenderEngine::GridLines Renderer::s_GetGridlines(const TextAttribute& textAttri
     {
         lines |= IRenderEngine::GridLines::DoubleUnderline;
     }
+
+    if (textAttribute.IsHyperlink())
+    {
+        lines |= IRenderEngine::GridLines::DashedUnderline;
+    }
     return lines;
 }
 

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -188,6 +188,7 @@ namespace Microsoft::Console::Render
         ::Microsoft::WRL::ComPtr<CustomTextLayout> _customLayout;
         ::Microsoft::WRL::ComPtr<CustomTextRenderer> _customRenderer;
         ::Microsoft::WRL::ComPtr<ID2D1StrokeStyle> _strokeStyle;
+        ::Microsoft::WRL::ComPtr<ID2D1StrokeStyle> _dashStrokeStyle;
 
         // Device-Dependent Resources
         bool _recreateDeviceRequested;

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -38,7 +38,8 @@ namespace Microsoft::Console::Render
             Right = 0x8,
             Underline = 0x10,
             DoubleUnderline = 0x20,
-            Strikethrough = 0x40
+            Strikethrough = 0x40,
+            DashedUnderline = 0x80
         };
 
         virtual ~IRenderEngine() = 0;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Renders hyperlinks with a dashed underline

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
#5001 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] I work here
* [ ] Tests added/passed
* [x] I've discussed this with core contributors already. 

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Introduced a new underline type (DashedUnderline), supports rendering for it, and uses it to render hyperlinks

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
<img width="806" alt="link" src="https://user-images.githubusercontent.com/26824113/91358221-6f951600-e7c0-11ea-9627-ad13d411e719.png">
