### PR TITLE
Add support for chaining OSC 10-12

### DIFF
--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -13,6 +13,7 @@
 using namespace Microsoft::Console;
 using namespace Microsoft::Console::VirtualTerminal;
 
+// the console uses 0xffffffff as an "invalid color" value
 constexpr COLORREF INVALID_COLOR = 0xffffffff;
 
 // takes ownership of pDispatch

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -672,36 +672,40 @@ bool OutputStateMachineEngine::ActionOscDispatch(const wchar_t /*wch*/,
         break;
     }
     case OscActionCodes::SetForegroundColor:
-    {
-        std::vector<DWORD> colors;
-        success = _GetOscSetColor(string, colors);
-        if (success && colors.size() > 0)
-        {
-            success = _dispatch->SetDefaultForeground(til::at(colors, 0));
-        }
-        TermTelemetry::Instance().Log(TermTelemetry::Codes::OSCFG);
-        break;
-    }
     case OscActionCodes::SetBackgroundColor:
-    {
-        std::vector<DWORD> colors;
-        success = _GetOscSetColor(string, colors);
-        if (success && colors.size() > 0)
-        {
-            success = _dispatch->SetDefaultBackground(til::at(colors, 0));
-        }
-        TermTelemetry::Instance().Log(TermTelemetry::Codes::OSCBG);
-        break;
-    }
     case OscActionCodes::SetCursorColor:
     {
         std::vector<DWORD> colors;
         success = _GetOscSetColor(string, colors);
-        if (success && colors.size() > 0)
+        if (success)
         {
-            success = _dispatch->SetCursorColor(til::at(colors, 0));
+            size_t opIndex = parameter;
+            size_t colorIndex = 0;
+
+            if (opIndex == OscActionCodes::SetForegroundColor && colors.size() > colorIndex)
+            {
+                success = success && _dispatch->SetDefaultForeground(til::at(colors, colorIndex));
+                TermTelemetry::Instance().Log(TermTelemetry::Codes::OSCFG);
+                opIndex++;
+                colorIndex++;
+            }
+
+            if (opIndex == OscActionCodes::SetBackgroundColor && colors.size() > colorIndex)
+            {
+                success = success && _dispatch->SetDefaultBackground(til::at(colors, colorIndex));
+                TermTelemetry::Instance().Log(TermTelemetry::Codes::OSCBG);
+                opIndex++;
+                colorIndex++;
+            }
+
+            if (opIndex == OscActionCodes::SetCursorColor && colors.size() > colorIndex)
+            {
+                success = success && _dispatch->SetCursorColor(til::at(colors, colorIndex));
+                TermTelemetry::Instance().Log(TermTelemetry::Codes::OSCSCC);
+                opIndex++;
+                colorIndex++;
+            }
         }
-        TermTelemetry::Instance().Log(TermTelemetry::Codes::OSCSCC);
         break;
     }
     case OscActionCodes::SetClipboard:


### PR DESCRIPTION
This adds the support for chaining OSC 10-12, allowing users to set all
of them at once.

**BREAKING CHANGE**
Before this PR, the OSC 10/11/12 command will only be dispatched iff the
first color is valid. This is no longer true. The new implementation
strictly follows xterm's behavior. Each color is treated independently.
For example, `\e]10;invalid;white\e\\` is effectively `\e]11;white\e\\`.

## Validation Steps Performed

Tests added. Manually tested.

Main OSC color tracking issue: #942
OSC 4 & Initial OSC 10-12 PR: #7578

Closes one item in #942