### PR TITLE
wpf: prevent a 0 size when VS builds the Terminal window too early

### DIFF
--- a/src/cascadia/WpfTerminalControl/TerminalContainer.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalContainer.cs
@@ -138,7 +138,9 @@ namespace Microsoft.Terminal.Wpf
 
             NativeMethods.TerminalSetTheme(this.terminal, theme, fontFamily, fontSize, (int)dpiScale.PixelsPerInchX);
 
-            if (!this.RenderSize.IsEmpty && !this.TerminalControlSize.IsEmpty)
+            // Validate before resizing that we have a non-zero size.
+            if (!this.RenderSize.IsEmpty && !this.TerminalControlSize.IsEmpty
+                && this.TerminalControlSize.Width != 0 && this.TerminalControlSize.Height != 0)
             {
                 this.Resize(this.TerminalControlSize);
             }
@@ -166,7 +168,7 @@ namespace Microsoft.Terminal.Wpf
         {
             if (renderSize.Width == 0 || renderSize.Height == 0)
             {
-                throw new ArgumentException(nameof(renderSize), "Terminal column or row count cannot be 0.");
+                throw new ArgumentException("Terminal column or row count cannot be 0.", nameof(renderSize));
             }
 
             NativeMethods.TerminalTriggerResize(
@@ -191,11 +193,11 @@ namespace Microsoft.Terminal.Wpf
         {
             if (rows == 0)
             {
-                throw new ArgumentException(nameof(rows), "Terminal row count cannot be 0.");
+                throw new ArgumentException("Terminal row count cannot be 0.", nameof(rows));
             }
             else if (columns == 0)
             {
-                throw new ArgumentException(nameof(columns), "Terminal column count cannot be 0.");
+                throw new ArgumentException("Terminal column count cannot be 0.", nameof(columns));
             }
 
             NativeMethods.SIZE dimensionsInPixels;

--- a/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
@@ -133,6 +133,11 @@ namespace Microsoft.Terminal.Wpf
             rendersize.Width *= dpiScale.DpiScaleX;
             rendersize.Height *= dpiScale.DpiScaleY;
 
+            if (rendersize.Width == 0 || rendersize.Height == 0)
+            {
+                return (0, 0);
+            }
+
             this.termContainer.Resize(rendersize);
 
             return (this.Rows, this.Columns);


### PR DESCRIPTION
The terminal WPF container might have a (0,0) render size when VS
eagerly attempts to initialize the terminal tool window when it is
pinned during startup, but no actual UI is shown due to the VS welcome
dialog that shows up before VS can build the terminal tool window.

We've fixed this issue previously in other areas but only recently did
we get a complete enough dump to find the corner cases for this issue. 

This should patch all the gaps that cause this bug.

## Validation Steps Performed
I've manually validated the scenarios shown in the user dumps.
