### PR TITLE
Fix parallel builds by specifying the application type for WAP

### DIFF
--- a/build/pipelines/templates/build-console-steps.yml
+++ b/build/pipelines/templates/build-console-steps.yml
@@ -33,30 +33,15 @@ steps:
     restoreDirectory: '$(Build.SourcesDirectory)\packages'
 
 - task: VSBuild@1
-  displayName: 'Build solution **\OpenConsole.sln (no packages)'
+  displayName: 'Build solution **\OpenConsole.sln'
   inputs:
     solution: '**\OpenConsole.sln'
     vsVersion: 16.0
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
-    # Until there is a servicing release of Visual Studio 2019 Update *7*, we must force the values of:
-    # GenerateAppxPackageOnBuild
-    # because otherwise, they will cause a build instability where MSBuild considers all projects
-    # to always be out-of-date.
-    msbuildArgs: "${{ parameters.additionalBuildArguments }} /p:GenerateAppxPackageOnBuild=false"
+    msbuildArgs: "${{ parameters.additionalBuildArguments }}"
     clean: true
-    maximumCpuCount: true
-
-- task: VSBuild@1
-  displayName: 'Build solution **\OpenConsole.sln (CascadiaPackage only)'
-  inputs:
-    solution: '**\OpenConsole.sln'
-    vsVersion: 16.0
-    platform: '$(BuildPlatform)'
-    configuration: '$(BuildConfiguration)'
-    msbuildArgs: "${{ parameters.additionalBuildArguments }} /p:GenerateAppxPackageOnBuild=true /t:Terminal\\CascadiaPackage;Terminal\\WindowsTerminalUniversal"
-    clean: false # we're relying on build output from the previous run
-    maximumCpuCount: true
+    maximumCpuCount: false
 
 - task: PowerShell@2
   displayName: 'Check MSIX for common regressions'

--- a/build/pipelines/templates/build-console-steps.yml
+++ b/build/pipelines/templates/build-console-steps.yml
@@ -33,15 +33,30 @@ steps:
     restoreDirectory: '$(Build.SourcesDirectory)\packages'
 
 - task: VSBuild@1
-  displayName: 'Build solution **\OpenConsole.sln'
+  displayName: 'Build solution **\OpenConsole.sln (no packages)'
   inputs:
     solution: '**\OpenConsole.sln'
     vsVersion: 16.0
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
-    msbuildArgs: "${{ parameters.additionalBuildArguments }}"
+    # Until there is a servicing release of Visual Studio 2019 Update *7*, we must force the values of:
+    # GenerateAppxPackageOnBuild
+    # because otherwise, they will cause a build instability where MSBuild considers all projects
+    # to always be out-of-date.
+    msbuildArgs: "${{ parameters.additionalBuildArguments }} /p:GenerateAppxPackageOnBuild=false"
     clean: true
-    maximumCpuCount: false
+    maximumCpuCount: true
+
+- task: VSBuild@1
+  displayName: 'Build solution **\OpenConsole.sln (CascadiaPackage only)'
+  inputs:
+    solution: '**\OpenConsole.sln'
+    vsVersion: 16.0
+    platform: '$(BuildPlatform)'
+    configuration: '$(BuildConfiguration)'
+    msbuildArgs: "${{ parameters.additionalBuildArguments }} /p:GenerateAppxPackageOnBuild=true /t:Terminal\\CascadiaPackage;Terminal\\WindowsTerminalUniversal"
+    clean: false # we're relying on build output from the previous run
+    maximumCpuCount: true
 
 - task: PowerShell@2
   displayName: 'Check MSIX for common regressions'

--- a/build/pipelines/templates/build-console-steps.yml
+++ b/build/pipelines/templates/build-console-steps.yml
@@ -41,7 +41,7 @@ steps:
     configuration: '$(BuildConfiguration)'
     msbuildArgs: "${{ parameters.additionalBuildArguments }}"
     clean: true
-    maximumCpuCount: false
+    maximumCpuCount: true
 
 - task: PowerShell@2
   displayName: 'Check MSIX for common regressions'

--- a/src/cascadia/TerminalAzBridge/TerminalAzBridge.vcxproj
+++ b/src/cascadia/TerminalAzBridge/TerminalAzBridge.vcxproj
@@ -11,6 +11,7 @@
     <OpenConsoleUniversalApp>false</OpenConsoleUniversalApp>
     <ApplicationType>Windows Store</ApplicationType>
     <NoOutputRedirection>true</NoOutputRedirection>
+    <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
   </PropertyGroup>
 
   <Import Project="..\..\..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />

--- a/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
+++ b/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
@@ -18,6 +18,7 @@
     <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <!-- DON'T REDIRECT OUR OUTPUT -->
     <NoOutputRedirection>true</NoOutputRedirection>
+    <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
   </PropertyGroup>
 
   <Import Project="..\..\..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />


### PR DESCRIPTION
The WAP packaging project is sensitive to including applications that it
thinks are UWPs. The changes we made to separate WindowsStoreApp and
WindowsAppContainer weren't comprehensive enough to convince WAP that we
were not still UWPs.

Because of that, it would run sub-builds of each of these projects (and
all their dependencies) with an additional `GenerateAppxPackageOnBuild`
property set. The existence of this property caused MSBuild to think the
projects needed to be built *again*.