### PR TITLE
Add a setting to disable automatic pattern detection

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -963,6 +963,11 @@
           "description": "By default Windows treats Ctrl+Alt as an alias for AltGr. When altGrAliasing is set to false, this behavior will be disabled.",
           "type": "boolean"
         },
+        "detectPatterns": {
+          "default": true,
+          "description": "By default, we detect URLs in the application and make them clickable. When detectPatterns is set to false, this behavior will be disabled.",
+          "type": "boolean"
+        }
         "source": {
           "description": "Stores the name of the profile generator that originated this profile.",
           "type": ["string", "null"]

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -963,9 +963,9 @@
           "description": "By default Windows treats Ctrl+Alt as an alias for AltGr. When altGrAliasing is set to false, this behavior will be disabled.",
           "type": "boolean"
         },
-        "detectPatterns": {
+        "detectHyperlinks": {
           "default": true,
-          "description": "By default, we detect URLs in the application and make them clickable. When detectPatterns is set to false, this behavior will be disabled.",
+          "description": "By default, we detect URLs in the application and make them clickable. When detectHyperlinks is set to false, this behavior will be disabled.",
           "type": "boolean"
         }
         "source": {

--- a/src/cascadia/TerminalApp/TerminalSettings.cpp
+++ b/src/cascadia/TerminalApp/TerminalSettings.cpp
@@ -95,6 +95,7 @@ namespace winrt::TerminalApp::implementation
         _Commandline = profile.Commandline();
 
         _StartingDirectory = profile.EvaluatedStartingDirectory();
+        _DetectPatterns = profile.DetectPatterns();
 
         // GH#2373: Use the tabTitle as the starting title if it exists, otherwise
         // use the profile name

--- a/src/cascadia/TerminalApp/TerminalSettings.cpp
+++ b/src/cascadia/TerminalApp/TerminalSettings.cpp
@@ -95,7 +95,7 @@ namespace winrt::TerminalApp::implementation
         _Commandline = profile.Commandline();
 
         _StartingDirectory = profile.EvaluatedStartingDirectory();
-        _DetectPatterns = profile.DetectPatterns();
+        _DetectHyperlinks = profile.DetectHyperlinks();
 
         // GH#2373: Use the tabTitle as the starting title if it exists, otherwise
         // use the profile name

--- a/src/cascadia/TerminalApp/TerminalSettings.h
+++ b/src/cascadia/TerminalApp/TerminalSettings.h
@@ -99,7 +99,7 @@ namespace winrt::TerminalApp::implementation
         GETSET_PROPERTY(hstring, Commandline);
         GETSET_PROPERTY(hstring, StartingDirectory);
         GETSET_PROPERTY(hstring, StartingTitle);
-        GETSET_PROPERTY(bool, DetectPatterns);
+        GETSET_PROPERTY(bool, DetectHyperlinks);
         GETSET_PROPERTY(bool, SuppressApplicationTitle);
         GETSET_PROPERTY(hstring, EnvironmentVariables);
 

--- a/src/cascadia/TerminalApp/TerminalSettings.h
+++ b/src/cascadia/TerminalApp/TerminalSettings.h
@@ -99,6 +99,7 @@ namespace winrt::TerminalApp::implementation
         GETSET_PROPERTY(hstring, Commandline);
         GETSET_PROPERTY(hstring, StartingDirectory);
         GETSET_PROPERTY(hstring, StartingTitle);
+        GETSET_PROPERTY(bool, DetectPatterns);
         GETSET_PROPERTY(bool, SuppressApplicationTitle);
         GETSET_PROPERTY(hstring, EnvironmentVariables);
 

--- a/src/cascadia/TerminalCore/ICoreSettings.idl
+++ b/src/cascadia/TerminalCore/ICoreSettings.idl
@@ -24,7 +24,7 @@ namespace Microsoft.Terminal.TerminalControl
 
         Boolean SnapOnInput;
         Boolean AltGrAliasing;
-        Boolean DetectPatterns;
+        Boolean DetectHyperlinks;
 
         UInt32 CursorColor;
         CursorStyle CursorShape;

--- a/src/cascadia/TerminalCore/ICoreSettings.idl
+++ b/src/cascadia/TerminalCore/ICoreSettings.idl
@@ -24,6 +24,7 @@ namespace Microsoft.Terminal.TerminalControl
 
         Boolean SnapOnInput;
         Boolean AltGrAliasing;
+        Boolean DetectPatterns;
 
         UInt32 CursorColor;
         CursorStyle CursorShape;

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -80,10 +80,6 @@ void Terminal::Create(COORD viewportSize, SHORT scrollbackLines, IRenderTarget& 
     const TextAttribute attr{};
     const UINT cursorSize = 12;
     _buffer = std::make_unique<TextBuffer>(bufferSize, attr, cursorSize, renderTarget);
-    // Add regex pattern recognizers to the buffer
-    // For now, we only add the URI regex pattern
-    std::wstring_view linkPattern{ LR"(\b(https?|ftp|file)://[-A-Za-z0-9+&@#/%?=~_|$!:,.;]*[A-Za-z0-9+&@#/%=~_|$])" };
-    _hyperlinkPatternId = _buffer->AddPatternRecognizer(linkPattern);
 }
 
 // Method Description:
@@ -101,6 +97,14 @@ void Terminal::CreateFromSettings(ICoreSettings settings,
     Create(viewportSize, Utils::ClampToShortMax(settings.HistorySize(), 0), renderTarget);
 
     UpdateSettings(settings);
+
+    if (settings.DetectPatterns())
+    {
+        // Add regex pattern recognizers to the buffer
+        // For now, we only add the URI regex pattern
+        std::wstring_view linkPattern{ LR"(\b(https?|ftp|file)://[-A-Za-z0-9+&@#/%?=~_|$!:,.;]*[A-Za-z0-9+&@#/%=~_|$])" };
+        _hyperlinkPatternId = _buffer->AddPatternRecognizer(linkPattern);
+    }
 }
 
 // Method Description:

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -98,7 +98,7 @@ void Terminal::CreateFromSettings(ICoreSettings settings,
 
     UpdateSettings(settings);
 
-    if (settings.DetectPatterns())
+    if (settings.DetectHyperlinks())
     {
         // Add regex pattern recognizers to the buffer
         // For now, we only add the URI regex pattern

--- a/src/cascadia/TerminalSettingsModel/Profile.cpp
+++ b/src/cascadia/TerminalSettingsModel/Profile.cpp
@@ -58,6 +58,7 @@ static constexpr std::string_view RetroTerminalEffectKey{ "experimental.retroTer
 static constexpr std::string_view AntialiasingModeKey{ "antialiasingMode" };
 static constexpr std::string_view TabColorKey{ "tabColor" };
 static constexpr std::string_view BellStyleKey{ "bellStyle" };
+static constexpr std::string_view DetectPatternsKey{ "detectPatterns" };
 
 static constexpr std::wstring_view DesktopWallpaperEnum{ L"desktopWallpaper" };
 
@@ -109,6 +110,7 @@ winrt::com_ptr<Profile> Profile::CopySettings(winrt::com_ptr<Profile> source)
     profile->_CursorShape = source->_CursorShape;
     profile->_CursorHeight = source->_CursorHeight;
     profile->_BellStyle = source->_BellStyle;
+    profile->_DetectPatterns = source->_DetectPatterns;
     profile->_BackgroundImageAlignment = source->_BackgroundImageAlignment;
     profile->_ConnectionType = source->_ConnectionType;
 
@@ -337,6 +339,7 @@ void Profile::LayerJson(const Json::Value& json)
     JsonUtils::GetValueForKey(json, TabColorKey, _TabColor);
 
     JsonUtils::GetValueForKey(json, BellStyleKey, _BellStyle);
+    JsonUtils::GetValueForKey(json, DetectPatternsKey, _DetectPatterns);
 }
 
 // Method Description:

--- a/src/cascadia/TerminalSettingsModel/Profile.cpp
+++ b/src/cascadia/TerminalSettingsModel/Profile.cpp
@@ -58,7 +58,7 @@ static constexpr std::string_view RetroTerminalEffectKey{ "experimental.retroTer
 static constexpr std::string_view AntialiasingModeKey{ "antialiasingMode" };
 static constexpr std::string_view TabColorKey{ "tabColor" };
 static constexpr std::string_view BellStyleKey{ "bellStyle" };
-static constexpr std::string_view DetectPatternsKey{ "detectPatterns" };
+static constexpr std::string_view DetectHyperlinksKey{ "detectHyperlinks" };
 
 static constexpr std::wstring_view DesktopWallpaperEnum{ L"desktopWallpaper" };
 
@@ -110,7 +110,7 @@ winrt::com_ptr<Profile> Profile::CopySettings(winrt::com_ptr<Profile> source)
     profile->_CursorShape = source->_CursorShape;
     profile->_CursorHeight = source->_CursorHeight;
     profile->_BellStyle = source->_BellStyle;
-    profile->_DetectPatterns = source->_DetectPatterns;
+    profile->_DetectHyperlinks = source->_DetectHyperlinks;
     profile->_BackgroundImageAlignment = source->_BackgroundImageAlignment;
     profile->_ConnectionType = source->_ConnectionType;
 
@@ -340,7 +340,7 @@ void Profile::LayerJson(const Json::Value& json)
     JsonUtils::GetValueForKey(json, TabColorKey, _TabColor);
 
     JsonUtils::GetValueForKey(json, BellStyleKey, _BellStyle);
-    JsonUtils::GetValueForKey(json, DetectPatternsKey, _DetectPatterns);
+    JsonUtils::GetValueForKey(json, DetectHyperlinksKey, _DetectHyperlinks);
 }
 
 // Method Description:
@@ -580,6 +580,7 @@ Json::Value Profile::ToJson() const
     JsonUtils::SetValueForKey(json, AntialiasingModeKey, _AntialiasingMode);
     JsonUtils::SetValueForKey(json, TabColorKey, _TabColor);
     JsonUtils::SetValueForKey(json, BellStyleKey, _BellStyle);
+    JsonUtils::SetValueForKey(json, DetectHyperlinksKey, _DetectHyperlinks);
 
     return json;
 }

--- a/src/cascadia/TerminalSettingsModel/Profile.h
+++ b/src/cascadia/TerminalSettingsModel/Profile.h
@@ -119,7 +119,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         GETSET_SETTING(Model::BellStyle, BellStyle, BellStyle::Audible);
 
-        GETSET_SETTING(bool, DetectPatterns, true);
+        GETSET_SETTING(bool, DetectHyperlinks, true);
 
     private:
         std::optional<std::tuple<Windows::UI::Xaml::HorizontalAlignment, Windows::UI::Xaml::VerticalAlignment>> _BackgroundImageAlignment{ std::nullopt };

--- a/src/cascadia/TerminalSettingsModel/Profile.h
+++ b/src/cascadia/TerminalSettingsModel/Profile.h
@@ -119,6 +119,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         GETSET_SETTING(Model::BellStyle, BellStyle, BellStyle::Audible);
 
+        GETSET_SETTING(bool, DetectPatterns, true);
+
     private:
         std::optional<std::tuple<Windows::UI::Xaml::HorizontalAlignment, Windows::UI::Xaml::VerticalAlignment>> _BackgroundImageAlignment{ std::nullopt };
         std::optional<std::tuple<Windows::UI::Xaml::HorizontalAlignment, Windows::UI::Xaml::VerticalAlignment>> _getBackgroundImageAlignmentImpl() const

--- a/src/cascadia/TerminalSettingsModel/Profile.idl
+++ b/src/cascadia/TerminalSettingsModel/Profile.idl
@@ -172,5 +172,9 @@ namespace Microsoft.Terminal.Settings.Model
         Boolean HasBellStyle();
         void ClearBellStyle();
         BellStyle BellStyle;
+
+        Boolean HasDetectPatterns();
+        void ClearDetectPatterns();
+        Boolean DetectPatterns;
     }
 }

--- a/src/cascadia/TerminalSettingsModel/Profile.idl
+++ b/src/cascadia/TerminalSettingsModel/Profile.idl
@@ -173,8 +173,8 @@ namespace Microsoft.Terminal.Settings.Model
         void ClearBellStyle();
         BellStyle BellStyle;
 
-        Boolean HasDetectPatterns();
-        void ClearDetectPatterns();
-        Boolean DetectPatterns;
+        Boolean HasDetectHyperlinks();
+        void ClearDetectHyperlinks();
+        Boolean DetectHyperlinks;
     }
 }

