### PR TITLE
Initialize stack variables. check return code from shell lnk loading

### DIFF
--- a/src/interactivity/win32/SystemConfigurationProvider.cpp
+++ b/src/interactivity/win32/SystemConfigurationProvider.cpp
@@ -120,21 +120,23 @@ void SystemConfigurationProvider::GetSettingsFromLink(
                     // guarantee null termination to make OACR happy.
                     wszLinkTarget[ARRAYSIZE(wszLinkTarget) - 1] = L'\0';
                 }
+            }
 
-                if (wszShortcutTitle[0] != L'\0')
+            // if we got a title, use it. even on overall link value load failure, the title will be correct if
+            // filled out.
+            if (wszShortcutTitle[0] != L'\0')
+            {
+                // guarantee null termination to make OACR happy.
+                wszShortcutTitle[ARRAYSIZE(wszShortcutTitle) - 1] = L'\0';
+                StringCbCopyW(pwszTitle, *pdwTitleLength, wszShortcutTitle);
+
+                // OACR complains about the use of a DWORD here, so roundtrip through a size_t
+                size_t cbTitleLength;
+                if (SUCCEEDED(StringCbLengthW(pwszTitle, *pdwTitleLength, &cbTitleLength)))
                 {
-                    // guarantee null termination to make OACR happy.
-                    wszShortcutTitle[ARRAYSIZE(wszShortcutTitle) - 1] = L'\0';
-                    StringCbCopyW(pwszTitle, *pdwTitleLength, wszShortcutTitle);
-
-                    // OACR complains about the use of a DWORD here, so roundtrip through a size_t
-                    size_t cbTitleLength;
-                    if (SUCCEEDED(StringCbLengthW(pwszTitle, *pdwTitleLength, &cbTitleLength)))
-                    {
-                        // don't care about return result -- the buffer is guaranteed null terminated to at least
-                        // the length of Title
-                        (void)SizeTToDWord(cbTitleLength, pdwTitleLength);
-                    }
+                    // don't care about return result -- the buffer is guaranteed null terminated to at least
+                    // the length of Title
+                    (void)SizeTToDWord(cbTitleLength, pdwTitleLength);
                 }
             }
 


### PR DESCRIPTION
## References
* Commit f273aa679d4d9fb516678fc7ed5fc6495a8e8532 from os repository.

## PR Checklist
* [x] Closes #7650 
* [x] I work here.
* [x] Tests passed

## Detailed Description of the Pull Request / Additional comments
* We found and fixed this in November 2017, but I fumbled the replication and accidentally overwrote the commit. This digs it up from history and puts it back in our code.
* When the shortcut file cannot be read for whatever reason, we are setting the hotkey value to uninitialized data as we never initialize several members on the stack in this function. It just so happens that the one in the `dwHotkey` field is commonly `0x4c` or the letter `L` which is then sent into the window procedure to tell the OS to capture it as a global hotkey and foreground the `conhost.exe` that was started. We should realize the load failure and not set any hotkey at all and we should initialize the stack variables. This does both.

## Validation Steps Performed
* [x] Manual scenario running LNK file that cannot be loaded from customer report (make LNK to cmd.exe, make it inaccessible to conhost so it can't load/read it.)
* [x] Manual scenario with `mklink`'d link that makes the shortcut parser attempt to load (and fail because it isn't a LNK at all from #7650)
