### PR TITLE
Reduce instances of font fallback dialog

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2113,7 +2113,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         //      actually fail. We need a way to gracefully fallback.
         _renderer->TriggerFontChange(newDpi, _desiredFont, _actualFont);
 
-         // If the actual font went through the last-chance fallback routines...
+        // If the actual font went through the last-chance fallback routines...
         if (_actualFont.GetFallback())
         {
             // Then warn the user that we picked something because we couldn't find their font.

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2113,8 +2113,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         //      actually fail. We need a way to gracefully fallback.
         _renderer->TriggerFontChange(newDpi, _desiredFont, _actualFont);
 
-        // If the actual font isn't what was requested...
-        if (_actualFont.GetFaceName() != _desiredFont.GetFaceName())
+         // If the actual font went through the last-chance fallback routines...
+        if (_actualFont.GetFallback())
         {
             // Then warn the user that we picked something because we couldn't find their font.
 

--- a/src/renderer/base/fontinfo.cpp
+++ b/src/renderer/base/fontinfo.cpp
@@ -20,7 +20,8 @@ FontInfo::FontInfo(const std::wstring_view faceName,
                    const bool fSetDefaultRasterFont /* = false */) :
     FontInfoBase(faceName, family, weight, fSetDefaultRasterFont, codePage),
     _coordSize(coordSize),
-    _coordSizeUnscaled(coordSize)
+    _coordSizeUnscaled(coordSize),
+    _didFallback(false)
 {
     ValidateFont();
 }
@@ -58,6 +59,16 @@ void FontInfo::SetFromEngine(const std::wstring_view faceName,
     _coordSizeUnscaled = coordSizeUnscaled;
 
     _ValidateCoordSize();
+}
+
+bool FontInfo::GetFallback() const noexcept
+{
+    return _didFallback;
+}
+
+void FontInfo::SetFallback(const bool didFallback) noexcept
+{
+    _didFallback = didFallback;
 }
 
 void FontInfo::ValidateFont()

--- a/src/renderer/dx/DxFontRenderData.cpp
+++ b/src/renderer/dx/DxFontRenderData.cpp
@@ -63,7 +63,7 @@ DxFontRenderData::DxFontRenderData(::Microsoft::WRL::ComPtr<IDWriteFactory1> dwr
                  auto extension = p.path().extension().wstring();
                  std::transform(extension.begin(), extension.end(), extension.begin(), std::towlower);
 
-                 const std::wstring_view ttfExtension{ L"ttf" };
+                 const std::wstring_view ttfExtension{ L".ttf" };
                  if (ttfExtension == extension)
                  {
                      fontSetBuilder2->AddFontFile(p.path().c_str());
@@ -666,7 +666,7 @@ CATCH_RETURN()
             familyName = familyName.substr(0, lastSpace);
 
             // Try to find it with the shortened family name
-            auto face = _FindFontFace(familyName, weight, stretch, style, localeName);
+            face = _FindFontFace(familyName, weight, stretch, style, localeName);
         }
 
         // Alright, if our quick shot at trimming didn't work either...

--- a/src/renderer/dx/DxFontRenderData.cpp
+++ b/src/renderer/dx/DxFontRenderData.cpp
@@ -60,14 +60,14 @@ DxFontRenderData::DxFontRenderData(::Microsoft::WRL::ComPtr<IDWriteFactory1> dwr
         {
             if (p.is_regular_file())
             {
-                 auto extension = p.path().extension().wstring();
-                 std::transform(extension.begin(), extension.end(), extension.begin(), std::towlower);
+                auto extension = p.path().extension().wstring();
+                std::transform(extension.begin(), extension.end(), extension.begin(), std::towlower);
 
-                 const std::wstring_view ttfExtension{ L".ttf" };
-                 if (ttfExtension == extension)
-                 {
-                     fontSetBuilder2->AddFontFile(p.path().c_str());
-                 }
+                const std::wstring_view ttfExtension{ L".ttf" };
+                if (ttfExtension == extension)
+                {
+                    fontSetBuilder2->AddFontFile(p.path().c_str());
+                }
             }
         }
 

--- a/src/renderer/dx/DxFontRenderData.cpp
+++ b/src/renderer/dx/DxFontRenderData.cpp
@@ -644,7 +644,7 @@ CATCH_RETURN()
     if (!face)
     {
         // If we missed, try looking a little more by trimming the last word off the requested family name a few times.
-        // Quite often, folks are specifying weights or something in the familyName and it causes misresolution and
+        // Quite often, folks are specifying weights or something in the familyName and it causes failed resolution and
         // an unexpected error dialog. We theoretically could detect the weight words and convert them, but this
         // is the quick fix for the majority scenario.
         // The long/full fix is backlogged to GH#xxxx

--- a/src/renderer/dx/DxFontRenderData.cpp
+++ b/src/renderer/dx/DxFontRenderData.cpp
@@ -737,7 +737,7 @@ CATCH_RETURN()
     // If the system collection missed, try the files sitting next to our binary.
     if (!familyExists)
     {
-        const auto nearbyCollection = NearbyCollection();
+        auto&& nearbyCollection = NearbyCollection();
 
         // May be null on OS below Windows 10. If null, just skip the attempt.
         if (nearbyCollection)

--- a/src/renderer/dx/DxFontRenderData.h
+++ b/src/renderer/dx/DxFontRenderData.h
@@ -35,7 +35,7 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] Microsoft::WRL::ComPtr<IDWriteFontFallback> SystemFontFallback();
 
-        [[nodiscard]] Microsoft::WRL::ComPtr<IDWriteFontCollection1> NearbyCollection() const;
+        [[nodiscard]] const Microsoft::WRL::ComPtr<IDWriteFontCollection1>& NearbyCollection() const;
 
         [[nodiscard]] til::size GlyphCell() noexcept;
         [[nodiscard]] LineMetrics GetLineMetrics() noexcept;

--- a/src/renderer/dx/DxFontRenderData.h
+++ b/src/renderer/dx/DxFontRenderData.h
@@ -35,6 +35,8 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] Microsoft::WRL::ComPtr<IDWriteFontFallback> SystemFontFallback();
 
+        [[nodiscard]] Microsoft::WRL::ComPtr<IDWriteFontCollection1> PackageCollection() const;
+
         [[nodiscard]] til::size GlyphCell() noexcept;
         [[nodiscard]] LineMetrics GetLineMetrics() noexcept;
 
@@ -88,6 +90,7 @@ namespace Microsoft::Console::Render
         ::Microsoft::WRL::ComPtr<IBoxDrawingEffect> _boxDrawingEffect;
 
         ::Microsoft::WRL::ComPtr<IDWriteFontFallback> _systemFontFallback;
+        mutable ::Microsoft::WRL::ComPtr<IDWriteFontCollection1> _packageLoadCollection;
         std::wstring _userLocaleName;
 
         til::size _glyphCell;

--- a/src/renderer/dx/DxFontRenderData.h
+++ b/src/renderer/dx/DxFontRenderData.h
@@ -35,7 +35,7 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] Microsoft::WRL::ComPtr<IDWriteFontFallback> SystemFontFallback();
 
-        [[nodiscard]] Microsoft::WRL::ComPtr<IDWriteFontCollection1> PackageCollection() const;
+        [[nodiscard]] Microsoft::WRL::ComPtr<IDWriteFontCollection1> NearbyCollection() const;
 
         [[nodiscard]] til::size GlyphCell() noexcept;
         [[nodiscard]] LineMetrics GetLineMetrics() noexcept;
@@ -79,6 +79,8 @@ namespace Microsoft::Console::Render
         // A locale that can be used on construction of assorted DX objects that want to know one.
         [[nodiscard]] std::wstring _GetUserLocaleName();
 
+        [[nodiscard]] static std::vector<std::filesystem::path> s_GetNearbyFonts();
+
         ::Microsoft::WRL::ComPtr<IDWriteFactory1> _dwriteFactory;
 
         ::Microsoft::WRL::ComPtr<IDWriteTextAnalyzer1> _dwriteTextAnalyzer;
@@ -90,7 +92,7 @@ namespace Microsoft::Console::Render
         ::Microsoft::WRL::ComPtr<IBoxDrawingEffect> _boxDrawingEffect;
 
         ::Microsoft::WRL::ComPtr<IDWriteFontFallback> _systemFontFallback;
-        mutable ::Microsoft::WRL::ComPtr<IDWriteFontCollection1> _packageLoadCollection;
+        mutable ::Microsoft::WRL::ComPtr<IDWriteFontCollection1> _nearbyCollection;
         std::wstring _userLocaleName;
 
         til::size _glyphCell;

--- a/src/renderer/dx/DxFontRenderData.h
+++ b/src/renderer/dx/DxFontRenderData.h
@@ -62,7 +62,8 @@ namespace Microsoft::Console::Render
                                                                                               DWRITE_FONT_WEIGHT& weight,
                                                                                               DWRITE_FONT_STRETCH& stretch,
                                                                                               DWRITE_FONT_STYLE& style,
-                                                                                              std::wstring& localeName) const;
+                                                                                              std::wstring& localeName,
+                                                                                              bool& didFallback) const;
 
         [[nodiscard]] ::Microsoft::WRL::ComPtr<IDWriteFontFace1> _FindFontFace(std::wstring& familyName,
                                                                                DWRITE_FONT_WEIGHT& weight,

--- a/src/renderer/inc/FontInfo.hpp
+++ b/src/renderer/inc/FontInfo.hpp
@@ -47,6 +47,9 @@ public:
                        const COORD coordSize,
                        const COORD coordSizeUnscaled);
 
+    bool GetFallback() const noexcept;
+    void SetFallback(const bool didFallback) noexcept;
+
     void ValidateFont();
 
     friend bool operator==(const FontInfo& a, const FontInfo& b);
@@ -56,6 +59,7 @@ private:
 
     COORD _coordSize;
     COORD _coordSizeUnscaled;
+    bool _didFallback;
 };
 
 bool operator==(const FontInfo& a, const FontInfo& b);


### PR DESCRIPTION
Reduce instances of font fallback dialog through package font loading,
basic name trimming, and revised fallback test

- Adjusts the font dialog to only show when we attempt last-chance
  resolution from our hardcoded list of font names with a flag instead
  of with a string comparison by name
- Adds a resolution step to trim the font name by word from the end and
  retry to attempt to resolve a proper font that just has a weight
  suffix
- Adds a second font collection to font loading that will attempt to
  locate all TTF files sitting next to our binary, like in our package

- [x] Wrote my font preference in the JSON as `Cascadia Code Heavy` and
  watched it quietly resolve to just `Cascadia Code` without the dialog.
- [x] Put a font that isn't registered with the system into the layout
  directory for the package, set it as my desired font in Terminal, and
  watched it load just fine.
- [x] Try a font name with different casing and see if dialog doesn't
  pop anymore
- [x] Try a font with different (localized) names like ＭＳ ゴシック and
  see if dialog doesn't pop anymore
- [x] Check Win7 with WPF target

Closes #9375