### PR TITLE
Teach Find command to populate the search box with selected text 

### DIFF
--- a/src/cascadia/TerminalControl/SearchBoxControl.cpp
+++ b/src/cascadia/TerminalControl/SearchBoxControl.cpp
@@ -111,6 +111,20 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
     }
 
     // Method Description:
+    // - Allows to set the value of the text to search
+    // Arguments:
+    // - text: string value to populate in the TextBox
+    // Return Value:
+    // - <none>
+    void SearchBoxControl::PopulateTextbox(winrt::hstring const& text)
+    {
+        if (TextBox())
+        {
+            TextBox().Text(text);
+        }
+    }
+
+    // Method Description:
     // - Check if the current focus is on any element within the
     //   search box
     // Arguments:

--- a/src/cascadia/TerminalControl/SearchBoxControl.h
+++ b/src/cascadia/TerminalControl/SearchBoxControl.h
@@ -29,6 +29,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         void TextBoxKeyDown(winrt::Windows::Foundation::IInspectable const& /*sender*/, winrt::Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e);
 
         void SetFocusOnTextbox();
+        void PopulateTextbox(winrt::hstring const& text);
         bool ContainsFocus();
 
         void GoBackwardClicked(winrt::Windows::Foundation::IInspectable const& /*sender*/, winrt::Windows::UI::Xaml::RoutedEventArgs const& /*e*/);

--- a/src/cascadia/TerminalControl/SearchBoxControl.idl
+++ b/src/cascadia/TerminalControl/SearchBoxControl.idl
@@ -9,6 +9,7 @@ namespace Microsoft.Terminal.TerminalControl
     {
         SearchBoxControl();
         void SetFocusOnTextbox();
+        void PopulateTextbox(String text);
         Boolean ContainsFocus();
 
         event SearchHandler Search;

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -203,6 +203,22 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                 // get at its private implementation
                 _searchBox.copy_from(winrt::get_self<implementation::SearchBoxControl>(searchBox));
                 _searchBox->Visibility(Visibility::Visible);
+
+                // If a text is selected inside terminal, use it to populate the search box.
+                // If the search box already contains a value, it will be overridden.
+                if (_terminal->IsSelectionActive())
+                {
+                    // Currently we populate the search box only if a single line is selected.
+                    // Empirically, multi-line selection works as well on sample scenarios,
+                    // but since code paths differ, extra work is required to ensure correctness.
+                    const auto bufferData = _terminal->RetrieveSelectedTextFromBuffer(true);
+                    if (bufferData.text.size() == 1)
+                    {
+                        const auto selectedLine{ til::at(bufferData.text, 0) };
+                        _searchBox->PopulateTextbox(selectedLine.data());
+                    }
+                }
+
                 _searchBox->SetFocusOnTextbox();
             }
         }


### PR DESCRIPTION
If a single line of text is selected, use it to populate the search box.

Closes #8307