### PR TITLE
OpenConsole.psm1: use DevShell module; tidy up for PowerShell 6+

### DIFF
--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -40,11 +40,8 @@ function Import-LocalModule
     } else {
         Write-Verbose "$Name already downloaded"
         $versions = Get-ChildItem "$modules_root\$Name" | Sort-Object
-        if($PSVersionTable.PSEdition -eq "Desktop"){
-            Get-ChildItem -Path "$modules_root\$Name\$($versions[0])\$Name.psd1" | Import-Module
-        }else {
-            Get-ChildItem -Path "$($versions[0])\$Name.psd1" | Import-Module
-        }
+
+        Get-ChildItem -Path "$modules_root\$Name\$($versions[0].name)\$Name.psd1" | Import-Module
     }
 }
 

--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -41,7 +41,7 @@ function Import-LocalModule
         Write-Verbose "$Name already downloaded"
         $versions = Get-ChildItem "$modules_root\$Name" | Sort-Object
 
-        Get-ChildItem -Path "$modules_root\$Name\$($versions[0].name)\$Name.psd1" | Import-Module
+        Get-ChildItem -Path "$($versions[0].FullName)\$Name.psd1" | Import-Module
     }
 }
 

--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -77,16 +77,13 @@ function Set-MsbuildDevEnvironment
         default { throw "Unknown architecture: $switch" }
     }
 
-    $vcvarsall = "$vspath\VC\Auxiliary\Build\vcvarsall.bat"
+    $devshellmodule = "$vspath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+
+    Import-Module -Global -Name $devshellmodule
 
     Write-Verbose 'Setting up environment variables'
-    cmd /c ("`"$vcvarsall`" $arch & set") | ForEach-Object {
-        if ($_ -match '=')
-        {
-            $s = $_.Split("=");
-            Set-Item -force -path "env:\$($s[0])" -value "$($s[1])"
-        }
-    }
+    Enter-VsDevShell -VsInstanceId $vsinfo.InstanceId -SkipAutomaticLocation `
+        -devCmdArguments "-arch=$arch" > $null
 
     Write-Host "Dev environment variables set" -ForegroundColor Green
 }

--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -82,8 +82,10 @@ function Set-MsbuildDevEnvironment
     Import-Module -Global -Name $devshellmodule
 
     Write-Verbose 'Setting up environment variables'
-    Enter-VsDevShell -VsInstanceId $vsinfo.InstanceId -SkipAutomaticLocation `
-        -devCmdArguments "-arch=$arch" > $null
+    Enter-VsDevShell -VsInstallPath $vspath -SkipAutomaticLocation `
+        -devCmdArguments "-arch=$arch" | Out-Null
+        
+    New-Item -Force -path Env:\Platform -Value $arch | Out-Null
 
     Write-Host "Dev environment variables set" -ForegroundColor Green
 }

--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -40,8 +40,11 @@ function Import-LocalModule
     } else {
         Write-Verbose "$Name already downloaded"
         $versions = Get-ChildItem "$modules_root\$Name" | Sort-Object
-
-        Get-ChildItem -Path "$modules_root\$Name\$($versions[0])\$Name.psd1" | Import-Module
+        if($PSVersionTable.PSEdition -eq "Desktop"){
+            Get-ChildItem -Path "$modules_root\$Name\$($versions[0])\$Name.psd1" | Import-Module
+        }else {
+            Get-ChildItem -Path "$($versions[0])\$Name.psd1" | Import-Module
+        }
     }
 }
 

--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -82,7 +82,7 @@ function Set-MsbuildDevEnvironment
     Enter-VsDevShell -VsInstallPath $vspath -SkipAutomaticLocation `
         -devCmdArguments "-arch=$arch" | Out-Null
         
-    New-Item -Force -path Env:\Platform -Value $arch | Out-Null
+    Set-Item -Force -path "Env:\Platform" -Value $arch | Out-Null
 
     Write-Host "Dev environment variables set" -ForegroundColor Green
 }

--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -82,7 +82,7 @@ function Set-MsbuildDevEnvironment
     Enter-VsDevShell -VsInstallPath $vspath -SkipAutomaticLocation `
         -devCmdArguments "-arch=$arch" | Out-Null
         
-    Set-Item -Force -path "Env:\Platform" -Value $arch | Out-Null
+    Set-Item -Force -path "Env:\Platform" -Value $arch
 
     Write-Host "Dev environment variables set" -ForegroundColor Green
 }

--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -74,9 +74,9 @@ function Set-MsbuildDevEnvironment
         default { throw "Unknown architecture: $switch" }
     }
 
-    $devshellmodule = "$vspath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+    $devShellModule = "$vspath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
 
-    Import-Module -Global -Name $devshellmodule
+    Import-Module -Global -Name $devShellModule
 
     Write-Verbose 'Setting up environment variables'
     Enter-VsDevShell -VsInstallPath $vspath -SkipAutomaticLocation `


### PR DESCRIPTION
Saw this while snooping around, the gci command on PowerShell core seems
to store the full path in the variable as oppose to just the leaf.

The other modification is to use the PowerShell module that vs ships to
setup the environment.