### PR TITLE
Fix the path to the local unittests in `runut`

### DIFF
--- a/tools/runut.cmd
+++ b/tools/runut.cmd
@@ -8,9 +8,9 @@ rem That's a cppwinrt project, that doesn't use %PLATFORM% in it's path when the
 rem platform is Win32/x86.
 rem set a helper for us to find that test
 
-set _TestHostAppPath=%OPENCON%\%PLATFORM%\%_LAST_BUILD_CONF%\TestHostApp
+set _TestHostAppPath=%OPENCON%\bin\%PLATFORM%\%_LAST_BUILD_CONF%\TestHostApp
 if "%PLATFORM%" == "Win32" (
-    set _TestHostAppPath=%OPENCON%\%_LAST_BUILD_CONF%\TestHostApp
+    set _TestHostAppPath=%OPENCON%\bin\%_LAST_BUILD_CONF%\TestHostApp
 )
 
 call %TAEF% ^


### PR DESCRIPTION
This is the same root cause as #8485. We moved the output of a bunch of projects to be unified. We forgot to update all the test scripts.

In this case, the LocalTests were still using the old path that's _not_ under `bin/`