### PR TITLE
TSE: Replace TSM.Profile with a ProfileViewModel

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -30,13 +30,12 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     private:
         Model::CascadiaSettings _settingsSource;
         Model::CascadiaSettings _settingsClone;
-        winrt::Windows::Foundation::Collections::IMap<Model::Profile, winrt::Microsoft::UI::Xaml::Controls::NavigationViewItem> _profileToNavItemMap;
 
         std::optional<HWND> _hostingHwnd;
 
         void _InitializeProfilesList();
         void _CreateAndNavigateToNewProfile(const uint32_t index);
-        winrt::Microsoft::UI::Xaml::Controls::NavigationViewItem _CreateProfileNavViewItem(const Model::Profile& profile);
+        winrt::Microsoft::UI::Xaml::Controls::NavigationViewItem _CreateProfileNavViewItem(const ProfileViewModel& profile);
 
         void _Navigate(hstring clickedItemTag);
         void _RefreshCurrentPage();

--- a/src/cascadia/TerminalSettingsEditor/Profiles.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.cpp
@@ -103,7 +103,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         StorageFile file = co_await picker.PickSingleFileAsync();
         if (file != nullptr)
         {
-            BackgroundImage().Text(file.Path());
+            _State.Profile().BackgroundImagePath(file.Path());
         }
     }
 
@@ -124,7 +124,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         StorageFile file = co_await picker.PickSingleFileAsync();
         if (file != nullptr)
         {
-            Icon().Text(file.Path());
+            _State.Profile().Icon(file.Path());
         }
     }
 
@@ -142,7 +142,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         StorageFile file = co_await picker.PickSingleFileAsync();
         if (file != nullptr)
         {
-            Commandline().Text(file.Path());
+            _State.Profile().Commandline(file.Path());
         }
     }
 
@@ -157,7 +157,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         if (folder != nullptr)
         {
             StorageApplicationPermissions::FutureAccessList().AddOrReplace(L"PickedFolderToken", folder);
-            StartingDirectory().Text(folder.Path());
+            _State.Profile().StartingDirectory(folder.Path());
         }
     }
 

--- a/src/cascadia/TerminalSettingsEditor/Profiles.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.h
@@ -5,15 +5,66 @@
 
 #include "Profiles.g.h"
 #include "ProfilePageNavigationState.g.h"
+#include "ProfileViewModel.g.h"
 #include "Utils.h"
