### PR TITLE
Fix garbling when copying multibyte text via OSC 52

### DIFF
--- a/.github/actions/spell-check/dictionary/apis.txt
+++ b/.github/actions/spell-check/dictionary/apis.txt
@@ -47,6 +47,7 @@ serializer
 SIZENS
 spsc
 STDCPP
+strchr
 syscall
 tmp
 tx

--- a/.github/actions/spell-check/patterns/patterns.txt
+++ b/.github/actions/spell-check/patterns/patterns.txt
@@ -18,5 +18,5 @@ TestUtils::VerifyExpectedString\(tb, L"[^"]+"
 \b([A-Za-z])\1{3,}\b
 Base64::s_(?:En|De)code\(L"[^"]+"
 VERIFY_ARE_EQUAL\(L"[^"]+"
-L"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789\+/"
+"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789\+/"
 std::memory_order_[\w]+

--- a/src/terminal/parser/base64.cpp
+++ b/src/terminal/parser/base64.cpp
@@ -177,11 +177,7 @@ bool Base64::s_Decode(const std::wstring_view src, std::wstring& dst) noexcept
         return false;
     }
 
-    const auto wstrLen = MultiByteToWideChar(CP_UTF8, 0, mbStr.c_str(), (int)mbStr.length(), nullptr, 0);
-    dst.resize(wstrLen);
-    const auto err = MultiByteToWideChar(CP_UTF8, 0, mbStr.c_str(), (int)mbStr.length(), dst.data(), wstrLen);
-
-    return err != 0;
+    return SUCCEEDED(til::u8u16(mbStr, dst));
 }
 
 // Routine Description:

--- a/src/terminal/parser/ut_parser/Base64Test.cpp
+++ b/src/terminal/parser/ut_parser/Base64Test.cpp
@@ -84,5 +84,18 @@ class Microsoft::Console::VirtualTerminal::Base64Test
 
         success = Base64::s_Decode(L"Zm9vYg=", result);
         VERIFY_ARE_EQUAL(false, success);
+
+        // U+306b U+307b U+3093 U+3054 U+6c49 U+8bed U+d55c U+ad6d
+        result = L"";
+        success = Base64::s_Decode(L"44Gr44G744KT44GU5rGJ6K+t7ZWc6rWt", result);
+        VERIFY_ARE_EQUAL(true, success);
+        VERIFY_ARE_EQUAL(L"にほんご汉语한국", result);
+
+        // U+d83d U+dc4d U+d83d U+dc4d U+d83c U+dffb U+d83d U+dc4d U+d83c U+dffc U+d83d
+        // U+dc4d U+d83c U+dffd U+d83d U+dc4d U+d83c U+dffe U+d83d U+dc4d U+d83c U+dfff
+        result = L"";
+        success = Base64::s_Decode(L"8J+RjfCfkY3wn4+78J+RjfCfj7zwn5GN8J+PvfCfkY3wn4++8J+RjfCfj78=", result);
+        VERIFY_ARE_EQUAL(true, success);
+        VERIFY_ARE_EQUAL(L"👍👍🏻👍🏼👍🏽👍🏾👍🏿", result);
     }
 };

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -2627,6 +2627,21 @@ class StateMachineExternalTest final
 
         pDispatch->ClearState();
 
+        // Passing an empty `Pc` param and a base64-encoded multibyte text `Pd` works.
+        // U+306b U+307b U+3093 U+3054 U+6c49 U+8bed U+d55c U+ad6d
+        mach.ProcessString(L"\x1b]52;;44Gr44G744KT44GU5rGJ6K+t7ZWc6rWt\x07");
+        VERIFY_ARE_EQUAL(L"にほんご汉语한국", pDispatch->_copyContent);
+
+        pDispatch->ClearState();
+
+        // Passing an empty `Pc` param and a base64-encoded multibyte text w/ emoji sequences `Pd` works.
+        // U+d83d U+dc4d U+d83d U+dc4d U+d83c U+dffb U+d83d U+dc4d U+d83c U+dffc U+d83d
+        // U+dc4d U+d83c U+dffd U+d83d U+dc4d U+d83c U+dffe U+d83d U+dc4d U+d83c U+dfff
+        mach.ProcessString(L"\x1b]52;;8J+RjfCfkY3wn4+78J+RjfCfj7zwn5GN8J+PvfCfkY3wn4++8J+RjfCfj78=\x07");
+        VERIFY_ARE_EQUAL(L"👍👍🏻👍🏼👍🏽👍🏾👍🏿", pDispatch->_copyContent);
+
+        pDispatch->ClearState();
+
         // Passing a non-empty `Pc` param (`s0` is ignored) and a valid `Pd` param works.
         mach.ProcessString(L"\x1b]52;s0;Zm9v\x07");
         VERIFY_ARE_EQUAL(L"foo", pDispatch->_copyContent);


### PR DESCRIPTION
This commit adds a missing conversion utf8 to utf16 in decoding base64
for handling multibyte text in copying via OSC 52.

## Validation Steps Performed
* automatically
    * Tests w/ multibyte characters
* manually
    * case1
        * Executed `printf "\x1b]52;;%s\x1b\\" "$(printf '👍👍🏻👍🏼👍🏽👍🏾👍🏿' | base64)"`
        * Verified `👍👍🏻👍🏼👍🏽👍🏾👍🏿` in my clipboard
    * case2
        * Copied `👍👍🏻👍🏼👍🏽👍🏾👍🏿` by tmux 2.6 default copy function (OSC 52)
        * Verified `👍👍🏻👍🏼👍🏽👍🏾👍🏿` in my clipboard

Closes #7819