### PR TITLE
Polish layout for Settings UI

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -46,33 +46,27 @@ the MIT License. See LICENSE in the project root for license information. -->
         <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="1*" />
+                <ColumnDefinition Width="1*" MaxWidth="480"/>
                 <ColumnDefinition Width="1*" />
             </Grid.ColumnDefinitions>
 
-            <TextBlock x:Uid="ColorScheme_ColorSchemes"
-                       Style="{StaticResource SubheaderTextBlockStyle}"
-                       Margin="10,0,0,20"
-                       Grid.Row="0" />
+            <ComboBox x:Name="ColorSchemeComboBox"
+                      Grid.Row="0"
+                      Grid.Column="0"
+                      Margin="10,0,0,20"
+                      SelectedIndex="0"
+                      ItemsSource="{x:Bind ColorSchemeList, Mode=OneWay}"
+                      SelectionChanged="ColorSchemeSelectionChanged"/>
 
-            <StackPanel Grid.Row="1"
-                        Grid.Column="0">
-                <ComboBox x:Name="ColorSchemeComboBox"
-                          Margin="10,0,0,0"
-                          SelectedIndex="0"
-                          ItemsSource="{x:Bind ColorSchemeList, Mode=OneWay}"
-                          SelectionChanged="ColorSchemeSelectionChanged" Width="160">
-                </ComboBox>
-            </StackPanel>
-
+            <!-- Color Table -->
             <ItemsControl x:Name="ColorTableControl"
                           ItemsSource="{x:Bind CurrentColorTable, Mode=OneWay}"
-                          Grid.Row="2"
+                          Grid.Row="1"
                           Grid.Column="0">
+
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
                         <ItemsWrapGrid Orientation="Horizontal"
@@ -98,9 +92,10 @@ the MIT License. See LICENSE in the project root for license information. -->
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
 
+            <!-- Additional Colors -->
             <ItemsControl Grid.Row="2"
                           Grid.Column="1">
-                <StackPanel Orientation="Vertical" Height="59">
+                <StackPanel Height="59">
                     <TextBlock x:Uid="ColorScheme_Foreground"
                                Margin="10,0,0,10"/>
                     <Button Background="{Binding Color, ElementName=ForegroundPicker, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}">
@@ -111,35 +106,38 @@ the MIT License. See LICENSE in the project root for license information. -->
                         </Button.Flyout>
                     </Button>
                 </StackPanel>
-                <StackPanel Orientation="Vertical" Height="59">
+                <StackPanel Height="59">
                     <TextBlock x:Uid="ColorScheme_Background"
                                Margin="10,0,0,10"/>
                     <Button Background="{Binding Color, ElementName=BackgroundPicker, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}">
                         <Button.Flyout>
                             <Flyout>
-                                <ColorPicker x:Name="BackgroundPicker" Color="{x:Bind CurrentColorScheme.Background, Mode=TwoWay}" />
+                                <ColorPicker x:Name="BackgroundPicker"
+                                             Color="{x:Bind CurrentColorScheme.Background, Mode=TwoWay}"/>
                             </Flyout>
                         </Button.Flyout>
                     </Button>
                 </StackPanel>
-                <StackPanel Orientation="Vertical" Height="59">
+                <StackPanel Height="59">
                     <TextBlock x:Uid="ColorScheme_CursorColor"
                                Margin="10,0,0,10"/>
                     <Button Background="{Binding Color, ElementName=CursorColorPicker, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}">
                         <Button.Flyout>
                             <Flyout>
-                                <ColorPicker x:Name="CursorColorPicker" Color="{x:Bind CurrentColorScheme.CursorColor, Mode=TwoWay}" />
+                                <ColorPicker x:Name="CursorColorPicker"
+                                             Color="{x:Bind CurrentColorScheme.CursorColor, Mode=TwoWay}"/>
                             </Flyout>
                         </Button.Flyout>
                     </Button>
                 </StackPanel>
-                <StackPanel Orientation="Vertical" Height="59">
+                <StackPanel Height="59">
                     <TextBlock x:Uid="ColorScheme_SelectionBackground"
                                Margin="10,0,0,10"/>
                     <Button Background="{Binding Color, ElementName=SelectionBackgroundPicker, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}">
                         <Button.Flyout>
                             <Flyout>
-                                <ColorPicker x:Name="SelectionBackgroundPicker" Color="{x:Bind CurrentColorScheme.SelectionBackground, Mode=TwoWay}" />
+                                <ColorPicker x:Name="SelectionBackgroundPicker"
+                                             Color="{x:Bind CurrentColorScheme.SelectionBackground, Mode=TwoWay}"/>
                             </Flyout>
                         </Button.Flyout>
                     </Button>

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -12,8 +12,13 @@ the MIT License. See LICENSE in the project root for license information. -->
     mc:Ignorable="d">
 
     <Page.Resources>
-        <Style TargetType="StackPanel">
+        <Style x:Key="ColorStackPanelStyle" TargetType="StackPanel">
             <Setter Property="Margin" Value="0,0,0,20"/>
+            <Setter Property="Height" Value="59"/>
+        </Style>
+
+        <Style x:Key="ColorHeaderStyle" TargetType="TextBlock">
+            <Setter Property="Margin" Value="10,0,0,10"/>
         </Style>
 
         <Style TargetType="Button">
@@ -75,9 +80,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                 </ItemsControl.ItemsPanel>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="local:ColorTableEntry">
-                        <StackPanel>
-                            <TextBlock Text="{x:Bind Name, Mode=OneWay}"
-                                       Margin="10,0,0,10"/>
+                        <StackPanel Style="{StaticResource ColorStackPanelStyle}">
+                            <TextBlock Text="{x:Bind Name, Mode=OneWay}" Style="{StaticResource ColorHeaderStyle}"/>
                             <Button Background="{x:Bind Color, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}">
                                 <Button.Flyout>
                                     <Flyout>
@@ -95,9 +99,8 @@ the MIT License. See LICENSE in the project root for license information. -->
             <!-- Additional Colors -->
             <ItemsControl Grid.Row="2"
                           Grid.Column="1">
-                <StackPanel Height="59">
-                    <TextBlock x:Uid="ColorScheme_Foreground"
-                               Margin="10,0,0,10"/>
+                <StackPanel Style="{StaticResource ColorStackPanelStyle}">
+                    <TextBlock x:Uid="ColorScheme_Foreground" Style="{StaticResource ColorHeaderStyle}"/>
                     <Button Background="{Binding Color, ElementName=ForegroundPicker, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}">
                         <Button.Flyout>
                             <Flyout>
@@ -106,9 +109,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                         </Button.Flyout>
                     </Button>
                 </StackPanel>
-                <StackPanel Height="59">
-                    <TextBlock x:Uid="ColorScheme_Background"
-                               Margin="10,0,0,10"/>
+                <StackPanel Style="{StaticResource ColorStackPanelStyle}">
+                    <TextBlock x:Uid="ColorScheme_Background" Style="{StaticResource ColorHeaderStyle}"/>
                     <Button Background="{Binding Color, ElementName=BackgroundPicker, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}">
                         <Button.Flyout>
                             <Flyout>
@@ -118,9 +120,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                         </Button.Flyout>
                     </Button>
                 </StackPanel>
-                <StackPanel Height="59">
-                    <TextBlock x:Uid="ColorScheme_CursorColor"
-                               Margin="10,0,0,10"/>
+                <StackPanel Style="{StaticResource ColorStackPanelStyle}">
+                    <TextBlock x:Uid="ColorScheme_CursorColor" Style="{StaticResource ColorHeaderStyle}"/>
                     <Button Background="{Binding Color, ElementName=CursorColorPicker, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}">
                         <Button.Flyout>
                             <Flyout>
@@ -130,9 +131,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                         </Button.Flyout>
                     </Button>
                 </StackPanel>
-                <StackPanel Height="59">
-                    <TextBlock x:Uid="ColorScheme_SelectionBackground"
-                               Margin="10,0,0,10"/>
+                <StackPanel Style="{StaticResource ColorStackPanelStyle}">
+                    <TextBlock x:Uid="ColorScheme_SelectionBackground" Style="{StaticResource ColorHeaderStyle}"/>
                     <Button Background="{Binding Color, ElementName=SelectionBackgroundPicker, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}">
                         <Button.Flyout>
                             <Flyout>

--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -42,6 +42,7 @@
         <Setter Property="FontSize" Value="15"/>
         <Setter Property="ToolTipService.Placement" Value="Mouse"/>
         <Setter Property="Width" Value="300"/>
+        <Setter Property="HorizontalAlignment" Value="Left"/>
     </Style>
 
     <Style TargetType="muxc:NumberBox">

--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -50,8 +50,6 @@
         <Setter Property="FontSize" Value="15"/>
         <Setter Property="ToolTipService.Placement" Value="Mouse"/>
         <Setter Property="SpinButtonPlacementMode" Value="Compact"/>
-        <Setter Property="SmallChange" Value="10"/>
-        <Setter Property="LargeChange" Value="100"/>
     </Style>
 
 </ResourceDictionary>

--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -31,4 +31,26 @@
         <Setter Property="ToolTipService.Placement" Value="Mouse"/>
     </Style>
 
+    <Style TargetType="ComboBox">
+        <Setter Property="Margin" Value="0,0,0,20"/>
+        <Setter Property="FontSize" Value="15"/>
+        <Setter Property="ToolTipService.Placement" Value="Mouse"/>
+    </Style>
+
+    <Style TargetType="TextBox">
+        <Setter Property="Margin" Value="0,0,0,20"/>
+        <Setter Property="FontSize" Value="15"/>
+        <Setter Property="ToolTipService.Placement" Value="Mouse"/>
+        <Setter Property="Width" Value="300"/>
+    </Style>
+
+    <Style TargetType="muxc:NumberBox">
+        <Setter Property="Margin" Value="0,0,0,20"/>
+        <Setter Property="FontSize" Value="15"/>
+        <Setter Property="ToolTipService.Placement" Value="Mouse"/>
+        <Setter Property="SpinButtonPlacementMode" Value="Compact"/>
+        <Setter Property="SmallChange" Value="10"/>
+        <Setter Property="LargeChange" Value="100"/>
+    </Style>
+
 </ResourceDictionary>

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
@@ -23,34 +23,25 @@ the MIT License. See LICENSE in the project root for license information. -->
     </Page.Resources>
 
     <ScrollViewer>
