### PR TITLE
Prevent leftover cursor fragments when scrolling in PowerShell

### DIFF
--- a/src/renderer/gdi/paint.cpp
+++ b/src/renderer/gdi/paint.cpp
@@ -258,6 +258,13 @@ using namespace Microsoft::Console::Render;
 // - S_OK or suitable GDI HRESULT error.
 [[nodiscard]] HRESULT GdiEngine::PaintBackground() noexcept
 {
+    // We need to clear the cursorInvertRects at the start of a paint cycle so
+    // we don't inadvertently retain the invert region from the last paint after
+    // the cursor is hidden. If we don't, the ScrollFrame method may attempt to
+    // clean up a cursor that is no longer there, and instead leave a bunch of
+    // "ghost" cursor instances on the screen.
+    cursorInvertRects.clear();
+
     if (_psInvalidData.fErase)
     {
         RETURN_IF_FAILED(_PaintBackgroundColor(&_psInvalidData.rcPaint));


### PR DESCRIPTION
There are certain cursor movement operations (in conhost) that can
result in "ghost" cursor instances being left behind, if the move causes
the viewport to scroll while the cursor is blinking off. Pressing enter
in a PowerShell prompt when at the bottom of the screen was one example
of this. This PR fixes that problem.

Whenever the cursor renders with an `InvertRect`, the affected areas of
the screen are saved in the `cursorInvertRects` variable. If the screen
is then scrolled while the cursor is visible, those rects are
"uninverted" in the `GdiEngine::ScrollFrame` method before the scrolling
takes place.

When the cursor has blinked off, though, the `GdiEngine::PaintCursor`
method won't set the `cursorInvertRects` variable, but it also doesn't
clear it. So if the screen is scrolled at that point, the `ScrollFrame`
method tries to "uninvert" the area where the cursor had previously been
painted. And since the cursor is no longer there, this has the opposite
effect, leaving an unwanted mark on the screen.

I've fixed this by clearing the `cursorInvertRects` at the start of the
paint cycle, in the the `GdiEngine::PaintBackground` method. Since this
occurs after the `ScrollFrame` step, it still allows for legitimate
cursor instances to be cleaned up when scrolling, but makes sure that
the variable will be cleared for the next cycle if the cursor is no
longer visible.

## Validation Steps Performed

I've manually verified that I no longer see ghost cursor fragments when
scrolling in PowerShell.

Closes #804