### PR TITLE
Include UWP styling guidance in settings UI

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -65,8 +65,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             <StackPanel Orientation="Horizontal"
                         Grid.Row="0"
                         Grid.Column="0"
-                        Grid.ColumnSpan="2"
-                        Margin="{StaticResource StandardControlSpacing}">
+                        Grid.ColumnSpan="2">
 
                 <StackPanel Orientation="Horizontal"
                             Visibility="{x:Bind IsRenaming, Converter={StaticResource InvertedBooleanToVisibilityConverter}, Mode=OneWay}">
@@ -89,7 +88,11 @@ the MIT License. See LICENSE in the project root for license information. -->
                             Style="{StaticResource BrowseButtonStyle}"
                             Click="Rename_Click"
                             IsEnabled="{x:Bind CanDeleteCurrentScheme, Mode=OneWay}">
-                        <FontIcon Glyph="&#xE8AC;"/>
+                        <StackPanel Orientation="Horizontal">
+                            <FontIcon Glyph="&#xE8AC;"
+                                      FontSize="{StaticResource StandardIconSize}"/>
+                            <TextBlock/>
+                        </StackPanel>
                     </Button>
                 </StackPanel>
 
@@ -101,12 +104,20 @@ the MIT License. See LICENSE in the project root for license information. -->
                     <Button x:Uid="RenameAccept"
                             Style="{StaticResource AccentBrowseButtonStyle}"
                             Click="RenameAccept_Click">
-                        <FontIcon Glyph="&#xE8FB;"/>
+                        <StackPanel Orientation="Horizontal">
+                            <FontIcon Glyph="&#xE8FB;"
+                                      FontSize="{StaticResource StandardIconSize}"/>
+                            <TextBlock/>
+                        </StackPanel>
                     </Button>
                     <Button x:Uid="RenameCancel"
                             Style="{StaticResource BrowseButtonStyle}"
                             Click="RenameCancel_Click">
-                        <FontIcon Glyph="&#xE711;"/>
+                        <StackPanel Orientation="Horizontal">
+                            <FontIcon Glyph="&#xE711;"
+                                      FontSize="{StaticResource StandardIconSize}"/>
+                            <TextBlock/>
+                        </StackPanel>
                     </Button>
                 </StackPanel>
 
@@ -115,10 +126,9 @@ the MIT License. See LICENSE in the project root for license information. -->
                         Style="{StaticResource BrowseButtonStyle}">
                     <StackPanel Orientation="Horizontal">
                         <FontIcon Glyph="&#xE710;"
-                                  FontSize="15"/>
+                                  FontSize="{StaticResource StandardIconSize}"/>
                         <TextBlock x:Uid="ColorScheme_AddNewButton"
-                                   Margin="10,0,0,0"
-                                   FontSize="15"/>
+                                   Style="{StaticResource IconButtonTextBlockStyle}"/>
                     </StackPanel>
                 </Button>
             </StackPanel>
@@ -127,7 +137,8 @@ the MIT License. See LICENSE in the project root for license information. -->
             <ItemsControl x:Name="ColorTableControl"
                           ItemsSource="{x:Bind CurrentColorTable, Mode=OneWay}"
                           Grid.Row="1"
-                          Grid.Column="0">
+                          Grid.Column="0"
+                          Style="{StaticResource ItemsControlStyle}">
 
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
@@ -173,7 +184,8 @@ the MIT License. See LICENSE in the project root for license information. -->
 
             <!-- Additional Colors (Right Column) -->
             <ItemsControl Grid.Row="1"
-                          Grid.Column="1">
+                          Grid.Column="1"
+                          Style="{StaticResource ItemsControlStyle}">
                 <StackPanel Style="{StaticResource ColorStackPanelStyle}">
                     <TextBlock x:Uid="ColorScheme_Foreground"
                                Style="{StaticResource ColorHeaderStyle}"/>
@@ -295,11 +307,10 @@ the MIT License. See LICENSE in the project root for license information. -->
             <StackPanel Grid.Row="2"
                         Grid.Column="0"
                         Grid.ColumnSpan="2"
-                        Margin="{StaticResource StandardControlSpacing}">
+                        Style="{StaticResource PivotStackStyle}">
                 <Button x:Name="DeleteButton"
                         Style="{StaticResource BaseButtonStyle}"
-                        IsEnabled="{x:Bind CanDeleteCurrentScheme, Mode=OneWay}"
-                        Margin="0,0,0,10">
+                        IsEnabled="{x:Bind CanDeleteCurrentScheme, Mode=OneWay}">
                     <Button.Resources>
                         <ResourceDictionary>
                             <ResourceDictionary.ThemeDictionaries>
@@ -332,11 +343,9 @@ the MIT License. See LICENSE in the project root for license information. -->
                     </Button.Resources>
                     <Button.Content>
                         <StackPanel Orientation="Horizontal">
-                            <FontIcon Glyph="&#xE74D;"
-                                      FontSize="{StaticResource StandardFontSize}"/>
+                            <FontIcon Glyph="&#xE74D;"/>
                             <TextBlock x:Uid="ColorScheme_DeleteButton"
-                                       FontSize="{StaticResource StandardFontSize}"
-                                       Margin="10,0,0,0"/>
+                                       Style="{StaticResource IconButtonTextBlockStyle}"/>
                         </StackPanel>
                     </Button.Content>
                     <Button.Flyout>

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -24,7 +24,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             </Style>
 
             <Style x:Key="ColorHeaderStyle" TargetType="TextBlock">
-                <Setter Property="Margin" Value="0,0,0,4"/>
+                <Setter Property="Margin" Value="0,0,0,5"/>
             </Style>
 
             <Style TargetType="Button">
@@ -85,13 +85,12 @@ the MIT License. See LICENSE in the project root for license information. -->
                     <!--Rename Button-->
                     <!--Bind IsEnabled to prevent a the color scheme from returning from the dead-->
                     <Button x:Uid="Rename"
-                            Style="{StaticResource BrowseButtonStyle}"
+                            Style="{StaticResource SmallButtonStyle}"
                             Click="Rename_Click"
                             IsEnabled="{x:Bind CanDeleteCurrentScheme, Mode=OneWay}">
                         <StackPanel Orientation="Horizontal">
                             <FontIcon Glyph="&#xE8AC;"
                                       FontSize="{StaticResource StandardIconSize}"/>
-                            <TextBlock/>
                         </StackPanel>
                     </Button>
                 </StackPanel>
@@ -102,21 +101,19 @@ the MIT License. See LICENSE in the project root for license information. -->
                              Style="{StaticResource TextBoxSettingStyle}"
                              PreviewKeyDown="NameBox_PreviewKeyDown"/>
                     <Button x:Uid="RenameAccept"
-                            Style="{StaticResource AccentBrowseButtonStyle}"
+                            Style="{StaticResource AccentSmallButtonStyle}"
                             Click="RenameAccept_Click">
                         <StackPanel Orientation="Horizontal">
                             <FontIcon Glyph="&#xE8FB;"
                                       FontSize="{StaticResource StandardIconSize}"/>
-                            <TextBlock/>
                         </StackPanel>
                     </Button>
                     <Button x:Uid="RenameCancel"
-                            Style="{StaticResource BrowseButtonStyle}"
+                            Style="{StaticResource SmallButtonStyle}"
                             Click="RenameCancel_Click">
                         <StackPanel Orientation="Horizontal">
                             <FontIcon Glyph="&#xE711;"
                                       FontSize="{StaticResource StandardIconSize}"/>
-                            <TextBlock/>
                         </StackPanel>
                     </Button>
                 </StackPanel>

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -307,7 +307,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                         Style="{StaticResource PivotStackStyle}">
                 <Button x:Name="DeleteButton"
                         IsEnabled="{x:Bind CanDeleteCurrentScheme, Mode=OneWay}"
-                        Style="{StaticResource BaseButtonStyle}">
+                        Style="{StaticResource BaseButtonStyle}"
+                        Margin="0,0,0,10">
                     <Button.Resources>
                         <ResourceDictionary>
                             <ResourceDictionary.ThemeDictionaries>

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -27,7 +27,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <Setter Property="Margin" Value="0,0,0,4"/>
             </Style>
 
-            <Style TargetType="Button" BasedOn="{StaticResource BaseButtonStyle}">
+            <Style TargetType="Button">
                 <Setter Property="BorderBrush" Value="{StaticResource SystemBaseLowColor}"/>
                 <Setter Property="Height" Value="30"/>
                 <Setter Property="Width" Value="100"/>
@@ -309,8 +309,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                         Grid.ColumnSpan="2"
                         Style="{StaticResource PivotStackStyle}">
                 <Button x:Name="DeleteButton"
-                        Style="{StaticResource BaseButtonStyle}"
-                        IsEnabled="{x:Bind CanDeleteCurrentScheme, Mode=OneWay}">
+                        IsEnabled="{x:Bind CanDeleteCurrentScheme, Mode=OneWay}"
+                        Style="{StaticResource BaseButtonStyle}">
                     <Button.Resources>
                         <ResourceDictionary>
                             <ResourceDictionary.ThemeDictionaries>
@@ -353,8 +353,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                             <StackPanel>
                                 <TextBlock x:Uid="ColorScheme_DeleteConfirmationMessage"
                                            Style="{StaticResource CustomFlyoutTextStyle}"/>
-                                <Button x:Uid="ColorScheme_DeleteConfirmationButton"
-                                        Style="{StaticResource BaseButtonStyle}"
+                                <Button x:Uid="ColorScheme_DeleteConfirmationButton"   
                                         Click="DeleteConfirmation_Click"/>
                             </StackPanel>
                         </Flyout>

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -307,8 +307,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                         Style="{StaticResource PivotStackStyle}">
                 <Button x:Name="DeleteButton"
                         IsEnabled="{x:Bind CanDeleteCurrentScheme, Mode=OneWay}"
-                        Style="{StaticResource BaseButtonStyle}"
-                        Margin="0,0,0,10">
+                        Style="{StaticResource DeleteButtonStyle}">
                     <Button.Resources>
                         <ResourceDictionary>
                             <ResourceDictionary.ThemeDictionaries>

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -27,7 +27,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <Setter Property="Margin" Value="0,0,0,5"/>
             </Style>
 
-            <Style TargetType="Button">
+            <Style TargetType="Button" BasedOn="{StaticResource BaseButtonStyle}">
                 <Setter Property="BorderBrush" Value="{StaticResource SystemBaseLowColor}"/>
                 <Setter Property="Height" Value="30"/>
                 <Setter Property="Width" Value="100"/>

--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -45,6 +45,11 @@
         <Setter Property="ToolTipService.Placement" Value="Mouse"/>
     </Style>
 
+    <!--Toggle Switch-->
+    <Style x:Key="ToggleSwitchSettingStyle" TargetType="ToggleSwitch" BasedOn="{StaticResource DefaultToggleSwitchStyle}">
+        <Setter Property="ToolTipService.Placement" Value="Mouse"/>
+    </Style>
+
     <!--Combo Box-->
     <Style x:Key="ComboBoxSettingStyle" TargetType="ComboBox" BasedOn="{StaticResource DefaultComboBoxStyle}">
         <Setter Property="ToolTipService.Placement" Value="Mouse"/>

--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -103,6 +103,7 @@
         <Setter Property="Width" Value="35"/>
         <Setter Property="HorizontalAlignment" Value="Left"/>
         <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="Margin" Value="5,0,0,0"/>
     </Style>
 
     <Style x:Key="SliderHeaderStyle" TargetType="TextBlock" BasedOn="{StaticResource CustomSettingHeaderStyle}">
@@ -110,7 +111,7 @@
     </Style>
 
     <Style x:Key="CustomSliderControlGridStyle" TargetType="Grid">
-        <Setter Property="Width" Value="300"/>
+        <Setter Property="Width" Value="{StaticResource StandardBoxMinWidth}"/>
         <Setter Property="HorizontalAlignment" Value="Left"/>
     </Style>
 </ResourceDictionary>

--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -88,7 +88,6 @@
     <!--Slider-Related Styling-->
     <Style x:Key="SliderValueLabelStyle" TargetType="TextBlock">
         <Setter Property="Width" Value="35"/>
-        <Setter Property="Margin" Value="10,0,0,20"/>
         <Setter Property="HorizontalAlignment" Value="Left"/>
         <Setter Property="VerticalAlignment" Value="Center"/>
     </Style>

--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -77,6 +77,10 @@
         <Setter Property="Height" Value="33"/>
     </Style>
 
+    <Style x:Key="DeleteButtonStyle" TargetType="Button" BasedOn="{StaticResource BaseButtonStyle}">
+        <Setter Property="Margin" Value="0,0,0,10"/>
+    </Style>
+
     <Style x:Key="SmallButtonStyle" TargetType="Button" BasedOn="{StaticResource BrowseButtonStyle}">
         <Setter Property="Height" Value="33"/>
         <Setter Property="Width" Value="33"/>

--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -3,53 +3,56 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls">
 
-    <x:Double x:Key="StandardFontSize">15.0</x:Double>
-    <Thickness x:Key="StandardIndentMargin">20,0,0,0</Thickness>
-    <Thickness x:Key="StandardControlSpacing">0,0,0,20</Thickness>
+    <x:Double x:Key="StandardIconSize">14.0</x:Double>
+    <Thickness x:Key="StandardIndentMargin">13,0,0,0</Thickness>
     <x:Double x:Key="StandardBoxMinWidth">250</x:Double>
-    
-    <Thickness x:Key="PivotIndentMargin">10,0,0,0</Thickness>
-    <Thickness x:Key="PivotStackPanelMargin">0,10,0,0</Thickness>
 
     <!-- This is for easier transition to the SettingsContainer control.
          The SettingsContainer will wrap a setting with inheritance UI.-->
     <Style x:Key="SettingContainerStyle" TargetType="ContentPresenter">
-        <Setter Property="Padding" Value="{StaticResource StandardControlSpacing}"/>
+        <Setter Property="Margin" Value="0,24,0,0"/>
+    </Style>
+
+    <!-- This is for styling the entire items control used on the
+         color schemes page-->
+    <Style x:Key="ItemsControlStyle" TargetType="ItemsControl">
+        <Setter Property="Margin" Value="0,24,0,0"/>
     </Style>
 
     <!--Used to stack a group of settings-->
     <Style x:Key="SettingsStackStyle" TargetType="StackPanel">
         <Setter Property="HorizontalAlignment" Value="Left"/>
-        <Setter Property="Margin" Value="{StaticResource StandardIndentMargin}"/>
+        <Setter Property="Margin" Value="13,0,0,48"/>
+    </Style>
+
+    <!--Used to stack a group of settings inside a pivot-->
+    <Style x:Key="PivotStackStyle" TargetType="StackPanel">
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="Margin" Value="0,0,0,48"/>
     </Style>
 
     <!--Radio Button-->
     <Style x:Key="RadioButtonsSettingStyle" TargetType="muxc:RadioButtons">
-        <Setter Property="FontSize" Value="{StaticResource StandardFontSize}"/>
         <Setter Property="ToolTipService.Placement" Value="Mouse"/>
     </Style>
 
     <Style x:Key="RadioButtonSettingStyle" TargetType="RadioButton" BasedOn="{StaticResource DefaultRadioButtonStyle}">