-        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-          Margin="0,12,0,0">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" />
-            </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="1*" />
-                <ColumnDefinition Width="1*" />
-            </Grid.ColumnDefinitions>
-            <TextBlock x:Uid="Globals_GlobalAppearance"
-                   Style="{StaticResource SubheaderTextBlockStyle}"
-                   Margin="0,0,0,20" />
-            <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,100,0">
-                <Controls:RadioButtons x:Uid="Globals_Theme"
+        <StackPanel>
+            <Controls:RadioButtons x:Uid="Globals_Theme"
                                        SelectedItem="{x:Bind CurrentTheme, Mode=TwoWay}"
                                        ItemsSource="{x:Bind ThemeList, Mode=OneWay}"
                                        ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
-                <CheckBox x:Uid="Globals_ShowTitlebar" IsChecked="{x:Bind State.Globals.ShowTabsInTitlebar, Mode=TwoWay}"/>
-                <CheckBox x:Uid="Globals_ShowTitleInTitlebar" IsChecked="{x:Bind State.Globals.ShowTitleInTitlebar, Mode=TwoWay}"/>
-                <CheckBox x:Uid="Globals_AlwaysShowTabs" IsChecked="{x:Bind State.Globals.AlwaysShowTabs, Mode=TwoWay}"/>
-                <Controls:RadioButtons x:Uid="Globals_TabWidthMode"
-                                       SelectedItem="{x:Bind CurrentTabWidthMode, Mode=TwoWay}"
-                                       ItemsSource="{x:Bind TabWidthModeList, Mode=OneWay}"
-                                       ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
-                <CheckBox x:Uid="Globals_ConfirmCloseAllTabs" IsChecked="{x:Bind State.Globals.ConfirmCloseAllTabs, Mode=TwoWay}"/>
-                <CheckBox x:Uid="Globals_DisableAnimations" IsChecked="{x:Bind State.Globals.DisableAnimations, Mode=TwoWay}"/>
-            </StackPanel>
-        </Grid>
+            <CheckBox x:Uid="Globals_ShowTitlebar"
+                      IsChecked="{x:Bind State.Globals.ShowTabsInTitlebar, Mode=TwoWay}"/>
+            <CheckBox x:Uid="Globals_ShowTitleInTitlebar"
+                      IsChecked="{x:Bind State.Globals.ShowTitleInTitlebar, Mode=TwoWay}"/>
+            <CheckBox x:Uid="Globals_AlwaysShowTabs"
+                      IsChecked="{x:Bind State.Globals.AlwaysShowTabs, Mode=TwoWay}"/>
+            <Controls:RadioButtons x:Uid="Globals_TabWidthMode"
+                                   SelectedItem="{x:Bind CurrentTabWidthMode, Mode=TwoWay}"
+                                   ItemsSource="{x:Bind TabWidthModeList, Mode=OneWay}"
+                                   ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
+            <CheckBox x:Uid="Globals_ConfirmCloseAllTabs"
+                      IsChecked="{x:Bind State.Globals.ConfirmCloseAllTabs, Mode=TwoWay}"/>
+            <CheckBox x:Uid="Globals_DisableAnimations"
+                      IsChecked="{x:Bind State.Globals.DisableAnimations, Mode=TwoWay}"/>
+        </StackPanel>
     </ScrollViewer>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Interaction.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.xaml
@@ -9,27 +9,25 @@ the MIT License. See LICENSE in the project root for license information. -->
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:Controls="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d">
+
+    <Page.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="CommonResources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Page.Resources>
+    
     <ScrollViewer>
-        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-          Margin="0,12,0,0">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" />
-            </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="1*" />
-                <ColumnDefinition Width="1*" />
-            </Grid.ColumnDefinitions>
-            <TextBlock x:Uid="Globals_Interaction"
-                   Style="{StaticResource SubheaderTextBlockStyle}"
-                   Margin="0,0,0,20" />
-            <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,100,0">
-                <CheckBox x:Uid="Globals_CopyOnSelect" IsChecked="{x:Bind State.Globals.CopyOnSelect, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
-                <!--TODO: Converter Here-->
-                <!--<CheckBox x:Uid="Globals_CopyFormatting" IsChecked="{x:Bind GlobalSettings.CopyFormatting, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />-->
-                <TextBox x:Uid="Globals_WordDelimiters" Text="{x:Bind State.Globals.WordDelimiters, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
-                <CheckBox x:Uid="Globals_SnapToGridOnResize" IsChecked="{x:Bind State.Globals.SnapToGridOnResize, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
-            </StackPanel>
-        </Grid>
+        <StackPanel HorizontalAlignment="Left">
+            <CheckBox x:Uid="Globals_CopyOnSelect"
+                      IsChecked="{x:Bind State.Globals.CopyOnSelect, Mode=TwoWay}"/>
+            <!--TODO: Converter Here-->
+            <!--<CheckBox x:Uid="Globals_CopyFormatting" IsChecked="{x:Bind GlobalSettings.CopyFormatting, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />-->
+            <TextBox x:Uid="Globals_WordDelimiters"
+                     Text="{x:Bind State.Globals.WordDelimiters, Mode=TwoWay}"/>
+            <CheckBox x:Uid="Globals_SnapToGridOnResize"
+                      IsChecked="{x:Bind State.Globals.SnapToGridOnResize, Mode=TwoWay}"/>
+        </StackPanel>
     </ScrollViewer>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -26,9 +26,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <ColumnDefinition Width="1*" />
                 <ColumnDefinition Width="1*" />
             </Grid.ColumnDefinitions>
-            <TextBlock x:Uid="Globals_Startup"
-                       Style="{StaticResource SubheaderTextBlockStyle}"
-                       Margin="0,0,0,20" />
+            
             <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,100,0">
                 <ComboBox x:Uid="Globals_DefaultProfile"
                           x:Name="DefaultProfile"

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -96,7 +96,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             else if (const auto profile = clickedItemContainer.Tag().try_as<Model::Profile>())
             {
                 // Navigate to a page with the given profile
-                SettingsNavHeader().Text(profile.Name());
+                SettingsNav().Header(winrt::box_value(profile.Name()));
                 contentFrame().Navigate(xaml_typename<Editor::Profiles>(), winrt::make<ProfilePageNavigationState>(profile, _settingsClone.GlobalSettings().ColorSchemes()));
             }
         }
@@ -106,32 +106,32 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         if (clickedItemTag == launchTag)
         {
-            SettingsNavHeader().Text(RS_(L"Header_StartupPage"));
+            SettingsNav().Header(winrt::box_value(RS_(L"Header_StartupPage")));
             contentFrame().Navigate(xaml_typename<Editor::Launch>(), winrt::make<LaunchPageNavigationState>(_settingsClone));
         }
         else if (clickedItemTag == interactionTag)
         {
-            SettingsNavHeader().Text(RS_(L"Header_InteractionPage"));
+            SettingsNav().Header(winrt::box_value(RS_(L"Header_InteractionPage")));
             contentFrame().Navigate(xaml_typename<Editor::Interaction>(), winrt::make<InteractionPageNavigationState>(_settingsClone.GlobalSettings()));
         }
         else if (clickedItemTag == renderingTag)
         {
-            SettingsNavHeader().Text(RS_(L"Header_RenderingPage"));
+            SettingsNav().Header(winrt::box_value(RS_(L"Header_RenderingPage")));
             contentFrame().Navigate(xaml_typename<Editor::Rendering>(), winrt::make<RenderingPageNavigationState>(_settingsClone.GlobalSettings()));
         }
         else if (clickedItemTag == globalProfileTag)
         {
-            SettingsNavHeader().Text(RS_(L"Header_ProfileDefaultsPage"));
+            SettingsNav().Header(winrt::box_value(RS_(L"Header_ProfileDefaultsPage")));
             contentFrame().Navigate(xaml_typename<Editor::Profiles>(), winrt::make<ProfilePageNavigationState>(_settingsClone.ProfileDefaults(), _settingsClone.GlobalSettings().ColorSchemes()));
         }
         else if (clickedItemTag == colorSchemesTag)
         {
-            SettingsNavHeader().Text(RS_(L"Header_ColorSchemesPage"));
+            SettingsNav().Header(winrt::box_value(RS_(L"Header_ColorSchemesPage")));
             contentFrame().Navigate(xaml_typename<Editor::ColorSchemes>(), winrt::make<ColorSchemesPageNavigationState>(_settingsClone.GlobalSettings()));
         }
         else if (clickedItemTag == globalAppearanceTag)
         {
-            SettingsNavHeader().Text(RS_(L"Header_GlobalAppearancePage"));
+            SettingsNav().Header(winrt::box_value(RS_(L"Header_GlobalAppearancePage")));
             contentFrame().Navigate(xaml_typename<Editor::GlobalAppearance>(), winrt::make<GlobalAppearancePageNavigationState>(_settingsClone.GlobalSettings()));
         }
     }
@@ -149,8 +149,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
 
         if (SettingsNav().IsPaneOpen() &&
-            (SettingsNav().DisplayMode() == MUX::Controls::NavigationViewDisplayMode(1) ||
-             SettingsNav().DisplayMode() == MUX::Controls::NavigationViewDisplayMode(0)))
+            (SettingsNav().DisplayMode() == MUX::Controls::NavigationViewDisplayMode::Compact ||
+             SettingsNav().DisplayMode() == MUX::Controls::NavigationViewDisplayMode::Minimal))
         {
             return false;
         }
@@ -216,7 +216,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // TODO: Setting SelectedItem here doesn't seem to update
         // the NavigationView selected visual indicator, not sure where
         // it needs to be...
-        SettingsNavHeader().Text(newProfile.Name());
+        SettingsNav().Header(winrt::box_value(newProfile.Name()));
         contentFrame().Navigate(xaml_typename<Editor::Profiles>(), winrt::make<ProfilePageNavigationState>(newProfile, _settingsClone.GlobalSettings().ColorSchemes()));
     }
 

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -96,7 +96,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             else if (const auto profile = clickedItemContainer.Tag().try_as<Model::Profile>())
             {
                 // Navigate to a page with the given profile
-                SettingsNav().Header(winrt::box_value(profile.Name()));
                 contentFrame().Navigate(xaml_typename<Editor::Profiles>(), winrt::make<ProfilePageNavigationState>(profile, _settingsClone.GlobalSettings().ColorSchemes()));
             }
         }
