### PR TITLE
wpf: fix margin calculations and resize events

### DIFF
--- a/.github/actions/spell-check/dictionary/microsoft.txt
+++ b/.github/actions/spell-check/dictionary/microsoft.txt
@@ -32,6 +32,7 @@ tasklist
 tdbuildteamid
 vcruntime
 visualstudio
+VSTHRD
 wlk
 wslpath
 wtl

--- a/src/cascadia/WpfTerminalControl/TerminalContainer.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalContainer.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Terminal.Wpf
         /// Gets or sets a value indicating whether if the renderer should automatically resize to fill the control
         /// on user action.
         /// </summary>
-        internal bool AutoFill { get; set; } = true;
+        internal bool AutoResize { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the size of the parent user control that hosts the terminal hwnd.
@@ -137,10 +137,8 @@ namespace Microsoft.Terminal.Wpf
             var dpiScale = VisualTreeHelper.GetDpi(this);
 
             NativeMethods.TerminalSetTheme(this.terminal, theme, fontFamily, fontSize, (int)dpiScale.PixelsPerInchX);
-            var size = this.CalculateRowsAndColumns(this.TerminalControlSize);
 
-            this.Rows = (int)size.rows;
-            this.Columns = (int)size.columns;
+            this.Resize(this.TerminalControlSize);
         }
 
         /// <summary>
@@ -163,12 +161,11 @@ namespace Microsoft.Terminal.Wpf
         /// <param name="renderSize">Size of the rendering window.</param>
         internal void Resize(Size renderSize)
         {
-            NativeMethods.COORD dimensions;
             NativeMethods.TerminalTriggerResize(
                 this.terminal,
                 Convert.ToInt16(renderSize.Width),
                 Convert.ToInt16(renderSize.Height),
-                out dimensions);
+                out NativeMethods.COORD dimensions);
 
             this.Rows = dimensions.Y;
             this.Columns = dimensions.X;
@@ -212,8 +209,7 @@ namespace Microsoft.Terminal.Wpf
         /// <returns>Amount of rows and columns that would fit the given size.</returns>
         internal (uint columns, uint rows) CalculateRowsAndColumns(Size size)
         {
-            NativeMethods.COORD dimensions;
-            NativeMethods.TerminalCalculateResize(this.terminal, (short)size.Width, (short)size.Height, out dimensions);
+            NativeMethods.TerminalCalculateResize(this.terminal, (short)size.Width, (short)size.Height, out NativeMethods.COORD dimensions);
 
             return ((uint)dimensions.X, (uint)dimensions.Y);
         }
@@ -354,8 +350,7 @@ namespace Microsoft.Terminal.Wpf
 
                         NativeMethods.COORD dimensions;
 
-                        // We only trigger a resize if we want to automatically fill to maximum size.
-                        if (this.AutoFill)
+                        if (this.AutoResize)
                         {
                             NativeMethods.TerminalTriggerResize(this.terminal, (short)windowpos.cx, (short)windowpos.cy, out dimensions);
 

--- a/src/cascadia/WpfTerminalControl/TerminalContainer.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalContainer.cs
@@ -66,7 +66,18 @@ namespace Microsoft.Terminal.Wpf
         /// Gets or sets a value indicating whether if the renderer should automatically resize to fill the control
         /// on user action.
         /// </summary>
-        public bool AutoFill { get; set; } = true;
+        internal bool AutoFill { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the size of the parent user control that hosts the terminal hwnd.
+        /// </summary>
+        /// <remarks>Control size is in device independent units, but for simplicity all sizes should be scaled.</remarks>
+        internal Size TerminalControlSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the size of the terminal renderer.
+        /// </summary>
+        internal Size TerminalRendererSize { get; set; }
 
         /// <summary>
         /// Gets the current character rows available to the terminal.
@@ -77,18 +88,6 @@ namespace Microsoft.Terminal.Wpf
         /// Gets the current character columns available to the terminal.
         /// </summary>
         internal int Columns { get; private set; }
-
-        /// <summary>
-        /// Gets the maximum amount of character rows that can fit in this control.
-        /// </summary>
-        /// <remarks>This will be in sync with <see cref="Rows"/> unless <see cref="AutoFill"/> is set to false.</remarks>
-        internal int MaxRows { get; private set; }
-
-        /// <summary>
-        /// Gets the maximum amount of character columns that can fit in this control.
-        /// </summary>
-        /// <remarks>This will be in sync with <see cref="Columns"/> unless <see cref="AutoFill"/> is set to false.</remarks>
-        internal int MaxColumns { get; private set; }
 
         /// <summary>
         /// Gets the window handle of the terminal.
@@ -138,8 +137,10 @@ namespace Microsoft.Terminal.Wpf
             var dpiScale = VisualTreeHelper.GetDpi(this);
 
             NativeMethods.TerminalSetTheme(this.terminal, theme, fontFamily, fontSize, (int)dpiScale.PixelsPerInchX);
+            var size = this.CalculateRowsAndColumns(this.TerminalControlSize);
 
-            this.TriggerResize(this.RenderSize);
+            this.Rows = (int)size.rows;
+            this.Columns = (int)size.columns;
         }
 
         /// <summary>
@@ -157,26 +158,23 @@ namespace Microsoft.Terminal.Wpf
         }
 
         /// <summary>
