### PR TITLE
Introduce Page parameters to SUI

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
@@ -2,21 +2,20 @@
 // Licensed under the MIT license.
 
 #include "pch.h"
-#include "MainPage.h"
 #include "ColorSchemes.h"
 #include "ColorTableEntry.g.cpp"
 #include "ColorSchemes.g.cpp"
+#include "ColorSchemesPageNavigationState.g.cpp"
 
 #include <LibraryResources.h>
 
 using namespace winrt;
 using namespace winrt::Windows::UI;
-using namespace winrt::Windows::UI::Xaml;
+using namespace winrt::Windows::UI::Xaml::Navigation;
 using namespace winrt::Windows::UI::Xaml::Controls;
 using namespace winrt::Windows::UI::Xaml::Media;
 using namespace winrt::Windows::Foundation;
 using namespace winrt::Windows::Foundation::Collections;
-using namespace winrt::Microsoft::Terminal::Settings::Model;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
@@ -46,9 +45,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         InitializeComponent();
     }
 
-    void ColorSchemes::OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e)
+    void ColorSchemes::OnNavigatedTo(NavigationEventArgs e)
     {
-        _GlobalSettings = e.Parameter().as<Model::GlobalAppSettings>();
+        _State = e.Parameter().as<Editor::ColorSchemesPageNavigationState>();
         _UpdateColorSchemeList();
 
         // Initialize our color table view model with 16 dummy colors
@@ -75,7 +74,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         //  Update the color scheme this page is modifying
         auto str = winrt::unbox_value<hstring>(args.AddedItems().GetAt(0));
-        auto colorScheme = GlobalSettings().ColorSchemes().Lookup(str);
+        auto colorScheme = _State.Globals().ColorSchemes().Lookup(str);
         CurrentColorScheme(colorScheme);
         _UpdateColorTable(colorScheme);
     }
@@ -88,8 +87,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     // - <none>
     void ColorSchemes::_UpdateColorSchemeList()
     {
-        auto colorSchemeMap = GlobalSettings().ColorSchemes();
-        for (const auto& pair : GlobalSettings().ColorSchemes())
+        auto colorSchemeMap = _State.Globals().ColorSchemes();
+        for (const auto& pair : _State.Globals().ColorSchemes())
         {
             _ColorSchemeList.Append(pair.Key());
         }

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
@@ -44,6 +44,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _CurrentColorTable{ single_threaded_observable_vector<Editor::ColorTableEntry>() }
     {
         InitializeComponent();
+    }
+
+    void ColorSchemes::OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e)
+    {
+        _GlobalSettings = e.Parameter().as<Model::GlobalAppSettings>();
         _UpdateColorSchemeList();
 
         // Initialize our color table view model with 16 dummy colors
@@ -58,11 +63,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
     }
 
-    IObservableVector<hstring> ColorSchemes::ColorSchemeList()
-    {
-        return _ColorSchemeList;
-    }
-
     // Function Description:
     // - Called when a different color scheme is selected. Updates our current
     //   color scheme and updates our currently modifiable color table.
@@ -75,7 +75,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         //  Update the color scheme this page is modifying
         auto str = winrt::unbox_value<hstring>(args.AddedItems().GetAt(0));
-        auto colorScheme = MainPage::Settings().GlobalSettings().ColorSchemes().Lookup(str);
+        auto colorScheme = GlobalSettings().ColorSchemes().Lookup(str);
         CurrentColorScheme(colorScheme);
         _UpdateColorTable(colorScheme);
     }
@@ -88,8 +88,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     // - <none>
     void ColorSchemes::_UpdateColorSchemeList()
     {
-        auto colorSchemeMap = MainPage::Settings().GlobalSettings().ColorSchemes();
-        for (const auto& pair : MainPage::Settings().GlobalSettings().ColorSchemes())
+        auto colorSchemeMap = GlobalSettings().ColorSchemes();
+        for (const auto& pair : GlobalSettings().ColorSchemes())
         {
             _ColorSchemeList.Append(pair.Key());
         }

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
@@ -45,7 +45,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         InitializeComponent();
     }
 
-    void ColorSchemes::OnNavigatedTo(NavigationEventArgs e)
+    void ColorSchemes::OnNavigatedTo(const NavigationEventArgs& e)
     {
         _State = e.Parameter().as<Editor::ColorSchemesPageNavigationState>();
         _UpdateColorSchemeList();

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
@@ -5,10 +5,20 @@
 
 #include "ColorTableEntry.g.h"
 #include "ColorSchemes.g.h"
+#include "ColorSchemesPageNavigationState.g.h"
 #include "Utils.h"
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    struct ColorSchemesPageNavigationState : ColorSchemesPageNavigationStateT<ColorSchemesPageNavigationState>
+    {
+    public:
+        ColorSchemesPageNavigationState(Model::GlobalAppSettings settings) :
+            _Globals{ settings } {}
+
+        GETSET_PROPERTY(Model::GlobalAppSettings, Globals, nullptr);
+    };
+
     struct ColorSchemes : ColorSchemesT<ColorSchemes>
     {
         ColorSchemes();
@@ -18,7 +28,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void ColorSchemeSelectionChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::Controls::SelectionChangedEventArgs const& args);
         void ColorPickerChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::Controls::ColorChangedEventArgs const& args);
 
-        GETSET_PROPERTY(Model::GlobalAppSettings, GlobalSettings, nullptr);
+        GETSET_PROPERTY(Editor::ColorSchemesPageNavigationState, State, nullptr);
         GETSET_PROPERTY(Windows::Foundation::Collections::IObservableVector<winrt::Microsoft::Terminal::Settings::Editor::ColorTableEntry>, CurrentColorTable, nullptr);
         GETSET_PROPERTY(Windows::Foundation::Collections::IObservableVector<winrt::hstring>, ColorSchemeList, nullptr);
 

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
@@ -13,19 +13,19 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         ColorSchemes();
 
+        void OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e);
+
         void ColorSchemeSelectionChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::Controls::SelectionChangedEventArgs const& args);
         void ColorPickerChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::Controls::ColorChangedEventArgs const& args);
 
-        Windows::Foundation::Collections::IObservableVector<winrt::hstring> ColorSchemeList();
-
+        GETSET_PROPERTY(Model::GlobalAppSettings, GlobalSettings, nullptr);
         GETSET_PROPERTY(Windows::Foundation::Collections::IObservableVector<winrt::Microsoft::Terminal::Settings::Editor::ColorTableEntry>, CurrentColorTable, nullptr);
+        GETSET_PROPERTY(Windows::Foundation::Collections::IObservableVector<winrt::hstring>, ColorSchemeList, nullptr);
 
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
         OBSERVABLE_GETSET_PROPERTY(winrt::Microsoft::Terminal::Settings::Model::ColorScheme, CurrentColorScheme, _PropertyChangedHandlers, nullptr);
 
     private:
-        Windows::Foundation::Collections::IObservableVector<winrt::hstring> _ColorSchemeList{ nullptr };
-
         void _UpdateColorTable(const winrt::Microsoft::Terminal::Settings::Model::ColorScheme& colorScheme);
         void _UpdateColorSchemeList();
     };

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
@@ -13,7 +13,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     struct ColorSchemesPageNavigationState : ColorSchemesPageNavigationStateT<ColorSchemesPageNavigationState>
     {
     public:
-        ColorSchemesPageNavigationState(Model::GlobalAppSettings settings) :
+        ColorSchemesPageNavigationState(const Model::GlobalAppSettings& settings) :
             _Globals{ settings } {}
 
         GETSET_PROPERTY(Model::GlobalAppSettings, Globals, nullptr);
@@ -23,7 +23,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         ColorSchemes();
 
-        void OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e);
+        void OnNavigatedTo(const winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
 
         void ColorSchemeSelectionChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::Controls::SelectionChangedEventArgs const& args);
         void ColorPickerChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::Controls::ColorChangedEventArgs const& args);

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.idl
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.idl
@@ -3,9 +3,15 @@
 
 namespace Microsoft.Terminal.Settings.Editor
 {
+    runtimeclass ColorSchemesPageNavigationState
+    {
+        Microsoft.Terminal.Settings.Model.GlobalAppSettings Globals;
+    };
+
     [default_interface] runtimeclass ColorSchemes : Windows.UI.Xaml.Controls.Page, Windows.UI.Xaml.Data.INotifyPropertyChanged
     {
         ColorSchemes();
+        ColorSchemesPageNavigationState State { get; };
 
         Microsoft.Terminal.Settings.Model.ColorScheme CurrentColorScheme { get; };
         Windows.Foundation.Collections.IObservableVector<ColorTableEntry> CurrentColorTable;

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -11,7 +11,6 @@ the MIT License. See LICENSE in the project root for license information. -->
     xmlns:controls="clr-namespace:Windows.UI.Xaml.Controls;assembly=Windows.Foundation.UniversalApiContract" xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
     mc:Ignorable="d">
 
-
     <Page.Resources>
         <Style TargetType="StackPanel">
             <Setter Property="Margin" Value="0,0,0,20"/>

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.cpp
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.cpp
@@ -4,7 +4,7 @@
 #include "pch.h"
 #include "GlobalAppearance.h"
 #include "GlobalAppearance.g.cpp"
-#include "MainPage.h"
+#include "GlobalAppearancePageNavigationState.g.cpp"
 #include "EnumEntry.h"
 
 using namespace winrt;
@@ -25,6 +25,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void GlobalAppearance::OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e)
     {
-        _GlobalSettings = e.Parameter().as<Model::GlobalAppSettings>();
+        _State = e.Parameter().as<Editor::GlobalAppearancePageNavigationState>();
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.cpp
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.cpp
@@ -9,6 +9,7 @@
 
 using namespace winrt;
 using namespace winrt::Windows::UI::Xaml;
+using namespace winrt::Windows::UI::Xaml::Navigation;
 using namespace winrt::Windows::UI::Xaml::Controls;
 using namespace winrt::Microsoft::Terminal::Settings::Model;
 using namespace winrt::Windows::Foundation::Collections;
@@ -23,7 +24,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         INITIALIZE_BINDABLE_ENUM_SETTING(TabWidthMode, TabViewWidthMode, winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode, L"Globals_TabWidthMode", L"Content");
     }
 
-    void GlobalAppearance::OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e)
+    void GlobalAppearance::OnNavigatedTo(const NavigationEventArgs& e)
     {
         _State = e.Parameter().as<Editor::GlobalAppearancePageNavigationState>();
     }

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.cpp
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.cpp
@@ -23,8 +23,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         INITIALIZE_BINDABLE_ENUM_SETTING(TabWidthMode, TabViewWidthMode, winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode, L"Globals_TabWidthMode", L"Content");
     }
 
