### PR TITLE
Introduce a mechanism for passing through DCS data strings

### DIFF
--- a/src/terminal/parser/IStateMachineEngine.hpp
+++ b/src/terminal/parser/IStateMachineEngine.hpp
@@ -20,6 +20,8 @@ namespace Microsoft::Console::VirtualTerminal
     class IStateMachineEngine
     {
     public:
+        using StringHandler = std::function<bool(const wchar_t)>;
+
         virtual ~IStateMachineEngine() = 0;
         IStateMachineEngine(const IStateMachineEngine&) = default;
         IStateMachineEngine(IStateMachineEngine&&) = default;
@@ -36,6 +38,7 @@ namespace Microsoft::Console::VirtualTerminal
         virtual bool ActionEscDispatch(const VTID id) = 0;
         virtual bool ActionVt52EscDispatch(const VTID id, const VTParameters parameters) = 0;
         virtual bool ActionCsiDispatch(const VTID id, const VTParameters parameters) = 0;
+        virtual StringHandler ActionDcsDispatch(const VTID id, const VTParameters parameters) = 0;
 
         virtual bool ActionClear() = 0;
 

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -447,6 +447,21 @@ bool InputStateMachineEngine::ActionCsiDispatch(const VTID id, const VTParameter
 }
 
 // Routine Description:
+// - Triggers the DcsDispatch action to indicate that the listener should handle
+//      a control sequence. Returns the handler function that is to be used to
+//      process the subsequent data string characters in the sequence.
+// Arguments:
+// - id - Identifier of the control sequence to dispatch.
+// - parameters - set of numeric parameters collected while parsing the sequence.
+// Return Value:
+// - the data string handler function or nullptr if the sequence is not supported
+IStateMachineEngine::StringHandler InputStateMachineEngine::ActionDcsDispatch(const VTID /*id*/, const VTParameters /*parameters*/) noexcept
+{
+    // DCS escape sequences are not used in the input state machine.
+    return nullptr;
+}
+
+// Routine Description:
 // - Triggers the Ss3Dispatch action to indicate that the listener should handle
 //      a control sequence. These sequences perform various API-type commands
 //      that can include many parameters.

--- a/src/terminal/parser/InputStateMachineEngine.hpp
+++ b/src/terminal/parser/InputStateMachineEngine.hpp
@@ -146,6 +146,8 @@ namespace Microsoft::Console::VirtualTerminal
 
         bool ActionCsiDispatch(const VTID id, const VTParameters parameters) override;
 
+        StringHandler ActionDcsDispatch(const VTID id, const VTParameters parameters) noexcept override;
+
         bool ActionClear() noexcept override;
 
         bool ActionIgnore() noexcept override;

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -637,6 +637,24 @@ bool OutputStateMachineEngine::ActionCsiDispatch(const VTID id, const VTParamete
 }
 
 // Routine Description:
+// - Triggers the DcsDispatch action to indicate that the listener should handle
+//      a control sequence. Returns the handler function that is to be used to
+//      process the subsequent data string characters in the sequence.
+// Arguments:
+// - id - Identifier of the control sequence to dispatch.
+// - parameters - set of numeric parameters collected while parsing the sequence.
+// Return Value:
+// - the data string handler function or nullptr if the sequence is not supported
+IStateMachineEngine::StringHandler OutputStateMachineEngine::ActionDcsDispatch(const VTID /*id*/, const VTParameters /*parameters*/) noexcept
+{
+    StringHandler handler = nullptr;
+
+    _ClearLastChar();
+
+    return handler;
+}
+
+// Routine Description:
 // - Triggers the Clear action to indicate that the state machine should erase
 //      all internal state.
 // Arguments:

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -39,6 +39,8 @@ namespace Microsoft::Console::VirtualTerminal
 
         bool ActionCsiDispatch(const VTID id, const VTParameters parameters) override;
 
+        StringHandler ActionDcsDispatch(const VTID id, const VTParameters parameters) noexcept override;
+
         bool ActionClear() noexcept override;
 
         bool ActionIgnore() noexcept override;

--- a/src/terminal/parser/stateMachine.hpp
+++ b/src/terminal/parser/stateMachine.hpp
@@ -71,6 +71,7 @@ namespace Microsoft::Console::VirtualTerminal
 
         void _ActionClear();
         void _ActionIgnore() noexcept;
+        void _ActionInterrupt();
 
         void _EnterGround() noexcept;
         void _EnterEscape();
@@ -90,9 +91,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _EnterDcsIgnore() noexcept;
         void _EnterDcsIntermediate() noexcept;
         void _EnterDcsPassThrough() noexcept;
-        void _EnterDcsTermination() noexcept;
         void _EnterSosPmApcString() noexcept;
-        void _EnterSosPmApcTermination() noexcept;
 
         void _EventGround(const wchar_t wch);
         void _EventEscape(const wchar_t wch);
@@ -103,6 +102,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _EventCsiParam(const wchar_t wch);
         void _EventOscParam(const wchar_t wch) noexcept;
         void _EventOscString(const wchar_t wch);
+        void _EventOscTermination(const wchar_t wch);
         void _EventSs3Entry(const wchar_t wch);
         void _EventSs3Param(const wchar_t wch);
         void _EventVt52Param(const wchar_t wch);
@@ -112,10 +112,8 @@ namespace Microsoft::Console::VirtualTerminal
         void _EventDcsParam(const wchar_t wch);
         void _EventDcsPassThrough(const wchar_t wch);
         void _EventSosPmApcString(const wchar_t wch) noexcept;
-        void _EventVariableLengthStringTermination(const wchar_t wch);
 
         void _AccumulateTo(const wchar_t wch, size_t& value) noexcept;
-        const bool _IsVariableLengthStringState() const noexcept;
 
         enum class VTStates
         {
@@ -137,9 +135,7 @@ namespace Microsoft::Console::VirtualTerminal
             DcsIntermediate,
             DcsParam,
             DcsPassThrough,
-            DcsTermination,
-            SosPmApcString,
-            SosPmApcTermination
+            SosPmApcString
         };
 
         Microsoft::Console::VirtualTerminal::ParserTracing _trace;

--- a/src/terminal/parser/stateMachine.hpp
+++ b/src/terminal/parser/stateMachine.hpp
@@ -67,7 +67,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _ActionOscPut(const wchar_t wch);
         void _ActionOscDispatch(const wchar_t wch);
         void _ActionSs3Dispatch(const wchar_t wch);
-        void _ActionDcsPassThrough(const wchar_t wch);
+        void _ActionDcsDispatch(const wchar_t wch);
 
         void _ActionClear();
         void _ActionIgnore() noexcept;
@@ -158,6 +158,8 @@ namespace Microsoft::Console::VirtualTerminal
 
         std::wstring _oscString;
         size_t _oscParameter;
+
+        IStateMachineEngine::StringHandler _dcsStringHandler;
 
         std::optional<std::wstring> _cachedSequence;
 

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -176,7 +176,7 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
             mach._dcsStringHandler = [](const auto) { return true; };
             break;
         }
