### PR TITLE
Bugfix: sync color scheme rename with profile reference

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
@@ -53,17 +53,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void ColorSchemesPageNavigationState::RenameColorScheme(hstring oldName, hstring newName)
     {
-        // dispatch an event to update all references to <oldName> with <newName>
-        auto renameSchemeArgs {winrt::make_self<ModifyColorSchemeNameEventArgs>(oldName, newName)};
-        _ModifyColorSchemeNameHandlers(*this, *renameSchemeArgs);
+        _Settings.RenameColorScheme(oldName, newName);
     }
 
     void ColorSchemesPageNavigationState::DeleteColorScheme(hstring name)
     {
-        // dispatch an event to update all references to <name> with "Campbell"
         // This ensures that the JSON is updated with "Campbell", because the color scheme was deleted
-        auto deleteSchemeArgs{ winrt::make_self<ModifyColorSchemeNameEventArgs>(name, L"Campbell") };
-        _ModifyColorSchemeNameHandlers(*this, *deleteSchemeArgs);
+        _Settings.RenameColorScheme(name, L"Campbell");
     }
 
     ColorSchemes::ColorSchemes() :

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
@@ -53,13 +53,19 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void ColorSchemesPageNavigationState::RenameColorScheme(hstring oldName, hstring newName)
     {
-        _Settings.RenameColorScheme(oldName, newName);
+        auto scheme{ _Globals.ColorSchemes().Lookup(oldName) };
+        scheme.Name(newName);
+        _Globals.RemoveColorScheme(oldName);
+        _Globals.AddColorScheme(scheme);
+
+        _Settings.UpdateColorSchemeReferences(oldName, newName);
     }
 
     void ColorSchemesPageNavigationState::DeleteColorScheme(hstring name)
     {
         // This ensures that the JSON is updated with "Campbell", because the color scheme was deleted
-        _Settings.RenameColorScheme(name, L"Campbell");
+        _Globals.RemoveColorScheme(name);
+        _Settings.UpdateColorSchemeReferences(name, L"Campbell");
     }
 
     ColorSchemes::ColorSchemes() :

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
@@ -263,6 +263,20 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void ColorSchemes::_RenameCurrentScheme(hstring newName)
     {
+        // check if different name is already in use
+        if (newName != CurrentColorScheme().Name() && _State.Globals().ColorSchemes().HasKey(newName))
+        {
+            // open the error tip
+            RenameErrorTip().Target(NameBox());
+            RenameErrorTip().IsOpen(true);
+
+            // focus the name box
+            NameBox().Focus(FocusState::Programmatic);
+            NameBox().SelectAll();
+            return;
+        }
+        RenameErrorTip().IsOpen(false);
+
         winrt::get_self<ColorSchemesPageNavigationState>(_State)->RenameColorScheme(CurrentColorScheme().Name(), newName);
         CurrentColorScheme().Name(newName);
         IsRenaming(false);

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
@@ -251,7 +251,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     void ColorSchemes::_RenameCurrentScheme(hstring newName)
     {
         // check if different name is already in use
-        auto oldName{ CurrentColorScheme().Name() };
+        const auto oldName{ CurrentColorScheme().Name() };
         if (newName != oldName && _State.Settings().GlobalSettings().ColorSchemes().HasKey(newName))
         {
             // open the error tip
@@ -265,10 +265,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
 
         // update the settings model
-        auto scheme{ _State.Settings().GlobalSettings().ColorSchemes().Lookup(oldName) };
-        scheme.Name(newName);
+        CurrentColorScheme().Name(newName);
         _State.Settings().GlobalSettings().RemoveColorScheme(oldName);
-        _State.Settings().GlobalSettings().AddColorScheme(scheme);
+        _State.Settings().GlobalSettings().AddColorScheme(CurrentColorScheme());
         _State.Settings().UpdateColorSchemeReferences(oldName, newName);
 
         // update the UI

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
@@ -14,17 +14,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
     public:
         ColorSchemesPageNavigationState(const Model::CascadiaSettings& settings) :
-            _Globals{ settings.GlobalSettings() },
             _Settings{ settings } {}
 
-        void RenameColorScheme(hstring oldName, hstring newName);
-        void DeleteColorScheme(hstring name);
-
-        GETSET_PROPERTY(Model::GlobalAppSettings, Globals, nullptr);
+        GETSET_PROPERTY(Model::CascadiaSettings, Settings, nullptr);
         GETSET_PROPERTY(winrt::hstring, LastSelectedScheme, L"");
-
-    private:
-        Model::CascadiaSettings _Settings;
     };
 
     struct ColorSchemes : ColorSchemesT<ColorSchemes>

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
@@ -6,39 +6,25 @@
 #include "ColorTableEntry.g.h"
 #include "ColorSchemes.g.h"
 #include "ColorSchemesPageNavigationState.g.h"
-#include "ModifyColorSchemeNameEventArgs.g.h"
 #include "Utils.h"
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
-    struct ModifyColorSchemeNameEventArgs :
-        public ModifyColorSchemeNameEventArgsT<ModifyColorSchemeNameEventArgs>
-    {
-    public:
-        ModifyColorSchemeNameEventArgs(hstring oldName, hstring newName) :
-            _OldName{ oldName },
-            _NewName{ newName } {}
-
-        hstring OldName() const noexcept { return _OldName; }
-        hstring NewName() const noexcept { return _NewName; }
-
-    private:
-        hstring _OldName;
-        hstring _NewName;
-    };
-
     struct ColorSchemesPageNavigationState : ColorSchemesPageNavigationStateT<ColorSchemesPageNavigationState>
     {
     public:
-        ColorSchemesPageNavigationState(const Model::GlobalAppSettings& settings) :
-            _Globals{ settings } {}
+        ColorSchemesPageNavigationState(const Model::CascadiaSettings& settings) :
+            _Globals{ settings.GlobalSettings() },
+            _Settings{ settings } {}
 
         void RenameColorScheme(hstring oldName, hstring newName);
         void DeleteColorScheme(hstring name);
 
-        TYPED_EVENT(ModifyColorSchemeName, Editor::ColorSchemesPageNavigationState, Editor::ModifyColorSchemeNameEventArgs);
         GETSET_PROPERTY(Model::GlobalAppSettings, Globals, nullptr);
         GETSET_PROPERTY(winrt::hstring, LastSelectedScheme, L"");
+
+    private:
+        Model::CascadiaSettings _Settings;
     };
 
     struct ColorSchemes : ColorSchemesT<ColorSchemes>

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
@@ -6,16 +6,37 @@
 #include "ColorTableEntry.g.h"
 #include "ColorSchemes.g.h"
 #include "ColorSchemesPageNavigationState.g.h"
+#include "ModifyColorSchemeNameEventArgs.g.h"
 #include "Utils.h"
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    struct ModifyColorSchemeNameEventArgs :
+        public ModifyColorSchemeNameEventArgsT<ModifyColorSchemeNameEventArgs>
+    {
+    public:
+        ModifyColorSchemeNameEventArgs(hstring oldName, hstring newName) :
+            _OldName{ oldName },
+            _NewName{ newName } {}
+
+        hstring OldName() const noexcept { return _OldName; }
+        hstring NewName() const noexcept { return _NewName; }
+
+    private:
+        hstring _OldName;
+        hstring _NewName;
+    };
+
     struct ColorSchemesPageNavigationState : ColorSchemesPageNavigationStateT<ColorSchemesPageNavigationState>
     {
     public:
         ColorSchemesPageNavigationState(const Model::GlobalAppSettings& settings) :
             _Globals{ settings } {}
 
+        void RenameColorScheme(hstring oldName, hstring newName);
+        void DeleteColorScheme(hstring name);
+
+        TYPED_EVENT(ModifyColorSchemeName, Editor::ColorSchemesPageNavigationState, Editor::ModifyColorSchemeNameEventArgs);
         GETSET_PROPERTY(Model::GlobalAppSettings, Globals, nullptr);
         GETSET_PROPERTY(winrt::hstring, LastSelectedScheme, L"");
     };

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.idl
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.idl
@@ -6,7 +6,7 @@ namespace Microsoft.Terminal.Settings.Editor
 
     runtimeclass ColorSchemesPageNavigationState
     {
-        Microsoft.Terminal.Settings.Model.GlobalAppSettings Globals;
+        Microsoft.Terminal.Settings.Model.CascadiaSettings Settings;
         String LastSelectedScheme;
     };
 

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.idl
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.idl
@@ -3,11 +3,18 @@
 
 namespace Microsoft.Terminal.Settings.Editor
 {
+    runtimeclass ModifyColorSchemeNameEventArgs
+    {
+        String OldName { get; };
+        String NewName { get; };
+    }
 
     runtimeclass ColorSchemesPageNavigationState
     {
         Microsoft.Terminal.Settings.Model.GlobalAppSettings Globals;
         String LastSelectedScheme;
+
+        event Windows.Foundation.TypedEventHandler<ColorSchemesPageNavigationState, ModifyColorSchemeNameEventArgs> ModifyColorSchemeName;
     };
 
     [default_interface] runtimeclass ColorSchemes : Windows.UI.Xaml.Controls.Page, Windows.UI.Xaml.Data.INotifyPropertyChanged

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.idl
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.idl
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Terminal.Settings.Editor
 {
+
     runtimeclass ColorSchemesPageNavigationState
     {
         Microsoft.Terminal.Settings.Model.GlobalAppSettings Globals;

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.idl
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.idl
@@ -3,18 +3,10 @@
 
 namespace Microsoft.Terminal.Settings.Editor
 {
-    runtimeclass ModifyColorSchemeNameEventArgs
-    {
-        String OldName { get; };
-        String NewName { get; };
-    }
-
     runtimeclass ColorSchemesPageNavigationState
     {
         Microsoft.Terminal.Settings.Model.GlobalAppSettings Globals;
         String LastSelectedScheme;
-
-        event Windows.Foundation.TypedEventHandler<ColorSchemesPageNavigationState, ModifyColorSchemeNameEventArgs> ModifyColorSchemeName;
     };
 
     [default_interface] runtimeclass ColorSchemes : Windows.UI.Xaml.Controls.Page, Windows.UI.Xaml.Data.INotifyPropertyChanged

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -6,6 +6,7 @@ the MIT License. See LICENSE in the project root for license information. -->
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.Terminal.Settings.Editor"
     xmlns:model="using:Microsoft.Terminal.Settings.Model"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
@@ -97,9 +98,17 @@ the MIT License. See LICENSE in the project root for license information. -->
 
                 <StackPanel Orientation="Horizontal"
                             Visibility="{x:Bind IsRenaming, Mode=OneWay}">
+
+                    <!--Shown when color scheme name is already in use-->
+                    <muxc:TeachingTip x:Name="RenameErrorTip"
+                                      x:Uid="ColorScheme_RenameErrorTip"/>
+
+                    <!--Name text box-->
                     <TextBox x:Name="NameBox"
                              Style="{StaticResource TextBoxSettingStyle}"
                              PreviewKeyDown="NameBox_PreviewKeyDown"/>
+
+                    <!--Accept rename button-->
                     <Button x:Uid="RenameAccept"
                             Style="{StaticResource AccentSmallButtonStyle}"
                             Click="RenameAccept_Click">
@@ -108,6 +117,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                                       FontSize="{StaticResource StandardIconSize}"/>
                         </StackPanel>
                     </Button>
+                    <!--Cancel rename button-->
                     <Button x:Uid="RenameCancel"
                             Style="{StaticResource SmallButtonStyle}"
                             Click="RenameCancel_Click">

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -51,6 +51,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _InitializeProfilesList();
 
         _colorSchemesNavState = winrt::make<ColorSchemesPageNavigationState>(_settingsClone.GlobalSettings());
+        _colorSchemesNavState.ModifyColorSchemeName({ this, &MainPage::_ModifyColorSchemeName });
     }
 
     // Method Description:
@@ -385,5 +386,21 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         const auto newSelectedItem{ menuItems.GetAt(index < menuItems.Size() - 1 ? index : index - 1) };
         SettingsNav().SelectedItem(newSelectedItem);
         _Navigate(newSelectedItem.try_as<MUX::Controls::NavigationViewItem>().Tag().try_as<Editor::ProfileViewModel>());
+    }
+
+    // Method Description:
+    // - Updates all references to a renamed/deleted color scheme
+    // Arguments:
+    // - sender - unused
+    // - args - data regarding the color scheme that was modified
+    void MainPage::_ModifyColorSchemeName(const IInspectable /*sender*/, const Editor::ModifyColorSchemeNameEventArgs& args)
+    {
+        for (auto profile : _settingsClone.AllProfiles())
+        {
+            if (profile.ColorSchemeName() == args.OldName())
+            {
+                profile.ColorSchemeName(args.NewName());
+            }
+        }
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -110,7 +110,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // Repopulate profile-related menu items
         _InitializeProfilesList();
         // Update the Nav State with the new version of the settings
-        _colorSchemesNavState.Globals(_settingsClone.GlobalSettings());
+        _colorSchemesNavState.Settings(_settingsClone);
 
         // now that the menuItems are repopulated,
         // refresh the current page using the SelectedItem data we collected before the refresh

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -50,8 +50,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         _InitializeProfilesList();
 
-        _colorSchemesNavState = winrt::make<ColorSchemesPageNavigationState>(_settingsClone.GlobalSettings());
-        _colorSchemesNavState.ModifyColorSchemeName({ this, &MainPage::_ModifyColorSchemeName });
+        _colorSchemesNavState = winrt::make<ColorSchemesPageNavigationState>(_settingsClone);
     }
 
     // Method Description:
@@ -386,21 +385,5 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         const auto newSelectedItem{ menuItems.GetAt(index < menuItems.Size() - 1 ? index : index - 1) };
         SettingsNav().SelectedItem(newSelectedItem);
         _Navigate(newSelectedItem.try_as<MUX::Controls::NavigationViewItem>().Tag().try_as<Editor::ProfileViewModel>());
-    }
-
-    // Method Description:
-    // - Updates all references to a renamed/deleted color scheme
-    // Arguments:
-    // - sender - unused
-    // - args - data regarding the color scheme that was modified
-    void MainPage::_ModifyColorSchemeName(const IInspectable /*sender*/, const Editor::ModifyColorSchemeNameEventArgs& args)
-    {
-        for (auto profile : _settingsClone.AllProfiles())
-        {
-            if (profile.ColorSchemeName() == args.OldName())
-            {
-                profile.ColorSchemeName(args.NewName());
-            }
-        }
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -37,7 +37,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void _CreateAndNavigateToNewProfile(const uint32_t index);
         winrt::Microsoft::UI::Xaml::Controls::NavigationViewItem _CreateProfileNavViewItem(const Editor::ProfileViewModel& profile);
         void _DeleteProfile(const Windows::Foundation::IInspectable sender, const Editor::DeleteProfileEventArgs& args);
-        void _ModifyColorSchemeName(const Windows::Foundation::IInspectable sender, const Editor::ModifyColorSchemeNameEventArgs& args);
 
         void _Navigate(hstring clickedItemTag);
         void _Navigate(const Editor::ProfileViewModel& profile);

--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -37,6 +37,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void _CreateAndNavigateToNewProfile(const uint32_t index);
         winrt::Microsoft::UI::Xaml::Controls::NavigationViewItem _CreateProfileNavViewItem(const Editor::ProfileViewModel& profile);
         void _DeleteProfile(const Windows::Foundation::IInspectable sender, const Editor::DeleteProfileEventArgs& args);
+        void _ModifyColorSchemeName(const Windows::Foundation::IInspectable sender, const Editor::ModifyColorSchemeNameEventArgs& args);
 
         void _Navigate(hstring clickedItemTag);
         void _Navigate(const Editor::ProfileViewModel& profile);

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -832,4 +832,10 @@
   <data name="Globals_CopyFormatAll.Content" xml:space="preserve">
     <value>Both HTML and RTF</value>
   </data>
+  <data name="ColorScheme_RenameErrorTip.Subtitle" xml:space="preserve">
+    <value>Please choose a different name.</value>
+  </data>
+  <data name="ColorScheme_RenameErrorTip.Title" xml:space="preserve">
+    <value>This color scheme name is already in use.</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -875,7 +875,7 @@ winrt::Microsoft::Terminal::Settings::Model::ColorScheme CascadiaSettings::GetCo
 void CascadiaSettings::UpdateColorSchemeReferences(const hstring oldName, const hstring newName)
 {
     // update all profiles referencing this color scheme
-    for (auto profile : _allProfiles)
+    for (const auto& profile : _allProfiles)
     {
         if (profile.ColorSchemeName() == oldName)
         {

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -866,29 +866,20 @@ winrt::Microsoft::Terminal::Settings::Model::ColorScheme CascadiaSettings::GetCo
 }
 
 // Method Description:
-// - renames a color scheme, and updates all references to that color scheme with the new name
+// - updates all references to that color scheme with the new name
 // Arguments:
 // - oldName: the original name for the color scheme
 // - newName: the new name for the color scheme
 // Return Value:
 // - <none>
-
-void CascadiaSettings::RenameColorScheme(const hstring oldName, const hstring newName)
+void CascadiaSettings::UpdateColorSchemeReferences(const hstring oldName, const hstring newName)
 {
-    if (auto scheme{ _globals->ColorSchemes().TryLookup(oldName) })
+    // update all profiles referencing this color scheme
+    for (auto profile : _allProfiles)
     {
-        // rename the ColorScheme object (update Globals)
-        _globals->RemoveColorScheme(oldName);
-        scheme.Name(newName);
-        _globals->AddColorScheme(scheme);
-
-        // update all profiles referencing this color scheme
-        for (auto profile : _allProfiles)
+        if (profile.ColorSchemeName() == oldName)
         {
-            if (profile.ColorSchemeName() == oldName)
-            {
-                profile.ColorSchemeName(newName);
-            }
+            profile.ColorSchemeName(newName);
         }
     }
 }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -865,6 +865,34 @@ winrt::Microsoft::Terminal::Settings::Model::ColorScheme CascadiaSettings::GetCo
     return _globals->ColorSchemes().TryLookup(schemeName);
 }
 
+// Method Description:
+// - renames a color scheme, and updates all references to that color scheme with the new name
+// Arguments:
+// - oldName: the original name for the color scheme
+// - newName: the new name for the color scheme
+// Return Value:
+// - <none>
+
+void CascadiaSettings::RenameColorScheme(const hstring oldName, const hstring newName)
+{
+    if (auto scheme{ _globals->ColorSchemes().TryLookup(oldName) })
+    {
+        // rename the ColorScheme object (update Globals)
+        _globals->RemoveColorScheme(oldName);
+        scheme.Name(newName);
+        _globals->AddColorScheme(scheme);
+
+        // update all profiles referencing this color scheme
+        for (auto profile : _allProfiles)
+        {
+            if (profile.ColorSchemeName() == oldName)
+            {
+                profile.ColorSchemeName(newName);
+            }
+        }
+    }
+}
+
 winrt::hstring CascadiaSettings::ApplicationDisplayName()
 {
     try

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -88,7 +88,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         Model::Profile CreateNewProfile();
         Model::Profile FindProfile(guid profileGuid) const noexcept;
         Model::ColorScheme GetColorSchemeForProfile(const guid profileGuid) const;
-        void RenameColorScheme(const hstring oldName, const hstring newName);
+        void UpdateColorSchemeReferences(const hstring oldName, const hstring newName);
 
         Windows::Foundation::Collections::IVectorView<SettingsLoadWarnings> Warnings();
         void ClearWarnings();

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -88,6 +88,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         Model::Profile CreateNewProfile();
         Model::Profile FindProfile(guid profileGuid) const noexcept;
         Model::ColorScheme GetColorSchemeForProfile(const guid profileGuid) const;
+        void RenameColorScheme(const hstring oldName, const hstring newName);
 
         Windows::Foundation::Collections::IVectorView<SettingsLoadWarnings> Warnings();
         void ClearWarnings();

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.idl
@@ -39,7 +39,7 @@ namespace Microsoft.Terminal.Settings.Model
         Profile CreateNewProfile();
         Profile FindProfile(Guid profileGuid);
         ColorScheme GetColorSchemeForProfile(Guid profileGuid);
-        void RenameColorScheme(String oldName, String newName);
+        void UpdateColorSchemeReferences(String oldName, String newName);
 
         Guid GetProfileForArgs(NewTerminalArgs newTerminalArgs);
     }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.idl
@@ -39,6 +39,7 @@ namespace Microsoft.Terminal.Settings.Model
         Profile CreateNewProfile();
         Profile FindProfile(Guid profileGuid);
         ColorScheme GetColorSchemeForProfile(Guid profileGuid);
+        void RenameColorScheme(String oldName, String newName);
 
         Guid GetProfileForArgs(NewTerminalArgs newTerminalArgs);
     }


### PR DESCRIPTION
## Summary of the Pull Request
This fixes a bug where renaming/deleting a color scheme would not update profiles that referenced it.

This also adds detection for renaming a color scheme to a name that is already in use, and adds appropriate UI for that.

## References
#6800 - Settings UI Epic

## PR Checklist
* [X] Closes #8756 

## Detailed Description of the Pull Request / Additional comments
`Model::CascadiaSettings` was updated to have a `UpdateColorSchemeReferences()` function that updates all profiles referencing the newly renamed color scheme.

`Editor::ColorSchemesPageNavigationState` now takes and exposes a `Model::CascadiaSettings`.

When a color scheme is renamed or deleted, we use `CascadiaSettings` to update our list of color schemes appropriately, then call `UpdateColorSchemeReferences()` to update the profiles.

The tricky part is that `Profile` does not store a direct reference to `ColorScheme`, but rather the name of the color scheme. See [this tread](https://github.com/microsoft/terminal/issues/8756#issuecomment-760375027) for a discussion on this topic.

## Validation Steps Performed
Repro steps from #8756 when renaming/deleting a referenced color scheme.

## Demo
![Scheme Name Already In Use Demo](https://user-images.githubusercontent.com/11050425/105431427-6e023980-5c0a-11eb-894a-42152fc77f05.gif)
