### PR TITLE
Fix VT parser memory leak in tracing

### DIFF
--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -383,7 +383,10 @@ static constexpr bool _isActionableFromGround(const wchar_t wch) noexcept
 void StateMachine::_ActionExecute(const wchar_t wch)
 {
     _trace.TraceOnExecute(wch);
-    _engine->ActionExecute(wch);
+    const bool success = _engine->ActionExecute(wch);
+
+    // Trace the result.
+    _trace.DispatchSequenceTrace(success);
 }
 
 // Routine Description:
@@ -397,7 +400,11 @@ void StateMachine::_ActionExecute(const wchar_t wch)
 void StateMachine::_ActionExecuteFromEscape(const wchar_t wch)
 {
     _trace.TraceOnExecuteFromEscape(wch);
-    _engine->ActionExecuteFromEscape(wch);
+
+    const bool success = _engine->ActionExecuteFromEscape(wch);
+
+    // Trace the result.
+    _trace.DispatchSequenceTrace(success);
 }
 
 // Routine Description:
@@ -409,7 +416,11 @@ void StateMachine::_ActionExecuteFromEscape(const wchar_t wch)
 void StateMachine::_ActionPrint(const wchar_t wch)
 {
     _trace.TraceOnAction(L"Print");
-    _engine->ActionPrint(wch);
+
+    const bool success = _engine->ActionPrint(wch);
+
+    // Trace the result.
+    _trace.DispatchSequenceTrace(success);
 }
 
 // Routine Description:

--- a/src/terminal/parser/tracing.cpp
+++ b/src/terminal/parser/tracing.cpp
@@ -76,7 +76,11 @@ void ParserTracing::TraceCharInput(const wchar_t wch)
 
 void ParserTracing::AddSequenceTrace(const wchar_t wch)
 {
-    _sequenceTrace.push_back(wch);
+    // Don't waste time storing this if no one is listening.
+    if (TraceLoggingProviderEnabled(g_hConsoleVirtTermParserEventTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    {
+        _sequenceTrace.push_back(wch);
+    }
 }
 
 void ParserTracing::DispatchSequenceTrace(const bool fSuccess) noexcept


### PR DESCRIPTION
Fix memory leak that occurs from not dispatching the end of sequences on all actions (since it is buffering up all characters for trace reasons.) Also don't bother storing if no one is listening.

## PR Checklist
- [x] Closes #8283
* [x] Fixes leak found while bumbling around.
* [x] I work here.

## Detailed Description of the Pull Request / Additional comments
- We trace all the things leading up to the Action phase in the VT parser for ETW tracing to make debugging the parser easier, but we made two mistakes.
- At some point, three of the actions (related to print/execute) weren't dispatching the stored up sequence to tracing and not clearing it. So printing/executing in a giant run over and over caused the vector to bloat and bloat and bloat forever.
- We're storing things even when no one is listening. That's a waste.

## Validation Steps Performed
- Watched it grow every time I did `type big.txt` under `taskman.exe`. Then watched it not do that after.
- I did technically WPR it to figure out this was the culprit.
