### PR TITLE
Fix #5784: Key bindings won't consume dead keys

### DIFF
--- a/.github/actions/spell-check/dictionary/names.txt
+++ b/.github/actions/spell-check/dictionary/names.txt
@@ -31,9 +31,11 @@ mbadolato
 Mehrain
 mgravell
 michaelniksa
+michkap
 migrie
 mikegr
 mikemaccana
+miloush
 miniksa
 niksa
 oising

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -895,7 +895,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         // keybindings on the keyUp, then we'll still send the keydown to the
         // connected terminal application, and something like ctrl+shift+T will
         // emit a ^T to the pipe.
-        if (!modifiers.IsAltGrPressed() && keyDown && _TryHandleKeyBinding(vkey, modifiers))
+        if (!modifiers.IsAltGrPressed() && keyDown && _TryHandleKeyBinding(vkey, scanCode, modifiers))
         {
             e.Handled(true);
             return;
@@ -917,8 +917,9 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // - Attempt to handle this key combination as a key binding
     // Arguments:
     // - vkey: The vkey of the key pressed.
+    // - scanCode: The scan code of the key pressed.
     // - modifiers: The ControlKeyStates representing the modifier key states.
-    bool TermControl::_TryHandleKeyBinding(const WORD vkey, ::Microsoft::Terminal::Core::ControlKeyStates modifiers) const
+    bool TermControl::_TryHandleKeyBinding(const WORD vkey, const WORD scanCode, ::Microsoft::Terminal::Core::ControlKeyStates modifiers) const
     {
         auto bindings = _settings.KeyBindings();
         if (!bindings)
@@ -926,12 +927,44 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             return false;
         }
 
-        return bindings.TryKeyChord({
+        auto success = bindings.TryKeyChord({
             modifiers.IsCtrlPressed(),
             modifiers.IsAltPressed(),
             modifiers.IsShiftPressed(),
             vkey,
         });
+        if (!success)
+        {
+            return false;
+        }
+
+        // Let's assume the user has bound the dead key "^" to a sendInput command that sends "b".
+        // If the user presses the two keys "^a" it'll produce "bâ", despite us marking the key event as handled.
+        // The following is used to manually "consume" such dead keys and clear them from the keyboard state.
+        _ClearKeyboardState(vkey, scanCode);
+        return true;
+    }
+
+    // Method Description:
+    // - Discards currently pressed dead keys.
+    // Arguments:
+    // - vkey: The vkey of the key pressed.
+    // - scanCode: The scan code of the key pressed.
+    void TermControl::_ClearKeyboardState(const WORD vkey, const WORD scanCode) const noexcept
+    {
+        std::array<BYTE, 256> keyState;
+        if (!GetKeyboardState(keyState.data()))
+        {
+            return;
+        }
+
+        // As described in "Sometimes you *want* to interfere with the keyboard's state buffer":
+        //   http://archives.miloush.net/michkap/archive/2006/09/10/748775.html
+        // > "The key here is to keep trying to pass stuff to ToUnicode until -1 is not returned."
+        std::array<wchar_t, 16> buffer;
+        while (ToUnicodeEx(vkey, scanCode, keyState.data(), buffer.data(), gsl::narrow_cast<int>(buffer.size()), 0b1, nullptr) < 0)
+        {
+        }
     }
 
     // Method Description:
@@ -941,6 +974,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // - Makes the cursor briefly visible during typing.
     // Arguments:
     // - vkey: The vkey of the key pressed.
+    // - scanCode: The scan code of the key pressed.
     // - states: The Microsoft::Terminal::Core::ControlKeyStates representing the modifier key states.
     // - keyDown: If true, the key was pressed, otherwise the key was released.
     bool TermControl::_TrySendKeyEvent(const WORD vkey,

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -285,7 +285,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
 
         void _KeyHandler(Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e, const bool keyDown);
         ::Microsoft::Terminal::Core::ControlKeyStates _GetPressedModifierKeys() const;
-        bool _TryHandleKeyBinding(const WORD vkey, ::Microsoft::Terminal::Core::ControlKeyStates modifiers) const;
+        bool _TryHandleKeyBinding(const WORD vkey, const WORD scanCode, ::Microsoft::Terminal::Core::ControlKeyStates modifiers) const;
+        void _ClearKeyboardState(const WORD vkey, const WORD scanCode) const noexcept;
         bool _TrySendKeyEvent(const WORD vkey, const WORD scanCode, ::Microsoft::Terminal::Core::ControlKeyStates modifiers, const bool keyDown);
         bool _TrySendMouseEvent(Windows::UI::Input::PointerPoint const& point);
         bool _CanSendVTMouseInput();


### PR DESCRIPTION
## Summary of the Pull Request

Let's assume the user has bound the dead key <kbd>^</kbd> to a sendInput command that sends "b".
If the user presses the two keys <kbd>^</kbd><kbd>a</kbd> it'll produce "bâ", despite us marking the key event as handled.
We can use `ToUnicodeEx` to clear such dead keys from the keyboard state and should make use of that for keybindings.
Unfortunately `SetKeyboardState` cannot be used for this purpose as it doesn't clear the dead key state.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #5784
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

* Enabled a German keyboard layout
* Added the following two keybindings:
  ```json
  { "command": { "action": "sendInput", "input": "x" }, "keys": "q" },
  { "command": { "action": "sendInput", "input": "b" }, "keys": "^" }
  ```
* Pressed the following keys → and ensured that the given text is printed in that order:
  * <kbd>q</kbd> → x
  * <kbd>´</kbd> → nothing
  * <kbd>a</kbd> → á
  * <kbd>^</kbd> → b
  * <kbd>a</kbd> → a (previously this would print: â)
  * <kbd>´</kbd> → nothing
  * <kbd>^</kbd> → b
  * <kbd>a</kbd> → a (unfortunately we cannot specifically clear only ^)