### PR TITLE
Use LanguageStandard over explicit compiler flag for C++17

### DIFF
--- a/.github/actions/spell-check/expect/expect.txt
+++ b/.github/actions/spell-check/expect/expect.txt
@@ -2191,6 +2191,7 @@ Statusline
 stdafx
 STDAPI
 stdcall
+stdcpp
 stderr
 stdexcept
 stdin

--- a/src/common.build.pre.props
+++ b/src/common.build.pre.props
@@ -94,7 +94,8 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
-      <AdditionalOptions>/std:c++17 /utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <ResourceCompile>


### PR DESCRIPTION
Turns out there's an actual way to specify C++17 for MSBuild purposes
besides just passing the compile flag.

## References
* Future C++20 support (modules)

## PR Checklist
* [x] Closes random fact found while exploring VS16.8 preview C++20
  modules.
* [x] I work here.
* [x] It still builds.

## Detailed Description of the Pull Request / Additional comments
* We've been setting C++17 with just the flag passed to the compiler
  `cl.exe`. But it turns out that this particular `LanguageStandard`
  option will need to be set appropriately one day for us to use C++20
  modules (as evidenced by the latest VS16.8 preview that I tried out to
  explore modules.) The `AdditionalOption` alone isn't enough to ensure
  that modules can be "seen" by other projects after production, but
  `LanguageStandard` is (and will set the compiler option as appropriate
  as well as whatever internal goo that MSBuild needs to hook up other
  stuff.)

## Validation Steps Performed
* Built with it changed.