@@ -106,57 +105,28 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         if (clickedItemTag == launchTag)
         {
-            SettingsNav().Header(winrt::box_value(RS_(L"Header_StartupPage")));
             contentFrame().Navigate(xaml_typename<Editor::Launch>(), winrt::make<LaunchPageNavigationState>(_settingsClone));
         }
         else if (clickedItemTag == interactionTag)
         {
-            SettingsNav().Header(winrt::box_value(RS_(L"Header_InteractionPage")));
             contentFrame().Navigate(xaml_typename<Editor::Interaction>(), winrt::make<InteractionPageNavigationState>(_settingsClone.GlobalSettings()));
         }
         else if (clickedItemTag == renderingTag)
         {
-            SettingsNav().Header(winrt::box_value(RS_(L"Header_RenderingPage")));
             contentFrame().Navigate(xaml_typename<Editor::Rendering>(), winrt::make<RenderingPageNavigationState>(_settingsClone.GlobalSettings()));
         }
         else if (clickedItemTag == globalProfileTag)
         {
-            SettingsNav().Header(winrt::box_value(RS_(L"Header_ProfileDefaultsPage")));
             contentFrame().Navigate(xaml_typename<Editor::Profiles>(), winrt::make<ProfilePageNavigationState>(_settingsClone.ProfileDefaults(), _settingsClone.GlobalSettings().ColorSchemes()));
         }
         else if (clickedItemTag == colorSchemesTag)
         {
-            SettingsNav().Header(winrt::box_value(RS_(L"Header_ColorSchemesPage")));
             contentFrame().Navigate(xaml_typename<Editor::ColorSchemes>(), winrt::make<ColorSchemesPageNavigationState>(_settingsClone.GlobalSettings()));
         }
         else if (clickedItemTag == globalAppearanceTag)
         {
-            SettingsNav().Header(winrt::box_value(RS_(L"Header_GlobalAppearancePage")));
             contentFrame().Navigate(xaml_typename<Editor::GlobalAppearance>(), winrt::make<GlobalAppearancePageNavigationState>(_settingsClone.GlobalSettings()));
         }
-    }
-
-    void MainPage::SettingsNav_BackRequested(MUX::Controls::NavigationView const&, MUX::Controls::NavigationViewBackRequestedEventArgs const& /*args*/)
-    {
-        On_BackRequested();
-    }
-
-    bool MainPage::On_BackRequested()
-    {
-        if (!contentFrame().CanGoBack())
-        {
-            return false;
-        }
-
-        if (SettingsNav().IsPaneOpen() &&
-            (SettingsNav().DisplayMode() == MUX::Controls::NavigationViewDisplayMode::Compact ||
-             SettingsNav().DisplayMode() == MUX::Controls::NavigationViewDisplayMode::Minimal))
-        {
-            return false;
-        }
-
-        contentFrame().GoBack();
-        return true;
     }
 
     void MainPage::OpenJsonTapped(IInspectable const& /*sender*/, Windows::UI::Xaml::Input::TappedRoutedEventArgs const& /*args*/)
@@ -208,15 +178,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void MainPage::_CreateAndNavigateToNewProfile(const uint32_t index)
     {
-        auto newProfile = _settingsClone.CreateNewProfile();
-        auto navItem = _CreateProfileNavViewItem(newProfile);
+        const auto newProfile{ _settingsClone.CreateNewProfile() };
+        const auto navItem{ _CreateProfileNavViewItem(newProfile) };
         SettingsNav().MenuItems().InsertAt(index, navItem);
 
-        // Now nav to the new profile
-        // TODO: Setting SelectedItem here doesn't seem to update
-        // the NavigationView selected visual indicator, not sure where
-        // it needs to be...
-        SettingsNav().Header(winrt::box_value(newProfile.Name()));
+        // Select and navigate to the new profile
+        // TODO: Setting SelectedItem here doesn't update the NavigationView's selected visual indicator
+        SettingsNav().SelectedItem(navItem);
         contentFrame().Navigate(xaml_typename<Editor::Profiles>(), winrt::make<ProfilePageNavigationState>(newProfile, _settingsClone.GlobalSettings().ColorSchemes()));
     }
 

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -96,6 +96,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             else if (const auto profile = clickedItemContainer.Tag().try_as<Model::Profile>())
             {
                 // Navigate to a page with the given profile
+                SettingsNavHeader().Text(profile.Name());
                 contentFrame().Navigate(xaml_typename<Editor::Profiles>(), winrt::make<ProfilePageNavigationState>(profile, _settingsClone.GlobalSettings().ColorSchemes()));
             }
         }
@@ -105,26 +106,32 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         if (clickedItemTag == launchTag)
         {
+            SettingsNavHeader().Text(RS_(L"Header_StartupPage"));
             contentFrame().Navigate(xaml_typename<Editor::Launch>(), winrt::make<LaunchPageNavigationState>(_settingsClone));
         }
         else if (clickedItemTag == interactionTag)
         {
+            SettingsNavHeader().Text(RS_(L"Header_InteractionPage"));
             contentFrame().Navigate(xaml_typename<Editor::Interaction>(), winrt::make<InteractionPageNavigationState>(_settingsClone.GlobalSettings()));
         }
         else if (clickedItemTag == renderingTag)
         {
+            SettingsNavHeader().Text(RS_(L"Header_RenderingPage"));
             contentFrame().Navigate(xaml_typename<Editor::Rendering>(), winrt::make<RenderingPageNavigationState>(_settingsClone.GlobalSettings()));
         }
         else if (clickedItemTag == globalProfileTag)
         {
+            SettingsNavHeader().Text(RS_(L"Header_ProfileDefaultsPage"));
             contentFrame().Navigate(xaml_typename<Editor::Profiles>(), winrt::make<ProfilePageNavigationState>(_settingsClone.ProfileDefaults(), _settingsClone.GlobalSettings().ColorSchemes()));
         }
         else if (clickedItemTag == colorSchemesTag)
         {
+            SettingsNavHeader().Text(RS_(L"Header_ColorSchemesPage"));
             contentFrame().Navigate(xaml_typename<Editor::ColorSchemes>(), winrt::make<ColorSchemesPageNavigationState>(_settingsClone.GlobalSettings()));
         }
         else if (clickedItemTag == globalAppearanceTag)
         {
+            SettingsNavHeader().Text(RS_(L"Header_GlobalAppearancePage"));
             contentFrame().Navigate(xaml_typename<Editor::GlobalAppearance>(), winrt::make<GlobalAppearancePageNavigationState>(_settingsClone.GlobalSettings()));
         }
     }
@@ -209,6 +216,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // TODO: Setting SelectedItem here doesn't seem to update
         // the NavigationView selected visual indicator, not sure where
         // it needs to be...
+        SettingsNavHeader().Text(newProfile.Name());
         contentFrame().Navigate(xaml_typename<Editor::Profiles>(), winrt::make<ProfilePageNavigationState>(newProfile, _settingsClone.GlobalSettings().ColorSchemes()));
     }
 

--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -17,8 +17,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void OpenJsonTapped(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::TappedRoutedEventArgs const& args);
         void SettingsNav_Loaded(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& args);
         void SettingsNav_ItemInvoked(Microsoft::UI::Xaml::Controls::NavigationView const& sender, Microsoft::UI::Xaml::Controls::NavigationViewItemInvokedEventArgs const& args);
-        void SettingsNav_BackRequested(Microsoft::UI::Xaml::Controls::NavigationView const&, Microsoft::UI::Xaml::Controls::NavigationViewBackRequestedEventArgs const& args);
-        bool On_BackRequested();
 
         TYPED_EVENT(OpenJson, winrt::Windows::Foundation::IInspectable, winrt::Microsoft::Terminal::Settings::Model::SettingsTarget);
 

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -10,24 +10,6 @@ the MIT License. See LICENSE in the project root for license information. -->
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d">
 
-    <Page.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.ThemeDictionaries>
-                <ResourceDictionary x:Key="Dark">
-                    <Thickness x:Key="NavigationViewHeaderMargin">20,5,0,0</Thickness>
-                </ResourceDictionary>
-
-                <ResourceDictionary x:Key="Light">
-                    <Thickness x:Key="NavigationViewHeaderMargin">20,5,0,0</Thickness>
-                </ResourceDictionary>
-
-                <ResourceDictionary x:Key="HighContrast">
-                    <Thickness x:Key="NavigationViewHeaderMargin">20,5,0,0</Thickness>
-                </ResourceDictionary>
-            </ResourceDictionary.ThemeDictionaries>
-        </ResourceDictionary>
-    </Page.Resources>
-
     <Grid>
         <Grid.Resources>
             <AcrylicBrush x:Key="NavigationViewDefaultPaneBackground"
@@ -54,7 +36,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             <muxc:NavigationView.HeaderTemplate>
                 <DataTemplate x:DataType="x:String">
                     <TextBlock Text="{x:Bind}"
-                               Margin="0,10,0,0"
+                               Margin="8,10,0,0"
                                Style="{StaticResource TitleTextBlockStyle}"/>
                 </DataTemplate>
             </muxc:NavigationView.HeaderTemplate>

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -10,6 +10,13 @@ the MIT License. See LICENSE in the project root for license information. -->
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d">
 
+    <Page.Resources>
+        <TextBlock x:Name="SettingsNavHeader"
+                   x:Key="SettingsNavHeader"
+                   Style="{StaticResource SubheaderTextBlockStyle}"
+                   Margin="0,0,0,20"/>
+    </Page.Resources>
+    
     <Grid>
         <Grid.Resources>
             <AcrylicBrush x:Key="NavigationViewDefaultPaneBackground"
@@ -19,13 +26,15 @@ the MIT License. See LICENSE in the project root for license information. -->
             <AcrylicBrush x:Key="NavigationViewExpandedPaneBackground"
                   BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeMediumColor}" TintOpacity=".7"/>
         </Grid.Resources>
+
         <muxc:NavigationView x:Name="SettingsNav"
