### PR TITLE
Add profiles to the Jumplist

### DIFF
--- a/.github/actions/spell-check/dictionary/microsoft.txt
+++ b/.github/actions/spell-check/dictionary/microsoft.txt
@@ -18,6 +18,7 @@ pgo
 pgosweep
 powerrename
 powershell
+propkey
 pscustomobject
 robocopy
 SACLs

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -694,7 +694,7 @@ namespace winrt::TerminalApp::implementation
         // Register for directory change notification.
         _RegisterSettingsChange();
 
-        jumplist.UpdateJumplist(_settings);
+        Jumplist::UpdateJumplist(*_settings);
     }
 
     // Method Description:
@@ -854,7 +854,7 @@ namespace winrt::TerminalApp::implementation
         _RefreshThemeRoutine();
         _ApplyStartupTaskStateChange();
 
-        jumplist.UpdateJumplist(_settings);
+        Jumplist::UpdateJumplist(*_settings);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -694,7 +694,6 @@ namespace winrt::TerminalApp::implementation
         // Register for directory change notification.
         _RegisterSettingsChange();
 
-        // Update the jumplist
         jumplist.UpdateJumplist(_settings);
     }
 

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -693,6 +693,9 @@ namespace winrt::TerminalApp::implementation
 
         // Register for directory change notification.
         _RegisterSettingsChange();
+
+        // Update the jumplist
+        jumplist.UpdateJumplist(_settings);
     }
 
     // Method Description:
@@ -851,6 +854,8 @@ namespace winrt::TerminalApp::implementation
 
         _RefreshThemeRoutine();
         _ApplyStartupTaskStateChange();
+
+        jumplist.UpdateJumplist(_settings);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/AppLogic.h
+++ b/src/cascadia/TerminalApp/AppLogic.h
@@ -80,8 +80,6 @@ namespace winrt::TerminalApp::implementation
 
         std::shared_mutex _dialogLock;
 
-        Jumplist jumplist;
-
         std::atomic<bool> _settingsReloadQueued{ false };
 
         ::TerminalApp::AppCommandlineArgs _appArgs;

--- a/src/cascadia/TerminalApp/AppLogic.h
+++ b/src/cascadia/TerminalApp/AppLogic.h
@@ -8,6 +8,7 @@
 #include "Tab.h"
 #include "CascadiaSettings.h"
 #include "TerminalPage.h"
+#include "Jumplist.h"
 #include "../../cascadia/inc/cppwinrt_utils.h"
 
 namespace winrt::TerminalApp::implementation
@@ -78,6 +79,8 @@ namespace winrt::TerminalApp::implementation
         wil::unique_folder_change_reader_nothrow _reader;
 
         std::shared_mutex _dialogLock;
+
+        Jumplist jumplist;
 
         std::atomic<bool> _settingsReloadQueued{ false };
 

--- a/src/cascadia/TerminalApp/Jumplist.cpp
+++ b/src/cascadia/TerminalApp/Jumplist.cpp
@@ -8,11 +8,8 @@
 
 using namespace winrt::TerminalApp;
 
