### PR TITLE
Make CascadiaSettings a WinRT object

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/ColorSchemeTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/ColorSchemeTests.cpp
@@ -193,96 +193,96 @@ namespace TerminalAppLocalTests
         const auto scheme2Json = VerifyParseSucceeded(scheme2String);
         const auto scheme3Json = VerifyParseSucceeded(scheme3String);
 
-        CascadiaSettings settings;
+        auto settings = winrt::make_self<winrt::TerminalApp::implementation::CascadiaSettings>();
 
-        VERIFY_ARE_EQUAL(0u, settings._globals->GetColorSchemes().Size());
-        VERIFY_IS_NULL(settings._FindMatchingColorScheme(scheme0Json));
-        VERIFY_IS_NULL(settings._FindMatchingColorScheme(scheme1Json));
-        VERIFY_IS_NULL(settings._FindMatchingColorScheme(scheme2Json));
-        VERIFY_IS_NULL(settings._FindMatchingColorScheme(scheme3Json));
+        VERIFY_ARE_EQUAL(0u, settings->_globals->GetColorSchemes().Size());
+        VERIFY_IS_NULL(settings->_FindMatchingColorScheme(scheme0Json));
+        VERIFY_IS_NULL(settings->_FindMatchingColorScheme(scheme1Json));
+        VERIFY_IS_NULL(settings->_FindMatchingColorScheme(scheme2Json));
+        VERIFY_IS_NULL(settings->_FindMatchingColorScheme(scheme3Json));
 
-        settings._LayerOrCreateColorScheme(scheme0Json);
+        settings->_LayerOrCreateColorScheme(scheme0Json);
         {
-            for (auto kv : settings._globals->GetColorSchemes())
+            for (auto kv : settings->_globals->GetColorSchemes())
             {
                 Log::Comment(NoThrowString().Format(
                     L"kv:%s->%s", kv.Key().data(), kv.Value().Name().data()));
             }
-            VERIFY_ARE_EQUAL(1u, settings._globals->GetColorSchemes().Size());
+            VERIFY_ARE_EQUAL(1u, settings->_globals->GetColorSchemes().Size());
 
-            VERIFY_IS_TRUE(settings._globals->GetColorSchemes().HasKey(L"scheme0"));
-            auto scheme0Proj = settings._globals->GetColorSchemes().Lookup(L"scheme0");
+            VERIFY_IS_TRUE(settings->_globals->GetColorSchemes().HasKey(L"scheme0"));
+            auto scheme0Proj = settings->_globals->GetColorSchemes().Lookup(L"scheme0");
             auto scheme0 = winrt::get_self<ColorScheme>(scheme0Proj);
 
-            VERIFY_IS_NOT_NULL(settings._FindMatchingColorScheme(scheme0Json));
-            VERIFY_IS_NULL(settings._FindMatchingColorScheme(scheme1Json));
-            VERIFY_IS_NOT_NULL(settings._FindMatchingColorScheme(scheme2Json));
-            VERIFY_IS_NULL(settings._FindMatchingColorScheme(scheme3Json));
+            VERIFY_IS_NOT_NULL(settings->_FindMatchingColorScheme(scheme0Json));
+            VERIFY_IS_NULL(settings->_FindMatchingColorScheme(scheme1Json));
+            VERIFY_IS_NOT_NULL(settings->_FindMatchingColorScheme(scheme2Json));
+            VERIFY_IS_NULL(settings->_FindMatchingColorScheme(scheme3Json));
             VERIFY_ARE_EQUAL(ARGB(0, 0, 0, 0), scheme0->_defaultForeground);
             VERIFY_ARE_EQUAL(ARGB(0, 1, 1, 1), scheme0->_defaultBackground);
         }
 
-        settings._LayerOrCreateColorScheme(scheme1Json);
+        settings->_LayerOrCreateColorScheme(scheme1Json);
 
         {
-            VERIFY_ARE_EQUAL(2u, settings._globals->GetColorSchemes().Size());
+            VERIFY_ARE_EQUAL(2u, settings->_globals->GetColorSchemes().Size());
 
-            VERIFY_IS_TRUE(settings._globals->GetColorSchemes().HasKey(L"scheme0"));
-            auto scheme0Proj = settings._globals->GetColorSchemes().Lookup(L"scheme0");
+            VERIFY_IS_TRUE(settings->_globals->GetColorSchemes().HasKey(L"scheme0"));
+            auto scheme0Proj = settings->_globals->GetColorSchemes().Lookup(L"scheme0");
             auto scheme0 = winrt::get_self<ColorScheme>(scheme0Proj);
-            VERIFY_IS_TRUE(settings._globals->GetColorSchemes().HasKey(L"scheme1"));
-            auto scheme1Proj = settings._globals->GetColorSchemes().Lookup(L"scheme1");
+            VERIFY_IS_TRUE(settings->_globals->GetColorSchemes().HasKey(L"scheme1"));
+            auto scheme1Proj = settings->_globals->GetColorSchemes().Lookup(L"scheme1");
             auto scheme1 = winrt::get_self<ColorScheme>(scheme1Proj);
 
-            VERIFY_IS_NOT_NULL(settings._FindMatchingColorScheme(scheme0Json));
-            VERIFY_IS_NOT_NULL(settings._FindMatchingColorScheme(scheme1Json));
-            VERIFY_IS_NOT_NULL(settings._FindMatchingColorScheme(scheme2Json));
-            VERIFY_IS_NULL(settings._FindMatchingColorScheme(scheme3Json));
+            VERIFY_IS_NOT_NULL(settings->_FindMatchingColorScheme(scheme0Json));
+            VERIFY_IS_NOT_NULL(settings->_FindMatchingColorScheme(scheme1Json));
+            VERIFY_IS_NOT_NULL(settings->_FindMatchingColorScheme(scheme2Json));
+            VERIFY_IS_NULL(settings->_FindMatchingColorScheme(scheme3Json));
             VERIFY_ARE_EQUAL(ARGB(0, 0, 0, 0), scheme0->_defaultForeground);
             VERIFY_ARE_EQUAL(ARGB(0, 1, 1, 1), scheme0->_defaultBackground);
             VERIFY_ARE_EQUAL(ARGB(0, 2, 2, 2), scheme1->_defaultForeground);
             VERIFY_ARE_EQUAL(ARGB(0, 3, 3, 3), scheme1->_defaultBackground);
         }
-        settings._LayerOrCreateColorScheme(scheme2Json);
+        settings->_LayerOrCreateColorScheme(scheme2Json);
 
         {
-            VERIFY_ARE_EQUAL(2u, settings._globals->GetColorSchemes().Size());
+            VERIFY_ARE_EQUAL(2u, settings->_globals->GetColorSchemes().Size());
 
-            VERIFY_IS_TRUE(settings._globals->GetColorSchemes().HasKey(L"scheme0"));
-            auto scheme0Proj = settings._globals->GetColorSchemes().Lookup(L"scheme0");
+            VERIFY_IS_TRUE(settings->_globals->GetColorSchemes().HasKey(L"scheme0"));
+            auto scheme0Proj = settings->_globals->GetColorSchemes().Lookup(L"scheme0");
             auto scheme0 = winrt::get_self<ColorScheme>(scheme0Proj);
-            VERIFY_IS_TRUE(settings._globals->GetColorSchemes().HasKey(L"scheme1"));
-            auto scheme1Proj = settings._globals->GetColorSchemes().Lookup(L"scheme1");
+            VERIFY_IS_TRUE(settings->_globals->GetColorSchemes().HasKey(L"scheme1"));
+            auto scheme1Proj = settings->_globals->GetColorSchemes().Lookup(L"scheme1");
             auto scheme1 = winrt::get_self<ColorScheme>(scheme1Proj);
 
-            VERIFY_IS_NOT_NULL(settings._FindMatchingColorScheme(scheme0Json));
-            VERIFY_IS_NOT_NULL(settings._FindMatchingColorScheme(scheme1Json));
-            VERIFY_IS_NOT_NULL(settings._FindMatchingColorScheme(scheme2Json));
-            VERIFY_IS_NULL(settings._FindMatchingColorScheme(scheme3Json));
+            VERIFY_IS_NOT_NULL(settings->_FindMatchingColorScheme(scheme0Json));
+            VERIFY_IS_NOT_NULL(settings->_FindMatchingColorScheme(scheme1Json));
+            VERIFY_IS_NOT_NULL(settings->_FindMatchingColorScheme(scheme2Json));
+            VERIFY_IS_NULL(settings->_FindMatchingColorScheme(scheme3Json));
             VERIFY_ARE_EQUAL(ARGB(0, 4, 4, 4), scheme0->_defaultForeground);
             VERIFY_ARE_EQUAL(ARGB(0, 5, 5, 5), scheme0->_defaultBackground);
             VERIFY_ARE_EQUAL(ARGB(0, 2, 2, 2), scheme1->_defaultForeground);
             VERIFY_ARE_EQUAL(ARGB(0, 3, 3, 3), scheme1->_defaultBackground);
         }
-        settings._LayerOrCreateColorScheme(scheme3Json);
+        settings->_LayerOrCreateColorScheme(scheme3Json);
 
         {
-            VERIFY_ARE_EQUAL(3u, settings._globals->GetColorSchemes().Size());
+            VERIFY_ARE_EQUAL(3u, settings->_globals->GetColorSchemes().Size());
 
-            VERIFY_IS_TRUE(settings._globals->GetColorSchemes().HasKey(L"scheme0"));
-            auto scheme0Proj = settings._globals->GetColorSchemes().Lookup(L"scheme0");
+            VERIFY_IS_TRUE(settings->_globals->GetColorSchemes().HasKey(L"scheme0"));
+            auto scheme0Proj = settings->_globals->GetColorSchemes().Lookup(L"scheme0");
             auto scheme0 = winrt::get_self<ColorScheme>(scheme0Proj);
-            VERIFY_IS_TRUE(settings._globals->GetColorSchemes().HasKey(L"scheme1"));
-            auto scheme1Proj = settings._globals->GetColorSchemes().Lookup(L"scheme1");
+            VERIFY_IS_TRUE(settings->_globals->GetColorSchemes().HasKey(L"scheme1"));
+            auto scheme1Proj = settings->_globals->GetColorSchemes().Lookup(L"scheme1");
             auto scheme1 = winrt::get_self<ColorScheme>(scheme1Proj);
-            VERIFY_IS_TRUE(settings._globals->GetColorSchemes().HasKey(L""));
-            auto scheme2Proj = settings._globals->GetColorSchemes().Lookup(L"");
+            VERIFY_IS_TRUE(settings->_globals->GetColorSchemes().HasKey(L""));
+            auto scheme2Proj = settings->_globals->GetColorSchemes().Lookup(L"");
             auto scheme2 = winrt::get_self<ColorScheme>(scheme2Proj);
 
-            VERIFY_IS_NOT_NULL(settings._FindMatchingColorScheme(scheme0Json));
-            VERIFY_IS_NOT_NULL(settings._FindMatchingColorScheme(scheme1Json));
-            VERIFY_IS_NOT_NULL(settings._FindMatchingColorScheme(scheme2Json));
-            VERIFY_IS_NULL(settings._FindMatchingColorScheme(scheme3Json));
+            VERIFY_IS_NOT_NULL(settings->_FindMatchingColorScheme(scheme0Json));
+            VERIFY_IS_NOT_NULL(settings->_FindMatchingColorScheme(scheme1Json));
+            VERIFY_IS_NOT_NULL(settings->_FindMatchingColorScheme(scheme2Json));
+            VERIFY_IS_NULL(settings->_FindMatchingColorScheme(scheme3Json));
             VERIFY_ARE_EQUAL(ARGB(0, 4, 4, 4), scheme0->_defaultForeground);
             VERIFY_ARE_EQUAL(ARGB(0, 5, 5, 5), scheme0->_defaultBackground);
             VERIFY_ARE_EQUAL(ARGB(0, 2, 2, 2), scheme1->_defaultForeground);

--- a/src/cascadia/LocalTests_TerminalApp/ProfileTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/ProfileTests.cpp
@@ -253,57 +253,57 @@ namespace TerminalAppLocalTests
         const auto profile3Json = VerifyParseSucceeded(profile3String);
         const auto profile4Json = VerifyParseSucceeded(profile4String);
 
-        CascadiaSettings settings;
+        auto settings = winrt::make_self<winrt::TerminalApp::implementation::CascadiaSettings>();
 
-        VERIFY_ARE_EQUAL(0u, settings._profiles.size());
-        VERIFY_IS_NULL(settings._FindMatchingProfile(profile0Json));
-        VERIFY_IS_NULL(settings._FindMatchingProfile(profile1Json));
-        VERIFY_IS_NULL(settings._FindMatchingProfile(profile2Json));
-        VERIFY_IS_NULL(settings._FindMatchingProfile(profile3Json));
-        VERIFY_IS_NULL(settings._FindMatchingProfile(profile4Json));
+        VERIFY_ARE_EQUAL(0u, settings->_profiles.Size());
+        VERIFY_IS_NULL(settings->_FindMatchingProfile(profile0Json));
+        VERIFY_IS_NULL(settings->_FindMatchingProfile(profile1Json));
+        VERIFY_IS_NULL(settings->_FindMatchingProfile(profile2Json));
+        VERIFY_IS_NULL(settings->_FindMatchingProfile(profile3Json));
+        VERIFY_IS_NULL(settings->_FindMatchingProfile(profile4Json));
 
-        settings._LayerOrCreateProfile(profile0Json);
-        VERIFY_ARE_EQUAL(1u, settings._profiles.size());
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile0Json));
-        VERIFY_IS_NULL(settings._FindMatchingProfile(profile1Json));
-        VERIFY_IS_NULL(settings._FindMatchingProfile(profile2Json));
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile3Json));
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile4Json));
+        settings->_LayerOrCreateProfile(profile0Json);
+        VERIFY_ARE_EQUAL(1u, settings->_profiles.Size());
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile0Json));
+        VERIFY_IS_NULL(settings->_FindMatchingProfile(profile1Json));
+        VERIFY_IS_NULL(settings->_FindMatchingProfile(profile2Json));
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile3Json));
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile4Json));
 
-        settings._LayerOrCreateProfile(profile1Json);
-        VERIFY_ARE_EQUAL(2u, settings._profiles.size());
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile0Json));
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile1Json));
-        VERIFY_IS_NULL(settings._FindMatchingProfile(profile2Json));
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile3Json));
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile4Json));
+        settings->_LayerOrCreateProfile(profile1Json);
+        VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile0Json));
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile1Json));
+        VERIFY_IS_NULL(settings->_FindMatchingProfile(profile2Json));
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile3Json));
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile4Json));
 
-        settings._LayerOrCreateProfile(profile2Json);
-        VERIFY_ARE_EQUAL(3u, settings._profiles.size());
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile0Json));
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile1Json));
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile2Json));
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile3Json));
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile4Json));
-        VERIFY_ARE_EQUAL(L"profile0", settings._profiles.at(0).Name());
+        settings->_LayerOrCreateProfile(profile2Json);
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile0Json));
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile1Json));
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile2Json));
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile3Json));
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile4Json));
+        VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(0).Name());
 
-        settings._LayerOrCreateProfile(profile3Json);
-        VERIFY_ARE_EQUAL(3u, settings._profiles.size());
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile0Json));
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile1Json));
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile2Json));
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile3Json));
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile4Json));
-        VERIFY_ARE_EQUAL(L"profile3", settings._profiles.at(0).Name());
+        settings->_LayerOrCreateProfile(profile3Json);
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile0Json));
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile1Json));
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile2Json));
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile3Json));
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile4Json));
+        VERIFY_ARE_EQUAL(L"profile3", settings->_profiles.GetAt(0).Name());
 
-        settings._LayerOrCreateProfile(profile4Json);
-        VERIFY_ARE_EQUAL(3u, settings._profiles.size());
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile0Json));
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile1Json));
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile2Json));
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile3Json));
-        VERIFY_IS_NOT_NULL(settings._FindMatchingProfile(profile4Json));
-        VERIFY_ARE_EQUAL(L"profile4", settings._profiles.at(0).Name());
+        settings->_LayerOrCreateProfile(profile4Json);
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile0Json));
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile1Json));
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile2Json));
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile3Json));
+        VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile4Json));
+        VERIFY_ARE_EQUAL(L"profile4", settings->_profiles.GetAt(0).Name());
     }
 
 }

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -2693,7 +2693,7 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"${profile.name}", realArgs.TerminalArgs().Profile());
         }
 
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles(), settings->_globals->GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles().GetView(), settings->_globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
@@ -2824,7 +2824,7 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"${profile.name}", realArgs.TerminalArgs().Profile());
         }
 
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles(), settings->_globals->GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles().GetView(), settings->_globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
@@ -2958,7 +2958,7 @@ namespace TerminalAppLocalTests
         }
 
         settings->_ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles(), settings->_globals->GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles().GetView(), settings->_globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
@@ -3080,7 +3080,7 @@ namespace TerminalAppLocalTests
 
         auto commands = settings->_globals->GetCommands();
         settings->_ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles(), settings->_globals->GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles().GetView(), settings->_globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
@@ -3189,7 +3189,7 @@ namespace TerminalAppLocalTests
 
         auto commands = settings->_globals->GetCommands();
         settings->_ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles(), settings->_globals->GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles().GetView(), settings->_globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
@@ -3329,7 +3329,7 @@ namespace TerminalAppLocalTests
 
         auto commands = settings->_globals->GetCommands();
         settings->_ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles(), settings->_globals->GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles().GetView(), settings->_globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
@@ -3483,7 +3483,7 @@ namespace TerminalAppLocalTests
 
         auto commands = settings->_globals->GetCommands();
         settings->_ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles(), settings->_globals->GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles().GetView(), settings->_globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
@@ -3597,7 +3597,7 @@ namespace TerminalAppLocalTests
 
         auto commands = settings->_globals->GetCommands();
         settings->_ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles(), settings->_globals->GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles().GetView(), settings->_globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
@@ -4035,7 +4035,7 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"${scheme.name}", realArgs.TerminalArgs().Profile());
         }
 
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles(), settings->_globals->GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles().GetView(), settings->_globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings->_warnings.size());

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -165,13 +165,13 @@ namespace TerminalAppLocalTests
         {
             // Case 1: Good settings
             const auto settingsObject = VerifyParseSucceeded(settingsWithProfiles);
-            auto settings = CascadiaSettings::FromJson(settingsObject);
+            auto settings = implementation::CascadiaSettings::FromJson(settingsObject);
             settings->_ValidateProfilesExist();
         }
         {
             // Case 2: Bad settings
             const auto settingsObject = VerifyParseSucceeded(settingsWithoutProfiles);
-            auto settings = CascadiaSettings::FromJson(settingsObject);
+            auto settings = implementation::CascadiaSettings::FromJson(settingsObject);
             bool caughtExpectedException = false;
             try
             {
@@ -187,7 +187,7 @@ namespace TerminalAppLocalTests
         {
             // Case 3: Bad settings
             const auto settingsObject = VerifyParseSucceeded(settingsWithEmptyProfiles);
-            auto settings = CascadiaSettings::FromJson(settingsObject);
+            auto settings = implementation::CascadiaSettings::FromJson(settingsObject);
             bool caughtExpectedException = false;
             try
             {
@@ -269,52 +269,52 @@ namespace TerminalAppLocalTests
             Log::Comment(NoThrowString().Format(
                 L"Testing a pair of profiles with unique guids, and the defaultProfile is one of those guids"));
             const auto settingsObject = VerifyParseSucceeded(goodProfiles);
-            auto settings = CascadiaSettings::FromJson(settingsObject);
+            auto settings = implementation::CascadiaSettings::FromJson(settingsObject);
             settings->_ResolveDefaultProfile();
             settings->_ValidateDefaultProfileExists();
             VERIFY_ARE_EQUAL(static_cast<size_t>(0), settings->_warnings.size());
-            VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_profiles.size());
-            VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.at(0).Guid());
+            VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.GetAt(0).Guid());
         }
         {
             // Case 2: Bad settings
             Log::Comment(NoThrowString().Format(
                 L"Testing a pair of profiles with unique guids, but the defaultProfile is NOT one of those guids"));
             const auto settingsObject = VerifyParseSucceeded(badProfiles);
-            auto settings = CascadiaSettings::FromJson(settingsObject);
+            auto settings = implementation::CascadiaSettings::FromJson(settingsObject);
             settings->_ResolveDefaultProfile();
             settings->_ValidateDefaultProfileExists();
             VERIFY_ARE_EQUAL(static_cast<size_t>(1), settings->_warnings.size());
             VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingDefaultProfile, settings->_warnings.at(0));
 
-            VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_profiles.size());
-            VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.at(0).Guid());
+            VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.GetAt(0).Guid());
         }
         {
             // Case 2: Bad settings
             Log::Comment(NoThrowString().Format(
                 L"Testing a pair of profiles with unique guids, and no defaultProfile at all"));
             const auto settingsObject = VerifyParseSucceeded(badProfiles);
-            auto settings = CascadiaSettings::FromJson(settingsObject);
+            auto settings = implementation::CascadiaSettings::FromJson(settingsObject);
             settings->_ResolveDefaultProfile();
             settings->_ValidateDefaultProfileExists();
             VERIFY_ARE_EQUAL(static_cast<size_t>(1), settings->_warnings.size());
             VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingDefaultProfile, settings->_warnings.at(0));
 
-            VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_profiles.size());
-            VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.at(0).Guid());
+            VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.GetAt(0).Guid());
         }
         {
             // Case 4: Good settings, default profile is a string
             Log::Comment(NoThrowString().Format(
                 L"Testing a pair of profiles with unique guids, and the defaultProfile is one of the profile names"));
             const auto settingsObject = VerifyParseSucceeded(goodProfilesSpecifiedByName);
-            auto settings = CascadiaSettings::FromJson(settingsObject);
+            auto settings = implementation::CascadiaSettings::FromJson(settingsObject);
             settings->_ResolveDefaultProfile();
             settings->_ValidateDefaultProfileExists();
             VERIFY_ARE_EQUAL(static_cast<size_t>(0), settings->_warnings.size());
-            VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_profiles.size());
-            VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.at(1).Guid());
+            VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.GetAt(1).Guid());
         }
     }
 
@@ -401,56 +401,56 @@ namespace TerminalAppLocalTests
             Log::Comment(NoThrowString().Format(
                 L"Testing a pair of profiles with unique guids"));
 
-            CascadiaSettings settings;
-            settings._profiles.push_back(profile0);
-            settings._profiles.push_back(profile1);
+            auto settings = winrt::make_self<implementation::CascadiaSettings>();
+            settings->_profiles.Append(profile0);
+            settings->_profiles.Append(profile1);
 
-            settings._ValidateNoDuplicateProfiles();
+            settings->_ValidateNoDuplicateProfiles();
 
-            VERIFY_ARE_EQUAL(static_cast<size_t>(0), settings._warnings.size());
-            VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings._profiles.size());
+            VERIFY_ARE_EQUAL(static_cast<size_t>(0), settings->_warnings.size());
+            VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_profiles.Size());
         }
         {
             // Case 2: Bad settings
             Log::Comment(NoThrowString().Format(
                 L"Testing a pair of profiles with the same guid"));
 
-            CascadiaSettings settings;
-            settings._profiles.push_back(profile2);
-            settings._profiles.push_back(profile3);
+            auto settings = winrt::make_self<implementation::CascadiaSettings>();
+            settings->_profiles.Append(profile2);
+            settings->_profiles.Append(profile3);
 
-            settings._ValidateNoDuplicateProfiles();
+            settings->_ValidateNoDuplicateProfiles();
 
-            VERIFY_ARE_EQUAL(static_cast<size_t>(1), settings._warnings.size());
-            VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::DuplicateProfile, settings._warnings.at(0));
+            VERIFY_ARE_EQUAL(static_cast<size_t>(1), settings->_warnings.size());
+            VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::DuplicateProfile, settings->_warnings.at(0));
 
-            VERIFY_ARE_EQUAL(static_cast<size_t>(1), settings._profiles.size());
-            VERIFY_ARE_EQUAL(L"profile2", settings._profiles.at(0).Name());
+            VERIFY_ARE_EQUAL(static_cast<size_t>(1), settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(0).Name());
         }
         {
             // Case 3: Very bad settings
             Log::Comment(NoThrowString().Format(
                 L"Testing a set of profiles, many of which with duplicated guids"));
 
-            CascadiaSettings settings;
-            settings._profiles.push_back(profile0);
-            settings._profiles.push_back(profile1);
-            settings._profiles.push_back(profile2);
-            settings._profiles.push_back(profile3);
-            settings._profiles.push_back(profile4);
-            settings._profiles.push_back(profile5);
-            settings._profiles.push_back(profile6);
+            auto settings = winrt::make_self<implementation::CascadiaSettings>();
+            settings->_profiles.Append(profile0);
+            settings->_profiles.Append(profile1);
+            settings->_profiles.Append(profile2);
+            settings->_profiles.Append(profile3);
+            settings->_profiles.Append(profile4);
+            settings->_profiles.Append(profile5);
+            settings->_profiles.Append(profile6);
 
-            settings._ValidateNoDuplicateProfiles();
+            settings->_ValidateNoDuplicateProfiles();
 
-            VERIFY_ARE_EQUAL(static_cast<size_t>(1), settings._warnings.size());
-            VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::DuplicateProfile, settings._warnings.at(0));
+            VERIFY_ARE_EQUAL(static_cast<size_t>(1), settings->_warnings.size());
+            VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::DuplicateProfile, settings->_warnings.at(0));
 
-            VERIFY_ARE_EQUAL(static_cast<size_t>(4), settings._profiles.size());
-            VERIFY_ARE_EQUAL(L"profile0", settings._profiles.at(0).Name());
-            VERIFY_ARE_EQUAL(L"profile1", settings._profiles.at(1).Name());
-            VERIFY_ARE_EQUAL(L"profile4", settings._profiles.at(2).Name());
-            VERIFY_ARE_EQUAL(L"profile6", settings._profiles.at(3).Name());
+            VERIFY_ARE_EQUAL(static_cast<size_t>(4), settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(L"profile4", settings->_profiles.GetAt(2).Name());
+            VERIFY_ARE_EQUAL(L"profile6", settings->_profiles.GetAt(3).Name());
         }
     }
 
@@ -483,10 +483,10 @@ namespace TerminalAppLocalTests
         Log::Comment(NoThrowString().Format(
             L"Testing a pair of profiles with the same guid"));
         const auto settingsObject = VerifyParseSucceeded(badProfiles);
-        auto settings = CascadiaSettings::FromJson(settingsObject);
+        auto settings = implementation::CascadiaSettings::FromJson(settingsObject);
 
-        settings->_profiles.push_back(profile4);
-        settings->_profiles.push_back(profile5);
+        settings->_profiles.Append(profile4);
+        settings->_profiles.Append(profile5);
 
         settings->_ValidateSettings();
 
@@ -495,11 +495,11 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::MissingDefaultProfile, settings->_warnings.at(1));
         VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::UnknownColorScheme, settings->_warnings.at(2));
 
-        VERIFY_ARE_EQUAL(3u, settings->_profiles.size());
-        VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.at(0).Guid());
-        VERIFY_IS_TRUE(settings->_profiles.at(0).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.at(1).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.at(2).HasGuid());
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.GetAt(0).Guid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
     }
 
     void SettingsTests::LayerGlobalProperties()
@@ -519,19 +519,19 @@ namespace TerminalAppLocalTests
         const auto settings0Json = VerifyParseSucceeded(settings0String);
         const auto settings1Json = VerifyParseSucceeded(settings1String);
 
-        CascadiaSettings settings;
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
 
-        settings.LayerJson(settings0Json);
-        VERIFY_ARE_EQUAL(true, settings._globals->AlwaysShowTabs());
-        VERIFY_ARE_EQUAL(120, settings._globals->InitialCols());
-        VERIFY_ARE_EQUAL(30, settings._globals->InitialRows());
-        VERIFY_ARE_EQUAL(true, settings._globals->ShowTabsInTitlebar());
+        settings->LayerJson(settings0Json);
+        VERIFY_ARE_EQUAL(true, settings->_globals->AlwaysShowTabs());
+        VERIFY_ARE_EQUAL(120, settings->_globals->InitialCols());
+        VERIFY_ARE_EQUAL(30, settings->_globals->InitialRows());
+        VERIFY_ARE_EQUAL(true, settings->_globals->ShowTabsInTitlebar());
 
