### PR TITLE
Shell extension: Use WT's icon as our icon

### DIFF
--- a/src/cascadia/ShellExtension/OpenTerminalHere.cpp
+++ b/src/cascadia/ShellExtension/OpenTerminalHere.cpp
@@ -185,12 +185,17 @@ HRESULT OpenTerminalHere::GetState(IShellItemArray* /*psiItemArray*/,
 
 HRESULT OpenTerminalHere::GetIcon(IShellItemArray* /*psiItemArray*/,
                                   LPWSTR* ppszIcon)
+try
 {
-    // the icon ref ("dll,-<resid>") is provided here, in this case none is provided
-    *ppszIcon = nullptr;
-    // TODO GH#6111: Return the Terminal icon here
-    return E_NOTIMPL;
+    std::filesystem::path modulePath{ wil::GetModuleFileNameW<std::wstring>(wil::GetModuleInstanceHandle()) };
+    modulePath.replace_filename(WindowsTerminalExe);
+    // WindowsTerminal.exe,-101 will be the first icon group in WT
+    // We're using WindowsTerminal here explicitly, and not wt (from _getExePath), because
+    // WindowsTerminal is the only one built with the right icons.
+    const auto resource{ modulePath.wstring() + L",-101" };
+    return SHStrDupW(resource.c_str(), ppszIcon);
 }
+CATCH_RETURN();
 
 HRESULT OpenTerminalHere::GetFlags(EXPCMDFLAGS* pFlags)
 {


### PR DESCRIPTION
This is cheaper than storing another icon in another resource fork.

Eventually, we could support high contrast just by varying the icon ID.

Fixes #6246. Looks pretty good, too.

![image](https://user-images.githubusercontent.com/189190/97379930-38f08000-1883-11eb-8d37-a7741ea55b29.png)
