### PR TITLE
Store and expose hidden profiles

### DIFF
--- a/src/cascadia/LocalTests_SettingsModel/DeserializationTests.cpp
+++ b/src/cascadia/LocalTests_SettingsModel/DeserializationTests.cpp
@@ -680,7 +680,7 @@ namespace SettingsModelLocalTests
             VERIFY_ARE_EQUAL(true, settings->_allProfiles.GetAt(1).Hidden());
 
             settings->_ReorderProfilesToMatchUserSettingsOrder();
-            settings->_RemoveHiddenProfiles();
+            settings->_UpdateActiveProfiles();
             VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
             VERIFY_ARE_EQUAL(1u, settings->_activeProfiles.Size());
             VERIFY_ARE_EQUAL(L"profile1", settings->_activeProfiles.GetAt(0).Name());
@@ -710,7 +710,7 @@ namespace SettingsModelLocalTests
             VERIFY_ARE_EQUAL(true, settings->_allProfiles.GetAt(3).Hidden());
 
             settings->_ReorderProfilesToMatchUserSettingsOrder();
-            settings->_RemoveHiddenProfiles();
+            settings->_UpdateActiveProfiles();
             VERIFY_ARE_EQUAL(4u, settings->_allProfiles.Size());
             VERIFY_ARE_EQUAL(2u, settings->_activeProfiles.Size());
             VERIFY_ARE_EQUAL(L"profile5", settings->_activeProfiles.GetAt(0).Name());
@@ -1238,7 +1238,7 @@ namespace SettingsModelLocalTests
             settings->_ParseJsonString(settingsWithProfiles, false);
             settings->LayerJson(settings->_userSettings);
 
-            settings->_RemoveHiddenProfiles();
+            settings->_UpdateActiveProfiles();
             Log::Comment(NoThrowString().Format(
                 L"settingsWithProfiles successfully parsed and validated"));
             VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
@@ -1253,7 +1253,7 @@ namespace SettingsModelLocalTests
             bool caughtExpectedException = false;
             try
             {
-                settings->_RemoveHiddenProfiles();
+                settings->_UpdateActiveProfiles();
             }
             catch (const implementation::SettingsException& ex)
             {

--- a/src/cascadia/LocalTests_SettingsModel/DeserializationTests.cpp
+++ b/src/cascadia/LocalTests_SettingsModel/DeserializationTests.cpp
@@ -247,8 +247,8 @@ namespace SettingsModelLocalTests
             settings->_ResolveDefaultProfile();
             settings->_ValidateDefaultProfileExists();
             VERIFY_ARE_EQUAL(static_cast<size_t>(0), settings->_warnings.Size());
-            VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_profiles.Size());
-            VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.GetAt(0).Guid());
+            VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_allProfiles.Size());
+            VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_allProfiles.GetAt(0).Guid());
         }
         {
             // Case 2: Bad settings
@@ -261,8 +261,8 @@ namespace SettingsModelLocalTests
             VERIFY_ARE_EQUAL(static_cast<size_t>(1), settings->_warnings.Size());
             VERIFY_ARE_EQUAL(SettingsLoadWarnings::MissingDefaultProfile, settings->_warnings.GetAt(0));
 
-            VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_profiles.Size());
-            VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.GetAt(0).Guid());
+            VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_allProfiles.Size());
+            VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_allProfiles.GetAt(0).Guid());
         }
         {
             // Case 2: Bad settings
@@ -275,8 +275,8 @@ namespace SettingsModelLocalTests
             VERIFY_ARE_EQUAL(static_cast<size_t>(1), settings->_warnings.Size());
             VERIFY_ARE_EQUAL(SettingsLoadWarnings::MissingDefaultProfile, settings->_warnings.GetAt(0));
 
-            VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_profiles.Size());
-            VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.GetAt(0).Guid());
+            VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_allProfiles.Size());
+            VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_allProfiles.GetAt(0).Guid());
         }
         {
             // Case 4: Good settings, default profile is a string
@@ -287,8 +287,8 @@ namespace SettingsModelLocalTests
             settings->_ResolveDefaultProfile();
             settings->_ValidateDefaultProfileExists();
             VERIFY_ARE_EQUAL(static_cast<size_t>(0), settings->_warnings.Size());
-            VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_profiles.Size());
-            VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.GetAt(1).Guid());
+            VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_allProfiles.Size());
+            VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_allProfiles.GetAt(1).Guid());
         }
     }
 
@@ -376,13 +376,13 @@ namespace SettingsModelLocalTests
                 L"Testing a pair of profiles with unique guids"));
 
             auto settings = winrt::make_self<implementation::CascadiaSettings>();
-            settings->_profiles.Append(profile0);
-            settings->_profiles.Append(profile1);
+            settings->_allProfiles.Append(profile0);
+            settings->_allProfiles.Append(profile1);
 
             settings->_ValidateNoDuplicateProfiles();
 
             VERIFY_ARE_EQUAL(static_cast<size_t>(0), settings->_warnings.Size());
-            VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(static_cast<size_t>(2), settings->_allProfiles.Size());
         }
         {
             // Case 2: Bad settings
@@ -390,16 +390,16 @@ namespace SettingsModelLocalTests
                 L"Testing a pair of profiles with the same guid"));
 
             auto settings = winrt::make_self<implementation::CascadiaSettings>();
-            settings->_profiles.Append(profile2);
-            settings->_profiles.Append(profile3);
+            settings->_allProfiles.Append(profile2);
+            settings->_allProfiles.Append(profile3);
 
             settings->_ValidateNoDuplicateProfiles();
 
             VERIFY_ARE_EQUAL(static_cast<size_t>(1), settings->_warnings.Size());
             VERIFY_ARE_EQUAL(SettingsLoadWarnings::DuplicateProfile, settings->_warnings.GetAt(0));
 
-            VERIFY_ARE_EQUAL(static_cast<size_t>(1), settings->_profiles.Size());
-            VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(static_cast<size_t>(1), settings->_allProfiles.Size());
+            VERIFY_ARE_EQUAL(L"profile2", settings->_allProfiles.GetAt(0).Name());
         }
         {
             // Case 3: Very bad settings
@@ -407,24 +407,24 @@ namespace SettingsModelLocalTests
                 L"Testing a set of profiles, many of which with duplicated guids"));
 
             auto settings = winrt::make_self<implementation::CascadiaSettings>();
-            settings->_profiles.Append(profile0);
-            settings->_profiles.Append(profile1);
-            settings->_profiles.Append(profile2);
-            settings->_profiles.Append(profile3);
-            settings->_profiles.Append(profile4);
-            settings->_profiles.Append(profile5);
-            settings->_profiles.Append(profile6);
+            settings->_allProfiles.Append(profile0);
+            settings->_allProfiles.Append(profile1);
+            settings->_allProfiles.Append(profile2);
+            settings->_allProfiles.Append(profile3);
+            settings->_allProfiles.Append(profile4);
+            settings->_allProfiles.Append(profile5);
+            settings->_allProfiles.Append(profile6);
 
             settings->_ValidateNoDuplicateProfiles();
 
             VERIFY_ARE_EQUAL(static_cast<size_t>(1), settings->_warnings.Size());
             VERIFY_ARE_EQUAL(SettingsLoadWarnings::DuplicateProfile, settings->_warnings.GetAt(0));
 
-            VERIFY_ARE_EQUAL(static_cast<size_t>(4), settings->_profiles.Size());
-            VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(0).Name());
-            VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(1).Name());
-            VERIFY_ARE_EQUAL(L"profile4", settings->_profiles.GetAt(2).Name());
-            VERIFY_ARE_EQUAL(L"profile6", settings->_profiles.GetAt(3).Name());
+            VERIFY_ARE_EQUAL(static_cast<size_t>(4), settings->_allProfiles.Size());
+            VERIFY_ARE_EQUAL(L"profile0", settings->_allProfiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile1", settings->_allProfiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(L"profile4", settings->_allProfiles.GetAt(2).Name());
+            VERIFY_ARE_EQUAL(L"profile6", settings->_allProfiles.GetAt(3).Name());
         }
     }
 
@@ -459,8 +459,8 @@ namespace SettingsModelLocalTests
         const auto settingsObject = VerifyParseSucceeded(badProfiles);
         auto settings = implementation::CascadiaSettings::FromJson(settingsObject);
 
-        settings->_profiles.Append(profile4);
-        settings->_profiles.Append(profile5);
+        settings->_allProfiles.Append(profile4);
+        settings->_allProfiles.Append(profile5);
 
         settings->_ValidateSettings();
 
@@ -469,11 +469,11 @@ namespace SettingsModelLocalTests
         VERIFY_ARE_EQUAL(SettingsLoadWarnings::MissingDefaultProfile, settings->_warnings.GetAt(1));
         VERIFY_ARE_EQUAL(SettingsLoadWarnings::UnknownColorScheme, settings->_warnings.GetAt(2));
 
-        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
-        VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_profiles.GetAt(0).Guid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
+        VERIFY_ARE_EQUAL(3u, settings->_allProfiles.Size());
+        VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), settings->_allProfiles.GetAt(0).Guid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(2).HasGuid());
     }
 
     void DeserializationTests::LayerGlobalProperties()
@@ -564,20 +564,20 @@ namespace SettingsModelLocalTests
             auto settings = winrt::make_self<implementation::CascadiaSettings>();
             settings->_ParseJsonString(defaultProfilesString, true);
             settings->LayerJson(settings->_defaultSettings);
-            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
-            VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(0).Name());
-            VERIFY_ARE_EQUAL(L"profile3", settings->_profiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
+            VERIFY_ARE_EQUAL(L"profile2", settings->_allProfiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile3", settings->_allProfiles.GetAt(1).Name());
 
             settings->_ParseJsonString(userProfiles0String, false);
             settings->LayerJson(settings->_userSettings);
-            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
-            VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(0).Name());
-            VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
+            VERIFY_ARE_EQUAL(L"profile1", settings->_allProfiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile0", settings->_allProfiles.GetAt(1).Name());
 
             settings->_ReorderProfilesToMatchUserSettingsOrder();
-            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
-            VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(0).Name());
-            VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
+            VERIFY_ARE_EQUAL(L"profile0", settings->_allProfiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile1", settings->_allProfiles.GetAt(1).Name());
         }
 
         {
@@ -587,22 +587,22 @@ namespace SettingsModelLocalTests
             auto settings = winrt::make_self<implementation::CascadiaSettings>();
             settings->_ParseJsonString(defaultProfilesString, true);
             settings->LayerJson(settings->_defaultSettings);
-            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
-            VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(0).Name());
-            VERIFY_ARE_EQUAL(L"profile3", settings->_profiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
+            VERIFY_ARE_EQUAL(L"profile2", settings->_allProfiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile3", settings->_allProfiles.GetAt(1).Name());
 
             settings->_ParseJsonString(userProfiles1String, false);
             settings->LayerJson(settings->_userSettings);
-            VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
-            VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(0).Name());
-            VERIFY_ARE_EQUAL(L"profile4", settings->_profiles.GetAt(1).Name());
-            VERIFY_ARE_EQUAL(L"profile5", settings->_profiles.GetAt(2).Name());
+            VERIFY_ARE_EQUAL(3u, settings->_allProfiles.Size());
+            VERIFY_ARE_EQUAL(L"profile2", settings->_allProfiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile4", settings->_allProfiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(L"profile5", settings->_allProfiles.GetAt(2).Name());
 
             settings->_ReorderProfilesToMatchUserSettingsOrder();
-            VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
-            VERIFY_ARE_EQUAL(L"profile4", settings->_profiles.GetAt(0).Name());
-            VERIFY_ARE_EQUAL(L"profile5", settings->_profiles.GetAt(1).Name());
-            VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(2).Name());
+            VERIFY_ARE_EQUAL(3u, settings->_allProfiles.Size());
+            VERIFY_ARE_EQUAL(L"profile4", settings->_allProfiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile5", settings->_allProfiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(L"profile2", settings->_allProfiles.GetAt(2).Name());
         }
     }
 
@@ -665,56 +665,58 @@ namespace SettingsModelLocalTests
             auto settings = winrt::make_self<implementation::CascadiaSettings>();
             settings->_ParseJsonString(defaultProfilesString, true);
             settings->LayerJson(settings->_defaultSettings);
-            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
-            VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(0).Name());
-            VERIFY_ARE_EQUAL(L"profile3", settings->_profiles.GetAt(1).Name());
-            VERIFY_ARE_EQUAL(false, settings->_profiles.GetAt(0).Hidden());
-            VERIFY_ARE_EQUAL(false, settings->_profiles.GetAt(1).Hidden());
+            VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
+            VERIFY_ARE_EQUAL(L"profile2", settings->_allProfiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile3", settings->_allProfiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(false, settings->_allProfiles.GetAt(0).Hidden());
+            VERIFY_ARE_EQUAL(false, settings->_allProfiles.GetAt(1).Hidden());
 
             settings->_ParseJsonString(userProfiles0String, false);
             settings->LayerJson(settings->_userSettings);
-            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
-            VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(0).Name());
-            VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(1).Name());
-            VERIFY_ARE_EQUAL(false, settings->_profiles.GetAt(0).Hidden());
-            VERIFY_ARE_EQUAL(true, settings->_profiles.GetAt(1).Hidden());
+            VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
+            VERIFY_ARE_EQUAL(L"profile1", settings->_allProfiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile0", settings->_allProfiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(false, settings->_allProfiles.GetAt(0).Hidden());
+            VERIFY_ARE_EQUAL(true, settings->_allProfiles.GetAt(1).Hidden());
 
             settings->_ReorderProfilesToMatchUserSettingsOrder();
             settings->_RemoveHiddenProfiles();
-            VERIFY_ARE_EQUAL(1u, settings->_profiles.Size());
-            VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(0).Name());
-            VERIFY_ARE_EQUAL(false, settings->_profiles.GetAt(0).Hidden());
+            VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
+            VERIFY_ARE_EQUAL(1u, settings->_activeProfiles.Size());
+            VERIFY_ARE_EQUAL(L"profile1", settings->_activeProfiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(false, settings->_activeProfiles.GetAt(0).Hidden());
         }
 
         {
             auto settings = winrt::make_self<implementation::CascadiaSettings>();
             settings->_ParseJsonString(defaultProfilesString, true);
             settings->LayerJson(settings->_defaultSettings);
-            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
-            VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(0).Name());
-            VERIFY_ARE_EQUAL(L"profile3", settings->_profiles.GetAt(1).Name());
-            VERIFY_ARE_EQUAL(false, settings->_profiles.GetAt(0).Hidden());
-            VERIFY_ARE_EQUAL(false, settings->_profiles.GetAt(1).Hidden());
+            VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
+            VERIFY_ARE_EQUAL(L"profile2", settings->_allProfiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile3", settings->_allProfiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(false, settings->_allProfiles.GetAt(0).Hidden());
+            VERIFY_ARE_EQUAL(false, settings->_allProfiles.GetAt(1).Hidden());
 
             settings->_ParseJsonString(userProfiles1String, false);
             settings->LayerJson(settings->_userSettings);
-            VERIFY_ARE_EQUAL(4u, settings->_profiles.Size());
-            VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(0).Name());
-            VERIFY_ARE_EQUAL(L"profile4", settings->_profiles.GetAt(1).Name());
-            VERIFY_ARE_EQUAL(L"profile5", settings->_profiles.GetAt(2).Name());
-            VERIFY_ARE_EQUAL(L"profile6", settings->_profiles.GetAt(3).Name());
-            VERIFY_ARE_EQUAL(false, settings->_profiles.GetAt(0).Hidden());
-            VERIFY_ARE_EQUAL(true, settings->_profiles.GetAt(1).Hidden());
-            VERIFY_ARE_EQUAL(false, settings->_profiles.GetAt(2).Hidden());
-            VERIFY_ARE_EQUAL(true, settings->_profiles.GetAt(3).Hidden());
+            VERIFY_ARE_EQUAL(4u, settings->_allProfiles.Size());
+            VERIFY_ARE_EQUAL(L"profile2", settings->_allProfiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile4", settings->_allProfiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(L"profile5", settings->_allProfiles.GetAt(2).Name());
+            VERIFY_ARE_EQUAL(L"profile6", settings->_allProfiles.GetAt(3).Name());
+            VERIFY_ARE_EQUAL(false, settings->_allProfiles.GetAt(0).Hidden());
+            VERIFY_ARE_EQUAL(true, settings->_allProfiles.GetAt(1).Hidden());
+            VERIFY_ARE_EQUAL(false, settings->_allProfiles.GetAt(2).Hidden());
+            VERIFY_ARE_EQUAL(true, settings->_allProfiles.GetAt(3).Hidden());
 
             settings->_ReorderProfilesToMatchUserSettingsOrder();
             settings->_RemoveHiddenProfiles();
-            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
-            VERIFY_ARE_EQUAL(L"profile5", settings->_profiles.GetAt(0).Name());
-            VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(1).Name());
-            VERIFY_ARE_EQUAL(false, settings->_profiles.GetAt(0).Hidden());
-            VERIFY_ARE_EQUAL(false, settings->_profiles.GetAt(1).Hidden());
+            VERIFY_ARE_EQUAL(4u, settings->_allProfiles.Size());
+            VERIFY_ARE_EQUAL(2u, settings->_activeProfiles.Size());
+            VERIFY_ARE_EQUAL(L"profile5", settings->_activeProfiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile2", settings->_activeProfiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(false, settings->_activeProfiles.GetAt(0).Hidden());
+            VERIFY_ARE_EQUAL(false, settings->_activeProfiles.GetAt(1).Hidden());
         }
     }
 
