### PR TITLE
Show indicator of bell in tab

### DIFF
--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -368,27 +368,18 @@ void Pane::_ControlWarningBellHandler(const winrt::Windows::Foundation::IInspect
     auto paneProfile = settings.FindProfile(_profile.value());
     if (paneProfile)
     {
-        // We only want to do anything if either visual or audible is set, so check for that first
-        if (WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Visual) ||
-            WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Audible))
+        // We don't want to do anything if nothing is set, so check for that first
+        if (static_cast<int>(paneProfile.BellStyle()) != 0)
         {
-            if (WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Visual))
-            {
-                // Visual is set, raise the event with the bool set to true
-                _PaneRaiseBellHandlers(nullptr, true);
-            }
-            else
-            {
-                // Visual is not set, raise the event with the bool set to false
-                _PaneRaiseBellHandlers(nullptr, false);
-            }
-
             if (WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Audible))
             {
                 // Audible is set, play the sound
                 const auto soundAlias = reinterpret_cast<LPCTSTR>(SND_ALIAS_SYSTEMHAND);
                 PlaySound(soundAlias, NULL, SND_ALIAS_ID | SND_ASYNC | SND_SENTRY);
             }
+
+            // raise the event with the bool value corresponding to the visual flag
+            _PaneRaiseBellHandlers(nullptr, WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Visual));
         }
     }
 }

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -368,23 +368,22 @@ void Pane::_ControlWarningBellHandler(const winrt::Windows::Foundation::IInspect
     auto paneProfile = settings.FindProfile(_profile.value());
     if (paneProfile)
     {
-        if (WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Audible) &&
-            WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Visual))
+        if (WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Visual))
         {
-            const auto soundAlias = reinterpret_cast<LPCTSTR>(SND_ALIAS_SYSTEMHAND);
-            PlaySound(soundAlias, NULL, SND_ALIAS_ID | SND_ASYNC | SND_SENTRY);
+            // Visual is set, raise the event with the bool set to true
             _PaneRaiseBellHandlers(nullptr, true);
         }
-        else if (WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Audible))
+        else
         {
-            const auto soundAlias = reinterpret_cast<LPCTSTR>(SND_ALIAS_SYSTEMHAND);
-            PlaySound(soundAlias, NULL, SND_ALIAS_ID | SND_ASYNC | SND_SENTRY);
+            // Visual is not set, raise the event with the bool set to false
             _PaneRaiseBellHandlers(nullptr, false);
         }
-        else if (WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Visual))
+
+        if (WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Audible))
         {
-            // Bubble this event up to app host, starting with bubbling to the hosting tab
-            _PaneRaiseBellHandlers(nullptr, true);
+            // Audible is set, play the sound
+            const auto soundAlias = reinterpret_cast<LPCTSTR>(SND_ALIAS_SYSTEMHAND);
+            PlaySound(soundAlias, NULL, SND_ALIAS_ID | SND_ASYNC | SND_SENTRY);
         }
     }
 }

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -368,22 +368,27 @@ void Pane::_ControlWarningBellHandler(const winrt::Windows::Foundation::IInspect
     auto paneProfile = settings.FindProfile(_profile.value());
     if (paneProfile)
     {
-        if (WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Visual))
+        // We only want to do anything if either visual or audible is set, so check for that first
+        if (WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Visual) ||
+            WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Audible))
         {
-            // Visual is set, raise the event with the bool set to true
-            _PaneRaiseBellHandlers(nullptr, true);
-        }
-        else
-        {
-            // Visual is not set, raise the event with the bool set to false
-            _PaneRaiseBellHandlers(nullptr, false);
-        }
+            if (WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Visual))
+            {
+                // Visual is set, raise the event with the bool set to true
+                _PaneRaiseBellHandlers(nullptr, true);
+            }
+            else
+            {
+                // Visual is not set, raise the event with the bool set to false
+                _PaneRaiseBellHandlers(nullptr, false);
+            }
 
