### PR TITLE
Update C++/WinRT to 2.0.210309.3

### DIFF
--- a/src/cascadia/Remoting/WindowActivatedArgs.h
+++ b/src/cascadia/Remoting/WindowActivatedArgs.h
@@ -28,7 +28,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
     struct WindowActivatedArgs : public WindowActivatedArgsT<WindowActivatedArgs>
     {
         WINRT_PROPERTY(uint64_t, PeasantID, 0);
-        WINRT_PROPERTY(winrt::guid, DesktopID, {});
+        WINRT_PROPERTY(winrt::guid, DesktopID);
         WINRT_PROPERTY(winrt::Windows::Foundation::DateTime, ActivatedTime, {});
         WINRT_PROPERTY(uint64_t, Hwnd, 0);
 

--- a/src/cascadia/Remoting/packages.config
+++ b/src/cascadia/Remoting/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.201017.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
 </packages>

--- a/src/cascadia/ShellExtension/packages.config
+++ b/src/cascadia/ShellExtension/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.201017.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
 </packages>

--- a/src/cascadia/TerminalApp/packages.config
+++ b/src/cascadia/TerminalApp/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Toolkit.Win32.UI.XamlApplication" version="6.1.2" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.5.0-prerelease.201202003" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.201017.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
 </packages>

--- a/src/cascadia/TerminalAzBridge/packages.config
+++ b/src/cascadia/TerminalAzBridge/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.201017.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
 </packages>

--- a/src/cascadia/TerminalConnection/packages.config
+++ b/src/cascadia/TerminalConnection/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.201017.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
   <package id="vcpkg-cpprestsdk" version="2.10.14" targetFramework="native" />
 </packages>

--- a/src/cascadia/TerminalControl/packages.config
+++ b/src/cascadia/TerminalControl/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.201017.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
 </packages>

--- a/src/cascadia/TerminalCore/packages.config
+++ b/src/cascadia/TerminalCore/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.201017.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
 </packages>

--- a/src/cascadia/TerminalSettingsEditor/packages.config
+++ b/src/cascadia/TerminalSettingsEditor/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.UI.Xaml" version="2.5.0-prerelease.201202003" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.201017.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
 </packages>

--- a/src/cascadia/TerminalSettingsModel/packages.config
+++ b/src/cascadia/TerminalSettingsModel/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.201017.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
 </packages>

--- a/src/cascadia/WinRTUtils/packages.config
+++ b/src/cascadia/WinRTUtils/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.201017.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
 </packages>

--- a/src/cascadia/WindowsTerminal/packages.config
+++ b/src/cascadia/WindowsTerminal/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.201017.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
   <package id="Microsoft.Toolkit.Win32.UI.XamlApplication" version="6.1.2" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.5.0-prerelease.201202003" targetFramework="native" />
   <package id="Microsoft.VCRTForwarders.140" version="1.0.4" targetFramework="native" />

--- a/src/cascadia/WindowsTerminalUniversal/packages.config
+++ b/src/cascadia/WindowsTerminalUniversal/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Toolkit.Win32.UI.XamlApplication" version="6.1.2" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.201017.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
 </packages>

--- a/src/cppwinrt.build.post.props
+++ b/src/cppwinrt.build.post.props
@@ -3,13 +3,13 @@
   <Import Project="$(MSBuildThisFileDirectory)common.build.post.props" />
 
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.201017.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.201017.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.201017.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.201017.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.201017.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.201017.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>
 </Project>

--- a/src/cppwinrt.build.pre.props
+++ b/src/cppwinrt.build.pre.props
@@ -8,7 +8,7 @@
 
   <Import Project="..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
 
-  <Import Project="$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.201017.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.201017.1\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.props')" />
 
   <PropertyGroup Label="Globals">
     <!-- 17134 is RS4, 17763 is RS5, 18362 is 19H1 -->


### PR DESCRIPTION
This update shrinks our binaries a little bit.

From a representative build on VS 16.8:

Note   | App     | Control | Connection | TSE     | WT     | Total   | msix (zip) |
--     | --      | --      | --         | --      | --     | --      | --         |
Before | 2610176 | 1006592 | 433152     | 1352192 | 321536 | 5723648 | 8336910    |
After  | 2532352 | 986624  | 431104     | 1312768 | 313344 | 5576192 | 8287648    |
Delta  | 77824   | 19968   | 2048       | 39424   | 8192   | 147456  | 49262      |
%Delta | 2.98%   | 1.98%   | 0.47%      | 2.92%   | 2.55%  | 2.58%   | 0.59%      |