### PR TITLE
Fix selection on multi-click with no shift

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1381,7 +1381,8 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                 }
                 else if (mode != ::Terminal::SelectionExpansionMode::Cell || shiftEnabled)
                 {
-                    // If we are handling a double / triple-click or shift+single clicks we establish selection using the selected mode
+                    // If we are handling a double / triple-click or shift+single click
+                    // we establish selection using the selected mode
                     // (expand both "start" and "end" selection points)
                     _terminal->MultiClickSelection(terminalPosition, mode);
                     _selectionNeedsToBeCopied = true;

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1372,20 +1372,18 @@ namespace winrt::Microsoft::Terminal::TerminalControl::implementation
                     _selectionNeedsToBeCopied = false; // there's no selection, so there's nothing to update
                 }
 
-                if (shiftEnabled)
+                if (shiftEnabled && _terminal->IsSelectionActive())
                 {
-                    if (_terminal->IsSelectionActive())
-                    {
-                        // If there is a selection we extend it using the selection mode
-                        // (expand the "end"selection point)
-                        _terminal->SetSelectionEnd(terminalPosition, mode);
-                    }
-                    else
-                    {
-                        // If there is no selection we establish it using the selected mode
-                        // (expand both "start" and "end" selection points)
-                        _terminal->MultiClickSelection(terminalPosition, mode);
-                    }
+                    // If shift is pressed and there is a selection we extend it using the selection mode
+                    // (expand the "end"selection point)
+                    _terminal->SetSelectionEnd(terminalPosition, mode);
+                    _selectionNeedsToBeCopied = true;
+                }
+                else if (mode != ::Terminal::SelectionExpansionMode::Cell || shiftEnabled)
+                {
+                    // If we are handling a double / triple-click or shift+single clicks we establish selection using the selected mode
+                    // (expand both "start" and "end" selection points)
+                    _terminal->MultiClickSelection(terminalPosition, mode);
                     _selectionNeedsToBeCopied = true;
                 }
 


### PR DESCRIPTION
When working on #9403 I completely forgot that
double-click and triple-click should work even without shift.
Fixed it by allowing multi-selection even if not shift is pressed.

Closes #9453

## Validation Steps Performed
* [x] single click = no selection
* [x] single click and drag = selection starting from first point
* [x] single click in unfocused pane and drag = focus pane, selection starting from first point
* [x] double-click = selects a whole word
* [x] triple-click = selects a whole line
* [x] double-click and drag = selects a whole word, drag selects whole words
* [x] triple-click and drag = selects a whole line, drag selects whole lines
* [x] Shift single-click = defines start point
* [x] second Shift single-click = defines end point
* [x] Shift double-click = selects entire word
* [x] Shift triple-click = selects entire line
* [x] Shift double-click and drag = selects entire word, drag selects whole words
* [x] Mouse mode: Shift single-click = defines start point
* [x] Mouse mode: second Shift single-click = defines end point
* [x] Mouse mode: Shift double-click = selects entire word
* [x] Mouse mode: Shift triple-click = selects entire line
* [x] Mouse mode: Shift double-click and drag = selects entire word, drag selects whole words
