### PR TITLE
Bind LaunchMode and TabSwitcherMode properly in SUI

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Interaction.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.xaml
@@ -55,7 +55,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             <!--Tab Switcher Mode-->
             <ContentPresenter Style="{StaticResource SettingContainerStyle}">
                 <muxc:RadioButtons x:Uid="Globals_TabSwitcherMode"
-                                   SelectedItem="{x:Bind CurrentTabSwitcherMode}"
+                                   SelectedItem="{x:Bind CurrentTabSwitcherMode, Mode=TwoWay}"
                                    ItemsSource="{x:Bind TabSwitcherModeList}"
                                    ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
             </ContentPresenter>

--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -77,7 +77,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <!--Launch Mode-->
                 <ContentPresenter Style="{StaticResource SettingContainerStyle}">
                     <muxc:RadioButtons x:Uid="Globals_LaunchMode"
-                                   SelectedItem="{x:Bind CurrentLaunchMode}"
+                                   SelectedItem="{x:Bind CurrentLaunchMode, Mode=TwoWay}"
                                    ItemsSource="{x:Bind LaunchModeList}"
                                    ItemTemplate="{StaticResource EnumRadioButtonTemplate}"/>
                 </ContentPresenter>


### PR DESCRIPTION
## Summary of the Pull Request
Properly binds `CurrentLaunchMode` and `CurrentTabSwitcherMode` in the Settings UI. The default mode is `OneTime`, resulting in the setting never being set.

I performed a regex search of all "SelectedItem" bindings and these were the only two that were not properly bound.

## References
#6800 - Settings UI Epic

## Validation Steps Performed
Modified tab switcher mode and launch mode via the settings UI. Then saved. Before, the settings would revert back and not get applied. Now they got applied.

Closes #8947 