### PR TITLE
Introduce MS.Term.Core.Color to replace W.U.Color for Core/Control/TSM

### DIFF
--- a/src/cascadia/LocalTests_SettingsModel/pch.h
+++ b/src/cascadia/LocalTests_SettingsModel/pch.h
@@ -56,6 +56,8 @@ Author(s):
 
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 
+#include <winrt/Microsoft.Terminal.Core.h>
+
 // Manually include til after we include Windows.Foundation to give it winrt superpowers
 #include "til.h"
 

--- a/src/cascadia/TerminalControl/IControlSettings.idl
+++ b/src/cascadia/TerminalControl/IControlSettings.idl
@@ -51,7 +51,7 @@ namespace Microsoft.Terminal.Control
         Windows.UI.Xaml.HorizontalAlignment BackgroundImageHorizontalAlignment;
         Windows.UI.Xaml.VerticalAlignment BackgroundImageVerticalAlignment;
 
-        UInt32 SelectionBackground;
+        Microsoft.Terminal.Core.Color SelectionBackground;
 
         TextAntialiasingMode AntialiasingMode;
 

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -327,7 +327,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         }
 
         // Update DxEngine settings under the lock
-        _renderEngine->SetSelectionBackground(til::color{_settings.SelectionBackground()});
+        _renderEngine->SetSelectionBackground(til::color{ _settings.SelectionBackground() });
 
         _renderEngine->SetRetroTerminalEffect(_settings.RetroTerminalEffect());
         _renderEngine->SetPixelShaderPath(_settings.PixelShaderPath());
@@ -503,7 +503,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
             // see GH#1082: Initialize background color so we don't get a
             // fade/flash when _BackgroundColorChanged is called
-            auto bgColor = til::color{_settings.DefaultBackground()}.with_alpha(0xff);
+            auto bgColor = til::color{ _settings.DefaultBackground() }.with_alpha(0xff);
 
             acrylic.FallbackColor(bgColor);
             acrylic.TintColor(bgColor);
@@ -769,7 +769,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             LOG_IF_FAILED(dxEngine->SetWindowSize({ viewInPixels.Width(), viewInPixels.Height() }));
 
             // Update DxEngine's SelectionBackground
-            dxEngine->SetSelectionBackground(til::color{_settings.SelectionBackground()});
+            dxEngine->SetSelectionBackground(til::color{ _settings.SelectionBackground() });
 
             const auto vp = dxEngine->GetViewportInCharacters(viewInPixels);
             const auto width = vp.Width();
@@ -2523,7 +2523,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                   TextBuffer::GenHTML(bufferData,
                                                       _actualFont.GetUnscaledSize().Y,
                                                       _actualFont.GetFaceName(),
-                                                      til::color{_settings.DefaultBackground()}) :
+                                                      til::color{ _settings.DefaultBackground() }) :
                                   "";
 
         // convert to RTF format
@@ -2531,7 +2531,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                  TextBuffer::GenRTF(bufferData,
                                                     _actualFont.GetUnscaledSize().Y,
                                                     _actualFont.GetFaceName(),
-                                                      til::color{_settings.DefaultBackground()}) :
+                                                    til::color{ _settings.DefaultBackground() }) :
                                  "";
 
         if (!_settings.CopyOnSelect())
@@ -3267,7 +3267,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     Windows::Foundation::IReference<winrt::Windows::UI::Color> TermControl::TabColor() noexcept
     {
         auto coreColor = _terminal->GetTabColor();
-        return coreColor.has_value() ? Windows::Foundation::IReference<winrt::Windows::UI::Color>(til::color{coreColor.value()}) : nullptr;
+        return coreColor.has_value() ? Windows::Foundation::IReference<winrt::Windows::UI::Color>(til::color{ coreColor.value() }) : nullptr;
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -327,7 +327,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         }
 
         // Update DxEngine settings under the lock
-        _renderEngine->SetSelectionBackground(_settings.SelectionBackground());
+        _renderEngine->SetSelectionBackground(til::color{_settings.SelectionBackground()});
 
         _renderEngine->SetRetroTerminalEffect(_settings.RetroTerminalEffect());
         _renderEngine->SetPixelShaderPath(_settings.PixelShaderPath());
@@ -427,7 +427,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
         _InitializeBackgroundBrush();
 
-        COLORREF bg = newSettings.DefaultBackground();
+        const auto bg = newSettings.DefaultBackground();
         _BackgroundColorChanged(bg);
 
         // Apply padding as swapChainPanel's margin
@@ -503,12 +503,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
             // see GH#1082: Initialize background color so we don't get a
             // fade/flash when _BackgroundColorChanged is called
-            uint32_t color = _settings.DefaultBackground();
-            winrt::Windows::UI::Color bgColor{};
-            bgColor.R = GetRValue(color);
-            bgColor.G = GetGValue(color);
-            bgColor.B = GetBValue(color);
-            bgColor.A = 255;
+            auto bgColor = til::color{_settings.DefaultBackground()}.with_alpha(0xff);
 
             acrylic.FallbackColor(bgColor);
             acrylic.TintColor(bgColor);
@@ -579,7 +574,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - color: The background color to use as a uint32 (aka DWORD COLORREF)
     // Return Value:
     // - <none>
-    winrt::fire_and_forget TermControl::_BackgroundColorChanged(const COLORREF color)
+    winrt::fire_and_forget TermControl::_BackgroundColorChanged(const til::color color)
     {
         til::color newBgColor{ color };
 
@@ -774,7 +769,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             LOG_IF_FAILED(dxEngine->SetWindowSize({ viewInPixels.Width(), viewInPixels.Height() }));
 
             // Update DxEngine's SelectionBackground
-            dxEngine->SetSelectionBackground(_settings.SelectionBackground());
+            dxEngine->SetSelectionBackground(til::color{_settings.SelectionBackground()});
 
             const auto vp = dxEngine->GetViewportInCharacters(viewInPixels);
             const auto width = vp.Width();
@@ -1710,7 +1705,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                 {
                     _settings.UseAcrylic(false);
                     _InitializeBackgroundBrush();
-                    COLORREF bg = _settings.DefaultBackground();
+                    const auto bg = _settings.DefaultBackground();
                     _BackgroundColorChanged(bg);
                 }
                 else
@@ -2528,7 +2523,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                   TextBuffer::GenHTML(bufferData,
                                                       _actualFont.GetUnscaledSize().Y,
                                                       _actualFont.GetFaceName(),
-                                                      _settings.DefaultBackground()) :
+                                                      til::color{_settings.DefaultBackground()}) :
                                   "";
 
         // convert to RTF format
@@ -2536,7 +2531,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                  TextBuffer::GenRTF(bufferData,
                                                     _actualFont.GetUnscaledSize().Y,
                                                     _actualFont.GetFaceName(),
-                                                    _settings.DefaultBackground()) :
+                                                      til::color{_settings.DefaultBackground()}) :
                                  "";
 
         if (!_settings.CopyOnSelect())
