### PR TITLE
Move CI and audit build to the WinDev scale set pool

### DIFF
--- a/build/pipelines/templates/build-console-audit-job.yml
+++ b/build/pipelines/templates/build-console-audit-job.yml
@@ -8,7 +8,9 @@ jobs:
   variables:
     BuildConfiguration: AuditMode
     BuildPlatform: ${{ parameters.platform }}
-  pool: { vmImage: windows-2019 }
+  pool: "windevbuildagents"
+  # The public pool is also an option!
+  # pool: { vmImage: windows-2019 }
 
   steps:
   - checkout: self

--- a/build/pipelines/templates/build-console-ci.yml
+++ b/build/pipelines/templates/build-console-ci.yml
@@ -11,7 +11,9 @@ jobs:
   variables:
     BuildConfiguration: ${{ parameters.configuration }}
     BuildPlatform: ${{ parameters.platform }}
-  pool: { vmImage: windows-2019 }
+  pool: "windevbuildagents"
+  # The public pool is also an option!
+  # pool: { vmImage: windows-2019 }
 
   steps:
   - template: build-console-steps.yml

--- a/build/pipelines/templates/build-console-steps.yml
+++ b/build/pipelines/templates/build-console-steps.yml
@@ -41,9 +41,7 @@ steps:
     configuration: '$(BuildConfiguration)'
     msbuildArgs: "${{ parameters.additionalBuildArguments }}"
     clean: true
-    # The build agents cannot currently support parallel build due to the
-    # memory requirements of our PCH files.
-    maximumCpuCount: false
+    maximumCpuCount: true
 
 - task: PowerShell@2
   displayName: 'Check MSIX for common regressions'

--- a/src/common.build.post.props
+++ b/src/common.build.post.props
@@ -54,7 +54,7 @@
   <Target Name="CleanUpPrecompForSmallCIAgents"
           DependsOnTargets="_ComputePrecompToCleanUp"
           AfterTargets="AfterBuild"
-          Condition="'$(AGENT_ID)' != '' and !$(ProjectName.Contains('TerminalApp'))">
+          Condition="'$(OpenConsoleCleanPCH)' == 'true' and '$(AGENT_ID)' != '' and !$(ProjectName.Contains('TerminalApp'))">
     <!-- We just need to keep *TerminalApp*'s PCHs because they get rebuilt more often. -->
     <Delete Files="@(_PCHFileToCleanWithTimestamp)"/>
     <Touch Files="@(_PCHFileToCleanWithTimestamp)" Time="%(LastWriteTime)" AlwaysCreate="true" />


### PR DESCRIPTION
This pull request switches us to the new WinDev scaleset agent pool. It
should be faster than the hosted pool, and the larger disks allow us to
get rid of our PCH cleanup step.