### PR TITLE
Enable auto-elevation for a profile

### DIFF
--- a/src/cascadia/ShellExtension/OpenTerminalHere.cpp
+++ b/src/cascadia/ShellExtension/OpenTerminalHere.cpp
@@ -3,108 +3,16 @@
 
 #include "pch.h"
 #include "OpenTerminalHere.h"
+#include "../WinRTUtils/inc/WtExeUtils.h"
 
 // TODO GH#6112: Localize these strings
 static constexpr std::wstring_view VerbDisplayName{ L"Open in Windows Terminal" };
 static constexpr std::wstring_view VerbDevBuildDisplayName{ L"Open in Windows Terminal (Dev Build)" };
 static constexpr std::wstring_view VerbName{ L"WindowsTerminalOpenHere" };
 
-static constexpr std::wstring_view WtExe{ L"wt.exe" };
-static constexpr std::wstring_view WtdExe{ L"wtd.exe" };
-static constexpr std::wstring_view WindowsTerminalExe{ L"WindowsTerminal.exe" };
-
-static constexpr std::wstring_view LocalAppDataAppsPath{ L"%LOCALAPPDATA%\\Microsoft\\WindowsApps\\" };
-
 // This code is aggressively copied from
 //   https://github.com/microsoft/Windows-classic-samples/blob/master/Samples/
 //   Win7Samples/winui/shell/appshellintegration/ExplorerCommandVerb/ExplorerCommandVerb.cpp
-
-// Function Description:
-// - This is a helper to determine if we're running as a part of the Dev Build
-//   Package or the release package. We'll need to return different text, icons,
-//   and use different commandlines depending on which one the user requested.
-// - Uses a C++11 "magic static" to make sure this is only computed once.
-// - If we can't determine if it's the dev build or not, we'll default to true
-// Arguments:
-// - <none>
-// Return Value:
-// - true if we believe this extension is being run in the dev build package.
-static bool IsDevBuild()
-{
-    // use C++11 magic statics to make sure we only do this once.
-    static bool isDevBuild = []() -> bool {
-        try
-        {
-            const auto package{ winrt::Windows::ApplicationModel::Package::Current() };
-            const auto id = package.Id();
-            const std::wstring name{ id.FullName() };
-            // Does our PFN start with WindowsTerminalDev?
-            return name.rfind(L"WindowsTerminalDev", 0) == 0;
-        }
-        CATCH_LOG();
-        return true;
-    }();
-
-    return isDevBuild;
-}
-
-// Function Description:
-// - Helper function for getting the path to the appropriate executable to use
-//   for this instance of the shell extension. If we're running the dev build,
-//   it should be a `wtd.exe`, but if we're preview or release, we want to make
-//   sure to get the correct `wt.exe` that corresponds to _us_.
-// - If we're unpackaged, this needs to get us `WindowsTerminal.exe`, because
-//   the `wt*exe` alias won't have been installed for this install.
-// Arguments:
-// - <none>
-// Return Value:
-// - the full path to the exe, one of `wt.exe`, `wtd.exe`, or `WindowsTerminal.exe`.
-static std::wstring _getExePath()
-{
-    // use C++11 magic statics to make sure we only do this once.
-    static const std::wstring exePath = []() -> std::wstring {
-        // First, check a packaged location for the exe. If we've got a package
-        // family name, that means we're one of the packaged Dev build, packaged
-        // Release build, or packaged Preview build.
-        //
-        // If we're the preview or release build, there's no way of knowing if the
-        // `wt.exe` on the %PATH% is us or not. Fortunately, _our_ execution alias
-        // is located in "%LOCALAPPDATA%\Microsoft\WindowsApps\<our package family
-        // name>", _always_, so we can use that to look up the exe easier.
-        try
-        {
-            const auto package{ winrt::Windows::ApplicationModel::Package::Current() };
-            const auto id = package.Id();
-            const std::wstring pfn{ id.FamilyName() };
-            if (!pfn.empty())
-            {
-                const std::filesystem::path windowsAppsPath{ wil::ExpandEnvironmentStringsW<std::wstring>(LocalAppDataAppsPath.data()) };
-                const std::filesystem::path wtPath = windowsAppsPath / pfn / (IsDevBuild() ? WtdExe : WtExe);
-                return wtPath;
-            }
-        }
-        CATCH_LOG();
-
-        // If we're here, then we couldn't resolve our exe from the package. This
-        // means we're running unpackaged. We should just use the
-        // WindowsTerminal.exe that's sitting in the directory next to us.
-        try
-        {
-            HMODULE hModule = GetModuleHandle(nullptr);
-            THROW_LAST_ERROR_IF(hModule == nullptr);
-            std::wstring dllPathString;
-            THROW_IF_FAILED(wil::GetModuleFileNameW(hModule, dllPathString));
-            const std::filesystem::path dllPath{ dllPathString };
-            const std::filesystem::path rootDir = dllPath.parent_path();
-            std::filesystem::path wtPath = rootDir / WindowsTerminalExe;
-            return wtPath;
-        }
-        CATCH_LOG();
-
-        return L"wt.exe";
-    }();
-    return exePath;
-}
 
 // Method Description:
 // - This method is called when the user activates the context menu item. We'll
