### PR TITLE
Swap the command palette modes for the prefix `>`

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -663,7 +663,7 @@ namespace winrt::TerminalApp::implementation
             break;
         case CommandPaletteMode::ActionMode:
         default:
-            SearchBoxPlaceholderText(RS_(L"CmdPalActionPrompt"));
+            SearchBoxPlaceholderText(RS_(L"CommandPalette_SearchBox/PlaceholderText"));
             NoMatchesText(RS_(L"CommandPalette_NoMatchesText/Text"));
             ControlName(RS_(L"CommandPaletteControlName"));
             PrefixCharacter(L">");

--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -40,7 +40,7 @@ namespace winrt::TerminalApp::implementation
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
         OBSERVABLE_GETSET_PROPERTY(winrt::hstring, NoMatchesText, _PropertyChangedHandlers);
         OBSERVABLE_GETSET_PROPERTY(winrt::hstring, SearchBoxPlaceholderText, _PropertyChangedHandlers);
-        OBSERVABLE_GETSET_PROPERTY(winrt::hstring, FakePlaceholderText, _PropertyChangedHandlers);
+        OBSERVABLE_GETSET_PROPERTY(winrt::hstring, PrefixCharacter, _PropertyChangedHandlers);
         OBSERVABLE_GETSET_PROPERTY(winrt::hstring, ControlName, _PropertyChangedHandlers);
         OBSERVABLE_GETSET_PROPERTY(winrt::hstring, ParentCommandName, _PropertyChangedHandlers);
 
@@ -55,6 +55,8 @@ namespace winrt::TerminalApp::implementation
         winrt::TerminalApp::ShortcutActionDispatch _dispatch;
 
         Windows::Foundation::Collections::IVector<Microsoft::Terminal::Settings::Model::Command> _commandsToFilter();
+
+        bool _lastFilterTextWasEmpty{ true };
 
         void _filterTextChanged(Windows::Foundation::IInspectable const& sender,
                                 Windows::UI::Xaml::RoutedEventArgs const& args);
@@ -85,8 +87,8 @@ namespace winrt::TerminalApp::implementation
         CommandPaletteMode _currentMode;
         void _switchToMode(CommandPaletteMode mode);
 
+        std::wstring _getTrimmedInput();
         void _evaluatePrefix();
-        std::wstring _getPostPrefixInput();
 
         Microsoft::Terminal::TerminalControl::IKeyBindings _bindings;
 

--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -39,7 +39,8 @@ namespace winrt::TerminalApp::implementation
 
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
         OBSERVABLE_GETSET_PROPERTY(winrt::hstring, NoMatchesText, _PropertyChangedHandlers);
-        OBSERVABLE_GETSET_PROPERTY(winrt::hstring, SearchBoxText, _PropertyChangedHandlers);
+        OBSERVABLE_GETSET_PROPERTY(winrt::hstring, SearchBoxPlaceholderText, _PropertyChangedHandlers);
+        OBSERVABLE_GETSET_PROPERTY(winrt::hstring, FakePlaceholderText, _PropertyChangedHandlers);
         OBSERVABLE_GETSET_PROPERTY(winrt::hstring, ControlName, _PropertyChangedHandlers);
         OBSERVABLE_GETSET_PROPERTY(winrt::hstring, ParentCommandName, _PropertyChangedHandlers);
 

--- a/src/cascadia/TerminalApp/CommandPalette.idl
+++ b/src/cascadia/TerminalApp/CommandPalette.idl
@@ -12,7 +12,7 @@ namespace TerminalApp
 
         String NoMatchesText { get; };
         String SearchBoxPlaceholderText { get; };
-        String FakePlaceholderText { get; };
+        String PrefixCharacter { get; };
         String ControlName { get; };
         String ParentCommandName { get; };
 

--- a/src/cascadia/TerminalApp/CommandPalette.idl
+++ b/src/cascadia/TerminalApp/CommandPalette.idl
@@ -11,7 +11,8 @@ namespace TerminalApp
         CommandPalette();
 
         String NoMatchesText { get; };
-        String SearchBoxText { get; };
+        String SearchBoxPlaceholderText { get; };
+        String FakePlaceholderText { get; };
         String ControlName { get; };
         String ParentCommandName { get; };
 

