### PR TITLE
Teach Find command to search selected text

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -174,6 +174,14 @@
       ],
       "type": "string"
     },
+    "FindSelectionMode": {
+      "enum": [
+        "none",
+        "singleLine",
+        "multiLine"
+      ],
+      "type": "string"
+    },
     "NewTerminalArgs": {
       "properties": {
         "commandline": {
@@ -540,6 +548,22 @@
               "$ref": "#/definitions/CommandPaletteLaunchMode",
               "default": "action",
               "description": "Toggle command palette in either action or command line mode. If no value is provided, the palette will launch in action mode."
+            }
+          }
+        }
+      ]
+    },
+    "FindAction": {
+      "description": "Arguments for a find action",
+      "allOf": [
+        { "$ref": "#/definitions/ShortcutAction" },
+        {
+          "properties": {
+            "action": { "type": "string", "pattern": "find" },
+            "selectionMode": {
+              "$ref": "#/definitions/FindSelectionMode",
+              "default": "none",
+              "description": "Defines whether selected text should be used when invoking find. In \"singleLine\" mode the find will use only single-line selections. In \"multiLine\" mode the entire selected text will be used (lines will be concatenated with trailing line-breaks omitted). If no value or \"none\" is provided, the selected text will not be used."
             }
           }
         }

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -269,8 +269,11 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_HandleFind(const IInspectable& /*sender*/,
                                    const ActionEventArgs& args)
     {
-        _Find();
-        args.Handled(true);
+        if (const auto& realArgs = args.ActionArgs().try_as<FindArgs>())
+        {
+            _Find(realArgs.SelectionMode());
+            args.Handled(true);
+        }
     }
 
     void TerminalPage::_HandleResetFontSize(const IInspectable& /*sender*/,

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2435,10 +2435,14 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     // Return Value:
     // - <none>
-    void TerminalPage::_Find()
+    void TerminalPage::_Find(winrt::Microsoft::Terminal::Settings::Model::FindSelectionMode selectionMode)
     {
         const auto termControl = _GetActiveControl();
-        termControl.CreateSearchBoxControl();
+
+        const auto populateFromSelection = selectionMode != winrt::Microsoft::Terminal::Settings::Model::FindSelectionMode::None;
+        const auto allowMultiSelection = selectionMode == winrt::Microsoft::Terminal::Settings::Model::FindSelectionMode::MultiLine;
+
+        termControl.CreateSearchBoxControl(populateFromSelection, allowMultiSelection);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -220,7 +220,7 @@ namespace winrt::TerminalApp::implementation
         void _OnFirstLayout(const IInspectable& sender, const IInspectable& eventArgs);
         void _UpdatedSelectedTab(const int32_t index);
 
-        void _Find();
+        void _Find(winrt::Microsoft::Terminal::Settings::Model::FindSelectionMode selectionMode);
 
         winrt::fire_and_forget _RefreshUIForSettingsReload();
 

--- a/src/cascadia/TerminalControl/SearchBoxControl.cpp
+++ b/src/cascadia/TerminalControl/SearchBoxControl.cpp
@@ -111,6 +111,20 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     }
 
     // Method Description:
+    // - Allows to set the value of the text to search
+    // Arguments:
+    // - text: string value to populate in the TextBox
+    // Return Value:
+    // - <none>
+    void SearchBoxControl::PopulateTextbox(winrt::hstring const& text)
+    {
+        if (TextBox())
+        {
+            TextBox().Text(text);
+        }
+    }
+
+    // Method Description:
     // - Check if the current focus is on any element within the
     //   search box
     // Arguments:

--- a/src/cascadia/TerminalControl/SearchBoxControl.h
+++ b/src/cascadia/TerminalControl/SearchBoxControl.h
@@ -29,6 +29,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void TextBoxKeyDown(winrt::Windows::Foundation::IInspectable const& /*sender*/, winrt::Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e);
 
         void SetFocusOnTextbox();
+        void PopulateTextbox(winrt::hstring const& text);
         bool ContainsFocus();
 
         void GoBackwardClicked(winrt::Windows::Foundation::IInspectable const& /*sender*/, winrt::Windows::UI::Xaml::RoutedEventArgs const& /*e*/);

--- a/src/cascadia/TerminalControl/SearchBoxControl.idl
+++ b/src/cascadia/TerminalControl/SearchBoxControl.idl
@@ -9,6 +9,7 @@ namespace Microsoft.Terminal.TerminalControl
     {
         SearchBoxControl();
         void SetFocusOnTextbox();
+        void PopulateTextbox(String text);
         Boolean ContainsFocus();
 
         event SearchHandler Search;

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -203,6 +203,22 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                 // get at its private implementation
                 _searchBox.copy_from(winrt::get_self<implementation::SearchBoxControl>(searchBox));
                 _searchBox->Visibility(Visibility::Visible);
+
+                // If a text is selected inside terminal, use it to populate the search box.
+                // If the search box already contains a value, it will be overridden.
+                if (_terminal->IsSelectionActive())
+                {
+                    // Currently we populate the search box only if a single line is selected.
+                    // Empirically, multi-line selection works as well on sample scenarios,
+                    // but since code paths differ, extra work is required to ensure correctness.
+                    const auto bufferData = _terminal->RetrieveSelectedTextFromBuffer(true);
+                    if (bufferData.text.size() == 1)
+                    {
+                        const auto selectedLine{ til::at(bufferData.text, 0) };
+                        _searchBox->PopulateTextbox(selectedLine.data());
+                    }
+                }
+
                 _searchBox->SetFocusOnTextbox();
             }
         }

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -129,7 +129,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         winrt::fire_and_forget _RendererEnteredErrorState();
         void _RenderRetryButton_Click(IInspectable const& button, IInspectable const& args);
 
-        void CreateSearchBoxControl();
+        void CreateSearchBoxControl(bool populateFromSelection, bool allowMultilineSelection);
 
         bool OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool down);
 

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -98,7 +98,7 @@ namespace Microsoft.Terminal.TerminalControl
         Int32 GetViewHeight();
         event ScrollPositionChangedEventArgs ScrollPositionChanged;
 
-        void CreateSearchBoxControl();
+        void CreateSearchBoxControl(Boolean populateFromSelection, Boolean allowMultiLineSelection);
 
         void AdjustFontSize(Int32 fontSizeDelta);
         void ResetFontSize();

--- a/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
@@ -139,6 +139,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         { ShortcutAction::ScrollDown, ScrollDownArgs::FromJson },
         { ShortcutAction::MoveTab, MoveTabArgs::FromJson },
         { ShortcutAction::ToggleCommandPalette, ToggleCommandPaletteArgs::FromJson },
+        { ShortcutAction::Find, FindArgs::FromJson },
 
         { ShortcutAction::Invalid, nullptr },
     };

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
@@ -24,6 +24,7 @@
 #include "CloseTabsAfterArgs.g.cpp"
 #include "MoveTabArgs.g.cpp"
 #include "ToggleCommandPaletteArgs.g.cpp"
