### PR TITLE
Remove AcrylicOpacity from AzureCloudShellGenerator

### DIFF
--- a/src/cascadia/TerminalApp/AzureCloudShellGenerator.cpp
+++ b/src/cascadia/TerminalApp/AzureCloudShellGenerator.cpp
@@ -38,8 +38,6 @@ std::vector<Profile> AzureCloudShellGenerator::GenerateProfiles()
         azureCloudShellProfile.Commandline(L"Azure");
         azureCloudShellProfile.StartingDirectory(DEFAULT_STARTING_DIRECTORY);
         azureCloudShellProfile.ColorSchemeName(L"Vintage");
-        azureCloudShellProfile.AcrylicOpacity(0.6);
-        azureCloudShellProfile.UseAcrylic(true);
         azureCloudShellProfile.ConnectionType(AzureConnectionType);
         profiles.emplace_back(azureCloudShellProfile);
     }


### PR DESCRIPTION
Removed Acrylic Opacity from AzureCloudShellGenerator.

## PR Checklist
* [x] Closes #7245 
* [x] CLA signed
* [x] I've discussed this with core contributors already