@@ -132,7 +40,7 @@ HRESULT OpenTerminalHere::Invoke(IShellItemArray* psiItemArray,
         siEx.StartupInfo.cb = sizeof(STARTUPINFOEX);
 
         // Append a "\." to the given path, so that this will work in "C:\"
-        std::wstring cmdline = fmt::format(L"\"{}\" -d \"{}\\.\"", _getExePath(), pszName.get());
+        std::wstring cmdline = fmt::format(L"\"{}\" -d \"{}\\.\"", GetWtExePath(), pszName.get());
         RETURN_IF_WIN32_BOOL_FALSE(CreateProcessW(
             nullptr,
             cmdline.data(),
@@ -190,7 +98,7 @@ try
     std::filesystem::path modulePath{ wil::GetModuleFileNameW<std::wstring>(wil::GetModuleInstanceHandle()) };
     modulePath.replace_filename(WindowsTerminalExe);
     // WindowsTerminal.exe,-101 will be the first icon group in WT
-    // We're using WindowsTerminal here explicitly, and not wt (from _getExePath), because
+    // We're using WindowsTerminal here explicitly, and not wt (from GetWtExePath), because
     // WindowsTerminal is the only one built with the right icons.
     const auto resource{ modulePath.wstring() + L",-101" };
     return SHStrDupW(resource.c_str(), ppszIcon);

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -599,6 +599,18 @@ namespace winrt::TerminalApp::implementation
         _newTabButton.Flyout().ShowAt(_newTabButton, options);
     }
 
+    fire_and_forget _OpenElevatedTab()
+    {
+        co_await winrt::resume_background();
+        ShellExecute(nullptr,
+                     L"runas",
+                     L"wt.exe",
+                     L"new-tab --tabColor #ff0000 ",
+                     nullptr,
+                     SW_SHOWNORMAL);
+        co_return;
+    }
+
     // Method Description:
     // - Open a new tab. This will create the TerminalControl hosting the
     //   terminal, and add a new Tab to our list of tabs. The method can
@@ -611,6 +623,12 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_OpenNewTab(const NewTerminalArgs& newTerminalArgs)
     try
     {
+        if (newTerminalArgs.Elevated())
+        {
+            _OpenElevatedTab();
+            return;
+        }
+
         auto [profileGuid, settings] = TerminalSettings::BuildSettings(_settings, newTerminalArgs, *_bindings);
 
         _CreateNewTabFromSettings(profileGuid, settings);

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -644,12 +644,129 @@ namespace winrt::TerminalApp::implementation
         co_return;
     }
 
+    HRESULT _JustDoExactlyTheRaymondChenThingHesAlwaysRight()
+    {
+        HWND hwnd = GetShellWindow();
+
+        DWORD pid;
+        GetWindowThreadProcessId(hwnd, &pid);
+
+        HANDLE process =
+            OpenProcess(PROCESS_CREATE_PROCESS, FALSE, pid);
+
+        SIZE_T size;
+        InitializeProcThreadAttributeList(nullptr, 1, 0, &size);
+        auto p = (PPROC_THREAD_ATTRIBUTE_LIST) new char[size];
+
+        InitializeProcThreadAttributeList(p, 1, 0, &size);
+        UpdateProcThreadAttribute(p, 0, PROC_THREAD_ATTRIBUTE_PARENT_PROCESS, &process, sizeof(process), nullptr, nullptr);
+
+        wchar_t cmd[] = L"C:\\Windows\\System32\\cmd.exe";
+        STARTUPINFOEX siex = {};
+        siex.lpAttributeList = p;
+        siex.StartupInfo.cb = sizeof(siex);
+        PROCESS_INFORMATION pi;
+
+        CreateProcessW(cmd, cmd, nullptr, nullptr, FALSE, CREATE_NEW_CONSOLE | EXTENDED_STARTUPINFO_PRESENT, nullptr, nullptr, &siex.StartupInfo, &pi);
+
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
+        delete[](char*) p;
+        CloseHandle(process);
+        return 0;
+    }
+
+    //     HRESULT _ActuallyOpenUnelevatedWindow(const NewTerminalArgs& newTerminalArgs)
+    //     {
+    //         wil::unique_hwnd hwnd{ GetShellWindow() };
+    //         RETURN_LAST_ERROR_IF(!hwnd);
+
+    //         // GetWindowThreadProcessId returns the identifier of the thread that
+    //         // created the window. We don't need that.
+    //         DWORD pid;
+    //         GetWindowThreadProcessId(hwnd.get(), &pid);
+
+    //         wil::unique_handle process{ OpenProcess(PROCESS_CREATE_PROCESS, FALSE, pid) };
+    //         RETURN_LAST_ERROR_IF(!process);
+
+    //         STARTUPINFOEX siEx{ 0 };
+    //         siEx.StartupInfo.cb = sizeof(STARTUPINFOEX);
+
+    //         SIZE_T size;
+    //         InitializeProcThreadAttributeList(nullptr, 1, 0, &size);
+
+    //         // auto p = (PPROC_THREAD_ATTRIBUTE_LIST)new char[size];
+    // #pragma warning(suppress : 26414) // We don't move/touch this smart pointer, but we have to allocate strangely for the adjustable size list.
+    //         auto attrList{ std::make_unique<std::byte[]>(size) };
+    // #pragma warning(suppress : 26490) // We have to use reinterpret_cast because we allocated a byte array as a proxy for the adjustable size list.
+    //         siEx.lpAttributeList = reinterpret_cast<PPROC_THREAD_ATTRIBUTE_LIST>(attrList.get());
+
+    //         // InitializeProcThreadAttributeList(p, 1, 0, &size);
+    //         RETURN_IF_WIN32_BOOL_FALSE(InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, &size));
+    //         auto cleanupAttributes = wil::scope_exit([&siEx]() {
+    //             DeleteProcThreadAttributeList(siEx.lpAttributeList);
+    //         });
+
+    //         RETURN_IF_WIN32_BOOL_FALSE(UpdateProcThreadAttribute(siEx.lpAttributeList,
+    //                                                              0,
+    //                                                              PROC_THREAD_ATTRIBUTE_PARENT_PROCESS,
+    //                                                              process.get(),
+    //                                                              sizeof(HANDLE),
+    //                                                              nullptr,
+    //                                                              nullptr));
+
+    //         wchar_t cmd[] = L"C:\\Windows\\System32\\cmd.exe";
+    //         // STARTUPINFOEX siex = {};
+    //         // siex.lpAttributeList = p;
+    //         // siex.StartupInfo.cb = sizeof(siex);
+    //         wil::unique_process_information pi;
+
+    //         // winrt::hstring cmdline{ fmt::format(L"{} new-tab {}",
+    //         //                                     GetWtExePath().c_str(),
+    //         //                                     newTerminalArgs.ToCommandline().c_str()) };
+    //         auto wtExeCommandline{ fmt::format(L"{} new-tab {}",
+    //                                            GetWtExePath().c_str(),
+    //                                            newTerminalArgs.ToCommandline()) };
+    //         std::wstring cmdline{ wtExeCommandline }; // mutable copy -- required for CreateProcessW
+
+    //         // RETURN_IF_WIN32_BOOL_FALSE(CreateProcessW(nullptr,
+    //         //                                           cmdline.data(),
+    //         //                                           nullptr,
+    //         //                                           nullptr,
+    //         //                                           FALSE, // bInheritHandles
+    //         //                                           EXTENDED_STARTUPINFO_PRESENT,
+    //         //                                           nullptr,
+    //         //                                           nullptr,
+    //         //                                           &siEx.StartupInfo,
+    //         //                                           &pi));
+
+    //         RETURN_IF_WIN32_BOOL_FALSE(CreateProcessW(cmd,
+    //                                                   cmd,
+    //                                                   nullptr,
+    //                                                   nullptr,
+    //                                                   FALSE, // bInheritHandles
+    //                                                   EXTENDED_STARTUPINFO_PRESENT,
+    //                                                   nullptr,
+    //                                                   nullptr,
+    //                                                   &siEx.StartupInfo,
+    //                                                   &pi));
+
+    //         // CloseHandle(pi.hProcess);
+    //         // CloseHandle(pi.hThread);
+    //         // delete[](char*) p;
+    //         // DeleteProcThreadAttributeList(siEx.lpAttributeList);
+    //         // CloseHandle(process);
+    //         // return 0;
+    //         return S_OK;
+    //     }
+
     // Important: Don't take the param by reference, since we'll be doing work
     // on another thread.
-    fire_and_forget _OpenUnElevatedWT(const NewTerminalArgs newTerminalArgs)
+    winrt::fire_and_forget _OpenUnElevatedWT(const NewTerminalArgs newTerminalArgs)
     {
         co_await winrt::resume_background();
-        // TODO:
+        // LOG_IF_FAILED(_ActuallyOpenUnelevatedWindow(newTerminalArgs));
+        LOG_IF_FAILED(_JustDoExactlyTheRaymondChenThingHesAlwaysRight());
         co_return;
     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -13,6 +13,8 @@
 #include <winrt/Windows.Storage.h>
 #include <winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>
 
+#include "../WinRTUtils/inc/WtExeUtils.h"
+
 #include "TabRowControl.h"
 #include "ColorHelper.h"
 #include "DebugTapConnection.h"
@@ -635,7 +637,7 @@ namespace winrt::TerminalApp::implementation
         winrt::hstring cmdline{ fmt::format(L"new-tab {}", newTerminalArgs.ToCommandline().c_str()) };
         ShellExecute(nullptr,
                      L"runas",
-                     L"wtd.exe",
+                     GetWtExePath().c_str(),
                      cmdline.c_str(),
                      nullptr,
                      SW_SHOWNORMAL);

--- a/src/cascadia/TerminalApp/TerminalSettings.cpp
+++ b/src/cascadia/TerminalApp/TerminalSettings.cpp
@@ -65,6 +65,10 @@ namespace winrt::TerminalApp::implementation
             {
                 settings.StartingTabColor(static_cast<uint32_t>(til::color(newTerminalArgs.TabColor().Value())));
             }
+            if (newTerminalArgs.Elevated()) // Remember, Elevated is an optional value
+            {
+                settings.Elevated(newTerminalArgs.Elevated());
+            }
         }
 
         return { profileGuid, settings };
@@ -155,6 +159,8 @@ namespace winrt::TerminalApp::implementation
             const til::color colorRef{ profile.TabColor().Value() };
             _TabColor = static_cast<uint32_t>(colorRef);
         }
+
+        _Elevated = profile.Elevated();
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TerminalSettings.cpp
+++ b/src/cascadia/TerminalApp/TerminalSettings.cpp
@@ -65,9 +65,13 @@ namespace winrt::TerminalApp::implementation
             {
                 settings.StartingTabColor(static_cast<uint32_t>(til::color(newTerminalArgs.TabColor().Value())));
             }
-            if (newTerminalArgs.Elevated()) // Remember, Elevated is an optional value
+            // Elevate on NewTerminalArgs is an optional value, so the default
+            // value (null) doesn't override a profile's value. Note that
+            // elevate:false in an already elevated terminal does nothing - the
+            // profile will still be launched elevated.
+            if (newTerminalArgs.Elevate())
             {
-                settings.Elevated(newTerminalArgs.Elevated());
+                settings.Elevate(newTerminalArgs.Elevate().Value());
             }
         }
 
