### PR TITLE
Fix failing HyperlinkIdConsistency unit test

### DIFF
--- a/src/cascadia/UnitTests_TerminalCore/ConptyRoundtripTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ConptyRoundtripTests.cpp
@@ -3491,7 +3491,7 @@ void ConptyRoundtripTests::HyperlinkIdConsistency()
 
     _flushFirstFrame();
 
-    hostSm.ProcessString(L"\x1b]8;;http://example.com\x1b/Link\x1b]8;;\x1b/");
+    hostSm.ProcessString(L"\x1b]8;;http://example.com\x1b\\Link\x1b]8;;\x1b\\");
 
     // For self-generated IDs, conpty will send a custom ID of the form
     // {sessionID}-{self-generated ID}


### PR DESCRIPTION
## Summary of the Pull Request

This fixes a typo in the `HyperlinkIdConsistency` unit test which was causing that test to fail. It was mistakenly using a `/` instead of `\` for the string terminator sequences.

## References

The test initially worked because of a bug in the state machine parser, but that bug was recently fixed in PR #7340.

## PR Checklist
* [x] Closes #7654
* [x] CLA signed. 
* [x] Tests passed
* [ ] Documentation updated. 
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.

## Validation Steps Performed

I've run the test again and it now passes.