### PR TITLE
Prevent tab icon from blinking upon tab gaining focus

### DIFF
--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -219,17 +219,19 @@ namespace winrt::TerminalApp::implementation
 
         if (auto tab{ weakThis.get() })
         {
-            if (hide)
+            if (tab->_iconHidden != hide)
             {
-                Icon({});
-                TabViewItem().IconSource(IconPathConverter::IconSourceMUX({}));
-                tab->_iconHidden = true;
-            }
-            else
-            {
-                Icon(_lastIconPath);
-                TabViewItem().IconSource(IconPathConverter::IconSourceMUX(_lastIconPath));
-                tab->_iconHidden = false;
+                if (hide)
+                {
+                    Icon({});
+                    TabViewItem().IconSource(IconPathConverter::IconSourceMUX({}));
+                }
+                else
+                {
+                    Icon(_lastIconPath);
+                    TabViewItem().IconSource(IconPathConverter::IconSourceMUX(_lastIconPath));
+                }
+                tab->_iconHidden = hide;
             }
         }
     }


### PR DESCRIPTION
Looks like recent regression:
1. Every time the tab gains focus (e.g., upon tab switching) we trigger `TaskbarProgressChanged`
2. This call results in `HideIcon` call
3. This call resets the value of Icon even if hide=false
4. This triggers reload of the image resulting in blinking