### PR TITLE
[v1.6] Add help text to 'more options' in command palette

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.xaml
+++ b/src/cascadia/TerminalApp/CommandPalette.xaml
@@ -33,6 +33,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             <local:EmptyStringVisibilityConverter x:Key="ParsedCommandLineTextVisibilityConverter"/>
             <local:EmptyStringVisibilityConverter x:Key="ParentCommandVisibilityConverter"/>
             <local:HasNestedCommandsVisibilityConverter x:Key="HasNestedCommandsVisibilityConverter"/>
+            <local:HasNestedCommandsHelpTextConverter x:Key="HasNestedCommandsHelpTextConverter"/>
             <model:IconPathConverter x:Key="IconSourceConverter"/>
 
             <ResourceDictionary.ThemeDictionaries>
@@ -286,7 +287,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                         to make sure it takes the entire width of the line -->
                         <ListViewItem HorizontalContentAlignment="Stretch"
                                   AutomationProperties.Name="{x:Bind Item.Name, Mode=OneWay}"
-                                  AutomationProperties.AcceleratorKey="{x:Bind Item.KeyChordText, Mode=OneWay}">
+                                  AutomationProperties.AcceleratorKey="{x:Bind Item.KeyChordText, Mode=OneWay}"
+                                  AutomationProperties.HelpText="{x:Bind Item, Mode=OneWay, Converter={StaticResource HasNestedCommandsHelpTextConverter}}">
 
                             <Grid HorizontalAlignment="Stretch" ColumnSpacing="8" >
                                 <Grid.ColumnDefinitions>

--- a/src/cascadia/TerminalApp/HasNestedCommandsVisibilityConverter.cpp
+++ b/src/cascadia/TerminalApp/HasNestedCommandsVisibilityConverter.cpp
@@ -46,7 +46,7 @@ namespace winrt::TerminalApp::implementation
                                                                          hstring const& /* language */)
     {
         const auto paletteItem{ value.try_as<winrt::TerminalApp::ActionPaletteItem>() };
-        const auto& hasNestedCommands = paletteItem && paletteItem.Command().HasNestedCommands();
+        const auto hasNestedCommands = paletteItem && paletteItem.Command().HasNestedCommands();
         return winrt::box_value(hasNestedCommands ? RS_(L"CommandPalette_MoreOptionsHelpText") : L"");
     }
 

--- a/src/cascadia/TerminalApp/HasNestedCommandsVisibilityConverter.cpp
+++ b/src/cascadia/TerminalApp/HasNestedCommandsVisibilityConverter.cpp
@@ -1,6 +1,9 @@
 #include "pch.h"
 #include "HasNestedCommandsVisibilityConverter.h"
 #include "HasNestedCommandsVisibilityConverter.g.cpp"
+#include "HasNestedCommandsHelpTextConverter.g.cpp"
+
+#include "LibraryResources.h"
 
 using namespace winrt::Windows;
 using namespace winrt::Windows::UI::Xaml;
@@ -33,6 +36,25 @@ namespace winrt::TerminalApp::implementation
                                                                                Windows::UI::Xaml::Interop::TypeName const& /* targetType */,
                                                                                Foundation::IInspectable const& /* parameter */,
                                                                                hstring const& /* language */)
+    {
+        throw hresult_not_implemented();
+    }
+
+    Foundation::IInspectable HasNestedCommandsHelpTextConverter::Convert(Foundation::IInspectable const& value,
+                                                                         Windows::UI::Xaml::Interop::TypeName const& /* targetType */,
+                                                                         Foundation::IInspectable const& /* parameter */,
+                                                                         hstring const& /* language */)
+    {
+        const auto paletteItem{ value.try_as<winrt::TerminalApp::ActionPaletteItem>() };
+        const auto& hasNestedCommands = paletteItem && paletteItem.Command().HasNestedCommands();
+        return winrt::box_value(hasNestedCommands ? RS_(L"CommandPalette_MoreOptionsHelpText") : L"");
+    }
+
+    // unused for one-way bindings
+    Foundation::IInspectable HasNestedCommandsHelpTextConverter::ConvertBack(Foundation::IInspectable const& /* value */,
+                                                                             Windows::UI::Xaml::Interop::TypeName const& /* targetType */,
+                                                                             Foundation::IInspectable const& /* parameter */,
+                                                                             hstring const& /* language */)
     {
         throw hresult_not_implemented();
     }