@@ -776,41 +778,40 @@ namespace SettingsModelLocalTests
         VERIFY_ARE_EQUAL(profile4->Guid(), cmdGuid);
 
         auto settings = winrt::make_self<implementation::CascadiaSettings>();
-        settings->_profiles.Append(*profile0);
-        settings->_profiles.Append(*profile1);
-        settings->_profiles.Append(*profile2);
-        settings->_profiles.Append(*profile3);
-        settings->_profiles.Append(*profile4);
-        settings->_profiles.Append(*profile5);
+        settings->_allProfiles.Append(*profile0);
+        settings->_allProfiles.Append(*profile1);
+        settings->_allProfiles.Append(*profile2);
+        settings->_allProfiles.Append(*profile3);
+        settings->_allProfiles.Append(*profile4);
+        settings->_allProfiles.Append(*profile5);
 
-        settings->_ValidateProfilesHaveGuid();
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(3).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(4).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(5).HasGuid());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(0).HasGuid());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(1).HasGuid());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(2).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(3).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(4).HasGuid());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(5).HasGuid());
 
-        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(0).Guid(), nullGuid);
-        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(1).Guid(), nullGuid);
-        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(2).Guid(), nullGuid);
-        VERIFY_ARE_EQUAL(settings->_profiles.GetAt(3).Guid(), nullGuid);
-        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(4).Guid(), nullGuid);
-        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(5).Guid(), nullGuid);
+        VERIFY_ARE_NOT_EQUAL(settings->_allProfiles.GetAt(0).Guid(), nullGuid);
+        VERIFY_ARE_NOT_EQUAL(settings->_allProfiles.GetAt(1).Guid(), nullGuid);
+        VERIFY_ARE_NOT_EQUAL(settings->_allProfiles.GetAt(2).Guid(), nullGuid);
+        VERIFY_ARE_EQUAL(settings->_allProfiles.GetAt(3).Guid(), nullGuid);
+        VERIFY_ARE_NOT_EQUAL(settings->_allProfiles.GetAt(4).Guid(), nullGuid);
+        VERIFY_ARE_NOT_EQUAL(settings->_allProfiles.GetAt(5).Guid(), nullGuid);
 
-        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(0).Guid(), cmdGuid);
-        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(1).Guid(), cmdGuid);
-        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(2).Guid(), cmdGuid);
-        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(3).Guid(), cmdGuid);
-        VERIFY_ARE_EQUAL(settings->_profiles.GetAt(4).Guid(), cmdGuid);
-        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(5).Guid(), cmdGuid);
+        VERIFY_ARE_NOT_EQUAL(settings->_allProfiles.GetAt(0).Guid(), cmdGuid);
+        VERIFY_ARE_NOT_EQUAL(settings->_allProfiles.GetAt(1).Guid(), cmdGuid);
+        VERIFY_ARE_NOT_EQUAL(settings->_allProfiles.GetAt(2).Guid(), cmdGuid);
+        VERIFY_ARE_NOT_EQUAL(settings->_allProfiles.GetAt(3).Guid(), cmdGuid);
+        VERIFY_ARE_EQUAL(settings->_allProfiles.GetAt(4).Guid(), cmdGuid);
+        VERIFY_ARE_NOT_EQUAL(settings->_allProfiles.GetAt(5).Guid(), cmdGuid);
 
-        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(0).Guid(), settings->_profiles.GetAt(2).Guid());
-        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(1).Guid(), settings->_profiles.GetAt(2).Guid());
-        VERIFY_ARE_EQUAL(settings->_profiles.GetAt(2).Guid(), settings->_profiles.GetAt(2).Guid());
-        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(3).Guid(), settings->_profiles.GetAt(2).Guid());
-        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(4).Guid(), settings->_profiles.GetAt(2).Guid());
-        VERIFY_ARE_EQUAL(settings->_profiles.GetAt(5).Guid(), settings->_profiles.GetAt(2).Guid());
+        VERIFY_ARE_NOT_EQUAL(settings->_allProfiles.GetAt(0).Guid(), settings->_allProfiles.GetAt(2).Guid());
+        VERIFY_ARE_NOT_EQUAL(settings->_allProfiles.GetAt(1).Guid(), settings->_allProfiles.GetAt(2).Guid());
+        VERIFY_ARE_EQUAL(settings->_allProfiles.GetAt(2).Guid(), settings->_allProfiles.GetAt(2).Guid());
+        VERIFY_ARE_NOT_EQUAL(settings->_allProfiles.GetAt(3).Guid(), settings->_allProfiles.GetAt(2).Guid());
+        VERIFY_ARE_NOT_EQUAL(settings->_allProfiles.GetAt(4).Guid(), settings->_allProfiles.GetAt(2).Guid());
+        VERIFY_ARE_EQUAL(settings->_allProfiles.GetAt(5).Guid(), settings->_allProfiles.GetAt(2).Guid());
     }
 
     void DeserializationTests::GeneratedGuidRoundtrips()
@@ -835,18 +836,17 @@ namespace SettingsModelLocalTests
         VERIFY_IS_TRUE(profile1->HasGuid());
 
         auto settings = winrt::make_self<implementation::CascadiaSettings>();
-        settings->_profiles.Append(*profile1);
-        settings->_ValidateProfilesHaveGuid();
+        settings->_allProfiles.Append(*profile1);
 
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(0).HasGuid());
 
-        const auto profileImpl = winrt::get_self<implementation::Profile>(settings->_profiles.GetAt(0));
+        const auto profileImpl = winrt::get_self<implementation::Profile>(settings->_allProfiles.GetAt(0));
         const auto serialized1Profile = profileImpl->GenerateStub();
 
         const auto profile2 = implementation::Profile::FromJson(serialized1Profile);
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(0).HasGuid());
         VERIFY_IS_TRUE(profile2->HasGuid());
-        VERIFY_ARE_EQUAL(settings->_profiles.GetAt(0).Guid(), profile2->Guid());
+        VERIFY_ARE_EQUAL(settings->_allProfiles.GetAt(0).Guid(), profile2->Guid());
     }
 
     void DeserializationTests::TestAllValidationsWithNullGuids()
@@ -874,15 +874,15 @@ namespace SettingsModelLocalTests
         settings->_ParseJsonString(settings0String, false);
         settings->LayerJson(settings->_userSettings);
 
-        VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(0).HasGuid());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(1).HasGuid());
 
         settings->_ValidateSettings();
         VERIFY_ARE_EQUAL(0u, settings->_warnings.Size());
-        VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(1).HasGuid());
     }
 
     void DeserializationTests::TestReorderWithNullGuids()
@@ -910,36 +910,36 @@ namespace SettingsModelLocalTests
         auto settings = winrt::make_self<implementation::CascadiaSettings>();
         settings->_ParseJsonString(DefaultJson, true);
         settings->LayerJson(settings->_defaultSettings);
-        VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(0).Name());
-        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_profiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(1).HasGuid());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_allProfiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_allProfiles.GetAt(1).Name());
 
         settings->_ParseJsonString(settings0String, false);
         settings->LayerJson(settings->_userSettings);
 
-        VERIFY_ARE_EQUAL(4u, settings->_profiles.Size());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(3).HasGuid());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(0).Name());
-        VERIFY_ARE_EQUAL(L"cmdFromUserSettings", settings->_profiles.GetAt(1).Name());
-        VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(2).Name());
-        VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(3).Name());
+        VERIFY_ARE_EQUAL(4u, settings->_allProfiles.Size());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(2).HasGuid());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(3).HasGuid());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_allProfiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"cmdFromUserSettings", settings->_allProfiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"profile0", settings->_allProfiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"profile1", settings->_allProfiles.GetAt(3).Name());
 
         settings->_ValidateSettings();
         VERIFY_ARE_EQUAL(0u, settings->_warnings.Size());
-        VERIFY_ARE_EQUAL(4u, settings->_profiles.Size());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(3).HasGuid());
-        VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(0).Name());
-        VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(1).Name());
-        VERIFY_ARE_EQUAL(L"cmdFromUserSettings", settings->_profiles.GetAt(2).Name());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(3).Name());
+        VERIFY_ARE_EQUAL(4u, settings->_allProfiles.Size());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(2).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(3).HasGuid());
+        VERIFY_ARE_EQUAL(L"profile0", settings->_allProfiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"profile1", settings->_allProfiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"cmdFromUserSettings", settings->_allProfiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_allProfiles.GetAt(3).Name());
     }
 
     void DeserializationTests::TestReorderingWithoutGuid()
@@ -1011,36 +1011,36 @@ namespace SettingsModelLocalTests
         auto settings = winrt::make_self<implementation::CascadiaSettings>();
         settings->_ParseJsonString(DefaultJson, true);
         settings->LayerJson(settings->_defaultSettings);
-        VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(0).Name());
-        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_profiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(1).HasGuid());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_allProfiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_allProfiles.GetAt(1).Name());
 
         settings->_ParseJsonString(settings0String, false);
         settings->LayerJson(settings->_userSettings);
 
-        VERIFY_ARE_EQUAL(4u, settings->_profiles.Size());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(2).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(3).HasGuid());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(0).Name());
-        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_profiles.GetAt(1).Name());
-        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotCrash", settings->_profiles.GetAt(2).Name());
-        VERIFY_ARE_EQUAL(L"Ubuntu", settings->_profiles.GetAt(3).Name());
+        VERIFY_ARE_EQUAL(4u, settings->_allProfiles.Size());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(1).HasGuid());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(2).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(3).HasGuid());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_allProfiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_allProfiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotCrash", settings->_allProfiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"Ubuntu", settings->_allProfiles.GetAt(3).Name());
 
         settings->_ValidateSettings();
         VERIFY_ARE_EQUAL(0u, settings->_warnings.Size());
-        VERIFY_ARE_EQUAL(4u, settings->_profiles.Size());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(3).HasGuid());
-        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_profiles.GetAt(0).Name());
-        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotCrash", settings->_profiles.GetAt(1).Name());
-        VERIFY_ARE_EQUAL(L"Ubuntu", settings->_profiles.GetAt(2).Name());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(3).Name());
+        VERIFY_ARE_EQUAL(4u, settings->_allProfiles.Size());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(2).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(3).HasGuid());
+        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_allProfiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotCrash", settings->_allProfiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"Ubuntu", settings->_allProfiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_allProfiles.GetAt(3).Name());
     }
 
     void DeserializationTests::TestLayeringNameOnlyProfiles()
@@ -1072,28 +1072,28 @@ namespace SettingsModelLocalTests
         auto settings = winrt::make_self<implementation::CascadiaSettings>();
         settings->_ParseJsonString(DefaultJson, true);
         settings->LayerJson(settings->_defaultSettings);
-        VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(0).Name());
-        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_profiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(1).HasGuid());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_allProfiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_allProfiles.GetAt(1).Name());
 
         Log::Comment(NoThrowString().Format(
             L"Parse the user settings"));
         settings->_ParseJsonString(settings0String, false);
         settings->LayerJson(settings->_userSettings);
 
-        VERIFY_ARE_EQUAL(5u, settings->_profiles.Size());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(3).HasGuid());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(4).HasGuid());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(0).Name());
-        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_profiles.GetAt(1).Name());
-        VERIFY_ARE_EQUAL(L"ThisProfileIsGood", settings->_profiles.GetAt(2).Name());
-        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotLayer", settings->_profiles.GetAt(3).Name());
-        VERIFY_ARE_EQUAL(L"NeitherShouldThisOne", settings->_profiles.GetAt(4).Name());
+        VERIFY_ARE_EQUAL(5u, settings->_allProfiles.Size());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(2).HasGuid());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(3).HasGuid());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(4).HasGuid());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_allProfiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_allProfiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"ThisProfileIsGood", settings->_allProfiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotLayer", settings->_allProfiles.GetAt(3).Name());
+        VERIFY_ARE_EQUAL(L"NeitherShouldThisOne", settings->_allProfiles.GetAt(4).Name());
     }
 
     void DeserializationTests::TestExplodingNameOnlyProfiles()
@@ -1125,28 +1125,28 @@ namespace SettingsModelLocalTests
         auto settings = winrt::make_self<implementation::CascadiaSettings>();
         settings->_ParseJsonString(DefaultJson, true);
         settings->LayerJson(settings->_defaultSettings);
-        VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(0).Name());
-        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_profiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(1).HasGuid());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_allProfiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_allProfiles.GetAt(1).Name());
 
         Log::Comment(NoThrowString().Format(
             L"Parse the user settings"));
         settings->_ParseJsonString(settings0String, false);
         settings->LayerJson(settings->_userSettings);
 
