### PR TITLE
Fix the WINRT_NO_MAKE_DETECTION build break

### DIFF
--- a/src/cascadia/ut_app/TerminalApp.UnitTests.vcxproj
+++ b/src/cascadia/ut_app/TerminalApp.UnitTests.vcxproj
@@ -64,6 +64,10 @@
 
       <!-- Manually disable unreachable code warning, because jconcpp has a ton of that. -->
       <DisableSpecificWarnings>4702;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+
+      <!-- Many of our projects use XAML, which cannot handle make detection.
+      We cannot link static libs with differing values of WINRT_NO_MAKE_DETECTION, so let's force it for everyone. -->
+      <PreprocessorDefinitions>WINRT_NO_MAKE_DETECTION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>WindowsApp.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/cppwinrt.build.pre.props
+++ b/src/cppwinrt.build.pre.props
@@ -78,6 +78,10 @@
       <DisableSpecificWarnings>28204;%(DisableSpecificWarnings)</DisableSpecificWarnings>
 
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+
+      <!-- Many of our projects use XAML, which cannot handle make detection.
+      We cannot link static libs with differing values of WINRT_NO_MAKE_DETECTION, so let's force it for everyone. -->
+      <PreprocessorDefinitions>WINRT_NO_MAKE_DETECTION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem Condition="'%(SubSystem)'==''">Console</SubSystem>


### PR DESCRIPTION
C++/WinRT added a feature where it will detect a mismatch in some of its
build flags.

Because we build XAML projects and non-XAML projects, and try to link
them together in static libraries, we need those flags to always match.

C++/WinRT only respects this flag when `DEBUG` is set, so our CI missed
this.

With thanks to @carlos-zamora for letting me build/test/commit this on
his computer.
