### PR TITLE
7124: Add focus and maximizedFocus launch modes

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -543,18 +543,18 @@
         },
         "initialCols": {
           "default": 120,
-          "description": "The number of columns displayed in the window upon first load.",
+          "description": "The number of columns displayed in the window upon first load. If \"launchMode\" is set to \"maximized\" (or \"maximizedFocus\"), this property is ignored.",
           "maximum": 999,
           "minimum": 1,
           "type": "integer"
         },
         "initialPosition": {
           "$ref": "#/definitions/Coordinates",
-          "description": "The position of the top left corner of the window upon first load. On a system with multiple displays, these coordinates are relative to the top left of the primary display. If \"launchMode\" is set to maximized, the window will be maximized on the monitor specified by those coordinates."
+          "description": "The position of the top left corner of the window upon first load. On a system with multiple displays, these coordinates are relative to the top left of the primary display. If \"launchMode\" is set to \"maximized\" (or \"maximizedFocus\"), the window will be maximized on the monitor specified by those coordinates."
         },
         "initialRows": {
           "default": 30,
-          "description": "The number of rows displayed in the window upon first load.",
+          "description": "The number of rows displayed in the window upon first load. If \"launchMode\" is set to \"maximized\" (or \"maximizedFocus\"), this property is ignored.",
           "maximum": 999,
           "minimum": 1,
           "type": "integer"
@@ -566,11 +566,13 @@
         },
         "launchMode": {
           "default": "default",
-          "description": "Defines whether the terminal will launch as maximized, full screen, or in a window.",
+          "description": "Defines whether the terminal will launch as maximized, full screen, or in a window. Setting this to \"focus\" is equivalent to launching the terminal in the \"default\" mode, but with the focus mode enabled. Similar, setting this to \"maximizedFocus\" will result in lauching the terminal in a maximized window with the focus mode enabled.",
           "enum": [
             "fullscreen",
             "maximized",
-            "default"
+            "default",
+            "focus",
+            "maximizedFocus"
           ],
           "type": "string"
         },

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -566,7 +566,7 @@
         },
         "launchMode": {
           "default": "default",
-          "description": "Defines whether the terminal will launch as maximized, full screen, or in a window. Setting this to \"focus\" is equivalent to launching the terminal in the \"default\" mode, but with the focus mode enabled. Similar, setting this to \"maximizedFocus\" will result in lauching the terminal in a maximized window with the focus mode enabled.",
+          "description": "Defines whether the terminal will launch as maximized, full screen, or in a window. Setting this to \"focus\" is equivalent to launching the terminal in the \"default\" mode, but with the focus mode enabled. Similar, setting this to \"maximizedFocus\" will result in launching the terminal in a maximized window with the focus mode enabled.",
           "enum": [
             "fullscreen",
             "maximized",

--- a/src/cascadia/LocalTests_TerminalApp/CommandlineTest.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/CommandlineTest.cpp
@@ -57,6 +57,7 @@ namespace TerminalAppLocalTests
         TEST_METHOD(TestSimpleExecuteCommandlineAction);
         TEST_METHOD(TestMultipleCommandExecuteCommandlineAction);
         TEST_METHOD(TestInvalidExecuteCommandlineAction);
+        TEST_METHOD(TestLaunchMode);
 
     private:
         void _buildCommandlinesHelper(AppCommandlineArgs& appArgs,
@@ -1131,5 +1132,80 @@ namespace TerminalAppLocalTests
         ExecuteCommandlineArgs args{ L"split-pane -H -V" };
         auto actions = implementation::TerminalPage::ConvertExecuteCommandlineToActions(args);
         VERIFY_ARE_EQUAL(0u, actions.size());
+    }
+
+    void CommandlineTest::TestLaunchMode()
+    {
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_IS_FALSE(appArgs.GetLaunchMode().has_value());
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-F" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_IS_TRUE(appArgs.GetLaunchMode().has_value());
+            VERIFY_ARE_EQUAL(appArgs.GetLaunchMode().value(), LaunchMode::FullscreenMode);
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"--fullscreen" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_IS_TRUE(appArgs.GetLaunchMode().has_value());
+            VERIFY_ARE_EQUAL(appArgs.GetLaunchMode().value(), LaunchMode::FullscreenMode);
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-M" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_IS_TRUE(appArgs.GetLaunchMode().has_value());
+            VERIFY_ARE_EQUAL(appArgs.GetLaunchMode().value(), LaunchMode::MaximizedMode);
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"--maximized" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_IS_TRUE(appArgs.GetLaunchMode().has_value());
+            VERIFY_ARE_EQUAL(appArgs.GetLaunchMode().value(), LaunchMode::MaximizedMode);
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-f" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_IS_TRUE(appArgs.GetLaunchMode().has_value());
+            VERIFY_ARE_EQUAL(appArgs.GetLaunchMode().value(), LaunchMode::FocusMode);
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"--focus" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_IS_TRUE(appArgs.GetLaunchMode().has_value());
+            VERIFY_ARE_EQUAL(appArgs.GetLaunchMode().value(), LaunchMode::FocusMode);
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-fM" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_IS_TRUE(appArgs.GetLaunchMode().has_value());
+            VERIFY_ARE_EQUAL(appArgs.GetLaunchMode().value(), LaunchMode::MaximizedFocusMode);
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"--maximized", L"--focus" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_IS_TRUE(appArgs.GetLaunchMode().has_value());
+            VERIFY_ARE_EQUAL(appArgs.GetLaunchMode().value(), LaunchMode::MaximizedFocusMode);
+        }
     }
 }

