### PR TITLE
Inform user that holding alt opens a new pane

### DIFF
--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -291,8 +291,11 @@
   <data name="NewTabSplitButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>New Tab</value>
   </data>
-  <data name="NewTabSplitButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>New Tab</value>
+  <data name="NewTabRun.Text" xml:space="preserve">
+    <value>Open a new tab</value>
+  </data>
+  <data name="NewPaneRun.Text" xml:space="preserve">
+    <value>Hold alt to open a new pane instead</value>
   </data>
   <data name="WindowCloseButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Close</value>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -295,7 +295,7 @@
     <value>Open a new tab</value>
   </data>
   <data name="NewPaneRun.Text" xml:space="preserve">
-    <value>Hold alt to open a new pane instead</value>
+    <value>Alt+Click to split the current window</value>
   </data>
   <data name="WindowCloseButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Close</value>

--- a/src/cascadia/TerminalApp/TabRowControl.xaml
+++ b/src/cascadia/TerminalApp/TabRowControl.xaml
@@ -35,8 +35,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                 CornerRadius="{Binding Source={ThemeResource OverlayCornerRadius}, Converter={StaticResource TopCornerRadiusFilterConverter}}"
                 AutomationProperties.AccessibilityView="Control">
                 <ToolTipService.ToolTip>
-                    <ToolTip x:Name="TabTip"
-                             Placement="Mouse">
+                    <ToolTip Placement="Mouse">
                         <TextBlock IsTextSelectionEnabled="False">
                             <Run x:Uid="NewTabRun"/> <LineBreak />
                             <Run x:Uid="NewPaneRun"

--- a/src/cascadia/TerminalApp/TabRowControl.xaml
+++ b/src/cascadia/TerminalApp/TabRowControl.xaml
@@ -34,6 +34,17 @@ the MIT License. See LICENSE in the project root for license information. -->
                 BorderThickness="0"
                 CornerRadius="{Binding Source={ThemeResource OverlayCornerRadius}, Converter={StaticResource TopCornerRadiusFilterConverter}}"
                 AutomationProperties.AccessibilityView="Control">
+                <ToolTipService.ToolTip>
+                    <ToolTip x:Name="TabTip"
+                             Placement="Mouse">
+                        <TextBlock IsTextSelectionEnabled="False">
+                            <Run x:Uid="NewTabRun"/> <LineBreak />
+                            <Run x:Uid="NewPaneRun"
+                                 FontStyle="Italic">
+                            </Run>
+                        </TextBlock>
+                    </ToolTip>
+                </ToolTipService.ToolTip>
                 <!-- U+E710 is the fancy plus icon. -->
                 <mux:SplitButton.Resources>
 		    <!-- Override the SplitButton* resources to match the tab view's button's styles. -->

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -464,8 +464,20 @@ namespace winrt::TerminalApp::implementation
                 profileMenuItem.FontWeight(FontWeights::Bold());
             }
 
-            auto tabRowImpl = winrt::get_self<implementation::TabRowControl>(_tabRow);
-            WUX::Controls::ToolTipService::SetToolTip(profileMenuItem, tabRowImpl->TabTip());
+            auto newTabRun = WUX::Documents::Run();
+            newTabRun.Text(RS_(L"NewTabRun/Text"));
+            auto newPaneRun = WUX::Documents::Run();
+            newPaneRun.Text(RS_(L"NewPaneRun/Text"));
+            newPaneRun.FontStyle(FontStyle::Italic);
+
+            auto textBlock = WUX::Controls::TextBlock{};
+            textBlock.Inlines().Append(newTabRun);
+            textBlock.Inlines().Append(WUX::Documents::LineBreak{});
+            textBlock.Inlines().Append(newPaneRun);
+
+            auto toolTip = WUX::Controls::ToolTip{};
+            toolTip.Content(textBlock);
+            WUX::Controls::ToolTipService::SetToolTip(profileMenuItem, toolTip);
 
             profileMenuItem.Click([profileIndex, weakThis{ get_weak() }](auto&&, auto&&) {
                 if (auto page{ weakThis.get() })

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -464,6 +464,9 @@ namespace winrt::TerminalApp::implementation
                 profileMenuItem.FontWeight(FontWeights::Bold());
             }
 
+            auto tabRowImpl = winrt::get_self<implementation::TabRowControl>(_tabRow);
+            WUX::Controls::ToolTipService::SetToolTip(profileMenuItem, tabRowImpl->TabTip());
+
             profileMenuItem.Click([profileIndex, weakThis{ get_weak() }](auto&&, auto&&) {
                 if (auto page{ weakThis.get() })
                 {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds a tooltip to the new tab button to let the user know that holding alt will open a new pane instead

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #7851 
* [x] I work here

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
<img width="870" alt="panetip" src="https://user-images.githubusercontent.com/26824113/95505459-5ca76100-097c-11eb-8f73-a6a4393def39.png">
