### PR TITLE
Revert tab switching to *off* in 1.4

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -620,7 +620,7 @@
           "type": "boolean"
         },
         "useTabSwitcher": {
-          "default": true,
+          "default": false,
           "description": "When set to \"true\", the \"nextTab\" and \"prevTab\" commands will use the tab switcher UI.",
           "type": "boolean"
         }

--- a/src/cascadia/TerminalApp/GlobalAppSettings.h
+++ b/src/cascadia/TerminalApp/GlobalAppSettings.h
@@ -75,7 +75,7 @@ namespace winrt::TerminalApp::implementation
         GETSET_PROPERTY(bool, DebugFeaturesEnabled); // default value set in constructor
         GETSET_PROPERTY(bool, StartOnUserLogin, false);
         GETSET_PROPERTY(bool, AlwaysOnTop, false);
-        GETSET_PROPERTY(bool, UseTabSwitcher, true);
+        GETSET_PROPERTY(bool, UseTabSwitcher, false);
 
     private:
         hstring _unparsedDefaultProfile;

--- a/src/cascadia/TerminalApp/defaults.json
+++ b/src/cascadia/TerminalApp/defaults.json
@@ -18,7 +18,7 @@
     "showTabsInTitlebar": true,
     "showTerminalTitleInTitlebar": true,
     "tabWidthMode": "equal",
-    "useTabSwitcher": true,
+    "useTabSwitcher": false,
 
     // Miscellaneous
     "confirmCloseAllTabs": true,


### PR DESCRIPTION
Revert the tab switcher behavior for 1.4.

The default is once again `"useTabSwitcher":false`, since we
ninja-changed `true` to MRU switching. That was maybe a bad call. 