### PR TITLE
Teach the renderer to keep thread alive if engine requests it

### DIFF
--- a/src/renderer/base/RenderEngineBase.cpp
+++ b/src/renderer/base/RenderEngineBase.cpp
@@ -42,6 +42,16 @@ HRESULT RenderEngineBase::PrepareRenderInfo(const RenderFrameInfo& /*info*/) noe
 }
 
 // Method Description:
+// - By default, no one should need continuous redraw. It ruins performance
+//   in terms of CPU, memory, and battery life to just paint forever.
+//   That's why we sleep when there's nothing to draw.
+//   But if you REALLY WANT to do special effects... you need to keep painting.
+[[nodiscard]] bool RenderEngineBase::RequiresContinuousRedraw() noexcept
+{
+    return false;
+}
+
+// Method Description:
 // - Blocks until the engine is able to render without blocking.
 void RenderEngineBase::WaitUntilCanRender() noexcept
 {

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -135,7 +135,7 @@ try
         LOG_IF_FAILED(pEngine->EndPaint());
 
         // If the engine tells us it really wants to redraw immediately,
-        // tell the thread so it doesn't go to sleep and ticks again 
+        // tell the thread so it doesn't go to sleep and ticks again
         // at the next opportunity.
         if (pEngine->RequiresContinuousRedraw())
         {

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -133,6 +133,14 @@ try
 
     auto endPaint = wil::scope_exit([&]() {
         LOG_IF_FAILED(pEngine->EndPaint());
+
+        // If the engine tells us it really wants to redraw immediately,
+        // tell the thread so it doesn't go to sleep and ticks again 
+        // at the next opportunity.
+        if (pEngine->RequiresContinuousRedraw())
+        {
+            _NotifyPaintFrame();
+        }
     });
 
     // A. Prep Colors

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1440,6 +1440,18 @@ CATCH_RETURN()
 }
 
 // Method Description:
+// - When the shaders are on, say that we need to keep redrawing every
+//   possible frame in case they have some smooth action on every frame tick.
+//   It is presumed that if you're using shaders, you're not about performance...
+//   You're instead about OOH SHINY. And that's OK. But returning true here is 100%
+//   a perf detriment.
+[[nodiscard]] 
+bool DxEngine::RequiresContinuousRedraw() noexcept
+{
+    return _HasShaderEffects();
+}
+
+// Method Description:
 // - Blocks until the engine is able to render without blocking.
 // - See https://docs.microsoft.com/en-us/windows/uwp/gaming/reduce-latency-with-dxgi-1-3-swap-chains.
 void DxEngine::WaitUntilCanRender() noexcept

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1445,8 +1445,7 @@ CATCH_RETURN()
 //   It is presumed that if you're using shaders, you're not about performance...
 //   You're instead about OOH SHINY. And that's OK. But returning true here is 100%
 //   a perf detriment.
-[[nodiscard]] 
-bool DxEngine::RequiresContinuousRedraw() noexcept
+[[nodiscard]] bool DxEngine::RequiresContinuousRedraw() noexcept
 {
     // We're only going to request continuous redraw if someone is using
     // a pixel shader from a path because we cannot tell if those are using the

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1448,7 +1448,7 @@ CATCH_RETURN()
 [[nodiscard]] 
 bool DxEngine::RequiresContinuousRedraw() noexcept
 {
-    return _HasShaderEffects();
+    return _HasTerminalEffects();
 }
 
 // Method Description:

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1448,7 +1448,18 @@ CATCH_RETURN()
 [[nodiscard]] 
 bool DxEngine::RequiresContinuousRedraw() noexcept
 {
-    return _HasTerminalEffects();
+    // We're only going to request continuous redraw if someone is using
+    // a pixel shader from a path because we cannot tell if those are using the
+    // time parameter or not.
+    // And if they are using time, they probably need it to tick continuously.
+    //
+    // By contrast, the in-built retro effect does NOT need it,
+    // so let's not tick for it and save some amount of performance.
+    //
+    // Finally... if we're not using effects at all... let the render thread
+    // go to sleep. It deserves it. That thread works hard. Also it sleeping
+    // saves battery power and all sorts of related perf things.
+    return _terminalEffectsEnabled && !_pixelShaderPath.empty();
 }
 
 // Method Description:

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -84,6 +84,8 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT StartPaint() noexcept override;
         [[nodiscard]] HRESULT EndPaint() noexcept override;
 
+        [[nodiscard]] bool RequiresContinuousRedraw() noexcept override;
+
         void WaitUntilCanRender() noexcept override;
         [[nodiscard]] HRESULT Present() noexcept override;
 

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -55,6 +55,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] virtual HRESULT StartPaint() noexcept = 0;
         [[nodiscard]] virtual HRESULT EndPaint() noexcept = 0;
 
+        [[nodiscard]] virtual bool RequiresContinuousRedraw() noexcept = 0;
         virtual void WaitUntilCanRender() noexcept = 0;
         [[nodiscard]] virtual HRESULT Present() noexcept = 0;
 

--- a/src/renderer/inc/RenderEngineBase.hpp
+++ b/src/renderer/inc/RenderEngineBase.hpp
@@ -40,6 +40,8 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT PrepareRenderInfo(const RenderFrameInfo& info) noexcept override;
 
+        [[nodiscard]] virtual bool RequiresContinuousRedraw() noexcept override;
+
         void WaitUntilCanRender() noexcept override;
 
     protected:


### PR DESCRIPTION
Teaches renderer base to keep thread alive if engine requests it.
`DxEngine` now requests it if shaders are on.

- The render engine interface now has a true/false to return whether the
  specific renderer wants another frame to immediately follow up. The
  renderer base will ask for this information as it ends the paint on
  any particular engine (which is the time where invalid regions are
  typically cleaned up) and just poke the render thread the same as if
  an invalidation request came in from outside of render-land. That will
  trigger the render thread to just keep moving in the same way as any
  other invalidation.

## Validation Steps Performed
- [x] Actually built it
- [x] Actually try it

I promised this in #8994