### PR TITLE
[Settings UI] Allow renaming a profile

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -373,6 +373,21 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         icon.IconSource(iconSource);
         profileNavItem.Icon(icon);
 
+        // Update the menu item when the icon/name changes
+        profile.PropertyChanged([profileNavItem](const auto&, const WUX::Data::PropertyChangedEventArgs& args) {
+            const auto& tag{ profileNavItem.Tag().as<Editor::ProfileViewModel>() };
+            if (args.PropertyName() == L"Icon")
+            {
+                const auto iconSource{ IconPathConverter::IconSourceWUX(tag.Icon()) };
+                WUX::Controls::IconSourceElement icon;
+                icon.IconSource(iconSource);
+                profileNavItem.Icon(icon);
+            }
+            else if (args.PropertyName() == L"Name")
+            {
+                profileNavItem.Content(box_value(tag.Name()));
+            }
+        });
         return profileNavItem;
     }
 

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -374,18 +374,20 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         profileNavItem.Icon(icon);
 
         // Update the menu item when the icon/name changes
-        profile.PropertyChanged([profileNavItem](const auto&, const WUX::Data::PropertyChangedEventArgs& args) {
-            const auto& tag{ profileNavItem.Tag().as<Editor::ProfileViewModel>() };
+        auto weakMenuItem{ make_weak(profileNavItem) };
+        profile.PropertyChanged([weakMenuItem](const auto&, const WUX::Data::PropertyChangedEventArgs& args) {
+            auto menuItem{ weakMenuItem.get() };
+            const auto& tag{ menuItem.Tag().as<Editor::ProfileViewModel>() };
             if (args.PropertyName() == L"Icon")
             {
                 const auto iconSource{ IconPathConverter::IconSourceWUX(tag.Icon()) };
                 WUX::Controls::IconSourceElement icon;
                 icon.IconSource(iconSource);
-                profileNavItem.Icon(icon);
+                menuItem.Icon(icon);
             }
             else if (args.PropertyName() == L"Name")
             {
-                profileNavItem.Content(box_value(tag.Name()));
+                menuItem.Content(box_value(tag.Name()));
             }
         });
         return profileNavItem;

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -376,18 +376,20 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // Update the menu item when the icon/name changes
         auto weakMenuItem{ make_weak(profileNavItem) };
         profile.PropertyChanged([weakMenuItem](const auto&, const WUX::Data::PropertyChangedEventArgs& args) {
-            auto menuItem{ weakMenuItem.get() };
-            const auto& tag{ menuItem.Tag().as<Editor::ProfileViewModel>() };
-            if (args.PropertyName() == L"Icon")
+            if (auto menuItem{ weakMenuItem.get() })
             {
-                const auto iconSource{ IconPathConverter::IconSourceWUX(tag.Icon()) };
-                WUX::Controls::IconSourceElement icon;
-                icon.IconSource(iconSource);
-                menuItem.Icon(icon);
-            }
-            else if (args.PropertyName() == L"Name")
-            {
-                menuItem.Content(box_value(tag.Name()));
+                const auto& tag{ menuItem.Tag().as<Editor::ProfileViewModel>() };
+                if (args.PropertyName() == L"Icon")
+                {
+                    const auto iconSource{ IconPathConverter::IconSourceWUX(tag.Icon()) };
+                    WUX::Controls::IconSourceElement icon;
+                    icon.IconSource(iconSource);
+                    menuItem.Icon(icon);
+                }
+                else if (args.PropertyName() == L"Name")
+                {
+                    menuItem.Content(box_value(tag.Name()));
+                }
             }
         });
         return profileNavItem;

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -60,8 +60,9 @@ the MIT License. See LICENSE in the project root for license information. -->
                     <StackPanel Style="{StaticResource PivotStackStyle}">
                         
                         <!--Name-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}"
-                                          Margin="0">
+                        <ContentPresenter Visibility="{x:Bind State.Profile.IsBaseLayer, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}"
+                                          Style="{StaticResource SettingContainerStyle}"
+                                          Margin="0,0,0,24">
                             <TextBox x:Uid="Profile_Name"
                                      Text="{x:Bind State.Profile.Name, Mode=TwoWay}"
                                      Style="{StaticResource TextBoxSettingStyle}"/>
@@ -69,7 +70,8 @@ the MIT License. See LICENSE in the project root for license information. -->
 
                         <!--Commandline-->
                         <ContentPresenter Visibility="{x:Bind State.Profile.IsBaseLayer, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}"
-                                          Style="{StaticResource SettingContainerStyle}">
+                                          Style="{StaticResource SettingContainerStyle}"
+                                          Margin="0,0,0,24">
                             <StackPanel Orientation="Horizontal">
                                 <TextBox x:Uid="Profile_Commandline"
                                          x:Name="Commandline"
@@ -82,7 +84,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                         </ContentPresenter>
 
                         <!--Starting Directory-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
+                        <ContentPresenter Style="{StaticResource SettingContainerStyle}"
+                                          Margin="0">
                             <StackPanel Orientation="Vertical">
                                 <StackPanel Orientation="Horizontal">
                                     <TextBox x:Uid="Profile_StartingDirectory"

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -58,10 +58,18 @@ the MIT License. See LICENSE in the project root for license information. -->
             <PivotItem x:Uid="Profile_General">
                 <ScrollViewer>
                     <StackPanel Style="{StaticResource PivotStackStyle}">
+                        
+                        <!--Name-->
+                        <ContentPresenter Style="{StaticResource SettingContainerStyle}"
+                                          Margin="0">
+                            <TextBox x:Uid="Profile_Name"
+                                     Text="{x:Bind State.Profile.Name, Mode=TwoWay}"
+                                     Style="{StaticResource TextBoxSettingStyle}"/>
+                        </ContentPresenter>
+
                         <!--Commandline-->
                         <ContentPresenter Visibility="{x:Bind State.Profile.IsBaseLayer, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}"
-                                          Style="{StaticResource SettingContainerStyle}"
-                                          Margin="0,0,0,24">
+                                          Style="{StaticResource SettingContainerStyle}">
                             <StackPanel Orientation="Horizontal">
                                 <TextBox x:Uid="Profile_Commandline"
                                          x:Name="Commandline"
@@ -74,8 +82,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                         </ContentPresenter>
 
                         <!--Starting Directory-->
-                        <ContentPresenter Style="{StaticResource SettingContainerStyle}"
-                                          Margin="0">
+                        <ContentPresenter Style="{StaticResource SettingContainerStyle}">
                             <StackPanel Orientation="Vertical">
                                 <StackPanel Orientation="Horizontal">
                                     <TextBox x:Uid="Profile_StartingDirectory"


### PR DESCRIPTION
This adds a "Name" text box to the Profile page in the Settings UI.
Any changes to the name/icon are propagated to the relevant
NavigationViewItem.

Base Layer does not have a "Name".

## References
#6800 - Settings UI Epic