-        settings.LayerJson(settings1Json);
-        VERIFY_ARE_EQUAL(true, settings._globals->AlwaysShowTabs());
-        VERIFY_ARE_EQUAL(240, settings._globals->InitialCols());
-        VERIFY_ARE_EQUAL(60, settings._globals->InitialRows());
-        VERIFY_ARE_EQUAL(false, settings._globals->ShowTabsInTitlebar());
+        settings->LayerJson(settings1Json);
+        VERIFY_ARE_EQUAL(true, settings->_globals->AlwaysShowTabs());
+        VERIFY_ARE_EQUAL(240, settings->_globals->InitialCols());
+        VERIFY_ARE_EQUAL(60, settings->_globals->InitialRows());
+        VERIFY_ARE_EQUAL(false, settings->_globals->ShowTabsInTitlebar());
     }
 
     void SettingsTests::ValidateProfileOrdering()
@@ -587,48 +587,48 @@ namespace TerminalAppLocalTests
                 L"Case 1: Simple swapping of the ordering. The user has the "
                 L"default profiles in the opposite order of the default ordering."));
 
-            CascadiaSettings settings;
-            settings._ParseJsonString(defaultProfilesString, true);
-            settings.LayerJson(settings._defaultSettings);
-            VERIFY_ARE_EQUAL(2u, settings._profiles.size());
-            VERIFY_ARE_EQUAL(L"profile2", settings._profiles.at(0).Name());
-            VERIFY_ARE_EQUAL(L"profile3", settings._profiles.at(1).Name());
+            auto settings = winrt::make_self<implementation::CascadiaSettings>();
+            settings->_ParseJsonString(defaultProfilesString, true);
+            settings->LayerJson(settings->_defaultSettings);
+            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile3", settings->_profiles.GetAt(1).Name());
 
-            settings._ParseJsonString(userProfiles0String, false);
-            settings.LayerJson(settings._userSettings);
-            VERIFY_ARE_EQUAL(2u, settings._profiles.size());
-            VERIFY_ARE_EQUAL(L"profile1", settings._profiles.at(0).Name());
-            VERIFY_ARE_EQUAL(L"profile0", settings._profiles.at(1).Name());
+            settings->_ParseJsonString(userProfiles0String, false);
+            settings->LayerJson(settings->_userSettings);
+            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(1).Name());
 
-            settings._ReorderProfilesToMatchUserSettingsOrder();
-            VERIFY_ARE_EQUAL(2u, settings._profiles.size());
-            VERIFY_ARE_EQUAL(L"profile0", settings._profiles.at(0).Name());
-            VERIFY_ARE_EQUAL(L"profile1", settings._profiles.at(1).Name());
+            settings->_ReorderProfilesToMatchUserSettingsOrder();
+            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(1).Name());
         }
 
         {
             Log::Comment(NoThrowString().Format(
                 L"Case 2: Make sure all the user's profiles appear before the defaults."));
 
-            CascadiaSettings settings;
-            settings._ParseJsonString(defaultProfilesString, true);
-            settings.LayerJson(settings._defaultSettings);
-            VERIFY_ARE_EQUAL(2u, settings._profiles.size());
-            VERIFY_ARE_EQUAL(L"profile2", settings._profiles.at(0).Name());
-            VERIFY_ARE_EQUAL(L"profile3", settings._profiles.at(1).Name());
+            auto settings = winrt::make_self<implementation::CascadiaSettings>();
+            settings->_ParseJsonString(defaultProfilesString, true);
+            settings->LayerJson(settings->_defaultSettings);
+            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile3", settings->_profiles.GetAt(1).Name());
 
-            settings._ParseJsonString(userProfiles1String, false);
-            settings.LayerJson(settings._userSettings);
-            VERIFY_ARE_EQUAL(3u, settings._profiles.size());
-            VERIFY_ARE_EQUAL(L"profile2", settings._profiles.at(0).Name());
-            VERIFY_ARE_EQUAL(L"profile4", settings._profiles.at(1).Name());
-            VERIFY_ARE_EQUAL(L"profile5", settings._profiles.at(2).Name());
+            settings->_ParseJsonString(userProfiles1String, false);
+            settings->LayerJson(settings->_userSettings);
+            VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile4", settings->_profiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(L"profile5", settings->_profiles.GetAt(2).Name());
 
-            settings._ReorderProfilesToMatchUserSettingsOrder();
-            VERIFY_ARE_EQUAL(3u, settings._profiles.size());
-            VERIFY_ARE_EQUAL(L"profile4", settings._profiles.at(0).Name());
-            VERIFY_ARE_EQUAL(L"profile5", settings._profiles.at(1).Name());
-            VERIFY_ARE_EQUAL(L"profile2", settings._profiles.at(2).Name());
+            settings->_ReorderProfilesToMatchUserSettingsOrder();
+            VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(L"profile4", settings->_profiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile5", settings->_profiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(2).Name());
         }
     }
 
@@ -688,59 +688,59 @@ namespace TerminalAppLocalTests
         const auto defaultProfilesJson = VerifyParseSucceeded(defaultProfilesString);
 
         {
-            CascadiaSettings settings;
-            settings._ParseJsonString(defaultProfilesString, true);
-            settings.LayerJson(settings._defaultSettings);
-            VERIFY_ARE_EQUAL(2u, settings._profiles.size());
-            VERIFY_ARE_EQUAL(L"profile2", settings._profiles.at(0).Name());
-            VERIFY_ARE_EQUAL(L"profile3", settings._profiles.at(1).Name());
-            VERIFY_ARE_EQUAL(false, settings._profiles.at(0).Hidden());
-            VERIFY_ARE_EQUAL(false, settings._profiles.at(1).Hidden());
+            auto settings = winrt::make_self<implementation::CascadiaSettings>();
+            settings->_ParseJsonString(defaultProfilesString, true);
+            settings->LayerJson(settings->_defaultSettings);
+            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile3", settings->_profiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(false, settings->_profiles.GetAt(0).Hidden());
+            VERIFY_ARE_EQUAL(false, settings->_profiles.GetAt(1).Hidden());
 
-            settings._ParseJsonString(userProfiles0String, false);
-            settings.LayerJson(settings._userSettings);
-            VERIFY_ARE_EQUAL(2u, settings._profiles.size());
-            VERIFY_ARE_EQUAL(L"profile1", settings._profiles.at(0).Name());
-            VERIFY_ARE_EQUAL(L"profile0", settings._profiles.at(1).Name());
-            VERIFY_ARE_EQUAL(false, settings._profiles.at(0).Hidden());
-            VERIFY_ARE_EQUAL(true, settings._profiles.at(1).Hidden());
+            settings->_ParseJsonString(userProfiles0String, false);
+            settings->LayerJson(settings->_userSettings);
+            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(false, settings->_profiles.GetAt(0).Hidden());
+            VERIFY_ARE_EQUAL(true, settings->_profiles.GetAt(1).Hidden());
 
-            settings._ReorderProfilesToMatchUserSettingsOrder();
-            settings._RemoveHiddenProfiles();
-            VERIFY_ARE_EQUAL(1u, settings._profiles.size());
-            VERIFY_ARE_EQUAL(L"profile1", settings._profiles.at(0).Name());
-            VERIFY_ARE_EQUAL(false, settings._profiles.at(0).Hidden());
+            settings->_ReorderProfilesToMatchUserSettingsOrder();
+            settings->_RemoveHiddenProfiles();
+            VERIFY_ARE_EQUAL(1u, settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(false, settings->_profiles.GetAt(0).Hidden());
         }
 
         {
-            CascadiaSettings settings;
-            settings._ParseJsonString(defaultProfilesString, true);
-            settings.LayerJson(settings._defaultSettings);
-            VERIFY_ARE_EQUAL(2u, settings._profiles.size());
-            VERIFY_ARE_EQUAL(L"profile2", settings._profiles.at(0).Name());
-            VERIFY_ARE_EQUAL(L"profile3", settings._profiles.at(1).Name());
-            VERIFY_ARE_EQUAL(false, settings._profiles.at(0).Hidden());
-            VERIFY_ARE_EQUAL(false, settings._profiles.at(1).Hidden());
+            auto settings = winrt::make_self<implementation::CascadiaSettings>();
+            settings->_ParseJsonString(defaultProfilesString, true);
+            settings->LayerJson(settings->_defaultSettings);
+            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile3", settings->_profiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(false, settings->_profiles.GetAt(0).Hidden());
+            VERIFY_ARE_EQUAL(false, settings->_profiles.GetAt(1).Hidden());
 
-            settings._ParseJsonString(userProfiles1String, false);
-            settings.LayerJson(settings._userSettings);
-            VERIFY_ARE_EQUAL(4u, settings._profiles.size());
-            VERIFY_ARE_EQUAL(L"profile2", settings._profiles.at(0).Name());
-            VERIFY_ARE_EQUAL(L"profile4", settings._profiles.at(1).Name());
-            VERIFY_ARE_EQUAL(L"profile5", settings._profiles.at(2).Name());
-            VERIFY_ARE_EQUAL(L"profile6", settings._profiles.at(3).Name());
-            VERIFY_ARE_EQUAL(false, settings._profiles.at(0).Hidden());
-            VERIFY_ARE_EQUAL(true, settings._profiles.at(1).Hidden());
-            VERIFY_ARE_EQUAL(false, settings._profiles.at(2).Hidden());
-            VERIFY_ARE_EQUAL(true, settings._profiles.at(3).Hidden());
+            settings->_ParseJsonString(userProfiles1String, false);
+            settings->LayerJson(settings->_userSettings);
+            VERIFY_ARE_EQUAL(4u, settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile4", settings->_profiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(L"profile5", settings->_profiles.GetAt(2).Name());
+            VERIFY_ARE_EQUAL(L"profile6", settings->_profiles.GetAt(3).Name());
+            VERIFY_ARE_EQUAL(false, settings->_profiles.GetAt(0).Hidden());
+            VERIFY_ARE_EQUAL(true, settings->_profiles.GetAt(1).Hidden());
+            VERIFY_ARE_EQUAL(false, settings->_profiles.GetAt(2).Hidden());
+            VERIFY_ARE_EQUAL(true, settings->_profiles.GetAt(3).Hidden());
 
-            settings._ReorderProfilesToMatchUserSettingsOrder();
-            settings._RemoveHiddenProfiles();
-            VERIFY_ARE_EQUAL(2u, settings._profiles.size());
-            VERIFY_ARE_EQUAL(L"profile5", settings._profiles.at(0).Name());
-            VERIFY_ARE_EQUAL(L"profile2", settings._profiles.at(1).Name());
-            VERIFY_ARE_EQUAL(false, settings._profiles.at(0).Hidden());
-            VERIFY_ARE_EQUAL(false, settings._profiles.at(1).Hidden());
+            settings->_ReorderProfilesToMatchUserSettingsOrder();
+            settings->_RemoveHiddenProfiles();
+            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(L"profile5", settings->_profiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(false, settings->_profiles.GetAt(0).Hidden());
+            VERIFY_ARE_EQUAL(false, settings->_profiles.GetAt(1).Hidden());
         }
     }
 
@@ -801,42 +801,42 @@ namespace TerminalAppLocalTests
         VERIFY_ARE_EQUAL(profile3->Guid(), nullGuid);
         VERIFY_ARE_EQUAL(profile4->Guid(), cmdGuid);
 
-        CascadiaSettings settings;
-        settings._profiles.emplace_back(profile0.as<Profile>());
-        settings._profiles.emplace_back(profile1.as<Profile>());
-        settings._profiles.emplace_back(profile2.as<Profile>());
-        settings._profiles.emplace_back(profile3.as<Profile>());
-        settings._profiles.emplace_back(profile4.as<Profile>());
-        settings._profiles.emplace_back(profile5.as<Profile>());
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_profiles.Append(*profile0);
+        settings->_profiles.Append(*profile1);
+        settings->_profiles.Append(*profile2);
+        settings->_profiles.Append(*profile3);
+        settings->_profiles.Append(*profile4);
+        settings->_profiles.Append(*profile5);
 
-        settings._ValidateProfilesHaveGuid();
-        VERIFY_IS_TRUE(settings._profiles.at(0).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(1).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(2).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(3).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(4).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(5).HasGuid());
+        settings->_ValidateProfilesHaveGuid();
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(3).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(4).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(5).HasGuid());
 
-        VERIFY_ARE_NOT_EQUAL(settings._profiles.at(0).Guid(), nullGuid);
-        VERIFY_ARE_NOT_EQUAL(settings._profiles.at(1).Guid(), nullGuid);
-        VERIFY_ARE_NOT_EQUAL(settings._profiles.at(2).Guid(), nullGuid);
-        VERIFY_ARE_EQUAL(settings._profiles.at(3).Guid(), nullGuid);
-        VERIFY_ARE_NOT_EQUAL(settings._profiles.at(4).Guid(), nullGuid);
-        VERIFY_ARE_NOT_EQUAL(settings._profiles.at(5).Guid(), nullGuid);
+        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(0).Guid(), nullGuid);
+        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(1).Guid(), nullGuid);
+        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(2).Guid(), nullGuid);
+        VERIFY_ARE_EQUAL(settings->_profiles.GetAt(3).Guid(), nullGuid);
+        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(4).Guid(), nullGuid);
+        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(5).Guid(), nullGuid);
 
-        VERIFY_ARE_NOT_EQUAL(settings._profiles.at(0).Guid(), cmdGuid);
-        VERIFY_ARE_NOT_EQUAL(settings._profiles.at(1).Guid(), cmdGuid);
-        VERIFY_ARE_NOT_EQUAL(settings._profiles.at(2).Guid(), cmdGuid);
-        VERIFY_ARE_NOT_EQUAL(settings._profiles.at(3).Guid(), cmdGuid);
-        VERIFY_ARE_EQUAL(settings._profiles.at(4).Guid(), cmdGuid);
-        VERIFY_ARE_NOT_EQUAL(settings._profiles.at(5).Guid(), cmdGuid);
+        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(0).Guid(), cmdGuid);
+        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(1).Guid(), cmdGuid);
+        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(2).Guid(), cmdGuid);
+        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(3).Guid(), cmdGuid);
+        VERIFY_ARE_EQUAL(settings->_profiles.GetAt(4).Guid(), cmdGuid);
+        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(5).Guid(), cmdGuid);
 
-        VERIFY_ARE_NOT_EQUAL(settings._profiles.at(0).Guid(), settings._profiles.at(2).Guid());
-        VERIFY_ARE_NOT_EQUAL(settings._profiles.at(1).Guid(), settings._profiles.at(2).Guid());
-        VERIFY_ARE_EQUAL(settings._profiles.at(2).Guid(), settings._profiles.at(2).Guid());
-        VERIFY_ARE_NOT_EQUAL(settings._profiles.at(3).Guid(), settings._profiles.at(2).Guid());
-        VERIFY_ARE_NOT_EQUAL(settings._profiles.at(4).Guid(), settings._profiles.at(2).Guid());
-        VERIFY_ARE_EQUAL(settings._profiles.at(5).Guid(), settings._profiles.at(2).Guid());
+        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(0).Guid(), settings->_profiles.GetAt(2).Guid());
+        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(1).Guid(), settings->_profiles.GetAt(2).Guid());
+        VERIFY_ARE_EQUAL(settings->_profiles.GetAt(2).Guid(), settings->_profiles.GetAt(2).Guid());
+        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(3).Guid(), settings->_profiles.GetAt(2).Guid());
+        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(4).Guid(), settings->_profiles.GetAt(2).Guid());
+        VERIFY_ARE_EQUAL(settings->_profiles.GetAt(5).Guid(), settings->_profiles.GetAt(2).Guid());
     }
 
     void SettingsTests::GeneratedGuidRoundtrips()
@@ -860,19 +860,19 @@ namespace TerminalAppLocalTests
         VERIFY_IS_FALSE(profile0->HasGuid());
         VERIFY_IS_FALSE(profile1->HasGuid());
 
-        CascadiaSettings settings;
-        settings._profiles.emplace_back(profile1.as<Profile>());
-        settings._ValidateProfilesHaveGuid();
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_profiles.Append(*profile1);
+        settings->_ValidateProfilesHaveGuid();
 
-        VERIFY_IS_TRUE(settings._profiles.at(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
 
-        const auto profileImpl = winrt::get_self<implementation::Profile>(settings._profiles.at(0));
+        const auto profileImpl = winrt::get_self<implementation::Profile>(settings->_profiles.GetAt(0));
         const auto serialized1Profile = profileImpl->GenerateStub();
 
         const auto profile2 = implementation::Profile::FromJson(serialized1Profile);
-        VERIFY_IS_TRUE(settings._profiles.at(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
         VERIFY_IS_TRUE(profile2->HasGuid());
-        VERIFY_ARE_EQUAL(settings._profiles.at(0).Guid(), profile2->Guid());
+        VERIFY_ARE_EQUAL(settings->_profiles.GetAt(0).Guid(), profile2->Guid());
     }
 
     void SettingsTests::TestAllValidationsWithNullGuids()
@@ -896,19 +896,19 @@ namespace TerminalAppLocalTests
 
         const auto settings0Json = VerifyParseSucceeded(settings0String);
 
-        CascadiaSettings settings;
-        settings._ParseJsonString(settings0String, false);
-        settings.LayerJson(settings._userSettings);
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settings0String, false);
+        settings->LayerJson(settings->_userSettings);
 
-        VERIFY_ARE_EQUAL(2u, settings._profiles.size());
-        VERIFY_IS_TRUE(settings._profiles.at(0).HasGuid());
-        VERIFY_IS_FALSE(settings._profiles.at(1).HasGuid());
+        VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(1).HasGuid());
 
-        settings._ValidateSettings();
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
-        VERIFY_ARE_EQUAL(2u, settings._profiles.size());
-        VERIFY_IS_TRUE(settings._profiles.at(0).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(1).HasGuid());
+        settings->_ValidateSettings();
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
+        VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
     }
 
     void SettingsTests::TestReorderWithNullGuids()
@@ -933,39 +933,39 @@ namespace TerminalAppLocalTests
 
         const auto settings0Json = VerifyParseSucceeded(settings0String);
 
-        CascadiaSettings settings;
-        settings._ParseJsonString(DefaultJson, true);
-        settings.LayerJson(settings._defaultSettings);
-        VERIFY_ARE_EQUAL(2u, settings._profiles.size());
-        VERIFY_IS_TRUE(settings._profiles.at(0).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(1).HasGuid());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings._profiles.at(0).Name());
-        VERIFY_ARE_EQUAL(L"Command Prompt", settings._profiles.at(1).Name());
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(DefaultJson, true);
+        settings->LayerJson(settings->_defaultSettings);
+        VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_profiles.GetAt(1).Name());
 
-        settings._ParseJsonString(settings0String, false);
-        settings.LayerJson(settings._userSettings);
+        settings->_ParseJsonString(settings0String, false);
+        settings->LayerJson(settings->_userSettings);
 
-        VERIFY_ARE_EQUAL(4u, settings._profiles.size());
-        VERIFY_IS_TRUE(settings._profiles.at(0).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(1).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(2).HasGuid());
-        VERIFY_IS_FALSE(settings._profiles.at(3).HasGuid());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings._profiles.at(0).Name());
-        VERIFY_ARE_EQUAL(L"cmdFromUserSettings", settings._profiles.at(1).Name());
-        VERIFY_ARE_EQUAL(L"profile0", settings._profiles.at(2).Name());
-        VERIFY_ARE_EQUAL(L"profile1", settings._profiles.at(3).Name());
+        VERIFY_ARE_EQUAL(4u, settings->_profiles.Size());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(3).HasGuid());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"cmdFromUserSettings", settings->_profiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(3).Name());
 
-        settings._ValidateSettings();
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
-        VERIFY_ARE_EQUAL(4u, settings._profiles.size());
-        VERIFY_IS_TRUE(settings._profiles.at(0).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(1).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(2).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(3).HasGuid());
-        VERIFY_ARE_EQUAL(L"profile0", settings._profiles.at(0).Name());
-        VERIFY_ARE_EQUAL(L"profile1", settings._profiles.at(1).Name());
-        VERIFY_ARE_EQUAL(L"cmdFromUserSettings", settings._profiles.at(2).Name());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings._profiles.at(3).Name());
+        settings->_ValidateSettings();
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
+        VERIFY_ARE_EQUAL(4u, settings->_profiles.Size());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(3).HasGuid());
+        VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"cmdFromUserSettings", settings->_profiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(3).Name());
     }
 
     void SettingsTests::TestReorderingWithoutGuid()
@@ -1034,39 +1034,39 @@ namespace TerminalAppLocalTests
 
         const auto settings0Json = VerifyParseSucceeded(settings0String);
 
-        CascadiaSettings settings;
-        settings._ParseJsonString(DefaultJson, true);
-        settings.LayerJson(settings._defaultSettings);
-        VERIFY_ARE_EQUAL(2u, settings._profiles.size());
-        VERIFY_IS_TRUE(settings._profiles.at(0).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(1).HasGuid());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings._profiles.at(0).Name());
-        VERIFY_ARE_EQUAL(L"Command Prompt", settings._profiles.at(1).Name());
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(DefaultJson, true);
+        settings->LayerJson(settings->_defaultSettings);
+        VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_profiles.GetAt(1).Name());
 
-        settings._ParseJsonString(settings0String, false);
-        settings.LayerJson(settings._userSettings);
+        settings->_ParseJsonString(settings0String, false);
+        settings->LayerJson(settings->_userSettings);
 
-        VERIFY_ARE_EQUAL(4u, settings._profiles.size());
-        VERIFY_IS_TRUE(settings._profiles.at(0).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(1).HasGuid());
-        VERIFY_IS_FALSE(settings._profiles.at(2).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(3).HasGuid());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings._profiles.at(0).Name());
-        VERIFY_ARE_EQUAL(L"Command Prompt", settings._profiles.at(1).Name());
-        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotCrash", settings._profiles.at(2).Name());
-        VERIFY_ARE_EQUAL(L"Ubuntu", settings._profiles.at(3).Name());
+        VERIFY_ARE_EQUAL(4u, settings->_profiles.Size());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(2).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(3).HasGuid());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_profiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotCrash", settings->_profiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"Ubuntu", settings->_profiles.GetAt(3).Name());
 
-        settings._ValidateSettings();
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
-        VERIFY_ARE_EQUAL(4u, settings._profiles.size());
-        VERIFY_IS_TRUE(settings._profiles.at(0).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(1).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(2).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(3).HasGuid());
-        VERIFY_ARE_EQUAL(L"Command Prompt", settings._profiles.at(0).Name());
-        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotCrash", settings._profiles.at(1).Name());
-        VERIFY_ARE_EQUAL(L"Ubuntu", settings._profiles.at(2).Name());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings._profiles.at(3).Name());
+        settings->_ValidateSettings();
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
+        VERIFY_ARE_EQUAL(4u, settings->_profiles.Size());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(3).HasGuid());
+        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_profiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotCrash", settings->_profiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"Ubuntu", settings->_profiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(3).Name());
     }
 
     void SettingsTests::TestLayeringNameOnlyProfiles()
@@ -1095,31 +1095,31 @@ namespace TerminalAppLocalTests
 
         const auto settings0Json = VerifyParseSucceeded(settings0String);
 
-        CascadiaSettings settings;
-        settings._ParseJsonString(DefaultJson, true);
-        settings.LayerJson(settings._defaultSettings);
-        VERIFY_ARE_EQUAL(2u, settings._profiles.size());
-        VERIFY_IS_TRUE(settings._profiles.at(0).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(1).HasGuid());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings._profiles.at(0).Name());
-        VERIFY_ARE_EQUAL(L"Command Prompt", settings._profiles.at(1).Name());
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(DefaultJson, true);
+        settings->LayerJson(settings->_defaultSettings);
+        VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_profiles.GetAt(1).Name());
 
         Log::Comment(NoThrowString().Format(
             L"Parse the user settings"));
-        settings._ParseJsonString(settings0String, false);
-        settings.LayerJson(settings._userSettings);
+        settings->_ParseJsonString(settings0String, false);
+        settings->LayerJson(settings->_userSettings);
 
-        VERIFY_ARE_EQUAL(5u, settings._profiles.size());
-        VERIFY_IS_TRUE(settings._profiles.at(0).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(1).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(2).HasGuid());
-        VERIFY_IS_FALSE(settings._profiles.at(3).HasGuid());
-        VERIFY_IS_FALSE(settings._profiles.at(4).HasGuid());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings._profiles.at(0).Name());
-        VERIFY_ARE_EQUAL(L"Command Prompt", settings._profiles.at(1).Name());
-        VERIFY_ARE_EQUAL(L"ThisProfileIsGood", settings._profiles.at(2).Name());
-        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotLayer", settings._profiles.at(3).Name());
-        VERIFY_ARE_EQUAL(L"NeitherShouldThisOne", settings._profiles.at(4).Name());
+        VERIFY_ARE_EQUAL(5u, settings->_profiles.Size());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(3).HasGuid());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(4).HasGuid());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_profiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"ThisProfileIsGood", settings->_profiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotLayer", settings->_profiles.GetAt(3).Name());
+        VERIFY_ARE_EQUAL(L"NeitherShouldThisOne", settings->_profiles.GetAt(4).Name());
     }
 
     void SettingsTests::TestExplodingNameOnlyProfiles()
@@ -1148,81 +1148,81 @@ namespace TerminalAppLocalTests
 
         const auto settings0Json = VerifyParseSucceeded(settings0String);
 
-        CascadiaSettings settings;
-        settings._ParseJsonString(DefaultJson, true);
-        settings.LayerJson(settings._defaultSettings);
-        VERIFY_ARE_EQUAL(2u, settings._profiles.size());
-        VERIFY_IS_TRUE(settings._profiles.at(0).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(1).HasGuid());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings._profiles.at(0).Name());
-        VERIFY_ARE_EQUAL(L"Command Prompt", settings._profiles.at(1).Name());
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(DefaultJson, true);
+        settings->LayerJson(settings->_defaultSettings);
+        VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_profiles.GetAt(1).Name());
 
         Log::Comment(NoThrowString().Format(
             L"Parse the user settings"));
-        settings._ParseJsonString(settings0String, false);
-        settings.LayerJson(settings._userSettings);
+        settings->_ParseJsonString(settings0String, false);
+        settings->LayerJson(settings->_userSettings);
 
-        VERIFY_ARE_EQUAL(5u, settings._profiles.size());
-        VERIFY_IS_TRUE(settings._profiles.at(0).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(1).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(2).HasGuid());
-        VERIFY_IS_FALSE(settings._profiles.at(3).HasGuid());
-        VERIFY_IS_FALSE(settings._profiles.at(4).HasGuid());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings._profiles.at(0).Name());
-        VERIFY_ARE_EQUAL(L"Command Prompt", settings._profiles.at(1).Name());
-        VERIFY_ARE_EQUAL(L"ThisProfileIsGood", settings._profiles.at(2).Name());
-        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotDuplicate", settings._profiles.at(3).Name());
-        VERIFY_ARE_EQUAL(L"NeitherShouldThisOne", settings._profiles.at(4).Name());
+        VERIFY_ARE_EQUAL(5u, settings->_profiles.Size());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(3).HasGuid());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(4).HasGuid());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_profiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"ThisProfileIsGood", settings->_profiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotDuplicate", settings->_profiles.GetAt(3).Name());
+        VERIFY_ARE_EQUAL(L"NeitherShouldThisOne", settings->_profiles.GetAt(4).Name());
 
         Log::Comment(NoThrowString().Format(
             L"Pretend like we're checking to append dynamic profiles to the "
             L"user's settings file. We absolutely _shouldn't_ be adding anything here."));
-        bool const needToWriteFile = settings._AppendDynamicProfilesToUserSettings();
+        bool const needToWriteFile = settings->_AppendDynamicProfilesToUserSettings();
         VERIFY_IS_FALSE(needToWriteFile);
