### PR TITLE
Represent BackgroundImageAlignment as ConvergedAlignment

### DIFF
--- a/src/cascadia/TerminalApp/TerminalSettings.cpp
+++ b/src/cascadia/TerminalApp/TerminalSettings.cpp
@@ -11,6 +11,43 @@ using namespace winrt::Microsoft::Terminal::Settings::Model;
 
 namespace winrt::TerminalApp::implementation
 {
+    static std::tuple<Windows::UI::Xaml::HorizontalAlignment, Windows::UI::Xaml::VerticalAlignment> ConvertConvergedAlignment(ConvergedAlignment alignment)
+    {
+        // extract horizontal alignment
+        Windows::UI::Xaml::HorizontalAlignment horizAlign;
+        switch (alignment & static_cast<ConvergedAlignment>(0x0F))
+        {
+        case ConvergedAlignment::Horizontal_Left:
+            horizAlign = Windows::UI::Xaml::HorizontalAlignment::Left;
+            break;
+        case ConvergedAlignment::Horizontal_Right:
+            horizAlign = Windows::UI::Xaml::HorizontalAlignment::Right;
+            break;
+        case ConvergedAlignment::Horizontal_Center:
+        default:
+            horizAlign = Windows::UI::Xaml::HorizontalAlignment::Center;
+            break;
+        }
+
+        // extract vertical alignment
+        Windows::UI::Xaml::VerticalAlignment vertAlign;
+        switch (alignment & static_cast<ConvergedAlignment>(0xF0))
+        {
+        case ConvergedAlignment::Vertical_Top:
+            vertAlign = Windows::UI::Xaml::VerticalAlignment::Top;
+            break;
+        case ConvergedAlignment::Vertical_Bottom:
+            vertAlign = Windows::UI::Xaml::VerticalAlignment::Bottom;
+            break;
+        case ConvergedAlignment::Vertical_Center:
+        default:
+            vertAlign = Windows::UI::Xaml::VerticalAlignment::Center;
+            break;
+        }
+
+        return { horizAlign, vertAlign };
+    }
+
     TerminalSettings::TerminalSettings(const CascadiaSettings& appSettings, winrt::guid profileGuid, const IKeyBindings& keybindings) :
         _KeyBindings{ keybindings }
     {
@@ -142,9 +179,7 @@ namespace winrt::TerminalApp::implementation
 
         _BackgroundImageOpacity = profile.BackgroundImageOpacity();
         _BackgroundImageStretchMode = profile.BackgroundImageStretchMode();
-
-        _BackgroundImageHorizontalAlignment = profile.BackgroundImageHorizontalAlignment();
-        _BackgroundImageVerticalAlignment = profile.BackgroundImageVerticalAlignment();
+        std::tie(_BackgroundImageHorizontalAlignment, _BackgroundImageVerticalAlignment) = ConvertConvergedAlignment(profile.BackgroundImageAlignment());
 
         _RetroTerminalEffect = profile.RetroTerminalEffect();
 

--- a/src/cascadia/TerminalSettingsModel/Profile.cpp
+++ b/src/cascadia/TerminalSettingsModel/Profile.cpp
@@ -473,54 +473,6 @@ winrt::guid Profile::GetGuidOrGenerateForJson(const Json::Value& json) noexcept
     return Profile::_GenerateGuidForProfile(name, source);
 }
 
-#pragma region BackgroundImageAlignment
-bool Profile::HasBackgroundImageAlignment() const noexcept
-{
-    return _BackgroundImageAlignment.has_value();
-}
-
-void Profile::ClearBackgroundImageAlignment() noexcept
-{
-    _BackgroundImageAlignment = std::nullopt;
-}
-
-const HorizontalAlignment Profile::BackgroundImageHorizontalAlignment() const noexcept
-{
-    const auto val{ _getBackgroundImageAlignmentImpl() };
-    return val ? std::get<HorizontalAlignment>(*val) : HorizontalAlignment::Center;
-}
-
-void Profile::BackgroundImageHorizontalAlignment(const HorizontalAlignment& value) noexcept
-{
-    if (HasBackgroundImageAlignment())
-    {
-        std::get<HorizontalAlignment>(*_BackgroundImageAlignment) = value;
-    }
-    else
-    {
-        _BackgroundImageAlignment = { value, VerticalAlignment::Center };
-    }
-}
-
-const VerticalAlignment Profile::BackgroundImageVerticalAlignment() const noexcept
-{
-    const auto val{ _getBackgroundImageAlignmentImpl() };
-    return val ? std::get<VerticalAlignment>(*val) : VerticalAlignment::Center;
-}
-
-void Profile::BackgroundImageVerticalAlignment(const VerticalAlignment& value) noexcept
-{
-    if (HasBackgroundImageAlignment())
-    {
-        std::get<VerticalAlignment>(*_BackgroundImageAlignment) = value;
-    }
-    else
-    {
-        _BackgroundImageAlignment = { HorizontalAlignment::Center, value };
-    }
-}
-#pragma endregion
-
 // Method Description:
 // - Create a new serialized JsonObject from an instance of this class
 // Arguments:

--- a/src/cascadia/TerminalSettingsModel/Profile.h
+++ b/src/cascadia/TerminalSettingsModel/Profile.h
@@ -61,14 +61,6 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         hstring ExpandedBackgroundImagePath() const;
         static guid GetGuidOrGenerateForJson(const Json::Value& json) noexcept;
 
-        // BackgroundImageAlignment is 1 setting saved as 2 separate values
-        bool HasBackgroundImageAlignment() const noexcept;
-        void ClearBackgroundImageAlignment() noexcept;
-        const Windows::UI::Xaml::HorizontalAlignment BackgroundImageHorizontalAlignment() const noexcept;
-        void BackgroundImageHorizontalAlignment(const Windows::UI::Xaml::HorizontalAlignment& value) noexcept;
-        const Windows::UI::Xaml::VerticalAlignment BackgroundImageVerticalAlignment() const noexcept;
-        void BackgroundImageVerticalAlignment(const Windows::UI::Xaml::VerticalAlignment& value) noexcept;
-
         GETSET_SETTING(guid, Guid, _GenerateGuidForProfile(Name(), Source()));
         GETSET_SETTING(hstring, Name, L"Default");
         GETSET_SETTING(hstring, Source);
@@ -97,6 +89,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         GETSET_SETTING(hstring, BackgroundImagePath);
         GETSET_SETTING(double, BackgroundImageOpacity, 1.0);
         GETSET_SETTING(Windows::UI::Xaml::Media::Stretch, BackgroundImageStretchMode, Windows::UI::Xaml::Media::Stretch::UniformToFill);
+        GETSET_SETTING(ConvergedAlignment, BackgroundImageAlignment, ConvergedAlignment::Horizontal_Center | ConvergedAlignment::Vertical_Center);
 
         GETSET_SETTING(Microsoft::Terminal::TerminalControl::TextAntialiasingMode, AntialiasingMode, Microsoft::Terminal::TerminalControl::TextAntialiasingMode::Grayscale);
         GETSET_SETTING(bool, RetroTerminalEffect, false);
@@ -120,28 +113,6 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         GETSET_SETTING(Model::BellStyle, BellStyle, BellStyle::Audible);
 
     private:
-        std::optional<std::tuple<Windows::UI::Xaml::HorizontalAlignment, Windows::UI::Xaml::VerticalAlignment>> _BackgroundImageAlignment{ std::nullopt };
-        std::optional<std::tuple<Windows::UI::Xaml::HorizontalAlignment, Windows::UI::Xaml::VerticalAlignment>> _getBackgroundImageAlignmentImpl() const
-        {
-            /*return user set value*/
-            if (_BackgroundImageAlignment)
-            {
-                return _BackgroundImageAlignment;
-            }
-
-            /*user set value was not set*/ /*iterate through parents to find a value*/
-            for (auto parent : _parents)
-            {
-                if (auto val{ parent->_getBackgroundImageAlignmentImpl() })
-                {
-                    return val;
-                }
-            }
-
-            /*no value was found*/
-            return std::nullopt;
-        };
-
         static std::wstring EvaluateStartingDirectory(const std::wstring& directory);
 
         static guid _GenerateGuidForProfile(const hstring& name, const hstring& source) noexcept;

--- a/src/cascadia/TerminalSettingsModel/Profile.idl
+++ b/src/cascadia/TerminalSettingsModel/Profile.idl
@@ -18,6 +18,19 @@ namespace Microsoft.Terminal.Settings.Model
         All = 0xffffffff
     };
 
