### PR TITLE
Add scrollviewers to settings UI

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -57,39 +57,40 @@ the MIT License. See LICENSE in the project root for license information. -->
         </DataTemplate>
     </Page.Resources>
 
-
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="1*" />
-            <ColumnDefinition Width="1*" />
-        </Grid.ColumnDefinitions>
-        <TextBlock x:Uid="ColorScheme_ColorSchemes"
+    <ScrollViewer>
+        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1*" />
+                <ColumnDefinition Width="1*" />
+            </Grid.ColumnDefinitions>
+            <TextBlock x:Uid="ColorScheme_ColorSchemes"
                    Style="{StaticResource SubheaderTextBlockStyle}"
                    Margin="0,0,0,20"
                    Grid.Row="0" />
 
-        <StackPanel Grid.Row="1"
+            <StackPanel Grid.Row="1"
                     Grid.Column="0">
-            <ComboBox x:Name="ColorSchemeComboBox"
+                <ComboBox x:Name="ColorSchemeComboBox"
                       SelectedIndex="0"
                       ItemsSource="{x:Bind ColorSchemeList, Mode=OneWay}"
                       SelectionChanged="ColorSchemeSelectionChanged" Width="160">
-            </ComboBox>
-        </StackPanel>
+                </ComboBox>
+            </StackPanel>
 
-        <ScrollViewer Grid.Row="2"
+            <ScrollViewer Grid.Row="2"
                       Grid.Column="0"
                       HorizontalScrollBarVisibility="Auto"
                       VerticalScrollBarVisibility="Auto">
-            <ItemsControl x:Name="ColorTableControl"
+                <ItemsControl x:Name="ColorTableControl"
                           ItemsSource="{x:Bind CurrentColorTable, Mode=TwoWay}"
                           ItemTemplate="{StaticResource ColorTableTemplate}">
-            </ItemsControl>
-        </ScrollViewer>
-    </Grid>
+                </ItemsControl>
+            </ScrollViewer>
+        </Grid>
+    </ScrollViewer>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
@@ -10,35 +10,36 @@ the MIT License. See LICENSE in the project root for license information. -->
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:Controls="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d">
-
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    <ScrollViewer>
+        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
           Margin="0,12,0,0">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="1*" />
-            <ColumnDefinition Width="1*" />
-        </Grid.ColumnDefinitions>
-        <TextBlock x:Uid="Globals_GlobalAppearance"
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1*" />
+                <ColumnDefinition Width="1*" />
+            </Grid.ColumnDefinitions>
+            <TextBlock x:Uid="Globals_GlobalAppearance"
                    Style="{StaticResource SubheaderTextBlockStyle}"
                    Margin="0,0,0,20" />
-        <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,100,0">
-            <Controls:RadioButtons x:Uid="Globals_Theme" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
-                <RadioButton x:Uid="Globals_ThemeDefault" x:Name="DefaultTheme"/>
-                <RadioButton x:Uid="Globals_ThemeDark" x:Name="DarkTheme"/>
-                <RadioButton x:Uid="Globals_ThemeLight" x:Name="LightTheme"/>
-            </Controls:RadioButtons>
-            <CheckBox x:Uid="Globals_ShowTitlebar" IsChecked="{x:Bind GlobalSettings.ShowTabsInTitlebar, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
-            <CheckBox x:Uid="Globals_ShowTitleInTitlebar" IsChecked="{x:Bind GlobalSettings.ShowTitleInTitlebar, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
-            <CheckBox x:Uid="Globals_AlwaysShowTabs" IsChecked="{x:Bind GlobalSettings.AlwaysShowTabs, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
-            <Controls:RadioButtons x:Uid="Globals_TabWidthMode" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
-                <RadioButton x:Uid="Globals_TabWidthModeEqual" x:Name="EqualTabWidthMode"/>
-                <RadioButton x:Uid="Globals_TabWidthModeTitleLength" x:Name="TitleLengthTabWidthMode"/>
-                <RadioButton x:Uid="Globals_TabWidthModeCompact" x:Name="CompactTabWidthMode"/>
-            </Controls:RadioButtons>
-            <CheckBox x:Uid="Globals_ConfirmCloseAllTabs" IsChecked="{x:Bind GlobalSettings.ConfirmCloseAllTabs, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
-        </StackPanel>
-    </Grid>
+            <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,100,0">
+                <Controls:RadioButtons x:Uid="Globals_Theme" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
+                    <RadioButton x:Uid="Globals_ThemeDefault" x:Name="DefaultTheme"/>
+                    <RadioButton x:Uid="Globals_ThemeDark" x:Name="DarkTheme"/>
+                    <RadioButton x:Uid="Globals_ThemeLight" x:Name="LightTheme"/>
+                </Controls:RadioButtons>
+                <CheckBox x:Uid="Globals_ShowTitlebar" IsChecked="{x:Bind GlobalSettings.ShowTabsInTitlebar, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
+                <CheckBox x:Uid="Globals_ShowTitleInTitlebar" IsChecked="{x:Bind GlobalSettings.ShowTitleInTitlebar, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
+                <CheckBox x:Uid="Globals_AlwaysShowTabs" IsChecked="{x:Bind GlobalSettings.AlwaysShowTabs, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
+                <Controls:RadioButtons x:Uid="Globals_TabWidthMode" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
+                    <RadioButton x:Uid="Globals_TabWidthModeEqual" x:Name="EqualTabWidthMode"/>
+                    <RadioButton x:Uid="Globals_TabWidthModeTitleLength" x:Name="TitleLengthTabWidthMode"/>
+                    <RadioButton x:Uid="Globals_TabWidthModeCompact" x:Name="CompactTabWidthMode"/>
+                </Controls:RadioButtons>
+                <CheckBox x:Uid="Globals_ConfirmCloseAllTabs" IsChecked="{x:Bind GlobalSettings.ConfirmCloseAllTabs, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
+            </StackPanel>
+        </Grid>
+    </ScrollViewer>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Home.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Home.xaml
@@ -17,62 +17,63 @@ the MIT License. See LICENSE in the project root for license information. -->
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Page.Resources>
-
-    <Frame x:Name="frame">
-        <Frame.ContentTransitions>
-            <TransitionCollection>
-                <NavigationThemeTransition/>
-            </TransitionCollection>
-        </Frame.ContentTransitions>
-        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-            Margin="0,12,0,0">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="1*" />
-        </Grid.ColumnDefinitions>
-        <TextBlock Grid.Row="0"
-                    Text="Windows Terminal Settings"
-                    Style="{StaticResource HeaderTextBlockStyle}"
-                    TextAlignment="Center"
-                    Margin="0,0,0,20" />
-        <GridView Grid.Row="1"
-                    x:Name="HomeGridView"
-                    ItemsSource="{x:Bind HomeViewModel.HomeGridItems}"
-                    ItemContainerStyle="{StaticResource GridViewItemStyle}"
-                    IsItemClickEnabled="True"
-                    SelectionMode="None"
-                    ItemClick="HomeGridItemClickHandler">
-            <GridView.ItemTemplate>
-                <DataTemplate x:DataType="local:HomeGridItem">
-                    <UserControl>
-                        <Grid
-                        x:Name="homeGridItemRoot"
-                        Width="344"
-                        Height="140"
-                        Padding="12"
-                        Background="{ThemeResource SystemControlBackgroundListLowBrush}">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="Auto" />
-                            </Grid.ColumnDefinitions>
-                            <RelativePanel Grid.Column="1" Grid.ColumnSpan="2" Margin="16,6,0,0">
-                                <TextBlock
-                                x:Name="titleText"
-                                Style="{StaticResource SubheaderTextBlockStyle}"
-                                Text="{x:Bind Title}"
-                                Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
-                                TextLineBounds="TrimToCapHeight"
-                                TextWrapping="NoWrap" />
-                            </RelativePanel>
-                        </Grid>
-                    </UserControl>
-                </DataTemplate>
-            </GridView.ItemTemplate>
-        </GridView>
-    </Grid>
-    </Frame>
+    <ScrollViewer>
+        <Frame x:Name="frame">
+            <Frame.ContentTransitions>
+                <TransitionCollection>
+                    <NavigationThemeTransition/>
+                </TransitionCollection>
+            </Frame.ContentTransitions>
+            <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+                Margin="0,12,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1*" />
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Row="0"
+                        Text="Windows Terminal Settings"
+                        Style="{StaticResource HeaderTextBlockStyle}"
+                        TextAlignment="Center"
+                        Margin="0,0,0,20" />
+            <GridView Grid.Row="1"
+                        x:Name="HomeGridView"
+                        ItemsSource="{x:Bind HomeViewModel.HomeGridItems}"
+                        ItemContainerStyle="{StaticResource GridViewItemStyle}"
+                        IsItemClickEnabled="True"
+                        SelectionMode="None"
+                        ItemClick="HomeGridItemClickHandler">
+                <GridView.ItemTemplate>
+                    <DataTemplate x:DataType="local:HomeGridItem">
+                        <UserControl>
+                            <Grid
+                            x:Name="homeGridItemRoot"
+                            Width="344"
+                            Height="140"
+                            Padding="12"
+                            Background="{ThemeResource SystemControlBackgroundListLowBrush}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <RelativePanel Grid.Column="1" Grid.ColumnSpan="2" Margin="16,6,0,0">
+                                    <TextBlock
+                                    x:Name="titleText"
+                                    Style="{StaticResource SubheaderTextBlockStyle}"
+                                    Text="{x:Bind Title}"
+                                    Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
+                                    TextLineBounds="TrimToCapHeight"
+                                    TextWrapping="NoWrap" />
+                                </RelativePanel>
+                            </Grid>
+                        </UserControl>
+                    </DataTemplate>
+                </GridView.ItemTemplate>
+            </GridView>
+        </Grid>
+        </Frame>
+    </ScrollViewer>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Interaction.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.xaml
@@ -9,26 +9,27 @@ the MIT License. See LICENSE in the project root for license information. -->
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:Controls="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d">
-
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    <ScrollViewer>
+        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
           Margin="0,12,0,0">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="1*" />
