### PR TITLE
Fix intermittent crash in settings reload

### DIFF
--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -975,7 +975,7 @@ try
     {
         // Enable shader effects if the path isn't empty. Otherwise leave it untouched.
         _terminalEffectsEnabled = value.empty() ? _terminalEffectsEnabled : true;
-        _pixelShaderPath = { value };
+        _pixelShaderPath = value.empty() ? L"" : std::wstring{ value };
         _recreateDeviceRequested = true;
         LOG_IF_FAILED(InvalidateAll());
     }


### PR DESCRIPTION
## Summary of the Pull Request

I can't reliably get the original crash to repro unfortunately. When it did crash, this was the line of code that the debugger would open on. It was crashing trying to `memcpy` some garbage out of `value`, in the case where `value` is empty. 

So I'm guessing that the fix it to _not_ try and make a `wstring` from garbage, and instead construct it from the empty string. Again, I can't repro consistently, so this is a spitball. But the code _looks_ wrong.

## References
* #8565 

## PR Checklist
* [x] Closes #8723
* [x] I work here
* [ ] Tests added/passed
