### PR TITLE
Nit: update string in cursor shape

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -506,7 +506,7 @@
     <comment>{Locked="▃"}</comment>
   </data>
   <data name="Profile_CursorShapeDoubleUnderscore.Content" xml:space="preserve">
-    <value>Double Underscore ( ‗ )</value>
+    <value>Double underscore ( ‗ )</value>
     <comment>{Locked="‗"}</comment>
   </data>
   <data name="Profile_FontFace.Header" xml:space="preserve">


### PR DESCRIPTION
This should technically be a lowercase 'u'. We don't have to merge this until after 1.6 because of localization, but I figured I'd make the PR for it.