### PR TITLE
Change TAEF nuget package to use new Microsoft.Taef name; Update to 10.58 release build version.

### DIFF
--- a/build/Helix/PrepareHelixPayload.ps1
+++ b/build/Helix/PrepareHelixPayload.ps1
@@ -19,8 +19,8 @@ New-Item -ItemType Directory -Force -Path $payloadDir
 
 # Copy files from nuget packages
 Copy-Item "$nugetPackagesDir\microsoft.windows.apps.test.1.0.181203002\lib\netcoreapp2.1\*.dll" $payloadDir
-Copy-Item "$nugetPackagesDir\taef.redist.wlk.10.57.200731005-develop\build\Binaries\$Platform\*" $payloadDir
-Copy-Item "$nugetPackagesDir\taef.redist.wlk.10.57.200731005-develop\build\Binaries\$Platform\CoreClr\*" $payloadDir
+Copy-Item "$nugetPackagesDir\Microsoft.Taef.10.58.210305002\build\Binaries\$Platform\*" $payloadDir
+Copy-Item "$nugetPackagesDir\Microsoft.Taef.10.58.210305002\build\Binaries\$Platform\CoreClr\*" $payloadDir
 New-Item -ItemType Directory -Force -Path "$payloadDir\.NETCoreApp2.1\"
 Copy-Item "$nugetPackagesDir\runtime.win-$Platform.microsoft.netcore.app.2.1.0\runtimes\win-$Platform\lib\netcoreapp2.1\*" "$payloadDir\.NETCoreApp2.1\"
 Copy-Item "$nugetPackagesDir\runtime.win-$Platform.microsoft.netcore.app.2.1.0\runtimes\win-$Platform\native\*" "$payloadDir\.NETCoreApp2.1\"

--- a/build/Helix/packages.config
+++ b/build/Helix/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MUXCustomBuildTasks" version="1.0.48" targetFramework="native" />
-  <package id="TAEF.Redist.Wlk" version="10.57.200731005-develop" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210305002" targetFramework="native" />
   <package id="microsoft.windows.apps.test" version="1.0.181203002" targetFramework="native" />
   <package id="runtime.win-x86.microsoft.netcore.app" version="2.1.0" targetFramework="native" />
   <package id="runtime.win-x64.microsoft.netcore.app" version="2.1.0" targetFramework="native" />

--- a/build/packages.config
+++ b/build/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MUXCustomBuildTasks" version="1.0.48" targetFramework="native" />
-  <package id="TAEF.Redist.Wlk" version="10.57.200731005-develop" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210305002" targetFramework="native" />
 </packages>

--- a/build/pipelines/templates/helix-createprojfile-steps.yml
+++ b/build/pipelines/templates/helix-createprojfile-steps.yml
@@ -12,4 +12,4 @@ steps:
     inputs:
       targetType: filePath
       filePath: build\Helix\GenerateTestProjFile.ps1
-      arguments: -TestFile '${{ parameters.testFilePath }}' -OutputProjFile '$(Build.ArtifactStagingDirectory)\${{ parameters.outputProjFileName }}' -JobTestSuiteName '${{ parameters.testSuite }}' -TaefPath '$(Build.SourcesDirectory)\build\Helix\packages\taef.redist.wlk.10.57.200731005-develop\build\Binaries\x86' -TaefQuery '${{ parameters.taefQuery }}'
+      arguments: -TestFile '${{ parameters.testFilePath }}' -OutputProjFile '$(Build.ArtifactStagingDirectory)\${{ parameters.outputProjFileName }}' -JobTestSuiteName '${{ parameters.testSuite }}' -TaefPath '$(Build.SourcesDirectory)\build\Helix\packages\Microsoft.Taef.10.58.210305002\build\Binaries\x86' -TaefQuery '${{ parameters.taefQuery }}'

--- a/build/pipelines/templates/helix-runtests-job.yml
+++ b/build/pipelines/templates/helix-runtests-job.yml
@@ -36,7 +36,7 @@ jobs:
     matrix: ${{ parameters.matrix }}
   variables:
     artifactsDir: $(Build.SourcesDirectory)\Artifacts
-    taefPath: $(Build.SourcesDirectory)\build\Helix\packages\taef.redist.wlk.10.57.200731005-develop\build\Binaries\$(buildPlatform)
+    taefPath: $(Build.SourcesDirectory)\build\Helix\packages\Microsoft.Taef.10.58.210305002\build\Binaries\$(buildPlatform)
     helixCommonArgs: '/binaryLogger:$(Build.SourcesDirectory)/${{parameters.name}}.$(buildPlatform).$(buildConfiguration).binlog /p:HelixBuild=$(Build.BuildId).$(buildPlatform).$(buildConfiguration) /p:Platform=$(buildPlatform) /p:Configuration=$(buildConfiguration) /p:HelixType=${{parameters.helixType}} /p:TestSuite=${{parameters.testSuite}} /p:ProjFilesPath=$(Build.ArtifactStagingDirectory) /p:rerunPassesRequiredToAvoidFailure=${{parameters.rerunPassesRequiredToAvoidFailure}}'
 
 

