### PR TITLE
Improve OSC 9;9 parsing logic & add tests

### DIFF
--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -483,7 +483,7 @@ bool TerminalDispatch::DoConEmuAction(const std::wstring_view string) noexcept
             }
             else
             {
-                // If we fail to find the surrouding quotation marks, we'll give the path a try anyway.
+                // If we fail to find the surrounding quotation marks, we'll give the path a try anyway.
                 // ConEmu also does this.
                 return _terminalApi.SetWorkingDirectory(path);
             }

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -474,7 +474,19 @@ bool TerminalDispatch::DoConEmuAction(const std::wstring_view string) noexcept
     {
         if (parts.size() >= 2)
         {
-            return _terminalApi.SetWorkingDirectory(til::at(parts, 1));
+            const auto path = til::at(parts, 1);
+            // The path should be surrounded with '"' according to the documentation of ConEmu.
+            // An example: 9;"D:/"
+            if (path.at(0) == L'"' && path.at(path.size() - 1) == L'"' && path.size() >= 3)
+            {
+                return _terminalApi.SetWorkingDirectory(path.substr(1, path.size() - 2));
+            }
+            else
+            {
+                // If we fail to find the surrouding quotation marks, we'll give the path a try anyway.
+                // ConEmu also does this.
+                return _terminalApi.SetWorkingDirectory(path);
+            }
         }
     }
 

--- a/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
@@ -40,6 +40,7 @@ namespace TerminalCoreUnitTests
         TEST_METHOD(AddHyperlinkCustomIdDifferentUri);
 
         TEST_METHOD(SetTaskbarProgress);
+        TEST_METHOD(SetWorkingDirectory);
     };
 };
 
@@ -387,4 +388,60 @@ void TerminalCoreUnitTests::TerminalApiTest::SetTaskbarProgress()
     // Additional params should be ignored, state and progress still set normally
     VERIFY_ARE_EQUAL(term.GetTaskbarState(), gsl::narrow<size_t>(1));
     VERIFY_ARE_EQUAL(term.GetTaskbarProgress(), gsl::narrow<size_t>(80));
+}
+
+void TerminalCoreUnitTests::TerminalApiTest::SetWorkingDirectory()
+{
+    Terminal term;
+    DummyRenderTarget emptyRT;
+    term.Create({ 100, 100 }, 0, emptyRT);
+
+    auto& stateMachine = *(term._stateMachine);
+
+    // Test setting working directory using OSC 9;9
+    // Initial CWD should be empty
+    VERIFY_IS_TRUE(term.GetWorkingDirectory().empty());
+
+    // Invalid sequences should not change CWD
+    stateMachine.ProcessString(L"\x1b]9;9\x9c");
+    VERIFY_IS_TRUE(term.GetWorkingDirectory().empty());
+
+    stateMachine.ProcessString(L"\x1b]9;9\"\x9c");
+    VERIFY_IS_TRUE(term.GetWorkingDirectory().empty());
+
+    stateMachine.ProcessString(L"\x1b]9;9\"C:\\\"\x9c");
+    VERIFY_IS_TRUE(term.GetWorkingDirectory().empty());
+
+    // Valid sequences should change CWD
+    stateMachine.ProcessString(L"\x1b]9;9;\"C:\\\"\x9c");
+    VERIFY_ARE_EQUAL(term.GetWorkingDirectory(), L"C:\\");
+
+    stateMachine.ProcessString(L"\x1b]9;9;\"C:\\Program Files\"\x9c");
+    VERIFY_ARE_EQUAL(term.GetWorkingDirectory(), L"C:\\Program Files");
+
+    stateMachine.ProcessString(L"\x1b]9;9;\"D:\\中文\"\x9c");
+    VERIFY_ARE_EQUAL(term.GetWorkingDirectory(), L"D:\\中文");
+
+    // Test OSC 9;9 sequences without quotation marks
+    stateMachine.ProcessString(L"\x1b]9;9;C:\\\x9c");
+    VERIFY_ARE_EQUAL(term.GetWorkingDirectory(), L"C:\\");
+
+    stateMachine.ProcessString(L"\x1b]9;9;C:\\Program Files\x9c");
+    VERIFY_ARE_EQUAL(term.GetWorkingDirectory(), L"C:\\Program Files");
+
+    stateMachine.ProcessString(L"\x1b]9;9;D:\\中文\x9c");
+    VERIFY_ARE_EQUAL(term.GetWorkingDirectory(), L"D:\\中文");
+
+    // These OSC 9;9 sequences will result in invalid CWD. We shouldn't crash on these.
+    stateMachine.ProcessString(L"\x1b]9;9;\"\x9c");
+    VERIFY_ARE_EQUAL(term.GetWorkingDirectory(), L"\"");
+
+    stateMachine.ProcessString(L"\x1b]9;9;\"\"\x9c");
+    VERIFY_ARE_EQUAL(term.GetWorkingDirectory(), L"\"\"");
+
+    stateMachine.ProcessString(L"\x1b]9;9;\"\"\"\x9c");
+    VERIFY_ARE_EQUAL(term.GetWorkingDirectory(), L"\"");
+
+    stateMachine.ProcessString(L"\x1b]9;9;\"\"\"\"\x9c");
+    VERIFY_ARE_EQUAL(term.GetWorkingDirectory(), L"\"\"");
 }


### PR DESCRIPTION
This PR fixes the parsing of OSC 9;9 sequences with path surrounded by
quotation marks.

Original OSC 9;9 PR: #8330 

Unit test added. Manually tested with oh-my-posh.

Closes #8930