### PR TITLE
Sort fonts alphabetically

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Profiles.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.cpp
@@ -153,10 +153,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
 
         // sort and save the lists
-        std::sort(begin(fontList), end(fontList));
+        std::sort(begin(fontList), end(fontList), FontComparator());
         _FontList = single_threaded_observable_vector<Editor::Font>(std::move(fontList));
 
-        std::sort(begin(monospaceFontList), end(monospaceFontList));
+        std::sort(begin(monospaceFontList), end(monospaceFontList), FontComparator());
         _MonospaceFontList = single_threaded_observable_vector<Editor::Font>(std::move(monospaceFontList));
     }
     CATCH_LOG();

--- a/src/cascadia/TerminalSettingsEditor/Profiles.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.h
@@ -13,6 +13,14 @@
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
+    struct FontComparator
+    {
+        bool operator()(const Font& lhs, const Font& rhs) const
+        {
+            return lhs.LocalizedName() < rhs.LocalizedName();
+        }
+    };
+
     struct Font : FontT<Font>
     {
     public:


### PR DESCRIPTION
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #9594 
* [x ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Validated this only by following the issue description and verified fonts appeared to be sorted alphabetically now.

Happy to add automated tests as well but would need some help where to add these since I'm probably overlooking where fonts are covered now.
