### PR TITLE
Add X Macro for fun and for profit

### DIFF
--- a/src/cascadia/TerminalApp/ShortcutActionDispatch.cpp
+++ b/src/cascadia/TerminalApp/ShortcutActionDispatch.cpp
@@ -41,61 +41,9 @@ namespace winrt::TerminalApp::implementation
 
         switch (action)
         {
-            ACTION_CASE(CopyText);
-            ACTION_CASE(PasteText);
-            ACTION_CASE(OpenNewTabDropdown);
-            ACTION_CASE(DuplicateTab);
-            ACTION_CASE(OpenSettings);
-            ACTION_CASE(NewTab);
-            ACTION_CASE(CloseWindow);
-            ACTION_CASE(CloseTab);
-            ACTION_CASE(ClosePane);
-            ACTION_CASE(ScrollUp);
-            ACTION_CASE(ScrollDown);
-            ACTION_CASE(ScrollUpPage);
-            ACTION_CASE(ScrollDownPage);
-            ACTION_CASE(ScrollToTop);
-            ACTION_CASE(ScrollToBottom);
-            ACTION_CASE(NextTab);
-            ACTION_CASE(PrevTab);
-            ACTION_CASE(SendInput);
-
-        case ShortcutAction::SplitVertical:
-        case ShortcutAction::SplitHorizontal:
-        case ShortcutAction::SplitPane:
-        {
-            _SplitPaneHandlers(*this, eventArgs);
-            break;
-        }
-
-            ACTION_CASE(TogglePaneZoom);
-            ACTION_CASE(SwitchToTab);
-            ACTION_CASE(ResizePane);
-            ACTION_CASE(MoveFocus);
-            ACTION_CASE(AdjustFontSize);
-            ACTION_CASE(Find);
-            ACTION_CASE(ResetFontSize);
-            ACTION_CASE(ToggleShaderEffects);
-            ACTION_CASE(ToggleFocusMode);
-            ACTION_CASE(ToggleFullscreen);
-            ACTION_CASE(ToggleAlwaysOnTop);
-            ACTION_CASE(ToggleCommandPalette);
-            ACTION_CASE(SetColorScheme);
-            ACTION_CASE(SetTabColor);
-            ACTION_CASE(OpenTabColorPicker);
-            ACTION_CASE(RenameTab);
-            ACTION_CASE(OpenTabRenamer);
-            ACTION_CASE(ExecuteCommandline);
-            ACTION_CASE(CloseOtherTabs);
-            ACTION_CASE(CloseTabsAfter);
-            ACTION_CASE(MoveTab);
-            ACTION_CASE(TabSearch);
-            ACTION_CASE(BreakIntoDebugger);
-            ACTION_CASE(FindMatch);
-            ACTION_CASE(TogglePaneReadOnly);
-            ACTION_CASE(NewWindow);
-            ACTION_CASE(IdentifyWindow);
-            ACTION_CASE(IdentifyWindows);
+#define ON_ALL_ACTIONS(id) ACTION_CASE(id);
+            ALL_SHORTCUT_ACTIONS
+#undef ON_ALL_ACTIONS
         default:
             return false;
         }

--- a/src/cascadia/TerminalApp/ShortcutActionDispatch.h
+++ b/src/cascadia/TerminalApp/ShortcutActionDispatch.h
@@ -5,6 +5,7 @@
 
 #include "ShortcutActionDispatch.g.h"
 #include "../inc/cppwinrt_utils.h"
+#include "../TerminalSettingsModel/AllShortcutActions.h"
 
 // fwdecl unittest classes
 namespace TerminalAppLocalTests
@@ -23,55 +24,9 @@ namespace winrt::TerminalApp::implementation
 
         bool DoAction(const Microsoft::Terminal::Settings::Model::ActionAndArgs& actionAndArgs);
 
