### PR TITLE
7571: do not activate terminal window upon settings modificaion

### DIFF
--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -263,7 +263,7 @@ void IslandWindow::Initialize()
 void IslandWindow::OnSize(const UINT width, const UINT height)
 {
     // update the interop window size
-    SetWindowPos(_interopWindowHandle, nullptr, 0, 0, width, height, SWP_SHOWWINDOW);
+    SetWindowPos(_interopWindowHandle, nullptr, 0, 0, width, height, SWP_SHOWWINDOW | SWP_NOACTIVATE);
 
     if (_rootGrid)
     {
@@ -499,7 +499,7 @@ void IslandWindow::SetAlwaysOnTop(const bool alwaysOnTop)
                      0,
                      0,
                      0,
-                     SWP_NOMOVE | SWP_NOSIZE);
+                     SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
     }
 }
 
@@ -613,7 +613,7 @@ void IslandWindow::_SetIsBorderless(const bool borderlessEnabled)
                  windowPos.top<int>(),
                  windowPos.width<int>(),
                  windowPos.height<int>(),
-                 SWP_SHOWWINDOW | SWP_FRAMECHANGED);
+                 SWP_SHOWWINDOW | SWP_FRAMECHANGED | SWP_NOACTIVATE);
 }
 
 // Method Description:
@@ -699,7 +699,7 @@ void IslandWindow::_ApplyWindowSize()
                                          newSize.top,
                                          newSize.right - newSize.left,
                                          newSize.bottom - newSize.top,
-                                         SWP_FRAMECHANGED));
+                                         SWP_FRAMECHANGED | SWP_NOACTIVATE));
 }
 
 DEFINE_EVENT(IslandWindow, DragRegionClicked, _DragRegionClickedHandlers, winrt::delegate<>);

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -370,7 +370,7 @@ void NonClientIslandWindow::_UpdateIslandPosition(const UINT windowWidth, const 
                                    newIslandPos.Y,
                                    windowWidth,
                                    windowHeight - topBorderHeight,
-                                   SWP_SHOWWINDOW));
+                                   SWP_SHOWWINDOW | SWP_NOACTIVATE));
 
     // This happens when we go from maximized to restored or the opposite
     // because topBorderHeight changes.
@@ -849,7 +849,7 @@ void NonClientIslandWindow::_SetIsBorderless(const bool borderlessEnabled)
                  windowPos.top<int>(),
                  windowPos.width<int>(),
                  windowPos.height<int>(),
-                 SWP_SHOWWINDOW | SWP_FRAMECHANGED);
+                 SWP_SHOWWINDOW | SWP_FRAMECHANGED | SWP_NOACTIVATE);
 }
 
 // Method Description:


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Took this as an easy starter. The method IslandWindow::SetAlwaysOnTop is triggered once terminal settings are reloaded (in TerminalPage::_RefreshUIForSettingsReload flow). This method calls SetWindowPos without SWP_NOACTIVATE. As a result the window gets activated, the focus is set and the cursor starts blinking.

Added SWP_NOACTIVATE flag there and in few additional places in island windows. See a discussion below.
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes https://github.com/microsoft/terminal/issues/7571
* [X] CLA signed. 
* [ ] Tests added/passed
* [ ] Documentation updated - irrelevant
* [ ] Schema updated - irrelevant
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Added SWP_NOACTIVATE  in all SetWindowPos calls  from IslandWindow and NoClientIslandWindow (where it was missing). Please let  me know if this is an overkill - it is not required to fix the issue, however seems a good practice, that might help if we decide to apply more settings immediately.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Only manual testing - please guide me to the relevant UT framework, if exists. 
* Trying to reproduce this with VS attached doesn't work - the window gets the focus in any case.
* Tested as a standalone application, by modifying different settings (and comparing the results before and after the fix).
* Checked with Spy++ that no WM_ACTIVATE / WM_SETFOCUS is thrown upon settings modification
* Applied terminal resizing, toggling full screen and focus mode to check no regression was introduced.