@@ -160,7 +164,7 @@ namespace winrt::TerminalApp::implementation
             _TabColor = static_cast<uint32_t>(colorRef);
         }
 
-        _Elevated = profile.Elevated();
+        _Elevate = profile.Elevate();
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TerminalSettings.h
+++ b/src/cascadia/TerminalApp/TerminalSettings.h
@@ -121,6 +121,8 @@ namespace winrt::TerminalApp::implementation
         GETSET_PROPERTY(bool, SoftwareRendering, false);
         GETSET_PROPERTY(bool, ForceVTInput, false);
 
+        GETSET_PROPERTY(Windows::Foundation::IReference<bool>, Elevated, nullptr);
+
 #pragma warning(pop)
 
     private:

--- a/src/cascadia/TerminalApp/TerminalSettings.h
+++ b/src/cascadia/TerminalApp/TerminalSettings.h
@@ -121,7 +121,7 @@ namespace winrt::TerminalApp::implementation
         GETSET_PROPERTY(bool, SoftwareRendering, false);
         GETSET_PROPERTY(bool, ForceVTInput, false);
 
-        GETSET_PROPERTY(Windows::Foundation::IReference<bool>, Elevated, nullptr);
+        GETSET_PROPERTY(bool, Elevate, nullptr);
 
 #pragma warning(pop)
 

