### PR TITLE
Add skeleton code for bracketed paste mode

### DIFF
--- a/.github/actions/spell-check/patterns/patterns.txt
+++ b/.github/actions/spell-check/patterns/patterns.txt
@@ -5,6 +5,7 @@ https://www\.vt100\.net/docs/[-a-zA-Z0-9#_\/.]*
 https://www.w3.org/[-a-zA-Z0-9?&=\/_#]*
 https://(?:(?:www\.|)youtube\.com|youtu.be)/[-a-zA-Z0-9?&=]*
 https://[a-z-]+\.githubusercontent\.com/[-a-zA-Z0-9?&=_\/.]*
+https://www.xfree86.org/[-a-zA-Z0-9?&=\/_#]*
 [Pp]ublicKeyToken="?[0-9a-fA-F]{16}"?
 (?:[{"]|UniqueIdentifier>)[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}(?:[}"]|</UniqueIdentifier)
 (?:0[Xx]|\\x|U\+|#)[a-f0-9A-FGgRr]{2,}[Uu]?[Ll]{0,2}\b

--- a/src/cascadia/TerminalCore/ITerminalApi.hpp
+++ b/src/cascadia/TerminalCore/ITerminalApi.hpp
@@ -55,8 +55,8 @@ namespace Microsoft::Terminal::Core
         virtual bool EnableButtonEventMouseMode(const bool enabled) noexcept = 0;
         virtual bool EnableAnyEventMouseMode(const bool enabled) noexcept = 0;
         virtual bool EnableAlternateScrollMode(const bool enabled) noexcept = 0;
-        virtual bool EnableBracketedPasteMode(const bool enabled) noexcept = 0;
-        virtual bool IsBracketedPasteModeEnabled() const = 0;
+        virtual bool EnableXtermBracketedPasteMode(const bool enabled) noexcept = 0;
+        virtual bool IsXtermBracketedPasteModeEnabled() const = 0;
 
         virtual bool IsVtInputEnabled() const = 0;
 

--- a/src/cascadia/TerminalCore/ITerminalApi.hpp
+++ b/src/cascadia/TerminalCore/ITerminalApi.hpp
@@ -55,6 +55,8 @@ namespace Microsoft::Terminal::Core
         virtual bool EnableButtonEventMouseMode(const bool enabled) noexcept = 0;
         virtual bool EnableAnyEventMouseMode(const bool enabled) noexcept = 0;
         virtual bool EnableAlternateScrollMode(const bool enabled) noexcept = 0;
+        virtual bool EnableBracketedPasteMode(const bool enabled) noexcept = 0;
+        virtual bool IsBracketedPasteModeEnabled() const = 0;
 
         virtual bool IsVtInputEnabled() const = 0;
 

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -108,6 +108,8 @@ public:
     bool EnableButtonEventMouseMode(const bool enabled) noexcept override;
     bool EnableAnyEventMouseMode(const bool enabled) noexcept override;
     bool EnableAlternateScrollMode(const bool enabled) noexcept override;
+    bool EnableBracketedPasteMode(const bool enabled) noexcept override;
+    bool IsBracketedPasteModeEnabled() const noexcept override;
 
     bool IsVtInputEnabled() const noexcept override;
 
@@ -249,6 +251,7 @@ private:
     bool _snapOnInput;
     bool _altGrAliasing;
     bool _suppressApplicationTitle;
+    bool _bracketedPasteMode;
 
     size_t _taskbarState;
     size_t _taskbarProgress;

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -108,8 +108,8 @@ public:
     bool EnableButtonEventMouseMode(const bool enabled) noexcept override;
     bool EnableAnyEventMouseMode(const bool enabled) noexcept override;
     bool EnableAlternateScrollMode(const bool enabled) noexcept override;
-    bool EnableBracketedPasteMode(const bool enabled) noexcept override;
-    bool IsBracketedPasteModeEnabled() const noexcept override;
+    bool EnableXtermBracketedPasteMode(const bool enabled) noexcept override;
+    bool IsXtermBracketedPasteModeEnabled() const noexcept override;
 
     bool IsVtInputEnabled() const noexcept override;
 

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -537,13 +537,13 @@ bool Terminal::EnableAlternateScrollMode(const bool enabled) noexcept
     return true;
 }
 
-bool Terminal::EnableBracketedPasteMode(const bool enabled) noexcept
+bool Terminal::EnableXtermBracketedPasteMode(const bool enabled) noexcept
 {
     _bracketedPasteMode = enabled;
     return true;
 }
 
-bool Terminal::IsBracketedPasteModeEnabled() const noexcept
+bool Terminal::IsXtermBracketedPasteModeEnabled() const noexcept
 {
     return _bracketedPasteMode;
 }

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -537,6 +537,17 @@ bool Terminal::EnableAlternateScrollMode(const bool enabled) noexcept
     return true;
 }
 
