### PR TITLE
Add a simple page for keybindings

### DIFF
--- a/src/cascadia/TerminalApp/ActionPaletteItem.cpp
+++ b/src/cascadia/TerminalApp/ActionPaletteItem.cpp
@@ -23,7 +23,7 @@ namespace winrt::TerminalApp::implementation
     {
         Name(command.Name());
         KeyChordText(command.KeyChordText());
-        Icon(command.Icon());
+        Icon(command.IconPath());
 
         _commandChangedRevoker = command.PropertyChanged(winrt::auto_revoke, [weakThis{ get_weak() }](auto& sender, auto& e) {
             auto item{ weakThis.get() };
@@ -40,9 +40,9 @@ namespace winrt::TerminalApp::implementation
                 {
                     item->KeyChordText(senderCommand.KeyChordText());
                 }
-                else if (changedProperty == L"Icon")
+                else if (changedProperty == L"IconPath")
                 {
-                    item->Icon(senderCommand.Icon());
+                    item->Icon(senderCommand.IconPath());
                 }
             }
         });

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -93,21 +93,27 @@ namespace winrt::TerminalApp::implementation
     winrt::fire_and_forget TerminalPage::SetSettings(CascadiaSettings settings, bool needRefreshUI)
     {
         _settings = settings;
-        if (needRefreshUI)
-        {
-            _RefreshUIForSettingsReload();
-        }
-
-        // Upon settings update we reload the system settings for scrolling as well.
-        // TODO: consider reloading this value periodically.
-        _systemRowsToScroll = _ReadSystemRowsToScroll();
 
         auto weakThis{ get_weak() };
         co_await winrt::resume_foreground(Dispatcher());
         if (auto page{ weakThis.get() })
         {
+            // Make sure to _UpdateCommandsForPalette before
+            // _RefreshUIForSettingsReload. _UpdateCommandsForPalette will make
+            // sure the KeyChordText of Commands is updated, which needs to
+            // happen before the Settings UI is reloaded and tries to re-read
+            // those values.
             _UpdateCommandsForPalette();
             CommandPalette().SetKeyMap(_settings.KeyMap());
+
+            if (needRefreshUI)
+            {
+                _RefreshUIForSettingsReload();
+            }
+
+            // Upon settings update we reload the system settings for scrolling as well.
+            // TODO: consider reloading this value periodically.
+            _systemRowsToScroll = _ReadSystemRowsToScroll();
         }
     }
 

--- a/src/cascadia/TerminalSettingsEditor/Actions.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Actions.cpp
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "Actions.h"
+#include "Actions.g.cpp"
+#include "ActionsPageNavigationState.g.cpp"
+#include "EnumEntry.h"
+
+using namespace winrt::Windows::UI::Xaml::Navigation;
+using namespace winrt::Windows::Foundation;
+using namespace winrt::Microsoft::Terminal::Settings::Model;
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
+{
+    Actions::Actions()
+    {
+        InitializeComponent();
+
+        _filteredActions = winrt::single_threaded_observable_vector<winrt::Microsoft::Terminal::Settings::Model::Command>();
+
+        for (const auto& [k, v] : _State.Settings().GlobalSettings().Commands())
+        {
+            _filteredActions.Append(v);
+        }
+    }
+
+    void Actions::OnNavigatedTo(const NavigationEventArgs& e)
+    {
+        _State = e.Parameter().as<Editor::ActionsPageNavigationState>();
+    }
+
+    Collections::IObservableVector<Command> Actions::FilteredActions()
+    {
+        return _filteredActions;
+    }
+
+}

--- a/src/cascadia/TerminalSettingsEditor/Actions.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Actions.cpp
@@ -42,4 +42,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         return _filteredActions;
     }
 
+    void Actions::_OpenSettingsClick(const IInspectable& /*sender*/,
+                                     const Windows::UI::Xaml::RoutedEventArgs& /*eventArgs*/)
+    {
+        _State.RequestOpenJson();
+    }
+
 }

--- a/src/cascadia/TerminalSettingsEditor/Actions.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Actions.cpp
@@ -19,15 +19,16 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         _filteredActions = winrt::single_threaded_observable_vector<winrt::Microsoft::Terminal::Settings::Model::Command>();
 
-        for (const auto& [k, v] : _State.Settings().GlobalSettings().Commands())
-        {
-            _filteredActions.Append(v);
-        }
     }
 
     void Actions::OnNavigatedTo(const NavigationEventArgs& e)
     {
         _State = e.Parameter().as<Editor::ActionsPageNavigationState>();
+
+        for (const auto& [k, v] : _State.Settings().GlobalSettings().Commands())
+        {
+            _filteredActions.Append(v);
+        }
     }
 
     Collections::IObservableVector<Command> Actions::FilteredActions()

--- a/src/cascadia/TerminalSettingsEditor/Actions.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Actions.cpp
@@ -18,16 +18,22 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         InitializeComponent();
 
         _filteredActions = winrt::single_threaded_observable_vector<winrt::Microsoft::Terminal::Settings::Model::Command>();
-
     }
 
     void Actions::OnNavigatedTo(const NavigationEventArgs& e)
     {
         _State = e.Parameter().as<Editor::ActionsPageNavigationState>();
 
-        for (const auto& [k, v] : _State.Settings().GlobalSettings().Commands())
+        for (const auto& [k, command] : _State.Settings().GlobalSettings().Commands())
         {
-            _filteredActions.Append(v);
+            // Filter out nested commands, and commands that aren't bound to a
+            // key. This page is currently just for displaying the actions that
+            // _are_ bound to keys.
+            if (command.HasNestedCommands() || command.KeyChordText().empty())
+            {
+                continue;
+            }
+            _filteredActions.Append(command);
         }
     }
 

--- a/src/cascadia/TerminalSettingsEditor/Actions.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Actions.cpp
@@ -7,8 +7,10 @@
 #include "ActionsPageNavigationState.g.cpp"
 #include "EnumEntry.h"
 
-using namespace winrt::Windows::UI::Xaml::Navigation;
 using namespace winrt::Windows::Foundation;
+using namespace winrt::Windows::System;
+using namespace winrt::Windows::UI::Core;
+using namespace winrt::Windows::UI::Xaml::Navigation;
 using namespace winrt::Microsoft::Terminal::Settings::Model;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
