### PR TITLE
Add support for the BEL control in Windows Terminal

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -8,6 +8,7 @@
 #include "AppLogic.h"
 #include "../../types/inc/utils.hpp"
 
+#include <Mmsystem.h>
 #include <LibraryResources.h>
 
 #include "TerminalPage.g.cpp"
@@ -1141,6 +1142,8 @@ namespace winrt::TerminalApp::implementation
         // Add an event handler when the terminal wants to paste data from the Clipboard.
         term.PasteFromClipboard({ this, &TerminalPage::_PasteFromClipboardHandler });
 
+        term.WarningBell({ this, &TerminalPage::_WarningBellHandler });
+
         term.OpenHyperlink({ this, &TerminalPage::_OpenHyperlinkHandler });
 
         // Bind Tab events to the TermControl and the Tab's Pane
@@ -1799,6 +1802,18 @@ namespace winrt::TerminalApp::implementation
             eventArgs.HandleClipboardData(text);
         }
         CATCH_LOG();
+    }
+
+    // Method Description:
+    // - Plays a warning note when triggered by the BEL control character,
+    //   using the sound configured for the "Critical Stop" system event.
+    //   This matches the behavior of the Windows Console host.
+    // Arguments:
+    // - <none>
+    void TerminalPage::_WarningBellHandler(const IInspectable sender, const IInspectable eventArgs)
+    {
+        const auto soundAlias = reinterpret_cast<LPCTSTR>(SND_ALIAS_SYSTEMHAND);
+        PlaySound(soundAlias, NULL, SND_ALIAS_ID | SND_ASYNC | SND_SENTRY);
     }
 
     void TerminalPage::_OpenHyperlinkHandler(const IInspectable /*sender*/, const Microsoft::Terminal::TerminalControl::OpenHyperlinkEventArgs eventArgs)

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -176,6 +176,7 @@ namespace winrt::TerminalApp::implementation
         winrt::fire_and_forget _PasteFromClipboardHandler(const IInspectable sender,
                                                           const Microsoft::Terminal::TerminalControl::PasteFromClipboardEventArgs eventArgs);
 
+        void _WarningBellHandler(const IInspectable sender, const IInspectable eventArgs);
         void _OpenHyperlinkHandler(const IInspectable sender, const Microsoft::Terminal::TerminalControl::OpenHyperlinkEventArgs eventArgs);
         void _ShowCouldNotOpenDialog(winrt::hstring reason, winrt::hstring uri);
         bool _CopyText(const bool singleLine, const Windows::Foundation::IReference<Microsoft::Terminal::TerminalControl::CopyFormat>& formats);

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -5,7 +5,6 @@
 #include "TermControl.h"
 #include <argb.h>
 #include <DefaultSettings.h>
-#include <Mmsystem.h>
 #include <unicode.hpp>
 #include <Utf16Parser.hpp>
 #include <Utils.h>
@@ -2131,18 +2130,9 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         }
     }
 
-    // Method Description:
-    // - Plays a warning note when triggered by the BEL control character,
-    //   using the sound configured for the "Critical Stop" system event.
-    //   This matches the behavior of the Windows Console host.
-    // Arguments:
-    // - <none>
-    // Return Value:
-    // - <none>
     void TermControl::_TerminalWarningBell()
     {
-        const auto soundAlias = reinterpret_cast<LPCTSTR>(SND_ALIAS_SYSTEMHAND);
-        PlaySound(soundAlias, NULL, SND_ALIAS_ID | SND_ASYNC | SND_SENTRY);
+        _WarningBellHandlers(*this, nullptr);
     }
 
     void TermControl::_TerminalTitleChanged(const std::wstring_view& wstr)

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -5,6 +5,7 @@
 #include "TermControl.h"
 #include <argb.h>
 #include <DefaultSettings.h>
+#include <Mmsystem.h>
 #include <unicode.hpp>
 #include <Utf16Parser.hpp>
 #include <Utils.h>
@@ -81,6 +82,9 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         InitializeComponent();
 
         _terminal = std::make_unique<::Microsoft::Terminal::Core::Terminal>();
+
+        auto pfnWarningBell = std::bind(&TermControl::_TerminalWarningBell, this);
+        _terminal->SetWarningBellCallback(pfnWarningBell);
 
         auto pfnTitleChanged = std::bind(&TermControl::_TerminalTitleChanged, this, std::placeholders::_1);
         _terminal->SetTitleChangedCallback(pfnTitleChanged);
@@ -2125,6 +2129,20 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         {
             _connection.Resize(vp.Height(), vp.Width());
         }
