### PR TITLE
Make sure we don't hide the cursor until the IME starts

### DIFF
--- a/.github/actions/spell-check/expect/expect.txt
+++ b/.github/actions/spell-check/expect/expect.txt
@@ -2715,6 +2715,7 @@ WNDCLASSW
 Wndproc
 WNegative
 WNull
+wnwb
 workarea
 workaround
 workflow
@@ -2762,6 +2763,7 @@ wtof
 wtoi
 wtw
 wtypes
+Wubi
 WUX
 WVerify
 wwaproj

--- a/src/host/conimeinfo.cpp
+++ b/src/host/conimeinfo.cpp
@@ -62,6 +62,10 @@ void ConsoleImeInfo::WriteCompMessage(const std::wstring_view text,
 {
     ClearAllAreas();
 
+    // MSFT:29219348 only hide the cursor after the IME produces a string.
+    // See notes in convarea.cpp ImeStartComposition().
+    SaveCursorVisibility();
+
     // Save copies of the composition message in case we need to redraw it as things scroll/resize
     _text = text;
     _attributes.assign(attributes.begin(), attributes.end());

--- a/src/host/convarea.cpp
+++ b/src/host/convarea.cpp
@@ -104,8 +104,16 @@ void WriteConvRegionToScreen(const SCREEN_INFORMATION& ScreenInfo,
     gci.LockConsole();
     auto unlock = wil::scope_exit([&] { gci.UnlockConsole(); });
 
-    ConsoleImeInfo* const pIme = &gci.ConsoleIme;
-    pIme->SaveCursorVisibility();
+    // MSFT:29219348 Some IME implementations do not
+    // produce composition strings, and their users
+    // have come to rely on the cursor that conhost
+    // traditionally left on until a composition
+    // string showed up.
+    // We shouldn't hide the cursor here so as to not
+    // break those IMEs.
+    //
+    // ConsoleImeInfo* const pIme = &gci.ConsoleIme;
+    // pIme->SaveCursorVisibility();
 
     gci.pInputBuffer->fInComposition = true;
     return S_OK;

--- a/src/host/convarea.cpp
+++ b/src/host/convarea.cpp
@@ -109,6 +109,8 @@ void WriteConvRegionToScreen(const SCREEN_INFORMATION& ScreenInfo,
     // have come to rely on the cursor that conhost
     // traditionally left on until a composition
     // string showed up.
+    // One such IME is WNWB's "Universal Wubi input
+    // method" from wnwb.com (version 10+).
     // We shouldn't hide the cursor here so as to not
     // break those IMEs.
     //

--- a/src/host/convarea.cpp
+++ b/src/host/convarea.cpp
@@ -104,18 +104,11 @@ void WriteConvRegionToScreen(const SCREEN_INFORMATION& ScreenInfo,
     gci.LockConsole();
     auto unlock = wil::scope_exit([&] { gci.UnlockConsole(); });
 
-    // MSFT:29219348 Some IME implementations do not
-    // produce composition strings, and their users
-    // have come to rely on the cursor that conhost
-    // traditionally left on until a composition
-    // string showed up.
-    // One such IME is WNWB's "Universal Wubi input
-    // method" from wnwb.com (version 10+).
-    // We shouldn't hide the cursor here so as to not
-    // break those IMEs.
-    //
-    // ConsoleImeInfo* const pIme = &gci.ConsoleIme;
-    // pIme->SaveCursorVisibility();
+    // MSFT:29219348 Some IME implementations do not produce composition strings, and
+    // their users have come to rely on the cursor that conhost traditionally left on
+    // until a composition string showed up.
+    // One such IME is WNWB's "Universal Wubi input method" from wnwb.com (v. 10+).
+    // We shouldn't hide the cursor here so as to not break those IMEs.
 
     gci.pInputBuffer->fInComposition = true;
     return S_OK;


### PR DESCRIPTION
Some IME implementations do not produce composition strings, and their
users have come to rely on the cursor that conhost traditionally left on
until a composition string showed up. We shouldn't hide the cursor until
we get a string (as opposed to hiding it when composition begins) so as
to not break those IMEs.

Related to #6207.

Fixes MSFT:29219348