-        // clang-format off
-        DECLARE_ACTION(CopyText);
-        DECLARE_ACTION(PasteText);
-        DECLARE_ACTION(OpenNewTabDropdown);
-        DECLARE_ACTION(DuplicateTab);
-        DECLARE_ACTION(NewTab);
-        DECLARE_ACTION(CloseWindow);
-        DECLARE_ACTION(CloseTab);
-        DECLARE_ACTION(ClosePane);
-        DECLARE_ACTION(SwitchToTab);
-        DECLARE_ACTION(NextTab);
-        DECLARE_ACTION(PrevTab);
-        DECLARE_ACTION(SendInput);
-        DECLARE_ACTION(SplitPane);
-        DECLARE_ACTION(TogglePaneZoom);
-        DECLARE_ACTION(AdjustFontSize);
-        DECLARE_ACTION(ResetFontSize);
-        DECLARE_ACTION(ScrollUp);
-        DECLARE_ACTION(ScrollDown);
-        DECLARE_ACTION(ScrollUpPage);
-        DECLARE_ACTION(ScrollDownPage);
-        DECLARE_ACTION(ScrollToTop);
-        DECLARE_ACTION(ScrollToBottom);
-        DECLARE_ACTION(OpenSettings);
-        DECLARE_ACTION(ResizePane);
-        DECLARE_ACTION(Find);
-        DECLARE_ACTION(MoveFocus);
-        DECLARE_ACTION(ToggleShaderEffects);
-        DECLARE_ACTION(ToggleFocusMode);
-        DECLARE_ACTION(ToggleFullscreen);
-        DECLARE_ACTION(ToggleAlwaysOnTop);
-        DECLARE_ACTION(ToggleCommandPalette);
-        DECLARE_ACTION(SetColorScheme);
-        DECLARE_ACTION(SetTabColor);
-        DECLARE_ACTION(OpenTabColorPicker);
-        DECLARE_ACTION(RenameTab);
-        DECLARE_ACTION(OpenTabRenamer);
-        DECLARE_ACTION(ExecuteCommandline);
-        DECLARE_ACTION(CloseOtherTabs);
-        DECLARE_ACTION(CloseTabsAfter);
-        DECLARE_ACTION(TabSearch);
-        DECLARE_ACTION(MoveTab);
-        DECLARE_ACTION(BreakIntoDebugger);
-        DECLARE_ACTION(FindMatch);
-        DECLARE_ACTION(TogglePaneReadOnly);
-        DECLARE_ACTION(NewWindow);
-        DECLARE_ACTION(IdentifyWindow);
-        DECLARE_ACTION(IdentifyWindows);
-        // clang-format on
+#define ON_ALL_ACTIONS(action) DECLARE_ACTION(action);
+        ALL_SHORTCUT_ACTIONS
+#undef ON_ALL_ACTIONS
 
     private:
         friend class TerminalAppLocalTests::SettingsTests;

--- a/src/cascadia/TerminalApp/ShortcutActionDispatch.idl
+++ b/src/cascadia/TerminalApp/ShortcutActionDispatch.idl
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+#include "../TerminalSettingsModel/AllShortcutActions.h"
 
 #define ACTION_EVENT(name) event Windows.Foundation.TypedEventHandler<ShortcutActionDispatch, Microsoft.Terminal.Settings.Model.ActionEventArgs> name
 
@@ -10,53 +11,10 @@ namespace TerminalApp
 
         Boolean DoAction(Microsoft.Terminal.Settings.Model.ActionAndArgs actionAndArgs);
 
