### PR TITLE
Prepare for the primary branch name to change to main

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,7 +16,7 @@ name: Lint Code Base
 #############################
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 ###############
 # Set the Job #
@@ -48,7 +48,7 @@ jobs:
         uses: github/super-linter@v3
         env:
           VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: master
+          DEFAULT_BRANCH: main
           MARKDOWN_CONFIG_FILE: .markdown-lint.yml
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_EDITORCONFIG: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ The point of doing all this work in public is to ensure that we are holding ours
 
 The team triages new issues several times a week. During triage, the team uses labels to categorize, manage, and drive the project workflow.
 
-We employ [a bot engine](https://github.com/microsoft/terminal/blob/master/doc/bot.md) to help us automate common processes within our workflow.
+We employ [a bot engine](https://github.com/microsoft/terminal/blob/main/doc/bot.md) to help us automate common processes within our workflow.
 
 We drive the bot by tagging issues with specific labels which cause the bot engine to close issues, merge branches, etc. This bot engine helps us keep the repo clean by automating the process of notifying appropriate parties if/when information/follow-up is needed, and closing stale issues/PRs after reminders have remained unanswered for several days.
 
@@ -156,7 +156,7 @@ When you'd like the team to take a look, (even if the work is not yet fully-comp
 
 ### Merge
 
-Once your code has been reviewed and approved by the requisite number of team members, it will be merged into the master branch. Once merged, your PR will be automatically closed.
+Once your code has been reviewed and approved by the requisite number of team members, it will be merged into the main branch. Once merged, your PR will be automatically closed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This repository contains the source code for:
 * [Windows Terminal Preview](https://aka.ms/terminal-preview)
 * The Windows console host (`conhost.exe`)
 * Components shared between the two projects
-* [ColorTool](https://github.com/Microsoft/Terminal/tree/master/src/tools/ColorTool)
-* [Sample projects](https://github.com/Microsoft/Terminal/tree/master/samples)
+* [ColorTool](https://github.com/microsoft/terminal/tree/main/src/tools/ColorTool)
+* [Sample projects](https://github.com/microsoft/terminal/tree/main/samples)
   that show how to consume the Windows Console APIs
 
 Related repositories include:
@@ -105,7 +105,7 @@ here](/doc/terminal-v2-roadmap.md) and will be updated as the project proceeds.
 
 Project|Build Status
 ---|---
-Terminal|[![Terminal Build Status](https://dev.azure.com/ms/Terminal/_apis/build/status/Terminal%20CI?branchName=master)](https://dev.azure.com/ms/Terminal/_build?definitionId=136)
+Terminal|[![Terminal Build Status](https://dev.azure.com/ms/terminal/_apis/build/status/terminal%20CI?branchName=main)](https://dev.azure.com/ms/terminal/_build?definitionId=136)
 ColorTool|![Colortool Build Status](https://microsoft.visualstudio.com/_apis/public/build/definitions/c93e867a-8815-43c1-92c4-e7dd5404f1e1/17023/badge)
 
 ---
@@ -241,7 +241,7 @@ enhance Windows Terminal\!
 
 ***BEFORE you start work on a feature/fix***, please read & follow our
 [Contributor's
-Guide](https://github.com/microsoft/terminal/blob/master/CONTRIBUTING.md) to
+Guide](https://github.com/microsoft/terminal/blob/main/CONTRIBUTING.md) to
 help avoid any wasted or duplicate effort.
 
 ## Communicating with the Team
@@ -340,10 +340,10 @@ Please review these brief docs below about our coding practices.
 This is a work in progress as we learn what we'll need to provide people in
 order to be effective contributors to our project.
 
-* [Coding Style](https://github.com/Microsoft/Terminal/blob/master/doc/STYLE.md)
-* [Code Organization](https://github.com/Microsoft/Terminal/blob/master/doc/ORGANIZATION.md)
-* [Exceptions in our legacy codebase](https://github.com/Microsoft/Terminal/blob/master/doc/EXCEPTIONS.md)
-* [Helpful smart pointers and macros for interfacing with Windows in WIL](https://github.com/Microsoft/Terminal/blob/master/doc/WIL.md)
+* [Coding Style](https://github.com/microsoft/terminal/blob/main/doc/STYLE.md)
+* [Code Organization](https://github.com/microsoft/terminal/blob/main/doc/ORGANIZATION.md)
+* [Exceptions in our legacy codebase](https://github.com/microsoft/terminal/blob/main/doc/EXCEPTIONS.md)
+* [Helpful smart pointers and macros for interfacing with Windows in WIL](https://github.com/microsoft/terminal/blob/main/doc/WIL.md)
 
 ---
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -14,4 +14,4 @@ Support for Windows Terminal is limited to the resources listed above.
 [gh-bug]: https://github.com/microsoft/terminal/issues/new?assignees=&labels=Issue-Bug&template=bug_report.md&title=
 [gh-feature]: https://github.com/microsoft/terminal/issues/new?assignees=&labels=Issue-Feature&template=Feature_Request.md&title=
 [docs]: https://docs.microsoft.com/windows/terminal
-[contributor]: https://github.com/microsoft/terminal/blob/master/CONTRIBUTING.md
+[contributor]: https://github.com/microsoft/terminal/blob/main/CONTRIBUTING.md

--- a/build/pipelines/ci.yml
+++ b/build/pipelines/ci.yml
@@ -2,7 +2,7 @@ trigger:
   batch: true
   branches:
     include:
-      - master
+      - main
       - feature/*
   paths:
     exclude:
@@ -13,7 +13,7 @@ trigger:
 pr:
   branches:
     include:
-      - master
+      - main
       - feature/*
   paths:
     exclude:

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/microsoft/terminal/blob/master/doc/cascadia/profiles.schema.json",
+  "$id": "https://github.com/microsoft/terminal/blob/main/doc/cascadia/profiles.schema.json",
   "$schema": "https://json-schema.org/draft/2019-09/schema#",
   "title": "Microsoft's Windows Terminal Settings Profile Schema",
   "definitions": {

--- a/doc/specs/#1571 - New Tab Menu Customization/#1571 - New Tab Menu Customization.md
+++ b/doc/specs/#1571 - New Tab Menu Customization/#1571 - New Tab Menu Customization.md
@@ -293,7 +293,7 @@ And assuming the user has bound:
 
 <!-- Footnotes -->
 [#2046]: https://github.com/microsoft/terminal/issues/2046
-[Command Palette, Addendum 1]: https://github.com/microsoft/terminal/blob/master/doc/specs/%232046%20-%20Unified%20keybindings%20and%20commands%2C%20and%20synthesized%20action%20names.md
+[Command Palette, Addendum 1]: https://github.com/microsoft/terminal/blob/main/doc/specs/%232046%20-%20Unified%20keybindings%20and%20commands%2C%20and%20synthesized%20action%20names.md
 
 [#3337]: https://github.com/microsoft/terminal/issues/3337
 [#6899]: https://github.com/microsoft/terminal/issues/6899

--- a/doc/specs/#2046 - Unified keybindings and commands, and synthesized action names.md
+++ b/doc/specs/#2046 - Unified keybindings and commands, and synthesized action names.md
@@ -605,4 +605,4 @@ as well as 3 schemes: "Scheme 1", "Scheme 2", and "Scheme 3".
 
 
 <!-- Footnotes -->
-[Command Palette Spec]: https://github.com/microsoft/terminal/blob/master/doc/specs/%232046%20-%20Command%20Palette.md
+[Command Palette Spec]: https://github.com/microsoft/terminal/blob/main/doc/specs/%232046%20-%20Command%20Palette.md

--- a/doc/specs/#6899 - Action IDs/#6899 - Action IDs.md
+++ b/doc/specs/#6899 - Action IDs/#6899 - Action IDs.md
@@ -215,8 +215,8 @@ actions manually.
       the tab context menu or the control context menu.
 
 <!-- Footnotes -->
-[Command Palette Spec]: https://github.com/microsoft/terminal/blob/master/doc/specs/%232046%20-%20Command%20Palette.md
-[New Tab Menu Customization Spec]: https://github.com/microsoft/terminal/blob/master/doc/specs/%231571%20-%20New%20Tab%20Menu%20Customization.md
+[Command Palette Spec]: https://github.com/microsoft/terminal/blob/main/doc/specs/%232046%20-%20Command%20Palette.md
+[New Tab Menu Customization Spec]: https://github.com/microsoft/terminal/blob/main/doc/specs/%231571%20-%20New%20Tab%20Menu%20Customization.md
 
 [#1571]: https://github.com/microsoft/terminal/issues/1571
 [#1912]: https://github.com/microsoft/terminal/issues/1912

--- a/doc/submitting_code.md
+++ b/doc/submitting_code.md
@@ -1,11 +1,11 @@
 
 # Branches in Openconsole
 
-In Openconsole, `dev/main` is the master branch for the repo.
+In OpenConsole, `dev/main` is the primary branch for the repo.
 
 Any branch that begins with `dev/` is recognized by our CI system and will automatically run x86 and amd64 builds and run our unit and feature tests. For feature branches the pattern we use is `dev/<alias>/<whatever you want here>`. ex. `dev/austdi/SomeCoolUnicodeFeature`. The important parts are the dev prefix and your alias.
 
-`inbox` is a special branch that coordinates Openconsole code to the main OS repo.
+`inbox` is a special branch that coordinates OpenConsole code to the main OS repo.
 
 The code will be checked into the OS repo at `/onecore/windows/core/console/open`. It would be prudent to make sure that directory builds in razzle with your submitted changes.
 

--- a/res/README.md
+++ b/res/README.md
@@ -2,17 +2,17 @@
 
 ## Images
 
-The images in this directory do not fall under the same [license](https://raw.githubusercontent.com/microsoft/terminal/master/LICENSE) as the rest
+The images in this directory do not fall under the same [license](https://raw.githubusercontent.com/microsoft/terminal/main/LICENSE) as the rest
 of the Windows Terminal code.
 
 Please consult the [license](./LICENSE) in this directory for terms applicable to the image assets in this directory.
 
 ## Fonts
 
-The fonts in this directory do not fall under the same [license](https://raw.githubusercontent.com/microsoft/terminal/master/LICENSE) as the rest
+The fonts in this directory do not fall under the same [license](https://raw.githubusercontent.com/microsoft/terminal/main/LICENSE) as the rest
 of the Windows Terminal code.
 
-Please consult the [license](https://raw.githubusercontent.com/microsoft/cascadia-code/master/LICENSE) in the
+Please consult the [license](https://raw.githubusercontent.com/microsoft/cascadia-code/main/LICENSE) in the
 [microsoft/cascadia-code](https://github.com/microsoft/cascadia-code) repository for terms applicable to the fonts in this directory.
 
 ### Fonts Included

--- a/src/cascadia/CascadiaPackage/NOTICE.html
+++ b/src/cascadia/CascadiaPackage/NOTICE.html
@@ -5,7 +5,7 @@
     <p>
       This is a development build of Windows Terminal. The third-party notices
       for this project can be found on
-      <a href="https://github.com/microsoft/terminal/blob/master/NOTICE.md">the
+      <a href="https://github.com/microsoft/terminal/blob/main/NOTICE.md">the
       project's GitHub page</a>.
     </p>
     <p>


### PR DESCRIPTION
This commit fixes up all references to `master` in the source, docs,
specs and comments.
Related to #6739.