### PR TITLE
5366: delay scrolling / clear selection until the input sequence is created

### DIFF
--- a/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
@@ -242,7 +242,7 @@ HRESULT HwndTerminal::Initialize()
     _terminal->Create(COORD{ 80, 25 }, 1000, *_renderer);
     _terminal->SetDefaultBackground(RGB(12, 12, 12));
     _terminal->SetDefaultForeground(RGB(204, 204, 204));
-    _terminal->SetWriteInputCallback([=](std::wstring& input) noexcept { _WriteTextToConnection(input); });
+    _terminal->SetWriteInputCallback([=](std::wstring& input, const IInputEvent* const /*pInEvent*/) noexcept { _WriteTextToConnection(input); });
     localPointerToThread->EnablePainting();
 
     _multiClickTime = std::chrono::milliseconds{ GetDoubleClickTime() };

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -255,8 +255,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _CursorTimerTick(Windows::Foundation::IInspectable const& sender, Windows::Foundation::IInspectable const& e);
         void _BlinkTimerTick(Windows::Foundation::IInspectable const& sender, Windows::Foundation::IInspectable const& e);
         void _SetEndSelectionPointAtCursor(Windows::Foundation::Point const& cursorPosition);
-        void _SendInputToConnection(const winrt::hstring& wstr);
-        void _SendInputToConnection(std::wstring_view wstr);
+        void _SendInputToConnection(const winrt::hstring& wstr, const IInputEvent* const pInEvent);
+        void _SendInputToConnection(std::wstring_view wstr, const IInputEvent* const pInEvent);
         void _SendPastedTextToConnection(const std::wstring& wstr);
         void _SwapChainSizeChanged(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::SizeChangedEventArgs const& e);
         void _SwapChainScaleChanged(Windows::UI::Xaml::Controls::SwapChainPanel const& sender, Windows::Foundation::IInspectable const& args);
@@ -303,6 +303,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _FontInfoHandler(const IInspectable& sender, const FontInfoEventArgs& eventArgs);
 
         winrt::fire_and_forget _AsyncCloseConnection();
+
+        void _UpdateTerminalOnInput(const IInputEvent* const pInEvent);
     };
 }
 

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -175,7 +175,7 @@ public:
     void ColorSelection(const COORD coordSelectionStart, const COORD coordSelectionEnd, const TextAttribute) override;
 #pragma endregion
 
-    void SetWriteInputCallback(std::function<void(std::wstring&)> pfn) noexcept;
+    void SetWriteInputCallback(std::function<void(std::wstring&, const IInputEvent* const)> pfn) noexcept;
     void SetWarningBellCallback(std::function<void()> pfn) noexcept;
     void SetTitleChangedCallback(std::function<void(const std::wstring_view&)> pfn) noexcept;
     void SetTabColorChangedCallback(std::function<void(const std::optional<til::color>)> pfn) noexcept;
@@ -208,7 +208,7 @@ public:
 #pragma endregion
 
 private:
-    std::function<void(std::wstring&)> _pfnWriteInput;
+    std::function<void(std::wstring&, const IInputEvent* const)> _pfnWriteInput;
     std::function<void()> _pfnWarningBell;
     std::function<void(const std::wstring_view&)> _pfnTitleChanged;
     std::function<void(const std::wstring_view&)> _pfnCopyToClipboard;

--- a/src/cascadia/UnitTests_TerminalCore/InputTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/InputTest.cpp
@@ -23,7 +23,7 @@ namespace TerminalCoreUnitTests
         {
             DummyRenderTarget emptyRT;
             term.Create({ 100, 100 }, 0, emptyRT);
-            auto inputFn = std::bind(&InputTest::_VerifyExpectedInput, this, std::placeholders::_1);
+            auto inputFn = std::bind(&InputTest::_VerifyExpectedInput, this, std::placeholders::_1, std::placeholders::_2);
             term.SetWriteInputCallback(inputFn);
             return true;
         };
@@ -32,7 +32,7 @@ namespace TerminalCoreUnitTests
         TEST_METHOD(AltSpace);
         TEST_METHOD(InvalidKeyEvent);
 