--- a/src/cascadia/LocalTests_TerminalApp/CommandlineTest.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/CommandlineTest.cpp
@@ -1207,5 +1207,21 @@ namespace TerminalAppLocalTests
             VERIFY_IS_TRUE(appArgs.GetLaunchMode().has_value());
             VERIFY_ARE_EQUAL(appArgs.GetLaunchMode().value(), LaunchMode::MaximizedFocusMode);
         }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"--maximized", L"--focus", L"--focus" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_IS_TRUE(appArgs.GetLaunchMode().has_value());
+            VERIFY_ARE_EQUAL(appArgs.GetLaunchMode().value(), LaunchMode::MaximizedFocusMode);
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"--maximized", L"--focus", L"--maximized" };
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_IS_TRUE(appArgs.GetLaunchMode().has_value());
+            VERIFY_ARE_EQUAL(appArgs.GetLaunchMode().value(), LaunchMode::MaximizedFocusMode);
+        }
     }
 }

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -175,7 +175,7 @@ void AppCommandlineArgs::_buildParser()
     //   -M,--maximized: Maximizes the window on launch
     //   -F,--fullscreen: Fullscreens the window on launch
     //   -f,--focus: Sets the terminal into the Focus mode
-    // While fullscreen excludes both maximized and focus mode, the user can combine betwen the maximized and focused (-fM)
+    // While fullscreen excludes both maximized and focus mode, the user can combine between the maximized and focused (-fM)
     auto maximizedCallback = [this](int64_t /*count*/) {
         _launchMode = (_launchMode.has_value() && _launchMode.value() == LaunchMode::FocusMode) ?
                           LaunchMode::MaximizedFocusMode :

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -175,7 +175,7 @@ void AppCommandlineArgs::_buildParser()
     //   -M,--maximized: Maximizes the window on launch
     //   -F,--fullscreen: Fullscreens the window on launch
     //   -f,--focus: Sets the terminal into the Focus mode
-    // While fullscreen ecludes both maximized and focus mode, the user can combine betwen the maximized and focused (-fM)
+    // While fullscreen excludes both maximized and focus mode, the user can combine betwen the maximized and focused (-fM)
     auto maximizedCallback = [this](int64_t /*count*/) {
         _launchMode = (_launchMode.has_value() && _launchMode.value() == LaunchMode::FocusMode) ?
                           LaunchMode::MaximizedFocusMode :

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -175,14 +175,24 @@ void AppCommandlineArgs::_buildParser()
     //   -M,--maximized: Maximizes the window on launch
     //   -F,--fullscreen: Fullscreens the window on launch
     auto maximizedCallback = [this](int64_t /*count*/) {
-        _launchMode = winrt::Microsoft::Terminal::Settings::Model::LaunchMode::MaximizedMode;
+        _launchMode = (_launchMode.has_value() && _launchMode.value() == winrt::Microsoft::Terminal::Settings::Model::LaunchMode::FocusMode) ?
+                          winrt::Microsoft::Terminal::Settings::Model::LaunchMode::MaximizedFocusMode :
+                          winrt::Microsoft::Terminal::Settings::Model::LaunchMode::MaximizedMode;
     };
     auto fullscreenCallback = [this](int64_t /*count*/) {
         _launchMode = winrt::Microsoft::Terminal::Settings::Model::LaunchMode::FullscreenMode;
     };
+    auto focusCallback = [this](int64_t /*count*/) {
+        _launchMode = (_launchMode.has_value() && _launchMode.value() == winrt::Microsoft::Terminal::Settings::Model::LaunchMode::MaximizedMode) ?
+                          winrt::Microsoft::Terminal::Settings::Model::LaunchMode::MaximizedFocusMode :
+                          winrt::Microsoft::Terminal::Settings::Model::LaunchMode::FocusMode;
+    };
+
     auto maximized = _app.add_flag_function("-M,--maximized", maximizedCallback, RS_A(L"CmdMaximizedDesc"));
     auto fullscreen = _app.add_flag_function("-F,--fullscreen", fullscreenCallback, RS_A(L"CmdFullscreenDesc"));
+    auto focus = _app.add_flag_function("-f,--focus", focusCallback, RS_A(L"CmdFocusDesc"));
     maximized->excludes(fullscreen);
+    focus->excludes(fullscreen);
 
     // Subcommands
     _buildNewTabParser();

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -171,21 +171,23 @@ void AppCommandlineArgs::_buildParser()
     };
     _app.add_flag_function("-v,--version", versionCallback, RS_A(L"CmdVersionDesc"));
 
-    // Maximized and Fullscreen flags
+    // Launch mode related flags
     //   -M,--maximized: Maximizes the window on launch
     //   -F,--fullscreen: Fullscreens the window on launch
+    //   -f,--focus: Sets the terminal into the Focus mode
+    // While fullscreen ecludes both maximized and focus mode, the user can combine betwen the maximized and focused (-fM)
     auto maximizedCallback = [this](int64_t /*count*/) {
-        _launchMode = (_launchMode.has_value() && _launchMode.value() == winrt::Microsoft::Terminal::Settings::Model::LaunchMode::FocusMode) ?
-                          winrt::Microsoft::Terminal::Settings::Model::LaunchMode::MaximizedFocusMode :
-                          winrt::Microsoft::Terminal::Settings::Model::LaunchMode::MaximizedMode;
+        _launchMode = (_launchMode.has_value() && _launchMode.value() == LaunchMode::FocusMode) ?
+                          LaunchMode::MaximizedFocusMode :
+                          LaunchMode::MaximizedMode;
     };
     auto fullscreenCallback = [this](int64_t /*count*/) {
-        _launchMode = winrt::Microsoft::Terminal::Settings::Model::LaunchMode::FullscreenMode;
+        _launchMode = LaunchMode::FullscreenMode;
     };
     auto focusCallback = [this](int64_t /*count*/) {
-        _launchMode = (_launchMode.has_value() && _launchMode.value() == winrt::Microsoft::Terminal::Settings::Model::LaunchMode::MaximizedMode) ?
-                          winrt::Microsoft::Terminal::Settings::Model::LaunchMode::MaximizedFocusMode :
-                          winrt::Microsoft::Terminal::Settings::Model::LaunchMode::FocusMode;
+        _launchMode = (_launchMode.has_value() && _launchMode.value() == LaunchMode::MaximizedMode) ?
+                          LaunchMode::MaximizedFocusMode :
+                          LaunchMode::FocusMode;
     };
 
     auto maximized = _app.add_flag_function("-M,--maximized", maximizedCallback, RS_A(L"CmdMaximizedDesc"));

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -265,6 +265,10 @@ namespace winrt::TerminalApp::implementation
             {
                 _root->ToggleFullscreen();
             }
+            else if(launchMode == LaunchMode::FocusedMode || launchMode == LaunchMode::MaximizedFocusedMode)
+            {
+                _root->ToggleFocusMode();
+            }
         });
         _root->Create();
 

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -265,7 +265,7 @@ namespace winrt::TerminalApp::implementation
             {
                 _root->ToggleFullscreen();
             }
