### PR TITLE
[Settings UI] Clamp vintage cursor height and history size

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -320,6 +320,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                                                     Visibility="{x:Bind IsVintageCursor, Mode=OneWay}">
                                 <muxc:NumberBox Value="{x:Bind State.Profile.CursorHeight, Mode=TwoWay}"
                                                 Style="{StaticResource NumberBoxSettingStyle}"
+                                                Minimum="1"
+                                                Maximum="100"
                                                 SmallChange="1"
                                                 LargeChange="10"/>
                             </local:SettingContainer>

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -664,6 +664,7 @@ the MIT License. See LICENSE in the project root for license information. -->
                                                 SettingOverrideSource="{x:Bind State.Profile.HistorySizeOverrideSource, Mode=OneWay}">
                             <muxc:NumberBox Value="{x:Bind State.Profile.HistorySize, Mode=TwoWay}"
                                             Style="{StaticResource NumberBoxSettingStyle}"
+                                            Minimum="0"
                                             SmallChange="10"
                                             LargeChange="100"/>
                         </local:SettingContainer>


### PR DESCRIPTION
## Summary of the Pull Request
Add `Minimum` and `Maximum` for the cursor height numberbox in the SUI.
Add `Minimum` for the history size numberbox in the SUI.

## PR Checklist
* [x] Closes #9357, Closes #9175
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA

## Validation Steps Performed
Manual validation