+#include "FindArgs.g.cpp"
 
 #include <LibraryResources.h>
 
@@ -421,5 +422,18 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             return RS_(L"ToggleCommandPaletteCommandLineModeCommandKey");
         }
         return RS_(L"ToggleCommandPaletteCommandKey");
+    }
+
+    winrt::hstring FindArgs::GenerateName() const
+    {
+        switch (_SelectionMode)
+        {
+        case FindSelectionMode::SingleLine:
+            return RS_(L"FindSelectionSingleLineCommandKey");
+        case FindSelectionMode::MultiLine:
+            return RS_(L"FindSelectionMultiLineCommandKey");
+        default:
+            return RS_(L"FindCommandKey");
+        }
     }
 }

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -26,6 +26,7 @@
 #include "ScrollDownArgs.g.h"
 #include "MoveTabArgs.g.h"
 #include "ToggleCommandPaletteArgs.g.h"
+#include "FindArgs.g.h"
 
 #include "../../cascadia/inc/cppwinrt_utils.h"
 #include "JsonUtils.h"
@@ -820,6 +821,42 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         {
             auto copy{ winrt::make_self<ToggleCommandPaletteArgs>() };
             copy->_LaunchMode = _LaunchMode;
+            return *copy;
+        }
+    };
+
+    struct FindArgs : public FindArgsT<FindArgs>
+    {
+        FindArgs() = default;
+
+        // To preserve backward compatibility the default is Action.
+        GETSET_PROPERTY(FindSelectionMode, SelectionMode, FindSelectionMode::None);
+
+        static constexpr std::string_view SelectionModeKey{ "selectionMode" };
+
+    public:
+        hstring GenerateName() const;
+
+        bool Equals(const IActionArgs& other)
+        {
+            auto otherAsUs = other.try_as<FindArgs>();
+            if (otherAsUs)
+            {
+                return otherAsUs->_SelectionMode == _SelectionMode;
+            }
+            return false;
+        };
+        static FromJsonResult FromJson(const Json::Value& json)
+        {
+            // LOAD BEARING: Not using make_self here _will_ break you in the future!
+            auto args = winrt::make_self<FindArgs>();
+            JsonUtils::GetValueForKey(json, SelectionModeKey, args->_SelectionMode);
+            return { *args, {} };
+        }
+        IActionArgs Copy() const
+        {
+            auto copy{ winrt::make_self<FindArgs>() };
+            copy->_SelectionMode = _SelectionMode;
             return *copy;
         }
     };

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -59,6 +59,13 @@ namespace Microsoft.Terminal.Settings.Model
         CommandLine
     };
 