-            <ColumnDefinition Width="1*" />
-        </Grid.ColumnDefinitions>
-        <TextBlock x:Uid="Globals_Interaction"
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1*" />
+                <ColumnDefinition Width="1*" />
+            </Grid.ColumnDefinitions>
+            <TextBlock x:Uid="Globals_Interaction"
                    Style="{StaticResource SubheaderTextBlockStyle}"
                    Margin="0,0,0,20" />
-        <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,100,0">
-            <CheckBox x:Uid="Globals_CopyOnSelect" IsChecked="{x:Bind GlobalSettings.CopyOnSelect, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
-            <!--TODO: Converter Here-->
-            <!--<CheckBox x:Uid="Globals_CopyFormatting" IsChecked="{x:Bind GlobalSettings.CopyFormatting, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />-->
-            <TextBox x:Uid="Globals_WordDelimiters" Text="{x:Bind GlobalSettings.WordDelimiters, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
-            <CheckBox x:Uid="Globals_SnapToGridOnResize" IsChecked="{x:Bind GlobalSettings.SnapToGridOnResize, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
-        </StackPanel>
-    </Grid>
+            <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,100,0">
+                <CheckBox x:Uid="Globals_CopyOnSelect" IsChecked="{x:Bind GlobalSettings.CopyOnSelect, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
+                <!--TODO: Converter Here-->
+                <!--<CheckBox x:Uid="Globals_CopyFormatting" IsChecked="{x:Bind GlobalSettings.CopyFormatting, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />-->
+                <TextBox x:Uid="Globals_WordDelimiters" Text="{x:Bind GlobalSettings.WordDelimiters, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
+                <CheckBox x:Uid="Globals_SnapToGridOnResize" IsChecked="{x:Bind GlobalSettings.SnapToGridOnResize, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
+            </StackPanel>
+        </Grid>
+    </ScrollViewer>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Keybindings.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Keybindings.xaml
@@ -8,146 +8,157 @@ the MIT License. See LICENSE in the project root for license information. -->
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
-
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    <ScrollViewer>
+        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
           Margin="0,12,0,0">
-        <StackPanel>
-            <TextBlock x:Name="TitleTextBox" 
+            <StackPanel>
+                <TextBlock x:Name="TitleTextBox" 
                    Text="Keyboard"
                    Style="{StaticResource HeaderTextBlockStyle}"
                    Margin="0,0,0,8" />
 
-            <Button Click="Button_Click">Open Window</Button>
+                <Button Click="Button_Click">Open Window</Button>
 
-            <Popup VerticalOffset="10" HorizontalOffset="200" x:Name="StandardPopup">
-                <Border BorderBrush="{StaticResource ApplicationForegroundThemeBrush}" 
+                <Popup VerticalOffset="10" HorizontalOffset="200" x:Name="StandardPopup">
+                    <Border BorderBrush="{StaticResource ApplicationForegroundThemeBrush}" 
                 Background="{StaticResource ApplicationPageBackgroundThemeBrush}"
                 BorderThickness="1" MinWidth="600" MinHeight="300" MaxHeight="700" Margin="10">
-                    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-                    <StackPanel HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Padding="20">
-                        <TextBlock x:Name="PopupTitleTextBox" Text="Edit" Style="{StaticResource HeaderTextBlockStyle}" Margin="0,8,0,0" />
-                        <TextBlock Text="Command" HorizontalAlignment="Left" Margin="0,8,0,0" />
-                        <ComboBox HorizontalAlignment="Stretch" Name="CommandComboBox" SelectionChanged="CommandComboBox_SelectionChanged" Margin="0,8,0,0">
-                            <!-- Application-level commands -->
-                            <ComboBoxItem Content="Close the window" Tag="closeWindow"/>
-                            <ComboBoxItem Content="Find" Tag="find"/>
-                            <ComboBoxItem Content="Open the new tab dropdown menu" Tag="openNewTabDropdown"/>
-                            <ComboBoxItem Content="Open settings files" Tag="openSettings"/> <!-- Can have opt values -->
-                            <ComboBoxItem Content="Toggle full screen" Tag="toggleFullscreen"/>
-                            <ComboBoxItem Content="Toggle focus mode" Tag="toggleFocusMode"/>
-                            <ComboBoxItem Content="Toggle always on top mode" Tag="toggleAlwaysOnTop"/>
+                        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                            <StackPanel HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Padding="20">
+                                <TextBlock x:Name="PopupTitleTextBox" Text="Edit" Style="{StaticResource HeaderTextBlockStyle}" Margin="0,8,0,0" />
+                                <TextBlock Text="Command" HorizontalAlignment="Left" Margin="0,8,0,0" />
+                                <ComboBox HorizontalAlignment="Stretch" Name="CommandComboBox" SelectionChanged="CommandComboBox_SelectionChanged" Margin="0,8,0,0">
+                                    <!-- Application-level commands -->
+                                    <ComboBoxItem Content="Close the window" Tag="closeWindow"/>
+                                    <ComboBoxItem Content="Find" Tag="find"/>
+                                    <ComboBoxItem Content="Open the new tab dropdown menu" Tag="openNewTabDropdown"/>
+                                    <ComboBoxItem Content="Open settings files" Tag="openSettings"/>
+                                    <!-- Can have opt values -->
+                                    <ComboBoxItem Content="Toggle full screen" Tag="toggleFullscreen"/>
+                                    <ComboBoxItem Content="Toggle focus mode" Tag="toggleFocusMode"/>
+                                    <ComboBoxItem Content="Toggle always on top mode" Tag="toggleAlwaysOnTop"/>
 
