### PR TITLE
Reduce Transient Allocations during Bulk Text Output

### DIFF
--- a/src/buffer/out/AttrRow.cpp
+++ b/src/buffer/out/AttrRow.cpp
@@ -185,14 +185,14 @@ size_t ATTR_ROW::FindAttrIndex(const size_t index, size_t* const pApplies) const
 // - Finds the hyperlink IDs present in this row and returns them
 // Return value:
 // - An unordered set containing the hyperlink IDs present in this row
-std::unordered_set<uint16_t> ATTR_ROW::GetHyperlinks()
+std::vector<uint16_t> ATTR_ROW::GetHyperlinks()
 {
-    std::unordered_set<uint16_t> ids;
+    std::vector<uint16_t> ids;
     for (const auto& run : _list)
     {
         if (run.GetAttributes().IsHyperlink())
         {
-            ids.emplace(run.GetAttributes().GetHyperlinkId());
+            ids.emplace_back(run.GetAttributes().GetHyperlinkId());
         }
     }
     return ids;

--- a/src/buffer/out/AttrRow.cpp
+++ b/src/buffer/out/AttrRow.cpp
@@ -184,7 +184,7 @@ size_t ATTR_ROW::FindAttrIndex(const size_t index, size_t* const pApplies) const
 // Routine Description:
 // - Finds the hyperlink IDs present in this row and returns them
 // Return value:
-// - An unordered set containing the hyperlink IDs present in this row
+// - The hyperlink IDs present in this row
 std::vector<uint16_t> ATTR_ROW::GetHyperlinks()
 {
     std::vector<uint16_t> ids;

--- a/src/buffer/out/AttrRow.hpp
+++ b/src/buffer/out/AttrRow.hpp
@@ -20,7 +20,6 @@ Revision History:
 
 #pragma once
 
-#include "boost/container/small_vector.hpp"
 #include "TextAttributeRun.hpp"
 #include "AttrRowIterator.hpp"
 

--- a/src/buffer/out/AttrRow.hpp
+++ b/src/buffer/out/AttrRow.hpp
@@ -51,7 +51,7 @@ public:
     size_t FindAttrIndex(const size_t index,
                          size_t* const pApplies) const;
 
-    std::unordered_set<uint16_t> GetHyperlinks();
+    std::vector<uint16_t> GetHyperlinks();
 
     bool SetAttrToEnd(const UINT iStart, const TextAttribute attr);
     void ReplaceAttrs(const TextAttribute& toBeReplacedAttr, const TextAttribute& replaceWith) noexcept;

--- a/src/buffer/out/AttrRowIterator.hpp
+++ b/src/buffer/out/AttrRowIterator.hpp
@@ -15,7 +15,6 @@ Author(s):
 
 #pragma once
 
-#include "boost/container/small_vector.hpp"
 #include "TextAttribute.hpp"
 #include "TextAttributeRun.hpp"
 

--- a/src/buffer/out/CharRow.hpp
+++ b/src/buffer/out/CharRow.hpp
@@ -24,7 +24,6 @@ Revision History:
 #include "CharRowCellReference.hpp"
 #include "CharRowCell.hpp"
 #include "UnicodeStorage.hpp"
-#include "boost/container/small_vector.hpp"
 
 class ROW;
 

--- a/src/host/precomp.h
+++ b/src/host/precomp.h
@@ -88,8 +88,6 @@ TRACELOGGING_DECLARE_PROVIDER(g_hConhostV2EventTraceProvider);
 #include "../inc/operators.hpp"
 #include "../inc/conattrs.hpp"
 
-#include "boost/container/small_vector.hpp"
-
 // TODO: MSFT 9355094 Find a better way of doing this. http://osgvsowi/9355094
 [[nodiscard]] inline NTSTATUS NTSTATUS_FROM_HRESULT(HRESULT hr)
 {

--- a/src/host/tracing.cpp
+++ b/src/host/tracing.cpp
@@ -216,7 +216,7 @@ void Tracing::s_TraceApi(const CONSOLE_MODE_MSG* const a, const std::wstring_vie
         g_hConhostV2EventTraceProvider,
         "API_GetConsoleMode",
         TraceLoggingHexUInt32(a->Mode, "Mode"),
-        TraceLoggingCountedWideString(handleType.data(), handleType.size(), "Handle type"),
+        TraceLoggingCountedWideString(handleType.data(), gsl::narrow_cast<ULONG>(handleType.size()), "Handle type"),
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
         TraceLoggingKeyword(TraceKeywords::API));
 }

--- a/src/host/tracing.cpp
+++ b/src/host/tracing.cpp
@@ -210,13 +210,13 @@ void Tracing::s_TraceApi(const CONSOLE_SCREENBUFFERINFO_MSG* const a)
     static_assert(sizeof(UINT32) == sizeof(*a->ColorTable), "a->ColorTable");
 }
 
-void Tracing::s_TraceApi(const CONSOLE_MODE_MSG* const a, const std::wstring& handleType)
+void Tracing::s_TraceApi(const CONSOLE_MODE_MSG* const a, const std::wstring_view handleType)
 {
     TraceLoggingWrite(
         g_hConhostV2EventTraceProvider,
         "API_GetConsoleMode",
         TraceLoggingHexUInt32(a->Mode, "Mode"),
-        TraceLoggingWideString(handleType.c_str(), "Handle type"),
+        TraceLoggingCountedWideString(handleType.data(), handleType.size(), "Handle type"),
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
         TraceLoggingKeyword(TraceKeywords::API));
 }

--- a/src/host/tracing.hpp
+++ b/src/host/tracing.hpp
@@ -50,7 +50,7 @@ public:
     static void s_TraceApi(_In_ const void* const buffer, const CONSOLE_WRITECONSOLE_MSG* const a);
 
     static void s_TraceApi(const CONSOLE_SCREENBUFFERINFO_MSG* const a);
-    static void s_TraceApi(const CONSOLE_MODE_MSG* const a, const std::wstring& handleType);
+    static void s_TraceApi(const CONSOLE_MODE_MSG* const a, const std::wstring_view handleType);
     static void s_TraceApi(const CONSOLE_SETTEXTATTRIBUTE_MSG* const a);
     static void s_TraceApi(const CONSOLE_WRITECONSOLEOUTPUTSTRING_MSG* const a);
 

--- a/src/inc/LibraryIncludes.h
+++ b/src/inc/LibraryIncludes.h
@@ -74,6 +74,9 @@
 #include <base/numerics/safe_math.h>
 #pragma warning(pop)
 
+// Boost
+#include "boost/container/small_vector.hpp"
+
 // IntSafe
 #define ENABLE_INTSAFE_SIGNED_FUNCTIONS
 #include <intsafe.h>

--- a/src/server/ApiDispatchers.cpp
+++ b/src/server/ApiDispatchers.cpp
@@ -35,7 +35,7 @@
 {
     Telemetry::Instance().LogApiCall(Telemetry::ApiCall::GetConsoleMode);
     CONSOLE_MODE_MSG* const a = &m->u.consoleMsgL1.GetConsoleMode;
-    std::wstring handleType = L"unknown";
+    std::wstring_view handleType = L"unknown";
 
     TraceLoggingWrite(g_hConhostV2EventTraceProvider,
                       "API_GetConsoleMode",
@@ -54,14 +54,14 @@
     RETURN_HR_IF_NULL(E_HANDLE, pObjectHandle);
     if (pObjectHandle->IsInputHandle())
     {
-        handleType = L"input handle";
+        handleType = L"input";
         InputBuffer* pObj;
         RETURN_IF_FAILED(pObjectHandle->GetInputBuffer(GENERIC_READ, &pObj));
         m->_pApiRoutines->GetConsoleInputModeImpl(*pObj, a->Mode);
     }
     else
     {
-        handleType = L"output handle";
+        handleType = L"output";
         SCREEN_INFORMATION* pObj;
         RETURN_IF_FAILED(pObjectHandle->GetScreenBuffer(GENERIC_READ, &pObj));
         m->_pApiRoutines->GetConsoleOutputModeImpl(*pObj, a->Mode);

--- a/src/server/ApiMessage.cpp
+++ b/src/server/ApiMessage.cpp
@@ -9,10 +9,18 @@
 #include "DeviceComm.h"
 
 _CONSOLE_API_MSG::_CONSOLE_API_MSG() :
+    Complete{ 0 },
+    State{ 0 },
     _pDeviceComm(nullptr),
-    _pApiRoutines(nullptr)
+    _pApiRoutines(nullptr),
+    _inputBuffer{},
+    _outputBuffer{},
+    Descriptor{ 0 },
+    CreateObject{ 0 },
+    CreateScreenBuffer{ 0 },
+    msgHeader{ 0 }
 {
-    ZeroMemory(this, sizeof(_CONSOLE_API_MSG));
+    
 }
 
 ConsoleProcessHandle* _CONSOLE_API_MSG::GetProcessHandle() const
@@ -57,6 +65,7 @@ ConsoleHandleData* _CONSOLE_API_MSG::GetObjectHandle() const
 // -  HRESULT indicating if the input buffer was successfully retrieved.
 [[nodiscard]] HRESULT _CONSOLE_API_MSG::GetInputBuffer(_Outptr_result_bytebuffer_(*pcbSize) void** const ppvBuffer,
                                                        _Out_ ULONG* const pcbSize)
+try
 {
     // Initialize the buffer if it hasn't been initialized yet.
     if (State.InputBuffer == nullptr)
@@ -65,12 +74,11 @@ ConsoleHandleData* _CONSOLE_API_MSG::GetObjectHandle() const
 
         ULONG const cbReadSize = Descriptor.InputSize - State.ReadOffset;
 
-        wistd::unique_ptr<BYTE[]> pPayload = wil::make_unique_nothrow<BYTE[]>(cbReadSize);
-        RETURN_IF_NULL_ALLOC(pPayload);
+        _inputBuffer.resize(cbReadSize);
 
-        RETURN_IF_FAILED(ReadMessageInput(0, pPayload.get(), cbReadSize));
+        RETURN_IF_FAILED(ReadMessageInput(0, _inputBuffer.data(), cbReadSize));
 
-        State.InputBuffer = pPayload.release(); // TODO: MSFT: 9565140 - don't release, maintain as smart pointer.
+        State.InputBuffer = _inputBuffer.data();
         State.InputBufferSize = cbReadSize;
     }
 
@@ -80,6 +88,7 @@ ConsoleHandleData* _CONSOLE_API_MSG::GetObjectHandle() const
 
     return S_OK;
 }
+CATCH_RETURN();
 
 // Routine Description:
 // - This routine retrieves the output buffer associated with this message. It will allocate one if needed.
@@ -94,6 +103,7 @@ ConsoleHandleData* _CONSOLE_API_MSG::GetObjectHandle() const
 [[nodiscard]] HRESULT _CONSOLE_API_MSG::GetAugmentedOutputBuffer(const ULONG cbFactor,
                                                                  _Outptr_result_bytebuffer_(*pcbSize) PVOID* const ppvBuffer,
                                                                  _Out_ PULONG pcbSize)
+try
 {
     // Initialize the buffer if it hasn't been initialized yet.
     if (State.OutputBuffer == nullptr)
@@ -103,11 +113,12 @@ ConsoleHandleData* _CONSOLE_API_MSG::GetObjectHandle() const
         ULONG cbWriteSize = Descriptor.OutputSize - State.WriteOffset;
         RETURN_IF_FAILED(ULongMult(cbWriteSize, cbFactor, &cbWriteSize));
 
-        BYTE* pPayload = new (std::nothrow) BYTE[cbWriteSize];
-        RETURN_IF_NULL_ALLOC(pPayload);
-        ZeroMemory(pPayload, sizeof(BYTE) * cbWriteSize);
+        _outputBuffer.resize(cbWriteSize);
 
-        State.OutputBuffer = pPayload; // TODO: MSFT: 9565140 - maintain as smart pointer.
+        // 0 it out.
+        std::fill(_outputBuffer.begin(), _outputBuffer.end(), (BYTE)0);
+
+        State.OutputBuffer = _outputBuffer.data();
         State.OutputBufferSize = cbWriteSize;
     }
 
@@ -117,6 +128,7 @@ ConsoleHandleData* _CONSOLE_API_MSG::GetObjectHandle() const
 
     return S_OK;
 }
+CATCH_RETURN();
 
 // Routine Description:
 // - This routine retrieves the output buffer associated with this message. It will allocate one if needed.
@@ -148,8 +160,9 @@ ConsoleHandleData* _CONSOLE_API_MSG::GetObjectHandle() const
 
     if (State.InputBuffer != nullptr)
     {
-        delete[] static_cast<BYTE*>(State.InputBuffer);
+        _inputBuffer.clear();
         State.InputBuffer = nullptr;
+        State.InputBufferSize = 0;
     }
 
     if (State.OutputBuffer != nullptr)
@@ -165,8 +178,9 @@ ConsoleHandleData* _CONSOLE_API_MSG::GetObjectHandle() const
             LOG_IF_FAILED(_pDeviceComm->WriteOutput(&IoOperation));
         }
 
-        delete[] static_cast<BYTE*>(State.OutputBuffer);
+        _outputBuffer.clear();
         State.OutputBuffer = nullptr;
+        State.OutputBufferSize = 0;
     }
 
     return hr;