-        /// Triggers a refresh of the terminal with the given size.
+        /// Triggers a resize of the terminal with the given size, redrawing the rendered text.
         /// </summary>
         /// <param name="renderSize">Size of the rendering window.</param>
-        /// <returns>Tuple with rows and columns.</returns>
-        internal (int rows, int columns) TriggerResize(Size renderSize)
+        internal void Resize(Size renderSize)
         {
-            var dpiScale = VisualTreeHelper.GetDpi(this);
-
             NativeMethods.COORD dimensions;
             NativeMethods.TerminalTriggerResize(
                 this.terminal,
-                Convert.ToInt16(renderSize.Width * dpiScale.DpiScaleX),
-                Convert.ToInt16(renderSize.Height * dpiScale.DpiScaleY),
+                Convert.ToInt16(renderSize.Width),
+                Convert.ToInt16(renderSize.Height),
                 out dimensions);
 
             this.Rows = dimensions.Y;
             this.Columns = dimensions.X;
+            this.TerminalRendererSize = renderSize;
 
             this.Connection?.Resize((uint)dimensions.Y, (uint)dimensions.X);
-            return (dimensions.Y, dimensions.X);
         }
 
         /// <summary>
@@ -184,8 +182,7 @@ namespace Microsoft.Terminal.Wpf
         /// </summary>
         /// <param name="rows">Number of rows to show.</param>
         /// <param name="columns">Number of columns to show.</param>
-        /// <returns><see cref="long"/> pair with the new width and height size in pixels for the renderer.</returns>
-        internal (int width, int height) Resize(uint rows, uint columns)
+        internal void Resize(uint rows, uint columns)
         {
             NativeMethods.SIZE dimensionsInPixels;
             NativeMethods.COORD dimensions = new NativeMethods.COORD
@@ -196,20 +193,42 @@ namespace Microsoft.Terminal.Wpf
 
             NativeMethods.TerminalTriggerResizeWithDimension(this.terminal, dimensions, out dimensionsInPixels);
 
-            // If AutoFill is true, keep Rows and Columns in sync with MaxRows and MaxColumns.
-            // Otherwise, MaxRows and MaxColumns will be set on startup and on control resize by the user.
-            if (this.AutoFill)
-            {
-                this.MaxColumns = dimensions.X;
-                this.MaxRows = dimensions.Y;
-            }
-
             this.Columns = dimensions.X;
             this.Rows = dimensions.Y;
 
-            this.Connection?.Resize((uint)dimensions.Y, (uint)dimensions.X);
+            this.TerminalRendererSize = new Size()
+            {
+                Width = dimensionsInPixels.cx,
+                Height = dimensionsInPixels.cy,
+            };
 
-            return (dimensionsInPixels.cx, dimensionsInPixels.cy);
+            this.Connection?.Resize((uint)dimensions.Y, (uint)dimensions.X);
+        }
+
+        /// <summary>
+        /// Calculates the rows and columns that would fit in the given size.
+        /// </summary>
+        /// <param name="size">DPI scaled size.</param>
+        /// <returns>Amount of rows and columns that would fit the given size.</returns>
+        internal (uint columns, uint rows) CalculateRowsAndColumns(Size size)
+        {
+            NativeMethods.COORD dimensions;
+            NativeMethods.TerminalCalculateResize(this.terminal, (short)size.Width, (short)size.Height, out dimensions);
+
+            return ((uint)dimensions.X, (uint)dimensions.Y);
+        }
+
+        /// <summary>
+        /// Triggers the terminal resize event if more space is available in the terminal control.
+        /// </summary>
+        internal void RaiseResizedIfDrawSpaceIncreased()
+        {
+            (var columns, var rows) = this.CalculateRowsAndColumns(this.TerminalControlSize);
+
+            if (this.Columns < columns || this.Rows < rows)
+            {
+                this.connection?.Resize(rows, columns);
+            }
         }
 
         /// <inheritdoc/>
