### PR TITLE
Increase contrast ratio on the CmdPal shortcut text

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.xaml
+++ b/src/cascadia/TerminalApp/CommandPalette.xaml
@@ -58,7 +58,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                     <Style x:Key="KeyChordBorderStyle" TargetType="Border">
                         <Setter Property="BorderThickness" Value="1" />
                         <Setter Property="CornerRadius" Value="1" />
-                        <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
+                        <Setter Property="Background" Value="{ThemeResource SystemAltMediumLowColor}" />
                         <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
                     </Style>
                     <Style x:Key="KeyChordTextBlockStyle" TargetType="TextBlock">
@@ -89,7 +89,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                     <Style x:Key="KeyChordBorderStyle" TargetType="Border">
                         <Setter Property="BorderThickness" Value="1" />
                         <Setter Property="CornerRadius" Value="1" />
-                        <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
+                        <Setter Property="Background" Value="{ThemeResource SystemAltMediumLowColor}" />
                         <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
                     </Style>
                     <Style x:Key="KeyChordTextBlockStyle" TargetType="TextBlock">


### PR DESCRIPTION
## Summary of the Pull Request

Increase the contrast ratio between the text of the keyboard shortcuts in the cmdpal and their background
### Dark mode
![image](https://user-images.githubusercontent.com/18356694/96165352-1ef98980-0ee2-11eb-8bc8-78578ae72b88.png)

### Light mode
![image](https://user-images.githubusercontent.com/18356694/96165369-23be3d80-0ee2-11eb-9770-24b285bde1ff.png)

## References

## PR Checklist
* [x] Addresses #7915 (actual issue must be closed by external team)
* [x] I work here
* [n/a] Tests added/passed
* [n/a] Requires documentation to be updated
