### PR TITLE
Limit the max parameter count in the state machine

### DIFF
--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -513,10 +513,16 @@ void StateMachine::_ActionParam(const wchar_t wch)
         _parameters.push_back(0);
     }
 
+    // Refuse to add more parameters when the size hits the limit.
+    if (_parameters.size() >= MAX_PARAMETER_COUNT)
+    {
+        return;
+    }
+
     // On a delimiter, increase the number of params we've seen.
     // "Empty" params should still count as a param -
     //      eg "\x1b[0;;m" should be three "0" params
-    if (wch == L';')
+    if (_isParameterDelimiter(wch))
     {
         // Move to next param.
         _parameters.push_back(0);

--- a/src/terminal/parser/stateMachine.hpp
+++ b/src/terminal/parser/stateMachine.hpp
@@ -27,6 +27,8 @@ namespace Microsoft::Console::VirtualTerminal
     // but for now 32767 is the safest limit for our existing code base.
     constexpr size_t MAX_PARAMETER_VALUE = 32767;
 
+    constexpr size_t MAX_PARAMETER_COUNT = 16384;
+
     class StateMachine final
     {
 #ifdef UNIT_TESTING


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Currently there's no limit how many parameters that a control sequence can have. This PR fixes that.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments



<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
