### PR TITLE
Remove the shell extension's dependency on fmt for huge savings

### DIFF
--- a/src/cascadia/ShellExtension/OpenTerminalHere.cpp
+++ b/src/cascadia/ShellExtension/OpenTerminalHere.cpp
@@ -56,7 +56,7 @@ HRESULT OpenTerminalHere::Invoke(IShellItemArray* psiItemArray,
         siEx.StartupInfo.cb = sizeof(STARTUPINFOEX);
 
         // Append a "\." to the given path, so that this will work in "C:\"
-        std::wstring cmdline = fmt::format(L"\"{}\" -d \"{}\\.\"", GetWtExePath(), pszName.get());
+        auto cmdline{ wil::str_printf<std::wstring>(LR"-("%s" -d "%s\.")-", GetWtExePath().c_str(), pszName.get()) };
         RETURN_IF_WIN32_BOOL_FALSE(CreateProcessW(
             nullptr,
             cmdline.data(),


### PR DESCRIPTION
Yeah, this one-line change shaves off almost half the binary.

Binary size savings (x64 Release):

Note   | WindowsTerminalShellExt.dll
------ | ---------------------------
Before | 130048
After  | 73728
Delta  | -56320
%Delta | -43.3%