### PR TITLE
Show clipboard contents in multiple line paste warning dialog

### DIFF
--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -405,7 +405,7 @@
   <data name="MultiLinePasteDialog.CloseButtonText" xml:space="preserve">
     <value>Cancel</value>
   </data>
-  <data name="MultiLinePasteDialog.Content" xml:space="preserve">
+  <data name="MultiLineWarningText.Text" xml:space="preserve">
     <value>You are about to paste text that contains multiple lines. If you paste this text into your shell, it may result in the unexpected execution of commands. Do you wish to continue?</value>
   </data>
   <data name="MultiLinePasteDialog.PrimaryButtonText" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -406,7 +406,7 @@
     <value>Cancel</value>
   </data>
   <data name="MultiLineWarningText.Text" xml:space="preserve">
-    <value>You are about to paste text that contains multiple lines. If you paste this text into your shell, it may result in the unexpected execution of commands. Do you wish to continue?</value>
+    <value>You are about to paste text that contains multiple lines. If you paste this text into your shell, it may result in the unexpected execution of commands. Do you wish to continue? Here are your clipboard contents:</value>
   </data>
   <data name="MultiLinePasteDialog.PrimaryButtonText" xml:space="preserve">
     <value>Paste anyway</value>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -406,7 +406,7 @@
     <value>Cancel</value>
   </data>
   <data name="MultiLineWarningText.Text" xml:space="preserve">
-    <value>You are about to paste text that contains multiple lines. If you paste this text into your shell, it may result in the unexpected execution of commands. Do you wish to continue? Here are your clipboard contents:</value>
+    <value>You are about to paste text that contains multiple lines. If you paste this text into your shell, it may result in the unexpected execution of commands. Do you wish to continue?</value>
   </data>
   <data name="MultiLinePasteDialog.PrimaryButtonText" xml:space="preserve">
     <value>Paste anyway</value>
@@ -526,5 +526,8 @@
   </data>
   <data name="NoticeWarning" xml:space="preserve">
     <value>Warning</value>
+  </data>
+  <data name="ClipboardTextHeader.Text" xml:space="preserve">
+    <value>Clipboard contents (preview):</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1974,6 +1974,9 @@ namespace winrt::TerminalApp::implementation
                     warningResult = co_await _ShowLargePasteWarningDialog();
                 }
 
+                // Clear the clipboard text so it doesn't lie around in memory
+                ClipboardText().Text(L"");
+
                 if (warningResult != ContentDialogResult::Primary)
                 {
                     // user rejected the paste

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1957,7 +1957,12 @@ namespace winrt::TerminalApp::implementation
             {
                 co_await winrt::resume_foreground(Dispatcher());
 
-                ClipboardText().Text(text.c_str());
+                // We have to initialize the dialog here to be able to change the text of the textblock within it
+                FindName(L"MultiLinePasteDialog").try_as<WUX::Controls::ContentDialog>();
+                ClipboardText().Text(text);
+
+                // The vertical offset on the scrollbar does not reset automatically, so reset it manually
+                ClipboardContentScrollViewer().ScrollToVerticalOffset(0);
 
                 ContentDialogResult warningResult;
                 if (warnMultiLine)

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1957,7 +1957,7 @@ namespace winrt::TerminalApp::implementation
             {
                 co_await winrt::resume_foreground(Dispatcher());
 
-                // We have to initialize the dialog here to be able to change the text of the textblock within it
+                // We have to initialize the dialog here to be able to change the text of the text block within it
                 FindName(L"MultiLinePasteDialog").try_as<WUX::Controls::ContentDialog>();
                 ClipboardText().Text(text);
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1957,6 +1957,8 @@ namespace winrt::TerminalApp::implementation
             {
                 co_await winrt::resume_foreground(Dispatcher());
 
+                ClipboardText().Text(text.c_str());
+
                 ContentDialogResult warningResult;
                 if (warnMultiLine)
                 {

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -60,12 +60,10 @@ the MIT License. See LICENSE in the project root for license information. -->
             DefaultButton="Primary">
             <StackPanel>
                 <TextBlock
-                    x:Name="MultiLineWarningText"
                     x:Uid="MultiLineWarningText"
                     TextWrapping="Wrap">
                 </TextBlock>
                 <TextBlock
-                    x:Name="ClipboardTextHeader"
                     x:Uid="ClipboardTextHeader"
                     Margin="0,16,0,0">
                 </TextBlock>

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -64,13 +64,19 @@ the MIT License. See LICENSE in the project root for license information. -->
                     x:Uid="MultiLineWarningText"
                     TextWrapping="Wrap">
                 </TextBlock>
+                <TextBlock
+                    x:Name="ClipboardTextHeader"
+                    x:Uid="ClipboardTextHeader"
+                    Margin="0,16,0,0">
+                </TextBlock>
                 <ScrollViewer
-                    Margin="0,16,0,0"
+                    Margin="0,8,0,0"
                     x:Name="ClipboardContentScrollViewer"
                     MaxHeight="100">
                     <TextBlock
                         x:Name="ClipboardText"
-                        TextWrapping="Wrap">
+                        TextWrapping="Wrap"
+                        FontFamily="Cascadia Mono">
                     </TextBlock>
                 </ScrollViewer>
             </StackPanel>

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -64,7 +64,10 @@ the MIT License. See LICENSE in the project root for license information. -->
                     x:Uid="MultiLineWarningText"
                     TextWrapping="Wrap">
                 </TextBlock>
-                <ScrollViewer>
+                <ScrollViewer
+                    Margin="0,16,0,0"
+                    x:Name="ClipboardContentScrollViewer"
+                    MaxHeight="100">
                     <TextBlock
                         x:Name="ClipboardText"
                         TextWrapping="Wrap">

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -58,6 +58,19 @@ the MIT License. See LICENSE in the project root for license information. -->
             x:Name="MultiLinePasteDialog"
             x:Uid="MultiLinePasteDialog"
             DefaultButton="Primary">
+            <StackPanel>
+                <TextBlock
+                    x:Name="MultiLineWarningText"
+                    x:Uid="MultiLineWarningText"
+                    TextWrapping="Wrap">
+                </TextBlock>
+                <ScrollViewer>
+                    <TextBlock
+                        x:Name="ClipboardText"
+                        TextWrapping="Wrap">
+                    </TextBlock>
+                </ScrollViewer>
+            </StackPanel>
         </ContentDialog>
 
         <ContentDialog


### PR DESCRIPTION
When we display a dialog to warn the user that they are doing a
multi-line paste, we show the clipboard contents

The contents are shown in a scroll viewer with a fixed maximum height.

Closes #7997 