### PR TITLE
Make command palette ephemeral

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -446,7 +446,7 @@ namespace winrt::TerminalApp::implementation
     // We say we lost focus if our root element and all its descendants lost focus.
     // This handler is invoked when our root element or some descendant loses focus.
     // At this point we need to learn if the newly focused element belongs to this palette.
-    // To achieve this we:
+    // To achieve this:
     // - We start with the newly focused element to and traverse its visual hierarchy up to the Xaml root.
     // - If on the path we meet this CommandPalette, then by our definition the focus is not lost
     // - If we reach the Xaml root without meeting this CommandPalette,

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -443,25 +443,25 @@ namespace winrt::TerminalApp::implementation
 
     // Method Description:
     // - The purpose of this event handler is to hide the palette if it loses focus.
-    // Since the focus might move within the palette we need to register this handler for all focusable children
-    // Right now this is achieved by explicitly registering on the root on the highlighted text controls.
-    // Few notes:
-    // - found no way to entirely disable focus on list-view elements in single-item-selection mode without breaking list behavior
-    // - TODO: the explicit implementation can be generalized by checking if the focused element is a descendant of palette
-    //         by iterating from it to the root of the Xaml tree using VisualTreeHelper::GetParent.
-    //         If this element is a descendant of palette register lost-focus-handler on it as well
     // Arguments:
     // - <unused>
     // Return Value:
     // - <none>
