### PR TITLE
Propagate IslandWindow's HWND into any component that needs it

### DIFF
--- a/.github/actions/spell-check/dictionary/apis.txt
+++ b/.github/actions/spell-check/dictionary/apis.txt
@@ -61,6 +61,7 @@ rx
 schandle
 semver
 serializer
+shobjidl
 SIZENS
 GETDESKWALLPAPER
 snprintf

--- a/.github/actions/spell-check/expect/expect.txt
+++ b/.github/actions/spell-check/expect/expect.txt
@@ -1062,7 +1062,9 @@ IFont
 ifstream
 IGNOREEND
 IHigh
+IHosted
 iid
+IInitialize
 IInput
 IInspectable
 IInteract

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -197,6 +197,12 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Method Description:
+    // - Implements the IInitializeWithWindow interface from shobjidl_core.
+    HRESULT AppLogic::Initialize(HWND hwnd) {
+        return _root->Initialize(hwnd);
+    }
+
+    // Method Description:
     // - Called around the codebase to discover if this is a UWP where we need to turn off specific settings.
     // Arguments:
     // - <none> - reports internal state

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -198,7 +198,8 @@ namespace winrt::TerminalApp::implementation
 
     // Method Description:
     // - Implements the IInitializeWithWindow interface from shobjidl_core.
