### PR TITLE
Hook up the keybindings to the SUI

### DIFF
--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -107,9 +107,11 @@ namespace winrt::TerminalApp::implementation
         }
         else if (const auto& realArgs = args.ActionArgs().try_as<SendInputArgs>())
         {
-            const auto termControl = _GetActiveControl();
-            termControl.SendInput(realArgs.Input());
-            args.Handled(true);
+            if (const auto termControl{ _GetActiveControl() })
+            {
+                termControl.SendInput(realArgs.Input());
+                args.Handled(true);
+            }
         }
     }
 
@@ -275,9 +277,11 @@ namespace winrt::TerminalApp::implementation
     {
         if (const auto& realArgs = args.ActionArgs().try_as<AdjustFontSizeArgs>())
         {
-            const auto termControl = _GetActiveControl();
-            termControl.AdjustFontSize(realArgs.Delta());
-            args.Handled(true);
+            if (const auto& termControl{ _GetActiveControl() })
+            {
+                termControl.AdjustFontSize(realArgs.Delta());
+                args.Handled(true);
+            }
         }
     }
 
@@ -291,17 +295,21 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_HandleResetFontSize(const IInspectable& /*sender*/,
                                             const ActionEventArgs& args)
     {
-        const auto termControl = _GetActiveControl();
-        termControl.ResetFontSize();
-        args.Handled(true);
+        if (const auto& termControl{ _GetActiveControl() })
+        {
+            termControl.ResetFontSize();
+            args.Handled(true);
+        }
     }
 
     void TerminalPage::_HandleToggleShaderEffects(const IInspectable& /*sender*/,
                                                   const ActionEventArgs& args)
     {
-        const auto termControl = _GetActiveControl();
-        termControl.ToggleShaderEffects();
-        args.Handled(true);
+        if (const auto& termControl{ _GetActiveControl() })
+        {
+            termControl.ToggleShaderEffects();
+            args.Handled(true);
+        }
     }
 
     void TerminalPage::_HandleToggleFocusMode(const IInspectable& /*sender*/,

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2806,6 +2806,7 @@ namespace winrt::TerminalApp::implementation
             {
                 sui.SetHostingWindow(reinterpret_cast<uint64_t>(*_hostingHwnd));
             }
+            sui.PreviewKeyDown({ this, &TerminalPage::_KeyDownHandler });
 
             sui.OpenJson([weakThis{ get_weak() }](auto&& /*s*/, winrt::Microsoft::Terminal::Settings::Model::SettingsTarget e) {
                 if (auto page{ weakThis.get() })

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1717,10 +1717,12 @@ namespace winrt::TerminalApp::implementation
         // Do nothing if for some reason, there's no terminal tab in focus. We don't want to crash.
         if (const auto terminalTab{ _GetFocusedTabImpl() })
         {
-            const auto control = _GetActiveControl();
-            const auto termHeight = control.GetViewHeight();
-            auto scrollDelta = _ComputeScrollDelta(scrollDirection, termHeight);
-            terminalTab->Scroll(scrollDelta);
+            if (const auto& control{ _GetActiveControl() })
+            {
+                const auto termHeight = control.GetViewHeight();
+                auto scrollDelta = _ComputeScrollDelta(scrollDirection, termHeight);
+                terminalTab->Scroll(scrollDelta);
+            }
         }
     }
 
@@ -2074,8 +2076,11 @@ namespace winrt::TerminalApp::implementation
     // - true iff we we able to copy text (if a selection was active)
     bool TerminalPage::_CopyText(const bool singleLine, const Windows::Foundation::IReference<CopyFormat>& formats)
     {
-        const auto control = _GetActiveControl();
-        return control.CopySelectionToClipboard(singleLine, formats);
+        if (const auto& control{ _GetActiveControl() })
+        {
+            return control.CopySelectionToClipboard(singleLine, formats);
+        }
+        return false;
     }
 
     // Method Description:
@@ -2092,8 +2097,10 @@ namespace winrt::TerminalApp::implementation
     // - Paste text from the Windows Clipboard to the focused terminal
     void TerminalPage::_PasteText()
     {
-        const auto control = _GetActiveControl();
-        control.PasteTextFromClipboard();
+        if (const auto& control{ _GetActiveControl() })
+        {
+            control.PasteTextFromClipboard();
+        }
     }
 
     // Function Description:
@@ -2517,8 +2524,10 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     void TerminalPage::_Find()
     {
-        const auto termControl = _GetActiveControl();
-        termControl.CreateSearchBoxControl();
+        if (const auto& control{ _GetActiveControl() })
+        {
+            control.CreateSearchBoxControl();
+        }
     }
 
     // Method Description:


### PR DESCRIPTION
## Summary of the Pull Request

This is really similar to what we're doing with the CommandPalette. We're adding a `PreviewKeyDown` handler to the SUI `MainPage`, that connects to `TerminalPage::_HandleKey`. That allows the SUI a chance to search the keymap to dispatch actions for keybindings, similar to how the command palette does it. 

This also means it's now possible for the SUI to invoke _all_ the actions available to the Terminal. This includes the ones like `IncreaseFontSize`, which require a _Terminal_ to actually do something. So we have to make sure all the calls to `_GetActiveControl` actually check that the result is non-null before using it. 

A bunch of the actions do nothing now from a SUI tab, others behave _weird_. Like "Rename tab" / "Open Tab Renamer" do nothing. "Duplicate Tab" again does nothing - we try making a new settings tab, which just focuses the settings tab again. "Copy text" definitely does nothing, same with paste.

## PR Checklist
* [x] Closes #8767
* [x] I work here
* [ ] Tests not added 
* [n/a] Requires documentation to be updated

## Validation Steps Performed
I performed all the actions that I changed. I did not test all actions exhaustively, because I felt that searching for callers of `GetActiveTerminalControl()` was exhaustive enough.