-    GlobalAppSettings GlobalAppearance::GlobalSettings()
+    void GlobalAppearance::OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e)
     {
-        return MainPage::Settings().GlobalSettings();
+        _GlobalSettings = e.Parameter().as<Model::GlobalAppSettings>();
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.h
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.h
@@ -12,7 +12,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     struct GlobalAppearancePageNavigationState : GlobalAppearancePageNavigationStateT<GlobalAppearancePageNavigationState>
     {
     public:
-        GlobalAppearancePageNavigationState(Model::GlobalAppSettings settings) :
+        GlobalAppearancePageNavigationState(const Model::GlobalAppSettings& settings) :
             _Globals{ settings } {}
 
         GETSET_PROPERTY(Model::GlobalAppSettings, Globals, nullptr)
@@ -23,7 +23,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     public:
         GlobalAppearance();
 
-        void OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e);
+        void OnNavigatedTo(const winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
 
         GETSET_PROPERTY(Editor::GlobalAppearancePageNavigationState, State, nullptr);
 

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.h
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.h
@@ -12,7 +12,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
     public:
         GlobalAppearance();
-        winrt::Microsoft::Terminal::Settings::Model::GlobalAppSettings GlobalSettings();
+
+        void OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e);
+
+        GETSET_PROPERTY(Model::GlobalAppSettings, GlobalSettings, nullptr);
 
         GETSET_BINDABLE_ENUM_SETTING(Theme, winrt::Windows::UI::Xaml::ElementTheme, GlobalSettings, Theme);
         GETSET_BINDABLE_ENUM_SETTING(TabWidthMode, winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode, GlobalSettings, TabWidthMode);

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.h
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.h
@@ -4,10 +4,20 @@
 #pragma once
 
 #include "GlobalAppearance.g.h"
+#include "GlobalAppearancePageNavigationState.g.h"
 #include "Utils.h"
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    struct GlobalAppearancePageNavigationState : GlobalAppearancePageNavigationStateT<GlobalAppearancePageNavigationState>
+    {
+    public:
+        GlobalAppearancePageNavigationState(Model::GlobalAppSettings settings) :
+            _Globals{ settings } {}
+
+        GETSET_PROPERTY(Model::GlobalAppSettings, Globals, nullptr)
+    };
+
     struct GlobalAppearance : GlobalAppearanceT<GlobalAppearance>
     {
     public:
@@ -15,10 +25,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         void OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e);
 
-        GETSET_PROPERTY(Model::GlobalAppSettings, GlobalSettings, nullptr);
+        GETSET_PROPERTY(Editor::GlobalAppearancePageNavigationState, State, nullptr);
 
-        GETSET_BINDABLE_ENUM_SETTING(Theme, winrt::Windows::UI::Xaml::ElementTheme, GlobalSettings, Theme);
-        GETSET_BINDABLE_ENUM_SETTING(TabWidthMode, winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode, GlobalSettings, TabWidthMode);
+        GETSET_BINDABLE_ENUM_SETTING(Theme, winrt::Windows::UI::Xaml::ElementTheme, State().Globals, Theme);
+        GETSET_BINDABLE_ENUM_SETTING(TabWidthMode, winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode, State().Globals, TabWidthMode);
     };
 }
 

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.idl
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.idl
@@ -5,10 +5,15 @@ import "EnumEntry.idl";
 
 namespace Microsoft.Terminal.Settings.Editor
 {
+    runtimeclass GlobalAppearancePageNavigationState
+    {
+        Microsoft.Terminal.Settings.Model.GlobalAppSettings Globals;
+    };
+
     [default_interface] runtimeclass GlobalAppearance : Windows.UI.Xaml.Controls.Page
     {
         GlobalAppearance();
-        Microsoft.Terminal.Settings.Model.GlobalAppSettings GlobalSettings { get; };
+        GlobalAppearancePageNavigationState State { get; };
 
         IInspectable CurrentTheme;
         Windows.Foundation.Collections.IObservableVector<Microsoft.Terminal.Settings.Editor.EnumEntry> ThemeList { get; };

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
@@ -41,15 +41,15 @@ the MIT License. See LICENSE in the project root for license information. -->
                                        SelectedItem="{x:Bind CurrentTheme, Mode=TwoWay}"
                                        ItemsSource="{x:Bind ThemeList, Mode=OneWay}"
                                        ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
-                <CheckBox x:Uid="Globals_ShowTitlebar" IsChecked="{x:Bind GlobalSettings.ShowTabsInTitlebar, Mode=TwoWay}"/>
-                <CheckBox x:Uid="Globals_ShowTitleInTitlebar" IsChecked="{x:Bind GlobalSettings.ShowTitleInTitlebar, Mode=TwoWay}"/>
-                <CheckBox x:Uid="Globals_AlwaysShowTabs" IsChecked="{x:Bind GlobalSettings.AlwaysShowTabs, Mode=TwoWay}"/>
+                <CheckBox x:Uid="Globals_ShowTitlebar" IsChecked="{x:Bind State.Globals.ShowTabsInTitlebar, Mode=TwoWay}"/>
+                <CheckBox x:Uid="Globals_ShowTitleInTitlebar" IsChecked="{x:Bind State.Globals.ShowTitleInTitlebar, Mode=TwoWay}"/>
+                <CheckBox x:Uid="Globals_AlwaysShowTabs" IsChecked="{x:Bind State.Globals.AlwaysShowTabs, Mode=TwoWay}"/>
                 <Controls:RadioButtons x:Uid="Globals_TabWidthMode"
                                        SelectedItem="{x:Bind CurrentTabWidthMode, Mode=TwoWay}"
                                        ItemsSource="{x:Bind TabWidthModeList, Mode=OneWay}"
                                        ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
-                <CheckBox x:Uid="Globals_ConfirmCloseAllTabs" IsChecked="{x:Bind GlobalSettings.ConfirmCloseAllTabs, Mode=TwoWay}"/>
-                <CheckBox x:Uid="Globals_DisableAnimations" IsChecked="{x:Bind GlobalSettings.DisableAnimations, Mode=TwoWay}"/>
+                <CheckBox x:Uid="Globals_ConfirmCloseAllTabs" IsChecked="{x:Bind State.Globals.ConfirmCloseAllTabs, Mode=TwoWay}"/>
+                <CheckBox x:Uid="Globals_DisableAnimations" IsChecked="{x:Bind State.Globals.DisableAnimations, Mode=TwoWay}"/>
             </StackPanel>
         </Grid>
     </ScrollViewer>

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
@@ -1,6 +1,5 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under
 the MIT License. See LICENSE in the project root for license information. -->
-    <!--TODO: SETTINGS UI All strings must be attached to UIDs-->
 <Page
     x:Class="Microsoft.Terminal.Settings.Editor.GlobalAppearance"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"

--- a/src/cascadia/TerminalSettingsEditor/Interaction.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.cpp
@@ -17,8 +17,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         InitializeComponent();
     }
 
-    GlobalAppSettings Interaction::GlobalSettings()
+    void Interaction::OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e)
     {
-        return MainPage::Settings().GlobalSettings();
+        _GlobalSettings = e.Parameter().as<Model::GlobalAppSettings>();
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Interaction.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.cpp
@@ -15,7 +15,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         InitializeComponent();
     }
 
-    void Interaction::OnNavigatedTo(NavigationEventArgs e)
+    void Interaction::OnNavigatedTo(const NavigationEventArgs& e)
     {
         _State = e.Parameter().as<Editor::InteractionPageNavigationState>();
     }

--- a/src/cascadia/TerminalSettingsEditor/Interaction.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.cpp
@@ -4,11 +4,9 @@
 #include "pch.h"
 #include "Interaction.h"
 #include "Interaction.g.cpp"
-#include "MainPage.h"
+#include "InteractionPageNavigationState.g.cpp"
 
-using namespace winrt;
-using namespace winrt::Windows::UI::Xaml;
-using namespace winrt::Microsoft::Terminal::Settings::Model;
+using namespace winrt::Windows::UI::Xaml::Navigation;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
@@ -17,8 +15,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         InitializeComponent();
     }
 
-    void Interaction::OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e)
+    void Interaction::OnNavigatedTo(NavigationEventArgs e)
     {
-        _GlobalSettings = e.Parameter().as<Model::GlobalAppSettings>();
+        _State = e.Parameter().as<Editor::InteractionPageNavigationState>();
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Interaction.h
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.h
@@ -11,7 +11,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     struct Interaction : InteractionT<Interaction>
     {
         Interaction();
-        winrt::Microsoft::Terminal::Settings::Model::GlobalAppSettings GlobalSettings();
+
+        void OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e);
+        GETSET_PROPERTY(Model::GlobalAppSettings, GlobalSettings, nullptr);
     };
 }
 

--- a/src/cascadia/TerminalSettingsEditor/Interaction.h
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.h
@@ -4,16 +4,27 @@
 #pragma once
 
 #include "Interaction.g.h"
+#include "InteractionPageNavigationState.g.h"
 #include "Utils.h"
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    struct InteractionPageNavigationState : InteractionPageNavigationStateT<InteractionPageNavigationState>
+    {
+    public:
+        InteractionPageNavigationState(Model::GlobalAppSettings settings) :
+            _Globals{ settings } {}
+
+        GETSET_PROPERTY(Model::GlobalAppSettings, Globals, nullptr)
+    };
+
     struct Interaction : InteractionT<Interaction>
     {
         Interaction();
 
         void OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e);
-        GETSET_PROPERTY(Model::GlobalAppSettings, GlobalSettings, nullptr);
+
+        GETSET_PROPERTY(Editor::InteractionPageNavigationState, State, nullptr);
     };
 }
 

