### PR TITLE
Fix the erroneous TargetRuntime causing a warning in VS

### DIFF
--- a/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
+++ b/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
@@ -3,8 +3,7 @@
   <Import Project="..\..\..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
   <Import Project="$(OpenConsoleDir)src\wap-common.build.pre.props" />
   <PropertyGroup Label="Configuration">
-    <!-- This is necessary so the build system doesn't think we're a .NET project... -->
-    <!-- <TargetRuntime>Native</TargetRuntime> -->
+
     <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <!--

--- a/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
+++ b/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
@@ -4,7 +4,7 @@
   <Import Project="$(OpenConsoleDir)src\wap-common.build.pre.props" />
   <PropertyGroup Label="Configuration">
     <!-- This is necessary so the build system doesn't think we're a .NET project... -->
-    <TargetRuntime>Native</TargetRuntime>
+    <!-- <TargetRuntime>Native</TargetRuntime> -->
     <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <!--


### PR DESCRIPTION
## Summary of the Pull Request

Apparently, we don't need this `TargetRuntime`. That's what was causing VS to think that we were a C# project, and give us that warning. This is the solution we got from the owner of the `.wapproj` plugin.

## References
* Introduced in c33883d8520e2efee233d4af0addff0775327e22, in PR #8062

## PR Checklist
* [x] Closes #8301
* [x] I work here


Build and ran it fine. Changed TermControl, built and ran it fine. Now let's hope CI likes it. 
