### PR TITLE
[1.3 STABLE ONLY] Unbind `togglePaneZoom`

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -67,7 +67,6 @@
         "toggleAlwaysOnTop",
         "toggleFocusMode",
         "toggleFullscreen",
-        "togglePaneZoom",
         "toggleRetroEffect",
         "wt",
         "unbound"

--- a/src/cascadia/TerminalApp/ActionAndArgs.cpp
+++ b/src/cascadia/TerminalApp/ActionAndArgs.cpp
@@ -22,7 +22,7 @@ static constexpr std::string_view NewTabKey{ "newTab" };
 static constexpr std::string_view NewWindowKey{ "newWindow" };
 static constexpr std::string_view NextTabKey{ "nextTab" };
 static constexpr std::string_view OpenNewTabDropdownKey{ "openNewTabDropdown" };
-static constexpr std::string_view OpenSettingsKey{ "openSettings" };
+static constexpr std::string_view OpenSettingsKey{ "openSettings" }; // TODO GH#2557: Add args for OpenSettings
 static constexpr std::string_view OpenTabColorPickerKey{ "openTabColorPicker" };
 static constexpr std::string_view PasteTextKey{ "paste" };
 static constexpr std::string_view PrevTabKey{ "prevTab" };
@@ -43,7 +43,7 @@ static constexpr std::string_view ToggleAlwaysOnTopKey{ "toggleAlwaysOnTop" };
 static constexpr std::string_view ToggleCommandPaletteKey{ "commandPalette" };
 static constexpr std::string_view ToggleFocusModeKey{ "toggleFocusMode" };
 static constexpr std::string_view ToggleFullscreenKey{ "toggleFullscreen" };
-//static constexpr std::string_view TogglePaneZoomKey{ "togglePaneZoom" }; // TODO GH#7252: Re-enable pane zooming
+static constexpr std::string_view TogglePaneZoomKey{ "togglePaneZoom" };
 static constexpr std::string_view ToggleRetroEffectKey{ "toggleRetroEffect" };
 
 static constexpr std::string_view ActionKey{ "action" };
@@ -283,7 +283,7 @@ namespace winrt::TerminalApp::implementation
                 { ShortcutAction::ToggleCommandPalette, RS_(L"ToggleCommandPaletteCommandKey") },
                 { ShortcutAction::ToggleFocusMode, RS_(L"ToggleFocusModeCommandKey") },
                 { ShortcutAction::ToggleFullscreen, RS_(L"ToggleFullscreenCommandKey") },
-                // { ShortcutAction::TogglePaneZoom, RS_(L"TogglePaneZoomCommandKey") }, // TODO GH#7252: Re-enable pane zooming
+                { ShortcutAction::TogglePaneZoom, RS_(L"TogglePaneZoomCommandKey") },
                 { ShortcutAction::ToggleRetroEffect, RS_(L"ToggleRetroEffectCommandKey") },
             };
         }();

--- a/src/cascadia/TerminalApp/ActionAndArgs.cpp
+++ b/src/cascadia/TerminalApp/ActionAndArgs.cpp
@@ -22,7 +22,7 @@ static constexpr std::string_view NewTabKey{ "newTab" };
 static constexpr std::string_view NewWindowKey{ "newWindow" };
 static constexpr std::string_view NextTabKey{ "nextTab" };
 static constexpr std::string_view OpenNewTabDropdownKey{ "openNewTabDropdown" };
-static constexpr std::string_view OpenSettingsKey{ "openSettings" }; // TODO GH#2557: Add args for OpenSettings
+static constexpr std::string_view OpenSettingsKey{ "openSettings" };
 static constexpr std::string_view OpenTabColorPickerKey{ "openTabColorPicker" };
 static constexpr std::string_view PasteTextKey{ "paste" };
 static constexpr std::string_view PrevTabKey{ "prevTab" };
