### PR TITLE
Teach tab tool tips to show key bindings

### DIFF
--- a/src/cascadia/TerminalApp/TabBase.cpp
+++ b/src/cascadia/TerminalApp/TabBase.cpp
@@ -138,10 +138,63 @@ namespace winrt::TerminalApp::implementation
         TabViewIndex(idx);
         TabViewNumTabs(numTabs);
         _EnableCloseMenuItems();
+        _UpdateSwitchToTabKeyChord();
     }
 
     void TabBase::SetDispatch(const winrt::TerminalApp::ShortcutActionDispatch& dispatch)
     {
         _dispatch = dispatch;
+    }
+
+    void TabBase::SetKeyMap(const Microsoft::Terminal::Settings::Model::KeyMapping& keymap)
+    {
+        _keymap = keymap;
+        _UpdateSwitchToTabKeyChord();
+    }
+
+    // Method Description:
+    // - Sets the key chord resulting in switch to the current tab.
+    // Updates tool tip if required
+    // Arguments:
+    // - keyChord - string representation of the key chord that switches to the current tab
+    // Return Value:
+    // - <none>
+    winrt::fire_and_forget TabBase::_UpdateSwitchToTabKeyChord()
+    {
+        SwitchToTabArgs args{ _TabViewIndex };
+        ActionAndArgs switchToTab{ ShortcutAction::SwitchToTab, args };
+        const auto keyChord = _keymap ? _keymap.GetKeyBindingForActionWithArgs(switchToTab) : nullptr;
+        const auto keyChordText = keyChord ? KeyChordSerialization::ToString(keyChord) : L"";
+
+        if (_keyChord == keyChordText)
+        {
+            return;
+        }
+
+        _keyChord = keyChordText;
+
+        auto weakThis{ get_weak() };
+
+        co_await winrt::resume_foreground(TabViewItem().Dispatcher());
+
+        if (auto tab{ weakThis.get() })
+        {
+            _UpdateToolTip();
+        }
+    }
+
+    // Method Description:
+    // - Sets tab tool tip to a concatenation of title and key chord
+    // Arguments:
+    // - <none>
+    // Return Value:
+    // - <none>
+    void TabBase::_UpdateToolTip()
+    {
+        const auto toolTipText = _keyChord.empty() ? _Title : winrt::hstring(fmt::format(L"{}({})", _Title, _keyChord));
+
+        WUX::Controls::ToolTip toolTip{};
+        toolTip.Content(winrt::box_value(toolTipText));
+        WUX::Controls::ToolTipService::SetToolTip(TabViewItem(), toolTip);
     }
 }

--- a/src/cascadia/TerminalApp/TabBase.cpp
+++ b/src/cascadia/TerminalApp/TabBase.cpp
@@ -191,10 +191,24 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     void TabBase::_UpdateToolTip()
     {
-        const auto toolTipText = _keyChord.empty() ? _Title : winrt::hstring(fmt::format(L"{}({})", _Title, _keyChord));
+        auto titleRun = WUX::Documents::Run();
+        titleRun.Text(_Title);
+
+        auto textBlock = WUX::Controls::TextBlock{};
+        textBlock.TextAlignment(WUX::TextAlignment::Center);
+        textBlock.Inlines().Append(titleRun);
+
+        if (!_keyChord.empty())
+        {
+            auto keyChordRun = WUX::Documents::Run();
+            keyChordRun.Text(_keyChord);
+            keyChordRun.FontStyle(winrt::Windows::UI::Text::FontStyle::Italic);
+            textBlock.Inlines().Append(WUX::Documents::LineBreak{});
+            textBlock.Inlines().Append(keyChordRun);
+        }
 
         WUX::Controls::ToolTip toolTip{};
-        toolTip.Content(winrt::box_value(toolTipText));
+        toolTip.Content(textBlock);
         WUX::Controls::ToolTipService::SetToolTip(TabViewItem(), toolTip);
     }
 }

--- a/src/cascadia/TerminalApp/TabBase.h
+++ b/src/cascadia/TerminalApp/TabBase.h
@@ -23,6 +23,7 @@ namespace winrt::TerminalApp::implementation
         void SetDispatch(const winrt::TerminalApp::ShortcutActionDispatch& dispatch);
 
         void UpdateTabViewIndex(const uint32_t idx, const uint32_t numTabs);