+    }
+
+    // Method Description:
+    // - Plays a warning note when triggered by the BEL control character,
+    //   using the sound configured for the "Critical Stop" system event.
+    //   This matches the behavior of the Windows Console host.
+    // Arguments:
+    // - <none>
+    // Return Value:
+    // - <none>
+    void TermControl::_TerminalWarningBell()
+    {
+        const auto soundAlias = reinterpret_cast<LPCTSTR>(SND_ALIAS_SYSTEMHAND);
+        PlaySound(soundAlias, NULL, SND_ALIAS_ID | SND_ASYNC | SND_SENTRY);
     }
 
     void TermControl::_TerminalTitleChanged(const std::wstring_view& wstr)

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -259,6 +259,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _SwapChainScaleChanged(Windows::UI::Xaml::Controls::SwapChainPanel const& sender, Windows::Foundation::IInspectable const& args);
         void _DoResizeUnderLock(const double newWidth, const double newHeight);
         void _RefreshSizeUnderLock();
+        void _TerminalWarningBell();
         void _TerminalTitleChanged(const std::wstring_view& wstr);
         void _TerminalTabColorChanged(const std::optional<til::color> color);
         void _CopyToClipboard(const std::wstring_view& wstr);

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -149,6 +149,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         DECLARE_EVENT_WITH_TYPED_EVENT_HANDLER(CopyToClipboard,     _clipboardCopyHandlers,     TerminalControl::TermControl, TerminalControl::CopyToClipboardEventArgs);
         DECLARE_EVENT_WITH_TYPED_EVENT_HANDLER(OpenHyperlink, _openHyperlinkHandlers, TerminalControl::TermControl, TerminalControl::OpenHyperlinkEventArgs);
 
+        TYPED_EVENT(WarningBell, IInspectable, IInspectable);
         TYPED_EVENT(ConnectionStateChanged, TerminalControl::TermControl, IInspectable);
         TYPED_EVENT(Initialized, TerminalControl::TermControl, Windows::UI::Xaml::RoutedEventArgs);
         TYPED_EVENT(TabColorChanged, IInspectable, IInspectable);

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -60,6 +60,7 @@ namespace Microsoft.Terminal.TerminalControl
         event Windows.Foundation.TypedEventHandler<TermControl, CopyToClipboardEventArgs> CopyToClipboard;
         event Windows.Foundation.TypedEventHandler<TermControl, PasteFromClipboardEventArgs> PasteFromClipboard;
         event Windows.Foundation.TypedEventHandler<TermControl, OpenHyperlinkEventArgs> OpenHyperlink;
+        event Windows.Foundation.TypedEventHandler<Object, Object> WarningBell;
 
         event Windows.Foundation.TypedEventHandler<TermControl, Windows.UI.Xaml.RoutedEventArgs> Initialized;
         // This is an event handler forwarder for the underlying connection.

--- a/src/cascadia/TerminalCore/ITerminalApi.hpp
+++ b/src/cascadia/TerminalCore/ITerminalApi.hpp
@@ -34,6 +34,7 @@ namespace Microsoft::Terminal::Core
         virtual bool EraseInLine(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) noexcept = 0;
         virtual bool EraseInDisplay(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) noexcept = 0;
 
+        virtual bool WarningBell() noexcept = 0;
         virtual bool SetWindowTitle(std::wstring_view title) noexcept = 0;
 
         virtual bool SetColorTableEntry(const size_t tableIndex, const DWORD color) noexcept = 0;

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -965,6 +965,11 @@ void Terminal::SetWriteInputCallback(std::function<void(std::wstring&)> pfn) noe
     _pfnWriteInput.swap(pfn);
 }
 
+void Terminal::SetWarningBellCallback(std::function<void()> pfn) noexcept
+{
+    _pfnWarningBell.swap(pfn);
+}
+
 void Terminal::SetTitleChangedCallback(std::function<void(const std::wstring_view&)> pfn) noexcept
 {
     _pfnTitleChanged.swap(pfn);

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -90,6 +90,7 @@ public:
     bool EraseCharacters(const size_t numChars) noexcept override;
     bool EraseInLine(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) noexcept override;
     bool EraseInDisplay(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) noexcept override;
+    bool WarningBell() noexcept override;
     bool SetWindowTitle(std::wstring_view title) noexcept override;
     bool SetColorTableEntry(const size_t tableIndex, const COLORREF color) noexcept override;
     bool SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) noexcept override;

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -176,6 +176,7 @@ public:
 #pragma endregion
 
     void SetWriteInputCallback(std::function<void(std::wstring&)> pfn) noexcept;