-                            <!-- Tab management commands -->
-                            <ComboBoxItem Content="Close the tab" Tag="closeTab"/>
-                            <ComboBoxItem Content="Duplicate tab" Tag="duplicateTab"/>
-                            <ComboBoxItem Content="New tab" Tag="newTab"/> <!-- Can have opt values -->
-                            <ComboBoxItem Content="Open next tab" Tag="nextTab"/>
-                            <ComboBoxItem Content="Open previous tab" Tag="prevTab"/>
-                            <ComboBoxItem Content="Open a specific tab" Tag="switchToTab"/> <!-- Can have opt values -->
-                            <ComboBoxItem Content="Rename tab" Tag="renameTab"/> <!-- Can have opt values -->
-                            <ComboBoxItem Content="Change tab color" Tag="setTabColor"/> <!-- Can have opt values -->
-                            <ComboBoxItem Content="Open tab color picker" Tag="openTabColorPicker"/>
+                                    <!-- Tab management commands -->
+                                    <ComboBoxItem Content="Close the tab" Tag="closeTab"/>
+                                    <ComboBoxItem Content="Duplicate tab" Tag="duplicateTab"/>
+                                    <ComboBoxItem Content="New tab" Tag="newTab"/>
+                                    <!-- Can have opt values -->
+                                    <ComboBoxItem Content="Open next tab" Tag="nextTab"/>
+                                    <ComboBoxItem Content="Open previous tab" Tag="prevTab"/>
+                                    <ComboBoxItem Content="Open a specific tab" Tag="switchToTab"/>
+                                    <!-- Can have opt values -->
+                                    <ComboBoxItem Content="Rename tab" Tag="renameTab"/>
+                                    <!-- Can have opt values -->
+                                    <ComboBoxItem Content="Change tab color" Tag="setTabColor"/>
+                                    <!-- Can have opt values -->
+                                    <ComboBoxItem Content="Open tab color picker" Tag="openTabColorPicker"/>
 
-                            <!-- Pane management commands -->
-                            <ComboBoxItem Content="Close pane" Tag="closePane"/>
-                            <ComboBoxItem Content="Move pane focus" Tag="moveFocus"/> <!-- Can have opt values -->
-                            <ComboBoxItem Content="Resize pane" Tag="resizePane"/> <!-- Can have opt values -->
-                            <ComboBoxItem Content="Split a pane" Tag="splitPane"/> <!-- Can have opt values -->
+                                    <!-- Pane management commands -->
+                                    <ComboBoxItem Content="Close pane" Tag="closePane"/>
+                                    <ComboBoxItem Content="Move pane focus" Tag="moveFocus"/>
+                                    <!-- Can have opt values -->
+                                    <ComboBoxItem Content="Resize pane" Tag="resizePane"/>
+                                    <!-- Can have opt values -->
+                                    <ComboBoxItem Content="Split a pane" Tag="splitPane"/>
+                                    <!-- Can have opt values -->
 
-                            <!-- Clipboard integration commands -->
-                            <ComboBoxItem Content="Copy" Tag="copy"/> <!-- Can have opt values -->
-                            <ComboBoxItem Content="Paste" Tag="paste"/>
-                            <ComboBoxItem Content="Scroll up" Tag="scrollUp"/>
-                            <ComboBoxItem Content="Scroll down" Tag="scrollDown"/>
-                            <ComboBoxItem Content="Scroll up a whole page" Tag="scrollUpPage"/>
-                            <ComboBoxItem Content="Scroll down a whole page" Tag="scrollDownPage"/>
+                                    <!-- Clipboard integration commands -->
+                                    <ComboBoxItem Content="Copy" Tag="copy"/>
+                                    <!-- Can have opt values -->
+                                    <ComboBoxItem Content="Paste" Tag="paste"/>
+                                    <ComboBoxItem Content="Scroll up" Tag="scrollUp"/>
+                                    <ComboBoxItem Content="Scroll down" Tag="scrollDown"/>
+                                    <ComboBoxItem Content="Scroll up a whole page" Tag="scrollUpPage"/>
+                                    <ComboBoxItem Content="Scroll down a whole page" Tag="scrollDownPage"/>
 
-                            <!-- Visual adjustment commands -->
-                            <ComboBoxItem Content="Adjust font size" Tag="adjustFontSize"/> <!-- Can have opt values -->
-                            <ComboBoxItem Content="Reset font size" Tag="resetFontSize"/>
-                            <ComboBoxItem Content="Toggle retro terminal effects" Tag="toggleRetroEffect"/>
-                        </ComboBox>
-
-                        <StackPanel Visibility="Collapsed" Name="OptionalSettingsPanel">
-                            <TextBlock Text="Arguments" Style="{StaticResource SubheaderTextBlockStyle}" Margin="0,8,0,0"/>
-
-                            <!-- Args for Open Settings -->
-                            <StackPanel x:Name="openSettingsOptionPanel" Visibility="Collapsed" Orientation="Horizontal" Margin="0,8,0,0">
-                                <TextBlock Text="Target" />
-                                <TextBox Name="OpenSettingsTarget"/>
-                            </StackPanel>
-
-                            <!-- Args for New Tab -->
-                            <StackPanel x:Name="newTabOptionPanel" Visibility="Collapsed" Orientation="Vertical" Margin="0,8,0,0">
-                            </StackPanel>
-
-                            <!-- Args for Switch To Tab -->
-                            <StackPanel x:Name="switchToTabOptionPanel" Visibility="Collapsed" Orientation="Horizontal" Margin="0,8,0,0">
-                                <TextBlock Text="Target" />
-                                <TextBox Name="switchToTabIndex"/>
-                            </StackPanel>
-
-                            <!-- Args for Rename Tab -->
-                            <StackPanel x:Name="renameTabOptionPanel" Visibility="Collapsed" Orientation="Horizontal" Margin="0,8,0,0">
-                                <TextBlock Text="Title" />
-                                <TextBox Name="renameTabTextBox"/>
-                            </StackPanel>
-
-                            <!-- Args for Set Tab Color -->
-                            <StackPanel x:Name="setTabColorOptionPanel" Visibility="Collapsed" Orientation="Horizontal" Margin="0,8,0,0">
-                                <TextBlock Text="Color" />
-                                <ColorPicker Name="setTabColorTextBox"/>
-                            </StackPanel>
-
-                            <!-- Args for Move Focus and Resize -->
-                            <StackPanel x:Name="moveResizeFocusOptionPanel" Visibility="Collapsed" Orientation="Horizontal" Margin="0,8,0,0">
-                                <TextBlock Text="Direction"/>
-                                <ComboBox>
-                                    <ComboBoxItem Content="Left" Tag="left"/>
-                                    <ComboBoxItem Content="Right" Tag="right"/>
-                                    <ComboBoxItem Content="Up" Tag="up"/>
-                                    <ComboBoxItem Content="Down" Tag="down"/>
+                                    <!-- Visual adjustment commands -->
+                                    <ComboBoxItem Content="Adjust font size" Tag="adjustFontSize"/>
+                                    <!-- Can have opt values -->
+                                    <ComboBoxItem Content="Reset font size" Tag="resetFontSize"/>
+                                    <ComboBoxItem Content="Toggle retro terminal effects" Tag="toggleRetroEffect"/>
                                 </ComboBox>