-        void _VerifyExpectedInput(std::wstring& actualInput)
+        void _VerifyExpectedInput(std::wstring& actualInput, const IInputEvent* const /*pInEvent*/)
         {
             VERIFY_ARE_EQUAL(expectedinput.size(), actualInput.size());
             VERIFY_ARE_EQUAL(expectedinput, actualInput);

--- a/src/terminal/adapter/ut_adapter/MouseInputTest.cpp
+++ b/src/terminal/adapter/ut_adapter/MouseInputTest.cpp
@@ -85,7 +85,7 @@ class MouseInputTest
 public:
     TEST_CLASS(MouseInputTest);
 
-    static void s_MouseInputTestCallback(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& events)
+    static void s_MouseInputTestCallback(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& events, const IInputEvent* const /*pInEvent*/)
     {
         Log::Comment(L"MouseInput successfully generated a sequence for the input, and sent it.");
 

--- a/src/terminal/adapter/ut_adapter/inputTest.cpp
+++ b/src/terminal/adapter/ut_adapter/inputTest.cpp
@@ -38,8 +38,8 @@ class Microsoft::Console::VirtualTerminal::InputTest
 public:
     TEST_CLASS(InputTest);
 
-    static void s_TerminalInputTestCallback(_In_ std::deque<std::unique_ptr<IInputEvent>>& inEvents);
-    static void s_TerminalInputTestNullCallback(_In_ std::deque<std::unique_ptr<IInputEvent>>& inEvents);
+    static void s_TerminalInputTestCallback(_In_ std::deque<std::unique_ptr<IInputEvent>>& inEvents, const IInputEvent* const /*pInEvent*/);
+    static void s_TerminalInputTestNullCallback(_In_ std::deque<std::unique_ptr<IInputEvent>>& inEvents, const IInputEvent* const /*pInEvent*/);
 
     TEST_METHOD(TerminalInputTests);
     TEST_METHOD(TerminalInputModifierKeyTests);
@@ -78,7 +78,7 @@ public:
     }
 };
 
-void InputTest::s_TerminalInputTestCallback(_In_ std::deque<std::unique_ptr<IInputEvent>>& inEvents)
+void InputTest::s_TerminalInputTestCallback(_In_ std::deque<std::unique_ptr<IInputEvent>>& inEvents, const IInputEvent* const /*pInEvent*/)
 {
     auto records = IInputEvent::ToInputRecords(inEvents);
 
@@ -100,7 +100,7 @@ void InputTest::s_TerminalInputTestCallback(_In_ std::deque<std::unique_ptr<IInp
     }
 }
 
