### PR TITLE
Azure: fall back to powershell when no preferred shell is set

### DIFF
--- a/src/cascadia/TerminalConnection/AzureConnection.cpp
+++ b/src/cascadia/TerminalConnection/AzureConnection.cpp
@@ -719,14 +719,13 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             return;
         }
 
-        const auto shellType = _ParsePreferredShellType(settingsResponse);
-
         // Request for a cloud shell
         _WriteStringWithNewline(RS_(L"AzureRequestingCloud"));
         _cloudShellUri = _GetCloudShell();
         _WriteStringWithNewline(RS_(L"AzureSuccess"));
 
         // Request for a terminal for said cloud shell
+        const auto shellType = _ParsePreferredShellType(settingsResponse);
         _WriteStringWithNewline(RS_(L"AzureRequestingTerminal"));
         const auto socketUri = _GetTerminal(shellType.value_or(L"pwsh"));
         _TerminalOutputHandlers(L"\r\n");

--- a/src/cascadia/TerminalConnection/AzureConnection.h
+++ b/src/cascadia/TerminalConnection/AzureConnection.h
@@ -95,6 +95,8 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         std::optional<std::wstring> _ReadUserInput(InputMode mode);
 
         web::websockets::client::websocket_client _cloudShellSocket;
+
+        static std::optional<utility::string_t> _ParsePreferredShellType(const web::json::value& settingsResponse);
     };
 }
 

--- a/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
@@ -148,6 +148,10 @@
     <value>You have not set up your cloud shell account yet. Please go to https://shell.azure.com to set it up.</value>
     <comment>{Locked="https://shell.azure.com"} This URL should not be localized. Everything else should.</comment>
   </data>
+  <data name="AzureInvalidUserSettings" xml:space="preserve">
+    <value>Your cloud shell account misses some mandatory settings. Please go to https://shell.azure.com to set it up.</value>
+    <comment>{Locked="https://shell.azure.com"} This URL should not be localized. Everything else should.</comment>
+  </data>
   <data name="AzureStorePrompt" xml:space="preserve">
     <value>Do you want to save these connection settings for future logins? [{0}/{1}]</value>
     <comment>{0} and {1} will be replaced with AzureUserEntry_Yes and AzureUserEntry_No. They are single-character shorthands for "yes" and "no" in this language.</comment>

--- a/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
@@ -148,10 +148,6 @@
     <value>You have not set up your cloud shell account yet. Please go to https://shell.azure.com to set it up.</value>
     <comment>{Locked="https://shell.azure.com"} This URL should not be localized. Everything else should.</comment>
   </data>
-  <data name="AzureInvalidUserSettings" xml:space="preserve">
-    <value>Your cloud shell account misses some mandatory settings. Please go to https://shell.azure.com to set it up.</value>
-    <comment>{Locked="https://shell.azure.com"} This URL should not be localized. Everything else should.</comment>
-  </data>
   <data name="AzureStorePrompt" xml:space="preserve">
     <value>Do you want to save these connection settings for future logins? [{0}/{1}]</value>
     <comment>{0} and {1} will be replaced with AzureUserEntry_Yes and AzureUserEntry_No. They are single-character shorthands for "yes" and "no" in this language.</comment>


### PR DESCRIPTION
Fallback to powershell if "preferred shell" is not specified in the user
settings of Azure CLI.

I am still not sure what is the full set of scenarios that the problem
might occur, but for me it occurred for an "old" cloud shell account,
and didn't reproduce since I have reconfigured it. These behavior might
be explained by the fact that "preferred shell type" did not exist in
the API originally and thus was not set.  In such case, Terminal
succeeds to retrieve to the settings but then crashes when reading the
missing field.  To fix it, I handle the case where the field is missing
and fallback to powershell

## Validation Steps Performed
* Tested manually, only once.

Closes #7056