### PR TITLE
Add an indicator in the tab if bellStyle is set to audible

### DIFF
--- a/src/cascadia/TerminalApp/TabHeaderControl.h
+++ b/src/cascadia/TerminalApp/TabHeaderControl.h
@@ -5,6 +5,7 @@
 
 #include "winrt/Microsoft.UI.Xaml.Controls.h"
 #include "inc/cppwinrt_utils.h"
+#include "AppLogic.h"
 
 #include "TabHeaderControl.g.h"
 
@@ -23,6 +24,7 @@ namespace winrt::TerminalApp::implementation
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
         OBSERVABLE_GETSET_PROPERTY(winrt::hstring, Title, _PropertyChangedHandlers);
         OBSERVABLE_GETSET_PROPERTY(bool, IsPaneZoomed, _PropertyChangedHandlers);
+        OBSERVABLE_GETSET_PROPERTY(bool, IsAudible, _PropertyChangedHandlers);
 
     private:
         bool _receivedKeyDown{ false };

--- a/src/cascadia/TerminalApp/TabHeaderControl.h
+++ b/src/cascadia/TerminalApp/TabHeaderControl.h
@@ -5,7 +5,6 @@
 
 #include "winrt/Microsoft.UI.Xaml.Controls.h"
 #include "inc/cppwinrt_utils.h"
-#include "AppLogic.h"
 
 #include "TabHeaderControl.g.h"
 

--- a/src/cascadia/TerminalApp/TabHeaderControl.idl
+++ b/src/cascadia/TerminalApp/TabHeaderControl.idl
@@ -9,6 +9,7 @@ namespace TerminalApp
     {
         String Title { get; set; };
         Boolean IsPaneZoomed { get; set; };
+        Boolean IsAudible{ get; set; };
 
         TabHeaderControl();
         void BeginRename();

--- a/src/cascadia/TerminalApp/TabHeaderControl.xaml
+++ b/src/cascadia/TerminalApp/TabHeaderControl.xaml
@@ -20,6 +20,12 @@ the MIT License. See LICENSE in the project root for license information. -->
         <TextBlock x:Name="HeaderTextBlock"
                    Visibility="Visible"
                    Text="{x:Bind Title, Mode=OneWay}"/>
+        <FontIcon x:Name="BellIndicatior"
+                  FontFamily="Segoe MDL2 Assets"
+                  Visibility="{x:Bind IsAudible, Mode=OneWay}"
+                  Glyph="&#xE189;"
+                  FontSize="12"
+                  Margin="5,0,8,0"/>
         <TextBox x:Name="HeaderRenamerTextBox"
                  Visibility="Collapsed"
                  MinHeight="0"

--- a/src/cascadia/TerminalApp/TabHeaderControl.xaml
+++ b/src/cascadia/TerminalApp/TabHeaderControl.xaml
@@ -23,7 +23,7 @@ the MIT License. See LICENSE in the project root for license information. -->
         <FontIcon x:Name="BellIndicatior"
                   FontFamily="Segoe MDL2 Assets"
                   Visibility="{x:Bind IsAudible, Mode=OneWay}"
-                  Glyph="&#xE189;"
+                  Glyph="&#xE198;"
                   FontSize="12"
                   Margin="5,0,8,0"/>
         <TextBox x:Name="HeaderRenamerTextBox"

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -54,7 +54,7 @@ namespace winrt::TerminalApp::implementation
         auto TabHeaderProfile = settings.FindProfile(profile);
         if (TabHeaderProfile)
         {
-            if (WI_IsFlagSet(TabHeaderProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Audible))
+            if (!WI_IsFlagSet(TabHeaderProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Audible))
             {
                 _headerControl.IsAudible(true);
             }

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -8,6 +8,7 @@
 #include "TerminalTab.g.cpp"
 #include "Utils.h"
 #include "ColorHelper.h"
+#include "AppLogic.h"
 
 using namespace winrt;
 using namespace winrt::Windows::UI::Xaml;
@@ -48,6 +49,16 @@ namespace winrt::TerminalApp::implementation
 
         // Use our header control as the TabViewItem's header
         TabViewItem().Header(_headerControl);
+
+        auto settings{ winrt::TerminalApp::implementation::AppLogic::CurrentAppSettings() };
+        auto TabHeaderProfile = settings.FindProfile(profile);
+        if (TabHeaderProfile)
+        {
+            if (WI_IsFlagSet(TabHeaderProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Audible))
+            {
+                _headerControl.IsAudible(true);
+            }
+        }
     }
 
     // Method Description:
@@ -155,7 +166,7 @@ namespace winrt::TerminalApp::implementation
     // - profile: The GUID of the profile these settings should apply to.
     // Return Value:
     // - <none>
-    void TerminalTab::UpdateSettings(const TerminalSettings& settings, const GUID& profile)
+    void TerminalTab::UpdateSettings(const winrt::TerminalApp::TerminalSettings& settings, const GUID& profile)
     {
         _rootPane->UpdateSettings(settings, profile);
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Chose an Audio for glyph. I hesitated over which to choose between Audio and Mute. However if I chose Mute, I have to set it when `"bellStyle": "none"` 
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #8106 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