-    HRESULT AppLogic::Initialize(HWND hwnd) {
+    HRESULT AppLogic::Initialize(HWND hwnd)
+    {
         return _root->Initialize(hwnd);
     }
 

--- a/src/cascadia/TerminalApp/AppLogic.h
+++ b/src/cascadia/TerminalApp/AppLogic.h
@@ -10,7 +10,7 @@
 
 namespace winrt::TerminalApp::implementation
 {
-    struct AppLogic : AppLogicT<AppLogic>
+    struct AppLogic : AppLogicT<AppLogic, IInitializeWithWindow>
     {
     public:
         static AppLogic* Current() noexcept;
@@ -18,6 +18,8 @@ namespace winrt::TerminalApp::implementation
 
         AppLogic();
         ~AppLogic() = default;
+
+        STDMETHODIMP Initialize(HWND hwnd);
 
         void Create();
         bool IsUwp() const noexcept;

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -45,9 +45,18 @@ namespace winrt::TerminalApp::implementation
     TerminalPage::TerminalPage() :
         _tabs{ winrt::single_threaded_observable_vector<TerminalApp::TabBase>() },
         _mruTabActions{ winrt::single_threaded_vector<Command>() },
-        _startupActions{ winrt::single_threaded_vector<ActionAndArgs>() }
+        _startupActions{ winrt::single_threaded_vector<ActionAndArgs>() },
+        _hostingHwnd{}
     {
         InitializeComponent();
+    }
+
+    // Method Description:
+    // - implements the IInitializeWithWindow interface from shobjidl_core.
+    HRESULT TerminalPage::Initialize(HWND hwnd)
+    {
+        _hostingHwnd = hwnd;
+        return S_OK;
     }
 
     // Function Description:
@@ -2738,6 +2747,11 @@ namespace winrt::TerminalApp::implementation
         if (!_switchToSettingsCommand)
         {
             winrt::Microsoft::Terminal::Settings::Editor::MainPage sui{ _settings };
+            if (_hostingHwnd)
+            {
+                sui.SetHostingWindow(reinterpret_cast<uint64_t>(*_hostingHwnd));
+            }
+
             sui.OpenJson([weakThis{ get_weak() }](auto&& /*s*/, winrt::Microsoft::Terminal::Settings::Model::SettingsTarget e) {
                 if (auto page{ weakThis.get() })
                 {

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -41,6 +41,10 @@ namespace winrt::TerminalApp::implementation
     public:
         TerminalPage();
 
+        // This implements shobjidl's IInitializeWithWindow, but due to a XAML Compiler bug we cannot
+        // put it in our inheritance graph. https://github.com/microsoft/microsoft-ui-xaml/issues/3331
+        STDMETHODIMP Initialize(HWND hwnd);
+
         winrt::fire_and_forget SetSettings(Microsoft::Terminal::Settings::Model::CascadiaSettings settings, bool needRefreshUI);
 
         void Create();
@@ -90,6 +94,7 @@ namespace winrt::TerminalApp::implementation
 
     private:
         friend struct TerminalPageT<TerminalPage>; // for Xaml to bind events
+        std::optional<HWND> _hostingHwnd;
 
         // If you add controls here, but forget to null them either here or in
         // the ctor, you're going to have a bad time. It'll mysteriously fail to

--- a/src/cascadia/TerminalApp/pch.h
+++ b/src/cascadia/TerminalApp/pch.h
@@ -64,6 +64,7 @@ TRACELOGGING_DECLARE_PROVIDER(g_hTerminalAppProvider);
 #include <TraceLoggingActivity.h>
 
 #include <shellapi.h>
+#include <shobjidl_core.h>
 
 #include <winrt/Microsoft.Terminal.TerminalControl.h>
 #include <winrt/Microsoft.Terminal.TerminalConnection.h>

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -46,6 +46,23 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _InitializeProfilesList();
     }
 
+    void MainPage::SetHostingWindow(uint64_t hostingWindow) noexcept
+    {
+        _hostingHwnd.emplace(reinterpret_cast<HWND>(hostingWindow));
+    }
+
+    bool MainPage::TryPropagateHostingWindow(IInspectable object) noexcept
+    {
+        if (_hostingHwnd)
+        {
+            if (auto initializeWithWindow{ object.try_as<IInitializeWithWindow>() })
+            {
+                return SUCCEEDED(initializeWithWindow->Initialize(*_hostingHwnd));
+            }
+        }
+        return false;
+    }
+
     // Function Description:
     // - Called when the NavigationView is loaded. Navigates to the first item in the NavigationView, if no item is selected
     // Arguments:
@@ -95,7 +112,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             else if (const auto profile = clickedItemContainer.Tag().try_as<Model::Profile>())
             {
                 // Navigate to a page with the given profile
-                contentFrame().Navigate(xaml_typename<Editor::Profiles>(), winrt::make<ProfilePageNavigationState>(profile, _settingsClone.GlobalSettings().ColorSchemes()));
+                contentFrame().Navigate(xaml_typename<Editor::Profiles>(), winrt::make<ProfilePageNavigationState>(profile, _settingsClone.GlobalSettings().ColorSchemes(), *this));
             }
         }
     }
@@ -116,7 +133,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
         else if (clickedItemTag == globalProfileTag)
         {
-            contentFrame().Navigate(xaml_typename<Editor::Profiles>(), winrt::make<ProfilePageNavigationState>(_settingsClone.ProfileDefaults(), _settingsClone.GlobalSettings().ColorSchemes()));
+            contentFrame().Navigate(xaml_typename<Editor::Profiles>(), winrt::make<ProfilePageNavigationState>(_settingsClone.ProfileDefaults(), _settingsClone.GlobalSettings().ColorSchemes(), *this));
         }
         else if (clickedItemTag == colorSchemesTag)
         {
@@ -184,7 +201,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // Select and navigate to the new profile
         // TODO: Setting SelectedItem here doesn't update the NavigationView's selected visual indicator
         SettingsNav().SelectedItem(navItem);
-        contentFrame().Navigate(xaml_typename<Editor::Profiles>(), winrt::make<ProfilePageNavigationState>(newProfile, _settingsClone.GlobalSettings().ColorSchemes()));
+        contentFrame().Navigate(xaml_typename<Editor::Profiles>(), winrt::make<ProfilePageNavigationState>(newProfile, _settingsClone.GlobalSettings().ColorSchemes(), *this));
     }
 
     MUX::Controls::NavigationViewItem MainPage::_CreateProfileNavViewItem(const Profile& profile)

--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -18,6 +18,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void SettingsNav_Loaded(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& args);
         void SettingsNav_ItemInvoked(Microsoft::UI::Xaml::Controls::NavigationView const& sender, Microsoft::UI::Xaml::Controls::NavigationViewItemInvokedEventArgs const& args);
 
+        void SetHostingWindow(uint64_t hostingWindow) noexcept;
+        bool TryPropagateHostingWindow(IInspectable object) noexcept;
+
         TYPED_EVENT(OpenJson, winrt::Windows::Foundation::IInspectable, winrt::Microsoft::Terminal::Settings::Model::SettingsTarget);
 
     private:
@@ -26,6 +29,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         winrt::Microsoft::Terminal::Settings::Model::CascadiaSettings _settingsSource;
         winrt::Microsoft::Terminal::Settings::Model::CascadiaSettings _settingsClone;
         winrt::Windows::Foundation::Collections::IMap<winrt::Microsoft::Terminal::Settings::Model::Profile, winrt::Microsoft::UI::Xaml::Controls::NavigationViewItem> _profileToNavItemMap;
+
+        std::optional<HWND> _hostingHwnd;
 
         void _InitializeProfilesList();
         void _CreateAndNavigateToNewProfile(const uint32_t index);

--- a/src/cascadia/TerminalSettingsEditor/MainPage.idl
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.idl
@@ -3,10 +3,23 @@
 
 namespace Microsoft.Terminal.Settings.Editor
 {
-    [default_interface] runtimeclass MainPage : Windows.UI.Xaml.Controls.Page
+    // Due to a XAML Compiler bug, it is hard for us to propagate an HWND into a XAML-using runtimeclass.
+    // To work around that, we'll only propagate the HWND (when we need to) into the settings' toplevel page
+    // and use IHostedInWindow to hide the implementation detail where we use IInitializeWithWindow (shobjidl_core)
+    // https://github.com/microsoft/microsoft-ui-xaml/issues/3331
+    interface IHostedInWindow
+    {
+        Boolean TryPropagateHostingWindow(IInspectable i);
+    }
+
+    [default_interface] runtimeclass MainPage : Windows.UI.Xaml.Controls.Page, IHostedInWindow
     {
         MainPage(Microsoft.Terminal.Settings.Model.CascadiaSettings settings);
 
         event Windows.Foundation.TypedEventHandler<Object, Microsoft.Terminal.Settings.Model.SettingsTarget> OpenJson;
+
+        // Due to the aforementioned bug, we can't use IInitializeWithWindow _here_ either.
+        // Let's just smuggle the HWND in as a UInt64 :|
+        void SetHostingWindow(UInt64 window);
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Profiles.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.cpp
@@ -39,6 +39,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         FileOpenPicker picker;
 
+        _State.WindowRoot().TryPropagateHostingWindow(picker); // if we don't do this, there's no HWND for it to attach to
         picker.ViewMode(PickerViewMode::Thumbnail);
         picker.SuggestedStartLocation(PickerLocationId::PicturesLibrary);
         picker.FileTypeFilter().ReplaceAll({ L".jpg", L".jpeg", L".png", L".gif" });
@@ -57,6 +58,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         FileOpenPicker picker;
 
         //TODO: SETTINGS UI Commandline handling should be robust and intelligent
+        _State.WindowRoot().TryPropagateHostingWindow(picker); // if we don't do this, there's no HWND for it to attach to
         picker.ViewMode(PickerViewMode::Thumbnail);
         picker.SuggestedStartLocation(PickerLocationId::ComputerFolder);
         picker.FileTypeFilter().ReplaceAll({ L".bat", L".exe" });
@@ -68,14 +70,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
     }
 
-    // TODO GH#1564: Settings UI
-    // This crashes on click, for some reason
-    /*
     fire_and_forget Profiles::StartingDirectory_Click(IInspectable const&, RoutedEventArgs const&)
     {
         auto lifetime = get_strong();
         FolderPicker picker;
+        _State.WindowRoot().TryPropagateHostingWindow(picker); // if we don't do this, there's no HWND for it to attach to
         picker.SuggestedStartLocation(PickerLocationId::DocumentsLibrary);
+        picker.FileTypeFilter().ReplaceAll({ L"*" });
         StorageFolder folder = co_await picker.PickSingleFolderAsync();
         if (folder != nullptr)
         {
@@ -83,5 +84,4 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             StartingDirectory().Text(folder.Path());
         }
     }
-    */
 }

--- a/src/cascadia/TerminalSettingsEditor/Profiles.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.h
@@ -16,7 +16,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             _Profile{ profile },
             _Schemes{ schemes },
             _WindowRoot{ windowRoot }
-        {}
+        {
+        }
 
         Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme> Schemes() { return _Schemes; }
         void Schemes(const Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme>& val) { _Schemes = val; }

--- a/src/cascadia/TerminalSettingsEditor/Profiles.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.h
@@ -12,14 +12,17 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     struct ProfilePageNavigationState : ProfilePageNavigationStateT<ProfilePageNavigationState>
     {
     public:
-        ProfilePageNavigationState(const Model::Profile& profile, const Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme>& schemes) :
+        ProfilePageNavigationState(const Model::Profile& profile, const Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme>& schemes, const IHostedInWindow& windowRoot) :
             _Profile{ profile },
-            _Schemes{ schemes } {}
+            _Schemes{ schemes },
+            _WindowRoot{ windowRoot }
+        {}
 
         Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme> Schemes() { return _Schemes; }
         void Schemes(const Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme>& val) { _Schemes = val; }
 
         GETSET_PROPERTY(Model::Profile, Profile, nullptr);
+        GETSET_PROPERTY(IHostedInWindow, WindowRoot, nullptr);
 
     private:
         Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme> _Schemes;
@@ -34,9 +37,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         fire_and_forget BackgroundImage_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
         fire_and_forget Commandline_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
-        // TODO GH#1564: Settings UI
-        // This crashes on click, for some reason
-        //fire_and_forget StartingDirectory_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
+        fire_and_forget StartingDirectory_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
 
         GETSET_PROPERTY(Editor::ProfilePageNavigationState, State, nullptr);
         GETSET_BINDABLE_ENUM_SETTING(CursorShape, winrt::Microsoft::Terminal::TerminalControl::CursorStyle, State().Profile, CursorShape);

--- a/src/cascadia/TerminalSettingsEditor/Profiles.idl
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.idl
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import "EnumEntry.idl";
+import "MainPage.idl";
 
 namespace Microsoft.Terminal.Settings.Editor
 {
@@ -9,6 +10,7 @@ namespace Microsoft.Terminal.Settings.Editor
     {
         Windows.Foundation.Collections.IMapView<String, Microsoft.Terminal.Settings.Model.ColorScheme> Schemes;
         Microsoft.Terminal.Settings.Model.Profile Profile;
+        IHostedInWindow WindowRoot; // necessary to send the right HWND into the file picker dialogs.
     };
 
     [default_interface] runtimeclass Profiles : Windows.UI.Xaml.Controls.Page

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -47,6 +47,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                                  x:Name="StartingDirectory"
                                  Text="{x:Bind State.Profile.StartingDirectory, Mode=TwoWay}"/>
                         <Button x:Uid="Profile_StartingDirectoryBrowse"
+                                Click="StartingDirectory_Click"
                                 Margin="10,0,0,0"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">

--- a/src/cascadia/TerminalSettingsEditor/pch.h
+++ b/src/cascadia/TerminalSettingsEditor/pch.h
@@ -51,5 +51,7 @@
 #include <winrt/Microsoft.Terminal.TerminalControl.h>
 #include <winrt/Microsoft.Terminal.Settings.Model.h>
 
+#include "shobjidl_core.h"
+
 // Manually include til after we include Windows.Foundation to give it winrt superpowers
 #include "til.h"

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -163,6 +163,11 @@ void AppHost::Initialize()
 {
     _window->Initialize();
 
+    if (auto withWindow{ _logic.try_as<IInitializeWithWindow>() })
+    {
+        withWindow->Initialize(_window->GetHandle());
+    }
+
     if (_useNonClientArea)
     {
         // Register our callback for when the app's non-client content changes.


### PR DESCRIPTION
This fixes the issue with the settings UI where clicking the browse
buttons would cause an exception to be thrown when we tried to display a
picker without an originating HWND.

It turns out that pickers need a hosting/parent window, and Xaml Islands
doesn't furnish us with a CoreWindow that's set up for that use case.
Alas!

Raymond Chen's [blog post on the matter] suggests that we should
hand the HWND off through some classic COM interface. To do that
properly, Terminal's various components need to implement that interface
and propagate the HWND down where it's needed.

Thanks to a [Xaml compiler issue], we can't actually do that. To work
around that, we've begged and borrowed different methods for pushing
HWNDs around:

1. Using IInitializeWithWindow in secret
2. A member that takes a uint64
3. An interface that offers a function that will "wire up" the HWND.

I chose (1) because AppHost can implement IInitializeWithWindow, but
TerminalPage cannot. We're just pretending that TerminalPage _can_.

I chose (2) because none of the Xaml types in TerminalSettingsEditor can
implement the interface thanks to the aforementioned compiler issue, but
we don't have an escape hatch like AppHost that lives in the same module
and can help us do the propagation.

I chose (3) because I didn't want to commit the same sin as (2) _seven
times_ for every different type of settings page that exists. (3) is
backed by "IHostedInWindow", and anybody who knows they have to use
IInitializeWithWindow to tie an HWND to an object can call
IHostedInWindow.TryPropagateHostingWindow() on that object.

House of cards.

[Xaml compiler issue]: https://github.com/microsoft/microsoft-ui-xaml/issues/3331
[blog post on the matter]: https://devblogs.microsoft.com/oldnewthing/20190412-00/?p=102413
