### PR TITLE
Quickly fix a mistake in #8602

### DIFF
--- a/src/cascadia/TerminalApp/TerminalSettings.cpp
+++ b/src/cascadia/TerminalApp/TerminalSettings.cpp
@@ -3,11 +3,13 @@
 
 #include "pch.h"
 #include "TerminalSettings.h"
+#include "../../types/inc/colorTable.hpp"
 
 #include "TerminalSettings.g.cpp"
 
 using namespace winrt::Microsoft::Terminal::TerminalControl;
 using namespace winrt::Microsoft::Terminal::Settings::Model;
+using namespace Microsoft::Console::Utils;
 
 namespace winrt::TerminalApp::implementation
 {

--- a/src/cascadia/TerminalApp/TerminalSettings.h
+++ b/src/cascadia/TerminalApp/TerminalSettings.h
@@ -17,11 +17,8 @@ Author(s):
 #include "TerminalSettings.g.h"
 #include "../TerminalSettingsModel/IInheritable.h"
 #include "../inc/cppwinrt_utils.h"
-#include "../../types/inc/colorTable.hpp"
 #include <DefaultSettings.h>
 #include <conattrs.hpp>
-
-using namespace Microsoft::Console::Utils;
 
 // fwdecl unittest classes
 namespace TerminalAppLocalTests


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
There was a mistake in #8602, this change fixes that (`using` and `include` moved to cpp file)