--- a/src/cascadia/TerminalSettingsEditor/Interaction.h
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.h
@@ -12,7 +12,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     struct InteractionPageNavigationState : InteractionPageNavigationStateT<InteractionPageNavigationState>
     {
     public:
-        InteractionPageNavigationState(Model::GlobalAppSettings settings) :
+        InteractionPageNavigationState(const Model::GlobalAppSettings& settings) :
             _Globals{ settings } {}
 
         GETSET_PROPERTY(Model::GlobalAppSettings, Globals, nullptr)
@@ -22,7 +22,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         Interaction();
 
-        void OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e);
+        void OnNavigatedTo(const winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
 
         GETSET_PROPERTY(Editor::InteractionPageNavigationState, State, nullptr);
     };

--- a/src/cascadia/TerminalSettingsEditor/Interaction.idl
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.idl
@@ -3,10 +3,14 @@
 
 namespace Microsoft.Terminal.Settings.Editor
 {
+    runtimeclass InteractionPageNavigationState
+    {
+        Microsoft.Terminal.Settings.Model.GlobalAppSettings Globals;
+    };
+
     [default_interface] runtimeclass Interaction : Windows.UI.Xaml.Controls.Page
     {
         Interaction();
-
-        Microsoft.Terminal.Settings.Model.GlobalAppSettings GlobalSettings { get; };
+        InteractionPageNavigationState State { get; };
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Interaction.idl
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.idl
@@ -6,6 +6,7 @@ namespace Microsoft.Terminal.Settings.Editor
     [default_interface] runtimeclass Interaction : Windows.UI.Xaml.Controls.Page
     {
         Interaction();
+
         Microsoft.Terminal.Settings.Model.GlobalAppSettings GlobalSettings { get; };
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Interaction.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.xaml
@@ -24,11 +24,11 @@ the MIT License. See LICENSE in the project root for license information. -->
                    Style="{StaticResource SubheaderTextBlockStyle}"
                    Margin="0,0,0,20" />
             <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,100,0">
-                <CheckBox x:Uid="Globals_CopyOnSelect" IsChecked="{x:Bind GlobalSettings.CopyOnSelect, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
+                <CheckBox x:Uid="Globals_CopyOnSelect" IsChecked="{x:Bind State.Globals.CopyOnSelect, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
                 <!--TODO: Converter Here-->
                 <!--<CheckBox x:Uid="Globals_CopyFormatting" IsChecked="{x:Bind GlobalSettings.CopyFormatting, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />-->
-                <TextBox x:Uid="Globals_WordDelimiters" Text="{x:Bind GlobalSettings.WordDelimiters, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
-                <CheckBox x:Uid="Globals_SnapToGridOnResize" IsChecked="{x:Bind GlobalSettings.SnapToGridOnResize, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
+                <TextBox x:Uid="Globals_WordDelimiters" Text="{x:Bind State.Globals.WordDelimiters, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
+                <CheckBox x:Uid="Globals_SnapToGridOnResize" IsChecked="{x:Bind State.Globals.SnapToGridOnResize, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
             </StackPanel>
         </Grid>
     </ScrollViewer>

--- a/src/cascadia/TerminalSettingsEditor/Launch.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Launch.cpp
@@ -16,7 +16,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         InitializeComponent();
     }
 
-    void Launch::OnNavigatedTo(NavigationEventArgs e)
+    void Launch::OnNavigatedTo(const NavigationEventArgs& e)
     {
         _State = e.Parameter().as<Editor::LaunchPageNavigationState>();
     }

--- a/src/cascadia/TerminalSettingsEditor/Launch.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Launch.cpp
@@ -4,13 +4,10 @@
 #include "pch.h"
 #include "Launch.h"
 #include "Launch.g.cpp"
-#include "MainPage.h"
+#include "LaunchPageNavigationState.g.cpp"
 
-using namespace winrt;
-using namespace winrt::Windows::UI::Xaml;
-using namespace winrt::Windows::UI::Xaml::Controls;
+using namespace winrt::Windows::UI::Xaml::Navigation;
 using namespace winrt::Windows::Foundation;
-using namespace winrt::Microsoft::Terminal::Settings::Model;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
@@ -19,19 +16,20 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         InitializeComponent();
     }
 
-    void Launch::OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e)
+    void Launch::OnNavigatedTo(NavigationEventArgs e)
     {
-        _Settings = e.Parameter().as<Model::CascadiaSettings>();
+        _State = e.Parameter().as<Editor::LaunchPageNavigationState>();
     }
 
     IInspectable Launch::CurrentDefaultProfile()
     {
-        return winrt::box_value(_Settings.FindProfile(_Settings.GlobalSettings().DefaultProfile()));
+        const auto defaultProfileGuid{ _State.Settings().GlobalSettings().DefaultProfile() };
+        return winrt::box_value(_State.Settings().FindProfile(defaultProfileGuid));
     }
 
     void Launch::CurrentDefaultProfile(const IInspectable& value)
     {
         const auto profile{ winrt::unbox_value<Model::Profile>(value) };
-        _Settings.GlobalSettings().DefaultProfile(profile.Guid());
+        _State.Settings().GlobalSettings().DefaultProfile(profile.Guid());
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Launch.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Launch.cpp
@@ -19,19 +19,19 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         InitializeComponent();
     }
 
-    GlobalAppSettings Launch::GlobalSettings()
+    void Launch::OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e)
     {
-        return MainPage::Settings().GlobalSettings();
+        _Settings = e.Parameter().as<Model::CascadiaSettings>();
     }
 
     IInspectable Launch::CurrentDefaultProfile()
     {
-        return winrt::box_value(MainPage::Settings().FindProfile(GlobalSettings().DefaultProfile()));
+        return winrt::box_value(_Settings.FindProfile(_Settings.GlobalSettings().DefaultProfile()));
     }
 
     void Launch::CurrentDefaultProfile(const IInspectable& value)
     {
         const auto profile{ winrt::unbox_value<Model::Profile>(value) };
-        GlobalSettings().DefaultProfile(profile.Guid());
+        _Settings.GlobalSettings().DefaultProfile(profile.Guid());
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Launch.h
+++ b/src/cascadia/TerminalSettingsEditor/Launch.h
@@ -4,10 +4,20 @@
 #pragma once
 
 #include "Launch.g.h"
+#include "LaunchPageNavigationState.g.h"
 #include "Utils.h"
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    struct LaunchPageNavigationState : LaunchPageNavigationStateT<LaunchPageNavigationState>
+    {
+    public:
+        LaunchPageNavigationState(Model::CascadiaSettings settings) :
+            _Settings{ settings } {}
+
+        GETSET_PROPERTY(Model::CascadiaSettings, Settings, nullptr)
+    };
+
     struct Launch : LaunchT<Launch>
     {
     public:
@@ -18,7 +28,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         IInspectable CurrentDefaultProfile();
         void CurrentDefaultProfile(const IInspectable& value);
 
-        GETSET_PROPERTY(Model::CascadiaSettings, Settings, nullptr);
+        GETSET_PROPERTY(Editor::LaunchPageNavigationState, State, nullptr);
     };
 }
 

--- a/src/cascadia/TerminalSettingsEditor/Launch.h
+++ b/src/cascadia/TerminalSettingsEditor/Launch.h
@@ -13,10 +13,12 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     public:
         Launch();
 
-        winrt::Microsoft::Terminal::Settings::Model::GlobalAppSettings GlobalSettings();
+        void OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e);
 
         IInspectable CurrentDefaultProfile();
         void CurrentDefaultProfile(const IInspectable& value);
+
+        GETSET_PROPERTY(Model::CascadiaSettings, Settings, nullptr);
     };
 }
 

