### PR TITLE
[v1.6 ONLY] Make Settings UI inaccessible

### DIFF
--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -378,8 +378,7 @@ JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::SettingsTarget)
     JSON_MAPPINGS(4) = {
         pair_type{ "settingsFile", ValueType::SettingsFile },
         pair_type{ "defaultsFile", ValueType::DefaultsFile },
-        pair_type{ "allFiles", ValueType::AllFiles },
-        pair_type{ "settingsUI", ValueType::SettingsUI },
+        pair_type{ "allFiles", ValueType::AllFiles }
     };
 };
 

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -375,7 +375,7 @@ JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::SplitType)
 
 JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::SettingsTarget)
 {
-    JSON_MAPPINGS(4) = {
+    JSON_MAPPINGS(3) = {
         pair_type{ "settingsFile", ValueType::SettingsFile },
         pair_type{ "defaultsFile", ValueType::DefaultsFile },
         pair_type{ "allFiles", ValueType::AllFiles }


### PR DESCRIPTION
This PR removes access to the Settings UI for v1.6 stable. Any attempts to bind the Settings UI result in a parsing error as shown below:

![Error parsing settings ui attempt](https://user-images.githubusercontent.com/11050425/108569004-00f0cb00-72c0-11eb-8a78-a15d27262f89.png)

#6800 - Settings UI Epic