### PR TITLE
Teach flyouts and palette to prefer user bindings over defaults

### DIFF
--- a/src/cascadia/TerminalSettingsModel/KeyMapping.cpp
+++ b/src/cascadia/TerminalSettingsModel/KeyMapping.cpp
@@ -41,6 +41,12 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     void KeyMapping::SetKeyBinding(const Microsoft::Terminal::Settings::Model::ActionAndArgs& actionAndArgs,
                                    const KeyChord& chord)
     {
+        // if the chord is already mapped - clear the mapping
+        if (_keyShortcuts.find(chord) != _keyShortcuts.end())
+        {
+            ClearKeyBinding(chord);
+        }
+
         _keyShortcuts[chord] = actionAndArgs;
         _keyShortcutsByInsertionOrder.push_back(std::make_pair(chord, actionAndArgs));
     }

--- a/src/cascadia/TerminalSettingsModel/KeyMapping.cpp
+++ b/src/cascadia/TerminalSettingsModel/KeyMapping.cpp
@@ -42,7 +42,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                                    const KeyChord& chord)
     {
         _keyShortcuts[chord] = actionAndArgs;
-        _orderedKeyShortcuts.push_back(std::make_pair(chord, actionAndArgs));
+        _keyShortcutsByInsertionOrder.push_back(std::make_pair(chord, actionAndArgs));
     }
 
     // Method Description:
@@ -56,15 +56,15 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         _keyShortcuts.erase(chord);
 
         KeyChordEquality keyChordEquality;
-        _orderedKeyShortcuts.erase(std::remove_if(_orderedKeyShortcuts.begin(), _orderedKeyShortcuts.end(), [keyChordEquality, chord](const auto& mapping) {
-                                       return keyChordEquality(mapping.first, chord);
-                                   }),
-                                   _orderedKeyShortcuts.end());
+        _keyShortcutsByInsertionOrder.erase(std::remove_if(_keyShortcutsByInsertionOrder.begin(), _keyShortcutsByInsertionOrder.end(), [keyChordEquality, chord](const auto& keyBinding) {
+                                                return keyChordEquality(keyBinding.first, chord);
+                                            }),
+                                            _keyShortcutsByInsertionOrder.end());
     }
 
     KeyChord KeyMapping::GetKeyBindingForAction(Microsoft::Terminal::Settings::Model::ShortcutAction const& action)
     {
-        for (auto it = _orderedKeyShortcuts.rbegin(); it != _orderedKeyShortcuts.rend(); ++it)
+        for (auto it = _keyShortcutsByInsertionOrder.rbegin(); it != _keyShortcutsByInsertionOrder.rend(); ++it)
         {
             const auto& kv = *it;
             if (kv.second.Action() == action)
@@ -92,7 +92,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             return { nullptr };
         }
 
-        for (auto it = _orderedKeyShortcuts.rbegin(); it != _orderedKeyShortcuts.rend(); ++it)
+        for (auto it = _keyShortcutsByInsertionOrder.rbegin(); it != _keyShortcutsByInsertionOrder.rend(); ++it)
         {
             const auto& kv = *it;
             const auto action = kv.second.Action();

--- a/src/cascadia/TerminalSettingsModel/KeyMapping.h
+++ b/src/cascadia/TerminalSettingsModel/KeyMapping.h
@@ -71,6 +71,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
     private:
         std::unordered_map<TerminalControl::KeyChord, Model::ActionAndArgs, KeyChordHash, KeyChordEquality> _keyShortcuts;
+        std::vector<std::pair<TerminalControl::KeyChord, Model::ActionAndArgs>> _orderedKeyShortcuts;
 
         friend class SettingsModelLocalTests::DeserializationTests;
         friend class SettingsModelLocalTests::KeyBindingsTests;

--- a/src/cascadia/TerminalSettingsModel/KeyMapping.h
+++ b/src/cascadia/TerminalSettingsModel/KeyMapping.h
@@ -71,7 +71,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
     private:
         std::unordered_map<TerminalControl::KeyChord, Model::ActionAndArgs, KeyChordHash, KeyChordEquality> _keyShortcuts;
-        std::vector<std::pair<TerminalControl::KeyChord, Model::ActionAndArgs>> _orderedKeyShortcuts;
+        std::vector<std::pair<TerminalControl::KeyChord, Model::ActionAndArgs>> _keyShortcutsByInsertionOrder;
 
         friend class SettingsModelLocalTests::DeserializationTests;
         friend class SettingsModelLocalTests::KeyBindingsTests;


### PR DESCRIPTION
Store the order of the bindings and upon lookup prefer the binding
that was added last.
The defaults will always "loose" to user overrides.

Closes #2991