-        <Setter Property="FontSize" Value="{StaticResource StandardFontSize}"/>
         <Setter Property="ToolTipService.Placement" Value="Mouse"/>
     </Style>
 
     <!--Check Box-->
     <Style x:Key="CheckBoxSettingStyle" TargetType="CheckBox" BasedOn="{StaticResource DefaultCheckBoxStyle}">
-        <Setter Property="FontSize" Value="{StaticResource StandardFontSize}"/>
         <Setter Property="ToolTipService.Placement" Value="Mouse"/>
     </Style>
 
     <!--Combo Box-->
     <Style x:Key="ComboBoxSettingStyle" TargetType="ComboBox" BasedOn="{StaticResource DefaultComboBoxStyle}">
-        <Setter Property="FontSize" Value="{StaticResource StandardFontSize}"/>
         <Setter Property="ToolTipService.Placement" Value="Mouse"/>
         <Setter Property="MinWidth" Value="{StaticResource StandardBoxMinWidth}"/>
     </Style>
 
     <!--Text Box-->
     <Style x:Key="TextBoxSettingStyle" TargetType="TextBox" BasedOn="{StaticResource DefaultTextBoxStyle}">
-        <Setter Property="FontSize" Value="{StaticResource StandardFontSize}"/>
         <Setter Property="ToolTipService.Placement" Value="Mouse"/>
         <Setter Property="Width" Value="{StaticResource StandardBoxMinWidth}"/>
         <Setter Property="HorizontalAlignment" Value="Left"/>
@@ -58,32 +61,23 @@
 
     <!--Used to create a header for a control-->
     <Style x:Key="CustomSettingHeaderStyle" TargetType="TextBlock">
-        <Setter Property="FontSize" Value="{StaticResource StandardFontSize}"/>
         <Setter Property="Margin" Value="0,0,0,4"/>
-    </Style>
-
-    <!-- Used to create a header for a group of settings -->
-    <Style x:Key="GroupingHeader" TargetType="TextBlock" BasedOn="{StaticResource SubtitleTextBlockStyle}">
-        <Setter Property="Margin" Value="0,20,0,10"/>
     </Style>
 
     <!--Used for disclaimers-->
     <Style x:Key="DisclaimerStyle" TargetType="TextBlock">
-        <Setter Property="FontSize" Value="{StaticResource StandardFontSize}"/>
         <Setter Property="FontStyle" Value="Italic"/>
         <Setter Property="TextWrapping" Value="WrapWholeWords"/>
     </Style>
 
     <!--Used for flyout messages-->
     <Style x:Key="CustomFlyoutTextStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
-        <Setter Property="FontSize" Value="{StaticResource StandardFontSize}"/>
         <Setter Property="FontWeight" Value="Bold"/>
         <Setter Property="Margin" Value="0,0,0,12"/>
     </Style>
 
     <!--Number Box-->
     <Style x:Key="NumberBoxSettingStyle" TargetType="muxc:NumberBox">
-        <Setter Property="FontSize" Value="{StaticResource StandardFontSize}"/>
         <Setter Property="ToolTipService.Placement" Value="Mouse"/>
         <Setter Property="SpinButtonPlacementMode" Value="Compact"/>
         <Setter Property="HorizontalAlignment" Value="Left"/>
@@ -91,7 +85,6 @@
 
     <!--Button-Related Styling-->
     <Style x:Key="BaseButtonStyle" TargetType="Button" BasedOn="{StaticResource DefaultButtonStyle}">
-        <Setter Property="FontSize" Value="{StaticResource StandardFontSize}"/>
         <Setter Property="ToolTipService.Placement" Value="Mouse"/>
     </Style>
 
@@ -101,22 +94,23 @@
     </Style>
 
     <Style x:Key="AccentBrowseButtonStyle" TargetType="Button" BasedOn="{StaticResource AccentButtonStyle}">
-        <Setter Property="FontSize" Value="{StaticResource StandardFontSize}"/>
         <Setter Property="ToolTipService.Placement" Value="Mouse"/>
         <Setter Property="Margin" Value="10,0,0,0"/>
         <Setter Property="VerticalAlignment" Value="Bottom"/>
     </Style>
 
+    <Style x:Key="IconButtonTextBlockStyle" TargetType="TextBlock">
+        <Setter Property="Margin" Value="10,0,0,0"/>
+    </Style>
+
     <!--Slider-Related Styling-->
     <Style x:Key="SliderSettingStyle" TargetType="Slider" BasedOn="{StaticResource DefaultSliderStyle}">
-        <Setter Property="FontSize" Value="{StaticResource StandardFontSize}"/>
         <Setter Property="ToolTipService.Placement" Value="Mouse"/>
     </Style>
 
     <Style x:Key="SliderValueLabelStyle" TargetType="TextBlock">
         <Setter Property="Width" Value="35"/>
         <Setter Property="Margin" Value="10,0,0,20"/>
-        <Setter Property="FontSize" Value="15"/>
         <Setter Property="HorizontalAlignment" Value="Left"/>
         <Setter Property="VerticalAlignment" Value="Center"/>
         <Setter Property="ToolTipService.Placement" Value="Mouse"/>

--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -5,18 +5,19 @@
 
     <x:Double x:Key="StandardIconSize">14.0</x:Double>
     <Thickness x:Key="StandardIndentMargin">13,0,0,0</Thickness>
+    <Thickness x:Key="StandardControlMargin">0,24,0,0</Thickness>
     <x:Double x:Key="StandardBoxMinWidth">250</x:Double>
 
     <!-- This is for easier transition to the SettingsContainer control.
          The SettingsContainer will wrap a setting with inheritance UI.-->
     <Style x:Key="SettingContainerStyle" TargetType="ContentPresenter">
-        <Setter Property="Margin" Value="0,24,0,0"/>
+        <Setter Property="Margin" Value="{StaticResource StandardControlMargin}"/>
     </Style>
 
     <!-- This is for styling the entire items control used on the
          color schemes page-->
     <Style x:Key="ItemsControlStyle" TargetType="ItemsControl">
-        <Setter Property="Margin" Value="0,24,0,0"/>
+        <Setter Property="Margin" Value="{StaticResource StandardControlMargin}"/>
     </Style>
 
     <!--Used to stack a group of settings-->
@@ -31,34 +32,13 @@
         <Setter Property="Margin" Value="0,0,0,48"/>
     </Style>
 
-    <!--Radio Button-->
-    <Style x:Key="RadioButtonsSettingStyle" TargetType="muxc:RadioButtons">
-        <Setter Property="ToolTipService.Placement" Value="Mouse"/>
-    </Style>
-
-    <Style x:Key="RadioButtonSettingStyle" TargetType="RadioButton" BasedOn="{StaticResource DefaultRadioButtonStyle}">
-        <Setter Property="ToolTipService.Placement" Value="Mouse"/>
-    </Style>
-
-    <!--Check Box-->
-    <Style x:Key="CheckBoxSettingStyle" TargetType="CheckBox" BasedOn="{StaticResource DefaultCheckBoxStyle}">
-        <Setter Property="ToolTipService.Placement" Value="Mouse"/>
-    </Style>
-
-    <!--Toggle Switch-->
-    <Style x:Key="ToggleSwitchSettingStyle" TargetType="ToggleSwitch" BasedOn="{StaticResource DefaultToggleSwitchStyle}">
-        <Setter Property="ToolTipService.Placement" Value="Mouse"/>
-    </Style>
-
     <!--Combo Box-->
     <Style x:Key="ComboBoxSettingStyle" TargetType="ComboBox" BasedOn="{StaticResource DefaultComboBoxStyle}">
-        <Setter Property="ToolTipService.Placement" Value="Mouse"/>
         <Setter Property="MinWidth" Value="{StaticResource StandardBoxMinWidth}"/>
     </Style>
 
     <!--Text Box-->
     <Style x:Key="TextBoxSettingStyle" TargetType="TextBox" BasedOn="{StaticResource DefaultTextBoxStyle}">
-        <Setter Property="ToolTipService.Placement" Value="Mouse"/>
         <Setter Property="Width" Value="{StaticResource StandardBoxMinWidth}"/>
         <Setter Property="HorizontalAlignment" Value="Left"/>
         <Setter Property="TextWrapping" Value="Wrap"/>
@@ -83,23 +63,20 @@
 
     <!--Number Box-->
     <Style x:Key="NumberBoxSettingStyle" TargetType="muxc:NumberBox">
-        <Setter Property="ToolTipService.Placement" Value="Mouse"/>
         <Setter Property="SpinButtonPlacementMode" Value="Compact"/>
         <Setter Property="HorizontalAlignment" Value="Left"/>
     </Style>
 
     <!--Button-Related Styling-->
     <Style x:Key="BaseButtonStyle" TargetType="Button" BasedOn="{StaticResource DefaultButtonStyle}">
-        <Setter Property="ToolTipService.Placement" Value="Mouse"/>
+        <Setter Property="VerticalAlignment" Value="Bottom"/>
     </Style>
 
     <Style x:Key="BrowseButtonStyle" TargetType="Button" BasedOn="{StaticResource BaseButtonStyle}">
         <Setter Property="Margin" Value="10,0,0,0"/>
-        <Setter Property="VerticalAlignment" Value="Bottom"/>
     </Style>
 
     <Style x:Key="AccentBrowseButtonStyle" TargetType="Button" BasedOn="{StaticResource AccentButtonStyle}">
-        <Setter Property="ToolTipService.Placement" Value="Mouse"/>
         <Setter Property="Margin" Value="10,0,0,0"/>
         <Setter Property="VerticalAlignment" Value="Bottom"/>
     </Style>
@@ -109,21 +86,15 @@
     </Style>
 
     <!--Slider-Related Styling-->
-    <Style x:Key="SliderSettingStyle" TargetType="Slider" BasedOn="{StaticResource DefaultSliderStyle}">
-        <Setter Property="ToolTipService.Placement" Value="Mouse"/>
-    </Style>
-
     <Style x:Key="SliderValueLabelStyle" TargetType="TextBlock">
         <Setter Property="Width" Value="35"/>
         <Setter Property="Margin" Value="10,0,0,20"/>
         <Setter Property="HorizontalAlignment" Value="Left"/>
         <Setter Property="VerticalAlignment" Value="Center"/>
-        <Setter Property="ToolTipService.Placement" Value="Mouse"/>
     </Style>
 
     <Style x:Key="SliderHeaderStyle" TargetType="TextBlock" BasedOn="{StaticResource CustomSettingHeaderStyle}">
         <Setter Property="HorizontalAlignment" Value="Left"/>
-        <Setter Property="ToolTipService.Placement" Value="Mouse"/>
     </Style>
 
     <Style x:Key="CustomSliderControlGridStyle" TargetType="Grid">

--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -58,7 +58,7 @@
     <!--Used for flyout messages-->
     <Style x:Key="CustomFlyoutTextStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
         <Setter Property="FontWeight" Value="Bold"/>
-        <Setter Property="Margin" Value="0,0,0,12"/>
+        <Setter Property="Margin" Value="0,0,0,10"/>
     </Style>
 
     <!--Number Box-->
@@ -74,11 +74,24 @@
 
     <Style x:Key="BrowseButtonStyle" TargetType="Button" BasedOn="{StaticResource BaseButtonStyle}">
         <Setter Property="Margin" Value="10,0,0,0"/>
+        <Setter Property="Height" Value="33"/>
+    </Style>
+
+    <Style x:Key="SmallButtonStyle" TargetType="Button" BasedOn="{StaticResource BrowseButtonStyle}">
+        <Setter Property="Height" Value="33"/>
+        <Setter Property="Width" Value="33"/>
     </Style>
 
     <Style x:Key="AccentBrowseButtonStyle" TargetType="Button" BasedOn="{StaticResource AccentButtonStyle}">
         <Setter Property="Margin" Value="10,0,0,0"/>
         <Setter Property="VerticalAlignment" Value="Bottom"/>
+    </Style>
+
+    <Style x:Key="AccentSmallButtonStyle" TargetType="Button" BasedOn="{StaticResource AccentButtonStyle}">
+        <Setter Property="Margin" Value="10,0,0,0"/>
+        <Setter Property="VerticalAlignment" Value="Bottom"/>
+        <Setter Property="Height" Value="33"/>
+        <Setter Property="Width" Value="33"/>
     </Style>
 
     <Style x:Key="IconButtonTextBlockStyle" TargetType="TextBlock">

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
@@ -17,8 +17,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             </ResourceDictionary.MergedDictionaries>
 
             <DataTemplate x:DataType="local:EnumEntry" x:Key="EnumRadioButtonTemplate">
-                <RadioButton Content="{x:Bind EnumName, Mode=OneWay}"
-                             Style="{StaticResource RadioButtonSettingStyle}"/>
+                <RadioButton Content="{x:Bind EnumName, Mode=OneWay}"/>
             </DataTemplate>
         </ResourceDictionary>
     </Page.Resources>
@@ -30,36 +29,31 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <muxc:RadioButtons x:Uid="Globals_Theme"
                                    SelectedItem="{x:Bind CurrentTheme, Mode=TwoWay}"
                                    ItemsSource="{x:Bind ThemeList, Mode=OneWay}"
-                                   ItemTemplate="{StaticResource EnumRadioButtonTemplate}"
-                                   Style="{StaticResource RadioButtonsSettingStyle}"/>
+                                   ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
             </ContentPresenter>
 
             <!--Always show tabs-->
             <ContentPresenter Style="{StaticResource SettingContainerStyle}">
                 <ToggleSwitch x:Uid="Globals_AlwaysShowTabs"
-                              IsOn="{x:Bind State.Globals.AlwaysShowTabs, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
+                              IsOn="{x:Bind State.Globals.AlwaysShowTabs, Mode=TwoWay}"/>
             </ContentPresenter>
 
             <!--Show Titlebar-->
             <ContentPresenter Style="{StaticResource SettingContainerStyle}">
                 <ToggleSwitch x:Uid="Globals_ShowTitlebar"
-                              IsOn="{x:Bind State.Globals.ShowTabsInTitlebar, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
+                              IsOn="{x:Bind State.Globals.ShowTabsInTitlebar, Mode=TwoWay}"/>
             </ContentPresenter>
 
             <!--Show Title in Titlebar-->
             <ContentPresenter Style="{StaticResource SettingContainerStyle}">
                 <ToggleSwitch x:Uid="Globals_ShowTitleInTitlebar"
-                              IsOn="{x:Bind State.Globals.ShowTitleInTitlebar, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
+                              IsOn="{x:Bind State.Globals.ShowTitleInTitlebar, Mode=TwoWay}"/>
             </ContentPresenter>
 
             <!--Always on Top-->
             <ContentPresenter Style="{StaticResource SettingContainerStyle}">
                 <ToggleSwitch x:Uid="Globals_AlwaysOnTop"
-                              IsOn="{x:Bind State.Globals.AlwaysOnTop, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
+                              IsOn="{x:Bind State.Globals.AlwaysOnTop, Mode=TwoWay}"/>
             </ContentPresenter>
 
             <!--Tab Width Mode-->
@@ -67,15 +61,13 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <muxc:RadioButtons x:Uid="Globals_TabWidthMode"
                                    SelectedItem="{x:Bind CurrentTabWidthMode, Mode=TwoWay}"
                                    ItemsSource="{x:Bind TabWidthModeList, Mode=OneWay}"
