### PR TITLE
Open up content dialogs for invalid URIs and unsupported schemes

### DIFF
--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -204,12 +204,12 @@
     <value>Warnings were found while parsing your keybindings:</value>
   </data>
   <data name="TooManyKeysForChord" xml:space="preserve">
-    <value>&#x2022; Found a keybinding with too many strings for the "keys" array. There should only be one string value in the "keys" array.</value>
-    <comment>{Locked="\"keys\"","&#x2022;"} This glyph is a bullet, used in a bulleted list.</comment>
+    <value>• Found a keybinding with too many strings for the "keys" array. There should only be one string value in the "keys" array.</value>
+    <comment>{Locked="\"keys\"","•"} This glyph is a bullet, used in a bulleted list.</comment>
   </data>
   <data name="MissingRequiredParameter" xml:space="preserve">
-    <value>&#x2022; Found a keybinding that was missing a required parameter value. This keybinding will be ignored.</value>
-    <comment>{Locked="&#x2022;"} This glyph is a bullet, used in a bulleted list.</comment>
+    <value>• Found a keybinding that was missing a required parameter value. This keybinding will be ignored.</value>
+    <comment>{Locked="•"} This glyph is a bullet, used in a bulleted list.</comment>
   </data>
   <data name="LegacyGlobalsProperty" xml:space="preserve">
     <value>The "globals" property is deprecated - your settings might need updating. </value>
@@ -651,5 +651,19 @@
   </data>
   <data name="CloseTabsAfterDefaultCommandKey" xml:space="preserve">
     <value>Close all tabs after the current tab</value>
+  </data>
+  <data name="InvalidLinkContent" xml:space="preserve">
+    <value>The URI "{0}" is invalid. </value>
+    <comment>{0} will be replaced by the URI the user is attempting to open. </comment>
+  </data>
+  <data name="InvalidLinkDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="UnsupportedSchemeContent" xml:space="preserve">
+    <value>The scheme "{0}" is not supported. </value>
+    <comment>{0} will be replaced with the scheme the user is trying to use.</comment>
+  </data>
+  <data name="UnsupportedSchemeDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Cancel</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -204,12 +204,12 @@
     <value>Warnings were found while parsing your keybindings:</value>
   </data>
   <data name="TooManyKeysForChord" xml:space="preserve">
-    <value>• Found a keybinding with too many strings for the "keys" array. There should only be one string value in the "keys" array.</value>
-    <comment>{Locked="\"keys\"","•"} This glyph is a bullet, used in a bulleted list.</comment>
+    <value>&#x2022; Found a keybinding with too many strings for the "keys" array. There should only be one string value in the "keys" array.</value>
+    <comment>{Locked="\"keys\"","&#x2022;"} This glyph is a bullet, used in a bulleted list.</comment>
   </data>
   <data name="MissingRequiredParameter" xml:space="preserve">
-    <value>• Found a keybinding that was missing a required parameter value. This keybinding will be ignored.</value>
-    <comment>{Locked="•"} This glyph is a bullet, used in a bulleted list.</comment>
+    <value>&#x2022; Found a keybinding that was missing a required parameter value. This keybinding will be ignored.</value>
+    <comment>{Locked="&#x2022;"} This glyph is a bullet, used in a bulleted list.</comment>
   </data>
   <data name="LegacyGlobalsProperty" xml:space="preserve">
     <value>The "globals" property is deprecated - your settings might need updating. </value>
@@ -652,9 +652,8 @@
   <data name="CloseTabsAfterDefaultCommandKey" xml:space="preserve">
     <value>Close all tabs after the current tab</value>
   </data>
-  <data name="InvalidLinkContent" xml:space="preserve">
-    <value>The URI "{0}" is invalid. </value>
-    <comment>{0} will be replaced by the URI the user is attempting to open. </comment>
+  <data name="InvalidLinkDialog.Content" xml:space="preserve">
+    <value>There was an error reading this hyperlink.</value>
   </data>
   <data name="InvalidLinkDialog.PrimaryButtonText" xml:space="preserve">
     <value>Cancel</value>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -652,20 +652,13 @@
   <data name="CloseTabsAfterDefaultCommandKey" xml:space="preserve">
     <value>Close all tabs after the current tab</value>
   </data>