-        case 18:
+        case 17:
         {
             Log::Comment(L"Escape from SosPmApcString");
             shouldEscapeOut = false;

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -56,7 +56,7 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
     TEST_METHOD(TestEscapePath)
     {
         BEGIN_TEST_METHOD_PROPERTIES()
-            TEST_METHOD_PROPERTY(L"Data:uiTest", L"{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19}") // one value for each type of state test below.
+            TEST_METHOD_PROPERTY(L"Data:uiTest", L"{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17}") // one value for each type of state test below.
         END_TEST_METHOD_PROPERTIES()
 
         size_t uiTest;
@@ -173,12 +173,7 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
             Log::Comment(L"Escape from DcsPassThrough");
             shouldEscapeOut = false;
             mach._state = StateMachine::VTStates::DcsPassThrough;
-            break;
-        }
-        case 17:
-        {
-            Log::Comment(L"Escape from DcsTermination");
-            mach._state = StateMachine::VTStates::DcsTermination;
+            mach._dcsStringHandler = [](const auto) { return true; };
             break;
         }
         case 18:
@@ -186,12 +181,6 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
             Log::Comment(L"Escape from SosPmApcString");
             shouldEscapeOut = false;
             mach._state = StateMachine::VTStates::SosPmApcString;
-            break;
-        }
-        case 19:
-        {
-            Log::Comment(L"Escape from SosPmApcTermination");
-            mach._state = StateMachine::VTStates::SosPmApcTermination;
             break;
         }
         }
