### PR TITLE
Add functionality to be able to press page up/down in the command palette

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -107,22 +107,12 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     void CommandPalette::SelectNextItem(const bool moveDown, const bool pageButtonPressed)
     {
-        uint8_t numberOfRows{};
-
-        if (pageButtonPressed)
-        {
-            numberOfRows = 9;
-        }
-        else if (!pageButtonPressed)
-        {
-            numberOfRows = 1;
-        }
         const auto selected = _filteredActionsView().SelectedIndex();
         const int numItems = ::base::saturated_cast<int>(_filteredActionsView().Items().Size());
         // Wraparound math. By adding numItems and then calculating modulo numItems,
         // we clamp the values to the range [0, numItems) while still supporting moving
         // upward from 0 to numItems - 1.
-        const auto newIndex = ((numItems + selected + (moveDown ? numberOfRows : -numberOfRows)) % numItems);
+        const auto newIndex = ((numItems + selected + (moveDown ? (pageButtonPressed ? 9 : 1) : (pageButtonPressed ? -9 : -1))) % numItems);
         _filteredActionsView().SelectedIndex(newIndex);
         _filteredActionsView().ScrollIntoView(_filteredActionsView().SelectedItem());
     }

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -126,6 +126,7 @@ namespace winrt::TerminalApp::implementation
         _filteredActionsView().SelectedIndex(newIndex);
         _filteredActionsView().ScrollIntoView(_filteredActionsView().SelectedItem());
     }
+
     void CommandPalette::_previewKeyDownHandler(IInspectable const& /*sender*/,
                                                 Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e)
     {

--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -31,7 +31,7 @@ namespace winrt::TerminalApp::implementation
 
         bool OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool down);
 
-        void SelectNextItem(const bool moveDown);
+        void SelectNextItem(const bool moveDown, const bool pageButtonPressed);
 
         // Tab Switcher
         void EnableTabSwitcherMode(const bool searchMode, const uint32_t startIdx);

--- a/src/cascadia/TerminalApp/CommandPalette.idl
+++ b/src/cascadia/TerminalApp/CommandPalette.idl
@@ -21,7 +21,7 @@ namespace TerminalApp
         void SetKeyBindings(Microsoft.Terminal.TerminalControl.IKeyBindings bindings);
         void EnableCommandPaletteMode();
 
-        void SelectNextItem(Boolean moveDown);
+        void SelectNextItem(Boolean moveDown, Boolean pageButtonPressed);
 
         void SetDispatch(ShortcutActionDispatch dispatch);
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1211,7 +1211,7 @@ namespace winrt::TerminalApp::implementation
             {
                 if (CommandPalette().Visibility() == Visibility::Visible)
                 {
-                    CommandPalette().SelectNextItem(bMoveRight);
+                    CommandPalette().SelectNextItem(bMoveRight, false);
                 }
 
                 CommandPalette().EnableTabSwitcherMode(false, newTabIndex);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
I tried to come up with new ideas to handle page up/down button referencing Microsoft doc. However I could not find a way other than using SelectedIndex(). So I just reimplemented the function by adding another parameter for the function.
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #7729 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Build locally using Visual Studio 2019
2. Deploy CascadiaPackage
3. Open commandPalette
4. Verified PG UP & PG DN works on it.