+bool Terminal::EnableBracketedPasteMode(const bool enabled) noexcept
+{
+    _bracketedPasteMode = enabled;
+    return true;
+}
+
+bool Terminal::IsBracketedPasteModeEnabled() const noexcept
+{
+    return _bracketedPasteMode;
+}
+
 bool Terminal::IsVtInputEnabled() const noexcept
 {
     // We should never be getting this call in Terminal.

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -371,6 +371,19 @@ bool TerminalDispatch::EnableAlternateScroll(const bool enabled) noexcept
     return true;
 }
 
+//Routine Description:
+// Enable Bracketed Paste Mode -  this changes the behavior of pasting.
+//      See: https://www.xfree86.org/current/ctlseqs.html#Bracketed%20Paste%20Mode
+//Arguments:
+// - enabled - true to enable, false to disable.
+// Return value:
+// True if handled successfully. False otherwise.
+bool TerminalDispatch::EnableBracketedPasteMode(const bool enabled) noexcept
+{
+    _terminalApi.EnableBracketedPasteMode(enabled);
+    return true;
+}
+
 bool TerminalDispatch::SetMode(const DispatchTypes::ModeParams param) noexcept
 {
     return _ModeParamsHelper(param, true);
@@ -510,6 +523,9 @@ bool TerminalDispatch::_ModeParamsHelper(const DispatchTypes::ModeParams param, 
         break;
     case DispatchTypes::ModeParams::ATT610_StartCursorBlink:
         success = EnableCursorBlinking(enable);
+        break;
+    case DispatchTypes::ModeParams::XTERM_BracketedPasteMode:
+        success = EnableBracketedPasteMode(enable);
         break;
     case DispatchTypes::ModeParams::W32IM_Win32InputMode:
         success = EnableWin32InputMode(enable);

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -378,9 +378,9 @@ bool TerminalDispatch::EnableAlternateScroll(const bool enabled) noexcept
 // - enabled - true to enable, false to disable.
 // Return value:
 // True if handled successfully. False otherwise.
-bool TerminalDispatch::EnableBracketedPasteMode(const bool enabled) noexcept
+bool TerminalDispatch::EnableXtermBracketedPasteMode(const bool enabled) noexcept
 {
-    _terminalApi.EnableBracketedPasteMode(enabled);
+    _terminalApi.EnableXtermBracketedPasteMode(enabled);
     return true;
 }
 
@@ -525,7 +525,7 @@ bool TerminalDispatch::_ModeParamsHelper(const DispatchTypes::ModeParams param, 
         success = EnableCursorBlinking(enable);
         break;
     case DispatchTypes::ModeParams::XTERM_BracketedPasteMode:
-        success = EnableBracketedPasteMode(enable);
+        success = EnableXtermBracketedPasteMode(enable);
         break;
     case DispatchTypes::ModeParams::W32IM_Win32InputMode:
         success = EnableWin32InputMode(enable);

--- a/src/cascadia/TerminalCore/TerminalDispatch.hpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.hpp
@@ -63,7 +63,7 @@ public:
     bool EnableButtonEventMouseMode(const bool enabled) noexcept override; // ?1002
     bool EnableAnyEventMouseMode(const bool enabled) noexcept override; // ?1003
     bool EnableAlternateScroll(const bool enabled) noexcept override; // ?1007
-    bool EnableBracketedPasteMode(const bool enabled) noexcept override; // ?2004
+    bool EnableXtermBracketedPasteMode(const bool enabled) noexcept override; // ?2004
 
     bool SetMode(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ModeParams /*param*/) noexcept override; // DECSET
     bool ResetMode(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ModeParams /*param*/) noexcept override; // DECRST

--- a/src/cascadia/TerminalCore/TerminalDispatch.hpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.hpp
@@ -63,6 +63,7 @@ public:
     bool EnableButtonEventMouseMode(const bool enabled) noexcept override; // ?1002
     bool EnableAnyEventMouseMode(const bool enabled) noexcept override; // ?1003
     bool EnableAlternateScroll(const bool enabled) noexcept override; // ?1007
+    bool EnableBracketedPasteMode(const bool enabled) noexcept override; // ?2004
 
     bool SetMode(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ModeParams /*param*/) noexcept override; // DECSET
     bool ResetMode(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ModeParams /*param*/) noexcept override; // DECRST

--- a/src/terminal/adapter/DispatchTypes.hpp
+++ b/src/terminal/adapter/DispatchTypes.hpp
@@ -338,6 +338,7 @@ namespace Microsoft::Console::VirtualTerminal::DispatchTypes
         SGR_EXTENDED_MODE = DECPrivateMode(1006),
         ALTERNATE_SCROLL = DECPrivateMode(1007),
         ASB_AlternateScreenBuffer = DECPrivateMode(1049),
+        XTERM_BracketedPasteMode = DECPrivateMode(2004),
         W32IM_Win32InputMode = DECPrivateMode(9001),
     };
 

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -78,7 +78,7 @@ public:
     virtual bool EnableButtonEventMouseMode(const bool enabled) = 0; // ?1002
     virtual bool EnableAnyEventMouseMode(const bool enabled) = 0; // ?1003
     virtual bool EnableAlternateScroll(const bool enabled) = 0; // ?1007
-    virtual bool EnableBracketedPasteMode(const bool enabled) = 0; // ?2004
+    virtual bool EnableXtermBracketedPasteMode(const bool enabled) = 0; // ?2004
     virtual bool SetColorTableEntry(const size_t tableIndex, const DWORD color) = 0; // OSCColorTable
     virtual bool SetDefaultForeground(const DWORD color) = 0; // OSCDefaultForeground
     virtual bool SetDefaultBackground(const DWORD color) = 0; // OSCDefaultBackground

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -78,6 +78,7 @@ public:
     virtual bool EnableButtonEventMouseMode(const bool enabled) = 0; // ?1002
     virtual bool EnableAnyEventMouseMode(const bool enabled) = 0; // ?1003
     virtual bool EnableAlternateScroll(const bool enabled) = 0; // ?1007
+    virtual bool EnableBracketedPasteMode(const bool enabled) = 0; // ?2004
     virtual bool SetColorTableEntry(const size_t tableIndex, const DWORD color) = 0; // OSCColorTable
     virtual bool SetDefaultForeground(const DWORD color) = 0; // OSCDefaultForeground
     virtual bool SetDefaultBackground(const DWORD color) = 0; // OSCDefaultBackground

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -2166,6 +2166,17 @@ bool AdaptDispatch::EnableAlternateScroll(const bool enabled)
 }
 
 //Routine Description:
+// Enable "bracketed paste mode".
+//Arguments:
+// - enabled - true to enable, false to disable.
+// Return value:
+// True if handled successfully. False otherwise.
+bool AdaptDispatch::EnableBracketedPasteMode(const bool /*enabled*/)
+{
+    return false;
+}
+
+//Routine Description:
 // Set Cursor Style - Changes the cursor's style to match the given Dispatch
 //      cursor style. Unix styles are a combination of the shape and the blinking state.
 //Arguments:

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -2171,9 +2171,9 @@ bool AdaptDispatch::EnableAlternateScroll(const bool enabled)
 // - enabled - true to enable, false to disable.
 // Return value:
 // True if handled successfully. False otherwise.
-bool AdaptDispatch::EnableBracketedPasteMode(const bool /*enabled*/)
+bool AdaptDispatch::EnableBracketedPasteMode(const bool /*enabled*/) noexcept
 {
-    return false;
+    return NoOp();
 }
 
 //Routine Description:

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -2171,7 +2171,7 @@ bool AdaptDispatch::EnableAlternateScroll(const bool enabled)
 // - enabled - true to enable, false to disable.
 // Return value:
 // True if handled successfully. False otherwise.
-bool AdaptDispatch::EnableBracketedPasteMode(const bool /*enabled*/) noexcept
+bool AdaptDispatch::EnableXtermBracketedPasteMode(const bool /*enabled*/) noexcept
 {
     return NoOp();
 }

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -106,6 +106,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool EnableButtonEventMouseMode(const bool enabled) override; // ?1002
         bool EnableAnyEventMouseMode(const bool enabled) override; // ?1003
         bool EnableAlternateScroll(const bool enabled) override; // ?1007
+        bool EnableBracketedPasteMode(const bool enabled) override; // ?2004
         bool SetCursorStyle(const DispatchTypes::CursorStyle cursorStyle) override; // DECSCUSR
         bool SetCursorColor(const COLORREF cursorColor) override;
 

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -106,7 +106,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool EnableButtonEventMouseMode(const bool enabled) override; // ?1002
         bool EnableAnyEventMouseMode(const bool enabled) override; // ?1003
         bool EnableAlternateScroll(const bool enabled) override; // ?1007
-        bool EnableBracketedPasteMode(const bool enabled) override; // ?2004
+        bool EnableBracketedPasteMode(const bool enabled) noexcept override; // ?2004
         bool SetCursorStyle(const DispatchTypes::CursorStyle cursorStyle) override; // DECSCUSR
         bool SetCursorColor(const COLORREF cursorColor) override;
 

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -106,7 +106,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool EnableButtonEventMouseMode(const bool enabled) override; // ?1002
         bool EnableAnyEventMouseMode(const bool enabled) override; // ?1003
         bool EnableAlternateScroll(const bool enabled) override; // ?1007
-        bool EnableBracketedPasteMode(const bool enabled) noexcept override; // ?2004
+        bool EnableXtermBracketedPasteMode(const bool enabled) noexcept override; // ?2004
         bool SetCursorStyle(const DispatchTypes::CursorStyle cursorStyle) override; // DECSCUSR
         bool SetCursorColor(const COLORREF cursorColor) override;
 

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -72,6 +72,7 @@ public:
     bool EnableButtonEventMouseMode(const bool /*enabled*/) noexcept override { return false; } // ?1002
     bool EnableAnyEventMouseMode(const bool /*enabled*/) noexcept override { return false; } // ?1003
     bool EnableAlternateScroll(const bool /*enabled*/) noexcept override { return false; } // ?1007
+    bool EnableBracketedPasteMode(const bool /*enabled*/) noexcept override { return false; } // ?2004
     bool SetColorTableEntry(const size_t /*tableIndex*/, const DWORD /*color*/) noexcept override { return false; } // OSCColorTable
     bool SetDefaultForeground(const DWORD /*color*/) noexcept override { return false; } // OSCDefaultForeground
     bool SetDefaultBackground(const DWORD /*color*/) noexcept override { return false; } // OSCDefaultBackground

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -72,7 +72,7 @@ public:
     bool EnableButtonEventMouseMode(const bool /*enabled*/) noexcept override { return false; } // ?1002
     bool EnableAnyEventMouseMode(const bool /*enabled*/) noexcept override { return false; } // ?1003
     bool EnableAlternateScroll(const bool /*enabled*/) noexcept override { return false; } // ?1007
-    bool EnableBracketedPasteMode(const bool /*enabled*/) noexcept override { return false; } // ?2004
+    bool EnableXtermBracketedPasteMode(const bool /*enabled*/) noexcept override { return false; } // ?2004
     bool SetColorTableEntry(const size_t /*tableIndex*/, const DWORD /*color*/) noexcept override { return false; } // OSCColorTable
     bool SetDefaultForeground(const DWORD /*color*/) noexcept override { return false; } // OSCDefaultForeground
     bool SetDefaultBackground(const DWORD /*color*/) noexcept override { return false; } // OSCDefaultBackground

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -1046,6 +1046,7 @@ public:
         _tabClearTypes{},
         _isDECCOLMAllowed{ false },
         _windowWidth{ 80 },
+        _bracketPasteMode { false },
         _win32InputMode{ false },
         _setDefaultForeground(false),
         _defaultForegroundColor{ RGB(0, 0, 0) },
@@ -1284,6 +1285,9 @@ public:
         case DispatchTypes::ModeParams::ASB_AlternateScreenBuffer:
             fSuccess = fEnable ? UseAlternateScreenBuffer() : UseMainScreenBuffer();
             break;
+        case DispatchTypes::ModeParams::XTERM_BracketedPasteMode:
+            fSuccess = EnableBracketedPasteMode(fEnable);
+            break;
         case DispatchTypes::ModeParams::W32IM_Win32InputMode:
             fSuccess = EnableWin32InputMode(fEnable);
             break;
@@ -1314,6 +1318,12 @@ public:
     bool SetVirtualTerminalInputMode(const bool fApplicationMode) noexcept
     {
         _cursorKeysMode = fApplicationMode;
+        return true;
+    }
+
+    bool EnableBracketPasteMode(const bool enable) noexcept
+    {
+        _bracketPasteMode = false;
         return true;
     }
 
@@ -1511,6 +1521,7 @@ public:
     std::vector<DispatchTypes::TabClearType> _tabClearTypes;
     bool _isDECCOLMAllowed;
     size_t _windowWidth;
+    bool _bracketPasteMode;
     bool _win32InputMode;
     bool _setDefaultForeground;
     DWORD _defaultForegroundColor;

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -1286,7 +1286,7 @@ public:
             fSuccess = fEnable ? UseAlternateScreenBuffer() : UseMainScreenBuffer();
             break;
         case DispatchTypes::ModeParams::XTERM_BracketedPasteMode:
-            fSuccess = EnableBracketedPasteMode(fEnable);
+            fSuccess = EnableXtermBracketedPasteMode(fEnable);
             break;
         case DispatchTypes::ModeParams::W32IM_Win32InputMode:
             fSuccess = EnableWin32InputMode(fEnable);
@@ -1321,7 +1321,7 @@ public:
         return true;
     }
 
