### PR TITLE
Delete the old PackageES code signing configs

### DIFF
--- a/build/config/SignConfig.NuGet.xml
+++ b/build/config/SignConfig.NuGet.xml
@@ -1,5 +1,0 @@
-<SignConfigXML>
-  <job platform="" configuration="" dest="__INPATHROOT__" jobname="EngFunSimpleSign" approvers="">
-   <file src="__INPATHROOT__\Microsoft.Terminal*.nupkg" signType="NuGet" /> 
-  </job>
-</SignConfigXML>

--- a/build/config/SignConfig.WindowsTerminal.xml
+++ b/build/config/SignConfig.WindowsTerminal.xml
@@ -1,5 +1,0 @@
-<SignConfigXML>
-  <job platform="" configuration="" certSubject="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" jobname="EngFunSimpleSign" approvers="">
-   <file src="__INPATHROOT__\Microsoft.WindowsTerminal*.msixbundle" signType="136020001" />
-  </job>
-</SignConfigXML>


### PR DESCRIPTION
We've moved to the recommended internal code signing service
and no longer need these configurations.