-        VERIFY_ARE_EQUAL(5u, settings->_profiles.Size());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(3).HasGuid());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(4).HasGuid());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(0).Name());
-        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_profiles.GetAt(1).Name());
-        VERIFY_ARE_EQUAL(L"ThisProfileIsGood", settings->_profiles.GetAt(2).Name());
-        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotDuplicate", settings->_profiles.GetAt(3).Name());
-        VERIFY_ARE_EQUAL(L"NeitherShouldThisOne", settings->_profiles.GetAt(4).Name());
+        VERIFY_ARE_EQUAL(5u, settings->_allProfiles.Size());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(2).HasGuid());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(3).HasGuid());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(4).HasGuid());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_allProfiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_allProfiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"ThisProfileIsGood", settings->_allProfiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotDuplicate", settings->_allProfiles.GetAt(3).Name());
+        VERIFY_ARE_EQUAL(L"NeitherShouldThisOne", settings->_allProfiles.GetAt(4).Name());
 
         Log::Comment(NoThrowString().Format(
             L"Pretend like we're checking to append dynamic profiles to the "
@@ -1163,40 +1163,40 @@ namespace SettingsModelLocalTests
             auto settings2 = winrt::make_self<implementation::CascadiaSettings>();
             settings2->_ParseJsonString(DefaultJson, true);
             settings2->LayerJson(settings2->_defaultSettings);
-            VERIFY_ARE_EQUAL(2u, settings2->_profiles.Size());
+            VERIFY_ARE_EQUAL(2u, settings2->_allProfiles.Size());
             // Initialize the second settings object from the first settings
             // object's settings string, the one that we synthesized.
             const auto firstSettingsString = settings->_userSettingsString;
             settings2->_ParseJsonString(firstSettingsString, false);
             settings2->LayerJson(settings2->_userSettings);
-            VERIFY_ARE_EQUAL(5u, settings2->_profiles.Size());
-            VERIFY_IS_TRUE(settings2->_profiles.GetAt(0).HasGuid());
-            VERIFY_IS_TRUE(settings2->_profiles.GetAt(1).HasGuid());
-            VERIFY_IS_TRUE(settings2->_profiles.GetAt(2).HasGuid());
-            VERIFY_IS_FALSE(settings2->_profiles.GetAt(3).HasGuid());
-            VERIFY_IS_FALSE(settings2->_profiles.GetAt(4).HasGuid());
-            VERIFY_ARE_EQUAL(L"Windows PowerShell", settings2->_profiles.GetAt(0).Name());
-            VERIFY_ARE_EQUAL(L"Command Prompt", settings2->_profiles.GetAt(1).Name());
-            VERIFY_ARE_EQUAL(L"ThisProfileIsGood", settings2->_profiles.GetAt(2).Name());
-            VERIFY_ARE_EQUAL(L"ThisProfileShouldNotDuplicate", settings2->_profiles.GetAt(3).Name());
-            VERIFY_ARE_EQUAL(L"NeitherShouldThisOne", settings2->_profiles.GetAt(4).Name());
+            VERIFY_ARE_EQUAL(5u, settings2->_allProfiles.Size());
+            VERIFY_IS_TRUE(settings2->_allProfiles.GetAt(0).HasGuid());
+            VERIFY_IS_TRUE(settings2->_allProfiles.GetAt(1).HasGuid());
+            VERIFY_IS_TRUE(settings2->_allProfiles.GetAt(2).HasGuid());
+            VERIFY_IS_FALSE(settings2->_allProfiles.GetAt(3).HasGuid());
+            VERIFY_IS_FALSE(settings2->_allProfiles.GetAt(4).HasGuid());
+            VERIFY_ARE_EQUAL(L"Windows PowerShell", settings2->_allProfiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"Command Prompt", settings2->_allProfiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(L"ThisProfileIsGood", settings2->_allProfiles.GetAt(2).Name());
+            VERIFY_ARE_EQUAL(L"ThisProfileShouldNotDuplicate", settings2->_allProfiles.GetAt(3).Name());
+            VERIFY_ARE_EQUAL(L"NeitherShouldThisOne", settings2->_allProfiles.GetAt(4).Name());
         }
 
         Log::Comment(NoThrowString().Format(
             L"Validate the settings. All the profiles we have should be valid."));
         settings->_ValidateSettings();
 
-        VERIFY_ARE_EQUAL(5u, settings->_profiles.Size());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(3).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(4).HasGuid());
-        VERIFY_ARE_EQUAL(L"ThisProfileIsGood", settings->_profiles.GetAt(0).Name());
-        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotDuplicate", settings->_profiles.GetAt(1).Name());
-        VERIFY_ARE_EQUAL(L"NeitherShouldThisOne", settings->_profiles.GetAt(2).Name());
-        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_profiles.GetAt(3).Name());
-        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_profiles.GetAt(4).Name());
+        VERIFY_ARE_EQUAL(5u, settings->_allProfiles.Size());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(2).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(3).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(4).HasGuid());
+        VERIFY_ARE_EQUAL(L"ThisProfileIsGood", settings->_allProfiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"ThisProfileShouldNotDuplicate", settings->_allProfiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"NeitherShouldThisOne", settings->_allProfiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"Windows PowerShell", settings->_allProfiles.GetAt(3).Name());
+        VERIFY_ARE_EQUAL(L"Command Prompt", settings->_allProfiles.GetAt(4).Name());
     }
 
     void DeserializationTests::TestHideAllProfiles()
@@ -1241,7 +1241,8 @@ namespace SettingsModelLocalTests
             settings->_RemoveHiddenProfiles();
             Log::Comment(NoThrowString().Format(
                 L"settingsWithProfiles successfully parsed and validated"));
-            VERIFY_ARE_EQUAL(1u, settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
+            VERIFY_ARE_EQUAL(1u, settings->_activeProfiles.Size());
         }
         {
             // Case 2: Bad settings
@@ -1302,24 +1303,24 @@ namespace SettingsModelLocalTests
         settings->_ParseJsonString(settings0String, false);
         settings->LayerJson(settings->_userSettings);
 
-        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(3u, settings->_allProfiles.Size());
         VERIFY_ARE_EQUAL(2u, settings->_globals->ColorSchemes().Size());
 
-        VERIFY_ARE_EQUAL(L"schemeOne", settings->_profiles.GetAt(0).ColorSchemeName());
-        VERIFY_ARE_EQUAL(L"InvalidSchemeName", settings->_profiles.GetAt(1).ColorSchemeName());
-        VERIFY_ARE_EQUAL(L"Campbell", settings->_profiles.GetAt(2).ColorSchemeName());
+        VERIFY_ARE_EQUAL(L"schemeOne", settings->_allProfiles.GetAt(0).ColorSchemeName());
+        VERIFY_ARE_EQUAL(L"InvalidSchemeName", settings->_allProfiles.GetAt(1).ColorSchemeName());
+        VERIFY_ARE_EQUAL(L"Campbell", settings->_allProfiles.GetAt(2).ColorSchemeName());
 
         settings->_ValidateAllSchemesExist();
 
         VERIFY_ARE_EQUAL(1u, settings->_warnings.Size());
         VERIFY_ARE_EQUAL(SettingsLoadWarnings::UnknownColorScheme, settings->_warnings.GetAt(0));
 
-        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(3u, settings->_allProfiles.Size());
         VERIFY_ARE_EQUAL(2u, settings->_globals->ColorSchemes().Size());
 
-        VERIFY_ARE_EQUAL(L"schemeOne", settings->_profiles.GetAt(0).ColorSchemeName());
-        VERIFY_ARE_EQUAL(L"Campbell", settings->_profiles.GetAt(1).ColorSchemeName());
-        VERIFY_ARE_EQUAL(L"Campbell", settings->_profiles.GetAt(2).ColorSchemeName());
+        VERIFY_ARE_EQUAL(L"schemeOne", settings->_allProfiles.GetAt(0).ColorSchemeName());
+        VERIFY_ARE_EQUAL(L"Campbell", settings->_allProfiles.GetAt(1).ColorSchemeName());
+        VERIFY_ARE_EQUAL(L"Campbell", settings->_allProfiles.GetAt(2).ColorSchemeName());
     }
 
     void DeserializationTests::TestHelperFunctions()
@@ -1402,8 +1403,8 @@ namespace SettingsModelLocalTests
         auto settings = winrt::make_self<implementation::CascadiaSettings>();
         settings->_ParseJsonString(settingsJson, false);
         settings->LayerJson(settings->_userSettings);
-        VERIFY_ARE_NOT_EQUAL(0u, settings->_profiles.Size());
-        VERIFY_ARE_EQUAL(expectedPath, settings->_profiles.GetAt(0).ExpandedBackgroundImagePath());
+        VERIFY_ARE_NOT_EQUAL(0u, settings->_allProfiles.Size());
+        VERIFY_ARE_EQUAL(expectedPath, settings->_allProfiles.GetAt(0).ExpandedBackgroundImagePath());
     }
     void DeserializationTests::TestProfileBackgroundImageWithDesktopWallpaper()
     {
@@ -1424,8 +1425,8 @@ namespace SettingsModelLocalTests
         auto settings = winrt::make_self<implementation::CascadiaSettings>();
         settings->_ParseJsonString(settingsJson, false);
         settings->LayerJson(settings->_userSettings);
-        VERIFY_ARE_EQUAL(expectedBackgroundImagePath, settings->_profiles.GetAt(0).BackgroundImagePath());
-        VERIFY_ARE_NOT_EQUAL(expectedBackgroundImagePath, settings->_profiles.GetAt(0).ExpandedBackgroundImagePath());
+        VERIFY_ARE_EQUAL(expectedBackgroundImagePath, settings->_allProfiles.GetAt(0).BackgroundImagePath());
+        VERIFY_ARE_NOT_EQUAL(expectedBackgroundImagePath, settings->_allProfiles.GetAt(0).ExpandedBackgroundImagePath());
     }
     void DeserializationTests::TestCloseOnExitParsing()
     {
@@ -1456,12 +1457,12 @@ namespace SettingsModelLocalTests
         auto settings = winrt::make_self<implementation::CascadiaSettings>();
         settings->_ParseJsonString(settingsJson, false);
         settings->LayerJson(settings->_userSettings);
-        VERIFY_ARE_EQUAL(CloseOnExitMode::Graceful, settings->_profiles.GetAt(0).CloseOnExit());
-        VERIFY_ARE_EQUAL(CloseOnExitMode::Always, settings->_profiles.GetAt(1).CloseOnExit());
-        VERIFY_ARE_EQUAL(CloseOnExitMode::Never, settings->_profiles.GetAt(2).CloseOnExit());
+        VERIFY_ARE_EQUAL(CloseOnExitMode::Graceful, settings->_allProfiles.GetAt(0).CloseOnExit());
+        VERIFY_ARE_EQUAL(CloseOnExitMode::Always, settings->_allProfiles.GetAt(1).CloseOnExit());
+        VERIFY_ARE_EQUAL(CloseOnExitMode::Never, settings->_allProfiles.GetAt(2).CloseOnExit());
 
         // Unknown modes parse as "Graceful"
-        VERIFY_ARE_EQUAL(CloseOnExitMode::Graceful, settings->_profiles.GetAt(3).CloseOnExit());
+        VERIFY_ARE_EQUAL(CloseOnExitMode::Graceful, settings->_allProfiles.GetAt(3).CloseOnExit());
     }
     void DeserializationTests::TestCloseOnExitCompatibilityShim()
     {
@@ -1484,8 +1485,8 @@ namespace SettingsModelLocalTests
         auto settings = winrt::make_self<implementation::CascadiaSettings>();
         settings->_ParseJsonString(settingsJson, false);
         settings->LayerJson(settings->_userSettings);
-        VERIFY_ARE_EQUAL(CloseOnExitMode::Graceful, settings->_profiles.GetAt(0).CloseOnExit());
-        VERIFY_ARE_EQUAL(CloseOnExitMode::Never, settings->_profiles.GetAt(1).CloseOnExit());
+        VERIFY_ARE_EQUAL(CloseOnExitMode::Graceful, settings->_allProfiles.GetAt(0).CloseOnExit());
+        VERIFY_ARE_EQUAL(CloseOnExitMode::Never, settings->_allProfiles.GetAt(1).CloseOnExit());
     }
 
     void DeserializationTests::TestLayerUserDefaultsBeforeProfiles()
@@ -1529,10 +1530,10 @@ namespace SettingsModelLocalTests
             settings->LayerJson(settings->_userSettings);
 
             VERIFY_ARE_EQUAL(guid1String, settings->_globals->UnparsedDefaultProfile());
-            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
 
-            VERIFY_ARE_EQUAL(2345, settings->_profiles.GetAt(0).HistorySize());
-            VERIFY_ARE_EQUAL(1234, settings->_profiles.GetAt(1).HistorySize());
+            VERIFY_ARE_EQUAL(2345, settings->_allProfiles.GetAt(0).HistorySize());
+            VERIFY_ARE_EQUAL(1234, settings->_allProfiles.GetAt(1).HistorySize());
         }
     }
 
@@ -1572,7 +1573,7 @@ namespace SettingsModelLocalTests
             auto settings = winrt::make_self<implementation::CascadiaSettings>(false);
             settings->_ParseJsonString(DefaultJson, true);
             settings->LayerJson(settings->_defaultSettings);
-            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
 
             settings->_ParseJsonString(settings0String, false);
             VERIFY_IS_NULL(settings->_userDefaultProfileSettings);
@@ -1581,16 +1582,16 @@ namespace SettingsModelLocalTests
 
             Log::Comment(NoThrowString().Format(
                 L"Ensure that cmd and powershell don't get their GUIDs overwritten"));
-            VERIFY_ARE_NOT_EQUAL(guid2, settings->_profiles.GetAt(0).Guid());
-            VERIFY_ARE_NOT_EQUAL(guid2, settings->_profiles.GetAt(1).Guid());
+            VERIFY_ARE_NOT_EQUAL(guid2, settings->_allProfiles.GetAt(0).Guid());
+            VERIFY_ARE_NOT_EQUAL(guid2, settings->_allProfiles.GetAt(1).Guid());
 
             settings->LayerJson(settings->_userSettings);
 
             VERIFY_ARE_EQUAL(guid1String, settings->_globals->UnparsedDefaultProfile());
-            VERIFY_ARE_EQUAL(4u, settings->_profiles.Size());
+            VERIFY_ARE_EQUAL(4u, settings->_allProfiles.Size());
 
-            VERIFY_ARE_EQUAL(guid1, settings->_profiles.GetAt(2).Guid());
-            VERIFY_IS_FALSE(settings->_profiles.GetAt(3).HasGuid());
+            VERIFY_ARE_EQUAL(guid1, settings->_allProfiles.GetAt(2).Guid());
+            VERIFY_IS_FALSE(settings->_allProfiles.GetAt(3).HasGuid());
         }
     }
 