-            else if (launchMode == LaunchMode::FocusedMode || launchMode == LaunchMode::MaximizedFocusedMode)
+            else if (launchMode == LaunchMode::FocusMode || launchMode == LaunchMode::MaximizedFocusMode)
             {
                 _root->ToggleFocusMode();
             }

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -265,7 +265,7 @@ namespace winrt::TerminalApp::implementation
             {
                 _root->ToggleFullscreen();
             }
-            else if(launchMode == LaunchMode::FocusedMode || launchMode == LaunchMode::MaximizedFocusedMode)
+            else if (launchMode == LaunchMode::FocusedMode || launchMode == LaunchMode::MaximizedFocusedMode)
             {
                 _root->ToggleFocusMode();
             }

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -285,6 +285,9 @@
   <data name="CmdFullscreenDesc" xml:space="preserve">
     <value>Launch the window in fullscreen mode</value>
   </data>
+  <data name="CmdFocusDesc" xml:space="preserve">
+    <value>Launch the window in focus mode</value>
+  </data>
   <data name="NewTabSplitButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.HelpText" xml:space="preserve">
     <value>Press the button to open a new terminal tab with your default profile. Open the flyout to select which profile you want to open.</value>
   </data>

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -22,6 +22,8 @@ namespace Microsoft.Terminal.Settings.Model
         DefaultMode,
         MaximizedMode,
         FullscreenMode,
