### PR TITLE
Fix #8695: til::spsc assignment operators don't return anything

### DIFF
--- a/src/inc/til/spsc.h
+++ b/src/inc/til/spsc.h
@@ -425,6 +425,7 @@ namespace til::spsc
         {
             drop();
             _arc = std::exchange(other._arc, nullptr);
+            return *this;
         }
 
         ~producer()
@@ -543,6 +544,7 @@ namespace til::spsc
         {
             drop();
             _arc = std::exchange(other._arc, nullptr);
+            return *this;
         }
 
         ~consumer()


### PR DESCRIPTION
The following code didn't previously work as the assignment operators
didn't return a self reference:

```cpp
auto channel = til::spsc::channel<QueueItem>(100);
auto producer = std::move(channel.first);
channel.first = std::move(producer);
```

## Validation Steps Performed

I've added a basic smoke test for `til::spsc`.

Closes #8695