-                        IsSettingsVisible="False"
-                        Loaded="SettingsNav_Loaded"
-                        ItemInvoked="SettingsNav_ItemInvoked"
-                        IsBackButtonVisible="Auto"
-                        IsBackEnabled="True"
-                        BackRequested="SettingsNav_BackRequested">
+                             IsSettingsVisible="False"
+                             Header="{StaticResource SettingsNavHeader}"
+                             Loaded="SettingsNav_Loaded"
+                             ItemInvoked="SettingsNav_ItemInvoked"
+                             IsBackButtonVisible="Auto"
+                             IsBackEnabled="True"
+                             BackRequested="SettingsNav_BackRequested">
             <muxc:NavigationView.MenuItems>
 
                 <muxc:NavigationViewItem x:Uid="Nav_Launch"

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -11,62 +11,87 @@ the MIT License. See LICENSE in the project root for license information. -->
     mc:Ignorable="d">
 
     <Page.Resources>
-        <TextBlock x:Name="SettingsNavHeader"
-                   x:Key="SettingsNavHeader"
-                   Style="{StaticResource SubheaderTextBlockStyle}"
-                   Margin="0,0,0,20"/>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Dark">
+                    <Thickness x:Key="NavigationViewHeaderMargin">20,5,0,0</Thickness>
+                </ResourceDictionary>
+
+                <ResourceDictionary x:Key="Light">
+                    <Thickness x:Key="NavigationViewHeaderMargin">20,5,0,0</Thickness>
+                </ResourceDictionary>
+
+                <ResourceDictionary x:Key="HighContrast">
+                    <Thickness x:Key="NavigationViewHeaderMargin">20,5,0,0</Thickness>
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+        </ResourceDictionary>
     </Page.Resources>
-    
+
     <Grid>
         <Grid.Resources>
             <AcrylicBrush x:Key="NavigationViewDefaultPaneBackground"
-                  BackgroundSource="Backdrop" TintColor="{ThemeResource SystemChromeMediumColor}" TintOpacity=".5"/>
+                          BackgroundSource="Backdrop"
+                          TintColor="{ThemeResource SystemChromeMediumColor}"
+                          TintOpacity=".5"/>
             <AcrylicBrush x:Key="NavigationViewTopPaneBackground"
-                  BackgroundSource="Backdrop" TintColor="{ThemeResource SystemChromeMediumColor}" TintOpacity=".5"/>
+                          BackgroundSource="Backdrop"
+                          TintColor="{ThemeResource SystemChromeMediumColor}"
+                          TintOpacity=".5"/>
             <AcrylicBrush x:Key="NavigationViewExpandedPaneBackground"
-                  BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeMediumColor}" TintOpacity=".7"/>
+                          BackgroundSource="HostBackdrop"
+                          TintColor="{ThemeResource SystemChromeMediumColor}"
+                          TintOpacity=".7"/>
         </Grid.Resources>
 
         <muxc:NavigationView x:Name="SettingsNav"
                              IsSettingsVisible="False"
-                             Header="{StaticResource SettingsNavHeader}"
                              Loaded="SettingsNav_Loaded"
                              ItemInvoked="SettingsNav_ItemInvoked"
                              IsBackButtonVisible="Auto"
                              IsBackEnabled="True"
                              BackRequested="SettingsNav_BackRequested">
+
+            <muxc:NavigationView.HeaderTemplate>
+                <DataTemplate x:DataType="x:String">
+                    <TextBlock Text="{x:Bind}"
+                               Margin="0,10,0,0"
+                               Style="{StaticResource TitleTextBlockStyle}"/>
+                </DataTemplate>
+            </muxc:NavigationView.HeaderTemplate>
+            
             <muxc:NavigationView.MenuItems>
 
                 <muxc:NavigationViewItem x:Uid="Nav_Launch"
-                                                Tag="Launch_Nav">
+                                         Tag="Launch_Nav">
                     <muxc:NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE7B5;"/>
                     </muxc:NavigationViewItem.Icon>
                 </muxc:NavigationViewItem>
 
                 <muxc:NavigationViewItem x:Uid="Nav_Interaction"
-                                                Tag="Interaction_Nav">
+                                         Tag="Interaction_Nav">
                     <muxc:NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE7C9;"/>
                     </muxc:NavigationViewItem.Icon>
                 </muxc:NavigationViewItem>
 
                 <muxc:NavigationViewItem x:Uid="Nav_Appearance"
-                                                Tag="GlobalAppearance_Nav">
+                                         Tag="GlobalAppearance_Nav">
                     <muxc:NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE771;"/>
                     </muxc:NavigationViewItem.Icon>
                 </muxc:NavigationViewItem>
 
                 <muxc:NavigationViewItem x:Uid="Nav_ColorSchemes"
-                                                Tag="ColorSchemes_Nav">
+                                         Tag="ColorSchemes_Nav">
                     <muxc:NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE790;"/>
                     </muxc:NavigationViewItem.Icon>
                 </muxc:NavigationViewItem>
 
                 <muxc:NavigationViewItem x:Uid="Nav_Rendering"
-                                                 Tag="Rendering_Nav" >
+                                         Tag="Rendering_Nav" >
                     <muxc:NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE7F8;"/>
                     </muxc:NavigationViewItem.Icon>
@@ -75,7 +100,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <muxc:NavigationViewItemHeader x:Uid="Nav_Profiles"/>
 
                 <muxc:NavigationViewItem x:Uid="Nav_ProfileGlobal"
-                                            Tag="GlobalProfile_Nav">
+                                         Tag="GlobalProfile_Nav">
                     <muxc:NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE756;"/>
                     </muxc:NavigationViewItem.Icon>
@@ -83,7 +108,9 @@ the MIT License. See LICENSE in the project root for license information. -->
 
             </muxc:NavigationView.MenuItems>
             <muxc:NavigationView.PaneFooter>
-                <muxc:NavigationViewItem x:Uid="Nav_OpenJSON" Tapped="OpenJsonTapped" KeyDown="OpenJsonKeyDown">
+                <muxc:NavigationViewItem x:Uid="Nav_OpenJSON"
+                                         Tapped="OpenJsonTapped"
+                                         KeyDown="OpenJsonKeyDown">
                     <muxc:NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE713;" />
                     </muxc:NavigationViewItem.Icon>
@@ -101,10 +128,22 @@ the MIT License. See LICENSE in the project root for license information. -->
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"></ColumnDefinition>
                     </Grid.ColumnDefinitions>
-                    <TextBlock x:Uid="Settings_UnsavedSettingsWarning" Visibility="Collapsed" Foreground="Goldenrod" FontSize="15" VerticalAlignment="Center" HorizontalAlignment="Left" TextAlignment="Left" Margin="30,0,0,0"/>
+                    <TextBlock x:Uid="Settings_UnsavedSettingsWarning"
+                               Visibility="Collapsed"
+                               Foreground="Goldenrod"
+                               FontSize="15"
+                               VerticalAlignment="Center"
+                               HorizontalAlignment="Left"
+                               TextAlignment="Left"
+                               Margin="30,0,0,0"/>
                     <StackPanel VerticalAlignment="Center" HorizontalAlignment="Right" Orientation="Horizontal" Margin="0,0,30,0">
-                        <Button x:Uid="Settings_ResetSettingsButton" FontSize="15" ToolTipService.Placement="Mouse"/>
-                        <Button x:Uid="Settings_SaveSettingsButton" FontSize="15" Style="{StaticResource AccentButtonStyle}" Margin="10,0,0,0"/>
+                        <Button x:Uid="Settings_ResetSettingsButton"
+                                FontSize="15"
+                                ToolTipService.Placement="Mouse"/>
+                        <Button x:Uid="Settings_SaveSettingsButton"
+                                FontSize="15"
+                                Style="{StaticResource AccentButtonStyle}"
+                                Margin="10,0,0,0"/>
                     </StackPanel>
                 </Grid>
             </Grid>

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -46,11 +46,10 @@ the MIT License. See LICENSE in the project root for license information. -->
 
         <muxc:NavigationView x:Name="SettingsNav"
                              IsSettingsVisible="False"
+                             Header="{Binding ElementName=SettingsNav, Path=SelectedItem.Content, Mode=OneWay}"
                              Loaded="SettingsNav_Loaded"
                              ItemInvoked="SettingsNav_ItemInvoked"
-                             IsBackButtonVisible="Auto"
-                             IsBackEnabled="True"
-                             BackRequested="SettingsNav_BackRequested">
+                             IsBackButtonVisible="Collapsed">
 
             <muxc:NavigationView.HeaderTemplate>
                 <DataTemplate x:DataType="x:String">

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -9,7 +9,6 @@ the MIT License. See LICENSE in the project root for license information. -->
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:Controls="using:Microsoft.UI.Xaml.Controls"
-    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
     mc:Ignorable="d">
 
     <Page.Resources>
@@ -17,6 +16,10 @@ the MIT License. See LICENSE in the project root for license information. -->
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="CommonResources.xaml"/>
             </ResourceDictionary.MergedDictionaries>
+
+            <Style TargetType="ScrollViewer">
+                <Setter Property="Margin" Value="0,10,0,0"/>
+            </Style>
 
             <DataTemplate x:DataType="local:EnumEntry" x:Key="EnumRadioButtonTemplate">
                 <RadioButton Content="{x:Bind EnumName, Mode=OneWay}"/>
@@ -26,251 +29,156 @@ the MIT License. See LICENSE in the project root for license information. -->
         </ResourceDictionary>
     </Page.Resources>
 
