### PR TITLE
 Allow configuring suppressApplicationTitle in new tab/pane/window commands

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -222,6 +222,11 @@
           "$ref": "#/definitions/Color",
           "default": null,
           "description": "If provided, will set the tab's color to the given value"
+        },
+        "suppressApplicationTitle": {
+          "type": "boolean",
+          "default": "false",
+          "description": "When set to true, tabTitle overrides the default title of the tab and any title change messages from the application will be suppressed. When set to false, tabTitle behaves as normal"
         }
       },
       "type": "object"

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -417,6 +417,11 @@ void AppCommandlineArgs::_addNewTerminalArgs(AppCommandlineArgs::NewTerminalSubc
                                                                   _startingTabColor,
                                                                   RS_A(L"CmdTabColorArgDesc"));
 
+    subcommand.suppressApplicationTitleOption = subcommand.subcommand->add_flag(
+        "--suppressApplicationTitle",
+        _suppressApplicationTitle,
+        RS_A(L"CmdSuppressApplicationTitleDesc"));
+
     // Using positionals_at_end allows us to support "wt new-tab -d wsl -d Ubuntu"
     // without CLI11 thinking that we've specified -d twice.
     // There's an alternate construction where we make all subcommands "prefix commands",
@@ -484,6 +489,11 @@ NewTerminalArgs AppCommandlineArgs::_getNewTerminalArgs(AppCommandlineArgs::NewT
         args.TabColor(static_cast<winrt::Windows::UI::Color>(tabColor));
     }
 
+    if (*subcommand.suppressApplicationTitleOption)
+    {
+        args.SuppressApplicationTitle(_suppressApplicationTitle);
+    }
+
     return args;
 }
 
@@ -522,6 +532,7 @@ void AppCommandlineArgs::_resetStateToDefault()
     _startingTitle.clear();
     _startingTabColor.clear();
     _commandline.clear();
+    _suppressApplicationTitle = false;
 
     _splitVertical = false;
     _splitHorizontal = false;

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -418,7 +418,7 @@ void AppCommandlineArgs::_addNewTerminalArgs(AppCommandlineArgs::NewTerminalSubc
                                                                   RS_A(L"CmdTabColorArgDesc"));
 
     subcommand.suppressApplicationTitleOption = subcommand.subcommand->add_flag(
-        "--suppressApplicationTitle",
+        "--suppressApplicationTitle,!--useApplicationTitle",
         _suppressApplicationTitle,
         RS_A(L"CmdSuppressApplicationTitleDesc"));
 

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.h
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.h
@@ -61,6 +61,7 @@ private:
         CLI::Option* startingDirectoryOption;
         CLI::Option* titleOption;
         CLI::Option* tabColorOption;
+        CLI::Option* suppressApplicationTitleOption;
     };
 
     struct NewPaneSubcommand : public NewTerminalSubcommand
@@ -85,6 +86,7 @@ private:
     std::string _startingDirectory;
     std::string _startingTitle;
     std::string _startingTabColor;
+    bool _suppressApplicationTitle{ false };
 
     winrt::Microsoft::Terminal::Settings::Model::FocusDirection _moveFocusDirection{ winrt::Microsoft::Terminal::Settings::Model::FocusDirection::None };
 

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -313,6 +313,10 @@
   <data name="CmdTabColorArgDesc" xml:space="preserve">
     <value>Open the tab with the specified color, in #rrggbb format</value>
   </data>
+  <data name="CmdSuppressApplicationTitleDesc" xml:space="preserve">
+    <value>Open the tab with tabTitle overriding default title and suppressing title change messages from the application</value>
+    <comment>{Locked="\"tabTitle\""}</comment>
+  </data>
   <data name="CmdVersionDesc" xml:space="preserve">
     <value>Display the application version</value>
   </data>

--- a/src/cascadia/TerminalApp/TerminalSettings.cpp
+++ b/src/cascadia/TerminalApp/TerminalSettings.cpp
@@ -104,6 +104,10 @@ namespace winrt::TerminalApp::implementation
             {
                 settings.StartingTabColor(static_cast<uint32_t>(til::color(newTerminalArgs.TabColor().Value())));
             }
+            if (newTerminalArgs.SuppressApplicationTitle())
+            {
+                settings.SuppressApplicationTitle(newTerminalArgs.SuppressApplicationTitle().Value());
+            }
         }
 
         return { profileGuid, settings };

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
@@ -114,6 +114,11 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             ss << fmt::format(L"--tabColor \"{}\" ", tabColor.ToHexString(true));
         }
 