@@ -3272,7 +3267,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     Windows::Foundation::IReference<winrt::Windows::UI::Color> TermControl::TabColor() noexcept
     {
         auto coreColor = _terminal->GetTabColor();
-        return coreColor.has_value() ? Windows::Foundation::IReference<winrt::Windows::UI::Color>(coreColor.value()) : nullptr;
+        return coreColor.has_value() ? Windows::Foundation::IReference<winrt::Windows::UI::Color>(til::color{coreColor.value()}) : nullptr;
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -200,7 +200,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void _UpdateSettingsOnUIThread();
         void _UpdateSystemParameterSettings() noexcept;
         void _InitializeBackgroundBrush();
-        winrt::fire_and_forget _BackgroundColorChanged(const COLORREF color);
+        winrt::fire_and_forget _BackgroundColorChanged(const til::color color);
         bool _InitializeTerminal();
         void _UpdateFont(const bool initialUpdate = false);
         void _SetFontSize(int fontSize);

--- a/src/cascadia/TerminalCore/ICoreSettings.idl
+++ b/src/cascadia/TerminalCore/ICoreSettings.idl
@@ -3,6 +3,24 @@
 
 namespace Microsoft.Terminal.Core
 {
+    // TerminalCore declares its own Color struct to avoid depending
+    // on Windows.UI.Color and to avoid passing around unclothed uint32s.
+    // It is supported by til::color for conversions in and out of WinRT land.
+    struct Color
+    {
+        UInt8 R;
+        UInt8 G;
+        UInt8 B;
+        UInt8 A;
+    };
+
+    declare
+    {
+        // Forward declare this parameterized specialization so that it lives
+        // in TerminalCore instead of being flung to the winds of all IDL dependents.
+        interface Windows.Foundation.IReference<Microsoft.Terminal.Core.Color>;
+    }
+
     enum CursorStyle
     {
         Vintage,
@@ -15,9 +33,9 @@ namespace Microsoft.Terminal.Core
 
     interface ICoreSettings
     {
-        UInt32 DefaultForeground;
-        UInt32 DefaultBackground;
-        UInt32 GetColorTableEntry(Int32 index);
+        Microsoft.Terminal.Core.Color DefaultForeground;
+        Microsoft.Terminal.Core.Color DefaultBackground;
+        Microsoft.Terminal.Core.Color GetColorTableEntry(Int32 index);
         // TODO:MSFT:20642297 - define a sentinel for Infinite Scrollback
         Int32 HistorySize;
         Int32 InitialRows;
@@ -26,7 +44,7 @@ namespace Microsoft.Terminal.Core
         Boolean SnapOnInput;
         Boolean AltGrAliasing;
 
-        UInt32 CursorColor;
+        Microsoft.Terminal.Core.Color CursorColor;
         CursorStyle CursorShape;
         UInt32 CursorHeight;
         String StartingTitle;
@@ -35,8 +53,8 @@ namespace Microsoft.Terminal.Core
 
         Boolean ForceVTInput;
 
-        Windows.Foundation.IReference<UInt32> TabColor;
-        Windows.Foundation.IReference<UInt32> StartingTabColor;
+        Windows.Foundation.IReference<Microsoft.Terminal.Core.Color> TabColor;
+        Windows.Foundation.IReference<Microsoft.Terminal.Core.Color> StartingTabColor;
     };
 
 }

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -145,7 +145,7 @@ void Terminal::UpdateSettings(ICoreSettings settings)
     if (_buffer)
     {
         _buffer->GetCursor().SetStyle(settings.CursorHeight(),
-                                      til::color{settings.CursorColor()},
+                                      til::color{ settings.CursorColor() },
                                       cursorShape);
     }
 
@@ -170,12 +170,12 @@ void Terminal::UpdateSettings(ICoreSettings settings)
     }
     else
     {
-        _tabColor = til::color{settings.TabColor().Value()}.with_alpha(0xff);
+        _tabColor = til::color{ settings.TabColor().Value() }.with_alpha(0xff);
     }
 
     if (!_startingTabColor && settings.StartingTabColor())
     {
-        _startingTabColor = til::color{settings.StartingTabColor().Value()}.with_alpha(0xff);
+        _startingTabColor = til::color{ settings.StartingTabColor().Value() }.with_alpha(0xff);
     }
 
     if (_pfnTabColorChanged)

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -114,7 +114,7 @@ void Terminal::UpdateSettings(ICoreSettings settings)
 {
     // Set the default background as transparent to prevent the
     // DX layer from overwriting the background image or acrylic effect
-    til::color newBackgroundColor{ static_cast<COLORREF>(settings.DefaultBackground()) };
+    til::color newBackgroundColor{ settings.DefaultBackground() };
     _defaultBg = newBackgroundColor.with_alpha(0);
     _defaultFg = settings.DefaultForeground();
 
@@ -145,7 +145,7 @@ void Terminal::UpdateSettings(ICoreSettings settings)
     if (_buffer)
     {
         _buffer->GetCursor().SetStyle(settings.CursorHeight(),
-                                      settings.CursorColor(),
+                                      til::color{settings.CursorColor()},
                                       cursorShape);
     }
 
@@ -153,7 +153,7 @@ void Terminal::UpdateSettings(ICoreSettings settings)
 
     for (int i = 0; i < 16; i++)
     {
-        _colorTable.at(i) = settings.GetColorTableEntry(i);
+        _colorTable.at(i) = til::color{ settings.GetColorTableEntry(i) };
     }
 
     _snapOnInput = settings.SnapOnInput();
@@ -170,12 +170,12 @@ void Terminal::UpdateSettings(ICoreSettings settings)
     }
     else
     {
-        _tabColor = til::color(settings.TabColor().Value() | 0xff000000);
+        _tabColor = til::color{settings.TabColor().Value()}.with_alpha(0xff);
     }
 
     if (!_startingTabColor && settings.StartingTabColor())
     {
-        _startingTabColor = til::color(settings.StartingTabColor().Value() | 0xff000000);
+        _startingTabColor = til::color{settings.StartingTabColor().Value()}.with_alpha(0xff);
     }
 
     if (_pfnTabColorChanged)
@@ -1128,8 +1128,8 @@ void Terminal::SetCursorPositionChangedCallback(std::function<void()> pfn) noexc
 // Method Description:
 // - Allows setting a callback for when the background color is changed
 // Arguments:
-// - pfn: a function callback that takes a uint32 (DWORD COLORREF) color in the format 0x00BBGGRR
-void Terminal::SetBackgroundCallback(std::function<void(const COLORREF)> pfn) noexcept
+// - pfn: a function callback that takes a color
+void Terminal::SetBackgroundCallback(std::function<void(const til::color)> pfn) noexcept
 {
     _pfnBackgroundColorChanged.swap(pfn);
 }

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -198,7 +198,7 @@ public:
     void SetCopyToClipboardCallback(std::function<void(const std::wstring_view&)> pfn) noexcept;
     void SetScrollPositionChangedCallback(std::function<void(const int, const int, const int)> pfn) noexcept;
     void SetCursorPositionChangedCallback(std::function<void()> pfn) noexcept;
-    void SetBackgroundCallback(std::function<void(const COLORREF)> pfn) noexcept;
+    void SetBackgroundCallback(std::function<void(const til::color)> pfn) noexcept;
     void TaskbarProgressChangedCallback(std::function<void()> pfn) noexcept;
 
     void SetCursorOn(const bool isOn);
@@ -236,7 +236,7 @@ private:
     std::function<void(const std::wstring_view&)> _pfnTitleChanged;
     std::function<void(const std::wstring_view&)> _pfnCopyToClipboard;
     std::function<void(const int, const int, const int)> _pfnScrollPositionChanged;
-    std::function<void(const COLORREF)> _pfnBackgroundColorChanged;
+    std::function<void(const til::color)> _pfnBackgroundColorChanged;
     std::function<void()> _pfnCursorPositionChanged;
     std::function<void(const std::optional<til::color>)> _pfnTabColorChanged;
     std::function<void()> _pfnTaskbarProgressChanged;
@@ -249,9 +249,10 @@ private:
     std::optional<til::color> _tabColor;
     std::optional<til::color> _startingTabColor;
 
+	// This is still stored as a COLORREF because it interacts with some code in ConTypes
     std::array<COLORREF, XTERM_COLOR_TABLE_SIZE> _colorTable;
-    COLORREF _defaultFg;
-    COLORREF _defaultBg;
+	til::color _defaultFg;
+	til::color _defaultBg;
     CursorType _defaultCursorShape;
     bool _screenReversed;
     mutable Microsoft::Console::Render::BlinkingState _blinkingState;

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -249,10 +249,10 @@ private:
     std::optional<til::color> _tabColor;
     std::optional<til::color> _startingTabColor;
 
-	// This is still stored as a COLORREF because it interacts with some code in ConTypes
+    // This is still stored as a COLORREF because it interacts with some code in ConTypes
     std::array<COLORREF, XTERM_COLOR_TABLE_SIZE> _colorTable;
-	til::color _defaultFg;
-	til::color _defaultBg;
+    til::color _defaultFg;
+    til::color _defaultBg;
     CursorType _defaultCursorShape;
     bool _screenReversed;
     mutable Microsoft::Console::Render::BlinkingState _blinkingState;

--- a/src/cascadia/TerminalCore/pch.h
+++ b/src/cascadia/TerminalCore/pch.h
@@ -3,5 +3,11 @@
 
 #pragma once
 
+// We're suspending the inclusion of til here so that we can include
+// it after some of our C++/WinRT headers.
+#define BLOCK_TIL
 #include <LibraryIncludes.h>
 #include "winrt/Windows.Foundation.h"
+
+#include "winrt/Microsoft.Terminal.Core.h"
+#include <til.h>

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
@@ -219,7 +219,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     void ColorSchemes::ColorPickerChanged(IInspectable const& sender,
                                           ColorChangedEventArgs const& args)
     {
-	    const til::color newColor{args.NewColor()};
+        const til::color newColor{ args.NewColor() };
         if (const auto& picker{ sender.try_as<ColorPicker>() })
         {
             if (const auto& tag{ picker.Tag() })
@@ -398,7 +398,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         for (uint8_t i = 0; i < TableColorNames.size(); ++i)
         {
-		til::color currentColor{colorScheme.Table()[i]};
+            til::color currentColor{ colorScheme.Table()[i] };
             if (i < ColorTableDivider)
             {
                 _CurrentNonBrightColorTable.GetAt(i).Color(currentColor);
@@ -408,10 +408,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 _CurrentBrightColorTable.GetAt(i - ColorTableDivider).Color(currentColor);
             }
         }
-        _CurrentForegroundColor.Color(til::color{colorScheme.Foreground()});
-        _CurrentBackgroundColor.Color(til::color{colorScheme.Background()});
-        _CurrentCursorColor.Color(til::color{colorScheme.CursorColor()});
-        _CurrentSelectionBackgroundColor.Color(til::color{colorScheme.SelectionBackground()});
+        _CurrentForegroundColor.Color(til::color{ colorScheme.Foreground() });
+        _CurrentBackgroundColor.Color(til::color{ colorScheme.Background() });
+        _CurrentCursorColor.Color(til::color{ colorScheme.CursorColor() });
+        _CurrentSelectionBackgroundColor.Color(til::color{ colorScheme.SelectionBackground() });
     }
 
     ColorTableEntry::ColorTableEntry(uint8_t index, Windows::UI::Color color)

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
@@ -219,43 +219,44 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     void ColorSchemes::ColorPickerChanged(IInspectable const& sender,
                                           ColorChangedEventArgs const& args)
     {
+	    const til::color newColor{args.NewColor()};
         if (const auto& picker{ sender.try_as<ColorPicker>() })
         {
             if (const auto& tag{ picker.Tag() })
             {
                 if (const auto index{ tag.try_as<uint8_t>() })
                 {
-                    CurrentColorScheme().SetColorTableEntry(*index, args.NewColor());
+                    CurrentColorScheme().SetColorTableEntry(*index, newColor);
                     if (index < ColorTableDivider)
                     {
-                        _CurrentNonBrightColorTable.GetAt(*index).Color(args.NewColor());
+                        _CurrentNonBrightColorTable.GetAt(*index).Color(newColor);
                     }
                     else
                     {
-                        _CurrentBrightColorTable.GetAt(*index - ColorTableDivider).Color(args.NewColor());
+                        _CurrentBrightColorTable.GetAt(*index - ColorTableDivider).Color(newColor);
                     }
                 }
                 else if (const auto stringTag{ tag.try_as<hstring>() })
                 {
                     if (stringTag == ForegroundColorTag)
                     {
-                        CurrentColorScheme().Foreground(args.NewColor());
-                        _CurrentForegroundColor.Color(args.NewColor());
+                        CurrentColorScheme().Foreground(newColor);
+                        _CurrentForegroundColor.Color(newColor);
                     }
                     else if (stringTag == BackgroundColorTag)
                     {
-                        CurrentColorScheme().Background(args.NewColor());
-                        _CurrentBackgroundColor.Color(args.NewColor());
+                        CurrentColorScheme().Background(newColor);
+                        _CurrentBackgroundColor.Color(newColor);
                     }
                     else if (stringTag == CursorColorTag)
                     {
-                        CurrentColorScheme().CursorColor(args.NewColor());
-                        _CurrentCursorColor.Color(args.NewColor());
+                        CurrentColorScheme().CursorColor(newColor);
+                        _CurrentCursorColor.Color(newColor);
                     }
                     else if (stringTag == SelectionBackgroundColorTag)
                     {
-                        CurrentColorScheme().SelectionBackground(args.NewColor());
-                        _CurrentSelectionBackgroundColor.Color(args.NewColor());
+                        CurrentColorScheme().SelectionBackground(newColor);
+                        _CurrentSelectionBackgroundColor.Color(newColor);
                     }
                 }
             }
@@ -397,19 +398,20 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         for (uint8_t i = 0; i < TableColorNames.size(); ++i)
         {
+		til::color currentColor{colorScheme.Table()[i]};
             if (i < ColorTableDivider)
             {
-                _CurrentNonBrightColorTable.GetAt(i).Color(colorScheme.Table()[i]);
+                _CurrentNonBrightColorTable.GetAt(i).Color(currentColor);
             }
             else
             {
-                _CurrentBrightColorTable.GetAt(i - ColorTableDivider).Color(colorScheme.Table()[i]);
+                _CurrentBrightColorTable.GetAt(i - ColorTableDivider).Color(currentColor);
             }
         }
-        _CurrentForegroundColor.Color(colorScheme.Foreground());
-        _CurrentBackgroundColor.Color(colorScheme.Background());
-        _CurrentCursorColor.Color(colorScheme.CursorColor());
-        _CurrentSelectionBackgroundColor.Color(colorScheme.SelectionBackground());
+        _CurrentForegroundColor.Color(til::color{colorScheme.Foreground()});
+        _CurrentBackgroundColor.Color(til::color{colorScheme.Background()});
+        _CurrentCursorColor.Color(til::color{colorScheme.CursorColor()});
+        _CurrentSelectionBackgroundColor.Color(til::color{colorScheme.SelectionBackground()});
     }
 
     ColorTableEntry::ColorTableEntry(uint8_t index, Windows::UI::Color color)

--- a/src/cascadia/TerminalSettingsEditor/Profiles.idl
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.idl
@@ -40,7 +40,7 @@ namespace Microsoft.Terminal.Settings.Editor
         OBSERVABLE_PROJECTED_PROFILE_SETTING(String, Icon);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Microsoft.Terminal.Settings.Model.CloseOnExitMode, CloseOnExit);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(String, TabTitle);
-        OBSERVABLE_PROJECTED_PROFILE_SETTING(Windows.Foundation.IReference<Windows.UI.Color>, TabColor);
+        OBSERVABLE_PROJECTED_PROFILE_SETTING(Windows.Foundation.IReference<Microsoft.Terminal.Core.Color>, TabColor);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, SuppressApplicationTitle);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, UseAcrylic);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Double, AcrylicOpacity);
@@ -60,10 +60,10 @@ namespace Microsoft.Terminal.Settings.Editor
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, ForceFullRepaintRendering);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, SoftwareRendering);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(String, ColorSchemeName);
-        OBSERVABLE_PROJECTED_PROFILE_SETTING(Windows.Foundation.IReference<Windows.UI.Color>, Foreground);
-        OBSERVABLE_PROJECTED_PROFILE_SETTING(Windows.Foundation.IReference<Windows.UI.Color>, Background);
-        OBSERVABLE_PROJECTED_PROFILE_SETTING(Windows.Foundation.IReference<Windows.UI.Color>, SelectionBackground);
-        OBSERVABLE_PROJECTED_PROFILE_SETTING(Windows.Foundation.IReference<Windows.UI.Color>, CursorColor);
+        OBSERVABLE_PROJECTED_PROFILE_SETTING(Windows.Foundation.IReference<Microsoft.Terminal.Core.Color>, Foreground);
+        OBSERVABLE_PROJECTED_PROFILE_SETTING(Windows.Foundation.IReference<Microsoft.Terminal.Core.Color>, Background);
+        OBSERVABLE_PROJECTED_PROFILE_SETTING(Windows.Foundation.IReference<Microsoft.Terminal.Core.Color>, SelectionBackground);
+        OBSERVABLE_PROJECTED_PROFILE_SETTING(Windows.Foundation.IReference<Microsoft.Terminal.Core.Color>, CursorColor);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Int32, HistorySize);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, SnapOnInput);
         OBSERVABLE_PROJECTED_PROFILE_SETTING(Boolean, AltGrAliasing);