+#include "ViewModelHelpers.h"
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    struct ProfileViewModel : ProfileViewModelT<ProfileViewModel>, ViewModelHelper<ProfileViewModel>
+    {
+    public:
+        ProfileViewModel(const Model::Profile& profile) :
+            _profile{ profile } {}
+
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_profile, Guid);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_profile, ConnectionType);
+        OBSERVABLE_PROJECTED_SETTING(_profile, Name);
+        OBSERVABLE_PROJECTED_SETTING(_profile, Source);
+        OBSERVABLE_PROJECTED_SETTING(_profile, Hidden);
+        OBSERVABLE_PROJECTED_SETTING(_profile, Icon);
+        OBSERVABLE_PROJECTED_SETTING(_profile, CloseOnExit);
+        OBSERVABLE_PROJECTED_SETTING(_profile, TabTitle);
+        OBSERVABLE_PROJECTED_SETTING(_profile, TabColor);
+        OBSERVABLE_PROJECTED_SETTING(_profile, SuppressApplicationTitle);
+        OBSERVABLE_PROJECTED_SETTING(_profile, UseAcrylic);
+        OBSERVABLE_PROJECTED_SETTING(_profile, AcrylicOpacity);
+        OBSERVABLE_PROJECTED_SETTING(_profile, ScrollState);
+        OBSERVABLE_PROJECTED_SETTING(_profile, FontFace);
+        OBSERVABLE_PROJECTED_SETTING(_profile, FontSize);
+        OBSERVABLE_PROJECTED_SETTING(_profile, FontWeight);
+        OBSERVABLE_PROJECTED_SETTING(_profile, Padding);
+        OBSERVABLE_PROJECTED_SETTING(_profile, Commandline);
+        OBSERVABLE_PROJECTED_SETTING(_profile, StartingDirectory);
+        OBSERVABLE_PROJECTED_SETTING(_profile, BackgroundImagePath);
+        OBSERVABLE_PROJECTED_SETTING(_profile, BackgroundImageOpacity);
+        OBSERVABLE_PROJECTED_SETTING(_profile, BackgroundImageStretchMode);
+        OBSERVABLE_PROJECTED_SETTING(_profile, BackgroundImageAlignment);
+        OBSERVABLE_PROJECTED_SETTING(_profile, AntialiasingMode);
+        OBSERVABLE_PROJECTED_SETTING(_profile, RetroTerminalEffect);
+        OBSERVABLE_PROJECTED_SETTING(_profile, ForceFullRepaintRendering);
+        OBSERVABLE_PROJECTED_SETTING(_profile, SoftwareRendering);
+        OBSERVABLE_PROJECTED_SETTING(_profile, ColorSchemeName);
+        OBSERVABLE_PROJECTED_SETTING(_profile, Foreground);
+        OBSERVABLE_PROJECTED_SETTING(_profile, Background);
+        OBSERVABLE_PROJECTED_SETTING(_profile, SelectionBackground);
+        OBSERVABLE_PROJECTED_SETTING(_profile, CursorColor);
+        OBSERVABLE_PROJECTED_SETTING(_profile, HistorySize);
+        OBSERVABLE_PROJECTED_SETTING(_profile, SnapOnInput);
+        OBSERVABLE_PROJECTED_SETTING(_profile, AltGrAliasing);
+        OBSERVABLE_PROJECTED_SETTING(_profile, CursorShape);
+        OBSERVABLE_PROJECTED_SETTING(_profile, CursorHeight);
+        OBSERVABLE_PROJECTED_SETTING(_profile, BellStyle);
+
+    private:
+        Model::Profile _profile;
+    };
+
     struct ProfilePageNavigationState : ProfilePageNavigationStateT<ProfilePageNavigationState>
     {
     public:
-        ProfilePageNavigationState(const Model::Profile& profile, const Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme>& schemes, const IHostedInWindow& windowRoot) :
-            _Profile{ profile },
+        ProfilePageNavigationState(const Editor::ProfileViewModel& viewModel, const Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme>& schemes, const IHostedInWindow& windowRoot) :
+            _Profile{ viewModel },
             _Schemes{ schemes },
             _WindowRoot{ windowRoot }
         {
@@ -22,8 +73,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme> Schemes() { return _Schemes; }
         void Schemes(const Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme>& val) { _Schemes = val; }
 
-        GETSET_PROPERTY(Model::Profile, Profile, nullptr);
         GETSET_PROPERTY(IHostedInWindow, WindowRoot, nullptr);
+        GETSET_PROPERTY(Editor::ProfileViewModel, Profile, nullptr);
 
     private:
         Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme> _Schemes;

--- a/src/cascadia/TerminalSettingsEditor/Profiles.idl
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.idl
@@ -4,13 +4,58 @@
 import "EnumEntry.idl";
 import "MainPage.idl";
 
+#include "ViewModelHelpers.idl.h"
+
 namespace Microsoft.Terminal.Settings.Editor
 {
+    runtimeclass ProfileViewModel : Windows.UI.Xaml.Data.INotifyPropertyChanged
+    {
+        OBSERVABLE_PROJECTED_SETTING(String, Name);
+        OBSERVABLE_PROJECTED_SETTING(Guid, Guid);
+        OBSERVABLE_PROJECTED_SETTING(String, Source);
+        OBSERVABLE_PROJECTED_SETTING(Guid, ConnectionType);
+        OBSERVABLE_PROJECTED_SETTING(Boolean, Hidden);
+        OBSERVABLE_PROJECTED_SETTING(String, Icon);
+        OBSERVABLE_PROJECTED_SETTING(Microsoft.Terminal.Settings.Model.CloseOnExitMode, CloseOnExit);
+        OBSERVABLE_PROJECTED_SETTING(String, TabTitle);
+        OBSERVABLE_PROJECTED_SETTING(Windows.Foundation.IReference<Windows.UI.Color>, TabColor);
+        OBSERVABLE_PROJECTED_SETTING(Boolean, SuppressApplicationTitle);
+        OBSERVABLE_PROJECTED_SETTING(Boolean, UseAcrylic);
+        OBSERVABLE_PROJECTED_SETTING(Double, AcrylicOpacity);
+        OBSERVABLE_PROJECTED_SETTING(Microsoft.Terminal.TerminalControl.ScrollbarState, ScrollState);
+        OBSERVABLE_PROJECTED_SETTING(String, FontFace);
+        OBSERVABLE_PROJECTED_SETTING(Int32, FontSize);
+        OBSERVABLE_PROJECTED_SETTING(Windows.UI.Text.FontWeight, FontWeight);
+        OBSERVABLE_PROJECTED_SETTING(String, Padding);
+        OBSERVABLE_PROJECTED_SETTING(String, Commandline);
+        OBSERVABLE_PROJECTED_SETTING(String, StartingDirectory);
+        OBSERVABLE_PROJECTED_SETTING(String, BackgroundImagePath);
+        OBSERVABLE_PROJECTED_SETTING(Double, BackgroundImageOpacity);
+        OBSERVABLE_PROJECTED_SETTING(Windows.UI.Xaml.Media.Stretch, BackgroundImageStretchMode);
+        OBSERVABLE_PROJECTED_SETTING(Microsoft.Terminal.Settings.Model.ConvergedAlignment, BackgroundImageAlignment);
+        OBSERVABLE_PROJECTED_SETTING(Microsoft.Terminal.TerminalControl.TextAntialiasingMode, AntialiasingMode);
+        OBSERVABLE_PROJECTED_SETTING(Boolean, RetroTerminalEffect);
+        OBSERVABLE_PROJECTED_SETTING(Boolean, ForceFullRepaintRendering);
+        OBSERVABLE_PROJECTED_SETTING(Boolean, SoftwareRendering);
+        OBSERVABLE_PROJECTED_SETTING(String, ColorSchemeName);
+        OBSERVABLE_PROJECTED_SETTING(Windows.Foundation.IReference<Windows.UI.Color>, Foreground);
+        OBSERVABLE_PROJECTED_SETTING(Windows.Foundation.IReference<Windows.UI.Color>, Background);
+        OBSERVABLE_PROJECTED_SETTING(Windows.Foundation.IReference<Windows.UI.Color>, SelectionBackground);
+        OBSERVABLE_PROJECTED_SETTING(Windows.Foundation.IReference<Windows.UI.Color>, CursorColor);
+        OBSERVABLE_PROJECTED_SETTING(Int32, HistorySize);
+        OBSERVABLE_PROJECTED_SETTING(Boolean, SnapOnInput);
+        OBSERVABLE_PROJECTED_SETTING(Boolean, AltGrAliasing);
+        OBSERVABLE_PROJECTED_SETTING(Microsoft.Terminal.TerminalControl.CursorStyle, CursorShape);
+        OBSERVABLE_PROJECTED_SETTING(UInt32, CursorHeight);
+        OBSERVABLE_PROJECTED_SETTING(Microsoft.Terminal.Settings.Model.BellStyle, BellStyle);
+    }
+
     runtimeclass ProfilePageNavigationState
     {
         Windows.Foundation.Collections.IMapView<String, Microsoft.Terminal.Settings.Model.ColorScheme> Schemes;
-        Microsoft.Terminal.Settings.Model.Profile Profile;
         IHostedInWindow WindowRoot; // necessary to send the right HWND into the file picker dialogs.
+
+        ProfileViewModel Profile { get; };
     };
 
     [default_interface] runtimeclass Profiles : Windows.UI.Xaml.Controls.Page, Windows.UI.Xaml.Data.INotifyPropertyChanged

--- a/src/cascadia/TerminalSettingsEditor/ViewModelHelpers.h
+++ b/src/cascadia/TerminalSettingsEditor/ViewModelHelpers.h
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+#include "../inc/cppwinrt_utils.h"
+
+template<typename T>
+struct ViewModelHelper
+{
+public:
+    winrt::event_token PropertyChanged(::winrt::Windows::UI::Xaml::Data::PropertyChangedEventHandler const& handler)
+    {
+        return _propertyChangedHandlers.add(handler);
+    }
+
+    void PropertyChanged(winrt::event_token const& token)
+    {
+        _propertyChangedHandlers.remove(token);
+    }
+
+protected:
+    void _NotifyChangeCore(const std::wstring_view name)
+    {
+        _propertyChangedHandlers(*static_cast<T*>(this), ::winrt::Windows::UI::Xaml::Data::PropertyChangedEventArgs{ name });
+    }
+
+    // template recursion base case: single dispatch
+    void _NotifyChanges(const std::wstring_view name) { _NotifyChangeCore(name); }
+
+    template<typename... Args>
+    void _NotifyChanges(const std::wstring_view name, Args&&... more)
+    {
+        _NotifyChangeCore(name);
+        _NotifyChanges(std::forward<Args>(more)...);
+    }
+
+private:
+    winrt::event<::winrt::Windows::UI::Xaml::Data::PropertyChangedEventHandler> _propertyChangedHandlers;
+};
+
+#define _BASE_OBSERVABLE_PROJECTED_SETTING(target, name)  \
+public:                                                   \
+    auto name() const noexcept { return target.name(); }; \
+    template<typename T>                                  \
+    void name(const T& value)                             \
+    {                                                     \
+        if (name() != value)                              \
+        {                                                 \
+            target.name(value);                           \
+            _NotifyChanges(L"Has" #name, L#name);         \
+        }                                                 \
+    }                                                     \
+    bool Has##name() { return target.Has##name(); }
+
+// Defines a setting that reflects another object's same-named
+// setting.
+#define OBSERVABLE_PROJECTED_SETTING(target, name)   \
+    _BASE_OBSERVABLE_PROJECTED_SETTING(target, name) \
+    void Clear##name()                               \
+    {                                                \
+        const auto hadValue{ target.Has##Name() };   \
+        target.Clear##name();                        \
+        if (hadValue)                                \
+        {                                            \
+            _NotifyChanges(L"Has" #name, L#name);    \
+        }                                            \
+    }
+
+// Defines a setting that reflects another object's same-named
+// setting, but which cannot be erased.
+#define PERMANENT_OBSERVABLE_PROJECTED_SETTING(target, name) \
+    _BASE_OBSERVABLE_PROJECTED_SETTING(target, name)         \
+    void Clear##name() {}

--- a/src/cascadia/TerminalSettingsEditor/ViewModelHelpers.idl.h
+++ b/src/cascadia/TerminalSettingsEditor/ViewModelHelpers.idl.h
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+#define OBSERVABLE_PROJECTED_SETTING(Type, Name) \
+    Type Name { get; set; };                     \
+    Boolean Has##Name { get; };                  \
+    void Clear##Name()

--- a/src/cascadia/TerminalSettingsEditor/ViewModelHelpers.idl.h
+++ b/src/cascadia/TerminalSettingsEditor/ViewModelHelpers.idl.h
@@ -4,6 +4,10 @@
 #pragma once
 
 #define OBSERVABLE_PROJECTED_SETTING(Type, Name) \
-    Type Name { get; set; };                     \
+    Type Name                                    \
+    {                                            \
+        get;                                     \
+        set;                                     \
+    };                                           \
     Boolean Has##Name { get; };                  \
     void Clear##Name()


### PR DESCRIPTION
It's generally accepted that in a graphical application you'll follow a
design pattern. The one this moves us towards is "MVVM" -- Model, View,
View Model.

In an ideal world, _all of our display smarts_ would be in the
ViewModel and the View would literally just be XAML. This moves us
closer to that reality.

The only thing the Profile page ViewModel does right now is proxy
requests through to the Profile behind it while adding some basic
invalidation logic and detection of a setting being set to its current
value.

We have to do this because (1) MVVM is better and (2) separation of
concerns dictates that TSM::Profile should **not** have a
Windows.UI.Xaml dependency (in IPropertyChangedNotifier). It therefore
**cannot** conform to Xaml's notion of what a ViewModel should be.

I've done this by introducing a heap of code-generating macros and a
template that work together to make the process of adding more settings
easier (if not "easy").

We are eventually going to need to do this for all of the existing TSM
model objects. In an ideal world, even our navigation would be driven
through a viewmodel that supports a notion of an "active page".

All I've done so far is break ProfilesPage's dependency on Profile entirely.
Weird how that works.

Fixes "browse buttons do not actually update the profile"
Fixes "we need to have convoluted local overrides that update the
  visibility of things like AcrylicOpacity"
Fixes "we'll eventually need a way to update a preview TermControl"
Fixes "we have no idea how we're going to update the Discard/Apply
  buttons or the unsaved changes label"

Having a PVM that notifies on icon/name change will also make it easier
for the MainPage to update its NavViewItems.