-    void CommandPalette::_lostFocusHandler(Windows::Foundation::IInspectable const& /* sender*/,
+    void CommandPalette::_lostFocusHandler(Windows::Foundation::IInspectable const& /*sender*/,
                                            Windows::UI::Xaml::RoutedEventArgs const& /*args*/)
     {
-        auto focusedElement = Input::FocusManager::GetFocusedElement(this->XamlRoot()).try_as<FrameworkElement>();
-        if (focusedElement && focusedElement != *this && focusedElement.Name() != L"_highlightedTextControl" && Visibility() != Visibility::Collapsed)
+        auto focusedElement = Input::FocusManager::GetFocusedElement(this->XamlRoot()).try_as<DependencyObject>();
+        while (focusedElement)
         {
-            _dismissPalette();
+            if (focusedElement == *this)
+            {
+                return;
+            }
+
+            focusedElement = winrt::Windows::UI::Xaml::Media::VisualTreeHelper::GetParent(focusedElement);
         }
+
+        _dismissPalette();
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -447,8 +447,8 @@ namespace winrt::TerminalApp::implementation
     // This handler is invoked when our root element or some descendant loses focus.
     // At this point we need to learn if the newly focused element belongs to this palette.
     // To achieve this:
-    // - We start with the newly focused element to and traverse its visual hierarchy up to the Xaml root.
-    // - If on the path we meet this CommandPalette, then by our definition the focus is not lost
+    // - We start with the newly focused element and traverse its visual ancestors up to the Xaml root.
+    // - If one of the ancestors is this CommandPalette, then by our definition the focus is not lost
     // - If we reach the Xaml root without meeting this CommandPalette,
     // then the focus is not contained in it anymore and it should be dismissed
     // Arguments:

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -442,11 +442,11 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Method Description:
-    // - The purpose of this event handler is to hind the palette if it loses focus.
+    // - The purpose of this event handler is to hide the palette if it loses focus.
     // Since the focus might move within the palette we need to register this handler for all focusable children
     // Right now this is achieved by explicitly registering on the root on the highlighted text controls.
     // Few notes:
-    // - found no way to entires disable focus on list-view elements in single-item-selection mode without breaking list behavior
+    // - found no way to entirely disable focus on list-view elements in single-item-selection mode without breaking list behavior
     // - TODO: the explicit implementation can be generalized by checking if the focused element is a descendant of palette
     //         by iterating from it to the root of the Xaml tree using VisualTreeHelper::GetParent.
     //         If this element is a descendant of palette register lost-focus-handler on it as well

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -435,7 +435,33 @@ namespace winrt::TerminalApp::implementation
     void CommandPalette::_rootPointerPressed(Windows::Foundation::IInspectable const& /*sender*/,
                                              Windows::UI::Xaml::Input::PointerRoutedEventArgs const& /*e*/)
     {
-        _dismissPalette();
+        if (Visibility() != Visibility::Collapsed)
+        {
+            _dismissPalette();
+        }
+    }
+
+    // Method Description:
+    // - The purpose of this event handler is to hind the palette if it loses focus.
+    // Since the focus might move within the palette we need to register this handler for all focusable children
+    // Right now this is achieved by explicitly registering on the root on the highlighted text controls.
+    // Few notes:
+    // - found no way to entires disable focus on list-view elements in single-item-selection mode without breaking list behavior
+    // - TODO: the explicit implementation can be generalized by checking if the focused element is a descendant of palette
+    //         by iterating from it to the root of the Xaml tree using VisualTreeHelper::GetParent.
+    //         If this element is a descendant of palette register lost-focus-handler on it as well
+    // Arguments:
+    // - <unused>
+    // Return Value:
+    // - <none>
+    void CommandPalette::_lostFocusHandler(Windows::Foundation::IInspectable const& /* sender*/,
+                                           Windows::UI::Xaml::RoutedEventArgs const& /*args*/)
+    {
+        auto focusedElement = Input::FocusManager::GetFocusedElement(this->XamlRoot()).try_as<FrameworkElement>();
+        if (focusedElement && focusedElement != *this && focusedElement.Name() != L"_highlightedTextControl" && Visibility() != Visibility::Collapsed)
+        {
+            _dismissPalette();
+        }
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -85,6 +85,9 @@ namespace winrt::TerminalApp::implementation
         void _updateUIForStackChange();
 
         void _rootPointerPressed(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
+
+        void _lostFocusHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& args);
+
         void _backdropPointerPressed(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs const& e);
 
         void _listItemClicked(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Controls::ItemClickEventArgs const& e);

--- a/src/cascadia/TerminalApp/CommandPalette.xaml
+++ b/src/cascadia/TerminalApp/CommandPalette.xaml
@@ -17,6 +17,7 @@ the MIT License. See LICENSE in the project root for license information. -->
     PreviewKeyDown="_previewKeyDownHandler"
     KeyDown="_keyDownHandler"
     PreviewKeyUp="_keyUpHandler"
+    LostFocus="_lostFocusHandler"
     mc:Ignorable="d"
     AutomationProperties.Name="{x:Bind ControlName, Mode=OneWay}">
 
@@ -245,8 +246,9 @@ the MIT License. See LICENSE in the project root for license information. -->
                         <!-- This HorizontalContentAlignment="Stretch" is important
                         to make sure it takes the entire width of the line -->
                         <ListViewItem HorizontalContentAlignment="Stretch"
-                                  AutomationProperties.Name="{x:Bind Command.Name, Mode=OneWay}"
-                                  AutomationProperties.AcceleratorKey="{x:Bind Command.KeyChordText, Mode=OneWay}">
+                                      IsTabStop="False"
+                                      AutomationProperties.Name="{x:Bind Command.Name, Mode=OneWay}"
+                                      AutomationProperties.AcceleratorKey="{x:Bind Command.KeyChordText, Mode=OneWay}">
 
                             <Grid HorizontalAlignment="Stretch" ColumnSpacing="8" >
                                 <Grid.ColumnDefinitions>
@@ -265,8 +267,10 @@ the MIT License. See LICENSE in the project root for license information. -->
                                                         Converter={StaticResource IconSourceConverter}}"/>
 
                                 <local:HighlightedTextControl
+                                    x:Name="_highlightedTextControl"
                                     Grid.Column="1"
                                     HorizontalAlignment="Left"
+                                    LostFocus="_lostFocusHandler"
                                     Text="{x:Bind HighlightedName, Mode=OneWay}"/>
 
                                 <!-- The block for the key chord is only visible

--- a/src/cascadia/TerminalApp/CommandPalette.xaml
+++ b/src/cascadia/TerminalApp/CommandPalette.xaml
@@ -270,7 +270,6 @@ the MIT License. See LICENSE in the project root for license information. -->
                                     x:Name="_highlightedTextControl"
                                     Grid.Column="1"
                                     HorizontalAlignment="Left"
-                                    LostFocus="_lostFocusHandler"
                                     Text="{x:Bind HighlightedName, Mode=OneWay}"/>
 
                                 <!-- The block for the key chord is only visible

--- a/src/cascadia/TerminalApp/CommandPalette.xaml
+++ b/src/cascadia/TerminalApp/CommandPalette.xaml
@@ -267,7 +267,6 @@ the MIT License. See LICENSE in the project root for license information. -->
                                                         Converter={StaticResource IconSourceConverter}}"/>
 
                                 <local:HighlightedTextControl
-                                    x:Name="_highlightedTextControl"
                                     Grid.Column="1"
                                     HorizontalAlignment="Left"
                                     Text="{x:Bind HighlightedName, Mode=OneWay}"/>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -581,7 +581,7 @@ namespace winrt::TerminalApp::implementation
         // We cannot do it on closing because if the window loses focus (alt+tab)
         // the closing event is not fired.
         // It is important to set the focus on the tab
-        // Sine the previous focus location might be discarded in the background,
+        // Since the previous focus location might be discarded in the background,
         // e.g., the command palette will be dismissed by the menu,
         // and then closing the fly-out will move the focus to wrong location.
         newTabFlyout.Opening([this](auto&&, auto&&) {

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1060,19 +1060,6 @@ namespace winrt::TerminalApp::implementation
         _tabView.TabItems().RemoveAt(tabIndex);
         _UpdateTabIndices();
 
-        // If the tab switcher is currently open, update it to reflect the
-        // current list of tabs.
-        const auto tabSwitchMode = _settings.GlobalSettings().TabSwitcherMode();
-        const bool commandPaletteIsVisible = CommandPalette().Visibility() == Visibility::Visible;
-        if (tabSwitchMode == TabSwitcherMode::MostRecentlyUsed && commandPaletteIsVisible)
-        {
-            CommandPalette().SetTabActions(_mruTabActions, false);
-        }
-        else if (commandPaletteIsVisible)
-        {
-            _UpdatePaletteWithInOrderTabs();
-        }
-
         // To close the window here, we need to close the hosting window.
         if (_tabs.Size() == 0)
         {
@@ -2083,6 +2070,7 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
+        CommandPalette().Visibility(Visibility::Collapsed);
         _UpdateTabView();
     }
 
@@ -2829,15 +2817,6 @@ namespace winrt::TerminalApp::implementation
             {
                 _mruTabActions.RemoveAt(mruIndex);
                 _mruTabActions.InsertAt(0, command);
-
-                // If the tab switcher is currently open, AND we're using it in
-                // MRU mode, then update it to reflect the current list of tabs.
-                const auto tabSwitchMode = _settings.GlobalSettings().TabSwitcherMode();
-                const bool commandPaletteIsVisible = CommandPalette().Visibility() == Visibility::Visible;
-                if (tabSwitchMode == TabSwitcherMode::MostRecentlyUsed && commandPaletteIsVisible)
-                {
-                    CommandPalette().SetTabActions(_mruTabActions, false);
-                }
             }
         }
     }


### PR DESCRIPTION
So the implementation is somewhat dirty.
The ideas was nice - add lostFocusHandler

However it broke few things:
* In the TabSwitcher the ListItem must be focusable since otherwise 
the SingleSelectionMode behavior breaks. 
To address this I had to put the lostFocusHandler on the items as well
 
* When you click the flyout, the palette loses focus, 
which makes the terminal page to set the focus on the tab, closing the flyout. 
To address this I had to ensure the tab won't get focused once the flyout is open.
In addition, flyout should fix the focus before opening, 
otherwise alt+tab will put a focus on a tab row rather than on tab

* I also had to close the palette if the tab order changes.
To prevent inconsistencies.

Closes #8355