@@ -1616,18 +1617,18 @@ namespace SettingsModelLocalTests
                 },
                 "list": [
                     {
-                        "name" : "profile0FromUserSettings", // this is _profiles.GetAt(0)
+                        "name" : "profile0FromUserSettings", // this is _allProfiles.GetAt(0)
                         "guid": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
                         "source": "Terminal.App.UnitTest.0"
                     },
                     {
-                        "name" : "profile1FromUserSettings", // this is _profiles.GetAt(2)
+                        "name" : "profile1FromUserSettings", // this is _allProfiles.GetAt(2)
                         "guid": "{6239a42c-2222-49a3-80bd-e8fdd045185c}",
                         "source": "Terminal.App.UnitTest.1",
                         "historySize": 4444
                     },
                     {
-                        "name" : "profile2FromUserSettings", // this is _profiles.GetAt(3)
+                        "name" : "profile2FromUserSettings", // this is _allProfiles.GetAt(3)
                         "guid": "{6239a42c-3333-49a3-80bd-e8fdd045185c}",
                         "historySize": 5555
                     }
@@ -1639,7 +1640,7 @@ namespace SettingsModelLocalTests
         gen0->pfnGenerate = [guid1, guid2]() {
             std::vector<Profile> profiles;
             Profile p0 = winrt::make<implementation::Profile>(guid1);
-            p0.Name(L"profile0"); // this is _profiles.GetAt(0)
+            p0.Name(L"profile0"); // this is _allProfiles.GetAt(0)
             p0.HistorySize(1111);
             profiles.push_back(p0);
             return profiles;
@@ -1649,8 +1650,8 @@ namespace SettingsModelLocalTests
             std::vector<Profile> profiles;
             Profile p0 = winrt::make<implementation::Profile>(guid1);
             Profile p1 = winrt::make<implementation::Profile>(guid2);
-            p0.Name(L"profile0"); // this is _profiles.GetAt(1)
-            p1.Name(L"profile1"); // this is _profiles.GetAt(2)
+            p0.Name(L"profile0"); // this is _allProfiles.GetAt(1)
+            p1.Name(L"profile1"); // this is _allProfiles.GetAt(2)
             p0.HistorySize(2222);
             profiles.push_back(p0);
             p1.HistorySize(3333);
@@ -1668,40 +1669,40 @@ namespace SettingsModelLocalTests
 
         // parse userProfiles as the user settings
         settings->_ParseJsonString(userProfiles, false);
-        VERIFY_ARE_EQUAL(0u, settings->_profiles.Size(), L"Just parsing the user settings doesn't actually layer them");
+        VERIFY_ARE_EQUAL(0u, settings->_allProfiles.Size(), L"Just parsing the user settings doesn't actually layer them");
         settings->_LoadDynamicProfiles();
-        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(3u, settings->_allProfiles.Size());
 
-        VERIFY_ARE_EQUAL(1111, settings->_profiles.GetAt(0).HistorySize());
-        VERIFY_ARE_EQUAL(2222, settings->_profiles.GetAt(1).HistorySize());
-        VERIFY_ARE_EQUAL(3333, settings->_profiles.GetAt(2).HistorySize());
+        VERIFY_ARE_EQUAL(1111, settings->_allProfiles.GetAt(0).HistorySize());
+        VERIFY_ARE_EQUAL(2222, settings->_allProfiles.GetAt(1).HistorySize());
+        VERIFY_ARE_EQUAL(3333, settings->_allProfiles.GetAt(2).HistorySize());
 
         settings->_ApplyDefaultsFromUserSettings();
 
-        VERIFY_ARE_EQUAL(1234, settings->_profiles.GetAt(0).HistorySize());
-        VERIFY_ARE_EQUAL(1234, settings->_profiles.GetAt(1).HistorySize());
-        VERIFY_ARE_EQUAL(1234, settings->_profiles.GetAt(2).HistorySize());
+        VERIFY_ARE_EQUAL(1234, settings->_allProfiles.GetAt(0).HistorySize());
+        VERIFY_ARE_EQUAL(1234, settings->_allProfiles.GetAt(1).HistorySize());
+        VERIFY_ARE_EQUAL(1234, settings->_allProfiles.GetAt(2).HistorySize());
 
         settings->LayerJson(settings->_userSettings);
-        VERIFY_ARE_EQUAL(4u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(4u, settings->_allProfiles.Size());
 
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(0).Source().empty());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(1).Source().empty());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(2).Source().empty());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(3).Source().empty());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(0).Source().empty());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(1).Source().empty());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(2).Source().empty());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(3).Source().empty());
 
-        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.0", settings->_profiles.GetAt(0).Source());
-        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_profiles.GetAt(1).Source());
-        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_profiles.GetAt(2).Source());
+        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.0", settings->_allProfiles.GetAt(0).Source());
+        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_allProfiles.GetAt(1).Source());
+        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_allProfiles.GetAt(2).Source());
 
-        VERIFY_ARE_EQUAL(guid1, settings->_profiles.GetAt(0).Guid());
-        VERIFY_ARE_EQUAL(guid1, settings->_profiles.GetAt(1).Guid());
-        VERIFY_ARE_EQUAL(guid2, settings->_profiles.GetAt(2).Guid());
+        VERIFY_ARE_EQUAL(guid1, settings->_allProfiles.GetAt(0).Guid());
+        VERIFY_ARE_EQUAL(guid1, settings->_allProfiles.GetAt(1).Guid());
+        VERIFY_ARE_EQUAL(guid2, settings->_allProfiles.GetAt(2).Guid());
 
-        VERIFY_ARE_EQUAL(L"profile0FromUserSettings", settings->_profiles.GetAt(0).Name());
-        VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(1).Name());
-        VERIFY_ARE_EQUAL(L"profile1FromUserSettings", settings->_profiles.GetAt(2).Name());
-        VERIFY_ARE_EQUAL(L"profile2FromUserSettings", settings->_profiles.GetAt(3).Name());
+        VERIFY_ARE_EQUAL(L"profile0FromUserSettings", settings->_allProfiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"profile0", settings->_allProfiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"profile1FromUserSettings", settings->_allProfiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"profile2FromUserSettings", settings->_allProfiles.GetAt(3).Name());
 
         Log::Comment(NoThrowString().Format(
             L"This is the real meat of the test: The two dynamic profiles that "
@@ -1709,10 +1710,10 @@ namespace SettingsModelLocalTests
             L"1234 as their historySize(from the defaultSettings).The other two"
             L" profiles should have their custom historySize value."));
 
-        VERIFY_ARE_EQUAL(1234, settings->_profiles.GetAt(0).HistorySize());
-        VERIFY_ARE_EQUAL(1234, settings->_profiles.GetAt(1).HistorySize());
-        VERIFY_ARE_EQUAL(4444, settings->_profiles.GetAt(2).HistorySize());
-        VERIFY_ARE_EQUAL(5555, settings->_profiles.GetAt(3).HistorySize());
+        VERIFY_ARE_EQUAL(1234, settings->_allProfiles.GetAt(0).HistorySize());
+        VERIFY_ARE_EQUAL(1234, settings->_allProfiles.GetAt(1).HistorySize());
+        VERIFY_ARE_EQUAL(4444, settings->_allProfiles.GetAt(2).HistorySize());
+        VERIFY_ARE_EQUAL(5555, settings->_allProfiles.GetAt(3).HistorySize());
     }
 
     void DeserializationTests::FindMissingProfile()
@@ -1955,9 +1956,9 @@ namespace SettingsModelLocalTests
         settings->LayerJson(settings->_userSettings);
         settings->_ValidateSettings();
 
-        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(3u, settings->_allProfiles.Size());
 
-        const auto profile2Guid = settings->_profiles.GetAt(2).Guid();
+        const auto profile2Guid = settings->_allProfiles.GetAt(2).Guid();
         VERIFY_ARE_NOT_EQUAL(winrt::guid{}, profile2Guid);
 
         auto keymap = winrt::get_self<implementation::KeyMapping>(settings->_globals->KeyMap());
@@ -2163,7 +2164,7 @@ namespace SettingsModelLocalTests
         settings->LayerJson(settings->_userSettings);
 
         VERIFY_ARE_EQUAL(0u, settings->_warnings.Size());
-        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(3u, settings->_allProfiles.Size());
 
         auto commands = settings->_globals->Commands();
         settings->_ValidateSettings();
@@ -2240,7 +2241,7 @@ namespace SettingsModelLocalTests
         settings->LayerJson(settings->_userSettings);
 
         VERIFY_ARE_EQUAL(0u, settings->_warnings.Size());
-        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(3u, settings->_allProfiles.Size());
 
         auto commands = settings->_globals->Commands();
         settings->_ValidateSettings();
@@ -2324,7 +2325,7 @@ namespace SettingsModelLocalTests
         settings->LayerJson(settings->_userSettings);
 
         VERIFY_ARE_EQUAL(0u, settings->_warnings.Size());
-        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(3u, settings->_allProfiles.Size());
 
         auto commands = settings->_globals->Commands();
         settings->_ValidateSettings();
@@ -2415,7 +2416,7 @@ namespace SettingsModelLocalTests
             [
                 { "command": "openSettings", "keys": "ctrl+," },
                 { "command": { "action": "openSettings", "target": "defaultsFile" }, "keys": "ctrl+alt+," },
-        
+
                 {
                     "name": { "key": "SetColorSchemeParentCommandName" },
                     "commands": [
@@ -2443,8 +2444,8 @@ namespace SettingsModelLocalTests
         VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), copyImpl->_globals->DefaultProfile());
 
         // test profiles
-        VERIFY_ARE_EQUAL(settings->_profiles.Size(), copyImpl->_profiles.Size());
-        VERIFY_ARE_EQUAL(settings->_profiles.GetAt(0).Name(), copyImpl->_profiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(settings->_allProfiles.Size(), copyImpl->_allProfiles.Size());
+        VERIFY_ARE_EQUAL(settings->_allProfiles.GetAt(0).Name(), copyImpl->_allProfiles.GetAt(0).Name());
 
         // test schemes
         const auto schemeName{ L"Campbell, but for a test" };
@@ -2502,10 +2503,10 @@ namespace SettingsModelLocalTests
         VERIFY_ARE_EQUAL(settings->_globals->DefaultProfile(), copyImpl->_globals->DefaultProfile());
 
         // test profiles
-        VERIFY_ARE_EQUAL(settings->_profiles.Size(), copyImpl->_profiles.Size());
-        VERIFY_ARE_EQUAL(settings->_profiles.GetAt(0).Name(), copyImpl->_profiles.GetAt(0).Name());
-        VERIFY_ARE_EQUAL(settings->_profiles.GetAt(1).Name(), copyImpl->_profiles.GetAt(1).Name());
-        VERIFY_ARE_EQUAL(settings->_profiles.GetAt(2).Name(), copyImpl->_profiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(settings->_allProfiles.Size(), copyImpl->_allProfiles.Size());
+        VERIFY_ARE_EQUAL(settings->_allProfiles.GetAt(0).Name(), copyImpl->_allProfiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(settings->_allProfiles.GetAt(1).Name(), copyImpl->_allProfiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(settings->_allProfiles.GetAt(2).Name(), copyImpl->_allProfiles.GetAt(2).Name());
         VERIFY_ARE_EQUAL(settings->_userDefaultProfileSettings->Name(), copyImpl->_userDefaultProfileSettings->Name());
 
         // Modifying profile.defaults should...
@@ -2513,12 +2514,12 @@ namespace SettingsModelLocalTests
         copyImpl->_userDefaultProfileSettings->Name(L"changed value");
 
         // ...keep the same name for the first two profiles
-        VERIFY_ARE_EQUAL(settings->_profiles.Size(), copyImpl->_profiles.Size());
-        VERIFY_ARE_EQUAL(settings->_profiles.GetAt(0).Name(), copyImpl->_profiles.GetAt(0).Name());
-        VERIFY_ARE_EQUAL(settings->_profiles.GetAt(1).Name(), copyImpl->_profiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(settings->_allProfiles.Size(), copyImpl->_allProfiles.Size());
+        VERIFY_ARE_EQUAL(settings->_allProfiles.GetAt(0).Name(), copyImpl->_allProfiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(settings->_allProfiles.GetAt(1).Name(), copyImpl->_allProfiles.GetAt(1).Name());
 
         // ...but change the name for the one that inherited it from profile.defaults
-        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(2).Name(), copyImpl->_profiles.GetAt(2).Name());
+        VERIFY_ARE_NOT_EQUAL(settings->_allProfiles.GetAt(2).Name(), copyImpl->_allProfiles.GetAt(2).Name());
 
         // profile.defaults should be different between the two graphs
         VERIFY_ARE_EQUAL(settings->_userDefaultProfileSettings->HasName(), copyImpl->_userDefaultProfileSettings->HasName());
@@ -2569,12 +2570,12 @@ namespace SettingsModelLocalTests
             VERIFY_IS_NULL(settings->_userDefaultProfileSettings);
             VERIFY_ARE_EQUAL(settings->_userDefaultProfileSettings, copyImpl->_userDefaultProfileSettings);
 
-            VERIFY_ARE_EQUAL(settings->Profiles().Size(), 1u);
-            VERIFY_ARE_EQUAL(settings->Profiles().Size(), copyImpl->Profiles().Size());
+            VERIFY_ARE_EQUAL(settings->ActiveProfiles().Size(), 1u);
+            VERIFY_ARE_EQUAL(settings->ActiveProfiles().Size(), copyImpl->ActiveProfiles().Size());
 
             // so we should only have one parent, instead of two
-            auto srcProfile{ winrt::get_self<implementation::Profile>(settings->Profiles().GetAt(0)) };
-            auto copyProfile{ winrt::get_self<implementation::Profile>(copyImpl->Profiles().GetAt(0)) };
+            auto srcProfile{ winrt::get_self<implementation::Profile>(settings->ActiveProfiles().GetAt(0)) };
+            auto copyProfile{ winrt::get_self<implementation::Profile>(copyImpl->ActiveProfiles().GetAt(0)) };
             VERIFY_ARE_EQUAL(srcProfile->Parents().size(), 0u);
             VERIFY_ARE_EQUAL(srcProfile->Parents().size(), copyProfile->Parents().size());
         };

--- a/src/cascadia/LocalTests_SettingsModel/ProfileTests.cpp
+++ b/src/cascadia/LocalTests_SettingsModel/ProfileTests.cpp
@@ -256,7 +256,7 @@ namespace SettingsModelLocalTests
 
         auto settings = winrt::make_self<implementation::CascadiaSettings>();
 
-        VERIFY_ARE_EQUAL(0u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(0u, settings->_allProfiles.Size());
         VERIFY_IS_NULL(settings->_FindMatchingProfile(profile0Json));
         VERIFY_IS_NULL(settings->_FindMatchingProfile(profile1Json));
         VERIFY_IS_NULL(settings->_FindMatchingProfile(profile2Json));
@@ -264,7 +264,7 @@ namespace SettingsModelLocalTests
         VERIFY_IS_NULL(settings->_FindMatchingProfile(profile4Json));
 
         settings->_LayerOrCreateProfile(profile0Json);
-        VERIFY_ARE_EQUAL(1u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(1u, settings->_allProfiles.Size());
         VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile0Json));
         VERIFY_IS_NULL(settings->_FindMatchingProfile(profile1Json));
         VERIFY_IS_NULL(settings->_FindMatchingProfile(profile2Json));
@@ -272,7 +272,7 @@ namespace SettingsModelLocalTests
         VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile4Json));
 
         settings->_LayerOrCreateProfile(profile1Json);
-        VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
         VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile0Json));
         VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile1Json));
         VERIFY_IS_NULL(settings->_FindMatchingProfile(profile2Json));
@@ -280,31 +280,31 @@ namespace SettingsModelLocalTests
         VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile4Json));
 
         settings->_LayerOrCreateProfile(profile2Json);
-        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(3u, settings->_allProfiles.Size());
         VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile0Json));
         VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile1Json));
         VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile2Json));
         VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile3Json));
         VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile4Json));
-        VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"profile0", settings->_allProfiles.GetAt(0).Name());
 
         settings->_LayerOrCreateProfile(profile3Json);
-        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(3u, settings->_allProfiles.Size());
         VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile0Json));
         VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile1Json));
         VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile2Json));
         VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile3Json));
         VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile4Json));
-        VERIFY_ARE_EQUAL(L"profile3", settings->_profiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"profile3", settings->_allProfiles.GetAt(0).Name());
 
         settings->_LayerOrCreateProfile(profile4Json);
