### PR TITLE
Avoid an access violation in pane animation if the child is closed

### DIFF
--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -1189,22 +1189,27 @@ void Pane::_SetupEntranceAnimation()
             if (auto pane{ weakThis.lock() })
             {
                 auto child = isFirstChild ? pane->_firstChild : pane->_secondChild;
-                auto childGrid = child->_root;
-                if (auto control = child->_control)
+
+                // ensure the child was not release in meanwhile
+                if (child)
                 {
-                    if (splitWidth)
+                    auto childGrid = child->_root;
+                    if (auto control = child->_control)
                     {
-                        control.Width(NAN);
-                        childGrid.Width(NAN);
-                        childGrid.HorizontalAlignment(HorizontalAlignment::Stretch);
-                        control.HorizontalAlignment(HorizontalAlignment::Stretch);
-                    }
-                    else
-                    {
-                        control.Height(NAN);
-                        childGrid.Height(NAN);
-                        childGrid.VerticalAlignment(VerticalAlignment::Stretch);
-                        control.VerticalAlignment(VerticalAlignment::Stretch);
+                        if (splitWidth)
+                        {
+                            control.Width(NAN);
+                            childGrid.Width(NAN);
+                            childGrid.HorizontalAlignment(HorizontalAlignment::Stretch);
+                            control.HorizontalAlignment(HorizontalAlignment::Stretch);
+                        }
+                        else
+                        {
+                            control.Height(NAN);
+                            childGrid.Height(NAN);
+                            childGrid.VerticalAlignment(VerticalAlignment::Stretch);
+                            control.VerticalAlignment(VerticalAlignment::Stretch);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Some UTs crash with access violation, that occurs during pane animation.
The reason for this is a race, upon which the pane is closed (set to
nullptr) before the parent is animated.  Added a simple check against
null.  Doubt it can happen in production, yet worth taking care!