--- a/src/cascadia/TerminalApp/TerminalSettings.idl
+++ b/src/cascadia/TerminalApp/TerminalSettings.idl
@@ -16,6 +16,8 @@ namespace TerminalApp
                                     Microsoft.Terminal.TerminalControl.IControlSettings
     {
         TerminalSettings();
+
+        Windows.Foundation.IReference<Boolean> Elevated;
     };
 
 }

--- a/src/cascadia/TerminalApp/TerminalSettings.idl
+++ b/src/cascadia/TerminalApp/TerminalSettings.idl
@@ -17,7 +17,7 @@ namespace TerminalApp
     {
         TerminalSettings();
 
-        Windows.Foundation.IReference<Boolean> Elevated;
+        Boolean Elevate;
     };
 
 }

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
@@ -74,6 +74,51 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         return winrt::hstring{ s.substr(0, s.size() - 2) };
     }
 
+    winrt::hstring NewTerminalArgs::ToCommandline() const
+    {
+        std::wstringstream ss;
+
+        if (!_Profile.empty())
+        {
+            ss << fmt::format(L"--profile \"{}\" ", _Profile);
+        }
+        // TODO
+        // else if (_ProfileIndex)
+        // {
+        //     ss << fmt::format(L"profile index: {}, ", _ProfileIndex.Value());
+        // }
+
+        if (!_StartingDirectory.empty())
+        {
+            ss << fmt::format(L"--directory \"{}\" ", _StartingDirectory);
+        }
+
+        if (!_TabTitle.empty())
+        {
+            ss << fmt::format(L"--title \"{}\" ", _TabTitle);
+        }
+
+        if (_TabColor)
+        {
+            const til::color tabColor{ _TabColor.Value() };
+            ss << fmt::format(L"--tabColor \"{}\" ", tabColor.ToHexString(true));
+        }
+
+        if (!_Commandline.empty())
+        {
+            ss << fmt::format(L" -- \"{}\" ", _Commandline);
+        }
+
+        auto s = ss.str();
+        if (s.empty())
+        {
+            return L"";
+        }
+
+        // Chop off the last " "
+        return winrt::hstring{ s.substr(0, s.size() - 1) };
+    }
+
     winrt::hstring CopyTextArgs::GenerateName() const
     {
         std::wstringstream ss;

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
@@ -82,7 +82,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         {
             ss << fmt::format(L"--profile \"{}\" ", _Profile);
         }
-        // TODO
+        // The caller is always expected to provide the evaluated profile in the
+        // NewTerminalArgs, not the index
+        //
         // else if (_ProfileIndex)
         // {
         //     ss << fmt::format(L"profile index: {}, ", _ProfileIndex.Value());
@@ -90,7 +92,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         if (!_StartingDirectory.empty())
         {
-            ss << fmt::format(L"--directory \"{}\" ", _StartingDirectory);
+            ss << fmt::format(L"--startingDirectory \"{}\" ", _StartingDirectory);
         }
 
         if (!_TabTitle.empty())

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -64,6 +64,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         GETSET_PROPERTY(Windows::Foundation::IReference<Windows::UI::Color>, TabColor, nullptr);
         GETSET_PROPERTY(Windows::Foundation::IReference<int32_t>, ProfileIndex, nullptr);
         GETSET_PROPERTY(winrt::hstring, Profile, L"");
+        GETSET_PROPERTY(Windows::Foundation::IReference<bool>, Elevated, nullptr);
 
         static constexpr std::string_view CommandlineKey{ "commandline" };
         static constexpr std::string_view StartingDirectoryKey{ "startingDirectory" };
@@ -71,6 +72,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static constexpr std::string_view TabColorKey{ "tabColor" };
         static constexpr std::string_view ProfileIndexKey{ "index" };
         static constexpr std::string_view ProfileKey{ "profile" };
+        static constexpr std::string_view ElevatedKey{ "elevated" };
 
     public:
         hstring GenerateName() const;
@@ -82,6 +84,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                    other.TabTitle() == _TabTitle &&
                    other.TabColor() == _TabColor &&
                    other.ProfileIndex() == _ProfileIndex &&
+                   other.Elevated() == _Elevated &&
                    other.Profile() == _Profile;
         };
         static Model::NewTerminalArgs FromJson(const Json::Value& json)