--- a/src/cascadia/TerminalSettingsEditor/Launch.h
+++ b/src/cascadia/TerminalSettingsEditor/Launch.h
@@ -12,7 +12,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     struct LaunchPageNavigationState : LaunchPageNavigationStateT<LaunchPageNavigationState>
     {
     public:
-        LaunchPageNavigationState(Model::CascadiaSettings settings) :
+        LaunchPageNavigationState(const Model::CascadiaSettings& settings) :
             _Settings{ settings } {}
 
         GETSET_PROPERTY(Model::CascadiaSettings, Settings, nullptr)
@@ -23,7 +23,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     public:
         Launch();
 
-        void OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e);
+        void OnNavigatedTo(const winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
 
         IInspectable CurrentDefaultProfile();
         void CurrentDefaultProfile(const IInspectable& value);

--- a/src/cascadia/TerminalSettingsEditor/Launch.idl
+++ b/src/cascadia/TerminalSettingsEditor/Launch.idl
@@ -7,7 +7,7 @@ namespace Microsoft.Terminal.Settings.Editor
     {
         Launch();
 
-        Microsoft.Terminal.Settings.Model.GlobalAppSettings GlobalSettings { get; };
+        Microsoft.Terminal.Settings.Model.CascadiaSettings Settings { get; };
         IInspectable CurrentDefaultProfile;
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Launch.idl
+++ b/src/cascadia/TerminalSettingsEditor/Launch.idl
@@ -3,11 +3,16 @@
 
 namespace Microsoft.Terminal.Settings.Editor
 {
+    runtimeclass LaunchPageNavigationState
+    {
+        Microsoft.Terminal.Settings.Model.CascadiaSettings Settings;
+    };
+
     [default_interface] runtimeclass Launch : Windows.UI.Xaml.Controls.Page
     {
         Launch();
+        LaunchPageNavigationState State { get; };
 
-        Microsoft.Terminal.Settings.Model.CascadiaSettings Settings { get; };
         IInspectable CurrentDefaultProfile;
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -28,7 +28,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <ComboBox x:Uid="Globals_DefaultProfile"
                           x:Name="DefaultProfile"
                           Margin="0,0,0,20"
-                          ItemsSource="{x:Bind Settings.AllProfiles, Mode=OneWay}"
+                          ItemsSource="{x:Bind State.Settings.AllProfiles, Mode=OneWay}"
                           SelectedItem="{x:Bind CurrentDefaultProfile, Mode=TwoWay}"
                           FontSize="15"
                           ToolTipService.Placement="Mouse">
@@ -38,7 +38,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                         </DataTemplate>
                     </ComboBox.ItemTemplate>
                 </ComboBox>
-                <CheckBox x:Uid="Globals_StartOnUserLogin" IsChecked="{x:Bind Settings.GlobalSettings.StartOnUserLogin, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
+                <CheckBox x:Uid="Globals_StartOnUserLogin" IsChecked="{x:Bind State.Settings.GlobalSettings.StartOnUserLogin, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
                 <Controls:RadioButtons x:Uid="Globals_LaunchSize" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
                     <RadioButton x:Uid="Globals_LaunchSizeDefault" x:Name="DefaultLaunchSize"/>
                     <RadioButton x:Uid="Globals_LaunchSizeMaximized" x:Name="MaximizedLaunchSize"/>

--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -28,7 +28,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <ComboBox x:Uid="Globals_DefaultProfile"
                           x:Name="DefaultProfile"
                           Margin="0,0,0,20"
-                          ItemsSource="{x:Bind local:MainPage.Settings.AllProfiles, Mode=OneWay}"
+                          ItemsSource="{x:Bind Settings.AllProfiles, Mode=OneWay}"
                           SelectedItem="{x:Bind CurrentDefaultProfile, Mode=TwoWay}"
                           FontSize="15"
                           ToolTipService.Placement="Mouse">
@@ -38,7 +38,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                         </DataTemplate>
                     </ComboBox.ItemTemplate>
                 </ComboBox>
-                <CheckBox x:Uid="Globals_StartOnUserLogin" IsChecked="{x:Bind GlobalSettings.StartOnUserLogin, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
+                <CheckBox x:Uid="Globals_StartOnUserLogin" IsChecked="{x:Bind Settings.GlobalSettings.StartOnUserLogin, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
                 <Controls:RadioButtons x:Uid="Globals_LaunchSize" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
                     <RadioButton x:Uid="Globals_LaunchSizeDefault" x:Name="DefaultLaunchSize"/>
                     <RadioButton x:Uid="Globals_LaunchSizeMaximized" x:Name="MaximizedLaunchSize"/>

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -29,55 +29,57 @@ using namespace winrt::Windows::UI::Xaml::Controls;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
-    winrt::Microsoft::Terminal::Settings::Model::CascadiaSettings MainPage::_settingsSource{ nullptr };
-
     MainPage::MainPage(CascadiaSettings settings) :
+        _settingsSource{ settings },
+        _settingsClone{ settings },
         _profileToNavItemMap{ winrt::single_threaded_map<Model::Profile, MUX::Controls::NavigationViewItem>() }
     {
         InitializeComponent();
 
-        // TODO GH#1564: When we actually connect this to Windows Terminal,
-        //       this section will clone the active AppSettings
-        MainPage::_settingsSource = settings;
-        _settingsClone = nullptr;
-
         _InitializeProfilesList();
     }
 
-    CascadiaSettings MainPage::Settings()
-    {
-        return _settingsSource;
-    }
-
+    // Function Description:
+    // - Called when the NavigationView is loaded. Navigates to the first item in the NavigationView
+    // Arguments:
+    // - <unused>
+    // Return Value:
+    // - <none>
     void MainPage::SettingsNav_Loaded(IInspectable const&, RoutedEventArgs const&)
     {
-        auto initialItem = SettingsNav().MenuItems().GetAt(0);
+        const auto initialItem = SettingsNav().MenuItems().GetAt(0);
         SettingsNav().SelectedItem(initialItem);
 
         // Manually navigate because setting the selected item programmatically doesn't trigger ItemInvoked.
-        if (auto tag = initialItem.as<MUX::Controls::NavigationViewItem>().Tag())
+        if (const auto tag = initialItem.as<MUX::Controls::NavigationViewItem>().Tag())
         {
-            Navigate(contentFrame(), unbox_value<hstring>(tag));
+            _Navigate(contentFrame(), unbox_value<hstring>(tag), _settingsClone);
         }
     }
 
+    // Function Description:
+    // - Called when NavigationView items are invoked. Navigates to the corresponding page.
+    // Arguments:
+    // - args - additional event info from invoking the NavViewItem
+    // Return Value:
+    // - <none>
     void MainPage::SettingsNav_ItemInvoked(MUX::Controls::NavigationView const&, MUX::Controls::NavigationViewItemInvokedEventArgs const& args)
     {
-        auto clickedItemContainer = args.InvokedItemContainer();
-
-        if (clickedItemContainer)
+        if (const auto clickedItemContainer = args.InvokedItemContainer())
         {
-            if (auto navString = clickedItemContainer.Tag().try_as<hstring>())
+            if (const auto navString = clickedItemContainer.Tag().try_as<hstring>())
             {
                 if (navString == L"AddProfile")
                 {
+                    // "AddProfile" needs to create a new profile before we can navigate to it
                     uint32_t insertIndex;
                     SettingsNav().MenuItems().IndexOf(clickedItemContainer, insertIndex);
                     _CreateAndNavigateToNewProfile(insertIndex);
                 }
                 else
                 {
-                    Navigate(contentFrame(), *navString);
+                    // Otherwise, navigate to the page
+                    _Navigate(contentFrame(), *navString, _settingsClone);
                 }
             }
             else if (auto profile = clickedItemContainer.Tag().try_as<Model::Profile>())
@@ -85,6 +87,43 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 // Navigate to a page with the given profile
                 contentFrame().Navigate(xaml_typename<Editor::Profiles>(), profile);
             }
+        }
+    }
+
+    void MainPage::_Navigate(Controls::Frame contentFrame, hstring clickedItemTag, CascadiaSettings settings)
+    {
+        const hstring launchSubpage = L"Launch_Nav";
+        const hstring interactionSubpage = L"Interaction_Nav";
+        const hstring renderingSubpage = L"Rendering_Nav";
+
+        const hstring globalProfileSubpage = L"GlobalProfile_Nav";
+
+        const hstring colorSchemesPage = L"ColorSchemes_Nav";
+        const hstring globalAppearancePage = L"GlobalAppearance_Nav";
+
+        if (clickedItemTag == launchSubpage)
+        {
+            contentFrame.Navigate(xaml_typename<Editor::Launch>(), settings);
+        }
+        else if (clickedItemTag == interactionSubpage)
+        {
+            contentFrame.Navigate(xaml_typename<Editor::Interaction>(), settings.GlobalSettings());
+        }
+        else if (clickedItemTag == renderingSubpage)
+        {
+            contentFrame.Navigate(xaml_typename<Editor::Rendering>(), settings.GlobalSettings());
+        }
+        else if (clickedItemTag == globalProfileSubpage)
+        {
+            contentFrame.Navigate(xaml_typename<Editor::Profiles>(), settings.ProfileDefaults());
+        }
+        else if (clickedItemTag == colorSchemesPage)
+        {
+            contentFrame.Navigate(xaml_typename<Editor::ColorSchemes>(), settings.GlobalSettings());
+        }
+        else if (clickedItemTag == globalAppearancePage)
+        {
+            contentFrame.Navigate(xaml_typename<Editor::GlobalAppearance>(), settings.GlobalSettings());
         }
     }
 
@@ -109,43 +148,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         contentFrame().GoBack();
         return true;
-    }
-
-    void MainPage::Navigate(Controls::Frame contentFrame, hstring clickedItemTag)
-    {
-        const hstring launchSubpage = L"Launch_Nav";
-        const hstring interactionSubpage = L"Interaction_Nav";
-        const hstring renderingSubpage = L"Rendering_Nav";
-
-        const hstring globalProfileSubpage = L"GlobalProfile_Nav";
-
-        const hstring colorSchemesPage = L"ColorSchemes_Nav";
-        const hstring globalAppearancePage = L"GlobalAppearance_Nav";
-
-        if (clickedItemTag == launchSubpage)
-        {
-            contentFrame.Navigate(xaml_typename<Editor::Launch>());
-        }
-        else if (clickedItemTag == interactionSubpage)
-        {
-            contentFrame.Navigate(xaml_typename<Editor::Interaction>());
-        }
-        else if (clickedItemTag == renderingSubpage)
-        {
-            contentFrame.Navigate(xaml_typename<Editor::Rendering>());
-        }
-        else if (clickedItemTag == globalProfileSubpage)
-        {
-            contentFrame.Navigate(xaml_typename<Editor::Profiles>(), Settings().DefaultProfileSettings());
-        }
-        else if (clickedItemTag == colorSchemesPage)
-        {
-            contentFrame.Navigate(xaml_typename<Editor::ColorSchemes>());
-        }
-        else if (clickedItemTag == globalAppearancePage)
-        {
-            contentFrame.Navigate(xaml_typename<Editor::GlobalAppearance>());
-        }
     }
 
     void MainPage::OpenJsonTapped(IInspectable const& /*sender*/, Windows::UI::Xaml::Input::TappedRoutedEventArgs const& /*args*/)
@@ -175,7 +177,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // and keep a reference to them in a map so that we
         // can easily modify the correct one when the associated
         // profile changes.
-        for (const auto& profile : Settings().AllProfiles())
+        for (const auto& profile : _settingsClone.AllProfiles())
         {
             auto navItem = _CreateProfileNavViewItem(profile);
             SettingsNav().MenuItems().Append(navItem);
@@ -197,7 +199,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void MainPage::_CreateAndNavigateToNewProfile(const uint32_t index)
     {
-        auto newProfile = Settings().CreateNewProfile();
+        auto newProfile = _settingsClone.CreateNewProfile();
         auto navItem = _CreateProfileNavViewItem(newProfile);
         SettingsNav().MenuItems().InsertAt(index, navItem);
 

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -48,20 +48,23 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     }
 
     // Function Description:
-    // - Called when the NavigationView is loaded. Navigates to the first item in the NavigationView
+    // - Called when the NavigationView is loaded. Navigates to the first item in the NavigationView, if no item is selected
     // Arguments:
     // - <unused>
     // Return Value:
     // - <none>
     void MainPage::SettingsNav_Loaded(IInspectable const&, RoutedEventArgs const&)
     {
-        const auto initialItem = SettingsNav().MenuItems().GetAt(0);
-        SettingsNav().SelectedItem(initialItem);
-
-        // Manually navigate because setting the selected item programmatically doesn't trigger ItemInvoked.
-        if (const auto tag = initialItem.as<MUX::Controls::NavigationViewItem>().Tag())
+        if (SettingsNav().SelectedItem() == nullptr)
         {
-            _Navigate(unbox_value<hstring>(tag));
+            const auto initialItem = SettingsNav().MenuItems().GetAt(0);
+            SettingsNav().SelectedItem(initialItem);
+
+            // Manually navigate because setting the selected item programmatically doesn't trigger ItemInvoked.
+            if (const auto tag = initialItem.as<MUX::Controls::NavigationViewItem>().Tag())
+            {
+                _Navigate(unbox_value<hstring>(tag));
+            }
         }
     }
 

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -27,6 +27,14 @@ using namespace winrt::Windows::UI::Core;
 using namespace winrt::Windows::System;
 using namespace winrt::Windows::UI::Xaml::Controls;
 
+static const winrt::hstring launchTag{ L"Launch_Nav" };
+static const winrt::hstring interactionTag{ L"Interaction_Nav" };
+static const winrt::hstring renderingTag{ L"Rendering_Nav" };
+static const winrt::hstring globalProfileTag{ L"GlobalProfile_Nav" };
+static const winrt::hstring addProfileTag{ L"AddProfile" };
+static const winrt::hstring colorSchemesTag{ L"ColorSchemes_Nav" };
+static const winrt::hstring globalAppearanceTag{ L"GlobalAppearance_Nav" };
+
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
     MainPage::MainPage(CascadiaSettings settings) :
@@ -53,7 +61,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // Manually navigate because setting the selected item programmatically doesn't trigger ItemInvoked.
         if (const auto tag = initialItem.as<MUX::Controls::NavigationViewItem>().Tag())
         {
-            _Navigate(contentFrame(), unbox_value<hstring>(tag), _settingsClone);
+            _Navigate(unbox_value<hstring>(tag));
         }
     }
 
@@ -69,7 +77,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         {
             if (const auto navString = clickedItemContainer.Tag().try_as<hstring>())
             {
-                if (navString == L"AddProfile")
+                if (navString == addProfileTag)
                 {
                     // "AddProfile" needs to create a new profile before we can navigate to it
                     uint32_t insertIndex;
@@ -79,51 +87,49 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 else
                 {
                     // Otherwise, navigate to the page
-                    _Navigate(contentFrame(), *navString, _settingsClone);
+                    _Navigate(*navString);
                 }
             }
-            else if (auto profile = clickedItemContainer.Tag().try_as<Model::Profile>())
+            else if (const auto profile = clickedItemContainer.Tag().try_as<Model::Profile>())
             {
                 // Navigate to a page with the given profile
-                contentFrame().Navigate(xaml_typename<Editor::Profiles>(), profile);
+                const auto state{ winrt::make<ProfilePageNavigationState>(profile, _settingsClone.GlobalSettings().ColorSchemes()) };
+                contentFrame().Navigate(xaml_typename<Editor::Profiles>(), state);
             }
         }
     }
 
-    void MainPage::_Navigate(Controls::Frame contentFrame, hstring clickedItemTag, CascadiaSettings settings)
+    void MainPage::_Navigate(hstring clickedItemTag)
     {
-        const hstring launchSubpage = L"Launch_Nav";
-        const hstring interactionSubpage = L"Interaction_Nav";
-        const hstring renderingSubpage = L"Rendering_Nav";
-
-        const hstring globalProfileSubpage = L"GlobalProfile_Nav";
-
-        const hstring colorSchemesPage = L"ColorSchemes_Nav";
-        const hstring globalAppearancePage = L"GlobalAppearance_Nav";
-
-        if (clickedItemTag == launchSubpage)
+        if (clickedItemTag == launchTag)
         {
-            contentFrame.Navigate(xaml_typename<Editor::Launch>(), settings);
+            const auto state{ winrt::make<LaunchPageNavigationState>(_settingsClone) };
+            contentFrame().Navigate(xaml_typename<Editor::Launch>(), state);
         }
-        else if (clickedItemTag == interactionSubpage)
+        else if (clickedItemTag == interactionTag)
         {
-            contentFrame.Navigate(xaml_typename<Editor::Interaction>(), settings.GlobalSettings());
+            const auto state{ winrt::make<InteractionPageNavigationState>(_settingsClone.GlobalSettings()) };
+            contentFrame().Navigate(xaml_typename<Editor::Interaction>(), state);
         }
-        else if (clickedItemTag == renderingSubpage)
+        else if (clickedItemTag == renderingTag)
         {
-            contentFrame.Navigate(xaml_typename<Editor::Rendering>(), settings.GlobalSettings());
+            const auto state{ winrt::make<RenderingPageNavigationState>(_settingsClone.GlobalSettings()) };
+            contentFrame().Navigate(xaml_typename<Editor::Rendering>(), state);
         }
-        else if (clickedItemTag == globalProfileSubpage)
+        else if (clickedItemTag == globalProfileTag)
         {
-            contentFrame.Navigate(xaml_typename<Editor::Profiles>(), settings.ProfileDefaults());
+            const auto state{ winrt::make<ProfilePageNavigationState>(_settingsClone.ProfileDefaults(), _settingsClone.GlobalSettings().ColorSchemes()) };
+            contentFrame().Navigate(xaml_typename<Editor::Profiles>(), state);
         }
-        else if (clickedItemTag == colorSchemesPage)
+        else if (clickedItemTag == colorSchemesTag)
         {
-            contentFrame.Navigate(xaml_typename<Editor::ColorSchemes>(), settings.GlobalSettings());
+            const auto state{ winrt::make<ColorSchemesPageNavigationState>(_settingsClone.GlobalSettings()) };
+            contentFrame().Navigate(xaml_typename<Editor::ColorSchemes>(), state);
         }
-        else if (clickedItemTag == globalAppearancePage)
+        else if (clickedItemTag == globalAppearanceTag)
         {
-            contentFrame.Navigate(xaml_typename<Editor::GlobalAppearance>(), settings.GlobalSettings());
+            const auto state{ winrt::make<GlobalAppearancePageNavigationState>(_settingsClone.GlobalSettings()) };
+            contentFrame().Navigate(xaml_typename<Editor::GlobalAppearance>(), state);
         }
     }
 

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -27,17 +27,17 @@ using namespace winrt::Windows::UI::Core;
 using namespace winrt::Windows::System;
 using namespace winrt::Windows::UI::Xaml::Controls;
 
-static const winrt::hstring launchTag{ L"Launch_Nav" };
-static const winrt::hstring interactionTag{ L"Interaction_Nav" };
-static const winrt::hstring renderingTag{ L"Rendering_Nav" };
-static const winrt::hstring globalProfileTag{ L"GlobalProfile_Nav" };
-static const winrt::hstring addProfileTag{ L"AddProfile" };
-static const winrt::hstring colorSchemesTag{ L"ColorSchemes_Nav" };
-static const winrt::hstring globalAppearanceTag{ L"GlobalAppearance_Nav" };
+static const std::wstring_view launchTag{ L"Launch_Nav" };
+static const std::wstring_view interactionTag{ L"Interaction_Nav" };
+static const std::wstring_view renderingTag{ L"Rendering_Nav" };
+static const std::wstring_view globalProfileTag{ L"GlobalProfile_Nav" };
+static const std::wstring_view addProfileTag{ L"AddProfile" };
+static const std::wstring_view colorSchemesTag{ L"ColorSchemes_Nav" };
+static const std::wstring_view globalAppearanceTag{ L"GlobalAppearance_Nav" };
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
-    MainPage::MainPage(CascadiaSettings settings) :
+    MainPage::MainPage(const CascadiaSettings& settings) :
         _settingsSource{ settings },
         _settingsClone{ settings },
         _profileToNavItemMap{ winrt::single_threaded_map<Model::Profile, MUX::Controls::NavigationViewItem>() }
@@ -96,8 +96,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             else if (const auto profile = clickedItemContainer.Tag().try_as<Model::Profile>())
             {
                 // Navigate to a page with the given profile
-                const auto state{ winrt::make<ProfilePageNavigationState>(profile, _settingsClone.GlobalSettings().ColorSchemes()) };
-                contentFrame().Navigate(xaml_typename<Editor::Profiles>(), state);
+                contentFrame().Navigate(xaml_typename<Editor::Profiles>(), winrt::make<ProfilePageNavigationState>(profile, _settingsClone.GlobalSettings().ColorSchemes()));
             }
         }
     }
