### PR TITLE
Revert "Maintain current Pivot selection... (#8803)"

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -42,7 +42,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void _Navigate(const Editor::ProfileViewModel& profile);
 
         ColorSchemesPageNavigationState _colorSchemesNavState{ nullptr };
-        ProfilePageNavigationState _profilesNavState{ nullptr };
     };
 }
 

--- a/src/cascadia/TerminalSettingsEditor/Profiles.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.cpp
@@ -185,9 +185,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         {
             StartingDirectoryUseParentCheckbox().IsChecked(true);
         }
-
-        // Navigate to the pivot in the provided navigation state
-        ProfilesPivot().SelectedIndex(static_cast<int>(_State.LastActivePivot()));
     }
 
     ColorScheme Profiles::CurrentColorScheme()
@@ -367,12 +364,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     bool Profiles::IsVintageCursor() const
     {
         return _State.Profile().CursorShape() == TerminalControl::CursorStyle::Vintage;
-    }
-
-    void Profiles::Pivot_SelectionChanged(Windows::Foundation::IInspectable const& /*sender*/,
-                                          Windows::UI::Xaml::RoutedEventArgs const& /*e*/)
-    {
-        _State.LastActivePivot(static_cast<Editor::ProfilesPivots>(ProfilesPivot().SelectedIndex()));
     }
 
 }

--- a/src/cascadia/TerminalSettingsEditor/Profiles.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.h
@@ -85,9 +85,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     struct ProfilePageNavigationState : ProfilePageNavigationStateT<ProfilePageNavigationState>
     {
     public:
-        ProfilePageNavigationState(const Editor::ProfileViewModel& viewModel,
-                                   const Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme>& schemes,
-                                   const IHostedInWindow& windowRoot) :
+        ProfilePageNavigationState(const Editor::ProfileViewModel& viewModel, const Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme>& schemes, const IHostedInWindow& windowRoot) :
             _Profile{ viewModel },
             _Schemes{ schemes },
             _WindowRoot{ windowRoot }
@@ -101,27 +99,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         TYPED_EVENT(DeleteProfile, Editor::ProfilePageNavigationState, Editor::DeleteProfileEventArgs);
         GETSET_PROPERTY(IHostedInWindow, WindowRoot, nullptr);
-        GETSET_PROPERTY(Editor::ProfilesPivots, LastActivePivot, Editor::ProfilesPivots::General);
-
-    public:
-        // Manually define Profile(), so we can overload the setter
-        Editor::ProfileViewModel Profile() const noexcept { return _Profile; }
-
-        void Profile(const Editor::ProfileViewModel& value) noexcept
-        {
-            // If the profile has a different guid than the new one, then reset
-            // the selected pivot to the "General" tab.
-            const auto& oldGuid = _Profile.Guid();
-            const auto& newGuid = value.Guid();
-            if (oldGuid != newGuid)
-            {
-                _LastActivePivot = Editor::ProfilesPivots::General;
-            }
-            _Profile = value;
-        }
+        GETSET_PROPERTY(Editor::ProfileViewModel, Profile, nullptr);
 
     private:
-        Editor::ProfileViewModel _Profile{ nullptr };
         Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme> _Schemes;
     };
 
@@ -143,7 +123,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void DeleteConfirmation_Click(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
         void UseParentProcessDirectory_Check(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
         void UseParentProcessDirectory_Uncheck(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
-        void Pivot_SelectionChanged(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);
 
         // CursorShape visibility logic
         void CursorShape_Changed(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const& e);

--- a/src/cascadia/TerminalSettingsEditor/Profiles.idl
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.idl
@@ -60,19 +60,12 @@ namespace Microsoft.Terminal.Settings.Editor
         Guid ProfileGuid { get; };
     }
 
-    enum ProfilesPivots {
-        General = 0,
-        Appearance = 1,
-        Advanced = 2
-    };
-
     runtimeclass ProfilePageNavigationState
     {
         Windows.Foundation.Collections.IMapView<String, Microsoft.Terminal.Settings.Model.ColorScheme> Schemes;
         IHostedInWindow WindowRoot; // necessary to send the right HWND into the file picker dialogs.
 
-        ProfileViewModel Profile;
-        ProfilesPivots LastActivePivot;
+        ProfileViewModel Profile { get; };
 
         event Windows.Foundation.TypedEventHandler<ProfilePageNavigationState, DeleteProfileEventArgs> DeleteProfile;
     };

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -49,10 +49,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                    Style="{StaticResource DisclaimerStyle}"
                    Visibility="{x:Bind State.Profile.IsBaseLayer}"/>
 
-        <Pivot x:Name="ProfilesPivot"
-               HorizontalAlignment="Left"
+        <Pivot HorizontalAlignment="Left"
                Grid.Row="1"
-               SelectionChanged="Pivot_SelectionChanged"
                Margin="1,0,0,0">
             <!-- General Tab -->
             <PivotItem x:Uid="Profile_General">


### PR DESCRIPTION
## Summary of the Pull Request
This reverts commit a7d7362b958ea98f20bab24e8c3ad605b51f8c66 introduced by #8803.

Reverting this commit fixes #8836 at the expense of the profile page remembering the last Pivot selection. The 

## References
#6800 - Settings UI Epic

## PR Checklist
* [X] Closes #8836 
* [X] Reopens first point in #8769 

## Detailed Description of the Pull Request / Additional comments
#8803 maintained a `ProfilePageNavigationState` in `MainPage` to remember the pivot position. However, the two-way binding on the TextBoxes now seem to happen too late (after the navigation occurs), resulting in the text being applied to the wrong profile. In other words, the sequence of events probably looks something like this:
1. user types text (_state.profile = old profile)
2. user moves to new profile
3. navigation completes (_state.profile = new profile)
4. textbox two-way binding fires, setting _state.profile.WHATEVER = value

## Validation Steps Performed
Performed repro sets from #8836. Bug no longer occurs. 