### PR TITLE
doc: add a link to MSYS2's WT profiles page

### DIFF
--- a/doc/user-docs/ThirdPartyToolProfiles.md
+++ b/doc/user-docs/ThirdPartyToolProfiles.md
@@ -96,7 +96,9 @@ Assuming that you've installed MSYS2 into `C:\\msys64`:
     "icon": "C:\\msys64\\msys2.ico",
     "startingDirectory": "C:\\msys64\\home\\user"
 }
-````
+```
+
+For more details, see [this page](https://www.msys2.org/docs/terminals/#windows-terminal) on the MSYS2 documentation.
 
 ## Developer Command Prompt for Visual Studio
 


### PR DESCRIPTION
MSYS2 actually has their own webpage that lists off some ways of adding MSYS2 to the Windows Terminal. I figured we should also link to it, since their documentation has some good details in it. 

* [x] I work here
* [x] This is a docs update