### PR TITLE
Display ATS tabs in MRU order

### DIFF
--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -489,16 +489,16 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_HandleOpenTabSearch(const IInspectable& /*sender*/,
                                             const ActionEventArgs& args)
     {
-        auto opt = _GetFocusedTabIndex();
-        uint32_t startIdx = opt.value_or(0);
-
-        // TODO: For now, tab search is always in order, no MRU.
+        // Tab search is always in-order.
         auto tabCommands = winrt::single_threaded_vector<Command>();
         for (const auto& tab : _tabs)
         {
             tabCommands.Append(tab.SwitchToTabCommand());
         }
         CommandPalette().SetTabActions(tabCommands);
+
+        auto opt = _GetFocusedTabIndex();
+        uint32_t startIdx = opt.value_or(0);
 
         CommandPalette().EnableTabSwitcherMode(true, startIdx);
         CommandPalette().Visibility(Visibility::Visible);

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -492,6 +492,14 @@ namespace winrt::TerminalApp::implementation
         auto opt = _GetFocusedTabIndex();
         uint32_t startIdx = opt.value_or(0);
 
+        // TODO: For now, tab search is always in order, no MRU.
+        auto tabCommands = winrt::single_threaded_vector<Command>();
+        for (const auto& tab : _tabs)
+        {
+            tabCommands.Append(tab.SwitchToTabCommand());
+        }
+        CommandPalette().SetTabActions(tabCommands);
+
         CommandPalette().EnableTabSwitcherMode(true, startIdx);
         CommandPalette().Visibility(Visibility::Visible);
 

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -620,6 +620,12 @@ namespace winrt::TerminalApp::implementation
         _updateFilteredActions();
     }
 
+    void CommandPalette::SetTabActions(Collections::IVector<Command> const& tabs)
+    {
+        _allTabActions = tabs;
+        _updateFilteredActions();
+    }
+
     void CommandPalette::EnableCommandPaletteMode()
     {
         _switchToMode(CommandPaletteMode::ActionMode);
@@ -973,45 +979,6 @@ namespace winrt::TerminalApp::implementation
 
         ParentCommandName(L"");
         _currentNestedCommands.Clear();
-    }
-
-    // Method Description:
-    // - Listens for changes to TerminalPage's _tabs vector. Updates our vector of
-    //   tab switching commands accordingly.
-    // Arguments:
-    // - s: The vector being listened to.
-    // - e: The vector changed args that tells us whether a change, insert, or removal was performed
-    //      on the listened-to vector.
-    // Return Value:
-    // - <none>
-    void CommandPalette::OnTabsChanged(const IInspectable& s, const IVectorChangedEventArgs& e)
-    {
-        if (auto tabList = s.try_as<IObservableVector<TerminalApp::Tab>>())
-        {
-            auto idx = e.Index();
-            auto changedEvent = e.CollectionChange();
-
-            switch (changedEvent)
-            {
-            case CollectionChange::ItemChanged:
-            {
-                break;
-            }
-            case CollectionChange::ItemInserted:
-            {
-                auto tab = tabList.GetAt(idx);
-                _allTabActions.InsertAt(idx, tab.SwitchToTabCommand());
-                break;
-            }
-            case CollectionChange::ItemRemoved:
-            {
-                _allTabActions.RemoveAt(idx);
-                break;
-            }
-            }
-
-            _updateFilteredActions();
-        }
     }
 
     void CommandPalette::EnableTabSwitcherMode(const bool searchMode, const uint32_t startIdx)

--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -23,6 +23,7 @@ namespace winrt::TerminalApp::implementation
         Windows::Foundation::Collections::IObservableVector<Microsoft::Terminal::Settings::Model::Command> FilteredActions();
 
         void SetCommands(Windows::Foundation::Collections::IVector<Microsoft::Terminal::Settings::Model::Command> const& actions);
+        void SetTabActions(Windows::Foundation::Collections::IVector<Microsoft::Terminal::Settings::Model::Command> const& tabs);
         void SetKeyBindings(Microsoft::Terminal::TerminalControl::IKeyBindings bindings);
 
         void EnableCommandPaletteMode();
@@ -35,7 +36,6 @@ namespace winrt::TerminalApp::implementation
 
         // Tab Switcher
         void EnableTabSwitcherMode(const bool searchMode, const uint32_t startIdx);
-        void OnTabsChanged(const Windows::Foundation::IInspectable& s, const Windows::Foundation::Collections::IVectorChangedEventArgs& e);
 
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
         OBSERVABLE_GETSET_PROPERTY(winrt::hstring, NoMatchesText, _PropertyChangedHandlers);

--- a/src/cascadia/TerminalApp/CommandPalette.idl
+++ b/src/cascadia/TerminalApp/CommandPalette.idl
@@ -18,6 +18,7 @@ namespace TerminalApp
         Windows.Foundation.Collections.IObservableVector<Microsoft.Terminal.Settings.Model.Command> FilteredActions { get; };
 
         void SetCommands(Windows.Foundation.Collections.IVector<Microsoft.Terminal.Settings.Model.Command> actions);
+        void SetTabActions(Windows.Foundation.Collections.IVector<Microsoft.Terminal.Settings.Model.Command> tabs);
         void SetKeyBindings(Microsoft.Terminal.TerminalControl.IKeyBindings bindings);
         void EnableCommandPaletteMode();
 