@@ -94,6 +97,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             JsonUtils::GetValueForKey(json, ProfileIndexKey, args->_ProfileIndex);
             JsonUtils::GetValueForKey(json, ProfileKey, args->_Profile);
             JsonUtils::GetValueForKey(json, TabColorKey, args->_TabColor);
+            JsonUtils::GetValueForKey(json, ElevatedKey, args->_Elevated);
             return *args;
         }
         Model::NewTerminalArgs Copy() const
@@ -105,6 +109,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             copy->_TabColor = _TabColor;
             copy->_ProfileIndex = _ProfileIndex;
             copy->_Profile = _Profile;
+            copy->_Elevated = _Elevated;
             return *copy;
         }
     };

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -77,6 +77,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     public:
         hstring GenerateName() const;
 
+        hstring ToCommandline() const;
+
         bool Equals(const Model::NewTerminalArgs& other)
         {
             return other.Commandline() == _Commandline &&

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -64,7 +64,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         GETSET_PROPERTY(Windows::Foundation::IReference<Windows::UI::Color>, TabColor, nullptr);
         GETSET_PROPERTY(Windows::Foundation::IReference<int32_t>, ProfileIndex, nullptr);
         GETSET_PROPERTY(winrt::hstring, Profile, L"");
-        GETSET_PROPERTY(Windows::Foundation::IReference<bool>, Elevated, nullptr);
+        GETSET_PROPERTY(Windows::Foundation::IReference<bool>, Elevate, nullptr);
 
         static constexpr std::string_view CommandlineKey{ "commandline" };
         static constexpr std::string_view StartingDirectoryKey{ "startingDirectory" };
@@ -72,7 +72,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static constexpr std::string_view TabColorKey{ "tabColor" };
         static constexpr std::string_view ProfileIndexKey{ "index" };
         static constexpr std::string_view ProfileKey{ "profile" };
-        static constexpr std::string_view ElevatedKey{ "elevated" };
+        static constexpr std::string_view ElevateKey{ "elevate" };
 
     public:
         hstring GenerateName() const;
@@ -86,7 +86,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                    other.TabTitle() == _TabTitle &&
                    other.TabColor() == _TabColor &&
                    other.ProfileIndex() == _ProfileIndex &&
-                   other.Elevated() == _Elevated &&
+                   other.Elevate() == _Elevate &&
                    other.Profile() == _Profile;
         };
         static Model::NewTerminalArgs FromJson(const Json::Value& json)
