### PR TITLE
Add support for the DECID report

### DIFF
--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -226,6 +226,10 @@ bool OutputStateMachineEngine::ActionEscDispatch(const VTID id)
         success = _dispatch->HorizontalTabSet();
         TermTelemetry::Instance().Log(TermTelemetry::Codes::HTS);
         break;
+    case EscActionCodes::DECID_IdentifyDevice:
+        success = _dispatch->DeviceAttributes();
+        TermTelemetry::Instance().Log(TermTelemetry::Codes::DA);
+        break;
     case EscActionCodes::RIS_ResetToInitialState:
         success = _dispatch->HardReset();
         TermTelemetry::Instance().Log(TermTelemetry::Codes::RIS);

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -78,6 +78,7 @@ namespace Microsoft::Console::VirtualTerminal
             RI_ReverseLineFeed = VTID("M"),
             SS2_SingleShift = VTID("N"),
             SS3_SingleShift = VTID("O"),
+            DECID_IdentifyDevice = VTID("Z"),
             ST_StringTerminator = VTID("\\"),
             RIS_ResetToInitialState = VTID("c"),
             LS2_LockingShift = VTID("n"),

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -2800,11 +2800,32 @@ class StateMachineExternalTest final
         VERIFY_ARE_EQUAL(5u, pDispatch->_column - 1); // so are 1 more than the expected values.
 
         pDispatch->ClearState();
+    }
 
-        Log::Comment(L"Identify Device");
+    TEST_METHOD(TestIdentifyDeviceReport)
+    {
+        auto dispatch = std::make_unique<StatefulDispatch>();
+        auto pDispatch = dispatch.get();
+        auto engine = std::make_unique<OutputStateMachineEngine>(std::move(dispatch));
+        StateMachine mach(std::move(engine));
+
+        Log::Comment(L"Identify Device in VT52 mode.");
+        mach.SetAnsiMode(false);
         mach.ProcessCharacter(AsciiChars::ESC);
         mach.ProcessCharacter(L'Z');
         VERIFY_IS_TRUE(pDispatch->_vt52DeviceAttributes);
+        VERIFY_IS_FALSE(pDispatch->_deviceAttributes);
+
+        pDispatch->ClearState();
+
+        Log::Comment(L"Identify Device in ANSI mode.");
+        mach.SetAnsiMode(true);
+        mach.ProcessCharacter(AsciiChars::ESC);
+        mach.ProcessCharacter(L'Z');
+        VERIFY_IS_TRUE(pDispatch->_deviceAttributes);
+        VERIFY_IS_FALSE(pDispatch->_vt52DeviceAttributes);
+
+        pDispatch->ClearState();
     }
 
     TEST_METHOD(TestOscSetDefaultForeground)


### PR DESCRIPTION
This PR adds support for the `DECID` (Identify Device) escape sequence,
which allows for querying the terminal type in a way that is backwards
compatible with VT52 terminals.

This simply checks for the `ESC Z` sequence in the `ActionEscDispatch`
method of output state machine, and forwards the query to the existing
`DeviceAttributes` dispatch method, since the expected response is
identical to a `DA` report.

## Validation Steps Performed
I've added an output engine test that verifies that the `ESC Z` sequence
is correctly interpreted as a `DA` query when in ANSI mode, and as a
VT52 identification query when in VT52 mode.

Closes #8857