### PR TITLE
Fire and forget Hyperlink handling to break deadlock

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -3012,10 +3012,20 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     // - Checks if the uri is valid and sends an event if so
     // Arguments:
     // - The uri
-    void TermControl::_HyperlinkHandler(const std::wstring_view uri)
+    winrt::fire_and_forget TermControl::_HyperlinkHandler(const std::wstring_view uri)
     {
-        auto hyperlinkArgs = winrt::make_self<OpenHyperlinkEventArgs>(winrt::hstring{ uri });
-        _openHyperlinkHandlers(*this, *hyperlinkArgs);
+        // Save things we need to resume later.
+        winrt::hstring heldUri{ uri };
+        auto strongThis{ get_strong() };
+
+        // Pop the rest of this function to the tail of the UI thread
+        // Just in case someone was holding a lock when they called us and
+        // the handlers decide to do something that take another lock
+        // (like ShellExecute pumping our messaging thread...GH#7994)
+        co_await Dispatcher();
+        
+        auto hyperlinkArgs = winrt::make_self<OpenHyperlinkEventArgs>(heldUri);
+        _openHyperlinkHandlers(*strongThis, *hyperlinkArgs);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -3023,7 +3023,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         // the handlers decide to do something that take another lock
         // (like ShellExecute pumping our messaging thread...GH#7994)
         co_await Dispatcher();
-        
+
         auto hyperlinkArgs = winrt::make_self<OpenHyperlinkEventArgs>(heldUri);
         _openHyperlinkHandlers(*strongThis, *hyperlinkArgs);
     }

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -256,7 +256,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void _LostFocusHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
         winrt::fire_and_forget _DragDropHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::DragEventArgs const e);
         void _DragOverHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::DragEventArgs const& e);
-        void _HyperlinkHandler(const std::wstring_view uri);
+        winrt::fire_and_forget _HyperlinkHandler(const std::wstring_view uri);
 
         void _CursorTimerTick(Windows::Foundation::IInspectable const& sender, Windows::Foundation::IInspectable const& e);
         void _BlinkTimerTick(Windows::Foundation::IInspectable const& sender, Windows::Foundation::IInspectable const& e);


### PR DESCRIPTION
Fire and forget on the hyperlink handler inside the TermControl. 

## PR Checklist
* [x] Closes #7994 
* [x] Tested manually
* [x] Hi, I work here.

## Detailed Description of the Pull Request / Additional comments
In `TermControl`, `_HyperlinkHandler` is called by
`_PointerPressedHandler` which has taken a write lock for all its
friends. However, `_HyperlinkHandler` downstreams to `ShellExecute`
which can pump the message queue looking for something. That pumping of
the queue can trigger messages that also want the write lock to update
state. They get stuck. Everything hangs. 

`_HyperlinkHandler` really only needs read lock and really only for as
long as it takes to fill up its parameters before it's invoked... but
the simpler and more contained solution is to just fire and forget the
rest of the method that causes the deadlock to a continuation at the
tail of the dispatcher queue so `_PointerPressedHandler` can complete
and naturally drop the write lock.

## Validation Steps Performed
- Launched `main` manually on my box and clicked the hyperlink that is
  detected when Powershell starts and it froze.
- Launched this change manually on my box and clicked the hyperlink that
  is detected when Powershell starts and it did not freeze.