--- a/doc/TAEF.md
+++ b/doc/TAEF.md
@@ -12,9 +12,9 @@ Use the [TAEF Verify Macros for C++](https://docs.microsoft.com/en-us/windows-ha
 
 ### Running Tests
 
-If you have Visual Studio and related C++ components installed, and you have successfully restored NuGets, you should have the TAEF test runner `te.exe` available locally as part of the `Taef.Redist.Wlk` package.
+If you have Visual Studio and related C++ components installed, and you have successfully restored NuGets, you should have the TAEF test runner `te.exe` available locally as part of the `Microsoft.Taef` package.
 
-> Note that you cannot easily run TAEF tests directly through Visual Studio. The `Taef.Redist.Wlk` NuGet package comes with an adapter that will let you browse and execute TAEF tests inside of Visual Studio, but its performance and reliability prevent us from recommending it here.
+> Note that you cannot easily run TAEF tests directly through Visual Studio. The `Microsoft.Taef` NuGet package comes with an adapter that will let you browse and execute TAEF tests inside of Visual Studio, but its performance and reliability prevent us from recommending it here.
 
 In a "normal" CMD environment, `te.exe` may not be directly available. Try the following command to set up the development enviroment first:
 

--- a/doc/cascadia/Unittesting-CppWinRT-Xaml.md
+++ b/doc/cascadia/Unittesting-CppWinRT-Xaml.md
@@ -166,7 +166,7 @@ should be working just the same as before.
 Now that you have a static library project, you can start building your unittest
 dll. Start by creating a new directory for your unittest code, and creating a
 `.vcxproj` for a TAEF unittest dll. For the Terminal solution, we use the TAEF
-nuget package `Taef.Redist.Wlk`.
+nuget package `Microsoft.Taef`.
 
 ### Referencing your C++/WinRT static lib
 

--- a/src/cascadia/LocalTests_TerminalApp/TestHostApp/TestHostApp.vcxproj
+++ b/src/cascadia/LocalTests_TerminalApp/TestHostApp/TestHostApp.vcxproj
@@ -117,7 +117,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestExecutor.WinRTCore">
-      <HintPath>$(OpenConsoleDir)\packages\Taef.Redist.Wlk.10.57.200731005-develop\lib\Microsoft.VisualStudio.TestPlatform.TestExecutor.WinRTCore.winmd</HintPath>
+      <HintPath>$(OpenConsoleDir)\packages\Microsoft.Taef.10.58.210305002\lib\Microsoft.VisualStudio.TestPlatform.TestExecutor.WinRTCore.winmd</HintPath>
       <IsWinMDFile>true</IsWinMDFile>
 
       <!-- This path is _relative to the .winmd_ -->

--- a/src/common.build.tests.props
+++ b/src/common.build.tests.props
@@ -5,11 +5,11 @@
       <PreprocessorDefinitions>INLINE_TEST_METHOD_MARKUP;UNIT_TESTING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
-  <Import Project="$(MSBuildThisFileDirectory)..\packages\Taef.Redist.Wlk.10.57.200731005-develop\build\Taef.Redist.Wlk.targets" Condition="Exists('$(MSBuildThisFileDirectory)..\packages\Taef.Redist.Wlk.10.57.200731005-develop\build\Taef.Redist.Wlk.targets')" />
+  <Import Project="$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets" Condition="Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(MSBuildThisFileDirectory)..\packages\Taef.Redist.Wlk.10.57.200731005-develop\build\Taef.Redist.Wlk.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(MSBuildThisFileDirectory)..\packages\Taef.Redist.Wlk.10.57.200731005-develop\build\Taef.Redist.Wlk.targets'))" />
+    <Error Condition="!Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets'))" />
   </Target>
 </Project>

--- a/src/host/ft_uia/Host.Tests.UIA.csproj
+++ b/src/host/ft_uia/Host.Tests.UIA.csproj
@@ -53,10 +53,10 @@
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="TE.Managed, Version=10.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Taef.Redist.Wlk.10.57.200731005-develop\lib\net45\TE.Managed.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Taef.10.58.210305002\lib\net45\TE.Managed.dll</HintPath>
     </Reference>
     <Reference Include="TE.Model.Managed, Version=10.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Taef.Redist.Wlk.10.57.200731005-develop\lib\net45\TE.Model.Managed.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Taef.10.58.210305002\lib\net45\TE.Model.Managed.dll</HintPath>
     </Reference>
     <Reference Include="UIAutomationClient" />
     <Reference Include="UIAutomationTypes" />
@@ -67,10 +67,10 @@
       <HintPath>..\..\..\packages\Selenium.Support.3.5.0\lib\net40\WebDriver.Support.dll</HintPath>
     </Reference>
     <Reference Include="Wex.Common.Managed, Version=10.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Taef.Redist.Wlk.10.57.200731005-develop\lib\net45\Wex.Common.Managed.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Taef.10.58.210305002\lib\net45\Wex.Common.Managed.dll</HintPath>
     </Reference>
     <Reference Include="Wex.Logger.Interop, Version=10.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Taef.Redist.Wlk.10.57.200731005-develop\lib\net45\Wex.Logger.Interop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Taef.10.58.210305002\lib\net45\Wex.Logger.Interop.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>
@@ -145,11 +145,11 @@
   <PropertyGroup>
     <PostBuildEvent>copy $(SolutionDir)\dep\WinAppDriver\* $(OutDir)\</PostBuildEvent>
   </PropertyGroup>
-  <Import Project="..\..\..\packages\Taef.Redist.Wlk.10.57.200731005-develop\build\Taef.Redist.Wlk.targets" Condition="Exists('..\..\..\packages\Taef.Redist.Wlk.10.57.200731005-develop\build\Taef.Redist.Wlk.targets')" />
+  <Import Project="..\..\..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets" Condition="Exists('..\..\..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\Taef.Redist.Wlk.10.57.200731005-develop\build\Taef.Redist.Wlk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Taef.Redist.Wlk.10.57.200731005-develop\build\Taef.Redist.Wlk.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets'))" />
   </Target>
 </Project>

--- a/src/host/ft_uia/packages.config
+++ b/src/host/ft_uia/packages.config
@@ -5,5 +5,5 @@
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
   <package id="Selenium.Support" version="3.5.0" targetFramework="net45" />
   <package id="Selenium.WebDriver" version="3.5.0" targetFramework="net45" />
-  <package id="Taef.Redist.Wlk" version="10.57.200731005-develop" targetFramework="net45" />
+  <package id="Microsoft.Taef" version="10.58.210305002" targetFramework="net45" />
 </packages>

--- a/src/terminal/parser/ut_parser/Parser.UnitTests.vcxproj
+++ b/src/terminal/parser/ut_parser/Parser.UnitTests.vcxproj
@@ -48,11 +48,11 @@
   <!-- Careful reordering these. Some default props (contained in these files) are order sensitive. -->
   <Import Project="$(SolutionDir)src\common.build.post.props" />
   <Import Project="$(SolutionDir)src\common.build.tests.props" />
-  <Import Project="..\..\..\..\packages\Taef.Redist.Wlk.10.57.200731005-develop\build\Taef.Redist.Wlk.targets" Condition="Exists('..\..\..\..\packages\Taef.Redist.Wlk.10.57.200731005-develop\build\Taef.Redist.Wlk.targets')" />
+  <Import Project="..\..\..\..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\Taef.Redist.Wlk.10.57.200731005-develop\build\Taef.Redist.Wlk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Taef.Redist.Wlk.10.57.200731005-develop\build\Taef.Redist.Wlk.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets'))" />
   </Target>
 </Project>

--- a/src/terminal/parser/ut_parser/Parser.UnitTests.vcxproj
+++ b/src/terminal/parser/ut_parser/Parser.UnitTests.vcxproj
@@ -48,11 +48,4 @@
   <!-- Careful reordering these. Some default props (contained in these files) are order sensitive. -->
   <Import Project="$(SolutionDir)src\common.build.post.props" />
   <Import Project="$(SolutionDir)src\common.build.tests.props" />
-  <Import Project="..\..\..\..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets'))" />
-  </Target>
 </Project>

--- a/src/terminal/parser/ut_parser/packages.config
+++ b/src/terminal/parser/ut_parser/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Taef.Redist.Wlk" version="10.57.200731005-develop" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.58.210305002" targetFramework="native" />
 </packages>

--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -200,7 +200,7 @@ function Invoke-OpenConsoleTests()
         $TestHostAppPath = "$root\$Configuration\TestHostApp"
     }
     $OpenConsolePath = "$env:OpenConsoleroot\bin\$OpenConsolePlatform\$Configuration\OpenConsole.exe"