-        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(3u, settings->_allProfiles.Size());
         VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile0Json));
         VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile1Json));
         VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile2Json));
         VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile3Json));
         VERIFY_IS_NOT_NULL(settings->_FindMatchingProfile(profile4Json));
-        VERIFY_ARE_EQUAL(L"profile4", settings->_profiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"profile4", settings->_allProfiles.GetAt(0).Name());
     }
 
 }

--- a/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/SettingsTests.cpp
@@ -139,9 +139,9 @@ namespace TerminalAppLocalTests
         CascadiaSettings settings{ til::u8u16(settingsJson) };
 
         auto keymap = settings.GlobalSettings().KeyMap();
-        VERIFY_ARE_EQUAL(3u, settings.Profiles().Size());
+        VERIFY_ARE_EQUAL(3u, settings.ActiveProfiles().Size());
 
-        const auto profile2Guid = settings.Profiles().GetAt(2).Guid();
+        const auto profile2Guid = settings.ActiveProfiles().GetAt(2).Guid();
         VERIFY_ARE_NOT_EQUAL(winrt::guid{}, profile2Guid);
 
         VERIFY_ARE_EQUAL(12u, keymap.Size());
@@ -478,8 +478,8 @@ namespace TerminalAppLocalTests
         CascadiaSettings settings{ til::u8u16(settingsString) };
 
         VERIFY_ARE_EQUAL(2u, settings.Warnings().Size());
-        VERIFY_ARE_EQUAL(2u, settings.Profiles().Size());
-        VERIFY_ARE_EQUAL(settings.GlobalSettings().DefaultProfile(), settings.Profiles().GetAt(0).Guid());
+        VERIFY_ARE_EQUAL(2u, settings.ActiveProfiles().Size());
+        VERIFY_ARE_EQUAL(settings.GlobalSettings().DefaultProfile(), settings.ActiveProfiles().GetAt(0).Guid());
         try
         {
             const auto [guid, termSettings] = winrt::TerminalApp::implementation::TerminalSettings::BuildSettings(settings, nullptr, nullptr);
@@ -540,7 +540,7 @@ namespace TerminalAppLocalTests
 
         CascadiaSettings settings{ til::u8u16(settings0String) };
 
-        VERIFY_ARE_EQUAL(6u, settings.Profiles().Size());
+        VERIFY_ARE_EQUAL(6u, settings.ActiveProfiles().Size());
         VERIFY_ARE_EQUAL(2u, settings.GlobalSettings().ColorSchemes().Size());
 
         auto createTerminalSettings = [&](const auto& profile, const auto& schemes) {
@@ -549,12 +549,12 @@ namespace TerminalAppLocalTests
             return terminalSettings;
         };
 
-        auto terminalSettings0 = createTerminalSettings(settings.Profiles().GetAt(0), settings.GlobalSettings().ColorSchemes());
-        auto terminalSettings1 = createTerminalSettings(settings.Profiles().GetAt(1), settings.GlobalSettings().ColorSchemes());
-        auto terminalSettings2 = createTerminalSettings(settings.Profiles().GetAt(2), settings.GlobalSettings().ColorSchemes());
-        auto terminalSettings3 = createTerminalSettings(settings.Profiles().GetAt(3), settings.GlobalSettings().ColorSchemes());
-        auto terminalSettings4 = createTerminalSettings(settings.Profiles().GetAt(4), settings.GlobalSettings().ColorSchemes());
-        auto terminalSettings5 = createTerminalSettings(settings.Profiles().GetAt(5), settings.GlobalSettings().ColorSchemes());
+        auto terminalSettings0 = createTerminalSettings(settings.ActiveProfiles().GetAt(0), settings.GlobalSettings().ColorSchemes());
+        auto terminalSettings1 = createTerminalSettings(settings.ActiveProfiles().GetAt(1), settings.GlobalSettings().ColorSchemes());
+        auto terminalSettings2 = createTerminalSettings(settings.ActiveProfiles().GetAt(2), settings.GlobalSettings().ColorSchemes());
+        auto terminalSettings3 = createTerminalSettings(settings.ActiveProfiles().GetAt(3), settings.GlobalSettings().ColorSchemes());
+        auto terminalSettings4 = createTerminalSettings(settings.ActiveProfiles().GetAt(4), settings.GlobalSettings().ColorSchemes());
+        auto terminalSettings5 = createTerminalSettings(settings.ActiveProfiles().GetAt(5), settings.GlobalSettings().ColorSchemes());
 
         VERIFY_ARE_EQUAL(ARGB(0, 0x12, 0x34, 0x56), terminalSettings0->CursorColor()); // from color scheme
         VERIFY_ARE_EQUAL(DEFAULT_CURSOR_COLOR, terminalSettings1->CursorColor()); // default
@@ -609,7 +609,7 @@ namespace TerminalAppLocalTests
 
         VERIFY_ARE_EQUAL(0u, settings.Warnings().Size());
 
-        VERIFY_ARE_EQUAL(3u, settings.Profiles().Size());
+        VERIFY_ARE_EQUAL(3u, settings.ActiveProfiles().Size());
 
         auto commands = settings.GlobalSettings().Commands();
         VERIFY_ARE_EQUAL(1u, commands.Size());
@@ -632,7 +632,7 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"${profile.name}", realArgs.TerminalArgs().Profile());
         }
 
-        auto expandedCommands = winrt::TerminalApp::implementation::TerminalPage::_ExpandCommands(commands, settings.Profiles().GetView(), settings.GlobalSettings().ColorSchemes());
+        auto expandedCommands = winrt::TerminalApp::implementation::TerminalPage::_ExpandCommands(commands, settings.ActiveProfiles().GetView(), settings.GlobalSettings().ColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings.Warnings().Size());
@@ -736,7 +736,7 @@ namespace TerminalAppLocalTests
 
         VERIFY_ARE_EQUAL(0u, settings.Warnings().Size());
 
-        VERIFY_ARE_EQUAL(3u, settings.Profiles().Size());
+        VERIFY_ARE_EQUAL(3u, settings.ActiveProfiles().Size());
 
         auto commands = settings.GlobalSettings().Commands();
         VERIFY_ARE_EQUAL(1u, commands.Size());
@@ -759,7 +759,7 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"${profile.name}", realArgs.TerminalArgs().Profile());
         }
 
-        auto expandedCommands = winrt::TerminalApp::implementation::TerminalPage::_ExpandCommands(commands, settings.Profiles().GetView(), settings.GlobalSettings().ColorSchemes());
+        auto expandedCommands = winrt::TerminalApp::implementation::TerminalPage::_ExpandCommands(commands, settings.ActiveProfiles().GetView(), settings.GlobalSettings().ColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings.Warnings().Size());
@@ -865,7 +865,7 @@ namespace TerminalAppLocalTests
 
         VERIFY_ARE_EQUAL(0u, settings.Warnings().Size());
 
-        VERIFY_ARE_EQUAL(3u, settings.Profiles().Size());
+        VERIFY_ARE_EQUAL(3u, settings.ActiveProfiles().Size());
 
         auto commands = settings.GlobalSettings().Commands();
         VERIFY_ARE_EQUAL(1u, commands.Size());
@@ -888,7 +888,7 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"${profile.name}", realArgs.TerminalArgs().Profile());
         }
 
-        auto expandedCommands = winrt::TerminalApp::implementation::TerminalPage::_ExpandCommands(commands, settings.Profiles().GetView(), settings.GlobalSettings().ColorSchemes());
+        auto expandedCommands = winrt::TerminalApp::implementation::TerminalPage::_ExpandCommands(commands, settings.ActiveProfiles().GetView(), settings.GlobalSettings().ColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings.Warnings().Size());
@@ -1002,10 +1002,10 @@ namespace TerminalAppLocalTests
         CascadiaSettings settings{ til::u8u16(settingsJson) };
 
         VERIFY_ARE_EQUAL(0u, settings.Warnings().Size());
-        VERIFY_ARE_EQUAL(3u, settings.Profiles().Size());
+        VERIFY_ARE_EQUAL(3u, settings.ActiveProfiles().Size());
 
         auto commands = settings.GlobalSettings().Commands();
-        auto expandedCommands = winrt::TerminalApp::implementation::TerminalPage::_ExpandCommands(commands, settings.Profiles().GetView(), settings.GlobalSettings().ColorSchemes());
+        auto expandedCommands = winrt::TerminalApp::implementation::TerminalPage::_ExpandCommands(commands, settings.ActiveProfiles().GetView(), settings.GlobalSettings().ColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings.Warnings().Size());
@@ -1097,10 +1097,10 @@ namespace TerminalAppLocalTests
         CascadiaSettings settings{ til::u8u16(settingsJson) };
 
         VERIFY_ARE_EQUAL(0u, settings.Warnings().Size());
-        VERIFY_ARE_EQUAL(3u, settings.Profiles().Size());
+        VERIFY_ARE_EQUAL(3u, settings.ActiveProfiles().Size());
 
         auto commands = settings.GlobalSettings().Commands();
-        auto expandedCommands = winrt::TerminalApp::implementation::TerminalPage::_ExpandCommands(commands, settings.Profiles().GetView(), settings.GlobalSettings().ColorSchemes());
+        auto expandedCommands = winrt::TerminalApp::implementation::TerminalPage::_ExpandCommands(commands, settings.ActiveProfiles().GetView(), settings.GlobalSettings().ColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings.Warnings().Size());
@@ -1220,10 +1220,10 @@ namespace TerminalAppLocalTests
         CascadiaSettings settings{ til::u8u16(settingsJson) };
 
         VERIFY_ARE_EQUAL(0u, settings.Warnings().Size());
-        VERIFY_ARE_EQUAL(3u, settings.Profiles().Size());
+        VERIFY_ARE_EQUAL(3u, settings.ActiveProfiles().Size());
 
         auto commands = settings.GlobalSettings().Commands();
-        auto expandedCommands = winrt::TerminalApp::implementation::TerminalPage::_ExpandCommands(commands, settings.Profiles().GetView(), settings.GlobalSettings().ColorSchemes());
+        auto expandedCommands = winrt::TerminalApp::implementation::TerminalPage::_ExpandCommands(commands, settings.ActiveProfiles().GetView(), settings.GlobalSettings().ColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings.Warnings().Size());
@@ -1357,10 +1357,10 @@ namespace TerminalAppLocalTests
         CascadiaSettings settings{ til::u8u16(settingsJson) };
 
         VERIFY_ARE_EQUAL(0u, settings.Warnings().Size());
-        VERIFY_ARE_EQUAL(3u, settings.Profiles().Size());
+        VERIFY_ARE_EQUAL(3u, settings.ActiveProfiles().Size());
 
         auto commands = settings.GlobalSettings().Commands();
-        auto expandedCommands = winrt::TerminalApp::implementation::TerminalPage::_ExpandCommands(commands, settings.Profiles().GetView(), settings.GlobalSettings().ColorSchemes());
+        auto expandedCommands = winrt::TerminalApp::implementation::TerminalPage::_ExpandCommands(commands, settings.ActiveProfiles().GetView(), settings.GlobalSettings().ColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings.Warnings().Size());
@@ -1460,10 +1460,10 @@ namespace TerminalAppLocalTests
         CascadiaSettings settings{ til::u8u16(settingsJson) };
 
         VERIFY_ARE_EQUAL(0u, settings.Warnings().Size());
-        VERIFY_ARE_EQUAL(3u, settings.Profiles().Size());
+        VERIFY_ARE_EQUAL(3u, settings.ActiveProfiles().Size());
 
         auto commands = settings.GlobalSettings().Commands();
-        auto expandedCommands = winrt::TerminalApp::implementation::TerminalPage::_ExpandCommands(commands, settings.Profiles().GetView(), settings.GlobalSettings().ColorSchemes());
+        auto expandedCommands = winrt::TerminalApp::implementation::TerminalPage::_ExpandCommands(commands, settings.ActiveProfiles().GetView(), settings.GlobalSettings().ColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         VERIFY_ARE_EQUAL(0u, settings.Warnings().Size());
@@ -1602,7 +1602,7 @@ namespace TerminalAppLocalTests
         // we add a warning saying "the color scheme is unknown"
         VERIFY_ARE_EQUAL(1u, settings.Warnings().Size());
 
-        VERIFY_ARE_EQUAL(3u, settings.Profiles().Size());
+        VERIFY_ARE_EQUAL(3u, settings.ActiveProfiles().Size());
 
         auto commands = settings.GlobalSettings().Commands();
         VERIFY_ARE_EQUAL(1u, commands.Size());
@@ -1625,7 +1625,7 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL(L"${scheme.name}", realArgs.TerminalArgs().Profile());
         }
 
-        auto expandedCommands = winrt::TerminalApp::implementation::TerminalPage::_ExpandCommands(commands, settings.Profiles().GetView(), settings.GlobalSettings().ColorSchemes());
+        auto expandedCommands = winrt::TerminalApp::implementation::TerminalPage::_ExpandCommands(commands, settings.ActiveProfiles().GetView(), settings.GlobalSettings().ColorSchemes());
         _logCommandNames(expandedCommands.GetView());
 
         // This is the same warning as above

