### PR TITLE
Add "strip line breaks" button to multiline paste warning dialog

### DIFF
--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -447,6 +447,9 @@
   <data name="MultiLinePasteDialog.PrimaryButtonText" xml:space="preserve">
     <value>Paste anyway</value>
   </data>
+  <data name="MultiLinePasteDialog.SecondaryButtonText" xml:space="preserve">
+    <value>Strip line breaks</value>
+  </data>
   <data name="MultiLinePasteDialog.Title" xml:space="preserve">
     <value>Warning</value>
   </data>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -448,7 +448,7 @@
     <value>Paste anyway</value>
   </data>
   <data name="MultiLinePasteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>Strip line breaks</value>
+    <value>Paste without line breaks</value>
   </data>
   <data name="MultiLinePasteDialog.Title" xml:space="preserve">
     <value>Warning</value>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -446,9 +446,11 @@
   </data>
   <data name="MultiLinePasteDialog.PrimaryButtonText" xml:space="preserve">
     <value>Paste anyway</value>
+    <comment>Pastes the clipboard text into the terminal with no modifications</comment>
   </data>
   <data name="MultiLinePasteDialog.SecondaryButtonText" xml:space="preserve">
     <value>Paste without line breaks</value>
+    <comment>Replaces all line breaks in the clipboard text with spaces, and then pastes it into the terminal</comment>
   </data>
   <data name="MultiLinePasteDialog.Title" xml:space="preserve">
     <value>Warning</value>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -446,11 +446,11 @@
   </data>
   <data name="MultiLinePasteDialog.PrimaryButtonText" xml:space="preserve">
     <value>Paste anyway</value>
-    <comment>Pastes the clipboard text into the terminal with no modifications</comment>
+    <comment>Label for button that pastes the clipboard text into the terminal with no modifications</comment>
   </data>
   <data name="MultiLinePasteDialog.SecondaryButtonText" xml:space="preserve">
     <value>Paste without line breaks</value>
-    <comment>Replaces all line breaks in the clipboard text with spaces, and then pastes it into the terminal</comment>
+    <comment>Label for button that replaces all line breaks in the clipboard text with spaces, and then pastes it into the terminal</comment>
   </data>
   <data name="MultiLinePasteDialog.Title" xml:space="preserve">
     <value>Warning</value>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2207,7 +2207,7 @@ namespace winrt::TerminalApp::implementation
                 if (warningResult == ContentDialogResult::Secondary)
                 {
                     // strip line breaks before pasting
-                    std::wstring strippedText{text};
+                    std::wstring strippedText{ text };
                     til::replace_needle_in_haystack_inplace(strippedText, L"\r\n", L" ");
                     til::replace_needle_in_haystack_inplace(strippedText, L"\n", L" ");
                     til::replace_needle_in_haystack_inplace(strippedText, L"\r", L" ");

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2204,7 +2204,16 @@ namespace winrt::TerminalApp::implementation
                 // Clear the clipboard text so it doesn't lie around in memory
                 ClipboardText().Text(L"");
 
-                if (warningResult != ContentDialogResult::Primary)
+                if (warningResult == ContentDialogResult::Secondary)
+                {
+                    // strip line breaks before pasting
+                    std::wstring strippedText{text};
+                    til::replace_needle_in_haystack_inplace(strippedText, L"\r\n", L" ");
+                    til::replace_needle_in_haystack_inplace(strippedText, L"\n", L" ");
+                    til::replace_needle_in_haystack_inplace(strippedText, L"\r", L" ");
+                    text = hstring(strippedText);
+                }
+                else if (warningResult != ContentDialogResult::Primary)
                 {
                     // user rejected the paste
                     co_return;


### PR DESCRIPTION
## Summary of the Pull Request
Adds a button to the multiline paste warning dialog that replaces line breaks (`\r\n`, `\r`, and `\n`) in the clipboard text with spaces before pasting.

## PR Checklist
* [x] Closes #9400
* [x] CLA signed.
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments
Sets the `SecondaryButtonText` property on the `MultiLinePasteDialog` via the `Resources.resw` file. Adds a condition in `TerminalPage::_PasteFromClipboardHandler` to check if the secondary button was pressed and to replace line breaks in the text with spaces, if so.

![multiline-paste-dialog with three buttons](https://user-images.githubusercontent.com/651955/110819412-e2d42480-82d9-11eb-9975-7f68426fce35.png)

C++ newbie, feedback welcome.

### Questions for reviewers:
1. Is the new button text (_"Strip line breaks"_) acceptable? Should any of the other text in the dialog be changed?
3. Is the stripping code appropriate? Should we trim the end of the string as well (I'm not sure if there's a preferred trim function)?

## Validation Steps Performed
Manually tested all three buttons with multiline text pastes using `\r\n`, `\r` and `\n` in PowerShell, Command Prompt, and Bash (WSL).