### PR TITLE
Added Types project reference to the FuzzWrapper project

### DIFF
--- a/src/terminal/parser/ft_fuzzwrapper/FuzzWrapper.vcxproj
+++ b/src/terminal/parser/ft_fuzzwrapper/FuzzWrapper.vcxproj
@@ -21,6 +21,9 @@
     <ClInclude Include="precomp.h" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\types\lib\types.vcxproj">
+      <Project>{18d09a24-8240-42d6-8cb6-236eee820263}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\lib\parser.vcxproj">
       <Project>{3ae13314-1939-4dfa-9c14-38ca0834050c}</Project>
     </ProjectReference>

--- a/src/terminal/parser/ft_fuzzwrapper/FuzzWrapper.vcxproj.filters
+++ b/src/terminal/parser/ft_fuzzwrapper/FuzzWrapper.vcxproj.filters
@@ -33,4 +33,7 @@
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="$(SolutionDir)tools\ConsoleTypes.natvis" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
The intent of this PR is to resolve the dependency errors reported in
#7931. The Types project has been added as a reference to the
FuzzWrapper project, which fixes the unresolved dependency errors
reported.

For validation steps, I:
1.) Pulled down main.
2.) Rebuilt the FuzzWrapper project and observed the unresolved
  dependency errors keeping it from building successfully.
3.) Added a project reference to the Types project.
4.) Rebuilt the FuzzWrapper project and verified that the dependency
  errors disappeared.

Closes #7931.