### PR TITLE
Add WPF API that allows gutter sizing without resizing the buffer

### DIFF
--- a/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
@@ -373,9 +373,6 @@ HRESULT HwndTerminal::Refresh(_In_ const SIZE windowSize, _In_ bool autoFit, _Ou
         // If this function succeeds with S_FALSE, then the terminal didn't
         //      actually change size. No need to notify the connection of this
         //      no-op.
-        // TODO: MSFT:20642295 Resizing the buffer will corrupt it
-        // I believe we'll need support for CSI 2J, and additionally I think
-        //      we're resetting the viewport to the top
         RETURN_IF_FAILED(_terminal->UserResize({ vp.Width(), vp.Height() }));
     }
 

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
@@ -777,10 +777,12 @@ HRESULT _stdcall TerminalResize(void* terminal, COORD dimensions)
 /// <summary>
 /// Resizes the renderer to fit the provided width and height without changing the text
 /// buffer size.
+/// The out parameter "dimensions" is the total amount of characters that would fit with this new size.
 /// </summary>
-HRESULT _stdcall ResizeRendererDrawSpace(void* terminal, double width, double height, _Out_ COORD* dimensions)
+HRESULT _stdcall ResizeRendererDrawSpace(_In_ void* terminal, _In_ short width, _In_ short height, _Out_ COORD* dimensions)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, dimensions);
+    RETURN_HR_IF_NULL(E_INVALIDARG, terminal);
 
     const auto publicTerminal = static_cast<HwndTerminal*>(terminal);
 
@@ -796,7 +798,7 @@ HRESULT _stdcall ResizeRendererDrawSpace(void* terminal, double width, double he
         static_cast<int>(height),
         0));
 
-    const SIZE windowSize{ static_cast<short>(width), static_cast<short>(height) };
+    const SIZE windowSize{ width, height };
 
     RETURN_IF_FAILED(publicTerminal->_renderEngine->SetWindowSize(windowSize));
 
@@ -805,7 +807,7 @@ HRESULT _stdcall ResizeRendererDrawSpace(void* terminal, double width, double he
 
     // Convert our new dimensions to characters
     const auto viewInPixels = Viewport::FromDimensions({ 0, 0 },
-                                                       { gsl::narrow<short>(windowSize.cx), gsl::narrow<short>(windowSize.cy) });
+                                                       { width, height });
     const auto vp = publicTerminal->_renderEngine->GetViewportInCharacters(viewInPixels);
 
     dimensions->X = vp.Width();

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
@@ -43,6 +43,7 @@ __declspec(dllexport) void _stdcall TerminalBlinkCursor(void* terminal);
 __declspec(dllexport) void _stdcall TerminalSetCursorVisible(void* terminal, const bool visible);
 __declspec(dllexport) void _stdcall TerminalSetFocus(void* terminal);
 __declspec(dllexport) void _stdcall TerminalKillFocus(void* terminal);
+__declspec(dllexport) HRESULT _stdcall ResizeRendererDrawSpace(void* terminal, double width, double height, _Out_ COORD* dimensions);
 };
 
 struct HwndTerminal : ::Microsoft::Console::Types::IControlAccessibilityInfo
@@ -103,6 +104,7 @@ private:
     friend void _stdcall TerminalSetCursorVisible(void* terminal, const bool visible);
     friend void _stdcall TerminalSetFocus(void* terminal);
     friend void _stdcall TerminalKillFocus(void* terminal);
