### PR TITLE
Cleanup NuGet.Config file.

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,6 +2,8 @@
 <configuration>
     <packageSources>
         <clear />
+        <!-- Dependencies that we can turn on to force override for testing purposes before uploading. -->
+        <!--<add key="Static Package Dependencies" value="dep\packages" />-->
         <add key="TerminalDependencies" value="https://pkgs.dev.azure.com/ms/terminal/_packaging/TerminalDependencies/nuget/v3/index.json" />
     </packageSources>
     <disabledPackageSources>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,24 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <packageSources>
-        <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
-        <!-- Add repositories here to the list of available repositories -->
-        
-        <!-- Dependencies that we must carry because they're not on public nuget feeds right now. -->
-        <!--<add key="Static Package Dependencies" value="dep\packages" />-->
-        
-        <!-- Use our own NuGet Feed -->
+        <clear />
         <add key="TerminalDependencies" value="https://pkgs.dev.azure.com/ms/terminal/_packaging/TerminalDependencies/nuget/v3/index.json" />
-		
-		<!-- Temporarily? use the feeds from our friends in MUX for Helix test stuff -->
-		<add key="dotnetfeed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
-        <add key="dnceng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
-        <add key="MUX-Dependencies" value="https://pkgs.dev.azure.com/ms/microsoft-ui-xaml/_packaging/MUX-Dependencies/nuget/v3/index.json" />
-        
-        <!-- Internal NuGet feeds that may not be accessible outside Microsoft corporate network -->
-        <!--<add key="TAEF - internal" value="https://microsoft.pkgs.visualstudio.com/DefaultCollection/_packaging/Taef/nuget/v3/index.json" />
-        <add key="OpenConsole - Internal" value="https://microsoft.pkgs.visualstudio.com/_packaging/OpenConsole/nuget/v3/index.json" />-->
     </packageSources>
+    <disabledPackageSources>
+        <clear />
+    </disabledPackageSources>
     <config>
         <add key="repositorypath" value=".\packages" />
     </config>


### PR DESCRIPTION
Cleans up a ton of competing and outdated sources from our NuGet.Config to improve reliability and maintainability.

## PR Checklist
* [x] Closes an overdue-to-clean mess.
* [x] I work here.
* [x] Tests covered below.
* [x] I've discussed this with @DHowett already.

## Validation Steps Performed
- [x] - NuGet restored everything I could get my hands on (all `packages.config`) in our project before and after the change.
- [x] - The build and tests still run fine. (PR automation should check this one)
