### PR TITLE
Create settings/tasks definitions for VScode builds and registration

### DIFF
--- a/.github/actions/spelling/dictionary/apis.txt
+++ b/.github/actions/spelling/dictionary/apis.txt
@@ -41,7 +41,7 @@ IObject
 IPackage
 IPeasant
 IStorage
-IStream
+istream
 IStringable
 ITab
 ITaskbar

--- a/.github/actions/spelling/dictionary/apis.txt
+++ b/.github/actions/spelling/dictionary/apis.txt
@@ -41,6 +41,7 @@ IObject
 IPackage
 IPeasant
 IStorage
+IStream
 IStringable
 ITab
 ITaskbar
@@ -108,4 +109,9 @@ wpc
 wsregex
 XDocument
 XElement
+xlocmes
+xlocmon
+xlocnum
+xloctime
 XParse
+xstring

--- a/.github/actions/spelling/dictionary/microsoft.txt
+++ b/.github/actions/spelling/dictionary/microsoft.txt
@@ -8,6 +8,8 @@ bitmaps
 BOMs
 CPLs
 CPRs
+cpptools
+cppvsdbg
 DACL
 DACLs
 diffs
@@ -16,6 +18,7 @@ dotnetfeed
 DTDs
 DWINRT
 enablewttlogging
+Intelli
 LKG
 mfcribbon
 microsoft
@@ -42,6 +45,7 @@ tdbuildteamid
 VCRT
 vcruntime
 visualstudio
+vscode
 VSTHRD
 wlk
 wslpath

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"ms-vscode.cpptools"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		
+	]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,13 +1,13 @@
 {
-	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
-	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+    // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+    // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
 
-	// List of extensions which should be recommended for users of this workspace.
-	"recommendations": [
-		"ms-vscode.cpptools"
-	],
-	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
-	"unwantedRecommendations": [
-		
-	]
+    // List of extensions which should be recommended for users of this workspace.
+    "recommendations": [
+        "ms-vscode.cpptools"
+    ],
+    // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+    "unwantedRecommendations": [
+        
+    ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Build and debug conhost (x64, debug)",
+            "name": "Debug OpenConsole by Launching (x64, debug)",
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}\\bin\\x64\\debug\\openconsole.exe",
@@ -13,14 +13,12 @@
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
             "environment": [],
