### PR TITLE
UIA: throw E_FAIL for out-of-bounds text

### DIFF
--- a/.github/actions/spell-check/dictionary/names.txt
+++ b/.github/actions/spell-check/dictionary/names.txt
@@ -38,6 +38,8 @@ mikemaccana
 miloush
 miniksa
 niksa
+nvaccess
+nvda
 oising
 oldnewthing
 osgwiki

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -544,7 +544,7 @@ std::wstring UiaTextRangeBase::_getTextValue(std::optional<unsigned int> maxLeng
         // otherwise, we'll FailFast catastrophically
         if (!bufferSize.IsInBounds(_start, true) || !bufferSize.IsInBounds(_end, true))
         {
-            throw E_FAIL;
+            THROW_HR(E_FAIL);
         }
 
         // convert _end to be inclusive

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -526,8 +526,7 @@ CATCH_RETURN();
 // - the text that the UiaTextRange encompasses
 #pragma warning(push)
 #pragma warning(disable : 26447) // compiler isn't filtering throws inside the try/catch
-std::wstring UiaTextRangeBase::_getTextValue(std::optional<unsigned int> maxLength) const noexcept
-try
+std::wstring UiaTextRangeBase::_getTextValue(std::optional<unsigned int> maxLength) const
 {
     _pData->LockConsole();
     auto Unlock = wil::scope_exit([&]() noexcept {
@@ -539,6 +538,14 @@ try
     {
         const auto& buffer = _pData->GetTextBuffer();
         const auto bufferSize = buffer.GetSize();
+
+        // TODO GH#5406: create a different UIA parent object for each TextBuffer
+        // nvaccess/nvda#11428: Ensure our endpoints are in bounds
+        // otherwise, we'll FailFast catastrophically
+        if (!bufferSize.IsInBounds(_start, true) || !bufferSize.IsInBounds(_end, true))
+        {
+            throw E_FAIL;
+        }
 
         // convert _end to be inclusive
         auto inclusiveEnd = _end;
@@ -563,11 +570,6 @@ try
     }
 
     return textData;
-}
-catch (...)
-{
-    LOG_CAUGHT_EXCEPTION();
-    return {};
 }
 #pragma warning(pop)
 

--- a/src/types/UiaTextRangeBase.hpp
+++ b/src/types/UiaTextRangeBase.hpp
@@ -142,7 +142,7 @@ namespace Microsoft::Console::Types
         // This is used by tracing to extract the text value
         // that the UiaTextRange currently encompasses.
         // GetText() cannot be used as it's not const
-        std::wstring _getTextValue(std::optional<unsigned int> maxLength = std::nullopt) const noexcept;
+        std::wstring _getTextValue(std::optional<unsigned int> maxLength = std::nullopt) const;
 
         RECT _getTerminalRect() const;
 


### PR DESCRIPTION
In https://github.com/nvaccess/nvda/issues/11428#issuecomment-715893846,
Andre9642 reported a Conhost crash when switching to/from the alt buffer
a few times with a Braille display connected. Upon further
investigation, @carlos-zamora and I discovered that the FailFast was in
`GetText`: more checks similar to #7677 were needed for this case.

Tested with NVDA using a [Focus](https://www.freedomscientific.com/products/blindness/focus40brailledisplay/) Braille display.

Improves nvaccess/nvda#11428