+    friend HRESULT _stdcall ResizeRendererDrawSpace(void* terminal, double width, double height, _Out_ COORD* dimensions);
 
     void _UpdateFont(int newDpi);
     void _WriteTextToConnection(const std::wstring& text) noexcept;

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
@@ -27,7 +27,7 @@ extern "C" {
 __declspec(dllexport) HRESULT _stdcall CreateTerminal(HWND parentHwnd, _Out_ void** hwnd, _Out_ void** terminal);
 __declspec(dllexport) void _stdcall TerminalSendOutput(void* terminal, LPCWSTR data);
 __declspec(dllexport) void _stdcall TerminalRegisterScrollCallback(void* terminal, void __stdcall callback(int, int, int));
-__declspec(dllexport) HRESULT _stdcall TerminalTriggerResize(void* terminal, double width, double height, _Out_ COORD* dimensions);
+__declspec(dllexport) HRESULT _stdcall TerminalTriggerResize(_In_ void* terminal, _In_ double width, _In_ double height, _In_ bool autoFit, _Out_ COORD* dimensions);
 __declspec(dllexport) HRESULT _stdcall TerminalResize(void* terminal, COORD dimensions);
 __declspec(dllexport) void _stdcall TerminalDpiChanged(void* terminal, int newDpi);
 __declspec(dllexport) void _stdcall TerminalUserScroll(void* terminal, int viewTop);
@@ -35,7 +35,7 @@ __declspec(dllexport) void _stdcall TerminalClearSelection(void* terminal);
 __declspec(dllexport) const wchar_t* _stdcall TerminalGetSelection(void* terminal);
 __declspec(dllexport) bool _stdcall TerminalIsSelectionActive(void* terminal);
 __declspec(dllexport) void _stdcall DestroyTerminal(void* terminal);
-__declspec(dllexport) void _stdcall TerminalSetTheme(void* terminal, TerminalTheme theme, LPCWSTR fontFamily, short fontSize, int newDpi);
+__declspec(dllexport) void _stdcall TerminalSetTheme(_In_ void* terminal, _In_ TerminalTheme theme, _In_ LPCWSTR fontFamily, _In_ short fontSize, _In_ int newDpi, _In_ bool autoFit);
 __declspec(dllexport) void _stdcall TerminalRegisterWriteCallback(void* terminal, const void __stdcall callback(wchar_t*));
 __declspec(dllexport) void _stdcall TerminalSendKeyEvent(void* terminal, WORD vkey, WORD scanCode, WORD flags, bool keyDown);
 __declspec(dllexport) void _stdcall TerminalSendCharEvent(void* terminal, wchar_t ch, WORD flags, WORD scanCode);
@@ -43,7 +43,6 @@ __declspec(dllexport) void _stdcall TerminalBlinkCursor(void* terminal);
 __declspec(dllexport) void _stdcall TerminalSetCursorVisible(void* terminal, const bool visible);
 __declspec(dllexport) void _stdcall TerminalSetFocus(void* terminal);
 __declspec(dllexport) void _stdcall TerminalKillFocus(void* terminal);
-__declspec(dllexport) HRESULT _stdcall ResizeRendererDrawSpace(_In_ void* terminal, _In_ short width, _In_ short height, _Out_ COORD* dimensions);
 };
 
 struct HwndTerminal : ::Microsoft::Console::Types::IControlAccessibilityInfo
@@ -60,7 +59,7 @@ public:
     HRESULT Initialize();
     void Teardown() noexcept;
     void SendOutput(std::wstring_view data);
-    HRESULT Refresh(const SIZE windowSize, _Out_ COORD* dimensions);
+    HRESULT Refresh(const SIZE windowSize,_In_ bool autoFit, _Out_ COORD* dimensions);
     void RegisterScrollCallback(std::function<void(int, int, int)> callback);
     void RegisterWriteCallback(const void _stdcall callback(wchar_t*));
     ::Microsoft::Console::Types::IUiaData* GetUiaData() const noexcept;
@@ -99,12 +98,11 @@ private:
     friend bool _stdcall TerminalIsSelectionActive(void* terminal);
     friend void _stdcall TerminalSendKeyEvent(void* terminal, WORD vkey, WORD scanCode, WORD flags, bool keyDown);
     friend void _stdcall TerminalSendCharEvent(void* terminal, wchar_t ch, WORD scanCode, WORD flags);
