### PR TITLE
Fix rightmost tab corner

### DIFF
--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -35,8 +35,8 @@ the MIT License. See LICENSE in the project root for license information. -->
                     is unfortunately static. -->
                     <SolidColorBrush x:Name="ErrorTextBrush" Color="{ThemeResource SystemErrorTextColor}" />
 
-                    <!-- Suppress all padding except left around the tabs. The TabView looks far better like this. -->
-                    <Thickness x:Key="TabViewHeaderPadding">8,0,0,0</Thickness>
+                    <!-- Suppress top padding -->
+                    <Thickness x:Key="TabViewHeaderPadding">8,0,8,0</Thickness>
 
                     <ResourceDictionary.ThemeDictionaries>
                         <ResourceDictionary x:Key="Dark">


### PR DESCRIPTION
Before and after:
![image](https://user-images.githubusercontent.com/78622729/111928492-710b9000-8abc-11eb-9760-0ecd3eb038fb.png)

The bottom right corner appeared without a radius because of the custom padding.