### PR TITLE
Fix potential over/underflow as noted by "TODO:" comment

### DIFF
--- a/src/host/selectionInput.cpp
+++ b/src/host/selectionInput.cpp
@@ -390,7 +390,7 @@ bool Selection::HandleKeyboardLineSelectionEvent(const INPUT_KEY_INFO* const pIn
             // shift + pgup/pgdn extends selection up or down one full screen
         case VK_NEXT:
         {
-            coordSelPoint.Y += sWindowHeight; // TODO: potential overflow
+            coordSelPoint.Y = base::CheckAdd(coordSelPoint.Y, sWindowHeight).ValueOrDefault(bufferSize.BottomInclusive());
             if (coordSelPoint.Y > bufferSize.BottomInclusive())
             {
                 coordSelPoint.Y = bufferSize.BottomInclusive();
@@ -399,7 +399,7 @@ bool Selection::HandleKeyboardLineSelectionEvent(const INPUT_KEY_INFO* const pIn
         }
         case VK_PRIOR:
         {
-            coordSelPoint.Y -= sWindowHeight; // TODO: potential underflow
+            coordSelPoint.Y = base::CheckSub(coordSelPoint.Y, sWindowHeight).ValueOrDefault(bufferSize.Top());
             if (coordSelPoint.Y < bufferSize.Top())
             {
                 coordSelPoint.Y = bufferSize.Top();


### PR DESCRIPTION
Fixed potential errors caused by overflow or underfow in
SectionInput.cpp

## PR Checklist
* [x] CLA signed
* [x] Tests added/passed

## Detailed Description of the Pull Request / Additional comments
In selectionInput.cpp, there is both a potential overflow and potential
underflow. To address this issue, I casted the calculation up to int,
which is then checked because of integer promotion. Underflow and
underflow is therefore impossible because now if the calculation exceeds
SHORT_MAX, it will have exceeded bufferSize.BottomInclusive() or
bufferSize.Top() anyway, and be set to them.

## Validation Steps Performed
Passed Unit Testing
Manual Validation