### PR TITLE
Display correct tooltip when window is maximized

### DIFF
--- a/src/cascadia/TerminalApp/MinMaxCloseControl.cpp
+++ b/src/cascadia/TerminalApp/MinMaxCloseControl.cpp
@@ -10,6 +10,9 @@
 #include "MinMaxCloseControl.h"
 
 #include "MinMaxCloseControl.g.cpp"
+
+#include <LibraryResources.h>
+
 using namespace winrt::Windows::UI::Xaml;
 
 namespace winrt::TerminalApp::implementation
@@ -77,6 +80,7 @@ namespace winrt::TerminalApp::implementation
             MinimizeButton().Height(maximizedHeight);
             MaximizeButton().Height(maximizedHeight);
             CloseButton().Height(maximizedHeight);
+            MaximizeToolTip().Text(RS_(L"WindowRestoreDownButtonToolTip"));
             break;
 
         case WindowVisualState::WindowVisualStateNormal:
@@ -87,6 +91,7 @@ namespace winrt::TerminalApp::implementation
             MinimizeButton().Height(windowedHeight);
             MaximizeButton().Height(windowedHeight);
             CloseButton().Height(windowedHeight);
+            MaximizeToolTip().Text(RS_(L"WindowMaximizeButtonToolTip"));
             break;
         }
     }

--- a/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
+++ b/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
@@ -188,6 +188,13 @@ the MIT License. See LICENSE in the project root for license information. -->
                 <x:String x:Key="CaptionButtonPathWindowMaximized">M 0 2 h 8 v 8 h -8 v -8 M 2 2 v -2 h 8 v 8 h -2</x:String>
             </ResourceDictionary>
         </Button.Resources>
+        <ToolTipService.ToolTip>
+            <ToolTip>
+                <TextBlock>
+                <Run x:Name="MaximizeToolTip"/>
+                </TextBlock>
+            </ToolTip>
+        </ToolTipService.ToolTip>
     </Button>
     <Button Height="{StaticResource CaptionButtonHeightWindowed}" MinWidth="46.0" Width="46.0"
             x:Name="CloseButton"

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -359,9 +359,6 @@
   <data name="WindowMaximizeButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Maximize</value>
   </data>
-  <data name="WindowMaximizeButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Maximize</value>
-  </data>
   <data name="WindowMinimizeButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Minimize</value>
   </data>
@@ -561,5 +558,11 @@
   </data>
   <data name="CommandPalette_MoreOptions.[using:Windows.UI.Xaml.Automation]AutomationProperties.HelpText" xml:space="preserve">
     <value>More options</value>
+  </data>
+  <data name="WindowMaximizeButtonToolTip" xml:space="preserve">
+    <value>Maximize</value>
+  </data>
+  <data name="WindowRestoreDownButtonToolTip" xml:space="preserve">
+    <value>Restore Down</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request
Instead of displaying "Maximize" in the tooltip for the maximize/restore button even when the window is maximized, it now displays "Restore Down".

## References
Fixes #5693

## PR Checklist
* [X] Closes #5693
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [X] Tests added/passed

## Validation Steps Performed
Tested manually.