### PR TITLE
Remove code to navigate to home page on SUI launch

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -44,20 +44,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void MainPage::SettingsNav_Loaded(IInspectable const&, RoutedEventArgs const&)
     {
-        //// set the initial selectedItem
-        for (uint32_t i = 0; i < SettingsNav().MenuItems().Size(); i++)
-        {
-            const auto item = SettingsNav().MenuItems().GetAt(i).as<Controls::ContentControl>();
-            const hstring homeNav = L"General_Nav";
-            const hstring itemTag = unbox_value<hstring>(item.Tag());
-
-            if (itemTag == homeNav)
-            {
-                SettingsNav().SelectedItem(item);
-                break;
-            }
-        }
-
         contentFrame().Navigate(xaml_typename<Editor::Launch>());
     }
 

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -44,7 +44,14 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void MainPage::SettingsNav_Loaded(IInspectable const&, RoutedEventArgs const&)
     {
-        contentFrame().Navigate(xaml_typename<Editor::Launch>());
+        auto initialItem = SettingsNav().MenuItems().GetAt(0);
+        SettingsNav().SelectedItem(initialItem);
+
+        // Manually navigate because setting the selected item programmatically doesn't trigger ItemInvoked.
+        if (auto tag = initialItem.as<MUX::Controls::NavigationViewItem>().Tag())
+        {
+            Navigate(contentFrame(), unbox_value<hstring>(tag));
+        }
     }
 
     void MainPage::SettingsNav_ItemInvoked(MUX::Controls::NavigationView const&, MUX::Controls::NavigationViewItemInvokedEventArgs const& args)


### PR DESCRIPTION
This PR fixes a crash where looping through a NavView's items would attempt to grab a `NavigationViewItemHeader`'s null tag and crash. This for-loop wasn't needed anyway since we've gotten rid of the home page.

