### PR TITLE
Bugfix: navigate to new profile ref on settings reload

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -154,7 +154,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                             {
                                 // found the one that was selected before the refresh
                                 SettingsNav().SelectedItem(item);
-                                _Navigate(*selectedItemProfileTag);
+                                _Navigate(*profileTag);
                                 co_return;
                             }
                         }


### PR DESCRIPTION
Upon a settings reload, we would select the correct navigation item for
a profile, but navigate to the old one. As a result, you would navigate
to the old page that points to a dead profile object. This would make it
appear like you did not discard/save the changes.

This bugfix navigates to the newly created profile, ensuring that your
changes are actually applied to the settings model's clone in use.

## References
#8773 - Introduced the bug
#6800 - Settings UI Epic

## Validation Steps Performed
- Navigate to "powershell" profile
- edit "tab title" value
- discard changes

Before: changes would persist unless you discarded changes again
Now: changes are discarded

Also verified expected behavior occurs when you click "save" instead of
"discard"