### PR TITLE
Add CenterOnLaunch property

### DIFF
--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -4,6 +4,8 @@
 #include "pch.h"
 #include "AppLogic.h"
 #include "AppLogic.g.cpp"
+#include "wtypes.h"
+#include "TerminalPage.h"
 #include <winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>
 
 #include <LibraryResources.h>
@@ -630,17 +632,46 @@ namespace winrt::TerminalApp::implementation
     // - a point containing the requested initial position in pixels.
     TerminalApp::InitialPosition AppLogic::GetInitialPosition(int64_t defaultInitialX, int64_t defaultInitialY)
     {
+        
         if (!_loadedInitialSettings)
         {
             // Load settings if we haven't already
             LoadSettings();
         }
 
+        UINT dpi = USER_DEFAULT_SCREEN_DPI;
+        int _width = 0;
+        int _height = 0;
+        GetDesktopResolution(_width, _height);
         const auto initialPosition{ _settings.GlobalSettings().InitialPosition() };
-        return {
-            initialPosition.X ? initialPosition.X.Value() : defaultInitialX,
-            initialPosition.Y ? initialPosition.Y.Value() : defaultInitialY
-        };
+        const auto CentreOnLaunch{ _settings.GlobalSettings().CentreOnLaunch() };
+        const auto dimentions = GetLaunchDimensions(dpi);
+        const auto appWidth = dimentions.Width;
+        const auto appHeight = dimentions.Height;
+
+        if (CentreOnLaunch)
+        {
+            return {
+                (_width / 2) - (static_cast<int>(appWidth) / 2),
+                (_height / 2) - (static_cast<int>(appHeight) / 2)
+            };
+        }
+        else
+        {
+            return {
+                initialPosition.X ? initialPosition.X.Value() : defaultInitialX,
+                initialPosition.Y ? initialPosition.Y.Value() : defaultInitialY
+            };
+        }
+    }
+
+    void AppLogic::GetDesktopResolution(int& width, int& height)
+    {
+        RECT desktop;
+        const HWND hDesktop = GetDesktopWindow();
+        GetWindowRect(hDesktop, &desktop);
+        width = desktop.right;
+        height= desktop.bottom;
     }
 
     winrt::Windows::UI::Xaml::ElementTheme AppLogic::GetRequestedTheme()

--- a/src/cascadia/TerminalApp/AppLogic.h
+++ b/src/cascadia/TerminalApp/AppLogic.h
@@ -34,6 +34,7 @@ namespace winrt::TerminalApp::implementation
         bool Fullscreen() const;
         bool AlwaysOnTop() const;
 
+        void GetDesktopResolution(int& horizontal, int& vertical);
         Windows::Foundation::Size GetLaunchDimensions(uint32_t dpi);
         TerminalApp::InitialPosition GetInitialPosition(int64_t defaultInitialX, int64_t defaultInitialY);
         winrt::Windows::UI::Xaml::ElementTheme GetRequestedTheme();
@@ -70,7 +71,7 @@ namespace winrt::TerminalApp::implementation
         winrt::com_ptr<TerminalPage> _root{ nullptr };
 
         Microsoft::Terminal::Settings::Model::CascadiaSettings _settings{ nullptr };
-
+        
         HRESULT _settingsLoadedResult;
         winrt::hstring _settingsLoadExceptionText{};
 

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -23,6 +23,7 @@ static constexpr std::string_view AlwaysShowTabsKey{ "alwaysShowTabs" };
 static constexpr std::string_view InitialRowsKey{ "initialRows" };
 static constexpr std::string_view InitialColsKey{ "initialCols" };
 static constexpr std::string_view InitialPositionKey{ "initialPosition" };
+static constexpr std::string_view CentreOnLaunchKey{ "centreOnLaunch" };
 static constexpr std::string_view ShowTitleInTitlebarKey{ "showTerminalTitleInTitlebar" };
 static constexpr std::string_view ThemeKey{ "theme" };
 static constexpr std::string_view TabWidthModeKey{ "tabWidthMode" };
@@ -104,6 +105,7 @@ winrt::com_ptr<GlobalAppSettings> GlobalAppSettings::Copy() const
     globals->_WarnAboutLargePaste = _WarnAboutLargePaste;
     globals->_WarnAboutMultiLinePaste = _WarnAboutMultiLinePaste;
     globals->_InitialPosition = _InitialPosition;
+    globals->_CentreOnLaunch = _CentreOnLaunch;
     globals->_LaunchMode = _LaunchMode;
     globals->_SnapToGridOnResize = _SnapToGridOnResize;
     globals->_ForceFullRepaintRendering = _ForceFullRepaintRendering;
@@ -257,6 +259,8 @@ void GlobalAppSettings::LayerJson(const Json::Value& json)
 
     JsonUtils::GetValueForKey(json, InitialPositionKey, _InitialPosition);
 
+    JsonUtils::GetValueForKey(json, CentreOnLaunchKey, _CentreOnLaunch);
+
     JsonUtils::GetValueForKey(json, ShowTitleInTitlebarKey, _ShowTitleInTitlebar);
 
     JsonUtils::GetValueForKey(json, ShowTabsInTitlebarKey, _ShowTabsInTitlebar);
@@ -369,6 +373,7 @@ Json::Value GlobalAppSettings::ToJson() const
     JsonUtils::SetValueForKey(json, InitialRowsKey,                 _InitialRows);
     JsonUtils::SetValueForKey(json, InitialColsKey,                 _InitialCols);
     JsonUtils::SetValueForKey(json, InitialPositionKey,             _InitialPosition);
+    JsonUtils::SetValueForKey(json, CentreOnLaunchKey,              _CentreOnLaunch);
     JsonUtils::SetValueForKey(json, ShowTitleInTitlebarKey,         _ShowTitleInTitlebar);
     JsonUtils::SetValueForKey(json, ShowTabsInTitlebarKey,          _ShowTabsInTitlebar);
     JsonUtils::SetValueForKey(json, WordDelimitersKey,              _WordDelimiters);

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
@@ -75,6 +75,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         GETSET_SETTING(bool, WarnAboutLargePaste, true);
         GETSET_SETTING(bool, WarnAboutMultiLinePaste, true);
         GETSET_SETTING(Model::LaunchPosition, InitialPosition, nullptr, nullptr);
+        GETSET_SETTING(bool, CentreOnLaunch, false);
         GETSET_SETTING(Model::LaunchMode, LaunchMode, LaunchMode::DefaultMode);
         GETSET_SETTING(bool, SnapToGridOnResize, true);
         GETSET_SETTING(bool, ForceFullRepaintRendering, false);

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -95,6 +95,10 @@ namespace Microsoft.Terminal.Settings.Model
         void ClearInitialPosition();
         LaunchPosition InitialPosition;
 
+        Boolean HasCentreOnLaunch();
+        void ClearCentreOnLaunch();
+        Boolean CentreOnLaunch;
+
         Boolean HasLaunchMode();
         void ClearLaunchMode();
         LaunchMode LaunchMode;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
If the users set true to this property, the terminal will appear on the center of the user's display.
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #7722 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