--- a/src/cascadia/TerminalSettingsEditor/pch.h
+++ b/src/cascadia/TerminalSettingsEditor/pch.h
@@ -50,6 +50,7 @@
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>
 
+#include <winrt/Microsoft.Terminal.Core.h>
 #include <winrt/Microsoft.Terminal.Control.h>
 #include <winrt/Microsoft.Terminal.Settings.Model.h>
 

--- a/src/cascadia/TerminalSettingsModel/ColorScheme.cpp
+++ b/src/cascadia/TerminalSettingsModel/ColorScheme.cpp
@@ -42,13 +42,13 @@ static constexpr std::array<std::string_view, 16> TableColors = {
 };
 
 ColorScheme::ColorScheme() :
-    ColorScheme(L"", DEFAULT_FOREGROUND_WITH_ALPHA, DEFAULT_BACKGROUND_WITH_ALPHA, DEFAULT_CURSOR_COLOR)
+    ColorScheme(L"", DEFAULT_FOREGROUND, DEFAULT_BACKGROUND, DEFAULT_CURSOR_COLOR)
 {
     Utils::InitializeCampbellColorTable(_table);
 }
 
 ColorScheme::ColorScheme(winrt::hstring name) :
-    ColorScheme(name, DEFAULT_FOREGROUND_WITH_ALPHA, DEFAULT_BACKGROUND_WITH_ALPHA, DEFAULT_CURSOR_COLOR)
+    ColorScheme(name, DEFAULT_FOREGROUND, DEFAULT_BACKGROUND, DEFAULT_CURSOR_COLOR)
 {
     Utils::InitializeCampbellColorTable(_table);
 }