+
+                                <StackPanel Visibility="Collapsed" Name="OptionalSettingsPanel">
+                                    <TextBlock Text="Arguments" Style="{StaticResource SubheaderTextBlockStyle}" Margin="0,8,0,0"/>
+
+                                    <!-- Args for Open Settings -->
+                                    <StackPanel x:Name="openSettingsOptionPanel" Visibility="Collapsed" Orientation="Horizontal" Margin="0,8,0,0">
+                                        <TextBlock Text="Target" />
+                                        <TextBox Name="OpenSettingsTarget"/>
+                                    </StackPanel>
+
+                                    <!-- Args for New Tab -->
+                                    <StackPanel x:Name="newTabOptionPanel" Visibility="Collapsed" Orientation="Vertical" Margin="0,8,0,0">
+                                    </StackPanel>
+
+                                    <!-- Args for Switch To Tab -->
+                                    <StackPanel x:Name="switchToTabOptionPanel" Visibility="Collapsed" Orientation="Horizontal" Margin="0,8,0,0">
+                                        <TextBlock Text="Target" />
+                                        <TextBox Name="switchToTabIndex"/>
+                                    </StackPanel>
+
+                                    <!-- Args for Rename Tab -->
+                                    <StackPanel x:Name="renameTabOptionPanel" Visibility="Collapsed" Orientation="Horizontal" Margin="0,8,0,0">
+                                        <TextBlock Text="Title" />
+                                        <TextBox Name="renameTabTextBox"/>
+                                    </StackPanel>
+
+                                    <!-- Args for Set Tab Color -->
+                                    <StackPanel x:Name="setTabColorOptionPanel" Visibility="Collapsed" Orientation="Horizontal" Margin="0,8,0,0">
+                                        <TextBlock Text="Color" />
+                                        <ColorPicker Name="setTabColorTextBox"/>
+                                    </StackPanel>
+
+                                    <!-- Args for Move Focus and Resize -->
+                                    <StackPanel x:Name="moveResizeFocusOptionPanel" Visibility="Collapsed" Orientation="Horizontal" Margin="0,8,0,0">
+                                        <TextBlock Text="Direction"/>
+                                        <ComboBox>
+                                            <ComboBoxItem Content="Left" Tag="left"/>
+                                            <ComboBoxItem Content="Right" Tag="right"/>
+                                            <ComboBoxItem Content="Up" Tag="up"/>
+                                            <ComboBoxItem Content="Down" Tag="down"/>
+                                        </ComboBox>
+                                    </StackPanel>
+
+                                    <!-- Args for Split Pane -->
+                                    <StackPanel x:Name="splitPaneOptionPanel" Visibility="Collapsed" Orientation="Vertical" Margin="0,8,0,0">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="*"/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Text="Split" VerticalAlignment="Center" Grid.Column="0"/>
+                                            <ComboBox Name="SplitComboBox" HorizontalAlignment="Stretch" Grid.Column="1">
+                                                <ComboBoxItem Content="Vertical" Tag="vertical"/>
+                                                <ComboBoxItem Content="Horizontal" Tag="horizontal"/>
+                                                <ComboBoxItem Content="Auto" Tag="auto"/>
+                                            </ComboBox>
+                                        </Grid>
+                                    </StackPanel>
+
+                                    <!-- Args for Copy -->
+                                    <StackPanel x:Name="copyOptionPanel" Visibility="Collapsed" Orientation="Horizontal" Margin="0,8,0,0">
+                                        <CheckBox x:Name="copyCheckBox" Content="Copy text as a single line" />
+                                    </StackPanel>
+
+                                    <!-- Args for Adjust Font Size -->
+                                    <StackPanel x:Name="adjustFontSizeOptionPanel" Visibility="Collapsed" Orientation="Horizontal" Margin="0,8,0,0">
+                                        <TextBlock Text="Delta" />
+                                        <TextBox Name="deltaTextBox"/>
+                                    </StackPanel>
+
+                                    <HyperlinkButton Content="+ Add new" Click="AddNewButton_Click" Name="AddNewLink" />
+                                </StackPanel>
+
+                                <TextBlock Text="Keys" HorizontalAlignment="Left" Margin="0,8,0,0"/>
+                                <TextBox Name="KeyBindTextBox" TextChanging="KeyBindTextBox_TextChanging" Margin="0,8,0,0"/>
+
+                                <Button Content="Save" Click="SaveButton_Click" HorizontalAlignment="Right" Margin="0,12,0,0"/>
                             </StackPanel>
-
-                            <!-- Args for Split Pane -->
-                            <StackPanel x:Name="splitPaneOptionPanel" Visibility="Collapsed" Orientation="Vertical" Margin="0,8,0,0">
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*"/>
-                                        <ColumnDefinition Width="*"/>
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock Text="Split" VerticalAlignment="Center" Grid.Column="0"/>
-                                    <ComboBox Name="SplitComboBox" HorizontalAlignment="Stretch" Grid.Column="1">
-                                        <ComboBoxItem Content="Vertical" Tag="vertical"/>
-                                        <ComboBoxItem Content="Horizontal" Tag="horizontal"/>
-                                        <ComboBoxItem Content="Auto" Tag="auto"/>
-                                    </ComboBox>                                    
-                                </Grid>
-                            </StackPanel>
-
-                            <!-- Args for Copy -->
-                            <StackPanel x:Name="copyOptionPanel" Visibility="Collapsed" Orientation="Horizontal" Margin="0,8,0,0">
-                                <CheckBox x:Name="copyCheckBox" Content="Copy text as a single line" />
-                            </StackPanel>
-
-                            <!-- Args for Adjust Font Size -->
-                            <StackPanel x:Name="adjustFontSizeOptionPanel" Visibility="Collapsed" Orientation="Horizontal" Margin="0,8,0,0">
-                                <TextBlock Text="Delta" />
-                                <TextBox Name="deltaTextBox"/>
-                            </StackPanel>
-
-                            <HyperlinkButton Content="+ Add new" Click="AddNewButton_Click" Name="AddNewLink" />
-                        </StackPanel>
-
-                        <TextBlock Text="Keys" HorizontalAlignment="Left" Margin="0,8,0,0"/>
-                        <TextBox Name="KeyBindTextBox" TextChanging="KeyBindTextBox_TextChanging" Margin="0,8,0,0"/>
-
-                        <Button Content="Save" Click="SaveButton_Click" HorizontalAlignment="Right" Margin="0,12,0,0"/>
-                    </StackPanel>
-                    </ScrollViewer>
-                </Border>
-            </Popup>
-        </StackPanel>
-    </Grid>
+                        </ScrollViewer>
+                    </Border>
+                </Popup>
+            </StackPanel>
+        </Grid>
+    </ScrollViewer>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -9,52 +9,53 @@ the MIT License. See LICENSE in the project root for license information. -->
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:Controls="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d">
-
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-          Margin="0,12,0,0">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="1*" />
-            <ColumnDefinition Width="1*" />
-        </Grid.ColumnDefinitions>
-        <TextBlock x:Uid="Globals_Startup"
-                   Style="{StaticResource SubheaderTextBlockStyle}"
-                   Margin="0,0,0,20" />
-        <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,100,0">
-            <TextBox x:Uid="Globals_DefaultProfile" Text="{x:Bind GlobalSettings.DefaultProfile}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
-            <CheckBox x:Uid="Globals_StartOnUserLogin" IsChecked="{x:Bind GlobalSettings.StartOnUserLogin, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
-            <Controls:RadioButtons x:Uid="Globals_LaunchSize" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
-                <RadioButton x:Uid="Globals_LaunchSizeDefault" x:Name="DefaultLaunchSize"/>
-                <RadioButton x:Uid="Globals_LaunchSizeMaximized" x:Name="MaximizedLaunchSize"/>
-                <RadioButton x:Uid="Globals_LaunchSizeFullscreen" x:Name="FullscreenLaunchSize"/>
-            </Controls:RadioButtons>
-            <!--TODO: Converter here for launch position into the cols and rows number boxes-->
-            <!--<TextBox x:Uid="Globals_LaunchPosition" Text="{x:Bind GlobalSettings.LaunchPosition, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse"/>
-            <Controls:NumberBox x:Uid="Globals_InitialCols"
-                                    x:Name="InitialCols"
-                                    Value="{x:Bind GlobalSettings.InitialCols, Mode=TwoWay}"
-                                    Margin="0,0,0,20"
-                                    FontSize="15"
-                                    SpinButtonPlacementMode="Compact" 
-                                    SmallChange="10"
-                                    LargeChange="100"
-                                    ToolTipService.Placement="Mouse"/>
-            <Controls:NumberBox x:Uid="Globals_InitialRows"
-                                x:Name="InitialRows"
-                                    Value="{x:Bind GlobalSettings.InitialRows, Mode=TwoWay}"
-                                    Margin="0,0,0,20"
-                                    FontSize="15"
-                                    SpinButtonPlacementMode="Compact" 
-                                    SmallChange="10"
-                                    LargeChange="100"
-                                    ToolTipService.Placement="Mouse"/>-->
-        </StackPanel>
-        <!--TODO: Setting doesn't exist?-->
-        <!--<StackPanel Grid.Row="1" Grid.Column="1" Margin="0,0,100,0">
-            <CheckBox x:Uid="Globals_DisableDynamicProfiles" IsChecked="{x:Bind GlobalSettings.DisableDynamicProfiles, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
-        </StackPanel>-->
-    </Grid>
+    <ScrollViewer>
+        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+              Margin="0,12,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1*" />
+                <ColumnDefinition Width="1*" />
+            </Grid.ColumnDefinitions>
+            <TextBlock x:Uid="Globals_Startup"
+                       Style="{StaticResource SubheaderTextBlockStyle}"
+                       Margin="0,0,0,20" />
+            <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,100,0">
+                <TextBox x:Uid="Globals_DefaultProfile" Text="{x:Bind GlobalSettings.DefaultProfile}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
+                <CheckBox x:Uid="Globals_StartOnUserLogin" IsChecked="{x:Bind GlobalSettings.StartOnUserLogin, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
+                <Controls:RadioButtons x:Uid="Globals_LaunchSize" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
+                    <RadioButton x:Uid="Globals_LaunchSizeDefault" x:Name="DefaultLaunchSize"/>
+                    <RadioButton x:Uid="Globals_LaunchSizeMaximized" x:Name="MaximizedLaunchSize"/>
+                    <RadioButton x:Uid="Globals_LaunchSizeFullscreen" x:Name="FullscreenLaunchSize"/>
+                </Controls:RadioButtons>
+                <!--TODO: Converter here for launch position into the cols and rows number boxes-->
+                <!--<TextBox x:Uid="Globals_LaunchPosition" Text="{x:Bind GlobalSettings.LaunchPosition, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse"/>
+                <Controls:NumberBox x:Uid="Globals_InitialCols"
+                                        x:Name="InitialCols"
+                                        Value="{x:Bind GlobalSettings.InitialCols, Mode=TwoWay}"
+                                        Margin="0,0,0,20"
+                                        FontSize="15"
+                                        SpinButtonPlacementMode="Compact" 
+                                        SmallChange="10"
+                                        LargeChange="100"
+                                        ToolTipService.Placement="Mouse"/>
+                <Controls:NumberBox x:Uid="Globals_InitialRows"
+                                    x:Name="InitialRows"
+                                        Value="{x:Bind GlobalSettings.InitialRows, Mode=TwoWay}"
+                                        Margin="0,0,0,20"
+                                        FontSize="15"
+                                        SpinButtonPlacementMode="Compact" 
+                                        SmallChange="10"
+                                        LargeChange="100"
+                                        ToolTipService.Placement="Mouse"/>-->
+            </StackPanel>
+            <!--TODO: Setting doesn't exist?-->
+            <!--<StackPanel Grid.Row="1" Grid.Column="1" Margin="0,0,100,0">
+                <CheckBox x:Uid="Globals_DisableDynamicProfiles" IsChecked="{x:Bind GlobalSettings.DisableDynamicProfiles, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
+            </StackPanel>-->
+        </Grid>
+    </ScrollViewer>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -23,41 +23,13 @@ the MIT License. See LICENSE in the project root for license information. -->
                          IsAlphaTextInputVisible="True" />
         </Flyout>-->
     </Page.Resources>