-        if (WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Audible))
-        {
-            // Audible is set, play the sound
-            const auto soundAlias = reinterpret_cast<LPCTSTR>(SND_ALIAS_SYSTEMHAND);
-            PlaySound(soundAlias, NULL, SND_ALIAS_ID | SND_ASYNC | SND_SENTRY);
+            if (WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Audible))
+            {
+                // Audible is set, play the sound
+                const auto soundAlias = reinterpret_cast<LPCTSTR>(SND_ALIAS_SYSTEMHAND);
+                PlaySound(soundAlias, NULL, SND_ALIAS_ID | SND_ASYNC | SND_SENTRY);
+            }
         }
     }
 }

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -367,15 +367,23 @@ void Pane::_ControlWarningBellHandler(const winrt::Windows::Foundation::IInspect
     auto paneProfile = settings.FindProfile(_profile.value());
     if (paneProfile)
     {
-        if (WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Audible))
+        if (WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Audible) &&
+            WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Visual))
         {
             const auto soundAlias = reinterpret_cast<LPCTSTR>(SND_ALIAS_SYSTEMHAND);
             PlaySound(soundAlias, NULL, SND_ALIAS_ID | SND_ASYNC | SND_SENTRY);
+            _PaneRaiseBellHandlers(nullptr, true);
         }
-        if (WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Visual))
+        else if (WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Audible))
+        {
+            const auto soundAlias = reinterpret_cast<LPCTSTR>(SND_ALIAS_SYSTEMHAND);
+            PlaySound(soundAlias, NULL, SND_ALIAS_ID | SND_ASYNC | SND_SENTRY);
+            _PaneRaiseBellHandlers(nullptr, false);
+        }
+        else if (WI_IsFlagSet(paneProfile.BellStyle(), winrt::Microsoft::Terminal::Settings::Model::BellStyle::Visual))
         {
             // Bubble this event up to app host, starting with bubbling to the hosting tab
-            _PaneRaiseVisualBellHandlers(nullptr);
+            _PaneRaiseBellHandlers(nullptr, true);
         }
     }
 }
@@ -2057,4 +2065,4 @@ std::optional<SplitState> Pane::PreCalculateAutoSplit(const std::shared_ptr<Pane
 }
 
 DEFINE_EVENT(Pane, GotFocus, _GotFocusHandlers, winrt::delegate<std::shared_ptr<Pane>>);
-DEFINE_EVENT(Pane, PaneRaiseVisualBell, _PaneRaiseVisualBellHandlers, winrt::delegate<std::shared_ptr<Pane>>);
+DEFINE_EVENT(Pane, PaneRaiseBell, _PaneRaiseBellHandlers, winrt::Windows::Foundation::EventHandler<bool>);

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -83,7 +83,7 @@ public:
 
     WINRT_CALLBACK(Closed, winrt::Windows::Foundation::EventHandler<winrt::Windows::Foundation::IInspectable>);
     DECLARE_EVENT(GotFocus, _GotFocusHandlers, winrt::delegate<std::shared_ptr<Pane>>);
-    DECLARE_EVENT(PaneRaiseVisualBell, _PaneRaiseVisualBellHandlers, winrt::delegate<std::shared_ptr<Pane>>);
+    DECLARE_EVENT(PaneRaiseBell, _PaneRaiseBellHandlers, winrt::Windows::Foundation::EventHandler<bool>);
 
 private:
     struct SnapSizeResult;

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -83,6 +83,7 @@ public:
 
     WINRT_CALLBACK(Closed, winrt::Windows::Foundation::EventHandler<winrt::Windows::Foundation::IInspectable>);
     DECLARE_EVENT(GotFocus, _GotFocusHandlers, winrt::delegate<std::shared_ptr<Pane>>);