-        ACTION_EVENT(CopyText);
-        ACTION_EVENT(PasteText);
-        ACTION_EVENT(NewTab);
-        ACTION_EVENT(OpenNewTabDropdown);
-        ACTION_EVENT(DuplicateTab);
-        ACTION_EVENT(CloseWindow);
-        ACTION_EVENT(CloseTab);
-        ACTION_EVENT(ClosePane);
-        ACTION_EVENT(SwitchToTab);
-        ACTION_EVENT(NextTab);
-        ACTION_EVENT(PrevTab);
-        ACTION_EVENT(SendInput);
-        ACTION_EVENT(SplitPane);
-        ACTION_EVENT(TogglePaneZoom);
-        ACTION_EVENT(AdjustFontSize);
-        ACTION_EVENT(ResetFontSize);
-        ACTION_EVENT(ScrollUp);
-        ACTION_EVENT(ScrollDown);
-        ACTION_EVENT(ScrollUpPage);
-        ACTION_EVENT(ScrollDownPage);
-        ACTION_EVENT(ScrollToTop);
-        ACTION_EVENT(ScrollToBottom);
-        ACTION_EVENT(OpenSettings);
-        ACTION_EVENT(ResizePane);
-        ACTION_EVENT(Find);
-        ACTION_EVENT(MoveFocus);
-        ACTION_EVENT(ToggleShaderEffects);
-        ACTION_EVENT(ToggleFocusMode);
-        ACTION_EVENT(ToggleFullscreen);
-        ACTION_EVENT(ToggleAlwaysOnTop);
-        ACTION_EVENT(ToggleCommandPalette);
-        ACTION_EVENT(SetColorScheme);
-        ACTION_EVENT(SetTabColor);
-        ACTION_EVENT(OpenTabColorPicker);
-        ACTION_EVENT(RenameTab);
-        ACTION_EVENT(OpenTabRenamer);
-        ACTION_EVENT(ExecuteCommandline);
-        ACTION_EVENT(CloseOtherTabs);
-        ACTION_EVENT(CloseTabsAfter);
-        ACTION_EVENT(TabSearch);
-        ACTION_EVENT(MoveTab);
-        ACTION_EVENT(BreakIntoDebugger);
-        ACTION_EVENT(FindMatch);
-        ACTION_EVENT(TogglePaneReadOnly);
-        ACTION_EVENT(NewWindow);
-        ACTION_EVENT(IdentifyWindow);
-        ACTION_EVENT(IdentifyWindows);
+        // When adding a new action, add them to AllShortcutActions.h!
+        #define ON_ALL_ACTIONS(action) ACTION_EVENT(action);
+        ALL_SHORTCUT_ACTIONS
+        #undef ON_ALL_ACTIONS
 
     }
 }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -949,53 +949,9 @@ namespace winrt::TerminalApp::implementation
         // Hook up the ShortcutActionDispatch object's events to our handlers.
         // They should all be hooked up here, regardless of whether or not
         // there's an actual keychord for them.
-        HOOKUP_ACTION(OpenNewTabDropdown);
-        HOOKUP_ACTION(DuplicateTab);
-        HOOKUP_ACTION(CloseTab);
-        HOOKUP_ACTION(ClosePane);
-        HOOKUP_ACTION(CloseWindow);
-        HOOKUP_ACTION(ScrollUp);
-        HOOKUP_ACTION(ScrollDown);
-        HOOKUP_ACTION(NextTab);
-        HOOKUP_ACTION(PrevTab);
-        HOOKUP_ACTION(SendInput);
-        HOOKUP_ACTION(SplitPane);
-        HOOKUP_ACTION(TogglePaneZoom);
-        HOOKUP_ACTION(ScrollUpPage);
-        HOOKUP_ACTION(ScrollDownPage);
-        HOOKUP_ACTION(ScrollToTop);
-        HOOKUP_ACTION(ScrollToBottom);
-        HOOKUP_ACTION(OpenSettings);
-        HOOKUP_ACTION(PasteText);
-        HOOKUP_ACTION(NewTab);
-        HOOKUP_ACTION(SwitchToTab);
-        HOOKUP_ACTION(ResizePane);
-        HOOKUP_ACTION(MoveFocus);
-        HOOKUP_ACTION(CopyText);
-        HOOKUP_ACTION(AdjustFontSize);
-        HOOKUP_ACTION(Find);
-        HOOKUP_ACTION(ResetFontSize);
-        HOOKUP_ACTION(ToggleShaderEffects);
-        HOOKUP_ACTION(ToggleFocusMode);
-        HOOKUP_ACTION(ToggleFullscreen);
-        HOOKUP_ACTION(ToggleAlwaysOnTop);
-        HOOKUP_ACTION(ToggleCommandPalette);
-        HOOKUP_ACTION(SetColorScheme);
-        HOOKUP_ACTION(SetTabColor);
-        HOOKUP_ACTION(OpenTabColorPicker);
-        HOOKUP_ACTION(RenameTab);
-        HOOKUP_ACTION(OpenTabRenamer);
-        HOOKUP_ACTION(ExecuteCommandline);
-        HOOKUP_ACTION(CloseOtherTabs);
-        HOOKUP_ACTION(CloseTabsAfter);
-        HOOKUP_ACTION(TabSearch);
-        HOOKUP_ACTION(MoveTab);
-        HOOKUP_ACTION(BreakIntoDebugger);
-        HOOKUP_ACTION(FindMatch);
-        HOOKUP_ACTION(TogglePaneReadOnly);
-        HOOKUP_ACTION(NewWindow);
-        HOOKUP_ACTION(IdentifyWindow);
-        HOOKUP_ACTION(IdentifyWindows);
+#define ON_ALL_ACTIONS(action) HOOKUP_ACTION(action);
+        ALL_SHORTCUT_ACTIONS
+#undef ON_ALL_ACTIONS
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -313,54 +313,9 @@ namespace winrt::TerminalApp::implementation
 
 #pragma region ActionHandlers
         // These are all defined in AppActionHandlers.cpp