-    
-    <Pivot>
-        <PivotItem x:Uid="Profile_General">
-            <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-                  Margin="0,12,0,0">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="1*" />
-                    <ColumnDefinition Width="1*" />
-                </Grid.ColumnDefinitions>
-                <TextBox x:Uid="Profile_Commandline" x:Name="Commandline" Margin="0,0,0,20" Grid.Row="0" Grid.Column="0" FontSize="15" Text="{x:Bind Profile.Commandline, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
-                <Button x:Uid="Profile_CommandlineBrowse" Click="Commandline_Click" Margin="5,0,0,0" Grid.Row="0" Grid.Column="1" FontSize="15"/>
-                <TextBox x:Uid="Profile_StartingDirectory" x:Name="StartingDirectory" Margin="0,0,0,20" Grid.Row="1" Grid.Column="0" FontSize="15" Text="{x:Bind Profile.StartingDirectory, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
-                <Button x:Uid="Profile_StartingDirectoryBrowse" Margin="5,0,0,0" Grid.Row="1" Grid.Column="1" FontSize="15"/>
-                <TextBox x:Uid="Profile_Icon" Margin="0,0,0,20" Grid.Row="2" Grid.Column="0" FontSize="15" Text="{x:Bind Profile.Icon, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
-                <Button x:Uid="Profile_IconBrowse" Margin="5,0,0,0" Grid.Row="2" Grid.Column="1" FontSize="15" />
-                <StackPanel Grid.Row="3" Grid.Column="0">
-                    <TextBox x:Uid="Profile_TabTitle" Margin="0,0,0,20" FontSize="15" Text="{x:Bind Profile.TabTitle, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
-                    <Controls:RadioButtons x:Uid="Profile_ScrollbarVisibility" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
-                        <RadioButton x:Uid="Profile_ScrollbarVisibilityVisible" x:Name="ScrollBarVisible"/>
-                        <RadioButton x:Uid="Profile_ScrollbarVisibilityHidden" x:Name="ScrollBarHidden"/>
-                    </Controls:RadioButtons>
-                </StackPanel>
-            </Grid>
-        </PivotItem>
-        <PivotItem x:Uid="Profile_Appearance">
-            <ScrollViewer>
+    <ScrollViewer>
+        <Pivot>
+            <PivotItem x:Uid="Profile_General">
                 <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-                      Margin="0,12,0,0">
+                  Margin="0,12,0,0">
                     <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="*" />
@@ -65,201 +37,230 @@ the MIT License. See LICENSE in the project root for license information. -->
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="1*" />
                         <ColumnDefinition Width="1*" />
-                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
-                    <!-- THIS IS WHERE THE MINI-TERMINAL WOULD GO -->
-
-
-                    <StackPanel Grid.Column="0" Grid.Row="0" Margin="0,0,100,0">
-                        <TextBox x:Uid="Profile_FontFace" Margin="0,0,0,20" FontSize="15" Text="{x:Bind Profile.FontFace, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
-                    </StackPanel>
-                    <StackPanel Grid.Column="0" Grid.Row="1" Margin="0,0,100,0">
-                        <Controls:NumberBox x:Uid="Profile_FontSize" Margin="0,0,0,20" FontSize="15" Value="{x:Bind Profile.FontSize, Mode=TwoWay}" SpinButtonPlacementMode="Compact" SmallChange="1" LargeChange="10" ToolTipService.Placement="Mouse" />
-                        <TextBox x:Uid="Profile_FontWeight" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse"/>
-                        <TextBox x:Uid="Profile_Padding" Margin="0,0,0,20" FontSize="15" Text="{x:Bind Profile.Padding, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
-                        <Controls:RadioButtons x:Uid="Profile_CursorShape" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
-                            <RadioButton x:Uid="Profile_CursorShapeBar" x:Name="CursorShapeBar"/>
-                            <RadioButton x:Uid="Profile_CursorShapeVintage" x:Name="CursorShapeVintage"/>
-                            <RadioButton x:Uid="Profile_CursorShapeUnderscore" x:Name="CursorShapeUnderscore"/>
-                            <RadioButton x:Uid="Profile_CursorShapeFilledBox" x:Name="CursorShapeFilledBox"/>
-                            <RadioButton x:Uid="Profile_CursorShapeEmptyBox" x:Name="CursorShapeEmptyBox"/>
+                    <TextBox x:Uid="Profile_Commandline" x:Name="Commandline" Margin="0,0,0,20" Grid.Row="0" Grid.Column="0" FontSize="15" Text="{x:Bind Profile.Commandline, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
+                    <Button x:Uid="Profile_CommandlineBrowse" Click="Commandline_Click" Margin="5,0,0,0" Grid.Row="0" Grid.Column="1" FontSize="15"/>
+                    <TextBox x:Uid="Profile_StartingDirectory" x:Name="StartingDirectory" Margin="0,0,0,20" Grid.Row="1" Grid.Column="0" FontSize="15" Text="{x:Bind Profile.StartingDirectory, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
+                    <Button x:Uid="Profile_StartingDirectoryBrowse" Margin="5,0,0,0" Grid.Row="1" Grid.Column="1" FontSize="15"/>
+                    <TextBox x:Uid="Profile_Icon" Margin="0,0,0,20" Grid.Row="2" Grid.Column="0" FontSize="15" Text="{x:Bind Profile.Icon, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
+                    <Button x:Uid="Profile_IconBrowse" Margin="5,0,0,0" Grid.Row="2" Grid.Column="1" FontSize="15" />
+                    <StackPanel Grid.Row="3" Grid.Column="0">
+                        <TextBox x:Uid="Profile_TabTitle" Margin="0,0,0,20" FontSize="15" Text="{x:Bind Profile.TabTitle, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
+                        <Controls:RadioButtons x:Uid="Profile_ScrollbarVisibility" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
+                            <RadioButton x:Uid="Profile_ScrollbarVisibilityVisible" x:Name="ScrollBarVisible"/>
+                            <RadioButton x:Uid="Profile_ScrollbarVisibilityHidden" x:Name="ScrollBarHidden"/>
                         </Controls:RadioButtons>