@@ -106,33 +105,27 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         if (clickedItemTag == launchTag)
         {
-            const auto state{ winrt::make<LaunchPageNavigationState>(_settingsClone) };
-            contentFrame().Navigate(xaml_typename<Editor::Launch>(), state);
+            contentFrame().Navigate(xaml_typename<Editor::Launch>(), winrt::make<LaunchPageNavigationState>(_settingsClone));
         }
         else if (clickedItemTag == interactionTag)
         {
-            const auto state{ winrt::make<InteractionPageNavigationState>(_settingsClone.GlobalSettings()) };
-            contentFrame().Navigate(xaml_typename<Editor::Interaction>(), state);
+            contentFrame().Navigate(xaml_typename<Editor::Interaction>(), winrt::make<InteractionPageNavigationState>(_settingsClone.GlobalSettings()));
         }
         else if (clickedItemTag == renderingTag)
         {
-            const auto state{ winrt::make<RenderingPageNavigationState>(_settingsClone.GlobalSettings()) };
-            contentFrame().Navigate(xaml_typename<Editor::Rendering>(), state);
+            contentFrame().Navigate(xaml_typename<Editor::Rendering>(), winrt::make<RenderingPageNavigationState>(_settingsClone.GlobalSettings()));
         }
         else if (clickedItemTag == globalProfileTag)
         {
-            const auto state{ winrt::make<ProfilePageNavigationState>(_settingsClone.ProfileDefaults(), _settingsClone.GlobalSettings().ColorSchemes()) };
-            contentFrame().Navigate(xaml_typename<Editor::Profiles>(), state);
+            contentFrame().Navigate(xaml_typename<Editor::Profiles>(), winrt::make<ProfilePageNavigationState>(_settingsClone.ProfileDefaults(), _settingsClone.GlobalSettings().ColorSchemes()));
         }
         else if (clickedItemTag == colorSchemesTag)
         {
-            const auto state{ winrt::make<ColorSchemesPageNavigationState>(_settingsClone.GlobalSettings()) };
-            contentFrame().Navigate(xaml_typename<Editor::ColorSchemes>(), state);
+            contentFrame().Navigate(xaml_typename<Editor::ColorSchemes>(), winrt::make<ColorSchemesPageNavigationState>(_settingsClone.GlobalSettings()));
         }
         else if (clickedItemTag == globalAppearanceTag)
         {
-            const auto state{ winrt::make<GlobalAppearancePageNavigationState>(_settingsClone.GlobalSettings()) };
-            contentFrame().Navigate(xaml_typename<Editor::GlobalAppearance>(), state);
+            contentFrame().Navigate(xaml_typename<Editor::GlobalAppearance>(), winrt::make<GlobalAppearancePageNavigationState>(_settingsClone.GlobalSettings()));
         }
     }
 
