### PR TITLE
Move the window settings below the acrylic settings

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Profiles.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.cpp
@@ -277,4 +277,31 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         return _State.Profile().CursorShape() == TerminalControl::CursorStyle::Vintage;
     }
+
+    void Profiles::UseAcrylic_Checked(Windows::Foundation::IInspectable const& /*sender*/,
+                                      Windows::UI::Xaml::RoutedEventArgs const& /*e*/)
+    {
+        // This isn't it.
+        // AcrylicOpacityControl().StartBringIntoView();
+
+        // This isn't quite right - it definitely scrolls, but not correctly. It
+        // seems to scroll up?
+        //
+        // auto delta = AcrylicOpacityControl().TransformToVisual(Appearance_ScrollViewer()).TransformPoint({0, 0});
+        // Appearance_ScrollViewer().ChangeView(nullptr, delta.Y, nullptr);
+
+        auto currentOffset = Appearance_ScrollViewer().VerticalOffset();
+        auto opacityControlOffset = AcrylicOpacityControl().TransformToVisual(Appearance_ScrollViewer());
+        auto delta = opacityControlOffset.TransformPoint({ 0, 0 });
+        auto scrollH = Appearance_ScrollViewer().ScrollableHeight();
+        scrollH;
+        auto veiwH = Appearance_ScrollViewer().ViewportHeight();
+        veiwH;
+        currentOffset;
+        delta;
+        // auto delta = AcrylicOpacityControl().TransformToVisual(Appearance_ScrollViewer()).TransformPoint({0, 0});
+        // Appearance_ScrollViewer().ChangeView(nullptr, currentOffset + delta.Y, nullptr);
+        // Appearance_ScrollViewer().ChangeView(nullptr, -delta.Y, nullptr);
+        Appearance_ScrollViewer().ChangeView(nullptr, scrollH - veiwH, nullptr);
+    }
 }

--- a/src/cascadia/TerminalSettingsEditor/Profiles.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.cpp
@@ -278,30 +278,4 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         return _State.Profile().CursorShape() == TerminalControl::CursorStyle::Vintage;
     }
 
-    void Profiles::UseAcrylic_Checked(Windows::Foundation::IInspectable const& /*sender*/,
-                                      Windows::UI::Xaml::RoutedEventArgs const& /*e*/)
-    {
-        // This isn't it.
-        // AcrylicOpacityControl().StartBringIntoView();
-
-        // This isn't quite right - it definitely scrolls, but not correctly. It
-        // seems to scroll up?
-        //
-        // auto delta = AcrylicOpacityControl().TransformToVisual(Appearance_ScrollViewer()).TransformPoint({0, 0});
-        // Appearance_ScrollViewer().ChangeView(nullptr, delta.Y, nullptr);
-
-        auto currentOffset = Appearance_ScrollViewer().VerticalOffset();
-        auto opacityControlOffset = AcrylicOpacityControl().TransformToVisual(Appearance_ScrollViewer());
-        auto delta = opacityControlOffset.TransformPoint({ 0, 0 });
-        auto scrollH = Appearance_ScrollViewer().ScrollableHeight();
-        scrollH;
-        auto veiwH = Appearance_ScrollViewer().ViewportHeight();
-        veiwH;
-        currentOffset;
-        delta;
-        // auto delta = AcrylicOpacityControl().TransformToVisual(Appearance_ScrollViewer()).TransformPoint({0, 0});
-        // Appearance_ScrollViewer().ChangeView(nullptr, currentOffset + delta.Y, nullptr);
-        // Appearance_ScrollViewer().ChangeView(nullptr, -delta.Y, nullptr);
-        Appearance_ScrollViewer().ChangeView(nullptr, scrollH - veiwH, nullptr);
-    }
 }

--- a/src/cascadia/TerminalSettingsEditor/Profiles.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.h
@@ -105,41 +105,42 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     public:
         Profiles();
 
