### PR TITLE
Prevent command palette from closing on right click

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -451,6 +451,12 @@ namespace winrt::TerminalApp::implementation
     void CommandPalette::_lostFocusHandler(Windows::Foundation::IInspectable const& /*sender*/,
                                            Windows::UI::Xaml::RoutedEventArgs const& /*args*/)
     {
+        const auto flyout = _searchBox().ContextFlyout();
+        if (flyout && flyout.IsOpen())
+        {
+            return;
+        }
+
         auto focusedElementOrAncestor = Input::FocusManager::GetFocusedElement(this->XamlRoot()).try_as<DependencyObject>();
         while (focusedElementOrAncestor)
         {


### PR DESCRIPTION
The command palette is ephemeral and is dismissed if the focus
moves to an element which is not the palette's descendant.

Unfortunately, this breaks the (right-click) context menu,
as it  is not a child of the palette
(popups are hosted on a separate root element).