-        VERIFY_ARE_EQUAL(settings0String.size(), settings._userSettingsString.size());
+        VERIFY_ARE_EQUAL(settings0String.size(), settings->_userSettingsString.size());
 
         Log::Comment(NoThrowString().Format(
             L"Re-parse the settings file. We should have the _same_ settings as before."));
         Log::Comment(NoThrowString().Format(
             L"Do this to a _new_ settings object, to make sure it turns out the same."));
         {
-            CascadiaSettings settings2;
-            settings2._ParseJsonString(DefaultJson, true);
-            settings2.LayerJson(settings2._defaultSettings);
-            VERIFY_ARE_EQUAL(2u, settings2._profiles.size());
+            auto settings2 = winrt::make_self<implementation::CascadiaSettings>();
+            settings2->_ParseJsonString(DefaultJson, true);
+            settings2->LayerJson(settings2->_defaultSettings);
+            VERIFY_ARE_EQUAL(2u, settings2->_profiles.Size());
             // Initialize the second settings object from the first settings
             // object's settings string, the one that we synthesized.
-            const auto firstSettingsString = settings._userSettingsString;
-            settings2._ParseJsonString(firstSettingsString, false);
-            settings2.LayerJson(settings2._userSettings);
-            VERIFY_ARE_EQUAL(5u, settings2._profiles.size());
-            VERIFY_IS_TRUE(settings2._profiles.at(0).HasGuid());
-            VERIFY_IS_TRUE(settings2._profiles.at(1).HasGuid());
-            VERIFY_IS_TRUE(settings2._profiles.at(2).HasGuid());
-            VERIFY_IS_FALSE(settings2._profiles.at(3).HasGuid());
-            VERIFY_IS_FALSE(settings2._profiles.at(4).HasGuid());
-            VERIFY_ARE_EQUAL(L"Windows PowerShell", settings2._profiles.at(0).Name());
-            VERIFY_ARE_EQUAL(L"Command Prompt", settings2._profiles.at(1).Name());
-            VERIFY_ARE_EQUAL(L"ThisProfileIsGood", settings2._profiles.at(2).Name());
-            VERIFY_ARE_EQUAL(L"ThisProfileShouldNotDuplicate", settings2._profiles.at(3).Name());
-            VERIFY_ARE_EQUAL(L"NeitherShouldThisOne", settings2._profiles.at(4).Name());
+            const auto firstSettingsString = settings->_userSettingsString;
+            settings2->_ParseJsonString(firstSettingsString, false);
+            settings2->LayerJson(settings2->_userSettings);
+            VERIFY_ARE_EQUAL(5u, settings2->_profiles.Size());
+            VERIFY_IS_TRUE(settings2->_profiles.GetAt(0).HasGuid());
+            VERIFY_IS_TRUE(settings2->_profiles.GetAt(1).HasGuid());
+            VERIFY_IS_TRUE(settings2->_profiles.GetAt(2).HasGuid());
+            VERIFY_IS_FALSE(settings2->_profiles.GetAt(3).HasGuid());
+            VERIFY_IS_FALSE(settings2->_profiles.GetAt(4).HasGuid());
+            VERIFY_ARE_EQUAL(L"Windows PowerShell", settings2->_profiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"Command Prompt", settings2->_profiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(L"ThisProfileIsGood", settings2->_profiles.GetAt(2).Name());
+            VERIFY_ARE_EQUAL(L"ThisProfileShouldNotDuplicate", settings2->_profiles.GetAt(3).Name());
+            VERIFY_ARE_EQUAL(L"NeitherShouldThisOne", settings2->_profiles.GetAt(4).Name());
         }
 
         Log::Comment(NoThrowString().Format(
             L"Validate the settings. All the profiles we have should be valid."));
-        settings._ValidateSettings();
+        settings->_ValidateSettings();
 
-        VERIFY_ARE_EQUAL(5u, settings._profiles.size());
-        VERIFY_IS_TRUE(settings._profiles.at(0).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(1).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(2).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(3).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(4).HasGuid());
-        VERIFY_ARE_EQUAL(L"ThisProfileIsGood", settings._profiles.at(0).Name());
-        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotDuplicate", settings._profiles.at(1).Name());
-        VERIFY_ARE_EQUAL(L"NeitherShouldThisOne", settings._profiles.at(2).Name());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings._profiles.at(3).Name());
-        VERIFY_ARE_EQUAL(L"Command Prompt", settings._profiles.at(4).Name());
+        VERIFY_ARE_EQUAL(5u, settings->_profiles.Size());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(3).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(4).HasGuid());
+        VERIFY_ARE_EQUAL(L"ThisProfileIsGood", settings->_profiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotDuplicate", settings->_profiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"NeitherShouldThisOne", settings->_profiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(3).Name());
+        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_profiles.GetAt(4).Name());
     }
 
     void SettingsTests::TestHideAllProfiles()
@@ -1260,26 +1260,25 @@ namespace TerminalAppLocalTests
 
         {
             // Case 1: Good settings
-            CascadiaSettings settings;
-            settings._ParseJsonString(settingsWithProfiles, false);
-            settings.LayerJson(settings._userSettings);
+            auto settings = winrt::make_self<implementation::CascadiaSettings>();
+            settings->_ParseJsonString(settingsWithProfiles, false);
+            settings->LayerJson(settings->_userSettings);
 
-            settings._RemoveHiddenProfiles();
+            settings->_RemoveHiddenProfiles();
             Log::Comment(NoThrowString().Format(
                 L"settingsWithProfiles successfully parsed and validated"));
-            VERIFY_ARE_EQUAL(1u, settings._profiles.size());
+            VERIFY_ARE_EQUAL(1u, settings->_profiles.Size());
         }
         {
             // Case 2: Bad settings
-
-            CascadiaSettings settings;
-            settings._ParseJsonString(settingsWithoutProfiles, false);
-            settings.LayerJson(settings._userSettings);
+            auto settings = winrt::make_self<implementation::CascadiaSettings>();
+            settings->_ParseJsonString(settingsWithoutProfiles, false);
+            settings->LayerJson(settings->_userSettings);
 
             bool caughtExpectedException = false;
             try
             {
-                settings._RemoveHiddenProfiles();
+                settings->_RemoveHiddenProfiles();
             }
             catch (const ::TerminalApp::SettingsException& ex)
             {
@@ -1325,28 +1324,28 @@ namespace TerminalAppLocalTests
 
         VerifyParseSucceeded(settings0String);
 
-        CascadiaSettings settings;
-        settings._ParseJsonString(settings0String, false);
-        settings.LayerJson(settings._userSettings);
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settings0String, false);
+        settings->LayerJson(settings->_userSettings);
 
-        VERIFY_ARE_EQUAL(3u, settings._profiles.size());
-        VERIFY_ARE_EQUAL(2u, settings._globals->GetColorSchemes().Size());
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(2u, settings->_globals->GetColorSchemes().Size());
 
-        VERIFY_ARE_EQUAL(L"schemeOne", settings._profiles.at(0).ColorSchemeName());
-        VERIFY_ARE_EQUAL(L"InvalidSchemeName", settings._profiles.at(1).ColorSchemeName());
-        VERIFY_ARE_EQUAL(L"Campbell", settings._profiles.at(2).ColorSchemeName());
+        VERIFY_ARE_EQUAL(L"schemeOne", settings->_profiles.GetAt(0).ColorSchemeName());
+        VERIFY_ARE_EQUAL(L"InvalidSchemeName", settings->_profiles.GetAt(1).ColorSchemeName());
+        VERIFY_ARE_EQUAL(L"Campbell", settings->_profiles.GetAt(2).ColorSchemeName());
 
-        settings._ValidateAllSchemesExist();
+        settings->_ValidateAllSchemesExist();
 
-        VERIFY_ARE_EQUAL(1u, settings._warnings.size());
-        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::UnknownColorScheme, settings._warnings.at(0));
+        VERIFY_ARE_EQUAL(1u, settings->_warnings.size());
+        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::UnknownColorScheme, settings->_warnings.at(0));
 
-        VERIFY_ARE_EQUAL(3u, settings._profiles.size());
-        VERIFY_ARE_EQUAL(2u, settings._globals->GetColorSchemes().Size());
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(2u, settings->_globals->GetColorSchemes().Size());
 
-        VERIFY_ARE_EQUAL(L"schemeOne", settings._profiles.at(0).ColorSchemeName());
-        VERIFY_ARE_EQUAL(L"Campbell", settings._profiles.at(1).ColorSchemeName());
-        VERIFY_ARE_EQUAL(L"Campbell", settings._profiles.at(2).ColorSchemeName());
+        VERIFY_ARE_EQUAL(L"schemeOne", settings->_profiles.GetAt(0).ColorSchemeName());
+        VERIFY_ARE_EQUAL(L"Campbell", settings->_profiles.GetAt(1).ColorSchemeName());
+        VERIFY_ARE_EQUAL(L"Campbell", settings->_profiles.GetAt(2).ColorSchemeName());
     }
 
     void SettingsTests::TestHelperFunctions()
@@ -1387,21 +1386,21 @@ namespace TerminalAppLocalTests
 
         VerifyParseSucceeded(settings0String);
 
-        CascadiaSettings settings;
-        settings._ParseJsonString(settings0String, false);
-        settings.LayerJson(settings._userSettings);
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settings0String, false);
+        settings->LayerJson(settings->_userSettings);
 
-        VERIFY_ARE_EQUAL(guid0, settings._GetProfileGuidByName(name0));
-        VERIFY_ARE_EQUAL(guid1, settings._GetProfileGuidByName(name1));
-        VERIFY_ARE_EQUAL(guid2, settings._GetProfileGuidByName(name2));
-        VERIFY_ARE_EQUAL(badGuid, settings._GetProfileGuidByName(name3));
-        VERIFY_ARE_EQUAL(badGuid, settings._GetProfileGuidByName(badName));
+        VERIFY_ARE_EQUAL(guid0, settings->_GetProfileGuidByName(name0));
+        VERIFY_ARE_EQUAL(guid1, settings->_GetProfileGuidByName(name1));
+        VERIFY_ARE_EQUAL(guid2, settings->_GetProfileGuidByName(name2));
+        VERIFY_ARE_EQUAL(badGuid, settings->_GetProfileGuidByName(name3));
+        VERIFY_ARE_EQUAL(badGuid, settings->_GetProfileGuidByName(badName));
 
-        auto prof0{ settings.FindProfile(guid0) };
-        auto prof1{ settings.FindProfile(guid1) };
-        auto prof2{ settings.FindProfile(guid2) };
+        auto prof0{ settings->FindProfile(guid0) };
+        auto prof1{ settings->FindProfile(guid1) };
+        auto prof2{ settings->FindProfile(guid2) };
 
-        auto badProf{ settings.FindProfile(fakeGuid) };
+        auto badProf{ settings->FindProfile(fakeGuid) };
         VERIFY_ARE_EQUAL(badProf, nullptr);
 
         VERIFY_ARE_EQUAL(name0, prof0.Name());
@@ -1424,11 +1423,12 @@ namespace TerminalAppLocalTests
         })" };
 
         VerifyParseSucceeded(settingsJson);
-        CascadiaSettings settings{};
-        settings._ParseJsonString(settingsJson, false);
-        settings.LayerJson(settings._userSettings);
-        VERIFY_IS_FALSE(settings._profiles.empty());
-        VERIFY_ARE_EQUAL(expectedPath, settings._profiles[0].GetExpandedIconPath());
+
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settingsJson, false);
+        settings->LayerJson(settings->_userSettings);
+        VERIFY_ARE_NOT_EQUAL(0u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(expectedPath, settings->_profiles.GetAt(0).GetExpandedIconPath());
     }
     void SettingsTests::TestProfileBackgroundImageWithEnvVar()
     {
@@ -1445,13 +1445,14 @@ namespace TerminalAppLocalTests
         })" };
 
         VerifyParseSucceeded(settingsJson);
-        CascadiaSettings settings{};
-        settings._ParseJsonString(settingsJson, false);
-        settings.LayerJson(settings._userSettings);
-        VERIFY_IS_FALSE(settings._profiles.empty());
+
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settingsJson, false);
+        settings->LayerJson(settings->_userSettings);
+        VERIFY_ARE_NOT_EQUAL(0u, settings->_profiles.Size());
 
         auto globalSettings{ winrt::make<implementation::GlobalAppSettings>() };
-        const auto profileImpl = winrt::get_self<implementation::Profile>(settings._profiles[0]);
+        const auto profileImpl = winrt::get_self<implementation::Profile>(settings->_profiles.GetAt(0));
         auto terminalSettings = profileImpl->CreateTerminalSettings(globalSettings.GetColorSchemes());
         VERIFY_ARE_EQUAL(expectedPath, terminalSettings.BackgroundImage());
     }
@@ -1480,15 +1481,16 @@ namespace TerminalAppLocalTests
         })" };
 
         VerifyParseSucceeded(settingsJson);
-        CascadiaSettings settings{};
-        settings._ParseJsonString(settingsJson, false);
-        settings.LayerJson(settings._userSettings);
-        VERIFY_ARE_EQUAL(CloseOnExitMode::Graceful, settings._profiles[0].CloseOnExit());
-        VERIFY_ARE_EQUAL(CloseOnExitMode::Always, settings._profiles[1].CloseOnExit());
-        VERIFY_ARE_EQUAL(CloseOnExitMode::Never, settings._profiles[2].CloseOnExit());
+
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settingsJson, false);
+        settings->LayerJson(settings->_userSettings);
+        VERIFY_ARE_EQUAL(CloseOnExitMode::Graceful, settings->_profiles.GetAt(0).CloseOnExit());
+        VERIFY_ARE_EQUAL(CloseOnExitMode::Always, settings->_profiles.GetAt(1).CloseOnExit());
+        VERIFY_ARE_EQUAL(CloseOnExitMode::Never, settings->_profiles.GetAt(2).CloseOnExit());
 
         // Unknown modes parse as "Graceful"
-        VERIFY_ARE_EQUAL(CloseOnExitMode::Graceful, settings._profiles[3].CloseOnExit());
+        VERIFY_ARE_EQUAL(CloseOnExitMode::Graceful, settings->_profiles.GetAt(3).CloseOnExit());
     }
     void SettingsTests::TestCloseOnExitCompatibilityShim()
     {
@@ -1507,11 +1509,12 @@ namespace TerminalAppLocalTests
         })" };
 
         VerifyParseSucceeded(settingsJson);
-        CascadiaSettings settings{};
-        settings._ParseJsonString(settingsJson, false);
-        settings.LayerJson(settings._userSettings);
-        VERIFY_ARE_EQUAL(CloseOnExitMode::Graceful, settings._profiles[0].CloseOnExit());
-        VERIFY_ARE_EQUAL(CloseOnExitMode::Never, settings._profiles[1].CloseOnExit());
+
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settingsJson, false);
+        settings->LayerJson(settings->_userSettings);
+        VERIFY_ARE_EQUAL(CloseOnExitMode::Graceful, settings->_profiles.GetAt(0).CloseOnExit());
+        VERIFY_ARE_EQUAL(CloseOnExitMode::Never, settings->_profiles.GetAt(1).CloseOnExit());
     }
 
     void SettingsTests::TestLayerUserDefaultsBeforeProfiles()
@@ -1547,18 +1550,18 @@ namespace TerminalAppLocalTests
         const auto guid1String = L"{6239a42c-1111-49a3-80bd-e8fdd045185c}";
 
         {
-            CascadiaSettings settings{ false };
-            settings._ParseJsonString(settings0String, false);
-            VERIFY_IS_TRUE(settings._userDefaultProfileSettings == Json::Value::null);
-            settings._ApplyDefaultsFromUserSettings();
-            VERIFY_IS_FALSE(settings._userDefaultProfileSettings == Json::Value::null);
-            settings.LayerJson(settings._userSettings);
+            auto settings = winrt::make_self<implementation::CascadiaSettings>(false);
+            settings->_ParseJsonString(settings0String, false);
+            VERIFY_IS_TRUE(settings->_userDefaultProfileSettings == Json::Value::null);
+            settings->_ApplyDefaultsFromUserSettings();
+            VERIFY_IS_FALSE(settings->_userDefaultProfileSettings == Json::Value::null);
+            settings->LayerJson(settings->_userSettings);
 
-            VERIFY_ARE_EQUAL(guid1String, settings._globals->UnparsedDefaultProfile());
-            VERIFY_ARE_EQUAL(2u, settings._profiles.size());
+            VERIFY_ARE_EQUAL(guid1String, settings->_globals->UnparsedDefaultProfile());
+            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
 
-            VERIFY_ARE_EQUAL(2345, settings._profiles.at(0).HistorySize());
-            VERIFY_ARE_EQUAL(1234, settings._profiles.at(1).HistorySize());
+            VERIFY_ARE_EQUAL(2345, settings->_profiles.GetAt(0).HistorySize());
+            VERIFY_ARE_EQUAL(1234, settings->_profiles.GetAt(1).HistorySize());
         }
     }
 
@@ -1595,28 +1598,28 @@ namespace TerminalAppLocalTests
         const winrt::guid guid2{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-2222-49a3-80bd-e8fdd045185c}") };
 
         {
-            CascadiaSettings settings{ false };
-            settings._ParseJsonString(DefaultJson, true);
-            settings.LayerJson(settings._defaultSettings);
-            VERIFY_ARE_EQUAL(2u, settings._profiles.size());
+            auto settings = winrt::make_self<implementation::CascadiaSettings>(false);
+            settings->_ParseJsonString(DefaultJson, true);
+            settings->LayerJson(settings->_defaultSettings);
+            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
 
-            settings._ParseJsonString(settings0String, false);
-            VERIFY_IS_TRUE(settings._userDefaultProfileSettings == Json::Value::null);
-            settings._ApplyDefaultsFromUserSettings();
-            VERIFY_IS_FALSE(settings._userDefaultProfileSettings == Json::Value::null);
+            settings->_ParseJsonString(settings0String, false);
+            VERIFY_IS_TRUE(settings->_userDefaultProfileSettings == Json::Value::null);
+            settings->_ApplyDefaultsFromUserSettings();
+            VERIFY_IS_FALSE(settings->_userDefaultProfileSettings == Json::Value::null);
 
             Log::Comment(NoThrowString().Format(
                 L"Ensure that cmd and powershell don't get their GUIDs overwritten"));
-            VERIFY_ARE_NOT_EQUAL(guid2, settings._profiles.at(0).Guid());
-            VERIFY_ARE_NOT_EQUAL(guid2, settings._profiles.at(1).Guid());
+            VERIFY_ARE_NOT_EQUAL(guid2, settings->_profiles.GetAt(0).Guid());
+            VERIFY_ARE_NOT_EQUAL(guid2, settings->_profiles.GetAt(1).Guid());
 
-            settings.LayerJson(settings._userSettings);
+            settings->LayerJson(settings->_userSettings);
 
-            VERIFY_ARE_EQUAL(guid1String, settings._globals->UnparsedDefaultProfile());
-            VERIFY_ARE_EQUAL(4u, settings._profiles.size());
+            VERIFY_ARE_EQUAL(guid1String, settings->_globals->UnparsedDefaultProfile());
+            VERIFY_ARE_EQUAL(4u, settings->_profiles.Size());
 
-            VERIFY_ARE_EQUAL(guid1, settings._profiles.at(2).Guid());
-            VERIFY_IS_FALSE(settings._profiles.at(3).HasGuid());
+            VERIFY_ARE_EQUAL(guid1, settings->_profiles.GetAt(2).Guid());
+            VERIFY_IS_FALSE(settings->_profiles.GetAt(3).HasGuid());
         }
     }
 
@@ -1642,18 +1645,18 @@ namespace TerminalAppLocalTests
                 },
                 "list": [
                     {
-                        "name" : "profile0FromUserSettings", // this is _profiles.at(0)
+                        "name" : "profile0FromUserSettings", // this is _profiles.GetAt(0)
                         "guid": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
                         "source": "Terminal.App.UnitTest.0"
                     },
                     {
-                        "name" : "profile1FromUserSettings", // this is _profiles.at(2)
+                        "name" : "profile1FromUserSettings", // this is _profiles.GetAt(2)
                         "guid": "{6239a42c-2222-49a3-80bd-e8fdd045185c}",
                         "source": "Terminal.App.UnitTest.1",
                         "historySize": 4444
                     },
                     {
-                        "name" : "profile2FromUserSettings", // this is _profiles.at(3)
+                        "name" : "profile2FromUserSettings", // this is _profiles.GetAt(3)
                         "guid": "{6239a42c-3333-49a3-80bd-e8fdd045185c}",
                         "historySize": 5555
                     }
@@ -1665,7 +1668,7 @@ namespace TerminalAppLocalTests
         gen0->pfnGenerate = [guid1, guid2]() {
             std::vector<Profile> profiles;
             Profile p0 = winrt::make<implementation::Profile>(guid1);
-            p0.Name(L"profile0"); // this is _profiles.at(0)
+            p0.Name(L"profile0"); // this is _profiles.GetAt(0)
             p0.HistorySize(1111);
             profiles.push_back(p0);
             return profiles;
@@ -1675,8 +1678,8 @@ namespace TerminalAppLocalTests
             std::vector<Profile> profiles;
             Profile p0 = winrt::make<implementation::Profile>(guid1);
             Profile p1 = winrt::make<implementation::Profile>(guid2);
-            p0.Name(L"profile0"); // this is _profiles.at(1)
-            p1.Name(L"profile1"); // this is _profiles.at(2)
+            p0.Name(L"profile0"); // this is _profiles.GetAt(1)
+            p1.Name(L"profile1"); // this is _profiles.GetAt(2)
             p0.HistorySize(2222);
             profiles.push_back(p0);
             p1.HistorySize(3333);
@@ -1684,54 +1687,54 @@ namespace TerminalAppLocalTests
             return profiles;
         };
 
-        CascadiaSettings settings{ false };
-        settings._profileGenerators.emplace_back(std::move(gen0));
-        settings._profileGenerators.emplace_back(std::move(gen1));
+        auto settings = winrt::make_self<implementation::CascadiaSettings>(false);
+        settings->_profileGenerators.emplace_back(std::move(gen0));
+        settings->_profileGenerators.emplace_back(std::move(gen1));
 
         Log::Comment(NoThrowString().Format(
             L"All profiles with the same name have the same GUID. However, they"
             L" will not be layered, because they have different source's"));
 
         // parse userProfiles as the user settings
-        settings._ParseJsonString(userProfiles, false);
-        VERIFY_ARE_EQUAL(0u, settings._profiles.size(), L"Just parsing the user settings doesn't actually layer them");
-        settings._LoadDynamicProfiles();
-        VERIFY_ARE_EQUAL(3u, settings._profiles.size());
+        settings->_ParseJsonString(userProfiles, false);
+        VERIFY_ARE_EQUAL(0u, settings->_profiles.Size(), L"Just parsing the user settings doesn't actually layer them");
+        settings->_LoadDynamicProfiles();
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
 
-        VERIFY_ARE_EQUAL(1111, settings._profiles.at(0).HistorySize());
-        VERIFY_ARE_EQUAL(2222, settings._profiles.at(1).HistorySize());
-        VERIFY_ARE_EQUAL(3333, settings._profiles.at(2).HistorySize());
+        VERIFY_ARE_EQUAL(1111, settings->_profiles.GetAt(0).HistorySize());
+        VERIFY_ARE_EQUAL(2222, settings->_profiles.GetAt(1).HistorySize());
+        VERIFY_ARE_EQUAL(3333, settings->_profiles.GetAt(2).HistorySize());
 
-        settings._ApplyDefaultsFromUserSettings();
+        settings->_ApplyDefaultsFromUserSettings();
 
-        VERIFY_ARE_EQUAL(1234, settings._profiles.at(0).HistorySize());
-        VERIFY_ARE_EQUAL(1234, settings._profiles.at(1).HistorySize());
-        VERIFY_ARE_EQUAL(1234, settings._profiles.at(2).HistorySize());
+        VERIFY_ARE_EQUAL(1234, settings->_profiles.GetAt(0).HistorySize());
+        VERIFY_ARE_EQUAL(1234, settings->_profiles.GetAt(1).HistorySize());
+        VERIFY_ARE_EQUAL(1234, settings->_profiles.GetAt(2).HistorySize());
 
-        settings.LayerJson(settings._userSettings);
-        VERIFY_ARE_EQUAL(4u, settings._profiles.size());
+        settings->LayerJson(settings->_userSettings);
+        VERIFY_ARE_EQUAL(4u, settings->_profiles.Size());
 
-        VERIFY_IS_FALSE(settings._profiles.at(0).Source().empty());
-        VERIFY_IS_FALSE(settings._profiles.at(1).Source().empty());
-        VERIFY_IS_FALSE(settings._profiles.at(2).Source().empty());
-        VERIFY_IS_TRUE(settings._profiles.at(3).Source().empty());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(0).Source().empty());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(1).Source().empty());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(2).Source().empty());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(3).Source().empty());
 
-        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.0", settings._profiles.at(0).Source());
-        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings._profiles.at(1).Source());
-        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings._profiles.at(2).Source());
+        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.0", settings->_profiles.GetAt(0).Source());
+        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_profiles.GetAt(1).Source());
+        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_profiles.GetAt(2).Source());
 
-        VERIFY_IS_TRUE(settings._profiles.at(0).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(1).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(2).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
 
-        VERIFY_ARE_EQUAL(guid1, settings._profiles.at(0).Guid());
-        VERIFY_ARE_EQUAL(guid1, settings._profiles.at(1).Guid());
-        VERIFY_ARE_EQUAL(guid2, settings._profiles.at(2).Guid());
+        VERIFY_ARE_EQUAL(guid1, settings->_profiles.GetAt(0).Guid());
+        VERIFY_ARE_EQUAL(guid1, settings->_profiles.GetAt(1).Guid());
+        VERIFY_ARE_EQUAL(guid2, settings->_profiles.GetAt(2).Guid());
 
-        VERIFY_ARE_EQUAL(L"profile0FromUserSettings", settings._profiles.at(0).Name());
-        VERIFY_ARE_EQUAL(L"profile0", settings._profiles.at(1).Name());
-        VERIFY_ARE_EQUAL(L"profile1FromUserSettings", settings._profiles.at(2).Name());
-        VERIFY_ARE_EQUAL(L"profile2FromUserSettings", settings._profiles.at(3).Name());
+        VERIFY_ARE_EQUAL(L"profile0FromUserSettings", settings->_profiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"profile1FromUserSettings", settings->_profiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"profile2FromUserSettings", settings->_profiles.GetAt(3).Name());
 
         Log::Comment(NoThrowString().Format(
             L"This is the real meat of the test: The two dynamic profiles that "
@@ -1739,10 +1742,10 @@ namespace TerminalAppLocalTests
             L"1234 as their historySize(from the defaultSettings).The other two"
             L" profiles should have their custom historySize value."));
 
-        VERIFY_ARE_EQUAL(1234, settings._profiles.at(0).HistorySize());
-        VERIFY_ARE_EQUAL(1234, settings._profiles.at(1).HistorySize());
-        VERIFY_ARE_EQUAL(4444, settings._profiles.at(2).HistorySize());
-        VERIFY_ARE_EQUAL(5555, settings._profiles.at(3).HistorySize());
+        VERIFY_ARE_EQUAL(1234, settings->_profiles.GetAt(0).HistorySize());
+        VERIFY_ARE_EQUAL(1234, settings->_profiles.GetAt(1).HistorySize());
+        VERIFY_ARE_EQUAL(4444, settings->_profiles.GetAt(2).HistorySize());
+        VERIFY_ARE_EQUAL(5555, settings->_profiles.GetAt(3).HistorySize());
     }
 
     void SettingsTests::TestTerminalArgsForBinding()
@@ -1789,15 +1792,16 @@ namespace TerminalAppLocalTests
         const winrt::guid guid1{ ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-1111-49a3-80bd-e8fdd045185c}") };
 
         VerifyParseSucceeded(settingsJson);
-        CascadiaSettings settings{};
-        settings._ParseJsonString(settingsJson, false);
-        settings.LayerJson(settings._userSettings);
-        settings._ValidateSettings();
 
-        auto appKeyBindingsProj = settings._globals->GetKeybindings();
-        VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settingsJson, false);
+        settings->LayerJson(settings->_userSettings);
+        settings->_ValidateSettings();
 
