### PR TITLE
[Settings UI] Represent Cursor Height as a slider

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -993,9 +993,9 @@
           "description": "Sets the color of the cursor. Overrides the cursor color from the color scheme. Uses hex color format: \"#rrggbb\"."
         },
         "cursorHeight": {
-          "description": "Sets the percentage height of the cursor starting from the bottom. Only works when cursorShape is set to \"vintage\". Accepts values from 25-100.",
+          "description": "Sets the percentage height of the cursor starting from the bottom. Only works when cursorShape is set to \"vintage\". Accepts values from 1-100.",
           "maximum": 100,
-          "minimum": 25,
+          "minimum": 1,
           "type": ["integer","null"],
           "default": 25
         },

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -318,12 +318,20 @@ the MIT License. See LICENSE in the project root for license information. -->
                                                     ClearSettingValue="{x:Bind State.Profile.ClearCursorHeight}"
                                                     SettingOverrideSource="{x:Bind State.Profile.CursorHeightOverrideSource, Mode=OneWay}"
                                                     Visibility="{x:Bind IsVintageCursor, Mode=OneWay}">
-                                <muxc:NumberBox Value="{x:Bind State.Profile.CursorHeight, Mode=TwoWay}"
-                                                Style="{StaticResource NumberBoxSettingStyle}"
-                                                Minimum="1"
-                                                Maximum="100"
-                                                SmallChange="1"
-                                                LargeChange="10"/>
+                                <Grid Style="{StaticResource CustomSliderControlGridStyle}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Slider x:Name="CursorHeightSlider"
+                                            Grid.Column="0"
+                                            Minimum="1"
+                                            Maximum="100"
+                                            Value="{x:Bind State.Profile.CursorHeight, Mode=TwoWay}"/>
+                                    <TextBlock Grid.Column="1"
+                                               Text="{Binding ElementName=CursorHeightSlider, Path=Value, Mode=OneWay}"
+                                               Style="{StaticResource SliderValueLabelStyle}"/>
+                                </Grid>
                             </local:SettingContainer>
                         </StackPanel>
 

--- a/src/renderer/dx/CustomTextRenderer.cpp
+++ b/src/renderer/dx/CustomTextRenderer.cpp
@@ -310,6 +310,8 @@ try
         // Enforce min/max cursor height
         ULONG ulHeight = std::clamp(options.ulCursorHeightPercent, MinCursorHeightPercent, MaxCursorHeightPercent);
         ulHeight = (glyphSize.height<ULONG>() * ulHeight) / 100;
+        ulHeight = std::max(ulHeight, MinCursorHeightPixels); // No smaller than 1px
+
         rect.top = rect.bottom - ulHeight;
         break;
     }

--- a/src/renderer/dx/CustomTextRenderer.h
+++ b/src/renderer/dx/CustomTextRenderer.h
@@ -55,6 +55,7 @@ namespace Microsoft::Console::Render
         Outline
     };
 
+    constexpr const ULONG MinCursorHeightPixels = 1;
     constexpr const ULONG MinCursorHeightPercent = 1;
     constexpr const ULONG MaxCursorHeightPercent = 100;
 

--- a/src/renderer/dx/CustomTextRenderer.h
+++ b/src/renderer/dx/CustomTextRenderer.h
@@ -55,7 +55,7 @@ namespace Microsoft::Console::Render
         Outline
     };
 
-    constexpr const ULONG MinCursorHeightPercent = 25;
+    constexpr const ULONG MinCursorHeightPercent = 1;
     constexpr const ULONG MaxCursorHeightPercent = 100;
 
     class CustomTextRenderer : public ::Microsoft::WRL::RuntimeClass<::Microsoft::WRL::RuntimeClassFlags<::Microsoft::WRL::ClassicCom | ::Microsoft::WRL::InhibitFtmBase>, IDWriteTextRenderer>


### PR DESCRIPTION
Change the vintage cursor height number box to a slider.

## References
Related:  #9370

## PR Checklist
* [x] Closes #9377
* [x] zadjii-msft edit: Now _this one_ closes #9175
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Schema updated.
* [ ] 

## Detailed Description of the Pull Request / Additional comments

It seems like the cursor height couldn't be lower than 25 percent regardless of the given value, so I've changed the `MinCursorHeightPercent` in CustomTextRenderer header file.

## Validation Steps Performed
Manual validation

![CursorHeightSlider](https://user-images.githubusercontent.com/39456018/110041939-bf076080-7d66-11eb-8d58-ba9a84922803.gif)
