### PR TITLE
oss: add a manifest for x11's rgb database

### DIFF
--- a/oss/xorg_apps_rgb/MAINTAINER_README.md
+++ b/oss/xorg_apps_rgb/MAINTAINER_README.md
@@ -1,0 +1,7 @@
+### Notes for Future Maintainers
+
+This manifest anchors our usage of rgb.txt from the X11 distribution.
+
+The provenance information (where it came from and which commit) is stored in the file `cgmanifest.json` in the same directory as this readme.
+Please update the provenance information in that file when ingesting an updated version of the dependent library.
+That provenance file is automatically read and inventoried by Microsoft systems to ensure compliance with appropiate governance standards.

--- a/oss/xorg_apps_rgb/cgmanifest.json
+++ b/oss/xorg_apps_rgb/cgmanifest.json
@@ -1,0 +1,13 @@
+{"Registrations":[ 
+    {
+      "component": { 
+       "type": "git", 
+       "git": { 
+         "repositoryUrl": "https://gitlab.freedesktop.org/xorg/app/rgb.git", 
+         "commitHash": "97820e748eb496a1f6d3fc3bf89688f0ce1f64f9" 
+         }
+       }
+    }
+ ],
+ "Version": 1
+}


### PR DESCRIPTION
We will want to add support for the x11 color names.
The name table is are MIT-licensed by the X.org Foundation.