### PR TITLE
Added negative value check for resize newsize

### DIFF
--- a/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
@@ -143,11 +143,16 @@ namespace Microsoft.Terminal.Wpf
         {
             var dpiScale = VisualTreeHelper.GetDpi(this);
 
-            // termContainer requires scaled sizes.
+            var newSizeWidth = (sizeInfo.NewSize.Width - this.scrollbar.ActualWidth) * dpiScale.DpiScaleX;
+            newSizeWidth = newSizeWidth < 0 ? 0 : newSizeWidth;
+
+            var newSizeHeight = sizeInfo.NewSize.Height * dpiScale.DpiScaleY;
+            newSizeHeight = newSizeHeight < 0 ? 0 : newSizeHeight;
+
             this.termContainer.TerminalControlSize = new Size()
             {
-                Width = (sizeInfo.NewSize.Width - this.scrollbar.ActualWidth) * dpiScale.DpiScaleX,
-                Height = sizeInfo.NewSize.Height * dpiScale.DpiScaleY,
+                Width = newSizeWidth,
+                Height = newSizeHeight,
             };
 
             if (!this.AutoResize)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds a negative value check for when the terminal window is hidden/show in VS

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
[Bug 1265984](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1265984): [Terminal] VS crashes when clicking the hidden terminal tab

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual validation.