### PR TITLE
Teach tab renamer to truncate tab title input

### DIFF
--- a/src/cascadia/TerminalApp/TabHeaderControl.xaml
+++ b/src/cascadia/TerminalApp/TabHeaderControl.xaml
@@ -25,6 +25,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                  MinHeight="0"
                  Padding="4,0,4,0"
                  Margin="0,-8,0,-8"
+                 MaxLength="1024"
                  LostFocus="RenameBoxLostFocusHandler"/>
     </StackPanel>
 </UserControl>


### PR DESCRIPTION
If we try set a very long title, "rename box" UI changes max height,
corrupting the layout.  There are several ways to fix it, e.g. by
limiting the MaxHeight (e.g. by binding it to the actual height of the
title bar).

However, I went for the most straightforward approach - truncating.  I
don't think we should allow long titles (though it can be a nice hidden
storage :blush:)

I considered to truncate it to the tab header width, but we can actually
see more data in tab-switcher, so I simply went for a hard-coded value
which should be large enough.

If this approach makes sense we need to consider updating the
documentation. 

Closes #8428