-                                   ItemTemplate="{StaticResource EnumRadioButtonTemplate}"
-                                   Style="{StaticResource RadioButtonsSettingStyle}"/>
+                                   ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
             </ContentPresenter>
 
             <!--Disable Animations-->
             <ContentPresenter Style="{StaticResource SettingContainerStyle}">
                 <ToggleSwitch x:Uid="Globals_DisableAnimations"
-                              IsOn="{x:Bind State.Globals.DisableAnimations, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
+                              IsOn="{x:Bind State.Globals.DisableAnimations, Mode=TwoWay}"/>
             </ContentPresenter>
         </StackPanel>
     </ScrollViewer>

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
@@ -25,7 +25,8 @@ the MIT License. See LICENSE in the project root for license information. -->
     <ScrollViewer>
         <StackPanel Style="{StaticResource SettingsStackStyle}">
             <!--Theme-->
-            <ContentPresenter>
+            <ContentPresenter Style="{StaticResource SettingContainerStyle}"
+                              Margin="0">
                 <muxc:RadioButtons x:Uid="Globals_Theme"
                                    SelectedItem="{x:Bind CurrentTheme, Mode=TwoWay}"
                                    ItemsSource="{x:Bind ThemeList, Mode=OneWay}"

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
@@ -36,30 +36,30 @@ the MIT License. See LICENSE in the project root for license information. -->
 
             <!--Always show tabs-->
             <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                <CheckBox x:Uid="Globals_AlwaysShowTabs"
-                          IsChecked="{x:Bind State.Globals.AlwaysShowTabs, Mode=TwoWay}"
-                          Style="{StaticResource CheckBoxSettingStyle}"/>
+                <ToggleSwitch x:Uid="Globals_AlwaysShowTabs"
+                              IsOn="{x:Bind State.Globals.AlwaysShowTabs, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
             </ContentPresenter>
 
             <!--Show Titlebar-->
             <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                <CheckBox x:Uid="Globals_ShowTitlebar"
-                          IsChecked="{x:Bind State.Globals.ShowTabsInTitlebar, Mode=TwoWay}"
-                          Style="{StaticResource CheckBoxSettingStyle}"/>
+                <ToggleSwitch x:Uid="Globals_ShowTitlebar"
+                              IsOn="{x:Bind State.Globals.ShowTabsInTitlebar, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
             </ContentPresenter>
 
             <!--Show Title in Titlebar-->
             <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                <CheckBox x:Uid="Globals_ShowTitleInTitlebar"
-                          IsChecked="{x:Bind State.Globals.ShowTitleInTitlebar, Mode=TwoWay}"
-                          Style="{StaticResource CheckBoxSettingStyle}"/>
+                <ToggleSwitch x:Uid="Globals_ShowTitleInTitlebar"
+                              IsOn="{x:Bind State.Globals.ShowTitleInTitlebar, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
             </ContentPresenter>
 
             <!--Always on Top-->
             <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                <CheckBox x:Uid="Globals_AlwaysOnTop"
-                          IsChecked="{x:Bind State.Globals.AlwaysOnTop, Mode=TwoWay}"
-                          Style="{StaticResource CheckBoxSettingStyle}"/>
+                <ToggleSwitch x:Uid="Globals_AlwaysOnTop"
+                              IsOn="{x:Bind State.Globals.AlwaysOnTop, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
             </ContentPresenter>
 
             <!--Tab Width Mode-->
@@ -73,9 +73,9 @@ the MIT License. See LICENSE in the project root for license information. -->
 
             <!--Disable Animations-->
             <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                <CheckBox x:Uid="Globals_DisableAnimations"
-                          IsChecked="{x:Bind State.Globals.DisableAnimations, Mode=TwoWay}"
-                          Style="{StaticResource CheckBoxSettingStyle}"/>
+                <ToggleSwitch x:Uid="Globals_DisableAnimations"
+                              IsOn="{x:Bind State.Globals.DisableAnimations, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
             </ContentPresenter>
         </StackPanel>
     </ScrollViewer>

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
@@ -26,7 +26,7 @@ the MIT License. See LICENSE in the project root for license information. -->
     <ScrollViewer>
         <StackPanel Style="{StaticResource SettingsStackStyle}">
             <!--Theme-->
-            <ContentPresenter Style="{StaticResource SettingContainerStyle}">
+            <ContentPresenter>
                 <muxc:RadioButtons x:Uid="Globals_Theme"
                                    SelectedItem="{x:Bind CurrentTheme, Mode=TwoWay}"
                                    ItemsSource="{x:Bind ThemeList, Mode=OneWay}"

--- a/src/cascadia/TerminalSettingsEditor/Interaction.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.xaml
@@ -25,7 +25,8 @@ the MIT License. See LICENSE in the project root for license information. -->
     <ScrollViewer>
         <StackPanel Style="{StaticResource SettingsStackStyle}">
             <!--Copy On Select-->
-            <ContentPresenter>
+            <ContentPresenter Style="{StaticResource SettingContainerStyle}"
+                              Margin="0">
                 <ToggleSwitch x:Uid="Globals_CopyOnSelect"
                               IsOn="{x:Bind State.Globals.CopyOnSelect, Mode=TwoWay}"/>
              </ContentPresenter>

--- a/src/cascadia/TerminalSettingsEditor/Interaction.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.xaml
@@ -26,7 +26,7 @@ the MIT License. See LICENSE in the project root for license information. -->
     <ScrollViewer>
         <StackPanel Style="{StaticResource SettingsStackStyle}">
             <!--Copy On Select-->
-            <ContentPresenter Style="{StaticResource SettingContainerStyle}">
+            <ContentPresenter>
                 <CheckBox x:Uid="Globals_CopyOnSelect"
                           IsChecked="{x:Bind State.Globals.CopyOnSelect, Mode=TwoWay}"
                           Style="{StaticResource CheckBoxSettingStyle}"/>

--- a/src/cascadia/TerminalSettingsEditor/Interaction.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.xaml
@@ -27,9 +27,9 @@ the MIT License. See LICENSE in the project root for license information. -->
         <StackPanel Style="{StaticResource SettingsStackStyle}">
             <!--Copy On Select-->
             <ContentPresenter>
-                <CheckBox x:Uid="Globals_CopyOnSelect"
-                          IsChecked="{x:Bind State.Globals.CopyOnSelect, Mode=TwoWay}"
-                          Style="{StaticResource CheckBoxSettingStyle}"/>
+                <ToggleSwitch x:Uid="Globals_CopyOnSelect"
+                              IsOn="{x:Bind State.Globals.CopyOnSelect, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
              </ContentPresenter>
 
             <!--Copy Format-->
@@ -50,9 +50,9 @@ the MIT License. See LICENSE in the project root for license information. -->
 
             <!--Snap On Resize-->
             <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                <CheckBox x:Uid="Globals_SnapToGridOnResize"
-                          IsChecked="{x:Bind State.Globals.SnapToGridOnResize, Mode=TwoWay}"
-                          Style="{StaticResource CheckBoxSettingStyle}"/>
+                <ToggleSwitch x:Uid="Globals_SnapToGridOnResize"
+                              IsOn="{x:Bind State.Globals.SnapToGridOnResize, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
             </ContentPresenter>
             
             <!--Tab Switcher Mode-->

--- a/src/cascadia/TerminalSettingsEditor/Interaction.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.xaml
@@ -17,8 +17,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             </ResourceDictionary.MergedDictionaries>
             
             <DataTemplate x:DataType="local:EnumEntry" x:Key="EnumRadioButtonTemplate">
-                <RadioButton Content="{x:Bind EnumName, Mode=OneWay}"
-                             Style="{StaticResource RadioButtonSettingStyle}"/>
+                <RadioButton Content="{x:Bind EnumName, Mode=OneWay}"/>
             </DataTemplate>
         </ResourceDictionary>
     </Page.Resources>
@@ -28,8 +27,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             <!--Copy On Select-->
             <ContentPresenter>
                 <ToggleSwitch x:Uid="Globals_CopyOnSelect"
-                              IsOn="{x:Bind State.Globals.CopyOnSelect, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
+                              IsOn="{x:Bind State.Globals.CopyOnSelect, Mode=TwoWay}"/>
              </ContentPresenter>
 
             <!--Copy Format-->
@@ -37,8 +35,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <muxc:RadioButtons x:Uid="Globals_CopyFormat"
                                    ItemsSource="{x:Bind CopyFormatList, Mode=OneWay}"
                                    SelectedItem="{x:Bind CurrentCopyFormat, Mode=TwoWay}"
-                                   ItemTemplate="{StaticResource EnumRadioButtonTemplate}"
-                                   Style="{StaticResource RadioButtonsSettingStyle}"/>
+                                   ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
             </ContentPresenter>
 
             <!--Word Delimiters-->
@@ -51,8 +48,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             <!--Snap On Resize-->
             <ContentPresenter Style="{StaticResource SettingContainerStyle}">
                 <ToggleSwitch x:Uid="Globals_SnapToGridOnResize"
-                              IsOn="{x:Bind State.Globals.SnapToGridOnResize, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
+                              IsOn="{x:Bind State.Globals.SnapToGridOnResize, Mode=TwoWay}"/>
             </ContentPresenter>
             
             <!--Tab Switcher Mode-->
@@ -60,8 +56,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <muxc:RadioButtons x:Uid="Globals_TabSwitcherMode"
                                    SelectedItem="{x:Bind CurrentTabSwitcherMode}"
                                    ItemsSource="{x:Bind TabSwitcherModeList}"
-                                   ItemTemplate="{StaticResource EnumRadioButtonTemplate}"
-                                   Style="{StaticResource RadioButtonsSettingStyle}"/>
+                                   ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
             </ContentPresenter>
         </StackPanel>
     </ScrollViewer>

--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -22,30 +22,36 @@ the MIT License. See LICENSE in the project root for license information. -->
                              Style="{StaticResource RadioButtonSettingStyle}"/>
             </DataTemplate>
             <SettingsModel:IconPathConverter x:Key="IconSourceConverter"/>
+            <Style x:Key="LaunchSizeNumberBoxStyle" TargetType="muxc:NumberBox" BasedOn="{StaticResource NumberBoxSettingStyle}">
+                <Setter Property="SmallChange" Value="1"/>
+                <Setter Property="LargeChange" Value="10"/>
+                <Setter Property="Minimum" Value="1"/>
+            </Style>
         </ResourceDictionary>
     </Page.Resources>
 
     <ScrollViewer>
-        <StackPanel Style="{StaticResource SettingsStackStyle}">
-            <!--Default Profile-->
-            <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                <ComboBox x:Uid="Globals_DefaultProfile"
+        <StackPanel>
+            <StackPanel Style="{StaticResource SettingsStackStyle}">
+                <!--Default Profile-->
+                <ContentPresenter>
+                    <ComboBox x:Uid="Globals_DefaultProfile"
                           x:Name="DefaultProfile"
                           ItemsSource="{x:Bind State.Settings.AllProfiles, Mode=OneWay}"
                           SelectedItem="{x:Bind CurrentDefaultProfile, Mode=TwoWay}"
                           Style="{StaticResource ComboBoxSettingStyle}">
-                    <ComboBox.ItemTemplate>
-                        <DataTemplate x:DataType="SettingsModel:Profile">
-                            <Grid HorizontalAlignment="Stretch" ColumnSpacing="8">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate x:DataType="SettingsModel:Profile">
+                                <Grid HorizontalAlignment="Stretch" ColumnSpacing="8">
 
-                                <Grid.ColumnDefinitions>
-                                    <!-- icon -->
-                                    <ColumnDefinition Width="16"/>
-                                    <!-- profile name -->
-                                    <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <!-- icon -->
+                                        <ColumnDefinition Width="16"/>
+                                        <!-- profile name -->
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
 
-                                <IconSourceElement
+                                    <IconSourceElement
                                     Grid.Column="0"
                                     Width="16"
                                     Height="16"
@@ -53,80 +59,51 @@ the MIT License. See LICENSE in the project root for license information. -->
                                                         Mode=OneWay,
                                                         Converter={StaticResource IconSourceConverter}}"/>
 
-                                <TextBlock Grid.Column="1"
-                                           Text="{x:Bind Name}"
-                                           FontSize="{StaticResource StandardFontSize}"/>
+                                    <TextBlock Grid.Column="1"
+                                           Text="{x:Bind Name}"/>
 
-                            </Grid>
-                        </DataTemplate>
-                    </ComboBox.ItemTemplate>
-                </ComboBox>
-            </ContentPresenter>
+                                </Grid>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                </ContentPresenter>
 
-            <!--Start on User Login-->
-            <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                <CheckBox x:Uid="Globals_StartOnUserLogin"
+                <!--Start on User Login-->
+                <ContentPresenter Style="{StaticResource SettingContainerStyle}">
+                    <CheckBox x:Uid="Globals_StartOnUserLogin"
                           IsChecked="{x:Bind State.Settings.GlobalSettings.StartOnUserLogin, Mode=TwoWay}"
                           Style="{StaticResource CheckBoxSettingStyle}"/>
-            </ContentPresenter>
+                </ContentPresenter>
 
-            <!--Launch Mode-->
-            <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                <muxc:RadioButtons x:Uid="Globals_LaunchMode"
+                <!--Launch Mode-->
+                <ContentPresenter Style="{StaticResource SettingContainerStyle}">
+                    <muxc:RadioButtons x:Uid="Globals_LaunchMode"
                                    SelectedItem="{x:Bind CurrentLaunchMode}"
                                    ItemsSource="{x:Bind LaunchModeList}"
                                    ItemTemplate="{StaticResource EnumRadioButtonTemplate}"
                                    Style="{StaticResource RadioButtonsSettingStyle}"/>
-            </ContentPresenter>
+                </ContentPresenter>
+            </StackPanel>
 
             <!--Launch Size-->
-            <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                <Grid>
-                    <Grid.Resources>
-                        <Style x:Key="LaunchSizeSubHeaderStyle" TargetType="TextBlock">
-                            <Setter Property="FontSize" Value="{StaticResource StandardFontSize}"/>
-                            <Setter Property="VerticalAlignment" Value="Center"/>
-                            <Setter Property="Margin" Value="0,0,5,0"/>
-                        </Style>
-                        <Style x:Key="LaunchSizeNumberBoxStyle" TargetType="muxc:NumberBox" BasedOn="{StaticResource NumberBoxSettingStyle}">
-                            <Setter Property="SmallChange" Value="1"/>
-                            <Setter Property="LargeChange" Value="10"/>
-                            <Setter Property="Minimum" Value="1"/>
-                        </Style>
-                    </Grid.Resources>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="auto"/>
-                        <RowDefinition Height="auto"/>
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="auto"/>
-                        <ColumnDefinition Width="auto"/>
-                    </Grid.ColumnDefinitions>
+            <StackPanel Style="{StaticResource SettingsStackStyle}">
+                <!--Header-->
+                <TextBlock x:Uid="Globals_LaunchSize"
+                            Style="{StaticResource SubtitleTextBlockStyle}"/>
 
