### PR TITLE
tools: update bcz.cmd to use the progress bar VT sequence

### DIFF
--- a/tools/bcz.cmd
+++ b/tools/bcz.cmd
@@ -79,7 +79,7 @@ echo Starting build...
 
 @rem start indeterminate progress in the taskbar
 @rem this `<NUL set /p =` magic will output the text _without a newline_
-<NUL set /p =]9;4;3;0
+<NUL set /p =]9;4;3
 
 %_BUILD_CMDLINE%
 
@@ -88,7 +88,7 @@ set _build_result=%errorlevel%
 if (%_build_result%) == (0) (
 
 @rem clear the progress
-<NUL set /p =]9;4;0;0
+<NUL set /p =]9;4
 
 ) else (
 
@@ -103,7 +103,7 @@ if (%_build_result%) == (0) (
 
 ping 128.0.0.1 -n 1 -w 500 > nul
 
-<NUL set /p =]9;4;0;0
+<NUL set /p =]9;4
 
 )
 

--- a/tools/bcz.cmd
+++ b/tools/bcz.cmd
@@ -76,13 +76,46 @@ set _BUILD_CMDLINE="%MSBUILD%" %OPENCON%\OpenConsole.sln /t:"%_MSBUILD_TARGET%" 
 
 echo %_BUILD_CMDLINE%
 echo Starting build...
+
+@rem start indeterminate progress in the taskbar
+@rem this `<NUL set /p =` magic will output the text _without a newline_
+<NUL set /p =]9;4;3;0
+
 %_BUILD_CMDLINE%
+
+@rem capture the return value of msbuild, so we can return that as our return value.
+set _build_result=%errorlevel%
+if (%_build_result%) == (0) (
+
+@rem clear the progress
+<NUL set /p =]9;4;0;0
+
+) else (
+
+@rem set the taskbar to the error state, then sleep for 500ms, before clearing
+@rem the progress state. This will "blink" the error state into the taskbar
+
+<NUL set /p =]9;4;2;100
+
+@rem this works to "sleep" the console for 500ms. `ping` can't wait for less
+@rem than 500ms, and it will only wait if the target address _doesn't_ respond,
+@rem hence why we're using 128., not 127.
+
+ping 128.0.0.1 -n 1 -w 500 > nul
+
+<NUL set /p =]9;4;0;0
+
+)
 
 rem Cleanup unused variables here. Note we cannot use setlocal because we need to pass modified
 rem _LAST_BUILD_CONF out to OpenCon.cmd later.
 rem
 set _MSBUILD_TARGET=
 set _BIN_=%~dp0\bin\%PLATFORM%\%_LAST_BUILD_CONF%
+
+@rem Exit with the value from msbuild. If msbuild is unsuccessful in building, this will be 1
+EXIT /b %_build_result%
+
 goto :eof
 
 rem ############################################################################


### PR DESCRIPTION
## Summary of the Pull Request

Does what the title says. Now while you're building terminal projects,
the taskbar will show indeterminate progress. If the build fails, it'll
blink the error state for 500ms before returning to normal.

## References
* Made possible by #8055 _and viewers like you_

## PR Checklist
* [x] scratches an itch I've had since at least 2018
* [x] I work here
* [x] this is a build script

## Validation Steps Performed
tested manually