### PR TITLE
Fix schema for `setColorScheme`

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -370,7 +370,7 @@
           }
         }
       ],
-      "required": [ "name" ]
+      "required": [ "colorScheme" ]
     },
     "WtAction": {
       "description": "Arguments corresponding to a wt Action",


### PR DESCRIPTION
`setColorScheme` should require `colorScheme` rather than `name`
