### PR TITLE
Add `identifyWindow(s?)` to the schema

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -77,6 +77,8 @@
         "duplicateTab",
         "find",
         "findMatch",
+        "identifyWindow",
+        "identifyWindows",
         "moveFocus",
         "moveTab",
         "newTab",


### PR DESCRIPTION
I forgot this in #9523 
* fixes #9721
* This is a docs fix
* I work here