-  <data name="InvalidLinkDialog.Content" xml:space="preserve">
-    <value>There was an error reading this hyperlink.</value>
+  <data name="InvalidUriText" xml:space="preserve">
+    <value>This link is invalid:</value>
   </data>
-  <data name="InvalidLinkDialog.PrimaryButtonText" xml:space="preserve">
+  <data name="UnsupportedSchemeText" xml:space="preserve">
+    <value>This link type is currently not supported:</value>
+  </data>
+  <data name="CouldNotOpenUriDialog.PrimaryButtonText" xml:space="preserve">
     <value>Cancel</value>
-  </data>
-  <data name="UnsupportedSchemeContent" xml:space="preserve">
-    <value>The scheme "{0}" is not supported. </value>
-    <comment>{0} will be replaced with the scheme the user is trying to use.</comment>
-  </data>
-  <data name="UnsupportedSchemeDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Cancel</value>
-  </data>
-  <data name="UnsupportedSchemeText.Text" xml:space="preserve">
-    <value>This link type is currently not supported.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -658,11 +658,18 @@
   <data name="InvalidLinkDialog.PrimaryButtonText" xml:space="preserve">
     <value>Cancel</value>
   </data>
+  <data name="UnopenedUriText" xml:space="preserve">
+    <value>{}</value>
+    <comment> {} will be replaced with the URI we could not open or parse </comment>
+  </data>
   <data name="UnsupportedSchemeContent" xml:space="preserve">
     <value>The scheme "{0}" is not supported. </value>
     <comment>{0} will be replaced with the scheme the user is trying to use.</comment>
   </data>
   <data name="UnsupportedSchemeDialog.PrimaryButtonText" xml:space="preserve">
     <value>Cancel</value>
+  </data>
+  <data name="UnsupportedSchemeText.Text" xml:space="preserve">
+    <value>This link type is currently not supported.</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -658,10 +658,6 @@
   <data name="InvalidLinkDialog.PrimaryButtonText" xml:space="preserve">
     <value>Cancel</value>
   </data>
-  <data name="UnopenedUriText" xml:space="preserve">
-    <value>{}</value>
-    <comment> {} will be replaced with the URI we could not open or parse </comment>
-  </data>
   <data name="UnsupportedSchemeContent" xml:space="preserve">
     <value>The scheme "{0}" is not supported. </value>
     <comment>{0} will be replaced with the scheme the user is trying to use.</comment>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1807,13 +1807,13 @@ namespace winrt::TerminalApp::implementation
             }
             else
             {
-                _ShowCouldNotOpenDialog(RS_(L"UnsupportedSchemeText"), eventArgs.Uri().c_str());
+                _ShowCouldNotOpenDialog(RS_(L"UnsupportedSchemeText"), eventArgs.Uri());
             }
         }
         catch (...)
         {
             LOG_CAUGHT_EXCEPTION();
-            _ShowCouldNotOpenDialog(RS_(L"InvalidUriText"), eventArgs.Uri().c_str());
+            _ShowCouldNotOpenDialog(RS_(L"InvalidUriText"), eventArgs.Uri());
         }
     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1805,8 +1805,37 @@ namespace winrt::TerminalApp::implementation
             {
                 ShellExecute(nullptr, L"open", eventArgs.Uri().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
             }
+            else if (auto presenter{ _dialogPresenter.get() })
+            {
+                // FindName needs to be called first to actually load the xaml object
+                FindName(L"UnsupportedSchemeDialog").try_as<WUX::Controls::ContentDialog>();
+
+                // Set the content
+                const auto errorMsg = fmt::format(std::wstring_view{ RS_(L"UnsupportedSchemeContent") },
+                                                  parsed.SchemeName());
+                UnsupportedSchemeDialog().Content(winrt::box_value(errorMsg));
+
+                // Show the dialog
+                presenter.ShowDialog(FindName(L"UnsupportedSchemeDialog").try_as<WUX::Controls::ContentDialog>());
+            }
         }