-        const auto profile2Guid = settings._profiles.at(2).Guid();
+        auto appKeyBindingsProj = settings->_globals->GetKeybindings();
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+
+        const auto profile2Guid = settings->_profiles.GetAt(2).Guid();
         VERIFY_ARE_NOT_EQUAL(winrt::guid{}, profile2Guid);
 
         const auto appKeyBindings = winrt::get_self<implementation::AppKeyBindings>(appKeyBindingsProj);
@@ -1817,7 +1821,7 @@ namespace TerminalAppLocalTests
             VERIFY_IS_TRUE(realArgs.TerminalArgs().TabTitle().empty());
             VERIFY_IS_TRUE(realArgs.TerminalArgs().Profile().empty());
 
-            const auto [guid, termSettings] = settings.BuildSettings(realArgs.TerminalArgs());
+            const auto [guid, termSettings] = settings->BuildSettings(realArgs.TerminalArgs());
             VERIFY_ARE_EQUAL(guid0, guid);
             VERIFY_ARE_EQUAL(L"cmd.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(1, termSettings.HistorySize());
@@ -1837,7 +1841,7 @@ namespace TerminalAppLocalTests
             VERIFY_IS_FALSE(realArgs.TerminalArgs().Profile().empty());
             VERIFY_ARE_EQUAL(L"{6239a42c-1111-49a3-80bd-e8fdd045185c}", realArgs.TerminalArgs().Profile());
 
-            const auto [guid, termSettings] = settings.BuildSettings(realArgs.TerminalArgs());
+            const auto [guid, termSettings] = settings->BuildSettings(realArgs.TerminalArgs());
             VERIFY_ARE_EQUAL(guid1, guid);
             VERIFY_ARE_EQUAL(L"pwsh.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(2, termSettings.HistorySize());
@@ -1857,7 +1861,7 @@ namespace TerminalAppLocalTests
             VERIFY_IS_FALSE(realArgs.TerminalArgs().Profile().empty());
             VERIFY_ARE_EQUAL(L"profile1", realArgs.TerminalArgs().Profile());
 
-            const auto [guid, termSettings] = settings.BuildSettings(realArgs.TerminalArgs());
+            const auto [guid, termSettings] = settings->BuildSettings(realArgs.TerminalArgs());
             VERIFY_ARE_EQUAL(guid1, guid);
             VERIFY_ARE_EQUAL(L"pwsh.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(2, termSettings.HistorySize());
@@ -1877,7 +1881,7 @@ namespace TerminalAppLocalTests
             VERIFY_IS_FALSE(realArgs.TerminalArgs().Profile().empty());
             VERIFY_ARE_EQUAL(L"profile2", realArgs.TerminalArgs().Profile());
 
-            const auto [guid, termSettings] = settings.BuildSettings(realArgs.TerminalArgs());
+            const auto [guid, termSettings] = settings->BuildSettings(realArgs.TerminalArgs());
             VERIFY_ARE_EQUAL(profile2Guid, guid);
             VERIFY_ARE_EQUAL(L"wsl.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(3, termSettings.HistorySize());
@@ -1897,7 +1901,7 @@ namespace TerminalAppLocalTests
             VERIFY_IS_TRUE(realArgs.TerminalArgs().Profile().empty());
             VERIFY_ARE_EQUAL(L"foo.exe", realArgs.TerminalArgs().Commandline());
 
-            const auto [guid, termSettings] = settings.BuildSettings(realArgs.TerminalArgs());
+            const auto [guid, termSettings] = settings->BuildSettings(realArgs.TerminalArgs());
             VERIFY_ARE_EQUAL(guid0, guid);
             VERIFY_ARE_EQUAL(L"foo.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(1, termSettings.HistorySize());
@@ -1918,7 +1922,7 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"profile1", realArgs.TerminalArgs().Profile());
             VERIFY_ARE_EQUAL(L"foo.exe", realArgs.TerminalArgs().Commandline());
 
-            const auto [guid, termSettings] = settings.BuildSettings(realArgs.TerminalArgs());
+            const auto [guid, termSettings] = settings->BuildSettings(realArgs.TerminalArgs());
             VERIFY_ARE_EQUAL(guid1, guid);
             VERIFY_ARE_EQUAL(L"foo.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(2, termSettings.HistorySize());
@@ -1936,7 +1940,7 @@ namespace TerminalAppLocalTests
             VERIFY_IS_TRUE(realArgs.TerminalArgs().TabTitle().empty());
             VERIFY_IS_TRUE(realArgs.TerminalArgs().Profile().empty());
 
-            const auto [guid, termSettings] = settings.BuildSettings(realArgs.TerminalArgs());
+            const auto [guid, termSettings] = settings->BuildSettings(realArgs.TerminalArgs());
             VERIFY_ARE_EQUAL(guid0, guid);
             VERIFY_ARE_EQUAL(L"cmd.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(1, termSettings.HistorySize());
@@ -1955,7 +1959,7 @@ namespace TerminalAppLocalTests
             VERIFY_IS_TRUE(realArgs.TerminalArgs().Profile().empty());
             VERIFY_ARE_EQUAL(L"c:\\foo", realArgs.TerminalArgs().StartingDirectory());
 
-            const auto [guid, termSettings] = settings.BuildSettings(realArgs.TerminalArgs());
+            const auto [guid, termSettings] = settings->BuildSettings(realArgs.TerminalArgs());
             VERIFY_ARE_EQUAL(guid0, guid);
             VERIFY_ARE_EQUAL(L"cmd.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(L"c:\\foo", termSettings.StartingDirectory());
@@ -1976,7 +1980,7 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"c:\\foo", realArgs.TerminalArgs().StartingDirectory());
             VERIFY_ARE_EQUAL(L"profile2", realArgs.TerminalArgs().Profile());
 
-            const auto [guid, termSettings] = settings.BuildSettings(realArgs.TerminalArgs());
+            const auto [guid, termSettings] = settings->BuildSettings(realArgs.TerminalArgs());
             VERIFY_ARE_EQUAL(profile2Guid, guid);
             VERIFY_ARE_EQUAL(L"wsl.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(L"c:\\foo", termSettings.StartingDirectory());
@@ -1996,7 +2000,7 @@ namespace TerminalAppLocalTests
             VERIFY_IS_TRUE(realArgs.TerminalArgs().Profile().empty());
             VERIFY_ARE_EQUAL(L"bar", realArgs.TerminalArgs().TabTitle());
 
-            const auto [guid, termSettings] = settings.BuildSettings(realArgs.TerminalArgs());
+            const auto [guid, termSettings] = settings->BuildSettings(realArgs.TerminalArgs());
             VERIFY_ARE_EQUAL(guid0, guid);
             VERIFY_ARE_EQUAL(L"cmd.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(L"bar", termSettings.StartingTitle());
@@ -2017,7 +2021,7 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"bar", realArgs.TerminalArgs().TabTitle());
             VERIFY_ARE_EQUAL(L"profile2", realArgs.TerminalArgs().Profile());
 
-            const auto [guid, termSettings] = settings.BuildSettings(realArgs.TerminalArgs());
+            const auto [guid, termSettings] = settings->BuildSettings(realArgs.TerminalArgs());
             VERIFY_ARE_EQUAL(profile2Guid, guid);
             VERIFY_ARE_EQUAL(L"wsl.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(L"bar", termSettings.StartingTitle());
@@ -2040,7 +2044,7 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"bar", realArgs.TerminalArgs().TabTitle());
             VERIFY_ARE_EQUAL(L"profile1", realArgs.TerminalArgs().Profile());
 
-            const auto [guid, termSettings] = settings.BuildSettings(realArgs.TerminalArgs());
+            const auto [guid, termSettings] = settings->BuildSettings(realArgs.TerminalArgs());
             VERIFY_ARE_EQUAL(guid1, guid);
             VERIFY_ARE_EQUAL(L"foo.exe", termSettings.Commandline());
             VERIFY_ARE_EQUAL(L"bar", termSettings.StartingTitle());
@@ -2068,7 +2072,7 @@ namespace TerminalAppLocalTests
             ]
         })" };
         const auto settingsJsonObj = VerifyParseSucceeded(settingsString);
-        auto settings = CascadiaSettings::FromJson(settingsJsonObj);
+        auto settings = implementation::CascadiaSettings::FromJson(settingsJsonObj);
 
         const auto guid1 = ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-1111-49a3-80bd-e8fdd045185c}");
         const auto guid2 = ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-2222-49a3-80bd-e8fdd045185c}");
@@ -2106,7 +2110,7 @@ namespace TerminalAppLocalTests
             ]
         })" };
         const auto settingsJsonObj = VerifyParseSucceeded(settingsString);
-        auto settings = CascadiaSettings::FromJson(settingsJsonObj);
+        auto settings = implementation::CascadiaSettings::FromJson(settingsJsonObj);
         settings->_ResolveDefaultProfile();
 
         const auto guid1 = ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-1111-49a3-80bd-e8fdd045185c}");
@@ -2172,12 +2176,12 @@ namespace TerminalAppLocalTests
             ]
         })" };
         const auto settingsJsonObj = VerifyParseSucceeded(settingsString);
-        auto settings = CascadiaSettings::FromJson(settingsJsonObj);
+        auto settings = implementation::CascadiaSettings::FromJson(settingsJsonObj);
         settings->_ValidateSettings();
 
         VERIFY_ARE_EQUAL(2u, settings->_warnings.size());
-        VERIFY_ARE_EQUAL(2u, settings->_profiles.size());
-        VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.at(0).Guid());
+        VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.GetAt(0).Guid());
         try
         {
             const auto [guid, termSettings] = settings->BuildSettings(nullptr);
@@ -2237,19 +2241,19 @@ namespace TerminalAppLocalTests
 
         VerifyParseSucceeded(settings0String);
 
-        CascadiaSettings settings;
-        settings._ParseJsonString(settings0String, false);
-        settings.LayerJson(settings._userSettings);
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settings0String, false);
+        settings->LayerJson(settings->_userSettings);
 
-        VERIFY_ARE_EQUAL(6u, settings._profiles.size());
-        VERIFY_ARE_EQUAL(2u, settings._globals->GetColorSchemes().Size());
+        VERIFY_ARE_EQUAL(6u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(2u, settings->_globals->GetColorSchemes().Size());
 
-        auto terminalSettings0 = winrt::get_self<implementation::Profile>(settings._profiles[0])->CreateTerminalSettings(settings._globals->GetColorSchemes());
-        auto terminalSettings1 = winrt::get_self<implementation::Profile>(settings._profiles[1])->CreateTerminalSettings(settings._globals->GetColorSchemes());
-        auto terminalSettings2 = winrt::get_self<implementation::Profile>(settings._profiles[2])->CreateTerminalSettings(settings._globals->GetColorSchemes());
-        auto terminalSettings3 = winrt::get_self<implementation::Profile>(settings._profiles[3])->CreateTerminalSettings(settings._globals->GetColorSchemes());
-        auto terminalSettings4 = winrt::get_self<implementation::Profile>(settings._profiles[4])->CreateTerminalSettings(settings._globals->GetColorSchemes());
-        auto terminalSettings5 = winrt::get_self<implementation::Profile>(settings._profiles[5])->CreateTerminalSettings(settings._globals->GetColorSchemes());
+        auto terminalSettings0 = winrt::get_self<implementation::Profile>(settings->_profiles.GetAt(0))->CreateTerminalSettings(settings->_globals->GetColorSchemes());
+        auto terminalSettings1 = winrt::get_self<implementation::Profile>(settings->_profiles.GetAt(1))->CreateTerminalSettings(settings->_globals->GetColorSchemes());
+        auto terminalSettings2 = winrt::get_self<implementation::Profile>(settings->_profiles.GetAt(2))->CreateTerminalSettings(settings->_globals->GetColorSchemes());
+        auto terminalSettings3 = winrt::get_self<implementation::Profile>(settings->_profiles.GetAt(3))->CreateTerminalSettings(settings->_globals->GetColorSchemes());
+        auto terminalSettings4 = winrt::get_self<implementation::Profile>(settings->_profiles.GetAt(4))->CreateTerminalSettings(settings->_globals->GetColorSchemes());
+        auto terminalSettings5 = winrt::get_self<implementation::Profile>(settings->_profiles.GetAt(5))->CreateTerminalSettings(settings->_globals->GetColorSchemes());
 
         VERIFY_ARE_EQUAL(ARGB(0, 0x12, 0x34, 0x56), terminalSettings0.CursorColor()); // from color scheme
         VERIFY_ARE_EQUAL(DEFAULT_CURSOR_COLOR, terminalSettings1.CursorColor()); // default
@@ -2282,7 +2286,7 @@ namespace TerminalAppLocalTests
         })" };
 
         const auto settingsObject = VerifyParseSucceeded(badSettings);
-        auto settings = CascadiaSettings::FromJson(settingsObject);
+        auto settings = implementation::CascadiaSettings::FromJson(settingsObject);
 
         VERIFY_ARE_EQUAL(0u, settings->_globals->_keybindings->_keyShortcuts.size());
 
@@ -2324,7 +2328,7 @@ namespace TerminalAppLocalTests
 
         const auto settingsObject = VerifyParseSucceeded(badSettings);
 
-        auto settings = CascadiaSettings::FromJson(settingsObject);
+        auto settings = implementation::CascadiaSettings::FromJson(settingsObject);
 
         VERIFY_ARE_EQUAL(0u, settings->_globals->_keybindings->_keyShortcuts.size());
 
@@ -2367,20 +2371,20 @@ namespace TerminalAppLocalTests
         })" };
 
         // Create the default settings
-        CascadiaSettings settings;
-        settings._ParseJsonString(DefaultJson, true);
-        settings.LayerJson(settings._defaultSettings);
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(DefaultJson, true);
+        settings->LayerJson(settings->_defaultSettings);
 
-        settings._ValidateNoGlobalsKey();
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
+        settings->_ValidateNoGlobalsKey();
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
 
         // Now layer on the user's settings
-        settings._ParseJsonString(badSettings, false);
-        settings.LayerJson(settings._userSettings);
+        settings->_ParseJsonString(badSettings, false);
+        settings->LayerJson(settings->_userSettings);
 
-        settings._ValidateNoGlobalsKey();
-        VERIFY_ARE_EQUAL(1u, settings._warnings.size());
-        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::LegacyGlobalsProperty, settings._warnings.at(0));
+        settings->_ValidateNoGlobalsKey();
+        VERIFY_ARE_EQUAL(1u, settings->_warnings.size());
+        VERIFY_ARE_EQUAL(::TerminalApp::SettingsLoadWarnings::LegacyGlobalsProperty, settings->_warnings.at(0));
     }
 
     void SettingsTests::TestTrailingCommas()
@@ -2402,15 +2406,15 @@ namespace TerminalAppLocalTests
         })" };
 
         // Create the default settings
-        CascadiaSettings settings;
-        settings._ParseJsonString(DefaultJson, true);
-        settings.LayerJson(settings._defaultSettings);
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(DefaultJson, true);
+        settings->LayerJson(settings->_defaultSettings);
 
         // Now layer on the user's settings
         try
         {
-            settings._ParseJsonString(badSettings, false);
-            settings.LayerJson(settings._userSettings);
+            settings->_ParseJsonString(badSettings, false);
+            settings->LayerJson(settings->_userSettings);
         }
         catch (...)
         {
@@ -2456,23 +2460,24 @@ namespace TerminalAppLocalTests
         const auto guid1 = ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-1111-49a3-80bd-e8fdd045185c}");
 
         VerifyParseSucceeded(settingsJson);
-        CascadiaSettings settings{};
-        settings._ParseJsonString(settingsJson, false);
-        settings.LayerJson(settings._userSettings);
-        settings._ValidateSettings();
 
-        VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settingsJson, false);
+        settings->LayerJson(settings->_userSettings);
+        settings->_ValidateSettings();
 
-        const auto profile2Guid = settings._profiles.at(2).Guid();
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+
+        const auto profile2Guid = settings->_profiles.GetAt(2).Guid();
         VERIFY_ARE_NOT_EQUAL(winrt::guid{}, profile2Guid);
 
-        auto appKeyBindings = winrt::get_self<implementation::AppKeyBindings>(settings._globals->GetKeybindings());
+        auto appKeyBindings = winrt::get_self<implementation::AppKeyBindings>(settings->_globals->GetKeybindings());
         VERIFY_ARE_EQUAL(5u, appKeyBindings->_keyShortcuts.size());
 
         // A/D, B, C, E will be in the list of commands, for 4 total.
         // * A and D share the same name, so they'll only generate a single action.
         // * F's name is set manually to `null`
-        auto commands = settings._globals->GetCommands();
+        auto commands = settings->_globals->GetCommands();
         VERIFY_ARE_EQUAL(4u, commands.Size());
 
         {
@@ -2658,15 +2663,16 @@ namespace TerminalAppLocalTests
         const auto guid1 = ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-1111-49a3-80bd-e8fdd045185c}");
 
         VerifyParseSucceeded(settingsJson);
-        CascadiaSettings settings{};
-        settings._ParseJsonString(settingsJson, false);
-        settings.LayerJson(settings._userSettings);
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settingsJson, false);
+        settings->LayerJson(settings->_userSettings);
 
-        VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
 
-        auto commands = settings._globals->GetCommands();
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+
+        auto commands = settings->_globals->GetCommands();
         VERIFY_ARE_EQUAL(1u, commands.Size());
 
         {
@@ -2687,10 +2693,10 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"${profile.name}", realArgs.TerminalArgs().Profile());
         }
 
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals->GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles(), settings->_globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
         VERIFY_ARE_EQUAL(3u, expandedCommands.Size());
 
         {
@@ -2788,15 +2794,16 @@ namespace TerminalAppLocalTests
         const auto guid1 = ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-1111-49a3-80bd-e8fdd045185c}");
 
         VerifyParseSucceeded(settingsJson);
-        CascadiaSettings settings{};
-        settings._ParseJsonString(settingsJson, false);
-        settings.LayerJson(settings._userSettings);
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settingsJson, false);
+        settings->LayerJson(settings->_userSettings);
 
-        VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
 
-        auto commands = settings._globals->GetCommands();
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+
+        auto commands = settings->_globals->GetCommands();
         VERIFY_ARE_EQUAL(1u, commands.Size());
 
         {
@@ -2817,10 +2824,10 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"${profile.name}", realArgs.TerminalArgs().Profile());
         }
 
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals->GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles(), settings->_globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
         VERIFY_ARE_EQUAL(3u, expandedCommands.Size());
 
         {
@@ -2920,15 +2927,16 @@ namespace TerminalAppLocalTests
         const auto guid1 = ::Microsoft::Console::Utils::GuidFromString(L"{6239a42c-1111-49a3-80bd-e8fdd045185c}");
 
         VerifyParseSucceeded(settingsJson);
-        CascadiaSettings settings{};
-        settings._ParseJsonString(settingsJson, false);
-        settings.LayerJson(settings._userSettings);
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settingsJson, false);
+        settings->LayerJson(settings->_userSettings);
 
-        VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
 
-        auto commands = settings._globals->GetCommands();
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+
+        auto commands = settings->_globals->GetCommands();
         VERIFY_ARE_EQUAL(1u, commands.Size());
 
         {
@@ -2949,11 +2957,11 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"${profile.name}", realArgs.TerminalArgs().Profile());
         }
 
-        settings._ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals->GetColorSchemes());
+        settings->_ValidateSettings();
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles(), settings->_globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
         VERIFY_ARE_EQUAL(3u, expandedCommands.Size());
 
         {
@@ -3062,19 +3070,20 @@ namespace TerminalAppLocalTests
         })" };
 
         VerifyParseSucceeded(settingsJson);
-        CascadiaSettings settings{};
-        settings._ParseJsonString(settingsJson, false);
-        settings.LayerJson(settings._userSettings);
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
-        VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settingsJson, false);
+        settings->LayerJson(settings->_userSettings);
 
-        auto commands = settings._globals->GetCommands();
-        settings._ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals->GetColorSchemes());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+
+        auto commands = settings->_globals->GetCommands();
+        settings->_ValidateSettings();
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles(), settings->_globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
         VERIFY_ARE_EQUAL(1u, expandedCommands.Size());
 
         auto rootCommandProj = expandedCommands.Lookup(L"Connect to ssh...");
@@ -3170,19 +3179,20 @@ namespace TerminalAppLocalTests
         })" };
 
         VerifyParseSucceeded(settingsJson);
-        CascadiaSettings settings{};
-        settings._ParseJsonString(settingsJson, false);
-        settings.LayerJson(settings._userSettings);
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
-        VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settingsJson, false);
+        settings->LayerJson(settings->_userSettings);
 
-        auto commands = settings._globals->GetCommands();
-        settings._ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals->GetColorSchemes());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+
+        auto commands = settings->_globals->GetCommands();
+        settings->_ValidateSettings();
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles(), settings->_globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
         VERIFY_ARE_EQUAL(1u, expandedCommands.Size());
 
         auto grandparentCommandProj = expandedCommands.Lookup(L"grandparent");
@@ -3309,19 +3319,20 @@ namespace TerminalAppLocalTests
         })" };
 
         VerifyParseSucceeded(settingsJson);
-        CascadiaSettings settings{};
-        settings._ParseJsonString(settingsJson, false);
-        settings.LayerJson(settings._userSettings);
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
-        VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settingsJson, false);
+        settings->LayerJson(settings->_userSettings);
 
-        auto commands = settings._globals->GetCommands();
-        settings._ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals->GetColorSchemes());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+
+        auto commands = settings->_globals->GetCommands();
+        settings->_ValidateSettings();
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles(), settings->_globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
 
         VERIFY_ARE_EQUAL(3u, expandedCommands.Size());
 
@@ -3462,19 +3473,20 @@ namespace TerminalAppLocalTests
         })" };
 
         VerifyParseSucceeded(settingsJson);
-        CascadiaSettings settings{};
-        settings._ParseJsonString(settingsJson, false);
-        settings.LayerJson(settings._userSettings);
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
-        VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settingsJson, false);
+        settings->LayerJson(settings->_userSettings);
 
-        auto commands = settings._globals->GetCommands();
-        settings._ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals->GetColorSchemes());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+
+        auto commands = settings->_globals->GetCommands();
+        settings->_ValidateSettings();
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles(), settings->_globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
         VERIFY_ARE_EQUAL(1u, expandedCommands.Size());
 
         auto rootCommandProj = expandedCommands.Lookup(L"New Tab With Profile...");
@@ -3575,19 +3587,20 @@ namespace TerminalAppLocalTests
         })" };
 
         VerifyParseSucceeded(settingsJson);
-        CascadiaSettings settings{};
-        settings._ParseJsonString(settingsJson, false);
-        settings.LayerJson(settings._userSettings);
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
-        VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settingsJson, false);
+        settings->LayerJson(settings->_userSettings);
 
-        auto commands = settings._globals->GetCommands();
-        settings._ValidateSettings();
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals->GetColorSchemes());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+
+        auto commands = settings->_globals->GetCommands();
+        settings->_ValidateSettings();
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles(), settings->_globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
         VERIFY_ARE_EQUAL(1u, expandedCommands.Size());
 
         auto rootCommandProj = expandedCommands.Lookup(L"New Pane...");
@@ -3736,18 +3749,19 @@ namespace TerminalAppLocalTests
         })" };
 
         VerifyParseSucceeded(settingsJson);
-        CascadiaSettings settings{};
-        settings._ParseJsonString(settingsJson, false);
-        settings.LayerJson(settings._userSettings);
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
-        VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settingsJson, false);
+        settings->LayerJson(settings->_userSettings);
 
-        auto commands = settings._globals->GetCommands();
-        settings._ValidateSettings();
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+
+        auto commands = settings->_globals->GetCommands();
+        settings->_ValidateSettings();
         _logCommandNames(commands);
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
 
         // Because the "parent" command didn't have a name, it couldn't be
         // placed into the list of commands. It and it's children are just
@@ -3813,27 +3827,27 @@ namespace TerminalAppLocalTests
         VerifyParseSucceeded(settingsJson);
         VerifyParseSucceeded(settings1Json);
 
-        CascadiaSettings settings{};
-        settings._ParseJsonString(settingsJson, false);
-        settings.LayerJson(settings._userSettings);
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settingsJson, false);
+        settings->LayerJson(settings->_userSettings);
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
-        VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
 
-        auto commands = settings._globals->GetCommands();
-        settings._ValidateSettings();
+        auto commands = settings->_globals->GetCommands();
+        settings->_ValidateSettings();
         _logCommandNames(commands);
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
         VERIFY_ARE_EQUAL(1u, commands.Size());
 
         Log::Comment(L"Layer second bit of json, to unbind the original command.");
 
-        settings._ParseJsonString(settings1Json, false);
-        settings.LayerJson(settings._userSettings);
-        settings._ValidateSettings();
+        settings->_ParseJsonString(settings1Json, false);
+        settings->LayerJson(settings->_userSettings);
+        settings->_ValidateSettings();
         _logCommandNames(commands);
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
         VERIFY_ARE_EQUAL(0u, commands.Size());
     }
 
@@ -3896,18 +3910,18 @@ namespace TerminalAppLocalTests
         VerifyParseSucceeded(settingsJson);
         VerifyParseSucceeded(settings1Json);
 
-        CascadiaSettings settings{};
-        settings._ParseJsonString(settingsJson, false);
-        settings.LayerJson(settings._userSettings);
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settingsJson, false);
+        settings->LayerJson(settings->_userSettings);
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
-        VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
 
-        auto commands = settings._globals->GetCommands();
-        settings._ValidateSettings();
+        auto commands = settings->_globals->GetCommands();
+        settings->_ValidateSettings();
         _logCommandNames(commands);
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
         VERIFY_ARE_EQUAL(1u, commands.Size());
 
         {
@@ -3923,11 +3937,11 @@ namespace TerminalAppLocalTests
         }
 
         Log::Comment(L"Layer second bit of json, to unbind the original command.");
-        settings._ParseJsonString(settings1Json, false);
-        settings.LayerJson(settings._userSettings);
-        settings._ValidateSettings();
+        settings->_ParseJsonString(settings1Json, false);
+        settings->LayerJson(settings->_userSettings);
+        settings->_ValidateSettings();
         _logCommandNames(commands);
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
         VERIFY_ARE_EQUAL(1u, commands.Size());
 
         {
@@ -3991,15 +4005,16 @@ namespace TerminalAppLocalTests
         })" };
 
         VerifyParseSucceeded(settingsJson);
-        CascadiaSettings settings{};
-        settings._ParseJsonString(settingsJson, false);
-        settings.LayerJson(settings._userSettings);
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
+        auto settings = winrt::make_self<implementation::CascadiaSettings>();
+        settings->_ParseJsonString(settingsJson, false);
+        settings->LayerJson(settings->_userSettings);
 
-        VERIFY_ARE_EQUAL(3u, settings.GetProfiles().size());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
 
-        auto commands = settings._globals->GetCommands();
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+
+        auto commands = settings->_globals->GetCommands();
         VERIFY_ARE_EQUAL(1u, commands.Size());
 
         {
@@ -4020,10 +4035,10 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"${scheme.name}", realArgs.TerminalArgs().Profile());
         }
 
-        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings.GetProfiles(), settings._globals->GetColorSchemes());
+        auto expandedCommands = implementation::TerminalPage::_ExpandCommands(commands, settings->Profiles(), settings->_globals->GetColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
-        VERIFY_ARE_EQUAL(0u, settings._warnings.size());
+        VERIFY_ARE_EQUAL(0u, settings->_warnings.size());
         VERIFY_ARE_EQUAL(3u, expandedCommands.Size());
 
         // Yes, this test is testing splitPane with profiles named after each

--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -75,7 +75,7 @@ namespace TerminalAppLocalTests
 
     private:
         void _initializeTerminalPage(winrt::com_ptr<winrt::TerminalApp::implementation::TerminalPage>& page,
-                                     std::shared_ptr<CascadiaSettings> initialSettings);
+                                     winrt::com_ptr<winrt::TerminalApp::implementation::CascadiaSettings>& initialSettings);
     };
 
     void TabTests::EnsureTestsActivate()