@@ -99,7 +99,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             JsonUtils::GetValueForKey(json, ProfileIndexKey, args->_ProfileIndex);
             JsonUtils::GetValueForKey(json, ProfileKey, args->_Profile);
             JsonUtils::GetValueForKey(json, TabColorKey, args->_TabColor);
-            JsonUtils::GetValueForKey(json, ElevatedKey, args->_Elevated);
+            JsonUtils::GetValueForKey(json, ElevateKey, args->_Elevate);
             return *args;
         }
         Model::NewTerminalArgs Copy() const
@@ -111,7 +111,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             copy->_TabColor = _TabColor;
             copy->_ProfileIndex = _ProfileIndex;
             copy->_Profile = _Profile;
-            copy->_Elevated = _Elevated;
+            copy->_Elevate = _Elevate;
             return *copy;
         }
     };

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -67,6 +67,8 @@ namespace Microsoft.Terminal.Settings.Model
         // a IReference, so it's nullable
         Windows.Foundation.IReference<Int32> ProfileIndex { get; };
 
+        Windows.Foundation.IReference<Boolean> Elevated { get; };
+
         Boolean Equals(NewTerminalArgs other);
         String GenerateName();
     };

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -71,6 +71,7 @@ namespace Microsoft.Terminal.Settings.Model
 
         Boolean Equals(NewTerminalArgs other);
         String GenerateName();
+        String ToCommandline();
     };
 
     [default_interface] runtimeclass ActionEventArgs : IActionEventArgs

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -67,7 +67,9 @@ namespace Microsoft.Terminal.Settings.Model
         // a IReference, so it's nullable
         Windows.Foundation.IReference<Int32> ProfileIndex { get; };
 
-        Windows.Foundation.IReference<Boolean> Elevated { get; };
+        // This needs to be an optional so that the default value (null) does
+        // not modifiy whatever the profile's value is (either true or false)
+        Windows.Foundation.IReference<Boolean> Elevate { get; };
 
         Boolean Equals(NewTerminalArgs other);
         String GenerateName();

--- a/src/cascadia/TerminalSettingsModel/Profile.cpp
+++ b/src/cascadia/TerminalSettingsModel/Profile.cpp
@@ -58,6 +58,7 @@ static constexpr std::string_view RetroTerminalEffectKey{ "experimental.retroTer
 static constexpr std::string_view AntialiasingModeKey{ "antialiasingMode" };
 static constexpr std::string_view TabColorKey{ "tabColor" };
 static constexpr std::string_view BellStyleKey{ "bellStyle" };
+static constexpr std::string_view ElevatedKey{ "elevated" };
 
 static constexpr std::wstring_view DesktopWallpaperEnum{ L"desktopWallpaper" };
 
@@ -334,10 +335,10 @@ void Profile::LayerJson(const Json::Value& json)
     JsonUtils::GetValueForKey(json, BackgroundImageAlignmentKey, _BackgroundImageAlignment);
     JsonUtils::GetValueForKey(json, RetroTerminalEffectKey, _RetroTerminalEffect);
     JsonUtils::GetValueForKey(json, AntialiasingModeKey, _AntialiasingMode);
-
     JsonUtils::GetValueForKey(json, TabColorKey, _TabColor);
-
     JsonUtils::GetValueForKey(json, BellStyleKey, _BellStyle);
+
+    JsonUtils::GetValueForKey(json, ElevatedKey, _Elevated);
 }
 
 // Method Description:
@@ -577,6 +578,8 @@ Json::Value Profile::ToJson() const
     JsonUtils::SetValueForKey(json, AntialiasingModeKey, _AntialiasingMode);
     JsonUtils::SetValueForKey(json, TabColorKey, _TabColor);
     JsonUtils::SetValueForKey(json, BellStyleKey, _BellStyle);
+
+    JsonUtils::SetValueForKey(json, ElevatedKey, _Elevated);
 
     return json;
 }

--- a/src/cascadia/TerminalSettingsModel/Profile.cpp
+++ b/src/cascadia/TerminalSettingsModel/Profile.cpp
@@ -58,7 +58,7 @@ static constexpr std::string_view RetroTerminalEffectKey{ "experimental.retroTer
 static constexpr std::string_view AntialiasingModeKey{ "antialiasingMode" };
 static constexpr std::string_view TabColorKey{ "tabColor" };
 static constexpr std::string_view BellStyleKey{ "bellStyle" };
-static constexpr std::string_view ElevatedKey{ "elevated" };
+static constexpr std::string_view ElevateKey{ "elevate" };
 
 static constexpr std::wstring_view DesktopWallpaperEnum{ L"desktopWallpaper" };
 
@@ -338,7 +338,7 @@ void Profile::LayerJson(const Json::Value& json)
     JsonUtils::GetValueForKey(json, TabColorKey, _TabColor);
     JsonUtils::GetValueForKey(json, BellStyleKey, _BellStyle);
 
-    JsonUtils::GetValueForKey(json, ElevatedKey, _Elevated);
+    JsonUtils::GetValueForKey(json, ElevateKey, _Elevate);
 }
 
 // Method Description:
