### PR TITLE
Optimize the binary size of the XOrg color table - part 2

### DIFF
--- a/src/types/colorTable.cpp
+++ b/src/types/colorTable.cpp
@@ -296,29 +296,32 @@ static constexpr std::array<til::color, 256> standardXterm256ColorTable{
 // - The result color
 static constexpr til::color _calculateXorgAppColorVariant(til::color baseColor, size_t variant)
 {
-    float ratio = 1.0f;
+    size_t kfactor = 1000;
     switch (variant)
     {
     case 1:
-        ratio = 1.0f;
+        kfactor = 1000;
         break;
     case 2:
-        ratio = 0.932f;
+        kfactor = 932;
         break;
     case 3:
-        ratio = 0.804f;
+        kfactor = 804;
         break;
     case 4:
-        ratio = 0.548f;
+        kfactor = 548;
         break;
     default:
         break;
     }
 
+    const auto r = (baseColor.r * kfactor + 500) / 1000;
+    const auto g = (baseColor.g * kfactor + 500) / 1000;
+    const auto b = (baseColor.b * kfactor + 500) / 1000;
     return til::color(
-        ::base::saturated_cast<uint8_t>(baseColor.r * ratio),
-        ::base::saturated_cast<uint8_t>(baseColor.g * ratio),
-        ::base::saturated_cast<uint8_t>(baseColor.b * ratio));
+        ::base::saturated_cast<uint8_t>(r),
+        ::base::saturated_cast<uint8_t>(g),
+        ::base::saturated_cast<uint8_t>(b));
 }
 
 static constexpr til::presorted_static_map xorgAppStandardVariantColorTable{
@@ -329,7 +332,7 @@ static constexpr til::presorted_static_map xorgAppStandardVariantColorTable{
     std::pair{ "chocolate"sv, std::array<til::color, 2>{ til::color{ 210, 105, 30 }, til::color{ 255, 127, 36 } } },
     std::pair{ "coral"sv, std::array<til::color, 2>{ til::color{ 255, 127, 80 }, til::color{ 255, 114, 86 } } },
     std::pair{ "darkgoldenrod"sv, std::array<til::color, 2>{ til::color{ 184, 134, 11 }, til::color{ 255, 185, 15 } } },
-    std::pair{ "darkolivegreen"sv, std::array<til::color, 2>{ til::color{ 85, 107, 47 } } },
+    std::pair{ "darkolivegreen"sv, std::array<til::color, 2>{ til::color{ 85, 107, 47 }, til::color{ 202, 255, 112 } } },
     std::pair{ "darkorange"sv, std::array<til::color, 2>{ til::color{ 255, 140, 0 }, til::color{ 255, 127, 0 } } },
     std::pair{ "darkorchid"sv, std::array<til::color, 2>{ til::color{ 153, 50, 204 }, til::color{ 191, 62, 255 } } },
     std::pair{ "darkseagreen"sv, std::array<til::color, 2>{ til::color{ 143, 188, 143 }, til::color{ 193, 255, 193 } } },
@@ -366,7 +369,7 @@ static constexpr til::presorted_static_map xorgAppStandardVariantColorTable{
     std::pair{ "steelblue"sv, std::array<til::color, 2>{ til::color{ 70, 130, 180 }, til::color{ 99, 184, 255 } } },
     std::pair{ "tan"sv, std::array<til::color, 2>{ til::color{ 210, 180, 140 }, til::color{ 255, 165, 79 } } },
     std::pair{ "thistle"sv, std::array<til::color, 2>{ til::color{ 216, 191, 216 }, til::color{ 255, 225, 255 } } },
-    std::pair{ "turquoise"sv, std::array<til::color, 2>{ til::color{ 64, 224, 208 } } },
+    std::pair{ "turquoise"sv, std::array<til::color, 2>{ til::color{ 64, 224, 208 }, til::color{ 0, 245, 255 } } },
     std::pair{ "violetred"sv, std::array<til::color, 2>{ til::color{ 208, 32, 144 }, til::color{ 255, 62, 150 } } },
     std::pair{ "wheat"sv, std::array<til::color, 2>{ til::color{ 245, 222, 179 }, til::color{ 255, 231, 186 } } },
 };

--- a/src/types/colorTable.cpp
+++ b/src/types/colorTable.cpp
@@ -286,6 +286,14 @@ static constexpr std::array<til::color, 256> standardXterm256ColorTable{
     til::color{ 0xEE, 0xEE, 0xEE },
 };
 
+// Routine Description:
+// - Calculate XOrg app color variant with given base color and variant index.
+//   See also https://en.wikipedia.org/wiki/X11_color_names
+// Arguments:
+// - baseColor - The base color to use.
+// - variant - The variant index.
+// Return Value:
+// - The result color
 static constexpr til::color _calculateXorgAppColorVariant(til::color baseColor, size_t variant)
 {
     float ratio = 1.0f;
@@ -313,33 +321,32 @@ static constexpr til::color _calculateXorgAppColorVariant(til::color baseColor, 
         ::base::saturated_cast<uint8_t>(baseColor.b * ratio));
 }
 
-static constexpr til::presorted_static_map xorgAppStandardVariantColorTable
-{
-    std::pair{ "antiquewhite"sv, std::array<til::color, 2>{ til::color{ 250, 235, 215 }, til::color{ 255, 239, 219 }}},
+static constexpr til::presorted_static_map xorgAppStandardVariantColorTable{
+    std::pair{ "antiquewhite"sv, std::array<til::color, 2>{ til::color{ 250, 235, 215 }, til::color{ 255, 239, 219 } } },
     std::pair{ "brown"sv, std::array<til::color, 2>{ til::color{ 165, 42, 42 }, til::color{ 255, 64, 64 } } },
     std::pair{ "burlywood"sv, std::array<til::color, 2>{ til::color{ 222, 184, 135 }, til::color{ 255, 211, 155 } } },
     std::pair{ "cadetblue"sv, std::array<til::color, 2>{ til::color{ 95, 158, 160 }, til::color{ 152, 245, 255 } } },
     std::pair{ "chocolate"sv, std::array<til::color, 2>{ til::color{ 210, 105, 30 }, til::color{ 255, 127, 36 } } },
-    std::pair{ "coral"sv, std::array<til::color, 2>{ til::color{ 255, 127, 80 }, til::color{ 255, 114, 86 }}},
+    std::pair{ "coral"sv, std::array<til::color, 2>{ til::color{ 255, 127, 80 }, til::color{ 255, 114, 86 } } },
     std::pair{ "darkgoldenrod"sv, std::array<til::color, 2>{ til::color{ 184, 134, 11 }, til::color{ 255, 185, 15 } } },
-    std::pair{ "darkolivegreen"sv, std::array<til::color, 2>{ til::color{ 85, 107, 47 }} },
+    std::pair{ "darkolivegreen"sv, std::array<til::color, 2>{ til::color{ 85, 107, 47 } } },
     std::pair{ "darkorange"sv, std::array<til::color, 2>{ til::color{ 255, 140, 0 }, til::color{ 255, 127, 0 } } },
     std::pair{ "darkorchid"sv, std::array<til::color, 2>{ til::color{ 153, 50, 204 }, til::color{ 191, 62, 255 } } },
     std::pair{ "darkseagreen"sv, std::array<til::color, 2>{ til::color{ 143, 188, 143 }, til::color{ 193, 255, 193 } } },
     std::pair{ "darkslategray"sv, std::array<til::color, 2>{ til::color{ 47, 79, 79 }, til::color{ 151, 255, 255 } } },
-    std::pair{ "firebrick"sv, std::array<til::color, 2>{ til::color{ 178, 34, 34 }, til::color{ 255, 48, 48 }} },
+    std::pair{ "firebrick"sv, std::array<til::color, 2>{ til::color{ 178, 34, 34 }, til::color{ 255, 48, 48 } } },
     std::pair{ "goldenrod"sv, std::array<til::color, 2>{ til::color{ 218, 165, 32 }, til::color{ 255, 193, 37 } } },
-    std::pair{ "hotpink"sv, std::array<til::color, 2>{ til::color{ 255, 105, 180 }, til::color{ 255, 110, 180 }} },
-    std::pair{ "indianred"sv, std::array<til::color, 2>{ til::color{ 205, 92, 92 }, til::color{ 255, 106, 106 }}},
+    std::pair{ "hotpink"sv, std::array<til::color, 2>{ til::color{ 255, 105, 180 }, til::color{ 255, 110, 180 } } },
+    std::pair{ "indianred"sv, std::array<til::color, 2>{ til::color{ 205, 92, 92 }, til::color{ 255, 106, 106 } } },
     std::pair{ "khaki"sv, std::array<til::color, 2>{ til::color{ 240, 230, 140 }, til::color{ 255, 246, 143 } } },
     std::pair{ "lightblue"sv, std::array<til::color, 2>{ til::color{ 173, 216, 230 }, til::color{ 191, 239, 255 } } },
     std::pair{ "lightgoldenrod"sv, std::array<til::color, 2>{ til::color{ 238, 221, 130 }, til::color{ 255, 236, 139 } } },
     std::pair{ "lightpink"sv, std::array<til::color, 2>{ til::color{ 255, 182, 193 }, til::color{ 255, 174, 185 } } },
     std::pair{ "lightskyblue"sv, std::array<til::color, 2>{ til::color{ 135, 206, 250 }, til::color{ 176, 226, 255 } } },
     std::pair{ "lightsteelblue"sv, std::array<til::color, 2>{ til::color{ 176, 196, 222 }, til::color{ 202, 225, 255 } } },
-    std::pair{ "maroon"sv, std::array<til::color, 2>{ til::color{ 176, 48, 96 }, til::color{ 255, 52, 179 }} },
+    std::pair{ "maroon"sv, std::array<til::color, 2>{ til::color{ 176, 48, 96 }, til::color{ 255, 52, 179 } } },
     std::pair{ "mediumorchid"sv, std::array<til::color, 2>{ til::color{ 186, 85, 211 }, til::color{ 224, 102, 255 } } },
-    std::pair{ "mediumpurple"sv, std::array<til::color, 2>{ til::color{ 147, 112, 219 }, til::color{ 171, 130, 255 }} },
+    std::pair{ "mediumpurple"sv, std::array<til::color, 2>{ til::color{ 147, 112, 219 }, til::color{ 171, 130, 255 } } },
     std::pair{ "olivedrab"sv, std::array<til::color, 2>{ til::color{ 107, 142, 35 }, til::color{ 192, 255, 62 } } },
     std::pair{ "orchid"sv, std::array<til::color, 2>{ til::color{ 218, 112, 214 }, til::color{ 255, 131, 250 } } },
     std::pair{ "palegreen"sv, std::array<til::color, 2>{ til::color{ 152, 251, 152 }, til::color{ 154, 255, 154 } } },
@@ -348,7 +355,7 @@ static constexpr til::presorted_static_map xorgAppStandardVariantColorTable
     std::pair{ "pink"sv, std::array<til::color, 2>{ til::color{ 255, 192, 203 }, til::color{ 255, 181, 197 } } },
     std::pair{ "plum"sv, std::array<til::color, 2>{ til::color{ 221, 160, 221 }, til::color{ 255, 187, 255 } } },
     std::pair{ "purple"sv, std::array<til::color, 2>{ til::color{ 160, 32, 240 }, til::color{ 155, 48, 255 } } },
-    std::pair{ "rosybrown"sv, std::array<til::color, 2>{ til::color{ 188, 143, 143 }, til::color{ 255, 193, 193 }} },
+    std::pair{ "rosybrown"sv, std::array<til::color, 2>{ til::color{ 188, 143, 143 }, til::color{ 255, 193, 193 } } },
     std::pair{ "royalblue"sv, std::array<til::color, 2>{ til::color{ 65, 105, 225 }, til::color{ 72, 118, 255 } } },
     std::pair{ "salmon"sv, std::array<til::color, 2>{ til::color{ 250, 128, 114 }, til::color{ 255, 140, 105 } } },
     std::pair{ "seagreen"sv, std::array<til::color, 2>{ til::color{ 46, 139, 87 }, til::color{ 84, 255, 159 } } },
@@ -368,17 +375,17 @@ static constexpr til::presorted_static_map xorgAppVariantColorTable{
     std::pair{ "aquamarine"sv, til::color{ 127, 255, 212 } },
     std::pair{ "azure"sv, til::color{ 240, 255, 255 } },
     std::pair{ "bisque"sv, til::color{ 255, 228, 196 } },
-    std::pair{ "blue"sv,til::color{ 0, 0, 255 } },
-    std::pair{ "chartreuse"sv,til::color{ 127, 255, 0 } },
+    std::pair{ "blue"sv, til::color{ 0, 0, 255 } },
+    std::pair{ "chartreuse"sv, til::color{ 127, 255, 0 } },
     std::pair{ "cornsilk"sv, til::color{ 255, 248, 220 } },
-    std::pair{ "cyan"sv, til::color{ 0, 255, 255 }},
+    std::pair{ "cyan"sv, til::color{ 0, 255, 255 } },
     std::pair{ "deeppink"sv, til::color{ 255, 20, 147 } },
     std::pair{ "deepskyblue"sv, til::color{ 0, 191, 255 } },
-    std::pair{ "dodgerblue"sv,  til::color{ 30, 144, 255 } },
-    std::pair{ "gold"sv,  til::color{ 255, 215, 0 }},
+    std::pair{ "dodgerblue"sv, til::color{ 30, 144, 255 } },
+    std::pair{ "gold"sv, til::color{ 255, 215, 0 } },
     std::pair{ "green"sv, til::color{ 0, 255, 0 } },
-    std::pair{ "honeydew"sv,  til::color{ 240, 255, 240 } },
-    std::pair{ "ivory"sv,  til::color{ 255, 255, 240 } },
+    std::pair{ "honeydew"sv, til::color{ 240, 255, 240 } },
+    std::pair{ "ivory"sv, til::color{ 255, 255, 240 } },
     std::pair{ "lavenderblush"sv, til::color{ 255, 240, 245 } },
     std::pair{ "lemonchiffon"sv, til::color{ 255, 250, 205 } },
     std::pair{ "lightcyan"sv, til::color{ 224, 255, 255 } },
@@ -386,15 +393,15 @@ static constexpr til::presorted_static_map xorgAppVariantColorTable{
     std::pair{ "lightyellow"sv, til::color{ 255, 255, 224 } },
     std::pair{ "magenta"sv, til::color{ 255, 0, 255 } },
     std::pair{ "mistyrose"sv, til::color{ 255, 228, 225 } },
-    std::pair{ "navajowhite"sv,til::color{ 255, 222, 173 } },
-    std::pair{ "orange"sv,til::color{ 255, 165, 0 } },
-    std::pair{ "orangered"sv,  til::color{ 255, 69, 0 } },
+    std::pair{ "navajowhite"sv, til::color{ 255, 222, 173 } },
+    std::pair{ "orange"sv, til::color{ 255, 165, 0 } },
+    std::pair{ "orangered"sv, til::color{ 255, 69, 0 } },
     std::pair{ "peachpuff"sv, til::color{ 255, 218, 185 } },
     std::pair{ "red"sv, til::color{ 255, 0, 0 } },
     std::pair{ "seashell"sv, til::color{ 255, 245, 238 } },
-    std::pair{ "snow"sv,  til::color{ 255, 250, 250 } },
-    std::pair{ "springgreen"sv, til::color{ 0, 255, 127 }},
-    std::pair{ "tomato"sv,til::color{ 255, 99, 71 } },
+    std::pair{ "snow"sv, til::color{ 255, 250, 250 } },
+    std::pair{ "springgreen"sv, til::color{ 0, 255, 127 } },
+    std::pair{ "tomato"sv, til::color{ 255, 99, 71 } },
     std::pair{ "yellow"sv, til::color{ 255, 255, 0 } },
 };
 
@@ -547,6 +554,7 @@ void Utils::Initialize256ColorTable(const gsl::span<COLORREF> table)
 
 // Function Description:
 // - Parses a color from a string based on the XOrg app color name table.
+//   See also https://en.wikipedia.org/wiki/X11_color_names
 // Arguments:
 // - str: a string representation of the color name to parse
 // Return Value:

--- a/src/types/colorTable.cpp
+++ b/src/types/colorTable.cpp
@@ -592,10 +592,10 @@ try
     }
 
     std::string name(ss.str());
-    const auto standartVariantColorIter = xorgAppStandardVariantColorTable.find(name);
-    if (standartVariantColorIter != xorgAppStandardVariantColorTable.end())
+    const auto standardVariantColorIter = xorgAppStandardVariantColorTable.find(name);
+    if (standardVariantColorIter != xorgAppStandardVariantColorTable.end())
     {
-        const auto standardAndVariantBaseColor = standartVariantColorIter->second;
+        const auto standardAndVariantBaseColor = standardVariantColorIter->second;
         if (variantIndex > 4)
         {
             return std::nullopt;

--- a/src/types/colorTable.cpp
+++ b/src/types/colorTable.cpp
@@ -286,85 +286,116 @@ static constexpr std::array<til::color, 256> standardXterm256ColorTable{
     til::color{ 0xEE, 0xEE, 0xEE },
 };
 
+static constexpr til::color _calculateXorgAppColorVariant(til::color baseColor, size_t variant)
+{
+    float ratio = 1.0f;
+    switch (variant)
+    {
+    case 1:
+        ratio = 1.0f;
+        break;
+    case 2:
+        ratio = 0.932f;
+        break;
+    case 3:
+        ratio = 0.804f;
+        break;
+    case 4:
+        ratio = 0.548f;
+        break;
+    default:
+        break;
+    }
+
+    return til::color(
+        ::base::saturated_cast<uint8_t>(baseColor.r * ratio),
+        ::base::saturated_cast<uint8_t>(baseColor.g * ratio),
+        ::base::saturated_cast<uint8_t>(baseColor.b * ratio));
+}
+
+static constexpr til::presorted_static_map xorgAppStandardVariantColorTable
+{
+    std::pair{ "antiquewhite"sv, std::array<til::color, 2>{ til::color{ 250, 235, 215 }, til::color{ 255, 239, 219 }}},
+    std::pair{ "brown"sv, std::array<til::color, 2>{ til::color{ 165, 42, 42 }, til::color{ 255, 64, 64 } } },
+    std::pair{ "burlywood"sv, std::array<til::color, 2>{ til::color{ 222, 184, 135 }, til::color{ 255, 211, 155 } } },
+    std::pair{ "cadetblue"sv, std::array<til::color, 2>{ til::color{ 95, 158, 160 }, til::color{ 152, 245, 255 } } },
+    std::pair{ "chocolate"sv, std::array<til::color, 2>{ til::color{ 210, 105, 30 }, til::color{ 255, 127, 36 } } },
+    std::pair{ "coral"sv, std::array<til::color, 2>{ til::color{ 255, 127, 80 }, til::color{ 255, 114, 86 }}},
+    std::pair{ "darkgoldenrod"sv, std::array<til::color, 2>{ til::color{ 184, 134, 11 }, til::color{ 255, 185, 15 } } },
+    std::pair{ "darkolivegreen"sv, std::array<til::color, 2>{ til::color{ 85, 107, 47 }} },
+    std::pair{ "darkorange"sv, std::array<til::color, 2>{ til::color{ 255, 140, 0 }, til::color{ 255, 127, 0 } } },
+    std::pair{ "darkorchid"sv, std::array<til::color, 2>{ til::color{ 153, 50, 204 }, til::color{ 191, 62, 255 } } },
+    std::pair{ "darkseagreen"sv, std::array<til::color, 2>{ til::color{ 143, 188, 143 }, til::color{ 193, 255, 193 } } },
+    std::pair{ "darkslategray"sv, std::array<til::color, 2>{ til::color{ 47, 79, 79 }, til::color{ 151, 255, 255 } } },
+    std::pair{ "firebrick"sv, std::array<til::color, 2>{ til::color{ 178, 34, 34 }, til::color{ 255, 48, 48 }} },
+    std::pair{ "goldenrod"sv, std::array<til::color, 2>{ til::color{ 218, 165, 32 }, til::color{ 255, 193, 37 } } },
+    std::pair{ "hotpink"sv, std::array<til::color, 2>{ til::color{ 255, 105, 180 }, til::color{ 255, 110, 180 }} },
+    std::pair{ "indianred"sv, std::array<til::color, 2>{ til::color{ 205, 92, 92 }, til::color{ 255, 106, 106 }}},
+    std::pair{ "khaki"sv, std::array<til::color, 2>{ til::color{ 240, 230, 140 }, til::color{ 255, 246, 143 } } },
+    std::pair{ "lightblue"sv, std::array<til::color, 2>{ til::color{ 173, 216, 230 }, til::color{ 191, 239, 255 } } },
+    std::pair{ "lightgoldenrod"sv, std::array<til::color, 2>{ til::color{ 238, 221, 130 }, til::color{ 255, 236, 139 } } },
+    std::pair{ "lightpink"sv, std::array<til::color, 2>{ til::color{ 255, 182, 193 }, til::color{ 255, 174, 185 } } },
+    std::pair{ "lightskyblue"sv, std::array<til::color, 2>{ til::color{ 135, 206, 250 }, til::color{ 176, 226, 255 } } },
+    std::pair{ "lightsteelblue"sv, std::array<til::color, 2>{ til::color{ 176, 196, 222 }, til::color{ 202, 225, 255 } } },
+    std::pair{ "maroon"sv, std::array<til::color, 2>{ til::color{ 176, 48, 96 }, til::color{ 255, 52, 179 }} },
+    std::pair{ "mediumorchid"sv, std::array<til::color, 2>{ til::color{ 186, 85, 211 }, til::color{ 224, 102, 255 } } },
+    std::pair{ "mediumpurple"sv, std::array<til::color, 2>{ til::color{ 147, 112, 219 }, til::color{ 171, 130, 255 }} },
+    std::pair{ "olivedrab"sv, std::array<til::color, 2>{ til::color{ 107, 142, 35 }, til::color{ 192, 255, 62 } } },
+    std::pair{ "orchid"sv, std::array<til::color, 2>{ til::color{ 218, 112, 214 }, til::color{ 255, 131, 250 } } },
+    std::pair{ "palegreen"sv, std::array<til::color, 2>{ til::color{ 152, 251, 152 }, til::color{ 154, 255, 154 } } },
+    std::pair{ "paleturquoise"sv, std::array<til::color, 2>{ til::color{ 175, 238, 238 }, til::color{ 187, 255, 255 } } },
+    std::pair{ "palevioletred"sv, std::array<til::color, 2>{ til::color{ 219, 112, 147 }, til::color{ 255, 130, 171 } } },
+    std::pair{ "pink"sv, std::array<til::color, 2>{ til::color{ 255, 192, 203 }, til::color{ 255, 181, 197 } } },
+    std::pair{ "plum"sv, std::array<til::color, 2>{ til::color{ 221, 160, 221 }, til::color{ 255, 187, 255 } } },
+    std::pair{ "purple"sv, std::array<til::color, 2>{ til::color{ 160, 32, 240 }, til::color{ 155, 48, 255 } } },
+    std::pair{ "rosybrown"sv, std::array<til::color, 2>{ til::color{ 188, 143, 143 }, til::color{ 255, 193, 193 }} },
+    std::pair{ "royalblue"sv, std::array<til::color, 2>{ til::color{ 65, 105, 225 }, til::color{ 72, 118, 255 } } },
+    std::pair{ "salmon"sv, std::array<til::color, 2>{ til::color{ 250, 128, 114 }, til::color{ 255, 140, 105 } } },
+    std::pair{ "seagreen"sv, std::array<til::color, 2>{ til::color{ 46, 139, 87 }, til::color{ 84, 255, 159 } } },
+    std::pair{ "sienna"sv, std::array<til::color, 2>{ til::color{ 160, 82, 45 }, til::color{ 255, 130, 71 } } },
+    std::pair{ "skyblue"sv, std::array<til::color, 2>{ til::color{ 135, 206, 235 }, til::color{ 135, 206, 255 } } },
+    std::pair{ "slateblue"sv, std::array<til::color, 2>{ til::color{ 106, 90, 205 }, til::color{ 131, 111, 255 } } },
+    std::pair{ "slategray"sv, std::array<til::color, 2>{ til::color{ 112, 128, 144 }, til::color{ 198, 226, 255 } } },
+    std::pair{ "steelblue"sv, std::array<til::color, 2>{ til::color{ 70, 130, 180 }, til::color{ 99, 184, 255 } } },
+    std::pair{ "tan"sv, std::array<til::color, 2>{ til::color{ 210, 180, 140 }, til::color{ 255, 165, 79 } } },
+    std::pair{ "thistle"sv, std::array<til::color, 2>{ til::color{ 216, 191, 216 }, til::color{ 255, 225, 255 } } },
+    std::pair{ "turquoise"sv, std::array<til::color, 2>{ til::color{ 64, 224, 208 } } },
+    std::pair{ "violetred"sv, std::array<til::color, 2>{ til::color{ 208, 32, 144 }, til::color{ 255, 62, 150 } } },
+    std::pair{ "wheat"sv, std::array<til::color, 2>{ til::color{ 245, 222, 179 }, til::color{ 255, 231, 186 } } },
+};
+
 static constexpr til::presorted_static_map xorgAppVariantColorTable{
-    std::pair{ "antiquewhite"sv, std::array<til::color, 5>{ til::color{ 250, 235, 215 }, til::color{ 255, 239, 219 }, til::color{ 238, 223, 204 }, til::color{ 205, 192, 176 }, til::color{ 139, 131, 120 } } },
-    std::pair{ "aquamarine"sv, std::array<til::color, 5>{ til::color{ 127, 255, 212 }, til::color{ 127, 255, 212 }, til::color{ 118, 238, 198 }, til::color{ 102, 205, 170 }, til::color{ 69, 139, 116 } } },
-    std::pair{ "azure"sv, std::array<til::color, 5>{ til::color{ 240, 255, 255 }, til::color{ 240, 255, 255 }, til::color{ 224, 238, 238 }, til::color{ 193, 205, 205 }, til::color{ 131, 139, 139 } } },
-    std::pair{ "bisque"sv, std::array<til::color, 5>{ til::color{ 255, 228, 196 }, til::color{ 255, 228, 196 }, til::color{ 238, 213, 183 }, til::color{ 205, 183, 158 }, til::color{ 139, 125, 107 } } },
-    std::pair{ "blue"sv, std::array<til::color, 5>{ til::color{ 0, 0, 255 }, til::color{ 0, 0, 255 }, til::color{ 0, 0, 238 }, til::color{ 0, 0, 205 }, til::color{ 0, 0, 139 } } },
-    std::pair{ "brown"sv, std::array<til::color, 5>{ til::color{ 165, 42, 42 }, til::color{ 255, 64, 64 }, til::color{ 238, 59, 59 }, til::color{ 205, 51, 51 }, til::color{ 139, 35, 35 } } },
-    std::pair{ "burlywood"sv, std::array<til::color, 5>{ til::color{ 222, 184, 135 }, til::color{ 255, 211, 155 }, til::color{ 238, 197, 145 }, til::color{ 205, 170, 125 }, til::color{ 139, 115, 85 } } },
-    std::pair{ "cadetblue"sv, std::array<til::color, 5>{ til::color{ 95, 158, 160 }, til::color{ 152, 245, 255 }, til::color{ 142, 229, 238 }, til::color{ 122, 197, 205 }, til::color{ 83, 134, 139 } } },
-    std::pair{ "chartreuse"sv, std::array<til::color, 5>{ til::color{ 127, 255, 0 }, til::color{ 127, 255, 0 }, til::color{ 118, 238, 0 }, til::color{ 102, 205, 0 }, til::color{ 69, 139, 0 } } },
-    std::pair{ "chocolate"sv, std::array<til::color, 5>{ til::color{ 210, 105, 30 }, til::color{ 255, 127, 36 }, til::color{ 238, 118, 33 }, til::color{ 205, 102, 29 }, til::color{ 139, 69, 19 } } },
-    std::pair{ "coral"sv, std::array<til::color, 5>{ til::color{ 255, 127, 80 }, til::color{ 255, 114, 86 }, til::color{ 238, 106, 80 }, til::color{ 205, 91, 69 }, til::color{ 139, 62, 47 } } },
-    std::pair{ "cornsilk"sv, std::array<til::color, 5>{ til::color{ 255, 248, 220 }, til::color{ 255, 248, 220 }, til::color{ 238, 232, 205 }, til::color{ 205, 200, 177 }, til::color{ 139, 136, 120 } } },
-    std::pair{ "cyan"sv, std::array<til::color, 5>{ til::color{ 0, 255, 255 }, til::color{ 0, 255, 255 }, til::color{ 0, 238, 238 }, til::color{ 0, 205, 205 }, til::color{ 0, 139, 139 } } },
-    std::pair{ "darkgoldenrod"sv, std::array<til::color, 5>{ til::color{ 184, 134, 11 }, til::color{ 255, 185, 15 }, til::color{ 238, 173, 14 }, til::color{ 205, 149, 12 }, til::color{ 139, 101, 8 } } },
-    std::pair{ "darkolivegreen"sv, std::array<til::color, 5>{ til::color{ 85, 107, 47 }, til::color{ 202, 255, 112 }, til::color{ 188, 238, 104 }, til::color{ 162, 205, 90 }, til::color{ 110, 139, 61 } } },
-    std::pair{ "darkorange"sv, std::array<til::color, 5>{ til::color{ 255, 140, 0 }, til::color{ 255, 127, 0 }, til::color{ 238, 118, 0 }, til::color{ 205, 102, 0 }, til::color{ 139, 69, 0 } } },
-    std::pair{ "darkorchid"sv, std::array<til::color, 5>{ til::color{ 153, 50, 204 }, til::color{ 191, 62, 255 }, til::color{ 178, 58, 238 }, til::color{ 154, 50, 205 }, til::color{ 104, 34, 139 } } },
-    std::pair{ "darkseagreen"sv, std::array<til::color, 5>{ til::color{ 143, 188, 143 }, til::color{ 193, 255, 193 }, til::color{ 180, 238, 180 }, til::color{ 155, 205, 155 }, til::color{ 105, 139, 105 } } },
-    std::pair{ "darkslategray"sv, std::array<til::color, 5>{ til::color{ 47, 79, 79 }, til::color{ 151, 255, 255 }, til::color{ 141, 238, 238 }, til::color{ 121, 205, 205 }, til::color{ 82, 139, 139 } } },
-    std::pair{ "deeppink"sv, std::array<til::color, 5>{ til::color{ 255, 20, 147 }, til::color{ 255, 20, 147 }, til::color{ 238, 18, 137 }, til::color{ 205, 16, 118 }, til::color{ 139, 10, 80 } } },
-    std::pair{ "deepskyblue"sv, std::array<til::color, 5>{ til::color{ 0, 191, 255 }, til::color{ 0, 191, 255 }, til::color{ 0, 178, 238 }, til::color{ 0, 154, 205 }, til::color{ 0, 104, 139 } } },
-    std::pair{ "dodgerblue"sv, std::array<til::color, 5>{ til::color{ 30, 144, 255 }, til::color{ 30, 144, 255 }, til::color{ 28, 134, 238 }, til::color{ 24, 116, 205 }, til::color{ 16, 78, 139 } } },
-    std::pair{ "firebrick"sv, std::array<til::color, 5>{ til::color{ 178, 34, 34 }, til::color{ 255, 48, 48 }, til::color{ 238, 44, 44 }, til::color{ 205, 38, 38 }, til::color{ 139, 26, 26 } } },
-    std::pair{ "gold"sv, std::array<til::color, 5>{ til::color{ 255, 215, 0 }, til::color{ 255, 215, 0 }, til::color{ 238, 201, 0 }, til::color{ 205, 173, 0 }, til::color{ 139, 117, 0 } } },
-    std::pair{ "goldenrod"sv, std::array<til::color, 5>{ til::color{ 218, 165, 32 }, til::color{ 255, 193, 37 }, til::color{ 238, 180, 34 }, til::color{ 205, 155, 29 }, til::color{ 139, 105, 20 } } },
-    std::pair{ "green"sv, std::array<til::color, 5>{ til::color{ 0, 255, 0 }, til::color{ 0, 255, 0 }, til::color{ 0, 238, 0 }, til::color{ 0, 205, 0 }, til::color{ 0, 139, 0 } } },
-    std::pair{ "honeydew"sv, std::array<til::color, 5>{ til::color{ 240, 255, 240 }, til::color{ 240, 255, 240 }, til::color{ 224, 238, 224 }, til::color{ 193, 205, 193 }, til::color{ 131, 139, 131 } } },
-    std::pair{ "hotpink"sv, std::array<til::color, 5>{ til::color{ 255, 105, 180 }, til::color{ 255, 110, 180 }, til::color{ 238, 106, 167 }, til::color{ 205, 96, 144 }, til::color{ 139, 58, 98 } } },
-    std::pair{ "indianred"sv, std::array<til::color, 5>{ til::color{ 205, 92, 92 }, til::color{ 255, 106, 106 }, til::color{ 238, 99, 99 }, til::color{ 205, 85, 85 }, til::color{ 139, 58, 58 } } },
-    std::pair{ "ivory"sv, std::array<til::color, 5>{ til::color{ 255, 255, 240 }, til::color{ 255, 255, 240 }, til::color{ 238, 238, 224 }, til::color{ 205, 205, 193 }, til::color{ 139, 139, 131 } } },
-    std::pair{ "khaki"sv, std::array<til::color, 5>{ til::color{ 240, 230, 140 }, til::color{ 255, 246, 143 }, til::color{ 238, 230, 133 }, til::color{ 205, 198, 115 }, til::color{ 139, 134, 78 } } },
-    std::pair{ "lavenderblush"sv, std::array<til::color, 5>{ til::color{ 255, 240, 245 }, til::color{ 255, 240, 245 }, til::color{ 238, 224, 229 }, til::color{ 205, 193, 197 }, til::color{ 139, 131, 134 } } },
-    std::pair{ "lemonchiffon"sv, std::array<til::color, 5>{ til::color{ 255, 250, 205 }, til::color{ 255, 250, 205 }, til::color{ 238, 233, 191 }, til::color{ 205, 201, 165 }, til::color{ 139, 137, 112 } } },
-    std::pair{ "lightblue"sv, std::array<til::color, 5>{ til::color{ 173, 216, 230 }, til::color{ 191, 239, 255 }, til::color{ 178, 223, 238 }, til::color{ 154, 192, 205 }, til::color{ 104, 131, 139 } } },
-    std::pair{ "lightcyan"sv, std::array<til::color, 5>{ til::color{ 224, 255, 255 }, til::color{ 224, 255, 255 }, til::color{ 209, 238, 238 }, til::color{ 180, 205, 205 }, til::color{ 122, 139, 139 } } },
-    std::pair{ "lightgoldenrod"sv, std::array<til::color, 5>{ til::color{ 238, 221, 130 }, til::color{ 255, 236, 139 }, til::color{ 238, 220, 130 }, til::color{ 205, 190, 112 }, til::color{ 139, 129, 76 } } },
-    std::pair{ "lightpink"sv, std::array<til::color, 5>{ til::color{ 255, 182, 193 }, til::color{ 255, 174, 185 }, til::color{ 238, 162, 173 }, til::color{ 205, 140, 149 }, til::color{ 139, 95, 101 } } },
-    std::pair{ "lightsalmon"sv, std::array<til::color, 5>{ til::color{ 255, 160, 122 }, til::color{ 255, 160, 122 }, til::color{ 238, 149, 114 }, til::color{ 205, 129, 98 }, til::color{ 139, 87, 66 } } },
-    std::pair{ "lightskyblue"sv, std::array<til::color, 5>{ til::color{ 135, 206, 250 }, til::color{ 176, 226, 255 }, til::color{ 164, 211, 238 }, til::color{ 141, 182, 205 }, til::color{ 96, 123, 139 } } },
-    std::pair{ "lightsteelblue"sv, std::array<til::color, 5>{ til::color{ 176, 196, 222 }, til::color{ 202, 225, 255 }, til::color{ 188, 210, 238 }, til::color{ 162, 181, 205 }, til::color{ 110, 123, 139 } } },
-    std::pair{ "lightyellow"sv, std::array<til::color, 5>{ til::color{ 255, 255, 224 }, til::color{ 255, 255, 224 }, til::color{ 238, 238, 209 }, til::color{ 205, 205, 180 }, til::color{ 139, 139, 122 } } },
-    std::pair{ "magenta"sv, std::array<til::color, 5>{ til::color{ 255, 0, 255 }, til::color{ 255, 0, 255 }, til::color{ 238, 0, 238 }, til::color{ 205, 0, 205 }, til::color{ 139, 0, 139 } } },
-    std::pair{ "maroon"sv, std::array<til::color, 5>{ til::color{ 176, 48, 96 }, til::color{ 255, 52, 179 }, til::color{ 238, 48, 167 }, til::color{ 205, 41, 144 }, til::color{ 139, 28, 98 } } },
-    std::pair{ "mediumorchid"sv, std::array<til::color, 5>{ til::color{ 186, 85, 211 }, til::color{ 224, 102, 255 }, til::color{ 209, 95, 238 }, til::color{ 180, 82, 205 }, til::color{ 122, 55, 139 } } },
-    std::pair{ "mediumpurple"sv, std::array<til::color, 5>{ til::color{ 147, 112, 219 }, til::color{ 171, 130, 255 }, til::color{ 159, 121, 238 }, til::color{ 137, 104, 205 }, til::color{ 93, 71, 139 } } },
-    std::pair{ "mistyrose"sv, std::array<til::color, 5>{ til::color{ 255, 228, 225 }, til::color{ 255, 228, 225 }, til::color{ 238, 213, 210 }, til::color{ 205, 183, 181 }, til::color{ 139, 125, 123 } } },
-    std::pair{ "navajowhite"sv, std::array<til::color, 5>{ til::color{ 255, 222, 173 }, til::color{ 255, 222, 173 }, til::color{ 238, 207, 161 }, til::color{ 205, 179, 139 }, til::color{ 139, 121, 94 } } },
-    std::pair{ "olivedrab"sv, std::array<til::color, 5>{ til::color{ 107, 142, 35 }, til::color{ 192, 255, 62 }, til::color{ 179, 238, 58 }, til::color{ 154, 205, 50 }, til::color{ 105, 139, 34 } } },
-    std::pair{ "orange"sv, std::array<til::color, 5>{ til::color{ 255, 165, 0 }, til::color{ 255, 165, 0 }, til::color{ 238, 154, 0 }, til::color{ 205, 133, 0 }, til::color{ 139, 90, 0 } } },
-    std::pair{ "orangered"sv, std::array<til::color, 5>{ til::color{ 255, 69, 0 }, til::color{ 255, 69, 0 }, til::color{ 238, 64, 0 }, til::color{ 205, 55, 0 }, til::color{ 139, 37, 0 } } },
-    std::pair{ "orchid"sv, std::array<til::color, 5>{ til::color{ 218, 112, 214 }, til::color{ 255, 131, 250 }, til::color{ 238, 122, 233 }, til::color{ 205, 105, 201 }, til::color{ 139, 71, 137 } } },
-    std::pair{ "palegreen"sv, std::array<til::color, 5>{ til::color{ 152, 251, 152 }, til::color{ 154, 255, 154 }, til::color{ 144, 238, 144 }, til::color{ 124, 205, 124 }, til::color{ 84, 139, 84 } } },
-    std::pair{ "paleturquoise"sv, std::array<til::color, 5>{ til::color{ 175, 238, 238 }, til::color{ 187, 255, 255 }, til::color{ 174, 238, 238 }, til::color{ 150, 205, 205 }, til::color{ 102, 139, 139 } } },
-    std::pair{ "palevioletred"sv, std::array<til::color, 5>{ til::color{ 219, 112, 147 }, til::color{ 255, 130, 171 }, til::color{ 238, 121, 159 }, til::color{ 205, 104, 137 }, til::color{ 139, 71, 93 } } },
-    std::pair{ "peachpuff"sv, std::array<til::color, 5>{ til::color{ 255, 218, 185 }, til::color{ 255, 218, 185 }, til::color{ 238, 203, 173 }, til::color{ 205, 175, 149 }, til::color{ 139, 119, 101 } } },
-    std::pair{ "pink"sv, std::array<til::color, 5>{ til::color{ 255, 192, 203 }, til::color{ 255, 181, 197 }, til::color{ 238, 169, 184 }, til::color{ 205, 145, 158 }, til::color{ 139, 99, 108 } } },
-    std::pair{ "plum"sv, std::array<til::color, 5>{ til::color{ 221, 160, 221 }, til::color{ 255, 187, 255 }, til::color{ 238, 174, 238 }, til::color{ 205, 150, 205 }, til::color{ 139, 102, 139 } } },
-    std::pair{ "purple"sv, std::array<til::color, 5>{ til::color{ 160, 32, 240 }, til::color{ 155, 48, 255 }, til::color{ 145, 44, 238 }, til::color{ 125, 38, 205 }, til::color{ 85, 26, 139 } } },
-    std::pair{ "red"sv, std::array<til::color, 5>{ til::color{ 255, 0, 0 }, til::color{ 255, 0, 0 }, til::color{ 238, 0, 0 }, til::color{ 205, 0, 0 }, til::color{ 139, 0, 0 } } },
-    std::pair{ "rosybrown"sv, std::array<til::color, 5>{ til::color{ 188, 143, 143 }, til::color{ 255, 193, 193 }, til::color{ 238, 180, 180 }, til::color{ 205, 155, 155 }, til::color{ 139, 105, 105 } } },
-    std::pair{ "royalblue"sv, std::array<til::color, 5>{ til::color{ 65, 105, 225 }, til::color{ 72, 118, 255 }, til::color{ 67, 110, 238 }, til::color{ 58, 95, 205 }, til::color{ 39, 64, 139 } } },
-    std::pair{ "salmon"sv, std::array<til::color, 5>{ til::color{ 250, 128, 114 }, til::color{ 255, 140, 105 }, til::color{ 238, 130, 98 }, til::color{ 205, 112, 84 }, til::color{ 139, 76, 57 } } },
-    std::pair{ "seagreen"sv, std::array<til::color, 5>{ til::color{ 46, 139, 87 }, til::color{ 84, 255, 159 }, til::color{ 78, 238, 148 }, til::color{ 67, 205, 128 }, til::color{ 46, 139, 87 } } },
-    std::pair{ "seashell"sv, std::array<til::color, 5>{ til::color{ 255, 245, 238 }, til::color{ 255, 245, 238 }, til::color{ 238, 229, 222 }, til::color{ 205, 197, 191 }, til::color{ 139, 134, 130 } } },
-    std::pair{ "sienna"sv, std::array<til::color, 5>{ til::color{ 160, 82, 45 }, til::color{ 255, 130, 71 }, til::color{ 238, 121, 66 }, til::color{ 205, 104, 57 }, til::color{ 139, 71, 38 } } },
-    std::pair{ "skyblue"sv, std::array<til::color, 5>{ til::color{ 135, 206, 235 }, til::color{ 135, 206, 255 }, til::color{ 126, 192, 238 }, til::color{ 108, 166, 205 }, til::color{ 74, 112, 139 } } },
-    std::pair{ "slateblue"sv, std::array<til::color, 5>{ til::color{ 106, 90, 205 }, til::color{ 131, 111, 255 }, til::color{ 122, 103, 238 }, til::color{ 105, 89, 205 }, til::color{ 71, 60, 139 } } },
-    std::pair{ "slategray"sv, std::array<til::color, 5>{ til::color{ 112, 128, 144 }, til::color{ 198, 226, 255 }, til::color{ 185, 211, 238 }, til::color{ 159, 182, 205 }, til::color{ 108, 123, 139 } } },
-    std::pair{ "snow"sv, std::array<til::color, 5>{ til::color{ 255, 250, 250 }, til::color{ 255, 250, 250 }, til::color{ 238, 233, 233 }, til::color{ 205, 201, 201 }, til::color{ 139, 137, 137 } } },
-    std::pair{ "springgreen"sv, std::array<til::color, 5>{ til::color{ 0, 255, 127 }, til::color{ 0, 255, 127 }, til::color{ 0, 238, 118 }, til::color{ 0, 205, 102 }, til::color{ 0, 139, 69 } } },
-    std::pair{ "steelblue"sv, std::array<til::color, 5>{ til::color{ 70, 130, 180 }, til::color{ 99, 184, 255 }, til::color{ 92, 172, 238 }, til::color{ 79, 148, 205 }, til::color{ 54, 100, 139 } } },
-    std::pair{ "tan"sv, std::array<til::color, 5>{ til::color{ 210, 180, 140 }, til::color{ 255, 165, 79 }, til::color{ 238, 154, 73 }, til::color{ 205, 133, 63 }, til::color{ 139, 90, 43 } } },
-    std::pair{ "thistle"sv, std::array<til::color, 5>{ til::color{ 216, 191, 216 }, til::color{ 255, 225, 255 }, til::color{ 238, 210, 238 }, til::color{ 205, 181, 205 }, til::color{ 139, 123, 139 } } },
-    std::pair{ "tomato"sv, std::array<til::color, 5>{ til::color{ 255, 99, 71 }, til::color{ 255, 99, 71 }, til::color{ 238, 92, 66 }, til::color{ 205, 79, 57 }, til::color{ 139, 54, 38 } } },
-    std::pair{ "turquoise"sv, std::array<til::color, 5>{ til::color{ 64, 224, 208 }, til::color{ 0, 245, 255 }, til::color{ 0, 229, 238 }, til::color{ 0, 197, 205 }, til::color{ 0, 134, 139 } } },
-    std::pair{ "violetred"sv, std::array<til::color, 5>{ til::color{ 208, 32, 144 }, til::color{ 255, 62, 150 }, til::color{ 238, 58, 140 }, til::color{ 205, 50, 120 }, til::color{ 139, 34, 82 } } },
-    std::pair{ "wheat"sv, std::array<til::color, 5>{ til::color{ 245, 222, 179 }, til::color{ 255, 231, 186 }, til::color{ 238, 216, 174 }, til::color{ 205, 186, 150 }, til::color{ 139, 126, 102 } } },
-    std::pair{ "yellow"sv, std::array<til::color, 5>{ til::color{ 255, 255, 0 }, til::color{ 255, 255, 0 }, til::color{ 238, 238, 0 }, til::color{ 205, 205, 0 }, til::color{ 139, 139, 0 } } },
+    std::pair{ "aquamarine"sv, til::color{ 127, 255, 212 } },
+    std::pair{ "azure"sv, til::color{ 240, 255, 255 } },
+    std::pair{ "bisque"sv, til::color{ 255, 228, 196 } },
+    std::pair{ "blue"sv,til::color{ 0, 0, 255 } },
+    std::pair{ "chartreuse"sv,til::color{ 127, 255, 0 } },
+    std::pair{ "cornsilk"sv, til::color{ 255, 248, 220 } },
+    std::pair{ "cyan"sv, til::color{ 0, 255, 255 }},
+    std::pair{ "deeppink"sv, til::color{ 255, 20, 147 } },
+    std::pair{ "deepskyblue"sv, til::color{ 0, 191, 255 } },
+    std::pair{ "dodgerblue"sv,  til::color{ 30, 144, 255 } },
+    std::pair{ "gold"sv,  til::color{ 255, 215, 0 }},
+    std::pair{ "green"sv, til::color{ 0, 255, 0 } },
+    std::pair{ "honeydew"sv,  til::color{ 240, 255, 240 } },
+    std::pair{ "ivory"sv,  til::color{ 255, 255, 240 } },
+    std::pair{ "lavenderblush"sv, til::color{ 255, 240, 245 } },
+    std::pair{ "lemonchiffon"sv, til::color{ 255, 250, 205 } },
+    std::pair{ "lightcyan"sv, til::color{ 224, 255, 255 } },
+    std::pair{ "lightsalmon"sv, til::color{ 255, 160, 122 } },
+    std::pair{ "lightyellow"sv, til::color{ 255, 255, 224 } },
+    std::pair{ "magenta"sv, til::color{ 255, 0, 255 } },
+    std::pair{ "mistyrose"sv, til::color{ 255, 228, 225 } },
+    std::pair{ "navajowhite"sv,til::color{ 255, 222, 173 } },
+    std::pair{ "orange"sv,til::color{ 255, 165, 0 } },
+    std::pair{ "orangered"sv,  til::color{ 255, 69, 0 } },
+    std::pair{ "peachpuff"sv, til::color{ 255, 218, 185 } },
+    std::pair{ "red"sv, til::color{ 255, 0, 0 } },
+    std::pair{ "seashell"sv, til::color{ 255, 245, 238 } },
+    std::pair{ "snow"sv,  til::color{ 255, 250, 250 } },
+    std::pair{ "springgreen"sv, til::color{ 0, 255, 127 }},
+    std::pair{ "tomato"sv,til::color{ 255, 99, 71 } },
+    std::pair{ "yellow"sv, til::color{ 255, 255, 0 } },
 };
 
 static constexpr til::presorted_static_map xorgAppColorTable{
@@ -561,13 +592,41 @@ try
     }
 
     std::string name(ss.str());
+    const auto standartVariantColorIter = xorgAppStandardVariantColorTable.find(name);
+    if (standartVariantColorIter != xorgAppStandardVariantColorTable.end())
+    {
+        const auto standardAndVariantBaseColor = standartVariantColorIter->second;
+        if (variantIndex > 4)
+        {
+            return std::nullopt;
+        }
+
+        if (foundVariant)
+        {
+            return _calculateXorgAppColorVariant(standardAndVariantBaseColor.at(1), variantIndex);
+        }
+        else
+        {
+            return standardAndVariantBaseColor.at(0);
+        }
+    }
+
     const auto variantColorIter = xorgAppVariantColorTable.find(name);
     if (variantColorIter != xorgAppVariantColorTable.end())
     {
-        const auto colors = variantColorIter->second;
-        if (variantIndex < colors.size())
+        const auto baseColor = variantColorIter->second;
+        if (variantIndex > 4)
         {
-            return colors.at(variantIndex);
+            return std::nullopt;
+        }
+
+        if (foundVariant)
+        {
+            return _calculateXorgAppColorVariant(baseColor, variantIndex);
+        }
+        else
+        {
+            return baseColor;
         }
     }
 

--- a/src/types/ut_types/UtilsTests.cpp
+++ b/src/types/ut_types/UtilsTests.cpp
@@ -190,9 +190,9 @@ void UtilsTests::TestColorFromXTermColor()
     _VerifyXTermColorResult(L"yellow", RGB(255, 255, 0));
     _VerifyXTermColorResult(L"yellow3", RGB(205, 205, 0));
     _VerifyXTermColorResult(L"wheat", RGB(245, 222, 179));
-    _VerifyXTermColorResult(L"wheat4", RGB(139, 126, 102));
+    _VerifyXTermColorResult(L"wheat4", RGB(139, 126, 101));
     _VerifyXTermColorResult(L"royalblue", RGB(65, 105, 225));
-    _VerifyXTermColorResult(L"royalblue3", RGB(58, 95, 205));
+    _VerifyXTermColorResult(L"royalblue3", RGB(57, 94, 205));
     _VerifyXTermColorResult(L"gray", RGB(190, 190, 190));
     _VerifyXTermColorResult(L"grey", RGB(190, 190, 190));
     _VerifyXTermColorResult(L"gray0", RGB(0, 0, 0));

--- a/src/types/ut_types/UtilsTests.cpp
+++ b/src/types/ut_types/UtilsTests.cpp
@@ -188,11 +188,14 @@ void UtilsTests::TestColorFromXTermColor()
     _VerifyXTermColorResult(L"medium sea green", RGB(60, 179, 113));
     _VerifyXTermColorResult(L"LightYellow", RGB(255, 255, 224));
     _VerifyXTermColorResult(L"yellow", RGB(255, 255, 0));
+    _VerifyXTermColorResult(L"yellow1", RGB(255, 255, 0));
     _VerifyXTermColorResult(L"yellow3", RGB(205, 205, 0));
     _VerifyXTermColorResult(L"wheat", RGB(245, 222, 179));
-    _VerifyXTermColorResult(L"wheat4", RGB(139, 126, 101));
+    _VerifyXTermColorResult(L"wheat1", RGB(255, 231, 186));
+    _VerifyXTermColorResult(L"wheat4", RGB(140, 127, 102));
     _VerifyXTermColorResult(L"royalblue", RGB(65, 105, 225));
-    _VerifyXTermColorResult(L"royalblue3", RGB(57, 94, 205));
+    _VerifyXTermColorResult(L"royalblue1", RGB(72, 118, 255));
+    _VerifyXTermColorResult(L"royalblue3", RGB(58, 95, 205));
     _VerifyXTermColorResult(L"gray", RGB(190, 190, 190));
     _VerifyXTermColorResult(L"grey", RGB(190, 190, 190));
     _VerifyXTermColorResult(L"gray0", RGB(0, 0, 0));


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This optimizes the binary size of the xorg color table. Think of it as a follow-up of #7929. 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [X] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Inspired by @DHowett 's suggestion in #7929, I figured why not calculating all the color variants. Turns out there's a way described in [wikipedia](https://en.wikipedia.org/wiki/X11_color_names). So I implemented it and guess what, another 1KB is stripped from the product. Besides, it makes the color table less lengthy (less scary to read).

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Tested passed. Manually tested.