@@ -806,9 +795,10 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         mach.ProcessCharacter(L' ');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsIntermediate);
         mach.ProcessCharacter(L'x');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsPassThrough);
+        // Note that without a dispatcher the pass through data is instead ignored.
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsIgnore);
         mach.ProcessCharacter(AsciiChars::ESC);
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsTermination);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);
         mach.ProcessCharacter(L'\\');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
     }
@@ -825,19 +815,20 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         mach.ProcessCharacter(L'P');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsEntry);
         mach.ProcessCharacter(L'q');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsPassThrough);
+        // Note that without a dispatcher the pass through state is instead ignored.
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsIgnore);
         mach.ProcessCharacter(L'#');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsPassThrough);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsIgnore);
         mach.ProcessCharacter(L'1');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsPassThrough);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsIgnore);
         mach.ProcessCharacter(L'N');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsPassThrough);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsIgnore);
         mach.ProcessCharacter(L'N');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsPassThrough);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsIgnore);
         mach.ProcessCharacter(L'N');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsPassThrough);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsIgnore);
         mach.ProcessCharacter(AsciiChars::ESC);
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsTermination);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);
         mach.ProcessCharacter(L'\\');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
     }
@@ -854,11 +845,11 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         mach.ProcessCharacter(L'P');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsEntry);
         mach.ProcessCharacter(L'q');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsPassThrough);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsIgnore);
         mach.ProcessCharacter(L'#');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsPassThrough);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsIgnore);
         mach.ProcessCharacter(AsciiChars::ESC);
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsTermination);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);
         mach.ProcessCharacter(L'['); // This is not a string terminator.
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiEntry);
         mach.ProcessCharacter(L'4');
@@ -885,7 +876,7 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         mach.ProcessCharacter(L'2');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
         mach.ProcessCharacter(AsciiChars::ESC);
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcTermination);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);
         mach.ProcessCharacter(L'\\');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
 
@@ -898,7 +889,7 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         mach.ProcessCharacter(L'4');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
         mach.ProcessCharacter(AsciiChars::ESC);
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcTermination);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);
         mach.ProcessCharacter(L'\\');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
 
@@ -911,7 +902,7 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         mach.ProcessCharacter(L'6');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcString);
         mach.ProcessCharacter(AsciiChars::ESC);
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::SosPmApcTermination);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);
         mach.ProcessCharacter(L'\\');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
     }
@@ -943,9 +934,9 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         mach.ProcessCharacter(L'P');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsEntry);
         mach.ProcessCharacter(L'q');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsPassThrough);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsIgnore);
         mach.ProcessCharacter(L'#');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsPassThrough);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::DcsIgnore);
         mach.ProcessCharacter(L'1');
         mach.ProcessCharacter(L'\x9c');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);

--- a/src/terminal/parser/ut_parser/StateMachineTest.cpp
+++ b/src/terminal/parser/ut_parser/StateMachineTest.cpp
@@ -32,10 +32,20 @@ public:
     {
         printed.clear();
         passedThrough.clear();
+        executed.clear();
+        csiId = 0;
         csiParams.clear();
+        dcsId = 0;
+        dcsParams.clear();
+        dcsDataString.clear();
     }
 
-    bool ActionExecute(const wchar_t /* wch */) override { return true; };
+    bool ActionExecute(const wchar_t wch) override
+    {
+        executed += wch;
+        return true;
+    };
+
     bool ActionExecuteFromEscape(const wchar_t /* wch */) override { return true; };
     bool ActionPrint(const wchar_t /* wch */) override { return true; };
     bool ActionPrintString(const std::wstring_view string) override