--- a/src/server/ApiMessage.cpp
+++ b/src/server/ApiMessage.cpp
@@ -20,7 +20,6 @@ _CONSOLE_API_MSG::_CONSOLE_API_MSG() :
     CreateScreenBuffer{ 0 },
     msgHeader{ 0 }
 {
-    
 }
 
 ConsoleProcessHandle* _CONSOLE_API_MSG::GetProcessHandle() const

--- a/src/server/ApiMessage.h
+++ b/src/server/ApiMessage.h
@@ -40,7 +40,6 @@ private:
     boost::container::small_vector<BYTE, 128> _outputBuffer;
 
 public:
-
     // From here down is the actual packet data sent/received.
     CD_IO_DESCRIPTOR Descriptor;
     union

--- a/src/server/ApiMessage.h
+++ b/src/server/ApiMessage.h
@@ -64,7 +64,9 @@ public:
     // End packet data
 
 public:
-    // DO NOT PUT MORE FIELDS DOWN HERE. They will be stomped by driver fills.
+    // DO NOT PUT MORE FIELDS DOWN HERE.
+    // The tail end of this structure will have a console driver packet
+    // copied over it and it will overwrite any fields declared here.
 
     ConsoleProcessHandle* GetProcessHandle() const;
     ConsoleHandleData* GetObjectHandle() const;
