### PR TITLE
Close tab context menu on titlebar click

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2226,6 +2226,15 @@ namespace winrt::TerminalApp::implementation
         {
             _newTabButton.Flyout().Hide();
         }
+
+        for (auto tab : _tabs)
+        {
+            auto tabImpl{ _GetStrongTabImpl(tab) };
+            if (tabImpl->GetTabViewItem().ContextFlyout())
+            {
+                tabImpl->GetTabViewItem().ContextFlyout().Hide();
+            }
+        }
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2227,7 +2227,7 @@ namespace winrt::TerminalApp::implementation
             _newTabButton.Flyout().Hide();
         }
 
-        for (auto tab : _tabs)
+        for (const auto& tab : _tabs)
         {
             auto tabImpl{ _GetStrongTabImpl(tab) };
             if (tabImpl->GetTabViewItem().ContextFlyout())


### PR DESCRIPTION
Close the tab context menu when clicking on the title bar

## Detailed Description of the Pull Request / Additional comments
Following #2438, hide the tabs context menu on `TerminalPage::TitlebarClicked()`. 
We don't know which of the tabs is showing the context menu, do it on all tabs.

## Validation Steps Performed
Open the context menu from any tab, click on title bar and see the context menu disappear.

Closes #7988