### PR TITLE
wpf: base margin height off Y dpi, not X dpi

### DIFF
--- a/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
@@ -191,7 +191,7 @@ namespace Microsoft.Terminal.Wpf
 
             if (this.TerminalRendererSize.Height != 0)
             {
-                height = controlSize.Height - (this.TerminalRendererSize.Height / dpiScale.DpiScaleX);
+                height = controlSize.Height - (this.TerminalRendererSize.Height / dpiScale.DpiScaleY);
             }
 
             width -= this.scrollbar.ActualWidth;


### PR DESCRIPTION
This PR resolves an issue I observed in
Microsoft.Terminal.Wpf.TerminalControl.CalculateMargins(). Specifically,
on line 194 in the project. In this example, the line: `height =
controlSize.Height - (this.TerminalRendererSize.Height /
dpiScale.DpiScaleX);` is associating the height margin with
dpiScale.DpiScaleX instead of dpiScale.DpiScaleY. This PR changes the
association to DpiScaleY.

Closes #8038