### PR TITLE
Fix read-only tab dialog to cancel tab closing when dismissed

### DIFF
--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -418,10 +418,10 @@
     <value>Do you want to close all tabs?</value>
   </data>
   <data name="CloseReadOnlyDialog.CloseButtonText" xml:space="preserve">
-    <value>Close anyway</value>
+    <value>Cancel</value>
   </data>
   <data name="CloseReadOnlyDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Cancel</value>
+    <value>Close anyway</value>
   </data>
   <data name="CloseReadOnlyDialog.Title" xml:space="preserve">
     <value>Warning</value>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1339,8 +1339,8 @@ namespace winrt::TerminalApp::implementation
         {
             ContentDialogResult warningResult = co_await _ShowCloseReadOnlyDialog();
 
-            // The primary action is canceling the removal
-            if (warningResult == ContentDialogResult::Primary)
+            // If the user didn't explicitly click on close tab - leave
+            if (warningResult != ContentDialogResult::Primary)
             {
                 co_return;
             }
@@ -1736,8 +1736,8 @@ namespace winrt::TerminalApp::implementation
                     {
                         ContentDialogResult warningResult = co_await _ShowCloseReadOnlyDialog();
 
-                        // The primary action is canceling the action
-                        if (warningResult == ContentDialogResult::Primary)
+                        // If the user didn't explicitly click on close tab - leave
+                        if (warningResult != ContentDialogResult::Primary)
                         {
                             co_return;
                         }

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -57,7 +57,7 @@ the MIT License. See LICENSE in the project root for license information. -->
             x:Load="False"
             x:Name="CloseReadOnlyDialog"
             x:Uid="CloseReadOnlyDialog"
-            DefaultButton="Primary">
+            DefaultButton="Close">
         </ContentDialog>
 
         <ContentDialog


### PR DESCRIPTION
Currently dismissing "are you sure you wish to close read-only tab or pane" 
dialog by pressing `ESC` will not abort tab closing
(aka the tab will be closed!)

The reason for this, is that we cancel, only if the "Cancel" is pressed
(aka result=PrimaryButton, while ESC returns result=None).

This PR fixes this, by doing what we usually do:
* Putting Cancel in the CloseButton (which is also triggered by ESC)
* Aborting the action if the result is not a Primary Button

However, since we want Cancel to be a default action,
we set CloseButton to be the DefaultButton  in XAML
