### PR TITLE
Teach tab to focus terminal after rename

### DIFF
--- a/src/cascadia/TerminalApp/TabHeaderControl.cpp
+++ b/src/cascadia/TerminalApp/TabHeaderControl.cpp
@@ -108,5 +108,6 @@ namespace winrt::TerminalApp::implementation
     {
         HeaderRenamerTextBox().Visibility(Windows::UI::Xaml::Visibility::Collapsed);
         HeaderTextBlock().Visibility(Windows::UI::Xaml::Visibility::Visible);
+        _RenameEndedHandlers(*this, nullptr);
     }
 }

--- a/src/cascadia/TerminalApp/TabHeaderControl.cpp
+++ b/src/cascadia/TerminalApp/TabHeaderControl.cpp
@@ -106,8 +106,11 @@ namespace winrt::TerminalApp::implementation
     // - Hides the rename box and displays the title text block
     void TabHeaderControl::_CloseRenameBox()
     {
-        HeaderRenamerTextBox().Visibility(Windows::UI::Xaml::Visibility::Collapsed);
-        HeaderTextBlock().Visibility(Windows::UI::Xaml::Visibility::Visible);
-        _RenameEndedHandlers(*this, nullptr);
+        if (HeaderRenamerTextBox().Visibility() == Windows::UI::Xaml::Visibility::Visible)
+        {
+            HeaderRenamerTextBox().Visibility(Windows::UI::Xaml::Visibility::Collapsed);
+            HeaderTextBlock().Visibility(Windows::UI::Xaml::Visibility::Visible);
+            _RenameEndedHandlers(*this, nullptr);
+        }
     }
 }

--- a/src/cascadia/TerminalApp/TabHeaderControl.h
+++ b/src/cascadia/TerminalApp/TabHeaderControl.h
@@ -25,6 +25,8 @@ namespace winrt::TerminalApp::implementation
         OBSERVABLE_GETSET_PROPERTY(double, RenamerMaxWidth, _PropertyChangedHandlers);
         OBSERVABLE_GETSET_PROPERTY(winrt::TerminalApp::TerminalTabStatus, TabStatus, _PropertyChangedHandlers);
 
+        TYPED_EVENT(RenameEnded, winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable);
+
     private:
         bool _receivedKeyDown{ false };
         bool _renameCancelled{ false };

--- a/src/cascadia/TerminalApp/TabHeaderControl.idl
+++ b/src/cascadia/TerminalApp/TabHeaderControl.idl
@@ -17,5 +17,6 @@ namespace TerminalApp
         TerminalTabStatus TabStatus { get;  set; };
 
         event TitleChangeRequestedArgs TitleChangeRequested;
+        event Windows.Foundation.TypedEventHandler<Object, Object> RenameEnded;
     }
 }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -858,6 +858,22 @@ namespace winrt::TerminalApp::implementation
             }
         });
 
+        newTabImpl->TabRenamerDeactivated([weakThis{ get_weak() }](auto&& /*s*/, auto&& /*e*/) {
+            if (const auto page{ weakThis.get() })
+            {
+                if (!page->_newTabButton.Flyout().IsOpen())
+                {
+                    if (const auto tab{ page->_GetFocusedTabImpl() })
+                    {
+                        if (const auto control{ tab->GetActiveTerminalControl() })
+                        {
+                            control.Focus(FocusState::Programmatic);
+                        }
+                    }
+                }
+            }
+        });
+
         if (debugConnection) // this will only be set if global debugging is on and tap is active
         {
             TermControl newControl{ settings, debugConnection };

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -863,12 +863,9 @@ namespace winrt::TerminalApp::implementation
             {
                 if (!page->_newTabButton.Flyout().IsOpen())
                 {
-                    if (const auto tab{ page->_GetFocusedTabImpl() })
+                    if (const auto tab{ page->_GetFocusedTab() })
                     {
-                        if (const auto control{ tab->GetActiveTerminalControl() })
-                        {
-                            control.Focus(FocusState::Programmatic);
-                        }
+                        tab.Focus(FocusState::Programmatic);
                     }
                 }
             }

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -53,6 +53,16 @@ namespace winrt::TerminalApp::implementation
             }
         });
 
+        _headerControl.RenameEnded([weakThis = get_weak()](auto&&, auto&&) {
+            if (auto tab{ weakThis.get() })
+            {
+                if (const auto control{ tab->GetActiveTerminalControl() })
+                {
+                    control.Focus(FocusState::Programmatic);
+                }
+            }
+        });
+
         _UpdateHeaderControlMaxWidth();
 
         // Use our header control as the TabViewItem's header

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -53,16 +53,6 @@ namespace winrt::TerminalApp::implementation
             }
         });
 
-        _headerControl.RenameEnded([weakThis = get_weak()](auto&&, auto&&) {
-            if (auto tab{ weakThis.get() })
-            {
-                if (const auto control{ tab->GetActiveTerminalControl() })
-                {
-                    control.Focus(FocusState::Programmatic);
-                }
-            }
-        });
-
         _UpdateHeaderControlMaxWidth();
 
         // Use our header control as the TabViewItem's header

--- a/src/cascadia/TerminalApp/TerminalTab.h
+++ b/src/cascadia/TerminalApp/TerminalTab.h
@@ -89,6 +89,7 @@ namespace winrt::TerminalApp::implementation
         DECLARE_EVENT(ColorSelected, _colorSelected, winrt::delegate<winrt::Windows::UI::Color>);
         DECLARE_EVENT(ColorCleared, _colorCleared, winrt::delegate<>);
         DECLARE_EVENT(TabRaiseVisualBell, _TabRaiseVisualBellHandlers, winrt::delegate<>);
+        FORWARDED_TYPED_EVENT(TabRenamerDeactivated, winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable, (&_headerControl), RenameEnded);
 
     private:
         std::shared_ptr<Pane> _rootPane{ nullptr };


### PR DESCRIPTION
## Summary of the Pull Request
After rename ends (either by enter or escape) the rename box
gets collapsed and the focus moves to the next tab stop
in the TabView (e.g., new tab button).

To overcome this:
* Added RenameEnded event to TabHeaderControl
* Forwarded it as RenamerDeactivated from TerminalTab
* Registered in the TerminalPage to focus the active control upon
RenamerDeactivated if focus didn't move to tab menu.

This means, no matter how you close the renamer,
the current terminal gains the focus.

## PR Checklist
* [x] Closes https://github.com/microsoft/terminal/issues/9160
* [x] CLA signed. 
* [ ] Tests added/passed
* [ ] Documentation updated. 
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. 
