### PR TITLE
Redesign color schemes page

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
@@ -61,17 +61,38 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         InitializeComponent();
 
-        ToolTipService::SetToolTip(ForegroundButton(), box_value(RS_(L"ColorScheme_Foreground/Text")));
-        Automation::AutomationProperties::SetName(ForegroundButton(), RS_(L"ColorScheme_Foreground/Text"));
+        const auto foregroundButton{ ForegroundButton() };
+        ToolTipService::SetToolTip(foregroundButton, box_value(RS_(L"ColorScheme_Foreground/Text")));
+        Automation::AutomationProperties::SetName(foregroundButton, RS_(L"ColorScheme_Foreground/Text"));
 
-        ToolTipService::SetToolTip(BackgroundButton(), box_value(RS_(L"ColorScheme_Background/Text")));
-        Automation::AutomationProperties::SetName(BackgroundButton(), RS_(L"ColorScheme_Background/Text"));
+        const auto backgroundButton{ BackgroundButton() };
+        ToolTipService::SetToolTip(backgroundButton, box_value(RS_(L"ColorScheme_Background/Text")));
+        Automation::AutomationProperties::SetName(backgroundButton, RS_(L"ColorScheme_Background/Text"));
 
-        ToolTipService::SetToolTip(CursorColorButton(), box_value(RS_(L"ColorScheme_CursorColor/Text")));
-        Automation::AutomationProperties::SetName(CursorColorButton(), RS_(L"ColorScheme_CursorColor/Text"));
+        const auto cursorColorButton{ CursorColorButton() };
+        ToolTipService::SetToolTip(cursorColorButton, box_value(RS_(L"ColorScheme_CursorColor/Text")));
+        Automation::AutomationProperties::SetName(cursorColorButton, RS_(L"ColorScheme_CursorColor/Text"));
 
