### PR TITLE
Update automation properties for tab header control

### DIFF
--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -359,6 +359,7 @@ namespace winrt::TerminalApp::implementation
 
             // Update the control to reflect the changed title
             _headerControl.Title(activeTitle);
+            Automation::AutomationProperties::SetName(tab->TabViewItem(), activeTitle);
             _UpdateToolTip();
         }
     }


### PR DESCRIPTION
This sets the automation property (name) on the tab view item we expose in XAML.

## PR Checklist
* [x] Closes #9254 

## Validation Steps Performed
Tested under NVDA and Accessibility Insights