### PR TITLE
Remove setting for close all tabs pop up

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
@@ -64,13 +64,6 @@ the MIT License. See LICENSE in the project root for license information. -->
                                    Style="{StaticResource RadioButtonsSettingStyle}"/>
             </ContentPresenter>
 
-            <!--Confirm Close All Tabs-->
-            <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                <CheckBox x:Uid="Globals_ConfirmCloseAllTabs"
-                          IsChecked="{x:Bind State.Globals.ConfirmCloseAllTabs, Mode=TwoWay}"
-                          Style="{StaticResource CheckBoxSettingStyle}"/>
-            </ContentPresenter>
-
             <!--Disable Animations-->
             <ContentPresenter Style="{StaticResource SettingContainerStyle}">
                 <CheckBox x:Uid="Globals_DisableAnimations"

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -184,12 +184,6 @@
     <value>When checked, tabs are always displayed. When unchecked and 'show the title bar' is checked, tabs only appear after opening a new tab.</value>
     <comment>'show the title bar' must match the value for &lt;Globals_ShowTitlebar.Content&gt;.</comment>
   </data>
-  <data name="Globals_ConfirmCloseAllTabs.Content" xml:space="preserve">
-    <value>Show close all tabs popup</value>
-  </data>
-  <data name="Globals_ConfirmCloseAllTabs.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>When checked, closing a window with multiple tabs open will require confirmation. When unchecked, the confirmation dialog will not appear.</value>
-  </data>
   <data name="Globals_CopyFormatting.Content" xml:space="preserve">
     <value>Copy formatting</value>
   </data>


### PR DESCRIPTION
Remove the setting for enabling/disabling the dialog that
shows up to confirm the closing of all tabs in the SUI

Closes #8757 