### PR TITLE
Fix crash when creating tab menu multiple times

### DIFF
--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -36,6 +36,7 @@ namespace winrt::TerminalApp::implementation
 
         _MakeTabViewItem();
         _MakeSwitchToTabCommand();
+        _CreateContextMenu();
     }
 
     // Method Description:
@@ -107,8 +108,7 @@ namespace winrt::TerminalApp::implementation
 
     // Method Description:
     // - Called after construction of a Tab object to bind event handlers to its
-    //   associated Pane and TermControl object and to create the context menu of
-    //   the tab item
+    //   associated Pane and TermControl object
     // Arguments:
     // - control: reference to the TermControl object to bind event to
     // Return Value:
@@ -116,7 +116,6 @@ namespace winrt::TerminalApp::implementation
     void Tab::Initialize(const TermControl& control)
     {
         _BindEventHandlers(control);
-        _CreateContextMenu();
     }
 
     // Method Description:


### PR DESCRIPTION
Fix for crash occurring when splitting a pane, due to tab context menu created multiple times.

## References
#7728 

## PR Checklist
* [x] Closes #7941 
* [x] CLA signed. 

## Detailed Description of the Pull Request / Additional comments
When splitting panes the `Tab::Initialize` function is called again. This rebuilt the context menu from scratch and appended the existing Close... sub-menu items to a new parent, thus causing the crash.
It is not necessary to re-create the context menu every time you split panes, it can be created only once.

## Validation Steps Performed
Manual verification:
- Play with the context menu, the Close... submenu is functioning
- Split panes (ALT + New tab), no crash occurs and context menu still functioning
