### PR TITLE
Fix updating with fragments ignoring original profile settings

### DIFF
--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -598,7 +598,6 @@ void CascadiaSettings::_ParseAndLayerFragmentFiles(const std::unordered_set<std:
                         auto childImpl{ matchingProfile->CreateChild() };
                         childImpl->LayerJson(profileStub);
                         childImpl->Origin(OriginTag::Fragment);
-                        childImpl->Source(source);
 
                         // replace parent in _profiles with child
                         _allProfiles.SetAt(_FindMatchingProfileIndex(matchingProfile->ToJson()).value(), *childImpl);


### PR DESCRIPTION
Turns out we were adding the fragment source to profiles we update. This
PR fixes it so we keep the original source. 

## Validation Steps Performed
Existing profile settings are maintained

Closes #9290 