### PR TITLE
Make the link underline less obtrusive; don't use it for pattern

### DIFF
--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -913,17 +913,18 @@ void Renderer::_PaintBufferOutputGridLineHelper(_In_ IRenderEngine* const pEngin
     IRenderEngine::GridLines lines = Renderer::s_GetGridlines(textAttribute);
 
     // For now, we dash underline patterns and switch to regular underline on hover
-    if (_pData->GetPatternId(coordTarget).size() > 0)
+    // Since we're only rendering pattern links on *hover*, there's no point in checking
+    // the pattern range if we aren't currently hovering.
+    if (_hoveredInterval.has_value())
     {
-        if (_hoveredInterval.has_value() &&
-            _hoveredInterval.value().start <= til::point{ coordTarget } &&
-            til::point{ coordTarget } <= _hoveredInterval.value().stop)
+        const til::point coordTargetTil{ coordTarget };
+        if (_hoveredInterval->start <= coordTargetTil &&
+            coordTargetTil <= _hoveredInterval->stop)
         {
-            lines |= IRenderEngine::GridLines::Underline;
-        }
-        else
-        {
-            lines |= IRenderEngine::GridLines::HyperlinkUnderline;
+            if (_pData->GetPatternId(coordTarget).size() > 0)
+            {
+                lines |= IRenderEngine::GridLines::Underline;
+            }
         }
     }
 

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -632,13 +632,17 @@ static constexpr D2D1_ALPHA_MODE _dxgiAlphaToD2d1Alpha(DXGI_ALPHA_MODE mode) noe
         _dashStrokeStyleProperties = D2D1_STROKE_STYLE_PROPERTIES{
             D2D1_CAP_STYLE_SQUARE, // startCap
             D2D1_CAP_STYLE_SQUARE, // endCap
-            D2D1_CAP_STYLE_SQUARE, // dashCap
+            D2D1_CAP_STYLE_FLAT, // dashCap
             D2D1_LINE_JOIN_MITER, // lineJoin
             0.f, // miterLimit
-            D2D1_DASH_STYLE_DASH, // dashStyle
+            D2D1_DASH_STYLE_CUSTOM, // dashStyle
             0.f, // dashOffset
         };
-        RETURN_IF_FAILED(_d2dFactory->CreateStrokeStyle(&_dashStrokeStyleProperties, nullptr, 0, &_dashStrokeStyle));
+        // Custom dashes:
+        // #   #   #   #
+        // 1234123412341234
+        static constexpr std::array<float, 2> hyperlinkDashes{ 1.f, 3.f };
+        RETURN_IF_FAILED(_d2dFactory->CreateStrokeStyle(&_dashStrokeStyleProperties, hyperlinkDashes.data(), gsl::narrow_cast<UINT32>(hyperlinkDashes.size()), &_dashStrokeStyle));
         _hyperlinkStrokeStyle = _dashStrokeStyle;
 
         // If in composition mode, apply scaling factor matrix


### PR DESCRIPTION
This pull request switches up the treatment we use for pattern-detected
links and OSC 8 hyperlinks:

* Links generated via OSC 8 have a sparse dotted underline instead of a
  thick dashed one
   * **BEFORE**
      * ![image](https://user-images.githubusercontent.com/189190/98027742-f9b1ba00-1dc1-11eb-9633-d5fa26898c81.png)
   * **AFTER**
      * ![image](https://user-images.githubusercontent.com/189190/98027715-edc5f800-1dc1-11eb-9ba6-73e6e40e4bc8.png)
* Links generated by pattern detection _are not underlined until they've
  hovered_
   * This papers over a visual glitch that is a result of us updating
     the pattern matches every ~500ms (on change)
   * **BEFORE**
      * ![image](https://user-images.githubusercontent.com/189190/98027899-2fef3980-1dc2-11eb-898f-047b5ea46ef9.png)
   * **AFTER**
      * ![image](https://user-images.githubusercontent.com/189190/98027853-2239b400-1dc2-11eb-929d-87b2fc21eba4.png)
      * ![image](https://user-images.githubusercontent.com/189190/98027870-2a91ef00-1dc2-11eb-83fa-111a3c5594a8.png)

Closes #8123