--- a/src/cascadia/TerminalApp/CommandPalette.xaml
+++ b/src/cascadia/TerminalApp/CommandPalette.xaml
@@ -135,27 +135,27 @@ the MIT License. See LICENSE in the project root for license information. -->
         to receive clicks _anywhere_ in its bounds. -->
 
         <Grid
-        x:Name="_shadowBackdrop"
-        Background="Transparent"
-        Grid.Column="0"
-        Grid.Row="0"
-        Grid.ColumnSpan="3"
-        Grid.RowSpan="2"
-        HorizontalAlignment="Stretch"
-        VerticalAlignment="Stretch">
+            x:Name="_shadowBackdrop"
+            Background="Transparent"
+            Grid.Column="0"
+            Grid.Row="0"
+            Grid.ColumnSpan="3"
+            Grid.RowSpan="2"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch">
         </Grid>
 
         <Grid
-        x:Name="_backdrop"
-        Style="{ThemeResource CommandPaletteBackground}"
-        CornerRadius="{ThemeResource ControlCornerRadius}"
-        PointerPressed="_backdropPointerPressed"
-        Margin="8"
-        Grid.Column="1"
-        Grid.Row="0"
-        Windows10version1903:Shadow="{StaticResource CommandPaletteShadow}"
-        HorizontalAlignment="Stretch"
-        VerticalAlignment="Top">
+            x:Name="_backdrop"
+            Style="{ThemeResource CommandPaletteBackground}"
+            CornerRadius="{ThemeResource ControlCornerRadius}"
+            PointerPressed="_backdropPointerPressed"
+            Margin="8"
+            Grid.Column="1"
+            Grid.Row="0"
+            Windows10version1903:Shadow="{StaticResource CommandPaletteShadow}"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Top">
 
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
@@ -164,14 +164,27 @@ the MIT License. See LICENSE in the project root for license information. -->
             </Grid.RowDefinitions>
 
             <TextBox
-            Grid.Row="0"
-            x:Name="_searchBox"
-            Margin="8"
-            IsSpellCheckEnabled="False"
-            TextChanged="_filterTextChanged"
-            PlaceholderText="{x:Bind SearchBoxText, Mode=OneWay}"
-            Text="">
+                Grid.Row="0"
+                x:Name="_searchBox"
+                Margin="8"
+                IsSpellCheckEnabled="False"
+                TextChanged="_filterTextChanged"
+                PlaceholderText="{x:Bind SearchBoxPlaceholderText, Mode=OneWay}"
+                Text="">
             </TextBox>
+
+            <TextBlock
+                Grid.Row="0"
+                x:Name="_fakePlaceholderText"
+                Margin="32,15,0,-8"
+                FontSize="13"
+                Foreground="{ThemeResource TextBoxPlaceholderTextThemeBrush}"
+                Visibility="{x:Bind FakePlaceholderText,
+                             Mode=OneWay,
+                             Converter={StaticResource ParentCommandVisibilityConverter}}"
+                Text="{x:Bind FakePlaceholderText, Mode=OneWay}"
+                >
+            </TextBlock>
 
             <TextBlock
                 Padding="16, 0, 16, 4"
@@ -194,17 +207,17 @@ the MIT License. See LICENSE in the project root for license information. -->
             </TextBlock>
 
             <ListView
-            Grid.Row="2"
-            x:Name="_filteredActionsView"
-            HorizontalAlignment="Stretch"
-            VerticalAlignment="Stretch"
-            SelectionMode="Single"
-            CanReorderItems="False"
-            AllowDrop="False"
-            IsItemClickEnabled="True"
-            ItemClick="_listItemClicked"
-            PreviewKeyDown="_keyDownHandler"
-            ItemsSource="{x:Bind FilteredActions}">
+                Grid.Row="2"
+                x:Name="_filteredActionsView"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch"
+                SelectionMode="Single"
+                CanReorderItems="False"
+                AllowDrop="False"
+                IsItemClickEnabled="True"
+                ItemClick="_listItemClicked"
+                PreviewKeyDown="_keyDownHandler"
+                ItemsSource="{x:Bind FilteredActions}">
 
                 <ItemsControl.ItemTemplate >
                     <DataTemplate x:DataType="SettingsModel:Command">