@@ -45,7 +47,15 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     void Actions::_OpenSettingsClick(const IInspectable& /*sender*/,
                                      const Windows::UI::Xaml::RoutedEventArgs& /*eventArgs*/)
     {
-        _State.RequestOpenJson();
+        const CoreWindow window = CoreWindow::GetForCurrentThread();
+        const auto rAltState = window.GetKeyState(VirtualKey::RightMenu);
+        const auto lAltState = window.GetKeyState(VirtualKey::LeftMenu);
+        const bool altPressed = WI_IsFlagSet(lAltState, CoreVirtualKeyStates::Down) ||
+                                WI_IsFlagSet(rAltState, CoreVirtualKeyStates::Down);
+
+        const auto target = altPressed ? SettingsTarget::DefaultsFile : SettingsTarget::SettingsFile;
+
+        _State.RequestOpenJson(target);
     }
 
 }

--- a/src/cascadia/TerminalSettingsEditor/Actions.h
+++ b/src/cascadia/TerminalSettingsEditor/Actions.h
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+#include "Actions.g.h"
+#include "ActionsPageNavigationState.g.h"
+#include "Utils.h"
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
+{
+    struct ActionsPageNavigationState : ActionsPageNavigationStateT<ActionsPageNavigationState>
+    {
+    public:
+        ActionsPageNavigationState(const Model::CascadiaSettings& settings) :
+            _Settings{ settings } {}
+
+        GETSET_PROPERTY(Model::CascadiaSettings, Settings, nullptr)
+    };
+
+    struct Actions : ActionsT<Actions>
+    {
+    public:
+        Actions();
+
+        void OnNavigatedTo(const winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
+
+        Windows::Foundation::Collections::IObservableVector<winrt::Microsoft::Terminal::Settings::Model::Command> FilteredActions();
+
+        GETSET_PROPERTY(Editor::ActionsPageNavigationState, State, nullptr);
+
+    private:
+        Windows::Foundation::Collections::IObservableVector<winrt::Microsoft::Terminal::Settings::Model::Command> _filteredActions{ nullptr };
+    };
+}
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::factory_implementation
+{
+    BASIC_FACTORY(Actions);
+}

--- a/src/cascadia/TerminalSettingsEditor/Actions.h
+++ b/src/cascadia/TerminalSettingsEditor/Actions.h
@@ -15,9 +15,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         ActionsPageNavigationState(const Model::CascadiaSettings& settings) :
             _Settings{ settings } {}
 
-        void RequestOpenJson()
+        void RequestOpenJson(const Model::SettingsTarget target)
         {
-            _OpenJsonHandlers(nullptr, winrt::Microsoft::Terminal::Settings::Model::SettingsTarget::SettingsFile);
+            _OpenJsonHandlers(nullptr, target);
         }
 
         GETSET_PROPERTY(Model::CascadiaSettings, Settings, nullptr)

--- a/src/cascadia/TerminalSettingsEditor/Actions.h
+++ b/src/cascadia/TerminalSettingsEditor/Actions.h
@@ -15,7 +15,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         ActionsPageNavigationState(const Model::CascadiaSettings& settings) :
             _Settings{ settings } {}
 
+        void RequestOpenJson()
+        {
+            _OpenJsonHandlers(nullptr, winrt::Microsoft::Terminal::Settings::Model::SettingsTarget::SettingsFile);
+        }
+
         GETSET_PROPERTY(Model::CascadiaSettings, Settings, nullptr)
+        TYPED_EVENT(OpenJson, Windows::Foundation::IInspectable, Model::SettingsTarget);
     };
 
     struct Actions : ActionsT<Actions>
@@ -30,7 +36,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         GETSET_PROPERTY(Editor::ActionsPageNavigationState, State, nullptr);
 
     private:
+        friend struct ActionsT<Actions>; // for Xaml to bind events
         Windows::Foundation::Collections::IObservableVector<winrt::Microsoft::Terminal::Settings::Model::Command> _filteredActions{ nullptr };
+
+        void _OpenSettingsClick(const IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& eventArgs);
     };
 }
 

--- a/src/cascadia/TerminalSettingsEditor/Actions.idl
+++ b/src/cascadia/TerminalSettingsEditor/Actions.idl
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "EnumEntry.idl";
+
+namespace Microsoft.Terminal.Settings.Editor
+{
+    runtimeclass ActionsPageNavigationState
+    {
+        Microsoft.Terminal.Settings.Model.CascadiaSettings Settings;
+    };
+
+    [default_interface] runtimeclass Actions : Windows.UI.Xaml.Controls.Page
+    {
+        Actions();
+        ActionsPageNavigationState State { get; };
+
+        IObservableVector<Microsoft.Terminal.Settings.Model.Command> FilteredActions { get; };
+    }
+}

--- a/src/cascadia/TerminalSettingsEditor/Actions.idl
+++ b/src/cascadia/TerminalSettingsEditor/Actions.idl
@@ -8,6 +8,8 @@ namespace Microsoft.Terminal.Settings.Editor
     runtimeclass ActionsPageNavigationState
     {
         Microsoft.Terminal.Settings.Model.CascadiaSettings Settings;
+        void RequestOpenJson();
+        event Windows.Foundation.TypedEventHandler<Object, Microsoft.Terminal.Settings.Model.SettingsTarget> OpenJson;
     };
 
     [default_interface] runtimeclass Actions : Windows.UI.Xaml.Controls.Page
@@ -16,5 +18,6 @@ namespace Microsoft.Terminal.Settings.Editor
         ActionsPageNavigationState State { get; };
 
         IObservableVector<Microsoft.Terminal.Settings.Model.Command> FilteredActions { get; };
+
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Actions.idl
+++ b/src/cascadia/TerminalSettingsEditor/Actions.idl
@@ -8,7 +8,7 @@ namespace Microsoft.Terminal.Settings.Editor
     runtimeclass ActionsPageNavigationState
     {
         Microsoft.Terminal.Settings.Model.CascadiaSettings Settings;
-        void RequestOpenJson();
+        void RequestOpenJson(Microsoft.Terminal.Settings.Model.SettingsTarget target);
         event Windows.Foundation.TypedEventHandler<Object, Microsoft.Terminal.Settings.Model.SettingsTarget> OpenJson;
     };
 