--- a/src/cascadia/TerminalApp/HasNestedCommandsVisibilityConverter.cpp
+++ b/src/cascadia/TerminalApp/HasNestedCommandsVisibilityConverter.cpp
@@ -47,7 +47,7 @@ namespace winrt::TerminalApp::implementation
     {
         const auto paletteItem{ value.try_as<winrt::TerminalApp::ActionPaletteItem>() };
         const auto hasNestedCommands = paletteItem && paletteItem.Command().HasNestedCommands();
-        return winrt::box_value(hasNestedCommands ? RS_(L"CommandPalette_MoreOptionsHelpText") : L"");
+        return winrt::box_value(hasNestedCommands ? RS_(L"CommandPalette_MoreOptions/[using:Windows.UI.Xaml.Automation]AutomationProperties/HelpText") : L"");
     }
 
     // unused for one-way bindings

--- a/src/cascadia/TerminalApp/HasNestedCommandsVisibilityConverter.h
+++ b/src/cascadia/TerminalApp/HasNestedCommandsVisibilityConverter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "HasNestedCommandsVisibilityConverter.g.h"
+#include "HasNestedCommandsHelpTextConverter.g.h"
 #include "../inc/cppwinrt_utils.h"
 
 namespace winrt::TerminalApp::implementation
@@ -19,9 +20,25 @@ namespace winrt::TerminalApp::implementation
                                                       Windows::Foundation::IInspectable const& parameter,
                                                       hstring const& language);
     };
+
+    struct HasNestedCommandsHelpTextConverter : HasNestedCommandsHelpTextConverterT<HasNestedCommandsHelpTextConverter>
+    {
+        HasNestedCommandsHelpTextConverter() = default;
+
+        Windows::Foundation::IInspectable Convert(Windows::Foundation::IInspectable const& value,
+                                                  Windows::UI::Xaml::Interop::TypeName const& targetType,
+                                                  Windows::Foundation::IInspectable const& parameter,
+                                                  hstring const& language);
+
+        Windows::Foundation::IInspectable ConvertBack(Windows::Foundation::IInspectable const& value,
+                                                      Windows::UI::Xaml::Interop::TypeName const& targetType,
+                                                      Windows::Foundation::IInspectable const& parameter,
+                                                      hstring const& language);
+    };
 }
 
 namespace winrt::TerminalApp::factory_implementation
 {
     BASIC_FACTORY(HasNestedCommandsVisibilityConverter);
+    BASIC_FACTORY(HasNestedCommandsHelpTextConverter);
 }

--- a/src/cascadia/TerminalApp/HasNestedCommandsVisibilityConverter.idl
+++ b/src/cascadia/TerminalApp/HasNestedCommandsVisibilityConverter.idl
@@ -16,4 +16,9 @@ namespace TerminalApp
         HasNestedCommandsVisibilityConverter();
     };
 
+    runtimeclass HasNestedCommandsHelpTextConverter : [default] Windows.UI.Xaml.Data.IValueConverter
+    {
+        HasNestedCommandsHelpTextConverter();
+    };
+
 }

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -436,7 +436,7 @@
   </data>
   <data name="CommandPalette_ParsedCommandLine" xml:space="preserve">
     <value>Executing command line will invoke the following commands:</value>
-	<comment>Will be followed by a list of strings describing parsed commands</comment>
+    <comment>Will be followed by a list of strings describing parsed commands</comment>
   </data>
   <data name="CommandPalette_FailedParsingCommandLine" xml:space="preserve">
     <value>Failed parsing command line:</value>
@@ -543,5 +543,8 @@
   </data>
   <data name="ClipboardTextHeader.Text" xml:space="preserve">
     <value>Clipboard contents (preview):</value>
+  </data>
+  <data name="CommandPalette_MoreOptionsHelpText" xml:space="preserve">
+    <value>More options</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -544,7 +544,7 @@
   <data name="ClipboardTextHeader.Text" xml:space="preserve">
     <value>Clipboard contents (preview):</value>
   </data>
-  <data name="CommandPalette_MoreOptionsHelpText" xml:space="preserve">
+  <data name="CommandPalette_MoreOptions.[using:Windows.UI.Xaml.Automation]AutomationProperties.HelpText" xml:space="preserve">
     <value>More options</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request

This adds help text (automation property) to command palette commands that expand to more options.

## PR Checklist
* [ ] Resolves ~#9247~ #7908

## Validation Steps Performed
If I have a nested command called "color tab", NVDA reads it as...
"Color tab. More options. 5 of 79."