-        CATCH_LOG();
+        catch (...)
+        {
+            LOG_CAUGHT_EXCEPTION();
+            if (auto presenter{ _dialogPresenter.get() })
+            {
+                // FindName needs to be called first to actually load the xaml object
+                FindName(L"InvalidLinkDialog").try_as<WUX::Controls::ContentDialog>();
+
+                // Set the content
+                const auto errorMsg = fmt::format(std::wstring_view{ RS_(L"InvalidLinkContent") },
+                                                  eventArgs.Uri());
+                InvalidLinkDialog().Content(winrt::box_value(errorMsg));
+
+                // Show the dialog
+                presenter.ShowDialog(FindName(L"InvalidLinkDialog").try_as<WUX::Controls::ContentDialog>());
+            }
+        }
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1805,34 +1805,36 @@ namespace winrt::TerminalApp::implementation
             {
                 ShellExecute(nullptr, L"open", eventArgs.Uri().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
             }
-            else if (auto presenter{ _dialogPresenter.get() })
+            else
             {
-                // FindName needs to be called first to actually load the xaml object
-                auto unopenedUriDialog = FindName(L"CouldNotOpenUriDialog").try_as<WUX::Controls::ContentDialog>();
-
-                // Insert the reason (unsupported scheme) and the URI
-                CouldNotOpenUriReason().Text(RS_(L"UnsupportedSchemeText"));
-                UnopenedUri().Text(eventArgs.Uri());
-
-                // Show the dialog
-                presenter.ShowDialog(unopenedUriDialog);
+                _ShowCouldNotOpenDialog(RS_(L"UnsupportedSchemeText"), eventArgs.Uri().c_str());
             }
         }
         catch (...)
         {
             LOG_CAUGHT_EXCEPTION();
-            if (auto presenter{ _dialogPresenter.get() })
-            {
-                // FindName needs to be called first to actually load the xaml object
-                auto unopenedUriDialog = FindName(L"CouldNotOpenUriDialog").try_as<WUX::Controls::ContentDialog>();
+            _ShowCouldNotOpenDialog(RS_(L"InvalidUriText"), eventArgs.Uri().c_str());
+        }
+    }
 
-                // Insert the reason (invalid URI) and the URI
-                CouldNotOpenUriReason().Text(RS_(L"InvalidUriText"));
-                UnopenedUri().Text(eventArgs.Uri());
+    // Method Description:
+    // - Opens up a dialog box explaining why we could not open a URI
+    // Arguments:
+    // - The reason (unsupported scheme, invalid uri, potentially more in the future)
+    // - The uri
+    void TerminalPage::_ShowCouldNotOpenDialog(winrt::hstring reason, winrt::hstring uri)
+    {
+        if (auto presenter{ _dialogPresenter.get() })
+        {
+            // FindName needs to be called first to actually load the xaml object
+            auto unopenedUriDialog = FindName(L"CouldNotOpenUriDialog").try_as<WUX::Controls::ContentDialog>();
 
-                // Show the dialog
-                presenter.ShowDialog(unopenedUriDialog);
-            }
+            // Insert the reason and the URI
+            CouldNotOpenUriReason().Text(reason);
+            UnopenedUri().Text(uri);
+
+            // Show the dialog
+            presenter.ShowDialog(unopenedUriDialog);
         }
     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1808,15 +1808,15 @@ namespace winrt::TerminalApp::implementation
             else if (auto presenter{ _dialogPresenter.get() })
             {
                 // FindName needs to be called first to actually load the xaml object
-                FindName(L"UnsupportedSchemeDialog").try_as<WUX::Controls::ContentDialog>();
+                auto unsupportedSchemeDialog = FindName(L"UnsupportedSchemeDialog").try_as<WUX::Controls::ContentDialog>();
 
                 // Set the content
                 const auto errorMsg = fmt::format(std::wstring_view{ RS_(L"UnsupportedSchemeContent") },
                                                   parsed.SchemeName());
-                UnsupportedSchemeDialog().Content(winrt::box_value(errorMsg));
+                unsupportedSchemeDialog.Content(winrt::box_value(errorMsg));
 
                 // Show the dialog
-                presenter.ShowDialog(FindName(L"UnsupportedSchemeDialog").try_as<WUX::Controls::ContentDialog>());
+                presenter.ShowDialog(unsupportedSchemeDialog);
             }
         }
         catch (...)