@@ -216,7 +209,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // TODO: Setting SelectedItem here doesn't seem to update
         // the NavigationView selected visual indicator, not sure where
         // it needs to be...
-        contentFrame().Navigate(xaml_typename<Editor::Profiles>(), newProfile);
+        contentFrame().Navigate(xaml_typename<Editor::Profiles>(), winrt::make<ProfilePageNavigationState>(newProfile, _settingsClone.GlobalSettings().ColorSchemes()));
     }
 
     MUX::Controls::NavigationViewItem MainPage::_CreateProfileNavViewItem(const Profile& profile)

--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -11,7 +11,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     struct MainPage : MainPageT<MainPage>
     {
         MainPage() = delete;
-        MainPage(winrt::Microsoft::Terminal::Settings::Model::CascadiaSettings settings);
+        MainPage(const Model::CascadiaSettings& settings);
 
         void OpenJsonKeyDown(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs const& args);
         void OpenJsonTapped(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::TappedRoutedEventArgs const& args);

--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -20,22 +20,20 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void SettingsNav_BackRequested(Microsoft::UI::Xaml::Controls::NavigationView const&, Microsoft::UI::Xaml::Controls::NavigationViewBackRequestedEventArgs const& args);
         bool On_BackRequested();
 
-        static void Navigate(Windows::UI::Xaml::Controls::Frame contentFrame, hstring clickedItemTag);
-
-        static winrt::Microsoft::Terminal::Settings::Model::CascadiaSettings Settings();
-
         TYPED_EVENT(OpenJson, winrt::Windows::Foundation::IInspectable, winrt::Microsoft::Terminal::Settings::Model::SettingsTarget);
 
     private:
         // XAML should data-bind to the _settingsClone
         // When "save" is pressed, _settingsSource = _settingsClone
-        static winrt::Microsoft::Terminal::Settings::Model::CascadiaSettings _settingsSource;
-        winrt::Microsoft::Terminal::Settings::Model::CascadiaSettings _settingsClone{ nullptr };
+        winrt::Microsoft::Terminal::Settings::Model::CascadiaSettings _settingsSource;
+        winrt::Microsoft::Terminal::Settings::Model::CascadiaSettings _settingsClone;
         winrt::Windows::Foundation::Collections::IMap<winrt::Microsoft::Terminal::Settings::Model::Profile, winrt::Microsoft::UI::Xaml::Controls::NavigationViewItem> _profileToNavItemMap;
 
         void _InitializeProfilesList();
         void _CreateAndNavigateToNewProfile(const uint32_t index);
         winrt::Microsoft::UI::Xaml::Controls::NavigationViewItem _CreateProfileNavViewItem(const winrt::Microsoft::Terminal::Settings::Model::Profile& profile);
+
+        static void _Navigate(Windows::UI::Xaml::Controls::Frame contentFrame, hstring clickedItemTag, Model::CascadiaSettings settings);
     };
 }
 

--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "Utils.h"
 #include "MainPage.g.h"
+#include "Utils.h"
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
@@ -33,7 +33,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void _CreateAndNavigateToNewProfile(const uint32_t index);
         winrt::Microsoft::UI::Xaml::Controls::NavigationViewItem _CreateProfileNavViewItem(const winrt::Microsoft::Terminal::Settings::Model::Profile& profile);
 
-        static void _Navigate(Windows::UI::Xaml::Controls::Frame contentFrame, hstring clickedItemTag, Model::CascadiaSettings settings);
+        void _Navigate(hstring clickedItemTag);
     };
 }
 

--- a/src/cascadia/TerminalSettingsEditor/MainPage.idl
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.idl
@@ -8,7 +8,5 @@ namespace Microsoft.Terminal.Settings.Editor
         MainPage(Microsoft.Terminal.Settings.Model.CascadiaSettings settings);
 
         event Windows.Foundation.TypedEventHandler<Object, Microsoft.Terminal.Settings.Model.SettingsTarget> OpenJson;
-
-        static Microsoft.Terminal.Settings.Model.CascadiaSettings Settings { get; };
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -27,7 +27,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                         IsBackEnabled="True"
                         BackRequested="SettingsNav_BackRequested">
             <muxc:NavigationView.MenuItems>
-                
+
                 <muxc:NavigationViewItem x:Uid="Nav_Launch"
                                                 Tag="Launch_Nav">
                     <muxc:NavigationViewItem.Icon>

--- a/src/cascadia/TerminalSettingsEditor/Profiles.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.cpp
@@ -28,7 +28,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         INITIALIZE_BINDABLE_ENUM_SETTING(ScrollState, ScrollbarState, winrt::Microsoft::Terminal::TerminalControl::ScrollbarState, L"Profile_ScrollbarVisibility", L"Content");
     }
 
-    void Profiles::OnNavigatedTo(NavigationEventArgs e)
+    void Profiles::OnNavigatedTo(const NavigationEventArgs& e)
     {
         _State = e.Parameter().as<Editor::ProfilePageNavigationState>();
     }

--- a/src/cascadia/TerminalSettingsEditor/Profiles.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.cpp
@@ -1,10 +1,13 @@
-﻿#include "pch.h"
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
 #include "Profiles.h"
 #include "Profiles.g.cpp"
 #include "EnumEntry.h"
 
-using namespace winrt;
 using namespace winrt::Windows::UI::Xaml;
+using namespace winrt::Windows::UI::Xaml::Navigation;
 using namespace winrt::Windows::Foundation;
 using namespace winrt::Windows::Storage;
 using namespace winrt::Windows::Storage::AccessCache;
@@ -25,9 +28,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         INITIALIZE_BINDABLE_ENUM_SETTING(ScrollState, ScrollbarState, winrt::Microsoft::Terminal::TerminalControl::ScrollbarState, L"Profile_ScrollbarVisibility", L"Content");
     }
 
-    void Profiles::OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e)
+    void Profiles::OnNavigatedTo(NavigationEventArgs e)
     {
-        _Profile = e.Parameter().as<Model::Profile>();
+        _State = e.Parameter().as<Editor::ProfilePageNavigationState>();
     }
 
     fire_and_forget Profiles::BackgroundImage_Click(IInspectable const&, RoutedEventArgs const&)

--- a/src/cascadia/TerminalSettingsEditor/Profiles.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.h
@@ -12,7 +12,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     struct ProfilePageNavigationState : ProfilePageNavigationStateT<ProfilePageNavigationState>
     {
     public:
-        ProfilePageNavigationState(Model::Profile profile, Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme> schemes) :
+        ProfilePageNavigationState(const Model::Profile& profile, const Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme>& schemes) :
             _Profile{ profile },
             _Schemes{ schemes } {}
 
@@ -30,7 +30,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     public:
         Profiles();
 
-        void OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e);
+        void OnNavigatedTo(const winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
 
         fire_and_forget BackgroundImage_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
         fire_and_forget Commandline_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);

--- a/src/cascadia/TerminalSettingsEditor/Profiles.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.h
@@ -1,14 +1,30 @@
-﻿
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
 #pragma once
 
-#include "Utils.h"
 #include "Profiles.g.h"
+#include "ProfilePageNavigationState.g.h"
+#include "Utils.h"
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    struct ProfilePageNavigationState : ProfilePageNavigationStateT<ProfilePageNavigationState>
+    {
+    public:
+        ProfilePageNavigationState(Model::Profile profile, Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme> schemes) :
+            _Profile{ profile },
+            _Schemes{ schemes } {}
+
+        Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme> Schemes() { return _Schemes; }
+        void Schemes(const Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme>& val) { _Schemes = val; }
+
+        GETSET_PROPERTY(Model::Profile, Profile, nullptr);
+
+    private:
+        Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme> _Schemes;
+    };
+
     struct Profiles : ProfilesT<Profiles>
     {
     public:
@@ -22,13 +38,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // This crashes on click, for some reason
         //fire_and_forget StartingDirectory_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
 
-        GETSET_PROPERTY(winrt::Microsoft::Terminal::Settings::Model::Profile, Profile);
-        GETSET_BINDABLE_ENUM_SETTING(CursorShape, winrt::Microsoft::Terminal::TerminalControl::CursorStyle, Profile, CursorShape);
-        GETSET_BINDABLE_ENUM_SETTING(BackgroundImageStretchMode, winrt::Windows::UI::Xaml::Media::Stretch, Profile, BackgroundImageStretchMode);
-        GETSET_BINDABLE_ENUM_SETTING(AntiAliasingMode, winrt::Microsoft::Terminal::TerminalControl::TextAntialiasingMode, Profile, AntialiasingMode);
-        GETSET_BINDABLE_ENUM_SETTING(CloseOnExitMode, winrt::Microsoft::Terminal::Settings::Model::CloseOnExitMode, Profile, CloseOnExit);
-        GETSET_BINDABLE_ENUM_SETTING(BellStyle, winrt::Microsoft::Terminal::Settings::Model::BellStyle, Profile, BellStyle);
-        GETSET_BINDABLE_ENUM_SETTING(ScrollState, winrt::Microsoft::Terminal::TerminalControl::ScrollbarState, Profile, ScrollState);
+        GETSET_PROPERTY(Editor::ProfilePageNavigationState, State, nullptr);
+        GETSET_BINDABLE_ENUM_SETTING(CursorShape, winrt::Microsoft::Terminal::TerminalControl::CursorStyle, State().Profile, CursorShape);
+        GETSET_BINDABLE_ENUM_SETTING(BackgroundImageStretchMode, winrt::Windows::UI::Xaml::Media::Stretch, State().Profile, BackgroundImageStretchMode);
+        GETSET_BINDABLE_ENUM_SETTING(AntiAliasingMode, winrt::Microsoft::Terminal::TerminalControl::TextAntialiasingMode, State().Profile, AntialiasingMode);
+        GETSET_BINDABLE_ENUM_SETTING(CloseOnExitMode, winrt::Microsoft::Terminal::Settings::Model::CloseOnExitMode, State().Profile, CloseOnExit);
+        GETSET_BINDABLE_ENUM_SETTING(BellStyle, winrt::Microsoft::Terminal::Settings::Model::BellStyle, State().Profile, BellStyle);
+        GETSET_BINDABLE_ENUM_SETTING(ScrollState, winrt::Microsoft::Terminal::TerminalControl::ScrollbarState, State().Profile, ScrollState);
     };
 }
 

