### PR TITLE
When win32 is resizing the viewport, make sure Right > Left

### DIFF
--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -1210,7 +1210,14 @@ void SCREEN_INFORMATION::_InternalSetViewportSize(const COORD* const pcoordSize,
     }
 
     // Bottom and right cannot pass the final characters in the array.
-    srNewViewport.Right = std::min(srNewViewport.Right, gsl::narrow<SHORT>(coordScreenBufferSize.X - 1));
+    const SHORT offRightDelta = srNewViewport.Right - (coordScreenBufferSize.X - 1);
+    if (offRightDelta > 0) // the viewport was off the right of the buffer...
+    {
+        // ...so slide both left/right back into the buffer. This will prevent us
+        // from having a negative width later.
+        srNewViewport.Right -= offRightDelta;
+        srNewViewport.Left = std::max<SHORT>(0, srNewViewport.Left - offRightDelta);
+    }
     srNewViewport.Bottom = std::min(srNewViewport.Bottom, gsl::narrow<SHORT>(coordScreenBufferSize.Y - 1));
 
     // See MSFT:19917443


### PR DESCRIPTION
Sometimes when we were sliding the viewport to fit inside the buffer, we
would end up with left > right.

That would cause us to crash down the line when rendering.

Fixes MSFT:28387423.
Fixes #7744.

## Validation

Manual run through 100% repro test case.