+        if (_SuppressApplicationTitle)
+        {
+            ss << fmt::format(L"--suppressApplicationTitle ");
+        }
+
         if (!_Commandline.empty())
         {
             ss << fmt::format(L"-- \"{}\" ", _Commandline);

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
@@ -67,9 +67,16 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             ss << fmt::format(L"tabColor: {}, ", tabColor.ToHexString(true));
         }
 
-        if (_SuppressApplicationTitle && _SuppressApplicationTitle.Value())
+        if (_SuppressApplicationTitle)
         {
-            ss << fmt::format(L"suppress application title, ");
+            if (_SuppressApplicationTitle.Value())
+            {
+                ss << fmt::format(L"suppress application title, ");
+            }
+            else
+            {
+                ss << fmt::format(L"use application title, ");
+            }
         }
 
         auto s = ss.str();
@@ -116,7 +123,14 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         if (_SuppressApplicationTitle)
         {
-            ss << fmt::format(L"--suppressApplicationTitle ");
+            if (_SuppressApplicationTitle.Value())
+            {
+                ss << fmt::format(L"--suppressApplicationTitle ");
+            }
+            else
+            {
+                ss << fmt::format(L"--useApplicationTitle ");
+            }
         }
 
         if (!_Commandline.empty())

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
@@ -67,6 +67,11 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             ss << fmt::format(L"tabColor: {}, ", tabColor.ToHexString(true));
         }
 
+        if (_SuppressApplicationTitle && _SuppressApplicationTitle.Value())
+        {
+            ss << fmt::format(L"suppress application title, ");
+        }
+
         auto s = ss.str();
         if (s.empty())
         {

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -67,6 +67,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         WINRT_PROPERTY(Windows::Foundation::IReference<Windows::UI::Color>, TabColor, nullptr);
         WINRT_PROPERTY(Windows::Foundation::IReference<int32_t>, ProfileIndex, nullptr);
         WINRT_PROPERTY(winrt::hstring, Profile, L"");
+        WINRT_PROPERTY(Windows::Foundation::IReference<bool>, SuppressApplicationTitle, nullptr);
 
         static constexpr std::string_view CommandlineKey{ "commandline" };
         static constexpr std::string_view StartingDirectoryKey{ "startingDirectory" };
@@ -74,6 +75,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static constexpr std::string_view TabColorKey{ "tabColor" };
         static constexpr std::string_view ProfileIndexKey{ "index" };
         static constexpr std::string_view ProfileKey{ "profile" };
+        static constexpr std::string_view SuppressApplicationTitleKey{ "suppressApplicationTitle" };
 
     public:
         hstring GenerateName() const;
@@ -86,7 +88,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                    other.TabTitle() == _TabTitle &&
                    other.TabColor() == _TabColor &&
                    other.ProfileIndex() == _ProfileIndex &&
-                   other.Profile() == _Profile;
+                   other.Profile() == _Profile &&
+                   other.SuppressApplicationTitle() == _SuppressApplicationTitle;
         };
         static Model::NewTerminalArgs FromJson(const Json::Value& json)
         {
@@ -98,6 +101,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             JsonUtils::GetValueForKey(json, ProfileIndexKey, args->_ProfileIndex);
             JsonUtils::GetValueForKey(json, ProfileKey, args->_Profile);
             JsonUtils::GetValueForKey(json, TabColorKey, args->_TabColor);
+            JsonUtils::GetValueForKey(json, SuppressApplicationTitleKey, args->_SuppressApplicationTitle);
             return *args;
         }
         Model::NewTerminalArgs Copy() const
@@ -109,6 +113,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             copy->_TabColor = _TabColor;
             copy->_ProfileIndex = _ProfileIndex;
             copy->_Profile = _Profile;
+            copy->_SuppressApplicationTitle = _SuppressApplicationTitle;
             return *copy;
         }
     };

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -91,6 +91,8 @@ namespace Microsoft.Terminal.Settings.Model
         // a IReference, so it's nullable
         Windows.Foundation.IReference<Int32> ProfileIndex { get; };
 
+        Windows.Foundation.IReference<Boolean> SuppressApplicationTitle;
+
         Boolean Equals(NewTerminalArgs other);
         String GenerateName();
         String ToCommandline();


### PR DESCRIPTION
## PR Checklist
* [x] Closes https://github.com/microsoft/terminal/issues/9345
* [x] CLA signed. 
* [ ] Tests added/passed
* [ ] Documentation updated - not yet, will be once conceptually approved
* [x] Schema updated.
* [ ] I've discussed this with core contributors already. 

## Detailed Description of the Pull Request / Additional comments
Introduce optional `suppressApplicationTitle` in to `NewTerminalArgs`.
When set (either to true or false) overrides profile configuration.

Introduce `--suppressApplicationTitle` flag to command line arguments.
When provided for sub=command, 
sets the value in the relevant `NewTerminalArgs` to `true`