### PR TITLE
Remove usage of old safe math and unused intsafe.h include

### DIFF
--- a/src/buffer/out/precomp.h
+++ b/src/buffer/out/precomp.h
@@ -29,7 +29,6 @@ Abstract:
 
 // Windows Header Files:
 #include <windows.h>
-#include <intsafe.h>
 
 // private dependencies
 #include "../inc/operators.hpp"

--- a/src/buffer/out/ut_textbuffer/precomp.h
+++ b/src/buffer/out/ut_textbuffer/precomp.h
@@ -30,7 +30,6 @@ Abstract:
 
 // Windows Header Files:
 #include <windows.h>
-#include <intsafe.h>
 
 // private dependencies
 #include "../host/conddkrefs.h"

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -43,8 +43,8 @@ try
     RETURN_BOOL_IF_FALSE(SUCCEEDED(SizeTToShort(column, &x)) &&
                          SUCCEEDED(SizeTToShort(line, &y)));
 
-    RETURN_BOOL_IF_FALSE(SUCCEEDED(ShortSub(x, 1, &x)) &&
-                         SUCCEEDED(ShortSub(y, 1, &y)));
+    RETURN_BOOL_IF_FALSE(base::CheckSub<SHORT>(x, 1).AssignIfValid(&x) &&
+                         base::CheckSub<SHORT>(y, 1).AssignIfValid(&y));
 
     return _terminalApi.SetCursorPosition(x, y);
 }

--- a/src/host/consoleInformation.cpp
+++ b/src/host/consoleInformation.cpp
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 #include "precomp.h"
-#include <intsafe.h>
 
 #include "misc.h"
 #include "output.h"

--- a/src/host/directio.cpp
+++ b/src/host/directio.cpp
@@ -994,14 +994,14 @@ void EventsToUnicode(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& inEvents,
         {
             // We find the offset into the original buffer by the dimensions of the original request rectangle.
             ptrdiff_t rowOffset = 0;
-            RETURN_IF_FAILED(PtrdiffTSub(target.Y, requestRectangle.Top(), &rowOffset));
-            RETURN_IF_FAILED(PtrdiffTMult(rowOffset, requestRectangle.Width(), &rowOffset));
+            RETURN_HR_IF(E_ABORT, !base::CheckSub<LONGLONG>(target.Y, requestRectangle.Top()).AssignIfValid(&rowOffset));
+            RETURN_HR_IF(E_ABORT, !base::CheckMul<LONGLONG>(rowOffset, requestRectangle.Width()).AssignIfValid(&rowOffset));
 
             ptrdiff_t colOffset = 0;
-            RETURN_IF_FAILED(PtrdiffTSub(target.X, requestRectangle.Left(), &colOffset));
+            RETURN_HR_IF(E_ABORT, !base::CheckSub<LONGLONG>(target.X, requestRectangle.Left()).AssignIfValid(&colOffset));
 
             ptrdiff_t totalOffset = 0;
-            RETURN_IF_FAILED(PtrdiffTAdd(rowOffset, colOffset, &totalOffset));
+            RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONGLONG>(rowOffset, colOffset).AssignIfValid(&totalOffset));
 
             // Now we make a subspan starting from that offset for as much of the original request as would fit
             const auto subspan = buffer.subspan(totalOffset, writeRectangle.Width());

--- a/src/host/precomp.h
+++ b/src/host/precomp.h
@@ -50,11 +50,6 @@ Abstract:
 
 #include "conv.h"
 
-#pragma prefast(push)
-#pragma prefast(disable : 26071, "Range violation in Intsafe. Not ours.")
-#define ENABLE_INTSAFE_SIGNED_FUNCTIONS // Only unsigned intsafe math/casts available without this def
-#include <intsafe.h>
-#pragma prefast(pop)
 #include <strsafe.h>
 #include <cwchar>
 #include <mmsystem.h>

--- a/src/host/telemetry.cpp
+++ b/src/host/telemetry.cpp
@@ -3,7 +3,6 @@
 
 #include "precomp.h"
 
-#include <Intsafe.h>
 #include "Shlwapi.h"
 #include "telemetry.hpp"
 #include <ctime>

--- a/src/inc/LibraryIncludes.h
+++ b/src/inc/LibraryIncludes.h
@@ -74,10 +74,6 @@
 #include <base/numerics/safe_math.h>
 #pragma warning(pop)
 
-// IntSafe
-#define ENABLE_INTSAFE_SIGNED_FUNCTIONS
-#include <intsafe.h>
-
 // LibPopCnt - Fast C/C++ bit population count library (on bits in an array)
 #include <libpopcnt.h>
 

--- a/src/interactivity/win32/precomp.h
+++ b/src/interactivity/win32/precomp.h
@@ -1,4 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+#pragma prefast(push)
+#pragma prefast(disable : 26071, "Range violation in Intsafe. Not ours.")
+#define ENABLE_INTSAFE_SIGNED_FUNCTIONS // Only unsigned intsafe math/casts available without this def
+#include <intsafe.h>
+#pragma prefast(pop)
+
 #include "../../host/precomp.h"

--- a/src/propsheet/precomp.h
+++ b/src/propsheet/precomp.h
@@ -42,7 +42,6 @@
 #include "dialogs.h"
 
 #include <strsafe.h>
-#include <intsafe.h>
 #include <cwchar>
 #include <shellapi.h>
 

--- a/src/propsheet/registry.cpp
+++ b/src/propsheet/registry.cpp
@@ -23,7 +23,6 @@ Revision History:
 #include "precomp.h"
 #include <shlwapi.h>
 #include <strsafe.h>
-#include <intsafe.h>
 #include "../inc/conattrs.hpp"
 #pragma hdrstop
 

--- a/src/propslib/ShortcutSerialization.cpp
+++ b/src/propslib/ShortcutSerialization.cpp
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 #include "precomp.h"
-#include <intsafe.h>
 #include <propvarutil.h>
 #include <shlwapi.h>
 

--- a/src/renderer/gdi/invalidate.cpp
+++ b/src/renderer/gdi/invalidate.cpp
@@ -38,8 +38,8 @@ HRESULT GdiEngine::InvalidateScroll(const COORD* const pcoordDelta) noexcept
         RETURN_IF_FAILED(_InvalidOffset(&ptDelta));
 
         SIZE szInvalidScrollNew;
-        RETURN_IF_FAILED(LongAdd(_szInvalidScroll.cx, ptDelta.x, &szInvalidScrollNew.cx));
-        RETURN_IF_FAILED(LongAdd(_szInvalidScroll.cy, ptDelta.y, &szInvalidScrollNew.cy));
+        RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(_szInvalidScroll.cx, ptDelta.x).AssignIfValid(&szInvalidScrollNew.cx));
+        RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(_szInvalidScroll.cy, ptDelta.y).AssignIfValid(&szInvalidScrollNew.cy));
 
         // Store if safemath succeeded
         _szInvalidScroll = szInvalidScrollNew;
