### PR TITLE
Add a template for discussing a settings change

### DIFF
--- a/doc/specs/settings-spec-template.md
+++ b/doc/specs/settings-spec-template.md
@@ -11,7 +11,7 @@ issue id: <github issue id>
 
 ## Abstract
 
-[comment]: # Outline what this spec describes. Include links to issues that might be relevant.
+[comment]: # Outline what this spec describes.
 
 ## Background
 
@@ -21,7 +21,7 @@ issue id: <github issue id>
 
 ### User Stories
 
-[comment]: # List off the use cases where two users might want a feature to have different behavior based on user preference
+[comment]: # List off the use cases where two users might want a feature to have different behavior based on user preference. Include links to issues that might be relevant.
 
 ### Future Considerations
 

--- a/doc/specs/settings-spec-template.md
+++ b/doc/specs/settings-spec-template.md
@@ -1,0 +1,74 @@
+---
+author: <first-name> <last-name> <github-id>/<email>
+created on: <yyyy-mm-dd>
+last updated: <yyyy-mm-dd>
+issue id: <github issue id>
+---
+
+[comment]: # Use this template for proposing a new setting, or new values for an existing setting
+
+# Spec Title
+
+## Abstract
+
+[comment]: # Outline what this spec describes
+
+## Background
+
+### Inspiration
+
+[comment]: # Are there existing precedents for this type of configuration? These may be in the Terminal, or in other applications
+
+### User Stories
+
+[comment]: # List off the use cases where two users might want a feature to have different behavior based on user preference
+
+### Future Considerations
+
+[comment]: # Are there other future features planned that might affect the current design of this setting? The team can help with this section during the review.
+
+## Solution Proposals
+
+[comment]: # Outline various different proposed designs for this setting. These won't all be winners, but may help during the decision making process. For each proposed design:
+
+### Proposal 1: <name of proposal>
+
+[comment]: # Describe the values for the properties, how it'll be exposed in both JSON and the Settings UI, and list pros and cons for this design. If there are technical details for this proposal, include them here.
+
+* **Pros**:
+* **Cons**:
+
+## Conclusion
+
+[comment]: # Of the above proposals, which should we decide on, and why?
+
+
+## UI/UX Design
+
+[comment]: # How will different values of this setting affect the end user?
+
+## Potential Issues
+
+<table>
+
+<tr>
+<td><strong>Compatibility</strong></td>
+<td>
+
+[comment]: # Will the proposed change break existing code/behaviors? If so, how, and is the breaking change "worth it"?
+
+</td>
+</tr>
+</table>
+
+[comment]: # If there are any other potential issues, make sure to include them here.
+
+
+## Resources
+
+[comment]: # Be sure to add links to references, resources, footnotes, etc.
+
+
+### Footnotes
+
+<a name="footnote-1"><a>[1]:

--- a/doc/specs/settings-spec-template.md
+++ b/doc/specs/settings-spec-template.md
@@ -11,7 +11,7 @@ issue id: <github issue id>
 
 ## Abstract
 
-[comment]: # Outline what this spec describes
+[comment]: # Outline what this spec describes. Include links to issues that might be relevant.
 
 ## Background
 

--- a/doc/specs/settings-spec-template.md
+++ b/doc/specs/settings-spec-template.md
@@ -27,9 +27,11 @@ issue id: <github issue id>
 
 [comment]: # Are there other future features planned that might affect the current design of this setting? The team can help with this section during the review.
 
-## Solution Proposals
+## Solution Design
 
-[comment]: # Outline various different proposed designs for this setting. These won't all be winners, but may help during the decision making process. For each proposed design:
+[comment]: # Add notes that might be relevant to the proposed solutions.
+
+[comment]: # Also, outline various different proposed designs for this setting. These won't all be winners, but may help during the decision making process. For each proposed design:
 
 ### Proposal 1: <name of proposal>
 


### PR DESCRIPTION
## Summary of the Pull Request

I think we all agree that the current spec template doesn't always work. I thought this layout might be better for the kinds of settings discussions we have (more and more frequently now).

This is largely for discussion with the team - if there are other things we want added, changed, or if we just want to merge this in with the primary spec template, I'm all ears. 

## References

* An example of using this spec: #8375

