### PR TITLE
Add missing functionality to SUI

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Profiles.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.cpp
@@ -114,6 +114,12 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             disclaimer = RS_(L"Profile_DeleteButtonDisclaimerDynamic");
         }
         DeleteButtonDisclaimer().Text(disclaimer);
+
+        // Check the use parent directory box if the starting directory is empty
+        if (_State.Profile().StartingDirectory().empty())
+        {
+            StartingDirectoryUseParentCheckbox().IsChecked(true);
+        }
     }
 
     ColorScheme Profiles::CurrentColorScheme()
@@ -140,6 +146,23 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         auto state{ winrt::get_self<ProfilePageNavigationState>(_State) };
         state->DeleteProfile();
+    }
+
+    void Profiles::UseParentProcessDirectory_Check(IInspectable const& /*sender*/, RoutedEventArgs const& /*e*/)
+    {
+        auto state{ winrt::get_self<ProfilePageNavigationState>(_State) };
+        state->Profile().StartingDirectory(L"");
+
+        // Disable the text box and browse button
+        StartingDirectory().IsEnabled(false);
+        StartingDirectoryBrowse().IsEnabled(false);
+    }
+
+    void Profiles::UseParentProcessDirectory_Uncheck(IInspectable const& /*sender*/, RoutedEventArgs const& /*e*/)
+    {
+        // Enable the text box and browse button
+        StartingDirectory().IsEnabled(true);
+        StartingDirectoryBrowse().IsEnabled(true);
     }
 
     fire_and_forget Profiles::BackgroundImage_Click(IInspectable const&, RoutedEventArgs const&)

--- a/src/cascadia/TerminalSettingsEditor/Profiles.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.h
@@ -116,6 +116,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         fire_and_forget Icon_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
         void BIAlignment_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
         void DeleteConfirmation_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
+        void UseParentProcessDirectory_Check (winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
+        void UseParentProcessDirectory_Uncheck(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
 
         // CursorShape visibility logic
         void CursorShape_Changed(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);

--- a/src/cascadia/TerminalSettingsEditor/Profiles.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.h
@@ -116,7 +116,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         fire_and_forget Icon_Click(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
         void BIAlignment_Click(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
         void DeleteConfirmation_Click(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
-        void UseParentProcessDirectory_Check (Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
+        void UseParentProcessDirectory_Check(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
         void UseParentProcessDirectory_Uncheck(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
 
         // CursorShape visibility logic

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -74,9 +74,19 @@ the MIT License. See LICENSE in the project root for license information. -->
                                          Text="{x:Bind State.Profile.StartingDirectory, Mode=TwoWay}"
                                          Style="{StaticResource TextBoxSettingStyle}"/>
                                 <Button x:Uid="Profile_StartingDirectoryBrowse"
+                                        x:Name="StartingDirectoryBrowse"
                                         Click="StartingDirectory_Click"
                                         Style="{StaticResource BrowseButtonStyle}"/>
                             </StackPanel>
+                        </ContentPresenter>
+
+                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
+                            <CheckBox x:Uid="Profile_StartingDirectoryUseParentCheckbox"
+                                      x:Name="StartingDirectoryUseParentCheckbox"
+                                      Style="{StaticResource CheckBoxSettingStyle}"
+                                      Margin="0,-20,0,0"
+                                      Checked="UseParentProcessDirectory_Check"
+                                      Unchecked="UseParentProcessDirectory_Uncheck"/>
                         </ContentPresenter>
 
                         <!--Icon-->

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -68,25 +68,23 @@ the MIT License. See LICENSE in the project root for license information. -->
 
                         <!--Starting Directory-->
                         <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                            <StackPanel Orientation="Horizontal">
-                                <TextBox x:Uid="Profile_StartingDirectory"
+                            <StackPanel Orientation="Vertical">
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBox x:Uid="Profile_StartingDirectory"
                                          x:Name="StartingDirectory"
                                          Text="{x:Bind State.Profile.StartingDirectory, Mode=TwoWay}"
                                          Style="{StaticResource TextBoxSettingStyle}"/>
-                                <Button x:Uid="Profile_StartingDirectoryBrowse"
+                                    <Button x:Uid="Profile_StartingDirectoryBrowse"
                                         x:Name="StartingDirectoryBrowse"
                                         Click="StartingDirectory_Click"
                                         Style="{StaticResource BrowseButtonStyle}"/>
-                            </StackPanel>
-                        </ContentPresenter>
-
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                            <CheckBox x:Uid="Profile_StartingDirectoryUseParentCheckbox"
+                                </StackPanel>
+                                <CheckBox x:Uid="Profile_StartingDirectoryUseParentCheckbox"
                                       x:Name="StartingDirectoryUseParentCheckbox"
                                       Style="{StaticResource CheckBoxSettingStyle}"
-                                      Margin="0,-20,0,0"
                                       Checked="UseParentProcessDirectory_Check"
                                       Unchecked="UseParentProcessDirectory_Uncheck"/>
+                            </StackPanel>
                         </ContentPresenter>
 
                         <!--Icon-->

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -608,7 +608,7 @@
     <value>Use parent process directory</value>
   </data>
   <data name="Profile_StartingDirectoryUseParentCheckbox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>If checked, the parent process directory will be used.</value>
+    <value>If checked, this profile will spawn in the directory from which Windows Terminal was launched.</value>
   </data>
   <data name="Profile_SuppressApplicationTitle.Content" xml:space="preserve">
     <value>Suppress title changes</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -604,6 +604,12 @@
   <data name="Profile_StartingDirectoryBrowse.Content" xml:space="preserve">
     <value>Browse...</value>
   </data>
+  <data name="Profile_StartingDirectoryUseParentCheckbox.Content" xml:space="preserve">
+    <value>Use parent process directory</value>
+  </data>
+  <data name="Profile_StartingDirectoryUseParentCheckbox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>If checked, the parent process directory will be used.</value>
+  </data>
   <data name="Profile_SuppressApplicationTitle.Content" xml:space="preserve">
     <value>Suppress title changes</value>
   </data>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Add checkbox for 'inherit from parent process' for starting directory
When checked, the textbox and browse button are disabled
If the starting directory is empty, the checkbox is automatically checked

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #8761 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I work here

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
<img width="328" alt="pardir1" src="https://user-images.githubusercontent.com/26824113/104529798-64038980-55bf-11eb-93fd-75e6cf1e2547.png">
<img width="317" alt="pardir2" src="https://user-images.githubusercontent.com/26824113/104529803-66fe7a00-55bf-11eb-89b6-5b35c8ab89b8.png">
