### PR TITLE
Replace the KB Dialog with a InfoBar

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2862,7 +2862,10 @@ namespace winrt::TerminalApp::implementation
     //   Service" is disabled.
     void TerminalPage::ShowKeyboardServiceWarning()
     {
-        KeyboardWarningInfoBar().IsOpen(true);
+        if (auto keyboardWarningInfoBar = FindName(L"KeyboardWarningInfoBar").try_as<MUX::Controls::InfoBar>())
+        {
+            keyboardWarningInfoBar.IsOpen(true);
+        }
     }
 
     // Function Description:

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2862,10 +2862,11 @@ namespace winrt::TerminalApp::implementation
     //   Service" is disabled.
     void TerminalPage::ShowKeyboardServiceWarning()
     {
-        if (auto presenter{ _dialogPresenter.get() })
-        {
-            presenter.ShowDialog(FindName(L"KeyboardServiceDisabledDialog").try_as<WUX::Controls::ContentDialog>());
-        }
+        // if (auto presenter{ _dialogPresenter.get() })
+        // {
+        //     presenter.ShowDialog(FindName(L"KeyboardServiceDisabledDialog").try_as<WUX::Controls::ContentDialog>());
+        // }
+        KeyboardWarningInfoBar().IsOpen(true);
     }
 
     // Function Description:

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2862,10 +2862,6 @@ namespace winrt::TerminalApp::implementation
     //   Service" is disabled.
     void TerminalPage::ShowKeyboardServiceWarning()
     {
-        // if (auto presenter{ _dialogPresenter.get() })
-        // {
-        //     presenter.ShowDialog(FindName(L"KeyboardServiceDisabledDialog").try_as<WUX::Controls::ContentDialog>());
-        // }
         KeyboardWarningInfoBar().IsOpen(true);
     }
 
@@ -2914,9 +2910,9 @@ namespace winrt::TerminalApp::implementation
 
     // Method Description:
     // - Return the fully-formed warning message for the
-    //   "KeyboardServiceDisabled" dialog. This dialog is used to warn the user
+    //   "KeyboardServiceDisabled" InfoBar. This InfoBar is used to warn the user
     //   if the keyboard service is disabled, and uses the OS localization for
-    //   the service's actual name. It's bound to the dialog in XAML.
+    //   the service's actual name. It's bound to the bar in XAML.
     // Return Value:
     // - The warning message, including the OS-localized service name.
     winrt::hstring TerminalPage::KeyboardServiceDisabledText()

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -110,5 +110,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             Grid.Row="1"
             Visibility="Collapsed"
             VerticalAlignment="Stretch" />
+
+        <mux:InfoBar x:Name="KeyboardWarningInfoBar" IsOpen="False" IsIconVisible="True" IsClosable="True" Severity="Warning" Message="{x:Bind KeyboardServiceDisabledText, Mode=OneWay}"></mux:InfoBar>
     </Grid>
 </Page>

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -98,6 +98,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             VerticalAlignment="Stretch" />
 
         <mux:InfoBar x:Name="KeyboardWarningInfoBar"
+                     x:Load="False"
                      IsClosable="True"
                      IsIconVisible="True"
                      IsOpen="False"

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -91,26 +91,17 @@ the MIT License. See LICENSE in the project root for license information. -->
             </TextBlock>
         </ContentDialog>
 
-
-        <ContentDialog
-            x:Load="False"
-            x:Name="KeyboardServiceDisabledDialog"
-            x:Uid="KeyboardServiceDisabledDialog"
-            DefaultButton="Primary">
-
-            <TextBlock
-                Foreground="{ThemeResource ErrorTextBrush}"
-                IsTextSelectionEnabled="True"
-                TextWrapping="WrapWholeWords"
-                Text="{x:Bind KeyboardServiceDisabledText, Mode=OneWay}" />
-        </ContentDialog>
-
         <local:CommandPalette
             x:Name="CommandPalette"
             Grid.Row="1"
             Visibility="Collapsed"
             VerticalAlignment="Stretch" />
 
-        <mux:InfoBar x:Name="KeyboardWarningInfoBar" IsOpen="False" IsIconVisible="True" IsClosable="True" Severity="Warning" Message="{x:Bind KeyboardServiceDisabledText, Mode=OneWay}"></mux:InfoBar>
+        <mux:InfoBar x:Name="KeyboardWarningInfoBar"
+                     IsClosable="True"
+                     IsIconVisible="True"
+                     IsOpen="False"
+                     Severity="Warning"
+                     Message="{x:Bind KeyboardServiceDisabledText, Mode=OneWay}"/>
     </Grid>
 </Page>


### PR DESCRIPTION
This changes the keyboard warning from a dialog to an `InfoBar`, which
we just got in MUX 2.5. Some users were unhappy that we'd always display
the dialog. We learned from the input team that this service _should_
always be enabled. We're also learing from users that they don't always
want it enabled. 

We're working with the Input team to help us figure out how this service
can be disabled _and the Terminal work just fine_. They're confident
that it _shouldn't_. For 99% of our users, they're right. So we don't
want to get rid of the dialog entirely, we want to understand how this
is possible. While we wait, let's make the message less aggressive.

This is instead of making a `iKnowWhatImDoingDisableTheKeyboardWarning`
setting to disable the dialog. Props to @cornem for suggesting the less
aggressive solution. 

## Validation Steps Performed
Tested manually, but by forcing the message to always display. Disabling
the service requires two full reboots, and _ain't nobody got time for
that_.

Closes #8228
Closes #4448, for now
