### PR TITLE
align command palette prefix > to left when visible

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.xaml
+++ b/src/cascadia/TerminalApp/CommandPalette.xaml
@@ -178,6 +178,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                 x:Name="_prefixCharacter"
                 Margin="16,16,0,-8"
                 FontSize="14"
+                HorizontalAlignment="Left"
                 Visibility="{x:Bind PrefixCharacter,
                              Mode=OneWay,
                              Converter={StaticResource ParentCommandVisibilityConverter}}"
@@ -185,7 +186,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                 >
             </TextBlock>
 
-          <StackPanel Orientation="Horizontal"
+            <StackPanel Orientation="Horizontal"
                     Padding="16, 0, 16, 4"
                     Grid.Row="1"
                     Visibility="{x:Bind ParentCommandName,
@@ -199,9 +200,9 @@ the MIT License. See LICENSE in the project root for license information. -->
                     Click="_moveBackButtonClicked"
                     ClickMode="Press"
                     VerticalAlignment="Center">
-                    <FontIcon 
+                    <FontIcon
                         FontSize="12"
-                        FontFamily="Segoe MDL2 Assets" 
+                        FontFamily="Segoe MDL2 Assets"
                         Glyph="&#xE76b;">
                     </FontIcon>
                 </Button>
@@ -267,7 +268,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                                     Grid.Column="1"
                                     HorizontalAlignment="Left"
                                     Text="{x:Bind HighlightedName, Mode=OneWay}"/>
-                                
+
                                 <!-- The block for the key chord is only visible
                                 when there's actual text set as the label. See
                                 CommandKeyChordVisibilityConverter for details. -->


### PR DESCRIPTION
Fixes the clear button to clear the typed command not clickable in the
command palette.

- From the primary investigation it looked like the `TextBlock` element
  introduced in #7935 was somehow blocking (appearing on top of) the
  clear button.
- It was also blocking the command palette input field from being able
  to access which was preventing the text in the input field from being
  selected and the cursor would still show as `pointer` cursor instead
  of a `text selection` cursor
- Adding `HorizontalAlignment="Left"` property to the above-mentioned
  `TextBlock` element fixed the issue.

## Validation Steps Performed
- Created the Dev build for `x64` in Visual Studio and verified the
  functionality manually.

Closes #8220