--- a/src/cascadia/TerminalApp/Jumplist.cpp
+++ b/src/cascadia/TerminalApp/Jumplist.cpp
@@ -139,7 +139,7 @@ winrt::fire_and_forget Jumplist::UpdateJumplist(const CascadiaSettings& settings
         THROW_IF_FAILED(jumplistItems->Clear());
 
         // Update the list of profiles.
-        THROW_IF_FAILED(_updateProfiles(jumplistItems.get(), strongSettings.Profiles().GetView()));
+        THROW_IF_FAILED(_updateProfiles(jumplistItems.get(), strongSettings.ActiveProfiles().GetView()));
 
         // TODO GH#1571: Add items from the future customizable new tab dropdown as well.
         // This could either replace the default profiles, or be added alongside them.

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -425,10 +425,10 @@ namespace winrt::TerminalApp::implementation
 
         const auto defaultProfileGuid = _settings.GlobalSettings().DefaultProfile();
         // the number of profiles should not change in the loop for this to work
-        auto const profileCount = gsl::narrow_cast<int>(_settings.Profiles().Size());
+        auto const profileCount = gsl::narrow_cast<int>(_settings.ActiveProfiles().Size());
         for (int profileIndex = 0; profileIndex < profileCount; profileIndex++)
         {
-            const auto profile = _settings.Profiles().GetAt(profileIndex);
+            const auto profile = _settings.ActiveProfiles().GetAt(profileIndex);
             auto profileMenuItem = WUX::Controls::MenuFlyoutItem{};
 
             // Add the keyboard shortcuts based on the number of profiles defined
@@ -2066,7 +2066,7 @@ namespace winrt::TerminalApp::implementation
         _HookupKeyBindings(_settings.KeyMap());
 
         // Refresh UI elements
-        auto profiles = _settings.Profiles();
+        auto profiles = _settings.ActiveProfiles();
         for (const auto& profile : profiles)
         {
             const auto profileGuid = profile.Guid();
@@ -2179,7 +2179,7 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_UpdateCommandsForPalette()
     {
         IMap<winrt::hstring, Command> copyOfCommands = _ExpandCommands(_settings.GlobalSettings().Commands(),
-                                                                       _settings.Profiles().GetView(),
+                                                                       _settings.ActiveProfiles().GetView(),
                                                                        _settings.GlobalSettings().ColorSchemes());
 
         _recursiveUpdateCommandKeybindingLabels(_settings, copyOfCommands.GetView());

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -45,7 +45,8 @@ CascadiaSettings::CascadiaSettings() :
 // - addDynamicProfiles: if true, we'll add the built-in DPGs.
 CascadiaSettings::CascadiaSettings(const bool addDynamicProfiles) :
     _globals{ winrt::make_self<implementation::GlobalAppSettings>() },
-    _profiles{ winrt::single_threaded_observable_vector<Model::Profile>() },
+    _allProfiles{ winrt::single_threaded_observable_vector<Model::Profile>() },
+    _activeProfiles{ winrt::single_threaded_observable_vector<Model::Profile>() },
     _warnings{ winrt::single_threaded_vector<SettingsLoadWarnings>() },
     _deserializationErrorMessage{ L"" }
 {
@@ -99,7 +100,7 @@ void CascadiaSettings::_CopyProfileInheritanceTree(winrt::com_ptr<CascadiaSettin
     //  we now have a root. So we'll do just that, then copy the inheritance graph
     //  from the dummyRoot.
     auto dummyRootSource{ winrt::make_self<Profile>() };
-    for (const auto& profile : _profiles)
+    for (const auto& profile : _allProfiles)
     {
         winrt::com_ptr<Profile> profileImpl;
         profileImpl.copy_from(winrt::get_self<Profile>(profile));
@@ -124,7 +125,11 @@ void CascadiaSettings::_CopyProfileInheritanceTree(winrt::com_ptr<CascadiaSettin
     const auto cloneParents{ dummyRootClone->Parents() };
     for (const auto& profile : cloneParents)
     {
-        cloneSettings->_profiles.Append(*profile);
+        cloneSettings->_allProfiles.Append(*profile);
+        if (!profile->Hidden())
+        {
+            cloneSettings->_activeProfiles.Append(*profile);
+        }
     }
 }
 
@@ -139,7 +144,7 @@ void CascadiaSettings::_CopyProfileInheritanceTree(winrt::com_ptr<CascadiaSettin
 winrt::Microsoft::Terminal::Settings::Model::Profile CascadiaSettings::FindProfile(winrt::guid profileGuid) const noexcept
 {
     const winrt::guid guid{ profileGuid };
-    for (auto profile : _profiles)
+    for (auto profile : _allProfiles)
     {
         try
         {
@@ -159,9 +164,20 @@ winrt::Microsoft::Terminal::Settings::Model::Profile CascadiaSettings::FindProfi
 // - <none>
 // Return Value:
 // - an iterable collection of all of our Profiles.
-IObservableVector<winrt::Microsoft::Terminal::Settings::Model::Profile> CascadiaSettings::Profiles() const noexcept
+IObservableVector<winrt::Microsoft::Terminal::Settings::Model::Profile> CascadiaSettings::AllProfiles() const noexcept
 {
-    return _profiles;
+    return _allProfiles;
+}
+
+// Method Description:
+// - Returns an iterable collection of all of our non-hidden Profiles.
+// Arguments:
+// - <none>
+// Return Value:
+// - an iterable collection of all of our Profiles.
+IObservableVector<winrt::Microsoft::Terminal::Settings::Model::Profile> CascadiaSettings::ActiveProfiles() const noexcept
+{
+    return _activeProfiles;
 }
 
 // Method Description:
@@ -279,7 +295,7 @@ void CascadiaSettings::_ValidateSettings()
 //   profiles at all, we'll throw an error if there aren't any profiles.
 void CascadiaSettings::_ValidateProfilesExist()
 {
-    const bool hasProfiles = _profiles.Size() > 0;
+    const bool hasProfiles = _allProfiles.Size() > 0;
     if (!hasProfiles)
     {
         // Throw an exception. This is an invalid state, and we want the app to
@@ -298,7 +314,7 @@ void CascadiaSettings::_ValidateProfilesExist()
 //   temporary runtime GUID for it. This validation does not add any warnings.
 void CascadiaSettings::_ValidateProfilesHaveGuid()
 {
-    for (auto profile : _profiles)
+    for (auto profile : _allProfiles)
     {
         auto profileImpl = winrt::get_self<implementation::Profile>(profile);
         profileImpl->GenerateGuidIfNecessary();
@@ -331,7 +347,7 @@ void CascadiaSettings::_ValidateDefaultProfileExists()
     const winrt::guid defaultProfileGuid{ GlobalSettings().DefaultProfile() };
     const bool nullDefaultProfile = defaultProfileGuid == winrt::guid{};
     bool defaultProfileNotInProfiles = true;
-    for (const auto& profile : _profiles)
+    for (const auto& profile : _allProfiles)
     {
         if (profile.Guid() == defaultProfileGuid)
         {
@@ -347,7 +363,7 @@ void CascadiaSettings::_ValidateDefaultProfileExists()
 
         // _temporarily_ set the default profile to the first profile. Because
         // we're adding a warning, this settings change won't be re-serialized.
-        GlobalSettings().DefaultProfile(_profiles.GetAt(0).Guid());
+        GlobalSettings().DefaultProfile(_allProfiles.GetAt(0).Guid());
     }
 }
 
@@ -367,9 +383,9 @@ void CascadiaSettings::_ValidateNoDuplicateProfiles()
 
     // Try collecting all the unique guids. If we ever encounter a guid that's
     // already in the set, then we need to delete that profile.
-    for (uint32_t i = 0; i < _profiles.Size(); i++)
+    for (uint32_t i = 0; i < _allProfiles.Size(); i++)
     {
-        if (!uniqueGuids.insert(_profiles.GetAt(i).Guid()).second)
+        if (!uniqueGuids.insert(_allProfiles.GetAt(i).Guid()).second)
         {
             foundDupe = true;
             indicesToDelete.push_back(i);
@@ -380,7 +396,7 @@ void CascadiaSettings::_ValidateNoDuplicateProfiles()
     // Walk backwards, so we don't accidentally shift any of the elements
     for (auto iter = indicesToDelete.rbegin(); iter != indicesToDelete.rend(); iter++)
     {
-        _profiles.RemoveAt(*iter);
+        _allProfiles.RemoveAt(*iter);
     }
 
     if (foundDupe)
@@ -423,22 +439,24 @@ void CascadiaSettings::_ReorderProfilesToMatchUserSettingsOrder()
     // Push all the defaultSettings profiles' GUIDS into the set
     collectGuids(_defaultSettings);
     std::equal_to<winrt::guid> equals;
-    // Re-order the list of _profiles to match that ordering
+    // Re-order the list of profiles to match that ordering
     // for (gIndex=0 -> uniqueGuids.size)
     //   pIndex = the pIndex of the profile with guid==guids[gIndex]
     //   profiles.swap(pIndex <-> gIndex)
     // This is O(N^2), which is kinda rough. I'm sure there's a better way
+    //uint32_t gIndex = 0;
     for (uint32_t gIndex = 0; gIndex < guidOrder.size(); gIndex++)
     {
-        const auto guid = guidOrder.at(gIndex);
-        for (uint32_t pIndex = gIndex; pIndex < _profiles.Size(); pIndex++)
+        auto guid = guidOrder.at(gIndex);
+        guid = guidOrder.at(gIndex);
+        for (uint32_t pIndex = gIndex; pIndex < _allProfiles.Size(); pIndex++)
         {
-            auto profileGuid = _profiles.GetAt(pIndex).Guid();
+            auto profileGuid = _allProfiles.GetAt(pIndex).Guid();
             if (equals(profileGuid, guid))
             {
-                auto prof1 = _profiles.GetAt(pIndex);
-                _profiles.SetAt(pIndex, _profiles.GetAt(gIndex));
-                _profiles.SetAt(gIndex, prof1);
+                auto prof1 = _allProfiles.GetAt(pIndex);
+                _allProfiles.SetAt(pIndex, _allProfiles.GetAt(gIndex));
+                _allProfiles.SetAt(gIndex, prof1);
                 break;
             }
         }
@@ -446,7 +464,7 @@ void CascadiaSettings::_ReorderProfilesToMatchUserSettingsOrder()
 }
 
 // Method Description:
-// - Removes any profiles marked "hidden" from the list of profiles.
+// - generates the list of active profiles from the list of all profiles
 // - Does not set any warnings.
 // Arguments:
 // - <none>
@@ -454,22 +472,17 @@ void CascadiaSettings::_ReorderProfilesToMatchUserSettingsOrder()
 // - <none>
 void CascadiaSettings::_RemoveHiddenProfiles()
 {
-    for (uint32_t i = 0; i < _profiles.Size();)
+    for (auto const& profile : _allProfiles)
     {
-        if (_profiles.GetAt(i).Hidden())
+        if (!profile.Hidden())
         {
-            // remove hidden profile, don't increment 'i'
-            _profiles.RemoveAt(i);
-        }
-        else
-        {
-            ++i;
+            _activeProfiles.Append(profile);
         }
     }
 
     // Ensure that we still have some profiles here. If we don't, then throw an
     // exception, so the app can use the defaults.
-    const bool hasProfiles = _profiles.Size() > 0;
+    const bool hasProfiles = _activeProfiles.Size() > 0;
     if (!hasProfiles)
     {
         // Throw an exception. This is an invalid state, and we want the app to
@@ -491,7 +504,7 @@ void CascadiaSettings::_RemoveHiddenProfiles()
 void CascadiaSettings::_ValidateAllSchemesExist()
 {
     bool foundInvalidScheme = false;
-    for (auto profile : _profiles)
+    for (auto profile : _allProfiles)
     {
         const auto schemeName = profile.ColorSchemeName();
         if (!_globals->ColorSchemes().HasKey(schemeName))
@@ -523,7 +536,7 @@ void CascadiaSettings::_ValidateMediaResources()
     bool invalidBackground{ false };
     bool invalidIcon{ false };
 
-    for (auto profile : _profiles)
+    for (auto profile : _allProfiles)
     {
         if (!profile.BackgroundImagePath().empty())
         {
@@ -635,7 +648,7 @@ try
         // Here, we were unable to use the profile string as a GUID to
         // lookup a profile. Instead, try using the string to look the
         // Profile up by name.
-        for (auto profile : _profiles)
+        for (auto profile : _allProfiles)
         {
             if (profile.Name() == name)
             {
@@ -669,9 +682,9 @@ std::optional<winrt::guid> CascadiaSettings::_GetProfileGuidByIndex(std::optiona
         const auto realIndex{ index.value() };
         // If we don't have that many profiles, then do nothing.
         if (realIndex >= 0 &&
-            realIndex < gsl::narrow_cast<decltype(realIndex)>(_profiles.Size()))
+            realIndex < gsl::narrow_cast<decltype(realIndex)>(_activeProfiles.Size()))
         {
-            const auto& selectedProfile = _profiles.GetAt(realIndex);
+            const auto& selectedProfile = _activeProfiles.GetAt(realIndex);
             return selectedProfile.Guid();
         }
     }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -138,7 +138,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         void _ValidateNoDuplicateProfiles();
         void _ResolveDefaultProfile();
         void _ReorderProfilesToMatchUserSettingsOrder();
-        void _RemoveHiddenProfiles();
+        void _UpdateActiveProfiles();
         void _ValidateAllSchemesExist();
         void _ValidateMediaResources();
         void _ValidateKeybindings();

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -67,7 +67,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static Model::CascadiaSettings LoadUniversal();
 
         Model::GlobalAppSettings GlobalSettings() const;
-        Windows::Foundation::Collections::IObservableVector<Model::Profile> Profiles() const noexcept;
+        Windows::Foundation::Collections::IObservableVector<Model::Profile> AllProfiles() const noexcept;
+        Windows::Foundation::Collections::IObservableVector<Model::Profile> ActiveProfiles() const noexcept;
         Model::KeyMapping KeyMap() const noexcept;
 
         static com_ptr<CascadiaSettings> FromJson(const Json::Value& json);
@@ -92,7 +93,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
     private:
         com_ptr<GlobalAppSettings> _globals;
-        Windows::Foundation::Collections::IObservableVector<Model::Profile> _profiles;
+        Windows::Foundation::Collections::IObservableVector<Model::Profile> _allProfiles;
+        Windows::Foundation::Collections::IObservableVector<Model::Profile> _activeProfiles;
         Windows::Foundation::Collections::IVector<Model::SettingsLoadWarnings> _warnings;
         Windows::Foundation::IReference<SettingsLoadErrors> _loadError;
         hstring _deserializationErrorMessage;

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.idl
@@ -23,7 +23,8 @@ namespace Microsoft.Terminal.Settings.Model
 
         GlobalAppSettings GlobalSettings { get; };
 
-        Windows.Foundation.Collections.IObservableVector<Profile> Profiles { get; };
+        Windows.Foundation.Collections.IObservableVector<Profile> AllProfiles { get; };
+        Windows.Foundation.Collections.IObservableVector<Profile> ActiveProfiles { get; };
 
         KeyMapping KeyMap { get; };
 

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -369,7 +369,7 @@ void CascadiaSettings::_LoadDynamicProfiles()
                     // we'll synthesize a GUID for it in _ValidateProfilesHaveGuid
                     profile.Source(generatorNamespace);
 
-                    _profiles.Append(profile);
+                    _allProfiles.Append(profile);
                 }
             }
             CATCH_LOG_MSG("Dynamic Profile Namespace: \"%ls\"", generatorNamespace.data());
@@ -517,7 +517,7 @@ bool CascadiaSettings::_AppendDynamicProfilesToUserSettings()
 
     bool changedFile = false;
 
-    for (const auto& profile : _profiles)
+    for (const auto& profile : _allProfiles)
     {
         // Skip profiles that are in the user settings or the default settings.
         if (isInJsonObj(profile, _userSettings) || isInJsonObj(profile, _defaultSettings))
@@ -626,7 +626,7 @@ void CascadiaSettings::_LayerOrCreateProfile(const Json::Value& profileJson)
     auto profileIndex{ _FindMatchingProfileIndex(profileJson) };
     if (profileIndex)
     {
-        auto parentProj{ _profiles.GetAt(*profileIndex) };
+        auto parentProj{ _allProfiles.GetAt(*profileIndex) };
         auto parent{ winrt::get_self<Profile>(parentProj) };
 
         if (_userDefaultProfileSettings)
@@ -643,7 +643,7 @@ void CascadiaSettings::_LayerOrCreateProfile(const Json::Value& profileJson)
             childImpl->LayerJson(profileJson);
 
             // replace parent in _profiles with child
-            _profiles.SetAt(*profileIndex, *childImpl);
+            _allProfiles.SetAt(*profileIndex, *childImpl);
         }
     }
     else
@@ -663,7 +663,7 @@ void CascadiaSettings::_LayerOrCreateProfile(const Json::Value& profileJson)
             }
 
             profile->LayerJson(profileJson);
-            _profiles.Append(*profile);
+            _allProfiles.Append(*profile);
         }
     }
 }
@@ -684,7 +684,7 @@ winrt::com_ptr<Profile> CascadiaSettings::_FindMatchingProfile(const Json::Value
     auto index{ _FindMatchingProfileIndex(profileJson) };
     if (index)
     {
-        auto profile{ _profiles.GetAt(*index) };
+        auto profile{ _allProfiles.GetAt(*index) };
         auto profileImpl{ winrt::get_self<Profile>(profile) };
         return profileImpl->get_strong();
     }
@@ -703,9 +703,9 @@ winrt::com_ptr<Profile> CascadiaSettings::_FindMatchingProfile(const Json::Value
 // - The index for the matching Profile, iff it exists. Otherwise, nullopt.
 std::optional<uint32_t> CascadiaSettings::_FindMatchingProfileIndex(const Json::Value& profileJson)
 {
-    for (uint32_t i = 0; i < _profiles.Size(); ++i)
+    for (uint32_t i = 0; i < _allProfiles.Size(); ++i)
     {
-        const auto profile{ _profiles.GetAt(i) };
+        const auto profile{ _allProfiles.GetAt(i) };
         const auto profileImpl = winrt::get_self<Profile>(profile);
         if (profileImpl->ShouldBeLayered(profileJson))
         {
@@ -750,11 +750,11 @@ void CascadiaSettings::_ApplyDefaultsFromUserSettings()
         _userDefaultProfileSettings = winrt::make_self<Profile>();
         _userDefaultProfileSettings->LayerJson(defaultSettings);
 
-        const auto numOfProfiles{ _profiles.Size() };
+        const auto numOfProfiles{ _allProfiles.Size() };
         for (uint32_t profileIndex = 0; profileIndex < numOfProfiles; ++profileIndex)
         {
             // create a child, so we inherit from the defaults.json layer
-            auto parentProj{ _profiles.GetAt(profileIndex) };
+            auto parentProj{ _allProfiles.GetAt(profileIndex) };
             auto parentImpl{ winrt::get_self<Profile>(parentProj) };
             auto childImpl{ parentImpl->CreateChild() };
 
@@ -762,7 +762,7 @@ void CascadiaSettings::_ApplyDefaultsFromUserSettings()
             childImpl->InsertParent(0, _userDefaultProfileSettings);
 
             // replace parent in _profiles with child
-            _profiles.SetAt(profileIndex, *childImpl);
+            _allProfiles.SetAt(profileIndex, *childImpl);
         }
     }
 }

--- a/src/cascadia/ut_app/DynamicProfileTests.cpp
+++ b/src/cascadia/ut_app/DynamicProfileTests.cpp
@@ -99,13 +99,13 @@ namespace TerminalAppUnitTests
         settings->_profileGenerators.emplace_back(std::move(gen1));
 
         settings->_LoadDynamicProfiles();
-        VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
 
-        VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(0).Name());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(0).HasGuid());
+        VERIFY_ARE_EQUAL(L"profile0", settings->_allProfiles.GetAt(0).Name());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(0).HasGuid());
 
-        VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(1).Name());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(1).HasGuid());
+        VERIFY_ARE_EQUAL(L"profile1", settings->_allProfiles.GetAt(1).Name());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(1).HasGuid());
     }
 
     void DynamicProfileTests::TestGenGuidsForProfiles()
@@ -119,7 +119,7 @@ namespace TerminalAppUnitTests
         gen0->pfnGenerate = []() {
             std::vector<Profile> profiles;
             Profile p0;
-            p0.Name(L"profile0"); // this is _profiles.at(2)
+            p0.Name(L"profile0"); // this is _allProfiles.at(2)
             profiles.push_back(p0);
             return profiles;
         };
@@ -127,8 +127,8 @@ namespace TerminalAppUnitTests
         gen1->pfnGenerate = []() {
             std::vector<Profile> profiles;
             Profile p0, p1;
-            p0.Name(L"profile0"); // this is _profiles.at(3)
-            p1.Name(L"profile1"); // this is _profiles.at(4)
+            p0.Name(L"profile0"); // this is _allProfiles.at(3)
+            p1.Name(L"profile1"); // this is _allProfiles.at(4)
             profiles.push_back(p0);
             profiles.push_back(p1);
             return profiles;
@@ -139,54 +139,54 @@ namespace TerminalAppUnitTests
         settings->_profileGenerators.emplace_back(std::move(gen1));
 
         Profile p0, p1;
-        p0.Name(L"profile0"); // this is _profiles.GetAt(0)
-        p1.Name(L"profile1"); // this is _profiles.GetAt(1)
-        settings->_profiles.Append(p0);
-        settings->_profiles.Append(p1);
+        p0.Name(L"profile0"); // this is _allProfiles.GetAt(0)
+        p1.Name(L"profile1"); // this is _allProfiles.GetAt(1)
+        settings->_allProfiles.Append(p0);
+        settings->_allProfiles.Append(p1);
 
         settings->_LoadDynamicProfiles();
-        VERIFY_ARE_EQUAL(5u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(5u, settings->_allProfiles.Size());
 
-        VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(0).Name());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(0).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).Source().empty());
+        VERIFY_ARE_EQUAL(L"profile0", settings->_allProfiles.GetAt(0).Name());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(0).Source().empty());
 
-        VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(1).Name());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(1).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).Source().empty());
+        VERIFY_ARE_EQUAL(L"profile1", settings->_allProfiles.GetAt(1).Name());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(1).Source().empty());
 
-        VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(2).Name());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(2).HasGuid());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(2).Source().empty());
+        VERIFY_ARE_EQUAL(L"profile0", settings->_allProfiles.GetAt(2).Name());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(2).HasGuid());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(2).Source().empty());
 
-        VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(3).Name());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(3).HasGuid());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(3).Source().empty());
+        VERIFY_ARE_EQUAL(L"profile0", settings->_allProfiles.GetAt(3).Name());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(3).HasGuid());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(3).Source().empty());
 