@@ -43,7 +43,7 @@ static constexpr std::string_view ToggleAlwaysOnTopKey{ "toggleAlwaysOnTop" };
 static constexpr std::string_view ToggleCommandPaletteKey{ "commandPalette" };
 static constexpr std::string_view ToggleFocusModeKey{ "toggleFocusMode" };
 static constexpr std::string_view ToggleFullscreenKey{ "toggleFullscreen" };
-static constexpr std::string_view TogglePaneZoomKey{ "togglePaneZoom" };
+//static constexpr std::string_view TogglePaneZoomKey{ "togglePaneZoom" }; // TODO GH#7252: Re-enable pane zooming
 static constexpr std::string_view ToggleRetroEffectKey{ "toggleRetroEffect" };
 
 static constexpr std::string_view ActionKey{ "action" };
@@ -100,7 +100,7 @@ namespace winrt::TerminalApp::implementation
         { ToggleCommandPaletteKey, ShortcutAction::ToggleCommandPalette },
         { ToggleFocusModeKey, ShortcutAction::ToggleFocusMode },
         { ToggleFullscreenKey, ShortcutAction::ToggleFullscreen },
-        { TogglePaneZoomKey, ShortcutAction::TogglePaneZoom },
+        // { TogglePaneZoomKey, ShortcutAction::TogglePaneZoom }, // TODO GH#7252: Re-enable pane zooming
         { ToggleRetroEffectKey, ShortcutAction::ToggleRetroEffect },
         { UnboundKey, ShortcutAction::Invalid },
     };
@@ -283,7 +283,7 @@ namespace winrt::TerminalApp::implementation
                 { ShortcutAction::ToggleCommandPalette, RS_(L"ToggleCommandPaletteCommandKey") },
                 { ShortcutAction::ToggleFocusMode, RS_(L"ToggleFocusModeCommandKey") },
                 { ShortcutAction::ToggleFullscreen, RS_(L"ToggleFullscreenCommandKey") },
-                { ShortcutAction::TogglePaneZoom, RS_(L"TogglePaneZoomCommandKey") },
+                // { ShortcutAction::TogglePaneZoom, RS_(L"TogglePaneZoomCommandKey") }, // TODO GH#7252: Re-enable pane zooming
                 { ShortcutAction::ToggleRetroEffect, RS_(L"ToggleRetroEffectCommandKey") },
             };
         }();

--- a/src/cascadia/TerminalApp/defaults.json
+++ b/src/cascadia/TerminalApp/defaults.json
@@ -327,8 +327,7 @@
         { "command": { "action": "moveFocus", "direction": "down" }, "keys": "alt+down" },
         { "command": { "action": "moveFocus", "direction": "left" }, "keys": "alt+left" },
         { "command": { "action": "moveFocus", "direction": "right" }, "keys": "alt+right" },
-        { "command": { "action": "moveFocus", "direction": "up" }, "keys": "alt+up" },
-        { "command": "togglePaneZoom" },
+        { "command": { "action": "moveFocus", "direction": "up" }, "keys": "alt+up" }
 
         // Clipboard Integration
         { "command": { "action": "copy", "singleLine": false }, "keys": "ctrl+shift+c" },

--- a/src/cascadia/TerminalApp/defaults.json
+++ b/src/cascadia/TerminalApp/defaults.json
@@ -327,7 +327,7 @@
         { "command": { "action": "moveFocus", "direction": "down" }, "keys": "alt+down" },
         { "command": { "action": "moveFocus", "direction": "left" }, "keys": "alt+left" },
         { "command": { "action": "moveFocus", "direction": "right" }, "keys": "alt+right" },
-        { "command": { "action": "moveFocus", "direction": "up" }, "keys": "alt+up" }
+        { "command": { "action": "moveFocus", "direction": "up" }, "keys": "alt+up" },
 
         // Clipboard Integration
         { "command": { "action": "copy", "singleLine": false }, "keys": "ctrl+shift+c" },


### PR DESCRIPTION
## Summary of the Pull Request

Disable `togglePaneZoom` as a binding. Remove it from defaults.json and the schema.

## References
#7252 - re-enable this binding when this blocking bug is resolved

## Validation Steps Performed
Successful deployment