### PR TITLE
Warn the user if the keyboard service is disabled

### DIFF
--- a/.github/actions/spell-check/dictionary/apis.txt
+++ b/.github/actions/spell-check/dictionary/apis.txt
@@ -50,6 +50,7 @@ rfind
 roundf
 RSHIFT
 rx
+schandle
 serializer
 SIZENS
 spsc

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -507,7 +507,7 @@ namespace winrt::TerminalApp::implementation
         // not be noisy with this dialog if we failed for some reason.
 
         // Open the service manager. This will return 0 if it failed.
-        wil::unique_schandle hManager{ OpenSCManager(nullptr, nullptr, SERVICE_QUERY_STATUS) };
+        wil::unique_schandle hManager{ OpenSCManager(nullptr, nullptr, 0) };
 
         if (LOG_LAST_ERROR_IF(!hManager.is_valid()))
         {

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -412,6 +412,7 @@ namespace winrt::TerminalApp::implementation
         DWORD cchBuffer = 0;
         GetServiceDisplayName(hManager.get(), L"TabletInputService", nullptr, &cchBuffer);
         std::wstring buffer;
+        cchBuffer += 1; // Add space for a null
         buffer.resize(cchBuffer);
 
         if (LOG_LAST_ERROR_IF(!GetServiceDisplayName(hManager.get(),
@@ -526,7 +527,8 @@ namespace winrt::TerminalApp::implementation
     void AppLogic::_OnLoaded(const IInspectable& /*sender*/,
                              const RoutedEventArgs& /*eventArgs*/)
     {
-        const auto keyboardServiceIsDisabled = !_IsKeyboardServiceEnabled();
+        const auto keyboardServiceIsDisabled = true;
+        // const auto keyboardServiceIsDisabled = !_IsKeyboardServiceEnabled();
         if (keyboardServiceIsDisabled)
         {
             _ShowKeyboardServiceDisabledDialog();

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -400,6 +400,12 @@ namespace winrt::TerminalApp::implementation
         ShowDialog(dialog);
     }
 
+    // Method Description:
+    // - Displays a dialog if the "Touch, Keyboard and Handwriting Panel
+    //   Service" is disabled. If it is, we want to warn the user, because they
+    //   won't be able to type in the Terminal.
+    // - Only one dialog can be visible at a time. If another dialog is visible
+    //   when this is called, nothing happens. See ShowDialog for details
     void AppLogic::_ShowKeyboardServiceDisabledDialog()
     {
         auto title = RS_(L"KeyboardServiceWarningTitle");
@@ -511,6 +517,14 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
+    // Method Description:
+    // - Helper for determining if the "Touch, Keyboard and Handwriting Panel
+    //   Service" is enabled. If it isn't, we want to be able to display a
+    //   warning to the user, because they won't be able to type in the
+    //   Terminal.
+    // Return Value:
+    // - true if the service is enabled, or if we fail to query the service. We
+    //   return true in that case, to be less noisy (though, that is unexpected)
     bool AppLogic::_IsKeyboardServiceEnabled()
     {
         if (IsUwp())
@@ -524,7 +538,7 @@ namespace winrt::TerminalApp::implementation
 
         // Open the service manager. This will return 0 if it failed.
         wil::unique_schandle hManager{ OpenSCManager(nullptr, nullptr, SERVICE_QUERY_STATUS) };
-        
+
         if (LOG_LAST_ERROR_IF(!hManager.is_valid()))
         {
             return true;

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -488,7 +488,7 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Method Description:
-    // - Helper for determining if the "Touch, Keyboard and Handwriting Panel
+    // - Helper for determining if the "Touch Keyboard and Handwriting Panel
     //   Service" is enabled. If it isn't, we want to be able to display a
     //   warning to the user, because they won't be able to type in the
     //   Terminal.
@@ -515,7 +515,7 @@ namespace winrt::TerminalApp::implementation
         }
 
         // Get a handle to the keyboard service
-        wil::unique_schandle hService{ OpenService(hManager.get(), L"TabletInputService", SERVICE_QUERY_STATUS) };
+        wil::unique_schandle hService{ OpenService(hManager.get(), TabletInputServiceKey.data(), SERVICE_QUERY_STATUS) };
         if (LOG_LAST_ERROR_IF(!hService.is_valid()))
         {
             return true;

--- a/src/cascadia/TerminalApp/AppLogic.h
+++ b/src/cascadia/TerminalApp/AppLogic.h
@@ -85,6 +85,8 @@ namespace winrt::TerminalApp::implementation
 
         void _ShowLoadErrorsDialog(const winrt::hstring& titleKey, const winrt::hstring& contentKey, HRESULT settingsLoadedResult);
         void _ShowLoadWarningsDialog();
+        bool _IsKeyboardServiceEnabled();
+        void _ShowKeyboardServiceDisabledDialog();
 
         fire_and_forget _LoadErrorsDialogRoutine();
         fire_and_forget _ShowLoadWarningsDialogRoutine();

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -148,6 +148,12 @@
   </data>
   <data name="SettingsValidateErrorTitle" xml:space="preserve">
     <value>Encountered errors while loading user settings</value>
+  </data>
+  <data name="KeyboardServiceWarningTitle" xml:space="preserve">
+    <value>Warning:</value>
+  </data>
+  <data name="KeyboardServiceWarningText" xml:space="preserve">
+    <value>The "Touch Keyboard and Handwriting Panel Service" isn't running on your machine. This can prevent the Terminal from receiving keyboard input.</value>
   </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -149,7 +149,10 @@
   <data name="SettingsValidateErrorTitle" xml:space="preserve">
     <value>Encountered errors while loading user settings</value>
   </data>
-  <data name="KeyboardServiceWarningTitle" xml:space="preserve">
+  <data name="KeyboardServiceDisabledDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Ok</value>
+  </data>
+  <data name="KeyboardServiceDisabledDialog.Title" xml:space="preserve">
     <value>Warning:</value>
   </data>
   <data name="KeyboardServiceWarningText" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -153,7 +153,7 @@
     <value>Warning:</value>
   </data>
   <data name="KeyboardServiceWarningText" xml:space="preserve">
-    <value>The "{0}" service isn't running on your machine. This can prevent the Terminal from receiving keyboard input.</value>
+    <value>The "{0}" isn't running on your machine. This can prevent the Terminal from receiving keyboard input.</value>
     <comment>{0} will be replaced with the OS-localized name of the TabletInputService</comment>
   </data>
   <data name="Ok" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -153,7 +153,8 @@
     <value>Warning:</value>
   </data>
   <data name="KeyboardServiceWarningText" xml:space="preserve">
-    <value>The "Touch Keyboard and Handwriting Panel Service" isn't running on your machine. This can prevent the Terminal from receiving keyboard input.</value>
+    <value>The "{0}" service isn't running on your machine. This can prevent the Terminal from receiving keyboard input.</value>
+    <comment>{0} will be replaced with the OS-localized name of the TabletInputService</comment>
   </data>
   <data name="Ok" xml:space="preserve">
     <value>OK</value>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -150,7 +150,7 @@
     <value>Encountered errors while loading user settings</value>
   </data>
   <data name="KeyboardServiceDisabledDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Ok</value>
+    <value>OK</value>
   </data>
   <data name="KeyboardServiceDisabledDialog.Title" xml:space="preserve">
     <value>Warning:</value>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2642,7 +2642,7 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Method Description:
-    // - Displays a dialog stating the "Touch, Keyboard and Handwriting Panel
+    // - Displays a dialog stating the "Touch Keyboard and Handwriting Panel
     //   Service" is disabled.
     void TerminalPage::ShowKeyboardServiceWarning()
     {
@@ -2653,12 +2653,12 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Function Description:
-    // - Helper function to get the OS-localized name for the "Touch, Keyboard
+    // - Helper function to get the OS-localized name for the "Touch Keyboard
     //   and Handwriting Panel Service". If we can't open up the service for any
     //   reason, then we'll just return the service's key, "TabletInputService".
     // Return Value:
     // - The OS-localized name for the TabletInputService
-    std::wstring _getTabletServiceName()
+    winrt::hstring _getTabletServiceName()
     {
         auto isUwp = false;
         try
@@ -2669,30 +2669,30 @@ namespace winrt::TerminalApp::implementation
 
         if (isUwp)
         {
-            return L"TabletInputService";
+            return winrt::hstring{ TabletInputServiceKey };
         }
 
         wil::unique_schandle hManager{ OpenSCManager(nullptr, nullptr, 0) };
 
         if (LOG_LAST_ERROR_IF(!hManager.is_valid()))
         {
-            return L"TabletInputService";
+            return winrt::hstring{ TabletInputServiceKey };
         }
 
         DWORD cchBuffer = 0;
-        GetServiceDisplayName(hManager.get(), L"TabletInputService", nullptr, &cchBuffer);
+        GetServiceDisplayName(hManager.get(), TabletInputServiceKey.data(), nullptr, &cchBuffer);
         std::wstring buffer;
         cchBuffer += 1; // Add space for a null
         buffer.resize(cchBuffer);
 
         if (LOG_LAST_ERROR_IF(!GetServiceDisplayName(hManager.get(),
-                                                     L"TabletInputService",
+                                                     TabletInputServiceKey.data(),
                                                      buffer.data(),
                                                      &cchBuffer)))
         {
-            return L"TabletInputService";
+            return winrt::hstring{ TabletInputServiceKey };
         }
-        return buffer;
+        return winrt::hstring{ buffer };
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2699,7 +2699,7 @@ namespace winrt::TerminalApp::implementation
     // - Return the fully-formed warning message for the
     //   "KeyboardServiceDisabled" dialog. This dialog is used to warn the user
     //   if the keyboard service is disabled, and uses the OS localization for
-    //   the service's actual name. It's boud to the dialog in XAML.
+    //   the service's actual name. It's bound to the dialog in XAML.
     // Return Value:
     // - The warning message, including the OS-localized service name.
     winrt::hstring TerminalPage::KeyboardServiceDisabledText()

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -71,6 +71,9 @@ namespace winrt::TerminalApp::implementation
         winrt::TerminalApp::IDialogPresenter DialogPresenter() const;
         void DialogPresenter(winrt::TerminalApp::IDialogPresenter dialogPresenter);
 
+        void ShowKeyboardServiceWarning();
+        winrt::hstring KeyboardServiceDisabledText();
+
         // -------------------------------- WinRT Events ---------------------------------
         DECLARE_EVENT_WITH_TYPED_EVENT_HANDLER(TitleChanged, _titleChangeHandlers, winrt::Windows::Foundation::IInspectable, winrt::hstring);
         DECLARE_EVENT_WITH_TYPED_EVENT_HANDLER(LastTabClosed, _lastTabClosedHandlers, winrt::Windows::Foundation::IInspectable, winrt::TerminalApp::LastTabClosedEventArgs);

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -13,7 +13,7 @@
 #include "AppCommandlineArgs.h"
 
 static constexpr uint32_t DefaultRowsToScroll{ 3 };
-
+static constexpr std::wstring_view TabletInputServiceKey{ L"TabletInputService" };
 // fwdecl unittest classes
 namespace TerminalAppLocalTests
 {

--- a/src/cascadia/TerminalApp/TerminalPage.idl
+++ b/src/cascadia/TerminalApp/TerminalPage.idl
@@ -26,6 +26,8 @@ namespace TerminalApp
         // that there's only one application-global dialog visible at a time,
         // and because of GH#5224.
         IDialogPresenter DialogPresenter;
+        void ShowKeyboardServiceWarning();
+        String KeyboardServiceDisabledText { get; };
 
         event Windows.Foundation.TypedEventHandler<Object, String> TitleChanged;
         event Windows.Foundation.TypedEventHandler<Object, LastTabClosedEventArgs> LastTabClosed;

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -82,6 +82,20 @@ the MIT License. See LICENSE in the project root for license information. -->
             </TextBlock>
         </ContentDialog>
 
+
+        <ContentDialog
+            x:Load="False"
+            x:Name="KeyboardServiceDisabledDialog"
+            x:Uid="KeyboardServiceDisabledDialog"
+            DefaultButton="Primary">
+
+            <TextBlock
+                Foreground="{ThemeResource ErrorTextBrush}"
+                IsTextSelectionEnabled="True"
+                TextWrapping="WrapWholeWords"
+                Text="{x:Bind KeyboardServiceDisabledText, Mode=OneWay}" />
+        </ContentDialog>
+
         <local:CommandPalette
             x:Name="CommandPalette"
             Grid.Row="1"

--- a/src/tools/scratch/main.cpp
+++ b/src/tools/scratch/main.cpp
@@ -2,9 +2,86 @@
 // Licensed under the MIT license.
 
 #include <windows.h>
+#include <stdio.h>
 
 // This wmain exists for help in writing scratch programs while debugging.
 int __cdecl wmain(int /*argc*/, WCHAR* /*argv[]*/)
 {
+    printf("Getting manager...\n");
+    auto hManager = OpenSCManager(nullptr, nullptr, SERVICE_QUERY_CONFIG);
+    // printf("OpenSCManager returned %d\n", static_cast<unsigned long long>(hManager));
+    if (hManager == 0)
+    {
+        auto gle = GetLastError();
+        printf("gle: %d", gle);
+        return gle;
+    }
+
+    printf("Getting service...\n");
+    auto hService = OpenService(hManager, L"TabletInputService", SERVICE_QUERY_CONFIG | SERVICE_QUERY_STATUS);
+    // printf("OpenService returned %d\n", static_cast<unsigned long long>(hService));
+    if (hService == 0)
+    {
+        auto gle = GetLastError();
+        printf("gle: %d", gle);
+        return gle;
+    }
+
+    DWORD dwBytesNeeded = 0;
+    LPQUERY_SERVICE_CONFIG lpsc = nullptr;
+
+    printf("Getting config size...\n");
+    if (!QueryServiceConfig(hService,
+                            NULL,
+                            0,
+                            &dwBytesNeeded))
+    {
+        auto gle = GetLastError();
+        if (ERROR_INSUFFICIENT_BUFFER == gle)
+        {
+            auto cbBufSize = dwBytesNeeded;
+            lpsc = (LPQUERY_SERVICE_CONFIG)LocalAlloc(LMEM_FIXED, cbBufSize);
+        }
+        else
+        {
+            printf("QueryServiceConfig failed (%d)", gle);
+            return gle;
+        }
+    }
+
+    printf("Getting config...\n");
+    if (!QueryServiceConfig(hService,
+                            lpsc,
+                            dwBytesNeeded,
+                            &dwBytesNeeded))
+    {
+        auto gle = GetLastError();
+        printf("QueryServiceConfig failed (%d)", gle);
+        return gle;
+    }
+
+    printf("Succeeded!\n");
+
+    printf("Start Type: 0x%x\n", lpsc->dwStartType);
+
+    SERVICE_STATUS status{ 0 };
+    if (!QueryServiceStatus(hService, &status))
+    {
+        auto gle = GetLastError();
+        printf("QueryServiceStatus failed (%d)", gle);
+        return gle;
+    }
+    printf("State: 0x%x\n", status.dwCurrentState);
+
+    auto state = status.dwCurrentState;
+    if (state != SERVICE_RUNNING && state != SERVICE_START_PENDING)
+    {
+        printf("The service is stopped\n");
+    }
+    else
+    {
+        printf("The service is running\n");
+    }
+
     return 0;
 }

--- a/src/tools/scratch/main.cpp
+++ b/src/tools/scratch/main.cpp
@@ -2,86 +2,9 @@
 // Licensed under the MIT license.
 
 #include <windows.h>
-#include <stdio.h>
 
 // This wmain exists for help in writing scratch programs while debugging.
 int __cdecl wmain(int /*argc*/, WCHAR* /*argv[]*/)
 {
-    printf("Getting manager...\n");
-    auto hManager = OpenSCManager(nullptr, nullptr, SERVICE_QUERY_CONFIG);
-    // printf("OpenSCManager returned %d\n", static_cast<unsigned long long>(hManager));
-    if (hManager == 0)
-    {
-        auto gle = GetLastError();
-        printf("gle: %d", gle);
-        return gle;
-    }
-
-    printf("Getting service...\n");
-    auto hService = OpenService(hManager, L"TabletInputService", SERVICE_QUERY_CONFIG | SERVICE_QUERY_STATUS);
-    // printf("OpenService returned %d\n", static_cast<unsigned long long>(hService));
-    if (hService == 0)
-    {
-        auto gle = GetLastError();
-        printf("gle: %d", gle);
-        return gle;
-    }
-
-    DWORD dwBytesNeeded = 0;
-    LPQUERY_SERVICE_CONFIG lpsc = nullptr;
-
-    printf("Getting config size...\n");
-    if (!QueryServiceConfig(hService,
-                            NULL,
-                            0,
-                            &dwBytesNeeded))
-    {
-        auto gle = GetLastError();
-        if (ERROR_INSUFFICIENT_BUFFER == gle)
-        {
-            auto cbBufSize = dwBytesNeeded;
-            lpsc = (LPQUERY_SERVICE_CONFIG)LocalAlloc(LMEM_FIXED, cbBufSize);
-        }
-        else
-        {
-            printf("QueryServiceConfig failed (%d)", gle);
-            return gle;
-        }
-    }
-
-    printf("Getting config...\n");
-    if (!QueryServiceConfig(hService,
-                            lpsc,
-                            dwBytesNeeded,
-                            &dwBytesNeeded))
-    {
-        auto gle = GetLastError();
-        printf("QueryServiceConfig failed (%d)", gle);
-        return gle;
-    }
-
-    printf("Succeeded!\n");
-
-    printf("Start Type: 0x%x\n", lpsc->dwStartType);
-
-    SERVICE_STATUS status{ 0 };
-    if (!QueryServiceStatus(hService, &status))
-    {
-        auto gle = GetLastError();
-        printf("QueryServiceStatus failed (%d)", gle);
-        return gle;
-    }
-    printf("State: 0x%x\n", status.dwCurrentState);
-
-    auto state = status.dwCurrentState;
-    if (state != SERVICE_RUNNING && state != SERVICE_START_PENDING)
-    {
-        printf("The service is stopped\n");
-    }
-    else
-    {
-        printf("The service is running\n");
-    }
-
     return 0;
 }


### PR DESCRIPTION
## Summary of the Pull Request

![kb-service-disabled](https://user-images.githubusercontent.com/18356694/97578533-eb792d80-19be-11eb-9b13-b771327a72a0.png)

With this PR, the Terminal will check to make sure the "Touch, Keyboard and Handwriting Panel Service" is enabled at startup. If it isn't, then the Terminal won't be able to receive keyboard input (see #4448 and the 20 linked issues to that one).

## References

* See #4448 for more details

## PR Checklist
* [x] Closes #7886 
* [ ] Should this make #4448 not-open as well?
* [x] I work here
* [n/a] Tests added/passed
* [x] Docs: https://github.com/MicrosoftDocs/terminal/pull/168

## Validation Steps Performed

I manually set the service to "Disabled", restarted the machine, verified the dialog opens (and that I'm unable to type in the Terminal), then re-set the service to automatic and rebooted, and the dialog doesn't appear.