--- a/src/cascadia/UnitTests_TerminalCore/MockTermSettings.h
+++ b/src/cascadia/UnitTests_TerminalCore/MockTermSettings.h
@@ -30,7 +30,7 @@ namespace TerminalCoreUnitTests
         uint32_t DefaultBackground() { return COLOR_BLACK; }
         bool SnapOnInput() { return false; }
         bool AltGrAliasing() { return true; }
-        bool DetectPatterns() { return true; }
+        bool DetectHyperlinks() { return true; }
         uint32_t CursorColor() { return COLOR_WHITE; }
         CursorStyle CursorShape() const noexcept { return CursorStyle::Vintage; }
         uint32_t CursorHeight() { return 42UL; }
@@ -52,7 +52,7 @@ namespace TerminalCoreUnitTests
         void DefaultBackground(uint32_t) {}
         void SnapOnInput(bool) {}
         void AltGrAliasing(bool) {}
-        void DetectPatterns(bool) {}
+        void DetectHyperlinks(bool) {}
         void CursorColor(uint32_t) {}
         void CursorShape(CursorStyle const&) noexcept {}
         void CursorHeight(uint32_t) {}

--- a/src/cascadia/UnitTests_TerminalCore/MockTermSettings.h
+++ b/src/cascadia/UnitTests_TerminalCore/MockTermSettings.h
@@ -30,6 +30,7 @@ namespace TerminalCoreUnitTests
         uint32_t DefaultBackground() { return COLOR_BLACK; }
         bool SnapOnInput() { return false; }
         bool AltGrAliasing() { return true; }
+        bool DetectPatterns() { return true; }
         uint32_t CursorColor() { return COLOR_WHITE; }
         CursorStyle CursorShape() const noexcept { return CursorStyle::Vintage; }
         uint32_t CursorHeight() { return 42UL; }
@@ -51,6 +52,7 @@ namespace TerminalCoreUnitTests
         void DefaultBackground(uint32_t) {}
         void SnapOnInput(bool) {}
         void AltGrAliasing(bool) {}
+        void DetectPatterns(bool) {}
         void CursorColor(uint32_t) {}
         void CursorShape(CursorStyle const&) noexcept {}
         void CursorHeight(uint32_t) {}


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds a new setting, `detectPatterns`, which takes a bool value indicating whether we should automatically detect patterns

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
#5001 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I work here

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual validation