@@ -176,10 +176,10 @@ HRESULT GdiEngine::_InvalidOffset(const POINT* const ppt) noexcept
     {
         RECT rcInvalidNew;
 
-        RETURN_IF_FAILED(LongAdd(_rcInvalid.left, ppt->x, &rcInvalidNew.left));
-        RETURN_IF_FAILED(LongAdd(_rcInvalid.right, ppt->x, &rcInvalidNew.right));
-        RETURN_IF_FAILED(LongAdd(_rcInvalid.top, ppt->y, &rcInvalidNew.top));
-        RETURN_IF_FAILED(LongAdd(_rcInvalid.bottom, ppt->y, &rcInvalidNew.bottom));
+        RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(_rcInvalid.left, ppt->x).AssignIfValid(&rcInvalidNew.left));
+        RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(_rcInvalid.right, ppt->x).AssignIfValid(&rcInvalidNew.right));
+        RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(_rcInvalid.top, ppt->y).AssignIfValid(&rcInvalidNew.top));
+        RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(_rcInvalid.bottom, ppt->y).AssignIfValid(&rcInvalidNew.bottom));
 
         // Add the scrolled invalid rectangle to what was left behind to get the new invalid area.
         // This is the equivalent of adding in the "update rectangle" that we would get out of ScrollWindowEx/ScrollDC.

--- a/src/renderer/gdi/math.cpp
+++ b/src/renderer/gdi/math.cpp
@@ -84,10 +84,10 @@ std::vector<til::rectangle> GdiEngine::GetDirtyArea()
     RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), coordFontSize.X == 0 || coordFontSize.Y == 0);
 
     RECT rc;