+    DECLARE_EVENT(LostFocus, _LostFocusHandlers, winrt::delegate<std::shared_ptr<Pane>>);
     DECLARE_EVENT(PaneRaiseBell, _PaneRaiseBellHandlers, winrt::Windows::Foundation::EventHandler<bool>);
 
 private:
@@ -111,6 +112,7 @@ private:
     winrt::event_token _warningBellToken{ 0 };
 
     winrt::Windows::UI::Xaml::UIElement::GotFocus_revoker _gotFocusRevoker;
+    winrt::Windows::UI::Xaml::UIElement::LostFocus_revoker _lostFocusRevoker;
 
     std::shared_mutex _createCloseLock{};
 
@@ -144,6 +146,8 @@ private:
                                     winrt::Windows::Foundation::IInspectable const& e);
     void _ControlGotFocusHandler(winrt::Windows::Foundation::IInspectable const& sender,
                                  winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
+    void _ControlLostFocusHandler(winrt::Windows::Foundation::IInspectable const& sender,
+                                  winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
 
     std::pair<float, float> _CalcChildrenSizes(const float fullSize) const;
     SnapChildrenSizeResult _CalcSnappedChildrenSizes(const bool widthOrHeight, const float fullSize) const;

--- a/src/cascadia/TerminalApp/TabHeaderControl.h
+++ b/src/cascadia/TerminalApp/TabHeaderControl.h
@@ -25,6 +25,7 @@ namespace winrt::TerminalApp::implementation
         OBSERVABLE_GETSET_PROPERTY(bool, IsPaneZoomed, _PropertyChangedHandlers);
         OBSERVABLE_GETSET_PROPERTY(bool, IsProgressRingActive, _PropertyChangedHandlers);
         OBSERVABLE_GETSET_PROPERTY(bool, IsProgressRingIndeterminate, _PropertyChangedHandlers);
+        OBSERVABLE_GETSET_PROPERTY(bool, BellIndicator, _PropertyChangedHandlers);
         OBSERVABLE_GETSET_PROPERTY(uint32_t, ProgressValue, _PropertyChangedHandlers);
 
     private:

--- a/src/cascadia/TerminalApp/TabHeaderControl.idl
+++ b/src/cascadia/TerminalApp/TabHeaderControl.idl
@@ -11,6 +11,7 @@ namespace TerminalApp
         Boolean IsPaneZoomed { get; set; };
         Boolean IsProgressRingActive { get; set; };
         Boolean IsProgressRingIndeterminate { get; set; };
+        Boolean BellIndicator { get; set; };
         UInt32 ProgressValue { get; set; };
 
         TabHeaderControl();

--- a/src/cascadia/TerminalApp/TabHeaderControl.xaml
+++ b/src/cascadia/TerminalApp/TabHeaderControl.xaml
@@ -26,6 +26,12 @@ the MIT License. See LICENSE in the project root for license information. -->
         <!--We want the progress ring to 'replace' the tab icon, but we don't have control
         over the tab icon here (the tab view item does) - so we hide the tab icon there
         and use a negative margin for the progress ring here to put it where the icon would be-->
+        <FontIcon x:Name="HeaderBellIndicator"
+                  FontFamily="Segoe MDL2 Assets"
+                  Visibility="{x:Bind BellIndicator, Mode=OneWay}"
+                  Glyph="&#xEA8F;"
+                  FontSize="12"
+                  Margin="0,0,8,0"/>
         <FontIcon x:Name="HeaderZoomIcon"
                   FontFamily="Segoe MDL2 Assets"
                   Visibility="{x:Bind IsPaneZoomed, Mode=OneWay}"

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -689,6 +689,13 @@ namespace winrt::TerminalApp::implementation
         // that as the empty string.
         const auto schemeName = scheme ? scheme.Name() : L"\0";
 
+        auto focusedObject{ Windows::UI::Xaml::Input::FocusManager::GetFocusedElement(XamlRoot()) };
+        if (focusedObject)
+        {
+
+        }
+
+
         TraceLoggingWrite(
             g_hTerminalAppProvider, // handle to TerminalApp tracelogging provider
             "TabInformation",

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -689,13 +689,6 @@ namespace winrt::TerminalApp::implementation
         // that as the empty string.
         const auto schemeName = scheme ? scheme.Name() : L"\0";
 
-        auto focusedObject{ Windows::UI::Xaml::Input::FocusManager::GetFocusedElement(XamlRoot()) };
-        if (focusedObject)
-        {
-
-        }
-
-
         TraceLoggingWrite(
             g_hTerminalAppProvider, // handle to TerminalApp tracelogging provider
             "TabInformation",

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -616,6 +616,21 @@ namespace winrt::TerminalApp::implementation
                     tab->_UpdateActivePane(sender);
                     tab->_RecalculateAndApplyTabColor();
                 }
+                tab->_focusState = WUX::FocusState::Programmatic;
+                if (tab->_headerControl.BellIndicator())
+                {
+                    tab->ShowBellIndicator(false);
+                }
+            }
+        });
+
+        pane->LostFocus([weakThis](std::shared_ptr<Pane> /*sender*/) {
+            // Do nothing if the Tab's lifetime is expired or pane isn't new.
+            auto tab{ weakThis.get() };
+
+            if (tab)
+            {
+                tab->_focusState = WUX::FocusState::Unfocused;
             }
         });
 
