### PR TITLE
sui: hide commandline and hidden option in base layer

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -54,17 +54,16 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <ScrollViewer>
                     <StackPanel Margin="{StaticResource PivotStackPanelMargin}">
                         <!--Commandline-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
+                        <ContentPresenter Style="{StaticResource SettingContainerStyle}"
+                                          Visibility="{x:Bind State.Profile.IsBaseLayer, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}">
                             <StackPanel Orientation="Horizontal">
                                 <TextBox x:Uid="Profile_Commandline"
                                          x:Name="Commandline"
                                          Text="{x:Bind State.Profile.Commandline, Mode=TwoWay}"
-                                         Style="{StaticResource TextBoxSettingStyle}"
-                                         Visibility="{x:Bind State.Profile.IsBaseLayer, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}"/>
+                                         Style="{StaticResource TextBoxSettingStyle}"/>
                                 <Button x:Uid="Profile_CommandlineBrowse"
                                         Click="Commandline_Click"
-                                        Style="{StaticResource BrowseButtonStyle}"
-                                        Visibility="{x:Bind State.Profile.IsBaseLayer, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}"/>
+                                        Style="{StaticResource BrowseButtonStyle}"/>
                             </StackPanel>
                         </ContentPresenter>
 
@@ -103,7 +102,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                         </ContentPresenter>
 
                         <!--Hidden-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
+                        <ContentPresenter Style="{StaticResource SettingContainerStyle}"
+                                          Visibility="{x:Bind State.Profile.IsBaseLayer, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}">
                             <CheckBox x:Uid="Profile_Hidden"
                                       IsChecked="{x:Bind State.Profile.Hidden, Mode=TwoWay}"
                                       Style="{StaticResource CheckBoxSettingStyle}"/>

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -59,10 +59,12 @@ the MIT License. See LICENSE in the project root for license information. -->
                                 <TextBox x:Uid="Profile_Commandline"
                                          x:Name="Commandline"
                                          Text="{x:Bind State.Profile.Commandline, Mode=TwoWay}"
-                                         Style="{StaticResource TextBoxSettingStyle}"/>
+                                         Style="{StaticResource TextBoxSettingStyle}"
+                                         Visibility="{x:Bind State.Profile.IsBaseLayer, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}"/>
                                 <Button x:Uid="Profile_CommandlineBrowse"
                                         Click="Commandline_Click"
-                                        Style="{StaticResource BrowseButtonStyle}"/>
+                                        Style="{StaticResource BrowseButtonStyle}"
+                                        Visibility="{x:Bind State.Profile.IsBaseLayer, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}"/>
                             </StackPanel>
                         </ContentPresenter>
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Do not allow the user to set commandline on the base layer of profiles

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
#8764 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I work here

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Commandline option is hidden