-    RETURN_IF_FAILED(LongMult(psr->Left, coordFontSize.X, &rc.left));
-    RETURN_IF_FAILED(LongMult(psr->Right, coordFontSize.X, &rc.right));
-    RETURN_IF_FAILED(LongMult(psr->Top, coordFontSize.Y, &rc.top));
-    RETURN_IF_FAILED(LongMult(psr->Bottom, coordFontSize.Y, &rc.bottom));
+    RETURN_HR_IF(E_ABORT, !base::CheckMul<LONG>(psr->Left, coordFontSize.X).AssignIfValid(&rc.left));
+    RETURN_HR_IF(E_ABORT, !base::CheckMul<LONG>(psr->Right, coordFontSize.X).AssignIfValid(&rc.right));
+    RETURN_HR_IF(E_ABORT, !base::CheckMul<LONG>(psr->Top, coordFontSize.Y).AssignIfValid(&rc.top));
+    RETURN_HR_IF(E_ABORT, !base::CheckMul<LONG>(psr->Bottom, coordFontSize.Y).AssignIfValid(&rc.bottom));
 
     *prc = rc;
 
@@ -107,8 +107,8 @@ std::vector<til::rectangle> GdiEngine::GetDirtyArea()
     RETURN_HR_IF(HRESULT_FROM_WIN32(ERROR_INVALID_STATE), coordFontSize.X == 0 || coordFontSize.Y == 0);
 
     POINT pt;
-    RETURN_IF_FAILED(LongMult(pcoord->X, coordFontSize.X, &pt.x));
-    RETURN_IF_FAILED(LongMult(pcoord->Y, coordFontSize.Y, &pt.y));
+    RETURN_HR_IF(E_ABORT, !base::CheckMul<LONG>(pcoord->X, coordFontSize.X).AssignIfValid(&pt.x));
+    RETURN_HR_IF(E_ABORT, !base::CheckMul<LONG>(pcoord->Y, coordFontSize.Y).AssignIfValid(&pt.y));
 
     *pPoint = pt;
 
@@ -155,12 +155,12 @@ std::vector<til::rectangle> GdiEngine::GetDirtyArea()
     LONG lBottom = prc->bottom;
 
     // Add the width of a font (in pixels) to the rect
-    RETURN_IF_FAILED(LongAdd(lRight, coordFontSize.X, &lRight));
-    RETURN_IF_FAILED(LongAdd(lBottom, coordFontSize.Y, &lBottom));
+    RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(lRight, coordFontSize.X).AssignIfValid(&lRight));
+    RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(lBottom, coordFontSize.Y).AssignIfValid(&lBottom));
 
     // Subtract 1 to ensure that we round down.
-    RETURN_IF_FAILED(LongSub(lRight, 1, &lRight));
-    RETURN_IF_FAILED(LongSub(lBottom, 1, &lBottom));
+    RETURN_HR_IF(E_ABORT, !base::CheckSub<LONG>(lRight, 1).AssignIfValid(&lRight));
+    RETURN_HR_IF(E_ABORT, !base::CheckSub<LONG>(lBottom, 1).AssignIfValid(&lBottom));
 
     // Divide by font size to see how many rows/columns
     // note: no safe math for div.
@@ -172,8 +172,8 @@ std::vector<til::rectangle> GdiEngine::GetDirtyArea()
     RETURN_IF_FAILED(LongToShort(lBottom, &sr.Bottom));
 
     // Pixels are exclusive and character rects are inclusive. Subtract 1 to go from exclusive to inclusive rect.
-    RETURN_IF_FAILED(ShortSub(sr.Right, 1, &sr.Right));
-    RETURN_IF_FAILED(ShortSub(sr.Bottom, 1, &sr.Bottom));
+    RETURN_HR_IF(E_ABORT, !base::CheckSub<SHORT>(sr.Right, 1).AssignIfValid(&sr.Right));
+    RETURN_HR_IF(E_ABORT, !base::CheckSub<SHORT>(sr.Bottom, 1).AssignIfValid(&sr.Bottom));
 
     *psr = sr;
 

--- a/src/renderer/gdi/paint.cpp
+++ b/src/renderer/gdi/paint.cpp
@@ -91,8 +91,8 @@ using namespace Microsoft::Console::Render;
     szGutter.cy = _szMemorySurface.cy % coordFontSize.Y;
 
     RECT rcScrollLimit = { 0 };
