### PR TITLE
Disable the json linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
-          
+
       ################################
       # Run Linter against code base #
       ################################
@@ -52,3 +52,5 @@ jobs:
           MARKDOWN_CONFIG_FILE: .markdown-lint.yml
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_EDITORCONFIG: false
+          # The json linter doesn't like JSONC, which we use all over. So just disable it.
+          VALIDATE_JSON: false


### PR DESCRIPTION
All our JSON files are _actually_ JSONC files - json with comments. 

A well-behaved application that accepts JSON should accept and ignore comments. However, `jsonlint` is not a well behaved application in this regard.

So, to prevent the linter from complaining about our JSON comments, we need to disable it entirely. THAT'S RIGHT, there's not a setting to allow JSONC. 

See #8076 as an example of this working.

This will also unblock #7462.