--- a/src/cascadia/TerminalApp/CommandPalette.xaml
+++ b/src/cascadia/TerminalApp/CommandPalette.xaml
@@ -167,6 +167,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                 Grid.Row="0"
                 x:Name="_searchBox"
                 Margin="8"
+                Padding="18,8,8,8"
                 IsSpellCheckEnabled="False"
                 TextChanged="_filterTextChanged"
                 PlaceholderText="{x:Bind SearchBoxPlaceholderText, Mode=OneWay}"
@@ -175,14 +176,13 @@ the MIT License. See LICENSE in the project root for license information. -->
 
             <TextBlock
                 Grid.Row="0"
-                x:Name="_fakePlaceholderText"
-                Margin="32,15,0,-8"
-                FontSize="13"
-                Foreground="{ThemeResource TextBoxPlaceholderTextThemeBrush}"
-                Visibility="{x:Bind FakePlaceholderText,
+                x:Name="_prefixCharacter"
+                Margin="16,16,0,-8"
+                FontSize="14"
+                Visibility="{x:Bind PrefixCharacter,
                              Mode=OneWay,
                              Converter={StaticResource ParentCommandVisibilityConverter}}"
-                Text="{x:Bind FakePlaceholderText, Mode=OneWay}"
+                Text="{x:Bind PrefixCharacter, Mode=OneWay}"
                 >
             </TextBlock>
 

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -379,8 +379,7 @@
     <value>Warning</value>
   </data>
   <data name="CommandPalette_SearchBox.PlaceholderText" xml:space="preserve">
-    <value>Enter a wt commandline to run</value>
-    <comment>{Locked="wt"} </comment>
+    <value>Type a command name...</value>
   </data>
   <data name="CommandPalette_NoMatchesText.Text" xml:space="preserve">
     <value>No matching commands</value>
@@ -396,9 +395,6 @@
   </data>
   <data name="TabSwitcher_NoMatchesText" xml:space="preserve">
     <value>No matching tab name</value>
-  </data>
-  <data name="CmdPalActionPrompt" xml:space="preserve">
-    <value>Type a command name...</value>
   </data>
   <data name="CmdPalCommandlinePrompt" xml:space="preserve">
     <value>Enter a wt commandline to run</value>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -379,7 +379,8 @@
     <value>Warning</value>
   </data>
   <data name="CommandPalette_SearchBox.PlaceholderText" xml:space="preserve">
-    <value>Type a command name...</value>
+    <value>Enter a wt commandline to run</value>
+    <comment>{Locked="wt"} </comment>
   </data>
   <data name="CommandPalette_NoMatchesText.Text" xml:space="preserve">
     <value>No matching commands</value>
@@ -395,6 +396,9 @@
   </data>
   <data name="TabSwitcher_NoMatchesText" xml:space="preserve">
     <value>No matching tab name</value>
+  </data>
+  <data name="CmdPalActionPrompt" xml:space="preserve">
+    <value>Type a command name...</value>
   </data>
   <data name="CmdPalCommandlinePrompt" xml:space="preserve">
     <value>Enter a wt commandline to run</value>


### PR DESCRIPTION
## Summary of the Pull Request

VsCode uses `>` as its "prefix" for the equivalent of their "action mode". This PR aligns the Terminal with their logic here. 
![cmdpal-swapped-prefix-000](https://user-images.githubusercontent.com/18356694/96163804-fbcdda80-0edf-11eb-8748-9c4e62bb2016.gif)

## PR Checklist
* [x] Closes #7736 
* [x] I work here
* [ ] Tests added/passed
* [ ] Oh gawrsh, all the gifs on the [CmdPal docs](https://docs.microsoft.com/en-us/windows/terminal/command-palette) will need to be updated, won't they 

## Detailed Description of the Pull Request / Additional comments

We have to be tricky - if we use the `>` in the actual input as the indicator for action mode, we can't display any placeholder text in the input to tell users to type a command. This wasn't an issue for the commandline mode previously, because we'd stick the "prompt" in the "no matches text" space. However, we can't do that for action mode. Instead, we'll stick a floating text block over the input box, and when the user's in action mode, we'll manually place a `>` into that space. When the user backspaces the `>`, we'll remove it from that block, and switch into commandline mode.


## Validation Steps Performed
Played with the cmdpal in lots of different modes, this finally feels good