### PR TITLE
Support for navigating panes by MRU

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -790,7 +790,7 @@
                 "desktopWallpaper"
               ]
             }
-          ]
+          ],
           "type": [ "string", "null" ]
         },
         "backgroundImageAlignment": {

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -113,7 +113,9 @@
         "left",
         "right",
         "up",
-        "down"
+        "down",
+        "next",
+        "previous"
       ],
       "type": "string"
     },
@@ -285,7 +287,7 @@
             "direction": {
               "$ref": "#/definitions/Direction",
               "default": "left",
-              "description": "The direction to move focus in, between panes"
+              "description": "The direction to move focus in, between panes. Direction can be 'previous' to move to the most recently used pane or 'next' to move to the least recently used pane."
             }
           }
         }
@@ -302,7 +304,7 @@
             "direction": {
               "$ref": "#/definitions/Direction",
               "default": "left",
-              "description": "The direction to move the pane separator in"
+              "description": "The direction to move the pane separator in. Direction cannot be 'next' or 'previous'."
             }
           }
         }

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -264,7 +264,7 @@
         { "$ref": "#/definitions/NewTerminalArgs" },
         {
           "properties": {
-            "action": { "type": "string", "pattern": "newTab" }
+            "action": { "type":"string", "pattern": "newTab" }
           }
         }
       ]
@@ -479,7 +479,7 @@
           "properties": {
             "action": { "type": "string", "pattern": "scrollUp" },
             "rowsToScroll": {
-              "type": [ "integer", "null" ],
+              "type": ["integer", "null"],
               "default": null,
               "description": "Scroll up rowsToScroll lines. If no value is provided, use the system-level defaults."
             }
@@ -495,7 +495,7 @@
           "properties": {
             "action": { "type": "string", "pattern": "scrollDown" },
             "rowsToScroll": {
-              "type": [ "integer", "null" ],
+              "type": ["integer", "null"],
               "default": null,
               "description": "Scroll down rowsToScroll lines. If no value is provided, use the system-level defaults."
             }
@@ -508,26 +508,26 @@
       "properties": {
         "command": {
           "description": "The action executed when the associated key bindings are pressed.",
-           "oneOf": [
-             { "$ref": "#/definitions/AdjustFontSizeAction" },
-             { "$ref": "#/definitions/CopyAction" },
-             { "$ref": "#/definitions/ShortcutActionName" },
-             { "$ref": "#/definitions/NewTabAction" },
-             { "$ref": "#/definitions/SwitchToTabAction" },
-             { "$ref": "#/definitions/MoveFocusAction" },
-             { "$ref": "#/definitions/ResizePaneAction" },
-             { "$ref": "#/definitions/SendInputAction" },
-             { "$ref": "#/definitions/SplitPaneAction" },
-             { "$ref": "#/definitions/OpenSettingsAction" },
-             { "$ref": "#/definitions/SetTabColorAction" },
-             { "$ref": "#/definitions/SetColorSchemeAction" },
-             { "$ref": "#/definitions/WtAction" },
-             { "$ref": "#/definitions/CloseOtherTabsAction" },
-             { "$ref": "#/definitions/CloseTabsAfterAction" },
-             { "$ref": "#/definitions/ScrollUpAction" },
-             { "$ref": "#/definitions/ScrollDownAction" },
-             { "type": "null" }
-           ]
+            "oneOf": [
+              { "$ref": "#/definitions/AdjustFontSizeAction" },
+              { "$ref": "#/definitions/CopyAction" },
+              { "$ref": "#/definitions/ShortcutActionName" },
+              { "$ref": "#/definitions/NewTabAction" },
+              { "$ref": "#/definitions/SwitchToTabAction" },
+              { "$ref": "#/definitions/MoveFocusAction" },
+              { "$ref": "#/definitions/ResizePaneAction" },
+              { "$ref": "#/definitions/SendInputAction" },
+              { "$ref": "#/definitions/SplitPaneAction" },
+              { "$ref": "#/definitions/OpenSettingsAction" },
+              { "$ref": "#/definitions/SetTabColorAction" },
+              { "$ref": "#/definitions/SetColorSchemeAction" },
+              { "$ref": "#/definitions/WtAction" },
+              { "$ref": "#/definitions/CloseOtherTabsAction" },
+              { "$ref": "#/definitions/CloseTabsAfterAction" },
+              { "$ref": "#/definitions/ScrollUpAction" },
+              { "$ref": "#/definitions/ScrollDownAction" },
+              { "type": "null" }
+            ]
         },
         "keys": {
           "description": "Defines the key combinations used to call the command. It must be composed of...\n -any number of modifiers (ctrl/alt/shift)\n -a non-modifier key",
@@ -862,7 +862,7 @@
         "cursorColor": {
           "oneOf": [
             { "$ref": "#/definitions/Color" },
-            { "type": "null" }
+            {"type": "null"}
           ],
           "description": "Sets the color of the cursor. Overrides the cursor color from the color scheme. Uses hex color format: \"#rrggbb\"."
         },
@@ -870,7 +870,7 @@
           "description": "Sets the percentage height of the cursor starting from the bottom. Only works when cursorShape is set to \"vintage\". Accepts values from 25-100.",
           "maximum": 100,
           "minimum": 25,
-          "type": ["integer", "null"],
+          "type": ["integer","null"],
           "default": 25
         },
         "cursorShape": {

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -295,7 +295,7 @@
             "direction": {
               "$ref": "#/definitions/FocusDirection",
               "default": "left",
-              "description": "The direction to move focus in, between panes. Direction can be 'previous' to move to the most recently used pane or 'next' to move to the least recently used pane."
+              "description": "The direction to move focus in, between panes. Direction can be 'previous' to move to the most recently used pane."
             }
           }
         }
@@ -722,7 +722,7 @@
               "enum": [
                 "mru",
                 "inOrder",
-                "disabled",
+                "disabled"
               ],
               "type": "string"
             }
@@ -740,7 +740,7 @@
               "enum": [
                 "mru",
                 "inOrder",
-                "disabled",
+                "disabled"
               ],
               "type": "string"
             }

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -218,10 +218,7 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": {
-              "type": "string",
-              "pattern": "adjustFontSize"
-            },
+            "action": { "type": "string", "pattern": "adjustFontSize" },
             "delta": {
               "type": "integer",
               "default": 0,
@@ -238,10 +235,7 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": {
-              "type": "string",
-              "pattern": "copy"
-            },
+            "action": { "type": "string", "pattern": "copy" },
             "singleLine": {
               "type": "boolean",
               "default": false,
@@ -270,10 +264,7 @@
         { "$ref": "#/definitions/NewTerminalArgs" },
         {
           "properties": {
-            "action": {
-              "type": "string",
-              "pattern": "newTab"
-            }
+            "action": { "type": "string", "pattern": "newTab" }
           }
         }
       ]