-    <ScrollViewer>
-        <Pivot>
-            <PivotItem x:Uid="Profile_General">
-                <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-                  Margin="0,12,0,0">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="1*" />
-                        <ColumnDefinition Width="1*" />
-                    </Grid.ColumnDefinitions>
-                    <TextBox x:Uid="Profile_Commandline" x:Name="Commandline" Margin="0,0,0,20" Grid.Row="0" Grid.Column="0" FontSize="15" Text="{x:Bind State.Profile.Commandline, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
-                    <Button x:Uid="Profile_CommandlineBrowse" Click="Commandline_Click" Margin="5,0,0,0" Grid.Row="0" Grid.Column="1" FontSize="15"/>
-                    <TextBox x:Uid="Profile_StartingDirectory" x:Name="StartingDirectory" Margin="0,0,0,20" Grid.Row="1" Grid.Column="0" FontSize="15" Text="{x:Bind State.Profile.StartingDirectory, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
-                    <Button x:Uid="Profile_StartingDirectoryBrowse" Margin="5,0,0,0" Grid.Row="1" Grid.Column="1" FontSize="15"/>
-                    <TextBox x:Uid="Profile_Icon" Margin="0,0,0,20" Grid.Row="2" Grid.Column="0" FontSize="15" Text="{x:Bind State.Profile.Icon, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
-                    <Button x:Uid="Profile_IconBrowse" Margin="5,0,0,0" Grid.Row="2" Grid.Column="1" FontSize="15" />
-                    <StackPanel Grid.Row="3" Grid.Column="0">
-                        <TextBox x:Uid="Profile_TabTitle" Margin="0,0,0,20" FontSize="15" Text="{x:Bind State.Profile.TabTitle, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
-                        <Controls:RadioButtons x:Uid="Profile_ScrollbarVisibility"
-                                               ItemsSource="{x:Bind ScrollStateList, Mode=OneWay}"
-                                               SelectedItem="{x:Bind CurrentScrollState, Mode=TwoWay}"
-                                               ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
+    <Pivot>
+        <!-- General Tab -->
+        <PivotItem x:Uid="Profile_General">
+            <ScrollViewer>
+                <StackPanel HorizontalAlignment="Left">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBox x:Uid="Profile_Commandline"
+                             x:Name="Commandline"
+                             Text="{x:Bind State.Profile.Commandline, Mode=TwoWay}"/>
+                        <Button x:Uid="Profile_CommandlineBrowse"
+                            Click="Commandline_Click"
+                            Margin="10,0,0,0"/>
                     </StackPanel>
-                </Grid>
-            </PivotItem>
-            <PivotItem x:Uid="Profile_Appearance">
-                <ScrollViewer>
-                    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-                      Margin="0,12,0,0">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="*" />
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="1*" />
-                            <ColumnDefinition Width="1*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <!-- THIS IS WHERE THE MINI-TERMINAL WOULD GO -->
+                    <StackPanel Orientation="Horizontal">
+                        <TextBox x:Uid="Profile_StartingDirectory"
+                                 x:Name="StartingDirectory"
+                                 Text="{x:Bind State.Profile.StartingDirectory, Mode=TwoWay}"/>
+                        <Button x:Uid="Profile_StartingDirectoryBrowse"
+                                Margin="10,0,0,0"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBox x:Uid="Profile_Icon"
+                                 Text="{x:Bind State.Profile.Icon, Mode=TwoWay}"/>
+                        <Button x:Uid="Profile_IconBrowse"
+                                Margin="10,0,0,0"/>
+                    </StackPanel>
+                    <TextBox x:Uid="Profile_TabTitle"
+                             Text="{x:Bind State.Profile.TabTitle, Mode=TwoWay}"
+                             HorizontalAlignment="Left"/>
+                    <Controls:RadioButtons x:Uid="Profile_ScrollbarVisibility"
+                                           ItemsSource="{x:Bind ScrollStateList, Mode=OneWay}"
+                                           SelectedItem="{x:Bind CurrentScrollState, Mode=TwoWay}"
+                                           ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
+                </StackPanel>
+            </ScrollViewer>
+        </PivotItem>
 
+        <!-- Appearance Tab -->
+        <PivotItem x:Uid="Profile_Appearance">
+            <ScrollViewer>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <!-- TODO GH#1564: Add an embedded TermControl in the 0th row-->
 
-                        <StackPanel Grid.Column="0" Grid.Row="0" Margin="0,0,100,0">
-                            <TextBox x:Uid="Profile_FontFace" Margin="0,0,0,20" FontSize="15" Text="{x:Bind State.Profile.FontFace, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
+                    <!-- Group 1 of Appearance Settings -->
+                    <StackPanel Grid.Column="0" HorizontalAlignment="Left">
+                        <TextBox x:Uid="Profile_FontFace"
+                                 Text="{x:Bind State.Profile.FontFace, Mode=TwoWay}"/>
+                        <Controls:NumberBox x:Uid="Profile_FontSize"
+                                            Value="{x:Bind State.Profile.FontSize, Mode=TwoWay}"
+                                            SmallChange="1"
+                                            LargeChange="10"/>
+                        <TextBox x:Uid="Profile_FontWeight"/>
+                        <TextBox x:Uid="Profile_Padding"
+                                 Text="{x:Bind State.Profile.Padding, Mode=TwoWay}"/>
+                        <Controls:RadioButtons x:Uid="Profile_CursorShape"
+                                               ItemsSource="{x:Bind CursorShapeList, Mode=OneWay}"
+                                               SelectedItem="{x:Bind CurrentCursorShape, Mode=TwoWay}"
+                                               ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
+                        <Controls:NumberBox x:Uid="Profile_CursorHeight"
+                                            Value="100"
+                                            SmallChange="1"
+                                            LargeChange="10"/>
+                        <ComboBox x:Uid="Profile_ColorScheme">
+                            <ComboBox.Items>
+                                <ComboBoxItem Content="Campbell"/>
+                                <ComboBoxItem Content="Campbell Powershell"/>
+                                <ComboBoxItem Content="Vintage"/>
+                                <ComboBoxItem Content="One Half Dark"/>
+                                <ComboBoxItem Content="One Half Light"/>
+                                <ComboBoxItem Content="Tango Dark"/>
+                                <ComboBoxItem Content="Tango Light"/>
+                            </ComboBox.Items>
+                        </ComboBox>
+                    </StackPanel>
+
+                    <!-- Group 2 of Appearance Settings -->
+                    <StackPanel Grid.Column="1" HorizontalAlignment="Left">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBox x:Uid="Profile_BackgroundImage"
+                                     x:Name="BackgroundImage" Text="{x:Bind State.Profile.BackgroundImagePath, Mode=TwoWay}"/>
+                            <Button x:Uid="Profile_BackgroundImageBrowse"
+                                    Click="BackgroundImage_Click"
+                                    Margin="10,0,0,0"/>
                         </StackPanel>
-                        <StackPanel Grid.Column="0" Grid.Row="1" Margin="0,0,100,0">
-                            <Controls:NumberBox x:Uid="Profile_FontSize" Margin="0,0,0,20" FontSize="15" Value="{x:Bind State.Profile.FontSize, Mode=TwoWay}" SpinButtonPlacementMode="Compact" SmallChange="1" LargeChange="10" ToolTipService.Placement="Mouse" />
-                            <TextBox x:Uid="Profile_FontWeight" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse"/>
-                            <TextBox x:Uid="Profile_Padding" Margin="0,0,0,20" FontSize="15" Text="{x:Bind State.Profile.Padding, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
-                            <Controls:RadioButtons x:Uid="Profile_CursorShape"
-                                                   ItemsSource="{x:Bind CursorShapeList, Mode=OneWay}"
-                                                   SelectedItem="{x:Bind CurrentCursorShape, Mode=TwoWay}"
-                                                   ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
-                            <Controls:NumberBox x:Uid="Profile_CursorHeight" Margin="0,0,0,20" FontSize="15" Value="100" SpinButtonPlacementMode="Compact" SmallChange="1" LargeChange="10" ToolTipService.Placement="Mouse" />
-                            <StackPanel x:Uid="Profile_CursorColorToolTip"
-                                    Orientation="Horizontal"
-                                    Margin="0,0,0,20"
-                                    ToolTipService.Placement="Mouse">
-                                <TextBox x:Uid="Profile_CursorColor"
-                                     FontSize="15"
-                                     Text="#FFFFFF" />
-                                <Button Background="White"
-                                    BorderBrush="{StaticResource SystemBaseLowColor}"
-                                    Height="37"
-                                    Width="37"
-                                    Margin="10,22,0,0"
-                                    CornerRadius="2">
-                                    <Button.Flyout>
-                                        <Flyout>
-                                            <ColorPicker IsColorSliderVisible="False"
-                                                     IsColorChannelTextInputVisible="False"
-                                                     IsHexInputVisible="False"
-                                                     IsAlphaEnabled="False"
-                                                     IsAlphaSliderVisible="True"
-                                                     IsAlphaTextInputVisible="True" />
-                                        </Flyout>
-                                    </Button.Flyout>
-                                </Button>
-                            </StackPanel>
-                            <DropDownButton x:Uid="Profile_ColorScheme" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse">
-                                <DropDownButton.Flyout>
-                                    <MenuFlyout Placement="Bottom">
-                                        <MenuFlyoutItem Text="Campbell"/>
-                                        <MenuFlyoutItem Text="Campbell Powershell"/>
-                                        <MenuFlyoutItem Text="Vintage"/>
-                                        <MenuFlyoutItem Text="One Half Dark"/>
-                                        <MenuFlyoutItem Text="One Half Light"/>
-                                        <MenuFlyoutItem Text="Tango Dark"/>
-                                        <MenuFlyoutItem Text="Tango Light"/>
-                                    </MenuFlyout>
-                                </DropDownButton.Flyout>
-                            </DropDownButton>
-                            <StackPanel x:Uid="Profile_ForegroundColorToolTip"
-                                    Orientation="Horizontal"
-                                    Margin="0,0,0,20"
-                                    ToolTipService.Placement="Mouse">
-                                <TextBox x:Uid="Profile_ForegroundColor"
-                                     FontSize="15"
-                                     Text="#FFFFFF" />
-                                <Button Background="White"
-                                    BorderBrush="{StaticResource SystemBaseLowColor}"
-                                    Height="37"
-                                    Width="37"
-                                    Margin="10,22,0,0"
-                                    CornerRadius="2">
-                                    <Button.Flyout>
-                                        <Flyout>
-                                            <ColorPicker IsColorSliderVisible="False"
-                                                     IsColorChannelTextInputVisible="False"
-                                                     IsHexInputVisible="False"
-                                                     IsAlphaEnabled="False"
-                                                     IsAlphaSliderVisible="True"
-                                                     IsAlphaTextInputVisible="True" />
-                                        </Flyout>
-                                    </Button.Flyout>
-                                </Button>
-                            </StackPanel>
-                            <StackPanel x:Uid="Profile_BackgroundColorToolTip"
-                                    Orientation="Horizontal"
-                                    Margin="0,0,0,20"
-                                    ToolTipService.Placement="Mouse">
-                                <TextBox x:Uid="Profile_BackgroundColor"
-                                     FontSize="15"
-                                     Text="#000000" />
-                                <Button Background="Black"
-                                    BorderBrush="{StaticResource SystemBaseLowColor}"
-                                    Height="37"
-                                    Width="37"
-                                    Margin="10,22,0,0"
-                                    CornerRadius="2">
-                                    <Button.Flyout>
-                                        <Flyout>
-                                            <ColorPicker IsColorSliderVisible="False"
-                                                     IsColorChannelTextInputVisible="False"
-                                                     IsHexInputVisible="False"
-                                                     IsAlphaEnabled="False"
-                                                     IsAlphaSliderVisible="True"
-                                                     IsAlphaTextInputVisible="True" />
-                                        </Flyout>
-                                    </Button.Flyout>
-                                </Button>
-                            </StackPanel>
-                            <StackPanel x:Uid="Profile_SelectionBackgroundColorToolTip"
-                                    Orientation="Horizontal"
-                                    Margin="0,0,0,20"
-                                    ToolTipService.Placement="Mouse">
-                                <TextBox x:Uid="Profile_SelectionBackgroundColor"
-                                     FontSize="15"
-                                     Text="#808080" />
-                                <Button Background="Gray"
-                                    BorderBrush="{StaticResource SystemBaseLowColor}"
-                                    Height="37"
-                                    Width="37"
-                                    Margin="10,22,0,0"
-                                    CornerRadius="2">
-                                    <Button.Flyout>
-                                        <Flyout>
-                                            <ColorPicker IsColorSliderVisible="False"
-                                                     IsColorChannelTextInputVisible="False"
-                                                     IsHexInputVisible="False"
-                                                     IsAlphaEnabled="False"
-                                                     IsAlphaSliderVisible="True"
-                                                     IsAlphaTextInputVisible="True" />
-                                        </Flyout>
-                                    </Button.Flyout>
-                                </Button>
-                            </StackPanel>
-                        </StackPanel>
-                        <TextBox x:Uid="Profile_BackgroundImage" x:Name="BackgroundImage" Margin="0,0,0,20" FontSize="15" Grid.Column="1" Grid.Row="0" Text="{x:Bind State.Profile.BackgroundImagePath, Mode=TwoWay}" ToolTipService.Placement="Mouse"/>
-                        <Button x:Uid="Profile_BackgroundImageBrowse" Click="BackgroundImage_Click" Margin="5,0,0,0" Grid.Column="2" Grid.Row="0"/>
-                        <StackPanel Grid.Column="1" Grid.Row="1" Margin="0,0,100,0">
-                            <Controls:RadioButtons x:Uid="Profile_BackgroundImageStretchMode"
+                        <Controls:RadioButtons x:Uid="Profile_BackgroundImageStretchMode"
                                                    ItemsSource="{x:Bind BackgroundImageStretchModeList, Mode=OneWay}"
                                                    SelectedItem="{x:Bind CurrentBackgroundImageStretchMode, Mode=TwoWay}"
                                                    ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