@@ -26,6 +27,5 @@ namespace TerminalApp
         void SetDispatch(ShortcutActionDispatch dispatch);
 
         void EnableTabSwitcherMode(Boolean searchMode, UInt32 startIdx);
-        void OnTabsChanged(IInspectable s, Windows.Foundation.Collections.IVectorChangedEventArgs e);
     }
 }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2576,7 +2576,6 @@ namespace winrt::TerminalApp::implementation
             {
                 tabCommands.Append(tab.SwitchToTabCommand());
             }
-
             CommandPalette().SetTabActions(tabCommands);
         }
     }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1178,7 +1178,7 @@ namespace winrt::TerminalApp::implementation
     // Method Description:
     // - Sets focus to the tab to the right or left the currently selected tab.
     void TerminalPage::_SelectNextTab(const bool bMoveRight)
-    {        
+    {
         if (_settings.GlobalSettings().UseTabSwitcher())
         {
             CommandPalette().SetTabActions(_mruTabActions);
@@ -1188,7 +1188,6 @@ namespace winrt::TerminalApp::implementation
             uint32_t tabCount = _mruTabActions.Size();
             auto newTabIndex = ((tabCount + (bMoveRight ? 1 : -1)) % tabCount);
 
-            // If the cmdpal was still visible, this means we're just previewing through the open list.
             if (CommandPalette().Visibility() == Visibility::Visible)
             {
                 CommandPalette().SelectNextItem(bMoveRight);

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2566,12 +2566,13 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_UpdateMRUTab(const uint32_t index)
     {
         uint32_t mruIndex;
-        if (_mruTabActions.IndexOf(_tabs.GetAt(index).SwitchToTabCommand(), mruIndex))
+        auto command = _tabs.GetAt(index).SwitchToTabCommand();
+        if (_mruTabActions.IndexOf(command, mruIndex))
         {
             if (mruIndex > 0)
             {
                 _mruTabActions.RemoveAt(mruIndex);
-                _mruTabActions.InsertAt(0, _tabs.GetAt(index).SwitchToTabCommand());
+                _mruTabActions.InsertAt(0, command);
                 CommandPalette().SetTabActions(_mruTabActions);
             }
         }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2587,6 +2587,7 @@ namespace winrt::TerminalApp::implementation
         {
             _mruTabs.RemoveAt(mruIndex);
             _mruTabs.InsertAt(0, _tabs.GetAt(index));
+            _UpdateTabSwitcherActions(true);
         }
     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -89,7 +89,7 @@ namespace winrt::TerminalApp::implementation
         Microsoft::Terminal::Settings::Model::CascadiaSettings _settings{ nullptr };
 
         Windows::Foundation::Collections::IObservableVector<TerminalApp::Tab> _tabs;
-        Windows::Foundation::Collections::IObservableVector<TerminalApp::Tab> _mruTabs;
+        Windows::Foundation::Collections::IVector<winrt::Microsoft::Terminal::Settings::Model::Command> _mruTabActions;
         winrt::com_ptr<Tab> _GetStrongTabImpl(const uint32_t index) const;
         winrt::com_ptr<Tab> _GetStrongTabImpl(const ::winrt::TerminalApp::Tab& tab) const;
         void _UpdateTabIndices();
@@ -207,7 +207,7 @@ namespace winrt::TerminalApp::implementation
 
         void _UnZoomIfNeeded();
 
-        void _UpdateTabSwitcherActions(bool mru);
+        void _UpdateTabSwitcherCommands(const bool mru);
         void _UpdateMRUTab(const uint32_t index);
 
 #pragma region ActionHandlers

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -207,6 +207,9 @@ namespace winrt::TerminalApp::implementation
 
         void _UnZoomIfNeeded();
 
+        void _UpdateTabSwitcherActions(bool mru);
+        void _UpdateMRUTab(const uint32_t index);
+
 #pragma region ActionHandlers
         // These are all defined in AppActionHandlers.cpp
         void _HandleOpenNewTabDropdown(const IInspectable& sender, const Microsoft::Terminal::Settings::Model::ActionEventArgs& args);

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -89,6 +89,7 @@ namespace winrt::TerminalApp::implementation
         Microsoft::Terminal::Settings::Model::CascadiaSettings _settings{ nullptr };
 
         Windows::Foundation::Collections::IObservableVector<TerminalApp::Tab> _tabs;
+        Windows::Foundation::Collections::IObservableVector<TerminalApp::Tab> _mruTabs;
         winrt::com_ptr<Tab> _GetStrongTabImpl(const uint32_t index) const;
         winrt::com_ptr<Tab> _GetStrongTabImpl(const ::winrt::TerminalApp::Tab& tab) const;
         void _UpdateTabIndices();


### PR DESCRIPTION
This PR changes the ATS display order to _always_ be in most recently
used (MRU) order. I chose not to give ATS the option to be displayed
in-order because that order is better served through the traditional
left-right TabRow switching. 

_Note_: `TabSearch` will stay in-order.

This means that users can only choose one order or another in their
`nextTab/prevTab` bindings. Setting `useTabSwitcher` to true will make
nT/pT open the ATS in MRU order. If it's set to false, the ATS won't
open and nT/pT will simply go left and right on the TabRow.

I'm open to getting rid of the global and making ATS its own keybinding,
but for now I figured I would keep the current behavior and open the PR
to get eyes on the code that doesn't have anything to do with the
settings.

Closes #973