@@ -190,7 +190,7 @@ namespace TerminalAppLocalTests
     // Return Value:
     // - <none>
     void TabTests::_initializeTerminalPage(winrt::com_ptr<winrt::TerminalApp::implementation::TerminalPage>& page,
-                                           std::shared_ptr<CascadiaSettings> initialSettings)
+                                           winrt::com_ptr<winrt::TerminalApp::implementation::CascadiaSettings>& initialSettings)
     {
         // This is super wacky, but we can't just initialize the
         // com_ptr<impl::TerminalPage> in the lambda and assign it back out of
@@ -277,7 +277,7 @@ namespace TerminalAppLocalTests
         })" };
 
         VerifyParseSucceeded(settingsJson0);
-        auto settings0 = std::make_shared<CascadiaSettings>(false);
+        auto settings0 = winrt::make_self<implementation::CascadiaSettings>(false);
         VERIFY_IS_NOT_NULL(settings0);
         settings0->_ParseJsonString(settingsJson0, false);
         settings0->LayerJson(settings0->_userSettings);
@@ -339,14 +339,14 @@ namespace TerminalAppLocalTests
         })" };
 
         VerifyParseSucceeded(settingsJson0);
-        auto settings0 = std::make_shared<CascadiaSettings>(false);
+        auto settings0 = winrt::make_self<implementation::CascadiaSettings>(false);
         VERIFY_IS_NOT_NULL(settings0);
         settings0->_ParseJsonString(settingsJson0, false);
         settings0->LayerJson(settings0->_userSettings);
         settings0->_ValidateSettings();
 
         VerifyParseSucceeded(settingsJson1);
-        auto settings1 = std::make_shared<CascadiaSettings>(false);
+        auto settings1 = winrt::make_self<implementation::CascadiaSettings>(false);
         VERIFY_IS_NOT_NULL(settings1);
         settings1->_ParseJsonString(settingsJson1, false);
         settings1->LayerJson(settings1->_userSettings);
@@ -434,14 +434,14 @@ namespace TerminalAppLocalTests
         })" };
 
         VerifyParseSucceeded(settingsJson0);
-        auto settings0 = std::make_shared<CascadiaSettings>(false);
+        auto settings0 = winrt::make_self<implementation::CascadiaSettings>(false);
         VERIFY_IS_NOT_NULL(settings0);
         settings0->_ParseJsonString(settingsJson0, false);
         settings0->LayerJson(settings0->_userSettings);
         settings0->_ValidateSettings();
 
         VerifyParseSucceeded(settingsJson1);
-        auto settings1 = std::make_shared<CascadiaSettings>(false);
+        auto settings1 = winrt::make_self<implementation::CascadiaSettings>(false);
         VERIFY_IS_NOT_NULL(settings1);
         settings1->_ParseJsonString(settingsJson1, false);
         settings1->LayerJson(settings1->_userSettings);

--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -206,7 +206,7 @@ namespace TerminalAppLocalTests
         auto result = RunOnUIThread([&projectedPage, &page, initialSettings]() {
             projectedPage = winrt::TerminalApp::TerminalPage();
             page.copy_from(winrt::get_self<winrt::TerminalApp::implementation::TerminalPage>(projectedPage));
-            page->_settings = initialSettings;
+            page->_settings = *initialSettings;
         });
         VERIFY_SUCCEEDED(result);
 
@@ -383,7 +383,7 @@ namespace TerminalAppLocalTests
             L"Change the settings of the TerminalPage so the first profile is "
             L"no longer in the list of profiles"));
         result = RunOnUIThread([&page, settings1]() {
-            page->_settings = settings1;
+            page->_settings = *settings1;
         });
         VERIFY_SUCCEEDED(result);
 
@@ -488,7 +488,7 @@ namespace TerminalAppLocalTests
             L"Change the settings of the TerminalPage so the first profile is "
             L"no longer in the list of profiles"));
         result = RunOnUIThread([&page, settings1]() {
-            page->_settings = settings1;
+            page->_settings = *settings1;
         });
         VERIFY_SUCCEEDED(result);
 

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -320,7 +320,8 @@ namespace winrt::TerminalApp::implementation
                 if (auto activeControl = activeTab->GetActiveTerminalControl())
                 {
                     auto controlSettings = activeControl.Settings();
-                    if (_settings->ApplyColorScheme(controlSettings, realArgs.SchemeName()))
+                    const auto settingsImpl{ winrt::get_self<implementation::CascadiaSettings>(_settings) };
+                    if (settingsImpl->ApplyColorScheme(controlSettings, realArgs.SchemeName()))
                     {
                         activeControl.UpdateSettings(controlSettings);
                         args.Handled(true);

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -616,8 +616,10 @@ namespace winrt::TerminalApp::implementation
         try
         {
             auto newSettings = _isUwp ? CascadiaSettings::LoadUniversal() : CascadiaSettings::LoadAll();
-            _settings = std::move(newSettings);
-            const auto& warnings = _settings->GetWarnings();
+            _settings.copy_from(winrt::get_self<CascadiaSettings>(newSettings));
+
+            auto settingsImpl = _settings.as<CascadiaSettings>();
+            const auto& warnings = settingsImpl->GetWarnings();
             hr = warnings.size() == 0 ? S_OK : S_FALSE;
         }
         catch (const winrt::hresult_error& e)
@@ -675,7 +677,7 @@ namespace winrt::TerminalApp::implementation
 
         if (FAILED(_settingsLoadedResult))
         {
-            _settings = CascadiaSettings::LoadDefaults();
+            _settings.copy_from(winrt::get_self<CascadiaSettings>(CascadiaSettings::LoadDefaults()));
         }
 
         auto end = std::chrono::high_resolution_clock::now();
@@ -859,9 +861,9 @@ namespace winrt::TerminalApp::implementation
 
     // Method Description:
     // - Returns a pointer to the global shared settings.
-    [[nodiscard]] std::shared_ptr<::TerminalApp::CascadiaSettings> AppLogic::GetSettings() const noexcept
+    [[nodiscard]] TerminalApp::CascadiaSettings AppLogic::GetSettings() const noexcept
     {
-        return _settings;
+        return *_settings;
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -709,7 +709,7 @@ namespace winrt::TerminalApp::implementation
         // Register for directory change notification.
         _RegisterSettingsChange();
 
-        Jumplist::UpdateJumplist(*_settings);
+        Jumplist::UpdateJumplist(_settings);
     }
 
     // Method Description:
@@ -869,7 +869,7 @@ namespace winrt::TerminalApp::implementation
         _RefreshThemeRoutine();
         _ApplyStartupTaskStateChange();
 
-        Jumplist::UpdateJumplist(*_settings);
+        Jumplist::UpdateJumplist(_settings);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -165,6 +165,17 @@ namespace winrt::TerminalApp::implementation
         return nullptr;
     }
 
+    // Method Description:
+    // - Returns the settings currently in use by the entire Terminal application.
+    // Throws:
+    // - HR E_INVALIDARG if the app isn't up and running.
+    const TerminalApp::CascadiaSettings AppLogic::CurrentAppSettings()
+    {
+        auto appLogic{ ::winrt::TerminalApp::implementation::AppLogic::Current() };
+        THROW_HR_IF_NULL(E_INVALIDARG, appLogic);
+        return appLogic->GetSettings();
+    }
+
     AppLogic::AppLogic() :
         _dialogLock{},
         _loadedInitialSettings{ false },
@@ -238,7 +249,7 @@ namespace winrt::TerminalApp::implementation
         // so this setting is overridden to false no matter what the preference is.
         if (_isUwp)
         {
-            _settings->GlobalSettings().ShowTabsInTitlebar(false);
+            _settings.GlobalSettings().ShowTabsInTitlebar(false);
         }
 
         _root->SetSettings(_settings, false);
@@ -256,14 +267,14 @@ namespace winrt::TerminalApp::implementation
         });
         _root->Create();
 
-        _ApplyTheme(_settings->GlobalSettings().Theme());
+        _ApplyTheme(_settings.GlobalSettings().Theme());
         _ApplyStartupTaskStateChange();
 
         TraceLoggingWrite(
             g_hTerminalAppProvider,
             "AppCreated",
             TraceLoggingDescription("Event emitted when the application is started"),
-            TraceLoggingBool(_settings->GlobalSettings().ShowTabsInTitlebar(), "TabsInTitlebar"),
+            TraceLoggingBool(_settings.GlobalSettings().ShowTabsInTitlebar(), "TabsInTitlebar"),
             TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
             TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
     }
@@ -310,7 +321,7 @@ namespace winrt::TerminalApp::implementation
         // details here, but it does have the desired effect.
         // It's not enough to set the theme on the dialog alone.
         auto themingLambda{ [this](const Windows::Foundation::IInspectable& sender, const RoutedEventArgs&) {
-            auto theme{ _settings->GlobalSettings().Theme() };
+            auto theme{ _settings.GlobalSettings().Theme() };
             auto element{ sender.try_as<winrt::Windows::UI::Xaml::FrameworkElement>() };
             while (element)
             {
@@ -400,7 +411,8 @@ namespace winrt::TerminalApp::implementation
         // Make sure the lines of text wrap
         warningsTextBlock.TextWrapping(TextWrapping::Wrap);
 
-        const auto& warnings = _settings->GetWarnings();
+        const auto settingsImpl{ winrt::get_self<implementation::CascadiaSettings>(_settings) };
+        const auto& warnings = settingsImpl->GetWarnings();
         for (const auto& warning : warnings)
         {
             // Try looking up the warning message key for each warning.
@@ -483,7 +495,8 @@ namespace winrt::TerminalApp::implementation
         }
 
         // Use the default profile to determine how big of a window we need.
-        const auto [_, settings] = _settings->BuildSettings(nullptr);
+        const auto settingsImpl{ winrt::get_self<implementation::CascadiaSettings>(_settings) };
+        const auto [_, settings] = settingsImpl->BuildSettings(nullptr);
 
         auto proposedSize = TermControl::GetProposedDimensions(settings, dpi);
 
@@ -492,7 +505,7 @@ namespace winrt::TerminalApp::implementation
         // GH#2061 - If the global setting "Always show tab bar" is
         // set or if "Show tabs in title bar" is set, then we'll need to add
         // the height of the tab bar here.
-        if (_settings->GlobalSettings().ShowTabsInTitlebar())
+        if (_settings.GlobalSettings().ShowTabsInTitlebar())
         {
             // If we're showing the tabs in the titlebar, we need to use a
             // TitlebarControl here to calculate how much space to reserve.
@@ -506,7 +519,7 @@ namespace winrt::TerminalApp::implementation
             titlebar.Measure({ SHRT_MAX, SHRT_MAX });
             proposedSize.Height += (titlebar.DesiredSize().Height) * scale;
         }
-        else if (_settings->GlobalSettings().AlwaysShowTabs())
+        else if (_settings.GlobalSettings().AlwaysShowTabs())
         {
             // Otherwise, let's use a TabRowControl to calculate how much extra
             // space we'll need.
@@ -544,7 +557,7 @@ namespace winrt::TerminalApp::implementation
 
         // GH#4620/#5801 - If the user passed --maximized or --fullscreen on the
         // commandline, then use that to override the value from the settings.
-        const auto valueFromSettings = _settings->GlobalSettings().LaunchMode();
+        const auto valueFromSettings = _settings.GlobalSettings().LaunchMode();
         const auto valueFromCommandlineArgs = _appArgs.GetLaunchMode();
         return valueFromCommandlineArgs.has_value() ?
                    valueFromCommandlineArgs.value() :
@@ -569,7 +582,7 @@ namespace winrt::TerminalApp::implementation
             LoadSettings();
         }
 
-        const auto initialPosition{ _settings->GlobalSettings().InitialPosition() };
+        const auto initialPosition{ _settings.GlobalSettings().InitialPosition() };
         return {
             initialPosition.X ? initialPosition.X.Value() : defaultInitialX,
             initialPosition.Y ? initialPosition.Y.Value() : defaultInitialY
@@ -584,7 +597,7 @@ namespace winrt::TerminalApp::implementation
             LoadSettings();
         }
 
-        return _settings->GlobalSettings().Theme();
+        return _settings.GlobalSettings().Theme();
     }
 
     bool AppLogic::GetShowTabsInTitlebar()
@@ -595,7 +608,7 @@ namespace winrt::TerminalApp::implementation
             LoadSettings();
         }
 
-        return _settings->GlobalSettings().ShowTabsInTitlebar();
+        return _settings.GlobalSettings().ShowTabsInTitlebar();
     }
 
     // Method Description:
@@ -616,9 +629,9 @@ namespace winrt::TerminalApp::implementation
         try
         {
             auto newSettings = _isUwp ? CascadiaSettings::LoadUniversal() : CascadiaSettings::LoadAll();
-            _settings.copy_from(winrt::get_self<CascadiaSettings>(newSettings));
+            _settings = newSettings;
 
-            auto settingsImpl = _settings.as<CascadiaSettings>();
+            const auto settingsImpl{ winrt::get_self<implementation::CascadiaSettings>(_settings) };
             const auto& warnings = settingsImpl->GetWarnings();
             hr = warnings.size() == 0 ? S_OK : S_FALSE;
         }
@@ -677,7 +690,7 @@ namespace winrt::TerminalApp::implementation
 
         if (FAILED(_settingsLoadedResult))
         {
-            _settings.copy_from(winrt::get_self<CascadiaSettings>(CascadiaSettings::LoadDefaults()));
+            _settings = CascadiaSettings::LoadDefaults();
         }
 
         auto end = std::chrono::high_resolution_clock::now();
@@ -775,7 +788,7 @@ namespace winrt::TerminalApp::implementation
         co_await winrt::resume_foreground(_root->Dispatcher());
 
         // Refresh the UI theme
-        _ApplyTheme(_settings->GlobalSettings().Theme());
+        _ApplyTheme(_settings.GlobalSettings().Theme());
     }
 
     fire_and_forget AppLogic::_ApplyStartupTaskStateChange()