--- a/src/cascadia/TerminalSettingsEditor/Actions.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Actions.xaml
@@ -160,7 +160,11 @@ the MIT License. See LICENSE in the project root for license information. -->
         <StackPanel Style="{StaticResource SettingsStackStyle}">
             <TextBlock x:Uid="Globals_KeybindingsDisclaimer"
                        Style="{StaticResource DisclaimerStyle}"/>
-            <HyperlinkButton x:Uid="Globals_KeybindingsLink"
+
+            <!-- The Nav_OpenJSON resource just so happens to have a .Content
+            and .Tooltip that are _exactly_ what we're looking for here. -->
+
+            <HyperlinkButton x:Uid="Nav_OpenJSON"
                              Click="_OpenSettingsClick" />
 
             <!-- Keybindings -->

--- a/src/cascadia/TerminalSettingsEditor/Actions.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Actions.xaml
@@ -19,6 +19,20 @@ the MIT License. See LICENSE in the project root for license information. -->
 
             <local:StringIsEmptyConverter x:Key="CommandKeyChordVisibilityConverter"/>
 
+            <!-- Template for actions. This is _heavily_ copied from the command
+            palette, with modifications:
+                * We don't need to use a HighlightedTextControl, because we're
+                  not filtering this list
+                * We don't need the chevron for nested commands
+                * We're not displaying the icon
+                * We're binding directly to a Command, not a FilteredCommand
+
+                If we wanted to reuse the command palette's list more directly,
+                that's theoretically possible, but then it would need to be
+                lifted out of TerminalApp and either moved into the
+                TerminalSettingsEditor or moved to it's own project consumed by
+                both TSE and TerminalApp.
+             -->
             <DataTemplate x:Key="GeneralItemTemplate" x:DataType="SettingsModel:Command">
 
                 <!-- This HorizontalContentAlignment="Stretch" is important
@@ -66,19 +80,13 @@ the MIT License. See LICENSE in the project root for license information. -->
                                        Text="{x:Bind KeyChordText, Mode=OneWay}"
                                        AutomationProperties.AccessibilityView="Raw" />
                         </Border>
-
-
                     </Grid>
                 </ListViewItem>
             </DataTemplate>
 
-
-
+            <!-- These resources again, HEAVILY copied from the command palette -->
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Dark">
-                    <Style x:Key="KeybindingsListStyle" TargetType="ListView">
-                        <Setter Property="Background" Value="#333333" />
-                    </Style>
                     <!-- TextBox colors !-->
                     <SolidColorBrush x:Key="TextControlBackground" Color="#333333"/>
                     <SolidColorBrush x:Key="TextBoxPlaceholderTextThemeBrush" Color="#B5B5B5"/>
@@ -108,21 +116,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                         <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
                     </Style>
 
-                    <!--  ParsedCommandLineText styles  -->
-                    <Style x:Key="ParsedCommandLineBorderStyle" TargetType="Border">
-                        <Setter Property="BorderThickness" Value="1" />
-                        <Setter Property="CornerRadius" Value="1" />
-                        <Setter Property="Background" Value="{ThemeResource SystemAltMediumLowColor}" />
-                        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
-                    </Style>
-                    <Style x:Key="ParsedCommandLineTextBlockStyle" TargetType="TextBlock">
-                        <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
-                    </Style>
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Light">
-                    <Style x:Key="KeybindingsListStyle" TargetType="ListView">
-                        <Setter Property="Background" Value="#CCCCCC" />
-                    </Style>
                     <!-- TextBox colors !-->
                     <SolidColorBrush x:Key="TextControlBackground" Color="#CCCCCC"/>
                     <SolidColorBrush x:Key="TextBoxPlaceholderTextThemeBrush" Color="#636363"/>
@@ -149,29 +144,13 @@ the MIT License. See LICENSE in the project root for license information. -->
                         <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
                     </Style>
 
-                    <!--  ParsedCommandLineText styles  -->
-                    <Style x:Key="ParsedCommandLineBorderStyle" TargetType="Border">
-                        <Setter Property="BorderThickness" Value="1" />
-                        <Setter Property="CornerRadius" Value="1" />
-                        <Setter Property="Background" Value="{ThemeResource SystemAltMediumLowColor}" />
-                        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
-                    </Style>
-                    <Style x:Key="ParsedCommandLineTextBlockStyle" TargetType="TextBlock">
-                        <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
-                    </Style>
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="HighContrast">
-                    <Style x:Key="KeybindingsListStyle" TargetType="ListView">
-                        <Setter Property="Background" Value="{ThemeResource SystemColorWindowColor}" />
-                    </Style>
 
                     <!--  KeyChordText styles (use XAML defaults for High Contrast theme) -->
                     <Style x:Key="KeyChordBorderStyle" TargetType="Border"/>
                     <Style x:Key="KeyChordTextBlockStyle" TargetType="TextBlock"/>
 
-                    <!--  ParsedCommandLineText styles (use XAML defaults for High Contrast theme) -->
-                    <Style x:Key="ParsedCommandLineBorderStyle" TargetType="Border"/>
-                    <Style x:Key="ParsedCommandLineTextBlockStyle" TargetType="TextBlock"/>
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
 
@@ -188,8 +167,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <!-- Keybindings -->
                 <local:SettingContainer x:Uid="Globals_Keybindings">
 
-                    <ListView Style="{ThemeResource KeybindingsListStyle}"
-                              HorizontalAlignment="Stretch"
+                    <ListView HorizontalAlignment="Stretch"
                               VerticalAlignment="Stretch"
                               SelectionMode="Single"
                               CanReorderItems="False"

--- a/src/cascadia/TerminalSettingsEditor/Actions.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Actions.xaml
@@ -36,9 +36,10 @@ the MIT License. See LICENSE in the project root for license information. -->
             <DataTemplate x:Key="GeneralItemTemplate" x:DataType="SettingsModel:Command">
 
                 <!-- This HorizontalContentAlignment="Stretch" is important
-                        to make sure it takes the entire width of the line -->
+                     to make sure it takes the entire width of the line -->
                 <ListViewItem HorizontalContentAlignment="Stretch"