-    friend void _stdcall TerminalSetTheme(void* terminal, TerminalTheme theme, LPCWSTR fontFamily, short fontSize, int newDpi);
+    friend void _stdcall TerminalSetTheme(_In_ void* terminal, _In_ TerminalTheme theme, _In_ LPCWSTR fontFamily, _In_ short fontSize, _In_ int newDpi, _In_ bool autoFit);
     friend void _stdcall TerminalBlinkCursor(void* terminal);
     friend void _stdcall TerminalSetCursorVisible(void* terminal, const bool visible);
     friend void _stdcall TerminalSetFocus(void* terminal);
     friend void _stdcall TerminalKillFocus(void* terminal);
-    friend HRESULT _stdcall ResizeRendererDrawSpace(_In_ void* terminal, _In_ short width, _In_ short height, _Out_ COORD* dimensions);
 
     void _UpdateFont(int newDpi);
     void _WriteTextToConnection(const std::wstring& text) noexcept;

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
@@ -43,7 +43,7 @@ __declspec(dllexport) void _stdcall TerminalBlinkCursor(void* terminal);
 __declspec(dllexport) void _stdcall TerminalSetCursorVisible(void* terminal, const bool visible);
 __declspec(dllexport) void _stdcall TerminalSetFocus(void* terminal);
 __declspec(dllexport) void _stdcall TerminalKillFocus(void* terminal);
-__declspec(dllexport) HRESULT _stdcall ResizeRendererDrawSpace(void* terminal, double width, double height, _Out_ COORD* dimensions);
+__declspec(dllexport) HRESULT _stdcall ResizeRendererDrawSpace(_In_ void* terminal, _In_ short width, _In_ short height, _Out_ COORD* dimensions);
 };
 
 struct HwndTerminal : ::Microsoft::Console::Types::IControlAccessibilityInfo
@@ -104,7 +104,7 @@ private:
     friend void _stdcall TerminalSetCursorVisible(void* terminal, const bool visible);
     friend void _stdcall TerminalSetFocus(void* terminal);
     friend void _stdcall TerminalKillFocus(void* terminal);
-    friend HRESULT _stdcall ResizeRendererDrawSpace(void* terminal, double width, double height, _Out_ COORD* dimensions);
+    friend HRESULT _stdcall ResizeRendererDrawSpace(_In_ void* terminal, _In_ short width, _In_ short height, _Out_ COORD* dimensions);
 
     void _UpdateFont(int newDpi);
     void _WriteTextToConnection(const std::wstring& text) noexcept;

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -168,7 +168,7 @@ void Terminal::UpdateSettings(ICoreSettings settings)
 }
 
 // Method Description:
-// - Resize the terminal as the result of some user interaction.
+// - Resize the terminal text buffer as the result of some user interaction.
 // Arguments:
 // - viewportSize: the new size of the viewport, in chars
 // Return Value:

--- a/src/cascadia/WpfTerminalControl/NativeMethods.cs
+++ b/src/cascadia/WpfTerminalControl/NativeMethods.cs
@@ -245,6 +245,9 @@ namespace Microsoft.Terminal.Wpf
         [DllImport("PublicTerminalCore.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
         public static extern void TerminalKillFocus(IntPtr terminal);
 
+        [DllImport("PublicTerminalCore.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
+        public static extern uint ResizeRendererDrawSpace(IntPtr terminal, double width, double height, out COORD dimensions);
+
         [DllImport("user32.dll", SetLastError = true)]
         public static extern IntPtr SetFocus(IntPtr hWnd);
 

--- a/src/cascadia/WpfTerminalControl/NativeMethods.cs
+++ b/src/cascadia/WpfTerminalControl/NativeMethods.cs
@@ -246,7 +246,7 @@ namespace Microsoft.Terminal.Wpf
         public static extern void TerminalKillFocus(IntPtr terminal);
 
         [DllImport("PublicTerminalCore.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
-        public static extern uint ResizeRendererDrawSpace(IntPtr terminal, double width, double height, out COORD dimensions);
+        public static extern uint ResizeRendererDrawSpace(IntPtr terminal, short width, short height, out COORD dimensions);
 
         [DllImport("user32.dll", SetLastError = true)]
         public static extern IntPtr SetFocus(IntPtr hWnd);

--- a/src/cascadia/WpfTerminalControl/NativeMethods.cs
+++ b/src/cascadia/WpfTerminalControl/NativeMethods.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Terminal.Wpf
         public static extern void TerminalSendOutput(IntPtr terminal, string lpdata);
 
         [DllImport("PublicTerminalCore.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
-        public static extern uint TerminalTriggerResize(IntPtr terminal, double width, double height, out COORD dimensions);
+        public static extern uint TerminalTriggerResize(IntPtr terminal, double width, double height, bool autoFit, out COORD dimensions);
 
         [DllImport("PublicTerminalCore.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
         public static extern uint TerminalResize(IntPtr terminal, COORD dimensions);
@@ -231,7 +231,7 @@ namespace Microsoft.Terminal.Wpf
         public static extern void TerminalSendCharEvent(IntPtr terminal, char ch, ushort scanCode, ushort flags);
 
         [DllImport("PublicTerminalCore.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
-        public static extern void TerminalSetTheme(IntPtr terminal, [MarshalAs(UnmanagedType.Struct)] TerminalTheme theme, string fontFamily, short fontSize, int newDpi);
+        public static extern void TerminalSetTheme(IntPtr terminal, [MarshalAs(UnmanagedType.Struct)] TerminalTheme theme, string fontFamily, short fontSize, int newDpi, bool autoFit);
 
         [DllImport("PublicTerminalCore.dll", CallingConvention = CallingConvention.StdCall)]
         public static extern void TerminalBlinkCursor(IntPtr terminal);
@@ -244,9 +244,6 @@ namespace Microsoft.Terminal.Wpf
 
         [DllImport("PublicTerminalCore.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
         public static extern void TerminalKillFocus(IntPtr terminal);
-
-        [DllImport("PublicTerminalCore.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
-        public static extern uint ResizeRendererDrawSpace(IntPtr terminal, short width, short height, out COORD dimensions);
 
         [DllImport("user32.dll", SetLastError = true)]
         public static extern IntPtr SetFocus(IntPtr hWnd);

--- a/src/cascadia/WpfTerminalControl/TerminalContainer.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalContainer.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Terminal.Wpf
         {
             var dpiScale = VisualTreeHelper.GetDpi(this);
 
-            NativeMethods.TerminalSetTheme(this.terminal, theme, fontFamily, fontSize, (int)dpiScale.PixelsPerInchX);
+            NativeMethods.TerminalSetTheme(this.terminal, theme, fontFamily, fontSize, (int)dpiScale.PixelsPerInchX, this.AutoFit);
 
             this.TriggerResize(this.RenderSize);
         }
@@ -166,7 +166,7 @@ namespace Microsoft.Terminal.Wpf
             var dpiScale = VisualTreeHelper.GetDpi(this);
 
             NativeMethods.COORD dimensions;
-            NativeMethods.TerminalTriggerResize(this.terminal, renderSize.Width * dpiScale.DpiScaleX, renderSize.Height * dpiScale.DpiScaleY, out dimensions);
+            NativeMethods.TerminalTriggerResize(this.terminal, renderSize.Width * dpiScale.DpiScaleX, renderSize.Height * dpiScale.DpiScaleY, this.AutoFit, out dimensions);
 
             this.Rows = dimensions.Y;
             this.Columns = dimensions.X;
@@ -323,15 +323,7 @@ namespace Microsoft.Terminal.Wpf
                         }
 
                         NativeMethods.COORD dimensions;
-
-                        if (this.AutoFit)
-                        {
-                            NativeMethods.TerminalTriggerResize(this.terminal, windowpos.cx, windowpos.cy, out dimensions);
-                        }
-                        else
-                        {
-                            NativeMethods.ResizeRendererDrawSpace(this.terminal, (short)windowpos.cx, (short)windowpos.cy, out dimensions);
-                        }
+                        NativeMethods.TerminalTriggerResize(this.terminal, windowpos.cx, windowpos.cy, this.autoFit, out dimensions);
 
                         this.connection?.Resize((uint)dimensions.Y, (uint)dimensions.X);
                         this.Columns = dimensions.X;

--- a/src/cascadia/WpfTerminalControl/TerminalContainer.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalContainer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Terminal.Wpf
     /// </remarks>
     public class TerminalContainer : HwndHost
     {
-        private bool autofit = true;
+        private bool autoFit = true;
         private ITerminalConnection connection;
         private IntPtr hwnd;
         private IntPtr terminal;
@@ -67,16 +67,16 @@ namespace Microsoft.Terminal.Wpf
         /// Gets or sets a value indicating whether resizing the control should also resize the text buffer.
         /// </summary>
         /// <remarks>Set to true by default. The renderer draw space will always fill the control, even if the text buffer doesn't.</remarks>
-        public bool Autofit
+        public bool AutoFit
         {
             get
             {
-                return this.autofit;
+                return this.autoFit;
             }
 
             set
             {
-                this.autofit = value;
+                this.autoFit = value;
             }
         }
 
@@ -190,10 +190,15 @@ namespace Microsoft.Terminal.Wpf
 
             NativeMethods.TerminalResize(this.terminal, dimensions);
 
-            this.Rows = dimensions.Y;
-            this.Columns = dimensions.X;
+            // If AutoFit is true, save the new dimensions, otherwise keep the old size since we are only
+            // resizing the text buffer and not the render space.
+            if (this.AutoFit)
+            {
+                this.Rows = dimensions.Y;
+                this.Columns = dimensions.X;
+            }
 
-            this.connection?.Resize((uint)dimensions.Y, (uint)dimensions.X);
+            this.connection?.Resize((uint)this.Rows, (uint)this.Columns);
         }
 
         /// <inheritdoc/>
@@ -319,13 +324,13 @@ namespace Microsoft.Terminal.Wpf
 
                         NativeMethods.COORD dimensions;
 
-                        if (this.Autofit)
+                        if (this.AutoFit)
                         {
                             NativeMethods.TerminalTriggerResize(this.terminal, windowpos.cx, windowpos.cy, out dimensions);
                         }
                         else
                         {
-                            NativeMethods.ResizeRendererDrawSpace(this.terminal, windowpos.cx, windowpos.cy, out dimensions);
+                            NativeMethods.ResizeRendererDrawSpace(this.terminal, (short)windowpos.cx, (short)windowpos.cy, out dimensions);
                         }
 
                         this.connection?.Resize((uint)dimensions.Y, (uint)dimensions.X);

--- a/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
@@ -56,16 +56,16 @@ namespace Microsoft.Terminal.Wpf
         /// Gets or sets a value indicating whether resizing the control should also resize the text buffer.
         /// </summary>
         /// <remarks>Set to true by default. The renderer draw space will always fill the control, even if the text buffer doesn't.</remarks>
-        public bool Autofit
+        public bool AutoFit
         {
             get
             {
-                return this.termContainer.Autofit;
+                return this.termContainer.AutoFit;
             }
 
             set
             {
-                this.termContainer.Autofit = value;
+                this.termContainer.AutoFit = value;
             }
         }
 

--- a/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
@@ -53,6 +53,23 @@ namespace Microsoft.Terminal.Wpf
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether resizing the control should also resize the text buffer.
+        /// </summary>
+        /// <remarks>Set to true by default. The renderer draw space will always fill the control, even if the text buffer doesn't.</remarks>
+        public bool Autofit
+        {
+            get
+            {
+                return this.termContainer.Autofit;
+            }
+
+            set
+            {
+                this.termContainer.Autofit = value;
+            }
+        }
+
+        /// <summary>
         /// Sets the theme for the terminal. This includes font family, size, color, as well as background and foreground colors.
         /// </summary>
         /// <param name="theme">The color theme to use in the terminal.</param>


### PR DESCRIPTION
This commit adds an API endpoint that switches between resizing both the
text buffer and renderer space, or only the renderer space when the
control is resized.

## Validation Steps Performed
Tested with the terminal service in Visual studio.