-                    <!--Header-->
-                    <TextBlock x:Uid="Globals_LaunchSize"
-                               Grid.Row="0" Grid.Column="0"
-                               Grid.ColumnSpan="2"
-                               Style="{StaticResource CustomSettingHeaderStyle}"/>
-                    
-                    <!--Columns-->
-                    <StackPanel Orientation="Horizontal"
-                                Grid.Row="1" Grid.Column="0"
-                                Margin="0,0,10,0">
-                        <TextBlock x:Uid="Globals_InitialCols" Style="{StaticResource LaunchSizeSubHeaderStyle}"/>
-                        <muxc:NumberBox Value="{x:Bind State.Settings.GlobalSettings.InitialCols, Mode=TwoWay}"
-                                        Style="{StaticResource LaunchSizeNumberBoxStyle}"/>
-                    </StackPanel>
-
-                    <!--Rows-->
-                    <StackPanel Orientation="Horizontal"
-                                Grid.Row="1" Grid.Column="1">
-                        <TextBlock x:Uid="Globals_InitialRows" Style="{StaticResource LaunchSizeSubHeaderStyle}"/>
-                        <muxc:NumberBox Value="{x:Bind State.Settings.GlobalSettings.InitialRows, Mode=TwoWay}"
-                                        Style="{StaticResource LaunchSizeNumberBoxStyle}"/>
-                    </StackPanel>
-                </Grid>
-             </ContentPresenter>
+                <!--Columns-->
+                <ContentPresenter>
+                    <muxc:NumberBox x:Uid="Globals_InitialCols"
+                                Value="{x:Bind State.Settings.GlobalSettings.InitialCols, Mode=TwoWay}"
+                                Style="{StaticResource LaunchSizeNumberBoxStyle}"/>
+                </ContentPresenter>
+                <!--Rows-->
+                <ContentPresenter Style="{StaticResource SettingContainerStyle}">
+                    <muxc:NumberBox x:Uid="Globals_InitialRows"
+                                Value="{x:Bind State.Settings.GlobalSettings.InitialRows, Mode=TwoWay}"
+                                Style="{StaticResource LaunchSizeNumberBoxStyle}"/>
+                </ContentPresenter>
+            </StackPanel>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -33,7 +33,8 @@ the MIT License. See LICENSE in the project root for license information. -->
         <StackPanel>
             <StackPanel Style="{StaticResource SettingsStackStyle}">
                 <!--Default Profile-->
-                <ContentPresenter>
+                <ContentPresenter Style="{StaticResource SettingContainerStyle}"
+                                  Margin="0">
                     <ComboBox x:Uid="Globals_DefaultProfile"
                           x:Name="DefaultProfile"
                           ItemsSource="{x:Bind State.Settings.AllProfiles, Mode=OneWay}"
@@ -89,7 +90,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                             Style="{StaticResource SubtitleTextBlockStyle}"/>
 
                 <!--Columns-->
-                <ContentPresenter>
+                <ContentPresenter Style="{StaticResource SettingContainerStyle}"
+                                  Margin="0">
                     <muxc:NumberBox x:Uid="Globals_InitialCols"
                                 Value="{x:Bind State.Settings.GlobalSettings.InitialCols, Mode=TwoWay}"
                                 Style="{StaticResource LaunchSizeNumberBoxStyle}"/>

--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -18,8 +18,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             </ResourceDictionary.MergedDictionaries>
 
             <DataTemplate x:DataType="local:EnumEntry" x:Key="EnumRadioButtonTemplate">
-                <RadioButton Content="{x:Bind EnumName, Mode=OneWay}"
-                             Style="{StaticResource RadioButtonSettingStyle}"/>
+                <RadioButton Content="{x:Bind EnumName, Mode=OneWay}"/>
             </DataTemplate>
             <SettingsModel:IconPathConverter x:Key="IconSourceConverter"/>
             <Style x:Key="LaunchSizeNumberBoxStyle" TargetType="muxc:NumberBox" BasedOn="{StaticResource NumberBoxSettingStyle}">
@@ -71,8 +70,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <!--Start on User Login-->
                 <ContentPresenter Style="{StaticResource SettingContainerStyle}">
                     <ToggleSwitch x:Uid="Globals_StartOnUserLogin"
-                                  IsOn="{x:Bind State.Settings.GlobalSettings.StartOnUserLogin, Mode=TwoWay}"
-                                  Style="{StaticResource ToggleSwitchSettingStyle}"/>
+                                  IsOn="{x:Bind State.Settings.GlobalSettings.StartOnUserLogin, Mode=TwoWay}"/>
                 </ContentPresenter>
 
                 <!--Launch Mode-->
@@ -80,8 +78,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                     <muxc:RadioButtons x:Uid="Globals_LaunchMode"
                                    SelectedItem="{x:Bind CurrentLaunchMode}"
                                    ItemsSource="{x:Bind LaunchModeList}"
-                                   ItemTemplate="{StaticResource EnumRadioButtonTemplate}"
-                                   Style="{StaticResource RadioButtonsSettingStyle}"/>
+                                   ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
                 </ContentPresenter>
             </StackPanel>
 

--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -70,9 +70,9 @@ the MIT License. See LICENSE in the project root for license information. -->
 
                 <!--Start on User Login-->
                 <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                    <CheckBox x:Uid="Globals_StartOnUserLogin"
-                          IsChecked="{x:Bind State.Settings.GlobalSettings.StartOnUserLogin, Mode=TwoWay}"
-                          Style="{StaticResource CheckBoxSettingStyle}"/>
+                    <ToggleSwitch x:Uid="Globals_StartOnUserLogin"
+                                  IsOn="{x:Bind State.Settings.GlobalSettings.StartOnUserLogin, Mode=TwoWay}"
+                                  Style="{StaticResource ToggleSwitchSettingStyle}"/>
                 </ContentPresenter>
 
                 <!--Launch Mode-->

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -37,14 +37,6 @@ the MIT License. See LICENSE in the project root for license information. -->
                          ItemInvoked="SettingsNav_ItemInvoked"
                          IsBackButtonVisible="Collapsed">
 
-        <muxc:NavigationView.HeaderTemplate>
-            <DataTemplate x:DataType="x:String">
-                <TextBlock Text="{x:Bind}"
-                           Margin="8,10,0,0"
-                           Style="{StaticResource TitleTextBlockStyle}"/>
-            </DataTemplate>
-        </muxc:NavigationView.HeaderTemplate>
-    
         <muxc:NavigationView.MenuItems>
     
             <muxc:NavigationViewItem x:Uid="Nav_Launch"
@@ -120,18 +112,15 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <TextBlock x:Uid="Settings_UnsavedSettingsWarning"
                            Visibility="Collapsed"
                            Foreground="Goldenrod"
-                           FontSize="15"
                            VerticalAlignment="Center"
                            HorizontalAlignment="Left"
                            TextAlignment="Left"
                            Margin="30,0,0,0"/>
                 <StackPanel VerticalAlignment="Center" HorizontalAlignment="Right" Orientation="Horizontal" Margin="0,0,30,0">
                     <Button x:Uid="Settings_ResetSettingsButton"
-                            FontSize="15"
                             ToolTipService.Placement="Mouse"
                             Click="ResetButton_Click"/>
                     <Button x:Uid="Settings_SaveSettingsButton"
-                            FontSize="15"
                             Style="{StaticResource AccentButtonStyle}"
                             Margin="10,0,0,0"
                             Click="SaveButton_Click"/>

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -117,9 +117,9 @@ the MIT License. See LICENSE in the project root for license information. -->
                         <!--Hidden-->
                         <ContentPresenter Style="{StaticResource SettingContainerStyle}"
                                           Visibility="{x:Bind State.Profile.IsBaseLayer, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}">
-                            <CheckBox x:Uid="Profile_Hidden"
-                                      IsChecked="{x:Bind State.Profile.Hidden, Mode=TwoWay}"
-                                      Style="{StaticResource CheckBoxSettingStyle}"/>
+                            <ToggleSwitch x:Uid="Profile_Hidden"
+                                          IsOn="{x:Bind State.Profile.Hidden, Mode=TwoWay}"
+                                          Style="{StaticResource ToggleSwitchSettingStyle}"/>
                         </ContentPresenter>
 
                         <!--Delete Button-->
@@ -263,9 +263,9 @@ the MIT License. See LICENSE in the project root for license information. -->
 
                             <!--Retro Terminal Effect-->
                             <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                                <CheckBox x:Uid="Profile_RetroTerminalEffect"
-                                      IsChecked="{x:Bind State.Profile.RetroTerminalEffect, Mode=TwoWay}"
-                                      Style="{StaticResource CheckBoxSettingStyle}"/>
+                                <ToggleSwitch x:Uid="Profile_RetroTerminalEffect"
+                                              IsOn="{x:Bind State.Profile.RetroTerminalEffect, Mode=TwoWay}"
+                                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
                             </ContentPresenter>
                         </StackPanel>
 
@@ -514,15 +514,15 @@ the MIT License. See LICENSE in the project root for license information. -->
 
                             <!--Use Acrylic-->
                             <ContentPresenter>
-                                <CheckBox x:Uid="Profile_UseAcrylic"
-                                      x:Name="UseAcrylicCheckBox"
-                                      IsChecked="{x:Bind State.Profile.UseAcrylic, Mode=TwoWay}"
-                                      Style="{StaticResource CheckBoxSettingStyle}"/>
+                                <ToggleSwitch x:Uid="Profile_UseAcrylic"
+                                              x:Name="UseAcrylicToggleSwitch"
+                                              IsOn="{x:Bind State.Profile.UseAcrylic, Mode=TwoWay}"
+                                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
                             </ContentPresenter>
 
                             <!--Acrylic Opacity-->
                             <ContentPresenter Style="{StaticResource SettingContainerStyle}"
-                                          Visibility="{Binding ElementName=UseAcrylicCheckBox, Path=IsChecked, Mode=OneWay}">
+                                          Visibility="{Binding ElementName=UseAcrylicToggleSwitch, Path=IsOn, Mode=OneWay}">
                                 <StackPanel x:Name="AcrylicOpacityControl">
                                     <TextBlock x:Uid="Profile_AcrylicOpacity"
                                            Style="{StaticResource SliderHeaderStyle}"/>
@@ -572,9 +572,9 @@ the MIT License. See LICENSE in the project root for license information. -->
                     <StackPanel Style="{StaticResource PivotStackStyle}">
                         <!--Suppress Application Title-->
                         <ContentPresenter>
-                            <CheckBox x:Uid="Profile_SuppressApplicationTitle"
-                                      IsChecked="{x:Bind State.Profile.SuppressApplicationTitle, Mode=TwoWay}"
-                                      Style="{StaticResource CheckBoxSettingStyle}"/>
+                            <ToggleSwitch x:Uid="Profile_SuppressApplicationTitle"
+                                          IsOn="{x:Bind State.Profile.SuppressApplicationTitle, Mode=TwoWay}"
+                                          Style="{StaticResource ToggleSwitchSettingStyle}"/>
                         </ContentPresenter>
 
                         <!--Antialiasing Mode-->
@@ -588,16 +588,16 @@ the MIT License. See LICENSE in the project root for license information. -->
 
                         <!--AltGr Aliasing-->
                         <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                            <CheckBox x:Uid="Profile_AltGrAliasing"
-                                      IsChecked="{x:Bind State.Profile.AltGrAliasing, Mode=TwoWay}"
-                                      Style="{StaticResource CheckBoxSettingStyle}"/>
+                            <ToggleSwitch x:Uid="Profile_AltGrAliasing"
+                                          IsOn="{x:Bind State.Profile.AltGrAliasing, Mode=TwoWay}"
+                                          Style="{StaticResource ToggleSwitchSettingStyle}"/>
                         </ContentPresenter>
 
                         <!--Snap On Input-->
                         <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                            <CheckBox x:Uid="Profile_SnapOnInput"
-                                      IsChecked="{x:Bind State.Profile.SnapOnInput, Mode=TwoWay}"
-                                      Style="{StaticResource CheckBoxSettingStyle}"/>
+                            <ToggleSwitch x:Uid="Profile_SnapOnInput"
+                                          IsOn="{x:Bind State.Profile.SnapOnInput, Mode=TwoWay}"
+                                          Style="{StaticResource ToggleSwitchSettingStyle}"/>
                         </ContentPresenter>
 
                         <!--History Size-->

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -126,7 +126,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                         <ContentPresenter Style="{StaticResource SettingContainerStyle}">
                             <StackPanel Visibility="{x:Bind State.Profile.IsBaseLayer, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}">
                                 <Button IsEnabled="{x:Bind State.Profile.CanDeleteProfile}"
-                                    Margin="0,0,0,10">
+                                    Style="{StaticResource DeleteButtonStyle}">
                                     <Button.Resources>
                                         <ResourceDictionary>
                                             <ResourceDictionary.ThemeDictionaries>

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -18,8 +18,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             </ResourceDictionary.MergedDictionaries>
 
             <DataTemplate x:DataType="local:EnumEntry" x:Key="EnumRadioButtonTemplate">
-                <RadioButton Content="{x:Bind EnumName, Mode=OneWay}"
-                             Style="{StaticResource RadioButtonSettingStyle}"/>
+                <RadioButton Content="{x:Bind EnumName, Mode=OneWay}"/>
             </DataTemplate>
 
             <DataTemplate x:DataType="local:EnumEntry" x:Key="EnumComboBoxItemTemplate">
@@ -87,7 +86,6 @@ the MIT License. See LICENSE in the project root for license information. -->
                                 </StackPanel>
                                 <CheckBox x:Uid="Profile_StartingDirectoryUseParentCheckbox"
                                       x:Name="StartingDirectoryUseParentCheckbox"
-                                      Style="{StaticResource CheckBoxSettingStyle}"
                                       Checked="UseParentProcessDirectory_Check"
                                       Unchecked="UseParentProcessDirectory_Uncheck"/>
                             </StackPanel>
@@ -118,15 +116,13 @@ the MIT License. See LICENSE in the project root for license information. -->
                         <ContentPresenter Style="{StaticResource SettingContainerStyle}"
                                           Visibility="{x:Bind State.Profile.IsBaseLayer, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}">
                             <ToggleSwitch x:Uid="Profile_Hidden"
-                                          IsOn="{x:Bind State.Profile.Hidden, Mode=TwoWay}"
-                                          Style="{StaticResource ToggleSwitchSettingStyle}"/>
+                                          IsOn="{x:Bind State.Profile.Hidden, Mode=TwoWay}"/>
                         </ContentPresenter>
 
                         <!--Delete Button-->
                         <ContentPresenter Style="{StaticResource SettingContainerStyle}">
                             <StackPanel Visibility="{x:Bind State.Profile.IsBaseLayer, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}">
-                                <Button Style="{StaticResource BaseButtonStyle}"
-                                    IsEnabled="{x:Bind State.Profile.CanDeleteProfile}"
+                                <Button IsEnabled="{x:Bind State.Profile.CanDeleteProfile}"
                                     Margin="0,0,0,10">
                                     <Button.Resources>
                                         <ResourceDictionary>
@@ -172,7 +168,6 @@ the MIT License. See LICENSE in the project root for license information. -->
                                                 <TextBlock x:Uid="Profile_DeleteConfirmationMessage"
                                                        Style="{StaticResource CustomFlyoutTextStyle}"/>
                                                 <Button x:Uid="Profile_DeleteConfirmationButton"
-                                                    Style="{StaticResource BaseButtonStyle}"
                                                     Click="DeleteConfirmation_Click"/>
                                             </StackPanel>
                                         </Flyout>
@@ -264,8 +259,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                             <!--Retro Terminal Effect-->
                             <ContentPresenter Style="{StaticResource SettingContainerStyle}">
                                 <ToggleSwitch x:Uid="Profile_RetroTerminalEffect"