-                              AutomationProperties.Name="{x:Bind Name, Mode=OneWay}">
+                              AutomationProperties.Name="{x:Bind Name, Mode=OneWay}"
+                              AutomationProperties.AcceleratorKey="{x:Bind KeyChordText, Mode=OneWay}">
 
                     <Grid HorizontalAlignment="Stretch" ColumnSpacing="8" >
                         <Grid.ColumnDefinitions>
@@ -59,11 +60,9 @@ the MIT License. See LICENSE in the project root for license information. -->
                         <!-- The block for the key chord is only visible
                                 when there's actual text set as the label. See
                                 CommandKeyChordVisibilityConverter for details.
-                             We're setting the accessibility view on the
-                                border and text block to Raw because otherwise,
-                                Narrator will read out the key chord. Problem is,
-                                it already did that because it was the list item's
-                                "AcceleratorKey". It's redundant. -->
+                             Inexplicably, we don't need to set the
+                                 AutomationProperties to Raw here, unlike in the
+                                 CommandPalette. We're not quite sure why.-->
                         <Border Grid.Column="2"
                                 Visibility="{x:Bind KeyChordText,
                                              Mode=OneWay,
@@ -71,8 +70,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                                 Style="{ThemeResource KeyChordBorderStyle}"
                                 Padding="2,0,2,0"
                                 HorizontalAlignment="Right"
-                                VerticalAlignment="Center"
-                                AutomationProperties.AccessibilityView="Raw">
+                                VerticalAlignment="Center">
 
                             <TextBlock Style="{ThemeResource KeyChordTextBlockStyle}"
                                        FontSize="12"

--- a/src/cascadia/TerminalSettingsEditor/Actions.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Actions.xaml
@@ -159,27 +159,31 @@ the MIT License. See LICENSE in the project root for license information. -->
     </Page.Resources>
 
     <ScrollViewer>
-        <StackPanel>
-            <StackPanel Style="{StaticResource SettingsStackStyle}">
+        <StackPanel Style="{StaticResource SettingsStackStyle}">
             <TextBlock x:Uid="Globals_KeybindingsDisclaimer"
                        Style="{StaticResource DisclaimerStyle}"/>
-            <TextBlock x:Uid="Globals_KeybindingsLink"/>
-                <!-- Keybindings -->
-                <local:SettingContainer x:Uid="Globals_Keybindings">
+            <HyperlinkButton x:Uid="Globals_KeybindingsLink"
+                             Click="_OpenSettingsClick" />
 
-                    <ListView HorizontalAlignment="Stretch"
-                              VerticalAlignment="Stretch"
-                              SelectionMode="Single"
-                              CanReorderItems="False"
-                              AllowDrop="False"
-                              ItemsSource="{x:Bind FilteredActions}"
-                              ItemTemplate="{StaticResource GeneralItemTemplate}">
-                    </ListView>
+            <!-- Keybindings -->
 
-                </local:SettingContainer>
+            <!-- NOTE: Globals_Keybindings.Header is not defined, because that
+            would result in the page having "Keybindings" displayed twice, which
+            looks quite redundant -->
+            <ContentPresenter x:Uid="Globals_Keybindings" Margin="0">
 
-            </StackPanel>
+                <ListView HorizontalAlignment="Stretch"
+                          VerticalAlignment="Stretch"
+                          SelectionMode="Single"
+                          CanReorderItems="False"
+                          AllowDrop="False"
+                          ItemsSource="{x:Bind FilteredActions}"
+                          ItemTemplate="{StaticResource GeneralItemTemplate}">
+                </ListView>
+
+            </ContentPresenter>
 
         </StackPanel>
+
     </ScrollViewer>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Actions.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Actions.xaml
@@ -38,8 +38,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <!-- This HorizontalContentAlignment="Stretch" is important
                         to make sure it takes the entire width of the line -->
                 <ListViewItem HorizontalContentAlignment="Stretch"
-                              AutomationProperties.Name="{x:Bind Name, Mode=OneWay}"
-                              AutomationProperties.AcceleratorKey="{x:Bind KeyChordText, Mode=OneWay}">
+                              AutomationProperties.Name="{x:Bind Name, Mode=OneWay}">
 
                     <Grid HorizontalAlignment="Stretch" ColumnSpacing="8" >
                         <Grid.ColumnDefinitions>
@@ -49,7 +48,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                             <!-- command label -->
                             <ColumnDefinition Width="*"/>
                             <!-- key chord -->
-                            <ColumnDefinition Width="16"/>
+                            <ColumnDefinition Width="32"/>
                             <!-- gutter for scrollbar -->
                         </Grid.ColumnDefinitions>
 
@@ -77,8 +76,7 @@ the MIT License. See LICENSE in the project root for license information. -->
 
                             <TextBlock Style="{ThemeResource KeyChordTextBlockStyle}"
                                        FontSize="12"
-                                       Text="{x:Bind KeyChordText, Mode=OneWay}"
-                                       AutomationProperties.AccessibilityView="Raw" />
+                                       Text="{x:Bind KeyChordText, Mode=OneWay}" />
                         </Border>
                     </Grid>
                 </ListViewItem>
@@ -174,10 +172,11 @@ the MIT License. See LICENSE in the project root for license information. -->
 
                 <ListView HorizontalAlignment="Stretch"
                           VerticalAlignment="Stretch"
-                          SelectionMode="Single"
+                          SelectionMode="None"
+                          IsItemClickEnabled="False"
                           CanReorderItems="False"
                           AllowDrop="False"
-                          ItemsSource="{x:Bind FilteredActions}"
+                          ItemsSource="{x:Bind FilteredActions, Mode=OneWay}"
                           ItemTemplate="{StaticResource GeneralItemTemplate}">
                 </ListView>
 

