### PR TITLE
Fix old reference to TermApp::Command

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -132,7 +132,7 @@ namespace winrt::TerminalApp::implementation
         if (_currentMode == CommandPaletteMode::TabSwitchMode)
         {
             const auto& selectedCommand = _filteredActionsView().SelectedItem();
-            if (const auto& command = selectedCommand.try_as<TerminalApp::Command>())
+            if (const auto& command = selectedCommand.try_as<Command>())
             {
                 const auto& actionAndArgs = command.Action();
                 _dispatch.DoAction(actionAndArgs);


### PR DESCRIPTION
#7796 and #7667 were being implemented concurrently. As a part of #7667, `Command` was moved from TermApp to TSM. This just applies that change to a line we missed in #7796 and fixes the build break.