### PR TITLE
Show the context menu verb only when shift key is down

### DIFF
--- a/src/cascadia/ShellExtension/OpenTerminalHere.cpp
+++ b/src/cascadia/ShellExtension/OpenTerminalHere.cpp
@@ -7,8 +7,8 @@
 #include <ShlObj.h>
 
 // TODO GH#6112: Localize these strings
-static constexpr std::wstring_view VerbDisplayName{ L"Open in Windows Terminal" };
-static constexpr std::wstring_view VerbDevBuildDisplayName{ L"Open in Windows Terminal (Dev Build)" };
+static constexpr std::wstring_view VerbDisplayName{ L"Open Windows Terminal here" };
+static constexpr std::wstring_view VerbDevBuildDisplayName{ L"Open Windows Terminal here (Dev Build)" };
 static constexpr std::wstring_view VerbName{ L"WindowsTerminalOpenHere" };
 
 // This code is aggressively copied from

--- a/src/cascadia/ShellExtension/OpenTerminalHere.cpp
+++ b/src/cascadia/ShellExtension/OpenTerminalHere.cpp
@@ -103,7 +103,15 @@ HRESULT OpenTerminalHere::GetState(IShellItemArray* /*psiItemArray*/,
     // We however don't need to bother with any of that, so we'll just return
     // ECS_ENABLED.
 
-    *pCmdState = ECS_ENABLED;
+    // Show the verb only when shift key is down
+    if ((GetKeyState(VK_SHIFT) & 0x8000) != 0)
+    {
+        *pCmdState = ECS_ENABLED;
+    }
+    else
+    {
+        *pCmdState = ECS_HIDDEN;
+    }
     return S_OK;
 }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

- Show the context menu verb only when shift key is down. Not configurable right now. Add a config in the future, maybe?
- Change the verb name a bit to keep it consistent with the existing "Open PowerShell window here". Anyway this should be overridden by #6112 at some point.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

Related: #8105

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #6113
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests ~~added/~~ passed (`Invoke-OpenConsoleTests` Total=329, Passed=329)
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Haven't found a proper way to test ShellExtension so I went creative: (much appreciated if anybody can point me to the proper way to test this :p)

- Installed Windows Terminal (stable) from Microsoft Store
- Built x64 Release WindowsTerminalShellExt.dll
- Copied built WindowsTerminalShellExt.dll under `C:\Program Files\WindowsApps\`
- (Optional) Copied WindowsTerminal.exe under `C:\Program Files\WindowsApps\` for verb icon
- Under `HKCR\PackagedCom\Package\Microsoft.WindowsTerminal_1.6.10571.0_x64__8wekyb3d8bbwe\Class\{9F156763-7844-4DC4-B2B1-901F640F5155}\`, changed `DllPath` to `..\WindowsTerminalShellExt.dll`
- Manually verified the change in explorer -- works as expected.

In a folder, shift up;
<img width="182" alt="1 in dir shift up" src="https://user-images.githubusercontent.com/10822203/109811516-cbad7c80-7bdf-11eb-8143-190414a7ff00.png">

In a folder, shift down:
<img width="212" alt="2 in dir shift down" src="https://user-images.githubusercontent.com/10822203/109811528-d1a35d80-7bdf-11eb-956a-18615570ef49.png">

On a folder, shift up:
<img width="224" alt="3 on dir shift up" src="https://user-images.githubusercontent.com/10822203/109811563-dcf68900-7bdf-11eb-894c-c43b2a53c967.png">

On a folder, shift down:
<img width="244" alt="4 on dir shift down" src="https://user-images.githubusercontent.com/10822203/109811592-e4b62d80-7bdf-11eb-8aed-06d1bf073038.png">
