### PR TITLE
Add initial support for bracketed paste mode

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2056,7 +2056,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         std::wstring::size_type pos = 0;
         std::wstring::size_type begin = 0;
 
-         auto bracket = [](const std::wstring& origin, const bool enabled) {
+        auto bracket = [](const std::wstring& origin, const bool enabled) {
             std::wstring bracketed{ origin };
             if (enabled)
             {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This adds "bracketed paste mode" to the Windows Terminal.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

Supersedes #7508

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #395 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
