### PR TITLE
Enable shortcut while CommandPalette is open 

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -944,9 +944,12 @@ namespace winrt::TerminalApp::implementation
         auto setting = AppLogic::CurrentAppSettings();
         auto keymap = setting.GlobalSettings().KeyMap();
         const auto actionAndArgs = keymap.TryLookup(kc);
-
         if (actionAndArgs)
         {
+            if (CommandPalette().Visibility() == Visibility::Visible && actionAndArgs.Action() != ShortcutAction::ToggleCommandPalette)
+            {
+                CommandPalette().Visibility(Visibility::Collapsed);
+            }
             _actionDispatch->DoAction(actionAndArgs);
             e.Handled(true);
         }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -933,7 +933,7 @@ namespace winrt::TerminalApp::implementation
     // - e: the KeyRoutedEventArgs containing info about the keystroke.
     // Return Value:
     // - <none>
-    void TerminalPage::_CommandPaletteKeyDownHandler(Windows::Foundation::IInspectable const& /*sender*/, Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e)
+    void TerminalPage::_KeyDownHandler(Windows::Foundation::IInspectable const& /*sender*/, Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e)
     {
         auto key = e.OriginalKey();
         auto const ctrlDown = WI_IsFlagSet(CoreWindow::GetForCurrentThread().GetKeyState(winrt::Windows::System::VirtualKey::Control), CoreVirtualKeyStates::Down);

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -928,6 +928,34 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Method Description:
+    // Called when the users pressed keyBindings while CommandPalette is open.
+    // Arguments:
+    // - e: the KeyRoutedEventArgs containing info about the keystroke.
+    // Return Value:
+    // - <none>
+    void TerminalPage::_CommandPaletteKeyDownHandler(Windows::Foundation::IInspectable const& /*sender*/, Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e)
+    {
+        auto key = e.OriginalKey();
+        auto const ctrlDown = WI_IsFlagSet(CoreWindow::GetForCurrentThread().GetKeyState(winrt::Windows::System::VirtualKey::Control), CoreVirtualKeyStates::Down);
+        auto const altDown = WI_IsFlagSet(CoreWindow::GetForCurrentThread().GetKeyState(winrt::Windows::System::VirtualKey::Menu), CoreVirtualKeyStates::Down);
+        auto const shiftDown = WI_IsFlagSet(CoreWindow::GetForCurrentThread().GetKeyState(winrt::Windows::System::VirtualKey::Shift), CoreVirtualKeyStates::Down);
+
+        winrt::Microsoft::Terminal::TerminalControl::KeyChord kc{ ctrlDown, altDown, shiftDown, static_cast<int32_t>(key) };
+        auto setting = AppLogic::CurrentAppSettings();
+        auto keymap = setting.GlobalSettings().KeyMap();
+        const auto actionAndArgs = keymap.TryLookup(kc);
+        if (actionAndArgs)
+        {
+            if (CommandPalette().Visibility() == Visibility::Visible && actionAndArgs.Action() != ShortcutAction::ToggleCommandPalette)
+            {
+                CommandPalette().Visibility(Visibility::Collapsed);
+            }
+            _actionDispatch->DoAction(actionAndArgs);
+            e.Handled(true);
+        }
+    }
+
+    // Method Description:
     // - Configure the AppKeyBindings to use our ShortcutActionDispatch and the updated KeyMapping
     // as the object to handle dispatching ShortcutAction events.
     // Arguments:

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -944,12 +944,9 @@ namespace winrt::TerminalApp::implementation
         auto setting = AppLogic::CurrentAppSettings();
         auto keymap = setting.GlobalSettings().KeyMap();
         const auto actionAndArgs = keymap.TryLookup(kc);
+
         if (actionAndArgs)
         {
-            if (CommandPalette().Visibility() == Visibility::Visible && actionAndArgs.Action() != ShortcutAction::ToggleCommandPalette)
-            {
-                CommandPalette().Visibility(Visibility::Collapsed);
-            }
             _actionDispatch->DoAction(actionAndArgs);
             e.Handled(true);
         }

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -156,7 +156,7 @@ namespace winrt::TerminalApp::implementation
         void _AboutButtonOnClick(const IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& eventArgs);
         void _ThirdPartyNoticesOnClick(const IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& eventArgs);
 
-        void _CommandPaletteKeyDownHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e);
+        void _KeyDownHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e);
         void _HookupKeyBindings(const Microsoft::Terminal::Settings::Model::KeyMapping& keymap) noexcept;
         void _RegisterActionCallbacks();
 

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -156,6 +156,7 @@ namespace winrt::TerminalApp::implementation
         void _AboutButtonOnClick(const IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& eventArgs);
         void _ThirdPartyNoticesOnClick(const IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& eventArgs);
 
+        void _CommandPaletteKeyDownHandler(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e);
         void _HookupKeyBindings(const Microsoft::Terminal::Settings::Model::KeyMapping& keymap) noexcept;
         void _RegisterActionCallbacks();
 

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -95,6 +95,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             x:Name="CommandPalette"
             Grid.Row="1"
             Visibility="Collapsed"
+            PreviewKeyDown ="_CommandPaletteKeyDownHandler"
             VerticalAlignment="Stretch" />
 
         <mux:InfoBar x:Name="KeyboardWarningInfoBar"

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -95,7 +95,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             x:Name="CommandPalette"
             Grid.Row="1"
             Visibility="Collapsed"
-            PreviewKeyDown ="_CommandPaletteKeyDownHandler"
+            PreviewKeyDown ="_KeyDownHandler"
             VerticalAlignment="Stretch" />
 
         <mux:InfoBar x:Name="KeyboardWarningInfoBar"


### PR DESCRIPTION
This commit introduces direct shortcut dispatch to TerminalPage, which
allows it to respond to key bindings before the command palette.

This allows the user to use shortcuts from the command palette while
it's open.

Closes #6679
