### PR TITLE
Set Tab tooltip explicitly

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -290,8 +290,7 @@ namespace winrt::TerminalApp::implementation
                                          Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e)
     {
         auto key = e.OriginalKey();
-        auto const ctrlDown = WI_IsFlagSet(CoreWindow::GetForCurrentThread().GetKeyState(winrt::Windows::System::VirtualKey::Control), CoreVirtualKeyStates::Down);
-
+        
         if (key == VirtualKey::Up)
         {
             // Action Mode: Move focus to the next item in the list.

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -290,7 +290,7 @@ namespace winrt::TerminalApp::implementation
                                          Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e)
     {
         auto key = e.OriginalKey();
-        
+
         if (key == VirtualKey::Up)
         {
             // Action Mode: Move focus to the next item in the list.

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -290,6 +290,7 @@ namespace winrt::TerminalApp::implementation
                                          Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e)
     {
         auto key = e.OriginalKey();
+        auto const ctrlDown = WI_IsFlagSet(CoreWindow::GetForCurrentThread().GetKeyState(winrt::Windows::System::VirtualKey::Control), CoreVirtualKeyStates::Down);
 
         if (key == VirtualKey::Up)
         {

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -45,10 +45,9 @@ namespace winrt::TerminalApp::implementation
                 tab->SetTabText(title);
             }
         });
-
         // Use our header control as the TabViewItem's header
         TabViewItem().Header(_headerControl);
-        
+        _SetToolTip(_GetActiveTitle());
     }
 
     // Method Description:
@@ -239,7 +238,6 @@ namespace winrt::TerminalApp::implementation
 
             // Update the control to reflect the changed title
             _headerControl.Title(activeTitle);
-            _SetToolTip(_GetActiveTitle());
         }
     }
 
@@ -297,6 +295,7 @@ namespace winrt::TerminalApp::implementation
         // possible that the focus events won't propagate immediately. Updating
         // the focus here will give the same effect though.
         _UpdateActivePane(second);
+        _SetToolTip(_GetActiveTitle());
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -47,7 +47,6 @@ namespace winrt::TerminalApp::implementation
         });
         // Use our header control as the TabViewItem's header
         TabViewItem().Header(_headerControl);
-        _SetToolTip(_GetActiveTitle());
     }
 
     // Method Description:
@@ -238,6 +237,7 @@ namespace winrt::TerminalApp::implementation
 
             // Update the control to reflect the changed title
             _headerControl.Title(activeTitle);
+            _SetToolTip(activeTitle);
         }
     }
 
@@ -295,7 +295,6 @@ namespace winrt::TerminalApp::implementation
         // possible that the focus events won't propagate immediately. Updating
         // the focus here will give the same effect though.
         _UpdateActivePane(second);
-        _SetToolTip(_GetActiveTitle());
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -72,7 +72,7 @@ namespace winrt::TerminalApp::implementation
 
     void TerminalTab::_SetToolTip(const winrt::hstring& tabTitle)
     {
-        auto toolTip = WUX::Controls::ToolTip{};
+        WUX::Controls::ToolTip toolTip{};
         toolTip.Content(winrt::box_value(tabTitle));
         WUX::Controls::ToolTipService::SetToolTip(TabViewItem(), toolTip);
     }

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -71,6 +71,17 @@ namespace winrt::TerminalApp::implementation
         _RecalculateAndApplyTabColor();
     }
 
+    void TerminalTab::_SetToolTip(const winrt::hstring& tabTitle)
+    {
+        auto toolTip = WUX::Controls::ToolTip{};
+        auto newTabRun = WUX::Documents::Run();
+        newTabRun.Text(tabTitle);
+        auto textBlock = WUX::Controls::TextBlock{};
+        textBlock.Inlines().Append(newTabRun);
+        toolTip.Content(textBlock);
+        WUX::Controls::ToolTipService::SetToolTip(TabViewItem(), toolTip);
+    }
+
     // Method Description:
     // - Returns nullptr if no children of this tab were the last control to be
     //   focused, or the TermControl that _was_ the last control to be focused (if
@@ -231,6 +242,7 @@ namespace winrt::TerminalApp::implementation
 
             // Update the control to reflect the changed title
             _headerControl.Title(activeTitle);
+            _SetToolTip(_GetActiveTitle());
         }
     }
 

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -48,6 +48,7 @@ namespace winrt::TerminalApp::implementation
 
         // Use our header control as the TabViewItem's header
         TabViewItem().Header(_headerControl);
+        
     }
 
     // Method Description:
@@ -74,11 +75,7 @@ namespace winrt::TerminalApp::implementation
     void TerminalTab::_SetToolTip(const winrt::hstring& tabTitle)
     {
         auto toolTip = WUX::Controls::ToolTip{};
-        auto newTabRun = WUX::Documents::Run();
-        newTabRun.Text(tabTitle);
-        auto textBlock = WUX::Controls::TextBlock{};
-        textBlock.Inlines().Append(newTabRun);
-        toolTip.Content(textBlock);
+        toolTip.Content(winrt::box_value(tabTitle));
         WUX::Controls::ToolTipService::SetToolTip(TabViewItem(), toolTip);
     }
 

--- a/src/cascadia/TerminalApp/TerminalTab.h
+++ b/src/cascadia/TerminalApp/TerminalTab.h
@@ -93,6 +93,8 @@ namespace winrt::TerminalApp::implementation
 
         void _MakeTabViewItem();
 
+        void _SetToolTip(const winrt::hstring& tabTitle);
+
         void _CreateContextMenu() override;
 
         void _RefreshVisualState();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The tab tooltip is no longer empty when it was toggle zoomed.
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #8199 
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