@@ -794,7 +807,7 @@ namespace winrt::TerminalApp::implementation
         if (auto page{ weakThis.get() })
         {
             StartupTaskState state;
-            bool tryEnableStartupTask = _settings->GlobalSettings().StartOnUserLogin();
+            bool tryEnableStartupTask = _settings.GlobalSettings().StartOnUserLogin();
             StartupTask task = co_await StartupTask::GetAsync(StartupTaskName);
 
             state = task.State();
@@ -863,7 +876,7 @@ namespace winrt::TerminalApp::implementation
     // - Returns a pointer to the global shared settings.
     [[nodiscard]] TerminalApp::CascadiaSettings AppLogic::GetSettings() const noexcept
     {
-        return *_settings;
+        return _settings;
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/AppLogic.h
+++ b/src/cascadia/TerminalApp/AppLogic.h
@@ -17,6 +17,7 @@ namespace winrt::TerminalApp::implementation
     {
     public:
         static AppLogic* Current() noexcept;
+        static const TerminalApp::CascadiaSettings CurrentAppSettings();
 
         AppLogic();
         ~AppLogic() = default;
@@ -69,7 +70,7 @@ namespace winrt::TerminalApp::implementation
         // updated in _ApplyTheme. The root currently is _root.
         winrt::com_ptr<TerminalPage> _root{ nullptr };
 
-        winrt::com_ptr<CascadiaSettings> _settings{ nullptr };
+        TerminalApp::CascadiaSettings _settings{ nullptr };
 
         HRESULT _settingsLoadedResult;
         winrt::hstring _settingsLoadExceptionText{};

--- a/src/cascadia/TerminalApp/AppLogic.h
+++ b/src/cascadia/TerminalApp/AppLogic.h
@@ -26,7 +26,7 @@ namespace winrt::TerminalApp::implementation
         void RunAsUwp();
         bool IsElevated() const noexcept;
         void LoadSettings();
-        [[nodiscard]] std::shared_ptr<::TerminalApp::CascadiaSettings> GetSettings() const noexcept;
+        [[nodiscard]] TerminalApp::CascadiaSettings GetSettings() const noexcept;
 
         int32_t SetStartupCommandline(array_view<const winrt::hstring> actions);
         winrt::hstring ParseCommandlineMessage();
@@ -69,7 +69,7 @@ namespace winrt::TerminalApp::implementation
         // updated in _ApplyTheme. The root currently is _root.
         winrt::com_ptr<TerminalPage> _root{ nullptr };
 
-        std::shared_ptr<::TerminalApp::CascadiaSettings> _settings{ nullptr };
+        winrt::com_ptr<CascadiaSettings> _settings{ nullptr };
 
         HRESULT _settingsLoadedResult;
         winrt::hstring _settingsLoadExceptionText{};

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -17,9 +17,12 @@
 #include "WslDistroGenerator.h"
 #include "AzureCloudShellGenerator.h"
 
+#include "CascadiaSettings.g.cpp"
+
 using namespace ::TerminalApp;
 using namespace winrt::Microsoft::Terminal::TerminalControl;
-using namespace winrt::TerminalApp;
+using namespace winrt::TerminalApp::implementation;
+using namespace winrt::Windows::Foundation::Collections;
 using namespace Microsoft::Console;
 
 static constexpr std::wstring_view PACKAGED_PROFILE_ICON_PATH{ L"ms-appx:///ProfileIcons/" };
@@ -29,17 +32,6 @@ static constexpr std::wstring_view DEFAULT_LINUX_ICON_GUID{ L"{9acb9455-ca41-5af
 
 // make sure this matches defaults.json.
 static constexpr std::wstring_view DEFAULT_WINDOWS_POWERSHELL_GUID{ L"{61c54bbd-c2c6-5271-96e7-009a87ff44bf}" };
-
-// Method Description:
-// - Returns the settings currently in use by the entire Terminal application.
-// Throws:
-// - HR E_INVALIDARG if the app isn't up and running.
-const CascadiaSettings& CascadiaSettings::GetCurrentAppSettings()
-{
-    auto appLogic{ ::winrt::TerminalApp::implementation::AppLogic::Current() };
-    THROW_HR_IF_NULL(E_INVALIDARG, appLogic);
-    return *(appLogic->GetSettings());
-}
 
 CascadiaSettings::CascadiaSettings() :
     CascadiaSettings(true)
@@ -53,7 +45,8 @@ CascadiaSettings::CascadiaSettings() :
 // Arguments:
 // - addDynamicProfiles: if true, we'll add the built-in DPGs.
 CascadiaSettings::CascadiaSettings(const bool addDynamicProfiles) :
-    _globals{ winrt::make_self<winrt::TerminalApp::implementation::GlobalAppSettings>() }
+    _globals{ winrt::make_self<implementation::GlobalAppSettings>() },
+    _profiles{ winrt::single_threaded_vector<TerminalApp::Profile>() }
 {
     if (addDynamicProfiles)
     {
@@ -71,10 +64,10 @@ CascadiaSettings::CascadiaSettings(const bool addDynamicProfiles) :
 // Return Value:
 // - a non-ownership pointer to the profile matching the given guid, or nullptr
 //      if there is no match.
-const Profile CascadiaSettings::FindProfile(winrt::guid profileGuid) const noexcept
+winrt::TerminalApp::Profile CascadiaSettings::FindProfile(winrt::guid profileGuid) const noexcept
 {
     const winrt::guid guid{ profileGuid };
-    for (auto& profile : _profiles)
+    for (auto profile : _profiles)
     {
         try
         {
@@ -94,9 +87,9 @@ const Profile CascadiaSettings::FindProfile(winrt::guid profileGuid) const noexc
 // - <none>
 // Return Value:
 // - an iterable collection of all of our Profiles.
-gsl::span<const Profile> CascadiaSettings::GetProfiles() const noexcept
+IVectorView<winrt::TerminalApp::Profile> CascadiaSettings::Profiles() const noexcept
 {
-    return { &_profiles[0], _profiles.size() };
+    return _profiles.GetView();
 }
 
 // Method Description:
@@ -105,7 +98,7 @@ gsl::span<const Profile> CascadiaSettings::GetProfiles() const noexcept
 // - <none>
 // Return Value:
 // - the globally configured keybindings
-AppKeyBindings CascadiaSettings::GetKeybindings() const noexcept
+winrt::TerminalApp::AppKeyBindings CascadiaSettings::Keybindings() const noexcept
 {
     return _globals->GetKeybindings();
 }
@@ -196,7 +189,7 @@ void CascadiaSettings::_ValidateSettings()
 //   profiles at all, we'll throw an error if there aren't any profiles.
 void CascadiaSettings::_ValidateProfilesExist()
 {
-    const bool hasProfiles = !_profiles.empty();
+    const bool hasProfiles = _profiles.Size() > 0;
     if (!hasProfiles)
     {
         // Throw an exception. This is an invalid state, and we want the app to
@@ -215,7 +208,7 @@ void CascadiaSettings::_ValidateProfilesExist()
 //   temporary runtime GUID for it. This validation does not add any warnings.
 void CascadiaSettings::_ValidateProfilesHaveGuid()
 {
-    for (auto& profile : _profiles)
+    for (auto profile : _profiles)
     {
         auto profileImpl = winrt::get_self<implementation::Profile>(profile);
         profileImpl->GenerateGuidIfNecessary();
@@ -264,7 +257,7 @@ void CascadiaSettings::_ValidateDefaultProfileExists()
 
         // _temporarily_ set the default profile to the first profile. Because
         // we're adding a warning, this settings change won't be re-serialized.
-        GlobalSettings().DefaultProfile(_profiles[0].Guid());
+        GlobalSettings().DefaultProfile(_profiles.GetAt(0).Guid());
     }
 }
 
@@ -278,15 +271,15 @@ void CascadiaSettings::_ValidateNoDuplicateProfiles()
 {
     bool foundDupe = false;
 
-    std::vector<size_t> indicesToDelete;
+    std::vector<uint32_t> indicesToDelete;
 
     std::set<winrt::guid> uniqueGuids;
 
     // Try collecting all the unique guids. If we ever encounter a guid that's
     // already in the set, then we need to delete that profile.
-    for (size_t i = 0; i < _profiles.size(); i++)
+    for (uint32_t i = 0; i < _profiles.Size(); i++)
     {
-        if (!uniqueGuids.insert(_profiles.at(i).Guid()).second)
+        if (!uniqueGuids.insert(_profiles.GetAt(i).Guid()).second)
         {
             foundDupe = true;
             indicesToDelete.push_back(i);
@@ -297,7 +290,7 @@ void CascadiaSettings::_ValidateNoDuplicateProfiles()
     // Walk backwards, so we don't accidentally shift any of the elements
     for (auto iter = indicesToDelete.rbegin(); iter != indicesToDelete.rend(); iter++)
     {
-        _profiles.erase(_profiles.begin() + *iter);
+        _profiles.RemoveAt(*iter);
     }
 
     if (foundDupe)
@@ -345,15 +338,17 @@ void CascadiaSettings::_ReorderProfilesToMatchUserSettingsOrder()
     //   pIndex = the pIndex of the profile with guid==guids[gIndex]
     //   profiles.swap(pIndex <-> gIndex)
     // This is O(N^2), which is kinda rough. I'm sure there's a better way
-    for (size_t gIndex = 0; gIndex < guidOrder.size(); gIndex++)
+    for (uint32_t gIndex = 0; gIndex < guidOrder.size(); gIndex++)
     {
         const auto guid = guidOrder.at(gIndex);
-        for (size_t pIndex = gIndex; pIndex < _profiles.size(); pIndex++)
+        for (uint32_t pIndex = gIndex; pIndex < _profiles.Size(); pIndex++)
         {
-            auto profileGuid = _profiles.at(pIndex).Guid();
+            auto profileGuid = _profiles.GetAt(pIndex).Guid();
             if (equals(profileGuid, guid))
             {
-                std::iter_swap(_profiles.begin() + pIndex, _profiles.begin() + gIndex);
+                auto prof1 = _profiles.GetAt(pIndex);
+                _profiles.SetAt(pIndex, _profiles.GetAt(gIndex));
+                _profiles.SetAt(gIndex, prof1);
                 break;
             }
         }
@@ -369,19 +364,23 @@ void CascadiaSettings::_ReorderProfilesToMatchUserSettingsOrder()
 // - <none>
 void CascadiaSettings::_RemoveHiddenProfiles()
 {
-    // remove_if will move all the profiles where the lambda is true to the end
-    // of the list, then return a iterator to the point in the list where those
-    // profiles start. The erase call will then remove all of those profiles
-    // from the list. This is the [erase-remove
-    // idiom](https://en.wikipedia.org/wiki/Erase%E2%80%93remove_idiom)
-    _profiles.erase(std::remove_if(_profiles.begin(),
-                                   _profiles.end(),
-                                   [](auto&& profile) { return profile.Hidden(); }),
-                    _profiles.end());
+    uint32_t i = 0;
+    while (i < _profiles.Size())
+    {
+        if (_profiles.GetAt(i).Hidden())
+        {
+            // remove hidden profile, don't increment 'i'
+            _profiles.RemoveAt(i);
+        }
+        else
+        {
+            ++i;
+        }
+    }
 
     // Ensure that we still have some profiles here. If we don't, then throw an
     // exception, so the app can use the defaults.
-    const bool hasProfiles = !_profiles.empty();
+    const bool hasProfiles = _profiles.Size() > 0;
     if (!hasProfiles)
     {
         // Throw an exception. This is an invalid state, and we want the app to
@@ -403,7 +402,7 @@ void CascadiaSettings::_RemoveHiddenProfiles()
 void CascadiaSettings::_ValidateAllSchemesExist()
 {
     bool foundInvalidScheme = false;
-    for (auto& profile : _profiles)
+    for (auto profile : _profiles)
     {
         const auto schemeName = profile.ColorSchemeName();
         if (!_globals->GetColorSchemes().HasKey(schemeName))
@@ -435,7 +434,7 @@ void CascadiaSettings::_ValidateMediaResources()
     bool invalidBackground{ false };
     bool invalidIcon{ false };
 
-    for (auto& profile : _profiles)
+    for (auto profile : _profiles)
     {
         if (!profile.BackgroundImagePath().empty())
         {
@@ -494,7 +493,7 @@ void CascadiaSettings::_ValidateMediaResources()
 //     the profile.
 // Return Value:
 // - the GUID of the created profile, and a fully initialized TerminalSettings object
-std::tuple<winrt::guid, TerminalSettings> CascadiaSettings::BuildSettings(const NewTerminalArgs& newTerminalArgs) const
+std::tuple<winrt::guid, winrt::TerminalApp::TerminalSettings> CascadiaSettings::BuildSettings(const winrt::TerminalApp::NewTerminalArgs& newTerminalArgs) const
 {
     const winrt::guid profileGuid = _GetProfileForArgs(newTerminalArgs);
     auto settings = BuildSettings(profileGuid);
@@ -527,13 +526,13 @@ std::tuple<winrt::guid, TerminalSettings> CascadiaSettings::BuildSettings(const 
 // - profileGuid: The GUID of a profile to use to create a settings object for.
 // Return Value:
 // - a fully initialized TerminalSettings object
-TerminalSettings CascadiaSettings::BuildSettings(winrt::guid profileGuid) const
+winrt::TerminalApp::TerminalSettings CascadiaSettings::BuildSettings(winrt::guid profileGuid) const
 {
     const auto profile = FindProfile(profileGuid);
     THROW_HR_IF_NULL(E_INVALIDARG, profile);
 
-    const auto profileImpl = winrt::get_self<implementation::Profile>(profile);
-    TerminalSettings result = profileImpl->CreateTerminalSettings(_globals->GetColorSchemes());
+    const auto profileImpl = winrt::get_self<Profile>(profile);
+    auto result = profileImpl->CreateTerminalSettings(_globals->GetColorSchemes());
 
     // Place our appropriate global settings into the Terminal Settings
     _globals->ApplyToSettings(result);
@@ -557,7 +556,7 @@ TerminalSettings CascadiaSettings::BuildSettings(winrt::guid profileGuid) const
 //   and attempt to look the profile up by name instead.
 // Return Value:
 // - the GUID of the profile corresponding to this combination of index and NewTerminalArgs
-winrt::guid CascadiaSettings::_GetProfileForArgs(const NewTerminalArgs& newTerminalArgs) const
+winrt::guid CascadiaSettings::_GetProfileForArgs(const winrt::TerminalApp::NewTerminalArgs& newTerminalArgs) const
 {
     std::optional<winrt::guid> profileByIndex, profileByName;
     if (newTerminalArgs)
@@ -579,7 +578,7 @@ winrt::guid CascadiaSettings::_GetProfileForArgs(const NewTerminalArgs& newTermi
 // - name: a guid string _or_ the name of a profile
 // Return Value:
 // - the GUID of the profile corresponding to this name
-std::optional<winrt::guid> CascadiaSettings::_GetProfileGuidByName(const std::wstring_view name) const
+std::optional<winrt::guid> CascadiaSettings::_GetProfileGuidByName(const winrt::hstring name) const
 try
 {
     // First, try and parse the "name" as a GUID. If it's a
@@ -603,13 +602,12 @@ try
         // Here, we were unable to use the profile string as a GUID to
         // lookup a profile. Instead, try using the string to look the
         // Profile up by name.
-        const auto profileIterator{ std::find_if(_profiles.cbegin(), _profiles.cend(), [&](auto&& profile) {
-            return profile.Name() == name;
-        }) };
-
-        if (profileIterator != _profiles.cend())
+        for (auto profile : _profiles)
         {
-            return profileIterator->Guid();
+            if (profile.Name() == name)
+            {
+                return profile.Guid();
+            }
         }
     }
 
@@ -638,9 +636,9 @@ std::optional<winrt::guid> CascadiaSettings::_GetProfileGuidByIndex(std::optiona
         const auto realIndex{ index.value() };
         // If we don't have that many profiles, then do nothing.
         if (realIndex >= 0 &&
-            realIndex < gsl::narrow_cast<decltype(realIndex)>(_profiles.size()))
+            realIndex < gsl::narrow_cast<decltype(realIndex)>(_profiles.Size()))
         {
-            const auto& selectedProfile = _profiles.at(realIndex);
+            const auto& selectedProfile = _profiles.GetAt(realIndex);
             return selectedProfile.Guid();
         }
     }
@@ -703,7 +701,7 @@ std::string CascadiaSettings::_ApplyFirstRunChangesToSettingsTemplate(std::strin
     std::string finalSettings{ settingsTemplate };
 
     std::wstring defaultProfileGuid{ DEFAULT_WINDOWS_POWERSHELL_GUID };
-    if (const auto psCoreProfileGuid{ _GetProfileGuidByName(PowershellCoreProfileGenerator::GetPreferredPowershellProfileName()) })
+    if (const auto psCoreProfileGuid{ _GetProfileGuidByName(PowershellCoreProfileGenerator::GetPreferredPowershellProfileName().data()) })
     {
         defaultProfileGuid = Utils::GuidToString(*psCoreProfileGuid);
     }
@@ -736,7 +734,7 @@ std::string CascadiaSettings::_ApplyFirstRunChangesToSettingsTemplate(std::strin
 // - profileGuid: the GUID of the profile to find the scheme for.
 // Return Value:
 // - a non-owning pointer to the scheme.
-const ColorScheme CascadiaSettings::GetColorSchemeForProfile(const winrt::guid profileGuid) const
+winrt::TerminalApp::ColorScheme CascadiaSettings::GetColorSchemeForProfile(const winrt::guid profileGuid) const
 {
     auto profile = FindProfile(profileGuid);
     if (!profile)
@@ -756,7 +754,7 @@ const ColorScheme CascadiaSettings::GetColorSchemeForProfile(const winrt::guid p
 // - name: the name of the scheme to apply
 // Return Value:
 // - true iff we found a matching scheme for the name schemeName
-bool CascadiaSettings::ApplyColorScheme(winrt::Microsoft::Terminal::TerminalControl::IControlSettings& settings,
+bool CascadiaSettings::ApplyColorScheme(winrt::Microsoft::Terminal::TerminalControl::IControlSettings settings,
                                         winrt::hstring schemeName)
 {
     if (auto scheme{ _globals->GetColorSchemes().TryLookup(schemeName) })

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -364,8 +364,7 @@ void CascadiaSettings::_ReorderProfilesToMatchUserSettingsOrder()
 // - <none>
 void CascadiaSettings::_RemoveHiddenProfiles()
 {
-    uint32_t i = 0;
-    while (i < _profiles.Size())
+    for (uint32_t i{}; i < _profiles.Size();)
     {
         if (_profiles.GetAt(i).Hidden())
         {
@@ -701,7 +700,7 @@ std::string CascadiaSettings::_ApplyFirstRunChangesToSettingsTemplate(std::strin
     std::string finalSettings{ settingsTemplate };
 
     std::wstring defaultProfileGuid{ DEFAULT_WINDOWS_POWERSHELL_GUID };
-    if (const auto psCoreProfileGuid{ _GetProfileGuidByName(PowershellCoreProfileGenerator::GetPreferredPowershellProfileName().data()) })
+    if (const auto psCoreProfileGuid{ _GetProfileGuidByName(hstring{ PowershellCoreProfileGenerator::GetPreferredPowershellProfileName() }) })
     {
         defaultProfileGuid = Utils::GuidToString(*psCoreProfileGuid);
     }

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -364,7 +364,7 @@ void CascadiaSettings::_ReorderProfilesToMatchUserSettingsOrder()
 // - <none>
 void CascadiaSettings::_RemoveHiddenProfiles()
 {
-    for (uint32_t i{}; i < _profiles.Size();)
+    for (uint32_t i = 0; i < _profiles.Size();)
     {
         if (_profiles.GetAt(i).Hidden())
         {

--- a/src/cascadia/TerminalApp/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettings.cpp
@@ -46,7 +46,7 @@ CascadiaSettings::CascadiaSettings() :
 // - addDynamicProfiles: if true, we'll add the built-in DPGs.
 CascadiaSettings::CascadiaSettings(const bool addDynamicProfiles) :
     _globals{ winrt::make_self<implementation::GlobalAppSettings>() },
-    _profiles{ winrt::single_threaded_vector<TerminalApp::Profile>() }
+    _profiles{ winrt::single_threaded_observable_vector<TerminalApp::Profile>() }
 {
     if (addDynamicProfiles)
     {
@@ -87,9 +87,9 @@ winrt::TerminalApp::Profile CascadiaSettings::FindProfile(winrt::guid profileGui
 // - <none>
 // Return Value:
 // - an iterable collection of all of our Profiles.
-IVectorView<winrt::TerminalApp::Profile> CascadiaSettings::Profiles() const noexcept
+IObservableVector<winrt::TerminalApp::Profile> CascadiaSettings::Profiles() const noexcept
 {
-    return _profiles.GetView();
+    return _profiles;
 }
 
 // Method Description:

--- a/src/cascadia/TerminalApp/CascadiaSettings.h
+++ b/src/cascadia/TerminalApp/CascadiaSettings.h
@@ -16,6 +16,9 @@ Author(s):
 
 --*/
 #pragma once
+
+#include "CascadiaSettings.g.h"
+
 #include <winrt/Microsoft.Terminal.TerminalConnection.h>
 #include "GlobalAppSettings.h"
 #include "TerminalWarnings.h"
@@ -42,7 +45,6 @@ namespace TerminalAppUnitTests
 namespace TerminalApp
 {
     class SettingsTypedDeserializationException;
-    class CascadiaSettings;
 };
 
 class TerminalApp::SettingsTypedDeserializationException final : public std::runtime_error
@@ -52,94 +54,100 @@ public:
         runtime_error(description.data()) {}
 };
 
-class TerminalApp::CascadiaSettings final
+namespace winrt::TerminalApp::implementation
 {
-public:
-    CascadiaSettings();
-    explicit CascadiaSettings(const bool addDynamicProfiles);
+    struct CascadiaSettings : CascadiaSettingsT<CascadiaSettings>
+    {
+    public:
+        CascadiaSettings();
+        CascadiaSettings(const bool addDynamicProfiles);
 
-    static std::unique_ptr<CascadiaSettings> LoadDefaults();
-    static std::unique_ptr<CascadiaSettings> LoadAll();
-    static std::unique_ptr<CascadiaSettings> LoadUniversal();
+        static TerminalApp::CascadiaSettings LoadDefaults();
+        static TerminalApp::CascadiaSettings LoadAll();
+        static TerminalApp::CascadiaSettings LoadUniversal();
 
-    static const CascadiaSettings& GetCurrentAppSettings();
+        std::tuple<guid, TerminalApp::TerminalSettings> BuildSettings(const TerminalApp::NewTerminalArgs& newTerminalArgs) const;
+        TerminalApp::TerminalSettings BuildSettings(guid profileGuid) const;
 
-    std::tuple<winrt::guid, winrt::TerminalApp::TerminalSettings> BuildSettings(const winrt::TerminalApp::NewTerminalArgs& newTerminalArgs) const;
-    winrt::TerminalApp::TerminalSettings BuildSettings(winrt::guid profileGuid) const;
+        TerminalApp::GlobalAppSettings GlobalSettings();
 
-    winrt::TerminalApp::GlobalAppSettings GlobalSettings();
+        Windows::Foundation::Collections::IVectorView<winrt::TerminalApp::Profile> Profiles() const noexcept;
 
-    gsl::span<const winrt::TerminalApp::Profile> GetProfiles() const noexcept;
+        TerminalApp::AppKeyBindings Keybindings() const noexcept;
 
-    winrt::TerminalApp::AppKeyBindings GetKeybindings() const noexcept;
+        static std::unique_ptr<CascadiaSettings> FromJson(const Json::Value& json);
+        void LayerJson(const Json::Value& json);
 
-    static std::unique_ptr<CascadiaSettings> FromJson(const Json::Value& json);
-    void LayerJson(const Json::Value& json);
+        static std::filesystem::path GetSettingsPath();
+        static std::filesystem::path GetDefaultSettingsPath();
 
-    static std::filesystem::path GetSettingsPath();
-    static std::filesystem::path GetDefaultSettingsPath();
+        TerminalApp::Profile FindProfile(guid profileGuid) const noexcept;
+        TerminalApp::ColorScheme GetColorSchemeForProfile(const guid profileGuid) const;
 
-    const winrt::TerminalApp::Profile FindProfile(winrt::guid profileGuid) const noexcept;
-    const winrt::TerminalApp::ColorScheme GetColorSchemeForProfile(const winrt::guid profileGuid) const;
+        std::vector<::TerminalApp::SettingsLoadWarnings>& GetWarnings();
 
-    std::vector<TerminalApp::SettingsLoadWarnings>& GetWarnings();
+        bool ApplyColorScheme(Microsoft::Terminal::TerminalControl::IControlSettings settings, hstring schemeName);
 
-    bool ApplyColorScheme(winrt::Microsoft::Terminal::TerminalControl::IControlSettings& settings, winrt::hstring schemeName);
+    private:
+        com_ptr<GlobalAppSettings> _globals;
+        Windows::Foundation::Collections::IVector<TerminalApp::Profile> _profiles;
+        std::vector<::TerminalApp::SettingsLoadWarnings> _warnings;
 
-private:
-    winrt::com_ptr<winrt::TerminalApp::implementation::GlobalAppSettings> _globals;
-    std::vector<winrt::TerminalApp::Profile> _profiles;
-    std::vector<TerminalApp::SettingsLoadWarnings> _warnings;
+        std::vector<std::unique_ptr<::TerminalApp::IDynamicProfileGenerator>> _profileGenerators;
 
-    std::vector<std::unique_ptr<TerminalApp::IDynamicProfileGenerator>> _profileGenerators;
+        std::string _userSettingsString;
+        Json::Value _userSettings;
+        Json::Value _defaultSettings;
+        Json::Value _userDefaultProfileSettings{ Json::Value::null };
 
-    std::string _userSettingsString;
-    Json::Value _userSettings;
-    Json::Value _defaultSettings;
-    Json::Value _userDefaultProfileSettings{ Json::Value::null };
+        void _LayerOrCreateProfile(const Json::Value& profileJson);
+        winrt::com_ptr<winrt::TerminalApp::implementation::Profile> _FindMatchingProfile(const Json::Value& profileJson);
+        void _LayerOrCreateColorScheme(const Json::Value& schemeJson);
+        winrt::com_ptr<winrt::TerminalApp::implementation::ColorScheme> _FindMatchingColorScheme(const Json::Value& schemeJson);
+        void _ParseJsonString(std::string_view fileData, const bool isDefaultSettings);
+        static const Json::Value& _GetProfilesJsonObject(const Json::Value& json);
+        static const Json::Value& _GetDisabledProfileSourcesJsonObject(const Json::Value& json);
+        bool _PrependSchemaDirective();
+        bool _AppendDynamicProfilesToUserSettings();
+        std::string _ApplyFirstRunChangesToSettingsTemplate(std::string_view settingsTemplate) const;
 
-    void _LayerOrCreateProfile(const Json::Value& profileJson);
-    winrt::com_ptr<winrt::TerminalApp::implementation::Profile> _FindMatchingProfile(const Json::Value& profileJson);
-    void _LayerOrCreateColorScheme(const Json::Value& schemeJson);
-    winrt::com_ptr<winrt::TerminalApp::implementation::ColorScheme> _FindMatchingColorScheme(const Json::Value& schemeJson);
-    void _ParseJsonString(std::string_view fileData, const bool isDefaultSettings);
-    static const Json::Value& _GetProfilesJsonObject(const Json::Value& json);
-    static const Json::Value& _GetDisabledProfileSourcesJsonObject(const Json::Value& json);
-    bool _PrependSchemaDirective();
-    bool _AppendDynamicProfilesToUserSettings();
-    std::string _ApplyFirstRunChangesToSettingsTemplate(std::string_view settingsTemplate) const;
+        void _ApplyDefaultsFromUserSettings();
 
-    void _ApplyDefaultsFromUserSettings();
+        void _LoadDynamicProfiles();
 
-    void _LoadDynamicProfiles();
+        static bool _IsPackaged();
+        static void _WriteSettings(const std::string_view content);
+        static std::optional<std::string> _ReadUserSettings();
+        static std::optional<std::string> _ReadFile(HANDLE hFile);
 
-    static bool _IsPackaged();
-    static void _WriteSettings(const std::string_view content);
-    static std::optional<std::string> _ReadUserSettings();
-    static std::optional<std::string> _ReadFile(HANDLE hFile);
+        std::optional<guid> _GetProfileGuidByName(const hstring) const;
+        std::optional<guid> _GetProfileGuidByIndex(std::optional<int> index) const;
+        guid _GetProfileForArgs(const winrt::TerminalApp::NewTerminalArgs& newTerminalArgs) const;
 
-    std::optional<winrt::guid> _GetProfileGuidByName(const std::wstring_view) const;
-    std::optional<winrt::guid> _GetProfileGuidByIndex(std::optional<int> index) const;
-    winrt::guid _GetProfileForArgs(const winrt::TerminalApp::NewTerminalArgs& newTerminalArgs) const;
+        void _ValidateSettings();
+        void _ValidateProfilesExist();
+        void _ValidateProfilesHaveGuid();
+        void _ValidateDefaultProfileExists();
+        void _ValidateNoDuplicateProfiles();
+        void _ResolveDefaultProfile();
+        void _ReorderProfilesToMatchUserSettingsOrder();
+        void _RemoveHiddenProfiles();
+        void _ValidateAllSchemesExist();
+        void _ValidateMediaResources();
+        void _ValidateKeybindings();
+        void _ValidateNoGlobalsKey();
 
-    void _ValidateSettings();
-    void _ValidateProfilesExist();
-    void _ValidateProfilesHaveGuid();
-    void _ValidateDefaultProfileExists();
-    void _ValidateNoDuplicateProfiles();
-    void _ResolveDefaultProfile();
-    void _ReorderProfilesToMatchUserSettingsOrder();
-    void _RemoveHiddenProfiles();
-    void _ValidateAllSchemesExist();
-    void _ValidateMediaResources();
-    void _ValidateKeybindings();
-    void _ValidateNoGlobalsKey();
+        friend class TerminalAppLocalTests::SettingsTests;
+        friend class TerminalAppLocalTests::ProfileTests;
+        friend class TerminalAppLocalTests::ColorSchemeTests;
+        friend class TerminalAppLocalTests::KeyBindingsTests;
+        friend class TerminalAppLocalTests::TabTests;
+        friend class TerminalAppUnitTests::DynamicProfileTests;
+        friend class TerminalAppUnitTests::JsonTests;
+    };
+}
 
-    friend class TerminalAppLocalTests::SettingsTests;
-    friend class TerminalAppLocalTests::ProfileTests;
-    friend class TerminalAppLocalTests::ColorSchemeTests;
-    friend class TerminalAppLocalTests::KeyBindingsTests;
-    friend class TerminalAppLocalTests::TabTests;
-    friend class TerminalAppUnitTests::DynamicProfileTests;
-    friend class TerminalAppUnitTests::JsonTests;
-};
+namespace winrt::TerminalApp::factory_implementation
+{
+    BASIC_FACTORY(CascadiaSettings);
+}

--- a/src/cascadia/TerminalApp/CascadiaSettings.h
+++ b/src/cascadia/TerminalApp/CascadiaSettings.h
@@ -60,7 +60,7 @@ namespace winrt::TerminalApp::implementation
     {
     public:
         CascadiaSettings();
-        CascadiaSettings(const bool addDynamicProfiles);
+        explicit CascadiaSettings(const bool addDynamicProfiles);
 
         static TerminalApp::CascadiaSettings LoadDefaults();
         static TerminalApp::CascadiaSettings LoadAll();

--- a/src/cascadia/TerminalApp/CascadiaSettings.h
+++ b/src/cascadia/TerminalApp/CascadiaSettings.h
@@ -71,7 +71,7 @@ namespace winrt::TerminalApp::implementation
 
         TerminalApp::GlobalAppSettings GlobalSettings();
 
-        Windows::Foundation::Collections::IVectorView<winrt::TerminalApp::Profile> Profiles() const noexcept;
+        Windows::Foundation::Collections::IObservableVector<winrt::TerminalApp::Profile> Profiles() const noexcept;
 
         TerminalApp::AppKeyBindings Keybindings() const noexcept;
 
@@ -90,7 +90,7 @@ namespace winrt::TerminalApp::implementation
 
     private:
         com_ptr<GlobalAppSettings> _globals;
-        Windows::Foundation::Collections::IVector<TerminalApp::Profile> _profiles;
+        Windows::Foundation::Collections::IObservableVector<TerminalApp::Profile> _profiles;
         std::vector<::TerminalApp::SettingsLoadWarnings> _warnings;
 
         std::vector<std::unique_ptr<::TerminalApp::IDynamicProfileGenerator>> _profileGenerators;

--- a/src/cascadia/TerminalApp/CascadiaSettings.idl
+++ b/src/cascadia/TerminalApp/CascadiaSettings.idl
@@ -19,7 +19,7 @@ namespace TerminalApp
 
         GlobalAppSettings GlobalSettings { get; };
 
-        Windows.Foundation.Collections.IVectorView<Profile> Profiles { get; };
+        Windows.Foundation.Collections.IObservableVector<Profile> Profiles { get; };
 
         AppKeyBindings Keybindings { get; };
 

--- a/src/cascadia/TerminalApp/CascadiaSettings.idl
+++ b/src/cascadia/TerminalApp/CascadiaSettings.idl
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "TerminalSettings.idl";
+import "GlobalAppSettings.idl";
+import "Profile.idl";
+
+namespace TerminalApp
+{
+    [default_interface] runtimeclass CascadiaSettings {
+        CascadiaSettings();
+        CascadiaSettings(Boolean addDynamicProfiles);
+
+        static CascadiaSettings LoadDefaults();
+        static CascadiaSettings LoadAll();
+        static CascadiaSettings LoadUniversal();
+
+        TerminalSettings BuildSettings(Guid profileGuid);
+
+        GlobalAppSettings GlobalSettings { get; };
+
+        Windows.Foundation.Collections.IVectorView<Profile> Profiles { get; };
+
+        AppKeyBindings Keybindings { get; };
+
+        Profile FindProfile(Guid profileGuid);
+        ColorScheme GetColorSchemeForProfile(Guid profileGuid);
+
+        Boolean ApplyColorScheme(Microsoft.Terminal.TerminalControl.IControlSettings settings, String schemeName);
+
+    }
+}

--- a/src/cascadia/TerminalApp/CascadiaSettings.idl
+++ b/src/cascadia/TerminalApp/CascadiaSettings.idl
@@ -1,21 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import "TerminalSettings.idl";
 import "GlobalAppSettings.idl";
 import "Profile.idl";
 
 namespace TerminalApp
 {
     [default_interface] runtimeclass CascadiaSettings {
-        CascadiaSettings();
-        CascadiaSettings(Boolean addDynamicProfiles);
-
         static CascadiaSettings LoadDefaults();
         static CascadiaSettings LoadAll();
         static CascadiaSettings LoadUniversal();
-
-        TerminalSettings BuildSettings(Guid profileGuid);
 
         GlobalAppSettings GlobalSettings { get; };
 
@@ -25,8 +19,5 @@ namespace TerminalApp
 
         Profile FindProfile(Guid profileGuid);
         ColorScheme GetColorSchemeForProfile(Guid profileGuid);
-
-        Boolean ApplyColorScheme(Microsoft.Terminal.TerminalControl.IControlSettings settings, String schemeName);
-
     }
 }

--- a/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
@@ -264,7 +264,7 @@ winrt::TerminalApp::CascadiaSettings CascadiaSettings::LoadUniversal()
     // If this throws, the app will catch it and use the default settings
     resultPtr->_ValidateSettings();
 
-    return resultPtr.as<winrt::TerminalApp::CascadiaSettings>();
+    return *resultPtr;
 }
 
 // Function Description:
@@ -620,7 +620,7 @@ void CascadiaSettings::_LayerOrCreateProfile(const Json::Value& profileJson)
             }
 
             profile->LayerJson(profileJson);
-            _profiles.Append(profile.as<winrt::TerminalApp::Profile>());
+            _profiles.Append(*profile);
         }
     }
 }

--- a/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalApp/CascadiaSettingsSerialization.cpp
@@ -19,7 +19,7 @@
 // "Generated Files" directory.
 
 using namespace ::TerminalApp;
-using namespace winrt::TerminalApp;
+using namespace winrt::TerminalApp::implementation;
 using namespace ::Microsoft::Console;
 
 static constexpr std::wstring_view SettingsFilename{ L"settings.json" };
@@ -101,9 +101,10 @@ static void _CatchRethrowSerializationExceptionWithLocationInfo(std::string_view
 //   profiles inserted into their list of profiles.
 // Return Value:
 // - a unique_ptr containing a new CascadiaSettings object.
-std::unique_ptr<CascadiaSettings> CascadiaSettings::LoadAll()
+winrt::TerminalApp::CascadiaSettings CascadiaSettings::LoadAll()
 {
-    auto resultPtr = LoadDefaults();
+    auto settings = LoadDefaults();
+    auto resultPtr = winrt::get_self<CascadiaSettings>(settings);
 
     // GH 3588, we need this below to know if the user chose something that wasn't our default.
     // Collect it up here in case it gets modified by any of the other layers between now and when
@@ -218,7 +219,7 @@ std::unique_ptr<CascadiaSettings> CascadiaSettings::LoadAll()
 
             // Run it through the object so we can parse it apart and then only serialize the fields we're interested in
             // and avoid extraneous data.
-            auto akb = winrt::make_self<implementation::AppKeyBindings>();
+            auto akb = winrt::make_self<AppKeyBindings>();
             akb->LayerJson(userKeybindings);
             auto value = akb->ToJson();
 
@@ -240,7 +241,7 @@ std::unique_ptr<CascadiaSettings> CascadiaSettings::LoadAll()
         }
     }
 
-    return resultPtr;
+    return *resultPtr;
 }
 
 // Function Description:
@@ -249,13 +250,13 @@ std::unique_ptr<CascadiaSettings> CascadiaSettings::LoadAll()
 // - <none>
 // Return Value:
 // - a unique_ptr to a CascadiaSettings with the connection types and settings for Universal terminal
-std::unique_ptr<CascadiaSettings> CascadiaSettings::LoadUniversal()
+winrt::TerminalApp::CascadiaSettings CascadiaSettings::LoadUniversal()
 {
     // We're going to do this ourselves because we want to exclude almost everything
     // from the special Universal-for-developers configuration
 
     // Create settings and get the universal defaults loaded up.
-    auto resultPtr = std::make_unique<CascadiaSettings>();
+    auto resultPtr = winrt::make_self<CascadiaSettings>();
     resultPtr->_ParseJsonString(DefaultUniversalJson, true);
     resultPtr->LayerJson(resultPtr->_defaultSettings);
 
@@ -263,7 +264,7 @@ std::unique_ptr<CascadiaSettings> CascadiaSettings::LoadUniversal()
     // If this throws, the app will catch it and use the default settings
     resultPtr->_ValidateSettings();
 
-    return resultPtr;
+    return resultPtr.as<winrt::TerminalApp::CascadiaSettings>();
 }
 
 // Function Description:
@@ -273,9 +274,9 @@ std::unique_ptr<CascadiaSettings> CascadiaSettings::LoadUniversal()
 // - <none>
 // Return Value:
 // - a unique_ptr to a CascadiaSettings with the settings from defaults.json
-std::unique_ptr<CascadiaSettings> CascadiaSettings::LoadDefaults()
+winrt::TerminalApp::CascadiaSettings CascadiaSettings::LoadDefaults()
 {
-    auto resultPtr = std::make_unique<CascadiaSettings>();
+    auto resultPtr = winrt::make_self<CascadiaSettings>();
 
     // We already have the defaults in memory, because we stamp them into a
     // header as part of the build process. We don't need to bother with reading
@@ -284,7 +285,7 @@ std::unique_ptr<CascadiaSettings> CascadiaSettings::LoadDefaults()
     resultPtr->LayerJson(resultPtr->_defaultSettings);
     resultPtr->_ResolveDefaultProfile();
 
-    return resultPtr;
+    return *resultPtr;
 }
 
 // Method Description:
@@ -329,7 +330,7 @@ void CascadiaSettings::_LoadDynamicProfiles()
                     // we'll synthesize a GUID for it in _ValidateProfilesHaveGuid
                     profile.Source(generatorNamespace);
 
-                    _profiles.emplace_back(profile);
+                    _profiles.Append(profile);
                 }
             }
             CATCH_LOG_MSG("Dynamic Profile Namespace: \"%ls\"", generatorNamespace.data());
@@ -607,9 +608,9 @@ void CascadiaSettings::_LayerOrCreateProfile(const Json::Value& profileJson)
         // If this JSON represents a dynamic profile, we _shouldn't_ create the
         // profile here. We only want to create profiles for profiles without a
         // `source`. Dynamic profiles _must_ be layered on an existing profile.
-        if (!implementation::Profile::IsDynamicProfileObject(profileJson))
+        if (!Profile::IsDynamicProfileObject(profileJson))
         {
-            auto profile = winrt::make_self<implementation::Profile>();
+            auto profile = winrt::make_self<Profile>();
 
             // GH#2325: If we have a set of default profile settings, apply them here.
             // We _won't_ have these settings yet for defaults, dynamic profiles.
@@ -619,7 +620,7 @@ void CascadiaSettings::_LayerOrCreateProfile(const Json::Value& profileJson)
             }
 
             profile->LayerJson(profileJson);
-            _profiles.emplace_back(*profile);
+            _profiles.Append(profile.as<winrt::TerminalApp::Profile>());
         }
     }
 }
@@ -635,11 +636,11 @@ void CascadiaSettings::_LayerOrCreateProfile(const Json::Value& profileJson)
 // Return Value:
 // - a Profile that can be layered with the given json object, iff such a
 //   profile exists.
-winrt::com_ptr<implementation::Profile> CascadiaSettings::_FindMatchingProfile(const Json::Value& profileJson)
+winrt::com_ptr<Profile> CascadiaSettings::_FindMatchingProfile(const Json::Value& profileJson)
 {
-    for (auto& profile : _profiles)
+    for (auto profile : _profiles)
     {
-        auto profileImpl = winrt::get_self<winrt::TerminalApp::implementation::Profile>(profile);
+        auto profileImpl = winrt::get_self<Profile>(profile);
         if (profileImpl->ShouldBeLayered(profileJson))
         {
             return profileImpl->get_strong();
@@ -682,9 +683,9 @@ void CascadiaSettings::_ApplyDefaultsFromUserSettings()
         // hyper-explode, so just don't let them do that.
         _userDefaultProfileSettings.removeMember({ "guid" });
 
-        for (auto& profile : _profiles)
+        for (auto profile : _profiles)
         {
-            auto profileImpl = winrt::get_self<implementation::Profile>(profile);
+            auto profileImpl = winrt::get_self<Profile>(profile);
             profileImpl->LayerJson(_userDefaultProfileSettings);
         }
     }
@@ -708,7 +709,7 @@ void CascadiaSettings::_LayerOrCreateColorScheme(const Json::Value& schemeJson)
     }
     else
     {
-        const auto scheme = implementation::ColorScheme::FromJson(schemeJson);
+        const auto scheme = ColorScheme::FromJson(schemeJson);
         _globals->AddColorScheme(*scheme);
     }
 }
@@ -724,13 +725,13 @@ void CascadiaSettings::_LayerOrCreateColorScheme(const Json::Value& schemeJson)
 // Return Value:
 // - a ColorScheme that can be layered with the given json object, iff such a
 //   color scheme exists.
-winrt::com_ptr<implementation::ColorScheme> CascadiaSettings::_FindMatchingColorScheme(const Json::Value& schemeJson)
+winrt::com_ptr<ColorScheme> CascadiaSettings::_FindMatchingColorScheme(const Json::Value& schemeJson)
 {
-    if (auto schemeName = implementation::ColorScheme::GetNameFromJson(schemeJson))
+    if (auto schemeName = ColorScheme::GetNameFromJson(schemeJson))
     {
         if (auto scheme{ _globals->GetColorSchemes().TryLookup(*schemeName) })
         {
-            return winrt::get_self<implementation::ColorScheme>(scheme)->get_strong();
+            return winrt::get_self<ColorScheme>(scheme)->get_strong();
         }
     }
     return nullptr;

--- a/src/cascadia/TerminalApp/Command.cpp
+++ b/src/cascadia/TerminalApp/Command.cpp
@@ -353,7 +353,7 @@ namespace winrt::TerminalApp::implementation
     // Return Value:
     // - <none>
     void Command::ExpandCommands(Windows::Foundation::Collections::IMap<winrt::hstring, winrt::TerminalApp::Command>& commands,
-                                 gsl::span<const winrt::TerminalApp::Profile> profiles,
+                                 Windows::Foundation::Collections::IVectorView<winrt::TerminalApp::Profile> profiles,
                                  gsl::span<winrt::TerminalApp::ColorScheme> schemes,
                                  std::vector<::TerminalApp::SettingsLoadWarnings>& warnings)
     {
@@ -409,7 +409,7 @@ namespace winrt::TerminalApp::implementation
     // - and empty vector if the command wasn't expandable, otherwise a list of
     //   the newly-created commands.
     std::vector<winrt::TerminalApp::Command> Command::_expandCommand(Command* const expandable,
-                                                                     gsl::span<const winrt::TerminalApp::Profile> profiles,
+                                                                     Windows::Foundation::Collections::IVectorView<winrt::TerminalApp::Profile> profiles,
                                                                      gsl::span<winrt::TerminalApp::ColorScheme> schemes,
                                                                      std::vector<::TerminalApp::SettingsLoadWarnings>& warnings)
     {

--- a/src/cascadia/TerminalApp/Command.h
+++ b/src/cascadia/TerminalApp/Command.h
@@ -41,7 +41,7 @@ namespace winrt::TerminalApp::implementation
                                                 std::vector<::TerminalApp::SettingsLoadWarnings>& warnings);
 
         static void ExpandCommands(Windows::Foundation::Collections::IMap<winrt::hstring, winrt::TerminalApp::Command>& commands,
-                                   gsl::span<const winrt::TerminalApp::Profile> profiles,
+                                   Windows::Foundation::Collections::IVectorView<winrt::TerminalApp::Profile> profiles,
                                    gsl::span<winrt::TerminalApp::ColorScheme> schemes,
                                    std::vector<::TerminalApp::SettingsLoadWarnings>& warnings);
 
@@ -69,7 +69,7 @@ namespace winrt::TerminalApp::implementation
         winrt::hstring _lastIconPath{};
 
         static std::vector<winrt::TerminalApp::Command> _expandCommand(Command* const expandable,
-                                                                       gsl::span<const winrt::TerminalApp::Profile> profiles,
+                                                                       Windows::Foundation::Collections::IVectorView<winrt::TerminalApp::Profile> profiles,
                                                                        gsl::span<winrt::TerminalApp::ColorScheme> schemes,
                                                                        std::vector<::TerminalApp::SettingsLoadWarnings>& warnings);
         friend class TerminalAppLocalTests::SettingsTests;

--- a/src/cascadia/TerminalApp/Jumplist.cpp
+++ b/src/cascadia/TerminalApp/Jumplist.cpp
@@ -83,7 +83,7 @@ static std::wstring_view _getExePath()
 // - settings - The settings object to update the jumplist with.
 // Return Value:
 // - <none>
-HRESULT Jumplist::UpdateJumplist(const TerminalApp::CascadiaSettings& settings) noexcept
+HRESULT Jumplist::UpdateJumplist(const CascadiaSettings& settings) noexcept
 {
     try
     {
@@ -99,7 +99,7 @@ HRESULT Jumplist::UpdateJumplist(const TerminalApp::CascadiaSettings& settings) 
         RETURN_IF_FAILED(jumplistItems->Clear());
 
         // Update the list of profiles.
-        RETURN_IF_FAILED(_updateProfiles(jumplistItems.get(), settings.GetProfiles()));
+        RETURN_IF_FAILED(_updateProfiles(jumplistItems.get(), settings.Profiles().GetView()));
 
         // TODO GH#1571: Add items from the future customizable new tab dropdown as well.
         // This could either replace the default profiles, or be added alongside them.
@@ -123,7 +123,7 @@ HRESULT Jumplist::UpdateJumplist(const TerminalApp::CascadiaSettings& settings) 
 // - profiles - The profiles to add to the jumplist
 // Return Value:
 // - S_OK or HRESULT failure code.
-[[nodiscard]] HRESULT Jumplist::_updateProfiles(IObjectCollection* jumplistItems, const gsl::span<const Profile>& profiles) noexcept
+[[nodiscard]] HRESULT Jumplist::_updateProfiles(IObjectCollection* jumplistItems, winrt::Windows::Foundation::Collections::IVectorView<winrt::TerminalApp::Profile> profiles) noexcept
 {
     try
     {

--- a/src/cascadia/TerminalApp/Jumplist.h
+++ b/src/cascadia/TerminalApp/Jumplist.h
@@ -13,7 +13,6 @@
 #pragma once
 
 #include "CascadiaSettings.h"
-#include "Profile.h"
 
 struct IObjectCollection;
 struct IShellLinkW;
@@ -21,9 +20,9 @@ struct IShellLinkW;
 class Jumplist
 {
 public:
-    static HRESULT UpdateJumplist(const TerminalApp::CascadiaSettings& settings) noexcept;
+    static HRESULT UpdateJumplist(const winrt::TerminalApp::CascadiaSettings& settings) noexcept;
 
 private:
-    [[nodiscard]] static HRESULT _updateProfiles(IObjectCollection* jumplistItems, const gsl::span<const winrt::TerminalApp::Profile>& profiles) noexcept;
+    [[nodiscard]] static HRESULT _updateProfiles(IObjectCollection* jumplistItems, winrt::Windows::Foundation::Collections::IVectorView<winrt::TerminalApp::Profile> profiles) noexcept;
     [[nodiscard]] static HRESULT _createShellLink(const std::wstring_view name, const std::wstring_view path, const std::wstring_view args, IShellLinkW** shLink) noexcept;
 };

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -4,7 +4,7 @@
 #include "pch.h"
 #include "Pane.h"
 #include "Profile.h"
-#include "CascadiaSettings.h"
+#include "AppLogic.h"
 
 using namespace winrt::Windows::Foundation;
 using namespace winrt::Windows::Graphics::Display;
@@ -319,7 +319,9 @@ void Pane::_ControlConnectionStateChangedHandler(const TermControl& /*sender*/, 
         return;
     }
 
-    const auto& settings = CascadiaSettings::GetCurrentAppSettings();
+    const auto appLogic{ winrt::TerminalApp::implementation::AppLogic::Current() };
+    THROW_HR_IF_NULL(E_INVALIDARG, appLogic);
+    auto settings = appLogic->GetSettings();
     auto paneProfile = settings.FindProfile(_profile.value());
     if (paneProfile)
     {

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -319,9 +319,7 @@ void Pane::_ControlConnectionStateChangedHandler(const TermControl& /*sender*/, 
         return;
     }
 
-    const auto appLogic{ winrt::TerminalApp::implementation::AppLogic::Current() };
-    THROW_HR_IF_NULL(E_INVALIDARG, appLogic);
-    auto settings = appLogic->GetSettings();
+    const auto settings{ winrt::TerminalApp::implementation::AppLogic::CurrentAppSettings() };
     auto paneProfile = settings.FindProfile(_profile.value());
     if (paneProfile)
     {

--- a/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
@@ -114,7 +114,9 @@
     <ClInclude Include="Profile.h">
       <DependentUpon>Profile.idl</DependentUpon>
     </ClInclude>
-    <ClInclude Include="CascadiaSettings.h" />
+    <ClInclude Include="CascadiaSettings.h">
+      <DependentUpon>CascadiaSettings.idl</DependentUpon>
+    </ClInclude>
     <ClInclude Include="KeyChordSerialization.h" />
     <ClInclude Include="JsonUtils.h" />
     <ClInclude Include="Utils.h" />
@@ -198,8 +200,12 @@
     <ClCompile Include="Profile.cpp">
       <DependentUpon>Profile.idl</DependentUpon>
     </ClCompile>
-    <ClCompile Include="CascadiaSettings.cpp" />
-    <ClCompile Include="CascadiaSettingsSerialization.cpp" />
+    <ClCompile Include="CascadiaSettings.cpp">
+      <DependentUpon>CascadiaSettings.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="CascadiaSettingsSerialization.cpp">
+      <DependentUpon>CascadiaSettings.idl</DependentUpon>
+    </ClCompile>
     <ClCompile Include="AppKeyBindingsSerialization.cpp" />
     <ClCompile Include="KeyChordSerialization.cpp" />
     <ClCompile Include="DefaultProfileUtils.cpp" />
@@ -288,6 +294,7 @@
     <Midl Include="ColorScheme.idl" />
     <Midl Include="Profile.idl" />
     <Midl Include="GlobalAppSettings.idl" />
+    <Midl Include="CascadiaSettings.idl" />
   </ItemGroup>
   <!-- ========================= Misc Files ======================== -->
   <ItemGroup>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -101,8 +101,7 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
-    winrt::fire_and_forget TerminalPage::SetSettings(winrt::com_ptr<CascadiaSettings> settings,
-                                                     bool needRefreshUI)
+    winrt::fire_and_forget TerminalPage::SetSettings(TerminalApp::CascadiaSettings settings, bool needRefreshUI)
     {
         _settings = settings;
         if (needRefreshUI)
@@ -115,14 +114,14 @@ namespace winrt::TerminalApp::implementation
         if (auto page{ weakThis.get() })
         {
             _UpdateCommandsForPalette();
-            CommandPalette().SetKeyBindings(_settings->Keybindings());
+            CommandPalette().SetKeyBindings(_settings.Keybindings());
         }
     }
 
     void TerminalPage::Create()
     {
         // Hookup the key bindings
-        _HookupKeyBindings(_settings->Keybindings());
+        _HookupKeyBindings(_settings.Keybindings());
 
         _tabContent = this->TabContent();
         _tabRow = this->TabRow();
@@ -178,7 +177,7 @@ namespace winrt::TerminalApp::implementation
         auto tabRowImpl = winrt::get_self<implementation::TabRowControl>(_tabRow);
         _newTabButton = tabRowImpl->NewTabButton();
 
-        if (_settings->GlobalSettings().ShowTabsInTitlebar())
+        if (_settings.GlobalSettings().ShowTabsInTitlebar())
         {
             // Remove the TabView from the page. We'll hang on to it, we need to
             // put it in the titlebar.
@@ -207,7 +206,7 @@ namespace winrt::TerminalApp::implementation
                                         WI_IsFlagSet(rAltState, CoreVirtualKeyStates::Down);
 
                 // Check for DebugTap
-                bool debugTap = page->_settings->GlobalSettings().DebugFeaturesEnabled() &&
+                bool debugTap = page->_settings.GlobalSettings().DebugFeaturesEnabled() &&
                                 WI_IsFlagSet(lAltState, CoreVirtualKeyStates::Down) &&
                                 WI_IsFlagSet(rAltState, CoreVirtualKeyStates::Down);
 
@@ -449,14 +448,14 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_CreateNewTabFlyout()
     {
         auto newTabFlyout = WUX::Controls::MenuFlyout{};
-        auto keyBindings = _settings->Keybindings();
+        auto keyBindings = _settings.Keybindings();
 
-        const winrt::guid defaultProfileGuid = _settings->GlobalSettings().DefaultProfile();
+        const auto defaultProfileGuid = _settings.GlobalSettings().DefaultProfile();
         // the number of profiles should not change in the loop for this to work
-        auto const profileCount = gsl::narrow_cast<int>(_settings->Profiles().Size());
+        auto const profileCount = gsl::narrow_cast<int>(_settings.Profiles().Size());
         for (int profileIndex = 0; profileIndex < profileCount; profileIndex++)
         {
-            const auto& profile = _settings->Profiles().GetAt(profileIndex);
+            const auto profile = _settings.Profiles().GetAt(profileIndex);
             auto profileMenuItem = WUX::Controls::MenuFlyoutItem{};
 
             // Add the keyboard shortcuts based on the number of profiles defined
@@ -512,7 +511,7 @@ namespace winrt::TerminalApp::implementation
                                             WI_IsFlagSet(rAltState, CoreVirtualKeyStates::Down);
 
                     // Check for DebugTap
-                    bool debugTap = page->_settings->GlobalSettings().DebugFeaturesEnabled() &&
+                    bool debugTap = page->_settings.GlobalSettings().DebugFeaturesEnabled() &&
                                     WI_IsFlagSet(lAltState, CoreVirtualKeyStates::Down) &&
                                     WI_IsFlagSet(rAltState, CoreVirtualKeyStates::Down);
 
@@ -617,7 +616,8 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_OpenNewTab(const winrt::TerminalApp::NewTerminalArgs& newTerminalArgs)
     try
     {
-        const auto [profileGuid, settings] = _settings.as<CascadiaSettings>()->BuildSettings(newTerminalArgs);
+        const auto settingsImpl{ winrt::get_self<implementation::CascadiaSettings>(_settings) };
+        const auto [profileGuid, settings] = settingsImpl->BuildSettings(newTerminalArgs);
 
         _CreateNewTabFromSettings(profileGuid, settings);
 
@@ -627,7 +627,7 @@ namespace winrt::TerminalApp::implementation
                                         newTerminalArgs.Profile().empty());
 
         // Lookup the name of the color scheme used by this profile.
-        const auto scheme = _settings->GetColorSchemeForProfile(profileGuid);
+        const auto scheme = _settings.GetColorSchemeForProfile(profileGuid);
         // If they explicitly specified `null` as the scheme (indicating _no_ scheme), log
         // that as the empty string.
         const auto schemeName = scheme ? scheme.Name() : L"\0";
@@ -669,7 +669,7 @@ namespace winrt::TerminalApp::implementation
         auto connection = _CreateConnectionFromSettings(profileGuid, settings);
 
         TerminalConnection::ITerminalConnection debugConnection{ nullptr };
-        if (_settings->GlobalSettings().DebugFeaturesEnabled())
+        if (_settings.GlobalSettings().DebugFeaturesEnabled())
         {
             const CoreWindow window = CoreWindow::GetForCurrentThread();
             const auto rAltState = window.GetKeyState(VirtualKey::RightMenu);
@@ -725,7 +725,7 @@ namespace winrt::TerminalApp::implementation
         }
 
         // Set this tab's icon to the icon from the user's profile
-        const auto profile = _settings->FindProfile(profileGuid);
+        const auto profile = _settings.FindProfile(profileGuid);
         if (profile != nullptr && !profile.IconPath().empty())
         {
             newTabImpl->UpdateIcon(profile.GetExpandedIconPath());
@@ -764,7 +764,7 @@ namespace winrt::TerminalApp::implementation
     TerminalConnection::ITerminalConnection TerminalPage::_CreateConnectionFromSettings(GUID profileGuid,
                                                                                         TerminalApp::TerminalSettings settings)
     {
-        const auto profile = _settings->FindProfile(profileGuid);
+        const auto profile = _settings.FindProfile(profileGuid);
 
         TerminalConnection::ITerminalConnection connection{ nullptr };
 
@@ -948,7 +948,7 @@ namespace winrt::TerminalApp::implementation
     {
         auto newTabTitle = tab.GetActiveTitle();
 
-        if (_settings->GlobalSettings().ShowTitleInTitlebar() &&
+        if (_settings.GlobalSettings().ShowTitleInTitlebar() &&
             tab.IsFocused())
         {
             _titleChangeHandlers(*this, newTabTitle);
@@ -966,7 +966,7 @@ namespace winrt::TerminalApp::implementation
         if (lastFocusedProfileOpt.has_value())
         {
             const auto lastFocusedProfile = lastFocusedProfileOpt.value();
-            const auto matchingProfile = _settings->FindProfile(lastFocusedProfile);
+            const auto matchingProfile = _settings.FindProfile(lastFocusedProfile);
             if (matchingProfile)
             {
                 tab.UpdateIcon(matchingProfile.GetExpandedIconPath());
@@ -982,7 +982,7 @@ namespace winrt::TerminalApp::implementation
     // - Handle changes to the tab width set by the user
     void TerminalPage::_UpdateTabWidthMode()
     {
-        _tabView.TabWidthMode(_settings->GlobalSettings().TabWidthMode());
+        _tabView.TabWidthMode(_settings.GlobalSettings().TabWidthMode());
     }
 
     // Method Description:
@@ -993,9 +993,9 @@ namespace winrt::TerminalApp::implementation
         // Show tabs when there's more than 1, or the user has chosen to always
         // show the tab bar.
         const bool isVisible = (!_isFullscreen && !_isInFocusMode) &&
-                               (_settings->GlobalSettings().ShowTabsInTitlebar() ||
+                               (_settings.GlobalSettings().ShowTabsInTitlebar() ||
                                 (_tabs.Size() > 1) ||
-                                _settings->GlobalSettings().AlwaysShowTabs());
+                                _settings.GlobalSettings().AlwaysShowTabs());
 
         // collapse/show the tabs themselves
         _tabView.Visibility(isVisible ? Visibility::Visible : Visibility::Collapsed);
@@ -1030,7 +1030,8 @@ namespace winrt::TerminalApp::implementation
                 const auto& profileGuid = focusedTab->GetFocusedProfile();
                 if (profileGuid.has_value())
                 {
-                    const auto settings = _settings->BuildSettings(profileGuid.value());
+                    const auto settingsImpl{ winrt::get_self<implementation::CascadiaSettings>(_settings) };
+                    const auto settings = settingsImpl->BuildSettings(profileGuid.value());
                     _CreateNewTabFromSettings(profileGuid.value(), settings);
                 }
             }
@@ -1199,7 +1200,7 @@ namespace winrt::TerminalApp::implementation
             // leftward from 0 to tabCount - 1.
             const auto newTabIndex = ((tabCount + *index + (bMoveRight ? 1 : -1)) % tabCount);
 
-            if (_settings->GlobalSettings().UseTabSwitcher())
+            if (_settings.GlobalSettings().UseTabSwitcher())
             {
                 if (CommandPalette().Visibility() == Visibility::Visible)
                 {
@@ -1387,7 +1388,7 @@ namespace winrt::TerminalApp::implementation
     //   than one tab opened, show a warning dialog.
     void TerminalPage::CloseWindow()
     {
-        if (_tabs.Size() > 1 && _settings->GlobalSettings().ConfirmCloseAllTabs())
+        if (_tabs.Size() > 1 && _settings.GlobalSettings().ConfirmCloseAllTabs())
         {
             _ShowCloseWarningDialog();
         }
@@ -1465,7 +1466,8 @@ namespace winrt::TerminalApp::implementation
                 if (current_guid)
                 {
                     profileFound = true;
-                    controlSettings = _settings->BuildSettings(current_guid.value());
+                    const auto settingsImpl{ winrt::get_self<implementation::CascadiaSettings>(_settings) };
+                    controlSettings = settingsImpl->BuildSettings(current_guid.value());
                     realGuid = current_guid.value();
                 }
                 // TODO: GH#5047 - In the future, we should get the Profile of
@@ -1483,7 +1485,8 @@ namespace winrt::TerminalApp::implementation
             }
             if (!profileFound)
             {
-                std::tie(realGuid, controlSettings) = _settings.as<CascadiaSettings>()->BuildSettings(newTerminalArgs);
+                const auto settingsImpl{ winrt::get_self<implementation::CascadiaSettings>(_settings) };
+                std::tie(realGuid, controlSettings) = settingsImpl->BuildSettings(newTerminalArgs);
             }
 
             const auto controlConnection = _CreateConnectionFromSettings(realGuid, controlSettings);
@@ -1567,7 +1570,7 @@ namespace winrt::TerminalApp::implementation
     // - the title of the focused control if there is one, else "Windows Terminal"
     hstring TerminalPage::Title()
     {
-        if (_settings->GlobalSettings().ShowTitleInTitlebar())
+        if (_settings.GlobalSettings().ShowTitleInTitlebar())
         {
             auto selectedIndex = _tabView.SelectedIndex();
             if (selectedIndex >= 0)
@@ -1662,7 +1665,7 @@ namespace winrt::TerminalApp::implementation
     // - See Pane::CalcSnappedDimension
     float TerminalPage::CalcSnappedDimension(const bool widthOrHeight, const float dimension) const
     {
-        if (_settings->GlobalSettings().SnapToGridOnResize())
+        if (_settings.GlobalSettings().SnapToGridOnResize())
         {
             if (auto index{ _GetFocusedTabIndex() })
             {
@@ -1690,7 +1693,7 @@ namespace winrt::TerminalApp::implementation
         //   iff it is set
         bool useGlobal = copiedData.Formats() == nullptr;
         auto copyFormats = useGlobal ?
-                               _settings->GlobalSettings().CopyFormatting() :
+                               _settings.GlobalSettings().CopyFormatting() :
                                copiedData.Formats().Value();
 
         // copy text to dataPack
@@ -1764,11 +1767,11 @@ namespace winrt::TerminalApp::implementation
             }
 
             const bool hasNewLine = std::find(text.cbegin(), text.cend(), L'\n') != text.cend();
-            const bool warnMultiLine = hasNewLine && _settings->GlobalSettings().WarnAboutMultiLinePaste();
+            const bool warnMultiLine = hasNewLine && _settings.GlobalSettings().WarnAboutMultiLinePaste();
 
             constexpr const std::size_t minimumSizeForWarning = 1024 * 5; // 5 KiB
             const bool warnLargeText = text.size() > minimumSizeForWarning &&
-                                       _settings->GlobalSettings().WarnAboutLargePaste();
+                                       _settings.GlobalSettings().WarnAboutLargePaste();
 
             if (warnMultiLine || warnLargeText)
             {
@@ -2013,11 +2016,11 @@ namespace winrt::TerminalApp::implementation
     {
         // Re-wire the keybindings to their handlers, as we'll have created a
         // new AppKeyBindings object.
-        _HookupKeyBindings(_settings->Keybindings());
+        _HookupKeyBindings(_settings.Keybindings());
 
         // Refresh UI elements
-        auto profiles = _settings->Profiles();
-        for (auto profile : profiles)
+        auto profiles = _settings.Profiles();
+        for (const auto& profile : profiles)
         {
             const auto profileGuid = profile.Guid();
 
@@ -2025,7 +2028,8 @@ namespace winrt::TerminalApp::implementation
             {
                 // BuildSettings can throw an exception if the profileGuid does
                 // not belong to an actual profile in the list of profiles.
-                const auto settings = _settings->BuildSettings(profileGuid);
+                const auto settingsImpl{ winrt::get_self<implementation::CascadiaSettings>(_settings) };
+                const auto settings = settingsImpl->BuildSettings(profileGuid);
 
                 for (auto tab : _tabs)
                 {
@@ -2065,7 +2069,7 @@ namespace winrt::TerminalApp::implementation
         // Reload the current value of alwaysOnTop from the settings file. This
         // will let the user hot-reload this setting, but any runtime changes to
         // the alwaysOnTop setting will be lost.
-        _isAlwaysOnTop = _settings->GlobalSettings().AlwaysOnTop();
+        _isAlwaysOnTop = _settings.GlobalSettings().AlwaysOnTop();
         _alwaysOnTopChangedHandlers(*this, nullptr);
     }
 
@@ -2123,11 +2127,11 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     void TerminalPage::_UpdateCommandsForPalette()
     {
-        IMap<winrt::hstring, winrt::TerminalApp::Command> copyOfCommands = _ExpandCommands(_settings->GlobalSettings().GetCommands(),
-                                                                                           _settings->Profiles().GetView(),
-                                                                                           _settings->GlobalSettings().GetColorSchemes());
+        IMap<winrt::hstring, winrt::TerminalApp::Command> copyOfCommands = _ExpandCommands(_settings.GlobalSettings().GetCommands(),
+                                                                                           _settings.Profiles().GetView(),
+                                                                                           _settings.GlobalSettings().GetColorSchemes());
 
-        _recursiveUpdateCommandKeybindingLabels(_settings.as<TerminalApp::CascadiaSettings>(), copyOfCommands.GetView());
+        _recursiveUpdateCommandKeybindingLabels(_settings, copyOfCommands.GetView());
         _recursiveUpdateCommandIcons(copyOfCommands.GetView());
 
         // Update the command palette when settings reload

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2124,7 +2124,7 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_UpdateCommandsForPalette()
     {
         IMap<winrt::hstring, winrt::TerminalApp::Command> copyOfCommands = _ExpandCommands(_settings->GlobalSettings().GetCommands(),
-                                                                                           _settings->Profiles(),
+                                                                                           _settings->Profiles().GetView(),
                                                                                            _settings->GlobalSettings().GetColorSchemes());
 
         _recursiveUpdateCommandKeybindingLabels(_settings.as<TerminalApp::CascadiaSettings>(), copyOfCommands.GetView());

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -33,7 +33,7 @@ namespace winrt::TerminalApp::implementation
     public:
         TerminalPage();
 
-        winrt::fire_and_forget SetSettings(std::shared_ptr<::TerminalApp::CascadiaSettings> settings, bool needRefreshUI);
+        winrt::fire_and_forget SetSettings(com_ptr<CascadiaSettings> settings, bool needRefreshUI);
 
         void Create();
 
@@ -86,7 +86,7 @@ namespace winrt::TerminalApp::implementation
         Windows::UI::Xaml::Controls::Grid _tabContent{ nullptr };
         Microsoft::UI::Xaml::Controls::SplitButton _newTabButton{ nullptr };
 
-        std::shared_ptr<::TerminalApp::CascadiaSettings> _settings{ nullptr };
+        com_ptr<CascadiaSettings> _settings{ nullptr };
 
         Windows::Foundation::Collections::IObservableVector<TerminalApp::Tab> _tabs;
         winrt::com_ptr<Tab> _GetStrongTabImpl(const uint32_t index) const;
@@ -137,7 +137,7 @@ namespace winrt::TerminalApp::implementation
         void _UpdateTabWidthMode();
         void _UpdateCommandsForPalette();
         static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, winrt::TerminalApp::Command> _ExpandCommands(Windows::Foundation::Collections::IMapView<winrt::hstring, winrt::TerminalApp::Command> commandsToExpand,
-                                                                                                                          gsl::span<const winrt::TerminalApp::Profile> profiles,
+                                                                                                                          Windows::Foundation::Collections::IVectorView<winrt::TerminalApp::Profile> profiles,
                                                                                                                           Windows::Foundation::Collections::IMapView<winrt::hstring, winrt::TerminalApp::ColorScheme> schemes);
 
         void _DuplicateTabViewItem();

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -33,7 +33,7 @@ namespace winrt::TerminalApp::implementation
     public:
         TerminalPage();
 
-        winrt::fire_and_forget SetSettings(com_ptr<CascadiaSettings> settings, bool needRefreshUI);
+        winrt::fire_and_forget SetSettings(TerminalApp::CascadiaSettings settings, bool needRefreshUI);
 
         void Create();
 
@@ -86,7 +86,7 @@ namespace winrt::TerminalApp::implementation
         Windows::UI::Xaml::Controls::Grid _tabContent{ nullptr };
         Microsoft::UI::Xaml::Controls::SplitButton _newTabButton{ nullptr };
 
-        com_ptr<CascadiaSettings> _settings{ nullptr };
+        TerminalApp::CascadiaSettings _settings{ nullptr };
 
         Windows::Foundation::Collections::IObservableVector<TerminalApp::Tab> _tabs;
         winrt::com_ptr<Tab> _GetStrongTabImpl(const uint32_t index) const;

--- a/src/cascadia/ut_app/DynamicProfileTests.cpp
+++ b/src/cascadia/ut_app/DynamicProfileTests.cpp
@@ -95,18 +95,18 @@ namespace TerminalAppUnitTests
             return profiles;
         };
 
-        CascadiaSettings settings{ false };
-        settings._profileGenerators.emplace_back(std::move(gen0));
-        settings._profileGenerators.emplace_back(std::move(gen1));
+        auto settings = winrt::make_self<implementation::CascadiaSettings>(false);
+        settings->_profileGenerators.emplace_back(std::move(gen0));
+        settings->_profileGenerators.emplace_back(std::move(gen1));
 
-        settings._LoadDynamicProfiles();
-        VERIFY_ARE_EQUAL(2u, settings._profiles.size());
+        settings->_LoadDynamicProfiles();
+        VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
 
-        VERIFY_ARE_EQUAL(L"profile0", settings._profiles.at(0).Name());
-        VERIFY_IS_FALSE(settings._profiles.at(0).HasGuid());
+        VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(0).Name());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(0).HasGuid());
 
-        VERIFY_ARE_EQUAL(L"profile1", settings._profiles.at(1).Name());
-        VERIFY_IS_FALSE(settings._profiles.at(1).HasGuid());
+        VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(1).Name());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(1).HasGuid());
     }
 
     void DynamicProfileTests::TestGenGuidsForProfiles()
@@ -135,59 +135,59 @@ namespace TerminalAppUnitTests
             return profiles;
         };
 
-        CascadiaSettings settings{ false };
-        settings._profileGenerators.emplace_back(std::move(gen0));
-        settings._profileGenerators.emplace_back(std::move(gen1));
+        auto settings = winrt::make_self<implementation::CascadiaSettings>(false);
+        settings->_profileGenerators.emplace_back(std::move(gen0));
+        settings->_profileGenerators.emplace_back(std::move(gen1));
 
         Profile p0, p1;
-        p0.Name(L"profile0"); // this is _profiles.at(0)
-        p1.Name(L"profile1"); // this is _profiles.at(1)
-        settings._profiles.push_back(p0);
-        settings._profiles.push_back(p1);
+        p0.Name(L"profile0"); // this is _profiles.GetAt(0)
+        p1.Name(L"profile1"); // this is _profiles.GetAt(1)
+        settings->_profiles.Append(p0);
+        settings->_profiles.Append(p1);
 
-        settings._LoadDynamicProfiles();
-        VERIFY_ARE_EQUAL(5u, settings._profiles.size());
+        settings->_LoadDynamicProfiles();
+        VERIFY_ARE_EQUAL(5u, settings->_profiles.Size());
 
-        VERIFY_ARE_EQUAL(L"profile0", settings._profiles.at(0).Name());
-        VERIFY_IS_FALSE(settings._profiles.at(0).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(0).Source().empty());
+        VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(0).Name());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).Source().empty());
 
-        VERIFY_ARE_EQUAL(L"profile1", settings._profiles.at(1).Name());
-        VERIFY_IS_FALSE(settings._profiles.at(1).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(1).Source().empty());
+        VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(1).Name());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).Source().empty());
 
-        VERIFY_ARE_EQUAL(L"profile0", settings._profiles.at(2).Name());
-        VERIFY_IS_FALSE(settings._profiles.at(2).HasGuid());
-        VERIFY_IS_FALSE(settings._profiles.at(2).Source().empty());
+        VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(2).Name());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(2).HasGuid());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(2).Source().empty());
 
-        VERIFY_ARE_EQUAL(L"profile0", settings._profiles.at(3).Name());
-        VERIFY_IS_FALSE(settings._profiles.at(3).HasGuid());
-        VERIFY_IS_FALSE(settings._profiles.at(3).Source().empty());
+        VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(3).Name());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(3).HasGuid());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(3).Source().empty());
 
-        VERIFY_ARE_EQUAL(L"profile1", settings._profiles.at(4).Name());
-        VERIFY_IS_FALSE(settings._profiles.at(4).HasGuid());
-        VERIFY_IS_FALSE(settings._profiles.at(4).Source().empty());
+        VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(4).Name());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(4).HasGuid());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(4).Source().empty());
 
-        settings._ValidateProfilesHaveGuid();
+        settings->_ValidateProfilesHaveGuid();
 
-        VERIFY_IS_TRUE(settings._profiles.at(0).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(1).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(2).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(3).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(4).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(3).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(4).HasGuid());
 
-        VERIFY_ARE_NOT_EQUAL(settings._profiles.at(0).Guid(),
-                             settings._profiles.at(1).Guid());
-        VERIFY_ARE_NOT_EQUAL(settings._profiles.at(0).Guid(),
-                             settings._profiles.at(2).Guid());
-        VERIFY_ARE_NOT_EQUAL(settings._profiles.at(0).Guid(),
-                             settings._profiles.at(3).Guid());
+        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(0).Guid(),
+                             settings->_profiles.GetAt(1).Guid());
+        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(0).Guid(),
+                             settings->_profiles.GetAt(2).Guid());
+        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(0).Guid(),
+                             settings->_profiles.GetAt(3).Guid());
 
-        VERIFY_ARE_NOT_EQUAL(settings._profiles.at(1).Guid(),
-                             settings._profiles.at(4).Guid());
+        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(1).Guid(),
+                             settings->_profiles.GetAt(4).Guid());
 
-        VERIFY_ARE_NOT_EQUAL(settings._profiles.at(3).Guid(),
-                             settings._profiles.at(4).Guid());
+        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(3).Guid(),
+                             settings->_profiles.GetAt(4).Guid());
     }
 
     void DynamicProfileTests::DontLayerUserProfilesOnDynamicProfiles()
@@ -229,43 +229,43 @@ namespace TerminalAppUnitTests
             return profiles;
         };
 
-        CascadiaSettings settings{ false };
-        settings._profileGenerators.emplace_back(std::move(gen0));
-        settings._profileGenerators.emplace_back(std::move(gen1));
+        auto settings = winrt::make_self<implementation::CascadiaSettings>(false);
+        settings->_profileGenerators.emplace_back(std::move(gen0));
+        settings->_profileGenerators.emplace_back(std::move(gen1));
 
         Log::Comment(NoThrowString().Format(
             L"All profiles with the same name have the same GUID. However, they"
             L" will not be layered, because they have different sources"));
 
         // parse userProfiles as the user settings
-        settings._ParseJsonString(userProfiles, false);
-        VERIFY_ARE_EQUAL(0u, settings._profiles.size(), L"Just parsing the user settings doesn't actually layer them");
-        settings._LoadDynamicProfiles();
-        VERIFY_ARE_EQUAL(3u, settings._profiles.size());
-        settings.LayerJson(settings._userSettings);
-        VERIFY_ARE_EQUAL(5u, settings._profiles.size());
+        settings->_ParseJsonString(userProfiles, false);
+        VERIFY_ARE_EQUAL(0u, settings->_profiles.Size(), L"Just parsing the user settings doesn't actually layer them");
+        settings->_LoadDynamicProfiles();
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        settings->LayerJson(settings->_userSettings);
+        VERIFY_ARE_EQUAL(5u, settings->_profiles.Size());
 
-        VERIFY_IS_FALSE(settings._profiles.at(0).Source().empty());
-        VERIFY_IS_FALSE(settings._profiles.at(1).Source().empty());
-        VERIFY_IS_FALSE(settings._profiles.at(2).Source().empty());
-        VERIFY_IS_TRUE(settings._profiles.at(3).Source().empty());
-        VERIFY_IS_TRUE(settings._profiles.at(4).Source().empty());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(0).Source().empty());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(1).Source().empty());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(2).Source().empty());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(3).Source().empty());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(4).Source().empty());
 
-        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.0", settings._profiles.at(0).Source());
-        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings._profiles.at(1).Source());
-        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings._profiles.at(2).Source());
+        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.0", settings->_profiles.GetAt(0).Source());
+        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_profiles.GetAt(1).Source());
+        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_profiles.GetAt(2).Source());
 
-        VERIFY_IS_TRUE(settings._profiles.at(0).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(1).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(2).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(3).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(4).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(3).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(4).HasGuid());
 
-        VERIFY_ARE_EQUAL(guid0, settings._profiles.at(0).Guid());
-        VERIFY_ARE_EQUAL(guid0, settings._profiles.at(1).Guid());
-        VERIFY_ARE_EQUAL(guid1, settings._profiles.at(2).Guid());
-        VERIFY_ARE_EQUAL(guid0, settings._profiles.at(3).Guid());
-        VERIFY_ARE_EQUAL(guid1, settings._profiles.at(4).Guid());
+        VERIFY_ARE_EQUAL(guid0, settings->_profiles.GetAt(0).Guid());
+        VERIFY_ARE_EQUAL(guid0, settings->_profiles.GetAt(1).Guid());
+        VERIFY_ARE_EQUAL(guid1, settings->_profiles.GetAt(2).Guid());
+        VERIFY_ARE_EQUAL(guid0, settings->_profiles.GetAt(3).Guid());
+        VERIFY_ARE_EQUAL(guid1, settings->_profiles.GetAt(4).Guid());
     }
 
     void DynamicProfileTests::DoLayerUserProfilesOnDynamicsWhenSourceMatches()
@@ -309,41 +309,41 @@ namespace TerminalAppUnitTests
             return profiles;
         };
 
-        CascadiaSettings settings{ false };
-        settings._profileGenerators.emplace_back(std::move(gen0));
-        settings._profileGenerators.emplace_back(std::move(gen1));
+        auto settings = winrt::make_self<implementation::CascadiaSettings>(false);
+        settings->_profileGenerators.emplace_back(std::move(gen0));
+        settings->_profileGenerators.emplace_back(std::move(gen1));
 
         Log::Comment(NoThrowString().Format(
             L"All profiles with the same name have the same GUID. However, they"
             L" will not be layered, because they have different source's"));
 
         // parse userProfiles as the user settings
-        settings._ParseJsonString(userProfiles, false);
-        VERIFY_ARE_EQUAL(0u, settings._profiles.size(), L"Just parsing the user settings doesn't actually layer them");
-        settings._LoadDynamicProfiles();
-        VERIFY_ARE_EQUAL(3u, settings._profiles.size());
-        settings.LayerJson(settings._userSettings);
-        VERIFY_ARE_EQUAL(3u, settings._profiles.size());
+        settings->_ParseJsonString(userProfiles, false);
+        VERIFY_ARE_EQUAL(0u, settings->_profiles.Size(), L"Just parsing the user settings doesn't actually layer them");
+        settings->_LoadDynamicProfiles();
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        settings->LayerJson(settings->_userSettings);
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
 
-        VERIFY_IS_FALSE(settings._profiles.at(0).Source().empty());
-        VERIFY_IS_FALSE(settings._profiles.at(1).Source().empty());
-        VERIFY_IS_FALSE(settings._profiles.at(2).Source().empty());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(0).Source().empty());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(1).Source().empty());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(2).Source().empty());
 
-        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.0", settings._profiles.at(0).Source());
-        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings._profiles.at(1).Source());
-        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings._profiles.at(2).Source());
+        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.0", settings->_profiles.GetAt(0).Source());
+        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_profiles.GetAt(1).Source());
+        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_profiles.GetAt(2).Source());
 
-        VERIFY_IS_TRUE(settings._profiles.at(0).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(1).HasGuid());
-        VERIFY_IS_TRUE(settings._profiles.at(2).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
 
-        VERIFY_ARE_EQUAL(guid0, settings._profiles.at(0).Guid());
-        VERIFY_ARE_EQUAL(guid0, settings._profiles.at(1).Guid());
-        VERIFY_ARE_EQUAL(guid1, settings._profiles.at(2).Guid());
+        VERIFY_ARE_EQUAL(guid0, settings->_profiles.GetAt(0).Guid());
+        VERIFY_ARE_EQUAL(guid0, settings->_profiles.GetAt(1).Guid());
+        VERIFY_ARE_EQUAL(guid1, settings->_profiles.GetAt(2).Guid());
 
-        VERIFY_ARE_EQUAL(L"profile0FromUserSettings", settings._profiles.at(0).Name());
-        VERIFY_ARE_EQUAL(L"profile0", settings._profiles.at(1).Name());
-        VERIFY_ARE_EQUAL(L"profile1FromUserSettings", settings._profiles.at(2).Name());
+        VERIFY_ARE_EQUAL(L"profile0FromUserSettings", settings->_profiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"profile1FromUserSettings", settings->_profiles.GetAt(2).Name());
     }
 
     void DynamicProfileTests::TestDontRunDisabledGenerators()
@@ -390,7 +390,7 @@ namespace TerminalAppUnitTests
         {
             Log::Comment(NoThrowString().Format(
                 L"Case 1: Disable a single profile generator"));
-            CascadiaSettings settings{ false };
+            auto settings = winrt::make_self<implementation::CascadiaSettings>(false);
 
             auto gen0 = std::make_unique<TestDynamicProfileGenerator>(L"Terminal.App.UnitTest.0");
             auto gen1 = std::make_unique<TestDynamicProfileGenerator>(L"Terminal.App.UnitTest.1");
@@ -398,54 +398,54 @@ namespace TerminalAppUnitTests
             gen0->pfnGenerate = gen0GenerateFn;
             gen1->pfnGenerate = gen1GenerateFn;
             gen2->pfnGenerate = gen2GenerateFn;
-            settings._profileGenerators.emplace_back(std::move(gen0));
-            settings._profileGenerators.emplace_back(std::move(gen1));
-            settings._profileGenerators.emplace_back(std::move(gen2));
+            settings->_profileGenerators.emplace_back(std::move(gen0));
+            settings->_profileGenerators.emplace_back(std::move(gen1));
+            settings->_profileGenerators.emplace_back(std::move(gen2));
 
             // Parse as the user settings:
-            settings._ParseJsonString(settings0String, false);
-            settings._LoadDynamicProfiles();
+            settings->_ParseJsonString(settings0String, false);
+            settings->_LoadDynamicProfiles();
 
-            VERIFY_ARE_EQUAL(4u, settings._profiles.size());
-            VERIFY_IS_FALSE(settings._profiles.at(0).Source().empty());
-            VERIFY_IS_FALSE(settings._profiles.at(1).Source().empty());
-            VERIFY_IS_FALSE(settings._profiles.at(2).Source().empty());
-            VERIFY_IS_FALSE(settings._profiles.at(3).Source().empty());
-            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings._profiles.at(0).Source());
-            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings._profiles.at(1).Source());
-            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.2", settings._profiles.at(2).Source());
-            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.2", settings._profiles.at(3).Source());
-            VERIFY_ARE_EQUAL(L"profile1", settings._profiles.at(0).Name());
-            VERIFY_ARE_EQUAL(L"profile2", settings._profiles.at(1).Name());
-            VERIFY_ARE_EQUAL(L"profile3", settings._profiles.at(2).Name());
-            VERIFY_ARE_EQUAL(L"profile4", settings._profiles.at(3).Name());
+            VERIFY_ARE_EQUAL(4u, settings->_profiles.Size());
+            VERIFY_IS_FALSE(settings->_profiles.GetAt(0).Source().empty());
+            VERIFY_IS_FALSE(settings->_profiles.GetAt(1).Source().empty());
+            VERIFY_IS_FALSE(settings->_profiles.GetAt(2).Source().empty());
+            VERIFY_IS_FALSE(settings->_profiles.GetAt(3).Source().empty());
+            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_profiles.GetAt(0).Source());
+            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_profiles.GetAt(1).Source());
+            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.2", settings->_profiles.GetAt(2).Source());
+            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.2", settings->_profiles.GetAt(3).Source());
+            VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(L"profile3", settings->_profiles.GetAt(2).Name());
+            VERIFY_ARE_EQUAL(L"profile4", settings->_profiles.GetAt(3).Name());
         }
 
         {
             Log::Comment(NoThrowString().Format(
                 L"Case 2: Disable multiple profile generators"));
-            CascadiaSettings settings{ false };
+            auto settings = winrt::make_self<implementation::CascadiaSettings>(false);
             auto gen0 = std::make_unique<TestDynamicProfileGenerator>(L"Terminal.App.UnitTest.0");
             auto gen1 = std::make_unique<TestDynamicProfileGenerator>(L"Terminal.App.UnitTest.1");
             auto gen2 = std::make_unique<TestDynamicProfileGenerator>(L"Terminal.App.UnitTest.2");
             gen0->pfnGenerate = gen0GenerateFn;
             gen1->pfnGenerate = gen1GenerateFn;
             gen2->pfnGenerate = gen2GenerateFn;
-            settings._profileGenerators.emplace_back(std::move(gen0));
-            settings._profileGenerators.emplace_back(std::move(gen1));
-            settings._profileGenerators.emplace_back(std::move(gen2));
+            settings->_profileGenerators.emplace_back(std::move(gen0));
+            settings->_profileGenerators.emplace_back(std::move(gen1));
+            settings->_profileGenerators.emplace_back(std::move(gen2));
 
             // Parse as the user settings:
-            settings._ParseJsonString(settings1String, false);
-            settings._LoadDynamicProfiles();
+            settings->_ParseJsonString(settings1String, false);
+            settings->_LoadDynamicProfiles();
 
-            VERIFY_ARE_EQUAL(2u, settings._profiles.size());
-            VERIFY_IS_FALSE(settings._profiles.at(0).Source().empty());
-            VERIFY_IS_FALSE(settings._profiles.at(1).Source().empty());
-            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.2", settings._profiles.at(0).Source());
-            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.2", settings._profiles.at(1).Source());
-            VERIFY_ARE_EQUAL(L"profile3", settings._profiles.at(0).Name());
-            VERIFY_ARE_EQUAL(L"profile4", settings._profiles.at(1).Name());
+            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+            VERIFY_IS_FALSE(settings->_profiles.GetAt(0).Source().empty());
+            VERIFY_IS_FALSE(settings->_profiles.GetAt(1).Source().empty());
+            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.2", settings->_profiles.GetAt(0).Source());
+            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.2", settings->_profiles.GetAt(1).Source());
+            VERIFY_ARE_EQUAL(L"profile3", settings->_profiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile4", settings->_profiles.GetAt(1).Name());
         }
     }
 
@@ -517,48 +517,48 @@ namespace TerminalAppUnitTests
             return profiles;
         };
 
-        CascadiaSettings settings{ false };
-        settings._profileGenerators.emplace_back(std::move(gen0));
-        settings._profileGenerators.emplace_back(std::move(gen1));
-        settings._profileGenerators.emplace_back(std::move(gen2));
+        auto settings = winrt::make_self<implementation::CascadiaSettings>(false);
+        settings->_profileGenerators.emplace_back(std::move(gen0));
+        settings->_profileGenerators.emplace_back(std::move(gen1));
+        settings->_profileGenerators.emplace_back(std::move(gen2));
 
-        settings._ParseJsonString(settings0String, false);
-        VERIFY_ARE_EQUAL(0u, settings._profiles.size());
+        settings->_ParseJsonString(settings0String, false);
+        VERIFY_ARE_EQUAL(0u, settings->_profiles.Size());
 
-        settings._LoadDynamicProfiles();
-        VERIFY_ARE_EQUAL(4u, settings._profiles.size());
+        settings->_LoadDynamicProfiles();
+        VERIFY_ARE_EQUAL(4u, settings->_profiles.Size());
 
-        VERIFY_IS_FALSE(settings._profiles.at(0).Source().empty());
-        VERIFY_IS_FALSE(settings._profiles.at(1).Source().empty());
-        VERIFY_IS_FALSE(settings._profiles.at(2).Source().empty());
-        VERIFY_IS_FALSE(settings._profiles.at(3).Source().empty());
-        VERIFY_ARE_EQUAL(L"Windows.Terminal.PowershellCore", settings._profiles.at(0).Source());
-        VERIFY_ARE_EQUAL(L"Windows.Terminal.Wsl", settings._profiles.at(1).Source());
-        VERIFY_ARE_EQUAL(L"Windows.Terminal.Wsl", settings._profiles.at(2).Source());
-        VERIFY_ARE_EQUAL(L"Windows.Terminal.Azure", settings._profiles.at(3).Source());
-        VERIFY_ARE_EQUAL(L"profile0", settings._profiles.at(0).Name());
-        VERIFY_ARE_EQUAL(L"profile1", settings._profiles.at(1).Name());
-        VERIFY_ARE_EQUAL(L"profile2", settings._profiles.at(2).Name());
-        VERIFY_ARE_EQUAL(L"profile3", settings._profiles.at(3).Name());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(0).Source().empty());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(1).Source().empty());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(2).Source().empty());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(3).Source().empty());
+        VERIFY_ARE_EQUAL(L"Windows.Terminal.PowershellCore", settings->_profiles.GetAt(0).Source());
+        VERIFY_ARE_EQUAL(L"Windows.Terminal.Wsl", settings->_profiles.GetAt(1).Source());
+        VERIFY_ARE_EQUAL(L"Windows.Terminal.Wsl", settings->_profiles.GetAt(2).Source());
+        VERIFY_ARE_EQUAL(L"Windows.Terminal.Azure", settings->_profiles.GetAt(3).Source());
+        VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"profile3", settings->_profiles.GetAt(3).Name());
 
-        settings.LayerJson(settings._userSettings);
-        VERIFY_ARE_EQUAL(5u, settings._profiles.size());
+        settings->LayerJson(settings->_userSettings);
+        VERIFY_ARE_EQUAL(5u, settings->_profiles.Size());
 
-        VERIFY_IS_FALSE(settings._profiles.at(0).Source().empty());
-        VERIFY_IS_FALSE(settings._profiles.at(1).Source().empty());
-        VERIFY_IS_FALSE(settings._profiles.at(2).Source().empty());
-        VERIFY_IS_FALSE(settings._profiles.at(3).Source().empty());
-        VERIFY_IS_TRUE(settings._profiles.at(4).Source().empty());
-        VERIFY_ARE_EQUAL(L"Windows.Terminal.PowershellCore", settings._profiles.at(0).Source());
-        VERIFY_ARE_EQUAL(L"Windows.Terminal.Wsl", settings._profiles.at(1).Source());
-        VERIFY_ARE_EQUAL(L"Windows.Terminal.Wsl", settings._profiles.at(2).Source());
-        VERIFY_ARE_EQUAL(L"Windows.Terminal.Azure", settings._profiles.at(3).Source());
-        // settings._profiles.at(4) does not have a source
-        VERIFY_ARE_EQUAL(L"profile0FromUserSettings", settings._profiles.at(0).Name());
-        VERIFY_ARE_EQUAL(L"profile1FromUserSettings", settings._profiles.at(1).Name());
-        VERIFY_ARE_EQUAL(L"profile2FromUserSettings", settings._profiles.at(2).Name());
-        VERIFY_ARE_EQUAL(L"profile3FromUserSettings", settings._profiles.at(3).Name());
-        VERIFY_ARE_EQUAL(L"profile4FromUserSettings", settings._profiles.at(4).Name());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(0).Source().empty());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(1).Source().empty());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(2).Source().empty());
+        VERIFY_IS_FALSE(settings->_profiles.GetAt(3).Source().empty());
+        VERIFY_IS_TRUE(settings->_profiles.GetAt(4).Source().empty());
+        VERIFY_ARE_EQUAL(L"Windows.Terminal.PowershellCore", settings->_profiles.GetAt(0).Source());
+        VERIFY_ARE_EQUAL(L"Windows.Terminal.Wsl", settings->_profiles.GetAt(1).Source());
+        VERIFY_ARE_EQUAL(L"Windows.Terminal.Wsl", settings->_profiles.GetAt(2).Source());
+        VERIFY_ARE_EQUAL(L"Windows.Terminal.Azure", settings->_profiles.GetAt(3).Source());
+        // settings->_profiles.GetAt(4) does not have a source
+        VERIFY_ARE_EQUAL(L"profile0FromUserSettings", settings->_profiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"profile1FromUserSettings", settings->_profiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"profile2FromUserSettings", settings->_profiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"profile3FromUserSettings", settings->_profiles.GetAt(3).Name());
+        VERIFY_ARE_EQUAL(L"profile4FromUserSettings", settings->_profiles.GetAt(4).Name());
     }
 
     void DynamicProfileTests::UserProfilesWithInvalidSourcesAreIgnored()
