### PR TITLE
Improve clipboard handling in "drag and drop" scenario 

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2973,6 +2973,10 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             }
             CATCH_LOG();
         }
+        // StorageItem must be last. Some applications put hybrid data format items
+        // in a drop message and we'll eat a crash when we request them.
+        // Those applications usually include Text as well, so having storage items
+        // last makes sure we'll hit text before getting to them.
         else if (e.DataView().Contains(StandardDataFormats::StorageItems()))
         {
             Windows::Foundation::Collections::IVectorView<Windows::Storage::IStorageItem> items;


### PR DESCRIPTION
This PR improves the clipboard handling logic of "drag and drop" in
TermControl, making it more useful and less likely to crash.

* Added support for two more categories of content, `ApplicationLink`
  and `WebLink`.
* Reordered the ifs, making `StorageItem` the last clause. With WT being
  a text-oriented application, I think we can safely assume that the
  content being pasted is likely to be text/links.
* Catch possible exceptions during
  `e.DataView().GetStorageItemsAsync()`.

Closes #7804