### PR TITLE
Fix multi line paste detection and filtering

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1974,7 +1974,7 @@ namespace winrt::TerminalApp::implementation
             }
 
             const auto isNewLineLambda = [](auto c) { return c == L'\n' || c == L'\r'; };
-            const auto hasNewLine = std::find_if(text.cbegin(), text.cend(), hasNewLineLambda) != text.cend();
+            const auto hasNewLine = std::find_if(text.cbegin(), text.cend(), isNewLineLambda) != text.cend();
             const auto warnMultiLine = hasNewLine && _settings.GlobalSettings().WarnAboutMultiLinePaste();
 
             constexpr const std::size_t minimumSizeForWarning = 1024 * 5; // 5 KiB

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1973,9 +1973,9 @@ namespace winrt::TerminalApp::implementation
                 }
             }
 
-            std::wregex newLine{ LR"((\r|\n))" };
-            const bool hasNewLine = std::regex_search(text.c_str(), newLine);
-            const bool warnMultiLine = hasNewLine && _settings.GlobalSettings().WarnAboutMultiLinePaste();
+            const auto hasNewLineLambda = [&](auto c) { return c == L'\n' || c == L'\r'; };
+            const auto hasNewLine = std::find_if(text.cbegin(), text.cend(), hasNewLineLambda) != text.cend();
+            const auto warnMultiLine = hasNewLine && _settings.GlobalSettings().WarnAboutMultiLinePaste();
 
             constexpr const std::size_t minimumSizeForWarning = 1024 * 5; // 5 KiB
             const bool warnLargeText = text.size() > minimumSizeForWarning &&

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1973,7 +1973,8 @@ namespace winrt::TerminalApp::implementation
                 }
             }
 
-            const bool hasNewLine = std::find(text.cbegin(), text.cend(), L'\n') != text.cend();
+            std::wregex newLine{ LR"((\r|\n))" };
+            const bool hasNewLine = std::regex_search(text.c_str(), newLine);
             const bool warnMultiLine = hasNewLine && _settings.GlobalSettings().WarnAboutMultiLinePaste();
 
             constexpr const std::size_t minimumSizeForWarning = 1024 * 5; // 5 KiB

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1973,7 +1973,7 @@ namespace winrt::TerminalApp::implementation
                 }
             }
 
-            const auto hasNewLineLambda = [&](auto c) { return c == L'\n' || c == L'\r'; };
+            const auto isNewLineLambda = [](auto c) { return c == L'\n' || c == L'\r'; };
             const auto hasNewLine = std::find_if(text.cbegin(), text.cend(), hasNewLineLambda) != text.cend();
             const auto warnMultiLine = hasNewLine && _settings.GlobalSettings().WarnAboutMultiLinePaste();
 

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2035,9 +2035,10 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         //   performance guarantees aren't exactly stellar)
         // - The STL doesn't have a simple string search/replace method.
         //   This fact is lamentable.
-        // - We search for \n, and when we find it we check the if the
-        //   previous character is \r, if so we copy the string up to
-        //   the \n (but not including it), otherwise we replace the lone \n with \r
+        // - We search for \n, and when we find it we copy the string up to
+        //   the \n (but not including it). Then, we check the if the
+        //   previous character is \r, if its not, then we had a lone \n
+        //   and so we append our own \r
 
         if (wstr.find(L"\n") == std::wstring::npos)
         {

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2061,7 +2061,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             begin = pos;
         }
 
-        if (begin == 0 && pos == std::wstring::npos)
+        if (begin == 0)
         {
             // we did not find a newline, just go ahead and write the original string
             _connection.WriteInput(wstr);

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2061,9 +2061,12 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
             begin = pos;
         }
 
+        // If we entered the while loop even once, begin would be non-zero
+        // (because we set begin = pos right after incrementing pos)
+        // So, if begin is still zero at this point it means we never found a newline
+        // and we can just write the original string
         if (begin == 0)
         {
-            // we did not find a newline, just go ahead and write the original string
             _connection.WriteInput(wstr);
         }
         else


### PR DESCRIPTION
- Detect `\r` when warning about multi line paste
- Translate `\n` to `\r` on paste

## PR Checklist
* [x] Closes #8601
* [x] Closes #5821

## Validation Steps Performed
Manual testing