### PR TITLE
Add support for LightDismissing the renamer

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -138,7 +138,8 @@
                          Title="{x:Bind WindowIdForDisplay}"
                          x:Load="False"
                          ActionButtonClick="_WindowRenamerActionClick"
-                         ActionButtonStyle="{ThemeResource AccentButtonStyle}">
+                         ActionButtonStyle="{ThemeResource AccentButtonStyle}"
+                         IsLightDismissEnabled="True">
             <mux:TeachingTip.Content>
                 <TextBox x:Name="WindowRenamerTextBox"
                          KeyUp="_WindowRenamerKeyUp"


### PR DESCRIPTION
## Summary of the Pull Request

Huh, I guess I missed making the window renamer light-dismissable. This is a oneline fix for that.

Light dismissing is treated as a _cancel_, not as a commit. 

## References
* Added in #9662

## PR Checklist
* [x] Closes #9718 
* [x] I work here
* [n/a] Tests added/passed
* [n/a] Requires documentation to be updated

## Validation Steps Performed

This feels right. 