-    $TaefExePath = "$root\packages\Taef.Redist.Wlk.10.57.200731005-develop\build\Binaries\$Platform\te.exe"
+    $TaefExePath = "$root\packages\Microsoft.Taef.10.58.210305002\build\Binaries\$Platform\te.exe"
     $BinDir = "$root\bin\$OpenConsolePlatform\$Configuration"
 
     [xml]$TestConfig = Get-Content "$root\tools\tests.xml"

--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -104,7 +104,7 @@ shift
 goto :ARGS_LOOP
 
 :POST_ARGS_LOOP
-set TAEF=%OPENCON%\packages\Taef.Redist.Wlk.10.57.200731005-develop\build\Binaries\%ARCH%\TE.exe
+set TAEF=%OPENCON%\packages\Microsoft.Taef.10.58.210305002\build\Binaries\%ARCH%\TE.exe
 rem Set this envvar so setup won't repeat itself
 set OpenConBuild=true
 


### PR DESCRIPTION
Change TAEF nuget package to use new Microsoft.Taef name; Update to 10.58 release build version.

## PR Checklist
* [x] Closes email from Phil letting us know TAEF has a new release build and a rename.
* [x] Closes annoying duplicate TAEF import warning in `Parser.UnitTests.vcxproj`
* [x] I work here.
* [ ] Need to see the tests run off CI to confirm this is fine for those environments and Helix

## Validation Steps Performed
* [x] Build/run tests locally
* [ ] Build/run unit and feature tests in CI
* [ ] Build/run Helix-lab tests in CI
