### PR TITLE
winconpty: close the pty host handle after terminating it

### DIFF
--- a/src/winconpty/winconpty.cpp
+++ b/src/winconpty/winconpty.cpp
@@ -269,6 +269,7 @@ void _ClosePseudoConsoleMembers(_In_ PseudoConsole* pPty)
             }
 
             TerminateProcess(pPty->hConPtyProcess, 0);
+            CloseHandle(pPty->hConPtyProcess);
             pPty->hConPtyProcess = nullptr;
         }
         // Then take care of the reference handle.

--- a/src/winconpty/winconpty.cpp
+++ b/src/winconpty/winconpty.cpp
@@ -196,6 +196,7 @@ HRESULT _CreatePseudoConsole(const HANDLE hToken,
     // Move the process handle out of the PROCESS_INFORMATION into out Pseudoconsole
     pPty->hConPtyProcess = pi.hProcess;
     pi.hProcess = nullptr;
+    CloseHandle(pi.hThread); // we do not need the thread handle
 
     RETURN_IF_NTSTATUS_FAILED(CreateClientHandle(&pPty->hPtyReference,
                                                  serverHandle.get(),

--- a/src/winconpty/winconpty.cpp
+++ b/src/winconpty/winconpty.cpp
@@ -196,7 +196,6 @@ HRESULT _CreatePseudoConsole(const HANDLE hToken,
     // Move the process handle out of the PROCESS_INFORMATION into out Pseudoconsole
     pPty->hConPtyProcess = pi.hProcess;
     pi.hProcess = nullptr;
-    CloseHandle(pi.hThread); // we do not need the thread handle
 
     RETURN_IF_NTSTATUS_FAILED(CreateClientHandle(&pPty->hPtyReference,
                                                  serverHandle.get(),


### PR DESCRIPTION
It rather raises the question as to how we missed this.

Closes #8706