@@ -661,7 +676,10 @@ namespace winrt::TerminalApp::implementation
                 // If this tab is focused, activate the bell indicator timer, which will
                 // remove the bell indicator once it fires
                 // (otherwise, the indicator is removed when the tab gets focus)
-                //tab->ActivateBellIndicatorTimer();
+                if (tab->_focusState != WUX::FocusState::Unfocused)
+                {
+                    tab->ActivateBellIndicatorTimer();
+                }
             }
         });
     }

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -61,14 +61,9 @@ namespace winrt::TerminalApp::implementation
     // - sender, e: not used
     void TerminalTab::_BellIndicatorTimerTick(Windows::Foundation::IInspectable const& /*sender*/, Windows::Foundation::IInspectable const& /*e*/)
     {
-        auto weakThis{ get_weak() };
-
-        if (auto tab{ weakThis.get() })
-        {
-            tab->ShowBellIndicator(false);
-            tab->_bellIndicatorTimer.value().Stop();
-            tab->_bellIndicatorTimer = std::nullopt;
-        }
+        ShowBellIndicator(false);
+        _bellIndicatorTimer->Stop();
+        _bellIndicatorTimer = std::nullopt;
     }
 
     // Method Description:
@@ -285,11 +280,14 @@ namespace winrt::TerminalApp::implementation
 
         if (auto tab{ weakThis.get() })
         {
-            DispatcherTimer bellIndicatorTimer;
-            bellIndicatorTimer.Interval(std::chrono::milliseconds(2000));
-            bellIndicatorTimer.Tick({ get_weak(), &TerminalTab::_BellIndicatorTimerTick });
-            bellIndicatorTimer.Start();
-            tab->_bellIndicatorTimer.emplace(std::move(bellIndicatorTimer));
+            if (!tab->_bellIndicatorTimer.has_value())
+            {
+                DispatcherTimer bellIndicatorTimer;
+                bellIndicatorTimer.Interval(std::chrono::milliseconds(2000));
+                bellIndicatorTimer.Tick({ get_weak(), &TerminalTab::_BellIndicatorTimerTick });
+                bellIndicatorTimer.Start();
+                tab->_bellIndicatorTimer.emplace(std::move(bellIndicatorTimer));
+            }
         }
     }
 

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -684,15 +684,16 @@ namespace winrt::TerminalApp::implementation
                 if (visual)
                 {
                     tab->_TabRaiseVisualBellHandlers();
-                }
-                tab->ShowBellIndicator(true);
 
