### PR TITLE
Fix the duplicate .xbf error after a TerminalControl build

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
@@ -215,13 +215,42 @@
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalConnection\TerminalConnection.vcxproj">
       <Private>false</Private>
     </ProjectReference>
-    <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\TerminalControl.vcxproj">
+
+    <!-- <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\TerminalControl.vcxproj">
       <Private>false</Private>
+    </ProjectReference> -->
+    <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\TerminalControl.vcxproj">
+      <!-- <Private>false</Private> -->
+      <Private>true</Private>
+      <!-- <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies> -->
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
+
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalSettingsModel\dll\Microsoft.Terminal.Settings.Model.vcxproj">
       <Private>false</Private>
     </ProjectReference>
   </ItemGroup>
+
+
+  <ItemGroup>
+    <!-- Manually add references to each of our dependent winmds. Mark them as
+    private=false and CopyLocalSatelliteAssemblies=false, so that we don't
+    propagate them upwards (which can make referencing this project result in
+    duplicate type definitions)-->
+<!--     <Reference Include="Microsoft.Terminal.TerminalConnection">
+      <HintPath>$(OpenConsoleCommonOutDir)TerminalConnection\Microsoft.Terminal.TerminalConnection.winmd</HintPath>
+      <IsWinMDFile>true</IsWinMDFile>
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+    </Reference> -->
+    <Reference Include="Microsoft.Terminal.TerminalControl">
+      <HintPath>$(OpenConsoleCommonOutDir)TerminalControl\Microsoft.Terminal.TerminalControl.winmd</HintPath>
+      <IsWinMDFile>true</IsWinMDFile>
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+    </Reference>
+  </ItemGroup>
+
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.post.props" />
   <Import Project="..\..\..\packages\Microsoft.UI.Xaml.2.5.0-prerelease.201202003\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\..\..\packages\Microsoft.UI.Xaml.2.5.0-prerelease.201202003\build\native\Microsoft.UI.Xaml.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
@@ -232,7 +232,7 @@
 
   <ItemGroup>
     <!-- Manually add a reference to TerminalControl here. We need this so
-    MDMERGE will know where the termcontrol types are defined. However, we need
+    MDMERGE will know where the TermControl types are defined. However, we need
     to do it exactly like this so the packaging project won't roll up
     TermControl's .xbf's from both the TermControl project and this one. -->
     <Reference Include="Microsoft.Terminal.TerminalControl">

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
@@ -216,13 +216,12 @@
       <Private>false</Private>
     </ProjectReference>
 
-    <!-- <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\TerminalControl.vcxproj">
-      <Private>false</Private>
-    </ProjectReference> -->
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\TerminalControl.vcxproj">
-      <!-- <Private>false</Private> -->
+      <!-- Private:false and ReferenceOutputAssembly:false, in combination with
+      the manual reference to TerminalControl.winmd below make sure that this
+      project will compile correct, and that we won't roll up the TermControl
+      xbf's into the packaging project twice. -->
       <Private>true</Private>
-      <!-- <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies> -->
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
 
@@ -231,18 +230,11 @@
     </ProjectReference>
   </ItemGroup>
 
-
   <ItemGroup>
-    <!-- Manually add references to each of our dependent winmds. Mark them as
-    private=false and CopyLocalSatelliteAssemblies=false, so that we don't
-    propagate them upwards (which can make referencing this project result in
-    duplicate type definitions)-->
-<!--     <Reference Include="Microsoft.Terminal.TerminalConnection">
-      <HintPath>$(OpenConsoleCommonOutDir)TerminalConnection\Microsoft.Terminal.TerminalConnection.winmd</HintPath>
-      <IsWinMDFile>true</IsWinMDFile>
-      <Private>false</Private>
-      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
-    </Reference> -->
+    <!-- Manually add a reference to TerminalControl here. We need this so
+    MDMERGE will know where the termcontrol types are defined. However, we need
+    to do it exactly like this so the packaging project won't roll up
+    TermControl's .xbf's from both the TermControl project and this one. -->
     <Reference Include="Microsoft.Terminal.TerminalControl">
       <HintPath>$(OpenConsoleCommonOutDir)TerminalControl\Microsoft.Terminal.TerminalControl.winmd</HintPath>
       <IsWinMDFile>true</IsWinMDFile>

--- a/src/cascadia/TerminalSettingsModel/dll/Microsoft.Terminal.Settings.Model.vcxproj
+++ b/src/cascadia/TerminalSettingsModel/dll/Microsoft.Terminal.Settings.Model.vcxproj
@@ -59,33 +59,29 @@
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalConnection\TerminalConnection.vcxproj">
       <Private>false</Private>
     </ProjectReference>
-    <!-- <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\TerminalControl.vcxproj" /> -->
+
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\TerminalControl.vcxproj">
-      <!-- <Private>false</Private> -->
+      <!-- Private:false and ReferenceOutputAssembly:false, in combination with
+      the manual reference to TerminalControl.winmd below make sure that this
+      project will compile correct, and that we won't roll up the TermControl
+      xbf's into the packaging project twice. -->
       <Private>true</Private>
-      <!-- <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies> -->
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
+
     <!-- Reference Microsoft.Terminal.Settings.ModelLib here, so we can use it's winmd as
     our winmd. This didn't work correctly in VS2017, you'd need to
     manually reference the lib -->
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalSettingsModel\Microsoft.Terminal.Settings.ModelLib.vcxproj">
       <Private>true</Private>