@@ -579,7 +579,7 @@ Json::Value Profile::ToJson() const
     JsonUtils::SetValueForKey(json, TabColorKey, _TabColor);
     JsonUtils::SetValueForKey(json, BellStyleKey, _BellStyle);
 
-    JsonUtils::SetValueForKey(json, ElevatedKey, _Elevated);
+    JsonUtils::SetValueForKey(json, ElevateKey, _Elevate);
 
     return json;
 }

--- a/src/cascadia/TerminalSettingsModel/Profile.h
+++ b/src/cascadia/TerminalSettingsModel/Profile.h
@@ -118,7 +118,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         GETSET_SETTING(uint32_t, CursorHeight, DEFAULT_CURSOR_HEIGHT);
 
         GETSET_SETTING(Model::BellStyle, BellStyle, BellStyle::Audible);
-        GETSET_NULLABLE_SETTING(bool, Elevated, nullptr);
+        GETSET_SETTING(bool, Elevate);
 
     private:
         std::optional<std::tuple<Windows::UI::Xaml::HorizontalAlignment, Windows::UI::Xaml::VerticalAlignment>> _BackgroundImageAlignment{ std::nullopt };

--- a/src/cascadia/TerminalSettingsModel/Profile.h
+++ b/src/cascadia/TerminalSettingsModel/Profile.h
@@ -118,6 +118,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         GETSET_SETTING(uint32_t, CursorHeight, DEFAULT_CURSOR_HEIGHT);
 
         GETSET_SETTING(Model::BellStyle, BellStyle, BellStyle::Audible);
+        GETSET_NULLABLE_SETTING(bool, Elevated, nullptr);
 
     private:
         std::optional<std::tuple<Windows::UI::Xaml::HorizontalAlignment, Windows::UI::Xaml::VerticalAlignment>> _BackgroundImageAlignment{ std::nullopt };

--- a/src/cascadia/TerminalSettingsModel/Profile.idl
+++ b/src/cascadia/TerminalSettingsModel/Profile.idl
@@ -175,8 +175,8 @@ namespace Microsoft.Terminal.Settings.Model
         void ClearBellStyle();
         BellStyle BellStyle;
 
-        Boolean HasElevated();
-        void ClearElevated();
-        Windows.Foundation.IReference<Boolean> Elevated;
+        Boolean HasElevate();
+        void ClearElevate();
+        Boolean Elevate;
     }
 }

--- a/src/cascadia/TerminalSettingsModel/Profile.idl
+++ b/src/cascadia/TerminalSettingsModel/Profile.idl
@@ -174,5 +174,9 @@ namespace Microsoft.Terminal.Settings.Model
         Boolean HasBellStyle();
         void ClearBellStyle();
         BellStyle BellStyle;
+
+        Boolean HasElevated();
+        void ClearElevated();
+        Windows.Foundation.IReference<Boolean> Elevated;
     }
 }