-        void OnNavigatedTo(const winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
+        void OnNavigatedTo(const Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
 
         Model::ColorScheme CurrentColorScheme();
         void CurrentColorScheme(const Model::ColorScheme& val);
 
-        fire_and_forget BackgroundImage_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
-        fire_and_forget Commandline_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
-        fire_and_forget StartingDirectory_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
-        fire_and_forget Icon_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
-        void BIAlignment_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
-        void DeleteConfirmation_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
+        fire_and_forget BackgroundImage_Click(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
+        fire_and_forget Commandline_Click(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
+        fire_and_forget StartingDirectory_Click(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
+        fire_and_forget Icon_Click(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
+        void BIAlignment_Click(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
+        void DeleteConfirmation_Click(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
+        void UseAcrylic_Checked(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
 
         // CursorShape visibility logic
         void CursorShape_Changed(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
         bool IsVintageCursor() const;
 
         // manually bind FontWeight
-        winrt::Windows::Foundation::IInspectable CurrentFontWeight() const;
-        void CurrentFontWeight(const winrt::Windows::Foundation::IInspectable& enumEntry);
+        Windows::Foundation::IInspectable CurrentFontWeight() const;
+        void CurrentFontWeight(const Windows::Foundation::IInspectable& enumEntry);
         bool IsCustomFontWeight();
-        GETSET_PROPERTY(winrt::Windows::Foundation::Collections::IObservableVector<winrt::Microsoft::Terminal::Settings::Editor::EnumEntry>, FontWeightList);
+        GETSET_PROPERTY(Windows::Foundation::Collections::IObservableVector<Microsoft::Terminal::Settings::Editor::EnumEntry>, FontWeightList);
 
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
 
         GETSET_PROPERTY(Editor::ProfilePageNavigationState, State, nullptr);
         GETSET_PROPERTY(Windows::Foundation::Collections::IObservableVector<Model::ColorScheme>, ColorSchemeList, nullptr);
-        GETSET_BINDABLE_ENUM_SETTING(CursorShape, winrt::Microsoft::Terminal::TerminalControl::CursorStyle, State().Profile, CursorShape);
-        GETSET_BINDABLE_ENUM_SETTING(BackgroundImageStretchMode, winrt::Windows::UI::Xaml::Media::Stretch, State().Profile, BackgroundImageStretchMode);
-        GETSET_BINDABLE_ENUM_SETTING(AntiAliasingMode, winrt::Microsoft::Terminal::TerminalControl::TextAntialiasingMode, State().Profile, AntialiasingMode);
-        GETSET_BINDABLE_ENUM_SETTING(CloseOnExitMode, winrt::Microsoft::Terminal::Settings::Model::CloseOnExitMode, State().Profile, CloseOnExit);
-        GETSET_BINDABLE_ENUM_SETTING(BellStyle, winrt::Microsoft::Terminal::Settings::Model::BellStyle, State().Profile, BellStyle);
-        GETSET_BINDABLE_ENUM_SETTING(ScrollState, winrt::Microsoft::Terminal::TerminalControl::ScrollbarState, State().Profile, ScrollState);
+        GETSET_BINDABLE_ENUM_SETTING(CursorShape, Microsoft::Terminal::TerminalControl::CursorStyle, State().Profile, CursorShape);
+        GETSET_BINDABLE_ENUM_SETTING(BackgroundImageStretchMode, Windows::UI::Xaml::Media::Stretch, State().Profile, BackgroundImageStretchMode);
+        GETSET_BINDABLE_ENUM_SETTING(AntiAliasingMode, Microsoft::Terminal::TerminalControl::TextAntialiasingMode, State().Profile, AntialiasingMode);
+        GETSET_BINDABLE_ENUM_SETTING(CloseOnExitMode, Microsoft::Terminal::Settings::Model::CloseOnExitMode, State().Profile, CloseOnExit);
+        GETSET_BINDABLE_ENUM_SETTING(BellStyle, Microsoft::Terminal::Settings::Model::BellStyle, State().Profile, BellStyle);
+        GETSET_BINDABLE_ENUM_SETTING(ScrollState, Microsoft::Terminal::TerminalControl::ScrollbarState, State().Profile, ScrollState);
 
     private:
-        winrt::Windows::Foundation::Collections::IMap<uint16_t, winrt::Microsoft::Terminal::Settings::Editor::EnumEntry> _FontWeightMap;
+        Windows::Foundation::Collections::IMap<uint16_t, Microsoft::Terminal::Settings::Editor::EnumEntry> _FontWeightMap;
         Editor::EnumEntry _CustomFontWeight{ nullptr };
         std::array<Windows::UI::Xaml::Controls::Primitives::ToggleButton, 9> _BIAlignmentButtons;
     };

--- a/src/cascadia/TerminalSettingsEditor/Profiles.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.h
@@ -116,7 +116,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         fire_and_forget Icon_Click(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
         void BIAlignment_Click(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
         void DeleteConfirmation_Click(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
-        void UseAcrylic_Checked(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
 
         // CursorShape visibility logic
         void CursorShape_Changed(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -39,7 +39,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             <RowDefinition Height="auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        
+
         <TextBlock x:Uid="Profile_BaseLayerDisclaimer"
                    Grid.Row="0"
                    Margin="{StaticResource StandardIndentMargin}"
@@ -174,7 +174,7 @@ the MIT License. See LICENSE in the project root for license information. -->
 
             <!-- Appearance Tab -->
             <PivotItem x:Uid="Profile_Appearance">
-                <ScrollViewer>
+                <ScrollViewer x:Name="Appearance_ScrollViewer">
                     <StackPanel>
 
                         <!--Grouping: Text-->
@@ -501,6 +501,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                             <CheckBox x:Uid="Profile_UseAcrylic"
                                       x:Name="UseAcrylicCheckBox"
                                       IsChecked="{x:Bind State.Profile.UseAcrylic, Mode=TwoWay}"
+                                      Checked="UseAcrylic_Checked"
                                       Style="{StaticResource CheckBoxSettingStyle}"/>
                         </ContentPresenter>
 

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -174,7 +174,7 @@ the MIT License. See LICENSE in the project root for license information. -->
 
             <!-- Appearance Tab -->
             <PivotItem x:Uid="Profile_Appearance">
-                <ScrollViewer x:Name="Appearance_ScrollViewer">
+                <ScrollViewer>
                     <StackPanel>
 
                         <!--Grouping: Text-->
@@ -251,25 +251,6 @@ the MIT License. See LICENSE in the project root for license information. -->
                             <CheckBox x:Uid="Profile_RetroTerminalEffect"
                                       IsChecked="{x:Bind State.Profile.RetroTerminalEffect, Mode=TwoWay}"
                                       Style="{StaticResource CheckBoxSettingStyle}"/>
-                        </ContentPresenter>
-
-                        <!--Grouping: Window-->
-                        <TextBlock x:Uid="Profile_WindowHeader" Style="{StaticResource GroupingHeader}"/>
-
-                        <!--Padding-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                            <TextBox x:Uid="Profile_Padding"
-                                     Text="{x:Bind State.Profile.Padding, Mode=TwoWay}"
-                                     Style="{StaticResource TextBoxSettingStyle}"/>
-                        </ContentPresenter>
-
-                        <!--Scrollbar Visibility-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                            <muxc:RadioButtons x:Uid="Profile_ScrollbarVisibility"
-                                               ItemsSource="{x:Bind ScrollStateList, Mode=OneWay}"
-                                               SelectedItem="{x:Bind CurrentScrollState, Mode=TwoWay}"
-                                               ItemTemplate="{StaticResource EnumRadioButtonTemplate}"
-                                               Style="{StaticResource RadioButtonsSettingStyle}"/>
                         </ContentPresenter>
 
                         <!--Grouping: Cursor-->
@@ -504,7 +485,6 @@ the MIT License. See LICENSE in the project root for license information. -->
                             <CheckBox x:Uid="Profile_UseAcrylic"
                                       x:Name="UseAcrylicCheckBox"
                                       IsChecked="{x:Bind State.Profile.UseAcrylic, Mode=TwoWay}"
-                                      Checked="UseAcrylic_Checked"
                                       Style="{StaticResource CheckBoxSettingStyle}"/>
                         </ContentPresenter>
 
@@ -527,6 +507,25 @@ the MIT License. See LICENSE in the project root for license information. -->
                                                Style="{StaticResource SliderValueLabelStyle}"/>
                                 </Grid>
                             </StackPanel>
+                        </ContentPresenter>
+
+                        <!--Grouping: Window-->
+                        <TextBlock x:Uid="Profile_WindowHeader" Style="{StaticResource GroupingHeader}"/>
+
+                        <!--Padding-->
+                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
+                            <TextBox x:Uid="Profile_Padding"
+                                     Text="{x:Bind State.Profile.Padding, Mode=TwoWay}"
+                                     Style="{StaticResource TextBoxSettingStyle}"/>
+                        </ContentPresenter>
+
+                        <!--Scrollbar Visibility-->
+                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
+                            <muxc:RadioButtons x:Uid="Profile_ScrollbarVisibility"
+                                               ItemsSource="{x:Bind ScrollStateList, Mode=OneWay}"
+                                               SelectedItem="{x:Bind CurrentScrollState, Mode=TwoWay}"
+                                               ItemTemplate="{StaticResource EnumRadioButtonTemplate}"
+                                               Style="{StaticResource RadioButtonsSettingStyle}"/>
                         </ContentPresenter>
                     </StackPanel>
                 </ScrollViewer>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18356694/104447754-d6de1780-5561-11eb-8d99-71f4ec5ad429.png)


Put some settings below the acrylic & background image settings. Those groups have controls that will become visible when the user enables the setting. If there's other controls below them, then it's less likely that the user has _exactly scrolled to the checkbox_. That means it's more likely that the newly visible controls will be on-screen.

* [x] closes one checkbox in #8764
* [x] I work here