### PR TITLE
Teach OpenConsole.psm1 to support multiple terminal checkouts

### DIFF
--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -1,6 +1,17 @@
 
 # The project's root directory.
-Set-Item -force -path "env:OpenConsoleRoot" -value "$PSScriptRoot\.."
+$script:OpenConsoleFallbackRoot="$PSScriptRoot\.."
+
+#.SYNOPSIS
+# Finds the root of the current Terminal checkout.
+function Find-OpenConsoleRoot
+{
+    $root = (git rev-parse --show-toplevel 2>$null)
+    If ($?) {
+        return $root
+    }
+    return $script:OpenConsoleFallbackRoot
+}
 
 #.SYNOPSIS
 # Finds and imports a module that should be local to the project
@@ -16,7 +27,7 @@ function Import-LocalModule
 
     $ErrorActionPreference = 'Stop'
 
-    $modules_root = "$env:OpenConsoleRoot\.PowershellModules"
+    $modules_root = "$(Find-OpenConsoleRoot)\.PowershellModules"
 
     $local = $null -eq (Get-Module -Name $Name)
 
@@ -175,29 +186,31 @@ function Invoke-OpenConsoleTests()
 
     )
 
+    $root = Find-OpenConsoleRoot
+
     if (($AllTests -and $FTOnly) -or ($AllTests -and $Test) -or ($FTOnly -and $Test))
     {
         Write-Host "Invalid combination of flags" -ForegroundColor Red
         return
     }
     $OpenConsolePlatform = $Platform
-    $TestHostAppPath = "$env:OpenConsoleRoot\$OpenConsolePlatform\$Configuration\TestHostApp"
+    $TestHostAppPath = "$root\$OpenConsolePlatform\$Configuration\TestHostApp"
     if ($Platform -eq 'x86')
     {
         $OpenConsolePlatform = 'Win32'
-        $TestHostAppPath = "$env:OpenConsoleRoot\$Configuration\TestHostApp"
+        $TestHostAppPath = "$root\$Configuration\TestHostApp"
     }
     $OpenConsolePath = "$env:OpenConsoleroot\bin\$OpenConsolePlatform\$Configuration\OpenConsole.exe"
-    $TaefExePath = "$env:OpenConsoleRoot\packages\Taef.Redist.Wlk.10.57.200731005-develop\build\Binaries\$Platform\te.exe"
-    $BinDir = "$env:OpenConsoleRoot\bin\$OpenConsolePlatform\$Configuration"
+    $TaefExePath = "$root\packages\Taef.Redist.Wlk.10.57.200731005-develop\build\Binaries\$Platform\te.exe"
+    $BinDir = "$root\bin\$OpenConsolePlatform\$Configuration"
 
-    [xml]$TestConfig = Get-Content "$env:OpenConsoleRoot\tools\tests.xml"
+    [xml]$TestConfig = Get-Content "$root\tools\tests.xml"
 
     # check if WinAppDriver needs to be started
     $WinAppDriverExe = $null
     if ($AllTests -or $FtOnly -or $Test -eq "uia")
     {
-        $WinAppDriverExe = [Diagnostics.Process]::Start("$env:OpenConsoleRoot\dep\WinAppDriver\WinAppDriver.exe")
+        $WinAppDriverExe = [Diagnostics.Process]::Start("$root\dep\WinAppDriver\WinAppDriver.exe")
     }
 
     # select tests to run
@@ -254,8 +267,9 @@ function Invoke-OpenConsoleTests()
 # Builds OpenConsole.sln using msbuild. Any arguments get passed on to msbuild.
 function Invoke-OpenConsoleBuild()
 {
-    & "$env:OpenConsoleRoot\dep\nuget\nuget.exe" restore "$env:OpenConsoleRoot\OpenConsole.sln"
-    msbuild.exe "$env:OpenConsoleRoot\OpenConsole.sln" @args
+    $root = Find-OpenConsoleRoot
+    & "$root\dep\nuget\nuget.exe" restore "$root\OpenConsole.sln"
+    msbuild.exe "$root\OpenConsole.sln" @args
 }
 
 #.SYNOPSIS
@@ -282,7 +296,7 @@ function Start-OpenConsole()
     {
         $Platform = "Win32"
     }
-    & "$env:OpenConsoleRoot\bin\$Platform\$Configuration\OpenConsole.exe"
+    & "$(Find-OpenConsoleRoot)\bin\$Platform\$Configuration\OpenConsole.exe"
 }
 
 #.SYNOPSIS
@@ -309,7 +323,7 @@ function Debug-OpenConsole()
     {
         $Platform = "Win32"
     }
-    $process = [Diagnostics.Process]::Start("$env:OpenConsoleRoot\bin\$Platform\$Configuration\OpenConsole.exe")
+    $process = [Diagnostics.Process]::Start("$(Find-OpenConsoleRoot)\bin\$Platform\$Configuration\OpenConsole.exe")
     Debug-Process -Id $process.Id
 }
 
@@ -353,10 +367,11 @@ function Invoke-ClangFormat {
 #.SYNOPSIS
 # runs code formatting on all c++ files
 function Invoke-CodeFormat() {
-    & "$env:OpenConsoleRoot\dep\nuget\nuget.exe" restore "$env:OpenConsoleRoot\tools\packages.config"
-    $clangPackage = ([xml](Get-Content "$env:OpenConsoleRoot\tools\packages.config")).packages.package | Where-Object id -like "clang-format*"
-    $clangFormatPath = "$env:OpenConsoleRoot\packages\$($clangPackage.id).$($clangPackage.version)\tools\clang-format.exe"
-    Get-ChildItem -Recurse "$env:OpenConsoleRoot/src" -Include *.cpp, *.hpp, *.h |
+    $root = Find-OpenConsoleRoot
+    & "$root\dep\nuget\nuget.exe" restore "$root\tools\packages.config"
+    $clangPackage = ([xml](Get-Content "$root\tools\packages.config")).packages.package | Where-Object id -like "clang-format*"
+    $clangFormatPath = "$root\packages\$($clangPackage.id).$($clangPackage.version)\tools\clang-format.exe"
+    Get-ChildItem -Recurse "$root\src" -Include *.cpp, *.hpp, *.h |
       Where FullName -NotLike "*Generated Files*" |
       Invoke-ClangFormat -ClangFormatPath $clangFormatPath
 }


### PR DESCRIPTION
OpenConsole.psm1 cached its root directory on import, which made it very
difficult to move into another Terminal clone and _do things_ (like code
formatting).

By resolving the root directory again per-cmdlet, we gain the ability
to...

```powershell
cd terminal
import-module ./tools/openconsole.psm1
cd ../terminal-2
invoke-codeformat
```

... and have it format the correct directory (terminal-2) instead of the
incorrect one (terminal).

This does unfortunately break the openconsole cmdlets _inside dep/wil
and dep/gsl_ because they are separate git repositories. This is taken
as an acceptable cost.