### PR TITLE
Prevent Tab Switcher from increasing Tab refcount

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -690,7 +690,10 @@ namespace winrt::TerminalApp::implementation
         {
             if (const auto tabPaletteItem{ filteredCommand.Item().try_as<winrt::TerminalApp::TabPaletteItem>() })
             {
-                _SwitchToTabRequestedHandlers(*this, tabPaletteItem.Tab());
+                if (const auto tab{ tabPaletteItem.Tab() })
+                {
+                    _SwitchToTabRequestedHandlers(*this, tab);
+                }
             }
         }
     }

--- a/src/cascadia/TerminalApp/TabPaletteItem.cpp
+++ b/src/cascadia/TerminalApp/TabPaletteItem.cpp
@@ -19,27 +19,9 @@ using namespace winrt::Microsoft::Terminal::Settings::Model;
 namespace winrt::TerminalApp::implementation
 {
     TabPaletteItem::TabPaletteItem(winrt::TerminalApp::TabBase const& tab) :
-        _Tab(tab)
+        _tab(tab)
     {
         Name(tab.Title());
         Icon(tab.Icon());
-
-        _tabChangedRevoker = tab.PropertyChanged(winrt::auto_revoke, [weakThis{ get_weak() }](auto& sender, auto& e) {
-            auto item{ weakThis.get() };
-            auto senderTab{ sender.try_as<TabBase>() };
-
-            if (item && senderTab)
-            {
-                auto changedProperty = e.PropertyName();
-                if (changedProperty == L"Title")
-                {
-                    item->Name(senderTab.Title());
-                }
-                else if (changedProperty == L"Icon")
-                {
-                    item->Icon(senderTab.Icon());
-                }
-            }
-        });
     }
 }

--- a/src/cascadia/TerminalApp/TabPaletteItem.cpp
+++ b/src/cascadia/TerminalApp/TabPaletteItem.cpp
@@ -23,5 +23,23 @@ namespace winrt::TerminalApp::implementation
     {
         Name(tab.Title());
         Icon(tab.Icon());
+
+        _tabChangedRevoker = tab.PropertyChanged(winrt::auto_revoke, [weakThis{ get_weak() }](auto& sender, auto& e) {
+            auto item{ weakThis.get() };
+            auto senderTab{ sender.try_as<TabBase>() };
+
+            if (item && senderTab)
+            {
+                auto changedProperty = e.PropertyName();
+                if (changedProperty == L"Title")
+                {
+                    item->Name(senderTab.Title());
+                }
+                else if (changedProperty == L"Icon")
+                {
+                    item->Icon(senderTab.Icon());
+                }
+            }
+        });
     }
 }

--- a/src/cascadia/TerminalApp/TabPaletteItem.h
+++ b/src/cascadia/TerminalApp/TabPaletteItem.h
@@ -14,10 +14,13 @@ namespace winrt::TerminalApp::implementation
         TabPaletteItem() = default;
         TabPaletteItem(winrt::TerminalApp::TabBase const& tab);
 
-        GETSET_PROPERTY(winrt::TerminalApp::TabBase, Tab, nullptr);
+        winrt::TerminalApp::TabBase Tab() const noexcept
+        {
+            return _tab.get();
+        }
 
     private:
-        Windows::UI::Xaml::Data::INotifyPropertyChanged::PropertyChanged_revoker _tabChangedRevoker;
+        winrt::weak_ref<winrt::TerminalApp::TabBase> _tab;
     };
 }
 

--- a/src/cascadia/TerminalApp/TabPaletteItem.h
+++ b/src/cascadia/TerminalApp/TabPaletteItem.h
@@ -21,6 +21,7 @@ namespace winrt::TerminalApp::implementation
 
     private:
         winrt::weak_ref<winrt::TerminalApp::TabBase> _tab;
+        Windows::UI::Xaml::Data::INotifyPropertyChanged::PropertyChanged_revoker _tabChangedRevoker;
     };
 }
 


### PR DESCRIPTION
Fix `TabPaletteItem` to hold only a weak reference to a tab.
This way we guarantee that the refcount of the closed tab 
gets to 0 immediately
(and that command palette cannot "raise it from the dead").

While this seems a correct thing to do, 
it is still not clear why the `FilteredCommand` itself 
(the one holding the `TabPaletteItem`) doesn't get released
until the UI is refreshed.

There is an impact of not registering to PropertyChanged event:
if the tab title changes during Tab Switcher navigation
the Tab Switcher item won't be updated immediately
(the change will apply next time the Tab Switcher is open).

Due to this change we need to make sure that the tabs binding
in https://github.com/microsoft/terminal/pull/8427
doesn't break the title / icon update.

## Validation Steps Performed
* Manual testing

Closes #8651