-                            <DropDownButton x:Uid="Profile_BackgroundImageAlignment"
-                                            Margin="0,0,0,20"
-                                            FontSize="15"
-                                            ToolTipService.Placement="Mouse">
-                                <DropDownButton.Flyout>
-                                    <MenuFlyout Placement="Bottom">
-                                        <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentCenter"/>
-                                        <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentLeft"/>
-                                        <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentTop"/>
-                                        <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentRight"/>
-                                        <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentBottom"/>
-                                        <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentTopLeft"/>
-                                        <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentTopRight"/>
-                                        <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentBottomLeft"/>
-                                        <MenuFlyoutItem x:Uid="Profile_BackgroundImageAlignmentBottomRight"/>
-                                    </MenuFlyout>
-                                </DropDownButton.Flyout>
-                            </DropDownButton>
-                            <Controls:NumberBox x:Uid="Profile_BackgroundImageOpacity" Margin="0,0,0,20" FontSize="15" Value="{x:Bind State.Profile.BackgroundImageOpacity, Mode=TwoWay}" SpinButtonPlacementMode="Compact" SmallChange="10" LargeChange="25" ToolTipService.Placement="Mouse" />
-                            <CheckBox x:Uid="Profile_UseAcrylic" IsChecked="{x:Bind State.Profile.UseAcrylic, Mode=TwoWay}"/>
-                            <Controls:NumberBox x:Uid="Profile_AcrylicOpacity" Margin="0,0,0,20" FontSize="15" Value="{x:Bind State.Profile.AcrylicOpacity, Mode=TwoWay}" SpinButtonPlacementMode="Compact" SmallChange="0.1" LargeChange="0.25" ToolTipService.Placement="Mouse" />
-                            <CheckBox x:Uid="Profile_RetroTerminalEffect" IsChecked="{x:Bind State.Profile.RetroTerminalEffect, Mode=TwoWay}"/>
-                        </StackPanel>
-                    </Grid>
-                </ScrollViewer>
-            </PivotItem>
-            <PivotItem x:Uid="Profile_Advanced">
-                <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-          Margin="0,12,0,0">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="1*" />
-                        <ColumnDefinition Width="1*" />
-                    </Grid.ColumnDefinitions>
-                    <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,100,0">
-                        <CheckBox x:Uid="Profile_Hidden" IsChecked="{x:Bind State.Profile.Hidden, Mode=TwoWay}"/>
-                        <CheckBox x:Uid="Profile_SuppressApplicationTitle" IsChecked="{x:Bind State.Profile.SuppressApplicationTitle, Mode=TwoWay}"/>
-                        <Controls:RadioButtons x:Uid="Profile_AntialiasingMode"
+                        <ComboBox x:Uid="Profile_BackgroundImageAlignment">
+                            <ComboBox.Items>
+                                <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentCenter"/>
+                                <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentLeft"/>
+                                <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentTop"/>
+                                <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentRight"/>
+                                <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentBottom"/>
+                                <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentTopLeft"/>
+                                <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentTopRight"/>
+                                <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentBottomLeft"/>
+                                <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentBottomRight"/>
+                            </ComboBox.Items>
+                        </ComboBox>
+                        <Controls:NumberBox x:Uid="Profile_BackgroundImageOpacity"
+                                            Value="{x:Bind State.Profile.BackgroundImageOpacity, Mode=TwoWay}"
+                                            SmallChange="10"
+                                            LargeChange="25"/>
+                        <CheckBox x:Uid="Profile_UseAcrylic"
+                                  IsChecked="{x:Bind State.Profile.UseAcrylic, Mode=TwoWay}"/>
+                        <Controls:NumberBox x:Uid="Profile_AcrylicOpacity"
+                                            Value="{x:Bind State.Profile.AcrylicOpacity, Mode=TwoWay}"
+                                            SmallChange="0.1"
+                                            LargeChange="0.25"/>
+                        <CheckBox x:Uid="Profile_RetroTerminalEffect"
+                                  IsChecked="{x:Bind State.Profile.RetroTerminalEffect, Mode=TwoWay}"/>
+                    </StackPanel>
+                </Grid>
+            </ScrollViewer>
+        </PivotItem>
+
+        <!-- Advanced Tab -->
+        <PivotItem x:Uid="Profile_Advanced">
+            <ScrollViewer>
+                <StackPanel HorizontalAlignment="Left">
+                    <CheckBox x:Uid="Profile_Hidden"
+                              IsChecked="{x:Bind State.Profile.Hidden, Mode=TwoWay}"/>
+                    <CheckBox x:Uid="Profile_SuppressApplicationTitle"
+                              IsChecked="{x:Bind State.Profile.SuppressApplicationTitle, Mode=TwoWay}"/>
+                    <Controls:RadioButtons x:Uid="Profile_AntialiasingMode"
                                                ItemsSource="{x:Bind AntiAliasingModeList, Mode=OneWay}"
                                                SelectedItem="{x:Bind CurrentAntiAliasingMode, Mode=TwoWay}"
                                                ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
-                        <CheckBox x:Uid="Profile_AltGrAliasing" IsChecked="{x:Bind State.Profile.AltGrAliasing, Mode=TwoWay}" />
-                        <CheckBox x:Uid="Profile_SnapOnInput" IsChecked="{x:Bind State.Profile.SnapOnInput, Mode=TwoWay}"/>
-                        <Controls:NumberBox x:Uid="Profile_HistorySize"
-                                            Margin="0,0,0,20"
-                                            FontSize="15"
-                                            Value="{x:Bind State.Profile.HistorySize, Mode=TwoWay}"
-                                            SpinButtonPlacementMode="Compact"
-                                            SmallChange="10"
-                                            LargeChange="100"
-                                            ToolTipService.Placement="Mouse" />
-                        <Controls:RadioButtons x:Uid="Profile_CloseOnExit"
-                                               ItemsSource="{x:Bind CloseOnExitModeList, Mode=OneWay}"
-                                               SelectedItem="{x:Bind CurrentCloseOnExitMode, Mode=TwoWay}"
-                                               ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
-                        <Controls:RadioButtons x:Uid="Profile_BellStyle"
-                                               ItemsSource="{x:Bind BellStyleList, Mode=OneWay}"
-                                               SelectedItem="{x:Bind CurrentBellStyle, Mode=TwoWay}"
-                                               ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
-                    </StackPanel>
-                </Grid>
-            </PivotItem>
-        </Pivot>
-    </ScrollViewer>
+                    <CheckBox x:Uid="Profile_AltGrAliasing"
+                              IsChecked="{x:Bind State.Profile.AltGrAliasing, Mode=TwoWay}" />
+                    <CheckBox x:Uid="Profile_SnapOnInput"
+                              IsChecked="{x:Bind State.Profile.SnapOnInput, Mode=TwoWay}"/>
+                    <Controls:NumberBox x:Uid="Profile_HistorySize"
+                                        Value="{x:Bind State.Profile.HistorySize, Mode=TwoWay}"/>
+                    <Controls:RadioButtons x:Uid="Profile_CloseOnExit"
+                                           ItemsSource="{x:Bind CloseOnExitModeList, Mode=OneWay}"
+                                           SelectedItem="{x:Bind CurrentCloseOnExitMode, Mode=TwoWay}"
+                                           ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
+                    <Controls:RadioButtons x:Uid="Profile_BellStyle"
+                                           ItemsSource="{x:Bind BellStyleList, Mode=OneWay}"
+                                           SelectedItem="{x:Bind CurrentBellStyle, Mode=TwoWay}"
+                                           ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
+                </StackPanel>
+            </ScrollViewer>
+        </PivotItem>
+    </Pivot>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -157,7 +157,9 @@ the MIT License. See LICENSE in the project root for license information. -->
                     <CheckBox x:Uid="Profile_SnapOnInput"
                               IsChecked="{x:Bind State.Profile.SnapOnInput, Mode=TwoWay}"/>
                     <Controls:NumberBox x:Uid="Profile_HistorySize"
