### PR TITLE
Move jumplist creation to background thread

### DIFF
--- a/src/cascadia/TerminalApp/Jumplist.cpp
+++ b/src/cascadia/TerminalApp/Jumplist.cpp
@@ -120,7 +120,11 @@ static std::wstring_view _getExePath()
 // - <none>
 winrt::fire_and_forget Jumplist::UpdateJumplist(const CascadiaSettings& settings) noexcept
 {
+    // make sure to copy the settings _before_ the co_await
+    const auto settingsCopy = settings.Copy();
+
     co_await winrt::resume_background();
+
     try
     {
         auto jumplistInstance = winrt::create_instance<ICustomDestinationList>(CLSID_DestinationList, CLSCTX_ALL);
@@ -135,7 +139,7 @@ winrt::fire_and_forget Jumplist::UpdateJumplist(const CascadiaSettings& settings
         THROW_IF_FAILED(jumplistItems->Clear());
 
         // Update the list of profiles.
-        THROW_IF_FAILED(_updateProfiles(jumplistItems.get(), settings.Profiles().GetView()));
+        THROW_IF_FAILED(_updateProfiles(jumplistItems.get(), settingsCopy.Profiles().GetView()));
 
         // TODO GH#1571: Add items from the future customizable new tab dropdown as well.
         // This could either replace the default profiles, or be added alongside them.

--- a/src/cascadia/TerminalApp/Jumplist.cpp
+++ b/src/cascadia/TerminalApp/Jumplist.cpp
@@ -120,8 +120,8 @@ static std::wstring_view _getExePath()
 // - <none>
 winrt::fire_and_forget Jumplist::UpdateJumplist(const CascadiaSettings& settings) noexcept
 {
-    // make sure to copy the settings _before_ the co_await
-    const auto settingsCopy = settings.Copy();
+    // make sure to capture the settings _before_ the co_await
+    const auto strongSettings = settings;
 
     co_await winrt::resume_background();
 
@@ -139,7 +139,7 @@ winrt::fire_and_forget Jumplist::UpdateJumplist(const CascadiaSettings& settings
         THROW_IF_FAILED(jumplistItems->Clear());
 
         // Update the list of profiles.
-        THROW_IF_FAILED(_updateProfiles(jumplistItems.get(), settingsCopy.Profiles().GetView()));
+        THROW_IF_FAILED(_updateProfiles(jumplistItems.get(), strongSettings.Profiles().GetView()));
 
         // TODO GH#1571: Add items from the future customizable new tab dropdown as well.
         // This could either replace the default profiles, or be added alongside them.

--- a/src/cascadia/TerminalApp/Jumplist.cpp
+++ b/src/cascadia/TerminalApp/Jumplist.cpp
@@ -118,8 +118,9 @@ static std::wstring_view _getExePath()
 // - settings - The settings object to update the jumplist with.
 // Return Value:
 // - <none>
-HRESULT Jumplist::UpdateJumplist(const CascadiaSettings& settings) noexcept
+winrt::fire_and_forget Jumplist::UpdateJumplist(const CascadiaSettings& settings) noexcept
 {
+    co_await winrt::resume_background();
     try
     {
         auto jumplistInstance = winrt::create_instance<ICustomDestinationList>(CLSID_DestinationList, CLSCTX_ALL);
@@ -131,10 +132,10 @@ HRESULT Jumplist::UpdateJumplist(const CascadiaSettings& settings) noexcept
 
         // It's easier to clear the list and re-add everything. The settings aren't
         // updated often, and there likely isn't a huge amount of items to add.
-        RETURN_IF_FAILED(jumplistItems->Clear());
+        THROW_IF_FAILED(jumplistItems->Clear());
 
         // Update the list of profiles.
-        RETURN_IF_FAILED(_updateProfiles(jumplistItems.get(), settings.Profiles().GetView()));
+        THROW_IF_FAILED(_updateProfiles(jumplistItems.get(), settings.Profiles().GetView()));
 
         // TODO GH#1571: Add items from the future customizable new tab dropdown as well.
         // This could either replace the default profiles, or be added alongside them.
@@ -142,13 +143,11 @@ HRESULT Jumplist::UpdateJumplist(const CascadiaSettings& settings) noexcept
         // Add the items to the jumplist Task section.
         // The Tasks section is immutable by the user, unlike the destinations
         // section that can have its items pinned and removed.
-        RETURN_IF_FAILED(jumplistInstance->AddUserTasks(jumplistItems.get()));
+        THROW_IF_FAILED(jumplistInstance->AddUserTasks(jumplistItems.get()));
 
-        RETURN_IF_FAILED(jumplistInstance->CommitList());
-
-        return S_OK;
+        THROW_IF_FAILED(jumplistInstance->CommitList());
     }
-    CATCH_RETURN();
+    CATCH_LOG();
 }
 
 // Method Description:

--- a/src/cascadia/TerminalApp/Jumplist.h
+++ b/src/cascadia/TerminalApp/Jumplist.h
@@ -18,7 +18,7 @@ struct IShellLinkW;
 class Jumplist
 {
 public:
-    static HRESULT UpdateJumplist(const winrt::Microsoft::Terminal::Settings::Model::CascadiaSettings& settings) noexcept;
+    static winrt::fire_and_forget UpdateJumplist(const winrt::Microsoft::Terminal::Settings::Model::CascadiaSettings& settings) noexcept;
 
 private:
     [[nodiscard]] static HRESULT _updateProfiles(IObjectCollection* jumplistItems, winrt::Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Settings::Model::Profile> profiles) noexcept;

--- a/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
@@ -244,7 +244,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     {
         auto copy{ winrt::make_self<ActionAndArgs>() };
         copy->_Action = _Action;
-        copy->_Args = _Args.Copy();
+        copy->_Args = _Args ? _Args.Copy() : IActionArgs{ nullptr };
         return copy;
     }
 

--- a/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
@@ -244,7 +244,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     {
         auto copy{ winrt::make_self<ActionAndArgs>() };
         copy->_Action = _Action;
-        copy->_Args = _Args ? _Args.Copy() : IActionArgs{ nullptr };
+        copy->_Args = _Args.Copy();
         return copy;
     }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Move jumplist creation to a background thread, it does not need to be on the main thread

## Reference
#7791 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #7791 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] I work here
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
We were not using the `HRESULT` return value of `UpdateJumplist` anywhere, so I changed its return type to `winrt::fire_and_forget` instead. Also replaced all `RETURN_IF_FAILED` calls in the function to `THROW_IF_FAILED` to accommodate the change in return type. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tracing with a release build:
<img width="791" alt="perf" src="https://user-images.githubusercontent.com/26824113/96631760-bf85ea00-12e4-11eb-8da7-d16fb5c45b9b.png">