@@ -81,6 +83,8 @@ public:
     void SetReplyStatus(const NTSTATUS Status);
     void SetReplyInformation(const ULONG_PTR pInformation);
 
-    // DO NOT PUT MORE FIELDS DOWN HERE. They will be stomped by driver fills.
+    // DO NOT PUT MORE FIELDS DOWN HERE.
+    // The tail end of this structure will have a console driver packet
+    // copied over it and it will overwrite any fields declared here.
 
 } CONSOLE_API_MSG, *PCONSOLE_API_MSG, * const PCCONSOLE_API_MSG;

--- a/src/server/ApiMessage.h
+++ b/src/server/ApiMessage.h
@@ -35,6 +35,12 @@ typedef struct _CONSOLE_API_MSG
     IDeviceComm* _pDeviceComm;
     IApiRoutines* _pApiRoutines;
 
+private:
+    boost::container::small_vector<BYTE, 128> _inputBuffer;
+    boost::container::small_vector<BYTE, 128> _outputBuffer;
+
+public:
+
     // From here down is the actual packet data sent/received.
     CD_IO_DESCRIPTOR Descriptor;
     union
@@ -58,6 +64,8 @@ typedef struct _CONSOLE_API_MSG
     // End packet data
 
 public:
+    // DO NOT PUT MORE FIELDS DOWN HERE. They will be stomped by driver fills.
+
     ConsoleProcessHandle* GetProcessHandle() const;
     ConsoleHandleData* GetObjectHandle() const;
 