-                // If this tab is focused, activate the bell indicator timer, which will
-                // remove the bell indicator once it fires
-                // (otherwise, the indicator is removed when the tab gets focus)
-                if (tab->_focusState != WUX::FocusState::Unfocused)
-                {
-                    tab->ActivateBellIndicatorTimer();
+                    tab->ShowBellIndicator(true);
+
+                    // If this tab is focused, activate the bell indicator timer, which will
+                    // remove the bell indicator once it fires
+                    // (otherwise, the indicator is removed when the tab gets focus)
+                    if (tab->_focusState != WUX::FocusState::Unfocused)
+                    {
+                        tab->ActivateBellIndicatorTimer();
+                    }
                 }
             }
         });

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -62,8 +62,12 @@ namespace winrt::TerminalApp::implementation
     void TerminalTab::_BellIndicatorTimerTick(Windows::Foundation::IInspectable const& /*sender*/, Windows::Foundation::IInspectable const& /*e*/)
     {
         ShowBellIndicator(false);
-        _bellIndicatorTimer->Stop();
-        _bellIndicatorTimer = std::nullopt;
+        // Just do a sanity check that the timer still exists before we stop it
+        if (_bellIndicatorTimer.has_value())
+        {
+            _bellIndicatorTimer->Stop();
+            _bellIndicatorTimer = std::nullopt;
+        }
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -62,7 +62,7 @@ namespace winrt::TerminalApp::implementation
     void TerminalTab::_BellIndicatorTimerTick(Windows::Foundation::IInspectable const& /*sender*/, Windows::Foundation::IInspectable const& /*e*/)
     {
         auto weakThis{ get_weak() };
-        
+
         if (auto tab{ weakThis.get() })
         {
             tab->ShowBellIndicator(false);

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -50,11 +50,15 @@ namespace winrt::TerminalApp::implementation
                 tab->SetTabText(title);
             }
         });
-
         // Use our header control as the TabViewItem's header
         TabViewItem().Header(_headerControl);
     }
 
+    // Method Description:
+    // - Called when the timer for the bell indicator in the tab header fires
+    // - Removes the bell indicator from the tab header
+    // Arguments:
+    // - sender, e: not used
     void TerminalTab::_BellIndicatorTimerTick(Windows::Foundation::IInspectable const& /*sender*/, Windows::Foundation::IInspectable const& /*e*/)
     {
         auto weakThis{ get_weak() };
@@ -142,6 +146,7 @@ namespace winrt::TerminalApp::implementation
                 lastFocusedControl.Focus(_focusState);
                 lastFocusedControl.TaskbarProgressChanged();
             }