-//  This property key isn't already defined, but is used by UWP Jumplist to determine the icon of the jumplist item.
-//  We need this because our icon paths are 
-//  Name:     System.AppUserModel.DestinationListLogoUri -- PKEY_AppUserModel_DestListLogoUri
-//  Type:     String -- VT_LPWSTR
-//  FormatID: {9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3}, 29
+//  This property key isn't already defined in Propkey.h, but is used by UWP Jumplist to determine the icon of the jumplist item.
+//  IShellLink's SetIconLocation isn't going to read "ms-appx://" icon paths, so we'll need to use this to set the icon.
 DEFINE_PROPERTYKEY(PKEY_AppUserModel_DestListLogoUri, 0x9F4C2855, 0x9F79, 0x4B39, 0xA8, 0xD0, 0xE1, 0xD4, 0x2D, 0xE1, 0xD5, 0xF3, 29);
 #define INIT_PKEY_AppUserModel_DestListLogoUri                                         \
 {                                                                                      \
@@ -41,8 +38,8 @@ void Jumplist::UpdateJumplist(std::shared_ptr<::TerminalApp::CascadiaSettings> s
         return;
     }
 
-    // TODO: It's just easier to clear the list and re-add everything. The settings aren't
-    // updated often, and there likely isn't a huge number of profiles to add.
+    // It's easier to clear the list and re-add everything. The settings aren't
+    // updated often, and there likely isn't a huge amount of items to add.
     jumplistItems->Clear();
 
     // Update the list of profiles.
@@ -52,6 +49,7 @@ void Jumplist::UpdateJumplist(std::shared_ptr<::TerminalApp::CascadiaSettings> s
     }
 
     // TODO: Add items from the future customizable new tab dropdown as well.
+    // This could either replace the default profiles, or be added alongside them.
 
     // Add the items to the jumplist Task section.
     // The Tasks section is immutable by the user, unlike the destinations
@@ -71,7 +69,7 @@ void Jumplist::UpdateJumplist(std::shared_ptr<::TerminalApp::CascadiaSettings> s
 // - profiles - The profiles to add to the jumplist
 // Return Value:
 // - S_OK or HRESULT failure code.
-HRESULT Jumplist::_updateProfiles(winrt::com_ptr<IObjectCollection>& jumplistItems, gsl::span<const Profile> profiles)
+HRESULT Jumplist::_updateProfiles(winrt::com_ptr<IObjectCollection>& jumplistItems, const gsl::span<const Profile>& profiles)
 {
     HRESULT result = S_OK;
 

--- a/src/cascadia/TerminalApp/Jumplist.cpp
+++ b/src/cascadia/TerminalApp/Jumplist.cpp
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "Jumplist.h"
+
+#include <Propkey.h>
+
+using namespace winrt::TerminalApp;
+
+//  This property key isn't already defined, but is used by UWP Jumplist to determine the icon of the jumplist item.
+//  We need this because our icon paths are 
+//  Name:     System.AppUserModel.DestinationListLogoUri -- PKEY_AppUserModel_DestListLogoUri
+//  Type:     String -- VT_LPWSTR
+//  FormatID: {9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3}, 29
+DEFINE_PROPERTYKEY(PKEY_AppUserModel_DestListLogoUri, 0x9F4C2855, 0x9F79, 0x4B39, 0xA8, 0xD0, 0xE1, 0xD4, 0x2D, 0xE1, 0xD5, 0xF3, 29);
+#define INIT_PKEY_AppUserModel_DestListLogoUri                                         \
+{                                                                                      \
+    { 0x9F4C2855, 0x9F79, 0x4B39, 0xA8, 0xD0, 0xE1, 0xD4, 0x2D, 0xE1, 0xD5, 0xF3 }, 29 \
+}
+
+// Method Description:
+// - Updates the items of the Jumplist based on the given settings.
+// Arguments:
+// - settings - The settings object to update the jumplist with.
+// Return Value:
+// - <none>
+void Jumplist::UpdateJumplist(std::shared_ptr<::TerminalApp::CascadiaSettings> settings)
+{
+    winrt::com_ptr<ICustomDestinationList> jumplistInstance;
+    if (FAILED(CoCreateInstance(CLSID_DestinationList, nullptr, CLSCTX_ALL, IID_PPV_ARGS(&jumplistInstance))))
+    {
+        return;
+    }
+
+    // Start the Jumplist edit transaction
+    uint32_t slots;
+    winrt::com_ptr<IObjectCollection> jumplistItems;
+    if (FAILED(jumplistInstance->BeginList(&slots, IID_PPV_ARGS(&jumplistItems))))
+    {
+        return;
+    }
+
+    // TODO: It's just easier to clear the list and re-add everything. The settings aren't
+    // updated often, and there likely isn't a huge number of profiles to add.
+    jumplistItems->Clear();
+
+    // Update the list of profiles.
+    if (FAILED(_updateProfiles(jumplistItems, settings->GetProfiles())))
+    {
+        return;
+    }
+
+    // TODO: Add items from the future customizable new tab dropdown as well.
+
+    // Add the items to the jumplist Task section.
+    // The Tasks section is immutable by the user, unlike the destinations
+    // section that can have its items pinned and removed.
+    jumplistInstance->AddUserTasks(jumplistItems.get());
+
+    if (FAILED(jumplistInstance->CommitList()))
+    {
+        return;
+    }
+}
+
+// Method Description:
+// - Creates and adds a ShellLink object to the Jumplist for each profile.
+// Arguments:
+// - jumplistItems - The jumplist item list
+// - profiles - The profiles to add to the jumplist
+// Return Value:
+// - S_OK or HRESULT failure code.
+HRESULT Jumplist::_updateProfiles(winrt::com_ptr<IObjectCollection>& jumplistItems, gsl::span<const Profile> profiles)
+{
+    HRESULT result = S_OK;
+
+    for (const auto& profile : profiles)
+    {
+        // Craft the arguments following "wt.exe"
+        auto profileName = profile.Name();
+        auto args = fmt::format(L"-p \"{}\"", profileName);
+
+        // Create the shell link object for the profile
+        winrt::com_ptr<IShellLink> shLink;
+        auto result = _createShellLink(profileName, profile.GetExpandedIconPath(), args, shLink);
+        if (FAILED(result))
+        {
+            return result;
+        }
+
+        jumplistItems->AddObject(shLink.get());
+    }
+
+    return result;
+}
+
+// Method Description:
+// - Creates a ShellLink object. Each item in a jumplist is a ShellLink, which is sort of
+//   like a shortcut. It requires the path to the application (wt.exe), the arguments to pass,
+//   and the path to the icon for the jumplist item. The path to the application isn't passed
+//   into this function, as we'll determine it with GetModuleFileName.
+// Arguments:
+// - name: The name of the item displayed in the jumplist.
+// - path: The path to the icon for the jumplist item.
+// - args: The arguments to pass along with wt.exe
+// Return Value:
+// - S_OK or HRESULT failure code.
+HRESULT Jumplist::_createShellLink(const std::wstring_view& name,
+                                   const std::wstring_view& path,
+                                   const std::wstring_view& args,
+                                   winrt::com_ptr<IShellLink>& shLink)
+{
+    // Create a shell link object
+    auto result = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_ALL, IID_PPV_ARGS(&shLink));
+    if (FAILED(result))
+    {
+        return result;
+    }
+
+    wchar_t wtExe[MAX_PATH];
+    // Passing null gives us the path of the executable file of the current process.
+    GetModuleFileName(NULL, wtExe, ARRAYSIZE(wtExe));
+    shLink->SetPath(wtExe);
+    shLink->SetArguments(args.data());
+
+    PROPVARIANT titleProp;
+    titleProp.vt = VT_LPWSTR;
+    titleProp.pwszVal = const_cast<wchar_t*>(name.data());
+
+    PROPVARIANT iconProp;
+    iconProp.vt = VT_LPWSTR;
+    iconProp.pwszVal = const_cast<wchar_t*>(path.data());
+
+    winrt::com_ptr<IPropertyStore> propStore = shLink.as<IPropertyStore>();
+    propStore->SetValue(PKEY_Title, titleProp);
+    propStore->SetValue(PKEY_AppUserModel_DestListLogoUri, iconProp);
+
+    result = propStore->Commit();
+    if (FAILED(result))
+    {
+        return result;
+    }
+
+    return result;
+}

--- a/src/cascadia/TerminalApp/Jumplist.cpp
+++ b/src/cascadia/TerminalApp/Jumplist.cpp
@@ -116,10 +116,8 @@ HRESULT Jumplist::_createShellLink(const std::wstring_view& name,
         return result;
     }
 
-    wchar_t wtExe[MAX_PATH];
-    // Passing null gives us the path of the executable file of the current process.
-    GetModuleFileName(NULL, wtExe, ARRAYSIZE(wtExe));
-    shLink->SetPath(wtExe);
+    std::filesystem::path module{ wil::GetModuleFileNameW<std::wstring>(nullptr) };
+    shLink->SetPath(module.c_str());
     shLink->SetArguments(args.data());
 
     PROPVARIANT titleProp;

--- a/src/cascadia/TerminalApp/Jumplist.cpp
+++ b/src/cascadia/TerminalApp/Jumplist.cpp
@@ -64,8 +64,7 @@ HRESULT Jumplist::_updateProfiles(IObjectCollection* jumplistItems, const gsl::s
     for (const auto& profile : profiles)
     {
         // Craft the arguments following "wt.exe"
-        auto guid = to_hstring(profile.Guid());
-        auto args = fmt::format(L"-p {}", guid);
+        auto args = fmt::format(L"-p {}", to_hstring(profile.Guid()));
 
         // Create the shell link object for the profile
         winrt::com_ptr<IShellLinkW> shLink;

--- a/src/cascadia/TerminalApp/Jumplist.cpp
+++ b/src/cascadia/TerminalApp/Jumplist.cpp
@@ -8,13 +8,13 @@
 
 using namespace winrt::TerminalApp;
 
-//  This property key isn't already defined in Propkey.h, but is used by UWP Jumplist to determine the icon of the jumplist item.
+//  This property key isn't already defined in propkey.h, but is used by UWP Jumplist to determine the icon of the jumplist item.
 //  IShellLink's SetIconLocation isn't going to read "ms-appx://" icon paths, so we'll need to use this to set the icon.
 DEFINE_PROPERTYKEY(PKEY_AppUserModel_DestListLogoUri, 0x9F4C2855, 0x9F79, 0x4B39, 0xA8, 0xD0, 0xE1, 0xD4, 0x2D, 0xE1, 0xD5, 0xF3, 29);
-#define INIT_PKEY_AppUserModel_DestListLogoUri                                         \
-{                                                                                      \
-    { 0x9F4C2855, 0x9F79, 0x4B39, 0xA8, 0xD0, 0xE1, 0xD4, 0x2D, 0xE1, 0xD5, 0xF3 }, 29 \
-}
+#define INIT_PKEY_AppUserModel_DestListLogoUri                                             \
+    {                                                                                      \
+        { 0x9F4C2855, 0x9F79, 0x4B39, 0xA8, 0xD0, 0xE1, 0xD4, 0x2D, 0xE1, 0xD5, 0xF3 }, 29 \
+    }
 
 // Method Description:
 // - Updates the items of the Jumplist based on the given settings.

--- a/src/cascadia/TerminalApp/Jumplist.h
+++ b/src/cascadia/TerminalApp/Jumplist.h
@@ -21,9 +21,9 @@ struct IShellLinkW;
 class Jumplist
 {
 public:
-    static HRESULT UpdateJumplist(const TerminalApp::CascadiaSettings& settings);
+    static HRESULT UpdateJumplist(const TerminalApp::CascadiaSettings& settings) noexcept;
 
 private:
-    static HRESULT _updateProfiles(IObjectCollection* jumplistItems, const gsl::span<const winrt::TerminalApp::Profile>& profiles);
-    static HRESULT _createShellLink(const std::wstring_view name, const std::wstring_view path, const std::wstring_view args, IShellLinkW** shLink);
+    [[nodiscard]] static HRESULT _updateProfiles(IObjectCollection* jumplistItems, const gsl::span<const winrt::TerminalApp::Profile>& profiles) noexcept;
+    [[nodiscard]] static HRESULT _createShellLink(const std::wstring_view name, const std::wstring_view path, const std::wstring_view args, IShellLinkW** shLink) noexcept;
 };

--- a/src/cascadia/TerminalApp/Jumplist.h
+++ b/src/cascadia/TerminalApp/Jumplist.h
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+// Module Name:
+// - Jumplist.h
+//
+// Abstract:
+// - The Jumplist is the menu that pops up when right clicking a pinned
+// item in the taskbar. This class handles updating the Terminal's jumplist
+// using the Terminal's settings.
+//
+
+#pragma once
+
+#include "CascadiaSettings.h"
+#include "Profile.h"
+
+#include <ShObjIdl.h>
+
+class Jumplist
+{
+public:
+    Jumplist() = default;
+    void UpdateJumplist(std::shared_ptr<TerminalApp::CascadiaSettings> settings);
+private:
+    HRESULT _updateProfiles(winrt::com_ptr<IObjectCollection>& jumplistItems, gsl::span<const winrt::TerminalApp::Profile> profiles);
+    HRESULT _createShellLink(const std::wstring_view& name, const std::wstring_view& path, const std::wstring_view& args, winrt::com_ptr<IShellLink>& shLink);
+};

--- a/src/cascadia/TerminalApp/Jumplist.h
+++ b/src/cascadia/TerminalApp/Jumplist.h
@@ -21,8 +21,8 @@ class Jumplist
 {
 public:
     Jumplist() = default;
-    void UpdateJumplist(std::shared_ptr<TerminalApp::CascadiaSettings> settings);
+    void UpdateJumplist(std::shared_ptr<::TerminalApp::CascadiaSettings> settings);
 private:
-    HRESULT _updateProfiles(winrt::com_ptr<IObjectCollection>& jumplistItems, gsl::span<const winrt::TerminalApp::Profile> profiles);
+    HRESULT _updateProfiles(winrt::com_ptr<IObjectCollection>& jumplistItems, const gsl::span<const winrt::TerminalApp::Profile>& profiles);
     HRESULT _createShellLink(const std::wstring_view& name, const std::wstring_view& path, const std::wstring_view& args, winrt::com_ptr<IShellLink>& shLink);
 };

--- a/src/cascadia/TerminalApp/Jumplist.h
+++ b/src/cascadia/TerminalApp/Jumplist.h
@@ -22,6 +22,7 @@ class Jumplist
 public:
     Jumplist() = default;
     void UpdateJumplist(std::shared_ptr<::TerminalApp::CascadiaSettings> settings);
+
 private:
     HRESULT _updateProfiles(winrt::com_ptr<IObjectCollection>& jumplistItems, const gsl::span<const winrt::TerminalApp::Profile>& profiles);
     HRESULT _createShellLink(const std::wstring_view& name, const std::wstring_view& path, const std::wstring_view& args, winrt::com_ptr<IShellLink>& shLink);

--- a/src/cascadia/TerminalApp/Jumplist.h
+++ b/src/cascadia/TerminalApp/Jumplist.h
@@ -15,15 +15,15 @@
 #include "CascadiaSettings.h"
 #include "Profile.h"
 
-#include <ShObjIdl.h>
+struct IObjectCollection;
+struct IShellLinkW;
 
 class Jumplist
 {
 public:
-    Jumplist() = default;
-    void UpdateJumplist(std::shared_ptr<::TerminalApp::CascadiaSettings> settings);
+    static HRESULT UpdateJumplist(const TerminalApp::CascadiaSettings& settings);
 
 private:
-    HRESULT _updateProfiles(winrt::com_ptr<IObjectCollection>& jumplistItems, const gsl::span<const winrt::TerminalApp::Profile>& profiles);
-    HRESULT _createShellLink(const std::wstring_view& name, const std::wstring_view& path, const std::wstring_view& args, winrt::com_ptr<IShellLink>& shLink);
+    static HRESULT _updateProfiles(IObjectCollection* jumplistItems, const gsl::span<const winrt::TerminalApp::Profile>& profiles);
+    static HRESULT _createShellLink(const std::wstring_view name, const std::wstring_view path, const std::wstring_view args, IShellLinkW** shLink);
 };

--- a/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
@@ -72,6 +72,7 @@
     <ClInclude Include="App.base.h" />
     <ClInclude Include="AppCommandlineArgs.h" />
     <ClInclude Include="Commandline.h" />
+    <ClInclude Include="Jumplist.h" />
     <ClInclude Include="MinMaxCloseControl.h">
       <DependentUpon>MinMaxCloseControl.xaml</DependentUpon>
     </ClInclude>
@@ -155,6 +156,7 @@
     <ClCompile Include="init.cpp" />
     <ClCompile Include="AppCommandlineArgs.cpp" />
     <ClCompile Include="Commandline.cpp" />
+    <ClCompile Include="Jumplist.cpp" />
     <ClCompile Include="MinMaxCloseControl.cpp">
       <DependentUpon>MinMaxCloseControl.xaml</DependentUpon>
     </ClCompile>


### PR DESCRIPTION
This commit introduces Jumplist customization and an item for each
profile to the Jumplist. Selecting an entry in the jumplist will pretty
much just execute  `wt.exe -p "{profile guid}"`, and so a new Terminal
will open with the selected profile.

Closes #576