### PR TITLE
Enable text search on combo boxes

### DIFF
--- a/.github/actions/spelling/dictionary/apis.txt
+++ b/.github/actions/spelling/dictionary/apis.txt
@@ -41,6 +41,7 @@ IObject
 IPackage
 IPeasant
 IStorage
+IStringable
 ITab
 ITaskbar
 LCID

--- a/src/cascadia/TerminalSettingsEditor/EnumEntry.h
+++ b/src/cascadia/TerminalSettingsEditor/EnumEntry.h
@@ -46,6 +46,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             _EnumName{ enumName },
             _EnumValue{ enumValue } {}
 
+        hstring ToString()
+        {
+            return EnumName();
+        }
+
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
         OBSERVABLE_GETSET_PROPERTY(winrt::hstring, EnumName, _PropertyChangedHandlers);
         OBSERVABLE_GETSET_PROPERTY(winrt::Windows::Foundation::IInspectable, EnumValue, _PropertyChangedHandlers);

--- a/src/cascadia/TerminalSettingsEditor/EnumEntry.idl
+++ b/src/cascadia/TerminalSettingsEditor/EnumEntry.idl
@@ -7,6 +7,5 @@ namespace Microsoft.Terminal.Settings.Editor
     {
         String EnumName { get; };
         IInspectable EnumValue { get; };
-        String ToString();
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/EnumEntry.idl
+++ b/src/cascadia/TerminalSettingsEditor/EnumEntry.idl
@@ -3,9 +3,10 @@
 
 namespace Microsoft.Terminal.Settings.Editor
 {
-    [default_interface] runtimeclass EnumEntry : Windows.UI.Xaml.Data.INotifyPropertyChanged
+    [default_interface] runtimeclass EnumEntry : Windows.UI.Xaml.Data.INotifyPropertyChanged, Windows.Foundation.IStringable
     {
         String EnumName { get; };
         IInspectable EnumValue { get; };
+        String ToString();
     }
 }

--- a/src/cascadia/TerminalSettingsModel/ColorScheme.h
+++ b/src/cascadia/TerminalSettingsModel/ColorScheme.h
@@ -37,6 +37,11 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         ColorScheme(hstring name, COLORREF defaultFg, COLORREF defaultBg, COLORREF cursorColor);
         com_ptr<ColorScheme> Copy() const;
 
+        hstring ToString()
+        {
+            return Name();
+        }
+
         static com_ptr<ColorScheme> FromJson(const Json::Value& json);
         bool ShouldBeLayered(const Json::Value& json) const;
         void LayerJson(const Json::Value& json);

--- a/src/cascadia/TerminalSettingsModel/ColorScheme.idl
+++ b/src/cascadia/TerminalSettingsModel/ColorScheme.idl
@@ -5,7 +5,6 @@ namespace Microsoft.Terminal.Settings.Model
 {
     [default_interface] runtimeclass ColorScheme : Windows.Foundation.IStringable {
         ColorScheme(String name);
-        String ToString();
 
         String Name;
 

--- a/src/cascadia/TerminalSettingsModel/ColorScheme.idl
+++ b/src/cascadia/TerminalSettingsModel/ColorScheme.idl
@@ -3,8 +3,9 @@
 
 namespace Microsoft.Terminal.Settings.Model
 {
-    [default_interface] runtimeclass ColorScheme {
+    [default_interface] runtimeclass ColorScheme : Windows.Foundation.IStringable {
         ColorScheme(String name);
+        String ToString();
 
         String Name;
 

--- a/src/cascadia/TerminalSettingsModel/Profile.h
+++ b/src/cascadia/TerminalSettingsModel/Profile.h
@@ -47,6 +47,12 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     public:
         Profile();
         Profile(guid guid);
+
+        hstring ToString()
+        {
+            return Name();
+        }
+
         static com_ptr<Profile> CloneInheritanceGraph(com_ptr<Profile> oldProfile, com_ptr<Profile> newProfile, std::unordered_map<void*, com_ptr<Profile>>& visited);
         static com_ptr<Profile> CopySettings(com_ptr<Profile> source);
 

--- a/src/cascadia/TerminalSettingsModel/Profile.idl
+++ b/src/cascadia/TerminalSettingsModel/Profile.idl
@@ -31,9 +31,11 @@ namespace Microsoft.Terminal.Settings.Model
         Vertical_Bottom = 0x20
     };
 
-    [default_interface] runtimeclass Profile {
+    [default_interface] runtimeclass Profile : Windows.Foundation.IStringable {
         Profile();
         Profile(Guid guid);
+
+        String ToString();
 
         Boolean HasName();
         void ClearName();

--- a/src/cascadia/TerminalSettingsModel/Profile.idl
+++ b/src/cascadia/TerminalSettingsModel/Profile.idl
@@ -35,8 +35,6 @@ namespace Microsoft.Terminal.Settings.Model
         Profile();
         Profile(Guid guid);
 
-        String ToString();
-
         Boolean HasName();
         void ClearName();
         String Name;


### PR DESCRIPTION
`ComboBox` has a text search function that allows users to type letters, and the `ComboBoxItem` starting with those letters is shown. In order to enable this functionality, the underlying items must be `IStringable`. This exposes a `ToString()` function and fixes all of our issues.

This PR adds the `IStringable` interface to `ColorScheme`, `Profile`, and `EnumEntry`.

## References
#6800 - Settings UI Epic
#8768 - Keyboard Navigation
https://github.com/microsoft/microsoft-ui-xaml/issues/4182 - discussion with WinUI about how to overcome this issue

## Validation Steps Performed
Tested...
- Launch > Default Profile
- Color Schemes > Name
- Profile > Appearance > Color scheme
- Profile > Appearance > Font weight

Also tested radio buttons, but those still don't work, unfortunately. Looks like they don't have the same underlying mechanism.