### PR TITLE
implement env vars in settings (#2785)

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -907,7 +907,7 @@ namespace winrt::TerminalApp::implementation
         {
             std::wstring guidWString = Utils::GuidToString(profileGuid);
 
-            StringMap envMap{};
+            auto envMap = settings.EnvironmentVariables();
             envMap.Insert(L"WT_PROFILE_ID", guidWString);
             envMap.Insert(L"WSLENV", L"WT_PROFILE_ID");
 

--- a/src/cascadia/TerminalApp/TerminalSettings.cpp
+++ b/src/cascadia/TerminalApp/TerminalSettings.cpp
@@ -193,6 +193,11 @@ namespace winrt::TerminalApp::implementation
             const til::color colorRef{ profile.TabColor().Value() };
             _TabColor = static_cast<uint32_t>(colorRef);
         }
+
+        if (profile.HasEnvironmentVariables())
+        {
+            _EnvironmentVariables = profile.EnvironmentVariables();
+        }
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TerminalSettings.h
+++ b/src/cascadia/TerminalApp/TerminalSettings.h
@@ -19,6 +19,9 @@ Author(s):
 #include "../inc/cppwinrt_utils.h"
 #include <DefaultSettings.h>
 #include <conattrs.hpp>
+#include <winrt/impl/Windows.Foundation.Collections.2.h>
+
+using namespace winrt::Windows::Foundation::Collections;
 
 // fwdecl unittest classes
 namespace TerminalAppLocalTests
@@ -108,7 +111,7 @@ namespace winrt::TerminalApp::implementation
         GETSET_SETTING(hstring, StartingDirectory);
         GETSET_SETTING(hstring, StartingTitle);
         GETSET_SETTING(bool, SuppressApplicationTitle);
-        GETSET_SETTING(hstring, EnvironmentVariables);
+        GETSET_SETTING(StringMap, EnvironmentVariables);
 
         GETSET_SETTING(Microsoft::Terminal::TerminalControl::ScrollbarState, ScrollState, Microsoft::Terminal::TerminalControl::ScrollbarState::Visible);
 

--- a/src/cascadia/TerminalControl/IControlSettings.idl
+++ b/src/cascadia/TerminalControl/IControlSettings.idl
@@ -43,7 +43,7 @@ namespace Microsoft.Terminal.TerminalControl
 
         String Commandline;
         String StartingDirectory;
-        String EnvironmentVariables;
+        Windows.Foundation.Collections.StringMap EnvironmentVariables;
 
         String BackgroundImage;
         Double BackgroundImageOpacity;

--- a/src/cascadia/TerminalSettingsEditor/Profiles.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.h
@@ -66,6 +66,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         OBSERVABLE_PROJECTED_SETTING(_profile, CursorShape);
         OBSERVABLE_PROJECTED_SETTING(_profile, CursorHeight);
         OBSERVABLE_PROJECTED_SETTING(_profile, BellStyle);
+        OBSERVABLE_PROJECTED_SETTING(_profile, EnvironmentVariables);
 
     private:
         Model::Profile _profile;

--- a/src/cascadia/TerminalSettingsEditor/Profiles.idl
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.idl
@@ -55,6 +55,7 @@ namespace Microsoft.Terminal.Settings.Editor
         OBSERVABLE_PROJECTED_SETTING(Microsoft.Terminal.TerminalControl.CursorStyle, CursorShape);
         OBSERVABLE_PROJECTED_SETTING(UInt32, CursorHeight);
         OBSERVABLE_PROJECTED_SETTING(Microsoft.Terminal.Settings.Model.BellStyle, BellStyle);
+        OBSERVABLE_PROJECTED_SETTING(Windows.Foundation.Collections.StringMap, EnvironmentVariables);
     }
 
     runtimeclass DeleteProfileEventArgs

--- a/src/cascadia/TerminalSettingsModel/Profile.h
+++ b/src/cascadia/TerminalSettingsModel/Profile.h
@@ -21,6 +21,9 @@ Author(s):
 #include "../inc/cppwinrt_utils.h"
 #include "JsonUtils.h"
 #include <DefaultSettings.h>
+#include <winrt/impl/Windows.Foundation.Collections.2.h>
+
+using namespace winrt::Windows::Foundation::Collections;
 
 // fwdecl unittest classes
 namespace SettingsModelLocalTests
@@ -113,6 +116,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         GETSET_SETTING(uint32_t, CursorHeight, DEFAULT_CURSOR_HEIGHT);
 
         GETSET_SETTING(Model::BellStyle, BellStyle, BellStyle::Audible);
+
+        GETSET_SETTING(StringMap, EnvironmentVariables);
 
     private:
         static std::wstring EvaluateStartingDirectory(const std::wstring& directory);

--- a/src/cascadia/TerminalSettingsModel/Profile.idl
+++ b/src/cascadia/TerminalSettingsModel/Profile.idl
@@ -190,5 +190,9 @@ namespace Microsoft.Terminal.Settings.Model
         Boolean HasBellStyle();
         void ClearBellStyle();
         BellStyle BellStyle;
+
+        Boolean HasEnvironmentVariables();
+        void ClearEnvironmentVariables();
+        Windows.Foundation.Collections.StringMap EnvironmentVariables;
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

* use StringMap as a container for environment key/value pairs
* recursively resolves ${env:NAME} vars in values in the StringMap or in the process' environment
* implement some tests

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #2785
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [x] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: [#250](https://github.com/MicrosoftDocs/terminal/pull/250)
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Wrote and ran the unit tests, tested manually to see environment variables were available.