-                                              IsOn="{x:Bind State.Profile.RetroTerminalEffect, Mode=TwoWay}"
-                                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
+                                              IsOn="{x:Bind State.Profile.RetroTerminalEffect, Mode=TwoWay}"/>
                             </ContentPresenter>
                         </StackPanel>
 
@@ -279,8 +273,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                                                    ItemsSource="{x:Bind CursorShapeList, Mode=OneWay}"
                                                    SelectedItem="{x:Bind CurrentCursorShape, Mode=TwoWay}"
                                                    ItemTemplate="{StaticResource EnumRadioButtonTemplate}"
-                                                   SelectionChanged="CursorShape_Changed"
-                                                   Style="{StaticResource RadioButtonsSettingStyle}"/>
+                                                   SelectionChanged="CursorShape_Changed"/>
                             </ContentPresenter>
 
                             <!--Cursor Height-->
@@ -314,8 +307,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                                     </StackPanel>
                                     <CheckBox x:Uid="Profile_UseDesktopImage"
                                           x:Name="UseDesktopImageCheckBox"
-                                          IsChecked="{x:Bind State.Profile.UseDesktopBGImage, Mode=TwoWay}"
-                                          Style="{StaticResource CheckBoxSettingStyle}"/>
+                                          IsChecked="{x:Bind State.Profile.UseDesktopBGImage, Mode=TwoWay}"/>
                                 </StackPanel>
                             </ContentPresenter>
 
@@ -325,8 +317,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                                 <muxc:RadioButtons x:Uid="Profile_BackgroundImageStretchMode"
                                                ItemsSource="{x:Bind BackgroundImageStretchModeList, Mode=OneWay}"
                                                SelectedItem="{x:Bind CurrentBackgroundImageStretchMode, Mode=TwoWay}"
-                                               ItemTemplate="{StaticResource EnumRadioButtonTemplate}"
-                                               Style="{StaticResource RadioButtonsSettingStyle}"/>
+                                               ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
                             </ContentPresenter>
 
                             <!--Background Image Alignment-->
@@ -516,8 +507,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                             <ContentPresenter>
                                 <ToggleSwitch x:Uid="Profile_UseAcrylic"
                                               x:Name="UseAcrylicToggleSwitch"
-                                              IsOn="{x:Bind State.Profile.UseAcrylic, Mode=TwoWay}"
-                                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
+                                              IsOn="{x:Bind State.Profile.UseAcrylic, Mode=TwoWay}"/>
                             </ContentPresenter>
 
                             <!--Acrylic Opacity-->
@@ -558,8 +548,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                                 <muxc:RadioButtons x:Uid="Profile_ScrollbarVisibility"
                                                ItemsSource="{x:Bind ScrollStateList, Mode=OneWay}"
                                                SelectedItem="{x:Bind CurrentScrollState, Mode=TwoWay}"
-                                               ItemTemplate="{StaticResource EnumRadioButtonTemplate}"
-                                               Style="{StaticResource RadioButtonsSettingStyle}"/>
+                                               ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
                             </ContentPresenter>
                         </StackPanel>
                     </StackPanel>
@@ -573,8 +562,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                         <!--Suppress Application Title-->
                         <ContentPresenter>
                             <ToggleSwitch x:Uid="Profile_SuppressApplicationTitle"
-                                          IsOn="{x:Bind State.Profile.SuppressApplicationTitle, Mode=TwoWay}"
-                                          Style="{StaticResource ToggleSwitchSettingStyle}"/>
+                                          IsOn="{x:Bind State.Profile.SuppressApplicationTitle, Mode=TwoWay}"/>
                         </ContentPresenter>
 
                         <!--Antialiasing Mode-->
@@ -582,22 +570,19 @@ the MIT License. See LICENSE in the project root for license information. -->
                             <muxc:RadioButtons x:Uid="Profile_AntialiasingMode"
                                                ItemsSource="{x:Bind AntiAliasingModeList, Mode=OneWay}"
                                                SelectedItem="{x:Bind CurrentAntiAliasingMode, Mode=TwoWay}"
-                                               ItemTemplate="{StaticResource EnumRadioButtonTemplate}"
-                                               Style="{StaticResource RadioButtonsSettingStyle}"/>
+                                               ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
                         </ContentPresenter>
 
                         <!--AltGr Aliasing-->
                         <ContentPresenter Style="{StaticResource SettingContainerStyle}">
                             <ToggleSwitch x:Uid="Profile_AltGrAliasing"
-                                          IsOn="{x:Bind State.Profile.AltGrAliasing, Mode=TwoWay}"
-                                          Style="{StaticResource ToggleSwitchSettingStyle}"/>
+                                          IsOn="{x:Bind State.Profile.AltGrAliasing, Mode=TwoWay}"/>
                         </ContentPresenter>
 
                         <!--Snap On Input-->
                         <ContentPresenter Style="{StaticResource SettingContainerStyle}">
                             <ToggleSwitch x:Uid="Profile_SnapOnInput"
-                                          IsOn="{x:Bind State.Profile.SnapOnInput, Mode=TwoWay}"
-                                          Style="{StaticResource ToggleSwitchSettingStyle}"/>
+                                          IsOn="{x:Bind State.Profile.SnapOnInput, Mode=TwoWay}"/>
                         </ContentPresenter>
 
                         <!--History Size-->
@@ -614,8 +599,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                             <muxc:RadioButtons x:Uid="Profile_CloseOnExit"
                                                ItemsSource="{x:Bind CloseOnExitModeList, Mode=OneWay}"
                                                SelectedItem="{x:Bind CurrentCloseOnExitMode, Mode=TwoWay}"
-                                               ItemTemplate="{StaticResource EnumRadioButtonTemplate}"
-                                               Style="{StaticResource RadioButtonsSettingStyle}"/>
+                                               ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
                         </ContentPresenter>
 
                         <!--Bell Style-->
@@ -623,8 +607,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                             <muxc:RadioButtons x:Uid="Profile_BellStyle"
                                                ItemsSource="{x:Bind BellStyleList, Mode=OneWay}"
                                                SelectedItem="{x:Bind CurrentBellStyle, Mode=TwoWay}"
-                                               ItemTemplate="{StaticResource EnumRadioButtonTemplate}"
-                                               Style="{StaticResource RadioButtonsSettingStyle}"/>
+                                               ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
                         </ContentPresenter>
                     </StackPanel>
                 </ScrollViewer>

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -23,7 +23,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             </DataTemplate>
 
             <DataTemplate x:DataType="local:EnumEntry" x:Key="EnumComboBoxItemTemplate">
-                <TextBlock Text="{x:Bind EnumName, Mode=OneWay}" FontSize="{StaticResource StandardFontSize}"/>
+                <TextBlock Text="{x:Bind EnumName, Mode=OneWay}"/>
             </DataTemplate>
 
             <local:ColorToBrushConverter x:Key="ColorToBrushConverter"/>
@@ -54,14 +54,13 @@ the MIT License. See LICENSE in the project root for license information. -->
                HorizontalAlignment="Left"
                Grid.Row="1"
                SelectionChanged="Pivot_SelectionChanged"
-               Margin="{StaticResource PivotIndentMargin}">
+               Margin="1,0,0,0">
             <!-- General Tab -->
             <PivotItem x:Uid="Profile_General">
                 <ScrollViewer>
-                    <StackPanel Margin="{StaticResource PivotStackPanelMargin}">
+                    <StackPanel Style="{StaticResource PivotStackStyle}">
                         <!--Commandline-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}"
-                                          Visibility="{x:Bind State.Profile.IsBaseLayer, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}">
+                        <ContentPresenter Visibility="{x:Bind State.Profile.IsBaseLayer, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}">
                             <StackPanel Orientation="Horizontal">
                                 <TextBox x:Uid="Profile_Commandline"
                                          x:Name="Commandline"
@@ -124,66 +123,66 @@ the MIT License. See LICENSE in the project root for license information. -->
                         </ContentPresenter>
 
                         <!--Delete Button-->
-                        <StackPanel Margin="{StaticResource StandardControlSpacing}"
-                                    Visibility="{x:Bind State.Profile.IsBaseLayer, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}">
-                            <Button Style="{StaticResource BaseButtonStyle}"
+                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
+                            <StackPanel Visibility="{x:Bind State.Profile.IsBaseLayer, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}">
+                                <Button Style="{StaticResource BaseButtonStyle}"
                                     IsEnabled="{x:Bind State.Profile.CanDeleteProfile}"
                                     Margin="0,0,0,10">
-                                <Button.Resources>
-                                    <ResourceDictionary>
-                                        <ResourceDictionary.ThemeDictionaries>
-                                            <ResourceDictionary x:Key="Light">
-                                                <SolidColorBrush x:Key="ButtonBackground" Color="Firebrick"/>
-                                                <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="#C23232"/>
-                                                <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#A21212"/>
-                                                <SolidColorBrush x:Key="ButtonForeground" Color="White"/>
-                                                <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="White"/>
-                                                <SolidColorBrush x:Key="ButtonForegroundPressed" Color="White"/>
-                                            </ResourceDictionary>
-                                            <ResourceDictionary x:Key="Dark">
-                                                <SolidColorBrush x:Key="ButtonBackground" Color="Firebrick"/>
-                                                <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="#C23232"/>
-                                                <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#A21212"/>
-                                                <SolidColorBrush x:Key="ButtonForeground" Color="White"/>
-                                                <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="White"/>
-                                                <SolidColorBrush x:Key="ButtonForegroundPressed" Color="White"/>
-                                            </ResourceDictionary>
-                                            <ResourceDictionary x:Key="HighContrast">
-                                                <SolidColorBrush x:Key="ButtonBackground" Color="{ThemeResource SystemColorButtonFaceColor}"/>
-                                                <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{ThemeResource SystemColorHighlightColor}"/>
-                                                <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="{ThemeResource SystemColorHighlightColor}"/>
-                                                <SolidColorBrush x:Key="ButtonForeground" Color="{ThemeResource SystemColorButtonTextColor}"/>
-                                                <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{ThemeResource SystemColorHighlightTextColor}"/>
-                                                <SolidColorBrush x:Key="ButtonForegroundPressed" Color="{ThemeResource SystemColorHighlightTextColor}"/>
-                                            </ResourceDictionary>
-                                        </ResourceDictionary.ThemeDictionaries>
-                                    </ResourceDictionary>
-                                </Button.Resources>
-                                <Button.Content>
-                                    <StackPanel Orientation="Horizontal">
-                                        <FontIcon Glyph="&#xE74D;"
-                                                  FontSize="{StaticResource StandardFontSize}"/>
-                                        <TextBlock x:Uid="Profile_DeleteButton"
-                                                   FontSize="{StaticResource StandardFontSize}"
+                                    <Button.Resources>
+                                        <ResourceDictionary>
+                                            <ResourceDictionary.ThemeDictionaries>
+                                                <ResourceDictionary x:Key="Light">
+                                                    <SolidColorBrush x:Key="ButtonBackground" Color="Firebrick"/>
+                                                    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="#C23232"/>
+                                                    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#A21212"/>
+                                                    <SolidColorBrush x:Key="ButtonForeground" Color="White"/>
+                                                    <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="White"/>
+                                                    <SolidColorBrush x:Key="ButtonForegroundPressed" Color="White"/>
+                                                </ResourceDictionary>
+                                                <ResourceDictionary x:Key="Dark">
+                                                    <SolidColorBrush x:Key="ButtonBackground" Color="Firebrick"/>
+                                                    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="#C23232"/>
+                                                    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#A21212"/>
+                                                    <SolidColorBrush x:Key="ButtonForeground" Color="White"/>
+                                                    <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="White"/>
+                                                    <SolidColorBrush x:Key="ButtonForegroundPressed" Color="White"/>
+                                                </ResourceDictionary>
+                                                <ResourceDictionary x:Key="HighContrast">
+                                                    <SolidColorBrush x:Key="ButtonBackground" Color="{ThemeResource SystemColorButtonFaceColor}"/>
+                                                    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{ThemeResource SystemColorHighlightColor}"/>
+                                                    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="{ThemeResource SystemColorHighlightColor}"/>
+                                                    <SolidColorBrush x:Key="ButtonForeground" Color="{ThemeResource SystemColorButtonTextColor}"/>
+                                                    <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{ThemeResource SystemColorHighlightTextColor}"/>
+                                                    <SolidColorBrush x:Key="ButtonForegroundPressed" Color="{ThemeResource SystemColorHighlightTextColor}"/>
+                                                </ResourceDictionary>
+                                            </ResourceDictionary.ThemeDictionaries>
+                                        </ResourceDictionary>
+                                    </Button.Resources>
+                                    <Button.Content>
+                                        <StackPanel Orientation="Horizontal">
+                                            <FontIcon Glyph="&#xE74D;"
+                                                  FontSize="{StaticResource StandardIconSize}"/>
+                                            <TextBlock x:Uid="Profile_DeleteButton"
                                                    Margin="10,0,0,0"/>
-                                    </StackPanel>
-                                </Button.Content>
-                                <Button.Flyout>
-                                    <Flyout>
-                                        <StackPanel>
-                                            <TextBlock x:Uid="Profile_DeleteConfirmationMessage"
+                                        </StackPanel>
+                                    </Button.Content>
+                                    <Button.Flyout>
+                                        <Flyout>
+                                            <StackPanel>
+                                                <TextBlock x:Uid="Profile_DeleteConfirmationMessage"
                                                        Style="{StaticResource CustomFlyoutTextStyle}"/>
-                                            <Button x:Uid="Profile_DeleteConfirmationButton"
+                                                <Button x:Uid="Profile_DeleteConfirmationButton"
                                                     Style="{StaticResource BaseButtonStyle}"
                                                     Click="DeleteConfirmation_Click"/>
-                                        </StackPanel>
-                                    </Flyout>
-                                </Button.Flyout>
-                            </Button>
-                            <TextBlock x:Name="DeleteButtonDisclaimer"
+                                            </StackPanel>
+                                        </Flyout>
+                                    </Button.Flyout>
+                                </Button>
+                                <TextBlock x:Name="DeleteButtonDisclaimer"
                                        Style="{StaticResource DisclaimerStyle}"
                                        VerticalAlignment="Center"/>
-                        </StackPanel>
+                            </StackPanel>
+                        </ContentPresenter>
                     </StackPanel>
                 </ScrollViewer>
             </PivotItem>
@@ -192,34 +191,34 @@ the MIT License. See LICENSE in the project root for license information. -->
             <PivotItem x:Uid="Profile_Appearance">
                 <ScrollViewer>
                     <StackPanel>
+                        <StackPanel Style="{StaticResource PivotStackStyle}">
+                            <!--Grouping: Text-->
+                            <TextBlock x:Uid="Profile_TextHeader" Style="{StaticResource SubtitleTextBlockStyle}"/>
 
-                        <!--Grouping: Text-->
-                        <TextBlock x:Uid="Profile_TextHeader" Style="{StaticResource GroupingHeader}" Margin="0,0,0,10"/>
-
-                        <!--Color Scheme-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                            <ComboBox x:Uid="Profile_ColorScheme"
+                            <!--Color Scheme-->
+                            <ContentPresenter>
+                                <ComboBox x:Uid="Profile_ColorScheme"
                                       ItemsSource="{x:Bind ColorSchemeList, Mode=OneWay}"
                                       SelectedItem="{x:Bind CurrentColorScheme, Mode=TwoWay}"
                                       Style="{StaticResource ComboBoxSettingStyle}">
