### PR TITLE
Hook up the WIL fallback error tracer in Terminal

### DIFF
--- a/.github/actions/spell-check/expect/expect.txt
+++ b/.github/actions/spell-check/expect/expect.txt
@@ -998,6 +998,7 @@ hpj
 hpp
 HPR
 HPROPSHEETPAGE
+HProvider
 HREDRAW
 hresult
 HRSRC

--- a/src/cascadia/TerminalApp/init.cpp
+++ b/src/cascadia/TerminalApp/init.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.h"
 #include <LibraryResources.h>
+#include <WilErrorReporting.h>
 
 // Note: Generate GUID using TlgGuid.exe tool
 TRACELOGGING_DEFINE_PROVIDER(
@@ -19,6 +20,7 @@ BOOL WINAPI DllMain(HINSTANCE hInstDll, DWORD reason, LPVOID /*reserved*/)
     case DLL_PROCESS_ATTACH:
         DisableThreadLibraryCalls(hInstDll);
         TraceLoggingRegister(g_hTerminalAppProvider);
+        Microsoft::Console::ErrorReporting::EnableFallbackFailureReporting(g_hTerminalAppProvider);
         break;
     case DLL_PROCESS_DETACH:
         if (g_hTerminalAppProvider)

--- a/src/cascadia/TerminalConnection/init.cpp
+++ b/src/cascadia/TerminalConnection/init.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.h"
 #include <LibraryResources.h>
+#include <WilErrorReporting.h>
 
 // Note: Generate GUID using TlgGuid.exe tool
 #pragma warning(suppress : 26477) // One of the macros uses 0/NULL. We don't have control to make it nullptr.
@@ -21,6 +22,7 @@ BOOL WINAPI DllMain(HINSTANCE hInstDll, DWORD reason, LPVOID /*reserved*/)
     case DLL_PROCESS_ATTACH:
         DisableThreadLibraryCalls(hInstDll);
         TraceLoggingRegister(g_hTerminalConnectionProvider);
+        Microsoft::Console::ErrorReporting::EnableFallbackFailureReporting(g_hTerminalConnectionProvider);
         break;
     case DLL_PROCESS_DETACH:
         if (g_hTerminalConnectionProvider)

--- a/src/cascadia/TerminalControl/init.cpp
+++ b/src/cascadia/TerminalControl/init.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.h"
 #include <LibraryResources.h>
+#include <WilErrorReporting.h>
 
 // Note: Generate GUID using TlgGuid.exe tool
 TRACELOGGING_DEFINE_PROVIDER(
@@ -19,6 +20,7 @@ BOOL WINAPI DllMain(HINSTANCE hInstDll, DWORD reason, LPVOID /*reserved*/)
     case DLL_PROCESS_ATTACH:
         DisableThreadLibraryCalls(hInstDll);
         TraceLoggingRegister(g_hTerminalControlProvider);
+        Microsoft::Console::ErrorReporting::EnableFallbackFailureReporting(g_hTerminalControlProvider);
         break;
     case DLL_PROCESS_DETACH:
         if (g_hTerminalControlProvider)

--- a/src/cascadia/TerminalSettingsModel/init.cpp
+++ b/src/cascadia/TerminalSettingsModel/init.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.h"
 #include <LibraryResources.h>
+#include <WilErrorReporting.h>
 
 // Note: Generate GUID using TlgGuid.exe tool
 TRACELOGGING_DEFINE_PROVIDER(
@@ -19,6 +20,7 @@ BOOL WINAPI DllMain(HINSTANCE hInstDll, DWORD reason, LPVOID /*reserved*/)
     case DLL_PROCESS_ATTACH:
         DisableThreadLibraryCalls(hInstDll);
         TraceLoggingRegister(g_hSettingsModelProvider);
+        Microsoft::Console::ErrorReporting::EnableFallbackFailureReporting(g_hSettingsModelProvider);
         break;
     case DLL_PROCESS_DETACH:
         if (g_hSettingsModelProvider)

--- a/src/cascadia/WindowsTerminal/main.cpp
+++ b/src/cascadia/WindowsTerminal/main.cpp
@@ -5,6 +5,7 @@
 #include "AppHost.h"
 #include "resource.h"
 #include "../types/inc/User32Utils.hpp"
+#include <WilErrorReporting.h>
 
 using namespace winrt;
 using namespace winrt::Windows::UI;
@@ -91,6 +92,7 @@ int __stdcall wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int)
         TraceLoggingDescription("Event emitted immediately on startup"),
         TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
         TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
+    ::Microsoft::Console::ErrorReporting::EnableFallbackFailureReporting(g_hWindowsTerminalProvider);
 
     // If Terminal is spawned by a shortcut that requests that it run in a new process group
     // while attached to a console session, that request is nonsense. That request will, however,

--- a/src/inc/WilErrorReporting.h
+++ b/src/inc/WilErrorReporting.h
@@ -1,0 +1,50 @@
+/*++
+Copyright (c) Microsoft Corporation
+Licensed under the MIT license.
+
+Module Name:
+- WilErrorReporting.h
+--*/
+#pragma once
+
+#include <winmeta.h>
+#include <wil/common.h>
+
+#define CONSOLE_WIL_TRACELOGGING_COMMON_FAILURE_PARAMS(failure)                                                                                                                                    \
+    TraceLoggingUInt32((failure).hr, "hresult", "Failure error code"),                                                                                                                             \
+        TraceLoggingString((failure).pszFile, "fileName", "Source code file name where the error occurred"),                                                                                       \
+        TraceLoggingUInt32((failure).uLineNumber, "lineNumber", "Line number within the source code file where the error occurred"),                                                               \
+        TraceLoggingString((failure).pszModule, "module", "Name of the binary where the error occurred"),                                                                                          \
+        TraceLoggingUInt32(static_cast<DWORD>((failure).type), "failureType", "Indicates what type of failure was observed (exception, returned error, logged error or fail fast"),                \
+        TraceLoggingWideString((failure).pszMessage, "message", "Custom message associated with the failure (if any)"),                                                                            \
+        TraceLoggingUInt32((failure).threadId, "threadId", "Identifier of the thread the error occurred on"),                                                                                      \
+        TraceLoggingString((failure).pszCallContext, "callContext", "List of containing this error"),                                                                                              \
+        TraceLoggingUInt32((failure).callContextOriginating.contextId, "originatingContextId", "Identifier for the oldest activity containing this error"),                                        \
+        TraceLoggingString((failure).callContextOriginating.contextName, "originatingContextName", "Name of the oldest activity containing this error"),                                           \
+        TraceLoggingWideString((failure).callContextOriginating.contextMessage, "originatingContextMessage", "Custom message associated with the oldest activity containing this error (if any)"), \
+        TraceLoggingUInt32((failure).callContextCurrent.contextId, "currentContextId", "Identifier for the newest activity containing this error"),                                                \
+        TraceLoggingString((failure).callContextCurrent.contextName, "currentContextName", "Name of the newest activity containing this error"),                                                   \
+        TraceLoggingWideString((failure).callContextCurrent.contextMessage, "currentContextMessage", "Custom message associated with the newest activity containing this error (if any)")
+
+#define CONSOLE_WIL_TRACELOGGING_FAILURE_PARAMS(failure)       \
+    TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance), \
+        TraceLoggingStruct(14, "wilResult"),                   \
+        CONSOLE_WIL_TRACELOGGING_COMMON_FAILURE_PARAMS(failure)
+
+namespace Microsoft::Console::ErrorReporting
+{
+    __declspec(selectany) TraceLoggingHProvider FallbackProvider;
+    __declspec(noinline) inline void WINAPI ReportFailureToFallbackProvider(bool alreadyReported, const wil::FailureInfo& failure) noexcept
+    {
+        if (!alreadyReported && FallbackProvider)
+        {
+            TraceLoggingWrite(FallbackProvider, "FallbackError", TraceLoggingKeyword(MICROSOFT_KEYWORD_TELEMETRY), TraceLoggingLevel(WINEVENT_LEVEL_ERROR), CONSOLE_WIL_TRACELOGGING_FAILURE_PARAMS(failure));
+        }
+    }
+
+    __declspec(noinline) inline void EnableFallbackFailureReporting(TraceLoggingHProvider provider) noexcept
+    {
+        FallbackProvider = provider;
+        ::wil::SetResultTelemetryFallback(::Microsoft::Console::ErrorReporting::ReportFailureToFallbackProvider);
+    }
+}


### PR DESCRIPTION
This pull request introduces (a very, very stripped-down copy of) the WIL fallback error reporter.

It emits error records, usually immediately before the application implodes, into the event stream.

This should improve diagnosability of issues that take Terminal down, and allow us to give out
a .wprp file to gather traces from users.