### PR TITLE
Fix command palette accessibility

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.xaml
+++ b/src/cascadia/TerminalApp/CommandPalette.xaml
@@ -40,7 +40,6 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <!-- This HorizontalContentAlignment="Stretch" is important
                         to make sure it takes the entire width of the line -->
                 <ListViewItem HorizontalContentAlignment="Stretch"
-                                  IsTabStop="False"
                                   AutomationProperties.Name="{x:Bind Item.Name, Mode=OneWay}"
                                   AutomationProperties.AcceleratorKey="{x:Bind Item.KeyChordText, Mode=OneWay}">
 
@@ -112,7 +111,6 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <!-- This HorizontalContentAlignment="Stretch" is important
                         to make sure it takes the entire width of the line -->
                 <ListViewItem HorizontalContentAlignment="Stretch"
-                                  IsTabStop="False"
                                   AutomationProperties.Name="{x:Bind Item.Name, Mode=OneWay}"
                                   AutomationProperties.AcceleratorKey="{x:Bind Item.KeyChordText, Mode=OneWay}">
 


### PR DESCRIPTION
Fixes a regression of command palette accessibility. The regression was
introduced in #8377 by setting `IsTabStop` to false. Though the commands
would light up, the focus didn't technically get on the command, so the
screen reader would just read the text box.

## Validation Steps Performed
Opened the command palette while NVDA is active. It now reads the
commands as focus moves on them.
