### PR TITLE
Give Tab ownership of its SwitchToTab command

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -87,8 +87,6 @@ namespace winrt::TerminalApp::implementation
         Microsoft::Terminal::TerminalControl::IKeyBindings _bindings;
 
         // Tab Switcher
-        void GenerateCommandForTab(const uint32_t idx, bool inserted, winrt::TerminalApp::Tab& tab);
-        void UpdateTabIndices(const uint32_t startIdx);
         Windows::Foundation::Collections::IVector<TerminalApp::Command> _allTabActions{ nullptr };
         uint32_t _switcherStartIdx;
         void _anchorKeyUpHandler();

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -8,6 +8,8 @@
 #include "Tab.g.cpp"
 #include "Utils.h"
 #include "ColorHelper.h"
+#include "ActionAndArgs.h"
+#include "ActionArgs.h"
 
 using namespace winrt;
 using namespace winrt::Windows::UI::Xaml;
@@ -34,6 +36,7 @@ namespace winrt::TerminalApp::implementation
         _activePane = _rootPane;
 
         _MakeTabViewItem();
+        _MakeSwitchToTabCommand();
     }
 
     // Method Description:
@@ -229,6 +232,9 @@ namespace winrt::TerminalApp::implementation
             // The TabViewItem Icon needs MUX while the IconSourceElement in the CommandPalette needs WUX...
             IconSource(GetColoredIcon<winrt::WUX::Controls::IconSource>(_lastIconPath));
             _tabViewItem.IconSource(GetColoredIcon<winrt::MUX::Controls::IconSource>(_lastIconPath));
+
+            // Update SwitchToTab command's icon
+            SwitchToTabCommand().IconSource(IconSource());
         }
     }
 
@@ -265,6 +271,9 @@ namespace winrt::TerminalApp::implementation
         {
             // Bubble our current tab text to anyone who's listening for changes.
             Title(GetActiveTitle());
+
+            // Update SwitchToTab command's name
+            SwitchToTabCommand().Name(Title());
 
             // Update the UI to reflect the changed
             _UpdateTabHeader();
@@ -1024,6 +1033,29 @@ namespace winrt::TerminalApp::implementation
     bool Tab::IsZoomed()
     {
         return _zoomedPane != nullptr;
+    }
+
+    void Tab::_MakeSwitchToTabCommand()
+    {
+        auto focusTabAction = winrt::make_self<implementation::ActionAndArgs>();
+        auto args = winrt::make_self<implementation::SwitchToTabArgs>();
+        args->TabIndex(_TabViewIndex);
+
+        focusTabAction->Action(ShortcutAction::SwitchToTab);
+        focusTabAction->Args(*args);
+
+        winrt::TerminalApp::Command command;
+        command.Action(*focusTabAction);
+        command.Name(Title());
+        command.IconSource(IconSource());
+
+        SwitchToTabCommand(command);
+    }
+
+    void Tab::UpdateTabViewIndex(const uint32_t idx)
+    {
+        TabViewIndex(idx);
+        SwitchToTabCommand().Action().Args().as<implementation::SwitchToTabArgs>()->TabIndex(idx);
     }
 
     DEFINE_EVENT(Tab, ActivePaneChanged, _ActivePaneChangedHandlers, winrt::delegate<>);

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -1035,6 +1035,12 @@ namespace winrt::TerminalApp::implementation
         return _zoomedPane != nullptr;
     }
 