--- a/src/cascadia/TerminalSettingsEditor/Profiles.idl
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.idl
@@ -1,14 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import "EnumEntry.idl"; 
+import "EnumEntry.idl";
 
 namespace Microsoft.Terminal.Settings.Editor
 {
+    runtimeclass ProfilePageNavigationState
+    {
+        Windows.Foundation.Collections.IMapView<String, Microsoft.Terminal.Settings.Model.ColorScheme> Schemes;
+        Microsoft.Terminal.Settings.Model.Profile Profile;
+    };
+
     [default_interface] runtimeclass Profiles : Windows.UI.Xaml.Controls.Page
     {
         Profiles();
-        Microsoft.Terminal.Settings.Model.Profile Profile { get; };
+        ProfilePageNavigationState State { get; };
 
         IInspectable CurrentCursorShape;
         Windows.Foundation.Collections.IObservableVector<Microsoft.Terminal.Settings.Editor.EnumEntry> CursorShapeList { get; };

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -41,14 +41,14 @@ the MIT License. See LICENSE in the project root for license information. -->
                         <ColumnDefinition Width="1*" />
                         <ColumnDefinition Width="1*" />
                     </Grid.ColumnDefinitions>
-                    <TextBox x:Uid="Profile_Commandline" x:Name="Commandline" Margin="0,0,0,20" Grid.Row="0" Grid.Column="0" FontSize="15" Text="{x:Bind Profile.Commandline, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
+                    <TextBox x:Uid="Profile_Commandline" x:Name="Commandline" Margin="0,0,0,20" Grid.Row="0" Grid.Column="0" FontSize="15" Text="{x:Bind State.Profile.Commandline, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
                     <Button x:Uid="Profile_CommandlineBrowse" Click="Commandline_Click" Margin="5,0,0,0" Grid.Row="0" Grid.Column="1" FontSize="15"/>
-                    <TextBox x:Uid="Profile_StartingDirectory" x:Name="StartingDirectory" Margin="0,0,0,20" Grid.Row="1" Grid.Column="0" FontSize="15" Text="{x:Bind Profile.StartingDirectory, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
+                    <TextBox x:Uid="Profile_StartingDirectory" x:Name="StartingDirectory" Margin="0,0,0,20" Grid.Row="1" Grid.Column="0" FontSize="15" Text="{x:Bind State.Profile.StartingDirectory, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
                     <Button x:Uid="Profile_StartingDirectoryBrowse" Margin="5,0,0,0" Grid.Row="1" Grid.Column="1" FontSize="15"/>
-                    <TextBox x:Uid="Profile_Icon" Margin="0,0,0,20" Grid.Row="2" Grid.Column="0" FontSize="15" Text="{x:Bind Profile.Icon, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
+                    <TextBox x:Uid="Profile_Icon" Margin="0,0,0,20" Grid.Row="2" Grid.Column="0" FontSize="15" Text="{x:Bind State.Profile.Icon, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
                     <Button x:Uid="Profile_IconBrowse" Margin="5,0,0,0" Grid.Row="2" Grid.Column="1" FontSize="15" />
                     <StackPanel Grid.Row="3" Grid.Column="0">
-                        <TextBox x:Uid="Profile_TabTitle" Margin="0,0,0,20" FontSize="15" Text="{x:Bind Profile.TabTitle, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
+                        <TextBox x:Uid="Profile_TabTitle" Margin="0,0,0,20" FontSize="15" Text="{x:Bind State.Profile.TabTitle, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
                         <Controls:RadioButtons x:Uid="Profile_ScrollbarVisibility"
                                                ItemsSource="{x:Bind ScrollStateList, Mode=OneWay}"
                                                SelectedItem="{x:Bind CurrentScrollState, Mode=TwoWay}"
@@ -74,12 +74,12 @@ the MIT License. See LICENSE in the project root for license information. -->
 
 
                         <StackPanel Grid.Column="0" Grid.Row="0" Margin="0,0,100,0">
-                            <TextBox x:Uid="Profile_FontFace" Margin="0,0,0,20" FontSize="15" Text="{x:Bind Profile.FontFace, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
+                            <TextBox x:Uid="Profile_FontFace" Margin="0,0,0,20" FontSize="15" Text="{x:Bind State.Profile.FontFace, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
                         </StackPanel>
                         <StackPanel Grid.Column="0" Grid.Row="1" Margin="0,0,100,0">
-                            <Controls:NumberBox x:Uid="Profile_FontSize" Margin="0,0,0,20" FontSize="15" Value="{x:Bind Profile.FontSize, Mode=TwoWay}" SpinButtonPlacementMode="Compact" SmallChange="1" LargeChange="10" ToolTipService.Placement="Mouse" />
+                            <Controls:NumberBox x:Uid="Profile_FontSize" Margin="0,0,0,20" FontSize="15" Value="{x:Bind State.Profile.FontSize, Mode=TwoWay}" SpinButtonPlacementMode="Compact" SmallChange="1" LargeChange="10" ToolTipService.Placement="Mouse" />
                             <TextBox x:Uid="Profile_FontWeight" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse"/>
-                            <TextBox x:Uid="Profile_Padding" Margin="0,0,0,20" FontSize="15" Text="{x:Bind Profile.Padding, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
+                            <TextBox x:Uid="Profile_Padding" Margin="0,0,0,20" FontSize="15" Text="{x:Bind State.Profile.Padding, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
                             <Controls:RadioButtons x:Uid="Profile_CursorShape"
                                                    ItemsSource="{x:Bind CursorShapeList, Mode=OneWay}"
                                                    SelectedItem="{x:Bind CurrentCursorShape, Mode=TwoWay}"
@@ -199,7 +199,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                                 </Button>
                             </StackPanel>
                         </StackPanel>
-                        <TextBox x:Uid="Profile_BackgroundImage" x:Name="BackgroundImage" Margin="0,0,0,20" FontSize="15" Grid.Column="1" Grid.Row="0" Text="{x:Bind Profile.BackgroundImagePath, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
+                        <TextBox x:Uid="Profile_BackgroundImage" x:Name="BackgroundImage" Margin="0,0,0,20" FontSize="15" Grid.Column="1" Grid.Row="0" Text="{x:Bind State.Profile.BackgroundImagePath, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
                         <Button x:Uid="Profile_BackgroundImageBrowse" Click="BackgroundImage_Click" Margin="5,0,0,0" Grid.Column="2" Grid.Row="0"/>
                         <StackPanel Grid.Column="1" Grid.Row="1" Margin="0,0,100,0">
                             <Controls:RadioButtons x:Uid="Profile_BackgroundImageStretchMode"
@@ -224,10 +224,10 @@ the MIT License. See LICENSE in the project root for license information. -->
                                     </MenuFlyout>
                                 </DropDownButton.Flyout>
                             </DropDownButton>
-                            <Controls:NumberBox x:Uid="Profile_BackgroundImageOpacity" Margin="0,0,0,20" FontSize="15" Value="{x:Bind Profile.BackgroundImageOpacity, Mode=TwoWay}" SpinButtonPlacementMode="Compact" SmallChange="10" LargeChange="25" ToolTipService.Placement="Mouse" />
-                            <CheckBox x:Uid="Profile_UseAcrylic" IsChecked="{x:Bind Profile.UseAcrylic, Mode=TwoWay}"/>
-                            <Controls:NumberBox x:Uid="Profile_AcrylicOpacity" Margin="0,0,0,20" FontSize="15" Value="{x:Bind Profile.AcrylicOpacity, Mode=TwoWay}" SpinButtonPlacementMode="Compact" SmallChange="0.1" LargeChange="0.25" ToolTipService.Placement="Mouse" />
-                            <CheckBox x:Uid="Profile_RetroTerminalEffect" IsChecked="{x:Bind Profile.RetroTerminalEffect, Mode=TwoWay}"/>
+                            <Controls:NumberBox x:Uid="Profile_BackgroundImageOpacity" Margin="0,0,0,20" FontSize="15" Value="{x:Bind State.Profile.BackgroundImageOpacity, Mode=TwoWay}" SpinButtonPlacementMode="Compact" SmallChange="10" LargeChange="25" ToolTipService.Placement="Mouse" />
+                            <CheckBox x:Uid="Profile_UseAcrylic" IsChecked="{x:Bind State.Profile.UseAcrylic, Mode=TwoWay}"/>
+                            <Controls:NumberBox x:Uid="Profile_AcrylicOpacity" Margin="0,0,0,20" FontSize="15" Value="{x:Bind State.Profile.AcrylicOpacity, Mode=TwoWay}" SpinButtonPlacementMode="Compact" SmallChange="0.1" LargeChange="0.25" ToolTipService.Placement="Mouse" />
+                            <CheckBox x:Uid="Profile_RetroTerminalEffect" IsChecked="{x:Bind State.Profile.RetroTerminalEffect, Mode=TwoWay}"/>
                         </StackPanel>
                     </Grid>
                 </ScrollViewer>
@@ -244,18 +244,18 @@ the MIT License. See LICENSE in the project root for license information. -->
                         <ColumnDefinition Width="1*" />
                     </Grid.ColumnDefinitions>
                     <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,100,0">
-                        <CheckBox x:Uid="Profile_Hidden" IsChecked="{x:Bind Profile.Hidden, Mode=TwoWay}"/>
-                        <CheckBox x:Uid="Profile_SuppressApplicationTitle" IsChecked="{x:Bind Profile.SuppressApplicationTitle, Mode=TwoWay}"/>
+                        <CheckBox x:Uid="Profile_Hidden" IsChecked="{x:Bind State.Profile.Hidden, Mode=TwoWay}"/>
+                        <CheckBox x:Uid="Profile_SuppressApplicationTitle" IsChecked="{x:Bind State.Profile.SuppressApplicationTitle, Mode=TwoWay}"/>
                         <Controls:RadioButtons x:Uid="Profile_AntialiasingMode"
                                                ItemsSource="{x:Bind AntiAliasingModeList, Mode=OneWay}"
                                                SelectedItem="{x:Bind CurrentAntiAliasingMode, Mode=TwoWay}"
                                                ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
-                        <CheckBox x:Uid="Profile_AltGrAliasing" IsChecked="{x:Bind Profile.AltGrAliasing, Mode=TwoWay}" />
-                        <CheckBox x:Uid="Profile_SnapOnInput" IsChecked="{x:Bind Profile.SnapOnInput, Mode=TwoWay}"/>
+                        <CheckBox x:Uid="Profile_AltGrAliasing" IsChecked="{x:Bind State.Profile.AltGrAliasing, Mode=TwoWay}" />
+                        <CheckBox x:Uid="Profile_SnapOnInput" IsChecked="{x:Bind State.Profile.SnapOnInput, Mode=TwoWay}"/>
                         <Controls:NumberBox x:Uid="Profile_HistorySize"
                                             Margin="0,0,0,20"
                                             FontSize="15"
-                                            Value="{x:Bind Profile.HistorySize, Mode=TwoWay}"
+                                            Value="{x:Bind State.Profile.HistorySize, Mode=TwoWay}"
                                             SpinButtonPlacementMode="Compact"
                                             SmallChange="10"
                                             LargeChange="100"

--- a/src/cascadia/TerminalSettingsEditor/Rendering.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Rendering.cpp
@@ -15,7 +15,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         InitializeComponent();
     }
 
-    void Rendering::OnNavigatedTo(NavigationEventArgs e)
+    void Rendering::OnNavigatedTo(const NavigationEventArgs& e)
     {
         _State = e.Parameter().as<Editor::RenderingPageNavigationState>();
     }

--- a/src/cascadia/TerminalSettingsEditor/Rendering.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Rendering.cpp
@@ -4,11 +4,9 @@
 #include "pch.h"
 #include "Rendering.h"
 #include "Rendering.g.cpp"
-#include "MainPage.h"
+#include "RenderingPageNavigationState.g.cpp"
 
-using namespace winrt;
-using namespace winrt::Windows::UI::Xaml;
-using namespace winrt::Microsoft::Terminal::Settings::Model;
+using namespace winrt::Windows::UI::Xaml::Navigation;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
@@ -17,8 +15,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         InitializeComponent();
     }
 
