### PR TITLE
Update active profiles when loading defaults

### DIFF
--- a/src/cascadia/LocalTests_SettingsModel/DeserializationTests.cpp
+++ b/src/cascadia/LocalTests_SettingsModel/DeserializationTests.cpp
@@ -83,6 +83,8 @@ namespace SettingsModelLocalTests
         TEST_METHOD(TestCopy);
         TEST_METHOD(TestCloneInheritanceTree);
 
+        TEST_METHOD(TestValidDefaults);
+
         TEST_CLASS_SETUP(ClassSetup)
         {
             InitializeJsonReader();
@@ -2582,5 +2584,14 @@ namespace SettingsModelLocalTests
 
         verifyEmptyPD(emptyPDJson);
         verifyEmptyPD(missingPDJson);
+    }
+
+    void DeserializationTests::TestValidDefaults()
+    {
+        // GH#8146: A LoadDefaults call should populate the list of active profiles
+
+        const auto settings{ CascadiaSettings::LoadDefaults() };
+        VERIFY_ARE_EQUAL(settings.ActiveProfiles().Size(), settings.AllProfiles().Size());
+        VERIFY_ARE_EQUAL(settings.AllProfiles().Size(), 2u);
     }
 }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -323,6 +323,7 @@ winrt::Microsoft::Terminal::Settings::Model::CascadiaSettings CascadiaSettings::
     resultPtr->_ParseJsonString(DefaultJson, true);
     resultPtr->LayerJson(resultPtr->_defaultSettings);
     resultPtr->_ResolveDefaultProfile();
+    resultPtr->_UpdateActiveProfiles();
 
     return *resultPtr;
 }


### PR DESCRIPTION
## Summary of the Pull Request
When we get a serialization error, we "catch" it in `AppLogic` and only
`LoadDefaults()`. Since `LoadDefaults()` doesn't perform a full
validation of `CascadiaSettings`, we need to manually update our list of
active profiles (similar to how we manually resolve the default
profile).

## Validation Steps Performed
Repro steps fixed:
1. add deserialization error to settings.json (i.e. "fontWeight": "wumbo")
2. launch WT
3. verify that dropdown is populated with active profiles

Closes #8146