### PR TITLE
Wrap the textblock containing the "invalid" URI

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -73,7 +73,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             x:Name="CouldNotOpenUriDialog"
             x:Uid="CouldNotOpenUriDialog"
             DefaultButton="Primary">
-            <TextBlock IsTextSelectionEnabled="True">
+            <TextBlock IsTextSelectionEnabled="True" TextWrapping="WrapWholeWords">
                 <Run x:Name="CouldNotOpenUriReason" /> <LineBreak />
                 <Run
                     x:Name="UnopenedUri"


### PR DESCRIPTION
It looks much better this way.

### Before

![image](https://user-images.githubusercontent.com/189190/93811571-3310da80-fc05-11ea-937b-c3a861c2a14d.png)


### After

![image](https://user-images.githubusercontent.com/189190/93811580-36a46180-fc05-11ea-84d0-0bb481886495.png)