-                        <Controls:NumberBox x:Uid="Profile_CursorHeight" Margin="0,0,0,20" FontSize="15" Value="100" SpinButtonPlacementMode="Compact" SmallChange="1" LargeChange="10" ToolTipService.Placement="Mouse" />
-                        <StackPanel x:Uid="Profile_CursorColorToolTip"
-                                    Orientation="Horizontal"
-                                    Margin="0,0,0,20"
-                                    ToolTipService.Placement="Mouse">
-                            <TextBox x:Uid="Profile_CursorColor"
-                                     FontSize="15"
-                                     Text="#FFFFFF" />
-                            <Button Background="White"
-                                    BorderBrush="{StaticResource SystemBaseLowColor}"
-                                    Height="37"
-                                    Width="37"
-                                    Margin="10,22,0,0"
-                                    CornerRadius="2">
-                                <Button.Flyout>
-                                    <Flyout>
-                                        <ColorPicker IsColorSliderVisible="False"
-                                                     IsColorChannelTextInputVisible="False"
-                                                     IsHexInputVisible="False"
-                                                     IsAlphaEnabled="False"
-                                                     IsAlphaSliderVisible="True"
-                                                     IsAlphaTextInputVisible="True" />       
-                                    </Flyout>
-                                </Button.Flyout>
-                            </Button>
-                        </StackPanel>
-                        <DropDownButton x:Uid="Profile_ColorScheme" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
-                            <DropDownButton.Flyout>
-                                <MenuFlyout Placement="Bottom">
-                                    <MenuFlyoutItem Text="Campbell"/>
-                                    <MenuFlyoutItem Text="Campbell Powershell"/>
-                                    <MenuFlyoutItem Text="Vintage"/>
-                                    <MenuFlyoutItem Text="One Half Dark"/>
-                                    <MenuFlyoutItem Text="One Half Light"/>
-                                    <MenuFlyoutItem Text="Tango Dark"/>
-                                    <MenuFlyoutItem Text="Tango Light"/>
-                                </MenuFlyout>
-                            </DropDownButton.Flyout>
-                        </DropDownButton>
-                        <StackPanel x:Uid="Profile_ForegroundColorToolTip"
-                                    Orientation="Horizontal"
-                                    Margin="0,0,0,20"
-                                    ToolTipService.Placement="Mouse">
-                            <TextBox x:Uid="Profile_ForegroundColor"
-                                     FontSize="15"
-                                     Text="#FFFFFF" />
-                            <Button Background="White"
-                                    BorderBrush="{StaticResource SystemBaseLowColor}"
-                                    Height="37"
-                                    Width="37"
-                                    Margin="10,22,0,0"
-                                    CornerRadius="2">
-                                <Button.Flyout>
-                                    <Flyout>
-                                        <ColorPicker IsColorSliderVisible="False"
-                                                     IsColorChannelTextInputVisible="False"
-                                                     IsHexInputVisible="False"
-                                                     IsAlphaEnabled="False"
-                                                     IsAlphaSliderVisible="True"
-                                                     IsAlphaTextInputVisible="True" />
-                                    </Flyout>
-                                </Button.Flyout>
-                            </Button>
-                        </StackPanel>
-                        <StackPanel x:Uid="Profile_BackgroundColorToolTip"
-                                    Orientation="Horizontal"
-                                    Margin="0,0,0,20"
-                                    ToolTipService.Placement="Mouse">
-                            <TextBox x:Uid="Profile_BackgroundColor"
-                                     FontSize="15"
-                                     Text="#000000" />
-                            <Button Background="Black"
-                                    BorderBrush="{StaticResource SystemBaseLowColor}"
-                                    Height="37"
-                                    Width="37"
-                                    Margin="10,22,0,0"
-                                    CornerRadius="2">
-                                <Button.Flyout>
-                                    <Flyout>
-                                        <ColorPicker IsColorSliderVisible="False"
-                                                     IsColorChannelTextInputVisible="False"
-                                                     IsHexInputVisible="False"
-                                                     IsAlphaEnabled="False"
-                                                     IsAlphaSliderVisible="True"
-                                                     IsAlphaTextInputVisible="True" />
-                                    </Flyout>
-                                </Button.Flyout>
-                            </Button>
-                        </StackPanel>
-                        <StackPanel x:Uid="Profile_SelectionBackgroundColorToolTip"
-                                    Orientation="Horizontal"
-                                    Margin="0,0,0,20"
-                                    ToolTipService.Placement="Mouse">
-                            <TextBox x:Uid="Profile_SelectionBackgroundColor"
-                                     FontSize="15"
-                                     Text="#808080" />
-                            <Button Background="Gray"
-                                    BorderBrush="{StaticResource SystemBaseLowColor}"
-                                    Height="37"
-                                    Width="37"
-                                    Margin="10,22,0,0"
-                                    CornerRadius="2">
-                                <Button.Flyout>
-                                    <Flyout>
-                                        <ColorPicker IsColorSliderVisible="False"
-                                                     IsColorChannelTextInputVisible="False"
-                                                     IsHexInputVisible="False"
-                                                     IsAlphaEnabled="False"
-                                                     IsAlphaSliderVisible="True"
-                                                     IsAlphaTextInputVisible="True" />
-                                    </Flyout>
-                                </Button.Flyout>
-                            </Button>
-                        </StackPanel>
-                    </StackPanel>
-                    <TextBox x:Uid="Profile_BackgroundImage" x:Name="BackgroundImage" Margin="0,0,0,20" FontSize="15" Grid.Column="1" Grid.Row="0" Text="{x:Bind Profile.BackgroundImagePath, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
-                    <Button x:Uid="Profile_BackgroundImageBrowse" Click="BackgroundImage_Click" Margin="5,0,0,0" Grid.Column="2" Grid.Row="0"/>
-                    <StackPanel Grid.Column="1" Grid.Row="1" Margin="0,0,100,0">
-                        <Controls:RadioButtons x:Uid="Profile_BackgroundImageStretchMode" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
-                            <RadioButton x:Uid="Profile_BackgroundImageStretchModeNone" x:Name="backgroundImageStretchModeNone"/>
-                            <RadioButton x:Uid="Profile_BackgroundImageStretchModeFill" x:Name="backgroundImageStretchModeFill"/>
-                            <RadioButton x:Uid="Profile_BackgroundImageStretchModeUniform" x:Name="backgroundImageStretchModeUniform"/>
-                            <RadioButton x:Uid="Profile_BackgroundImageStretchModeUniformToFill" x:Name="backgroundImageStretchModeUniformToFill"/>
-                        </Controls:RadioButtons>
-                        <DropDownButton x:Uid="Profile_BackgroundImageAlignment" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
-                            <DropDownButton.Flyout>
-                                <MenuFlyout Placement="Bottom">
-                                    <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentCenter"/>
-                                    <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentLeft"/>
-                                    <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentTop"/>
-                                    <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentRight"/>
-                                    <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentBottom"/>
-                                    <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentTopLeft"/>
-                                    <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentTopRight"/>
-                                    <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentBottomLeft"/>
-                                    <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentBottomRight"/>
-                                </MenuFlyout>
-                            </DropDownButton.Flyout>
-                        </DropDownButton>
-                        <Controls:NumberBox x:Uid="Profile_BackgroundImageOpacity" Margin="0,0,0,20" FontSize="15" Value="{x:Bind Profile.BackgroundImageOpacity, Mode=TwoWay}" SpinButtonPlacementMode="Compact" SmallChange="10" LargeChange="25" ToolTipService.Placement="Mouse" />
-                        <CheckBox x:Uid="Profile_UseAcrylic" Margin="0,0,0,20" FontSize="15" IsChecked="{x:Bind Profile.UseAcrylic, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
-                        <Controls:NumberBox x:Uid="Profile_AcrylicOpacity" Margin="0,0,0,20" FontSize="15" Value="{x:Bind Profile.AcrylicOpacity, Mode=TwoWay}" SpinButtonPlacementMode="Compact" SmallChange="0.1" LargeChange="0.25" ToolTipService.Placement="Mouse" />
-                        <CheckBox x:Uid="Profile_RetroTerminalEffect" Margin="0,0,0,20" FontSize="15" IsChecked="{x:Bind Profile.RetroTerminalEffect, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
                     </StackPanel>
                 </Grid>