@@ -335,21 +354,24 @@ namespace Microsoft.Terminal.Wpf
 
                         NativeMethods.COORD dimensions;
 
-                        // We only trigger a resize if we want to fill to maximum size.
+                        // We only trigger a resize if we want to automatically fill to maximum size.
                         if (this.AutoFill)
                         {
                             NativeMethods.TerminalTriggerResize(this.terminal, (short)windowpos.cx, (short)windowpos.cy, out dimensions);
 
                             this.Columns = dimensions.X;
                             this.Rows = dimensions.Y;
-                            this.MaxColumns = dimensions.X;
-                            this.MaxRows = dimensions.Y;
+
+                            this.TerminalRendererSize = new Size()
+                            {
+                                Width = windowpos.cx,
+                                Height = windowpos.cy,
+                            };
                         }
                         else
                         {
-                            NativeMethods.TerminalCalculateResize(this.terminal, (short)windowpos.cx, (short)windowpos.cy, out dimensions);
-                            this.MaxColumns = dimensions.X;
-                            this.MaxRows = dimensions.Y;
+                            // Calculate the new columns and rows that fit the total control size and alert the control to redraw the margins.
+                            NativeMethods.TerminalCalculateResize(this.terminal, (short)this.TerminalControlSize.Width, (short)this.TerminalControlSize.Height, out dimensions);
                         }
 
                         this.Connection?.Resize((uint)dimensions.Y, (uint)dimensions.X);

--- a/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Terminal.Wpf
                 };
             }
 
-            // During intialization, the terminal renderer size will be 0 and the terminal renderer
+            // During initialization, the terminal renderer size will be 0 and the terminal renderer
             // draws on all available space. Therefore no margins are needed until resized.
             if (this.TerminalRendererSize.Width != 0)
             {

--- a/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Terminal.Wpf
     using System.Windows.Controls;
     using System.Windows.Input;
     using System.Windows.Media;
-    using Microsoft.VisualStudio.Shell;
     using Task = System.Threading.Tasks.Task;
 
     /// <summary>
@@ -116,8 +115,11 @@ namespace Microsoft.Terminal.Wpf
         {
             this.termContainer.Resize(rows, columns);
 
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-            this.terminalGrid.Margin = this.CalculateMargins();
+#pragma warning disable VSTHRD001 // Avoid legacy thread switching APIs
+            await this.Dispatcher.BeginInvoke(
+                new Action(delegate() { this.terminalGrid.Margin = this.CalculateMargins(); }),
+                System.Windows.Threading.DispatcherPriority.Render);
+#pragma warning restore VSTHRD001 // Avoid legacy thread switching APIs
         }
 
         /// <summary>

--- a/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
@@ -56,10 +56,10 @@ namespace Microsoft.Terminal.Wpf
         /// Gets or sets a value indicating whether if the renderer should automatically resize to fill the control
         /// on user action.
         /// </summary>
-        public bool AutoFill
+        public bool AutoResize
         {
-            get => this.termContainer.AutoFill;
-            set => this.termContainer.AutoFill = value;
+            get => this.termContainer.AutoResize;
+            set => this.termContainer.AutoResize = value;
         }
 
         /// <summary>
@@ -147,10 +147,10 @@ namespace Microsoft.Terminal.Wpf
             this.termContainer.TerminalControlSize = new Size()
             {
                 Width = (sizeInfo.NewSize.Width - this.scrollbar.ActualWidth) * dpiScale.DpiScaleX,
-                Height = (sizeInfo.NewSize.Height - this.scrollbar.ActualWidth) * dpiScale.DpiScaleY,
+                Height = sizeInfo.NewSize.Height * dpiScale.DpiScaleY,
             };
 
-            if (this.AutoFill == false)
+            if (!this.AutoResize)
             {
                 // Renderer will not resize on control resize. We have to manually calculate the margin to fill in the space.
                 this.terminalGrid.Margin = this.CalculateMargins(sizeInfo.NewSize);

--- a/src/cascadia/WpfTerminalControl/WpfTerminalControl.csproj
+++ b/src/cascadia/WpfTerminalControl/WpfTerminalControl.csproj
@@ -23,6 +23,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="16.7.30329.88" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.7.56" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/cascadia/WpfTerminalControl/WpfTerminalControl.csproj
+++ b/src/cascadia/WpfTerminalControl/WpfTerminalControl.csproj
@@ -23,8 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="16.7.30329.88" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.7.56" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fixes various issues with autofill and resize events

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