-                                        Value="{x:Bind State.Profile.HistorySize, Mode=TwoWay}"/>
+                                        Value="{x:Bind State.Profile.HistorySize, Mode=TwoWay}"
+                                        SmallChange="10"
+                                        LargeChange="100"/>
                     <Controls:RadioButtons x:Uid="Profile_CloseOnExit"
                                            ItemsSource="{x:Bind CloseOnExitModeList, Mode=OneWay}"
                                            SelectedItem="{x:Bind CurrentCloseOnExitMode, Mode=TwoWay}"

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -69,85 +69,74 @@ the MIT License. See LICENSE in the project root for license information. -->
         <!-- Appearance Tab -->
         <PivotItem x:Uid="Profile_Appearance">
             <ScrollViewer>
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
-                    <!-- TODO GH#1564: Add an embedded TermControl in the 0th row-->
+                <StackPanel HorizontalAlignment="Left">
+                    <TextBox x:Uid="Profile_FontFace"
+                             Text="{x:Bind State.Profile.FontFace, Mode=TwoWay}"/>
+                    <Controls:NumberBox x:Uid="Profile_FontSize"
+                                        Value="{x:Bind State.Profile.FontSize, Mode=TwoWay}"
+                                        SmallChange="1"
+                                        LargeChange="10"/>
+                    <TextBox x:Uid="Profile_FontWeight"/>
+                    <TextBox x:Uid="Profile_Padding"
+                             Text="{x:Bind State.Profile.Padding, Mode=TwoWay}"/>
+                    <Controls:RadioButtons x:Uid="Profile_CursorShape"
+                                           ItemsSource="{x:Bind CursorShapeList, Mode=OneWay}"
+                                           SelectedItem="{x:Bind CurrentCursorShape, Mode=TwoWay}"
+                                           ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
+                    <Controls:NumberBox x:Uid="Profile_CursorHeight"
+                                        Value="100"
+                                        SmallChange="1"
+                                        LargeChange="10"/>
+                    <ComboBox x:Uid="Profile_ColorScheme">
+                        <ComboBox.Items>
+                            <ComboBoxItem Content="Campbell"/>
+                            <ComboBoxItem Content="Campbell Powershell"/>
+                            <ComboBoxItem Content="Vintage"/>
+                            <ComboBoxItem Content="One Half Dark"/>
+                            <ComboBoxItem Content="One Half Light"/>
+                            <ComboBoxItem Content="Tango Dark"/>
+                            <ComboBoxItem Content="Tango Light"/>
+                        </ComboBox.Items>
+                    </ComboBox>
 
-                    <!-- Group 1 of Appearance Settings -->
-                    <StackPanel Grid.Column="0" HorizontalAlignment="Left">
-                        <TextBox x:Uid="Profile_FontFace"
-                                 Text="{x:Bind State.Profile.FontFace, Mode=TwoWay}"/>
-                        <Controls:NumberBox x:Uid="Profile_FontSize"
-                                            Value="{x:Bind State.Profile.FontSize, Mode=TwoWay}"
-                                            SmallChange="1"
-                                            LargeChange="10"/>
-                        <TextBox x:Uid="Profile_FontWeight"/>
-                        <TextBox x:Uid="Profile_Padding"
-                                 Text="{x:Bind State.Profile.Padding, Mode=TwoWay}"/>
-                        <Controls:RadioButtons x:Uid="Profile_CursorShape"
-                                               ItemsSource="{x:Bind CursorShapeList, Mode=OneWay}"
-                                               SelectedItem="{x:Bind CurrentCursorShape, Mode=TwoWay}"
-                                               ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
-                        <Controls:NumberBox x:Uid="Profile_CursorHeight"
-                                            Value="100"
-                                            SmallChange="1"
-                                            LargeChange="10"/>
-                        <ComboBox x:Uid="Profile_ColorScheme">
-                            <ComboBox.Items>
-                                <ComboBoxItem Content="Campbell"/>
-                                <ComboBoxItem Content="Campbell Powershell"/>
-                                <ComboBoxItem Content="Vintage"/>
-                                <ComboBoxItem Content="One Half Dark"/>
-                                <ComboBoxItem Content="One Half Light"/>
-                                <ComboBoxItem Content="Tango Dark"/>
-                                <ComboBoxItem Content="Tango Light"/>
-                            </ComboBox.Items>
-                        </ComboBox>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBox x:Uid="Profile_BackgroundImage"
+                                 x:Name="BackgroundImage"
+                                 Text="{x:Bind State.Profile.BackgroundImagePath, Mode=TwoWay}"/>
+                        <Button x:Uid="Profile_BackgroundImageBrowse"
+                                Click="BackgroundImage_Click"
+                                Margin="10,0,0,0"/>
                     </StackPanel>
-
-                    <!-- Group 2 of Appearance Settings -->
-                    <StackPanel Grid.Column="1" HorizontalAlignment="Left">
-                        <StackPanel Orientation="Horizontal">
-                            <TextBox x:Uid="Profile_BackgroundImage"
-                                     x:Name="BackgroundImage" Text="{x:Bind State.Profile.BackgroundImagePath, Mode=TwoWay}"/>
-                            <Button x:Uid="Profile_BackgroundImageBrowse"
-                                    Click="BackgroundImage_Click"
-                                    Margin="10,0,0,0"/>
-                        </StackPanel>
-                        <Controls:RadioButtons x:Uid="Profile_BackgroundImageStretchMode"
-                                                   ItemsSource="{x:Bind BackgroundImageStretchModeList, Mode=OneWay}"
-                                                   SelectedItem="{x:Bind CurrentBackgroundImageStretchMode, Mode=TwoWay}"
-                                                   ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
-                        <ComboBox x:Uid="Profile_BackgroundImageAlignment">
-                            <ComboBox.Items>
-                                <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentCenter"/>
-                                <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentLeft"/>
-                                <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentTop"/>
-                                <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentRight"/>
-                                <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentBottom"/>
-                                <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentTopLeft"/>
-                                <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentTopRight"/>
-                                <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentBottomLeft"/>
-                                <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentBottomRight"/>
-                            </ComboBox.Items>
-                        </ComboBox>
-                        <Controls:NumberBox x:Uid="Profile_BackgroundImageOpacity"
-                                            Value="{x:Bind State.Profile.BackgroundImageOpacity, Mode=TwoWay}"
-                                            SmallChange="10"
-                                            LargeChange="25"/>
-                        <CheckBox x:Uid="Profile_UseAcrylic"
-                                  IsChecked="{x:Bind State.Profile.UseAcrylic, Mode=TwoWay}"/>
-                        <Controls:NumberBox x:Uid="Profile_AcrylicOpacity"
-                                            Value="{x:Bind State.Profile.AcrylicOpacity, Mode=TwoWay}"
-                                            SmallChange="0.1"
-                                            LargeChange="0.25"/>
-                        <CheckBox x:Uid="Profile_RetroTerminalEffect"
-                                  IsChecked="{x:Bind State.Profile.RetroTerminalEffect, Mode=TwoWay}"/>
-                    </StackPanel>
-                </Grid>
+                    <Controls:RadioButtons x:Uid="Profile_BackgroundImageStretchMode"
+                                           ItemsSource="{x:Bind BackgroundImageStretchModeList, Mode=OneWay}"
+                                           SelectedItem="{x:Bind CurrentBackgroundImageStretchMode, Mode=TwoWay}"
+                                           ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
+                    <ComboBox x:Uid="Profile_BackgroundImageAlignment">
+                        <ComboBox.Items>
+                            <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentCenter"/>
+                            <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentLeft"/>
+                            <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentTop"/>
+                            <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentRight"/>
+                            <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentBottom"/>
+                            <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentTopLeft"/>
+                            <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentTopRight"/>
+                            <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentBottomLeft"/>
+                            <ComboBoxItem x:Uid="Profile_BackgroundImageAlignmentBottomRight"/>
+                        </ComboBox.Items>
+                    </ComboBox>
+                    <Controls:NumberBox x:Uid="Profile_BackgroundImageOpacity"
+                                        Value="{x:Bind State.Profile.BackgroundImageOpacity, Mode=TwoWay}"
+                                        SmallChange="10"
+                                        LargeChange="25"/>
+                    <CheckBox x:Uid="Profile_UseAcrylic"
+                              IsChecked="{x:Bind State.Profile.UseAcrylic, Mode=TwoWay}"/>
+                    <Controls:NumberBox x:Uid="Profile_AcrylicOpacity"
+                                        Value="{x:Bind State.Profile.AcrylicOpacity, Mode=TwoWay}"
+                                        SmallChange="0.1"
+                                        LargeChange="0.25"/>
+                    <CheckBox x:Uid="Profile_RetroTerminalEffect"
+                              IsChecked="{x:Bind State.Profile.RetroTerminalEffect, Mode=TwoWay}"/>
+                </StackPanel>
             </ScrollViewer>
         </PivotItem>
 

--- a/src/cascadia/TerminalSettingsEditor/Rendering.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Rendering.xaml
@@ -19,9 +19,6 @@ the MIT License. See LICENSE in the project root for license information. -->
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="1*" />
             </Grid.ColumnDefinitions>
-            <TextBlock x:Uid="Globals_Rendering"
-                       Style="{StaticResource SubheaderTextBlockStyle}"
-                       Margin="0,0,0,20" />
             <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,100,0">
                 <TextBlock x:Uid="Globals_RenderingDisclaimer"
                        Style="{StaticResource BodyTextBlockStyle}"

--- a/src/cascadia/TerminalSettingsEditor/Rendering.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Rendering.xaml
@@ -9,23 +9,24 @@ the MIT License. See LICENSE in the project root for license information. -->
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:Controls="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d">
+
+    <Page.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="CommonResources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Page.Resources>
+    
     <ScrollViewer>