-        VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(4).Name());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(4).HasGuid());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(4).Source().empty());
+        VERIFY_ARE_EQUAL(L"profile1", settings->_allProfiles.GetAt(4).Name());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(4).HasGuid());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(4).Source().empty());
 
         settings->_ValidateProfilesHaveGuid();
 
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(3).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(4).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(2).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(3).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(4).HasGuid());
 
-        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(0).Guid(),
-                             settings->_profiles.GetAt(1).Guid());
-        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(0).Guid(),
-                             settings->_profiles.GetAt(2).Guid());
-        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(0).Guid(),
-                             settings->_profiles.GetAt(3).Guid());
+        VERIFY_ARE_NOT_EQUAL(settings->_allProfiles.GetAt(0).Guid(),
+                             settings->_allProfiles.GetAt(1).Guid());
+        VERIFY_ARE_NOT_EQUAL(settings->_allProfiles.GetAt(0).Guid(),
+                             settings->_allProfiles.GetAt(2).Guid());
+        VERIFY_ARE_NOT_EQUAL(settings->_allProfiles.GetAt(0).Guid(),
+                             settings->_allProfiles.GetAt(3).Guid());
 
-        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(1).Guid(),
-                             settings->_profiles.GetAt(4).Guid());
+        VERIFY_ARE_NOT_EQUAL(settings->_allProfiles.GetAt(1).Guid(),
+                             settings->_allProfiles.GetAt(4).Guid());
 
-        VERIFY_ARE_NOT_EQUAL(settings->_profiles.GetAt(3).Guid(),
-                             settings->_profiles.GetAt(4).Guid());
+        VERIFY_ARE_NOT_EQUAL(settings->_allProfiles.GetAt(3).Guid(),
+                             settings->_allProfiles.GetAt(4).Guid());
     }
 
     void DynamicProfileTests::DontLayerUserProfilesOnDynamicProfiles()
@@ -212,7 +212,7 @@ namespace TerminalAppUnitTests
         gen0->pfnGenerate = [guid0, guid1]() {
             std::vector<Profile> profiles;
             Profile p0 = winrt::make<implementation::Profile>(guid0);
-            p0.Name(L"profile0"); // this is _profiles.at(0)
+            p0.Name(L"profile0"); // this is _allProfiles.at(0)
             profiles.push_back(p0);
             return profiles;
         };
@@ -221,8 +221,8 @@ namespace TerminalAppUnitTests
             std::vector<Profile> profiles;
             Profile p0 = winrt::make<implementation::Profile>(guid0);
             Profile p1 = winrt::make<implementation::Profile>(guid1);
-            p0.Name(L"profile0"); // this is _profiles.at(1)
-            p1.Name(L"profile1"); // this is _profiles.at(2)
+            p0.Name(L"profile0"); // this is _allProfiles.at(1)
+            p1.Name(L"profile1"); // this is _allProfiles.at(2)
             profiles.push_back(p0);
             profiles.push_back(p1);
             return profiles;
@@ -238,33 +238,33 @@ namespace TerminalAppUnitTests
 
         // parse userProfiles as the user settings
         settings->_ParseJsonString(userProfiles, false);
-        VERIFY_ARE_EQUAL(0u, settings->_profiles.Size(), L"Just parsing the user settings doesn't actually layer them");
+        VERIFY_ARE_EQUAL(0u, settings->_allProfiles.Size(), L"Just parsing the user settings doesn't actually layer them");
         settings->_LoadDynamicProfiles();
-        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(3u, settings->_allProfiles.Size());
         settings->LayerJson(settings->_userSettings);
-        VERIFY_ARE_EQUAL(5u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(5u, settings->_allProfiles.Size());
 
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(0).Source().empty());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(1).Source().empty());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(2).Source().empty());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(3).Source().empty());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(4).Source().empty());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(0).Source().empty());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(1).Source().empty());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(2).Source().empty());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(3).Source().empty());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(4).Source().empty());
 
-        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.0", settings->_profiles.GetAt(0).Source());
-        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_profiles.GetAt(1).Source());
-        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_profiles.GetAt(2).Source());
+        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.0", settings->_allProfiles.GetAt(0).Source());
+        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_allProfiles.GetAt(1).Source());
+        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_allProfiles.GetAt(2).Source());
 
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(3).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(4).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(2).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(3).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(4).HasGuid());
 
-        VERIFY_ARE_EQUAL(guid0, settings->_profiles.GetAt(0).Guid());
-        VERIFY_ARE_EQUAL(guid0, settings->_profiles.GetAt(1).Guid());
-        VERIFY_ARE_EQUAL(guid1, settings->_profiles.GetAt(2).Guid());
-        VERIFY_ARE_EQUAL(guid0, settings->_profiles.GetAt(3).Guid());
-        VERIFY_ARE_EQUAL(guid1, settings->_profiles.GetAt(4).Guid());
+        VERIFY_ARE_EQUAL(guid0, settings->_allProfiles.GetAt(0).Guid());
+        VERIFY_ARE_EQUAL(guid0, settings->_allProfiles.GetAt(1).Guid());
+        VERIFY_ARE_EQUAL(guid1, settings->_allProfiles.GetAt(2).Guid());
+        VERIFY_ARE_EQUAL(guid0, settings->_allProfiles.GetAt(3).Guid());
+        VERIFY_ARE_EQUAL(guid1, settings->_allProfiles.GetAt(4).Guid());
     }
 
     void DynamicProfileTests::DoLayerUserProfilesOnDynamicsWhenSourceMatches()
@@ -276,12 +276,12 @@ namespace TerminalAppUnitTests
         {
             "profiles": [
                 {
-                    "name" : "profile0FromUserSettings", // this is _profiles.at(0)
+                    "name" : "profile0FromUserSettings", // this is _allProfiles.at(0)
                     "guid": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
                     "source": "Terminal.App.UnitTest.0"
                 },
                 {
-                    "name" : "profile1FromUserSettings", // this is _profiles.at(2)
+                    "name" : "profile1FromUserSettings", // this is _allProfiles.at(2)
                     "guid": "{6239a42c-2222-49a3-80bd-e8fdd045185c}",
                     "source": "Terminal.App.UnitTest.1"
                 }
@@ -292,7 +292,7 @@ namespace TerminalAppUnitTests
         gen0->pfnGenerate = [guid0, guid1]() {
             std::vector<Profile> profiles;
             Profile p0 = winrt::make<implementation::Profile>(guid0);
-            p0.Name(L"profile0"); // this is _profiles.at(0)
+            p0.Name(L"profile0"); // this is _allProfiles.at(0)
             profiles.push_back(p0);
             return profiles;
         };
@@ -301,8 +301,8 @@ namespace TerminalAppUnitTests
             std::vector<Profile> profiles;
             Profile p0 = winrt::make<implementation::Profile>(guid0);
             Profile p1 = winrt::make<implementation::Profile>(guid1);
-            p0.Name(L"profile0"); // this is _profiles.at(1)
-            p1.Name(L"profile1"); // this is _profiles.at(2)
+            p0.Name(L"profile0"); // this is _allProfiles.at(1)
+            p1.Name(L"profile1"); // this is _allProfiles.at(2)
             profiles.push_back(p0);
             profiles.push_back(p1);
             return profiles;
@@ -318,31 +318,31 @@ namespace TerminalAppUnitTests
 
         // parse userProfiles as the user settings
         settings->_ParseJsonString(userProfiles, false);
-        VERIFY_ARE_EQUAL(0u, settings->_profiles.Size(), L"Just parsing the user settings doesn't actually layer them");
+        VERIFY_ARE_EQUAL(0u, settings->_allProfiles.Size(), L"Just parsing the user settings doesn't actually layer them");
         settings->_LoadDynamicProfiles();
-        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(3u, settings->_allProfiles.Size());
         settings->LayerJson(settings->_userSettings);
-        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(3u, settings->_allProfiles.Size());
 
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(0).Source().empty());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(1).Source().empty());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(2).Source().empty());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(0).Source().empty());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(1).Source().empty());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(2).Source().empty());
 
-        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.0", settings->_profiles.GetAt(0).Source());
-        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_profiles.GetAt(1).Source());
-        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_profiles.GetAt(2).Source());
+        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.0", settings->_allProfiles.GetAt(0).Source());
+        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_allProfiles.GetAt(1).Source());
+        VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_allProfiles.GetAt(2).Source());
 
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(0).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(1).HasGuid());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(2).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(0).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(1).HasGuid());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(2).HasGuid());
 
-        VERIFY_ARE_EQUAL(guid0, settings->_profiles.GetAt(0).Guid());
-        VERIFY_ARE_EQUAL(guid0, settings->_profiles.GetAt(1).Guid());
-        VERIFY_ARE_EQUAL(guid1, settings->_profiles.GetAt(2).Guid());
+        VERIFY_ARE_EQUAL(guid0, settings->_allProfiles.GetAt(0).Guid());
+        VERIFY_ARE_EQUAL(guid0, settings->_allProfiles.GetAt(1).Guid());
+        VERIFY_ARE_EQUAL(guid1, settings->_allProfiles.GetAt(2).Guid());
 
-        VERIFY_ARE_EQUAL(L"profile0FromUserSettings", settings->_profiles.GetAt(0).Name());
-        VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(1).Name());
-        VERIFY_ARE_EQUAL(L"profile1FromUserSettings", settings->_profiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"profile0FromUserSettings", settings->_allProfiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"profile0", settings->_allProfiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"profile1FromUserSettings", settings->_allProfiles.GetAt(2).Name());
     }
 
     void DynamicProfileTests::TestDontRunDisabledGenerators()
@@ -405,19 +405,19 @@ namespace TerminalAppUnitTests
             settings->_ParseJsonString(settings0String, false);
             settings->_LoadDynamicProfiles();
 