+        FocusedMode,
+        MaximizedFocusedMode,
     };
 
     [default_interface] runtimeclass GlobalAppSettings {

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -22,8 +22,8 @@ namespace Microsoft.Terminal.Settings.Model
         DefaultMode,
         MaximizedMode,
         FullscreenMode,
-        FocusedMode,
-        MaximizedFocusedMode,
+        FocusMode,
+        MaximizedFocusMode,
     };
 
     [default_interface] runtimeclass GlobalAppSettings {

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -169,8 +169,8 @@ JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::LaunchMode)
         pair_type{ "default", ValueType::DefaultMode },
         pair_type{ "maximized", ValueType::MaximizedMode },
         pair_type{ "fullscreen", ValueType::FullscreenMode },
-        pair_type{ "focused", ValueType::FocusedMode },
-        pair_type{ "maximizedFocused", ValueType::MaximizedFocusedMode },
+        pair_type{ "focus", ValueType::FocusMode },
+        pair_type{ "maximizedFocus", ValueType::MaximizedFocusMode },
     };
 };
 

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -165,10 +165,12 @@ JSON_ENUM_MAPPER(::winrt::Windows::UI::Xaml::ElementTheme)
 
 JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::LaunchMode)
 {
-    JSON_MAPPINGS(3) = {
+    JSON_MAPPINGS(5) = {
         pair_type{ "default", ValueType::DefaultMode },
         pair_type{ "maximized", ValueType::MaximizedMode },
         pair_type{ "fullscreen", ValueType::FullscreenMode },
+        pair_type{ "focused", ValueType::FocusedMode },
+        pair_type{ "maximizedFocused", ValueType::MaximizedFocusedMode },
     };
 };
 

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -139,7 +139,7 @@ void IslandWindow::_HandleCreateWindow(const WPARAM, const LPARAM lParam) noexce
     }
 
     int nCmdShow = SW_SHOW;
-    if (launchMode == LaunchMode::MaximizedMode)
+    if (launchMode == LaunchMode::MaximizedMode || launchMode == LaunchMode::MaximizedFocusedMode)
     {
         nCmdShow = SW_MAXIMIZE;
     }

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -139,7 +139,7 @@ void IslandWindow::_HandleCreateWindow(const WPARAM, const LPARAM lParam) noexce
     }
 
     int nCmdShow = SW_SHOW;
-    if (launchMode == LaunchMode::MaximizedMode || launchMode == LaunchMode::MaximizedFocusedMode)
+    if (launchMode == LaunchMode::MaximizedMode || launchMode == LaunchMode::MaximizedFocusMode)
     {
         nCmdShow = SW_MAXIMIZE;
     }


### PR DESCRIPTION

This commit introduces two new launch modes: focus and maximizedFocus. 
* Focused mode, behaves like a default mode, but with the Focus Mode
  enabled.
* Maximized focused mode, behaves like a Maximized mode, but with the
  Focus Mode enabled.

There two ways to invoke these new modes:
* In the settings file: you set the "launchMode" to either "focus" or
  "maximizedFocus"
* In the command line options, you can path -f / --focus, which is
  mutually exclusive with the --fullscreen, but can be combined with the
  --maximized:
  * Passing -f / --focus will launch the terminal in the "focus" mode
  * Passing -fM / --focus --maximized will launch the terminal in the
    "maximizedFocus" mode

This should resolve a relevant part in the command line arguments
mega-thread #4632

Closes #7124
Closes #7825
Closes #7875