@@ -72,5 +80,7 @@ public:
 
     void SetReplyStatus(const NTSTATUS Status);
     void SetReplyInformation(const ULONG_PTR pInformation);
+
+    // DO NOT PUT MORE FIELDS DOWN HERE. They will be stomped by driver fills.
 
 } CONSOLE_API_MSG, *PCONSOLE_API_MSG, * const PCCONSOLE_API_MSG;


### PR DESCRIPTION
Make a few changes to memory usage throughout the application to reduce transient allocations from the `big.txt` test from ~213,000 to ~53,000.

## PR Checklist
* [x] Supports #3075
* [x] I work here.
* [x] Tested manually and WPR'd. Test suite should still pass.
* [x] Am core contributor

## Detailed Description of the Pull Request / Additional comments

Transient allocations are those that are new'd, used, then delete'd. Going back and forth to the system allocator for things we're just going to throw away or use rapidly again is a performance detriment. Not only is it a bunch of time to go ask the system with a syscall, it also hits a whole bunch of locks on the allocators. This PR identifies a few places where we were accidentally allocating and didn't mean to or were allocating and freeing just to turn around and allocate again. I chose other strategies to avoid this.

## Validation Steps Performed
- Ran `big.txt` sample (~6MB file) before and after. Observed heap allocations with WPR.