+        void SetKeyMap(const Microsoft::Terminal::Settings::Model::KeyMapping& keymap);
 
         WINRT_CALLBACK(Closed, winrt::Windows::Foundation::EventHandler<winrt::Windows::Foundation::IInspectable>);
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
@@ -43,12 +44,16 @@ namespace winrt::TerminalApp::implementation
         winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _closeOtherTabsMenuItem{};
         winrt::Windows::UI::Xaml::Controls::MenuFlyoutItem _closeTabsAfterMenuItem{};
         winrt::TerminalApp::ShortcutActionDispatch _dispatch;
+        Microsoft::Terminal::Settings::Model::KeyMapping _keymap{ nullptr };
+        winrt::hstring _keyChord{};
 
         virtual void _CreateContextMenu();
         winrt::Windows::UI::Xaml::Controls::MenuFlyoutSubItem _CreateCloseSubMenu();
         void _EnableCloseMenuItems();
         void _CloseTabsAfter();
         void _CloseOtherTabs();
+        winrt::fire_and_forget _UpdateSwitchToTabKeyChord();
+        void _UpdateToolTip();
 
         friend class ::TerminalAppLocalTests::TabTests;
     };

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -749,6 +749,7 @@ namespace winrt::TerminalApp::implementation
         _mruTabs.Append(*newTabImpl);
 
         newTabImpl->SetDispatch(*_actionDispatch);
+        newTabImpl->SetKeyMap(_settings.KeyMap());
 
         // Give the tab its index in the _tabs vector so it can manage its own SwitchToTab command.
         _UpdateTabIndices();
@@ -2341,6 +2342,9 @@ namespace winrt::TerminalApp::implementation
             {
                 settingsTab.UpdateSettings(_settings);
             }
+
+            auto tabImpl{ winrt::get_self<TabBase>(tab) };
+            tabImpl->SetKeyMap(_settings.KeyMap());
         }
 
         auto weakThis{ get_weak() };
@@ -2827,6 +2831,7 @@ namespace winrt::TerminalApp::implementation
             _mruTabs.Append(*newTabImpl);
 
             newTabImpl->SetDispatch(*_actionDispatch);
+            newTabImpl->SetKeyMap(_settings.KeyMap());
 
             // Give the tab its index in the _tabs vector so it can manage its own SwitchToTab command.
             _UpdateTabIndices();

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -98,13 +98,6 @@ namespace winrt::TerminalApp::implementation
         }
     }
 
-    void TerminalTab::_SetToolTip(const winrt::hstring& tabTitle)
-    {
-        WUX::Controls::ToolTip toolTip{};
-        toolTip.Content(winrt::box_value(tabTitle));
-        WUX::Controls::ToolTipService::SetToolTip(TabViewItem(), toolTip);
-    }
-
     // Method Description:
     // - Returns nullptr if no children of this tab were the last control to be
     //   focused, or the TermControl that _was_ the last control to be focused (if
@@ -299,7 +292,7 @@ namespace winrt::TerminalApp::implementation
 
             // Update the control to reflect the changed title
             _headerControl.Title(activeTitle);
-            _SetToolTip(activeTitle);
+            _UpdateToolTip();
         }
     }
 

--- a/src/cascadia/TerminalApp/TerminalTab.h
+++ b/src/cascadia/TerminalApp/TerminalTab.h
@@ -106,7 +106,6 @@ namespace winrt::TerminalApp::implementation
         void _MakeTabViewItem();
 
         winrt::fire_and_forget _UpdateHeaderControlMaxWidth();
-        void _SetToolTip(const winrt::hstring& tabTitle);
 
         void _CreateContextMenu() override;
 


### PR DESCRIPTION
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes https://github.com/microsoft/terminal/issues/2886
* [x] CLA signed. 
* [ ] Tests added/passed
* [ ] Documentation updated. 
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. 

## Detailed Description of the Pull Request / Additional comments
Currently the tab tool tip is the tab's title.
The PR teaches the TabBase to check if there is a switch to tab command 
associated with the current tab index,
if so concatenates the the relevant mapping to the too tip.

Of course, prefers user defined bindings to the default ones.

Moved tool tip logic to TabBase so SettingsTab has tooltip as well.

![TabToolTip](https://user-images.githubusercontent.com/4639110/104823154-a1cb1100-5850-11eb-9dbd-bf23f5e6979d.gif)