-                                <ComboBox.ItemTemplate>
-                                    <DataTemplate x:DataType="model:ColorScheme">
-                                        <TextBlock Text="{x:Bind Name, Mode=OneWay}"/>
-                                    </DataTemplate>
-                                </ComboBox.ItemTemplate>
-                            </ComboBox>
-                        </ContentPresenter>
+                                    <ComboBox.ItemTemplate>
+                                        <DataTemplate x:DataType="model:ColorScheme">
+                                            <TextBlock Text="{x:Bind Name, Mode=OneWay}"/>
+                                        </DataTemplate>
+                                    </ComboBox.ItemTemplate>
+                                </ComboBox>
+                            </ContentPresenter>
 
-                        <!--Font Face-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                            <TextBox x:Uid="Profile_FontFace"
+                            <!--Font Face-->
+                            <ContentPresenter Style="{StaticResource SettingContainerStyle}">
+                                <TextBox x:Uid="Profile_FontFace"
                                      Text="{x:Bind State.Profile.FontFace, Mode=TwoWay}"
                                      Style="{StaticResource TextBoxSettingStyle}"/>
-                        </ContentPresenter>
+                            </ContentPresenter>
 
-                        <!--Font Size-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                            <muxc:NumberBox x:Uid="Profile_FontSize"
+                            <!--Font Size-->
+                            <ContentPresenter Style="{StaticResource SettingContainerStyle}">
+                                <muxc:NumberBox x:Uid="Profile_FontSize"
                                             Value="{x:Bind State.Profile.FontSize, Mode=TwoWay}"
                                             Style="{StaticResource NumberBoxSettingStyle}"
                                             AcceptsExpression="False"
@@ -227,336 +226,342 @@ the MIT License. See LICENSE in the project root for license information. -->
                                             Maximum="128"
                                             SmallChange="1"
                                             LargeChange="10"/>
-                        </ContentPresenter>
+                            </ContentPresenter>
 
-                        <!--Font Weight-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                            <StackPanel>
-                                <ComboBox x:Uid="Profile_FontWeight"
+                            <!--Font Weight-->
+                            <ContentPresenter Style="{StaticResource SettingContainerStyle}">
+                                <StackPanel>
+                                    <ComboBox x:Uid="Profile_FontWeight"
                                           x:Name="FontWeightComboBox"
                                           ItemsSource="{x:Bind FontWeightList, Mode=OneWay}"
                                           SelectedItem="{x:Bind CurrentFontWeight, Mode=TwoWay}"
                                           ItemTemplate="{StaticResource EnumComboBoxItemTemplate}"
                                           Style="{StaticResource ComboBoxSettingStyle}"/>
 
-                                <!--Custom Font Weight Control-->
-                                <Grid Margin="0,10,0,0"
+                                    <!--Custom Font Weight Control-->
+                                    <Grid Margin="0,10,0,0"
                                       Visibility="{x:Bind IsCustomFontWeight, Mode=OneWay}"
                                       Style="{StaticResource CustomSliderControlGridStyle}">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*"/>
-                                        <ColumnDefinition Width="Auto"/>
-                                    </Grid.ColumnDefinitions>
-                                    <Slider x:Name="FontWeightSlider"
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Slider x:Name="FontWeightSlider"
                                             Grid.Column="0"
                                             Minimum="0" Maximum="1000"
                                             TickFrequency="50" TickPlacement="Outside"
                                             Value="{x:Bind State.Profile.FontWeight,
                                                     Converter={StaticResource FontWeightConverter},
                                                     Mode=TwoWay}"/>
-                                    <TextBlock Grid.Column="1"
+                                        <TextBlock Grid.Column="1"
                                                Text="{Binding ElementName=FontWeightSlider, Path=Value, Mode=OneWay}"
                                                Style="{StaticResource SliderValueLabelStyle}"
                                                Margin="10,0,0,0"/>
-                                </Grid>
-                            </StackPanel>
-                        </ContentPresenter>
+                                    </Grid>
+                                </StackPanel>
+                            </ContentPresenter>
 
-                        <!--Retro Terminal Effect-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                            <CheckBox x:Uid="Profile_RetroTerminalEffect"
+                            <!--Retro Terminal Effect-->
+                            <ContentPresenter Style="{StaticResource SettingContainerStyle}">
+                                <CheckBox x:Uid="Profile_RetroTerminalEffect"
                                       IsChecked="{x:Bind State.Profile.RetroTerminalEffect, Mode=TwoWay}"
                                       Style="{StaticResource CheckBoxSettingStyle}"/>
-                        </ContentPresenter>
+                            </ContentPresenter>
+                        </StackPanel>
 
                         <!--Grouping: Cursor-->
-                        <TextBlock x:Uid="Profile_CursorHeader" Style="{StaticResource GroupingHeader}"/>
+                        <StackPanel Style="{StaticResource PivotStackStyle}">
+                            <TextBlock x:Uid="Profile_CursorHeader" Style="{StaticResource SubtitleTextBlockStyle}"/>
 
-                        <!--Cursor Shape-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                            <muxc:RadioButtons x:Uid="Profile_CursorShape"
-                                               ItemsSource="{x:Bind CursorShapeList, Mode=OneWay}"
-                                               SelectedItem="{x:Bind CurrentCursorShape, Mode=TwoWay}"
-                                               ItemTemplate="{StaticResource EnumRadioButtonTemplate}"
-                                               SelectionChanged="CursorShape_Changed"
-                                               Style="{StaticResource RadioButtonsSettingStyle}"/>
-                        </ContentPresenter>
+                            <!--Cursor Shape-->
+                            <ContentPresenter>
+                                <muxc:RadioButtons x:Uid="Profile_CursorShape"
+                                                   ItemsSource="{x:Bind CursorShapeList, Mode=OneWay}"
+                                                   SelectedItem="{x:Bind CurrentCursorShape, Mode=TwoWay}"
+                                                   ItemTemplate="{StaticResource EnumRadioButtonTemplate}"
+                                                   SelectionChanged="CursorShape_Changed"
+                                                   Style="{StaticResource RadioButtonsSettingStyle}"/>
+                            </ContentPresenter>
 
-                        <!--Cursor Height-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}"
-                                          Visibility="{x:Bind IsVintageCursor, Mode=OneWay}">
-                            <muxc:NumberBox x:Uid="Profile_CursorHeight"
-                                            Value="{x:Bind State.Profile.CursorHeight, Mode=TwoWay}"
-                                            Style="{StaticResource NumberBoxSettingStyle}"
-                                            SmallChange="1"
-                                            LargeChange="10"/>
-                        </ContentPresenter>
+                            <!--Cursor Height-->
+                            <ContentPresenter Style="{StaticResource SettingContainerStyle}"
+                                              Visibility="{x:Bind IsVintageCursor, Mode=OneWay}">
+                                <muxc:NumberBox x:Uid="Profile_CursorHeight"
+                                                Value="{x:Bind State.Profile.CursorHeight, Mode=TwoWay}"
+                                                Style="{StaticResource NumberBoxSettingStyle}"
+                                                SmallChange="1"
+                                                LargeChange="10"/>
+                            </ContentPresenter>
+                        </StackPanel>
 
                         <!--Grouping: Background-->
-                        <TextBlock x:Uid="Profile_BackgroundHeader" Style="{StaticResource GroupingHeader}"/>
+                        <StackPanel Style="{StaticResource PivotStackStyle}">
+                            <TextBlock x:Uid="Profile_BackgroundHeader" Style="{StaticResource SubtitleTextBlockStyle}"/>
 
-                        <!--Background Image-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                        </ContentPresenter>
-
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                            <StackPanel Orientation="Vertical">
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBox x:Uid="Profile_BackgroundImage"
+                            <!--Background Image-->
+                            <ContentPresenter>
+                                <StackPanel Orientation="Vertical">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBox x:Uid="Profile_BackgroundImage"
                                              x:Name="BackgroundImage"
                                              Text="{x:Bind State.Profile.BackgroundImagePath, Mode=TwoWay, Converter={StaticResource DesktopWallpaperToEmptyStringConverter}}"
                                              IsEnabled="{x:Bind State.Profile.BackgroundImagePath, Mode=OneWay, Converter={StaticResource StringIsNotDesktopConverter}}"
                                              Style="{StaticResource TextBoxSettingStyle}"/>
-                                    <Button x:Uid="Profile_BackgroundImageBrowse"
+                                        <Button x:Uid="Profile_BackgroundImageBrowse"
                                             Click="BackgroundImage_Click"
                                             IsEnabled="{x:Bind State.Profile.BackgroundImagePath, Mode=OneWay, Converter={StaticResource StringIsNotDesktopConverter}}"
                                             Style="{StaticResource BrowseButtonStyle}"/>
-                                </StackPanel>
-                                <CheckBox x:Uid="Profile_UseDesktopImage"
+                                    </StackPanel>
+                                    <CheckBox x:Uid="Profile_UseDesktopImage"
                                           x:Name="UseDesktopImageCheckBox"
                                           IsChecked="{x:Bind State.Profile.UseDesktopBGImage, Mode=TwoWay}"
                                           Style="{StaticResource CheckBoxSettingStyle}"/>
-                            </StackPanel>
-                        </ContentPresenter>
+                                </StackPanel>
+                            </ContentPresenter>
 
-                        <!--Background Image Stretch Mode-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}"
+                            <!--Background Image Stretch Mode-->
+                            <ContentPresenter Style="{StaticResource SettingContainerStyle}"
                                           Visibility="{x:Bind State.Profile.BackgroundImageSettingsVisible, Mode=OneWay}">
-                            <muxc:RadioButtons x:Uid="Profile_BackgroundImageStretchMode"
+                                <muxc:RadioButtons x:Uid="Profile_BackgroundImageStretchMode"
                                                ItemsSource="{x:Bind BackgroundImageStretchModeList, Mode=OneWay}"
                                                SelectedItem="{x:Bind CurrentBackgroundImageStretchMode, Mode=TwoWay}"
                                                ItemTemplate="{StaticResource EnumRadioButtonTemplate}"
                                                Style="{StaticResource RadioButtonsSettingStyle}"/>
-                        </ContentPresenter>
+                            </ContentPresenter>
 
-                        <!--Background Image Alignment-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}"
+                            <!--Background Image Alignment-->
+                            <ContentPresenter Style="{StaticResource SettingContainerStyle}"
                                           Visibility="{x:Bind State.Profile.BackgroundImageSettingsVisible, Mode=OneWay}">
-                            <StackPanel HorizontalAlignment="Left">
-                                <TextBlock x:Uid="Profile_BackgroundImageAlignment"
+                                <StackPanel HorizontalAlignment="Left">
+                                    <TextBlock x:Uid="Profile_BackgroundImageAlignment"
                                            Style="{StaticResource CustomSettingHeaderStyle}"
                                            ToolTipService.Placement="Mouse"/>
-                                <Grid>
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                    </Grid.RowDefinitions>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition Width="Auto"/>
-                                    </Grid.ColumnDefinitions>
+                                    <Grid>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
 
-                                    <Grid.Resources>
-                                        <Style TargetType="ToggleButton" BasedOn="{StaticResource DefaultToggleButtonStyle}">
-                                            <Setter Property="Margin" Value="2"/>
-                                            <Setter Property="Width" Value="40"/>
-                                            <Setter Property="Height" Value="40"/>
-                                            <Setter Property="ToolTipService.Placement" Value="Mouse"/>
-                                        </Style>
-                                    </Grid.Resources>
+                                        <Grid.Resources>
+                                            <Style TargetType="ToggleButton" BasedOn="{StaticResource DefaultToggleButtonStyle}">
+                                                <Setter Property="Margin" Value="2"/>
+                                                <Setter Property="Width" Value="40"/>
+                                                <Setter Property="Height" Value="40"/>
+                                                <Setter Property="ToolTipService.Placement" Value="Mouse"/>
+                                            </Style>
+                                        </Grid.Resources>
 
-                                    <!--Top Row-->
-                                    <ToggleButton x:Uid="Profile_BackgroundImageAlignmentTopLeft"
+                                        <!--Top Row-->
+                                        <ToggleButton x:Uid="Profile_BackgroundImageAlignmentTopLeft"
                                                   x:Name="BIAlign_TopLeft"
                                                   Grid.Row="0" Grid.Column="0"
                                                   Click="BIAlignment_Click">
-                                        <ToggleButton.Tag>
-                                            <!--ConvergedAlignment: Vertical_Top (0x10) | Horizontal_Left (0x01)-->
-                                            <x:Int32>17</x:Int32>
-                                        </ToggleButton.Tag>
-                                        <ToggleButton.Content>
-                                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE744;" RenderTransformOrigin="0.5,0.5">
-                                                <FontIcon.RenderTransform>
-                                                    <RotateTransform Angle="90"/>
-                                                </FontIcon.RenderTransform>
-                                            </FontIcon>
-                                        </ToggleButton.Content>
-                                    </ToggleButton>
-                                    <ToggleButton x:Uid="Profile_BackgroundImageAlignmentTop"
+                                            <ToggleButton.Tag>
+                                                <!--ConvergedAlignment: Vertical_Top (0x10) | Horizontal_Left (0x01)-->
+                                                <x:Int32>17</x:Int32>
+                                            </ToggleButton.Tag>
+                                            <ToggleButton.Content>
+                                                <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE744;" RenderTransformOrigin="0.5,0.5">
+                                                    <FontIcon.RenderTransform>
+                                                        <RotateTransform Angle="90"/>
+                                                    </FontIcon.RenderTransform>
+                                                </FontIcon>
+                                            </ToggleButton.Content>
+                                        </ToggleButton>
+                                        <ToggleButton x:Uid="Profile_BackgroundImageAlignmentTop"
                                                   x:Name="BIAlign_Top"
                                                   Grid.Row="0" Grid.Column="1"
                                                   Click="BIAlignment_Click">
-                                        <ToggleButton.Tag>
-                                            <!--ConvergedAlignment: Vertical_Top (0x10) | Horizontal_Center (0x00)-->
-                                            <x:Int32>16</x:Int32>
-                                        </ToggleButton.Tag>
-                                        <ToggleButton.Content>
-                                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE745;" RenderTransformOrigin="0.5,0.5">
-                                                <FontIcon.RenderTransform>
-                                                    <RotateTransform Angle="180"/>
-                                                </FontIcon.RenderTransform>
-                                            </FontIcon>
-                                        </ToggleButton.Content>
-                                    </ToggleButton>
-                                    <ToggleButton x:Uid="Profile_BackgroundImageAlignmentTopRight"
+                                            <ToggleButton.Tag>
+                                                <!--ConvergedAlignment: Vertical_Top (0x10) | Horizontal_Center (0x00)-->
+                                                <x:Int32>16</x:Int32>
+                                            </ToggleButton.Tag>
+                                            <ToggleButton.Content>
+                                                <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE745;" RenderTransformOrigin="0.5,0.5">
+                                                    <FontIcon.RenderTransform>
+                                                        <RotateTransform Angle="180"/>
+                                                    </FontIcon.RenderTransform>
+                                                </FontIcon>
+                                            </ToggleButton.Content>
+                                        </ToggleButton>
+                                        <ToggleButton x:Uid="Profile_BackgroundImageAlignmentTopRight"
                                                   x:Name="BIAlign_TopRight"
                                                   Grid.Row="0" Grid.Column="2"
                                                   Click="BIAlignment_Click">