-        DECLARE_ACTION_HANDLER(OpenNewTabDropdown);
-        DECLARE_ACTION_HANDLER(DuplicateTab);
-        DECLARE_ACTION_HANDLER(CloseTab);
-        DECLARE_ACTION_HANDLER(ClosePane);
-        DECLARE_ACTION_HANDLER(ScrollUp);
-        DECLARE_ACTION_HANDLER(ScrollDown);
-        DECLARE_ACTION_HANDLER(NextTab);
-        DECLARE_ACTION_HANDLER(PrevTab);
-        DECLARE_ACTION_HANDLER(SendInput);
-        DECLARE_ACTION_HANDLER(SplitPane);
-        DECLARE_ACTION_HANDLER(TogglePaneZoom);
-        DECLARE_ACTION_HANDLER(ScrollUpPage);
-        DECLARE_ACTION_HANDLER(ScrollDownPage);
-        DECLARE_ACTION_HANDLER(ScrollToTop);
-        DECLARE_ACTION_HANDLER(ScrollToBottom);
-        DECLARE_ACTION_HANDLER(OpenSettings);
-        DECLARE_ACTION_HANDLER(PasteText);
-        DECLARE_ACTION_HANDLER(NewTab);
-        DECLARE_ACTION_HANDLER(SwitchToTab);
-        DECLARE_ACTION_HANDLER(ResizePane);
-        DECLARE_ACTION_HANDLER(MoveFocus);
-        DECLARE_ACTION_HANDLER(CopyText);
-        DECLARE_ACTION_HANDLER(CloseWindow);
-        DECLARE_ACTION_HANDLER(AdjustFontSize);
-        DECLARE_ACTION_HANDLER(Find);
-        DECLARE_ACTION_HANDLER(ResetFontSize);
-        DECLARE_ACTION_HANDLER(ToggleShaderEffects);
-        DECLARE_ACTION_HANDLER(ToggleFocusMode);
-        DECLARE_ACTION_HANDLER(ToggleFullscreen);
-        DECLARE_ACTION_HANDLER(ToggleAlwaysOnTop);
-        DECLARE_ACTION_HANDLER(SetColorScheme);
-        DECLARE_ACTION_HANDLER(SetTabColor);
-        DECLARE_ACTION_HANDLER(OpenTabColorPicker);
-        DECLARE_ACTION_HANDLER(RenameTab);
-        DECLARE_ACTION_HANDLER(OpenTabRenamer);
-        DECLARE_ACTION_HANDLER(ExecuteCommandline);
-        DECLARE_ACTION_HANDLER(ToggleCommandPalette);
-        DECLARE_ACTION_HANDLER(CloseOtherTabs);
-        DECLARE_ACTION_HANDLER(CloseTabsAfter);
-        DECLARE_ACTION_HANDLER(TabSearch);
-        DECLARE_ACTION_HANDLER(MoveTab);
-        DECLARE_ACTION_HANDLER(BreakIntoDebugger);
-        DECLARE_ACTION_HANDLER(FindMatch);
-        DECLARE_ACTION_HANDLER(TogglePaneReadOnly);
-        DECLARE_ACTION_HANDLER(NewWindow);
-        DECLARE_ACTION_HANDLER(IdentifyWindow);
-        DECLARE_ACTION_HANDLER(IdentifyWindows);
-        // Make sure to hook new actions up in _RegisterActionCallbacks!
+#define ON_ALL_ACTIONS(action) DECLARE_ACTION_HANDLER(action);
+        ALL_SHORTCUT_ACTIONS
+#undef ON_ALL_ACTIONS
 #pragma endregion
 
         friend class TerminalAppLocalTests::TabTests;

