### PR TITLE
Add Alt+Shift+Q key binding for closing pane

### DIFF
--- a/src/cascadia/TerminalApp/userDefaults.json
+++ b/src/cascadia/TerminalApp/userDefaults.json
@@ -66,10 +66,11 @@
         // Press Ctrl+Shift+F to open the search box
         { "command": "find", "keys": "ctrl+shift+f" },
 
-        // Press Alt+Shift+D to open a new pane.
+        // Press Alt+Shift+D to open a new pane or press Alt+Shift+Q to close the current pane.
         // - "split": "auto" makes this pane open in the direction that provides the most surface area.
         // - "splitMode": "duplicate" makes the new pane use the focused pane's profile.
         // To learn more about panes, visit https://aka.ms/terminal-panes
-        { "command": { "action": "splitPane", "split": "auto", "splitMode": "duplicate" }, "keys": "alt+shift+d" }
+        { "command": { "action": "splitPane", "split": "auto", "splitMode": "duplicate" }, "keys": "alt+shift+d" },
+        { "command": { "action": "closePane" }, "keys": "alt+shift+q" }
     ]
 }


### PR DESCRIPTION
Just add the `Alt+Shift+Q` key binding to the default `settings.json` for closing the current pane.
I think it's useful for default configuration.