### PR TITLE
Fix selection logic with shift on multi-click and in mouse mode

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -79,6 +79,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         _blinkTimer{},
         _lastMouseClickTimestamp{},
         _lastMouseClickPos{},
+        _lastMouseClickPosNoSelection{},
         _selectionNeedsToBeCopied{ false },
         _searchBox{ nullptr }
     {
@@ -1342,35 +1343,58 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                     mode = ::Terminal::SelectionExpansionMode::Line;
                 }
 
-                // Update the selection appropriately
                 if (ctrlEnabled && multiClickMapper == 1 &&
                     !(_terminal->GetHyperlinkAtPosition(terminalPosition).empty()))
                 {
                     _HyperlinkHandler(_terminal->GetHyperlinkAtPosition(terminalPosition));
                 }
-                else if (shiftEnabled && mode == ::Terminal::SelectionExpansionMode::Cell && _terminal->IsSelectionActive())
-                {
-                    // Shift+Click: only set expand on the "end" selection point
-                    _terminal->SetSelectionEnd(terminalPosition, mode);
-                    _selectionNeedsToBeCopied = true;
-                }
-                else if (mode == ::Terminal::SelectionExpansionMode::Cell && !shiftEnabled)
-                {
-                    // Single Click: reset the selection and begin a new one
-                    _terminal->ClearSelection();
-                    _singleClickTouchdownPos = cursorPosition;
-                    _selectionNeedsToBeCopied = false; // there's no selection, so there's nothing to update
-                }
                 else
                 {
-                    // Multi-Click Selection: expand both "start" and "end" selection points
-                    _terminal->MultiClickSelection(terminalPosition, mode);
-                    _selectionNeedsToBeCopied = true;
-                }
+                    // Update the selection appropriately
 
-                _lastMouseClickTimestamp = point.Timestamp();
-                _lastMouseClickPos = cursorPosition;
-                _renderer->TriggerSelection();
+                    // Capture the position of the first click when no selection is active
+                    if (mode == ::Terminal::SelectionExpansionMode::Cell && !_terminal->IsSelectionActive())
+                    {
+                        _singleClickTouchdownPos = cursorPosition;
+                        _lastMouseClickPosNoSelection = cursorPosition;
+                    }
+
+                    // We reset the active selection if one of the conditions apply:
+                    // - shift is not held
+                    // - GH#9384: the position is the same as of the first click starting the selection
+                    // (we need to reset selection on double-click or triple-click, so it captures the word  or the line,
+                    // rather than extending the selection)
+                    // - the click is the first click on selection anchor: we need to have a way to cancel selection with mouse,
+                    // even when shift is held (crucial for mouse mode, where all interaction with selection is done when shift is held)
+                    const auto isClickOnAnchor = _terminal->IsSelectionActive() && _terminal->GetSelectionAnchor() == terminalPosition && mode == ::Terminal::SelectionExpansionMode::Cell;
+                    if (_terminal->IsSelectionActive() && (!shiftEnabled || _lastMouseClickPosNoSelection == cursorPosition || isClickOnAnchor))
+                    {
+                        // Reset the selection
+                        _terminal->ClearSelection();
+                        _selectionNeedsToBeCopied = false; // there's no selection, so there's nothing to update
+                    }
+
+                    if (shiftEnabled && !isClickOnAnchor)
+                    {
+                        if (_terminal->IsSelectionActive())
+                        {
+                            // If there is a selection we extend it using the selection mode
+                            // (expand the "end"selection point)
+                            _terminal->SetSelectionEnd(terminalPosition, mode);
+                        }
+                        else
+                        {
+                            // If there is no selection we establish it using the selected mode
+                            // (expand both "start" and "end" selection points)
+                            _terminal->MultiClickSelection(terminalPosition, mode);
+                        }
+                        _selectionNeedsToBeCopied = true;
+                    }
+
+                    _lastMouseClickTimestamp = point.Timestamp();
+                    _lastMouseClickPos = cursorPosition;
+                    _renderer->TriggerSelection();
+                }
             }
             else if (point.Properties().IsRightButtonPressed())
             {

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1348,7 +1348,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                 {
                     _HyperlinkHandler(_terminal->GetHyperlinkAtPosition(terminalPosition));
                 }
-                else if (shiftEnabled && _terminal->IsSelectionActive())
+                else if (shiftEnabled && mode == ::Terminal::SelectionExpansionMode::Cell && _terminal->IsSelectionActive())
                 {
                     // Shift+Click: only set expand on the "end" selection point
                     _terminal->SetSelectionEnd(terminalPosition, mode);

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -261,6 +261,7 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
         unsigned int _multiClickCounter;
         Timestamp _lastMouseClickTimestamp;
         std::optional<winrt::Windows::Foundation::Point> _lastMouseClickPos;
+        std::optional<winrt::Windows::Foundation::Point> _lastMouseClickPosNoSelection;
         std::optional<winrt::Windows::Foundation::Point> _singleClickTouchdownPos;
         // This field tracks whether the selection has changed meaningfully
         // since it was last copied. It's generally used to prevent copyOnSelect


### PR DESCRIPTION
## PR Checklist
* [x] Closes https://github.com/microsoft/terminal/issues/9382
* [x] CLA signed. 
* [ ] Tests added/passed
* [ ] Documentation updated. 
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. 

## Detailed Description of the Pull Request / Additional comments
Currently, if selection is active, all clicks with `shift` pressed extend it, 
i.e., `shift+click`, `shift+double-click`, `shift+triple-click` extend the selection 
from anchor start to the current position.

While we can argue the correctness of this UX in general
(hint the terminals I checked usually do something else),
it is fully broken by #8611, that introduced cell selection on `shift+click`.
Currently, upon `shift+double-click`:
* the first click sets the selection
* the second click simply extends it
So instead of the word we get only partial selection.

To address this I suggest to change the selection logic to:
extend only on a `single-click`.
I.e., `shift+double-click` will select a word rather than
extending an existing selection.

This is how it works in ConEmu.
However MinTTY have even smarter solution 
where `shift+double-click` adds a word to existing selection.