-            VERIFY_ARE_EQUAL(4u, settings->_profiles.Size());
-            VERIFY_IS_FALSE(settings->_profiles.GetAt(0).Source().empty());
-            VERIFY_IS_FALSE(settings->_profiles.GetAt(1).Source().empty());
-            VERIFY_IS_FALSE(settings->_profiles.GetAt(2).Source().empty());
-            VERIFY_IS_FALSE(settings->_profiles.GetAt(3).Source().empty());
-            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_profiles.GetAt(0).Source());
-            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_profiles.GetAt(1).Source());
-            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.2", settings->_profiles.GetAt(2).Source());
-            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.2", settings->_profiles.GetAt(3).Source());
-            VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(0).Name());
-            VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(1).Name());
-            VERIFY_ARE_EQUAL(L"profile3", settings->_profiles.GetAt(2).Name());
-            VERIFY_ARE_EQUAL(L"profile4", settings->_profiles.GetAt(3).Name());
+            VERIFY_ARE_EQUAL(4u, settings->_allProfiles.Size());
+            VERIFY_IS_FALSE(settings->_allProfiles.GetAt(0).Source().empty());
+            VERIFY_IS_FALSE(settings->_allProfiles.GetAt(1).Source().empty());
+            VERIFY_IS_FALSE(settings->_allProfiles.GetAt(2).Source().empty());
+            VERIFY_IS_FALSE(settings->_allProfiles.GetAt(3).Source().empty());
+            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_allProfiles.GetAt(0).Source());
+            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.1", settings->_allProfiles.GetAt(1).Source());
+            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.2", settings->_allProfiles.GetAt(2).Source());
+            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.2", settings->_allProfiles.GetAt(3).Source());
+            VERIFY_ARE_EQUAL(L"profile1", settings->_allProfiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile2", settings->_allProfiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(L"profile3", settings->_allProfiles.GetAt(2).Name());
+            VERIFY_ARE_EQUAL(L"profile4", settings->_allProfiles.GetAt(3).Name());
         }
 
         {
@@ -438,13 +438,13 @@ namespace TerminalAppUnitTests
             settings->_ParseJsonString(settings1String, false);
             settings->_LoadDynamicProfiles();
 
-            VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
-            VERIFY_IS_FALSE(settings->_profiles.GetAt(0).Source().empty());
-            VERIFY_IS_FALSE(settings->_profiles.GetAt(1).Source().empty());
-            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.2", settings->_profiles.GetAt(0).Source());
-            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.2", settings->_profiles.GetAt(1).Source());
-            VERIFY_ARE_EQUAL(L"profile3", settings->_profiles.GetAt(0).Name());
-            VERIFY_ARE_EQUAL(L"profile4", settings->_profiles.GetAt(1).Name());
+            VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
+            VERIFY_IS_FALSE(settings->_allProfiles.GetAt(0).Source().empty());
+            VERIFY_IS_FALSE(settings->_allProfiles.GetAt(1).Source().empty());
+            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.2", settings->_allProfiles.GetAt(0).Source());
+            VERIFY_ARE_EQUAL(L"Terminal.App.UnitTest.2", settings->_allProfiles.GetAt(1).Source());
+            VERIFY_ARE_EQUAL(L"profile3", settings->_allProfiles.GetAt(0).Name());
+            VERIFY_ARE_EQUAL(L"profile4", settings->_allProfiles.GetAt(1).Name());
         }
     }
 
@@ -461,27 +461,27 @@ namespace TerminalAppUnitTests
             "profiles": [
                 {
                     // This pwsh profile does not have a source, but should still be layered
-                    "name" : "profile0FromUserSettings", // this is _profiles.at(0)
+                    "name" : "profile0FromUserSettings", // this is _allProfiles.at(0)
                     "guid": "{6239a42c-0000-49a3-80bd-e8fdd045185c}"
                 },
                 {
                     // This Azure profile does not have a source, but should still be layered
-                    "name" : "profile3FromUserSettings", // this is _profiles.at(3)
+                    "name" : "profile3FromUserSettings", // this is _allProfiles.at(3)
                     "guid": "{6239a42c-3333-49a3-80bd-e8fdd045185c}"
                 },
                 {
                     // This profile did not come from a dynamic source
-                    "name" : "profile4FromUserSettings", // this is _profiles.at(4)
+                    "name" : "profile4FromUserSettings", // this is _allProfiles.at(4)
                     "guid": "{6239a42c-4444-49a3-80bd-e8fdd045185c}"
                 },
                 {
                     // This WSL profile does not have a source, but should still be layered
-                    "name" : "profile1FromUserSettings", // this is _profiles.at(1)
+                    "name" : "profile1FromUserSettings", // this is _allProfiles.at(1)
                     "guid": "{6239a42c-1111-49a3-80bd-e8fdd045185c}"
                 },
                 {
                     // This WSL profile does have a source, and should be layered
-                    "name" : "profile2FromUserSettings", // this is _profiles.at(2)
+                    "name" : "profile2FromUserSettings", // this is _allProfiles.at(2)
                     "guid": "{6239a42c-2222-49a3-80bd-e8fdd045185c}",
                     "source": "Windows.Terminal.Wsl"
                 }
@@ -522,42 +522,42 @@ namespace TerminalAppUnitTests
         settings->_profileGenerators.emplace_back(std::move(gen2));
 
         settings->_ParseJsonString(settings0String, false);
-        VERIFY_ARE_EQUAL(0u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(0u, settings->_allProfiles.Size());
 
         settings->_LoadDynamicProfiles();
-        VERIFY_ARE_EQUAL(4u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(4u, settings->_allProfiles.Size());
 
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(0).Source().empty());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(1).Source().empty());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(2).Source().empty());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(3).Source().empty());
-        VERIFY_ARE_EQUAL(L"Windows.Terminal.PowershellCore", settings->_profiles.GetAt(0).Source());
-        VERIFY_ARE_EQUAL(L"Windows.Terminal.Wsl", settings->_profiles.GetAt(1).Source());
-        VERIFY_ARE_EQUAL(L"Windows.Terminal.Wsl", settings->_profiles.GetAt(2).Source());
-        VERIFY_ARE_EQUAL(L"Windows.Terminal.Azure", settings->_profiles.GetAt(3).Source());
-        VERIFY_ARE_EQUAL(L"profile0", settings->_profiles.GetAt(0).Name());
-        VERIFY_ARE_EQUAL(L"profile1", settings->_profiles.GetAt(1).Name());
-        VERIFY_ARE_EQUAL(L"profile2", settings->_profiles.GetAt(2).Name());
-        VERIFY_ARE_EQUAL(L"profile3", settings->_profiles.GetAt(3).Name());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(0).Source().empty());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(1).Source().empty());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(2).Source().empty());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(3).Source().empty());
+        VERIFY_ARE_EQUAL(L"Windows.Terminal.PowershellCore", settings->_allProfiles.GetAt(0).Source());
+        VERIFY_ARE_EQUAL(L"Windows.Terminal.Wsl", settings->_allProfiles.GetAt(1).Source());
+        VERIFY_ARE_EQUAL(L"Windows.Terminal.Wsl", settings->_allProfiles.GetAt(2).Source());
+        VERIFY_ARE_EQUAL(L"Windows.Terminal.Azure", settings->_allProfiles.GetAt(3).Source());
+        VERIFY_ARE_EQUAL(L"profile0", settings->_allProfiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"profile1", settings->_allProfiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"profile2", settings->_allProfiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"profile3", settings->_allProfiles.GetAt(3).Name());
 
         settings->LayerJson(settings->_userSettings);
-        VERIFY_ARE_EQUAL(5u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(5u, settings->_allProfiles.Size());
 
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(0).Source().empty());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(1).Source().empty());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(2).Source().empty());
-        VERIFY_IS_FALSE(settings->_profiles.GetAt(3).Source().empty());
-        VERIFY_IS_TRUE(settings->_profiles.GetAt(4).Source().empty());
-        VERIFY_ARE_EQUAL(L"Windows.Terminal.PowershellCore", settings->_profiles.GetAt(0).Source());
-        VERIFY_ARE_EQUAL(L"Windows.Terminal.Wsl", settings->_profiles.GetAt(1).Source());
-        VERIFY_ARE_EQUAL(L"Windows.Terminal.Wsl", settings->_profiles.GetAt(2).Source());
-        VERIFY_ARE_EQUAL(L"Windows.Terminal.Azure", settings->_profiles.GetAt(3).Source());
-        // settings->_profiles.GetAt(4) does not have a source
-        VERIFY_ARE_EQUAL(L"profile0FromUserSettings", settings->_profiles.GetAt(0).Name());
-        VERIFY_ARE_EQUAL(L"profile1FromUserSettings", settings->_profiles.GetAt(1).Name());
-        VERIFY_ARE_EQUAL(L"profile2FromUserSettings", settings->_profiles.GetAt(2).Name());
-        VERIFY_ARE_EQUAL(L"profile3FromUserSettings", settings->_profiles.GetAt(3).Name());
-        VERIFY_ARE_EQUAL(L"profile4FromUserSettings", settings->_profiles.GetAt(4).Name());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(0).Source().empty());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(1).Source().empty());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(2).Source().empty());
+        VERIFY_IS_FALSE(settings->_allProfiles.GetAt(3).Source().empty());
+        VERIFY_IS_TRUE(settings->_allProfiles.GetAt(4).Source().empty());
+        VERIFY_ARE_EQUAL(L"Windows.Terminal.PowershellCore", settings->_allProfiles.GetAt(0).Source());
+        VERIFY_ARE_EQUAL(L"Windows.Terminal.Wsl", settings->_allProfiles.GetAt(1).Source());
+        VERIFY_ARE_EQUAL(L"Windows.Terminal.Wsl", settings->_allProfiles.GetAt(2).Source());
+        VERIFY_ARE_EQUAL(L"Windows.Terminal.Azure", settings->_allProfiles.GetAt(3).Source());
+        // settings->_allProfiles.GetAt(4) does not have a source
+        VERIFY_ARE_EQUAL(L"profile0FromUserSettings", settings->_allProfiles.GetAt(0).Name());
+        VERIFY_ARE_EQUAL(L"profile1FromUserSettings", settings->_allProfiles.GetAt(1).Name());
+        VERIFY_ARE_EQUAL(L"profile2FromUserSettings", settings->_allProfiles.GetAt(2).Name());
+        VERIFY_ARE_EQUAL(L"profile3FromUserSettings", settings->_allProfiles.GetAt(3).Name());
+        VERIFY_ARE_EQUAL(L"profile4FromUserSettings", settings->_allProfiles.GetAt(4).Name());
     }
 
     void DynamicProfileTests::UserProfilesWithInvalidSourcesAreIgnored()
@@ -569,7 +569,7 @@ namespace TerminalAppUnitTests
         {
             "profiles": [
                 {
-                    "name" : "profile0FromUserSettings", // this is _profiles.at(0)
+                    "name" : "profile0FromUserSettings", // this is _allProfiles.at(0)
                     "guid": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
                     "source": "Terminal.App.UnitTest.0"
                 },
@@ -579,7 +579,7 @@ namespace TerminalAppUnitTests
                     "source": "Terminal.App.UnitTest.1"
                 },
                 {
-                    "name" : "profile3", // this is _profiles.at(3)
+                    "name" : "profile3", // this is _allProfiles.at(3)
                     "guid": "{6239a42c-4444-49a3-80bd-e8fdd045185c}"
                 }
             ]
@@ -589,7 +589,7 @@ namespace TerminalAppUnitTests
         gen0->pfnGenerate = [guid0, guid1]() {
             std::vector<Profile> profiles;
             Profile p0 = winrt::make<implementation::Profile>(guid0);
-            p0.Name(L"profile0"); // this is _profiles.at(0)
+            p0.Name(L"profile0"); // this is _allProfiles.at(0)
             profiles.push_back(p0);
             return profiles;
         };
@@ -598,8 +598,8 @@ namespace TerminalAppUnitTests
             std::vector<Profile> profiles;
             Profile p0 = winrt::make<implementation::Profile>(guid0);
             Profile p1 = winrt::make<implementation::Profile>(guid1);
-            p0.Name(L"profile0"); // this is _profiles.at(1)
-            p1.Name(L"profile1"); // this is _profiles.at(2)
+            p0.Name(L"profile0"); // this is _allProfiles.at(1)
+            p1.Name(L"profile1"); // this is _allProfiles.at(2)
             profiles.push_back(p0);
             profiles.push_back(p1);
             return profiles;
@@ -610,13 +610,13 @@ namespace TerminalAppUnitTests
         settings->_profileGenerators.emplace_back(std::move(gen1));
 
         settings->_ParseJsonString(settings0String, false);
-        VERIFY_ARE_EQUAL(0u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(0u, settings->_allProfiles.Size());
 
         settings->_LoadDynamicProfiles();
-        VERIFY_ARE_EQUAL(3u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(3u, settings->_allProfiles.Size());
 
         settings->LayerJson(settings->_userSettings);
-        VERIFY_ARE_EQUAL(4u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(4u, settings->_allProfiles.Size());
     }
 
     void DynamicProfileTests::UserProfilesFromDisabledSourcesDontAppear()
@@ -629,7 +629,7 @@ namespace TerminalAppUnitTests
             "disabledProfileSources": ["Terminal.App.UnitTest.1"],
             "profiles": [
                 {
-                    "name" : "profile0FromUserSettings", // this is _profiles.at(0)
+                    "name" : "profile0FromUserSettings", // this is _allProfiles.at(0)
                     "guid": "{6239a42c-1111-49a3-80bd-e8fdd045185c}",
                     "source": "Terminal.App.UnitTest.0"
                 },
@@ -639,7 +639,7 @@ namespace TerminalAppUnitTests
                     "source": "Terminal.App.UnitTest.1"
                 },
                 {
-                    "name" : "profile3", // this is _profiles.at(1)
+                    "name" : "profile3", // this is _allProfiles.at(1)
                     "guid": "{6239a42c-4444-49a3-80bd-e8fdd045185c}"
                 }
             ]
@@ -649,7 +649,7 @@ namespace TerminalAppUnitTests
         gen0->pfnGenerate = [guid0, guid1]() {
             std::vector<Profile> profiles;
             Profile p0 = winrt::make<implementation::Profile>(guid0);
-            p0.Name(L"profile0"); // this is _profiles.at(0)
+            p0.Name(L"profile0"); // this is _allProfiles.at(0)
             profiles.push_back(p0);
             return profiles;
         };
@@ -670,13 +670,13 @@ namespace TerminalAppUnitTests
         settings->_profileGenerators.emplace_back(std::move(gen1));
 
         settings->_ParseJsonString(settings0String, false);
-        VERIFY_ARE_EQUAL(0u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(0u, settings->_allProfiles.Size());
 
         settings->_LoadDynamicProfiles();
-        VERIFY_ARE_EQUAL(1u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(1u, settings->_allProfiles.Size());
 
         settings->LayerJson(settings->_userSettings);
-        VERIFY_ARE_EQUAL(2u, settings->_profiles.Size());
+        VERIFY_ARE_EQUAL(2u, settings->_allProfiles.Size());
     }
 
 };


### PR DESCRIPTION
## Summary of the Pull Request
This PR replaces `CascadiaSettings::_profiles` with...
- `_allProfiles`: the list of all available profiles in the settings model (i.e. settings.json, dynamic profiles, etc...)
- `_activeProfiles`: the list of all non-hidden profiles (used for the new tab dropdown)

## References
#8018: maintaining a list of all profiles allows us to serialize hidden profiles
#1564: Settings UI can link to `AllProfiles()` instead of `ActiveProfiles()` to expose hidden profiles

## PR Checklist
* [x] Closes #4139 
* [x] Tests added/passed

## Validation Steps Performed
Deploy and testing succeeded