-    void Rendering::OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e)
+    void Rendering::OnNavigatedTo(NavigationEventArgs e)
     {
-        _GlobalSettings = e.Parameter().as<Model::GlobalAppSettings>();
+        _State = e.Parameter().as<Editor::RenderingPageNavigationState>();
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Rendering.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Rendering.cpp
@@ -17,8 +17,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         InitializeComponent();
     }
 
-    GlobalAppSettings Rendering::GlobalSettings()
+    void Rendering::OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e)
     {
-        return MainPage::Settings().GlobalSettings();
+        _GlobalSettings = e.Parameter().as<Model::GlobalAppSettings>();
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Rendering.h
+++ b/src/cascadia/TerminalSettingsEditor/Rendering.h
@@ -12,7 +12,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     struct RenderingPageNavigationState : RenderingPageNavigationStateT<RenderingPageNavigationState>
     {
     public:
-        RenderingPageNavigationState(Model::GlobalAppSettings settings) :
+        RenderingPageNavigationState(const Model::GlobalAppSettings& settings) :
             _Globals{ settings } {}
 
         GETSET_PROPERTY(Model::GlobalAppSettings, Globals, nullptr)
@@ -22,7 +22,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         Rendering();
 
-        void OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e);
+        void OnNavigatedTo(const winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
 
         GETSET_PROPERTY(Editor::RenderingPageNavigationState, State, nullptr);
     };

--- a/src/cascadia/TerminalSettingsEditor/Rendering.h
+++ b/src/cascadia/TerminalSettingsEditor/Rendering.h
@@ -11,7 +11,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     struct Rendering : RenderingT<Rendering>
     {
         Rendering();
-        winrt::Microsoft::Terminal::Settings::Model::GlobalAppSettings GlobalSettings();
+
+        void OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e);
+
+        GETSET_PROPERTY(Model::GlobalAppSettings, GlobalSettings, nullptr);
     };
 }
 

--- a/src/cascadia/TerminalSettingsEditor/Rendering.h
+++ b/src/cascadia/TerminalSettingsEditor/Rendering.h
@@ -4,17 +4,27 @@
 #pragma once
 
 #include "Rendering.g.h"
+#include "RenderingPageNavigationState.g.h"
 #include "Utils.h"
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    struct RenderingPageNavigationState : RenderingPageNavigationStateT<RenderingPageNavigationState>
+    {
+    public:
+        RenderingPageNavigationState(Model::GlobalAppSettings settings) :
+            _Globals{ settings } {}
+
+        GETSET_PROPERTY(Model::GlobalAppSettings, Globals, nullptr)
+    };
+
     struct Rendering : RenderingT<Rendering>
     {
         Rendering();
 
         void OnNavigatedTo(winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs e);
 
-        GETSET_PROPERTY(Model::GlobalAppSettings, GlobalSettings, nullptr);
+        GETSET_PROPERTY(Editor::RenderingPageNavigationState, State, nullptr);
     };
 }
 

--- a/src/cascadia/TerminalSettingsEditor/Rendering.idl
+++ b/src/cascadia/TerminalSettingsEditor/Rendering.idl
@@ -3,9 +3,14 @@
 
 namespace Microsoft.Terminal.Settings.Editor
 {
+    runtimeclass RenderingPageNavigationState
+    {
+        Microsoft.Terminal.Settings.Model.GlobalAppSettings Globals;
+    };
+
     [default_interface] runtimeclass Rendering : Windows.UI.Xaml.Controls.Page
     {
         Rendering();
-        Microsoft.Terminal.Settings.Model.GlobalAppSettings GlobalSettings { get; };
+        RenderingPageNavigationState State { get; };
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Rendering.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Rendering.xaml
@@ -26,8 +26,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <TextBlock x:Uid="Globals_RenderingDisclaimer"
                        Style="{StaticResource BodyTextBlockStyle}"
                        Margin="0,0,0,20" />
-                <CheckBox x:Uid="Globals_ForceFullRepaint" IsChecked="{x:Bind GlobalSettings.ForceFullRepaintRendering, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
-                <CheckBox x:Uid="Globals_SoftwareRendering" IsChecked="{x:Bind GlobalSettings.SoftwareRendering, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
+                <CheckBox x:Uid="Globals_ForceFullRepaint" IsChecked="{x:Bind State.Globals.ForceFullRepaintRendering, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
+                <CheckBox x:Uid="Globals_SoftwareRendering" IsChecked="{x:Bind State.Globals.SoftwareRendering, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
             </StackPanel>
         </Grid>
     </ScrollViewer>

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -203,12 +203,12 @@ winrt::Microsoft::Terminal::Settings::Model::GlobalAppSettings CascadiaSettings:
 }
 
 // Method Description:
-// - Get a reference to our default profile settings
+// - Get a reference to our profiles.defaults object
 // Arguments:
 // - <none>
 // Return Value:
-// - a reference to our default profile settings
-winrt::Microsoft::Terminal::Settings::Model::Profile CascadiaSettings::DefaultProfileSettings() const
+// - a reference to our profile.defaults object
+winrt::Microsoft::Terminal::Settings::Model::Profile CascadiaSettings::ProfileDefaults() const
 {
     return *_userDefaultProfileSettings;
 }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -76,7 +76,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         static hstring SettingsPath();
         static hstring DefaultSettingsPath();
-        Model::Profile DefaultProfileSettings() const;
+        Model::Profile ProfileDefaults() const;
 
         static winrt::hstring ApplicationDisplayName();
         static winrt::hstring ApplicationVersion();

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.idl
@@ -23,7 +23,7 @@ namespace Microsoft.Terminal.Settings.Model
 
         GlobalAppSettings GlobalSettings { get; };
 
-        Profile DefaultProfileSettings { get; };
+        Profile ProfileDefaults { get; };
 
         Windows.Foundation.Collections.IObservableVector<Profile> AllProfiles { get; };
         Windows.Foundation.Collections.IObservableVector<Profile> ActiveProfiles { get; };


### PR DESCRIPTION
## Summary of the Pull Request
Navigating to pages in the Settings UI now passes in a state of the
relevant settings at the time of navigation. This helps scope each page
to its relevant settings. For example, a `Profile` page now has access
to the relevant `Profile` and color schemes. This allows the page to see
all of the relevant profile settings, and (soon) display the possible
color schemes to choose from.

If a developer wants a page to have access to more settings or context,
they can now add it to the pertinent NavigationState runtimeclass and
pass it to the page in `MainPage` (most likely `Navigate()`).

## References
#1564 - Settings UI

## Additional Comments
- Pages are not constructed when you navigate to them. Thus, we cannot
  track the state by passing it into the constructor of a `Page`.
- This PR also does a little bit of polish in `MainPage.cpp`'s
  navigation functions such as defining tags at the top of the file and
  simplifying/de-static-ifying `Navigate()`.
- This also fixes a bug where loading the settings page would always
  take you to the first item.

## Validation Steps Performed
Visited every page on the Settings UI.