-            "preLaunchTask": "Build OpenConsole.exe x64 Debug"
         },
         {
-            "name": "Build and debug terminal (x64, debug)",
+            "name": "Debug Terminal by Attaching (You go build/register/launch it first.)",
             "type": "cppvsdbg",
             "request": "attach",
-            "processId": "${command:pickProcess}",
-            "preLaunchTask": "Build, Register, and Run Windows Terminal x64 Debug"
+            "processId": "${command:pickProcess}"
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,8 +13,14 @@
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
             "environment": [],
-            "console": "externalTerminal",
             "preLaunchTask": "Build OpenConsole.exe x64 Debug"
+        },
+        {
+            "name": "Build and debug terminal (x64, debug)",
+            "type": "cppvsdbg",
+            "request": "attach",
+            "processId": "${command:pickProcess}",
+            "preLaunchTask": "Build, Register, and Run Windows Terminal x64 Debug"
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Build and debug conhost (x64, debug)",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}\\bin\\x64\\debug\\openconsole.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "console": "externalTerminal",
+            "preLaunchTask": "Build OpenConsole.exe x64 Debug"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,32 @@
+{
+    "C_Cpp.default.browse.databaseFilename": "${workspaceFolder}\\.vscode\\.BROWSE.VC.DB",
+    "C_Cpp.default.browse.path": [
+        "${workspaceFolder}"
+    ],
+    "C_Cpp.loggingLevel": "None",
+    "files.associations": {
+        "xstring": "cpp",
+        "*.idl": "cpp",
+        "array": "cpp",
+        "future": "cpp",
+        "istream": "cpp",
+        "memory": "cpp",
+        "tuple": "cpp",
+        "type_traits": "cpp",
+        "utility": "cpp",
+        "variant": "cpp",
+        "xlocmes": "cpp",
+        "xlocmon": "cpp",
+        "xlocnum": "cpp",
+        "xloctime": "cpp",
+        "multi_span": "cpp",
+        "pointers": "cpp",
+        "vector": "cpp"
+    },
+    "files.exclude": {
+        "**/bin/**": true,
+        "**/obj/**": true,
+        "**/packages/**": true,
+        "**/generated files/**": true
+    }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,49 +3,37 @@
 	"tasks": [
 		{
 			"type": "process",
-			"label": "Build OpenConsole.exe x64 Debug",
-			"command": "pwsh.exe",
+			"label": "Build Terminal/Console",
+			"command": "powershell.exe",
 			"args": [
 			  "-Command",
 			  "Import-Module ${workspaceFolder}\\tools\\OpenConsole.psm1;",
 			  "Set-MsBuildDevEnvironment;",
+			  "$project = switch(\"${input:buildProjectChoice}\"){OpenConsole{\"Conhost\\Host_EXE\"} Terminal{\"Terminal\\CascadiaPackage\"}};",
+			  "$target = switch(\"${input:buildModeChoice}\"){Build{\"\"} Rebuild{\":Rebuild\"} Clean{\":Clean\"}};",
+			  "$target = $project + $target;",
 			  "msbuild",
 			  "${workspaceFolder}\\OpenConsole.sln",
-			  "/p:Configuration=Debug",
-			  "/p:Platform=x64",
-			  "/t:Conhost\\Host_EXE"
+			  "/p:Configuration=${input:configChoice}",
+			  "/p:Platform=${input:platformChoice}",
+			  "/t:$target",
+			  "/verbosity:minimal"
 			],
 			"problemMatcher": ["$msCompile"],
 			"group": {
 			  "kind": "build",
 			  "isDefault": true
-			}
-		},
-		{
-			"type": "process",
-			"label": "Build Windows Terminal x64 Debug",
-			"command": "pwsh.exe",
-			"args": [
-			  "-Command",
-			  "Import-Module ${workspaceFolder}\\tools\\OpenConsole.psm1;",
-			  "Set-MsBuildDevEnvironment;",
-			  "msbuild",
-			  "${workspaceFolder}\\OpenConsole.sln",
-			  "/p:Configuration=Debug",
-			  "/p:Platform=x64",
-			  "/t:Terminal\\CascadiaPackage",
-			  "/p:AppxSymbolPackageEnabled=false"
-			],
-			"problemMatcher": ["$msCompile"],
-			"group": {
-			  "kind": "build",
-			  "isDefault": true
+			},
+			"runOptions": {
+				"reevaluateOnRerun": false,
+				"instanceLimit": 1,
+				"runOn": "default"
 			}
 		},
 		{
 			"type": "process",
 			"label": "Register Windows Terminal x64 Debug",
-			"command": "pwsh.exe",
+			"command": "powershell.exe",
 			"args": [
 			  "-Command",
 			  "Import-Module ${workspaceFolder}\\tools\\OpenConsole.psm1;",
@@ -64,47 +52,56 @@
 		},
 		{
 			"type": "process",
-			"label": "Run Windows Terminal x64 Debug",
+			"label": "Run Windows Terminal Dev",
 			"command": "wtd.exe",
 			"args": [
 			],
 			"problemMatcher": ["$msCompile"],
-		},
-		{
-			"type": "shell",
-			"label": "Build, Register, and Run Windows Terminal x64 Debug",
-			"command": "Write-Host Done!",
-			"problemMatcher": ["$msCompile"],
-			"group": {
-			  "kind": "build",
-			  "isDefault": true
-			},
-			"dependsOn": [
-				"Build Windows Terminal x64 Debug",
-				"Register Windows Terminal x64 Debug",
-				"Run Windows Terminal x64 Debug"
-			],
-			"dependsOrder": "sequence"
-		},
-		{
-			"type": "process",
-			"label": "Clean Windows Terminal x64 Debug",
-			"command": "pwsh.exe",
-			"args": [
-			  "-Command",
-			  "Import-Module ${workspaceFolder}\\tools\\OpenConsole.psm1;",
-			  "Set-MsBuildDevEnvironment;",
-			  "msbuild",
-			  "${workspaceFolder}\\OpenConsole.sln",
-			  "/p:Configuration=Debug",
-			  "/p:Platform=x64",
-			  "/t:Terminal\\CascadiaPackage:Clean"
-			],
-			"problemMatcher": ["$msCompile"],
-			"group": {
-			  "kind": "build",
-			  "isDefault": true
-			}
 		}
+	],
+	"inputs":[
+		{
+			"id": "platformChoice",
+			"type": "pickString",
+			"description": "Processor architecture choice",
+			"options":[
+				"x64",
+				"x86",
+				"arm64"
+			],
+			"default": "x64"
+		},
+		{
+			"id": "configChoice",
+			"type": "pickString",
+			"description": "Debug or release?",
+			"options":[
+				"Debug",
+				"Release"
+			],
+			"default": "Debug"
+		},
+		{
+			"id": "buildModeChoice",
+			"type": "pickString",
+			"description": "Build, rebuild, or clean?",
+			"options":[
+				"Build",
+				"Rebuild",
+				"Clean"
+			],
+			"default": "Build"
+		},
+		{
+			"id": "buildProjectChoice",
+			"type": "pickString",
+			"description": "OpenConsole or Terminal?",
+			"options":[
+				"OpenConsole",
+				"Terminal"
+			],
+			"default": "Terminal"
+		}
+
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,8 +19,92 @@
 			"group": {
 			  "kind": "build",
 			  "isDefault": true
+			}
+		},
+		{
+			"type": "process",
+			"label": "Build Windows Terminal x64 Debug",
+			"command": "pwsh.exe",
+			"args": [
+			  "-Command",
+			  "Import-Module ${workspaceFolder}\\tools\\OpenConsole.psm1;",
+			  "Set-MsBuildDevEnvironment;",
+			  "msbuild",
+			  "${workspaceFolder}\\OpenConsole.sln",
+			  "/p:Configuration=Debug",
+			  "/p:Platform=x64",
+			  "/t:Terminal\\CascadiaPackage",
+			  "/p:AppxSymbolPackageEnabled=false"
+			],
+			"problemMatcher": ["$msCompile"],
+			"group": {
+			  "kind": "build",
+			  "isDefault": true
+			}
+		},
+		{
+			"type": "process",
+			"label": "Register Windows Terminal x64 Debug",
+			"command": "pwsh.exe",
+			"args": [
+			  "-Command",
+			  "Import-Module ${workspaceFolder}\\tools\\OpenConsole.psm1;",
+			  "Set-MsBuildDevEnvironment;",
+			  "Set-Location -Path ${workspaceFolder}\\src\\cascadia\\CascadiaPackage\\AppPackages\\CascadiaPackage_0.0.1.0_x64_Debug_Test;",
+			  "if ((Get-AppxPackage -Name 'WindowsTerminalDev*') -ne $null) { Remove-AppxPackage 'WindowsTerminalDev_0.0.1.0_x64__8wekyb3d8bbwe'};",
+			  "New-Item ..\\loose -Type Directory -Force;",
+			  "makeappx unpack /v /o /p .\\CascadiaPackage_0.0.1.0_x64_Debug.msix /d ..\\Loose\\;",
+			  "Add-AppxPackage -Path ..\\loose\\AppxManifest.xml -Register -ForceUpdateFromAnyVersion -ForceApplicationShutdown"
+			],
+			"problemMatcher": ["$msCompile"],
+			"group": {
+			  "kind": "build",
+			  "isDefault": true
+			}
+		},
+		{
+			"type": "process",
+			"label": "Run Windows Terminal x64 Debug",
+			"command": "wtd.exe",
+			"args": [
+			],
+			"problemMatcher": ["$msCompile"],
+		},
+		{
+			"type": "shell",
+			"label": "Build, Register, and Run Windows Terminal x64 Debug",
+			"command": "Write-Host Done!",
+			"problemMatcher": ["$msCompile"],
+			"group": {
+			  "kind": "build",
+			  "isDefault": true
 			},
-			"dependsOn": "Enter dev environment"
+			"dependsOn": [
+				"Build Windows Terminal x64 Debug",
+				"Register Windows Terminal x64 Debug",
+				"Run Windows Terminal x64 Debug"
+			],
+			"dependsOrder": "sequence"
+		},
+		{
+			"type": "process",
+			"label": "Clean Windows Terminal x64 Debug",
+			"command": "pwsh.exe",
+			"args": [
+			  "-Command",
+			  "Import-Module ${workspaceFolder}\\tools\\OpenConsole.psm1;",
+			  "Set-MsBuildDevEnvironment;",
+			  "msbuild",
+			  "${workspaceFolder}\\OpenConsole.sln",
+			  "/p:Configuration=Debug",
+			  "/p:Platform=x64",
+			  "/t:Terminal\\CascadiaPackage:Clean"
+			],
+			"problemMatcher": ["$msCompile"],
+			"group": {
+			  "kind": "build",
+			  "isDefault": true
+			}
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,26 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "process",
+			"label": "Build OpenConsole.exe x64 Debug",
+			"command": "pwsh.exe",
+			"args": [
+			  "-Command",
+			  "Import-Module ${workspaceFolder}\\tools\\OpenConsole.psm1;",
+			  "Set-MsBuildDevEnvironment;",
+			  "msbuild",
+			  "${workspaceFolder}\\OpenConsole.sln",
+			  "/p:Configuration=Debug",
+			  "/p:Platform=x64",
+			  "/t:Conhost\\Host_EXE"
+			],
+			"problemMatcher": ["$msCompile"],
+			"group": {
+			  "kind": "build",
+			  "isDefault": true
+			},
+			"dependsOn": "Enter dev environment"
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,107 +1,107 @@
 {
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"type": "process",
-			"label": "Build Terminal/Console",
-			"command": "powershell.exe",
-			"args": [
-			  "-Command",
-			  "Import-Module ${workspaceFolder}\\tools\\OpenConsole.psm1;",
-			  "Set-MsBuildDevEnvironment;",
-			  "$project = switch(\"${input:buildProjectChoice}\"){OpenConsole{\"Conhost\\Host_EXE\"} Terminal{\"Terminal\\CascadiaPackage\"}};",
-			  "$target = switch(\"${input:buildModeChoice}\"){Build{\"\"} Rebuild{\":Rebuild\"} Clean{\":Clean\"}};",
-			  "$target = $project + $target;",
-			  "msbuild",
-			  "${workspaceFolder}\\OpenConsole.sln",
-			  "/p:Configuration=${input:configChoice}",
-			  "/p:Platform=${input:platformChoice}",
-			  "/t:$target",
-			  "/verbosity:minimal"
-			],
-			"problemMatcher": ["$msCompile"],
-			"group": {
-			  "kind": "build",
-			  "isDefault": true
-			},
-			"runOptions": {
-				"reevaluateOnRerun": false,
-				"instanceLimit": 1,
-				"runOn": "default"
-			}
-		},
-		{
-			"type": "process",
-			"label": "Register Windows Terminal x64 Debug",
-			"command": "powershell.exe",
-			"args": [
-			  "-Command",
-			  "Import-Module ${workspaceFolder}\\tools\\OpenConsole.psm1;",
-			  "Set-MsBuildDevEnvironment;",
-			  "Set-Location -Path ${workspaceFolder}\\src\\cascadia\\CascadiaPackage\\AppPackages\\CascadiaPackage_0.0.1.0_x64_Debug_Test;",
-			  "if ((Get-AppxPackage -Name 'WindowsTerminalDev*') -ne $null) { Remove-AppxPackage 'WindowsTerminalDev_0.0.1.0_x64__8wekyb3d8bbwe'};",
-			  "New-Item ..\\loose -Type Directory -Force;",
-			  "makeappx unpack /v /o /p .\\CascadiaPackage_0.0.1.0_x64_Debug.msix /d ..\\Loose\\;",
-			  "Add-AppxPackage -Path ..\\loose\\AppxManifest.xml -Register -ForceUpdateFromAnyVersion -ForceApplicationShutdown"
-			],
-			"problemMatcher": ["$msCompile"],
-			"group": {
-			  "kind": "build",
-			  "isDefault": true
-			}
-		},
-		{
-			"type": "process",
-			"label": "Run Windows Terminal Dev",
-			"command": "wtd.exe",
-			"args": [
-			],
-			"problemMatcher": ["$msCompile"],
-		}
-	],
-	"inputs":[
-		{
-			"id": "platformChoice",
-			"type": "pickString",
-			"description": "Processor architecture choice",
-			"options":[
-				"x64",
-				"x86",
-				"arm64"
-			],
-			"default": "x64"
-		},
-		{
-			"id": "configChoice",
-			"type": "pickString",
-			"description": "Debug or release?",
-			"options":[
-				"Debug",
-				"Release"
-			],
-			"default": "Debug"
-		},
-		{
-			"id": "buildModeChoice",
-			"type": "pickString",
-			"description": "Build, rebuild, or clean?",
-			"options":[
-				"Build",
-				"Rebuild",
-				"Clean"
-			],
-			"default": "Build"
-		},
-		{
-			"id": "buildProjectChoice",
-			"type": "pickString",
-			"description": "OpenConsole or Terminal?",
-			"options":[
-				"OpenConsole",
-				"Terminal"
-			],
-			"default": "Terminal"
-		}
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "process",
+            "label": "Build Terminal/Console",
+            "command": "powershell.exe",
+            "args": [
+              "-Command",
+              "Import-Module ${workspaceFolder}\\tools\\OpenConsole.psm1;",
+              "Set-MsBuildDevEnvironment;",
+              "$project = switch(\"${input:buildProjectChoice}\"){OpenConsole{\"Conhost\\Host_EXE\"} Terminal{\"Terminal\\CascadiaPackage\"}};",
+              "$target = switch(\"${input:buildModeChoice}\"){Build{\"\"} Rebuild{\":Rebuild\"} Clean{\":Clean\"}};",
+              "$target = $project + $target;",
+              "msbuild",
+              "${workspaceFolder}\\OpenConsole.sln",
+              "/p:Configuration=${input:configChoice}",
+              "/p:Platform=${input:platformChoice}",
+              "/t:$target",
+              "/verbosity:minimal"
+            ],
+            "problemMatcher": ["$msCompile"],
+            "group": {
+              "kind": "build",
+              "isDefault": true
+            },
+            "runOptions": {
+                "reevaluateOnRerun": false,
+                "instanceLimit": 1,
+                "runOn": "default"
+            }
+        },
+        {
+            "type": "process",
+            "label": "Register Windows Terminal x64 Debug",
+            "command": "powershell.exe",
+            "args": [
+              "-Command",
+              "Import-Module ${workspaceFolder}\\tools\\OpenConsole.psm1;",
+              "Set-MsBuildDevEnvironment;",
+              "Set-Location -Path ${workspaceFolder}\\src\\cascadia\\CascadiaPackage\\AppPackages\\CascadiaPackage_0.0.1.0_x64_Debug_Test;",
+              "if ((Get-AppxPackage -Name 'WindowsTerminalDev*') -ne $null) { Remove-AppxPackage 'WindowsTerminalDev_0.0.1.0_x64__8wekyb3d8bbwe'};",
+              "New-Item ..\\loose -Type Directory -Force;",
+              "makeappx unpack /v /o /p .\\CascadiaPackage_0.0.1.0_x64_Debug.msix /d ..\\Loose\\;",
+              "Add-AppxPackage -Path ..\\loose\\AppxManifest.xml -Register -ForceUpdateFromAnyVersion -ForceApplicationShutdown"
+            ],
+            "problemMatcher": ["$msCompile"],
+            "group": {
+              "kind": "build",
+              "isDefault": true
+            }
+        },
+        {
+            "type": "process",
+            "label": "Run Windows Terminal Dev",
+            "command": "wtd.exe",
+            "args": [
+            ],
+            "problemMatcher": ["$msCompile"],
+        }
+    ],
+    "inputs":[
+        {
+            "id": "platformChoice",
+            "type": "pickString",
+            "description": "Processor architecture choice",
+            "options":[
+                "x64",
+                "x86",
+                "arm64"
+            ],
+            "default": "x64"
+        },
+        {
+            "id": "configChoice",
+            "type": "pickString",
+            "description": "Debug or release?",
+            "options":[
+                "Debug",
+                "Release"
+            ],
+            "default": "Debug"
+        },
+        {
+            "id": "buildModeChoice",
+            "type": "pickString",
+            "description": "Build, rebuild, or clean?",
+            "options":[
+                "Build",
+                "Rebuild",
+                "Clean"
+            ],
+            "default": "Build"
+        },
+        {
+            "id": "buildProjectChoice",
+            "type": "pickString",
+            "description": "OpenConsole or Terminal?",
+            "options":[
+                "OpenConsole",
+                "Terminal"
+            ],
+            "default": "Terminal"
+        }
 
-	]
+    ]
 }

