### PR TITLE
Correct paths in the the runut and runft test scripts

### DIFF
--- a/tools/runft.cmd
+++ b/tools/runft.cmd
@@ -4,5 +4,5 @@ rem Run the console feature tests.
 rem Keep this file in sync with tests.xml
 
 call %TAEF% ^
-    %OPENCON%\bin\%ARCH%\Debug\ConHost.Feature.Tests.dll ^
+    %OPENCON%\bin\%ARCH%\%_LAST_BUILD_CONF%\ConHost.Feature.Tests.dll ^
     %*

--- a/tools/runut.cmd
+++ b/tools/runut.cmd
@@ -16,7 +16,7 @@ if "%PLATFORM%" == "Win32" (
 call %TAEF% ^
     %OPENCON%\bin\%PLATFORM%\%_LAST_BUILD_CONF%\Conhost.Unit.Tests.dll ^
     %OPENCON%\bin\%PLATFORM%\%_LAST_BUILD_CONF%\TextBuffer.Unit.Tests.dll ^
-    %OPENCON%\bin\%PLATFORM%\%_LAST_BUILD_CONF%\Terminal.Core.Unit.Tests.dll ^
+    %OPENCON%\bin\%PLATFORM%\%_LAST_BUILD_CONF%\UnitTests_TerminalCore\Terminal.Core.Unit.Tests.dll ^
     %OPENCON%\bin\%PLATFORM%\%_LAST_BUILD_CONF%\Conhost.Interactivity.Win32.Unit.Tests.dll ^
     %OPENCON%\bin\%PLATFORM%\%_LAST_BUILD_CONF%\ConParser.Unit.Tests.dll ^
     %OPENCON%\bin\%PLATFORM%\%_LAST_BUILD_CONF%\ConAdapter.Unit.Tests.dll ^


### PR DESCRIPTION
This corrects the path to `Terminal.Core.Unit.Tests.dll` in the `runut`
unit test script and makes the `runft` feature test script capable of
working with _Release_ builds as well as _Debug_ builds.

The path to `Terminal.Core.Unit.Tests.dll` changed when the project was
restructured, and the `runut` script was never updated to reflect that
change. That has now been corrected.

And the `runft` script used to be hard coded to look for tests in the
_Debug_ directory, but it has now been updated to use the
`%_LAST_BUILD_CONF%` environment variable, so it should work for both
_Debug_ and _Release_ builds.

## Validation Steps Performed
I've manually confirmed that the `runut` and `runft` scripts now work as
expected.

Closes #8485