+    void SetWarningBellCallback(std::function<void()> pfn) noexcept;
     void SetTitleChangedCallback(std::function<void(const std::wstring_view&)> pfn) noexcept;
     void SetTabColorChangedCallback(std::function<void(const std::optional<til::color>)> pfn) noexcept;
     void SetCopyToClipboardCallback(std::function<void(const std::wstring_view&)> pfn) noexcept;
@@ -206,6 +207,7 @@ public:
 
 private:
     std::function<void(std::wstring&)> _pfnWriteInput;
+    std::function<void()> _pfnWarningBell;
     std::function<void(const std::wstring_view&)> _pfnTitleChanged;
     std::function<void(const std::wstring_view&)> _pfnCopyToClipboard;
     std::function<void(const int, const int, const int)> _pfnScrollPositionChanged;

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -345,6 +345,22 @@ try
 }
 CATCH_LOG_RETURN_FALSE()
 
+// Method Description:
+// - Plays a warning note, using the sound configured for the "Critical Stop"
+//   system event. This matches the behavior of the Windows Console host.
+// Arguments:
+// - <none>
+// Return Value:
+// - true if succeeded, false otherwise
+bool Terminal::WarningBell() noexcept
+try
+{
+    const auto soundAlias = reinterpret_cast<LPCTSTR>(SND_ALIAS_SYSTEMHAND);
+    PlaySound(soundAlias, NULL, SND_ALIAS_ID | SND_ASYNC);
+    return true;
+}
+CATCH_LOG_RETURN_FALSE()
+
 bool Terminal::SetWindowTitle(std::wstring_view title) noexcept
 try
 {

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -345,18 +345,10 @@ try
 }
 CATCH_LOG_RETURN_FALSE()
 
-// Method Description:
-// - Plays a warning note, using the sound configured for the "Critical Stop"
-//   system event. This matches the behavior of the Windows Console host.
-// Arguments:
-// - <none>
-// Return Value:
-// - true if succeeded, false otherwise
 bool Terminal::WarningBell() noexcept
 try
 {
-    const auto soundAlias = reinterpret_cast<LPCTSTR>(SND_ALIAS_SYSTEMHAND);
-    PlaySound(soundAlias, NULL, SND_ALIAS_ID | SND_ASYNC | SND_SENTRY);
+    _pfnWarningBell();
     return true;
 }
 CATCH_LOG_RETURN_FALSE()

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -356,7 +356,7 @@ bool Terminal::WarningBell() noexcept
 try
 {
     const auto soundAlias = reinterpret_cast<LPCTSTR>(SND_ALIAS_SYSTEMHAND);
-    PlaySound(soundAlias, NULL, SND_ALIAS_ID | SND_ASYNC);
+    PlaySound(soundAlias, NULL, SND_ALIAS_ID | SND_ASYNC | SND_SENTRY);
     return true;
 }
 CATCH_LOG_RETURN_FALSE()

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -109,6 +109,13 @@ try
 }
 CATCH_LOG_RETURN_FALSE()
 
+bool TerminalDispatch::WarningBell() noexcept
+try
+{
+    return _terminalApi.WarningBell();
+}
+CATCH_LOG_RETURN_FALSE()
+
 bool TerminalDispatch::CarriageReturn() noexcept
 try
 {

--- a/src/cascadia/TerminalCore/TerminalDispatch.hpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.hpp
@@ -30,6 +30,7 @@ public:
     bool LineFeed(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::LineFeedType lineFeedType) noexcept override;
 
     bool EraseCharacters(const size_t numChars) noexcept override;
+    bool WarningBell() noexcept override;
     bool CarriageReturn() noexcept override;
     bool SetWindowTitle(std::wstring_view title) noexcept override;
 


### PR DESCRIPTION
## Summary of the Pull Request

This PR makes the Windows Terminal play an audible sound when the `BEL` control character is output.

## References

* There is a separate issue (#1608) to deal with configuring the `BEL` to trigger visual forms of notification.
* There was also an issue (#2360) requesting an option to disable the `BEL`, which should probably be reopened, because this PR does not include any such configuration.

## PR Checklist
* [x] Closes #4046
* [x] CLA signed. 
* [ ] Tests added/passed
* [ ] Documentation updated. 
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.

## Detailed Description of the Pull Request / Additional comments

The `BEL` control was already being forwarded through conpty, so it was just a matter of hooking up the `WarningBell` dispatch method to actually play a sound. I've used the `PlaySound` API to output the sound configured for the "Critical Stop" system event (aka _SystemHand_), since that is the sound used in conhost. 

## Validation Steps Performed

I've manually confirmed that the terminal produces the expected sound when executing `echo ^G` in a cmd shell, or `printf "\a"` in a WSL bash shell.