--- a/src/cascadia/WinRTUtils/inc/WtExeUtils.h
+++ b/src/cascadia/WinRTUtils/inc/WtExeUtils.h
@@ -1,0 +1,93 @@
+
+static constexpr std::wstring_view WtExe{ L"wt.exe" };
+static constexpr std::wstring_view WtdExe{ L"wtd.exe" };
+static constexpr std::wstring_view WindowsTerminalExe{ L"WindowsTerminal.exe" };
+
+static constexpr std::wstring_view LocalAppDataAppsPath{ L"%LOCALAPPDATA%\\Microsoft\\WindowsApps\\" };
+
+// Function Description:
+// - This is a helper to determine if we're running as a part of the Dev Build
+//   Package or the release package. We'll need to return different text, icons,
+//   and use different commandlines depending on which one the user requested.
+// - Uses a C++11 "magic static" to make sure this is only computed once.
+// - If we can't determine if it's the dev build or not, we'll default to true
+// Arguments:
+// - <none>
+// Return Value:
+// - true if we believe this extension is being run in the dev build package.
+bool IsDevBuild()
+{
+    // use C++11 magic statics to make sure we only do this once.
+    static bool isDevBuild = []() -> bool {
+        try
+        {
+            const auto package{ winrt::Windows::ApplicationModel::Package::Current() };
+            const auto id = package.Id();
+            const std::wstring name{ id.FullName() };
+            // Does our PFN start with WindowsTerminalDev?
+            return name.rfind(L"WindowsTerminalDev", 0) == 0;
+        }
+        CATCH_LOG();
+        return true;
+    }();
+
+    return isDevBuild;
+}
+
+// Function Description:
+// - Helper function for getting the path to the appropriate executable to use
+//   for this instance of the shell extension. If we're running the dev build,
+//   it should be a `wtd.exe`, but if we're preview or release, we want to make
+//   sure to get the correct `wt.exe` that corresponds to _us_.
+// - If we're unpackaged, this needs to get us `WindowsTerminal.exe`, because
+//   the `wt*exe` alias won't have been installed for this install.
+// Arguments:
+// - <none>
+// Return Value:
+// - the full path to the exe, one of `wt.exe`, `wtd.exe`, or `WindowsTerminal.exe`.
+std::wstring GetWtExePath()
+{
+    // use C++11 magic statics to make sure we only do this once.
+    static const std::wstring exePath = []() -> std::wstring {
+        // First, check a packaged location for the exe. If we've got a package
+        // family name, that means we're one of the packaged Dev build, packaged
+        // Release build, or packaged Preview build.
+        //
+        // If we're the preview or release build, there's no way of knowing if the
+        // `wt.exe` on the %PATH% is us or not. Fortunately, _our_ execution alias
+        // is located in "%LOCALAPPDATA%\Microsoft\WindowsApps\<our package family
+        // name>", _always_, so we can use that to look up the exe easier.
+        try
+        {
+            const auto package{ winrt::Windows::ApplicationModel::Package::Current() };
+            const auto id = package.Id();
+            const std::wstring pfn{ id.FamilyName() };
+            if (!pfn.empty())
+            {
+                const std::filesystem::path windowsAppsPath{ wil::ExpandEnvironmentStringsW<std::wstring>(LocalAppDataAppsPath.data()) };
+                const std::filesystem::path wtPath = windowsAppsPath / pfn / (IsDevBuild() ? WtdExe : WtExe);
+                return wtPath;
+            }
+        }
+        CATCH_LOG();
+
+        // If we're here, then we couldn't resolve our exe from the package. This
+        // means we're running unpackaged. We should just use the
+        // WindowsTerminal.exe that's sitting in the directory next to us.
+        try
+        {
+            HMODULE hModule = GetModuleHandle(nullptr);
+            THROW_LAST_ERROR_IF(hModule == nullptr);
+            std::wstring dllPathString;
+            THROW_IF_FAILED(wil::GetModuleFileNameW(hModule, dllPathString));
+            const std::filesystem::path dllPath{ dllPathString };
+            const std::filesystem::path rootDir = dllPath.parent_path();
+            std::filesystem::path wtPath = rootDir / WindowsTerminalExe;
+            return wtPath;
+        }
+        CATCH_LOG();
+
+        return L"wt.exe";
+    }();
+    return exePath;
+}

--- a/tools/runut.cmd
+++ b/tools/runut.cmd
@@ -8,9 +8,9 @@ rem That's a cppwinrt project, that doesn't use %PLATFORM% in it's path when the
 rem platform is Win32/x86.
 rem set a helper for us to find that test
 
-set _TestHostAppPath=%OPENCON%\%PLATFORM%\%_LAST_BUILD_CONF%\TestHostApp
+set _TestHostAppPath=%OPENCON%\bin\%PLATFORM%\%_LAST_BUILD_CONF%\TestHostApp
 if "%PLATFORM%" == "Win32" (
-    set _TestHostAppPath=%OPENCON%\%_LAST_BUILD_CONF%\TestHostApp
+    set _TestHostAppPath=%OPENCON%\bin\%_LAST_BUILD_CONF%\TestHostApp
 )
 
 call %TAEF% ^


### PR DESCRIPTION
## Summary of the Pull Request

This PR is a huge chunk of the implementation of my spec over in #8455. I know it's bad juju to send the implementation before the spec is approved, but here we are.

This PR adds two features:
* the `elevate: bool` property to profiles
  - If the user is running unelevated, **and** `elevate` is set to `true`, then instead of opening a new tab, we'll open an elevated Terminal window with the profile.
  - Otherwise, we'll just open a new tab in the existing window. This includes cases where the window is elevated, and the profile is set to `elevate:false`. `elevate:false` basically just means "do nothing special with me".
* the `elevate: bool?` property to `NewTerminalArgs` (`newTab`, `splitPane`)
  - This allows a user to create an action that will elevate the profile, even if the profile is not otherwise set to auto-elevate.
  - `elevate:null` (_the default_) does not change the profile's elevation status. The action will use whatever is set by the profile.
  - `elevate:true` will attempt to auto-elevate the profile
  - `elevate:false` will do nothing special. 

## References

* #5000 for obvious reasons
* Spec'd in #8455

## PR Checklist
* [x] Closes #632
* [x] I work here
* [x] Tests added/passed
* [n/a] Requires documentation to be updated

## Detailed Description of the Pull Request / Additional comments

After playing with de-elevation a bit, it turns out it behaves weirdly with packaged applications. I can try and ask `explorer.exe` to launch the process on our behalf. However, if the thing we're launching is an execution alias (`wt.exe`), and we're elevated, then the child process will _still launch elevated_. 

## Validation Steps Performed
* Ran tests
* Opened a bunch of terminal tabs at various different elevation levels
* opened new splits too