### PR TITLE
Replace conhost's fmt::format strings with FMT_COMPILEd ones

### DIFF
--- a/src/inc/LibraryIncludes.h
+++ b/src/inc/LibraryIncludes.h
@@ -94,6 +94,7 @@
 
 // {fmt}, a C++20-compatible formatting library
 #include <fmt/format.h>
+#include <fmt/compile.h>
 
 #define USE_INTERVAL_TREE_NAMESPACE
 #include <IntervalTree.h>

--- a/src/renderer/vt/VtSequences.cpp
+++ b/src/renderer/vt/VtSequences.cpp
@@ -472,9 +472,8 @@ using namespace Microsoft::Console::Render;
         // send the auto-assigned ID, prefixed with the PID of this session
         // (we do this so different conpty sessions do not overwrite each other's hyperlinks)
         const auto sessionID = GetCurrentProcessId();
-        const std::string fmt{ "\x1b]8;id={}-{};{}\x1b\\" };
         const std::string uri_str{ til::u16u8(uri) };
-        auto s = fmt::format(fmt, sessionID, numberId, uri_str);
+        auto s = fmt::format(FMT_COMPILE("\x1b]8;id={}-{};{}\x1b\\"), sessionID, numberId, uri_str);
         return _Write(s);
     }
     else
@@ -482,10 +481,9 @@ using namespace Microsoft::Console::Render;
         // This is the case of user-defined IDs:
         // send the user-defined ID, prefixed with a "u"
         // (we do this so no application can accidentally override a user defined ID)
-        const std::string fmt{ "\x1b]8;id=u-{};{}\x1b\\" };
         const std::string uri_str{ til::u16u8(uri) };
         const std::string customId_str{ til::u16u8(customId) };
-        auto s = fmt::format(fmt, customId_str, uri_str);
+        auto s = fmt::format(FMT_COMPILE("\x1b]8;id=u-{};{}\x1b\\"), customId_str, uri_str);
         return _Write(s);
     }
 }

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -784,7 +784,7 @@ std::wstring TerminalInput::_GenerateWin32KeySequence(const KeyEvent& key)
     //      Kd: the value of bKeyDown - either a '0' or '1'. If omitted, defaults to '0'.
     //      Cs: the value of dwControlKeyState - any number. If omitted, defaults to '0'.
     //      Rc: the value of wRepeatCount - any number. If omitted, defaults to '1'.
-    return fmt::format(L"\x1b[{};{};{};{};{};{}_",
+    return fmt::format(FMT_COMPILE(L"\x1b[{};{};{};{};{};{}_"),
                        key.GetVirtualKeyCode(),
                        key.GetVirtualScanCode(),
                        static_cast<int>(key.GetCharData()),


### PR DESCRIPTION
This reduces by 10% the binary size of OpenConsole x64 Release.

Note   | OpenConsole.exe
------ | ---------------------------
Before | 1156096
After  | 1037312
Delta  | -118784
%Delta | -10.27%