-                                        <ToggleButton.Tag>
-                                            <!--ConvergedAlignment: Vertical_Top (0x10) | Horizontal_Right (0x02)-->
-                                            <x:Int32>18</x:Int32>
-                                        </ToggleButton.Tag>
-                                        <ToggleButton.Content>
-                                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xEA5F;" RenderTransformOrigin="0.5,0.5">
-                                                <FontIcon.RenderTransform>
-                                                    <RotateTransform Angle="270"/>
-                                                </FontIcon.RenderTransform>
-                                            </FontIcon>
-                                        </ToggleButton.Content>
-                                    </ToggleButton>
+                                            <ToggleButton.Tag>
+                                                <!--ConvergedAlignment: Vertical_Top (0x10) | Horizontal_Right (0x02)-->
+                                                <x:Int32>18</x:Int32>
+                                            </ToggleButton.Tag>
+                                            <ToggleButton.Content>
+                                                <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xEA5F;" RenderTransformOrigin="0.5,0.5">
+                                                    <FontIcon.RenderTransform>
+                                                        <RotateTransform Angle="270"/>
+                                                    </FontIcon.RenderTransform>
+                                                </FontIcon>
+                                            </ToggleButton.Content>
+                                        </ToggleButton>
 
-                                    <!--Middle Row-->
-                                    <ToggleButton x:Uid="Profile_BackgroundImageAlignmentLeft"
+                                        <!--Middle Row-->
+                                        <ToggleButton x:Uid="Profile_BackgroundImageAlignmentLeft"
                                                   x:Name="BIAlign_Left"
                                                   Grid.Row="1" Grid.Column="0"
                                                   Click="BIAlignment_Click">
-                                        <ToggleButton.Tag>
-                                            <!--ConvergedAlignment: Vertical_Center (0x00) | Horizontal_Left (0x01)-->
-                                            <x:Int32>1</x:Int32>
-                                        </ToggleButton.Tag>
-                                        <ToggleButton.Content>
-                                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE746;"/>
-                                        </ToggleButton.Content>
-                                    </ToggleButton>
-                                    <ToggleButton x:Uid="Profile_BackgroundImageAlignmentCenter"
+                                            <ToggleButton.Tag>
+                                                <!--ConvergedAlignment: Vertical_Center (0x00) | Horizontal_Left (0x01)-->
+                                                <x:Int32>1</x:Int32>
+                                            </ToggleButton.Tag>
+                                            <ToggleButton.Content>
+                                                <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE746;"/>
+                                            </ToggleButton.Content>
+                                        </ToggleButton>
+                                        <ToggleButton x:Uid="Profile_BackgroundImageAlignmentCenter"
                                                   x:Name="BIAlign_Center"
                                                   Grid.Row="1" Grid.Column="1"
                                                   Click="BIAlignment_Click">
-                                        <ToggleButton.Tag>
-                                            <!--ConvergedAlignment: Vertical_Center (0x00) | Horizontal_Center (0x00)-->
-                                            <x:Int32>0</x:Int32>
-                                        </ToggleButton.Tag>
-                                        <ToggleButton.Content>
-                                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xF16E;"/>
-                                        </ToggleButton.Content>
-                                    </ToggleButton>
-                                    <ToggleButton x:Uid="Profile_BackgroundImageAlignmentRight"
+                                            <ToggleButton.Tag>
+                                                <!--ConvergedAlignment: Vertical_Center (0x00) | Horizontal_Center (0x00)-->
+                                                <x:Int32>0</x:Int32>
+                                            </ToggleButton.Tag>
+                                            <ToggleButton.Content>
+                                                <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xF16E;"/>
+                                            </ToggleButton.Content>
+                                        </ToggleButton>
+                                        <ToggleButton x:Uid="Profile_BackgroundImageAlignmentRight"
                                                   x:Name="BIAlign_Right"
                                                   Grid.Row="1" Grid.Column="2"
                                                   Click="BIAlignment_Click">
-                                        <ToggleButton.Tag>
-                                            <!--ConvergedAlignment: Vertical_Center (0x00) | Horizontal_Right (0x02)-->
-                                            <x:Int32>2</x:Int32>
-                                        </ToggleButton.Tag>
-                                        <ToggleButton.Content>
-                                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xEA61;"/>
-                                        </ToggleButton.Content>
-                                    </ToggleButton>
+                                            <ToggleButton.Tag>
+                                                <!--ConvergedAlignment: Vertical_Center (0x00) | Horizontal_Right (0x02)-->
+                                                <x:Int32>2</x:Int32>
+                                            </ToggleButton.Tag>
+                                            <ToggleButton.Content>
+                                                <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xEA61;"/>
+                                            </ToggleButton.Content>
+                                        </ToggleButton>
 
-                                    <!--Bottom Row-->
-                                    <ToggleButton x:Uid="Profile_BackgroundImageAlignmentBottomLeft"
+                                        <!--Bottom Row-->
+                                        <ToggleButton x:Uid="Profile_BackgroundImageAlignmentBottomLeft"
                                                   x:Name="BIAlign_BottomLeft"
                                                   Grid.Row="2" Grid.Column="0"
                                                   Click="BIAlignment_Click">
-                                        <ToggleButton.Tag>
-                                            <!--ConvergedAlignment: Vertical_Bottom (0x20) | Horizontal_Left (0x01)-->
-                                            <x:Int32>33</x:Int32>
-                                        </ToggleButton.Tag>
-                                        <ToggleButton.Content>
-                                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE744;"/>
-                                        </ToggleButton.Content>
-                                    </ToggleButton>
-                                    <ToggleButton x:Uid="Profile_BackgroundImageAlignmentBottom"
+                                            <ToggleButton.Tag>
+                                                <!--ConvergedAlignment: Vertical_Bottom (0x20) | Horizontal_Left (0x01)-->
+                                                <x:Int32>33</x:Int32>
+                                            </ToggleButton.Tag>
+                                            <ToggleButton.Content>
+                                                <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE744;"/>
+                                            </ToggleButton.Content>
+                                        </ToggleButton>
+                                        <ToggleButton x:Uid="Profile_BackgroundImageAlignmentBottom"
                                                   x:Name="BIAlign_Bottom"
                                                   Grid.Row="2" Grid.Column="1"
                                                   Click="BIAlignment_Click">
-                                        <ToggleButton.Tag>
-                                            <!--ConvergedAlignment: Vertical_Bottom (0x20) | Horizontal_Center (0x00)-->
-                                            <x:Int32>32</x:Int32>
-                                        </ToggleButton.Tag>
-                                        <ToggleButton.Content>
-                                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE745;"/>
-                                        </ToggleButton.Content>
-                                    </ToggleButton>
-                                    <ToggleButton x:Uid="Profile_BackgroundImageAlignmentBottomRight"
+                                            <ToggleButton.Tag>
+                                                <!--ConvergedAlignment: Vertical_Bottom (0x20) | Horizontal_Center (0x00)-->
+                                                <x:Int32>32</x:Int32>
+                                            </ToggleButton.Tag>
+                                            <ToggleButton.Content>
+                                                <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE745;"/>
+                                            </ToggleButton.Content>
+                                        </ToggleButton>
+                                        <ToggleButton x:Uid="Profile_BackgroundImageAlignmentBottomRight"
                                                   x:Name="BIAlign_BottomRight"
                                                   Grid.Row="2" Grid.Column="2"
                                                   Click="BIAlignment_Click">
-                                        <ToggleButton.Tag>
-                                            <!--ConvergedAlignment: Vertical_Top (0x20) | Horizontal_Right (0x02)-->
-                                            <x:Int32>34</x:Int32>
-                                        </ToggleButton.Tag>
-                                        <ToggleButton.Content>
-                                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xEA5F;"/>
-                                        </ToggleButton.Content>
-                                    </ToggleButton>
-                                </Grid>
-                            </StackPanel>
-                        </ContentPresenter>
+                                            <ToggleButton.Tag>
+                                                <!--ConvergedAlignment: Vertical_Top (0x20) | Horizontal_Right (0x02)-->
+                                                <x:Int32>34</x:Int32>
+                                            </ToggleButton.Tag>
+                                            <ToggleButton.Content>
+                                                <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xEA5F;"/>
+                                            </ToggleButton.Content>
+                                        </ToggleButton>
+                                    </Grid>
+                                </StackPanel>
+                            </ContentPresenter>
 
-                        <!--Background Image Opacity-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}"
+                            <!--Background Image Opacity-->
+                            <ContentPresenter Style="{StaticResource SettingContainerStyle}"
                                           Visibility="{x:Bind State.Profile.BackgroundImageSettingsVisible, Mode=OneWay}">
-                            <StackPanel>
-                                <TextBlock x:Uid="Profile_BackgroundImageOpacity"
+                                <StackPanel>
+                                    <TextBlock x:Uid="Profile_BackgroundImageOpacity"
                                            Style="{StaticResource SliderHeaderStyle}"/>
-                                <Grid Style="{StaticResource CustomSliderControlGridStyle}">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*"/>
-                                        <ColumnDefinition Width="Auto"/>
-                                    </Grid.ColumnDefinitions>
-                                    <Slider x:Name="BIOpacitySlider"
+                                    <Grid Style="{StaticResource CustomSliderControlGridStyle}">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Slider x:Name="BIOpacitySlider"
                                             Grid.Column="0"
                                             Value="{x:Bind State.Profile.BackgroundImageOpacity, Converter={StaticResource PercentageConverter}, Mode=TwoWay}"/>
-                                    <TextBlock Grid.Column="1"
+                                        <TextBlock Grid.Column="1"
                                                Text="{Binding ElementName=BIOpacitySlider, Path=Value, Mode=OneWay}"
                                                Style="{StaticResource SliderValueLabelStyle}"/>
-                                </Grid>
-                            </StackPanel>
-                        </ContentPresenter>
+                                    </Grid>
+                                </StackPanel>
+                            </ContentPresenter>
+                        </StackPanel>
 
                         <!--Grouping: Acrylic-->
-                        <TextBlock x:Uid="Profile_AcrylicHeader" Style="{StaticResource GroupingHeader}"/>
+                        <StackPanel Style="{StaticResource PivotStackStyle}">
+                            <TextBlock x:Uid="Profile_AcrylicHeader" Style="{StaticResource SubtitleTextBlockStyle}"/>
 
-                        <!--Use Acrylic-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                            <CheckBox x:Uid="Profile_UseAcrylic"
+                            <!--Use Acrylic-->
+                            <ContentPresenter>
+                                <CheckBox x:Uid="Profile_UseAcrylic"
                                       x:Name="UseAcrylicCheckBox"
                                       IsChecked="{x:Bind State.Profile.UseAcrylic, Mode=TwoWay}"
                                       Style="{StaticResource CheckBoxSettingStyle}"/>
-                        </ContentPresenter>
+                            </ContentPresenter>
 
-                        <!--Acrylic Opacity-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}"
+                            <!--Acrylic Opacity-->
+                            <ContentPresenter Style="{StaticResource SettingContainerStyle}"
                                           Visibility="{Binding ElementName=UseAcrylicCheckBox, Path=IsChecked, Mode=OneWay}">
-                            <StackPanel x:Name="AcrylicOpacityControl">
-                                <TextBlock x:Uid="Profile_AcrylicOpacity"
+                                <StackPanel x:Name="AcrylicOpacityControl">
+                                    <TextBlock x:Uid="Profile_AcrylicOpacity"
                                            Style="{StaticResource SliderHeaderStyle}"/>
-                                <Grid Style="{StaticResource CustomSliderControlGridStyle}">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*"/>
-                                        <ColumnDefinition Width="Auto"/>
-                                    </Grid.ColumnDefinitions>
-                                    <Slider x:Name="AcrylicOpacitySlider"
+                                    <Grid Style="{StaticResource CustomSliderControlGridStyle}">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Slider x:Name="AcrylicOpacitySlider"
                                             Grid.Column="0"
                                             Value="{x:Bind State.Profile.AcrylicOpacity, Converter={StaticResource PercentageConverter}, Mode=TwoWay}"/>
-                                    <TextBlock Grid.Column="1"
+                                        <TextBlock Grid.Column="1"
                                                Text="{Binding ElementName=AcrylicOpacitySlider, Path=Value, Mode=OneWay}"
                                                Style="{StaticResource SliderValueLabelStyle}"/>
-                                </Grid>
-                            </StackPanel>
-                        </ContentPresenter>
+                                    </Grid>
+                                </StackPanel>
+                            </ContentPresenter>
+                        </StackPanel>
 
                         <!--Grouping: Window-->
-                        <TextBlock x:Uid="Profile_WindowHeader" Style="{StaticResource GroupingHeader}"/>
+                        <StackPanel Style="{StaticResource PivotStackStyle}">
+                            <TextBlock x:Uid="Profile_WindowHeader" Style="{StaticResource SubtitleTextBlockStyle}"/>
 
-                        <!--Padding-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                            <TextBox x:Uid="Profile_Padding"
+                            <!--Padding-->
+                            <ContentPresenter>
+                                <TextBox x:Uid="Profile_Padding"
                                      Text="{x:Bind State.Profile.Padding, Mode=TwoWay}"
                                      Style="{StaticResource TextBoxSettingStyle}"/>
-                        </ContentPresenter>
+                            </ContentPresenter>
 
-                        <!--Scrollbar Visibility-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                            <muxc:RadioButtons x:Uid="Profile_ScrollbarVisibility"
+                            <!--Scrollbar Visibility-->
+                            <ContentPresenter Style="{StaticResource SettingContainerStyle}">
+                                <muxc:RadioButtons x:Uid="Profile_ScrollbarVisibility"
                                                ItemsSource="{x:Bind ScrollStateList, Mode=OneWay}"
                                                SelectedItem="{x:Bind CurrentScrollState, Mode=TwoWay}"
                                                ItemTemplate="{StaticResource EnumRadioButtonTemplate}"
                                                Style="{StaticResource RadioButtonsSettingStyle}"/>
-                        </ContentPresenter>
+                            </ContentPresenter>
+                        </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
             </PivotItem>
@@ -564,9 +569,9 @@ the MIT License. See LICENSE in the project root for license information. -->
             <!-- Advanced Tab -->
             <PivotItem x:Uid="Profile_Advanced">
                 <ScrollViewer>
-                    <StackPanel Margin="{StaticResource PivotStackPanelMargin}">
+                    <StackPanel Style="{StaticResource PivotStackStyle}">
                         <!--Suppress Application Title-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
+                        <ContentPresenter>
                             <CheckBox x:Uid="Profile_SuppressApplicationTitle"
                                       IsChecked="{x:Bind State.Profile.SuppressApplicationTitle, Mode=TwoWay}"
                                       Style="{StaticResource CheckBoxSettingStyle}"/>

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -59,7 +59,9 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <ScrollViewer>
                     <StackPanel Style="{StaticResource PivotStackStyle}">
                         <!--Commandline-->
-                        <ContentPresenter Visibility="{x:Bind State.Profile.IsBaseLayer, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}">
+                        <ContentPresenter Visibility="{x:Bind State.Profile.IsBaseLayer, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}"
+                                          Style="{StaticResource SettingContainerStyle}"
+                                          Margin="0,0,0,24">
                             <StackPanel Orientation="Horizontal">
                                 <TextBox x:Uid="Profile_Commandline"
                                          x:Name="Commandline"