-    bool EnableBracketedPasteMode(const bool enable) noexcept
+    bool EnableXtermBracketedPasteMode(const bool enable) noexcept
     {
         _bracketedPasteMode = enable;
         return true;

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -1046,7 +1046,7 @@ public:
         _tabClearTypes{},
         _isDECCOLMAllowed{ false },
         _windowWidth{ 80 },
-        _bracketedPasteMode { false },
+        _bracketedPasteMode{ false },
         _win32InputMode{ false },
         _setDefaultForeground(false),
         _defaultForegroundColor{ RGB(0, 0, 0) },

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -1323,7 +1323,7 @@ public:
 
     bool EnableBracketedPasteMode(const bool enable) noexcept
     {
-        _bracketedPasteMode = false;
+        _bracketedPasteMode = enable;
         return true;
     }
 

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -1046,7 +1046,7 @@ public:
         _tabClearTypes{},
         _isDECCOLMAllowed{ false },
         _windowWidth{ 80 },
-        _bracketPasteMode { false },
+        _bracketedPasteMode { false },
         _win32InputMode{ false },
         _setDefaultForeground(false),
         _defaultForegroundColor{ RGB(0, 0, 0) },
@@ -1321,9 +1321,9 @@ public:
         return true;
     }
 
-    bool EnableBracketPasteMode(const bool enable) noexcept
+    bool EnableBracketedPasteMode(const bool enable) noexcept
     {
-        _bracketPasteMode = false;
+        _bracketedPasteMode = false;
         return true;
     }
 
@@ -1521,7 +1521,7 @@ public:
     std::vector<DispatchTypes::TabClearType> _tabClearTypes;
     bool _isDECCOLMAllowed;
     size_t _windowWidth;
-    bool _bracketPasteMode;
+    bool _bracketedPasteMode;
     bool _win32InputMode;
     bool _setDefaultForeground;
     DWORD _defaultForegroundColor;


### PR DESCRIPTION
This adds the skeleton code for "bracketed paste mode" to the Windows
Terminal. No actual functionality is implemented yet, just the wiring
for handling DECSET/DECRST 2004.

References #395
Supersedes #7508