### PR TITLE
Allow ClosePane to close the Settings UI

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -981,7 +981,7 @@ namespace winrt::TerminalApp::implementation
 
         winrt::Microsoft::Terminal::TerminalControl::KeyChord kc{ ctrlDown, altDown, shiftDown, static_cast<int32_t>(key) };
         const auto actionAndArgs = _settings.KeyMap().TryLookup(kc);
-        if (actionAndArgs && (actionAndArgs.Action() == ShortcutAction::CloseTab || actionAndArgs.Action() == ShortcutAction::NextTab || actionAndArgs.Action() == ShortcutAction::PrevTab))
+        if (actionAndArgs && (actionAndArgs.Action() == ShortcutAction::CloseTab || actionAndArgs.Action() == ShortcutAction::NextTab || actionAndArgs.Action() == ShortcutAction::PrevTab || actionAndArgs.Action() == ShortcutAction::ClosePane))
         {
             _actionDispatch->DoAction(actionAndArgs);
             e.Handled(true);
@@ -1553,6 +1553,13 @@ namespace winrt::TerminalApp::implementation
         {
             _UnZoomIfNeeded();
             terminalTab->ClosePane();
+        }
+        else if (auto index{ _GetFocusedTabIndex() })
+        {
+            if (_tabs.GetAt(*index).try_as<TerminalApp::SettingsTab>())
+            {
+                _RemoveTabViewItemByIndex(*index);
+            }
         }
     }
 


### PR DESCRIPTION
This is an extension of #8885. A lot of users have grown accustomed to
using `closePane` to close a tab. This adds `closePane` to the list of
keybindings accepted by #8885, and modifies the `closePane` code to
close the Settings UI if we are in a `SettingsTab`.

## References

#6800: Settings UI Epic
#8885: PR - Settings UI should respect key bindings (temporary solution)
#8882: Issue - Settings UI should respect key bindings 