@@ -78,7 +88,7 @@ public:
     bool DispatchIntermediatesFromEscape() const override { return false; };
 
     // ActionCsiDispatch is the only method that's actually implemented.
-    bool ActionCsiDispatch(const VTID /*id*/, const VTParameters parameters) override
+    bool ActionCsiDispatch(const VTID id, const VTParameters parameters) override
     {
         // If flush to terminal is registered for a test, then use it.
         if (pfnFlushToTerminal)
@@ -88,6 +98,7 @@ public:
         }
         else
         {
+            csiId = id;
             for (size_t i = 0; i < parameters.size(); i++)
             {
                 csiParams.push_back(parameters.at(i).value_or(0));
@@ -96,12 +107,19 @@ public:
         }
     }
 
-    IStateMachineEngine::StringHandler ActionDcsDispatch(const VTID /*id*/, const VTParameters /*parameters*/) override
+    IStateMachineEngine::StringHandler ActionDcsDispatch(const VTID id, const VTParameters parameters) override
     {
-        return nullptr;
+        dcsId = id;
+        for (size_t i = 0; i < parameters.size(); i++)
+        {
+            dcsParams.push_back(parameters.at(i).value_or(0));
+        }
+        dcsDataString.clear();
+        return [=](const auto ch) { dcsDataString += ch; return true; };
     }
 
-    // This will only be populated if ActionCsiDispatch is called.
+    // These will only be populated if ActionCsiDispatch is called.
+    uint64_t csiId = 0;
     std::vector<size_t> csiParams;
 
     // Flush function for pass-through test.
@@ -112,6 +130,14 @@ public:
 
     // Printed string.
     std::wstring printed;
+
+    // Executed string.
+    std::wstring executed;
+
+    // These will only be populated if ActionDcsDispatch is called.
+    uint64_t dcsId = 0;
+    std::vector<size_t> dcsParams;
+    std::wstring dcsDataString;
 };
 
 class Microsoft::Console::VirtualTerminal::StateMachineTest
@@ -134,6 +160,8 @@ class Microsoft::Console::VirtualTerminal::StateMachineTest
     TEST_METHOD(RunStorageBeforeEscape);
     TEST_METHOD(BulkTextPrint);
     TEST_METHOD(PassThroughUnhandledSplitAcrossWrites);
+
+    TEST_METHOD(DcsDataStringsReceivedByHandler);
 };
 
 void StateMachineTest::TwoStateMachinesDoNotInterfereWithEachother()
@@ -250,4 +278,67 @@ void StateMachineTest::PassThroughUnhandledSplitAcrossWrites()
     machine.ProcessString(L"\\");
     VERIFY_ARE_EQUAL(L"\x1b]99;foo\x1b\\", engine.passedThrough);
     VERIFY_ARE_EQUAL(L"", engine.printed);
+}
+
+void StateMachineTest::DcsDataStringsReceivedByHandler()
+{
+    BEGIN_TEST_METHOD_PROPERTIES()
+        TEST_METHOD_PROPERTY(L"Data:terminatorType", L"{ 0, 1, 2, 3 }")
+    END_TEST_METHOD_PROPERTIES()
+
+    size_t terminatorType;
+    VERIFY_SUCCEEDED(TestData::TryGetValue(L"terminatorType", terminatorType));
+
+    auto enginePtr{ std::make_unique<TestStateMachineEngine>() };
+    // this dance is required because StateMachine presumes to take ownership of its engine.
+    auto& engine{ *enginePtr.get() };
+    StateMachine machine{ std::move(enginePtr) };
+
+    uint64_t expectedCsiId = 0;
+    std::wstring expectedExecuted = L"";
+
+    std::wstring terminatorString;
+    switch (terminatorType)
+    {
+    case 0:
+        Log::Comment(L"Data string terminated with ST");
+        terminatorString = L"\033\\";
+        break;
+    case 1:
+        Log::Comment(L"Data string terminated with CSI sequence");
+        terminatorString = L"\033[m";
+        expectedCsiId = VTID(L'm');
+        break;
+    case 2:
+        Log::Comment(L"Data string terminated with CAN");
+        terminatorString = L"\030";
+        expectedExecuted = L"\030";
+        break;
+    case 3:
+        Log::Comment(L"Data string terminated with SUB");
+        terminatorString = L"\032";
+        expectedExecuted = L"\032";
+        break;
+    }
+
+    // Output a DCS sequence terminated with the current test string
+    machine.ProcessString(L"\033P1;2;3|data string");
+    machine.ProcessString(terminatorString);
+    machine.ProcessString(L"printed text");
+
+    // Verify the sequence ID and parameters are received.
+    VERIFY_ARE_EQUAL(VTID("|"), engine.dcsId);
+    VERIFY_ARE_EQUAL(std::vector<size_t>({ 1, 2, 3 }), engine.dcsParams);
+
+    // Verify that the data string is received (ESC terminated).
+    VERIFY_ARE_EQUAL(L"data string\033", engine.dcsDataString);
+
+    // Verify the characters following the sequence are printed.
+    VERIFY_ARE_EQUAL(L"printed text", engine.printed);
+
+    // Verify the CSI sequence was received (if expected).
+    VERIFY_ARE_EQUAL(expectedCsiId, engine.csiId);
+
+    // Verify the control characters were executed (if expected).
+    VERIFY_ARE_EQUAL(expectedExecuted, engine.executed);
 }