@@ -1824,14 +1824,6 @@ namespace winrt::TerminalApp::implementation
             LOG_CAUGHT_EXCEPTION();
             if (auto presenter{ _dialogPresenter.get() })
             {
-                // FindName needs to be called first to actually load the xaml object
-                FindName(L"InvalidLinkDialog").try_as<WUX::Controls::ContentDialog>();
-
-                // Set the content
-                const auto errorMsg = fmt::format(std::wstring_view{ RS_(L"InvalidLinkContent") },
-                                                  eventArgs.Uri());
-                InvalidLinkDialog().Content(winrt::box_value(errorMsg));
-
                 // Show the dialog
                 presenter.ShowDialog(FindName(L"InvalidLinkDialog").try_as<WUX::Controls::ContentDialog>());
             }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1812,10 +1812,8 @@ namespace winrt::TerminalApp::implementation
                 auto unopenedUri = FindName(L"UnopenedUri").try_as<Windows::UI::Xaml::Documents::Run>();
 
                 // Insert the URI
-                const auto uriMsg = fmt::format(std::wstring_view{ RS_(L"UnopenedUriText") },
-                                                eventArgs.Uri().c_str());
-                unopenedUri.Text(uriMsg);
-                
+                unopenedUri.Text(eventArgs.Uri().c_str());
+
                 // Show the dialog
                 presenter.ShowDialog(unsupportedSchemeDialog);
             }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1807,14 +1807,15 @@ namespace winrt::TerminalApp::implementation
             }
             else if (auto presenter{ _dialogPresenter.get() })
             {
-                // FindName needs to be called first to actually load the xaml object
+                // FindName needs to be called first to actually load the xaml objects
                 auto unsupportedSchemeDialog = FindName(L"UnsupportedSchemeDialog").try_as<WUX::Controls::ContentDialog>();
+                auto unopenedUri = FindName(L"UnopenedUri").try_as<Windows::UI::Xaml::Documents::Run>();
 
-                // Set the content
-                const auto errorMsg = fmt::format(std::wstring_view{ RS_(L"UnsupportedSchemeContent") },
-                                                  parsed.SchemeName());
-                unsupportedSchemeDialog.Content(winrt::box_value(errorMsg));
-
+                // Insert the URI
+                const auto uriMsg = fmt::format(std::wstring_view{ RS_(L"UnopenedUriText") },
+                                                eventArgs.Uri().c_str());
+                unopenedUri.Text(uriMsg);
+                
                 // Show the dialog
                 presenter.ShowDialog(unsupportedSchemeDialog);
             }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1807,15 +1807,15 @@ namespace winrt::TerminalApp::implementation
             }
             else if (auto presenter{ _dialogPresenter.get() })
             {
-                // FindName needs to be called first to actually load the xaml objects
-                auto unsupportedSchemeDialog = FindName(L"UnsupportedSchemeDialog").try_as<WUX::Controls::ContentDialog>();
-                auto unopenedUri = FindName(L"UnopenedUri").try_as<Windows::UI::Xaml::Documents::Run>();
+                // FindName needs to be called first to actually load the xaml object
+                auto unopenedUriDialog = FindName(L"CouldNotOpenUriDialog").try_as<WUX::Controls::ContentDialog>();
 
-                // Insert the URI
-                unopenedUri.Text(eventArgs.Uri().c_str());
+                // Insert the reason (unsupported scheme) and the URI
+                CouldNotOpenUriReason().Text(RS_(L"UnsupportedSchemeText"));
+                UnopenedUri().Text(eventArgs.Uri());
 
                 // Show the dialog
-                presenter.ShowDialog(unsupportedSchemeDialog);
+                presenter.ShowDialog(unopenedUriDialog);
             }
         }
         catch (...)
