### PR TITLE
doc: add PowerShell install instructions added

### DIFF
--- a/.github/actions/spelling/dictionary/microsoft.txt
+++ b/.github/actions/spelling/dictionary/microsoft.txt
@@ -23,6 +23,7 @@ LKG
 mfcribbon
 microsoft
 microsoftonline
+msixbundle
 muxc
 netcore
 osgvsowi

--- a/README.md
+++ b/README.md
@@ -40,10 +40,13 @@ page](https://github.com/microsoft/terminal/releases).
 Download the `Microsoft.WindowsTerminal_<versionNumber>.msixbundle` file from
 the **Assets** section. To install the app, you can simply double-click on the
 `.msixbundle` file, and the app installer should automatically run. If that
-fails for any reason, you can try the following command at a PowerShell prompt
-instead:
+fails for any reason, you can try the following command at a PowerShell prompt:
 
 ```powershell
+# NOTE: If you are using PowerShell 7+, please run
+# Import-Module Appx -UseWindowsPowerShell
+# before using Add-AppxPackage.
+
 Add-AppxPackage Microsoft.WindowsTerminal_<versionNumber>.msixbundle
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,19 @@ This is our preferred method.
 
 #### Via GitHub
 
-For users who are unable to install Terminal from the Microsoft Store, Terminal
-builds can be manually downloaded from this repository's [Releases
+For users who are unable to install Windows Terminal from the Microsoft Store,
+released builds can be manually downloaded from this repository's [Releases
 page](https://github.com/microsoft/terminal/releases).
+
+Download the `Microsoft.WindowsTerminal_<versionNumber>.msixbundle` file from
+the **Assets** section. To install the app, you can simply double-click on the
+`.msixbundle` file, and the app installer should automatically run. If that
+fails for any reason, you can try the following command at a PowerShell prompt
+instead:
+
+```powershell
+Add-AppxPackage Microsoft.WindowsTerminal_<versionNumber>.msixbundle
+```
 
 > 🔴 Note: If you install Terminal manually:
 >


### PR DESCRIPTION
Updated README.md to add instructions for installing via the command
line. This is useful when the Microsoft Store is not available which is
the case in Windows Sandbox.

This completes what was started in #6942
Closes #9467