### PR TITLE
wpf: Make the terminal border fill more visible when the terminal renderer is smaller than the WPF window

### DIFF
--- a/src/cascadia/WpfTerminalControl/TerminalControl.xaml
+++ b/src/cascadia/WpfTerminalControl/TerminalControl.xaml
@@ -10,22 +10,10 @@
              x:Name="terminalUserControl">
     <Grid x:Name="terminalGrid">
         <Grid.ColumnDefinitions>
-            <!-- Terminal Renderer -->
             <ColumnDefinition />
-            <!-- Scrollbar -->
             <ColumnDefinition Width="Auto"/>
-            <!-- Right Border, only visible when autoresize is off. -->
-            <ColumnDefinition x:Name="RightColumn"/>
         </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <!-- Terminal Renderer -->
-            <RowDefinition/>
-            <!-- Bottom Border, only visible when autoresize is off. -->
-            <RowDefinition x:Name="BottomRow"/>
-        </Grid.RowDefinitions>
-        <local:TerminalContainer x:Name="termContainer" Grid.Column="0" Grid.Row="0"/>
+        <local:TerminalContainer x:Name="termContainer"/>
         <ScrollBar x:Name="scrollbar" Scroll="Scrollbar_Scroll" SmallChange="1" Grid.Column="1" />
-        <Border x:Name="BottomBorder" Grid.Row="1" Grid.ColumnSpan="2"/>
-        <Border x:Name="RightBorder" Grid.Column="2" Grid.RowSpan="2"/>
     </Grid>
 </UserControl>

--- a/src/cascadia/WpfTerminalControl/TerminalControl.xaml
+++ b/src/cascadia/WpfTerminalControl/TerminalControl.xaml
@@ -10,10 +10,22 @@
              x:Name="terminalUserControl">
     <Grid x:Name="terminalGrid">
         <Grid.ColumnDefinitions>
+            <!-- Terminal Renderer -->
             <ColumnDefinition />
+            <!-- Scrollbar -->
             <ColumnDefinition Width="Auto"/>
+            <!-- Right Border, only visible when autoresize is off. -->
+            <ColumnDefinition x:Name="RightColumn"/>
         </Grid.ColumnDefinitions>
-        <local:TerminalContainer x:Name="termContainer"/>
+        <Grid.RowDefinitions>
+            <!-- Terminal Renderer -->
+            <RowDefinition/>
+            <!-- Bottom Border, only visible when autoresize is off. -->
+            <RowDefinition x:Name="BottomRow"/>
+        </Grid.RowDefinitions>
+        <local:TerminalContainer x:Name="termContainer" Grid.Column="0" Grid.Row="0"/>
         <ScrollBar x:Name="scrollbar" Scroll="Scrollbar_Scroll" SmallChange="1" Grid.Column="1" />
+        <Border x:Name="BottomBorder" Grid.Row="1" Grid.ColumnSpan="2"/>
+        <Border x:Name="RightBorder" Grid.Column="2" Grid.RowSpan="2"/>
     </Grid>
 </UserControl>

--- a/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
@@ -92,7 +92,38 @@ namespace Microsoft.Terminal.Wpf
             byte g = Convert.ToByte((theme.DefaultBackground >> 8) & 0xff);
             byte r = Convert.ToByte(theme.DefaultBackground & 0xff);
 
-            this.terminalGrid.Background = new SolidColorBrush(Color.FromRgb(r, g, b));
+            var backgroundColor = new SolidColorBrush(Color.FromRgb(r, g, b));
+
+            // DefaultBackground uses Win32 COLORREF syntax which is BGR instead of RGB.
+            b = Convert.ToByte((theme.DefaultForeground >> 16) & 0xff);
+            g = Convert.ToByte((theme.DefaultForeground >> 8) & 0xff);
+            r = Convert.ToByte(theme.DefaultForeground & 0xff);
+
+            var foregroundColor = new SolidColorBrush(Color.FromRgb(r, g, b));
+
+            // Background for terminal border shown when the terminal renderer is smaller than the window size.
+            EllipseGeometry backgroundEllipse = new EllipseGeometry(new Point(10, 10), 20, 20);
+            RectangleGeometry dotRectangle = new RectangleGeometry(new Rect(1, 1, 1, 1));
+
+            GeometryGroup geometryGroup = new GeometryGroup();
+            geometryGroup.Children.Add(backgroundEllipse);
+            geometryGroup.Children.Add(dotRectangle);
+
+            GeometryDrawing backgroundGeometry = new GeometryDrawing();
+            backgroundGeometry.Geometry = geometryGroup;
+            backgroundGeometry.Brush = backgroundColor;
+            backgroundGeometry.Pen = new Pen(foregroundColor, 1);
+
+            DrawingBrush drawingBrush = new DrawingBrush()
+            {
+                Drawing = backgroundGeometry,
+                TileMode = TileMode.Tile,
+                Stretch = Stretch.None,
+                Viewport = new Rect(0, 0, 20, 20),
+                ViewportUnits = BrushMappingMode.Absolute,
+            };
+
+            this.terminalUserControl.Background = drawingBrush;
         }
 
         /// <summary>

--- a/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
@@ -94,14 +94,14 @@ namespace Microsoft.Terminal.Wpf
 
             var backgroundColor = new SolidColorBrush(Color.FromRgb(r, g, b));
 
-            // DefaultBackground uses Win32 COLORREF syntax which is BGR instead of RGB.
+            // DefaultForeground uses Win32 COLORREF syntax which is BGR instead of RGB.
             b = Convert.ToByte((theme.DefaultForeground >> 16) & 0xff);
             g = Convert.ToByte((theme.DefaultForeground >> 8) & 0xff);
             r = Convert.ToByte(theme.DefaultForeground & 0xff);
 
             var foregroundColor = new SolidColorBrush(Color.FromRgb(r, g, b));
 
-            // Background for terminal border shown when the terminal renderer is smaller than the window size.
+            // Background for terminal control shown when the terminal renderer is smaller than the window size.
             EllipseGeometry backgroundEllipse = new EllipseGeometry(new Point(10, 10), 20, 20);
             RectangleGeometry dotRectangle = new RectangleGeometry(new Rect(1, 1, 1, 1));
 
@@ -114,7 +114,7 @@ namespace Microsoft.Terminal.Wpf
             backgroundGeometry.Brush = backgroundColor;
             backgroundGeometry.Pen = new Pen(foregroundColor, 1);
 
-            DrawingBrush drawingBrush = new DrawingBrush()
+            DrawingBrush backgroundBrush = new DrawingBrush()
             {
                 Drawing = backgroundGeometry,
                 TileMode = TileMode.Tile,
@@ -123,7 +123,7 @@ namespace Microsoft.Terminal.Wpf
                 ViewportUnits = BrushMappingMode.Absolute,
             };
 
-            this.terminalUserControl.Background = drawingBrush;
+            this.terminalUserControl.Background = backgroundBrush;
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Changed the terminal background to a more visible graphic that uses the terminal foreground/background as the color scheme when the terminal theme is set. 
This is only shown when the terminal renderer is smaller than the WPF view.
![image](https://user-images.githubusercontent.com/2334756/107828335-819e4d00-6d3d-11eb-807d-d271c8260da2.png)


<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual validation.
