### PR TITLE
docs: use unlikely example versions in nuget package script

### DIFF
--- a/doc/building.md
+++ b/doc/building.md
@@ -67,12 +67,12 @@ To update the version of a given package, use the following snippet
 
 where:
 - `$PackageName` is the name of the package, e.g. Microsoft.UI.Xaml
-- `$OldVersionNumber` is the version number currently used, e.g. 2.4.0-prerelease.200506001
+- `$OldVersionNumber` is the version number currently used, e.g. 2.4.0-prerelease.200506002
 - `$NewVersionNumber` is the version number you want to migrate to, e.g. 2.5.0-prerelease.200812002
 
 Example usage:
 
-`git grep -z -l Microsoft.UI.Xaml | xargs -0 sed -i -e 's/2.4.0-prerelease.200506001/2.5.0-prerelease.200812002/g'`
+`git grep -z -l Microsoft.UI.Xaml | xargs -0 sed -i -e 's/2.4.0-prerelease.200506002/2.5.0-prerelease.200812002/g'`
 
 ## Using .nupkg files instead of downloaded Nuget packages
 If you want to use .nupkg files instead of the downloaded Nuget package, you can do this with the following steps:

--- a/doc/building.md
+++ b/doc/building.md
@@ -67,12 +67,12 @@ To update the version of a given package, use the following snippet
 
 where:
 - `$PackageName` is the name of the package, e.g. Microsoft.UI.Xaml
-- `$OldVersionNumber` is the version number currently used, e.g. 2.5.0-prerelease.200609001
-- `$NewVersionNumber` is the version number you want to migrate to, e.g. 2.4.200117003-prerelease
+- `$OldVersionNumber` is the version number currently used, e.g. 2.4.0-prerelease.200506001
+- `$NewVersionNumber` is the version number you want to migrate to, e.g. 2.5.0-prerelease.200812002
 
 Example usage:
 
-`git grep -z -l Microsoft.UI.Xaml | xargs -0 sed -i -e 's/2.5.0-prerelease.200609001/2.4.200117003-prerelease/g'`
+`git grep -z -l Microsoft.UI.Xaml | xargs -0 sed -i -e 's/2.4.0-prerelease.200506001/2.5.0-prerelease.200812002/g'`
 
 ## Using .nupkg files instead of downloaded Nuget packages
 If you want to use .nupkg files instead of the downloaded Nuget package, you can do this with the following steps:


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The versions used [here](https://github.com/microsoft/terminal/blob/master/doc/building.md#updating-nuget-package-references) are not good examples for two reasons:
- The old version is higher than the new version
- They refered to actual versions meaning they would be picked up by the script
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
N/A
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #6681

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