--- a/src/cascadia/TerminalSettingsModel/ColorScheme.cpp
+++ b/src/cascadia/TerminalSettingsModel/ColorScheme.cpp
@@ -53,7 +53,7 @@ ColorScheme::ColorScheme(winrt::hstring name) :
     Utils::InitializeCampbellColorTable(_table);
 }
 
-ColorScheme::ColorScheme(winrt::hstring name, COLORREF defaultFg, COLORREF defaultBg, COLORREF cursorColor) :
+ColorScheme::ColorScheme(winrt::hstring name, til::color defaultFg, til::color defaultBg, til::color cursorColor) :
     _Name{ name },
     _Foreground{ defaultFg },
     _Background{ defaultBg },
@@ -153,10 +153,10 @@ Json::Value ColorScheme::ToJson() const
     return json;
 }
 
-winrt::com_array<Color> ColorScheme::Table() const noexcept
+winrt::com_array<winrt::Microsoft::Terminal::Core::Color> ColorScheme::Table() const noexcept
 {
-    winrt::com_array<Color> result{ base::checked_cast<uint32_t>(_table.size()) };
-    std::transform(_table.begin(), _table.end(), result.begin(), [](til::color c) -> Color { return c; });
+    winrt::com_array<winrt::Microsoft::Terminal::Core::Color> result{ base::checked_cast<uint32_t>(_table.size()) };
+    std::transform(_table.begin(), _table.end(), result.begin(), [](til::color c) -> winrt::Microsoft::Terminal::Core::Color { return c; });
     return result;
 }
 
@@ -167,7 +167,7 @@ winrt::com_array<Color> ColorScheme::Table() const noexcept
 // - value: the color value we are setting the color table color to
 // Return Value:
 // - none
