### PR TITLE
Allow overriding tab switcher mode on command level

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -602,6 +602,58 @@
         }
       ]
     },
+    "PrevTabAction": {
+      "description": "Arguments corresponding to a Previous Tab Action",
+      "allOf": [
+        { "$ref": "#/definitions/ShortcutAction" },
+        {
+          "properties": {
+            "action": { "type":"string", "pattern": "prevTab" },
+            "tabSwitcherMode": {
+              "oneOf": [
+                { "type": "null" },
+                {
+                  "enum": [
+                    "mru",
+                    "inOrder",
+                    "disabled"
+                  ],
+                  "type": "string"
+                }
+              ],
+              "default": null,
+              "description": "Got to the previous tab using \"tabSwitcherMode\". If no mode is provided, use the one globally defined one."
+            }
+          }
+        }
+      ]
+    },
+    "NextTabAction": {
+      "description": "Arguments corresponding to a Next Tab Action",
+      "allOf": [
+        { "$ref": "#/definitions/ShortcutAction" },
+        {
+          "properties": {
+            "action": { "type":"string", "pattern": "nextTab" },
+            "tabSwitcherMode": {
+              "oneOf": [
+                { "type": "null" },
+                {
+                  "enum": [
+                    "mru",
+                    "inOrder",
+                    "disabled"
+                  ],
+                  "type": "string"
+                }
+              ],
+              "default": null,
+              "description": "Got to the next tab using \"tabSwitcherMode\". If no mode is provided, use the one globally defined one."
+            }
+          }
+        }
+      ]
+    },
     "Keybinding": {
       "additionalProperties": false,
       "properties": {
@@ -628,6 +680,8 @@
               { "$ref": "#/definitions/MoveTabAction" },
               { "$ref": "#/definitions/FindMatchAction" },
               { "$ref": "#/definitions/NewWindowAction" },
+              { "$ref": "#/definitions/NextTabAction" },
+              { "$ref": "#/definitions/PrevTabAction" },
               { "type": "null" }
             ]
         },

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -622,7 +622,7 @@
                 }
               ],
               "default": null,
-              "description": "Got to the previous tab using \"tabSwitcherMode\". If no mode is provided, use the one globally defined one."
+              "description": "Move to the previous tab using \"tabSwitcherMode\". If no mode is provided, use the one globally defined one."
             }
           }
         }
@@ -648,7 +648,7 @@
                 }
               ],
               "default": null,
-              "description": "Got to the next tab using \"tabSwitcherMode\". If no mode is provided, use the one globally defined one."
+              "description": "Move to the next tab using \"tabSwitcherMode\". If no mode is provided, use the one globally defined one."
             }
           }
         }

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -231,6 +231,19 @@
       },
       "type": "object"
     },
