### PR TITLE
Bind Profile Color Schemes

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
@@ -87,8 +87,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     // - <none>
     void ColorSchemes::_UpdateColorSchemeList()
     {
-        auto colorSchemeMap = _State.Globals().ColorSchemes();
-        for (const auto& pair : _State.Globals().ColorSchemes())
+        const auto& colorSchemeMap{ _State.Globals().ColorSchemes() };
+        for (const auto& pair : colorSchemeMap)
         {
             _ColorSchemeList.Append(pair.Key());
         }

--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -12,7 +12,12 @@ the MIT License. See LICENSE in the project root for license information. -->
     mc:Ignorable="d">
 
     <Page.Resources>
-        <SettingsModel:IconPathConverter x:Key="IconSourceConverter"/>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="CommonResources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <SettingsModel:IconPathConverter x:Key="IconSourceConverter"/>
+        </ResourceDictionary>
     </Page.Resources>
 
     <ScrollViewer>
@@ -26,15 +31,12 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <ColumnDefinition Width="1*" />
                 <ColumnDefinition Width="1*" />
             </Grid.ColumnDefinitions>
-            
+
             <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,100,0">
                 <ComboBox x:Uid="Globals_DefaultProfile"
                           x:Name="DefaultProfile"
-                          Margin="0,0,0,20"
                           ItemsSource="{x:Bind State.Settings.AllProfiles, Mode=OneWay}"
-                          SelectedItem="{x:Bind CurrentDefaultProfile, Mode=TwoWay}"
-                          FontSize="15"
-                          ToolTipService.Placement="Mouse">
+                          SelectedItem="{x:Bind CurrentDefaultProfile, Mode=TwoWay}">
                     <ComboBox.ItemTemplate>
                         <DataTemplate x:DataType="SettingsModel:Profile">
                             <Grid HorizontalAlignment="Stretch" ColumnSpacing="8" >
@@ -56,7 +58,7 @@ the MIT License. See LICENSE in the project root for license information. -->
 
                                 <TextBlock Grid.Column="1"
                                            Text="{x:Bind Name}"/>
-                                
+
                             </Grid>
                         </DataTemplate>
                     </ComboBox.ItemTemplate>

--- a/src/cascadia/TerminalSettingsEditor/Profiles.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.cpp
@@ -17,7 +17,7 @@ using namespace winrt::Microsoft::Terminal::Settings::Model;
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
     Profiles::Profiles() :
-        _ColorSchemeList{ single_threaded_observable_vector<hstring>() }
+        _ColorSchemeList{ single_threaded_observable_vector<ColorScheme>() }
     {
         InitializeComponent();
 
@@ -36,31 +36,28 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         const auto& colorSchemeMap{ _State.Schemes() };
         for (const auto& pair : colorSchemeMap)
         {
-            _ColorSchemeList.Append(pair.Key());
+            _ColorSchemeList.Append(pair.Value());
         }
     }
 
-    IInspectable Profiles::CurrentColorScheme()
+    ColorScheme Profiles::CurrentColorScheme()
     {
         const auto schemeName{ _State.Profile().ColorSchemeName() };
-        if (_State.Schemes().HasKey(schemeName))
+        if (const auto scheme{ _State.Schemes().TryLookup(schemeName) })
         {
-            return winrt::box_value(schemeName);
+            return scheme;
         }
         else
         {
             // This Profile points to a color scheme that was renamed or deleted.
             // Fallback to Campbell.
-            return winrt::box_value(L"Campbell");
+            return _State.Schemes().TryLookup(L"Campbell");
         }
     }
 
-    void Profiles::CurrentColorScheme(const IInspectable& val)
+    void Profiles::CurrentColorScheme(const ColorScheme& val)
     {
-        if (const auto schemeName{ val.try_as<hstring>() })
-        {
-            _State.Profile().ColorSchemeName(*schemeName);
-        }
+        _State.Profile().ColorSchemeName(val.Name());
     }
 
     fire_and_forget Profiles::BackgroundImage_Click(IInspectable const&, RoutedEventArgs const&)

--- a/src/cascadia/TerminalSettingsEditor/Profiles.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.h
@@ -32,8 +32,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         void OnNavigatedTo(const winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
 
-        winrt::Windows::Foundation::IInspectable CurrentColorScheme();
-        void CurrentColorScheme(const winrt::Windows::Foundation::IInspectable& val);
+        Model::ColorScheme CurrentColorScheme();
+        void CurrentColorScheme(const Model::ColorScheme& val);
 
         fire_and_forget BackgroundImage_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
         fire_and_forget Commandline_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
@@ -42,7 +42,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         //fire_and_forget StartingDirectory_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
 
         GETSET_PROPERTY(Editor::ProfilePageNavigationState, State, nullptr);
-        GETSET_PROPERTY(Windows::Foundation::Collections::IObservableVector<winrt::hstring>, ColorSchemeList, nullptr);
+        GETSET_PROPERTY(Windows::Foundation::Collections::IObservableVector<Model::ColorScheme>, ColorSchemeList, nullptr);
         GETSET_BINDABLE_ENUM_SETTING(CursorShape, winrt::Microsoft::Terminal::TerminalControl::CursorStyle, State().Profile, CursorShape);
         GETSET_BINDABLE_ENUM_SETTING(BackgroundImageStretchMode, winrt::Windows::UI::Xaml::Media::Stretch, State().Profile, BackgroundImageStretchMode);
         GETSET_BINDABLE_ENUM_SETTING(AntiAliasingMode, winrt::Microsoft::Terminal::TerminalControl::TextAntialiasingMode, State().Profile, AntialiasingMode);

--- a/src/cascadia/TerminalSettingsEditor/Profiles.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.h
@@ -32,6 +32,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         void OnNavigatedTo(const winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
 
+        winrt::Windows::Foundation::IInspectable CurrentColorScheme();
+        void CurrentColorScheme(const winrt::Windows::Foundation::IInspectable& val);
+
         fire_and_forget BackgroundImage_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
         fire_and_forget Commandline_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
         // TODO GH#1564: Settings UI
@@ -39,6 +42,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         //fire_and_forget StartingDirectory_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
 
         GETSET_PROPERTY(Editor::ProfilePageNavigationState, State, nullptr);
+        GETSET_PROPERTY(Windows::Foundation::Collections::IObservableVector<winrt::hstring>, ColorSchemeList, nullptr);
         GETSET_BINDABLE_ENUM_SETTING(CursorShape, winrt::Microsoft::Terminal::TerminalControl::CursorStyle, State().Profile, CursorShape);
         GETSET_BINDABLE_ENUM_SETTING(BackgroundImageStretchMode, winrt::Windows::UI::Xaml::Media::Stretch, State().Profile, BackgroundImageStretchMode);
         GETSET_BINDABLE_ENUM_SETTING(AntiAliasingMode, winrt::Microsoft::Terminal::TerminalControl::TextAntialiasingMode, State().Profile, AntialiasingMode);

--- a/src/cascadia/TerminalSettingsEditor/Profiles.idl
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.idl
@@ -34,7 +34,7 @@ namespace Microsoft.Terminal.Settings.Editor
         IInspectable CurrentScrollState;
         Windows.Foundation.Collections.IObservableVector<Microsoft.Terminal.Settings.Editor.EnumEntry> ScrollStateList { get; };
 
-        IInspectable CurrentColorScheme;
-        Windows.Foundation.Collections.IObservableVector<String> ColorSchemeList { get; };
+        Microsoft.Terminal.Settings.Model.ColorScheme CurrentColorScheme;
+        Windows.Foundation.Collections.IObservableVector<Microsoft.Terminal.Settings.Model.ColorScheme> ColorSchemeList { get; };
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Profiles.idl
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.idl
@@ -33,5 +33,8 @@ namespace Microsoft.Terminal.Settings.Editor
 
         IInspectable CurrentScrollState;
         Windows.Foundation.Collections.IObservableVector<Microsoft.Terminal.Settings.Editor.EnumEntry> ScrollStateList { get; };
+
+        IInspectable CurrentColorScheme;
+        Windows.Foundation.Collections.IObservableVector<String> ColorSchemeList { get; };
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -87,17 +87,9 @@ the MIT License. See LICENSE in the project root for license information. -->
                                         Value="100"
                                         SmallChange="1"
                                         LargeChange="10"/>
-                    <ComboBox x:Uid="Profile_ColorScheme">
-                        <ComboBox.Items>
-                            <ComboBoxItem Content="Campbell"/>
-                            <ComboBoxItem Content="Campbell Powershell"/>
-                            <ComboBoxItem Content="Vintage"/>
-                            <ComboBoxItem Content="One Half Dark"/>
-                            <ComboBoxItem Content="One Half Light"/>
-                            <ComboBoxItem Content="Tango Dark"/>
-                            <ComboBoxItem Content="Tango Light"/>
-                        </ComboBox.Items>
-                    </ComboBox>
+                    <ComboBox x:Uid="Profile_ColorScheme"
+                              ItemsSource="{x:Bind ColorSchemeList, Mode=OneWay}"
+                              SelectedItem="{x:Bind CurrentColorScheme, Mode=TwoWay}"/>
 
                     <StackPanel Orientation="Horizontal">
                         <TextBox x:Uid="Profile_BackgroundImage"

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -89,7 +89,13 @@ the MIT License. See LICENSE in the project root for license information. -->
                                         LargeChange="10"/>
                     <ComboBox x:Uid="Profile_ColorScheme"
                               ItemsSource="{x:Bind ColorSchemeList, Mode=OneWay}"
-                              SelectedItem="{x:Bind CurrentColorScheme, Mode=TwoWay}"/>
+                              SelectedItem="{x:Bind CurrentColorScheme, Mode=TwoWay}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate x:DataType="model:ColorScheme">
+                                <TextBlock Text="{x:Bind Name, Mode=OneWay}"/>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
 
                     <StackPanel Orientation="Horizontal">
                         <TextBox x:Uid="Profile_BackgroundImage"

--- a/src/cascadia/TerminalSettingsModel/ColorScheme.idl
+++ b/src/cascadia/TerminalSettingsModel/ColorScheme.idl
@@ -11,7 +11,10 @@ namespace Microsoft.Terminal.Settings.Model
         Windows.UI.Color SelectionBackground;
         Windows.UI.Color CursorColor;
 
-        Windows.UI.Color[] Table { get; };
+        // winrt::com_arrays prevent data binding.
+        // Instead of representing Table as a property,
+        // we expose the getter as a function.
+        Windows.UI.Color[] Table();
         void SetColorTableEntry(UInt8 index, Windows.UI.Color value);
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request
Binds `Profile.ColorScheme` to the list of Color Schemes available in the Settings UI.

## References
#1564 - Settings UI

## Detailed Description of the Pull Request / Additional comments
To my knowledge, there is no way to bind an `IMapView` to `ItemsSource`. `ItemsSource` requires an `IObservableVector`, so we need to manually populate `ColorSchemeList` when we navigate to the page.

`CurrentColorScheme` operates mostly like a standard getter/setter, except it needs to account for the upcoming scenario when a color scheme is renamed or deleted. For now, we fallback to Campbell if the scheme was not found. I would like to make it update automatically, but I feel that we have two approaches here:
1. TSM stores `Profile.ColorScheme` as a `ColorScheme` instead of only the name
2. When a color scheme name is modified in SUI, we iterate through all of the profiles and modify `Profile.ColorScheme` accordingly
Open to discuss these options or any other approaches.

## Validation Steps Performed
✅ selected item initialized correctly
✅ list initialized correctly
✅ selecting a new color scheme, then creating a new terminal from that profile uses the new color scheme
✅ setting the color scheme name to a color scheme that does not exist selects "Campbell"