### PR TITLE
res: prepend XML line to SVG files, to pass strict svg checks

### DIFF
--- a/res/terminal/Terminal.svg
+++ b/res/terminal/Terminal.svg
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M0 13H16V6H2C0.9 6 0 6.9 0 8V13Z" fill="#CCCCCC"/>
 <path d="M32 6H16V13H32V6Z" fill="#999999"/>

--- a/res/terminal/Terminal_Dev_HC.svg
+++ b/res/terminal/Terminal_Dev_HC.svg
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
 <defs>
 <linearGradient id="foreground"><stop stop-color="#000000"/></linearGradient>

--- a/res/terminal/Terminal_HC.svg
+++ b/res/terminal/Terminal_HC.svg
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
 <defs>
 <linearGradient id="foreground"><stop stop-color="#000000"/></linearGradient>


### PR DESCRIPTION
A header line is missing from a few `.svg` files, denying their use (via
a security error) in WordPress (if svg support is enabled). The upload
is rejected even though the web browser could display the image if it
were dragged into its own tab.

The `.svg` images appear to have been edited at different times and with
different tools.  Their contents are in a different style.  Two of them
are beautiful and the rest do not follow suit and do not function the
same.

I don't know enough to make them all the same style, but changes can be
made to three of them to make them work the way I was expecting (see
below).

## Validation Steps Performed
- Perform the change with a text editor
- Open a new WordPress post page
- Drag-and-drop the changed file into that WordPress edit box
- (The WordPress media upload dialog appears and the file is uploaded)
- Confirmed that the file does not trigger a "security error" (as seen
  at the top of the right-hand column)
- Confirmed that the image appears as a thumbnail preview

`Terminal_Pre_HC.svg` is not fixable in this way, and I don't understand
svg well enough to troubleshoot easily.