@@ -1823,8 +1823,15 @@ namespace winrt::TerminalApp::implementation
             LOG_CAUGHT_EXCEPTION();
             if (auto presenter{ _dialogPresenter.get() })
             {
+                // FindName needs to be called first to actually load the xaml object
+                auto unopenedUriDialog = FindName(L"CouldNotOpenUriDialog").try_as<WUX::Controls::ContentDialog>();
+
+                // Insert the reason (invalid URI) and the URI
+                CouldNotOpenUriReason().Text(RS_(L"InvalidUriText"));
+                UnopenedUri().Text(eventArgs.Uri());
+
                 // Show the dialog
-                presenter.ShowDialog(FindName(L"InvalidLinkDialog").try_as<WUX::Controls::ContentDialog>());
+                presenter.ShowDialog(unopenedUriDialog);
             }
         }
     }

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -173,6 +173,7 @@ namespace winrt::TerminalApp::implementation
                                                           const Microsoft::Terminal::TerminalControl::PasteFromClipboardEventArgs eventArgs);
 
         void _OpenHyperlinkHandler(const IInspectable sender, const Microsoft::Terminal::TerminalControl::OpenHyperlinkEventArgs eventArgs);
+        void _ShowCouldNotOpenDialog(winrt::hstring reason, winrt::hstring uri);
         bool _CopyText(const bool singleLine, const Windows::Foundation::IReference<Microsoft::Terminal::TerminalControl::CopyFormat>& formats);
 
         void _PasteText();

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -70,23 +70,16 @@ the MIT License. See LICENSE in the project root for license information. -->
 
         <ContentDialog
             x:Load="False"
-            x:Name="UnsupportedSchemeDialog"
-            x:Uid="UnsupportedSchemeDialog"
+            x:Name="CouldNotOpenUriDialog"
+            x:Uid="CouldNotOpenUriDialog"
             DefaultButton="Primary">
             <TextBlock IsTextSelectionEnabled="True">
-                <Run x:Uid="UnsupportedSchemeText" /> <LineBreak />
+                <Run x:Name="CouldNotOpenUriReason" /> <LineBreak />
                 <Run
                     x:Name="UnopenedUri"
                     FontFamily="Cascadia Mono">
                 </Run>
             </TextBlock>
-        </ContentDialog>
-
-        <ContentDialog
-            x:Load="False"
-            x:Name="InvalidLinkDialog"
-            x:Uid="InvalidLinkDialog"
-            DefaultButton="Primary">
         </ContentDialog>
 
         <local:CommandPalette

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -68,6 +68,20 @@ the MIT License. See LICENSE in the project root for license information. -->
             DefaultButton="Primary">
         </ContentDialog>
 
+        <ContentDialog
+            x:Load="False"
+            x:Name="UnsupportedSchemeDialog"
+            x:Uid="UnsupportedSchemeDialog"
+            DefaultButton="Primary">
+        </ContentDialog>
+
+        <ContentDialog
+            x:Load="False"
+            x:Name="InvalidLinkDialog"
+            x:Uid="InvalidLinkDialog"
+            DefaultButton="Primary">
+        </ContentDialog>
+
         <local:CommandPalette
             x:Name="CommandPalette"
             Grid.Row="1"

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -73,6 +73,13 @@ the MIT License. See LICENSE in the project root for license information. -->
             x:Name="UnsupportedSchemeDialog"
             x:Uid="UnsupportedSchemeDialog"
             DefaultButton="Primary">
+            <TextBlock IsTextSelectionEnabled="True">
+                <Run x:Uid="UnsupportedSchemeText" /> <LineBreak />
+                <Run
+                    x:Name="UnopenedUri"
+                    FontFamily="Cascadia Mono">
+                </Run>
+            </TextBlock>
         </ContentDialog>
 
         <ContentDialog


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
If a user clicks a link that is either invalid (cannot be parsed) or has a scheme we do not support (like file or mailto (for now)), we open up a dialog box telling them the issue.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
#5001 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] I work here
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
![dialog](https://user-images.githubusercontent.com/26824113/92272097-ef08a080-eeb6-11ea-86e7-de9bc5cbda9f.gif)


