### PR TITLE
Teach the command palette to clamp its indices on page up/down

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -123,7 +123,7 @@ namespace winrt::TerminalApp::implementation
     // - index within a list view of commands
     // Return Value:
     // - <none>
-    void CommandPalette::_scrollToindex(uint32_t index)
+    void CommandPalette::_scrollToIndex(uint32_t index)
     {
         auto numItems = _filteredActionsView().Items().Size();
 
@@ -163,7 +163,7 @@ namespace winrt::TerminalApp::implementation
     {
         auto selected = _filteredActionsView().SelectedIndex();
         auto numVisibleItems = _getNumVisibleItems();
-        _scrollToindex(selected - numVisibleItems);
+        _scrollToIndex(selected - numVisibleItems);
     }
 
     // Method Description:
@@ -176,7 +176,7 @@ namespace winrt::TerminalApp::implementation
     {
         auto selected = _filteredActionsView().SelectedIndex();
         auto numVisibleItems = _getNumVisibleItems();
-        _scrollToindex(selected + numVisibleItems);
+        _scrollToIndex(selected + numVisibleItems);
     }
 
     // Method Description:
@@ -187,7 +187,7 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     void CommandPalette::ScrollToTop()
     {
-        _scrollToindex(0);
+        _scrollToIndex(0);
     }
 
     // Method Description:
@@ -198,7 +198,7 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     void CommandPalette::ScrollToBottom()
     {
-        _scrollToindex(_filteredActionsView().Items().Size() - 1);
+        _scrollToIndex(_filteredActionsView().Items().Size() - 1);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -136,7 +136,7 @@ namespace winrt::TerminalApp::implementation
     // - index within a list
     // Return Value:
     // - <none>
-    uint32_t CommandPalette::_getVisibleItems()
+    uint32_t CommandPalette::_getNumVisibleItems()
     {
         const auto container = _filteredActionsView().ContainerFromIndex(0);
         const auto item = container.try_as<winrt::Windows::UI::Xaml::Controls::ListViewItem>();
@@ -154,7 +154,7 @@ namespace winrt::TerminalApp::implementation
     void CommandPalette::ScrollPageUp()
     {
         auto selected = _filteredActionsView().SelectedIndex();
-        auto numVisibleItems = _getVisibleItems();
+        auto numVisibleItems = _getNumVisibleItems();
         _scrollToindex(selected - numVisibleItems);
     }
 
@@ -167,7 +167,7 @@ namespace winrt::TerminalApp::implementation
     void CommandPalette::ScrollPageDown()
     {
         auto selected = _filteredActionsView().SelectedIndex();
-        auto numVisibleItems = _getVisibleItems();
+        auto numVisibleItems = _getNumVisibleItems();
         _scrollToindex(selected + numVisibleItems);
     }
 

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -120,7 +120,7 @@ namespace winrt::TerminalApp::implementation
     // Method Description:
     // - Scroll the command palette to the specified index
     // Arguments:
-    // - index within a list
+    // - index within a list view of commands
     // Return Value:
     // - <none>
     void CommandPalette::_scrollToindex(uint32_t index)
@@ -133,9 +133,9 @@ namespace winrt::TerminalApp::implementation
     // Method Description:
     // - Computes the number of visible commands
     // Arguments:
-    // - index within a list
-    // Return Value:
     // - <none>
+    // Return Value:
+    // - the approximate number of items visible in the list (in other words the size of the page)
     uint32_t CommandPalette::_getNumVisibleItems()
     {
         const auto container = _filteredActionsView().ContainerFromIndex(0);

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -125,7 +125,15 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     void CommandPalette::_scrollToindex(uint32_t index)
     {
-        auto clampedIndex = std::clamp<int32_t>(index, 0, _filteredActionsView().Items().Size() - 1);
+        auto numItems = _filteredActionsView().Items().Size();
+
+        if (numItems == 0)
+        {
+            // if the list is empty no need to scroll
+            return;
+        }
+
+        auto clampedIndex = std::clamp<int32_t>(index, 0, numItems - 1);
         _filteredActionsView().SelectedIndex(clampedIndex);
         _filteredActionsView().ScrollIntoView(_filteredActionsView().SelectedItem());
     }

--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -120,7 +120,7 @@ namespace winrt::TerminalApp::implementation
         void _dispatchCommandline();
         void _dismissPalette();
 
-        void _scrollToindex(uint32_t index);
+        void _scrollToIndex(uint32_t index);
         uint32_t _getNumVisibleItems();
     };
 }

--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -41,9 +41,10 @@ namespace winrt::TerminalApp::implementation
 
         void SelectNextItem(const bool moveDown);
 
-        void ScrollDown(const bool pageDown);
-
-        void GoEnd(const bool end);
+        void ScrollPageUp();
+        void ScrollPageDown();
+        void ScrollToTop();
+        void ScrollToBottom();
 
         // Tab Switcher
         void EnableTabSwitcherMode(const bool searchMode, const uint32_t startIdx);
@@ -118,6 +119,9 @@ namespace winrt::TerminalApp::implementation
         void _dispatchCommand(winrt::TerminalApp::FilteredCommand const& command);
         void _dispatchCommandline();
         void _dismissPalette();
+
+        void _scrollToindex(uint32_t index);
+        uint32_t _getVisibleItems();
     };
 }
 

--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -121,7 +121,7 @@ namespace winrt::TerminalApp::implementation
         void _dismissPalette();
 
         void _scrollToindex(uint32_t index);
-        uint32_t _getVisibleItems();
+        uint32_t _getNumVisibleItems();
     };
 }
 


### PR DESCRIPTION
This commit will teach CommandPalette to clamp the scroll page up and
scroll page down navigation so as to not wrap.

Closes #8189