### PR TITLE
8185: do not sort commands by name in tabswitcher mode

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -818,7 +818,7 @@ namespace winrt::TerminalApp::implementation
         for (const auto& action : commandsToFilter)
         {
             // Update filter for all commands
-            // This will modify the highlighting but will also lead to recomputation of weight (and consequently sorting).
+            // This will modify the highlighting but will also lead to re-computation of weight (and consequently sorting).
             // Pay attention that it already updates the highlighting in the UI
             action.UpdateFilter(searchText);
 
@@ -831,7 +831,7 @@ namespace winrt::TerminalApp::implementation
 
         // We want to present the commands sorted,
         // unless we are in the TabSwitcherMode and TabSearchMode,
-        // in which we want to preserver the insertion order
+        // in which we want to preserve the original order (to be aligned with the tab view)
         if (_currentMode != CommandPaletteMode::TabSearchMode && _currentMode != CommandPaletteMode::TabSwitchMode)
         {
             std::sort(actions.begin(), actions.end(), FilteredCommand::Compare);

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -829,8 +829,13 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
-        // Add all the commands, but make sure they're sorted.
-        std::sort(actions.begin(), actions.end(), FilteredCommand::Compare);
+        // We want to present the commands sorted,
+        // unless we are in the TabSwitcherMode and TabSearchMode,
+        // in which we want to preserver the insertion order
+        if (_currentMode != CommandPaletteMode::TabSearchMode && _currentMode != CommandPaletteMode::TabSwitchMode)
+        {
+            std::sort(actions.begin(), actions.end(), FilteredCommand::Compare);
+        }
         return actions;
     }
 

--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -10,7 +10,7 @@
 // fwdecl unittest classes
 namespace TerminalAppLocalTests
 {
-    class FilteredCommandTests;
+    class TabTests;
 };
 
 namespace winrt::TerminalApp::implementation
@@ -118,6 +118,8 @@ namespace winrt::TerminalApp::implementation
         void _dispatchCommand(winrt::TerminalApp::FilteredCommand const& command);
         void _dispatchCommandline();
         void _dismissPalette();
+
+        friend class TerminalAppLocalTests::TabTests;
     };
 }
 


### PR DESCRIPTION
In introduced a bug in #8185, due to which Command Palette sorts items
alphabetically in the tab switcher mode. This PR fixes it.

Validation:
Created tabs with different names and verified that the MRU order is
preserved

Closes #8185