### PR TITLE
Fix `wt --help`

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/pch.h
+++ b/src/cascadia/LocalTests_TerminalApp/pch.h
@@ -62,6 +62,8 @@ Author(s):
 #include <regex>
 #include <CLI11/CLI11.hpp>
 
+#include <shobjidl_core.h>
+
 // Manually include til after we include Windows.Foundation to give it winrt superpowers
 #include "til.h"
 

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -1216,6 +1216,13 @@ namespace winrt::TerminalApp::implementation
     // - anything else: We should handle the commandline in the window with the given ID.
     int32_t AppLogic::FindTargetWindow(array_view<const winrt::hstring> args)
     {
+        return AppLogic::_doFindTargetWindow(args, _settings.GlobalSettings().WindowingBehavior());
+    }
+
+    // The main body of this function is a static helper, to facilitate unit-testing
+    int32_t AppLogic::_doFindTargetWindow(array_view<const winrt::hstring> args,
+                                          const Microsoft::Terminal::Settings::Model::WindowingMode& windowingBehavior)
+    {
         ::TerminalApp::AppCommandlineArgs appArgs;
         const auto result = appArgs.ParseArgs(args);
         if (result == 0)
@@ -1238,7 +1245,6 @@ namespace winrt::TerminalApp::implementation
                 // If the user did not provide any value on the commandline,
                 // then lookup our windowing behavior to determine what to do
                 // now.
-                const auto windowingBehavior = _settings.GlobalSettings().WindowingBehavior();
                 switch (windowingBehavior)
                 {
                 case WindowingMode::UseExisting:

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -1220,6 +1220,11 @@ namespace winrt::TerminalApp::implementation
         const auto result = appArgs.ParseArgs(args);
         if (result == 0)
         {
+            if (!appArgs.GetExitMessage().empty())
+            {
+                return WindowingBehaviorUseNew;
+            }
+
             const auto parsedTarget = appArgs.GetTargetWindow();
             if (parsedTarget.has_value())
             {

--- a/src/cascadia/TerminalApp/AppLogic.h
+++ b/src/cascadia/TerminalApp/AppLogic.h
@@ -8,6 +8,14 @@
 #include "Jumplist.h"
 #include "../../cascadia/inc/cppwinrt_utils.h"
 
+#ifdef UNIT_TESTING
+// fwdecl unittest classes
+namespace TerminalAppLocalTests
+{
+    class CommandlineTest;
+};
+#endif
+
 namespace winrt::TerminalApp::implementation
 {
     struct AppLogic : AppLogicT<AppLogic, IInitializeWithWindow>
@@ -90,6 +98,8 @@ namespace winrt::TerminalApp::implementation
         ::TerminalApp::AppCommandlineArgs _appArgs;
         ::TerminalApp::AppCommandlineArgs _settingsAppArgs;
         int _ParseArgs(winrt::array_view<const hstring>& args);
+        static int32_t _doFindTargetWindow(winrt::array_view<const hstring> args,
+                                           const Microsoft::Terminal::Settings::Model::WindowingMode& windowingBehavior);
 
         void _ShowLoadErrorsDialog(const winrt::hstring& titleKey, const winrt::hstring& contentKey, HRESULT settingsLoadedResult);
         void _ShowLoadWarningsDialog();
@@ -125,6 +135,10 @@ namespace winrt::TerminalApp::implementation
         FORWARDED_TYPED_EVENT(AlwaysOnTopChanged, winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable, _root, AlwaysOnTopChanged);
         FORWARDED_TYPED_EVENT(RaiseVisualBell, winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable, _root, RaiseVisualBell);
         FORWARDED_TYPED_EVENT(SetTaskbarProgress, winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable, _root, SetTaskbarProgress);
+
+#ifdef UNIT_TESTING
+        friend class TerminalAppLocalTests::CommandlineTest;
+#endif
     };
 }
 


### PR DESCRIPTION
When the user executes `--help`, make sure we force the creation of a new window, so that the `MessageBox` will actually appear. 

Add tests too. 

* [x] I work here
* [x] Fixes #9230
* [x] Tests added


I'm gonna have to immediately rewrite those tests for https://github.com/microsoft/terminal/projects/5#card-51431478, but this issue is ship-blocking so I don't care