### PR TITLE
Fix desktopWallpaper background image casing

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -760,7 +760,9 @@
             {
               "enum": [
                 "desktopWallpaper"
-              ],
+              ]
+            },
+            {
               "type": "null"
             }
           ]

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -753,7 +753,17 @@
         },
         "backgroundImage": {
           "description": "Sets the file location of the image to draw over the window background.",
-          "type": ["string", "null"]
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "enum": [
+                "desktopWallpaper"
+              ],
+              "type": "null"
+            }
+          ]
         },
         "backgroundImageAlignment": {
           "default": "center",

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -755,15 +755,12 @@
           "description": "Sets the file location of the image to draw over the window background.",
           "oneOf": [
             {
-              "type": "string"
+              "type": ["string", null]
             },
             {
               "enum": [
                 "desktopWallpaper"
               ]
-            },
-            {
-              "type": "null"
             }
           ]
         },

--- a/src/cascadia/TerminalSettingsModel/Profile.cpp
+++ b/src/cascadia/TerminalSettingsModel/Profile.cpp
@@ -59,7 +59,7 @@ static constexpr std::string_view AntialiasingModeKey{ "antialiasingMode" };
 static constexpr std::string_view TabColorKey{ "tabColor" };
 static constexpr std::string_view BellStyleKey{ "bellStyle" };
 
-static const winrt::hstring DesktopWallpaperEnum{ L"desktopWallpaper" };
+static constexpr std::string_view DesktopWallpaperEnum{ "desktopWallpaper" };
 
 Profile::Profile()
 {

--- a/src/cascadia/TerminalSettingsModel/Profile.cpp
+++ b/src/cascadia/TerminalSettingsModel/Profile.cpp
@@ -59,7 +59,7 @@ static constexpr std::string_view AntialiasingModeKey{ "antialiasingMode" };
 static constexpr std::string_view TabColorKey{ "tabColor" };
 static constexpr std::string_view BellStyleKey{ "bellStyle" };
 
-static constexpr std::string_view DesktopWallpaperEnum{ "desktopWallpaper" };
+static constexpr std::wstring_view DesktopWallpaperEnum{ L"desktopWallpaper" };
 
 Profile::Profile()
 {
@@ -362,7 +362,7 @@ winrt::hstring Profile::ExpandedBackgroundImagePath() const
     }
     // checks if the user would like to copy their desktop wallpaper
     // if so, replaces the path with the desktop wallpaper's path
-    else if (path == to_hstring(DesktopWallpaperEnum))
+    else if (path == DesktopWallpaperEnum)
     {
         WCHAR desktopWallpaper[MAX_PATH];
 

--- a/src/cascadia/TerminalSettingsModel/Profile.cpp
+++ b/src/cascadia/TerminalSettingsModel/Profile.cpp
@@ -59,7 +59,7 @@ static constexpr std::string_view AntialiasingModeKey{ "antialiasingMode" };
 static constexpr std::string_view TabColorKey{ "tabColor" };
 static constexpr std::string_view BellStyleKey{ "bellStyle" };
 
-static const winrt::hstring DesktopWallpaperEnum{ L"DesktopWallpaper" };
+static const winrt::hstring DesktopWallpaperEnum{ L"desktopWallpaper" };
 
 Profile::Profile()
 {


### PR DESCRIPTION
- Change `DesktopWallpaper` to `desktopWallpaper` for `backgroundImage`
  to match our other settings
- Add `desktopWallpaper` to json schema