-        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-              Margin="0,12,0,0">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" />
-            </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="1*" />
-            </Grid.ColumnDefinitions>
-            <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,100,0">
-                <TextBlock x:Uid="Globals_RenderingDisclaimer"
+        <StackPanel>
+            <TextBlock x:Uid="Globals_RenderingDisclaimer"
                        Style="{StaticResource BodyTextBlockStyle}"
                        Margin="0,0,0,20" />
-                <CheckBox x:Uid="Globals_ForceFullRepaint" IsChecked="{x:Bind State.Globals.ForceFullRepaintRendering, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
-                <CheckBox x:Uid="Globals_SoftwareRendering" IsChecked="{x:Bind State.Globals.SoftwareRendering, Mode=TwoWay}" Margin="0,0,0,20" FontSize="15" ToolTipService.Placement="Mouse" />
-            </StackPanel>
-        </Grid>
+            <CheckBox x:Uid="Globals_ForceFullRepaint"
+                      IsChecked="{x:Bind State.Globals.ForceFullRepaintRendering, Mode=TwoWay}"/>
+            <CheckBox x:Uid="Globals_SoftwareRendering"
+                      IsChecked="{x:Bind State.Globals.SoftwareRendering, Mode=TwoWay}"/>
+        </StackPanel>
     </ScrollViewer>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -150,7 +150,7 @@
   <data name="ColorScheme_BrightYellow.Header" xml:space="preserve">
     <value>Bright yellow</value>
   </data>
-  <data name="ColorScheme_ColorSchemes.Text" xml:space="preserve">
+  <data name="Header_ColorSchemesPage" xml:space="preserve">
     <value>Color schemes</value>
   </data>
   <data name="ColorScheme_CursorColor.Text" xml:space="preserve">
@@ -220,7 +220,7 @@
   <data name="Globals_ForceFullRepaint.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>When checked, the terminal will redraw the entire screen each frame. When unchecked, the terminal will render only the updates to the screen between frames.</value>
   </data>
-  <data name="Globals_GlobalAppearance.Text" xml:space="preserve">
+  <data name="Header_GlobalAppearancePage" xml:space="preserve">
     <value>Global Appearance</value>
   </data>
   <data name="Globals_InitialCols.Header" xml:space="preserve">
@@ -235,7 +235,7 @@
   <data name="Globals_InitialRows.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>The number of rows displayed in the window upon first load.</value>
   </data>
-  <data name="Globals_Interaction.Text" xml:space="preserve">
+  <data name="Header_InteractionPage" xml:space="preserve">
     <value>Interaction</value>
   </data>
   <data name="Globals_LaunchPosition.Header" xml:space="preserve">
@@ -260,7 +260,7 @@
   <data name="Globals_LaunchSizeMaximized.Content" xml:space="preserve">
     <value>Maximized</value>
   </data>
-  <data name="Globals_Rendering.Text" xml:space="preserve">
+  <data name="Header_RenderingPage" xml:space="preserve">
     <value>Rendering</value>
   </data>
   <data name="Globals_RenderingDisclaimer.Text" xml:space="preserve">
@@ -296,7 +296,7 @@
   <data name="Globals_StartOnUserLogin.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>When checked, this enables the launch of Windows Terminal at machine startup.</value>
   </data>
-  <data name="Globals_Startup.Text" xml:space="preserve">
+  <data name="Header_StartupPage" xml:space="preserve">
     <value>Startup</value>
   </data>
   <data name="Globals_TabWidthMode.Header" xml:space="preserve">
@@ -683,5 +683,8 @@
   </data>
   <data name="Globals_DisableDynamicProfiles.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Enables all of the dynamic profile generators, adding their profiles to the list of profiles on startup.</value>
+  </data>
+  <data name="Header_ProfileDefaultsPage" xml:space="preserve">
+    <value>Global Profile Settings</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -150,9 +150,6 @@
   <data name="ColorScheme_BrightYellow.Header" xml:space="preserve">
     <value>Bright yellow</value>
   </data>
-  <data name="Header_ColorSchemesPage" xml:space="preserve">
-    <value>Color schemes</value>
-  </data>
   <data name="ColorScheme_CursorColor.Text" xml:space="preserve">
     <value>Cursor color</value>
   </data>
@@ -220,9 +217,6 @@
   <data name="Globals_ForceFullRepaint.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>When checked, the terminal will redraw the entire screen each frame. When unchecked, the terminal will render only the updates to the screen between frames.</value>
   </data>
-  <data name="Header_GlobalAppearancePage" xml:space="preserve">
-    <value>Global Appearance</value>
-  </data>
   <data name="Globals_InitialCols.Header" xml:space="preserve">
     <value>Columns on first launch (in characters)</value>
   </data>
@@ -234,9 +228,6 @@
   </data>
   <data name="Globals_InitialRows.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>The number of rows displayed in the window upon first load.</value>
-  </data>
-  <data name="Header_InteractionPage" xml:space="preserve">
-    <value>Interaction</value>
   </data>
   <data name="Globals_LaunchPosition.Header" xml:space="preserve">
     <value>Launch position</value>
@@ -259,9 +250,6 @@
   </data>
   <data name="Globals_LaunchSizeMaximized.Content" xml:space="preserve">
     <value>Maximized</value>
-  </data>
-  <data name="Header_RenderingPage" xml:space="preserve">
-    <value>Rendering</value>
   </data>
   <data name="Globals_RenderingDisclaimer.Text" xml:space="preserve">
     <value>These settings may be useful for troubleshooting an issue, however they will impact your performance.</value>
@@ -295,9 +283,6 @@
   </data>
   <data name="Globals_StartOnUserLogin.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>When checked, this enables the launch of Windows Terminal at machine startup.</value>
-  </data>
-  <data name="Header_StartupPage" xml:space="preserve">
-    <value>Startup</value>
   </data>
   <data name="Globals_TabWidthMode.Header" xml:space="preserve">
     <value>Tab width mode</value>
@@ -683,8 +668,5 @@
   </data>
   <data name="Globals_DisableDynamicProfiles.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Enables all of the dynamic profile generators, adding their profiles to the list of profiles on startup.</value>
-  </data>
-  <data name="Header_ProfileDefaultsPage" xml:space="preserve">
-    <value>Global Profile Settings</value>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -403,37 +403,37 @@
   <data name="Profile_BackgroundImage.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Sets the file location of the image to draw over the window background.</value>
   </data>
-  <data name="Profile_BackgroundImageAlignment.Content" xml:space="preserve">
+  <data name="Profile_BackgroundImageAlignment.Header" xml:space="preserve">
     <value>Background image alignment</value>
   </data>
   <data name="Profile_BackgroundImageAlignment.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Sets how the background image aligns to the boundaries of the window.</value>
   </data>
-  <data name="Profile_BackgroundImageAlignmentBottom.Text" xml:space="preserve">
+  <data name="Profile_BackgroundImageAlignmentBottom.Content" xml:space="preserve">
     <value>Bottom</value>
   </data>
-  <data name="Profile_BackgroundImageAlignmentBottomLeft.Text" xml:space="preserve">
+  <data name="Profile_BackgroundImageAlignmentBottomLeft.Content" xml:space="preserve">
     <value>Bottom left</value>
   </data>
-  <data name="Profile_BackgroundImageAlignmentBottomRight.Text" xml:space="preserve">
+  <data name="Profile_BackgroundImageAlignmentBottomRight.Content" xml:space="preserve">
     <value>Bottom right</value>
   </data>
-  <data name="Profile_BackgroundImageAlignmentCenter.Text" xml:space="preserve">
+  <data name="Profile_BackgroundImageAlignmentCenter.Content" xml:space="preserve">
     <value>Center</value>
   </data>
-  <data name="Profile_BackgroundImageAlignmentLeft.Text" xml:space="preserve">
+  <data name="Profile_BackgroundImageAlignmentLeft.Content" xml:space="preserve">
     <value>Left</value>
   </data>
-  <data name="Profile_BackgroundImageAlignmentRight.Text" xml:space="preserve">
+  <data name="Profile_BackgroundImageAlignmentRight.Content" xml:space="preserve">
     <value>Right</value>
   </data>
-  <data name="Profile_BackgroundImageAlignmentTop.Text" xml:space="preserve">
+  <data name="Profile_BackgroundImageAlignmentTop.Content" xml:space="preserve">
     <value>Top</value>
   </data>
-  <data name="Profile_BackgroundImageAlignmentTopLeft.Text" xml:space="preserve">
+  <data name="Profile_BackgroundImageAlignmentTopLeft.Content" xml:space="preserve">
     <value>Top left</value>
   </data>
-  <data name="Profile_BackgroundImageAlignmentTopRight.Text" xml:space="preserve">
+  <data name="Profile_BackgroundImageAlignmentTopRight.Content" xml:space="preserve">
     <value>Top right</value>
   </data>
   <data name="Profile_BackgroundImageBrowse.Content" xml:space="preserve">
@@ -478,7 +478,7 @@
   <data name="Profile_CloseOnExitNever.Content" xml:space="preserve">
     <value>Never</value>
   </data>
-  <data name="Profile_ColorScheme.Content" xml:space="preserve">
+  <data name="Profile_ColorScheme.Header" xml:space="preserve">
     <value>Color scheme</value>
   </data>
   <data name="Profile_ColorScheme.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">


### PR DESCRIPTION
## Summary of the Pull Request
This PR performs a wholistic polish on the Settings UI by doing the following:
- Use NavigationView's header to display which page you are currently on (and style it appropriately)
- Remove back button (deemed unnecessary)
- Rely more heavily on CommonResources.xaml for consistent styling
- Replace `profile.schemes` and `profile.backgroundImageAlignment` with ComboBox controls (still not bound)
- Replace Profile-->Appearance page grid layout with a stack
  - I know we desire a reflowable 2-column layout. But that's just too much work for now. I'm focusing on getting the Settings UI in a mergeable/shippable state.
- General code cleanup (particular focus on .xaml files)

Rather than posting many photos of all the changes, I suggest that you (the reviewer) just download and play with the branch. We shouldn't have any more weird resize scenarios.

## References
#1564 - Settings UI