-    RETURN_IF_FAILED(LongSub(_szMemorySurface.cx, szGutter.cx, &rcScrollLimit.right));
-    RETURN_IF_FAILED(LongSub(_szMemorySurface.cy, szGutter.cy, &rcScrollLimit.bottom));
+    RETURN_HR_IF(E_ABORT, !base::CheckSub<LONG>(_szMemorySurface.cx, szGutter.cx).AssignIfValid(&rcScrollLimit.right));
+    RETURN_HR_IF(E_ABORT, !base::CheckSub<LONG>(_szMemorySurface.cy, szGutter.cy).AssignIfValid(&rcScrollLimit.bottom));
 
     // Scroll real window and memory buffer in-sync.
     LOG_LAST_ERROR_IF(!ScrollWindowEx(_hwndTargetWindow,
@@ -549,15 +549,15 @@ using namespace Microsoft::Console::Render;
 
     // First set up a block cursor the size of the font.
     RECT rcBoundaries;
-    RETURN_IF_FAILED(LongMult(options.coordCursor.X, coordFontSize.X, &rcBoundaries.left));
-    RETURN_IF_FAILED(LongMult(options.coordCursor.Y, coordFontSize.Y, &rcBoundaries.top));
-    RETURN_IF_FAILED(LongAdd(rcBoundaries.left, coordFontSize.X, &rcBoundaries.right));
-    RETURN_IF_FAILED(LongAdd(rcBoundaries.top, coordFontSize.Y, &rcBoundaries.bottom));
+    RETURN_HR_IF(E_ABORT, !base::CheckMul<LONG>(options.coordCursor.X, coordFontSize.X).AssignIfValid(&rcBoundaries.left));
+    RETURN_HR_IF(E_ABORT, !base::CheckMul<LONG>(options.coordCursor.Y, coordFontSize.Y).AssignIfValid(&rcBoundaries.top));
+    RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(rcBoundaries.left, coordFontSize.X).AssignIfValid(&rcBoundaries.right));
+    RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(rcBoundaries.top, coordFontSize.Y).AssignIfValid(&rcBoundaries.bottom));
 
     // If we're double-width cursor, make it an extra font wider.
     if (options.fIsDoubleWidth)
     {
-        RETURN_IF_FAILED(LongAdd(rcBoundaries.right, coordFontSize.X, &rcBoundaries.right));
+        RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(rcBoundaries.right, coordFontSize.X).AssignIfValid(&rcBoundaries.right));
     }
 
     // Make a set of RECTs to paint.
@@ -578,7 +578,7 @@ using namespace Microsoft::Console::Render;
         ulHeight = MulDiv(coordFontSize.Y, ulHeight, 100); // divide by 100 because percent.
 
         // Reduce the height of the top to be relative to the bottom by the height we want.
-        RETURN_IF_FAILED(LongSub(rcInvert.bottom, ulHeight, &rcInvert.top));
+        RETURN_HR_IF(E_ABORT, !base::CheckSub<LONG>(rcInvert.bottom, ulHeight).AssignIfValid(&rcInvert.top));
 
         cursorInvertRects.push_back(rcInvert);
     }
@@ -586,7 +586,7 @@ using namespace Microsoft::Console::Render;
 
     case CursorType::VerticalBar:
         LONG proposedWidth;
-        RETURN_IF_FAILED(LongAdd(rcInvert.left, options.cursorPixelWidth, &proposedWidth));
+        RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(rcInvert.left, options.cursorPixelWidth).AssignIfValid(&proposedWidth));
         // It can't be wider than one cell or we'll have problems in invalidation, so restrict here.
         // It's either the left + the proposed width from the ease of access setting, or
         // it's the right edge of the block cursor as a maximum.
@@ -595,7 +595,7 @@ using namespace Microsoft::Console::Render;
         break;
 
     case CursorType::Underscore:
-        RETURN_IF_FAILED(LongAdd(rcInvert.bottom, -1, &rcInvert.top));
+        RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(rcInvert.bottom, -1).AssignIfValid(&rcInvert.top));
         cursorInvertRects.push_back(rcInvert);
         break;
 
@@ -603,15 +603,15 @@ using namespace Microsoft::Console::Render;
     {
         RECT top, left, right, bottom;
         top = left = right = bottom = rcBoundaries;
-        RETURN_IF_FAILED(LongAdd(top.top, 1, &top.bottom));
-        RETURN_IF_FAILED(LongAdd(bottom.bottom, -1, &bottom.top));
-        RETURN_IF_FAILED(LongAdd(left.left, 1, &left.right));
-        RETURN_IF_FAILED(LongAdd(right.right, -1, &right.left));
+        RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(top.top, 1).AssignIfValid(&top.bottom));
+        RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(bottom.bottom, -1).AssignIfValid(&bottom.top));
+        RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(left.left, 1).AssignIfValid(&left.right));
+        RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(right.right, -1).AssignIfValid(&right.left));
 
