### PR TITLE
Fix issues in tests.xml and OpenConsole.psm1

### DIFF
--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -116,7 +116,7 @@ function Invoke-TaefInNewWindow()
         [string]$TestDll,
 
         [parameter(Mandatory=$false)]
-        [string]$TaefArgs
+        [string[]]$TaefArgs
     )
 
     Start-Process $OpenConsolePath -Wait -ArgumentList "powershell.exe $TaefPath $TestDll $TaefArgs; Read-Host 'Press enter to continue...'"
@@ -163,7 +163,7 @@ function Invoke-OpenConsoleTests()
         [string]$Test,
 
         [parameter(Mandatory=$false)]
-        [string]$TaefArgs,
+        [string[]]$TaefArgs,
 
         [parameter(Mandatory=$false)]
         [ValidateSet('x64', 'x86')]
@@ -188,7 +188,6 @@ function Invoke-OpenConsoleTests()
         $TestHostAppPath = "$env:OpenConsoleRoot\$Configuration\TestHostApp"
     }
     $OpenConsolePath = "$env:OpenConsoleroot\bin\$OpenConsolePlatform\$Configuration\OpenConsole.exe"
-    $RunTePath = "$env:OpenConsoleRoot\tools\runte.cmd"
     $TaefExePath = "$env:OpenConsoleRoot\packages\Taef.Redist.Wlk.10.57.200731005-develop\build\Binaries\$Platform\te.exe"
     $BinDir = "$env:OpenConsoleRoot\bin\$OpenConsolePlatform\$Configuration"
 

--- a/tools/tests.xml
+++ b/tools/tests.xml
@@ -2,7 +2,7 @@
 <tests>
   <test name="host" type="unit" binary="Conhost.Unit.Tests.dll" />
   <test name="textBuffer" type="unit" binary="TextBuffer.Unit.Tests.dll" />
-  <test name="terminalCore" type="unit" binary="Terminal.Core.Unit.Tests.dll" />
+  <test name="terminalCore" type="unit" binary="UnitTests_TerminalCore\Terminal.Core.Unit.Tests.dll" />
   <test name="terminalApp" type="unit" binary="UnitTests_TerminalApp\Terminal.App.Unit.Tests.dll" />
   <test name="localTerminalApp" type="unit" runInHostApp="true" binary="TerminalApp.LocalTests.dll" />
   <test name="localSettingsModel" type="unit" runInHostApp="true" binary="SettingsModel.LocalTests.dll" />


### PR DESCRIPTION
* Fix the incorrect `terminalCore` path in `tests.xml`
* Change the `-TaefArgs` argument of `Invoke-OpenConsoleTests` and
  `Invoke-TaefInNewWindow` to be `[]string`, allowing multiple arguments
  to be passed to TAEF