-void InputTest::s_TerminalInputTestNullCallback(_In_ std::deque<std::unique_ptr<IInputEvent>>& inEvents)
+void InputTest::s_TerminalInputTestNullCallback(_In_ std::deque<std::unique_ptr<IInputEvent>>& inEvents, const IInputEvent* const /*pInEvent*/)
 {
     auto records = IInputEvent::ToInputRecords(inEvents);
 

--- a/src/terminal/input/mouseInput.cpp
+++ b/src/terminal/input/mouseInput.cpp
@@ -338,7 +338,8 @@ bool TerminalInput::HandleMouse(const COORD position,
     bool success = false;
     if (_ShouldSendAlternateScroll(button, delta))
     {
-        success = _SendAlternateScroll(delta);
+        // TODO - pass real mouse event
+        success = _SendAlternateScroll(delta, nullptr);
     }
     else
     {
@@ -411,7 +412,8 @@ bool TerminalInput::HandleMouse(const COORD position,
 
                 if (success)
                 {
-                    _SendInputSequence(sequence);
+                    // TODO - pass real mouse event
+                    _SendInputSequence(sequence, nullptr);
                     success = true;
                 }
                 if (_mouseInputState.trackingMode == TrackingMode::ButtonEvent || _mouseInputState.trackingMode == TrackingMode::AnyEvent)
@@ -563,15 +565,15 @@ bool TerminalInput::_ShouldSendAlternateScroll(const unsigned int button, const 
 // - delta: The scroll wheel delta of the input event
 // Return value:
 // True iff the input sequence was sent successfully.
-bool TerminalInput::_SendAlternateScroll(const short delta) const noexcept
+bool TerminalInput::_SendAlternateScroll(const short delta, const IInputEvent* const pInEvent) const noexcept
 {
     if (delta > 0)
     {
-        _SendInputSequence(_cursorApplicationMode ? ApplicationUpSequence : CursorUpSequence);
+        _SendInputSequence(_cursorApplicationMode ? ApplicationUpSequence : CursorUpSequence, pInEvent);
     }
     else
     {
-        _SendInputSequence(_cursorApplicationMode ? ApplicationDownSequence : CursorDownSequence);
+        _SendInputSequence(_cursorApplicationMode ? ApplicationDownSequence : CursorDownSequence, pInEvent);
     }
     return true;
 }

--- a/src/terminal/input/terminalInput.hpp
+++ b/src/terminal/input/terminalInput.hpp
@@ -22,7 +22,7 @@ namespace Microsoft::Console::VirtualTerminal
     class TerminalInput final
     {
     public:
-        TerminalInput(_In_ std::function<void(std::deque<std::unique_ptr<IInputEvent>>&)> pfn);
+        TerminalInput(_In_ std::function<void(std::deque<std::unique_ptr<IInputEvent>>&, const IInputEvent* const)> pfn);
 
         TerminalInput() = delete;
         TerminalInput(const TerminalInput& old) = default;
@@ -75,7 +75,7 @@ namespace Microsoft::Console::VirtualTerminal
 #pragma endregion
 
     private:
-        std::function<void(std::deque<std::unique_ptr<IInputEvent>>&)> _pfnWriteEvents;
+        std::function<void(std::deque<std::unique_ptr<IInputEvent>>&, const IInputEvent* const)> _pfnWriteEvents;
 
         // storage location for the leading surrogate of a utf-16 surrogate pair
         std::optional<wchar_t> _leadingSurrogate;
@@ -86,10 +86,10 @@ namespace Microsoft::Console::VirtualTerminal
         bool _win32InputMode{ false };
         bool _forceDisableWin32InputMode{ false };
 
-        void _SendChar(const wchar_t ch);
-        void _SendNullInputSequence(const DWORD dwControlKeyState) const;
-        void _SendInputSequence(const std::wstring_view sequence) const noexcept;
-        void _SendEscapedInputSequence(const wchar_t wch) const;
+        void _SendChar(const wchar_t ch, const IInputEvent* const pInEvent);
+        void _SendNullInputSequence(const DWORD dwControlKeyState, const IInputEvent* const pInEvent) const;
+        void _SendInputSequence(const std::wstring_view sequence, const IInputEvent* const pInEvent) const noexcept;
+        void _SendEscapedInputSequence(const wchar_t wch, const IInputEvent* const pInEvent) const;
         static std::wstring _GenerateWin32KeySequence(const KeyEvent& key);
 
 #pragma region MouseInputState Management
@@ -143,7 +143,7 @@ namespace Microsoft::Console::VirtualTerminal
                                                  const short delta);
 
         bool _ShouldSendAlternateScroll(const unsigned int button, const short delta) const noexcept;
-        bool _SendAlternateScroll(const short delta) const noexcept;
+        bool _SendAlternateScroll(const short delta, const IInputEvent* const pInEvent) const noexcept;
 
         static constexpr unsigned int s_GetPressedButton(const MouseButtonState state) noexcept;
 #pragma endregion

--- a/src/terminal/parser/ut_parser/InputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/InputEngineTest.cpp
@@ -977,7 +977,7 @@ void InputEngineTest::AltIntermediateTest()
     // First create the callback TerminalInput will call - this will be
     // triggered second, after both the state machine and the TerminalInput have
     // translated the characters.
-    auto pfnTerminalInputCallback = [&](std::deque<std::unique_ptr<IInputEvent>>& inEvents) {
+    auto pfnTerminalInputCallback = [&](std::deque<std::unique_ptr<IInputEvent>>& inEvents, const IInputEvent* const /*pInEvent*/) {
         // Get all the characters:
         std::wstring wstr = L"";
         for (auto& ev : inEvents)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Right now the decisions to clear text selection or to scroll down is triggered too early, before we even decided to handle the event at all. This PR is an attempt to delay this decision until TermControl gets notified about input sequence.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #https://github.com/microsoft/terminal/issues/5366
* [x] CLA signed.
* [ ] Tests added/passed - not added yet
* [ ] Documentation updated - irrelevant
* [ ] Schema updated - irrelevant
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
So this one should be very simple: don't invoke selection clearing / scrolling immediately, but rather in the TermControl once a sequence received from the callback. 

What confused me was that delaying the decision was not enough: there are sequences that we do send to the connection that actually don't require scrolling / clearing selection. For instance Print Screen key is sent to the connection, but no action should be taken on Terminal side.

So I still had to preserve the safeguards that exist today. The problem is that to preserve these safeguards, TermControl should be aware of the stuff like was it key-up / key-down, etc. Though this information can be decoded from the sequence I decided to propagate the IInputEvent all the way through. This required some massive change of function prototypes.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Manual tests only by now