### PR TITLE
Serialize 'disabledProfileSources'

### DIFF
--- a/src/cascadia/LocalTests_SettingsModel/SerializationTests.cpp
+++ b/src/cascadia/LocalTests_SettingsModel/SerializationTests.cpp
@@ -226,6 +226,7 @@ namespace SettingsModelLocalTests
         const std::string settingsString{ R"({
                                                 "$schema": "https://aka.ms/terminal-profiles-schema",
                                                 "defaultProfile": "{61c54bbd-1111-5271-96e7-009a87ff44bf}",
+                                                "disabledProfileSources": [ "Windows.Terminal.Wsl" ],
 
                                                 "profiles": {
                                                     "defaults": {

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -1078,9 +1078,13 @@ void CascadiaSettings::WriteSettingsToDisk() const
 Json::Value CascadiaSettings::ToJson() const
 {
     // top-level json object
-    // directly inject "globals" and "$schema" into here
+    // directly inject "globals", "$schema", and "disabledProfileSources" into here
     Json::Value json{ _globals->ToJson() };
     JsonUtils::SetValueForKey(json, SchemaKey, JsonKey(SchemaValue));
+    if (_userSettings.isMember(JsonKey(DisabledProfileSourcesKey)))
+    {
+        json[JsonKey(DisabledProfileSourcesKey)] = _userSettings[JsonKey(DisabledProfileSourcesKey)];
+    }
 
     // "profiles" will always be serialized as an object
     Json::Value profiles{ Json::ValueType::objectValue };


### PR DESCRIPTION
## Summary of the Pull Request
"disabledProfileSources" is saved to `CascadiaSettings` _not_ `GlobalAppSettings` (and, even then, it's only read when it's used, never saved). This PR specifically detects if it was defined in settings.json, and copies it over when the settings are serialized.

## References
#6800 - Settings UI epic

## Validation Steps Performed
1. Added "disabledProfileSources" to settings.json, then serialized. --> "disabledProfileSources" is now maintained.
2. Updated `CascadiaSettings` serialization test

Closes #9032 