@@ -72,7 +74,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                         </ContentPresenter>
 
                         <!--Starting Directory-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
+                        <ContentPresenter Style="{StaticResource SettingContainerStyle}"
+                                          Margin="0">
                             <StackPanel Orientation="Vertical">
                                 <StackPanel Orientation="Horizontal">
                                     <TextBox x:Uid="Profile_StartingDirectory"
@@ -191,7 +194,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                             <TextBlock x:Uid="Profile_TextHeader" Style="{StaticResource SubtitleTextBlockStyle}"/>
 
                             <!--Color Scheme-->
-                            <ContentPresenter>
+                            <ContentPresenter Style="{StaticResource SettingContainerStyle}"
+                                              Margin="0">
                                 <ComboBox x:Uid="Profile_ColorScheme"
                                       ItemsSource="{x:Bind ColorSchemeList, Mode=OneWay}"
                                       SelectedItem="{x:Bind CurrentColorScheme, Mode=TwoWay}"
@@ -268,7 +272,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                             <TextBlock x:Uid="Profile_CursorHeader" Style="{StaticResource SubtitleTextBlockStyle}"/>
 
                             <!--Cursor Shape-->
-                            <ContentPresenter>
+                            <ContentPresenter Style="{StaticResource SettingContainerStyle}"
+                                              Margin="0">
                                 <muxc:RadioButtons x:Uid="Profile_CursorShape"
                                                    ItemsSource="{x:Bind CursorShapeList, Mode=OneWay}"
                                                    SelectedItem="{x:Bind CurrentCursorShape, Mode=TwoWay}"
@@ -292,7 +297,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                             <TextBlock x:Uid="Profile_BackgroundHeader" Style="{StaticResource SubtitleTextBlockStyle}"/>
 
                             <!--Background Image-->
-                            <ContentPresenter>
+                            <ContentPresenter Style="{StaticResource SettingContainerStyle}"
+                                              Margin="0">
                                 <StackPanel Orientation="Vertical">
                                     <StackPanel Orientation="Horizontal">
                                         <TextBox x:Uid="Profile_BackgroundImage"
@@ -504,7 +510,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                             <TextBlock x:Uid="Profile_AcrylicHeader" Style="{StaticResource SubtitleTextBlockStyle}"/>
 
                             <!--Use Acrylic-->
-                            <ContentPresenter>
+                            <ContentPresenter Style="{StaticResource SettingContainerStyle}"
+                                              Margin="0">
                                 <ToggleSwitch x:Uid="Profile_UseAcrylic"
                                               x:Name="UseAcrylicToggleSwitch"
                                               IsOn="{x:Bind State.Profile.UseAcrylic, Mode=TwoWay}"/>
@@ -537,7 +544,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                             <TextBlock x:Uid="Profile_WindowHeader" Style="{StaticResource SubtitleTextBlockStyle}"/>
 
                             <!--Padding-->
-                            <ContentPresenter>
+                            <ContentPresenter Style="{StaticResource SettingContainerStyle}"
+                                              Margin="0">
                                 <TextBox x:Uid="Profile_Padding"
                                      Text="{x:Bind State.Profile.Padding, Mode=TwoWay}"
                                      Style="{StaticResource TextBoxSettingStyle}"/>
@@ -560,7 +568,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <ScrollViewer>
                     <StackPanel Style="{StaticResource PivotStackStyle}">
                         <!--Suppress Application Title-->
-                        <ContentPresenter>
+                        <ContentPresenter Style="{StaticResource SettingContainerStyle}"
+                                          Margin="0">
                             <ToggleSwitch x:Uid="Profile_SuppressApplicationTitle"
                                           IsOn="{x:Bind State.Profile.SuppressApplicationTitle, Mode=TwoWay}"/>
                         </ContentPresenter>

--- a/src/cascadia/TerminalSettingsEditor/Rendering.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Rendering.xaml
@@ -19,8 +19,7 @@ the MIT License. See LICENSE in the project root for license information. -->
     <ScrollViewer>
         <StackPanel Style="{StaticResource SettingsStackStyle}">
             <TextBlock x:Uid="Globals_RenderingDisclaimer"
-                       Style="{StaticResource DisclaimerStyle}"
-                       Margin="{StaticResource StandardControlSpacing}"/>
+                       Style="{StaticResource DisclaimerStyle}"/>
 
             <!--Force Full Repaint-->
             <ContentPresenter Style="{StaticResource SettingContainerStyle}">

--- a/src/cascadia/TerminalSettingsEditor/Rendering.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Rendering.xaml
@@ -24,15 +24,13 @@ the MIT License. See LICENSE in the project root for license information. -->
             <!--Force Full Repaint-->
             <ContentPresenter Style="{StaticResource SettingContainerStyle}">
                 <ToggleSwitch x:Uid="Globals_ForceFullRepaint"
-                              IsOn="{x:Bind State.Globals.ForceFullRepaintRendering, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
+                              IsOn="{x:Bind State.Globals.ForceFullRepaintRendering, Mode=TwoWay}"/>
             </ContentPresenter>
 
             <!--Software Rendering-->
             <ContentPresenter Style="{StaticResource SettingContainerStyle}">
                 <ToggleSwitch x:Uid="Globals_SoftwareRendering"
-                              IsOn="{x:Bind State.Globals.SoftwareRendering, Mode=TwoWay}"
-                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
+                              IsOn="{x:Bind State.Globals.SoftwareRendering, Mode=TwoWay}"/>
             </ContentPresenter>
         </StackPanel>
     </ScrollViewer>

--- a/src/cascadia/TerminalSettingsEditor/Rendering.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Rendering.xaml
@@ -23,16 +23,16 @@ the MIT License. See LICENSE in the project root for license information. -->
 
             <!--Force Full Repaint-->
             <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                <CheckBox x:Uid="Globals_ForceFullRepaint"
-                          IsChecked="{x:Bind State.Globals.ForceFullRepaintRendering, Mode=TwoWay}"
-                          Style="{StaticResource CheckBoxSettingStyle}"/>
+                <ToggleSwitch x:Uid="Globals_ForceFullRepaint"
+                              IsOn="{x:Bind State.Globals.ForceFullRepaintRendering, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
             </ContentPresenter>
 
             <!--Software Rendering-->
             <ContentPresenter Style="{StaticResource SettingContainerStyle}">
-                <CheckBox x:Uid="Globals_SoftwareRendering"
-                          IsChecked="{x:Bind State.Globals.SoftwareRendering, Mode=TwoWay}"
-                          Style="{StaticResource CheckBoxSettingStyle}"/>
+                <ToggleSwitch x:Uid="Globals_SoftwareRendering"
+                              IsOn="{x:Bind State.Globals.SoftwareRendering, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchSettingStyle}"/>
             </ContentPresenter>
         </StackPanel>
     </ScrollViewer>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -204,14 +204,14 @@
   <data name="Globals_ForceFullRepaint.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>When unchecked, the terminal will render only the updates to the screen between frames.</value>
   </data>
-  <data name="Globals_InitialCols.Text" xml:space="preserve">
-    <value>Columns:</value>
+  <data name="Globals_InitialCols.Header" xml:space="preserve">
+    <value>Columns</value>
   </data>
   <data name="Globals_InitialCols.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>The number of columns displayed in the window upon first load. Measured in characters.</value>
   </data>
-  <data name="Globals_InitialRows.Text" xml:space="preserve">
-    <value>Rows:</value>
+  <data name="Globals_InitialRows.Header" xml:space="preserve">
+    <value>Rows</value>
   </data>
   <data name="Globals_InitialRows.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>The number of rows displayed in the window upon first load. Measured in characters.</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -177,7 +177,7 @@
   <data name="ColorScheme_Yellow.Header" xml:space="preserve">
     <value>Yellow</value>
   </data>
-  <data name="Globals_AlwaysShowTabs.Content" xml:space="preserve">
+  <data name="Globals_AlwaysShowTabs.Header" xml:space="preserve">
     <value>Always show tabs</value>
   </data>
   <data name="Globals_AlwaysShowTabs.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
@@ -189,7 +189,7 @@
   <data name="Globals_CopyFormatting.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>When checked, the color and font formatting of selected text is also copied to your clipboard. When unchecked, only plain text is copied to your clipboard.</value>
   </data>
-  <data name="Globals_CopyOnSelect.Content" xml:space="preserve">
+  <data name="Globals_CopyOnSelect.Header" xml:space="preserve">
     <value>Automatically copy selection to clipboard</value>
   </data>
   <data name="Globals_DefaultProfile.Header" xml:space="preserve">
@@ -198,7 +198,7 @@
   <data name="Globals_DefaultProfile.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Profile that opens when clicking the '+' icon or by typing the new tab key binding.</value>
   </data>
-  <data name="Globals_ForceFullRepaint.Content" xml:space="preserve">
+  <data name="Globals_ForceFullRepaint.Header" xml:space="preserve">
     <value>Redraw entire screen when display updates</value>
   </data>
   <data name="Globals_ForceFullRepaint.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
@@ -235,37 +235,37 @@
   <data name="Globals_RenderingDisclaimer.Text" xml:space="preserve">
     <value>These settings may be useful for troubleshooting an issue, however they will impact your performance.</value>
   </data>
-  <data name="Globals_ShowTitlebar.Content" xml:space="preserve">
+  <data name="Globals_ShowTitlebar.Header" xml:space="preserve">
     <value>Hide the title bar (requires relaunch)</value>
   </data>
   <data name="Globals_ShowTitlebar.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>When unchecked, the title bar will appear above the tabs.</value>
   </data>
-  <data name="Globals_ShowTitleInTitlebar.Content" xml:space="preserve">
+  <data name="Globals_ShowTitleInTitlebar.Header" xml:space="preserve">
     <value>Use active terminal title as application title</value>
   </data>
   <data name="Globals_ShowTitleInTitlebar.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>When unchecked, the title bar will be 'Windows Terminal'.</value>
   </data>
-  <data name="Globals_SnapToGridOnResize.Content" xml:space="preserve">
+  <data name="Globals_SnapToGridOnResize.Header" xml:space="preserve">
     <value>Snap window resizing to character grid</value>
   </data>
   <data name="Globals_SnapToGridOnResize.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>When unchecked, the window will resize smoothly.</value>
   </data>
-  <data name="Globals_SoftwareRendering.Content" xml:space="preserve">
+  <data name="Globals_SoftwareRendering.Header" xml:space="preserve">
     <value>Use software rendering</value>
   </data>
   <data name="Globals_SoftwareRendering.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>When checked, the terminal will use the software renderer (a.k.a. WARP) instead of the hardware one.</value>
   </data>
-  <data name="Globals_StartOnUserLogin.Content" xml:space="preserve">
+  <data name="Globals_StartOnUserLogin.Header" xml:space="preserve">
     <value>Launch on machine startup</value>
   </data>
   <data name="Globals_StartOnUserLogin.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>When checked, this enables the launch of Windows Terminal at machine startup.</value>
   </data>
-  <data name="Globals_AlwaysOnTop.Content" xml:space="preserve">
+  <data name="Globals_AlwaysOnTop.Header" xml:space="preserve">
     <value>Always on top</value>
   </data>
   <data name="Globals_AlwaysOnTop.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
@@ -338,7 +338,7 @@
   <data name="Profile_Advanced.Header" xml:space="preserve">
     <value>Advanced</value>
   </data>
-  <data name="Profile_AltGrAliasing.Content" xml:space="preserve">
+  <data name="Profile_AltGrAliasing.Header" xml:space="preserve">
     <value>AltGr aliasing</value>
   </data>
   <data name="Profile_AltGrAliasing.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
@@ -532,7 +532,7 @@
   <data name="Profile_General.Header" xml:space="preserve">
     <value>General</value>
   </data>
-  <data name="Profile_Hidden.Content" xml:space="preserve">
+  <data name="Profile_Hidden.Header" xml:space="preserve">
     <value>Hide profile from dropdown</value>
   </data>
   <data name="Profile_Hidden.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
@@ -559,7 +559,7 @@
   <data name="Profile_Padding.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Sets the padding around the text within the window.</value>
   </data>
-  <data name="Profile_RetroTerminalEffect.Content" xml:space="preserve">
+  <data name="Profile_RetroTerminalEffect.Header" xml:space="preserve">
     <value>Retro terminal effects</value>
   </data>
   <data name="Profile_RetroTerminalEffect.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
@@ -580,7 +580,7 @@
   <data name="Profile_SelectionBackgroundColorToolTip.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Sets the background color of selected text. Overrides the selection background set in the color scheme.</value>
   </data>
-  <data name="Profile_SnapOnInput.Content" xml:space="preserve">
+  <data name="Profile_SnapOnInput.Header" xml:space="preserve">
     <value>Scroll to input when typing</value>
   </data>
   <data name="Profile_StartingDirectory.Header" xml:space="preserve">
@@ -598,7 +598,7 @@
   <data name="Profile_StartingDirectoryUseParentCheckbox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>If checked, this profile will spawn in the directory from which Windows Terminal was launched.</value>
   </data>
-  <data name="Profile_SuppressApplicationTitle.Content" xml:space="preserve">
+  <data name="Profile_SuppressApplicationTitle.Header" xml:space="preserve">
     <value>Suppress title changes</value>
   </data>
   <data name="Profile_SuppressApplicationTitle.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
@@ -610,7 +610,7 @@
   <data name="Profile_TabTitle.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Replaces the profile name as the title to pass to the shell on startup.</value>
   </data>
-  <data name="Profile_UseAcrylic.Content" xml:space="preserve">
+  <data name="Profile_UseAcrylic.Header" xml:space="preserve">
     <value>Enable acrylic</value>
   </data>
   <data name="Profile_UseAcrylic.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
@@ -660,7 +660,7 @@
   <data name="Profile_BellStyleNone.Content" xml:space="preserve">
     <value>None</value>
   </data>
-  <data name="Globals_DisableAnimations.Content" xml:space="preserve">
+  <data name="Globals_DisableAnimations.Header" xml:space="preserve">
     <value>Disable pane animations</value>
   </data>
   <data name="Profile_FontWeightBlack.Content" xml:space="preserve">


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The settings UI was _close_ to looking just right, it just needed some tweaks to adhere to the proper guidance: https://docs.microsoft.com/en-us/windows/uwp/design/controls-and-patterns/forms

This PR changes the font sizes, spacing, and layout of all of the pages to align with guidance.

Some pics:
![image](https://user-images.githubusercontent.com/48369326/105241313-58194980-5b22-11eb-9f18-524cc988ec33.png)

![image](https://user-images.githubusercontent.com/48369326/105241331-60718480-5b22-11eb-8698-b9fadf3c3016.png)

![image](https://user-images.githubusercontent.com/48369326/105244413-57ce7d80-5b25-11eb-87c3-ee5f19417318.png)

![image](https://user-images.githubusercontent.com/48369326/105241384-73845480-5b22-11eb-9517-4010b145ffc2.png)

Min width:
![image](https://user-images.githubusercontent.com/48369326/105241406-7aab6280-5b22-11eb-9c59-ffc72f66509d.png)

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #8816 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
* Removed custom font sizing, WinUI adheres to guidance anyway
* 24px spacing between controls and 48px between groupings
* Controls shouldn't be next to each other (see Launch size)
* Technically Launch size is a grouping, so it gets upgraded to subtitle status
* Left margins for pages have been fixed to left align with the page titles
* Single checkboxes have been changed to toggle switches

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
