### PR TITLE
Add a helper function to initialize TermControls in TerminalPage

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2498,7 +2498,7 @@ namespace winrt::TerminalApp::implementation
         _RemoveTabViewItem(tabViewItem);
     }
 
-    TermControl TerminalPage::_InitControl(TerminalApp::TerminalSettings& settings, ITerminalConnection connection)
+    TermControl TerminalPage::_InitControl(const TerminalApp::TerminalSettings& settings, const ITerminalConnection connection)
     {
         return TermControl{ *(winrt::get_self<TerminalSettings>(settings)->CreateChild()), connection };
     }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2498,7 +2498,7 @@ namespace winrt::TerminalApp::implementation
         _RemoveTabViewItem(tabViewItem);
     }
 
-    TermControl TerminalPage::_InitControl(const TerminalApp::TerminalSettings& settings, const ITerminalConnection connection)
+    TermControl TerminalPage::_InitControl(const TerminalApp::TerminalSettings& settings, const ITerminalConnection& connection)
     {
         return TermControl{ *(winrt::get_self<TerminalSettings>(settings)->CreateChild()), connection };
     }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -799,7 +799,7 @@ namespace winrt::TerminalApp::implementation
 
         // Give term control a child of the settings so that any overrides go in the child
         // This way, when we do a settings reload we just update the parent and the overrides remain
-        TermControl term{ *(winrt::get_self<TerminalSettings>(settings)->CreateChild()), connection };
+        auto term = _InitControl(settings, connection);
 
         auto newTabImpl = winrt::make_self<TerminalTab>(profileGuid, term);
 
@@ -882,7 +882,7 @@ namespace winrt::TerminalApp::implementation
 
         if (debugConnection) // this will only be set if global debugging is on and tap is active
         {
-            TermControl newControl{ *(winrt::get_self<TerminalSettings>(settings)->CreateChild()), debugConnection };
+            auto newControl = _InitControl(settings, debugConnection);
             _RegisterTerminalEvents(newControl, *newTabImpl);
             // Split (auto) with the debug tap.
             newTabImpl->SplitPane(SplitState::Automatic, 0.5f, profileGuid, newControl);
@@ -1865,7 +1865,7 @@ namespace winrt::TerminalApp::implementation
                 return;
             }
 
-            TermControl newControl{ *(winrt::get_self<TerminalSettings>(controlSettings)->CreateChild()), controlConnection };
+            auto newControl = _InitControl(controlSettings, controlConnection);
 
             // Hookup our event handlers to the new terminal
             _RegisterTerminalEvents(newControl, *focusedTab);
@@ -2496,6 +2496,11 @@ namespace winrt::TerminalApp::implementation
     {
         const auto tabViewItem = eventArgs.Tab();
         _RemoveTabViewItem(tabViewItem);
+    }
+
+    TermControl TerminalPage::_InitControl(TerminalApp::TerminalSettings& settings, ITerminalConnection connection)
+    {
+        return TermControl{ *(winrt::get_self<TerminalSettings>(settings)->CreateChild()), connection };
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -245,6 +245,9 @@ namespace winrt::TerminalApp::implementation
 
         void _Find();
 
+        winrt::Microsoft::Terminal::TerminalControl::TermControl _InitControl(winrt::TerminalApp::TerminalSettings& settings,
+                                                                              winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection connection);
+
         winrt::fire_and_forget _RefreshUIForSettingsReload();
 
         void _SetNonClientAreaColors(const Windows::UI::Color& selectedTabColor);

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -245,8 +245,8 @@ namespace winrt::TerminalApp::implementation
 
         void _Find();
 
-        winrt::Microsoft::Terminal::TerminalControl::TermControl _InitControl(winrt::TerminalApp::TerminalSettings& settings,
-                                                                              winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection connection);
+        winrt::Microsoft::Terminal::TerminalControl::TermControl _InitControl(const winrt::TerminalApp::TerminalSettings& settings,
+                                                                              const winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection connection);
 
         winrt::fire_and_forget _RefreshUIForSettingsReload();
 

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -246,7 +246,7 @@ namespace winrt::TerminalApp::implementation
         void _Find();
 
         winrt::Microsoft::Terminal::TerminalControl::TermControl _InitControl(const winrt::TerminalApp::TerminalSettings& settings,
-                                                                              const winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection connection);
+                                                                              const winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection& connection);
 
         winrt::fire_and_forget _RefreshUIForSettingsReload();
 


### PR DESCRIPTION
Since #8602 merged, we need to pass a child of the settings object to
the TermControl upon initializing it. Since this happens in a few places
in `TerminalPage`, its probably best to use a helper. 

Closes #9292 