### PR TITLE
Fix the Settings UI Color Pickers

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
@@ -45,6 +45,17 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         InitializeComponent();
         _UpdateColorSchemeList();
+
+        // Initialize our color table view model with 16 dummy colors
+        // so that on a ColorScheme selection change, we can loop through
+        // each ColorTableEntry and just change its color. Performing a
+        // clear and 16 appends doesn't seem to update the color pickers
+        // very accurately.
+        for (uint8_t i = 0; i < TableColorNames.size(); ++i)
+        {
+            auto entry = winrt::make<ColorTableEntry>(i, Windows::UI::Color{ 0, 0, 0, 0 });
+            _CurrentColorTable.Append(entry);
+        }
     }
 
     IObservableVector<hstring> ColorSchemes::ColorSchemeList()
@@ -116,11 +127,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     // - <none>
     void ColorSchemes::_UpdateColorTable(const Model::ColorScheme& colorScheme)
     {
-        _CurrentColorTable.Clear();
         for (uint8_t i = 0; i < TableColorNames.size(); ++i)
         {
-            auto entry = winrt::make<ColorTableEntry>(i, colorScheme.Table()[i]);
-            _CurrentColorTable.Append(entry);
+            _CurrentColorTable.GetAt(i).Color(colorScheme.Table()[i]);
         }
     }
 

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -71,7 +71,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             </StackPanel>
 
             <ItemsControl x:Name="ColorTableControl"
-                          ItemsSource="{x:Bind CurrentColorTable, Mode=TwoWay}"
+                          ItemsSource="{x:Bind CurrentColorTable, Mode=OneWay}"
                           Grid.Row="2"
                           Grid.Column="0">
                 <ItemsControl.ItemsPanel>
@@ -88,8 +88,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                             <Button Background="{x:Bind Color, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}">
                                 <Button.Flyout>
                                     <Flyout>
-                                        <ColorPicker Tag="{x:Bind Index, Mode=TwoWay}"
-                                                     Color="{x:Bind Color, Mode=TwoWay}"
+                                        <ColorPicker Tag="{x:Bind Index, Mode=OneWay}"
+                                                     Color="{x:Bind Color, Mode=OneWay}"
                                                      ColorChanged="ColorPickerChanged"/>
                                     </Flyout>
                                 </Button.Flyout>


### PR DESCRIPTION
This fixes the bug where on a Color Scheme change, a portion of the
color pickers will be set to the correct color, but the other portion of
the color pickers will be set to the same colors that the first portion
was set to. It looks like performing a `Clear` and `Append` confuses the
Color Pickers when they raise their `ColorChanged` events in response.
Avoiding the `Clear` and `Append` by just changing the `Color` property
allows the Color Pickers to keep their existing data bound object and
only react to their Color property changing instead of having to deal
with the whole object being swept out from under them and being given a
new one.