@@ -606,18 +606,18 @@ namespace TerminalAppUnitTests
             return profiles;
         };
 
-        CascadiaSettings settings{ false };
-        settings._profileGenerators.emplace_back(std::move(gen0));
-        settings._profileGenerators.emplace_back(std::move(gen1));
+        auto settings = winrt::make_self<implementation::CascadiaSettings>(false);
+        settings->_profileGenerators.emplace_back(std::move(gen0));
+        settings->_profileGenerators.emplace_back(std::move(gen1));
 
-        settings._ParseJsonString(settings0String, false);
-        VERIFY_ARE_EQUAL(0u, settings._profiles.size());
+        settings->_ParseJsonString(settings0String, false);
+        VERIFY_ARE_EQUAL(0u, settings->_profiles.Size());
 
-        settings._LoadDynamicProfiles();
-        VERIFY_ARE_EQUAL(3u, settings._profiles.size());
+        settings->_LoadDynamicProfiles();
+        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
 
-        settings.LayerJson(settings._userSettings);
-        VERIFY_ARE_EQUAL(4u, settings._profiles.size());
+        settings->LayerJson(settings->_userSettings);
+        VERIFY_ARE_EQUAL(4u, settings->_profiles.Size());
     }
 
     void DynamicProfileTests::UserProfilesFromDisabledSourcesDontAppear()
