### PR TITLE
Add "recent commands" to Command Palette in commandline mode

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -304,21 +304,9 @@ namespace winrt::TerminalApp::implementation
         }
         else if (key == VirtualKey::Enter)
         {
-            // Action, TabSwitch or TabSearchMode Mode: Dispatch the action of the selected command.
-            if (_currentMode != CommandPaletteMode::CommandlineMode)
-            {
-                const auto selectedCommand = _filteredActionsView().SelectedItem();
-                if (const auto filteredCommand = selectedCommand.try_as<winrt::TerminalApp::FilteredCommand>())
-                {
-                    _dispatchCommand(filteredCommand);
-                }
-            }
-            // Commandline Mode: Use the input to synthesize an ExecuteCommandline action
-            else if (_currentMode == CommandPaletteMode::CommandlineMode)
-            {
-                _dispatchCommandline();
-            }
-
+            const auto selectedCommand = _filteredActionsView().SelectedItem();
+            const auto filteredCommand = selectedCommand.try_as<winrt::TerminalApp::FilteredCommand>();
+            _dispatchCommand(filteredCommand);
             e.Handled(true);
         }
         else if (key == VirtualKey::Escape)
@@ -556,7 +544,11 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     void CommandPalette::_dispatchCommand(winrt::TerminalApp::FilteredCommand const& filteredCommand)
     {
-        if (filteredCommand)
+        if (_currentMode == CommandPaletteMode::CommandlineMode)
+        {
+            _dispatchCommandline(filteredCommand);
+        }
+        else if (filteredCommand)
         {
             if (filteredCommand.Command().HasNestedCommands())
             {
@@ -629,47 +621,48 @@ namespace winrt::TerminalApp::implementation
     // Method Description:
     // - Dispatch the current search text as a ExecuteCommandline action.
     // Arguments:
-    // - <none>
+    // - filteredCommand - Selected filtered command - might be null
     // Return Value:
     // - <none>
-    void CommandPalette::_dispatchCommandline()
+    void CommandPalette::_dispatchCommandline(winrt::TerminalApp::FilteredCommand const& command)
     {
-        const auto selectedCommand = _filteredActionsView().SelectedItem();
-        auto filteredCommand = selectedCommand.try_as<winrt::TerminalApp::FilteredCommand>();
-        if (!filteredCommand)
+        const auto filteredCommand = command ? command : _buildCommandLineCommand(_getTrimmedInput());
+        if (filteredCommand.has_value())
         {
-            auto cmdline{ _getTrimmedInput() };
-            if (cmdline.empty())
+            if (_commandLineHistory.Size() == CommandLineHistoryLength)
             {
-                return;
+                _commandLineHistory.RemoveAtEnd();
             }
+            _commandLineHistory.InsertAt(0, filteredCommand.value());
 
-            // Build the ExecuteCommandline action from the values we've parsed on the commandline.
-            ExecuteCommandlineArgs args{ cmdline };
-            ActionAndArgs executeActionAndArgs{ ShortcutAction::ExecuteCommandline, args };
-            Command command{};
-            command.Action(executeActionAndArgs);
-            command.Name(cmdline);
-            filteredCommand = winrt::make<FilteredCommand>(command);
+            TraceLoggingWrite(
+                g_hTerminalAppProvider, // handle to TerminalApp tracelogging provider
+                "CommandPaletteDispatchedCommandline",
+                TraceLoggingDescription("Event emitted when the user runs a commandline in the Command Palette"),
+                TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
+
+            if (_dispatch.DoAction(filteredCommand.value().Command().Action()))
+            {
+                _close();
+            }
         }
+    }
 
-        if (_commandLineHistory.Size() == CommandLineHistoryLength)
+    std::optional<winrt::TerminalApp::FilteredCommand> CommandPalette::_buildCommandLineCommand(std::wstring const& commandLine)
+    {
+        if (commandLine.empty())
         {
-            _commandLineHistory.RemoveAtEnd();
+            return std::nullopt;
         }
-        _commandLineHistory.InsertAt(0, filteredCommand);
 
-        TraceLoggingWrite(
-            g_hTerminalAppProvider, // handle to TerminalApp tracelogging provider
-            "CommandPaletteDispatchedCommandline",
-            TraceLoggingDescription("Event emitted when the user runs a commandline in the Command Palette"),
-            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
-            TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
-
-        if (_dispatch.DoAction(filteredCommand.Command().Action()))
-        {
-            _close();
-        }
+        // Build the ExecuteCommandline action from the values we've parsed on the commandline.
+        ExecuteCommandlineArgs args{ commandLine };
+        ActionAndArgs executeActionAndArgs{ ShortcutAction::ExecuteCommandline, args };
+        Command command{};
+        command.Action(executeActionAndArgs);
+        command.Name(commandLine);
+        return winrt::make<FilteredCommand>(command);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -117,7 +117,9 @@ namespace winrt::TerminalApp::implementation
         winrt::Windows::UI::Xaml::Controls::ListView::SizeChanged_revoker _sizeChangedRevoker;
 
         void _dispatchCommand(winrt::TerminalApp::FilteredCommand const& command);
-        void _dispatchCommandline();
+        void _dispatchCommandline(winrt::TerminalApp::FilteredCommand const& command);
+        std::optional<winrt::TerminalApp::FilteredCommand> _buildCommandLineCommand(std::wstring const& commandLine);
+
         void _dismissPalette();
 
         void _scrollToIndex(uint32_t index);

--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -123,6 +123,9 @@ namespace winrt::TerminalApp::implementation
         void _scrollToIndex(uint32_t index);
         uint32_t _getNumVisibleItems();
 
+        static constexpr int CommandLineHistoryLength = 10;
+        Windows::Foundation::Collections::IVector<winrt::TerminalApp::FilteredCommand> _commandLineHistory{ nullptr };
+
         friend class TerminalAppLocalTests::TabTests;
     };
 }


### PR DESCRIPTION
## Summary of the Pull Request
Add a history to command palette in the command line mode.
Few considerations/limitations
1. In-memory, 10 entries hard-coded
2. MRU
3. List rather than set
4. The user needs explicitly select command from the history

## PR Checklist
* [x] Closes https://github.com/microsoft/terminal/issues/8296
* [x] CLA signed. 
* [x] Tests added/passed
* [ ] Documentation updated - irrelevant
* [ ] Schema updated - irrelevant
* [ ] I've discussed this with core contributors already. 

## Validation Steps Performed
* Manual testing