-            </ScrollViewer>
-        </PivotItem>
-        <PivotItem x:Uid="Profile_Advanced">
-            <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+            </PivotItem>
+            <PivotItem x:Uid="Profile_Appearance">
+                <ScrollViewer>
+                    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+                      Margin="0,12,0,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="1*" />
+                            <ColumnDefinition Width="1*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <!-- THIS IS WHERE THE MINI-TERMINAL WOULD GO -->
+
+
+                        <StackPanel Grid.Column="0" Grid.Row="0" Margin="0,0,100,0">
+                            <TextBox x:Uid="Profile_FontFace" Margin="0,0,0,20" FontSize="15" Text="{x:Bind Profile.FontFace, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
+                        </StackPanel>
+                        <StackPanel Grid.Column="0" Grid.Row="1" Margin="0,0,100,0">
+                            <Controls:NumberBox x:Uid="Profile_FontSize" Margin="0,0,0,20" FontSize="15" Value="{x:Bind Profile.FontSize, Mode=TwoWay}" SpinButtonPlacementMode="Compact" SmallChange="1" LargeChange="10" ToolTipService.Placement="Mouse" />
+                            <TextBox x:Uid="Profile_FontWeight" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse"/>
+                            <TextBox x:Uid="Profile_Padding" Margin="0,0,0,20" FontSize="15" Text="{x:Bind Profile.Padding, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
+                            <Controls:RadioButtons x:Uid="Profile_CursorShape" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
+                                <RadioButton x:Uid="Profile_CursorShapeBar" x:Name="CursorShapeBar"/>
+                                <RadioButton x:Uid="Profile_CursorShapeVintage" x:Name="CursorShapeVintage"/>
+                                <RadioButton x:Uid="Profile_CursorShapeUnderscore" x:Name="CursorShapeUnderscore"/>
+                                <RadioButton x:Uid="Profile_CursorShapeFilledBox" x:Name="CursorShapeFilledBox"/>
+                                <RadioButton x:Uid="Profile_CursorShapeEmptyBox" x:Name="CursorShapeEmptyBox"/>
+                            </Controls:RadioButtons>
+                            <Controls:NumberBox x:Uid="Profile_CursorHeight" Margin="0,0,0,20" FontSize="15" Value="100" SpinButtonPlacementMode="Compact" SmallChange="1" LargeChange="10" ToolTipService.Placement="Mouse" />
+                            <StackPanel x:Uid="Profile_CursorColorToolTip"
+                                    Orientation="Horizontal"
+                                    Margin="0,0,0,20"
+                                    ToolTipService.Placement="Mouse">
+                                <TextBox x:Uid="Profile_CursorColor"
+                                     FontSize="15"
+                                     Text="#FFFFFF" />
+                                <Button Background="White"
+                                    BorderBrush="{StaticResource SystemBaseLowColor}"
+                                    Height="37"
+                                    Width="37"
+                                    Margin="10,22,0,0"
+                                    CornerRadius="2">
+                                    <Button.Flyout>
+                                        <Flyout>
+                                            <ColorPicker IsColorSliderVisible="False"
+                                                     IsColorChannelTextInputVisible="False"
+                                                     IsHexInputVisible="False"
+                                                     IsAlphaEnabled="False"
+                                                     IsAlphaSliderVisible="True"
+                                                     IsAlphaTextInputVisible="True" />
+                                        </Flyout>
+                                    </Button.Flyout>
+                                </Button>
+                            </StackPanel>
+                            <DropDownButton x:Uid="Profile_ColorScheme" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
+                                <DropDownButton.Flyout>
+                                    <MenuFlyout Placement="Bottom">
+                                        <MenuFlyoutItem Text="Campbell"/>
+                                        <MenuFlyoutItem Text="Campbell Powershell"/>
+                                        <MenuFlyoutItem Text="Vintage"/>
+                                        <MenuFlyoutItem Text="One Half Dark"/>
+                                        <MenuFlyoutItem Text="One Half Light"/>
+                                        <MenuFlyoutItem Text="Tango Dark"/>
+                                        <MenuFlyoutItem Text="Tango Light"/>
+                                    </MenuFlyout>
+                                </DropDownButton.Flyout>
+                            </DropDownButton>
+                            <StackPanel x:Uid="Profile_ForegroundColorToolTip"
+                                    Orientation="Horizontal"
+                                    Margin="0,0,0,20"
+                                    ToolTipService.Placement="Mouse">
+                                <TextBox x:Uid="Profile_ForegroundColor"
+                                     FontSize="15"
+                                     Text="#FFFFFF" />
+                                <Button Background="White"
+                                    BorderBrush="{StaticResource SystemBaseLowColor}"
+                                    Height="37"
+                                    Width="37"
+                                    Margin="10,22,0,0"
+                                    CornerRadius="2">
+                                    <Button.Flyout>
+                                        <Flyout>
+                                            <ColorPicker IsColorSliderVisible="False"
+                                                     IsColorChannelTextInputVisible="False"
+                                                     IsHexInputVisible="False"
+                                                     IsAlphaEnabled="False"
+                                                     IsAlphaSliderVisible="True"
+                                                     IsAlphaTextInputVisible="True" />
+                                        </Flyout>
+                                    </Button.Flyout>
+                                </Button>
+                            </StackPanel>
+                            <StackPanel x:Uid="Profile_BackgroundColorToolTip"
+                                    Orientation="Horizontal"
+                                    Margin="0,0,0,20"
+                                    ToolTipService.Placement="Mouse">
+                                <TextBox x:Uid="Profile_BackgroundColor"
+                                     FontSize="15"
+                                     Text="#000000" />
+                                <Button Background="Black"
+                                    BorderBrush="{StaticResource SystemBaseLowColor}"
+                                    Height="37"
+                                    Width="37"
+                                    Margin="10,22,0,0"
+                                    CornerRadius="2">
+                                    <Button.Flyout>
+                                        <Flyout>
+                                            <ColorPicker IsColorSliderVisible="False"
+                                                     IsColorChannelTextInputVisible="False"
+                                                     IsHexInputVisible="False"
+                                                     IsAlphaEnabled="False"
+                                                     IsAlphaSliderVisible="True"
+                                                     IsAlphaTextInputVisible="True" />
+                                        </Flyout>
+                                    </Button.Flyout>
+                                </Button>
+                            </StackPanel>
+                            <StackPanel x:Uid="Profile_SelectionBackgroundColorToolTip"
+                                    Orientation="Horizontal"
+                                    Margin="0,0,0,20"
+                                    ToolTipService.Placement="Mouse">
+                                <TextBox x:Uid="Profile_SelectionBackgroundColor"
+                                     FontSize="15"
+                                     Text="#808080" />
+                                <Button Background="Gray"
+                                    BorderBrush="{StaticResource SystemBaseLowColor}"
+                                    Height="37"
+                                    Width="37"
+                                    Margin="10,22,0,0"
+                                    CornerRadius="2">
+                                    <Button.Flyout>
+                                        <Flyout>
+                                            <ColorPicker IsColorSliderVisible="False"
+                                                     IsColorChannelTextInputVisible="False"
+                                                     IsHexInputVisible="False"
+                                                     IsAlphaEnabled="False"
+                                                     IsAlphaSliderVisible="True"
+                                                     IsAlphaTextInputVisible="True" />
+                                        </Flyout>
+                                    </Button.Flyout>
+                                </Button>
+                            </StackPanel>
+                        </StackPanel>
+                        <TextBox x:Uid="Profile_BackgroundImage" x:Name="BackgroundImage" Margin="0,0,0,20" FontSize="15" Grid.Column="1" Grid.Row="0" Text="{x:Bind Profile.BackgroundImagePath, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
+                        <Button x:Uid="Profile_BackgroundImageBrowse" Click="BackgroundImage_Click" Margin="5,0,0,0" Grid.Column="2" Grid.Row="0"/>
+                        <StackPanel Grid.Column="1" Grid.Row="1" Margin="0,0,100,0">
+                            <Controls:RadioButtons x:Uid="Profile_BackgroundImageStretchMode" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
+                                <RadioButton x:Uid="Profile_BackgroundImageStretchModeNone" x:Name="backgroundImageStretchModeNone"/>
+                                <RadioButton x:Uid="Profile_BackgroundImageStretchModeFill" x:Name="backgroundImageStretchModeFill"/>
+                                <RadioButton x:Uid="Profile_BackgroundImageStretchModeUniform" x:Name="backgroundImageStretchModeUniform"/>
+                                <RadioButton x:Uid="Profile_BackgroundImageStretchModeUniformToFill" x:Name="backgroundImageStretchModeUniformToFill"/>
+                            </Controls:RadioButtons>
+                            <DropDownButton x:Uid="Profile_BackgroundImageAlignment" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
+                                <DropDownButton.Flyout>
+                                    <MenuFlyout Placement="Bottom">
+                                        <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentCenter"/>
+                                        <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentLeft"/>
+                                        <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentTop"/>
+                                        <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentRight"/>
+                                        <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentBottom"/>
+                                        <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentTopLeft"/>
+                                        <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentTopRight"/>
+                                        <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentBottomLeft"/>
+                                        <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentBottomRight"/>
+                                    </MenuFlyout>
+                                </DropDownButton.Flyout>
+                            </DropDownButton>
+                            <Controls:NumberBox x:Uid="Profile_BackgroundImageOpacity" Margin="0,0,0,20" FontSize="15" Value="{x:Bind Profile.BackgroundImageOpacity, Mode=TwoWay}" SpinButtonPlacementMode="Compact" SmallChange="10" LargeChange="25" ToolTipService.Placement="Mouse" />
+                            <CheckBox x:Uid="Profile_UseAcrylic" Margin="0,0,0,20" FontSize="15" IsChecked="{x:Bind Profile.UseAcrylic, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
+                            <Controls:NumberBox x:Uid="Profile_AcrylicOpacity" Margin="0,0,0,20" FontSize="15" Value="{x:Bind Profile.AcrylicOpacity, Mode=TwoWay}" SpinButtonPlacementMode="Compact" SmallChange="0.1" LargeChange="0.25" ToolTipService.Placement="Mouse" />
+                            <CheckBox x:Uid="Profile_RetroTerminalEffect" Margin="0,0,0,20" FontSize="15" IsChecked="{x:Bind Profile.RetroTerminalEffect, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
+                        </StackPanel>
+                    </Grid>
+                </ScrollViewer>
+            </PivotItem>
+            <PivotItem x:Uid="Profile_Advanced">
+                <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
           Margin="0,12,0,0">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="1*" />