-      <!-- <CopyLocalSatelliteAssemblies>true</CopyLocalSatelliteAssemblies> -->
     </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Manually add references to each of our dependent winmds. Mark them as
-    private=false and CopyLocalSatelliteAssemblies=false, so that we don't
-    propagate them upwards (which can make referencing this project result in
-    duplicate type definitions)-->
-<!--     <Reference Include="Microsoft.Terminal.TerminalConnection">
-      <HintPath>$(OpenConsoleCommonOutDir)TerminalConnection\Microsoft.Terminal.TerminalConnection.winmd</HintPath>
-      <IsWinMDFile>true</IsWinMDFile>
-      <Private>false</Private>
-      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
-    </Reference> -->
+    <!-- Manually add a reference to TerminalControl here. We need this so
+    MDMERGE will know where the termcontrol types are defined. However, we need
+    to do it exactly like this so the packaging project won't roll up
+    TermControl's .xbf's from both the TermControl project and this one. -->
     <Reference Include="Microsoft.Terminal.TerminalControl">
       <HintPath>$(OpenConsoleCommonOutDir)TerminalControl\Microsoft.Terminal.TerminalControl.winmd</HintPath>
       <IsWinMDFile>true</IsWinMDFile>

--- a/src/cascadia/TerminalSettingsModel/dll/Microsoft.Terminal.Settings.Model.vcxproj
+++ b/src/cascadia/TerminalSettingsModel/dll/Microsoft.Terminal.Settings.Model.vcxproj
@@ -79,7 +79,7 @@
 
   <ItemGroup>
     <!-- Manually add a reference to TerminalControl here. We need this so
-    MDMERGE will know where the termcontrol types are defined. However, we need
+    MDMERGE will know where the TermControl types are defined. However, we need
     to do it exactly like this so the packaging project won't roll up
     TermControl's .xbf's from both the TermControl project and this one. -->
     <Reference Include="Microsoft.Terminal.TerminalControl">

--- a/src/cascadia/TerminalSettingsModel/dll/Microsoft.Terminal.Settings.Model.vcxproj
+++ b/src/cascadia/TerminalSettingsModel/dll/Microsoft.Terminal.Settings.Model.vcxproj
@@ -59,16 +59,39 @@
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalConnection\TerminalConnection.vcxproj">
       <Private>false</Private>
     </ProjectReference>
+    <!-- <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\TerminalControl.vcxproj" /> -->
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\TerminalControl.vcxproj">
-      <Private>false</Private>
+      <!-- <Private>false</Private> -->
+      <Private>true</Private>
+      <!-- <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies> -->
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
     <!-- Reference Microsoft.Terminal.Settings.ModelLib here, so we can use it's winmd as
     our winmd. This didn't work correctly in VS2017, you'd need to
     manually reference the lib -->
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalSettingsModel\Microsoft.Terminal.Settings.ModelLib.vcxproj">
       <Private>true</Private>
-      <CopyLocalSatelliteAssemblies>true</CopyLocalSatelliteAssemblies>
+      <!-- <CopyLocalSatelliteAssemblies>true</CopyLocalSatelliteAssemblies> -->
     </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Manually add references to each of our dependent winmds. Mark them as
+    private=false and CopyLocalSatelliteAssemblies=false, so that we don't
+    propagate them upwards (which can make referencing this project result in
+    duplicate type definitions)-->
+<!--     <Reference Include="Microsoft.Terminal.TerminalConnection">
+      <HintPath>$(OpenConsoleCommonOutDir)TerminalConnection\Microsoft.Terminal.TerminalConnection.winmd</HintPath>
+      <IsWinMDFile>true</IsWinMDFile>
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+    </Reference> -->
+    <Reference Include="Microsoft.Terminal.TerminalControl">
+      <HintPath>$(OpenConsoleCommonOutDir)TerminalControl\Microsoft.Terminal.TerminalControl.winmd</HintPath>
+      <IsWinMDFile>true</IsWinMDFile>
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+    </Reference>
   </ItemGroup>
 
   <Import Project="$(OpenConsoleDir)packages\Microsoft.UI.Xaml.2.5.0-prerelease.201202003\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('$(OpenConsoleDir)packages\Microsoft.UI.Xaml.2.5.0-prerelease.201202003\build\native\Microsoft.UI.Xaml.targets')" />


### PR DESCRIPTION
Whenever you'd make a change to anything in the Terminal Control
project, then tried deploying the package, you'd get errors like
"Package contains two files with the same name and different content,
files are `Thing.xbf` and
`.../bin/x64/debug/TSM/TerminalControl/Thing.xbf`". It seems like
`GetPackagingOutputs` was double counting these xbfs as being both from
TerminalControl and also TSM&TSE. So if you'd change TerminalControl,
it'd change the xbf files, but not the ones in TSM/TSE, and then
eventually the wapproj would fail to put it all together.

This combination of flags seems to
* make mdmerge work
* make the packaging project work
* make a partial rebuild of TerminalControl followed by a deploy work

I'm hoping that this PR build will confirm that this works in CI as well.

## PR Checklist
* [x] Fixes this minor annoyance I've been having for the past 2 months
* [x] I work here

## Validation Steps Performed
Validated locally on VS 16.8.3. Sure to break by 16.9 🙃.