+    // Method Description:
+    // - Initializes a SwitchToTab command object for this Tab instance.
+    // Arguments:
+    // - <none>
+    // Return Value:
+    // - <none>
     void Tab::_MakeSwitchToTabCommand()
     {
         auto focusTabAction = winrt::make_self<implementation::ActionAndArgs>();

--- a/src/cascadia/TerminalApp/Tab.h
+++ b/src/cascadia/TerminalApp/Tab.h
@@ -76,6 +76,7 @@ namespace winrt::TerminalApp::implementation
 
         OBSERVABLE_GETSET_PROPERTY(winrt::hstring, Title, _PropertyChangedHandlers);
         OBSERVABLE_GETSET_PROPERTY(winrt::Windows::UI::Xaml::Controls::IconSource, IconSource, _PropertyChangedHandlers, nullptr);
+        OBSERVABLE_GETSET_PROPERTY(winrt::TerminalApp::Command, SwitchToTabCommand, _PropertyChangedHandlers, nullptr);
 
     private:
         std::shared_ptr<Pane> _rootPane{ nullptr };

--- a/src/cascadia/TerminalApp/Tab.h
+++ b/src/cascadia/TerminalApp/Tab.h
@@ -68,6 +68,8 @@ namespace winrt::TerminalApp::implementation
 
         int GetLeafPaneCount() const noexcept;
 
+        void UpdateTabViewIndex(const uint32_t idx);
+
         WINRT_CALLBACK(Closed, winrt::Windows::Foundation::EventHandler<winrt::Windows::Foundation::IInspectable>);
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
         DECLARE_EVENT(ActivePaneChanged, _ActivePaneChangedHandlers, winrt::delegate<>);
@@ -77,6 +79,10 @@ namespace winrt::TerminalApp::implementation
         OBSERVABLE_GETSET_PROPERTY(winrt::hstring, Title, _PropertyChangedHandlers);
         OBSERVABLE_GETSET_PROPERTY(winrt::Windows::UI::Xaml::Controls::IconSource, IconSource, _PropertyChangedHandlers, nullptr);
         OBSERVABLE_GETSET_PROPERTY(winrt::TerminalApp::Command, SwitchToTabCommand, _PropertyChangedHandlers, nullptr);
+
+        // The TabViewIndex is the index this Tab object resides in TerminalPage's _tabs vector.
+        // This is needed since Tab is going to be managing its own SwitchToTab command.
+        OBSERVABLE_GETSET_PROPERTY(uint32_t, TabViewIndex, _PropertyChangedHandlers, 0);
 
     private:
         std::shared_ptr<Pane> _rootPane{ nullptr };
@@ -114,6 +120,8 @@ namespace winrt::TerminalApp::implementation
         void _RecalculateAndApplyTabColor();
         void _ApplyTabColor(const winrt::Windows::UI::Color& color);
         void _ClearTabBackgroundColor();
+
+        void _MakeSwitchToTabCommand();
 
         friend class ::TerminalAppLocalTests::TabTests;
     };

--- a/src/cascadia/TerminalApp/Tab.idl
+++ b/src/cascadia/TerminalApp/Tab.idl
@@ -10,5 +10,6 @@ namespace TerminalApp
         String Title { get; };
         Windows.UI.Xaml.Controls.IconSource IconSource { get; };
         Command SwitchToTabCommand { get; };
+        UInt32 TabViewIndex { get; };
     }
 }

--- a/src/cascadia/TerminalApp/Tab.idl
+++ b/src/cascadia/TerminalApp/Tab.idl
@@ -1,11 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import "Command.idl";
+
 namespace TerminalApp
 {
     [default_interface] runtimeclass Tab : Windows.UI.Xaml.Data.INotifyPropertyChanged
     {
         String Title { get; };
         Windows.UI.Xaml.Controls.IconSource IconSource { get; };
+        Command SwitchToTabCommand { get; };
     }
 }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2524,7 +2524,13 @@ namespace winrt::TerminalApp::implementation
         return _isAlwaysOnTop;
     }
 