-        RETURN_IF_FAILED(LongAdd(top.left, 1, &top.left));
-        RETURN_IF_FAILED(LongAdd(bottom.left, 1, &bottom.left));
-        RETURN_IF_FAILED(LongAdd(top.right, -1, &top.right));
-        RETURN_IF_FAILED(LongAdd(bottom.right, -1, &bottom.right));
+        RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(top.left, 1).AssignIfValid(&top.left));
+        RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(bottom.left, 1).AssignIfValid(&bottom.left));
+        RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(top.right, -1).AssignIfValid(&top.right));
+        RETURN_HR_IF(E_ABORT, !base::CheckAdd<LONG>(bottom.right, -1).AssignIfValid(&bottom.right));
 
         cursorInvertRects.push_back(top);
         cursorInvertRects.push_back(left);

--- a/src/renderer/gdi/precomp.h
+++ b/src/renderer/gdi/precomp.h
@@ -42,10 +42,3 @@ __inline int NTSTATUS_FROM_WIN32(long x)
 #else
 #define WHEN_DBG(x)
 #endif
-
-// SafeMath
-#pragma prefast(push)
-#pragma prefast(disable : 26071, "Range violation in Intsafe. Not ours.")
-#define ENABLE_INTSAFE_SIGNED_FUNCTIONS // Only unsigned intsafe math/casts available without this def
-#include <intsafe.h>
-#pragma prefast(pop)

--- a/src/renderer/vt/paint.cpp
+++ b/src/renderer/vt/paint.cpp
@@ -351,7 +351,7 @@ using namespace Microsoft::Console::Types;
         for (const auto& cluster : clusters)
         {
             _bufferLine.append(cluster.GetText());
-            RETURN_IF_FAILED(ShortAdd(totalWidth, gsl::narrow<short>(cluster.GetColumns()), &totalWidth));
+            RETURN_HR_IF(E_ABORT, !base::CheckAdd<SHORT>(totalWidth, gsl::narrow<short>(cluster.GetColumns())).AssignIfValid(&totalWidth));
         }
 
         RETURN_IF_FAILED(VtEngine::_WriteTerminalAscii(_bufferLine));
@@ -387,7 +387,7 @@ using namespace Microsoft::Console::Types;
     for (const auto& cluster : clusters)
     {
         _bufferLine.append(cluster.GetText());
-        RETURN_IF_FAILED(ShortAdd(totalWidth, static_cast<short>(cluster.GetColumns()), &totalWidth));
+        RETURN_HR_IF(E_ABORT, !base::CheckAdd<SHORT>(totalWidth, static_cast<short>(cluster.GetColumns())).AssignIfValid(&totalWidth));
     }
     const size_t cchLine = _bufferLine.size();
 

--- a/src/renderer/vt/precomp.h
+++ b/src/renderer/vt/precomp.h
@@ -43,9 +43,3 @@ __inline int NTSTATUS_FROM_WIN32(long x)
 #define WHEN_DBG(x)
 #endif
 
-// SafeMath
-#pragma prefast(push)
-#pragma prefast(disable : 26071, "Range violation in Intsafe. Not ours.")
-#define ENABLE_INTSAFE_SIGNED_FUNCTIONS // Only unsigned intsafe math/casts available without this def
-#include <intsafe.h>
-#pragma prefast(pop)

--- a/src/server/ApiMessage.cpp
+++ b/src/server/ApiMessage.cpp
@@ -3,8 +3,6 @@
 
 #include "precomp.h"
 
-#include <intsafe.h>
-
 #include "ApiMessage.h"
 #include "DeviceComm.h"
 

--- a/src/server/precomp.h
+++ b/src/server/precomp.h
@@ -62,7 +62,6 @@ __inline NTSTATUS_FROM_WIN32(long x)
 //#include <ntstatus.h>
 
 #include <winioctl.h>
-#include <intsafe.h>
 
 // This includes support libraries from the CRT, STL, WIL, and GSL
 #include "LibraryIncludes.h"