+    enum FindSelectionMode
+    {
+        None = 0,
+        SingleLine,
+        MultiLine
+    };
+
     [default_interface] runtimeclass NewTerminalArgs {
         NewTerminalArgs();
         NewTerminalArgs(Int32 profileIndex);
@@ -189,5 +196,10 @@ namespace Microsoft.Terminal.Settings.Model
     [default_interface] runtimeclass ToggleCommandPaletteArgs : IActionArgs
     {
         CommandPaletteLaunchMode LaunchMode { get; };
+    };
+
+    [default_interface] runtimeclass FindArgs : IActionArgs
+    {
+        FindSelectionMode SelectionMode { get; };
     };
 }

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -212,6 +212,12 @@
   <data name="FindCommandKey" xml:space="preserve">
     <value>Find</value>
   </data>
+  <data name="FindSelectionSingleLineCommandKey" xml:space="preserve">
+    <value>Find selected text (single-line)</value>
+  </data>
+  <data name="FindSelectionMultiLineCommandKey" xml:space="preserve">
+    <value>Find selected text</value>
+  </data>
   <data name="IncreaseFontSizeCommandKey" xml:space="preserve">
     <value>Increase font size</value>
   </data>

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -414,3 +414,12 @@ JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::CommandPaletteLa
         pair_type{ "commandLine", ValueType::CommandLine },
     };
 };
+
+JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::FindSelectionMode)
+{
+    JSON_MAPPINGS(3) = {
+        pair_type{ "none", ValueType::None },
+        pair_type{ "singleLine", ValueType::SingleLine },
+        pair_type{ "multiLine", ValueType::MultiLine },
+    };
+};


### PR DESCRIPTION
## PR Checklist
* [x] Closes https://github.com/microsoft/terminal/issues/8307
* [x] CLA signed. 
* [ ] Tests added/passed
* [ ] Documentation updated - not yet
* [x] Schema updated
* [x] I've discussed this with core contributors already. 

## Detailed Description of the Pull Request / Additional comments
Add `selectionMode` field to the `find` command.
* If no mode is specified (backward-compatibility) or `none` is provided - behave as before.
* If `selectionMode` is set to `singleLine` and a single line of text is selected,
use it to populate the search box.
* If `selectionMode` is set to `multiLine` concatenate all lines with line-breaks omitted,
and use the resulting string to populate the search box.

The population logic will be applied whenever the search box control gets loaded / 
reset by the consequent find command. 

If the population logic should be applied while the search box is already populated,
an old value will be overridden.

## Validation Steps Performed
* Manual tests