--- a/src/cascadia/TerminalSettingsEditor/Actions.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Actions.xaml
@@ -1,0 +1,208 @@
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under
+the MIT License. See LICENSE in the project root for license information. -->
+<Page
+    x:Class="Microsoft.Terminal.Settings.Editor.Actions"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Microsoft.Terminal.Settings.Editor"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:SettingsModel="using:Microsoft.Terminal.Settings.Model"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="CommonResources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <local:StringIsEmptyConverter x:Key="CommandKeyChordVisibilityConverter"/>
+
+            <DataTemplate x:Key="GeneralItemTemplate" x:DataType="SettingsModel:Command">
+
+                <!-- This HorizontalContentAlignment="Stretch" is important
+                        to make sure it takes the entire width of the line -->
+                <ListViewItem HorizontalContentAlignment="Stretch"
+                              AutomationProperties.Name="{x:Bind Name, Mode=OneWay}"
+                              AutomationProperties.AcceleratorKey="{x:Bind KeyChordText, Mode=OneWay}">
+
+                    <Grid HorizontalAlignment="Stretch" ColumnSpacing="8" >
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="16"/>
+                            <!-- icon -->
+                            <ColumnDefinition Width="Auto"/>
+                            <!-- command label -->
+                            <ColumnDefinition Width="*"/>
+                            <!-- key chord -->
+                            <ColumnDefinition Width="16"/>
+                            <!-- gutter for scrollbar -->
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Grid.Column="1"
+                                   HorizontalAlignment="Left"
+                                   Text="{x:Bind Name, Mode=OneWay}"/>
+
+                        <!-- The block for the key chord is only visible
+                                when there's actual text set as the label. See
+                                CommandKeyChordVisibilityConverter for details.
+                             We're setting the accessibility view on the
+                                border and text block to Raw because otherwise,
+                                Narrator will read out the key chord. Problem is,
+                                it already did that because it was the list item's
+                                "AcceleratorKey". It's redundant. -->
+                        <Border Grid.Column="2"
+                                Visibility="{x:Bind KeyChordText,
+                                             Mode=OneWay,
+                                             Converter={StaticResource CommandKeyChordVisibilityConverter}}"
+                                Style="{ThemeResource KeyChordBorderStyle}"
+                                Padding="2,0,2,0"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Center"
+                                AutomationProperties.AccessibilityView="Raw">
+
+                            <TextBlock Style="{ThemeResource KeyChordTextBlockStyle}"
+                                       FontSize="12"
+                                       Text="{x:Bind KeyChordText, Mode=OneWay}"
+                                       AutomationProperties.AccessibilityView="Raw" />
+                        </Border>
+
+
+                    </Grid>
+                </ListViewItem>
+            </DataTemplate>
+
+
+
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Dark">
+                    <Style x:Key="CommandPaletteBackground" TargetType="Grid">
+                        <Setter Property="Background" Value="#333333" />
+                    </Style>
+                    <!-- TextBox colors !-->
+                    <SolidColorBrush x:Key="TextControlBackground" Color="#333333"/>
+                    <SolidColorBrush x:Key="TextBoxPlaceholderTextThemeBrush" Color="#B5B5B5"/>
+                    <SolidColorBrush x:Key="TextControlForeground" Color="#B5B5B5"/>
+                    <SolidColorBrush x:Key="TextControlBorderBrush" Color="#404040"/>
+                    <SolidColorBrush x:Key="TextControlButtonForeground" Color="#B5B5B5"/>
+
+                    <SolidColorBrush x:Key="TextControlBackgroundPointerOver" Color="#404040"/>
+                    <SolidColorBrush x:Key="TextControlForegroundPointerOver" Color="#FFFFFF"/>
+                    <SolidColorBrush x:Key="TextControlBorderBrushPointerOver" Color="#404040"/>
+                    <SolidColorBrush x:Key="TextControlButtonForegroundPointerOver" Color="#FF4343"/>
+
+                    <SolidColorBrush x:Key="TextControlBackgroundFocused" Color="#333333"/>
+                    <SolidColorBrush x:Key="TextControlForegroundFocused" Color="#FFFFFF"/>
+                    <SolidColorBrush x:Key="TextControlBorderBrushFocused" Color="#404040"/>
+                    <SolidColorBrush x:Key="TextControlButtonForegroundPressed" Color="#FFFFFF"/>
+                    <SolidColorBrush x:Key="TextControlButtonBackgroundPressed" Color="#FF4343"/>
+
+                    <!--  KeyChordText styles  -->
+                    <Style x:Key="KeyChordBorderStyle" TargetType="Border">
+                        <Setter Property="BorderThickness" Value="1" />
+                        <Setter Property="CornerRadius" Value="1" />
+                        <Setter Property="Background" Value="{ThemeResource SystemAltMediumLowColor}" />
+                        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+                    </Style>
+                    <Style x:Key="KeyChordTextBlockStyle" TargetType="TextBlock">
+                        <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+                    </Style>
+
+                    <!--  ParsedCommandLineText styles  -->
+                    <Style x:Key="ParsedCommandLineBorderStyle" TargetType="Border">
+                        <Setter Property="BorderThickness" Value="1" />
+                        <Setter Property="CornerRadius" Value="1" />
+                        <Setter Property="Background" Value="{ThemeResource SystemAltMediumLowColor}" />
+                        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+                    </Style>
+                    <Style x:Key="ParsedCommandLineTextBlockStyle" TargetType="TextBlock">
+                        <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+                    </Style>
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Light">
+                    <Style x:Key="CommandPaletteBackground" TargetType="Grid">
+                        <Setter Property="Background" Value="#CCCCCC" />
+                    </Style>
+                    <!-- TextBox colors !-->
+                    <SolidColorBrush x:Key="TextControlBackground" Color="#CCCCCC"/>
+                    <SolidColorBrush x:Key="TextBoxPlaceholderTextThemeBrush" Color="#636363"/>
+                    <SolidColorBrush x:Key="TextControlBorderBrush" Color="#636363"/>
+                    <SolidColorBrush x:Key="TextControlButtonForeground" Color="#636363"/>
+
+                    <SolidColorBrush x:Key="TextControlBackgroundPointerOver" Color="#DADADA"/>
+                    <SolidColorBrush x:Key="TextControlBorderBrushPointerOver" Color="#636363"/>
+                    <SolidColorBrush x:Key="TextControlButtonForegroundPointerOver" Color="#FF4343"/>
+
+                    <SolidColorBrush x:Key="TextControlBackgroundFocused" Color="#CCCCCC"/>
+                    <SolidColorBrush x:Key="TextControlBorderBrushFocused" Color="#636363"/>
+                    <SolidColorBrush x:Key="TextControlButtonForegroundPressed" Color="#FFFFFF"/>
+                    <SolidColorBrush x:Key="TextControlButtonBackgroundPressed" Color="#FF4343"/>
+
+                    <!--  KeyChordText styles  -->
+                    <Style x:Key="KeyChordBorderStyle" TargetType="Border">
+                        <Setter Property="BorderThickness" Value="1" />
+                        <Setter Property="CornerRadius" Value="1" />
+                        <Setter Property="Background" Value="{ThemeResource SystemAltMediumLowColor}" />
+                        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+                    </Style>
+                    <Style x:Key="KeyChordTextBlockStyle" TargetType="TextBlock">
+                        <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+                    </Style>
+
+                    <!--  ParsedCommandLineText styles  -->
+                    <Style x:Key="ParsedCommandLineBorderStyle" TargetType="Border">
+                        <Setter Property="BorderThickness" Value="1" />
+                        <Setter Property="CornerRadius" Value="1" />
+                        <Setter Property="Background" Value="{ThemeResource SystemAltMediumLowColor}" />
+                        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+                    </Style>
+                    <Style x:Key="ParsedCommandLineTextBlockStyle" TargetType="TextBlock">
+                        <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+                    </Style>
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="HighContrast">
+                    <Style x:Key="CommandPaletteBackground" TargetType="Grid">
+                        <Setter Property="Background" Value="{ThemeResource SystemColorWindowColor}" />
+                    </Style>
+
+                    <!--  KeyChordText styles (use XAML defaults for High Contrast theme) -->
+                    <Style x:Key="KeyChordBorderStyle" TargetType="Border"/>
+                    <Style x:Key="KeyChordTextBlockStyle" TargetType="TextBlock"/>
+
+                    <!--  ParsedCommandLineText styles (use XAML defaults for High Contrast theme) -->
+                    <Style x:Key="ParsedCommandLineBorderStyle" TargetType="Border"/>
+                    <Style x:Key="ParsedCommandLineTextBlockStyle" TargetType="TextBlock"/>
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+
+
+        </ResourceDictionary>
+    </Page.Resources>
+
+    <ScrollViewer>
+        <StackPanel>
+            <StackPanel Style="{StaticResource SettingsStackStyle}">
+            <TextBlock x:Uid="Globals_KeybindingsDisclaimer"
+                       Style="{StaticResource DisclaimerStyle}"/>
+            <TextBlock x:Uid="Globals_KeybindingsLink"/>
+                <!-- Keybindings -->
+                <local:SettingContainer x:Uid="Globals_Keybindings">
+
+                    <ListView
+                        x:Name="_filteredActionsView"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch"
+                        SelectionMode="Single"
+                        CanReorderItems="False"
+                        AllowDrop="False"
+                        ItemsSource="{x:Bind FilteredActions}"
+                        ItemTemplate="{StaticResource GeneralItemTemplate}">
+                    </ListView>
+
+                </local:SettingContainer>
+
+            </StackPanel>
+
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/src/cascadia/TerminalSettingsEditor/Actions.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Actions.xaml
@@ -76,7 +76,7 @@ the MIT License. See LICENSE in the project root for license information. -->
 
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Dark">
-                    <Style x:Key="CommandPaletteBackground" TargetType="Grid">
+                    <Style x:Key="KeybindingsListStyle" TargetType="ListView">
                         <Setter Property="Background" Value="#333333" />
                     </Style>
                     <!-- TextBox colors !-->