+            // When we gain focus, remove the bell indicator if it is active
             if (_headerControl.BellIndicator())
             {
                 ShowBellIndicator(false);
@@ -253,6 +258,10 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
+    // Method Description:
+    // - Hide or show the bell indicator in the tab header
+    // Arguments:
+    // - show: if true, we show the indicator; if false, we hide the indicator
     winrt::fire_and_forget TerminalTab::ShowBellIndicator(const bool show)
     {
         auto weakThis{ get_weak() };
@@ -265,6 +274,9 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
+    // Method Description:
+    // - Activates the timer for the bell indicator in the tab
+    // - Called if a bell raised when the tab already has focus
     winrt::fire_and_forget TerminalTab::ActivateBellIndicatorTimer()
     {
         auto weakThis{ get_weak() };
@@ -617,6 +629,7 @@ namespace winrt::TerminalApp::implementation
                     tab->_RecalculateAndApplyTabColor();
                 }
                 tab->_focusState = WUX::FocusState::Programmatic;
+                // This tab has gained focus, remove the bell indicator if it is active
                 if (tab->_headerControl.BellIndicator())
                 {
                     tab->ShowBellIndicator(false);
@@ -630,6 +643,7 @@ namespace winrt::TerminalApp::implementation
 
             if (tab)
             {
+                // update this tab's focus state
                 tab->_focusState = WUX::FocusState::Unfocused;
             }
         });

--- a/src/cascadia/TerminalApp/TerminalTab.h
+++ b/src/cascadia/TerminalApp/TerminalTab.h
@@ -39,6 +39,7 @@ namespace winrt::TerminalApp::implementation
         winrt::fire_and_forget HideIcon(const bool hide);
 
         winrt::fire_and_forget ShowBellIndicator(const bool show);
+        winrt::fire_and_forget ActivateBellIndicatorTimer(const bool activate);
 
         float CalcSnappedDimension(const bool widthOrHeight, const float dimension) const;
         winrt::Microsoft::Terminal::Settings::Model::SplitState PreCalculateAutoSplit(winrt::Windows::Foundation::Size rootSize) const;
@@ -102,7 +103,7 @@ namespace winrt::TerminalApp::implementation
 
         winrt::TerminalApp::ShortcutActionDispatch _dispatch;
 
-        Windows::UI::Xaml::DispatcherTimer _bellIndicatorTimer;
+        std::optional<Windows::UI::Xaml::DispatcherTimer> _bellIndicatorTimer;
         void _BellIndicatorTimerTick(Windows::Foundation::IInspectable const& sender, Windows::Foundation::IInspectable const& e);
 
         void _MakeTabViewItem();

--- a/src/cascadia/TerminalApp/TerminalTab.h
+++ b/src/cascadia/TerminalApp/TerminalTab.h
@@ -38,6 +38,8 @@ namespace winrt::TerminalApp::implementation
         winrt::fire_and_forget UpdateIcon(const winrt::hstring iconPath);
         winrt::fire_and_forget HideIcon(const bool hide);
 
+        winrt::fire_and_forget ShowBellIndicator(const bool show);
+
         float CalcSnappedDimension(const bool widthOrHeight, const float dimension) const;
         winrt::Microsoft::Terminal::Settings::Model::SplitState PreCalculateAutoSplit(winrt::Windows::Foundation::Size rootSize) const;
         bool PreCalculateCanSplit(winrt::Microsoft::Terminal::Settings::Model::SplitState splitType,
@@ -99,6 +101,9 @@ namespace winrt::TerminalApp::implementation
         winrt::Windows::UI::Xaml::Controls::TextBox::LayoutUpdated_revoker _tabRenameBoxLayoutUpdatedRevoker;
 
         winrt::TerminalApp::ShortcutActionDispatch _dispatch;
+
+        Windows::UI::Xaml::DispatcherTimer _bellIndicatorTimer;
+        void _BellIndicatorTimerTick(Windows::Foundation::IInspectable const& sender, Windows::Foundation::IInspectable const& e);
 
         void _MakeTabViewItem();
 

--- a/src/cascadia/TerminalApp/TerminalTab.h
+++ b/src/cascadia/TerminalApp/TerminalTab.h
@@ -39,7 +39,7 @@ namespace winrt::TerminalApp::implementation
         winrt::fire_and_forget HideIcon(const bool hide);
 
         winrt::fire_and_forget ShowBellIndicator(const bool show);
-        winrt::fire_and_forget ActivateBellIndicatorTimer(const bool activate);
+        winrt::fire_and_forget ActivateBellIndicatorTimer();
 
         float CalcSnappedDimension(const bool widthOrHeight, const float dimension) const;
         winrt::Microsoft::Terminal::Settings::Model::SplitState PreCalculateAutoSplit(winrt::Windows::Foundation::Size rootSize) const;


### PR DESCRIPTION
When we emit a BEL (visual or audible), show an indicator in the tab
header

If the tab the BEL is coming from is not focused when the BEL is raised,
the indicator in its header will be removed when the tab gains focus. If
the tab was already focused when the BEL was emitted, then the indicator
goes away after 2 seconds.

Closes #8106 