-void ColorScheme::SetColorTableEntry(uint8_t index, const winrt::Windows::UI::Color& value) noexcept
+void ColorScheme::SetColorTableEntry(uint8_t index, const winrt::Microsoft::Terminal::Core::Color& value) noexcept
 {
     THROW_HR_IF(E_INVALIDARG, index > _table.size() - 1);
     _table[index] = value;

--- a/src/cascadia/TerminalSettingsModel/ColorScheme.h
+++ b/src/cascadia/TerminalSettingsModel/ColorScheme.h
@@ -31,12 +31,12 @@ namespace SettingsModelLocalTests
 // This should only be used for color types where there's no logic in the
 // getter/setter beyond just accessing/updating the value.
 // This takes advantage of til::color
-#define WINRT_TERMINAL_COLOR_PROPERTY(name, ...)                                             \
-public:                                                                             \
+#define WINRT_TERMINAL_COLOR_PROPERTY(name, ...)                                                  \
+public:                                                                                           \
     winrt::Microsoft::Terminal::Core::Color name() const noexcept { return _##name; }             \
     void name(const winrt::Microsoft::Terminal::Core::Color& value) noexcept { _##name = value; } \
-                                                                                    \
-private:                                                                            \
+                                                                                                  \
+private:                                                                                          \
     til::color _##name{ __VA_ARGS__ };
 
 namespace winrt::Microsoft::Terminal::Settings::Model::implementation

--- a/src/cascadia/TerminalSettingsModel/ColorScheme.h
+++ b/src/cascadia/TerminalSettingsModel/ColorScheme.h
@@ -27,6 +27,18 @@ namespace SettingsModelLocalTests
     class ColorSchemeTests;
 };
 
+// Use this macro to quick implement both the getter and setter for a color property.
+// This should only be used for color types where there's no logic in the
+// getter/setter beyond just accessing/updating the value.
+// This takes advantage of til::color
+#define WINRT_TERMINAL_COLOR_PROPERTY(name, ...)                                             \
+public:                                                                             \
+    winrt::Microsoft::Terminal::Core::Color name() const noexcept { return _##name; }             \
+    void name(const winrt::Microsoft::Terminal::Core::Color& value) noexcept { _##name = value; } \
+                                                                                    \
+private:                                                                            \
+    til::color _##name{ __VA_ARGS__ };
+
 namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 {
     struct ColorScheme : ColorSchemeT<ColorScheme>
@@ -34,7 +46,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     public:
         ColorScheme();
         ColorScheme(hstring name);
-        ColorScheme(hstring name, COLORREF defaultFg, COLORREF defaultBg, COLORREF cursorColor);
+        ColorScheme(hstring name, til::color defaultFg, til::color defaultBg, til::color cursorColor);
         com_ptr<ColorScheme> Copy() const;
 
         hstring ToString()
@@ -50,16 +62,16 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         static std::optional<std::wstring> GetNameFromJson(const Json::Value& json);
 
-        com_array<Windows::UI::Color> Table() const noexcept;
-        void SetColorTableEntry(uint8_t index, const winrt::Windows::UI::Color& value) noexcept;
+        com_array<winrt::Microsoft::Terminal::Core::Color> Table() const noexcept;
+        void SetColorTableEntry(uint8_t index, const winrt::Microsoft::Terminal::Core::Color& value) noexcept;
 
         static bool ValidateColorScheme(const Json::Value& scheme);
 
         WINRT_PROPERTY(winrt::hstring, Name);
-        GETSET_COLORPROPERTY(Foreground); // defined in constructor
-        GETSET_COLORPROPERTY(Background); // defined in constructor
-        GETSET_COLORPROPERTY(SelectionBackground); // defined in constructor
-        GETSET_COLORPROPERTY(CursorColor); // defined in constructor
+        WINRT_TERMINAL_COLOR_PROPERTY(Foreground); // defined in constructor
+        WINRT_TERMINAL_COLOR_PROPERTY(Background); // defined in constructor
+        WINRT_TERMINAL_COLOR_PROPERTY(SelectionBackground); // defined in constructor
+        WINRT_TERMINAL_COLOR_PROPERTY(CursorColor); // defined in constructor
 
     private:
         std::array<til::color, COLOR_TABLE_SIZE> _table;

--- a/src/cascadia/TerminalSettingsModel/ColorScheme.idl
+++ b/src/cascadia/TerminalSettingsModel/ColorScheme.idl
@@ -8,15 +8,15 @@ namespace Microsoft.Terminal.Settings.Model
 
         String Name;
 
-        Windows.UI.Color Foreground;
-        Windows.UI.Color Background;
-        Windows.UI.Color SelectionBackground;
-        Windows.UI.Color CursorColor;
+        Microsoft.Terminal.Core.Color Foreground;
+        Microsoft.Terminal.Core.Color Background;
+        Microsoft.Terminal.Core.Color SelectionBackground;
+        Microsoft.Terminal.Core.Color CursorColor;
 
         // winrt::com_arrays prevent data binding.
         // Instead of representing Table as a property,
         // we expose the getter as a function.
-        Windows.UI.Color[] Table();
-        void SetColorTableEntry(UInt8 index, Windows.UI.Color value);
+        Microsoft.Terminal.Core.Color[] Table();
+        void SetColorTableEntry(UInt8 index, Microsoft.Terminal.Core.Color value);
     }
 }

--- a/src/cascadia/TerminalSettingsModel/JsonUtils.h
+++ b/src/cascadia/TerminalSettingsModel/JsonUtils.h
@@ -438,6 +438,32 @@ namespace Microsoft::Terminal::Settings::Model::JsonUtils
     };
 #endif
 
+#ifdef WINRT_Microsoft_Terminal_Core_H
+    template<>
+    struct ConversionTrait<winrt::Microsoft::Terminal::Core::Color>
+    {
+        winrt::Microsoft::Terminal::Core::Color FromJson(const Json::Value& json) const
+        {
+            return static_cast<winrt::Microsoft::Terminal::Core::Color>(ConversionTrait<til::color>{}.FromJson(json));
+        }
+
+        bool CanConvert(const Json::Value& json) const
+        {
+            return ConversionTrait<til::color>{}.CanConvert(json);
+        }
+
+        Json::Value ToJson(const winrt::Microsoft::Terminal::Core::Color& val)
+        {
+            return ConversionTrait<til::color>{}.ToJson(val);
+        }
+
+        std::string TypeDescription() const
+        {
+            return ConversionTrait<til::color>{}.TypeDescription();
+        }
+    };
+#endif
+
     template<typename T, typename TDelegatedConverter = ConversionTrait<typename std::decay<T>::type>, typename TOpt = std::optional<typename std::decay<T>::type>>
     struct OptionalConverter
     {

--- a/src/cascadia/TerminalSettingsModel/Profile.h
+++ b/src/cascadia/TerminalSettingsModel/Profile.h
@@ -80,7 +80,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         INHERITABLE_SETTING(Model::Profile, CloseOnExitMode, CloseOnExit, CloseOnExitMode::Graceful);
         INHERITABLE_SETTING(Model::Profile, hstring, TabTitle);
-        INHERITABLE_NULLABLE_SETTING(Model::Profile, Windows::UI::Color, TabColor, nullptr);
+        INHERITABLE_NULLABLE_SETTING(Model::Profile, Microsoft::Terminal::Core::Color, TabColor, nullptr);
         INHERITABLE_SETTING(Model::Profile, bool, SuppressApplicationTitle, false);
 
         INHERITABLE_SETTING(Model::Profile, bool, UseAcrylic, false);
@@ -108,10 +108,10 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         INHERITABLE_SETTING(Model::Profile, hstring, ColorSchemeName, L"Campbell");
 
-        INHERITABLE_NULLABLE_SETTING(Model::Profile, Windows::UI::Color, Foreground, nullptr);
-        INHERITABLE_NULLABLE_SETTING(Model::Profile, Windows::UI::Color, Background, nullptr);
-        INHERITABLE_NULLABLE_SETTING(Model::Profile, Windows::UI::Color, SelectionBackground, nullptr);
-        INHERITABLE_NULLABLE_SETTING(Model::Profile, Windows::UI::Color, CursorColor, nullptr);
+        INHERITABLE_NULLABLE_SETTING(Model::Profile, Microsoft::Terminal::Core::Color, Foreground, nullptr);
+        INHERITABLE_NULLABLE_SETTING(Model::Profile, Microsoft::Terminal::Core::Color, Background, nullptr);
+        INHERITABLE_NULLABLE_SETTING(Model::Profile, Microsoft::Terminal::Core::Color, SelectionBackground, nullptr);
+        INHERITABLE_NULLABLE_SETTING(Model::Profile, Microsoft::Terminal::Core::Color, CursorColor, nullptr);
 
         INHERITABLE_SETTING(Model::Profile, int32_t, HistorySize, DEFAULT_HISTORY_SIZE);
         INHERITABLE_SETTING(Model::Profile, bool, SnapOnInput, true);

--- a/src/cascadia/TerminalSettingsModel/Profile.idl
+++ b/src/cascadia/TerminalSettingsModel/Profile.idl
@@ -66,7 +66,7 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_PROFILE_SETTING(String, Icon);
         INHERITABLE_PROFILE_SETTING(CloseOnExitMode, CloseOnExit);
         INHERITABLE_PROFILE_SETTING(String, TabTitle);
-        INHERITABLE_PROFILE_SETTING(Windows.Foundation.IReference<Windows.UI.Color>, TabColor);
+        INHERITABLE_PROFILE_SETTING(Windows.Foundation.IReference<Microsoft.Terminal.Core.Color>, TabColor);
         INHERITABLE_PROFILE_SETTING(Boolean, SuppressApplicationTitle);
         INHERITABLE_PROFILE_SETTING(Boolean, UseAcrylic);
         INHERITABLE_PROFILE_SETTING(Double, AcrylicOpacity);
@@ -92,10 +92,10 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_PROFILE_SETTING(Boolean, ForceFullRepaintRendering);
         INHERITABLE_PROFILE_SETTING(Boolean, SoftwareRendering);
         INHERITABLE_PROFILE_SETTING(String, ColorSchemeName);
-        INHERITABLE_PROFILE_SETTING(Windows.Foundation.IReference<Windows.UI.Color>, Foreground);
-        INHERITABLE_PROFILE_SETTING(Windows.Foundation.IReference<Windows.UI.Color>, Background);
-        INHERITABLE_PROFILE_SETTING(Windows.Foundation.IReference<Windows.UI.Color>, SelectionBackground);
-        INHERITABLE_PROFILE_SETTING(Windows.Foundation.IReference<Windows.UI.Color>, CursorColor);
+        INHERITABLE_PROFILE_SETTING(Windows.Foundation.IReference<Microsoft.Terminal.Core.Color>, Foreground);
+        INHERITABLE_PROFILE_SETTING(Windows.Foundation.IReference<Microsoft.Terminal.Core.Color>, Background);
+        INHERITABLE_PROFILE_SETTING(Windows.Foundation.IReference<Microsoft.Terminal.Core.Color>, SelectionBackground);
+        INHERITABLE_PROFILE_SETTING(Windows.Foundation.IReference<Microsoft.Terminal.Core.Color>, CursorColor);
         INHERITABLE_PROFILE_SETTING(Int32, HistorySize);
         INHERITABLE_PROFILE_SETTING(Boolean, SnapOnInput);
         INHERITABLE_PROFILE_SETTING(Boolean, AltGrAliasing);

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
@@ -112,7 +112,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             }
             if (newTerminalArgs.TabColor())
             {
-                settings.StartingTabColor(static_cast<uint32_t>(til::color(newTerminalArgs.TabColor().Value())));
+                settings.StartingTabColor(winrt::Windows::Foundation::IReference<winrt::Microsoft::Terminal::Core::Color>{til::color{ newTerminalArgs.TabColor().Value() }});
             }
             if (newTerminalArgs.SuppressApplicationTitle())
             {
@@ -239,7 +239,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         if (profile.TabColor())
         {
             const til::color colorRef{ profile.TabColor().Value() };
-            _TabColor = static_cast<uint32_t>(colorRef);
+            _TabColor = static_cast<winrt::Microsoft::Terminal::Core::Color>(colorRef);
         }
     }
 
@@ -277,44 +277,40 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         _CursorColor = til::color{ scheme.CursorColor() };
 
         const auto table = scheme.Table();
-        std::array<uint32_t, COLOR_TABLE_SIZE> colorTable{};
-        std::transform(table.cbegin(), table.cend(), colorTable.begin(), [](auto&& color) {
-            return static_cast<uint32_t>(til::color{ color });
-        });
+        std::array<winrt::Microsoft::Terminal::Core::Color, COLOR_TABLE_SIZE> colorTable{};
+        std::copy(table.cbegin(), table.cend(), colorTable.begin());
         ColorTable(colorTable);
     }
 
-    uint32_t TerminalSettings::GetColorTableEntry(int32_t index) noexcept
+    winrt::Microsoft::Terminal::Core::Color TerminalSettings::GetColorTableEntry(int32_t index) noexcept
     {
         return ColorTable().at(index);
     }
 
-    void TerminalSettings::ColorTable(std::array<uint32_t, 16> colors)
+    void TerminalSettings::ColorTable(std::array<winrt::Microsoft::Terminal::Core::Color, 16> colors)
     {
         _ColorTable = colors;
     }
 
-    std::array<uint32_t, COLOR_TABLE_SIZE> TerminalSettings::ColorTable()
+    std::array<winrt::Microsoft::Terminal::Core::Color, COLOR_TABLE_SIZE> TerminalSettings::ColorTable()
     {
         auto span = _getColorTableImpl();
-        std::array<uint32_t, COLOR_TABLE_SIZE> colorTable{};
+        std::array<winrt::Microsoft::Terminal::Core::Color, COLOR_TABLE_SIZE> colorTable{};
         if (span.size() > 0)
         {
-            std::transform(span.begin(), span.end(), colorTable.begin(), [](auto&& color) {
-                return static_cast<uint32_t>(til::color{ color });
-            });
+            std::copy(span.begin(), span.end(), colorTable.begin());
         }
         else
         {
             const auto campbellSpan = CampbellColorTable();
             std::transform(campbellSpan.begin(), campbellSpan.end(), colorTable.begin(), [](auto&& color) {
-                return static_cast<uint32_t>(til::color{ color });
+                return static_cast<winrt::Microsoft::Terminal::Core::Color>(til::color{ color });
             });
         }
         return colorTable;
     }
 
-    gsl::span<uint32_t> TerminalSettings::_getColorTableImpl()
+    gsl::span<winrt::Microsoft::Terminal::Core::Color> TerminalSettings::_getColorTableImpl()
     {
         if (_ColorTable.has_value())
         {

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
@@ -112,7 +112,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             }
             if (newTerminalArgs.TabColor())
             {
-                settings.StartingTabColor(winrt::Windows::Foundation::IReference<winrt::Microsoft::Terminal::Core::Color>{til::color{ newTerminalArgs.TabColor().Value() }});
+                settings.StartingTabColor(winrt::Windows::Foundation::IReference<winrt::Microsoft::Terminal::Core::Color>{ til::color{ newTerminalArgs.TabColor().Value() } });
             }
             if (newTerminalArgs.SuppressApplicationTitle())
             {

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -54,8 +54,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         void ColorTable(std::array<Microsoft::Terminal::Core::Color, 16> colors);
         std::array<Microsoft::Terminal::Core::Color, 16> ColorTable();
 
-        INHERITABLE_SETTING(Model::TerminalSettings, til::color, DefaultForeground, DEFAULT_FOREGROUND_WITH_ALPHA);
-        INHERITABLE_SETTING(Model::TerminalSettings, til::color, DefaultBackground, DEFAULT_BACKGROUND_WITH_ALPHA);
+        INHERITABLE_SETTING(Model::TerminalSettings, til::color, DefaultForeground, DEFAULT_FOREGROUND);
+        INHERITABLE_SETTING(Model::TerminalSettings, til::color, DefaultBackground, DEFAULT_BACKGROUND);
         INHERITABLE_SETTING(Model::TerminalSettings, til::color, SelectionBackground, DEFAULT_FOREGROUND);
         INHERITABLE_SETTING(Model::TerminalSettings, int32_t, HistorySize, DEFAULT_HISTORY_SIZE);
         INHERITABLE_SETTING(Model::TerminalSettings, int32_t, InitialRows, 30);

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -50,20 +50,20 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         // GetColorTableEntry needs to be implemented manually, to get a
         // particular value from the array.
-        uint32_t GetColorTableEntry(int32_t index) noexcept;
-        void ColorTable(std::array<uint32_t, 16> colors);
-        std::array<uint32_t, 16> ColorTable();
+	Microsoft::Terminal::Core::Color GetColorTableEntry(int32_t index) noexcept;
+        void ColorTable(std::array<Microsoft::Terminal::Core::Color, 16> colors);
+        std::array<Microsoft::Terminal::Core::Color, 16> ColorTable();
 
-        INHERITABLE_SETTING(Model::TerminalSettings, uint32_t, DefaultForeground, DEFAULT_FOREGROUND_WITH_ALPHA);
-        INHERITABLE_SETTING(Model::TerminalSettings, uint32_t, DefaultBackground, DEFAULT_BACKGROUND_WITH_ALPHA);
-        INHERITABLE_SETTING(Model::TerminalSettings, uint32_t, SelectionBackground, DEFAULT_FOREGROUND);
+        INHERITABLE_SETTING(Model::TerminalSettings, til::color, DefaultForeground, DEFAULT_FOREGROUND_WITH_ALPHA);
+        INHERITABLE_SETTING(Model::TerminalSettings, til::color, DefaultBackground, DEFAULT_BACKGROUND_WITH_ALPHA);
+        INHERITABLE_SETTING(Model::TerminalSettings, til::color, SelectionBackground, DEFAULT_FOREGROUND);
         INHERITABLE_SETTING(Model::TerminalSettings, int32_t, HistorySize, DEFAULT_HISTORY_SIZE);
         INHERITABLE_SETTING(Model::TerminalSettings, int32_t, InitialRows, 30);
         INHERITABLE_SETTING(Model::TerminalSettings, int32_t, InitialCols, 80);
 
         INHERITABLE_SETTING(Model::TerminalSettings, bool, SnapOnInput, true);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, AltGrAliasing, true);
-        INHERITABLE_SETTING(Model::TerminalSettings, uint32_t, CursorColor, DEFAULT_CURSOR_COLOR);
+        INHERITABLE_SETTING(Model::TerminalSettings, til::color, CursorColor, DEFAULT_CURSOR_COLOR);
         INHERITABLE_SETTING(Model::TerminalSettings, Microsoft::Terminal::Core::CursorStyle, CursorShape, Core::CursorStyle::Vintage);
         INHERITABLE_SETTING(Model::TerminalSettings, uint32_t, CursorHeight, DEFAULT_CURSOR_HEIGHT);
         INHERITABLE_SETTING(Model::TerminalSettings, hstring, WordDelimiters, DEFAULT_WORD_DELIMITERS);
@@ -71,7 +71,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         INHERITABLE_SETTING(Model::TerminalSettings, bool, InputServiceWarning, true);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, FocusFollowMouse, false);
 
-        INHERITABLE_SETTING(Model::TerminalSettings, Windows::Foundation::IReference<uint32_t>, TabColor, nullptr);
+        INHERITABLE_SETTING(Model::TerminalSettings, Windows::Foundation::IReference<Microsoft::Terminal::Core::Color>, TabColor, nullptr);
 
         // When set, StartingTabColor allows to create a terminal with a "sticky" tab color.
         // This color is prioritized above the TabColor (that is usually initialized based on profile settings).
@@ -81,7 +81,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         // TODO: to ensure that this property is not populated during settings reload,
         // we should consider moving this property to a separate interface,
         // passed to the terminal only upon creation.
-        INHERITABLE_SETTING(Model::TerminalSettings, Windows::Foundation::IReference<uint32_t>, StartingTabColor, nullptr);
+        INHERITABLE_SETTING(Model::TerminalSettings, Windows::Foundation::IReference<Microsoft::Terminal::Core::Color>, StartingTabColor, nullptr);
 
         // ------------------------ End of Core Settings -----------------------
 
@@ -121,8 +121,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         INHERITABLE_SETTING(Model::TerminalSettings, hstring, PixelShaderPath);
 
     private:
-        std::optional<std::array<uint32_t, COLOR_TABLE_SIZE>> _ColorTable;
-        gsl::span<uint32_t> _getColorTableImpl();
+        std::optional<std::array<Microsoft::Terminal::Core::Color, COLOR_TABLE_SIZE>> _ColorTable;
+        gsl::span<Microsoft::Terminal::Core::Color> _getColorTableImpl();
         void _ApplyProfileSettings(const Model::Profile& profile, const Windows::Foundation::Collections::IMapView<hstring, Model::ColorScheme>& schemes);
         void _ApplyGlobalSettings(const Model::GlobalAppSettings& globalSettings) noexcept;
 

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -50,7 +50,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         // GetColorTableEntry needs to be implemented manually, to get a
         // particular value from the array.
-	Microsoft::Terminal::Core::Color GetColorTableEntry(int32_t index) noexcept;
+        Microsoft::Terminal::Core::Color GetColorTableEntry(int32_t index) noexcept;
         void ColorTable(std::array<Microsoft::Terminal::Core::Color, 16> colors);
         std::array<Microsoft::Terminal::Core::Color, 16> ColorTable();
 

--- a/src/cascadia/TerminalSettingsModel/pch.h
+++ b/src/cascadia/TerminalSettingsModel/pch.h
@@ -54,6 +54,7 @@ TRACELOGGING_DECLARE_PROVIDER(g_hSettingsModelProvider);
 
 #include <shellapi.h>
 
+#include <winrt/Microsoft.Terminal.Core.h>
 #include <winrt/Microsoft.Terminal.Control.h>
 #include <winrt/Microsoft.Terminal.TerminalConnection.h>
 

--- a/src/cascadia/UnitTests_TerminalCore/MockTermSettings.h
+++ b/src/cascadia/UnitTests_TerminalCore/MockTermSettings.h
@@ -26,11 +26,11 @@ namespace TerminalCoreUnitTests
         int32_t HistorySize() { return _historySize; }
         int32_t InitialRows() { return _initialRows; }
         int32_t InitialCols() { return _initialCols; }
-	til::color DefaultForeground() { return COLOR_WHITE; }
-	til::color DefaultBackground() { return COLOR_BLACK; }
+        til::color DefaultForeground() { return COLOR_WHITE; }
+        til::color DefaultBackground() { return COLOR_BLACK; }
         bool SnapOnInput() { return false; }
         bool AltGrAliasing() { return true; }
-	til::color CursorColor() { return COLOR_WHITE; }
+        til::color CursorColor() { return COLOR_WHITE; }
         CursorStyle CursorShape() const noexcept { return CursorStyle::Vintage; }
         uint32_t CursorHeight() { return 42UL; }
         winrt::hstring WordDelimiters() { return winrt::hstring(DEFAULT_WORD_DELIMITERS); }
@@ -38,13 +38,13 @@ namespace TerminalCoreUnitTests
         bool FocusFollowMouse() { return _focusFollowMouse; }
         winrt::hstring StartingTitle() { return _startingTitle; }
         bool SuppressApplicationTitle() { return _suppressApplicationTitle; }
-	til::color SelectionBackground() { return COLOR_WHITE; }
+        til::color SelectionBackground() { return COLOR_WHITE; }
         bool ForceVTInput() { return false; }
         winrt::Windows::Foundation::IReference<winrt::Microsoft::Terminal::Core::Color> TabColor() { return nullptr; }
         winrt::Windows::Foundation::IReference<winrt::Microsoft::Terminal::Core::Color> StartingTabColor() { return nullptr; }
 
         // other implemented methods
-	til::color GetColorTableEntry(int32_t) const { return 123; }
+        til::color GetColorTableEntry(int32_t) const { return 123; }
 
         // property setters - all unimplemented
         void HistorySize(int32_t) {}
@@ -64,9 +64,8 @@ namespace TerminalCoreUnitTests
         void SuppressApplicationTitle(bool suppressApplicationTitle) { _suppressApplicationTitle = suppressApplicationTitle; }
         void SelectionBackground(til::color) {}
         void ForceVTInput(bool) {}
-        void TabColor(const IInspectable&) { }
-        void StartingTabColor(const IInspectable&) { }
-
+        void TabColor(const IInspectable&) {}
+        void StartingTabColor(const IInspectable&) {}
 
     private:
         int32_t _historySize;

--- a/src/cascadia/UnitTests_TerminalCore/MockTermSettings.h
+++ b/src/cascadia/UnitTests_TerminalCore/MockTermSettings.h
@@ -26,11 +26,11 @@ namespace TerminalCoreUnitTests
         int32_t HistorySize() { return _historySize; }
         int32_t InitialRows() { return _initialRows; }
         int32_t InitialCols() { return _initialCols; }
-        uint32_t DefaultForeground() { return COLOR_WHITE; }
-        uint32_t DefaultBackground() { return COLOR_BLACK; }
+	til::color DefaultForeground() { return COLOR_WHITE; }
+	til::color DefaultBackground() { return COLOR_BLACK; }
         bool SnapOnInput() { return false; }
         bool AltGrAliasing() { return true; }
-        uint32_t CursorColor() { return COLOR_WHITE; }
+	til::color CursorColor() { return COLOR_WHITE; }
         CursorStyle CursorShape() const noexcept { return CursorStyle::Vintage; }
         uint32_t CursorHeight() { return 42UL; }
         winrt::hstring WordDelimiters() { return winrt::hstring(DEFAULT_WORD_DELIMITERS); }
@@ -38,21 +38,23 @@ namespace TerminalCoreUnitTests
         bool FocusFollowMouse() { return _focusFollowMouse; }
         winrt::hstring StartingTitle() { return _startingTitle; }
         bool SuppressApplicationTitle() { return _suppressApplicationTitle; }
-        uint32_t SelectionBackground() { return COLOR_WHITE; }
+	til::color SelectionBackground() { return COLOR_WHITE; }
         bool ForceVTInput() { return false; }
+        winrt::Windows::Foundation::IReference<winrt::Microsoft::Terminal::Core::Color> TabColor() { return nullptr; }
+        winrt::Windows::Foundation::IReference<winrt::Microsoft::Terminal::Core::Color> StartingTabColor() { return nullptr; }
 
         // other implemented methods
-        uint32_t GetColorTableEntry(int32_t) const { return 123; }
+	til::color GetColorTableEntry(int32_t) const { return 123; }
 
         // property setters - all unimplemented
         void HistorySize(int32_t) {}
         void InitialRows(int32_t) {}
         void InitialCols(int32_t) {}
-        void DefaultForeground(uint32_t) {}
-        void DefaultBackground(uint32_t) {}
+        void DefaultForeground(til::color) {}
+        void DefaultBackground(til::color) {}
         void SnapOnInput(bool) {}
         void AltGrAliasing(bool) {}
-        void CursorColor(uint32_t) {}
+        void CursorColor(til::color) {}
         void CursorShape(CursorStyle const&) noexcept {}
         void CursorHeight(uint32_t) {}
         void WordDelimiters(winrt::hstring) {}
@@ -60,11 +62,11 @@ namespace TerminalCoreUnitTests
         void FocusFollowMouse(bool focusFollowMouse) { _focusFollowMouse = focusFollowMouse; }
         void StartingTitle(winrt::hstring const& value) { _startingTitle = value; }
         void SuppressApplicationTitle(bool suppressApplicationTitle) { _suppressApplicationTitle = suppressApplicationTitle; }
-        void SelectionBackground(uint32_t) {}
+        void SelectionBackground(til::color) {}
         void ForceVTInput(bool) {}
+        void TabColor(const IInspectable&) { }
+        void StartingTabColor(const IInspectable&) { }
 
-        WINRT_PROPERTY(winrt::Windows::Foundation::IReference<uint32_t>, TabColor, nullptr);
-        WINRT_PROPERTY(winrt::Windows::Foundation::IReference<uint32_t>, StartingTabColor, nullptr);
 
     private:
         int32_t _historySize;

--- a/src/cascadia/UnitTests_TerminalCore/pch.h
+++ b/src/cascadia/UnitTests_TerminalCore/pch.h
@@ -40,6 +40,8 @@ Author(s):
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
 
+#include <winrt/Microsoft.Terminal.Core.h>
+
 // Manually include til after we include Windows.Foundation to give it winrt superpowers
 #include "til.h"
 

--- a/src/cascadia/inc/cppwinrt_utils.h
+++ b/src/cascadia/inc/cppwinrt_utils.h
@@ -107,18 +107,6 @@ public:                                                        \
 private:                                                       \
     type _##name{ __VA_ARGS__ };
 
-// Use this macro to quick implement both the getter and setter for a color property.
-// This should only be used for color types where there's no logic in the
-// getter/setter beyond just accessing/updating the value.
-// This takes advantage of til::color
-#define GETSET_COLORPROPERTY(name, ...)                                             \
-public:                                                                             \
-    winrt::Windows::UI::Color name() const noexcept { return _##name; }             \
-    void name(const winrt::Windows::UI::Color& value) noexcept { _##name = value; } \
-                                                                                    \
-private:                                                                            \
-    til::color _##name{ __VA_ARGS__ };
-
 // Use this macro to quickly implement both the getter and setter for an
 // observable property. This is similar to the WINRT_PROPERTY macro above,
 // except this will also raise a PropertyChanged event with the name of the

--- a/src/cascadia/ut_app/precomp.h
+++ b/src/cascadia/ut_app/precomp.h
@@ -45,6 +45,8 @@ Author(s):
 #include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Text.h>
 
+#include <winrt/Microsoft.Terminal.Core.h>
+
 #include "winrtTaefTemplates.hpp"
 
 // Manually include til after we include Windows.Foundation to give it winrt superpowers

--- a/src/inc/DefaultSettings.h
+++ b/src/inc/DefaultSettings.h
@@ -14,14 +14,12 @@ Author(s):
 --*/
 #pragma once
 
-constexpr COLORREF COLOR_WHITE = 0x00ffffff;
-constexpr COLORREF COLOR_BLACK = 0x00000000;
+constexpr til::color COLOR_WHITE{ 0xff, 0xff, 0xff };
+constexpr til::color COLOR_BLACK{ 0, 0, 0 };
 constexpr COLORREF OPACITY_OPAQUE = 0xff000000;
 
-constexpr COLORREF DEFAULT_FOREGROUND = COLOR_WHITE;
-constexpr COLORREF DEFAULT_FOREGROUND_WITH_ALPHA = OPACITY_OPAQUE | DEFAULT_FOREGROUND;
-constexpr COLORREF DEFAULT_BACKGROUND = COLOR_BLACK;
-constexpr COLORREF DEFAULT_BACKGROUND_WITH_ALPHA = OPACITY_OPAQUE | DEFAULT_BACKGROUND;
+constexpr auto DEFAULT_FOREGROUND = COLOR_WHITE;
+constexpr auto DEFAULT_BACKGROUND = COLOR_BLACK;
 
 constexpr short DEFAULT_HISTORY_SIZE = 9001;
 
@@ -38,7 +36,7 @@ constexpr int DEFAULT_COLS = 120;
 const std::wstring DEFAULT_PADDING{ L"8, 8, 8, 8" };
 const std::wstring DEFAULT_STARTING_DIRECTORY{ L"%USERPROFILE%" };
 
-constexpr COLORREF DEFAULT_CURSOR_COLOR = COLOR_WHITE;
+constexpr auto DEFAULT_CURSOR_COLOR = COLOR_WHITE;
 constexpr COLORREF DEFAULT_CURSOR_HEIGHT = 25;
 
 const std::wstring DEFAULT_WORD_DELIMITERS{ L" ./\\()\"'-:,.;<>~!@#$%^&*|+=[]{}~?\u2502" };

--- a/src/inc/til/color.h
+++ b/src/inc/til/color.h
@@ -158,6 +158,23 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
         }
 #endif
 
+#ifdef WINRT_Microsoft_Terminal_Core_H
+        constexpr color(const winrt::Microsoft::Terminal::Core::Color& coreColor) :
+            color(coreColor.R, coreColor.G, coreColor.B, coreColor.A)
+        {
+        }
+
+        operator winrt::Microsoft::Terminal::Core::Color() const
+        {
+            winrt::Microsoft::Terminal::Core::Color ret;
+            ret.R = r;
+            ret.G = g;
+            ret.B = b;
+            ret.A = a;
+            return ret;
+        }
+#endif
+
         constexpr bool operator==(const til::color& other) const
         {
             return abgr == other.abgr;

--- a/src/inc/til/color.h
+++ b/src/inc/til/color.h
@@ -164,7 +164,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
         {
         }
 
-        operator winrt::Microsoft::Terminal::Core::Color() const
+        operator winrt::Microsoft::Terminal::Core::Color() const noexcept
         {
             winrt::Microsoft::Terminal::Core::Color ret;
             ret.R = r;


### PR DESCRIPTION
This pull request introduces Microsoft.Terminal.Core.Color as an
alternative to both Windows.UI.Color and uint32_t/COLORREF in the
TerminalCore, ...Control, ...SettingsModel and ...SettingsEditor layers.

M.T.C.Color is trivially convertible to/from til::color and therefore
to/from COLORREF, W.U.Color, and any other color representation we might
need².

I've replaced almost every use of W.U.Color and uint32_t-as-color in the
above layers, with minor exception¹.

The need for this work is twofold.

First: We cannot bear a dependency from TerminalCore (which should,
on paper, be Windows 7 compatible) on Windows.UI or any other WinRT
namespace.

This work removes one big dependency on Windows.UI, but it does not go
all the way.

Second: TerminalCore chose to communicate mostly in packed uint32s
(COLORREF), which was inherently lossy and dangerous.

¹ The UI layers (TerminalControl, TerminalApp) still use
Windows.UI.Color as they are intimately connected to the UWP XAML UI.

² In the future, we might even be able to *use* the alpha channel...

## PR Checklist
* [x] I ran into the need for this when I introduced cursor inversion
* [X] Fixes a longstanding itch

## Validation Steps Performed
Built and ran all tests for the impacted layers, even the local ones!