### PR TITLE
Hide commandline option for base layer

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -497,19 +497,19 @@
     <value>Sets the shape of the cursor.</value>
   </data>
   <data name="Profile_CursorShapeBar.Content" xml:space="preserve">
-    <value>Bar</value>
+    <value>Bar ( ┃ )</value>
   </data>
   <data name="Profile_CursorShapeEmptyBox.Content" xml:space="preserve">
-    <value>Empty box</value>
+    <value>Empty box ( ▯ )</value>
   </data>
   <data name="Profile_CursorShapeFilledBox.Content" xml:space="preserve">
-    <value>Filled box</value>
+    <value>Filled box ( █ )</value>
   </data>
   <data name="Profile_CursorShapeUnderscore.Content" xml:space="preserve">
-    <value>Underscore</value>
+    <value>Underscore ( ▁ )</value>
   </data>
   <data name="Profile_CursorShapeVintage.Content" xml:space="preserve">
-    <value>Vintage</value>
+    <value>Vintage ( ▃ )</value>
   </data>
   <data name="Profile_FontFace.Header" xml:space="preserve">
     <value>Font face</value>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Do not allow the user to set commandline on the base layer of profiles

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
#8764 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I work here

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Commandline option is hidden