@@ -120,7 +120,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                     </Style>
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Light">
-                    <Style x:Key="CommandPaletteBackground" TargetType="Grid">
+                    <Style x:Key="KeybindingsListStyle" TargetType="ListView">
                         <Setter Property="Background" Value="#CCCCCC" />
                     </Style>
                     <!-- TextBox colors !-->
@@ -161,7 +161,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                     </Style>
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="HighContrast">
-                    <Style x:Key="CommandPaletteBackground" TargetType="Grid">
+                    <Style x:Key="KeybindingsListStyle" TargetType="ListView">
                         <Setter Property="Background" Value="{ThemeResource SystemColorWindowColor}" />
                     </Style>
 
@@ -188,15 +188,14 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <!-- Keybindings -->
                 <local:SettingContainer x:Uid="Globals_Keybindings">
 
-                    <ListView
-                        x:Name="_filteredActionsView"
-                        HorizontalAlignment="Stretch"
-                        VerticalAlignment="Stretch"
-                        SelectionMode="Single"
-                        CanReorderItems="False"
-                        AllowDrop="False"
-                        ItemsSource="{x:Bind FilteredActions}"
-                        ItemTemplate="{StaticResource GeneralItemTemplate}">
+                    <ListView Style="{ThemeResource KeybindingsListStyle}"
+                              HorizontalAlignment="Stretch"
+                              VerticalAlignment="Stretch"
+                              SelectionMode="Single"
+                              CanReorderItems="False"
+                              AllowDrop="False"
+                              ItemsSource="{x:Bind FilteredActions}"
+                              ItemTemplate="{StaticResource GeneralItemTemplate}">
                     </ListView>
 
                 </local:SettingContainer>

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -7,6 +7,7 @@
 #include "Launch.h"
 #include "Interaction.h"
 #include "Rendering.h"
+#include "Actions.h"
 #include "Profiles.h"
 #include "GlobalAppearance.h"
 #include "ColorSchemes.h"
@@ -30,6 +31,7 @@ using namespace winrt::Windows::UI::Xaml::Controls;
 static const std::wstring_view launchTag{ L"Launch_Nav" };
 static const std::wstring_view interactionTag{ L"Interaction_Nav" };
 static const std::wstring_view renderingTag{ L"Rendering_Nav" };
+static const std::wstring_view actionsTag{ L"Actions_Nav" };
 static const std::wstring_view globalProfileTag{ L"GlobalProfile_Nav" };
 static const std::wstring_view addProfileTag{ L"AddProfile" };
 static const std::wstring_view colorSchemesTag{ L"ColorSchemes_Nav" };