--- a/src/terminal/adapter/InteractDispatch.cpp
+++ b/src/terminal/adapter/InteractDispatch.cpp
@@ -181,8 +181,8 @@ bool InteractDispatch::MoveCursor(const size_t row, const size_t col)
             if (success)
             {
                 // Set the line and column values as offsets from the viewport edge. Use safe math to prevent overflow.
-                success = SUCCEEDED(ShortAdd(coordCursor.Y, csbiex.srWindow.Top, &coordCursor.Y)) &&
-                          SUCCEEDED(ShortAdd(coordCursor.X, csbiex.srWindow.Left, &coordCursor.X));
+                success = base::CheckAdd<SHORT>(coordCursor.Y, csbiex.srWindow.Top).AssignIfValid(&coordCursor.Y) &&
+                          base::CheckAdd<SHORT>(coordCursor.X, csbiex.srWindow.Left).AssignIfValid(&coordCursor.X);
 
                 if (success)
                 {

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -448,12 +448,12 @@ bool AdaptDispatch::_InsertDeleteHelper(const size_t count, const bool isInsert)
     if (isInsert)
     {
         // Insert makes space by moving characters out to the right. So move the destination of the cut/paste region.
-        success = SUCCEEDED(ShortAdd(coordDestination.X, distance, &coordDestination.X));
+        success = base::CheckAdd<SHORT>(coordDestination.X, distance).AssignIfValid(&coordDestination.X);
     }
     else
     {
         // Delete scrolls the affected region to the left, relying on the clipping rect to actually delete the characters.
-        success = SUCCEEDED(ShortSub(coordDestination.X, distance, &coordDestination.X));
+        success = base::CheckSub<SHORT>(coordDestination.X, distance).AssignIfValid(&coordDestination.X);
     }
 
     if (success)

--- a/src/terminal/adapter/precomp.h
+++ b/src/terminal/adapter/precomp.h
@@ -14,8 +14,6 @@ Abstract:
 #include "LibraryIncludes.h"
 
 #include <cmath>
-#define ENABLE_INTSAFE_SIGNED_FUNCTIONS
-#include <intsafe.h>
 
 #include <sal.h>
 

--- a/src/terminal/parser/precomp.h
+++ b/src/terminal/parser/precomp.h
@@ -19,8 +19,5 @@ Abstract:
 
 #include <cstdio>
 
-#define ENABLE_INTSAFE_SIGNED_FUNCTIONS
-#include <intsafe.h>
-
 #include "telemetry.hpp"
 #include "tracing.hpp"

--- a/src/tsf/precomp.h
+++ b/src/tsf/precomp.h
@@ -29,7 +29,6 @@ extern "C" {
 #include <winuser.h>
 
 #include <ime.h>
-#include <intsafe.h>
 #include <strsafe.h>
 }
 

--- a/src/types/precomp.h
+++ b/src/types/precomp.h
@@ -39,11 +39,6 @@ Abstract:
 #include "LibraryIncludes.h"
 
 #include <winioctl.h>
-#pragma prefast(push)
-#pragma prefast(disable:26071, "Range violation in Intsafe. Not ours.")
-#define ENABLE_INTSAFE_SIGNED_FUNCTIONS // Only unsigned intsafe math/casts available without this def
-#include <intsafe.h>
-#pragma prefast(pop)
 
 // private dependencies
 #pragma warning(push)

--- a/src/types/viewport.cpp
+++ b/src/types/viewport.cpp
@@ -848,10 +848,10 @@ Viewport Viewport::ToOrigin() const noexcept
     SHORT newRight = original._sr.Right;
     SHORT newBottom = original._sr.Bottom;
 
-    THROW_IF_FAILED(ShortAdd(newLeft, delta.X, &newLeft));
-    THROW_IF_FAILED(ShortAdd(newRight, delta.X, &newRight));
-    THROW_IF_FAILED(ShortAdd(newTop, delta.Y, &newTop));
-    THROW_IF_FAILED(ShortAdd(newBottom, delta.Y, &newBottom));
+    THROW_HR_IF(E_ABORT, !base::CheckAdd(newLeft, delta.X).AssignIfValid(&newLeft));
+    THROW_HR_IF(E_ABORT, !base::CheckAdd(newRight, delta.X).AssignIfValid(&newRight));
+    THROW_HR_IF(E_ABORT, !base::CheckAdd(newTop, delta.Y).AssignIfValid(&newTop));
+    THROW_HR_IF(E_ABORT, !base::CheckAdd(newBottom, delta.Y).AssignIfValid(&newBottom));
 
     return Viewport({ newLeft, newTop, newRight, newBottom });
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

#4144 introduced the chromium safe math library.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #4153
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