+    "SwitchToAdjacentTabArgs" : {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "enum": [
+            "mru",
+            "inOrder",
+            "disabled"
+          ],
+          "type": "string"
+        }
+      ]
+    },
     "ShortcutAction": {
       "properties": {
         "action": {
@@ -610,17 +623,7 @@
           "properties": {
             "action": { "type":"string", "pattern": "prevTab" },
             "tabSwitcherMode": {
-              "oneOf": [
-                { "type": "null" },
-                {
-                  "enum": [
-                    "mru",
-                    "inOrder",
-                    "disabled"
-                  ],
-                  "type": "string"
-                }
-              ],
+              "$ref": "#/definitions/SwitchToAdjacentTabArgs",
               "default": null,
               "description": "Move to the previous tab using \"tabSwitcherMode\". If no mode is provided, use the one globally defined one."
             }
@@ -636,17 +639,7 @@
           "properties": {
             "action": { "type":"string", "pattern": "nextTab" },
             "tabSwitcherMode": {
-              "oneOf": [
-                { "type": "null" },
-                {
-                  "enum": [
-                    "mru",
-                    "inOrder",
-                    "disabled"
-                  ],
-                  "type": "string"
-                }
-              ],
+              "$ref": "#/definitions/SwitchToAdjacentTabArgs",
               "default": null,
               "description": "Move to the next tab using \"tabSwitcherMode\". If no mode is provided, use the one globally defined one."
             }

--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -782,8 +782,7 @@ namespace TerminalAppLocalTests
 
         Log::Comment(L"Switch to the next MRU tab, which is the fourth tab");
         TestOnUIThread([&page]() {
-            ActionEventArgs eventArgs{};
-            page->_HandleNextTab(nullptr, eventArgs);
+            page->_SelectNextTab(true, nullptr);
         });
 
         Log::Comment(L"Sleep to let events propagate");
@@ -804,8 +803,7 @@ namespace TerminalAppLocalTests
 
         Log::Comment(L"Switch to the next MRU tab, which is the second tab");
         TestOnUIThread([&page]() {
-            ActionEventArgs eventArgs{};
-            page->_HandleNextTab(nullptr, eventArgs);
+            page->_SelectNextTab(true, nullptr);
         });
 
         Log::Comment(L"Sleep to let events propagate");
@@ -829,8 +827,7 @@ namespace TerminalAppLocalTests
 
         Log::Comment(L"Switch to the next in-order tab, which is the third tab");
         TestOnUIThread([&page]() {
-            ActionEventArgs eventArgs{};
-            page->_HandleNextTab(nullptr, eventArgs);
+            page->_SelectNextTab(true, nullptr);
         });
         TestOnUIThread([&page]() {
             uint32_t focusedIndex = page->_GetFocusedTabIndex().value_or(-1);
@@ -842,8 +839,7 @@ namespace TerminalAppLocalTests
 
         Log::Comment(L"Switch to the next in-order tab, which is the fourth tab");
         TestOnUIThread([&page]() {
-            ActionEventArgs eventArgs{};
-            page->_HandleNextTab(nullptr, eventArgs);
+            page->_SelectNextTab(true, nullptr);
         });
         TestOnUIThread([&page]() {
             uint32_t focusedIndex = page->_GetFocusedTabIndex().value_or(-1);
@@ -916,7 +912,7 @@ namespace TerminalAppLocalTests
 
         Log::Comment(L"Switch to the next MRU tab, which is the third tab");
         RunOnUIThread([&page]() {
-            page->_SelectNextTab(true);
+            page->_SelectNextTab(true, nullptr);
             // In the course of a single tick, the Command Palette will:
             // * open
             // * select the proper tab from the mru's list

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -89,7 +89,7 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_HandleNextTab(const IInspectable& /*sender*/,
                                       const ActionEventArgs& args)
     {
-        const auto& realArgs = args.ActionArgs().try_as<SwitchToAdjacentTabArgs>();
+        const auto& realArgs = args.ActionArgs().try_as<NextTabArgs>();
         if (realArgs)
         {
             _SelectNextTab(true, realArgs.SwitcherMode());
@@ -100,7 +100,7 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_HandlePrevTab(const IInspectable& /*sender*/,
                                       const ActionEventArgs& args)
     {
-        const auto& realArgs = args.ActionArgs().try_as<SwitchToAdjacentTabArgs>();
+        const auto& realArgs = args.ActionArgs().try_as<PrevTabArgs>();
         if (realArgs)
         {
             _SelectNextTab(false, realArgs.SwitcherMode());

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -89,7 +89,7 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_HandleNextTab(const IInspectable& /*sender*/,
                                       const ActionEventArgs& args)
     {
-        const auto& realArgs = args.ActionArgs().try_as<SwithchToAdjacentTabArgs>();
+        const auto& realArgs = args.ActionArgs().try_as<SwitchToAdjacentTabArgs>();
         if (realArgs)
         {
             _SelectNextTab(true, realArgs.SwitcherMode());
@@ -100,7 +100,7 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_HandlePrevTab(const IInspectable& /*sender*/,
                                       const ActionEventArgs& args)
     {
-        const auto& realArgs = args.ActionArgs().try_as<SwithchToAdjacentTabArgs>();
+        const auto& realArgs = args.ActionArgs().try_as<SwitchToAdjacentTabArgs>();
         if (realArgs)
         {
             _SelectNextTab(false, realArgs.SwitcherMode());

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -89,15 +89,23 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_HandleNextTab(const IInspectable& /*sender*/,
                                       const ActionEventArgs& args)
     {
-        _SelectNextTab(true);
-        args.Handled(true);
+        const auto& realArgs = args.ActionArgs().try_as<SwithchToAdjacentTabArgs>();
+        if (realArgs)
+        {
+            _SelectNextTab(true, realArgs.SwitcherMode());
+            args.Handled(true);
+        }
     }
 
     void TerminalPage::_HandlePrevTab(const IInspectable& /*sender*/,
                                       const ActionEventArgs& args)
     {
-        _SelectNextTab(false);
-        args.Handled(true);
+        const auto& realArgs = args.ActionArgs().try_as<SwithchToAdjacentTabArgs>();
+        if (realArgs)
+        {
+            _SelectNextTab(false, realArgs.SwitcherMode());
+            args.Handled(true);
+        }
     }
 
     void TerminalPage::_HandleSendInput(const IInspectable& /*sender*/,

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1527,10 +1527,10 @@ namespace winrt::TerminalApp::implementation
 
     // Method Description:
     // - Sets focus to the tab to the right or left the currently selected tab.
-    void TerminalPage::_SelectNextTab(const bool bMoveRight)
+    void TerminalPage::_SelectNextTab(const bool bMoveRight, const Windows::Foundation::IReference<Microsoft::Terminal::Settings::Model::TabSwitcherMode>& customTabSwitcherMode)
     {
         const auto index{ _GetFocusedTabIndex().value_or(0) };
-        const auto tabSwitchMode = _settings.GlobalSettings().TabSwitcherMode();
+        const auto tabSwitchMode = customTabSwitcherMode ? customTabSwitcherMode.Value() : _settings.GlobalSettings().TabSwitcherMode();
         if (tabSwitchMode == TabSwitcherMode::Disabled)
         {
             uint32_t tabCount = _tabs.Size();

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -186,7 +186,7 @@ namespace winrt::TerminalApp::implementation
 
         void _RegisterTerminalEvents(Microsoft::Terminal::TerminalControl::TermControl term, TerminalTab& hostingTab);
 
-        void _SelectNextTab(const bool bMoveRight);
+        void _SelectNextTab(const bool bMoveRight, const Windows::Foundation::IReference<Microsoft::Terminal::Settings::Model::TabSwitcherMode>& customTabSwitcherMode);
         bool _SelectTab(const uint32_t tabIndex);
         void _MoveFocus(const Microsoft::Terminal::Settings::Model::FocusDirection& direction);
 

--- a/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
@@ -151,6 +151,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         { ShortcutAction::ToggleCommandPalette, ToggleCommandPaletteArgs::FromJson },
         { ShortcutAction::FindMatch, FindMatchArgs::FromJson },
         { ShortcutAction::NewWindow, NewWindowArgs::FromJson },
+        { ShortcutAction::PrevTab, PrevTabArgs::FromJson },
+        { ShortcutAction::NextTab, NextTabArgs::FromJson },
 
         { ShortcutAction::Invalid, nullptr },
     };

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
@@ -26,7 +26,6 @@
 #include "FindMatchArgs.g.cpp"
 #include "ToggleCommandPaletteArgs.g.cpp"
 #include "NewWindowArgs.g.cpp"
-#include "SwitchToAdjacentTabArgs.g.cpp"
 #include "PrevTabArgs.g.cpp"
 #include "NextTabArgs.g.cpp"
 
@@ -538,34 +537,25 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         };
     }
 
-    winrt::hstring SwitchToAdjacentTabArgs::GenerateName() const
-    {
-        if (_SwitcherMode && _SwitcherMode.Value() == TabSwitcherMode::MostRecentlyUsed)
-        {
-            return L"most recently used";
-        }
-        return L"in order";
-    }
-
     winrt::hstring PrevTabArgs::GenerateName() const
     {
-        const auto switchToAdjacentTabStr = SwitchToAdjacentTabArgs::GenerateName();
-        if (switchToAdjacentTabStr.empty())
+        if (!_SwitcherMode)
         {
             return RS_(L"PrevTabCommandKey");
         }
 
-        return winrt::hstring(fmt::format(L"{}, {}", RS_(L"PrevTabCommandKey"), switchToAdjacentTabStr));
+        const auto mode = _SwitcherMode.Value() == TabSwitcherMode::MostRecentlyUsed ? L"most recently used" : L"in order";
+        return winrt::hstring(fmt::format(L"{}, {}", RS_(L"PrevTabCommandKey"), mode));
     }
 
     winrt::hstring NextTabArgs::GenerateName() const
     {
-        const auto switchToAdjacentTabStr = SwitchToAdjacentTabArgs::GenerateName();
-        if (switchToAdjacentTabStr.empty())
+        if (!_SwitcherMode)
         {
             return RS_(L"NextTabCommandKey");
         }
 
-        return winrt::hstring(fmt::format(L"{}, {}", RS_(L"NextTabCommandKey"), switchToAdjacentTabStr));
+        const auto mode = _SwitcherMode.Value() == TabSwitcherMode::MostRecentlyUsed ? L"most recently used" : L"in order";
+        return winrt::hstring(fmt::format(L"{}, {}", RS_(L"NextTabCommandKey"), mode));
     }
 }

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
@@ -26,6 +26,9 @@
 #include "FindMatchArgs.g.cpp"
 #include "ToggleCommandPaletteArgs.g.cpp"
 #include "NewWindowArgs.g.cpp"
+#include "SwithchToAdjacentTabArgs.g.cpp"
+#include "PrevTabArgs.g.cpp"
+#include "NextTabArgs.g.cpp"
 
 #include <LibraryResources.h>
 
@@ -533,5 +536,36 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         return winrt::hstring{
             fmt::format(L"{}, {}", RS_(L"NewWindowCommandKey"), newTerminalArgsStr)
         };
+    }
+
+    winrt::hstring SwithchToAdjacentTabArgs::GenerateName() const
+    {
+        if (_SwitcherMode && _SwitcherMode.Value() == TabSwitcherMode::MostRecentlyUsed)
+        {
+            return L"most recently used";
+        }
+        return L"in order";
+    }
+
+    winrt::hstring PrevTabArgs::GenerateName() const
+    {
+        const auto swithchToAdjacentTabStr = SwithchToAdjacentTabArgs::GenerateName();
+        if (swithchToAdjacentTabStr.empty())
+        {
+            return RS_(L"PrevTabCommandKey");
+        }
+
+        return winrt::hstring(fmt::format(L"{}, {}", RS_(L"PrevTabCommandKey"), swithchToAdjacentTabStr));
+    }
+
+    winrt::hstring NextTabArgs::GenerateName() const
+    {
+        const auto swithchToAdjacentTabStr = SwithchToAdjacentTabArgs::GenerateName();
+        if (swithchToAdjacentTabStr.empty())
+        {
+            return RS_(L"NextTabCommandKey");
+        }
+
+        return winrt::hstring(fmt::format(L"{}, {}", RS_(L"NextTabCommandKey"), swithchToAdjacentTabStr));
     }
 }

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
@@ -26,7 +26,7 @@
 #include "FindMatchArgs.g.cpp"
 #include "ToggleCommandPaletteArgs.g.cpp"
 #include "NewWindowArgs.g.cpp"
-#include "SwithchToAdjacentTabArgs.g.cpp"
+#include "SwitchToAdjacentTabArgs.g.cpp"
 #include "PrevTabArgs.g.cpp"
 #include "NextTabArgs.g.cpp"
 
@@ -538,7 +538,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         };
     }
 
-    winrt::hstring SwithchToAdjacentTabArgs::GenerateName() const
+    winrt::hstring SwitchToAdjacentTabArgs::GenerateName() const
     {
         if (_SwitcherMode && _SwitcherMode.Value() == TabSwitcherMode::MostRecentlyUsed)
         {
@@ -549,23 +549,23 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
     winrt::hstring PrevTabArgs::GenerateName() const
     {
-        const auto swithchToAdjacentTabStr = SwithchToAdjacentTabArgs::GenerateName();
-        if (swithchToAdjacentTabStr.empty())
+        const auto switchToAdjacentTabStr = SwitchToAdjacentTabArgs::GenerateName();
+        if (switchToAdjacentTabStr.empty())
         {
             return RS_(L"PrevTabCommandKey");
         }
 
-        return winrt::hstring(fmt::format(L"{}, {}", RS_(L"PrevTabCommandKey"), swithchToAdjacentTabStr));
+        return winrt::hstring(fmt::format(L"{}, {}", RS_(L"PrevTabCommandKey"), switchToAdjacentTabStr));
     }
 
     winrt::hstring NextTabArgs::GenerateName() const
     {
-        const auto swithchToAdjacentTabStr = SwithchToAdjacentTabArgs::GenerateName();
-        if (swithchToAdjacentTabStr.empty())
+        const auto switchToAdjacentTabStr = SwitchToAdjacentTabArgs::GenerateName();
+        if (switchToAdjacentTabStr.empty())
         {
             return RS_(L"NextTabCommandKey");
         }
 
-        return winrt::hstring(fmt::format(L"{}, {}", RS_(L"NextTabCommandKey"), swithchToAdjacentTabStr));
+        return winrt::hstring(fmt::format(L"{}, {}", RS_(L"NextTabCommandKey"), switchToAdjacentTabStr));
     }
 }

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -28,6 +28,9 @@
 #include "ToggleCommandPaletteArgs.g.h"
 #include "FindMatchArgs.g.h"
 #include "NewWindowArgs.g.h"
+#include "SwithchToAdjacentTabArgs.g.h"
+#include "PrevTabArgs.g.h"
+#include "NextTabArgs.g.h"
 
 #include "../../cascadia/inc/cppwinrt_utils.h"
 #include "JsonUtils.h"
@@ -924,6 +927,50 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         }
     };
 
+    struct SwithchToAdjacentTabArgs : public SwithchToAdjacentTabArgsT<SwithchToAdjacentTabArgs>
+    {
+        SwithchToAdjacentTabArgs() = default;
+        WINRT_PROPERTY(Windows::Foundation::IReference<TabSwitcherMode>, SwitcherMode, nullptr);
+        static constexpr std::string_view SwitcherModeKey{ "tabSwitcherMode" };
+
+    public:
+        hstring GenerateName() const;
+
+        bool Equals(const IActionArgs& other)
+        {
+            auto otherAsUs = other.try_as<SwithchToAdjacentTabArgs>();
+            if (otherAsUs)
+            {
+                return otherAsUs->_SwitcherMode == _SwitcherMode;
+            }
+            return false;
+        };
+        static FromJsonResult FromJson(const Json::Value& json)
+        {
+            // LOAD BEARING: Not using make_self here _will_ break you in the future!
+            auto args = winrt::make_self<SwithchToAdjacentTabArgs>();
+            JsonUtils::GetValueForKey(json, SwitcherModeKey, args->_SwitcherMode);
+            return { *args, {} };
+        }
+        IActionArgs Copy() const
+        {
+            auto copy{ winrt::make_self<SwithchToAdjacentTabArgs>() };
+            copy->_SwitcherMode = _SwitcherMode;
+            return *copy;
+        }
+    };
+
+    struct PrevTabArgs : public PrevTabArgsT<PrevTabArgs, SwithchToAdjacentTabArgs>
+    {
+    public:
+        hstring GenerateName() const;
+    };
+
+    struct NextTabArgs : public NextTabArgsT<NextTabArgs, SwithchToAdjacentTabArgs>
+    {
+    public:
+        hstring GenerateName() const;
+    };
 }
 
 namespace winrt::Microsoft::Terminal::Settings::Model::factory_implementation

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -28,7 +28,6 @@
 #include "ToggleCommandPaletteArgs.g.h"
 #include "FindMatchArgs.g.h"
 #include "NewWindowArgs.g.h"
-#include "SwitchToAdjacentTabArgs.g.h"
 #include "PrevTabArgs.g.h"
 #include "NextTabArgs.g.h"
 
@@ -927,9 +926,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         }
     };
 
-    struct SwitchToAdjacentTabArgs : public SwitchToAdjacentTabArgsT<SwitchToAdjacentTabArgs>
+    struct PrevTabArgs : public PrevTabArgsT<PrevTabArgs>
     {
-        SwitchToAdjacentTabArgs() = default;
+        PrevTabArgs() = default;
         WINRT_PROPERTY(Windows::Foundation::IReference<TabSwitcherMode>, SwitcherMode, nullptr);
         static constexpr std::string_view SwitcherModeKey{ "tabSwitcherMode" };
 
@@ -938,7 +937,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         bool Equals(const IActionArgs& other)
         {
-            auto otherAsUs = other.try_as<SwitchToAdjacentTabArgs>();
+            auto otherAsUs = other.try_as<PrevTabArgs>();
             if (otherAsUs)
             {
                 return otherAsUs->_SwitcherMode == _SwitcherMode;
@@ -948,28 +947,49 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static FromJsonResult FromJson(const Json::Value& json)
         {
             // LOAD BEARING: Not using make_self here _will_ break you in the future!
-            auto args = winrt::make_self<SwitchToAdjacentTabArgs>();
+            auto args = winrt::make_self<PrevTabArgs>();
             JsonUtils::GetValueForKey(json, SwitcherModeKey, args->_SwitcherMode);
             return { *args, {} };
         }
         IActionArgs Copy() const
         {
-            auto copy{ winrt::make_self<SwitchToAdjacentTabArgs>() };
+            auto copy{ winrt::make_self<PrevTabArgs>() };
             copy->_SwitcherMode = _SwitcherMode;
             return *copy;
         }
     };
 
-    struct PrevTabArgs : public PrevTabArgsT<PrevTabArgs, SwitchToAdjacentTabArgs>
+    struct NextTabArgs : public NextTabArgsT<NextTabArgs>
     {
-    public:
-        hstring GenerateName() const;
-    };
+        NextTabArgs() = default;
+        WINRT_PROPERTY(Windows::Foundation::IReference<TabSwitcherMode>, SwitcherMode, nullptr);
+        static constexpr std::string_view SwitcherModeKey{ "tabSwitcherMode" };
 
-    struct NextTabArgs : public NextTabArgsT<NextTabArgs, SwitchToAdjacentTabArgs>
-    {
     public:
         hstring GenerateName() const;
+
+        bool Equals(const IActionArgs& other)
+        {
+            auto otherAsUs = other.try_as<NextTabArgs>();
+            if (otherAsUs)
+            {
+                return otherAsUs->_SwitcherMode == _SwitcherMode;
+            }
+            return false;
+        };
+        static FromJsonResult FromJson(const Json::Value& json)
+        {
+            // LOAD BEARING: Not using make_self here _will_ break you in the future!
+            auto args = winrt::make_self<NextTabArgs>();
+            JsonUtils::GetValueForKey(json, SwitcherModeKey, args->_SwitcherMode);
+            return { *args, {} };
+        }
+        IActionArgs Copy() const
+        {
+            auto copy{ winrt::make_self<NextTabArgs>() };
+            copy->_SwitcherMode = _SwitcherMode;
+            return *copy;
+        }
     };
 }
 

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -28,7 +28,7 @@
 #include "ToggleCommandPaletteArgs.g.h"
 #include "FindMatchArgs.g.h"
 #include "NewWindowArgs.g.h"
-#include "SwithchToAdjacentTabArgs.g.h"
+#include "SwitchToAdjacentTabArgs.g.h"
 #include "PrevTabArgs.g.h"
 #include "NextTabArgs.g.h"
 
@@ -927,9 +927,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         }
     };
 
-    struct SwithchToAdjacentTabArgs : public SwithchToAdjacentTabArgsT<SwithchToAdjacentTabArgs>
+    struct SwitchToAdjacentTabArgs : public SwitchToAdjacentTabArgsT<SwitchToAdjacentTabArgs>
     {
-        SwithchToAdjacentTabArgs() = default;
+        SwitchToAdjacentTabArgs() = default;
         WINRT_PROPERTY(Windows::Foundation::IReference<TabSwitcherMode>, SwitcherMode, nullptr);
         static constexpr std::string_view SwitcherModeKey{ "tabSwitcherMode" };
 
@@ -938,7 +938,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         bool Equals(const IActionArgs& other)
         {
-            auto otherAsUs = other.try_as<SwithchToAdjacentTabArgs>();
+            auto otherAsUs = other.try_as<SwitchToAdjacentTabArgs>();
             if (otherAsUs)
             {
                 return otherAsUs->_SwitcherMode == _SwitcherMode;
@@ -948,25 +948,25 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static FromJsonResult FromJson(const Json::Value& json)
         {
             // LOAD BEARING: Not using make_self here _will_ break you in the future!
-            auto args = winrt::make_self<SwithchToAdjacentTabArgs>();
+            auto args = winrt::make_self<SwitchToAdjacentTabArgs>();
             JsonUtils::GetValueForKey(json, SwitcherModeKey, args->_SwitcherMode);
             return { *args, {} };
         }
         IActionArgs Copy() const
         {
-            auto copy{ winrt::make_self<SwithchToAdjacentTabArgs>() };
+            auto copy{ winrt::make_self<SwitchToAdjacentTabArgs>() };
             copy->_SwitcherMode = _SwitcherMode;
             return *copy;
         }
     };
 
-    struct PrevTabArgs : public PrevTabArgsT<PrevTabArgs, SwithchToAdjacentTabArgs>
+    struct PrevTabArgs : public PrevTabArgsT<PrevTabArgs, SwitchToAdjacentTabArgs>
     {
     public:
         hstring GenerateName() const;
     };
 
-    struct NextTabArgs : public NextTabArgsT<NextTabArgs, SwithchToAdjacentTabArgs>
+    struct NextTabArgs : public NextTabArgsT<NextTabArgs, SwitchToAdjacentTabArgs>
     {
     public:
         hstring GenerateName() const;

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -77,6 +77,13 @@ namespace Microsoft.Terminal.Settings.Model
         CommandLine
     };
 
+    enum TabSwitcherMode
+    {
+        MostRecentlyUsed,
+        InOrder,
+        Disabled,
+    };
+
     [default_interface] runtimeclass NewTerminalArgs {
         NewTerminalArgs();
         NewTerminalArgs(Int32 profileIndex);
@@ -225,5 +232,18 @@ namespace Microsoft.Terminal.Settings.Model
     {
         NewWindowArgs(NewTerminalArgs terminalArgs);
         NewTerminalArgs TerminalArgs { get; };
+    };
+
+    unsealed runtimeclass SwithchToAdjacentTabArgs : IActionArgs
+    {
+        Windows.Foundation.IReference<TabSwitcherMode> SwitcherMode;
+    };
+
+    [default_interface] runtimeclass PrevTabArgs : SwithchToAdjacentTabArgs
+    {
+    };
+
+    [default_interface] runtimeclass NextTabArgs : SwithchToAdjacentTabArgs
+    {
     };
 }

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -234,16 +234,16 @@ namespace Microsoft.Terminal.Settings.Model
         NewTerminalArgs TerminalArgs { get; };
     };
 
-    unsealed runtimeclass SwithchToAdjacentTabArgs : IActionArgs
+    unsealed runtimeclass SwitchToAdjacentTabArgs : IActionArgs
     {
         Windows.Foundation.IReference<TabSwitcherMode> SwitcherMode;
     };
 
-    [default_interface] runtimeclass PrevTabArgs : SwithchToAdjacentTabArgs
+    [default_interface] runtimeclass PrevTabArgs : SwitchToAdjacentTabArgs
     {
     };
 
-    [default_interface] runtimeclass NextTabArgs : SwithchToAdjacentTabArgs
+    [default_interface] runtimeclass NextTabArgs : SwitchToAdjacentTabArgs
     {
     };
 }

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -234,16 +234,13 @@ namespace Microsoft.Terminal.Settings.Model
         NewTerminalArgs TerminalArgs { get; };
     };
 
-    unsealed runtimeclass SwitchToAdjacentTabArgs : IActionArgs
+    [default_interface] runtimeclass PrevTabArgs : IActionArgs
     {
         Windows.Foundation.IReference<TabSwitcherMode> SwitcherMode;
     };
 
-    [default_interface] runtimeclass PrevTabArgs : SwitchToAdjacentTabArgs
+    [default_interface] runtimeclass NextTabArgs : IActionArgs
     {
-    };
-
-    [default_interface] runtimeclass NextTabArgs : SwitchToAdjacentTabArgs
-    {
+        Windows.Foundation.IReference<TabSwitcherMode> SwitcherMode;
     };
 }

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -28,13 +28,6 @@ namespace Microsoft.Terminal.Settings.Model
         MaximizedFocusMode,
     };
 
-    enum TabSwitcherMode
-    {
-        MostRecentlyUsed,
-        InOrder,
-        Disabled,
-    };
-
     enum WindowingMode
     {
         UseNew,


### PR DESCRIPTION
## Summary of the Pull Request

Currently, when the MRU is enabled we lose the keybinding allowing us to 
go forward/backward (aka right/left in LTR) in the tab view.

To fix that, this PR introduces "tabSwitcherMode" optional parameter to 
the prevTab / nextTab commands.
If it is not provided the global setting will be used.


So if you want to go to adjacent tabs, even if MRU is enabled on the
system level you can use:
```
{ "command": { "action": "prevTab", "tabSwitcherMode": "inOrder" }, "keys": "ctrl+f1"}
{ "command": { "action": "nextTab", "tabSwitcherMode": "inOrder" }, "keys": "ctrl+f2"}
```
or even
```
{"command": { "action": "prevTab", "tabSwitcherMode": "disabled" }, "keys": "ctrl+f1"}
{ "command": { "action": "nextTab", "tabSwitcherMode": "disabled" }, "keys": "ctrl+f2"}
```
if you don't want tab switcher to show up

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes https://github.com/microsoft/terminal/issues/9330
* [x] CLA signed. 
* [x] Tests added/passed
* [ ] Documentation updated - not yet. Waiting for approval.
* [x] Schema updated.
* [ ] I've discussed this with core contributors already. 