-        ToolTipService::SetToolTip(SelectionBackgroundButton(), box_value(RS_(L"ColorScheme_SelectionBackground/Text")));
-        Automation::AutomationProperties::SetName(SelectionBackgroundButton(), RS_(L"ColorScheme_SelectionBackground/Text"));
+        const auto selectionBackgroundButton{ SelectionBackgroundButton() };
+        ToolTipService::SetToolTip(selectionBackgroundButton, box_value(RS_(L"ColorScheme_SelectionBackground/Text")));
+        Automation::AutomationProperties::SetName(selectionBackgroundButton, RS_(L"ColorScheme_SelectionBackground/Text"));
+
+        const auto comboBox{ ColorSchemeComboBox() };
+        Automation::AutomationProperties::SetName(comboBox, RS_(L"ColorScheme_Name/Header"));
+        Automation::AutomationProperties::SetFullDescription(comboBox, RS_(L"ColorScheme_Name/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
+        ToolTipService::SetToolTip(comboBox, box_value(RS_(L"ColorScheme_Name/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip")));
+
+        Automation::AutomationProperties::SetName(RenameButton(), RS_(L"Rename/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
+
+        const auto nameBox{ NameBox() };
+        Automation::AutomationProperties::SetName(nameBox, RS_(L"ColorScheme_Name/Header"));
+        Automation::AutomationProperties::SetFullDescription(nameBox, RS_(L"ColorScheme_Name/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
+        ToolTipService::SetToolTip(nameBox, box_value(RS_(L"ColorScheme_Name/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip")));
+
+        Automation::AutomationProperties::SetName(RenameAcceptButton(), RS_(L"RenameAccept/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
+        Automation::AutomationProperties::SetName(RenameCancelButton(), RS_(L"RenameCancel/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
+        Automation::AutomationProperties::SetName(AddNewButton(), RS_(L"ColorScheme_AddNewButton/Text"));
+        Automation::AutomationProperties::SetName(DeleteButton(), RS_(L"ColorScheme_DeleteButton/Text"));
     }
 
     void ColorSchemes::SizeChanged(IInspectable const& /*sender*/, Windows::UI::Xaml::SizeChangedEventArgs const& e)
@@ -128,10 +149,12 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         const auto colorLabelStyle{ Resources().Lookup(winrt::box_value(L"ColorLabelStyle")).as<Windows::UI::Xaml::Style>() };
         const auto colorControlStyle{ Resources().Lookup(winrt::box_value(L"ColorControlStyle")).as<Windows::UI::Xaml::Style>() };
         const auto colorTableEntryTemplate{ Resources().Lookup(winrt::box_value(L"ColorTableEntryTemplate")).as<DataTemplate>() };
-        auto setupColorControl = [colorTableEntryTemplate, colorControlStyle, colorTableGrid{ ColorTableGrid() }](auto colorRef, uint32_t row, uint32_t col) {
+        auto setupColorControl = [colorTableEntryTemplate, colorControlStyle, colorTableGrid{ ColorTableGrid() }](hstring colorName, auto&& colorRef, uint32_t row, uint32_t col) {
             ContentControl colorControl{};
             colorControl.ContentTemplate(colorTableEntryTemplate);
             colorControl.Style(colorControlStyle);
+            ToolTipService::SetToolTip(colorControl, box_value(colorName));
+            Automation::AutomationProperties::SetName(colorControl, colorName);
 
             Data::Binding binding{};
             binding.Source(colorRef);
@@ -153,10 +176,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             Grid::SetColumn(label, 0);
 
             // regular color
-            setupColorControl(_CurrentNonBrightColorTable.GetAt(row), row, 1);
+            setupColorControl(TableColorNames[row], _CurrentNonBrightColorTable.GetAt(row), row, 1);
 
             // bright color
-            setupColorControl(_CurrentBrightColorTable.GetAt(row), row, 2);
+            setupColorControl(TableColorNames[row + ColorTableDivider], _CurrentBrightColorTable.GetAt(row), row, 2);
         }
     }
 

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
@@ -128,7 +128,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         const auto colorLabelStyle{ Resources().Lookup(winrt::box_value(L"ColorLabelStyle")).as<Windows::UI::Xaml::Style>() };
         const auto colorControlStyle{ Resources().Lookup(winrt::box_value(L"ColorControlStyle")).as<Windows::UI::Xaml::Style>() };
         const auto colorTableEntryTemplate{ Resources().Lookup(winrt::box_value(L"ColorTableEntryTemplate")).as<DataTemplate>() };
-        auto setupColorControl = [colorTableEntryTemplate, colorControlStyle, colorTableGrid{ ColorTableGrid() }](hstring colorName, auto&& colorRef, uint32_t row, uint32_t col) {
+        auto setupColorControl = [colorTableEntryTemplate, colorControlStyle, colorTableGrid{ ColorTableGrid() }](const auto&& colorRef, const uint32_t& row, const uint32_t& col) {
             ContentControl colorControl{};
             colorControl.ContentTemplate(colorTableEntryTemplate);
             colorControl.Style(colorControlStyle);
@@ -153,10 +153,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             Grid::SetColumn(label, 0);
 
             // regular color
-            setupColorControl(TableColorNames[row], _CurrentNonBrightColorTable.GetAt(row), row, 1);
+            setupColorControl(_CurrentNonBrightColorTable.GetAt(row), row, 1);
 
             // bright color
-            setupColorControl(TableColorNames[row + ColorTableDivider], _CurrentBrightColorTable.GetAt(row), row, 2);
+            setupColorControl(_CurrentBrightColorTable.GetAt(row), row, 2);
         }
     }
 

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
@@ -96,6 +96,39 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             auto scheme = *it;
             ColorSchemeComboBox().SelectedItem(scheme);
         }
+
+        // populate color table grid
+        const auto colorLabelStyle{ Resources().Lookup(winrt::box_value(L"ColorLabelStyle")).as<Windows::UI::Xaml::Style>() };
+        const auto colorTableEntryTemplate{ Resources().Lookup(winrt::box_value(L"ColorTableEntryTemplate")).as<DataTemplate>() };
+        auto setupColorControl = [colorTableEntryTemplate, colorTableGrid{ ColorTableGrid() }](auto colorRef, uint32_t row, uint32_t col) {
+            ContentControl colorControl{};
+            colorControl.ContentTemplate(colorTableEntryTemplate);
+
+            Data::Binding binding{};
+            binding.Source(colorRef);
+            binding.Mode(Data::BindingMode::TwoWay);
+            colorControl.SetBinding(ContentControl::ContentProperty(), binding);
+
+            colorTableGrid.Children().Append(colorControl);
+            Grid::SetRow(colorControl, row);
+            Grid::SetColumn(colorControl, col);
+        };
+        for (uint32_t row = 0; row < ColorTableGrid().RowDefinitions().Size(); ++row)
+        {
+            // color label
+            TextBlock label{};
+            label.Text(TableColorNames[row]);
+            label.Style(colorLabelStyle);
+            ColorTableGrid().Children().Append(label);
+            Grid::SetRow(label, row);
+            Grid::SetColumn(label, 0);
+
+            // regular color
+            setupColorControl(_CurrentNonBrightColorTable.GetAt(row), row, 1);
+
+            // bright color
+            setupColorControl(_CurrentBrightColorTable.GetAt(row), row, 2);
+        }
     }
 
     // Function Description:

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
@@ -57,8 +57,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     ColorSchemes::ColorSchemes() :
         _ColorSchemeList{ single_threaded_observable_vector<Model::ColorScheme>() },
         _CurrentNonBrightColorTable{ single_threaded_observable_vector<Editor::ColorTableEntry>() },
-        _CurrentBrightColorTable{ single_threaded_observable_vector<Editor::ColorTableEntry>() },
-        _colorPanelHorizontalWidth{ std::nullopt }
+        _CurrentBrightColorTable{ single_threaded_observable_vector<Editor::ColorTableEntry>() }
     {
         InitializeComponent();
 
@@ -88,21 +87,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         Automation::AutomationProperties::SetName(RenameCancelButton(), RS_(L"RenameCancel/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
         Automation::AutomationProperties::SetName(AddNewButton(), RS_(L"ColorScheme_AddNewButton/Text"));
         Automation::AutomationProperties::SetName(DeleteButton(), RS_(L"ColorScheme_DeleteButton/Text"));
-    }
-
-    void ColorSchemes::SizeChanged(IInspectable const& /*sender*/, Windows::UI::Xaml::SizeChangedEventArgs const& e)
-    {
-        // Record the width for ColorPanel when it's in horizontal mode
-        if (!_colorPanelHorizontalWidth && ColorPanel().Orientation() == Orientation::Horizontal)
-        {
-            const auto indentMargin{ Resources().Lookup(winrt::box_value(L"StandardIndentMargin")).as<Thickness>() };
-            const auto colorPanelWidth{ ColorPanel().ActualWidth() };
-            _colorPanelHorizontalWidth = colorPanelWidth + indentMargin.Left + indentMargin.Right;
-        }
-
-        // Update the ColorPanel orientation
-        // If it doesn't fit, make it vertical
-        ColorPanel().Orientation(e.NewSize().Width < _colorPanelHorizontalWidth ? Orientation::Vertical : Orientation::Horizontal);
     }
 
     void ColorSchemes::OnNavigatedTo(const NavigationEventArgs& e)
@@ -148,8 +132,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             ContentControl colorControl{};
             colorControl.ContentTemplate(colorTableEntryTemplate);
             colorControl.Style(colorControlStyle);
-            ToolTipService::SetToolTip(colorControl, box_value(colorName));
-            Automation::AutomationProperties::SetName(colorControl, colorName);
 
             Data::Binding binding{};
             binding.Source(colorRef);

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
@@ -39,13 +39,17 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void DeleteConfirmation_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
 
         GETSET_PROPERTY(Editor::ColorSchemesPageNavigationState, State, nullptr);
+        GETSET_PROPERTY(Model::ColorScheme, CurrentColorScheme, nullptr);
         GETSET_PROPERTY(Windows::Foundation::Collections::IVector<Editor::ColorTableEntry>, CurrentNonBrightColorTable, nullptr);
         GETSET_PROPERTY(Windows::Foundation::Collections::IVector<Editor::ColorTableEntry>, CurrentBrightColorTable, nullptr);
         GETSET_PROPERTY(Windows::Foundation::Collections::IObservableVector<Model::ColorScheme>, ColorSchemeList, nullptr);
 
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
-        OBSERVABLE_GETSET_PROPERTY(winrt::Microsoft::Terminal::Settings::Model::ColorScheme, CurrentColorScheme, _PropertyChangedHandlers, nullptr);
         OBSERVABLE_GETSET_PROPERTY(bool, IsRenaming, _PropertyChangedHandlers, nullptr);
+        OBSERVABLE_GETSET_PROPERTY(Editor::ColorTableEntry, CurrentForegroundColor, _PropertyChangedHandlers, nullptr);
+        OBSERVABLE_GETSET_PROPERTY(Editor::ColorTableEntry, CurrentBackgroundColor, _PropertyChangedHandlers, nullptr);
+        OBSERVABLE_GETSET_PROPERTY(Editor::ColorTableEntry, CurrentCursorColor, _PropertyChangedHandlers, nullptr);
+        OBSERVABLE_GETSET_PROPERTY(Editor::ColorTableEntry, CurrentSelectionBackgroundColor, _PropertyChangedHandlers, nullptr);
 
     private:
         void _UpdateColorTable(const winrt::Microsoft::Terminal::Settings::Model::ColorScheme& colorScheme);
@@ -57,10 +61,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
     public:
         ColorTableEntry(uint8_t index, Windows::UI::Color color);
+        ColorTableEntry(std::wstring_view tag, Windows::UI::Color color);
 
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
         OBSERVABLE_GETSET_PROPERTY(winrt::hstring, Name, _PropertyChangedHandlers);
-        OBSERVABLE_GETSET_PROPERTY(IInspectable, Index, _PropertyChangedHandlers);
+        OBSERVABLE_GETSET_PROPERTY(IInspectable, Tag, _PropertyChangedHandlers);
         OBSERVABLE_GETSET_PROPERTY(Windows::UI::Color, Color, _PropertyChangedHandlers);
     };
 }

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
@@ -39,7 +39,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void DeleteConfirmation_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
 
         GETSET_PROPERTY(Editor::ColorSchemesPageNavigationState, State, nullptr);
-        GETSET_PROPERTY(Windows::Foundation::Collections::IObservableVector<winrt::Microsoft::Terminal::Settings::Editor::ColorTableEntry>, CurrentColorTable, nullptr);
+        GETSET_PROPERTY(Windows::Foundation::Collections::IVector<Editor::ColorTableEntry>, CurrentNonBrightColorTable, nullptr);
+        GETSET_PROPERTY(Windows::Foundation::Collections::IVector<Editor::ColorTableEntry>, CurrentBrightColorTable, nullptr);
         GETSET_PROPERTY(Windows::Foundation::Collections::IObservableVector<Model::ColorScheme>, ColorSchemeList, nullptr);
 
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
@@ -24,6 +24,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         ColorSchemes();
 
+        void SizeChanged(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::SizeChangedEventArgs const& e);
         void OnNavigatedTo(const winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
 
         void ColorSchemeSelectionChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::Controls::SelectionChangedEventArgs const& args);
@@ -51,6 +52,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void _UpdateColorTable(const winrt::Microsoft::Terminal::Settings::Model::ColorScheme& colorScheme);
         void _UpdateColorSchemeList();
         void _RenameCurrentScheme(hstring newName);
+
+        double _colorPanelHorizontalWidth;
     };
 
     struct ColorTableEntry : ColorTableEntryT<ColorTableEntry>

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
@@ -53,7 +53,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void _UpdateColorSchemeList();
         void _RenameCurrentScheme(hstring newName);
 
-        double _colorPanelHorizontalWidth;
+        std::optional<double> _colorPanelHorizontalWidth;
     };
 
     struct ColorTableEntry : ColorTableEntryT<ColorTableEntry>

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
@@ -24,7 +24,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         ColorSchemes();
 
-        void SizeChanged(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::SizeChangedEventArgs const& e);
         void OnNavigatedTo(const winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
 
         void ColorSchemeSelectionChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::Controls::SelectionChangedEventArgs const& args);
@@ -52,8 +51,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void _UpdateColorTable(const winrt::Microsoft::Terminal::Settings::Model::ColorScheme& colorScheme);
         void _UpdateColorSchemeList();
         void _RenameCurrentScheme(hstring newName);
-
-        std::optional<double> _colorPanelHorizontalWidth;
     };
 
     struct ColorTableEntry : ColorTableEntryT<ColorTableEntry>

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.idl
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.idl
@@ -19,7 +19,8 @@ namespace Microsoft.Terminal.Settings.Editor
         Boolean IsRenaming { get; };
 
         Microsoft.Terminal.Settings.Model.ColorScheme CurrentColorScheme { get; };
-        Windows.Foundation.Collections.IObservableVector<ColorTableEntry> CurrentColorTable;
+        Windows.Foundation.Collections.IVector<ColorTableEntry> CurrentNonBrightColorTable { get; };
+        Windows.Foundation.Collections.IVector<ColorTableEntry> CurrentBrightColorTable { get; };
         Windows.Foundation.Collections.IObservableVector<Microsoft.Terminal.Settings.Model.ColorScheme> ColorSchemeList { get; };
     }
 

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.idl
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.idl
@@ -18,16 +18,24 @@ namespace Microsoft.Terminal.Settings.Editor
         Boolean CanDeleteCurrentScheme { get; };
         Boolean IsRenaming { get; };
 
-        Microsoft.Terminal.Settings.Model.ColorScheme CurrentColorScheme { get; };
+        // Terminal Colors
         Windows.Foundation.Collections.IVector<ColorTableEntry> CurrentNonBrightColorTable { get; };
         Windows.Foundation.Collections.IVector<ColorTableEntry> CurrentBrightColorTable { get; };
+
+        // System Colors
+        ColorTableEntry CurrentForegroundColor;
+        ColorTableEntry CurrentBackgroundColor;
+        ColorTableEntry CurrentCursorColor;
+        ColorTableEntry CurrentSelectionBackgroundColor;
+
+
         Windows.Foundation.Collections.IObservableVector<Microsoft.Terminal.Settings.Model.ColorScheme> ColorSchemeList { get; };
     }
 
     [default_interface] runtimeclass ColorTableEntry : Windows.UI.Xaml.Data.INotifyPropertyChanged
     {
         String Name { get; };
-        IInspectable Index;
+        IInspectable Tag;
         Windows.UI.Color Color;
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -110,6 +110,20 @@ the MIT License. See LICENSE in the project root for license information. -->
     </Page.Resources>
 
     <ScrollViewer>
+        
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup>
+                <VisualState>
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="600"/>
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="ColorPanel.Orientation" Value="Horizontal"/>
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+
         <StackPanel Margin="{StaticResource StandardIndentMargin}"
                     Spacing="24">
 
@@ -190,7 +204,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             </StackPanel>
 
             <!-- Color Table (Left Column)-->
-            <StackPanel Orientation="Horizontal"
+            <StackPanel x:Name="ColorPanel"
                         Spacing="48">
                 <StackPanel>
                     <TextBlock x:Uid="ColorScheme_ColorTableHeader"

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -200,11 +200,11 @@ the MIT License. See LICENSE in the project root for license information. -->
                 </Button>
             </StackPanel>
 
-            <!-- Color Table (Left Column)-->
+            <!-- Terminal Colors (Left Column)-->
             <StackPanel x:Name="ColorPanel"
                         Spacing="48">
                 <StackPanel>
-                    <TextBlock x:Uid="ColorScheme_ColorTableHeader"
+                    <TextBlock x:Uid="ColorScheme_TerminalColorsHeader"
                                Style="{StaticResource GroupHeaderStyle}"/>
                     <Grid x:Name="ColorTableGrid"
                           Style="{StaticResource ColorTableGridStyle}">
@@ -232,9 +232,9 @@ the MIT License. See LICENSE in the project root for license information. -->
                     </Grid>
                 </StackPanel>
 
-                <!-- Additional Colors (Right Column) -->
+                <!-- System Colors (Right Column) -->
                 <StackPanel>
-                    <TextBlock x:Uid="ColorScheme_FunctionalColorsHeader"
+                    <TextBlock x:Uid="ColorScheme_SystemColorsHeader"
                                Style="{StaticResource GroupHeaderStyle}"/>
                     <Grid Style="{StaticResource ColorTableGridStyle}">
 

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -17,16 +17,18 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <ResourceDictionary Source="CommonResources.xaml"/>
             </ResourceDictionary.MergedDictionaries>
 
-            <Thickness x:Key="ColorSchemesStandardControlMargin">0,0,10,20</Thickness>
-            <Thickness x:Key="ColorEntrySpacing">0,10,10,0</Thickness>
-
-            <Style x:Key="ColorStackPanelStyle" TargetType="StackPanel">
-                <Setter Property="Margin" Value="{StaticResource ColorSchemesStandardControlMargin}"/>
-                <Setter Property="Height" Value="59"/>
+            <Style x:Key="GroupHeaderStyle" TargetType="TextBlock" BasedOn="{StaticResource SubtitleTextBlockStyle}">
+                <Setter Property="Margin" Value="0,0,0,4"/>
             </Style>
 
-            <Style x:Key="ColorHeaderStyle" TargetType="TextBlock">
-                <Setter Property="Margin" Value="0,0,0,5"/>
+            <Style x:Key="ColorLabelStyle" TargetType="TextBlock">
+                <Setter Property="HorizontalAlignment" Value="Left"/>
+                <Setter Property="VerticalAlignment" Value="Center"/>
+            </Style>
+
+            <Style x:Key="ColorTableGridStyle" TargetType="Grid">
+                <Setter Property="RowSpacing" Value="10"/>
+                <Setter Property="ColumnSpacing" Value="10"/>
             </Style>
 
             <Style x:Key="ColorButtonStyle" TargetType="Button" BasedOn="{StaticResource BaseButtonStyle}">
@@ -43,53 +45,9 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <Setter Property="IsAlphaTextInputVisible" Value="True"/>
             </Style>
 
-            <DataTemplate x:Key="LabelledColorTableEntry" x:DataType="local:ColorTableEntry">
-                <Grid Margin="{StaticResource ColorEntrySpacing}">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-
-                    <!--Label-->
-                    <TextBlock Text="{x:Bind Name}"
-                               HorizontalAlignment="Left"
-                               VerticalAlignment="Center"
-                               Grid.Column="0"/>
-                               <!--MinWidth="100"-->
-
-                    <Button Background="{x:Bind Color, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}"
-                            Style="{StaticResource ColorButtonStyle}"
-                            Grid.Column="1">
-                        <Button.Resources>
-                            <!-- Resources to colorize hover/pressed states based on the color of the button -->
-                            <ResourceDictionary>
-                                <ResourceDictionary.ThemeDictionaries>
-                                    <ResourceDictionary x:Key="Light">
-                                        <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{x:Bind Color, Converter={StaticResource ColorLightenConverter}, Mode=OneWay}"/>
-                                    </ResourceDictionary>
-                                    <ResourceDictionary x:Key="Dark">
-                                        <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{x:Bind Color, Converter={StaticResource ColorLightenConverter}, Mode=OneWay}"/>
-                                    </ResourceDictionary>
-                                    <!-- No High contrast dictionary, let's just leave that unchanged. -->
-                                </ResourceDictionary.ThemeDictionaries>
-                            </ResourceDictionary>
-                        </Button.Resources>
-
-                        <Button.Flyout>
-                            <Flyout>
-                                <ColorPicker Tag="{x:Bind Index, Mode=OneWay}"
-                                             Color="{x:Bind Color, Mode=OneWay}"
-                                             ColorChanged="ColorPickerChanged"/>
-                            </Flyout>
-                        </Button.Flyout>
-                    </Button>
-                </Grid>
-            </DataTemplate>
-
-            <DataTemplate x:Key="UnlabelledColorTableEntry" x:DataType="local:ColorTableEntry">
+            <DataTemplate x:Key="ColorTableEntryTemplate" x:DataType="local:ColorTableEntry">
                 <Button Background="{x:Bind Color, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}"
-                        Style="{StaticResource ColorButtonStyle}"
-                        Margin="{StaticResource ColorEntrySpacing}">
+                        Style="{StaticResource ColorButtonStyle}">
                     <Button.Resources>
                         <!-- Resources to colorize hover/pressed states based on the color of the button -->
                         <ResourceDictionary>
@@ -115,6 +73,34 @@ the MIT License. See LICENSE in the project root for license information. -->
                 </Button>
             </DataTemplate>
 
+            <DataTemplate x:Key="ColorTemplate" x:DataType="Color">
+                <Button Background="{Binding Color, ElementName=ColorPicker, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}"
+                        Style="{StaticResource ColorButtonStyle}">
+                    <Button.Resources>
+                        <!-- Resources to colorize hover/pressed states based on the color of the button -->
+                        <ResourceDictionary>
+                            <ResourceDictionary.ThemeDictionaries>
+                                <ResourceDictionary x:Key="Light">
+                                    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{Binding Color, ElementName=ColorPicker, Converter={StaticResource ColorLightenConverter}, Mode=OneWay}"/>
+                                </ResourceDictionary>
+                                <ResourceDictionary x:Key="Dark">
+                                    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{Binding Color, ElementName=ColorPicker, Converter={StaticResource ColorLightenConverter}, Mode=OneWay}"/>
+                                </ResourceDictionary>
+                                <!-- No High contrast dictionary, let's just leave that unchanged. -->
+                            </ResourceDictionary.ThemeDictionaries>
+                        </ResourceDictionary>
+                    </Button.Resources>
+
+                    <Button.Flyout>
+                        <Flyout>
+                            <ColorPicker x:Name="ColorPicker"
+                                         Color="{x:Bind Mode=OneWay}"
+                                         ColorChanged="ColorPickerChanged"/>
+                        </Flyout>
+                    </Button.Flyout>
+                </Button>
+            </DataTemplate>
+
             <local:ColorToBrushConverter x:Key="ColorToBrushConverter"/>
             <local:ColorToHexConverter x:Key="ColorToHexConverter"/>
             <local:InvertedBooleanToVisibilityConverter x:Key="InvertedBooleanToVisibilityConverter"/>
@@ -124,22 +110,11 @@ the MIT License. See LICENSE in the project root for license information. -->
     </Page.Resources>
 
     <ScrollViewer>
-        <Grid Margin="{StaticResource StandardIndentMargin}">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="1*" MaxWidth="480"/>
-                <ColumnDefinition Width="1*"/>
-            </Grid.ColumnDefinitions>
+        <StackPanel Margin="{StaticResource StandardIndentMargin}"
+                    Spacing="24">
 
             <!--Select Color and Add New Button-->
-            <StackPanel Orientation="Horizontal"
-                        Grid.Row="0"
-                        Grid.Column="0"
-                        Grid.ColumnSpan="2">
+            <StackPanel Orientation="Horizontal">
 
                 <StackPanel Orientation="Horizontal"
                             Visibility="{x:Bind IsRenaming, Converter={StaticResource InvertedBooleanToVisibilityConverter}, Mode=OneWay}">
@@ -215,163 +190,100 @@ the MIT License. See LICENSE in the project root for license information. -->
             </StackPanel>
 
             <!-- Color Table (Left Column)-->
-            <Grid Grid.Row="1"
-                  Grid.Column="0">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
+            <StackPanel Orientation="Horizontal"
+                        Spacing="48">
+                <StackPanel>
+                    <TextBlock x:Uid="ColorScheme_ColorTableHeader"
+                               Style="{StaticResource GroupHeaderStyle}"/>
+                    <Grid x:Name="ColorTableGrid"
+                          Style="{StaticResource ColorTableGridStyle}">
+                        <Grid.ColumnDefinitions>
+                            <!--Labels-->
+                            <ColumnDefinition Width="Auto"/>
 
-                <!--Non-Bright Colors-->
-                <ItemsControl Grid.Column="0"
-                              ItemsSource="{x:Bind CurrentNonBrightColorTable, Mode=OneWay}"
-                              ItemTemplate="{StaticResource LabelledColorTableEntry}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <ItemsStackPanel Orientation="Vertical"/>
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                </ItemsControl>
+                            <!--Regular Colors-->
+                            <ColumnDefinition Width="Auto"/>
 
-                <!--Bright Colors-->
-                <ItemsControl Grid.Column="1"
-                              ItemsSource="{x:Bind CurrentBrightColorTable, Mode=OneWay}"
-                              ItemTemplate="{StaticResource UnlabelledColorTableEntry}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <ItemsStackPanel Orientation="Vertical"/>
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                </ItemsControl>
-            </Grid>
+                            <!--Bright Colors-->
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
 
-            <!-- Additional Colors (Right Column) -->
-            <ItemsControl Grid.Row="1"
-                          Grid.Column="1"
-                          Style="{StaticResource ItemsControlStyle}">
-
-                <StackPanel Style="{StaticResource ColorStackPanelStyle}">
-                    <TextBlock x:Uid="ColorScheme_Foreground"
-                               Style="{StaticResource ColorHeaderStyle}"/>
-                    <Button Background="{Binding Color, ElementName=ForegroundPicker, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}">
-
-
-                        <Button.Resources>
-                            <!-- Resources to colorize hover/pressed states based on the color of the button -->
-                            <ResourceDictionary>
-                                <ResourceDictionary.ThemeDictionaries>
-                                    <ResourceDictionary x:Key="Light">
-                                        <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{Binding Color, ElementName=ForegroundPicker, Converter={StaticResource ColorLightenConverter}, Mode=OneWay}"/>
-                                    </ResourceDictionary>
-                                    <ResourceDictionary x:Key="Dark">
-                                        <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{Binding Color, ElementName=ForegroundPicker, Converter={StaticResource ColorLightenConverter}, Mode=OneWay}"/>
-                                    </ResourceDictionary>
-                                    <!-- No High contrast dictionary, let's just leave that unchanged. -->
-                                </ResourceDictionary.ThemeDictionaries>
-                            </ResourceDictionary>
-                        </Button.Resources>
-
-                        <Button.Flyout>
-                            <Flyout>
-                                <ColorPicker x:Name="ForegroundPicker" Color="{x:Bind CurrentColorScheme.Foreground, Mode=TwoWay}"/>
-                            </Flyout>
-                        </Button.Flyout>
-                    </Button>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                    </Grid>
                 </StackPanel>
-                <StackPanel Style="{StaticResource ColorStackPanelStyle}">
-                    <TextBlock x:Uid="ColorScheme_Background"
-                               Style="{StaticResource ColorHeaderStyle}"/>
-                    <Button Background="{Binding Color, ElementName=BackgroundPicker, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}">
 
+                <!-- Additional Colors (Right Column) -->
+                <StackPanel>
+                    <TextBlock x:Uid="ColorScheme_FunctionalColorsHeader"
+                               Style="{StaticResource GroupHeaderStyle}"/>
+                    <Grid Style="{StaticResource ColorTableGridStyle}">
 
-                        <Button.Resources>
-                            <!-- Resources to colorize hover/pressed states based on the color of the button -->
-                            <ResourceDictionary>
-                                <ResourceDictionary.ThemeDictionaries>
-                                    <ResourceDictionary x:Key="Light">
-                                        <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{Binding Color, ElementName=BackgroundPicker, Converter={StaticResource ColorLightenConverter}, Mode=OneWay}"/>
-                                    </ResourceDictionary>
-                                    <ResourceDictionary x:Key="Dark">
-                                        <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{Binding Color, ElementName=BackgroundPicker, Converter={StaticResource ColorLightenConverter}, Mode=OneWay}"/>
-                                    </ResourceDictionary>
-                                    <!-- No High contrast dictionary, let's just leave that unchanged. -->
-                                </ResourceDictionary.ThemeDictionaries>
-                            </ResourceDictionary>
-                        </Button.Resources>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
 
-                        <Button.Flyout>
-                            <Flyout>
-                                <ColorPicker x:Name="BackgroundPicker"
-                                             Color="{x:Bind CurrentColorScheme.Background, Mode=TwoWay}"/>
-                            </Flyout>
-                        </Button.Flyout>
-                    </Button>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <!--Foreground-->
+                        <TextBlock x:Uid="ColorScheme_Foreground"
+                                   Style="{StaticResource ColorLabelStyle}"
+                                   Grid.Row="0"
+                                   Grid.Column="0"/>
+                        <ContentControl ContentTemplate="{StaticResource ColorTemplate}"
+                                        Content="{x:Bind CurrentColorScheme.Foreground, Mode=TwoWay}"
+                                        Grid.Row="0"
+                                        Grid.Column="1"/>
+
+                        <!--Background-->
+                        <TextBlock x:Uid="ColorScheme_Background"
+                                   Style="{StaticResource ColorLabelStyle}"
+                                   Grid.Row="1"
+                                   Grid.Column="0"/>
+                        <ContentControl ContentTemplate="{StaticResource ColorTemplate}"
+                                        Content="{x:Bind CurrentColorScheme.Background, Mode=TwoWay}"
+                                        Grid.Row="1"
+                                        Grid.Column="1"/>
+
+                        <!--Cursor Color-->
+                        <TextBlock x:Uid="ColorScheme_CursorColor"
+                                   Style="{StaticResource ColorLabelStyle}"
+                                   Grid.Row="2"
+                                   Grid.Column="0"/>
+                        <ContentControl ContentTemplate="{StaticResource ColorTemplate}"
+                                        Content="{x:Bind CurrentColorScheme.CursorColor, Mode=TwoWay}"
+                                        Grid.Row="2"
+                                        Grid.Column="1"/>
+
+                        <!--Selection Background-->
+                        <TextBlock x:Uid="ColorScheme_SelectionBackground"
+                                   Style="{StaticResource ColorLabelStyle}"
+                                   Grid.Row="3"
+                                   Grid.Column="0"/>
+                        <ContentControl ContentTemplate="{StaticResource ColorTemplate}"
+                                        Content="{x:Bind CurrentColorScheme.SelectionBackground, Mode=TwoWay}"
+                                        Grid.Row="3"
+                                        Grid.Column="1"/>
+                    </Grid>
                 </StackPanel>
-                <StackPanel Style="{StaticResource ColorStackPanelStyle}">
-                    <TextBlock x:Uid="ColorScheme_CursorColor"
-                               Style="{StaticResource ColorHeaderStyle}"/>
-                    <Button Background="{Binding Color, ElementName=CursorColorPicker, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}">
-
-
-                        <Button.Resources>
-                            <!-- Resources to colorize hover/pressed states based on the color of the button -->
-                            <ResourceDictionary>
-                                <ResourceDictionary.ThemeDictionaries>
-                                    <ResourceDictionary x:Key="Light">
-                                        <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{Binding Color, ElementName=CursorColorPicker, Converter={StaticResource ColorLightenConverter}, Mode=OneWay}"/>
-                                    </ResourceDictionary>
-                                    <ResourceDictionary x:Key="Dark">
-                                        <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{Binding Color, ElementName=CursorColorPicker, Converter={StaticResource ColorLightenConverter}, Mode=OneWay}"/>
-                                    </ResourceDictionary>
-                                    <!-- No High contrast dictionary, let's just leave that unchanged. -->
-                                </ResourceDictionary.ThemeDictionaries>
-                            </ResourceDictionary>
-                        </Button.Resources>
-
-                        <Button.Flyout>
-                            <Flyout>
-                                <ColorPicker x:Name="CursorColorPicker"
-                                             Color="{x:Bind CurrentColorScheme.CursorColor, Mode=TwoWay}"/>
-                            </Flyout>
-                        </Button.Flyout>
-                    </Button>
-                </StackPanel>
-                <StackPanel Style="{StaticResource ColorStackPanelStyle}">
-                    <TextBlock x:Uid="ColorScheme_SelectionBackground"
-                               Style="{StaticResource ColorHeaderStyle}"/>
-                    <Button Background="{Binding Color, ElementName=SelectionBackgroundPicker, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}">
-
-
-                        <Button.Resources>
-                            <!-- Resources to colorize hover/pressed states based on the color of the button -->
-                            <ResourceDictionary>
-                                <ResourceDictionary.ThemeDictionaries>
-                                    <ResourceDictionary x:Key="Light">
-                                        <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{Binding Color, ElementName=SelectionBackgroundPicker, Converter={StaticResource ColorLightenConverter}, Mode=OneWay}"/>
-                                    </ResourceDictionary>
-                                    <ResourceDictionary x:Key="Dark">
-                                        <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{Binding Color, ElementName=SelectionBackgroundPicker, Converter={StaticResource ColorLightenConverter}, Mode=OneWay}"/>
-                                    </ResourceDictionary>
-                                    <!-- No High contrast dictionary, let's just leave that unchanged. -->
-                                </ResourceDictionary.ThemeDictionaries>
-                            </ResourceDictionary>
-                        </Button.Resources>
-
-                        <Button.Flyout>
-                            <Flyout>
-                                <ColorPicker x:Name="SelectionBackgroundPicker"
-                                             Color="{x:Bind CurrentColorScheme.SelectionBackground, Mode=TwoWay}"/>
-                            </Flyout>
-                        </Button.Flyout>
-                    </Button>
-                </StackPanel>
-            </ItemsControl>
+            </StackPanel>
 
             <!--Delete Button-->
-            <StackPanel Grid.Row="2"
-                        Grid.Column="0"
-                        Grid.ColumnSpan="2"
-                        Style="{StaticResource PivotStackStyle}">
+            <StackPanel Style="{StaticResource PivotStackStyle}">
                 <Button x:Name="DeleteButton"
                         IsEnabled="{x:Bind CanDeleteCurrentScheme, Mode=OneWay}"
                         Style="{StaticResource DeleteButtonStyle}">
@@ -427,6 +339,6 @@ the MIT License. See LICENSE in the project root for license information. -->
                            Style="{StaticResource DisclaimerStyle}"
                            VerticalAlignment="Center"/>
             </StackPanel>
-        </Grid>
+        </StackPanel>
     </ScrollViewer>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -274,7 +274,6 @@ the MIT License. See LICENSE in the project root for license information. -->
                                         ContentTemplate="{StaticResource ColorTemplate}"
                                         Content="{x:Bind CurrentColorScheme.Foreground, Mode=TwoWay}"
                                         Style="{StaticResource ColorControlStyle}"
-                                        ToolTipService.ToolTip="{Binding ElementName=ForegroundHeader, Path=Text}"
                                         Grid.Row="0"
                                         Grid.Column="1"/>
 

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -9,8 +9,7 @@ the MIT License. See LICENSE in the project root for license information. -->
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    SizeChanged="SizeChanged">
+    mc:Ignorable="d">
 
     <Page.Resources>
         <ResourceDictionary>
@@ -53,8 +52,8 @@ the MIT License. See LICENSE in the project root for license information. -->
             <DataTemplate x:Key="ColorTableEntryTemplate" x:DataType="local:ColorTableEntry">
                 <Button Background="{x:Bind Color, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}"
                         ToolTipService.ToolTip="{x:Bind Name}"
+                        AutomationProperties.Name="{x:Bind Name}"
                         Style="{StaticResource ColorButtonStyle}">
-                        <!--AutomationProperties.Name="{x:Bind Name}"-->
                     <Button.Resources>
                         <!-- Resources to colorize hover/pressed states based on the color of the button -->
                         <ResourceDictionary>
@@ -118,6 +117,22 @@ the MIT License. See LICENSE in the project root for license information. -->
     </Page.Resources>
 
     <ScrollViewer>
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup>
+                <VisualState>
+                    <VisualState.StateTriggers>
+                        <!--Official guidance states that 640 is the breakpoint between small and medium devices.
+                        Since MinWindowWidth is an inclusive range, we need to add 1 to it.-->
+                        <AdaptiveTrigger MinWindowWidth="641"/>
+                    </VisualState.StateTriggers>
+
+                    <VisualState.Setters>
+                        <Setter Target="ColorPanel.Orientation" Value="Horizontal"/>
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+
         <StackPanel Margin="{StaticResource StandardIndentMargin}"
                     Spacing="24">
 

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -9,7 +9,8 @@ the MIT License. See LICENSE in the project root for license information. -->
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    SizeChanged="SizeChanged">
 
     <Page.Resources>
         <ResourceDictionary>
@@ -31,6 +32,10 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <Setter Property="ColumnSpacing" Value="10"/>
             </Style>
 
+            <Style x:Key="ColorControlStyle" TargetType="ContentControl">
+                <Setter Property="IsTabStop" Value="False"/>
+            </Style>
+
             <Style x:Key="ColorButtonStyle" TargetType="Button" BasedOn="{StaticResource BaseButtonStyle}">
                 <Setter Property="BorderBrush" Value="{StaticResource SystemBaseLowColor}"/>
                 <Setter Property="Height" Value="30"/>
@@ -47,7 +52,9 @@ the MIT License. See LICENSE in the project root for license information. -->
 
             <DataTemplate x:Key="ColorTableEntryTemplate" x:DataType="local:ColorTableEntry">
                 <Button Background="{x:Bind Color, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}"
+                        ToolTipService.ToolTip="{x:Bind Name}"
                         Style="{StaticResource ColorButtonStyle}">
+                        <!--AutomationProperties.Name="{x:Bind Name}"-->
                     <Button.Resources>
                         <!-- Resources to colorize hover/pressed states based on the color of the button -->
                         <ResourceDictionary>
@@ -110,20 +117,6 @@ the MIT License. See LICENSE in the project root for license information. -->
     </Page.Resources>
 
     <ScrollViewer>
-        
-        <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup>
-                <VisualState>
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="600"/>
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="ColorPanel.Orientation" Value="Horizontal"/>
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
-
         <StackPanel Margin="{StaticResource StandardIndentMargin}"
                     Spacing="24">
 
@@ -258,8 +251,11 @@ the MIT License. See LICENSE in the project root for license information. -->
                                    Style="{StaticResource ColorLabelStyle}"
                                    Grid.Row="0"
                                    Grid.Column="0"/>
-                        <ContentControl ContentTemplate="{StaticResource ColorTemplate}"
+                        <ContentControl x:Name="ForegroundButton"
+                                        ContentTemplate="{StaticResource ColorTemplate}"
                                         Content="{x:Bind CurrentColorScheme.Foreground, Mode=TwoWay}"
+                                        Style="{StaticResource ColorControlStyle}"
+                                        ToolTipService.ToolTip="{Binding ElementName=ForegroundHeader, Path=Text}"
                                         Grid.Row="0"
                                         Grid.Column="1"/>
 
@@ -268,8 +264,10 @@ the MIT License. See LICENSE in the project root for license information. -->
                                    Style="{StaticResource ColorLabelStyle}"
                                    Grid.Row="1"
                                    Grid.Column="0"/>
-                        <ContentControl ContentTemplate="{StaticResource ColorTemplate}"
+                        <ContentControl x:Name="BackgroundButton"
+                                        ContentTemplate="{StaticResource ColorTemplate}"
                                         Content="{x:Bind CurrentColorScheme.Background, Mode=TwoWay}"
+                                        Style="{StaticResource ColorControlStyle}"
                                         Grid.Row="1"
                                         Grid.Column="1"/>
 
@@ -278,8 +276,10 @@ the MIT License. See LICENSE in the project root for license information. -->
                                    Style="{StaticResource ColorLabelStyle}"
                                    Grid.Row="2"
                                    Grid.Column="0"/>
-                        <ContentControl ContentTemplate="{StaticResource ColorTemplate}"
+                        <ContentControl x:Name="CursorColorButton"
+                                        ContentTemplate="{StaticResource ColorTemplate}"
                                         Content="{x:Bind CurrentColorScheme.CursorColor, Mode=TwoWay}"
+                                        Style="{StaticResource ColorControlStyle}"
                                         Grid.Row="2"
                                         Grid.Column="1"/>
 
@@ -288,8 +288,10 @@ the MIT License. See LICENSE in the project root for license information. -->
                                    Style="{StaticResource ColorLabelStyle}"
                                    Grid.Row="3"
                                    Grid.Column="0"/>
-                        <ContentControl ContentTemplate="{StaticResource ColorTemplate}"
+                        <ContentControl x:Name="SelectionBackgroundButton"
+                                        ContentTemplate="{StaticResource ColorTemplate}"
                                         Content="{x:Bind CurrentColorScheme.SelectionBackground, Mode=TwoWay}"
+                                        Style="{StaticResource ColorControlStyle}"
                                         Grid.Row="3"
                                         Grid.Column="1"/>
                     </Grid>

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -71,37 +71,8 @@ the MIT License. See LICENSE in the project root for license information. -->
 
                     <Button.Flyout>
                         <Flyout>
-                            <ColorPicker Tag="{x:Bind Index, Mode=OneWay}"
+                            <ColorPicker Tag="{x:Bind Tag, Mode=OneWay}"
                                          Color="{x:Bind Color, Mode=OneWay}"
-                                         ColorChanged="ColorPickerChanged"/>
-                        </Flyout>
-                    </Button.Flyout>
-                </Button>
-            </DataTemplate>
-
-            <DataTemplate x:Key="ColorTemplate" x:DataType="Color">
-                <Button x:Name="ColorButton"
-                        Background="{Binding Color, ElementName=ColorPicker, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}"
-                        Style="{StaticResource ColorButtonStyle}">
-                    <Button.Resources>
-                        <!-- Resources to colorize hover/pressed states based on the color of the button -->
-                        <ResourceDictionary>
-                            <ResourceDictionary.ThemeDictionaries>
-                                <ResourceDictionary x:Key="Light">
-                                    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{Binding Color, ElementName=ColorPicker, Converter={StaticResource ColorLightenConverter}, Mode=OneWay}"/>
-                                </ResourceDictionary>
-                                <ResourceDictionary x:Key="Dark">
-                                    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{Binding Color, ElementName=ColorPicker, Converter={StaticResource ColorLightenConverter}, Mode=OneWay}"/>
-                                </ResourceDictionary>
-                                <!-- No High contrast dictionary, let's just leave that unchanged. -->
-                            </ResourceDictionary.ThemeDictionaries>
-                        </ResourceDictionary>
-                    </Button.Resources>
-
-                    <Button.Flyout>
-                        <Flyout>
-                            <ColorPicker x:Name="ColorPicker"
-                                         Color="{x:Bind Mode=OneWay}"
                                          ColorChanged="ColorPickerChanged"/>
                         </Flyout>
                     </Button.Flyout>
@@ -271,8 +242,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                                    Grid.Row="0"
                                    Grid.Column="0"/>
                         <ContentControl x:Name="ForegroundButton"
-                                        ContentTemplate="{StaticResource ColorTemplate}"
-                                        Content="{x:Bind CurrentColorScheme.Foreground, Mode=TwoWay}"
+                                        ContentTemplate="{StaticResource ColorTableEntryTemplate}"
+                                        Content="{x:Bind CurrentForegroundColor, Mode=TwoWay}"
                                         Style="{StaticResource ColorControlStyle}"
                                         Grid.Row="0"
                                         Grid.Column="1"/>
@@ -283,8 +254,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                                    Grid.Row="1"
                                    Grid.Column="0"/>
                         <ContentControl x:Name="BackgroundButton"
-                                        ContentTemplate="{StaticResource ColorTemplate}"
-                                        Content="{x:Bind CurrentColorScheme.Background, Mode=TwoWay}"
+                                        ContentTemplate="{StaticResource ColorTableEntryTemplate}"
+                                        Content="{x:Bind CurrentBackgroundColor, Mode=TwoWay}"
                                         Style="{StaticResource ColorControlStyle}"
                                         Grid.Row="1"
                                         Grid.Column="1"/>
@@ -295,8 +266,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                                    Grid.Row="2"
                                    Grid.Column="0"/>
                         <ContentControl x:Name="CursorColorButton"
-                                        ContentTemplate="{StaticResource ColorTemplate}"
-                                        Content="{x:Bind CurrentColorScheme.CursorColor, Mode=TwoWay}"
+                                        ContentTemplate="{StaticResource ColorTableEntryTemplate}"
+                                        Content="{x:Bind CurrentCursorColor, Mode=TwoWay}"
                                         Style="{StaticResource ColorControlStyle}"
                                         Grid.Row="2"
                                         Grid.Column="1"/>
@@ -307,8 +278,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                                    Grid.Row="3"
                                    Grid.Column="0"/>
                         <ContentControl x:Name="SelectionBackgroundButton"
-                                        ContentTemplate="{StaticResource ColorTemplate}"
-                                        Content="{x:Bind CurrentColorScheme.SelectionBackground, Mode=TwoWay}"
+                                        ContentTemplate="{StaticResource ColorTableEntryTemplate}"
+                                        Content="{x:Bind CurrentSelectionBackgroundColor, Mode=TwoWay}"
                                         Style="{StaticResource ColorControlStyle}"
                                         Grid.Row="3"
                                         Grid.Column="1"/>

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -81,7 +81,8 @@ the MIT License. See LICENSE in the project root for license information. -->
             </DataTemplate>
 
             <DataTemplate x:Key="ColorTemplate" x:DataType="Color">
-                <Button Background="{Binding Color, ElementName=ColorPicker, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}"
+                <Button x:Name="ColorButton"
+                        Background="{Binding Color, ElementName=ColorPicker, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}"
                         Style="{StaticResource ColorButtonStyle}">
                     <Button.Resources>
                         <!-- Resources to colorize hover/pressed states based on the color of the button -->
@@ -166,6 +167,7 @@ the MIT License. See LICENSE in the project root for license information. -->
 
                     <!--Accept rename button-->
                     <Button x:Uid="RenameAccept"
+                            x:Name="RenameAcceptButton"
                             Style="{StaticResource AccentSmallButtonStyle}"
                             Click="RenameAccept_Click">
                         <StackPanel Orientation="Horizontal">
@@ -175,6 +177,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                     </Button>
                     <!--Cancel rename button-->
                     <Button x:Uid="RenameCancel"
+                            x:Name="RenameCancelButton"
                             Style="{StaticResource SmallButtonStyle}"
                             Click="RenameCancel_Click">
                         <StackPanel Orientation="Horizontal">
@@ -185,7 +188,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                 </StackPanel>
 
                 <!--Add new button-->
-                <Button Click="AddNew_Click"
+                <Button x:Name="AddNewButton"
+                        Click="AddNew_Click"
                         Style="{StaticResource BrowseButtonStyle}">
                     <StackPanel Orientation="Horizontal">
                         <FontIcon Glyph="&#xE710;"

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -18,6 +18,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             </ResourceDictionary.MergedDictionaries>
 
             <Thickness x:Key="ColorSchemesStandardControlMargin">0,0,10,20</Thickness>
+            <Thickness x:Key="ColorEntrySpacing">0,10,10,0</Thickness>
 
             <Style x:Key="ColorStackPanelStyle" TargetType="StackPanel">
                 <Setter Property="Margin" Value="{StaticResource ColorSchemesStandardControlMargin}"/>
@@ -28,7 +29,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <Setter Property="Margin" Value="0,0,0,5"/>
             </Style>
 
-            <Style TargetType="Button" BasedOn="{StaticResource BaseButtonStyle}">
+            <Style x:Key="ColorButtonStyle" TargetType="Button" BasedOn="{StaticResource BaseButtonStyle}">
                 <Setter Property="BorderBrush" Value="{StaticResource SystemBaseLowColor}"/>
                 <Setter Property="Height" Value="30"/>
                 <Setter Property="Width" Value="100"/>
@@ -41,6 +42,78 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <Setter Property="IsAlphaSliderVisible" Value="True"/>
                 <Setter Property="IsAlphaTextInputVisible" Value="True"/>
             </Style>
+
+            <DataTemplate x:Key="LabelledColorTableEntry" x:DataType="local:ColorTableEntry">
+                <Grid Margin="{StaticResource ColorEntrySpacing}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <!--Label-->
+                    <TextBlock Text="{x:Bind Name}"
+                               HorizontalAlignment="Left"
+                               VerticalAlignment="Center"
+                               Grid.Column="0"/>
+                               <!--MinWidth="100"-->
+
+                    <Button Background="{x:Bind Color, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}"
+                            Style="{StaticResource ColorButtonStyle}"
+                            Grid.Column="1">
+                        <Button.Resources>
+                            <!-- Resources to colorize hover/pressed states based on the color of the button -->
+                            <ResourceDictionary>
+                                <ResourceDictionary.ThemeDictionaries>
+                                    <ResourceDictionary x:Key="Light">
+                                        <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{x:Bind Color, Converter={StaticResource ColorLightenConverter}, Mode=OneWay}"/>
+                                    </ResourceDictionary>
+                                    <ResourceDictionary x:Key="Dark">
+                                        <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{x:Bind Color, Converter={StaticResource ColorLightenConverter}, Mode=OneWay}"/>
+                                    </ResourceDictionary>
+                                    <!-- No High contrast dictionary, let's just leave that unchanged. -->
+                                </ResourceDictionary.ThemeDictionaries>
+                            </ResourceDictionary>
+                        </Button.Resources>
+
+                        <Button.Flyout>
+                            <Flyout>
+                                <ColorPicker Tag="{x:Bind Index, Mode=OneWay}"
+                                             Color="{x:Bind Color, Mode=OneWay}"
+                                             ColorChanged="ColorPickerChanged"/>
+                            </Flyout>
+                        </Button.Flyout>
+                    </Button>
+                </Grid>
+            </DataTemplate>
+
+            <DataTemplate x:Key="UnlabelledColorTableEntry" x:DataType="local:ColorTableEntry">
+                <Button Background="{x:Bind Color, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}"
+                        Style="{StaticResource ColorButtonStyle}"
+                        Margin="{StaticResource ColorEntrySpacing}">
+                    <Button.Resources>
+                        <!-- Resources to colorize hover/pressed states based on the color of the button -->
+                        <ResourceDictionary>
+                            <ResourceDictionary.ThemeDictionaries>
+                                <ResourceDictionary x:Key="Light">
+                                    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{x:Bind Color, Converter={StaticResource ColorLightenConverter}, Mode=OneWay}"/>
+                                </ResourceDictionary>
+                                <ResourceDictionary x:Key="Dark">
+                                    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{x:Bind Color, Converter={StaticResource ColorLightenConverter}, Mode=OneWay}"/>
+                                </ResourceDictionary>
+                                <!-- No High contrast dictionary, let's just leave that unchanged. -->
+                            </ResourceDictionary.ThemeDictionaries>
+                        </ResourceDictionary>
+                    </Button.Resources>
+
+                    <Button.Flyout>
+                        <Flyout>
+                            <ColorPicker Tag="{x:Bind Index, Mode=OneWay}"
+                                         Color="{x:Bind Color, Mode=OneWay}"
+                                         ColorChanged="ColorPickerChanged"/>
+                        </Flyout>
+                    </Button.Flyout>
+                </Button>
+            </DataTemplate>
 
             <local:ColorToBrushConverter x:Key="ColorToBrushConverter"/>
             <local:ColorToHexConverter x:Key="ColorToHexConverter"/>
@@ -142,58 +215,41 @@ the MIT License. See LICENSE in the project root for license information. -->
             </StackPanel>
 
             <!-- Color Table (Left Column)-->
-            <ItemsControl x:Name="ColorTableControl"
-                          ItemsSource="{x:Bind CurrentColorTable, Mode=OneWay}"
-                          Grid.Row="1"
-                          Grid.Column="0"
-                          Style="{StaticResource ItemsControlStyle}">
+            <Grid Grid.Row="1"
+                  Grid.Column="0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
 
-                <ItemsControl.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <ItemsWrapGrid Orientation="Horizontal"
-                                       MaximumRowsOrColumns="4"/>
-                    </ItemsPanelTemplate>
-                </ItemsControl.ItemsPanel>
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate x:DataType="local:ColorTableEntry">
-                        <StackPanel Style="{StaticResource ColorStackPanelStyle}">
-                            <TextBlock Text="{x:Bind Name, Mode=OneWay}"
-                                       Style="{StaticResource ColorHeaderStyle}"/>
-                            <Button Background="{x:Bind Color, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}">
+                <!--Non-Bright Colors-->
+                <ItemsControl Grid.Column="0"
+                              ItemsSource="{x:Bind CurrentNonBrightColorTable, Mode=OneWay}"
+                              ItemTemplate="{StaticResource LabelledColorTableEntry}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <ItemsStackPanel Orientation="Vertical"/>
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                </ItemsControl>
 
-
-                                <Button.Resources>
-                                    <!-- Resources to colorize hover/pressed states based on the color of the button -->
-                                    <ResourceDictionary>
-                                        <ResourceDictionary.ThemeDictionaries>
-                                            <ResourceDictionary x:Key="Light">
-                                                <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{x:Bind Color, Converter={StaticResource ColorLightenConverter}, Mode=OneWay}"/>
-                                            </ResourceDictionary>
-                                            <ResourceDictionary x:Key="Dark">
-                                                <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{x:Bind Color, Converter={StaticResource ColorLightenConverter}, Mode=OneWay}"/>
-                                            </ResourceDictionary>
-                                            <!-- No High contrast dictionary, let's just leave that unchanged. -->
-                                        </ResourceDictionary.ThemeDictionaries>
-                                    </ResourceDictionary>
-                                </Button.Resources>
-
-                                <Button.Flyout>
-                                    <Flyout>
-                                        <ColorPicker Tag="{x:Bind Index, Mode=OneWay}"
-                                                     Color="{x:Bind Color, Mode=OneWay}"
-                                                     ColorChanged="ColorPickerChanged"/>
-                                    </Flyout>
-                                </Button.Flyout>
-                            </Button>
-                        </StackPanel>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
+                <!--Bright Colors-->
+                <ItemsControl Grid.Column="1"
+                              ItemsSource="{x:Bind CurrentBrightColorTable, Mode=OneWay}"
+                              ItemTemplate="{StaticResource UnlabelledColorTableEntry}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <ItemsStackPanel Orientation="Vertical"/>
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                </ItemsControl>
+            </Grid>
 
             <!-- Additional Colors (Right Column) -->
             <ItemsControl Grid.Row="1"
                           Grid.Column="1"
                           Style="{StaticResource ItemsControlStyle}">
+
                 <StackPanel Style="{StaticResource ColorStackPanelStyle}">
                     <TextBlock x:Uid="ColorScheme_Foreground"
                                Style="{StaticResource ColorHeaderStyle}"/>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -831,4 +831,10 @@
   <data name="Globals_FocusFollowMouse.HelpText" xml:space="preserve">
     <value>When checked, the terminal will the focus pane on mouse hover.</value>
   </data>
+  <data name="ColorScheme_ColorTableHeader.Text" xml:space="preserve">
+    <value>Color table</value>
+  </data>
+  <data name="ColorScheme_FunctionalColorsHeader.Text" xml:space="preserve">
+    <value>Functional colors</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -831,10 +831,10 @@
   <data name="Globals_FocusFollowMouse.HelpText" xml:space="preserve">
     <value>When checked, the terminal will the focus pane on mouse hover.</value>
   </data>
-  <data name="ColorScheme_ColorTableHeader.Text" xml:space="preserve">
-    <value>Color table</value>
+  <data name="ColorScheme_TerminalColorsHeader.Text" xml:space="preserve">
+    <value>Terminal colors</value>
   </data>
-  <data name="ColorScheme_FunctionalColorsHeader.Text" xml:space="preserve">
-    <value>Functional colors</value>
+  <data name="ColorScheme_SystemColorsHeader.Text" xml:space="preserve">
+    <value>System colors</value>
   </data>
 </root>


### PR DESCRIPTION
This PR performs a large overall polish of the color schemes page:
- Ensures keyboard navigation is holistically improved (i.e. fully
  accessible, no lost focus, etc...)
- Adds tooltips and automation properties to all controls
- Redesigns the page according to @mdtauk's approved design
  ([link](https://github.com/microsoft/terminal/pull/8997#issuecomment-771623842)).
  Note, there are some minor modifications to the design that were
  approved by @cinnamon-msft.
- Automatically reflow's the color buttons when they do not fit in
  horizontal mode

## Detailed Description of the Pull Request / Additional comments
- Redesign
  - a data template was introduced to make color representation
    consistent and straightforward
  - `ContentControl` is used to hold a reference to the
    `ColorTableEntry` and represent it properly using the aforementioned
    data template.
  - The design is mainly a StackPanel holding two grids: color table &
    functional colors.
  - The color table is populated via code. After much thought, this
    seems to be the easiest way to correctly bind 16 controls that are
    very similar.
  - The functional colors are populated via XAML manually.
  - We need a grid to separate the text and the buttons. This allows for
    scenarios like "selection background is the longest string" to force
    the buttons and text to be aligned.
- Reflow
  - A `VisualStateManager` uses an `AdaptiveTrigger` to change the
    orientation of the color tables' stack panel. The adaptive trigger
    was carefully calculated to align with the navigation view's
    breakpoint.
- Keyboard Navigation
  - (a lesson from `SettingContainer`) `ContentControl` can be focused
    as opposed to the content inside of it. We don't want that, so we
    set `IsTabStop` to false on it. That basically fixes all of our
    keyboard navigation issues in this new design.
- Automation Properties and ToolTips
  - As in my previous PRs, I can't seem to figure out how to bind to a
    control's automation property to its own tooltip. So I had to do
    this in the code and add a few `x:Name` around.

## Validation Steps Performed
- Manually tested...
  - tab navigation
  - accessibility insights
  - NVDA
  - changing color schemes updates color table
- specific scenario:
  - change a color table color and a functional color
  - navigate to a different color scheme
  - navigate back to the first color scheme
  - if the colors persist, the changes were propagated to the settings model

References #8997 - Based on the work from @Chips1234
References #6800 - Settings UI Epic
Closes #8765 - Polish Color Schemes page
Closes #8899 - Automation Properties
Closes #8768 - Keyboard Navigation