+    [flags]
+    enum ConvergedAlignment {
+        // low 4 bits are the horizontal
+        Horizontal_Center = 0x00,
+        Horizontal_Left = 0x01,
+        Horizontal_Right = 0x02,
+
+        // high 4 bits are the vertical
+        Vertical_Center = 0x00,
+        Vertical_Top = 0x10,
+        Vertical_Bottom = 0x20
+    };
+
     [default_interface] runtimeclass Profile {
         Profile();
         Profile(Guid guid);
@@ -112,8 +125,7 @@ namespace Microsoft.Terminal.Settings.Model
 
         Boolean HasBackgroundImageAlignment();
         void ClearBackgroundImageAlignment();
-        Windows.UI.Xaml.HorizontalAlignment BackgroundImageHorizontalAlignment;
-        Windows.UI.Xaml.VerticalAlignment BackgroundImageVerticalAlignment;
+        ConvergedAlignment BackgroundImageAlignment;
 
         Boolean HasAntialiasingMode();
         void ClearAntialiasingMode();

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -76,21 +76,19 @@ JSON_FLAG_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::BellStyle)
     }
 };
 
-JSON_ENUM_MAPPER(std::tuple<::winrt::Windows::UI::Xaml::HorizontalAlignment, ::winrt::Windows::UI::Xaml::VerticalAlignment>)
+JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::ConvergedAlignment)
 {
     // reduce repetition
-    using HA = ::winrt::Windows::UI::Xaml::HorizontalAlignment;
-    using VA = ::winrt::Windows::UI::Xaml::VerticalAlignment;
     static constexpr std::array<pair_type, 9> mappings = {
-        pair_type{ "center", std::make_tuple(HA::Center, VA::Center) },
-        pair_type{ "topLeft", std::make_tuple(HA::Left, VA::Top) },
-        pair_type{ "bottomLeft", std::make_tuple(HA::Left, VA::Bottom) },
-        pair_type{ "left", std::make_tuple(HA::Left, VA::Center) },
-        pair_type{ "topRight", std::make_tuple(HA::Right, VA::Top) },
-        pair_type{ "bottomRight", std::make_tuple(HA::Right, VA::Bottom) },
-        pair_type{ "right", std::make_tuple(HA::Right, VA::Center) },
-        pair_type{ "top", std::make_tuple(HA::Center, VA::Top) },
-        pair_type{ "bottom", std::make_tuple(HA::Center, VA::Bottom) }
+        pair_type{ "center", ValueType::Horizontal_Center | ValueType::Vertical_Center },
+        pair_type{ "topLeft", ValueType::Horizontal_Left | ValueType::Vertical_Top },
+        pair_type{ "bottomLeft", ValueType::Horizontal_Left | ValueType::Vertical_Bottom },
+        pair_type{ "left", ValueType::Horizontal_Left | ValueType::Vertical_Center },
+        pair_type{ "topRight", ValueType::Horizontal_Right | ValueType::Vertical_Top },
+        pair_type{ "bottomRight", ValueType::Horizontal_Right | ValueType::Vertical_Bottom },
+        pair_type{ "right", ValueType::Horizontal_Right | ValueType::Vertical_Center },
+        pair_type{ "top", ValueType::Horizontal_Center | ValueType::Vertical_Top },
+        pair_type{ "bottom", ValueType::Horizontal_Center | ValueType::Vertical_Bottom }
     };
 };
 


### PR DESCRIPTION
`backgroundImageAlignment` is exposed as 1 setting in the JSON, but
stored as two separate settings (`HorizontalAlignment` and
`VerticalAlignment`). This PR introduces `ConvergedAlignment` as a flag
enum that can be a combination of horizontal and vertical Alignments.
TSM now solely uses this `ConvergedAlignment`, and TerminalSettings
performs a conversion from this new enum to the traditional
`HorizontalAlignment` and `VerticalAlignment` for consumption.

## Validation Steps Performed
Manually tested changing the `backgroundImageAlignment` in my
settings.json and checking if the image updated appropriately.