@@ -284,10 +275,7 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": {
-              "type": "string",
-              "pattern": "switchToTab"
-            },
+            "action": { "type": "string", "pattern": "switchToTab" },
             "index": {
               "type": "integer",
               "default": 0,
@@ -304,10 +292,7 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": {
-              "type": "string",
-              "pattern": "moveFocus"
-            },
+            "action": { "type": "string", "pattern": "moveFocus" },
             "direction": {
               "$ref": "#/definitions/FocusDirection",
               "default": "left",
@@ -324,10 +309,7 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": {
-              "type": "string",
-              "pattern": "resizePane"
-            },
+            "action": { "type": "string", "pattern": "resizePane" },
             "direction": {
               "$ref": "#/definitions/ResizeDirection",
               "default": "left",
@@ -346,10 +328,7 @@
         },
         {
           "properties": {
-            "action": {
-              "type": "string",
-              "pattern": "sendInput"
-            },
+            "action": { "type": "string", "pattern": "sendInput" },
             "input": {
               "type": "string",
               "default": "",
@@ -367,10 +346,7 @@
         { "$ref": "#/definitions/NewTerminalArgs" },
         {
           "properties": {
-            "action": {
-              "type": "string",
-              "pattern": "splitPane"
-            },
+            "action": { "type": "string", "pattern": "splitPane" },
             "split": {
               "$ref": "#/definitions/SplitState",
               "default": "auto",
@@ -392,10 +368,7 @@
         },
         {
           "properties": {
-            "action": {
-              "type": "string",
-              "pattern": "openSettings"
-            },
+            "action": { "type": "string", "pattern": "openSettings" },
             "target": {
               "type": "string",
               "default": "settingsFile",
@@ -416,10 +389,7 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": {
-              "type": "string",
-              "pattern": "setTabColor"
-            },
+            "action": { "type": "string", "pattern": "setTabColor" },
             "color": {
               "$ref": "#/definitions/Color",
               "default": null,
@@ -435,10 +405,7 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": {
-              "type": "string",
-              "pattern": "setColorScheme"
-            },
+            "action": { "type": "string", "pattern": "setColorScheme" },
             "colorScheme": {
               "type": "string",
               "default": "",
@@ -455,10 +422,7 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": {
-              "type": "string",
-              "pattern": "wt"
-            },
+            "action": { "type": "string", "pattern": "wt" },
             "commandline": {
               "type": "string",
               "default": "",
@@ -475,10 +439,7 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": {
-              "type": "string",
-              "pattern": "closeOtherTabs"
-            },
+            "action": { "type": "string", "pattern": "closeOtherTabs" },
             "index": {
               "oneOf": [
                 { "type": "integer" },
@@ -497,10 +458,7 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": {
-              "type": "string",
-              "pattern": "closeTabsAfter"
-            },
+            "action": { "type": "string", "pattern": "closeTabsAfter" },
             "index": {
               "oneOf": [
                 { "type": "integer" },
@@ -519,10 +477,7 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": {
-              "type": "string",
-              "pattern": "scrollUp"
-            },
+            "action": { "type": "string", "pattern": "scrollUp" },
             "rowsToScroll": {
               "type": [ "integer", "null" ],
               "default": null,
@@ -538,10 +493,7 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": {
-              "type": "string",
-              "pattern": "scrollDown"
-            },
+            "action": { "type": "string", "pattern": "scrollDown" },
             "rowsToScroll": {
               "type": [ "integer", "null" ],
               "default": null,
@@ -556,26 +508,26 @@
       "properties": {
         "command": {
           "description": "The action executed when the associated key bindings are pressed.",
-          "oneOf": [
-            { "$ref": "#/definitions/AdjustFontSizeAction" },
-            { "$ref": "#/definitions/CopyAction" },
-            { "$ref": "#/definitions/ShortcutActionName" },
-            { "$ref": "#/definitions/NewTabAction" },
-            { "$ref": "#/definitions/SwitchToTabAction" },
-            { "$ref": "#/definitions/MoveFocusAction" },
-            { "$ref": "#/definitions/ResizePaneAction" },
-            { "$ref": "#/definitions/SendInputAction" },
-            { "$ref": "#/definitions/SplitPaneAction" },
-            { "$ref": "#/definitions/OpenSettingsAction" },
-            { "$ref": "#/definitions/SetTabColorAction" },
-            { "$ref": "#/definitions/SetColorSchemeAction" },
-            { "$ref": "#/definitions/WtAction" },
-            { "$ref": "#/definitions/CloseOtherTabsAction" },
-            { "$ref": "#/definitions/CloseTabsAfterAction" },
-            { "$ref": "#/definitions/ScrollUpAction" },
-            { "$ref": "#/definitions/ScrollDownAction" },
-            { "type": "null" }
-          ]
+           "oneOf": [
+             { "$ref": "#/definitions/AdjustFontSizeAction" },
+             { "$ref": "#/definitions/CopyAction" },
+             { "$ref": "#/definitions/ShortcutActionName" },
+             { "$ref": "#/definitions/NewTabAction" },
+             { "$ref": "#/definitions/SwitchToTabAction" },
+             { "$ref": "#/definitions/MoveFocusAction" },
+             { "$ref": "#/definitions/ResizePaneAction" },
+             { "$ref": "#/definitions/SendInputAction" },
+             { "$ref": "#/definitions/SplitPaneAction" },
+             { "$ref": "#/definitions/OpenSettingsAction" },
+             { "$ref": "#/definitions/SetTabColorAction" },
+             { "$ref": "#/definitions/SetColorSchemeAction" },
+             { "$ref": "#/definitions/WtAction" },
+             { "$ref": "#/definitions/CloseOtherTabsAction" },
+             { "$ref": "#/definitions/CloseTabsAfterAction" },
+             { "$ref": "#/definitions/ScrollUpAction" },
+             { "$ref": "#/definitions/ScrollDownAction" },
+             { "type": "null" }
+           ]
         },
         "keys": {
           "description": "Defines the key combinations used to call the command. It must be composed of...\n -any number of modifiers (ctrl/alt/shift)\n -a non-modifier key",
@@ -771,7 +723,7 @@
               "enum": [
                 "mru",
                 "inOrder",
-                "disabled"
+                "disabled",
               ],
               "type": "string"
             }
@@ -789,7 +741,7 @@
               "enum": [
                 "mru",
                 "inOrder",
-                "disabled"
+                "disabled",
               ],
               "type": "string"
             }
@@ -826,7 +778,7 @@
           "$ref": "#/definitions/Color",
           "default": "#0c0c0c",
           "description": "Sets the background color of the text. Overrides \"background\" from the color scheme. Uses hex color format: \"#rrggbb\".",
-          "type": [ "string", "null" ]
+          "type": ["string", "null"]
         },
         "backgroundImage": {
           "description": "Sets the file location of the image to draw over the window background.",
@@ -918,7 +870,7 @@
           "description": "Sets the percentage height of the cursor starting from the bottom. Only works when cursorShape is set to \"vintage\". Accepts values from 25-100.",
           "maximum": 100,
           "minimum": 25,
-          "type": [ "integer", "null" ],
+          "type": ["integer", "null"],
           "default": 25
         },
         "cursorShape": {
@@ -979,7 +931,7 @@
           "$ref": "#/definitions/Color",
           "default": "#cccccc",
           "description": "Sets the text color. Overrides \"foreground\" from the color scheme. Uses hex color format: \"#rrggbb\".",
-          "type": [ "string", "null" ]
+          "type": ["string", "null"]
         },
         "guid": {
           "$ref": "#/definitions/ProfileGuid",
@@ -996,7 +948,7 @@
           "minimum": -1,
           "type": "integer"
         },
-        "icon": { "$ref": "#/definitions/Icon" },
+        "icon":{ "$ref": "#/definitions/Icon" },
         "name": {
           "description": "Name of the profile. Displays in the dropdown menu.",
           "minLength": 1,
@@ -1026,7 +978,7 @@
         },
         "selectionBackground": {
           "oneOf": [
-            { "$ref": "#/definitions/Color" },
+            {"$ref": "#/definitions/Color"},
             { "type": "null" }
           ],
           "description": "Sets the background color of selected text. Overrides selectionBackground set in the color scheme. Uses hex color format: \"#rrggbb\"."
@@ -1043,7 +995,7 @@
         },
         "source": {
           "description": "Stores the name of the profile generator that originated this profile.",
-          "type": [ "string", "null" ]
+          "type": ["string", "null"]
         },
         "startingDirectory": {
           "description": "The directory the shell starts in when it is loaded.",
@@ -1056,7 +1008,7 @@
         },
         "tabTitle": {
           "description": "If set, will replace the name as the title to pass to the shell on startup. Some shells (like bash) may choose to ignore this initial value, while others (cmd, powershell) may use this value over the lifetime of the application.",
-          "type": [ "string", "null" ]
+          "type": ["string", "null"]
         },
         "useAcrylic": {
           "default": false,

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -108,7 +108,7 @@
       ],
       "type": "string"
     },
-    "Direction": {
+    "FocusDirection": {
       "enum": [
         "left",
         "right",
@@ -116,6 +116,15 @@
         "down",
         "next",
         "previous"
+      ],
+      "type": "string"
+    },
+    "ResizeDirection": {
+      "enum": [
+        "left",
+        "right",
+        "up",
+        "down"
       ],
       "type": "string"
     },
@@ -209,7 +218,10 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": { "type": "string", "pattern": "adjustFontSize" },
+            "action": {
+              "type": "string",
+              "pattern": "adjustFontSize"
+            },
             "delta": {
               "type": "integer",
               "default": 0,
@@ -226,7 +238,10 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": { "type": "string", "pattern": "copy" },
+            "action": {
+              "type": "string",
+              "pattern": "copy"
+            },
             "singleLine": {
               "type": "boolean",
               "default": false,
@@ -255,7 +270,10 @@
         { "$ref": "#/definitions/NewTerminalArgs" },
         {
           "properties": {
-            "action": { "type":"string", "pattern": "newTab" }
+            "action": {
+              "type": "string",
+              "pattern": "newTab"
+            }
           }
         }
       ]
@@ -266,7 +284,10 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": { "type": "string", "pattern": "switchToTab" },
+            "action": {
+              "type": "string",
+              "pattern": "switchToTab"
+            },
             "index": {
               "type": "integer",
               "default": 0,
@@ -283,9 +304,12 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": { "type": "string", "pattern": "moveFocus" },
+            "action": {
+              "type": "string",
+              "pattern": "moveFocus"
+            },
             "direction": {
-              "$ref": "#/definitions/Direction",
+              "$ref": "#/definitions/FocusDirection",
               "default": "left",
               "description": "The direction to move focus in, between panes. Direction can be 'previous' to move to the most recently used pane or 'next' to move to the least recently used pane."
             }
@@ -300,11 +324,14 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": { "type": "string", "pattern": "resizePane" },
+            "action": {
+              "type": "string",
+              "pattern": "resizePane"
+            },
             "direction": {
-              "$ref": "#/definitions/Direction",
+              "$ref": "#/definitions/ResizeDirection",
               "default": "left",
-              "description": "The direction to move the pane separator in. Direction cannot be 'next' or 'previous'."
+              "description": "The direction to move the pane separator in."
             }
           }
         }
@@ -340,7 +367,10 @@
         { "$ref": "#/definitions/NewTerminalArgs" },
         {
           "properties": {
-            "action": { "type": "string", "pattern": "splitPane" },
+            "action": {
+              "type": "string",
+              "pattern": "splitPane"
+            },
             "split": {
               "$ref": "#/definitions/SplitState",
               "default": "auto",
@@ -386,7 +416,10 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": { "type": "string", "pattern": "setTabColor" },
+            "action": {
+              "type": "string",
+              "pattern": "setTabColor"
+            },
             "color": {
               "$ref": "#/definitions/Color",
               "default": null,
@@ -402,7 +435,10 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": { "type": "string", "pattern": "setColorScheme" },
+            "action": {
+              "type": "string",
+              "pattern": "setColorScheme"
+            },
             "colorScheme": {
               "type": "string",
               "default": "",
@@ -419,7 +455,10 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": { "type": "string", "pattern": "wt" },
+            "action": {
+              "type": "string",
+              "pattern": "wt"
+            },
             "commandline": {
               "type": "string",
               "default": "",
@@ -436,7 +475,10 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": { "type": "string", "pattern": "closeOtherTabs" },
+            "action": {
+              "type": "string",
+              "pattern": "closeOtherTabs"
+            },
             "index": {
               "oneOf": [
                 { "type": "integer" },
@@ -455,7 +497,10 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": { "type": "string", "pattern": "closeTabsAfter" },
+            "action": {
+              "type": "string",
+              "pattern": "closeTabsAfter"
+            },
             "index": {
               "oneOf": [
                 { "type": "integer" },
@@ -474,9 +519,12 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": { "type": "string", "pattern": "scrollUp" },
+            "action": {
+              "type": "string",
+              "pattern": "scrollUp"
+            },
             "rowsToScroll": {
-              "type": ["integer", "null"],
+              "type": [ "integer", "null" ],
               "default": null,
               "description": "Scroll up rowsToScroll lines. If no value is provided, use the system-level defaults."
             }
@@ -490,9 +538,12 @@
         { "$ref": "#/definitions/ShortcutAction" },
         {
           "properties": {
-            "action": { "type": "string", "pattern": "scrollDown" },
+            "action": {
+              "type": "string",
+              "pattern": "scrollDown"
+            },
             "rowsToScroll": {
-              "type": ["integer", "null"],
+              "type": [ "integer", "null" ],
               "default": null,
               "description": "Scroll down rowsToScroll lines. If no value is provided, use the system-level defaults."
             }
@@ -505,26 +556,26 @@
       "properties": {
         "command": {
           "description": "The action executed when the associated key bindings are pressed.",
-            "oneOf": [
-              { "$ref": "#/definitions/AdjustFontSizeAction" },
-              { "$ref": "#/definitions/CopyAction" },
-              { "$ref": "#/definitions/ShortcutActionName" },
-              { "$ref": "#/definitions/NewTabAction" },
-              { "$ref": "#/definitions/SwitchToTabAction" },
-              { "$ref": "#/definitions/MoveFocusAction" },
-              { "$ref": "#/definitions/ResizePaneAction" },
-              { "$ref": "#/definitions/SendInputAction" },
-              { "$ref": "#/definitions/SplitPaneAction" },
-              { "$ref": "#/definitions/OpenSettingsAction" },
-              { "$ref": "#/definitions/SetTabColorAction" },
-              { "$ref": "#/definitions/SetColorSchemeAction" },
-              { "$ref": "#/definitions/WtAction" },
-              { "$ref": "#/definitions/CloseOtherTabsAction" },
-              { "$ref": "#/definitions/CloseTabsAfterAction" },
-              { "$ref": "#/definitions/ScrollUpAction" },
-              { "$ref": "#/definitions/ScrollDownAction" },
-              { "type": "null" }
-            ]
+          "oneOf": [
+            { "$ref": "#/definitions/AdjustFontSizeAction" },
+            { "$ref": "#/definitions/CopyAction" },
+            { "$ref": "#/definitions/ShortcutActionName" },
+            { "$ref": "#/definitions/NewTabAction" },
+            { "$ref": "#/definitions/SwitchToTabAction" },
+            { "$ref": "#/definitions/MoveFocusAction" },
+            { "$ref": "#/definitions/ResizePaneAction" },
+            { "$ref": "#/definitions/SendInputAction" },
+            { "$ref": "#/definitions/SplitPaneAction" },
+            { "$ref": "#/definitions/OpenSettingsAction" },
+            { "$ref": "#/definitions/SetTabColorAction" },
+            { "$ref": "#/definitions/SetColorSchemeAction" },
+            { "$ref": "#/definitions/WtAction" },
+            { "$ref": "#/definitions/CloseOtherTabsAction" },
+            { "$ref": "#/definitions/CloseTabsAfterAction" },
+            { "$ref": "#/definitions/ScrollUpAction" },
+            { "$ref": "#/definitions/ScrollDownAction" },
+            { "type": "null" }
+          ]
         },
         "keys": {
           "description": "Defines the key combinations used to call the command. It must be composed of...\n -any number of modifiers (ctrl/alt/shift)\n -a non-modifier key",
@@ -775,7 +826,7 @@
           "$ref": "#/definitions/Color",
           "default": "#0c0c0c",
           "description": "Sets the background color of the text. Overrides \"background\" from the color scheme. Uses hex color format: \"#rrggbb\".",
-          "type": ["string", "null"]
+          "type": [ "string", "null" ]
         },
         "backgroundImage": {
           "description": "Sets the file location of the image to draw over the window background.",
@@ -789,6 +840,7 @@
               ]
             }
           ]
+          "type": [ "string", "null" ]
         },
         "backgroundImageAlignment": {
           "default": "center",
@@ -858,7 +910,7 @@
         "cursorColor": {
           "oneOf": [
             { "$ref": "#/definitions/Color" },
-            {"type": "null"}
+            { "type": "null" }
           ],
           "description": "Sets the color of the cursor. Overrides the cursor color from the color scheme. Uses hex color format: \"#rrggbb\"."
         },
@@ -866,7 +918,7 @@
           "description": "Sets the percentage height of the cursor starting from the bottom. Only works when cursorShape is set to \"vintage\". Accepts values from 25-100.",
           "maximum": 100,
           "minimum": 25,
-          "type": ["integer","null"],
+          "type": [ "integer", "null" ],
           "default": 25
         },
         "cursorShape": {
@@ -927,7 +979,7 @@
           "$ref": "#/definitions/Color",
           "default": "#cccccc",
           "description": "Sets the text color. Overrides \"foreground\" from the color scheme. Uses hex color format: \"#rrggbb\".",
-          "type": ["string", "null"]
+          "type": [ "string", "null" ]
         },
         "guid": {
           "$ref": "#/definitions/ProfileGuid",
@@ -944,7 +996,7 @@
           "minimum": -1,
           "type": "integer"
         },
-        "icon":{ "$ref": "#/definitions/Icon" },
+        "icon": { "$ref": "#/definitions/Icon" },
         "name": {
           "description": "Name of the profile. Displays in the dropdown menu.",
           "minLength": 1,
@@ -974,7 +1026,7 @@
         },
         "selectionBackground": {
           "oneOf": [
-            {"$ref": "#/definitions/Color"},
+            { "$ref": "#/definitions/Color" },
             { "type": "null" }
           ],
           "description": "Sets the background color of selected text. Overrides selectionBackground set in the color scheme. Uses hex color format: \"#rrggbb\"."
@@ -991,7 +1043,7 @@
         },
         "source": {
           "description": "Stores the name of the profile generator that originated this profile.",
-          "type": ["string", "null"]
+          "type": [ "string", "null" ]
         },
         "startingDirectory": {
           "description": "The directory the shell starts in when it is loaded.",
@@ -1004,7 +1056,7 @@
         },
         "tabTitle": {
           "description": "If set, will replace the name as the title to pass to the shell on startup. Some shells (like bash) may choose to ignore this initial value, while others (cmd, powershell) may use this value over the lifetime of the application.",
-          "type": ["string", "null"]
+          "type": [ "string", "null" ]
         },
         "useAcrylic": {
           "default": false,

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -114,7 +114,6 @@
         "right",
         "up",
         "down",
-        "next",
         "previous"
       ],
       "type": "string"

--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -664,7 +664,7 @@ namespace TerminalAppLocalTests
         Log::Comment(L"Move focus. This will cause us to un-zoom.");
         result = RunOnUIThread([&page]() {
             // Set up action
-            MoveFocusArgs args{ Direction::Left };
+            MoveFocusArgs args{ FocusDirection::Left };
             ActionEventArgs eventArgs{ args };
 
             page->_HandleMoveFocus(nullptr, eventArgs);

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -214,14 +214,14 @@ namespace winrt::TerminalApp::implementation
     {
         if (const auto& realArgs = args.ActionArgs().try_as<ResizePaneArgs>())
         {
-            if (realArgs.Direction() == Direction::None)
+            if (realArgs.ResizeDirection() == ResizeDirection::None)
             {
                 // Do nothing
                 args.Handled(false);
             }
             else
             {
-                _ResizePane(realArgs.Direction());
+                _ResizePane(realArgs.ResizeDirection());
                 args.Handled(true);
             }
         }
@@ -232,14 +232,14 @@ namespace winrt::TerminalApp::implementation
     {
         if (const auto& realArgs = args.ActionArgs().try_as<MoveFocusArgs>())
         {
-            if (realArgs.Direction() == Direction::None)
+            if (realArgs.FocusDirection() == FocusDirection::None)
             {
                 // Do nothing
                 args.Handled(false);
             }
             else
             {
-                _MoveFocus(realArgs.Direction());
+                _MoveFocus(realArgs.FocusDirection());
                 args.Handled(true);
             }
         }

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -1566,6 +1566,32 @@ void Pane::Restore(std::shared_ptr<Pane> zoomedPane)
     }
 }
 
+uint16_t Pane::GetPaneId() noexcept
+{
+    return _paneId;
+}
+
+void Pane::SetPaneId(uint16_t id) noexcept
+{
+    _paneId = id;
+}
+
+void Pane::FocusPaneWithId(const uint16_t id)
+{
+    if (_IsLeaf() && id == _paneId)
+    {
+        _control.Focus(FocusState::Programmatic);
+    }
+    else
+    {
+        if (_firstChild && _secondChild)
+        {
+            _firstChild->FocusPaneWithId(id);
+            _secondChild->FocusPaneWithId(id);
+        }
+    }
+}
+
 // Method Description:
 // - Gets the size in pixels of each of our children, given the full size they
 //   should fill. Since these children own their own separators (borders), this

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -130,7 +130,7 @@ void Pane::Relayout()
 //   decreasing the size of our first child.
 // Return Value:
 // - false if we couldn't resize this pane in the given direction, else true.
-bool Pane::_Resize(const Direction& direction)
+bool Pane::_Resize(const ResizeDirection& direction)
 {
     if (!DirectionMatchesSplit(direction, _splitState))
     {
@@ -138,7 +138,7 @@ bool Pane::_Resize(const Direction& direction)
     }
 
     float amount = .05f;
-    if (direction == Direction::Right || direction == Direction::Down)
+    if (direction == ResizeDirection::Right || direction == ResizeDirection::Down)
     {
         amount = -amount;
     }
@@ -171,7 +171,7 @@ bool Pane::_Resize(const Direction& direction)
 // - direction: The direction to move the separator in.
 // Return Value:
 // - true if we or a child handled this resize request.
-bool Pane::ResizePane(const Direction& direction)
+bool Pane::ResizePane(const ResizeDirection& direction)
 {
     // If we're a leaf, do nothing. We can't possibly have a descendant with a
     // separator the correct direction.
@@ -223,14 +223,14 @@ bool Pane::ResizePane(const Direction& direction)
 // - direction: The direction to move the focus in.
 // Return Value:
 // - true if we handled this focus move request.
-bool Pane::_NavigateFocus(const Direction& direction)
+bool Pane::_NavigateFocus(const FocusDirection& direction)
 {
     if (!DirectionMatchesSplit(direction, _splitState))
     {
         return false;
     }
 
-    const bool focusSecond = (direction == Direction::Right) || (direction == Direction::Down);
+    const bool focusSecond = (direction == FocusDirection::Right) || (direction == FocusDirection::Down);
 
     const auto newlyFocusedChild = focusSecond ? _secondChild : _firstChild;
 
@@ -261,7 +261,7 @@ bool Pane::_NavigateFocus(const Direction& direction)
 // - direction: The direction to move the focus in.
 // Return Value:
 // - true if we or a child handled this focus move request.
-bool Pane::NavigateFocus(const Direction& direction)
+bool Pane::NavigateFocus(const FocusDirection& direction)
 {
     // If we're a leaf, do nothing. We can't possibly have a descendant with a
     // separator the correct direction.

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -1566,17 +1566,30 @@ void Pane::Restore(std::shared_ptr<Pane> zoomedPane)
     }
 }
 
-uint16_t Pane::GetPaneId() noexcept
+// Method Description:
+// - Retrieves the ID of this pane
+// Return Value:
+// - The ID of this pane
+uint16_t Pane::PaneId() noexcept
 {
     return _paneId;
 }
 
-void Pane::SetPaneId(uint16_t id) noexcept
+// Method Description:
+// - Sets this pane's ID
+// - Panes are given IDs upon creation by TerminalTab
+// Arguments:
+// - The number to set this pane's ID to
+void Pane::PaneId(uint16_t id) noexcept
 {
     _paneId = id;
 }
 
-void Pane::FocusPaneWithId(const uint16_t id)
+// Method Description:
+// - Recursive function that focuses a pane with the given ID
+// Arguments:
+// - The ID of the pane we want to focus
+void Pane::FocusPane(const uint16_t id)
 {
     if (_IsLeaf() && id == _paneId)
     {
@@ -1586,8 +1599,8 @@ void Pane::FocusPaneWithId(const uint16_t id)
     {
         if (_firstChild && _secondChild)
         {
-            _firstChild->FocusPaneWithId(id);
-            _secondChild->FocusPaneWithId(id);
+            _firstChild->FocusPane(id);
+            _secondChild->FocusPane(id);
         }
     }
 }

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -655,9 +655,10 @@ void Pane::_CloseChild(const bool closeFirst)
         // inherited from us, so the flag will be set for both children.
         _borders = _firstChild->_borders & _secondChild->_borders;
 
-        // take the control and profile of the pane that _wasn't_ closed.
+        // take the control, profile and id of the pane that _wasn't_ closed.
         _control = remainingChild->_control;
         _profile = remainingChild->_profile;
+        _id = remainingChild->Id();
 
         // Add our new event handler before revoking the old one.
         _connectionStateChangedToken = _control.ConnectionStateChanged({ this, &Pane::_ControlConnectionStateChangedHandler });
@@ -1493,6 +1494,9 @@ std::pair<std::shared_ptr<Pane>, std::shared_ptr<Pane>> Pane::_Split(SplitState 
 
     _SetupEntranceAnimation();
 
+    // Clear out our ID, only leaves should have IDs
+    _id = {};
+
     return { _firstChild, _secondChild };
 }
 
@@ -1568,11 +1572,13 @@ void Pane::Restore(std::shared_ptr<Pane> zoomedPane)
 
 // Method Description:
 // - Retrieves the ID of this pane
+// - NOTE: The caller should make sure that this pane is a leaf,
+//   otherwise the ID value will not make sense (leaves have IDs, parents do not)
 // Return Value:
 // - The ID of this pane
 uint16_t Pane::Id() noexcept
 {
-    return _id;
+    return _id.value();
 }
 
 // Method Description:

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -1570,9 +1570,9 @@ void Pane::Restore(std::shared_ptr<Pane> zoomedPane)
 // - Retrieves the ID of this pane
 // Return Value:
 // - The ID of this pane
-uint16_t Pane::PaneId() noexcept
+uint16_t Pane::Id() noexcept
 {
-    return _paneId;
+    return _id;
 }
 
 // Method Description:
@@ -1580,9 +1580,9 @@ uint16_t Pane::PaneId() noexcept
 // - Panes are given IDs upon creation by TerminalTab
 // Arguments:
 // - The number to set this pane's ID to
-void Pane::PaneId(uint16_t id) noexcept
+void Pane::Id(uint16_t id) noexcept
 {
-    _paneId = id;
+    _id = id;
 }
 
 // Method Description:
@@ -1591,7 +1591,7 @@ void Pane::PaneId(uint16_t id) noexcept
 // - The ID of the pane we want to focus
 void Pane::FocusPane(const uint16_t id)
 {
-    if (_IsLeaf() && id == _paneId)
+    if (_IsLeaf() && id == _id)
     {
         _control.Focus(FocusState::Programmatic);
     }

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -190,7 +190,7 @@ private:
 
     // Method Description
     // - Exactly the same as the above DirectionMatchesSplit, but for FocusDirection instead of Resize
-    // - Uused for moving focus between panes, which again happens _across_ a separator.
+    // - Used for moving focus between panes, which again happens _across_ a separator.
     // Arguments:
     // - direction: The Direction to compare
     // - splitType: The winrt::TerminalApp::SplitState to compare

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -55,8 +55,8 @@ public:
                         const GUID& profile);
     void ResizeContent(const winrt::Windows::Foundation::Size& newSize);
     void Relayout();
-    bool ResizePane(const winrt::Microsoft::Terminal::Settings::Model::Direction& direction);
-    bool NavigateFocus(const winrt::Microsoft::Terminal::Settings::Model::Direction& direction);
+    bool ResizePane(const winrt::Microsoft::Terminal::Settings::Model::ResizeDirection& direction);
+    bool NavigateFocus(const winrt::Microsoft::Terminal::Settings::Model::FocusDirection& direction);
 
     bool CanSplit(winrt::Microsoft::Terminal::Settings::Model::SplitState splitType);
     std::pair<std::shared_ptr<Pane>, std::shared_ptr<Pane>> Split(winrt::Microsoft::Terminal::Settings::Model::SplitState splitType,
@@ -130,8 +130,8 @@ private:
     void _SetupEntranceAnimation();
     void _UpdateBorders();
 
-    bool _Resize(const winrt::Microsoft::Terminal::Settings::Model::Direction& direction);
-    bool _NavigateFocus(const winrt::Microsoft::Terminal::Settings::Model::Direction& direction);
+    bool _Resize(const winrt::Microsoft::Terminal::Settings::Model::ResizeDirection& direction);
+    bool _NavigateFocus(const winrt::Microsoft::Terminal::Settings::Model::FocusDirection& direction);
 
     void _CloseChild(const bool closeFirst);
     winrt::fire_and_forget _CloseChildRoutine(const bool closeFirst);
@@ -162,15 +162,13 @@ private:
     // - This is used for pane resizing (which will need a pane separator
     //   that's perpendicular to the direction to be able to move the separator
     //   in that direction).
-    // - Additionally, it will be used for moving focus between panes, which
-    //   again happens _across_ a separator.
     // Arguments:
     // - direction: The Direction to compare
     // - splitType: The winrt::TerminalApp::SplitState to compare
     // Return Value:
     // - true iff the direction is perpendicular to the splitType. False for
     //   winrt::TerminalApp::SplitState::None.
-    static constexpr bool DirectionMatchesSplit(const winrt::Microsoft::Terminal::Settings::Model::Direction& direction,
+    static constexpr bool DirectionMatchesSplit(const winrt::Microsoft::Terminal::Settings::Model::ResizeDirection& direction,
                                                 const winrt::Microsoft::Terminal::Settings::Model::SplitState& splitType)
     {
         if (splitType == winrt::Microsoft::Terminal::Settings::Model::SplitState::None)
@@ -179,13 +177,42 @@ private:
         }
         else if (splitType == winrt::Microsoft::Terminal::Settings::Model::SplitState::Horizontal)
         {
-            return direction == winrt::Microsoft::Terminal::Settings::Model::Direction::Up ||
-                   direction == winrt::Microsoft::Terminal::Settings::Model::Direction::Down;
+            return direction == winrt::Microsoft::Terminal::Settings::Model::ResizeDirection::Up ||
+                   direction == winrt::Microsoft::Terminal::Settings::Model::ResizeDirection::Down;
         }
         else if (splitType == winrt::Microsoft::Terminal::Settings::Model::SplitState::Vertical)
         {
-            return direction == winrt::Microsoft::Terminal::Settings::Model::Direction::Left ||
-                   direction == winrt::Microsoft::Terminal::Settings::Model::Direction::Right;
+            return direction == winrt::Microsoft::Terminal::Settings::Model::ResizeDirection::Left ||
+                   direction == winrt::Microsoft::Terminal::Settings::Model::ResizeDirection::Right;
+        }
+        return false;
+    }
+
+    // Method Description
+    // - Exactly the same as the above DirectionMatchesSplit, but for FocusDirection instead of Resize
+    // - Uused for moving focus between panes, which again happens _across_ a separator.
+    // Arguments:
+    // - direction: The Direction to compare
+    // - splitType: The winrt::TerminalApp::SplitState to compare
+    // Return Value:
+    // - true iff the direction is perpendicular to the splitType. False for
+    //   winrt::TerminalApp::SplitState::None.
+    static constexpr bool DirectionMatchesSplit(const winrt::Microsoft::Terminal::Settings::Model::FocusDirection& direction,
+                                                const winrt::Microsoft::Terminal::Settings::Model::SplitState& splitType)
+    {
+        if (splitType == winrt::Microsoft::Terminal::Settings::Model::SplitState::None)
+        {
+            return false;
+        }
+        else if (splitType == winrt::Microsoft::Terminal::Settings::Model::SplitState::Horizontal)
+        {
+            return direction == winrt::Microsoft::Terminal::Settings::Model::FocusDirection::Up ||
+                   direction == winrt::Microsoft::Terminal::Settings::Model::FocusDirection::Down;
+        }
+        else if (splitType == winrt::Microsoft::Terminal::Settings::Model::SplitState::Vertical)
+        {
+            return direction == winrt::Microsoft::Terminal::Settings::Model::FocusDirection::Left ||
+                   direction == winrt::Microsoft::Terminal::Settings::Model::FocusDirection::Right;
         }
         return false;
     }

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -75,8 +75,8 @@ public:
     void Maximize(std::shared_ptr<Pane> zoomedPane);
     void Restore(std::shared_ptr<Pane> zoomedPane);
 
-    uint16_t PaneId() noexcept;
-    void PaneId(uint16_t id) noexcept;
+    uint16_t Id() noexcept;
+    void Id(uint16_t id) noexcept;
     void FocusPane(const uint16_t id);
 
     WINRT_CALLBACK(Closed, winrt::Windows::Foundation::EventHandler<winrt::Windows::Foundation::IInspectable>);
@@ -99,7 +99,7 @@ private:
     winrt::Microsoft::Terminal::Settings::Model::SplitState _splitState{ winrt::Microsoft::Terminal::Settings::Model::SplitState::None };
     float _desiredSplitPosition;
 
-    uint16_t _paneId;
+    uint16_t _id;
 
     bool _lastActive{ false };
     std::optional<GUID> _profile{ std::nullopt };

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -75,9 +75,9 @@ public:
     void Maximize(std::shared_ptr<Pane> zoomedPane);
     void Restore(std::shared_ptr<Pane> zoomedPane);
 
-    uint16_t GetPaneId() noexcept;
-    void SetPaneId(uint16_t id) noexcept;
-    void FocusPaneWithId(const uint16_t id);
+    uint16_t PaneId() noexcept;
+    void PaneId(uint16_t id) noexcept;
+    void FocusPane(const uint16_t id);
 
     WINRT_CALLBACK(Closed, winrt::Windows::Foundation::EventHandler<winrt::Windows::Foundation::IInspectable>);
     DECLARE_EVENT(GotFocus, _GotFocusHandlers, winrt::delegate<std::shared_ptr<Pane>>);

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -162,13 +162,15 @@ private:
     // - This is used for pane resizing (which will need a pane separator
     //   that's perpendicular to the direction to be able to move the separator
     //   in that direction).
+    // - Also used for moving focus between panes, which again happens _across_ a separator.
     // Arguments:
     // - direction: The Direction to compare
     // - splitType: The winrt::TerminalApp::SplitState to compare
     // Return Value:
     // - true iff the direction is perpendicular to the splitType. False for
     //   winrt::TerminalApp::SplitState::None.
-    static constexpr bool DirectionMatchesSplit(const winrt::Microsoft::Terminal::Settings::Model::ResizeDirection& direction,
+    template<typename T>
+    static constexpr bool DirectionMatchesSplit(const T& direction,
                                                 const winrt::Microsoft::Terminal::Settings::Model::SplitState& splitType)
     {
         if (splitType == winrt::Microsoft::Terminal::Settings::Model::SplitState::None)
@@ -177,42 +179,13 @@ private:
         }
         else if (splitType == winrt::Microsoft::Terminal::Settings::Model::SplitState::Horizontal)
         {
-            return direction == winrt::Microsoft::Terminal::Settings::Model::ResizeDirection::Up ||
-                   direction == winrt::Microsoft::Terminal::Settings::Model::ResizeDirection::Down;
+            return direction == T::Up ||
+                   direction == T::Down;
         }
         else if (splitType == winrt::Microsoft::Terminal::Settings::Model::SplitState::Vertical)
         {
-            return direction == winrt::Microsoft::Terminal::Settings::Model::ResizeDirection::Left ||
-                   direction == winrt::Microsoft::Terminal::Settings::Model::ResizeDirection::Right;
-        }
-        return false;
-    }
-
-    // Method Description
-    // - Exactly the same as the above DirectionMatchesSplit, but for FocusDirection instead of Resize
-    // - Used for moving focus between panes, which again happens _across_ a separator.
-    // Arguments:
-    // - direction: The Direction to compare
-    // - splitType: The winrt::TerminalApp::SplitState to compare
-    // Return Value:
-    // - true iff the direction is perpendicular to the splitType. False for
-    //   winrt::TerminalApp::SplitState::None.
-    static constexpr bool DirectionMatchesSplit(const winrt::Microsoft::Terminal::Settings::Model::FocusDirection& direction,
-                                                const winrt::Microsoft::Terminal::Settings::Model::SplitState& splitType)
-    {
-        if (splitType == winrt::Microsoft::Terminal::Settings::Model::SplitState::None)
-        {
-            return false;
-        }
-        else if (splitType == winrt::Microsoft::Terminal::Settings::Model::SplitState::Horizontal)
-        {
-            return direction == winrt::Microsoft::Terminal::Settings::Model::FocusDirection::Up ||
-                   direction == winrt::Microsoft::Terminal::Settings::Model::FocusDirection::Down;
-        }
-        else if (splitType == winrt::Microsoft::Terminal::Settings::Model::SplitState::Vertical)
-        {
-            return direction == winrt::Microsoft::Terminal::Settings::Model::FocusDirection::Left ||
-                   direction == winrt::Microsoft::Terminal::Settings::Model::FocusDirection::Right;
+            return direction == T::Left ||
+                   direction == T::Right;
         }
         return false;
     }

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -75,6 +75,10 @@ public:
     void Maximize(std::shared_ptr<Pane> zoomedPane);
     void Restore(std::shared_ptr<Pane> zoomedPane);
 
+    uint16_t GetPaneId() noexcept;
+    void SetPaneId(uint16_t id) noexcept;
+    void FocusPaneWithId(const uint16_t id);
+
     WINRT_CALLBACK(Closed, winrt::Windows::Foundation::EventHandler<winrt::Windows::Foundation::IInspectable>);
     DECLARE_EVENT(GotFocus, _GotFocusHandlers, winrt::delegate<std::shared_ptr<Pane>>);
     DECLARE_EVENT(PaneRaiseVisualBell, _PaneRaiseVisualBellHandlers, winrt::delegate<std::shared_ptr<Pane>>);
@@ -94,6 +98,8 @@ private:
     std::shared_ptr<Pane> _secondChild{ nullptr };
     winrt::Microsoft::Terminal::Settings::Model::SplitState _splitState{ winrt::Microsoft::Terminal::Settings::Model::SplitState::None };
     float _desiredSplitPosition;
+
+    uint16_t _paneId;
 
     bool _lastActive{ false };
     std::optional<GUID> _profile{ std::nullopt };

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -99,7 +99,7 @@ private:
     winrt::Microsoft::Terminal::Settings::Model::SplitState _splitState{ winrt::Microsoft::Terminal::Settings::Model::SplitState::None };
     float _desiredSplitPosition;
 
-    uint16_t _id;
+    std::optional<uint16_t> _id;
 
     bool _lastActive{ false };
     std::optional<GUID> _profile{ std::nullopt };

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1359,7 +1359,7 @@ namespace winrt::TerminalApp::implementation
     // - direction: The direction to move the focus in.
     // Return Value:
     // - <none>
-    void TerminalPage::_MoveFocus(const Direction& direction)
+    void TerminalPage::_MoveFocus(const FocusDirection& direction)
     {
         if (auto index{ _GetFocusedTabIndex() })
         {
@@ -1633,7 +1633,7 @@ namespace winrt::TerminalApp::implementation
     // - direction: The direction to move the separator in.
     // Return Value:
     // - <none>
-    void TerminalPage::_ResizePane(const Direction& direction)
+    void TerminalPage::_ResizePane(const ResizeDirection& direction)
     {
         if (auto index{ _GetFocusedTabIndex() })
         {

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -170,7 +170,7 @@ namespace winrt::TerminalApp::implementation
 
         void _SelectNextTab(const bool bMoveRight);
         bool _SelectTab(const uint32_t tabIndex);
-        void _MoveFocus(const Microsoft::Terminal::Settings::Model::Direction& direction);
+        void _MoveFocus(const Microsoft::Terminal::Settings::Model::FocusDirection& direction);
 
         winrt::Microsoft::Terminal::TerminalControl::TermControl _GetActiveControl();
         std::optional<uint32_t> _GetFocusedTabIndex() const noexcept;
@@ -186,7 +186,7 @@ namespace winrt::TerminalApp::implementation
         // MSFT:20641986: Add keybindings for New Window
         void _Scroll(ScrollDirection scrollDirection, const Windows::Foundation::IReference<uint32_t>& rowsToScroll);
         void _SplitPane(const Microsoft::Terminal::Settings::Model::SplitState splitType, const Microsoft::Terminal::Settings::Model::SplitType splitMode = Microsoft::Terminal::Settings::Model::SplitType::Manual, const Microsoft::Terminal::Settings::Model::NewTerminalArgs& newTerminalArgs = nullptr);
-        void _ResizePane(const Microsoft::Terminal::Settings::Model::Direction& direction);
+        void _ResizePane(const Microsoft::Terminal::Settings::Model::ResizeDirection& direction);
         void _ScrollPage(ScrollDirection scrollDirection);
         void _SetAcceleratorForMenuItem(Windows::UI::Xaml::Controls::MenuFlyoutItem& menuItem, const winrt::Microsoft::Terminal::TerminalControl::KeyChord& keyChord);
 

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -29,7 +29,7 @@ namespace winrt::TerminalApp::implementation
     {
         _rootPane = std::make_shared<Pane>(profile, control, true);
 
-        _rootPane->SetPaneId(_nextPaneId);
+        _rootPane->PaneId(_nextPaneId);
         _mruPanes.InsertAt(0, _nextPaneId);
         ++_nextPaneId;
 
@@ -279,10 +279,10 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     void TerminalTab::SplitPane(SplitState splitType, const GUID& profile, TermControl& control)
     {
-        const auto activePaneId = _activePane->GetPaneId();
+        const auto activePaneId = _activePane->PaneId();
         auto [first, second] = _activePane->Split(splitType, profile, control);
-        first->SetPaneId(activePaneId);
-        second->SetPaneId(_nextPaneId);
+        first->PaneId(activePaneId);
+        second->PaneId(_nextPaneId);
         ++_nextPaneId;
         _activePane = first;
         _AttachEventHandlersToControl(control);
@@ -346,11 +346,11 @@ namespace winrt::TerminalApp::implementation
         if (direction == Direction::Previous)
         {
             // To get to the previous pane, get the id of the previous pane and focus to that
-            _rootPane->FocusPaneWithId(_mruPanes.GetAt(1));
+            _rootPane->FocusPane(_mruPanes.GetAt(1));
         }
         else if (direction == Direction::Next)
         {
-            _rootPane->FocusPaneWithId(_mruPanes.GetAt(_mruPanes.Size() - 1));
+            _rootPane->FocusPane(_mruPanes.GetAt(_mruPanes.Size() - 1));
         }
         else
         {
@@ -474,7 +474,7 @@ namespace winrt::TerminalApp::implementation
         // We need to move the pane to the top of our mru list
         // If its already somewhere in the list, remove it first
         uint32_t mruPaneIndex;
-        const auto paneId = pane->GetPaneId();
+        const auto paneId = pane->PaneId();
         if (_mruPanes.IndexOf(paneId, mruPaneIndex))
         {
             _mruPanes.RemoveAt(mruPaneIndex);
@@ -526,7 +526,7 @@ namespace winrt::TerminalApp::implementation
                 if (auto pane = weakPane.lock())
                 {
                     uint32_t mruIndex;
-                    if (tab->_mruPanes.IndexOf(pane->GetPaneId(), mruIndex))
+                    if (tab->_mruPanes.IndexOf(pane->PaneId(), mruIndex))
                     {
                         tab->_mruPanes.RemoveAt(mruIndex);
                     }

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -279,6 +279,7 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     void TerminalTab::SplitPane(SplitState splitType, const GUID& profile, TermControl& control)
     {
+        // Make sure to take the ID before calling Split() - Split() will clear out the active pane's ID
         const auto activePaneId = _activePane->Id();
         auto [first, second] = _activePane->Split(splitType, profile, control);
         first->Id(activePaneId);

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -348,6 +348,10 @@ namespace winrt::TerminalApp::implementation
             // To get to the previous pane, get the id of the previous pane and focus to that
             _rootPane->FocusPaneWithId(_mruPanes.GetAt(1));
         }
+        else if (direction == Direction::Next)
+        {
+            _rootPane->FocusPaneWithId(_mruPanes.GetAt(_mruPanes.Size() - 1));
+        }
         else
         {
             // NOTE: This _must_ be called on the root pane, so that it can propagate

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -531,7 +531,6 @@ namespace winrt::TerminalApp::implementation
                             break;
                         }
                     }
-
                 }
             }
         });

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -29,7 +29,7 @@ namespace winrt::TerminalApp::implementation
     {
         _rootPane = std::make_shared<Pane>(profile, control, true);
 
-        _rootPane->PaneId(_nextPaneId);
+        _rootPane->Id(_nextPaneId);
         _mruPanes.InsertAt(0, _nextPaneId);
         ++_nextPaneId;
 
@@ -279,10 +279,10 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     void TerminalTab::SplitPane(SplitState splitType, const GUID& profile, TermControl& control)
     {
-        const auto activePaneId = _activePane->PaneId();
+        const auto activePaneId = _activePane->Id();
         auto [first, second] = _activePane->Split(splitType, profile, control);
-        first->PaneId(activePaneId);
-        second->PaneId(_nextPaneId);
+        first->Id(activePaneId);
+        second->Id(_nextPaneId);
         ++_nextPaneId;
         _activePane = first;
         _AttachEventHandlersToControl(control);
@@ -470,7 +470,7 @@ namespace winrt::TerminalApp::implementation
         // We need to move the pane to the top of our mru list
         // If its already somewhere in the list, remove it first
         uint32_t mruPaneIndex;
-        const auto paneId = pane->PaneId();
+        const auto paneId = pane->Id();
         if (_mruPanes.IndexOf(paneId, mruPaneIndex))
         {
             _mruPanes.RemoveAt(mruPaneIndex);
@@ -522,7 +522,7 @@ namespace winrt::TerminalApp::implementation
                 if (auto pane = weakPane.lock())
                 {
                     uint32_t mruIndex;
-                    if (tab->_mruPanes.IndexOf(pane->PaneId(), mruIndex))
+                    if (tab->_mruPanes.IndexOf(pane->Id(), mruIndex))
                     {
                         tab->_mruPanes.RemoveAt(mruIndex);
                     }

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -327,7 +327,7 @@ namespace winrt::TerminalApp::implementation
     // - direction: The direction to move the separator in.
     // Return Value:
     // - <none>
-    void TerminalTab::ResizePane(const Direction& direction)
+    void TerminalTab::ResizePane(const ResizeDirection& direction)
     {
         // NOTE: This _must_ be called on the root pane, so that it can propagate
         // throughout the entire tree.
@@ -341,14 +341,14 @@ namespace winrt::TerminalApp::implementation
     // - direction: The direction to move the focus in.
     // Return Value:
     // - <none>
-    void TerminalTab::NavigateFocus(const Direction& direction)
+    void TerminalTab::NavigateFocus(const FocusDirection& direction)
     {
-        if (direction == Direction::Previous)
+        if (direction == FocusDirection::Previous)
         {
             // To get to the previous pane, get the id of the previous pane and focus to that
             _rootPane->FocusPane(_mruPanes.GetAt(1));
         }
-        else if (direction == Direction::Next)
+        else if (direction == FocusDirection::Next)
         {
             _rootPane->FocusPane(_mruPanes.GetAt(_mruPanes.Size() - 1));
         }

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -348,10 +348,6 @@ namespace winrt::TerminalApp::implementation
             // To get to the previous pane, get the id of the previous pane and focus to that
             _rootPane->FocusPane(_mruPanes.GetAt(1));
         }
-        else if (direction == FocusDirection::Next)
-        {
-            _rootPane->FocusPane(_mruPanes.GetAt(_mruPanes.Size() - 1));
-        }
         else
         {
             // NOTE: This _must_ be called on the root pane, so that it can propagate

--- a/src/cascadia/TerminalApp/TerminalTab.h
+++ b/src/cascadia/TerminalApp/TerminalTab.h
@@ -83,6 +83,9 @@ namespace winrt::TerminalApp::implementation
         winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _closeTabsAfterMenuItem{};
         winrt::TerminalApp::TabHeaderControl _headerControl{};
 
+        Windows::Foundation::Collections::IVector<uint16_t> _mruPanes;
+        uint16_t _nextPaneId{ 0 };
+
         bool _receivedKeyDown{ false };
 
         winrt::hstring _runtimeTabText{};

--- a/src/cascadia/TerminalApp/TerminalTab.h
+++ b/src/cascadia/TerminalApp/TerminalTab.h
@@ -40,8 +40,8 @@ namespace winrt::TerminalApp::implementation
         bool PreCalculateCanSplit(winrt::Microsoft::Terminal::Settings::Model::SplitState splitType, winrt::Windows::Foundation::Size availableSpace) const;
 
         void ResizeContent(const winrt::Windows::Foundation::Size& newSize);
-        void ResizePane(const winrt::Microsoft::Terminal::Settings::Model::Direction& direction);
-        void NavigateFocus(const winrt::Microsoft::Terminal::Settings::Model::Direction& direction);
+        void ResizePane(const winrt::Microsoft::Terminal::Settings::Model::ResizeDirection& direction);
+        void NavigateFocus(const winrt::Microsoft::Terminal::Settings::Model::FocusDirection& direction);
 
         void UpdateSettings(const winrt::TerminalApp::TerminalSettings& settings, const GUID& profile);
         winrt::fire_and_forget UpdateTitle();

--- a/src/cascadia/TerminalApp/TerminalTab.h
+++ b/src/cascadia/TerminalApp/TerminalTab.h
@@ -83,7 +83,7 @@ namespace winrt::TerminalApp::implementation
         winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _closeTabsAfterMenuItem{};
         winrt::TerminalApp::TabHeaderControl _headerControl{};
 
-        Windows::Foundation::Collections::IVector<uint16_t> _mruPanes;
+        std::vector<uint16_t> _mruPanes;
         uint16_t _nextPaneId{ 0 };
 
         bool _receivedKeyDown{ false };

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
@@ -183,6 +183,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         case FocusDirection::Down:
             directionString = RS_(L"DirectionDown");
             break;
+        case FocusDirection::Previous:
+            return RS_(L"MoveFocusToLastUsedPane");
         }
         return winrt::hstring{
             fmt::format(std::wstring_view(RS_(L"MoveFocusWithArgCommandKey")),

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
@@ -145,18 +145,18 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     winrt::hstring ResizePaneArgs::GenerateName() const
     {
         winrt::hstring directionString;
-        switch (_Direction)
+        switch (_ResizeDirection)
         {
-        case Direction::Left:
+        case ResizeDirection::Left:
             directionString = RS_(L"DirectionLeft");
             break;
-        case Direction::Right:
+        case ResizeDirection::Right:
             directionString = RS_(L"DirectionRight");
             break;
-        case Direction::Up:
+        case ResizeDirection::Up:
             directionString = RS_(L"DirectionUp");
             break;
-        case Direction::Down:
+        case ResizeDirection::Down:
             directionString = RS_(L"DirectionDown");
             break;
         }
@@ -169,18 +169,18 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     winrt::hstring MoveFocusArgs::GenerateName() const
     {
         winrt::hstring directionString;
-        switch (_Direction)
+        switch (_FocusDirection)
         {
-        case Direction::Left:
+        case FocusDirection::Left:
             directionString = RS_(L"DirectionLeft");
             break;
-        case Direction::Right:
+        case FocusDirection::Right:
             directionString = RS_(L"DirectionRight");
             break;
-        case Direction::Up:
+        case FocusDirection::Up:
             directionString = RS_(L"DirectionUp");
             break;
-        case Direction::Down:
+        case FocusDirection::Down:
             directionString = RS_(L"DirectionDown");
             break;
         }

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -221,7 +221,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     struct ResizePaneArgs : public ResizePaneArgsT<ResizePaneArgs>
     {
         ResizePaneArgs() = default;
-        GETSET_PROPERTY(Model::Direction, Direction, Direction::None);
+        GETSET_PROPERTY(Model::ResizeDirection, ResizeDirection, ResizeDirection::None);
 
         static constexpr std::string_view DirectionKey{ "direction" };
 
@@ -233,7 +233,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             auto otherAsUs = other.try_as<ResizePaneArgs>();
             if (otherAsUs)
             {
-                return otherAsUs->_Direction == _Direction;
+                return otherAsUs->_ResizeDirection == _ResizeDirection;
             }
             return false;
         };
@@ -241,8 +241,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         {
             // LOAD BEARING: Not using make_self here _will_ break you in the future!
             auto args = winrt::make_self<ResizePaneArgs>();
-            JsonUtils::GetValueForKey(json, DirectionKey, args->_Direction);
-            if (args->_Direction == Direction::None)
+            JsonUtils::GetValueForKey(json, DirectionKey, args->_ResizeDirection);
+            if (args->_ResizeDirection == ResizeDirection::None)
             {
                 return { nullptr, { SettingsLoadWarnings::MissingRequiredParameter } };
             }
@@ -254,7 +254,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         IActionArgs Copy() const
         {
             auto copy{ winrt::make_self<ResizePaneArgs>() };
-            copy->_Direction = _Direction;
+            copy->_ResizeDirection = _ResizeDirection;
             return *copy;
         }
     };
@@ -262,10 +262,10 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     struct MoveFocusArgs : public MoveFocusArgsT<MoveFocusArgs>
     {
         MoveFocusArgs() = default;
-        MoveFocusArgs(Model::Direction direction) :
-            _Direction{ direction } {};
+        MoveFocusArgs(Model::FocusDirection direction) :
+            _FocusDirection{ direction } {};
 
-        GETSET_PROPERTY(Model::Direction, Direction, Direction::None);
+        GETSET_PROPERTY(Model::FocusDirection, FocusDirection, FocusDirection::None);
 
         static constexpr std::string_view DirectionKey{ "direction" };
 
@@ -277,7 +277,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             auto otherAsUs = other.try_as<MoveFocusArgs>();
             if (otherAsUs)
             {
-                return otherAsUs->_Direction == _Direction;
+                return otherAsUs->_FocusDirection == _FocusDirection;
             }
             return false;
         };
@@ -285,8 +285,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         {
             // LOAD BEARING: Not using make_self here _will_ break you in the future!
             auto args = winrt::make_self<MoveFocusArgs>();
-            JsonUtils::GetValueForKey(json, DirectionKey, args->_Direction);
-            if (args->_Direction == Direction::None)
+            JsonUtils::GetValueForKey(json, DirectionKey, args->_FocusDirection);
+            if (args->_FocusDirection == FocusDirection::None)
             {
                 return { nullptr, { SettingsLoadWarnings::MissingRequiredParameter } };
             }
@@ -298,7 +298,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         IActionArgs Copy() const
         {
             auto copy{ winrt::make_self<MoveFocusArgs>() };
-            copy->_Direction = _Direction;
+            copy->_FocusDirection = _FocusDirection;
             return *copy;
         }
     };

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -22,7 +22,8 @@ namespace Microsoft.Terminal.Settings.Model
         Left,
         Right,
         Up,
-        Down
+        Down,
+        Previous
     };
 
     enum SplitState

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -32,8 +32,7 @@ namespace Microsoft.Terminal.Settings.Model
         Right,
         Up,
         Down,
-        Previous,
-        Next
+        Previous
     };
 
     enum SplitState

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -23,7 +23,8 @@ namespace Microsoft.Terminal.Settings.Model
         Right,
         Up,
         Down,
-        Previous
+        Previous,
+        Next
     };
 
     enum SplitState

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -16,7 +16,16 @@ namespace Microsoft.Terminal.Settings.Model
         IActionArgs ActionArgs { get; };
     };
 
-    enum Direction
+    enum ResizeDirection
+    {
+        None = 0,
+        Left,
+        Right,
+        Up,
+        Down
+    };
+
+    enum FocusDirection
     {
         None = 0,
         Left,
@@ -92,13 +101,13 @@ namespace Microsoft.Terminal.Settings.Model
 
     [default_interface] runtimeclass ResizePaneArgs : IActionArgs
     {
-        Direction Direction { get; };
+        ResizeDirection ResizeDirection { get; };
     };
 
     [default_interface] runtimeclass MoveFocusArgs : IActionArgs
     {
-        MoveFocusArgs(Direction direction);
-        Direction Direction { get; };
+        MoveFocusArgs(FocusDirection direction);
+        FocusDirection FocusDirection { get; };
     };
 
     [default_interface] runtimeclass AdjustFontSizeArgs : IActionArgs

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -189,6 +189,9 @@
   <data name="DirectionUp" xml:space="preserve">
     <value>up</value>
   </data>
+  <data name="DirectionPrev" xml:space="preserve">
+    <value>prev</value>
+  </data>
   <data name="DuplicatePaneCommandKey" xml:space="preserve">
     <value>Duplicate pane</value>
   </data>
@@ -214,7 +217,7 @@
   </data>
   <data name="MoveFocusWithArgCommandKey" xml:space="preserve">
     <value>Move focus {0}</value>
-    <comment>{0} will be replaced with one of the four directions "DirectionLeft", "DirectionRight", "DirectionUp", or "DirectionDown"</comment>
+    <comment>{0} will be replaced with one of the five directions "DirectionLeft", "DirectionRight", "DirectionUp", "DirectionDown" or "DirectionPrev"</comment>
   </data>
   <data name="NewTabCommandKey" xml:space="preserve">
     <value>New tab</value>

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -189,8 +189,8 @@
   <data name="DirectionUp" xml:space="preserve">
     <value>up</value>
   </data>
-  <data name="DirectionPrev" xml:space="preserve">
-    <value>prev</value>
+  <data name="DirectionPrevious" xml:space="preserve">
+    <value>previous</value>
   </data>
   <data name="DuplicatePaneCommandKey" xml:space="preserve">
     <value>Duplicate pane</value>

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -217,7 +217,10 @@
   </data>
   <data name="MoveFocusWithArgCommandKey" xml:space="preserve">
     <value>Move focus {0}</value>
-    <comment>{0} will be replaced with one of the five directions "DirectionLeft", "DirectionRight", "DirectionUp", "DirectionDown" or "DirectionPrev"</comment>
+    <comment>{0} will be replaced with one of the four directions "DirectionLeft", "DirectionRight", "DirectionUp", "DirectionDown"</comment>
+  </data>
+  <data name="MoveFocusToLastUsedPane" xml:space="preserve">
+    <value>Move focus to the last used pane</value>
   </data>
   <data name="NewTabCommandKey" xml:space="preserve">
     <value>New tab</value>

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -333,11 +333,12 @@ struct ::Microsoft::Terminal::Settings::Model::JsonUtils::ConversionTrait<::winr
 // Possible Direction values
 JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::Direction)
 {
-    JSON_MAPPINGS(4) = {
+    JSON_MAPPINGS(5) = {
         pair_type{ "left", ValueType::Left },
         pair_type{ "right", ValueType::Right },
         pair_type{ "up", ValueType::Up },
         pair_type{ "down", ValueType::Down },
+        pair_type{ "previous", ValueType::Previous },
     };
 };
 

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -333,13 +333,12 @@ struct ::Microsoft::Terminal::Settings::Model::JsonUtils::ConversionTrait<::winr
 // Possible FocusDirection values
 JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::FocusDirection)
 {
-    JSON_MAPPINGS(6) = {
+    JSON_MAPPINGS(5) = {
         pair_type{ "left", ValueType::Left },
         pair_type{ "right", ValueType::Right },
         pair_type{ "up", ValueType::Up },
         pair_type{ "down", ValueType::Down },
         pair_type{ "previous", ValueType::Previous },
-        pair_type{ "next", ValueType::Next },
     };
 };
 

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -333,12 +333,13 @@ struct ::Microsoft::Terminal::Settings::Model::JsonUtils::ConversionTrait<::winr
 // Possible Direction values
 JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::Direction)
 {
-    JSON_MAPPINGS(5) = {
+    JSON_MAPPINGS(6) = {
         pair_type{ "left", ValueType::Left },
         pair_type{ "right", ValueType::Right },
         pair_type{ "up", ValueType::Up },
         pair_type{ "down", ValueType::Down },
         pair_type{ "previous", ValueType::Previous },
+        pair_type{ "next", ValueType::Next },
     };
 };
 

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -330,8 +330,8 @@ struct ::Microsoft::Terminal::Settings::Model::JsonUtils::ConversionTrait<::winr
     }
 };
 
-// Possible Direction values
-JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::Direction)
+// Possible FocusDirection values
+JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::FocusDirection)
 {
     JSON_MAPPINGS(6) = {
         pair_type{ "left", ValueType::Left },
@@ -340,6 +340,17 @@ JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::Direction)
         pair_type{ "down", ValueType::Down },
         pair_type{ "previous", ValueType::Previous },
         pair_type{ "next", ValueType::Next },
+    };
+};
+
+// Possible ResizeDirection values
+JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::ResizeDirection)
+{
+    JSON_MAPPINGS(6) = {
+        pair_type{ "left", ValueType::Left },
+        pair_type{ "right", ValueType::Right },
+        pair_type{ "up", ValueType::Up },
+        pair_type{ "down", ValueType::Down }
     };
 };
 

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -345,7 +345,7 @@ JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::FocusDirection)
 // Possible ResizeDirection values
 JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::ResizeDirection)
 {
-    JSON_MAPPINGS(6) = {
+    JSON_MAPPINGS(4) = {
         pair_type{ "left", ValueType::Left },
         pair_type{ "right", ValueType::Right },
         pair_type{ "up", ValueType::Up },

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -332,7 +332,6 @@
         { "command": { "action": "moveFocus", "direction": "right" }, "keys": "alt+right" },
         { "command": { "action": "moveFocus", "direction": "up" }, "keys": "alt+up" },
         { "command": { "action": "moveFocus", "direction": "previous" }, "keys": "ctrl+alt+left" },
-        { "command": { "action": "moveFocus", "direction": "next" }, "keys":  "ctrl+alt+right" },
         { "command": "togglePaneZoom" },
 
         // Clipboard Integration

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -331,7 +331,8 @@
         { "command": { "action": "moveFocus", "direction": "left" }, "keys": "alt+left" },
         { "command": { "action": "moveFocus", "direction": "right" }, "keys": "alt+right" },
         { "command": { "action": "moveFocus", "direction": "up" }, "keys": "alt+up" },
-        { "command": { "action": "moveFocus", "direction": "previous" }, "keys": "ctrl+shift+right" },
+        { "command": { "action": "moveFocus", "direction": "previous" }, "keys": "ctrl+shift+left" },
+        { "command": { "action": "moveFocus", "direction": "next" }, "keys":  "ctrl+shift+right" },
         { "command": "togglePaneZoom" },
 
         // Clipboard Integration

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -331,8 +331,8 @@
         { "command": { "action": "moveFocus", "direction": "left" }, "keys": "alt+left" },
         { "command": { "action": "moveFocus", "direction": "right" }, "keys": "alt+right" },
         { "command": { "action": "moveFocus", "direction": "up" }, "keys": "alt+up" },
-        { "command": { "action": "moveFocus", "direction": "previous" }, "keys": "ctrl+shift+left" },
-        { "command": { "action": "moveFocus", "direction": "next" }, "keys":  "ctrl+shift+right" },
+        { "command": { "action": "moveFocus", "direction": "previous" }, "keys": "ctrl+alt+left" },
+        { "command": { "action": "moveFocus", "direction": "next" }, "keys":  "ctrl+alt+right" },
         { "command": "togglePaneZoom" },
 
         // Clipboard Integration

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -331,6 +331,7 @@
         { "command": { "action": "moveFocus", "direction": "left" }, "keys": "alt+left" },
         { "command": { "action": "moveFocus", "direction": "right" }, "keys": "alt+right" },
         { "command": { "action": "moveFocus", "direction": "up" }, "keys": "alt+up" },
+        { "command": { "action": "moveFocus", "direction": "previous" }, "keys": "ctrl+shift+right" },
         { "command": "togglePaneZoom" },
 
         // Clipboard Integration


### PR DESCRIPTION
Adds a "move to previous pane" and "move to next pane" keybinding, which
navigates to the last/first focused pane

We assign pane IDs on creation and maintain a vector of active pane IDs
in MRU order. Navigating panes by MRU then requires specifying which
pane ID we want to focus. 

From our offline discussion (thanks @zadjii-msft for the concise
description):

> For the record, the full spec I'm imagining is:
> 
> { command": { "action": "focus(Next|Prev)Pane", "order": "inOrder"|"mru", "useSwitcher": true|false } },
> 
> and order defaults to mru, and useSwitcher will default to true, when
> there is a switcher. So 
> 
> { command": { "action": "focusNextPane" } },
> { command": { "action": "focusNextPane", "order": "mru" } },
> 
> these are the same action. (but right now we don't support the order
> param)
>  
> Then there'll be another PR for "focusPane(target=id)"
> 
> Then a third PR for "focus(Next|Prev)Pane(order=inOrder)"

> for the record, I prefer this approach over the "one action to rule
> them all" version with both target and order/direction as params,
> because I don't like the confusion of what happens if there's both
> target and order/direction provided. 

References #1000 
Closes #2871