### PR TITLE
Add some logging around tab renamer usage

### DIFF
--- a/src/cascadia/TerminalApp/TabHeaderControl.cpp
+++ b/src/cascadia/TerminalApp/TabHeaderControl.cpp
@@ -81,7 +81,7 @@ namespace winrt::TerminalApp::implementation
 
         TraceLoggingWrite(
             g_hTerminalAppProvider, // handle to TerminalApp tracelogging provider
-            "TabRenamerOpened",
+            "TabRenamerClosed",
             TraceLoggingDescription("Event emitted when the tab renamer is closed"),
             TraceLoggingBoolean(_renameCancelled, "CancelledRename", "True if the user cancelled the rename, false if they committed."),
             TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),

--- a/src/cascadia/TerminalApp/TabHeaderControl.cpp
+++ b/src/cascadia/TerminalApp/TabHeaderControl.cpp
@@ -59,6 +59,13 @@ namespace winrt::TerminalApp::implementation
         HeaderRenamerTextBox().Text(Title());
         HeaderRenamerTextBox().SelectAll();
         HeaderRenamerTextBox().Focus(Windows::UI::Xaml::FocusState::Programmatic);
+
+        TraceLoggingWrite(
+            g_hTerminalAppProvider, // handle to TerminalApp tracelogging provider
+            "TabRenamerOpened",
+            TraceLoggingDescription("Event emitted when the tab renamer is opened"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
     }
 
     // Method Description:
@@ -68,6 +75,18 @@ namespace winrt::TerminalApp::implementation
     void TabHeaderControl::RenameBoxLostFocusHandler(Windows::Foundation::IInspectable const& /*sender*/,
                                                      Windows::UI::Xaml::RoutedEventArgs const& /*e*/)
     {
+        // Log the data here, rather than in _CloseRenameBox. If we do it there,
+        // it'll get fired twice, once when the key is pressed to commit/cancel,
+        // and then again when the focus is lost
+
+        TraceLoggingWrite(
+            g_hTerminalAppProvider, // handle to TerminalApp tracelogging provider
+            "TabRenamerOpened",
+            TraceLoggingDescription("Event emitted when the tab renamer is closed"),
+            TraceLoggingBoolean(_renameCancelled, "CancelledRename", "True if the user cancelled the rename, false if they committed."),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
+
         _CloseRenameBox();
         if (!_renameCancelled)
         {


### PR DESCRIPTION
We've got similar logging around the command palette, we really should have the same logging on the tab renamer as well.

## PR Checklist
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated

## Validation Steps Performed

![image](https://user-images.githubusercontent.com/18356694/101487414-c237af80-3923-11eb-9997-81549e4f1a1b.png)
Look, it works