### PR TITLE
Fix Korean IME to display a character being composed in conhost

### DIFF
--- a/src/tsf/TfEditSession.cpp
+++ b/src/tsf/TfEditSession.cpp
@@ -1016,7 +1016,7 @@ CEditSessionObject::Release()
     RETURN_HR_IF(E_FAIL, lStartResult > 0);
 
     FullTextRange->CompareEnd(ec, InterimRange, TF_ANCHOR_END, &lEndResult);
-    RETURN_HR_IF(E_FAIL, lEndResult != 1);
+    RETURN_HR_IF(E_FAIL, lEndResult < 0);
 
     if (lStartResult < 0)
     {


### PR DESCRIPTION
## Summary of the Pull Request
This PR fixes Korean IME to display a character being composed in conhost.

### Before
![before](https://user-images.githubusercontent.com/58393346/102745310-03f23c80-439f-11eb-9f86-263da2dbddbb.gif)

### After
![after](https://user-images.githubusercontent.com/58393346/102745343-14a2b280-439f-11eb-853c-42b52bf442f4.gif)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #6227
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