@@ -255,6 +257,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         else if (clickedItemTag == renderingTag)
         {
             contentFrame().Navigate(xaml_typename<Editor::Rendering>(), winrt::make<RenderingPageNavigationState>(_settingsClone.GlobalSettings()));
+        }
+        else if (clickedItemTag == actionsTag)
+        {
+            contentFrame().Navigate(xaml_typename<Editor::Actions>(), winrt::make<ActionsPageNavigationState>(_settingsClone));
         }
         else if (clickedItemTag == globalProfileTag)
         {

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -260,7 +260,14 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
         else if (clickedItemTag == actionsTag)
         {
-            contentFrame().Navigate(xaml_typename<Editor::Actions>(), winrt::make<ActionsPageNavigationState>(_settingsClone));
+            auto actionsState{ winrt::make<ActionsPageNavigationState>(_settingsClone) };
+            actionsState.OpenJson([weakThis = get_weak()](auto&&, auto&& arg) {
+                if (auto self{ weakThis.get() })
+                {
+                    self->_OpenJsonHandlers(nullptr, arg);
+                }
+            });
+            contentFrame().Navigate(xaml_typename<Editor::Actions>(), actionsState);
         }
         else if (clickedItemTag == globalProfileTag)
         {

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -78,8 +78,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             <muxc:NavigationViewItem x:Uid="Nav_Actions"
                                      Tag="Actions_Nav" >
                 <muxc:NavigationViewItem.Icon>
-                  <!-- TODO -->
-                    <FontIcon Glyph="&#xE7F8;"/>
+                    <FontIcon Glyph="&#xE765;"/>
                 </muxc:NavigationViewItem.Icon>
             </muxc:NavigationViewItem>
 

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -39,44 +39,52 @@ the MIT License. See LICENSE in the project root for license information. -->
                          TabFocusNavigation="Cycle">
 
         <muxc:NavigationView.MenuItems>
-    
+
             <muxc:NavigationViewItem x:Uid="Nav_Launch"
                                      Tag="Launch_Nav">
                 <muxc:NavigationViewItem.Icon>
                     <FontIcon Glyph="&#xE7B5;"/>
                 </muxc:NavigationViewItem.Icon>
             </muxc:NavigationViewItem>
-    
+
             <muxc:NavigationViewItem x:Uid="Nav_Interaction"
                                      Tag="Interaction_Nav">
                 <muxc:NavigationViewItem.Icon>
                     <FontIcon Glyph="&#xE7C9;"/>
                 </muxc:NavigationViewItem.Icon>
             </muxc:NavigationViewItem>
-    
+
             <muxc:NavigationViewItem x:Uid="Nav_Appearance"
                                      Tag="GlobalAppearance_Nav">
                 <muxc:NavigationViewItem.Icon>
                     <FontIcon Glyph="&#xE771;"/>
                 </muxc:NavigationViewItem.Icon>
             </muxc:NavigationViewItem>
-    
+
             <muxc:NavigationViewItem x:Uid="Nav_ColorSchemes"
                                      Tag="ColorSchemes_Nav">
                 <muxc:NavigationViewItem.Icon>
                     <FontIcon Glyph="&#xE790;"/>
                 </muxc:NavigationViewItem.Icon>
             </muxc:NavigationViewItem>
-    
+
             <muxc:NavigationViewItem x:Uid="Nav_Rendering"
                                      Tag="Rendering_Nav" >
                 <muxc:NavigationViewItem.Icon>
                     <FontIcon Glyph="&#xE7F8;"/>
                 </muxc:NavigationViewItem.Icon>
             </muxc:NavigationViewItem>
-    
+
+            <muxc:NavigationViewItem x:Uid="Nav_Actions"
+                                     Tag="Actions_Nav" >
+                <muxc:NavigationViewItem.Icon>
+                  <!-- TODO -->
+                    <FontIcon Glyph="&#xE7F8;"/>
+                </muxc:NavigationViewItem.Icon>
+            </muxc:NavigationViewItem>
+
             <muxc:NavigationViewItemHeader x:Uid="Nav_Profiles"/>
-    
+
             <muxc:NavigationViewItem x:Uid="Nav_ProfileDefaults"
                                      x:Name="BaseLayerMenuItem"
                                      Tag="GlobalProfile_Nav">
@@ -84,9 +92,9 @@ the MIT License. See LICENSE in the project root for license information. -->
                     <FontIcon Glyph="&#xE81E;"/>
                 </muxc:NavigationViewItem.Icon>
             </muxc:NavigationViewItem>
-    
+
         </muxc:NavigationView.MenuItems>
-        
+
         <muxc:NavigationView.PaneFooter>
             <!--The OpenJson item needs both Tapped and KeyDown handler-->
             <muxc:NavigationViewItem x:Uid="Nav_OpenJSON"
@@ -98,7 +106,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                 </muxc:NavigationViewItem.Icon>
             </muxc:NavigationViewItem>
         </muxc:NavigationView.PaneFooter>
-        
+
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="*"></RowDefinition>

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
@@ -35,6 +35,9 @@
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.pre.props" />
   <!-- ========================= Headers ======================== -->
   <ItemGroup>
+    <ClInclude Include="Actions.h">
+      <DependentUpon>Actions.xaml</DependentUpon>
+    </ClInclude>
     <ClInclude Include="ColorToBrushConverter.h">
       <DependentUpon>Converters.idl</DependentUpon>
     </ClInclude>
@@ -99,6 +102,9 @@
   </ItemGroup>
   <!-- ========================= XAML files ======================== -->
   <ItemGroup>
+    <Page Include="Actions.xaml">
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="CommonResources.xaml">
       <SubType>Designer</SubType>
     </Page>
@@ -129,6 +135,9 @@
   </ItemGroup>
   <!-- ========================= Cpp Files ======================== -->
   <ItemGroup>
+    <ClCompile Include="Actions.cpp">
+      <DependentUpon>Actions.xaml</DependentUpon>
+    </ClCompile>
     <ClCompile Include="ColorToBrushConverter.cpp">
       <DependentUpon>Converters.idl</DependentUpon>
     </ClCompile>
@@ -193,6 +202,10 @@
   </ItemGroup>
   <!-- ========================= idl Files ======================== -->
   <ItemGroup>
+    <Midl Include="Actions.idl">
+      <DependentUpon>Actions.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Midl>
     <Midl Include="Converters.idl" />
     <Midl Include="EnumEntry.idl" />
     <Midl Include="GlobalAppearance.idl">

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -193,10 +193,7 @@
     <value>Automatically copy selection to clipboard</value>
   </data>
   <data name="Globals_KeybindingsDisclaimer.Text" xml:space="preserve">
-    <value>This is a list of the currently bound keys. Currently, these can only be edited in the settings file.</value>
-  </data>
-  <data name="Globals_KeybindingsLink.Content" xml:space="preserve">
-    <value>Open JSON settings</value>
+    <value>Below are the currently bound keys, which can be modified by editing the JSON settings file.</value>
   </data>
   <data name="Globals_DefaultProfile.Header" xml:space="preserve">
     <value>Default profile</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -192,16 +192,10 @@
   <data name="Globals_CopyOnSelect.Header" xml:space="preserve">
     <value>Automatically copy selection to clipboard</value>
   </data>
-  <data name="Globals_Keybindings.Header" xml:space="preserve">
-    <value>Keybindings</value>
-  </data>
-  <data name="Globals_Keybindings.HelpText" xml:space="preserve">
-    <value>A list of the currently bound keys.</value>
-  </data>
   <data name="Globals_KeybindingsDisclaimer.Text" xml:space="preserve">
     <value>This is a list of the currently bound keys. Currently, these can only be edited in the settings file directly.</value>
   </data>
-  <data name="Globals_KeybindingsLink.Text" xml:space="preserve">
+  <data name="Globals_KeybindingsLink.Content" xml:space="preserve">
     <value>Open JSON settings</value>
   </data>
   <data name="Globals_DefaultProfile.Header" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -193,7 +193,7 @@
     <value>Automatically copy selection to clipboard</value>
   </data>
   <data name="Globals_KeybindingsDisclaimer.Text" xml:space="preserve">
-    <value>This is a list of the currently bound keys. Currently, these can only be edited in the settings file directly.</value>
+    <value>This is a list of the currently bound keys. Currently, these can only be edited in the settings file.</value>
   </data>
   <data name="Globals_KeybindingsLink.Content" xml:space="preserve">
     <value>Open JSON settings</value>
@@ -351,7 +351,7 @@
     <value>Rendering</value>
   </data>
   <data name="Nav_Actions.Content" xml:space="preserve">
-    <value>Keybindings</value>
+    <value>Actions</value>
   </data>
   <data name="Profile_AcrylicOpacity.Header" xml:space="preserve">
     <value>Acrylic opacity</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -191,6 +191,18 @@
   </data>
   <data name="Globals_CopyOnSelect.Header" xml:space="preserve">
     <value>Automatically copy selection to clipboard</value>
+  </data>
+  <data name="Globals_Keybindings.Header" xml:space="preserve">
+    <value>Keybindings</value>
+  </data>
+  <data name="Globals_Keybindings.HelpText" xml:space="preserve">
+    <value>A list of the currently bound keys.</value>
+  </data>
+  <data name="Globals_KeybindingsDisclaimer.Text" xml:space="preserve">
+    <value>This is a list of the currently bound keys. Currently, these can only be edited in the settings file directly.</value>
+  </data>
+  <data name="Globals_KeybindingsLink.Text" xml:space="preserve">
+    <value>Open JSON settings</value>
   </data>
   <data name="Globals_DefaultProfile.Header" xml:space="preserve">
     <value>Default profile</value>
@@ -343,6 +355,9 @@
   </data>
   <data name="Nav_Rendering.Content" xml:space="preserve">
     <value>Rendering</value>
+  </data>
+  <data name="Nav_Actions.Content" xml:space="preserve">
+    <value>Keybindings</value>
   </data>
   <data name="Profile_AcrylicOpacity.Header" xml:space="preserve">
     <value>Acrylic opacity</value>

--- a/src/cascadia/TerminalSettingsModel/Command.cpp
+++ b/src/cascadia/TerminalSettingsModel/Command.cpp
@@ -44,7 +44,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         command->_Name = _Name;
         command->_Action = _Action;
         command->_KeyChordText = _KeyChordText;
-        command->_Icon = _Icon;
+        command->_IconPath = _IconPath;
         command->_IterateOn = _IterateOn;
 
         command->_originalJson = _originalJson;
@@ -171,7 +171,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             return nullptr;
         }
 
-        JsonUtils::GetValueForKey(json, IconKey, result->_Icon);
+        JsonUtils::GetValueForKey(json, IconKey, result->_IconPath);
 
         // If we're a nested command, we can ignore the current action.
         if (!nested)

--- a/src/cascadia/TerminalSettingsModel/Command.h
+++ b/src/cascadia/TerminalSettingsModel/Command.h
@@ -57,7 +57,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         OBSERVABLE_GETSET_PROPERTY(winrt::hstring, Name, _PropertyChangedHandlers);
         OBSERVABLE_GETSET_PROPERTY(Model::ActionAndArgs, Action, _PropertyChangedHandlers);
         OBSERVABLE_GETSET_PROPERTY(winrt::hstring, KeyChordText, _PropertyChangedHandlers);
-        OBSERVABLE_GETSET_PROPERTY(winrt::hstring, Icon, _PropertyChangedHandlers);
+        OBSERVABLE_GETSET_PROPERTY(winrt::hstring, IconPath, _PropertyChangedHandlers);
 
         GETSET_PROPERTY(ExpandCommandType, IterateOn, ExpandCommandType::None);
 

--- a/src/cascadia/TerminalSettingsModel/Command.idl
+++ b/src/cascadia/TerminalSettingsModel/Command.idl
@@ -16,7 +16,7 @@ namespace Microsoft.Terminal.Settings.Model
         ActionAndArgs Action;
         String KeyChordText;
 
-        String Icon;
+        String IconPath;
 
         Boolean HasNestedCommands { get; };
         Windows.Foundation.Collections.IMapView<String, Command> NestedCommands { get; };


### PR DESCRIPTION
This was the only thing blocking me from signing off on #9224 in 1.7.

! CHANGE WARNING !
If we bind to `T.S.M.Command`s in XAML, then the compiler gets _very
angry_ at us. It generates two different versions of
`GetReferenceTypeMember_Icon` in `XamlTypeInfo.g.cpp`. Presumably
because there's an Icon on a NavViewItem and an Icon on a Command. We
don't really know why. Fortunately, the fix is "rename Command::Icon" to
"Command::IconPath". It's dumb, but it works. Thanks for the help with
that one Carlos ☺️ 

Unblocks #9224