-    void TerminalPage::_UpdateSwitchToTabCommandIndices()
+    // Method Description:
+    // - Updates all tabs with their current index in _tabs.
+    // Arguments:
+    // - <none>
+    // Return Value:
+    // - <none>
+    void TerminalPage::_UpdateTabIndices()
     {
         for (uint32_t i = 0; i < _tabs.Size(); ++i)
         {

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -166,7 +166,7 @@ namespace winrt::TerminalApp::implementation
                     auto tab = tabs.GetAt(from.value());
                     tabs.RemoveAt(from.value());
                     tabs.InsertAt(to.value(), tab);
-                    page->_UpdateSwitchToTabCommandIndices();
+                    page->_UpdateTabIndices();
                 }
 
                 page->_rearranging = false;
@@ -1070,7 +1070,7 @@ namespace winrt::TerminalApp::implementation
 
         _tabs.RemoveAt(tabIndex);
         _tabView.TabItems().RemoveAt(tabIndex);
-        _UpdateSwitchToTabCommandIndices();
+        _UpdateTabIndices();
 
         // To close the window here, we need to close the hosting window.
         if (_tabs.Size() == 0)

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -166,6 +166,7 @@ namespace winrt::TerminalApp::implementation
                     auto tab = tabs.GetAt(from.value());
                     tabs.RemoveAt(from.value());
                     tabs.InsertAt(to.value(), tab);
+                    page->_UpdateSwitchToTabCommandIndices();
                 }
 
                 page->_rearranging = false;
@@ -687,6 +688,9 @@ namespace winrt::TerminalApp::implementation
         auto newTabImpl = winrt::make_self<Tab>(profileGuid, term);
         _tabs.Append(*newTabImpl);
 
+        // Give the tab its index in the _tabs vector so it can manage its own SwitchToTab command.
+        newTabImpl->UpdateTabViewIndex(_tabs.Size() - 1);
+
         // Hookup our event handlers to the new terminal
         _RegisterTerminalEvents(term, *newTabImpl);
 
@@ -1066,6 +1070,7 @@ namespace winrt::TerminalApp::implementation
 
         _tabs.RemoveAt(tabIndex);
         _tabView.TabItems().RemoveAt(tabIndex);
+        _UpdateSwitchToTabCommandIndices();
 
         // To close the window here, we need to close the hosting window.
         if (_tabs.Size() == 0)
@@ -2517,6 +2522,14 @@ namespace winrt::TerminalApp::implementation
     bool TerminalPage::AlwaysOnTop() const
     {
         return _isAlwaysOnTop;
+    }
+
+    void TerminalPage::_UpdateSwitchToTabCommandIndices()
+    {
+        for (uint32_t i = 0; i < _tabs.Size(); ++i)
+        {
+            _GetStrongTabImpl(i)->UpdateTabViewIndex(i);
+        }
     }
 
     // -------------------------------- WinRT Events ---------------------------------

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -93,6 +93,7 @@ namespace winrt::TerminalApp::implementation
         Windows::Foundation::Collections::IObservableVector<TerminalApp::Tab> _tabs;
         winrt::com_ptr<Tab> _GetStrongTabImpl(const uint32_t index) const;
         winrt::com_ptr<Tab> _GetStrongTabImpl(const ::winrt::TerminalApp::Tab& tab) const;
+        void _UpdateSwitchToTabCommandIndices();
 
         bool _isInFocusMode{ false };
         bool _isFullscreen{ false };

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -93,7 +93,7 @@ namespace winrt::TerminalApp::implementation
         Windows::Foundation::Collections::IObservableVector<TerminalApp::Tab> _tabs;
         winrt::com_ptr<Tab> _GetStrongTabImpl(const uint32_t index) const;
         winrt::com_ptr<Tab> _GetStrongTabImpl(const ::winrt::TerminalApp::Tab& tab) const;
-        void _UpdateSwitchToTabCommandIndices();
+        void _UpdateTabIndices();
 
         bool _isInFocusMode{ false };
         bool _isFullscreen{ false };


### PR DESCRIPTION
Currently, `CommandPalette` creates and maintains the `SwitchToTab`
commands used for the ATS. When `Command` goes into the
TerminalSettingsModel, the palette won't be able to access `Command`'s
implementation type, making it difficult for `CommandPalette` to tell
`Command` to listen to `Tab` for changes.

This PR changes the relationship up so `Tab` now manages its
`SwitchToTab` command, and `CommandPalette` just plops the command from
`Tab` into its list. 