--- a/src/terminal/parser/ut_parser/StateMachineTest.cpp
+++ b/src/terminal/parser/ut_parser/StateMachineTest.cpp
@@ -96,6 +96,11 @@ public:
         }
     }
 
+    IStateMachineEngine::StringHandler ActionDcsDispatch(const VTID /*id*/, const VTParameters /*parameters*/) override
+    {
+        return nullptr;
+    }
+
     // This will only be populated if ActionCsiDispatch is called.
     std::vector<size_t> csiParams;
 


### PR DESCRIPTION
This PR introduces a mechanism via which DCS data strings can be passed
through directly to the dispatch method that will be handling them, so
the data can be processed as it is received, rather than being buffered
in the state machine. This also simplifies the way string termination is
handled, so it now more closely matches the behaviour of the original
DEC terminals.

* Initial support for DCS sequences was introduced in PR #6328.
* Handling of DCS (and other) C1 controls was added in PR #7340.
* This is a prerequisite for Sixel (#448) and Soft Font (#9164) support.

The way this now works, a `DCS` sequence is dispatched as soon as the
final character of the `VTID` is received. Based on that ID, the
`OutputStateMachineEngine` should forward the call to the corresponding
dispatch method, and its the responsibility of that method to return an
appropriate handler function for the sequence.

From then on, the `StateMachine` will pass on all of the remaining bytes
in the data string to the handler function. When a data string is
terminated (with `CAN`, `SUB`, or `ESC`), the `StateMachine` will pass
on one final `ESC` character to let the handler know that the sequence
is finished. The handler can also end a sequence prematurely by
returning false, and then all remaining data bytes will be ignored.

Note that once a `DCS` sequence has been dispatched, it's not possible
to abort the data string. Both `CAN` and `SUB` are considered valid
forms of termination, and an `ESC` doesn't necessarily have to be
followed by a `\` for the string terminator. This is because the data
string is typically processed as it's received. For example, when
outputting a Sixel image, you wouldn't erase the parts that had already
been displayed if the data string is terminated early.

With this new way of handling the string termination, I was also able to
simplify some of the `StateMachine` processing, and get rid of a few
states that are no longer necessary. These changes don't apply to the
`OSC` sequences, though, since we're more likely to want to match the
XTerm behavior for those cases (which requires a valid `ST` control for
the sequence to be accepted).

## Validation Steps Performed

For the unit tests, I've had to make a few changes to some of the
`OutputEngineTests` to account for the updated `StateMachine`
processing. I've also added a new `StateMachineTest` to confirm that the
data strings are correctly passed through to the string handler under
all forms of termination.

To test whether the framework is actually usable, I've been working on
DRCS Soft Font support branched off of this PR, and haven't encountered
any problems. To test the throughput speed, I also hacked together a
basic Sixel parser, and that seemed to perform reasonably well.

Closes #7316