### PR TITLE
Fix slowdown on open/close tabs when the user has many profiles

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1903,10 +1903,6 @@ namespace winrt::TerminalApp::implementation
                 _rearrangeTo = eventArgs.Index();
             }
         }
-        else
-        {
-            _UpdateCommandsForPalette();
-        }
 
         _UpdateTabView();
     }


### PR DESCRIPTION
## Summary of the Pull Request
Just deleting an unnecessary call to `_UpdateCommandsForPalette`

**Note:** This only fixes slowdown when opening/closing a tab, but not upon first startup (we still need to call `_UpdateCommandsForPalette` there 

## References
Fixes the slowdown described in #7820 for opening and closing tabs, but doesn't improve startup time dramatically.

## Validation Steps Performed
Tested with ~100 profiles in my settings file