### PR TITLE
Fix next tab activation in focus mode upon tab closing

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1136,12 +1136,15 @@ namespace winrt::TerminalApp::implementation
         {
             _lastTabClosedHandlers(*this, nullptr);
         }
-        else if (_isFullscreen || _rearranging)
+        else if (_isFullscreen || _rearranging || _isInFocusMode)
         {
             // GH#5799 - If we're fullscreen, the TabView isn't visible. If it's
             // not Visible, it's _not_ going to raise a SelectionChanged event,
             // which is what we usually use to focus another tab. Instead, we'll
             // have to do it manually here.
+            //
+            // GH#7916 - Similarly, TabView isn't visible in focus mode.
+            // We need to focus another tab manually from the same considerations as above.
             //
             // GH#5559 Similarly, we suppress _OnTabItemsChanged events during a
             // rearrange, so if a tab is closed while we're rearranging tabs, do


### PR DESCRIPTION
## PR Checklist
* [x] Closes https://github.com/microsoft/terminal/issues/7916
* [x] CLA signed. 
* [ ] Tests added/passed
* [ ] Documentation updated. 
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. 

## Detailed Description of the Pull Request / Additional comments
Upon tab close the tabview is responsible to issue tab selection for the next active tab.
However this doesn't happen when tabview is hidden.
There was a special treatment for this scenario for full screen mode.
Added the same treatment to focus mode (as the tabview is not visible in this case as well).

## Validation Steps Performed
Manual tests