### PR TITLE
Add missing settings to Settings UI

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
@@ -39,6 +39,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                     <RadioButton x:Uid="Globals_TabWidthModeCompact" x:Name="CompactTabWidthMode"/>
                 </Controls:RadioButtons>
                 <CheckBox x:Uid="Globals_ConfirmCloseAllTabs" IsChecked="{x:Bind GlobalSettings.ConfirmCloseAllTabs, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
+                <CheckBox x:Uid="Globals_DisableAnimations" IsChecked="{x:Bind GlobalSettings.DisableAnimations, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
             </StackPanel>
         </Grid>
     </ScrollViewer>

--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -30,6 +30,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                     <RadioButton x:Uid="Globals_LaunchSizeDefault" x:Name="DefaultLaunchSize"/>
                     <RadioButton x:Uid="Globals_LaunchSizeMaximized" x:Name="MaximizedLaunchSize"/>
                     <RadioButton x:Uid="Globals_LaunchSizeFullscreen" x:Name="FullscreenLaunchSize"/>
+                    <RadioButton x:Uid="Globals_LaunchSizeFocus" x:Name="FocusLaunchSize"/>
+                    <RadioButton x:Uid="Globals_LaunchSizeMaximizedFocus" x:Name="MaximizedFocusLaunchSize"/>
                 </Controls:RadioButtons>
                 <!--TODO: Converter here for launch position into the cols and rows number boxes-->
                 <!--<TextBox x:Uid="Globals_LaunchPosition" Text="{x:Bind GlobalSettings.LaunchPosition, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse"/>

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -258,6 +258,10 @@ the MIT License. See LICENSE in the project root for license information. -->
                             <RadioButton x:Uid="Profile_CloseOnExitAlways" x:Name="closeOnExitAlways"/>
                             <RadioButton x:Uid="Profile_CloseOnExitNever" x:Name="closeOnExitNever"/>
                         </Controls:RadioButtons>
+                        <Controls:RadioButtons x:Uid="Profile_BellStyle" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
+                            <RadioButton x:Uid="Profile_BellStyleNone" x:Name="bellStyleNone"/>
+                            <RadioButton x:Uid="Profile_BellStyleAudible" x:Name="bellStyleAudible"/>
+                        </Controls:RadioButtons>
                     </StackPanel>
                 </Grid>
             </PivotItem>

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -259,8 +259,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                             <RadioButton x:Uid="Profile_CloseOnExitNever" x:Name="closeOnExitNever"/>
                         </Controls:RadioButtons>
                         <Controls:RadioButtons x:Uid="Profile_BellStyle" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
-                            <RadioButton x:Uid="Profile_BellStyleNone" x:Name="bellStyleNone"/>
                             <RadioButton x:Uid="Profile_BellStyleAudible" x:Name="bellStyleAudible"/>
+                            <RadioButton x:Uid="Profile_BellStyleNone" x:Name="bellStyleNone"/>
                         </Controls:RadioButtons>
                     </StackPanel>
                 </Grid>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -248,7 +248,8 @@
     <value>Launch size</value>
   </data>
   <data name="Globals_LaunchSize.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Defines whether the terminal will launch as maximized, full screen, or in a window. Setting this to "Focus" is equivalent to launching the terminal in the "Default" mode, but with the focus mode enabled. Similar, setting this to "Maximized Focus" will result in launching the terminal in a maximized window with the focus mode enabled.</value>
+    <value>Defines whether the terminal will launch as maximized, full screen, or in a window. Setting this to "Focus" is equivalent to launching the terminal in the "Default" mode, but with the focus mode enabled. Similarly, setting this to "Maximized Focus" will result in launching the terminal in a maximized window with the focus mode enabled.</value>
+
     <comment>"Focus", "Default", and "Maximized Focus" must match Globals_LaunchSizeFocus.Content, Globals_LaunchSizeDefault.Content, and Globals_LaunchSizeMaximizedFocus.Content values respectively.</comment>
   </data>
   <data name="Globals_LaunchSizeDefault.Content" xml:space="preserve">