--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -40,8 +40,7 @@ function Import-LocalModule
     } else {
         Write-Verbose "$Name already downloaded"
         $versions = Get-ChildItem "$modules_root\$Name" | Sort-Object
-
-        Get-ChildItem -Path "$modules_root\$Name\$($versions[0])\$Name.psd1" | Import-Module
+        Get-ChildItem -Path "$($versions[0])\$Name.psd1" | Import-Module
     }
 }
 

--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -40,7 +40,8 @@ function Import-LocalModule
     } else {
         Write-Verbose "$Name already downloaded"
         $versions = Get-ChildItem "$modules_root\$Name" | Sort-Object
-        Get-ChildItem -Path "$($versions[0])\$Name.psd1" | Import-Module
+
+        Get-ChildItem -Path "$modules_root\$Name\$($versions[0])\$Name.psd1" | Import-Module
     }
 }
 


### PR DESCRIPTION
I wanted to start using VScode. It wasn't easy. I wrote some tasks that allow us to build the various flavors of OpenConsole and Windows Terminal from one of the tasks. I also wrote a task that allows registration of the loose Windows Terminal package and a shortcut one to launch it. 

Also it was grinding away at its own Intellisense forever because it was indexing obj, bin, packages, etc. I excluded those.

Things should be easier now for folks in general. I expect we'll make more task types in the future.