### PR TITLE
Prevent context menu of tab renamer text box from canceling edit

### DIFF
--- a/src/cascadia/TerminalApp/TabHeaderControl.cpp
+++ b/src/cascadia/TerminalApp/TabHeaderControl.cpp
@@ -75,6 +75,14 @@ namespace winrt::TerminalApp::implementation
     void TabHeaderControl::RenameBoxLostFocusHandler(Windows::Foundation::IInspectable const& /*sender*/,
                                                      Windows::UI::Xaml::RoutedEventArgs const& /*e*/)
     {
+        // If the context menu associated with the renamer text box is open we know it gained the focus.
+        // In this case we ignore this event (we will regain the focus once the menu will be closed).
+        const auto flyout = HeaderRenamerTextBox().ContextFlyout();
+        if (flyout && flyout.IsOpen())
+        {
+            return;
+        }
+
         // Log the data here, rather than in _CloseRenameBox. If we do it there,
         // it'll get fired twice, once when the key is pressed to commit/cancel,
         // and then again when the focus is lost


### PR DESCRIPTION
## PR Checklist
* [x] Closes https://github.com/microsoft/terminal/issues/8975
* [x] CLA signed. 
* [ ] Tests added/passed
* [ ] Documentation updated. 
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. 

## Detailed Description of the Pull Request / Additional comments
* We dismiss the edit each time `HeaderRenamerTextBox` loses focus
* Unfortunately, this applies also to scenario where the context menu
(copy, paste, select, etc.) is open with the right-click
* The fix is to ignore focus loss if `HeaderRenamerTextBox().ContextFlyout()` is open.
* We can do it as upon the fly-out dismiss the text box regains the focus.

![RenamerContextMenu](https://user-images.githubusercontent.com/4639110/106394866-90b10100-6407-11eb-8e92-627be4f70500.gif)