-                    <ColumnDefinition Width="1*" />
-                </Grid.ColumnDefinitions>
-                <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,100,0">
-                    <CheckBox x:Uid="Profile_Hidden" ToolTipService.Placement="Mouse" />
-                    <CheckBox x:Uid="Profile_SuppressApplicationTitle" ToolTipService.Placement="Mouse" />
-                    <Controls:RadioButtons x:Uid="Profile_AntialiasingMode" Margin="0,0,0,10" ToolTipService.Placement="Mouse">
-                        <RadioButton x:Uid="Profile_AntialiasingModeGrayscale" x:Name="antialiasingTextGrayscale"/>
-                        <RadioButton x:Uid="Profile_AntialiasingModeClearType" x:Name="antialiasingTextClearType"/>
-                        <RadioButton x:Uid="Profile_AntialiasingModeAliased" x:Name="antialiasingTextAliased"/>
-                    </Controls:RadioButtons>
-                    <CheckBox x:Uid="Profile_AltGrAliasing" ToolTipService.Placement="Mouse" />
-                    <CheckBox x:Uid="Profile_SnapOnInput" ToolTipService.Placement="Mouse" />
-                    <Controls:NumberBox x:Uid="Profile_HistorySize" Margin="0,0,0,10" Value="9001" SpinButtonPlacementMode="Compact" SmallChange="10" LargeChange="100" ToolTipService.Placement="Mouse" />
-                    <Controls:RadioButtons x:Uid="Profile_CloseOnExit" Margin="0,0,0,10" ToolTipService.Placement="Mouse">
-                        <RadioButton x:Uid="Profile_CloseOnExitGraceful" x:Name="closeOnExitGraceful"/>
-                        <RadioButton x:Uid="Profile_CloseOnExitAlways" x:Name="closeOnExitAlways"/>
-                        <RadioButton x:Uid="Profile_CloseOnExitNever" x:Name="closeOnExitNever"/>
-                    </Controls:RadioButtons>
-                </StackPanel>
-            </Grid>
-        </PivotItem>
-    </Pivot>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="1*" />
+                        <ColumnDefinition Width="1*" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,100,0">
+                        <CheckBox x:Uid="Profile_Hidden" ToolTipService.Placement="Mouse" />
+                        <CheckBox x:Uid="Profile_SuppressApplicationTitle" ToolTipService.Placement="Mouse" />
+                        <Controls:RadioButtons x:Uid="Profile_AntialiasingMode" Margin="0,0,0,10" ToolTipService.Placement="Mouse">
+                            <RadioButton x:Uid="Profile_AntialiasingModeGrayscale" x:Name="antialiasingTextGrayscale"/>
+                            <RadioButton x:Uid="Profile_AntialiasingModeClearType" x:Name="antialiasingTextClearType"/>
+                            <RadioButton x:Uid="Profile_AntialiasingModeAliased" x:Name="antialiasingTextAliased"/>
+                        </Controls:RadioButtons>
+                        <CheckBox x:Uid="Profile_AltGrAliasing" ToolTipService.Placement="Mouse" />
+                        <CheckBox x:Uid="Profile_SnapOnInput" ToolTipService.Placement="Mouse" />
+                        <Controls:NumberBox x:Uid="Profile_HistorySize" Margin="0,0,0,10" Value="9001" SpinButtonPlacementMode="Compact" SmallChange="10" LargeChange="100" ToolTipService.Placement="Mouse" />
+                        <Controls:RadioButtons x:Uid="Profile_CloseOnExit" Margin="0,0,0,10" ToolTipService.Placement="Mouse">
+                            <RadioButton x:Uid="Profile_CloseOnExitGraceful" x:Name="closeOnExitGraceful"/>
+                            <RadioButton x:Uid="Profile_CloseOnExitAlways" x:Name="closeOnExitAlways"/>
+                            <RadioButton x:Uid="Profile_CloseOnExitNever" x:Name="closeOnExitNever"/>
+                        </Controls:RadioButtons>
+                    </StackPanel>
+                </Grid>
+            </PivotItem>
+        </Pivot>
+    </ScrollViewer>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Rendering.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Rendering.xaml
@@ -9,25 +9,26 @@ the MIT License. See LICENSE in the project root for license information. -->
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:Controls="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d">
-
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-          Margin="0,12,0,0">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="1*" />
-        </Grid.ColumnDefinitions>
-        <TextBlock x:Uid="Globals_Rendering"
-                   Style="{StaticResource SubheaderTextBlockStyle}"
-                   Margin="0,0,0,20" />
-        <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,100,0">
-            <TextBlock x:Uid="Globals_RenderingDisclaimer"
-                   Style="{StaticResource BodyTextBlockStyle}"
-                   Margin="0,0,0,20" />
-            <CheckBox x:Uid="Globals_ForceFullRepaint" IsChecked="{x:Bind GlobalSettings.ForceFullRepaintRendering, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
-            <CheckBox x:Uid="Globals_SoftwareRendering" IsChecked="{x:Bind GlobalSettings.SoftwareRendering, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
-        </StackPanel>
-    </Grid>
+    <ScrollViewer>
+        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+              Margin="0,12,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1*" />
+            </Grid.ColumnDefinitions>
+            <TextBlock x:Uid="Globals_Rendering"
+                       Style="{StaticResource SubheaderTextBlockStyle}"
+                       Margin="0,0,0,20" />
+            <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,100,0">
+                <TextBlock x:Uid="Globals_RenderingDisclaimer"
+                       Style="{StaticResource BodyTextBlockStyle}"
+                       Margin="0,0,0,20" />
+                <CheckBox x:Uid="Globals_ForceFullRepaint" IsChecked="{x:Bind GlobalSettings.ForceFullRepaintRendering, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
+                <CheckBox x:Uid="Globals_SoftwareRendering" IsChecked="{x:Bind GlobalSettings.SoftwareRendering, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
+            </StackPanel>
+        </Grid>
+    </ScrollViewer>
 </Page>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This fixes the bug where the reset/save footer covers settings.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
#1564 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