--- a/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
+++ b/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+// For a clearer explanation of how this file should be used, see:
+// https://en.wikipedia.org/wiki/X_Macro
+//
+// Include this file to be able to quickly define some code in the exact same
+// way for _every single shortcut action_. To use:
+//
+// 1. Include this file
+// 2. Define the ON_ALL_ACTIONS macro with what you want each action to show up
+//    as. Ex:
+//
+//    #define ON_ALL_ACTIONS(action) void action##Handler();
+//
+// 3. Then, use the ALL_SHORTCUT_ACTIONS macro to get the ON_ALL_ACTIONS marcro
+//    repeated once for every ShortcutAction
+//
+// This is used in KeyMapping.idl, ShortcutAction.*, TerminalPage.*, etc. to
+// reduce the number of places where we must copy-paste boiler-plate code for
+// each action. This is _NOT_ something that should be used when any individual
+// case should be customized.
+
+#define ALL_SHORTCUT_ACTIONS             \
+    ON_ALL_ACTIONS(CopyText)             \
+    ON_ALL_ACTIONS(PasteText)            \
+    ON_ALL_ACTIONS(OpenNewTabDropdown)   \
+    ON_ALL_ACTIONS(DuplicateTab)         \
+    ON_ALL_ACTIONS(NewTab)               \
+    ON_ALL_ACTIONS(CloseWindow)          \
+    ON_ALL_ACTIONS(CloseTab)             \
+    ON_ALL_ACTIONS(ClosePane)            \
+    ON_ALL_ACTIONS(NextTab)              \
+    ON_ALL_ACTIONS(PrevTab)              \
+    ON_ALL_ACTIONS(SendInput)            \
+    ON_ALL_ACTIONS(SplitPane)            \
+    ON_ALL_ACTIONS(TogglePaneZoom)       \
+    ON_ALL_ACTIONS(SwitchToTab)          \
+    ON_ALL_ACTIONS(AdjustFontSize)       \
+    ON_ALL_ACTIONS(ResetFontSize)        \
+    ON_ALL_ACTIONS(ScrollUp)             \
+    ON_ALL_ACTIONS(ScrollDown)           \
+    ON_ALL_ACTIONS(ScrollUpPage)         \
+    ON_ALL_ACTIONS(ScrollDownPage)       \
+    ON_ALL_ACTIONS(ScrollToTop)          \
+    ON_ALL_ACTIONS(ScrollToBottom)       \
+    ON_ALL_ACTIONS(ResizePane)           \
+    ON_ALL_ACTIONS(MoveFocus)            \
+    ON_ALL_ACTIONS(Find)                 \
+    ON_ALL_ACTIONS(ToggleShaderEffects)  \
+    ON_ALL_ACTIONS(ToggleFocusMode)      \
+    ON_ALL_ACTIONS(ToggleFullscreen)     \
+    ON_ALL_ACTIONS(ToggleAlwaysOnTop)    \
+    ON_ALL_ACTIONS(OpenSettings)         \
+    ON_ALL_ACTIONS(SetColorScheme)       \
+    ON_ALL_ACTIONS(SetTabColor)          \
+    ON_ALL_ACTIONS(OpenTabColorPicker)   \
+    ON_ALL_ACTIONS(RenameTab)            \
+    ON_ALL_ACTIONS(OpenTabRenamer)       \
+    ON_ALL_ACTIONS(ExecuteCommandline)   \
+    ON_ALL_ACTIONS(ToggleCommandPalette) \
+    ON_ALL_ACTIONS(CloseOtherTabs)       \
+    ON_ALL_ACTIONS(CloseTabsAfter)       \
+    ON_ALL_ACTIONS(TabSearch)            \
+    ON_ALL_ACTIONS(MoveTab)              \
+    ON_ALL_ACTIONS(BreakIntoDebugger)    \
+    ON_ALL_ACTIONS(TogglePaneReadOnly)   \
+    ON_ALL_ACTIONS(FindMatch)            \
+    ON_ALL_ACTIONS(NewWindow)            \
+    ON_ALL_ACTIONS(IdentifyWindow)       \
+    ON_ALL_ACTIONS(IdentifyWindows)