@@ -666,18 +666,18 @@ namespace TerminalAppUnitTests
             return profiles;
         };
 
-        CascadiaSettings settings{ false };
-        settings._profileGenerators.emplace_back(std::move(gen0));
-        settings._profileGenerators.emplace_back(std::move(gen1));
+        auto settings = winrt::make_self<implementation::CascadiaSettings>(false);
+        settings->_profileGenerators.emplace_back(std::move(gen0));
+        settings->_profileGenerators.emplace_back(std::move(gen1));
 
-        settings._ParseJsonString(settings0String, false);
-        VERIFY_ARE_EQUAL(0u, settings._profiles.size());
+        settings->_ParseJsonString(settings0String, false);
+        VERIFY_ARE_EQUAL(0u, settings->_profiles.Size());
 
-        settings._LoadDynamicProfiles();
-        VERIFY_ARE_EQUAL(1u, settings._profiles.size());
+        settings->_LoadDynamicProfiles();
+        VERIFY_ARE_EQUAL(1u, settings->_profiles.Size());
 
-        settings.LayerJson(settings._userSettings);
-        VERIFY_ARE_EQUAL(2u, settings._profiles.size());
+        settings->LayerJson(settings->_userSettings);
+        VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
     }
 
 };


### PR DESCRIPTION
CascadiaSettings is now a WinRT object in the TerminalApp project.

## References
#7141 - CascadiaSettings is a settings object
#885 - this new settings object will be moved to a new TerminalSettingsModel project

This one _looks_ big, but most of it is really just propagating the
changes to the tests. In fact, you can probably save yourself some time
because the tests were about an hour of Find&Replace.

`CascadiaSettings::GetCurrentAppSettings()` was only being used in
Pane.cpp. So I ripped out the 3 lines of code and stuffed them in there.

Follow-up work:
- There's a few places in AppLogic where I `get_self` to be able to get
  the warnings out. This will go away in the next PR (wrapping up #885)

## Validation Steps Performed
- [x] Tests passed
- [X] Deployment succeeded

Closes #7141