### PR TITLE
Preview tab switching with the ATS

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -95,6 +95,8 @@ namespace winrt::TerminalApp::implementation
             }
             _sizeChangedRevoker.revoke();
         });
+
+        _filteredActionsView().SelectionChanged({ this, &CommandPalette::_selectedCommandChanged });
     }
 
     // Method Description:
@@ -115,6 +117,29 @@ namespace winrt::TerminalApp::implementation
         const auto newIndex = ((numItems + selected + (moveDown ? 1 : -1)) % numItems);
         _filteredActionsView().SelectedIndex(newIndex);
         _filteredActionsView().ScrollIntoView(_filteredActionsView().SelectedItem());
+    }
+
+    // Method Description:
+    // - Called when the command selection changes. We'll use this in the tab
+    //   switcher to "preview" tabs as the user navigates the list of tabs. To
+    //   do that, we'll dispatch the switch to tab command for this tab, but not
+    //   dismiss the switcher.
+    // Arguments:
+    // - <unused>
+    // Return Value:
+    // - <none>
+    void CommandPalette::_selectedCommandChanged(const IInspectable& /*sender*/,
+                                                 const Windows::UI::Xaml::RoutedEventArgs& /*args*/)
+    {
+        if (_currentMode == CommandPaletteMode::TabSwitchMode)
+        {
+            const auto& selectedCommand = _filteredActionsView().SelectedItem();
+            if (const auto& command = selectedCommand.try_as<TerminalApp::Command>())
+            {
+                const auto& actionAndArgs = command.Action();
+                _dispatch.DoAction(actionAndArgs);
+            }
+        }
     }
 
     void CommandPalette::_previewKeyDownHandler(IInspectable const& /*sender*/,

--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -64,6 +64,9 @@ namespace winrt::TerminalApp::implementation
         void _keyUpHandler(Windows::Foundation::IInspectable const& sender,
                            Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e);
 
+        void _selectedCommandChanged(Windows::Foundation::IInspectable const& sender,
+                                     Windows::UI::Xaml::RoutedEventArgs const& args);
+
         void _updateUIForStackChange();
 
         void _rootPointerPressed(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1967,7 +1967,20 @@ namespace winrt::TerminalApp::implementation
                 _tabContent.Children().Clear();
                 _tabContent.Children().Append(tab->GetRootElement());
 
-                tab->SetFocused(true);
+                // GH#7409: If the tab switcher is open, then we _don't_ want to
+                // automatically focus the new tab here. The tab switcher wants
+                // to be able to "preview" the selected tab as the user tabs
+                // through the menu, but if we toss the focus to the control
+                // here, then the user won't be able to navigate the ATS any
+                // longer.
+                //
+                // When the tab swither is eventually dismissed, the focus will
+                // get tossed back to the focused terminal control, so we don't
+                // need to worry about focus getting lost.
+                if (CommandPalette().Visibility() != Visibility::Visible)
+                {
+                    tab->SetFocused(true);
+                }
 
                 // Raise an event that our title changed
                 _titleChangeHandlers(*this, tab->GetActiveTitle());


### PR DESCRIPTION
## Summary of the Pull Request

![preview-ats-000](https://user-images.githubusercontent.com/18356694/94801728-18302a00-03ac-11eb-851d-760b92ebb46f.gif)

This PR enables the ATS to display the active tab as the user navigates the tab switcher. We do this by dispatching the tab switch actions as the user navigates the menu, and manually _not_ focusing the new tab when the tab switcher is open. 

## References

* #6732 - original tab switcher PR
* #6689 - That's a more involved, generic version of this, but this PR will be enough to stop most of the complaints hopefully


## PR Checklist
* [x] Closes #7409
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated

## Validation Steps Performed

Opened tabs, tabbed through the menu, verified that it did what I'd expect