--- a/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
+++ b/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
@@ -15,7 +15,7 @@
 //
 //    #define ON_ALL_ACTIONS(action) void action##Handler();
 //
-// 3. Then, use the ALL_SHORTCUT_ACTIONS macro to get the ON_ALL_ACTIONS marcro
+// 3. Then, use the ALL_SHORTCUT_ACTIONS macro to get the ON_ALL_ACTIONS macro
 //    repeated once for every ShortcutAction
 //
 // This is used in KeyMapping.idl, ShortcutAction.*, TerminalPage.*, etc. to

--- a/src/cascadia/TerminalSettingsModel/KeyMapping.idl
+++ b/src/cascadia/TerminalSettingsModel/KeyMapping.idl
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+#include "AllShortcutActions.h"
+
 import "ActionArgs.idl";
 
 namespace Microsoft.Terminal.Settings.Model
@@ -8,55 +10,11 @@ namespace Microsoft.Terminal.Settings.Model
     enum ShortcutAction
     {
         Invalid = 0,
-        CopyText,
-        PasteText,
-        OpenNewTabDropdown,
-        DuplicateTab,
-        NewTab,
-        CloseWindow,
-        CloseTab,
-        ClosePane,
-        NextTab,
-        PrevTab,
-        SplitVertical,
-        SplitHorizontal,
-        SendInput,
-        SplitPane,
-        TogglePaneZoom,
-        SwitchToTab,
-        AdjustFontSize,
-        ResetFontSize,
-        ScrollUp,
-        ScrollDown,
-        ScrollUpPage,
-        ScrollDownPage,
-        ScrollToTop,
-        ScrollToBottom,
-        ResizePane,
-        MoveFocus,
-        Find,
-        ToggleShaderEffects,
-        ToggleFocusMode,
-        ToggleFullscreen,
-        ToggleAlwaysOnTop,
-        OpenSettings,
-        SetColorScheme,
-        SetTabColor,
-        OpenTabColorPicker,
-        RenameTab,
-        OpenTabRenamer,
-        ExecuteCommandline,
-        ToggleCommandPalette,
-        CloseOtherTabs,
-        CloseTabsAfter,
-        TabSearch,
-        MoveTab,
-        BreakIntoDebugger,
-        TogglePaneReadOnly,
-        FindMatch,
-        NewWindow,
-        IdentifyWindow,
-        IdentifyWindows
+
+        // When adding a new action, add them to AllShortcutActions.h!
+        #define ON_ALL_ACTIONS(action) action,
+        ALL_SHORTCUT_ACTIONS
+        #undef ON_ALL_ACTIONS
     };
 
     [default_interface] runtimeclass ActionAndArgs {


### PR DESCRIPTION
**Summary of the Pull Request**

This PR adds an X Macro for defining our ShortcutActions. This means that you can add the action in one place, and have the macro synthesize all sorts of boilerplate for you!

From the `AllShortcutActions.h` file:

> For a clearer explanation of how this file should be used, see:
> https://en.wikipedia.org/wiki/X_Macro
>
> Include this file to be able to quickly define some code in the exact same
> way for _every single shortcut action_. To use:
>
> 1. Include this file
> 2. Define the ON_ALL_ACTIONS macro with what you want each action to show up
>    as. Ex:
>
>    #define ON_ALL_ACTIONS(action) void action##Handler();
>
> 3. Then, use the ALL_SHORTCUT_ACTIONS macro to get the ON_ALL_ACTIONS marcro
>    repeated once for every ShortcutAction
>
> This is used in KeyMapping.idl, ShortcutAction.*, TerminalPage.*, etc. to
> reduce the number of places where we must copy-paste boiler-plate code for
> each action. This is _NOT_ something that should be used when any individual
> case should be customized.

**PR Checklist**
* [x] Scratches an itch
* [x] I work here
* [x] Tests passed
* [n/a] Requires documentation to be updated

**Detailed Description of the Pull Request / Additional comments**

Originally I had this blocked as a follow up to #9662. However, I've grown tired after a month of merging main into this branch, and I'm just shipping it separately. It will inevitably conflict with anyone who has actions in flight currently.

**Validation Steps Performed**
The code still builds exactly as before!