@@ -660,7 +661,8 @@
     <value>Bell notification style</value>
   </data>
   <data name="Profile_BellStyle.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Controls what happens when the application emits a BEL character. When set to "Audible", the Terminal will play a sound. When set to "None", nothing will happen.</value>
+    <value>Controls what happens when the application emits a BEL character.</value>
+
     <comment>"Audible" and "None" must match the values for Profile_BellStyleAudible.Content and Profile_BellStyleNone.Content respectively.</comment>
   </data>
   <data name="Profile_BellStyleAudible.Content" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -657,7 +657,7 @@
     <value>Maximized Focus</value>
   </data>
   <data name="Profile_BellStyle.Header" xml:space="preserve">
-    <value>Notification style for BEL character</value>
+    <value>Bell notification style</value>
   </data>
   <data name="Profile_BellStyle.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Controls what happens when the application emits a BEL character. When set to "Audible", the Terminal will play a sound. When set to "None", nothing will happen.</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -214,9 +214,6 @@
   <data name="Globals_DisableDynamicProfiles.Content" xml:space="preserve">
     <value>Automatically create new profiles when new shells are installed</value>
   </data>
-  <data name="Globals_DisableDynamicProfiles.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Enables all of the dynamic profile generators, adding their profiles to the list of profiles on startup.</value>
-  </data>
   <data name="Globals_ForceFullRepaint.Content" xml:space="preserve">
     <value>Redraw entire screen when display updates</value>
   </data>
@@ -251,7 +248,8 @@
     <value>Launch size</value>
   </data>
   <data name="Globals_LaunchSize.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Defines whether the terminal will launch in a window, maximized, or full screen.</value>
+    <value>Defines whether the terminal will launch as maximized, full screen, or in a window. Setting this to "Focus" is equivalent to launching the terminal in the "Default" mode, but with the focus mode enabled. Similar, setting this to "Maximized Focus" will result in launching the terminal in a maximized window with the focus mode enabled.</value>
+    <comment>"Focus", "Default", and "Maximized Focus" must match Globals_LaunchSizeFocus.Content, Globals_LaunchSizeDefault.Content, and Globals_LaunchSizeMaximizedFocus.Content values respectively.</comment>
   </data>
   <data name="Globals_LaunchSizeDefault.Content" xml:space="preserve">
     <value>Default</value>
@@ -651,5 +649,33 @@
   <data name="Settings_UnsavedSettingsWarning.Text" xml:space="preserve">
     <value>⚠ You have unsaved changes.</value>
     <comment>{Locked="⚠"}</comment>
+  </data>
+  <data name="Globals_LaunchSizeFocus.Content" xml:space="preserve">
+    <value>Focus</value>
+  </data>
+  <data name="Globals_LaunchSizeMaximizedFocus.Content" xml:space="preserve">
+    <value>Maximized Focus</value>
+  </data>
+  <data name="Profile_BellStyle.Header" xml:space="preserve">
+    <value>Notification style for BEL character</value>
+  </data>
+  <data name="Profile_BellStyle.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Controls what happens when the application emits a BEL character. When set to "Audible", the Terminal will play a sound. When set to "None", nothing will happen.</value>
+    <comment>"Audible" and "None" must match the values for Profile_BellStyleAudible.Content and Profile_BellStyleNone.Content respectively.</comment>
+  </data>
+  <data name="Profile_BellStyleAudible.Content" xml:space="preserve">
+    <value>Audible</value>
+  </data>
+  <data name="Profile_BellStyleNone.Content" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="Globals_DisableAnimations.Content" xml:space="preserve">
+    <value>Disable visual animations</value>
+  </data>
+  <data name="Globals_DisableAnimations.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>When checked, visual animations will be disabled across the application.</value>
+  </data>
+  <data name="Globals_DisableDynamicProfiles.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Enables all of the dynamic profile generators, adding their profiles to the list of profiles on startup.</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request
Since we've started working on the Settings UI, a few settings have been added on `main`. This adds those missing settings over. 

## References
Missing settings include...
- #7364: `disableAnimations`
- #7873: `launchMode` `focus` and `maximizedFocus`
- #7793: `bellStyle`

## Validation Steps Performed
Verified that those settings appear properly in the Settings UI.