### PR TITLE
Fix restore window position when exiting fullscreen

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,9 +28,5 @@
         "**/obj/**": true,
         "**/packages/**": true,
         "**/generated files/**": true
-    },
-    "vscode-nmake-tools.workspaceBuildDirectories": [
-        "f:\\terminal"
-    ],
-    "C_Cpp.default.configurationProvider": "microsoft.vscode-nmake-tools"
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,5 +28,9 @@
         "**/obj/**": true,
         "**/packages/**": true,
         "**/generated files/**": true
-    }
+    },
+    "vscode-nmake-tools.workspaceBuildDirectories": [
+        "f:\\terminal"
+    ],
+    "C_Cpp.default.configurationProvider": "microsoft.vscode-nmake-tools"
 }

--- a/src/cascadia/WindowsTerminal/IslandWindow.h
+++ b/src/cascadia/WindowsTerminal/IslandWindow.h
@@ -77,8 +77,8 @@ protected:
 
     virtual void _SetIsBorderless(const bool borderlessEnabled);
     virtual void _SetIsFullscreen(const bool fullscreenEnabled);
-    void _BackupWindowSizes();
-    void _ApplyWindowSize();
+    void _RestoreFullscreenPosition(const RECT rcWork);
+    void _SetFullscreenPosition(const RECT rcMonitor, const RECT rcWork);
 
     LONG _getDesiredWindowStyle() const;
 

--- a/src/cascadia/WindowsTerminal/IslandWindow.h
+++ b/src/cascadia/WindowsTerminal/IslandWindow.h
@@ -68,14 +68,16 @@ protected:
     [[nodiscard]] LRESULT _OnSizing(const WPARAM wParam, const LPARAM lParam);
 
     bool _borderless{ false };
-    bool _fullscreen{ false };
     bool _alwaysOnTop{ false };
-    RECT _fullscreenWindowSize;
-    RECT _nonFullscreenWindowSize;
+    bool _fullscreen{ false };
+    bool _fWasMaximizedBeforeFullscreen{ false };
+    RECT _rcWindowBeforeFullscreen;
+    RECT _rcWorkBeforeFullscreen;
+    UINT _dpiBeforeFullscreen;
 
     virtual void _SetIsBorderless(const bool borderlessEnabled);
     virtual void _SetIsFullscreen(const bool fullscreenEnabled);
-    void _BackupWindowSizes(const bool currentIsInFullscreen);
+    void _BackupWindowSizes();
     void _ApplyWindowSize();
 
     LONG _getDesiredWindowStyle() const;

--- a/src/interactivity/win32/window.cpp
+++ b/src/interactivity/win32/window.cpp
@@ -1097,11 +1097,90 @@ bool Window::IsInFullscreen() const
     return _fIsInFullscreen;
 }
 
+// Routine Description:
+// - Called when entering fullscreen, with the window's current monitor rect and work area.
+// - The current window position, dpi, work area, and maximized state are stored, and the
+//   window is positioned to the monitor rect.
+void Window::_SetFullscreenPosition(const RECT rcMonitor, const RECT rcWork)
+{
+    ::GetWindowRect(GetWindowHandle(), &_rcWindowBeforeFullscreen);
+    _dpiBeforeFullscreen = GetDpiForWindow(GetWindowHandle());
+    _fWasMaximizedBeforeFullscreen = IsZoomed(GetWindowHandle());
+    _rcWorkBeforeFullscreen = rcWork;
+
+    SetWindowPos(GetWindowHandle(),
+                 HWND_TOP,
+                 rcMonitor.left,
+                 rcMonitor.top,
+                 rcMonitor.right - rcMonitor.left,
+                 rcMonitor.bottom - rcMonitor.top,
+                 SWP_FRAMECHANGED);
+}
+
+// Routine Description:
+// - Called when exiting fullscreen, with the window's current monitor work area.
+// - The window is restored to its previous position, migrating that previous position to the
+//   window's current monitor (if the current work area or window DPI have changed).
+// - A fullscreen window's monitor can be changed by win+shift+left/right hotkeys or monitor
+//   topology changes (for example unplugging a monitor or disconnecting a remote session).
+void Window::_RestoreFullscreenPosition(const RECT rcWork)
+{
+    // If the window was previously maximized, re-maximize the window.
+    if (_fWasMaximizedBeforeFullscreen)
+    {
+        ShowWindow(GetWindowHandle(), SW_SHOWMAXIMIZED);
+        SetWindowPos(GetWindowHandle(), HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+
+        return;
+    }
+
+    // Start with the stored window position.
+    RECT rcRestore = _rcWindowBeforeFullscreen;
+
+    // If the window DPI has changed, re-size the stored position by the change in DPI. This
+    // ensures the window restores to the same logical size (even if to a monitor with a different
+    // DPI/ scale factor).
+    UINT dpiWindow = GetDpiForWindow(GetWindowHandle());
+    rcRestore.right = rcRestore.left + MulDiv(rcRestore.right - rcRestore.left, dpiWindow, _dpiBeforeFullscreen);
+    rcRestore.bottom = rcRestore.top + MulDiv(rcRestore.bottom - rcRestore.top, dpiWindow, _dpiBeforeFullscreen);
+
+    // Offset the stored position by the difference in work area.
+    OffsetRect(&rcRestore,
+               rcWork.left - _rcWorkBeforeFullscreen.left,
+               rcWork.top - _rcWorkBeforeFullscreen.top);
+
+    // Enforce that our position is entirely within the bounds of our work area.
+    // Prefer the top-left be on-screen rather than bottom-right (right before left, bottom before top).
+    if (rcRestore.right > rcWork.right)
+    {
+        OffsetRect(&rcRestore, rcWork.right - rcRestore.right, 0);
+    }
+    if (rcRestore.left < rcWork.left)
+    {
+        OffsetRect(&rcRestore, rcWork.left - rcRestore.left, 0);
+    }
+    if (rcRestore.bottom > rcWork.bottom)
+    {
+        OffsetRect(&rcRestore, 0, rcWork.bottom - rcRestore.bottom);
+    }
+    if (rcRestore.top < rcWork.top)
+    {
+        OffsetRect(&rcRestore, 0, rcWork.top - rcRestore.top);
+    }
+
+    // Show the window at the computed position.
+    SetWindowPos(GetWindowHandle(),
+                 HWND_TOP,
+                 rcRestore.left,
+                 rcRestore.top,
+                 rcRestore.right - rcRestore.left,
+                 rcRestore.bottom - rcRestore.top,
+                 SWP_SHOWWINDOW | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+}
+
 void Window::SetIsFullscreen(const bool fFullscreenEnabled)
 {
-    // It is possible to enter SetIsFullScreen even if we're already in full screen.
-    // Use the old is in fullscreen flag to gate checks that rely on the current state.
-    bool fOldIsInFullscreen = _fIsInFullscreen;
+    const bool fChangingFullscreen = (fFullscreenEnabled != _fIsInFullscreen);
     _fIsInFullscreen = fFullscreenEnabled;
 
     HWND const hWnd = GetWindowHandle();
@@ -1137,100 +1216,28 @@ void Window::SetIsFullscreen(const bool fFullscreenEnabled)
     }
     SetWindowLongW(hWnd, GWL_EXSTYLE, dwExWindowStyle);
 
-    if (_fIsInFullscreen && !fOldIsInFullscreen)
+    // Only change the window position if changing fullscreen state.
+    if (fChangingFullscreen)
     {
-        _BackupWindowSizes();
-    }
-    _ApplyWindowSize();
-}
+        // Get the monitor info for the window's current monitor.
+        MONITORINFO mi = {};
+        mi.cbSize = sizeof(mi);
+        GetMonitorInfo(MonitorFromWindow(GetWindowHandle(), MONITOR_DEFAULTTONEAREST), &mi);
 
-void Window::_BackupWindowSizes()
-{
-    ::GetWindowRect(GetWindowHandle(), &_rcWindowBeforeFullscreen);
-    _dpiBeforeFullscreen = GetDpiForWindow(GetWindowHandle());
-    _fWasMaximizedBeforeFullscreen = IsZoomed(GetWindowHandle());
-
-    HMONITOR hmon = MonitorFromWindow(GetWindowHandle(), MONITOR_DEFAULTTONEAREST);
-    MONITORINFO mi = {};
-    mi.cbSize = sizeof(mi);
-    GetMonitorInfo(hmon, &mi);
-
-    _rcWorkBeforeFullscreen = mi.rcWork;
-}
-
-void Window::_ApplyWindowSize()
-{
-    HMONITOR hmon = MonitorFromWindow(GetWindowHandle(), MONITOR_DEFAULTTONEAREST);
-    MONITORINFO mi = {};
-    mi.cbSize = sizeof(mi);
-    GetMonitorInfo(hmon, &mi);
-
-    if (_fIsInFullscreen)
-    {
-        SetWindowPos(GetWindowHandle(),
-                     HWND_TOP,
-                     mi.rcMonitor.left,
-                     mi.rcMonitor.top,
-                     mi.rcMonitor.right - mi.rcMonitor.left,
-                     mi.rcMonitor.bottom - mi.rcMonitor.top,
-                     SWP_FRAMECHANGED);
-    }
-    else
-    {
-        if (_fWasMaximizedBeforeFullscreen)
+        if (_fIsInFullscreen)
         {
-            ShowWindow(GetWindowHandle(), SW_SHOWMAXIMIZED);
-            SetWindowPos(GetWindowHandle(), HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+            // Store the window's current position and size the window to the monitor.
+            _SetFullscreenPosition(mi.rcMonitor, mi.rcWork);
         }
         else
         {
-            RECT rcRestore = _rcWindowBeforeFullscreen;
+            // Restore the stored window position.
+            _RestoreFullscreenPosition(mi.rcWork);
 
-            UINT dpiWindow = GetDpiForWindow(GetWindowHandle());
-
-            // If window has changed DPI since storing previous position, scale the size by the DPI change.
-            rcRestore.right = rcRestore.left + MulDiv(rcRestore.right - rcRestore.left, dpiWindow, _dpiBeforeFullscreen);
-            rcRestore.bottom = rcRestore.top + MulDiv(rcRestore.bottom - rcRestore.top, dpiWindow, _dpiBeforeFullscreen);
-
-            RECT rcWork = mi.rcWork;
-
-            // Offset the stored position by the difference in work area.
-            OffsetRect(&rcRestore,
-                       rcWork.left - _rcWorkBeforeFullscreen.left,
-                       rcWork.top - _rcWorkBeforeFullscreen.top);
-
-            // Enforce that our position is entirely within the bounds of our work area.
-            // Prefer the top-left be on-screen rather than bottom-right.
-            if (rcRestore.right > rcWork.right)
-            {
-                OffsetRect(&rcRestore, rcWork.right - rcRestore.right, 0);
-            }
-            if (rcRestore.left < rcWork.left)
-            {
-                OffsetRect(&rcRestore, rcWork.left - rcRestore.left, 0);
-            }
-            if (rcRestore.bottom > rcWork.bottom)
-            {
-                OffsetRect(&rcRestore, 0, rcWork.bottom - rcRestore.bottom);
-            }
-            if (rcRestore.top < rcWork.top)
-            {
-                OffsetRect(&rcRestore, 0, rcWork.top - rcRestore.top);
-            }
-
-            // Show the window at the computed position.
-            SetWindowPos(GetWindowHandle(),
-                         HWND_TOP,
-                         rcRestore.left,
-                         rcRestore.top,
-                         rcRestore.right - rcRestore.left,
-                         rcRestore.bottom - rcRestore.top,
-                         SWP_SHOWWINDOW | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+            SCREEN_INFORMATION& siAttached = GetScreenInfo();
+            siAttached.MakeCurrentCursorVisible();
         }
     }
-
-    SCREEN_INFORMATION& siAttached = GetScreenInfo();
-    siAttached.MakeCurrentCursorVisible();
 }
 
 void Window::ToggleFullscreen()

--- a/src/interactivity/win32/window.hpp
+++ b/src/interactivity/win32/window.hpp
@@ -147,12 +147,14 @@ namespace Microsoft::Console::Interactivity::Win32
         RECT _rcClientLast;
 
         // Full screen
-        void _BackupWindowSizes(const bool fCurrentIsInFullscreen);
+        void _BackupWindowSizes();
         void _ApplyWindowSize();
 
         bool _fIsInFullscreen;
-        RECT _rcFullscreenWindowSize;
-        RECT _rcNonFullscreenWindowSize;
+        bool _fWasMaximizedBeforeFullscreen;
+        RECT _rcWindowBeforeFullscreen;
+        RECT _rcWorkBeforeFullscreen;
+        UINT _dpiBeforeFullscreen;
 
         // math helpers
         void _CalculateWindowRect(const COORD coordWindowInChars,

--- a/src/interactivity/win32/window.hpp
+++ b/src/interactivity/win32/window.hpp
@@ -147,9 +147,8 @@ namespace Microsoft::Console::Interactivity::Win32
         RECT _rcClientLast;
 
         // Full screen
-        void _BackupWindowSizes();
-        void _ApplyWindowSize();
-
+        void _RestoreFullscreenPosition(const RECT rcWork);
+        void _SetFullscreenPosition(const RECT rcMonitor, const RECT rcWork);
         bool _fIsInFullscreen;
         bool _fWasMaximizedBeforeFullscreen;
         RECT _rcWindowBeforeFullscreen;

--- a/src/interactivity/win32/windowproc.cpp
+++ b/src/interactivity/win32/windowproc.cpp
@@ -226,18 +226,15 @@ using namespace Microsoft::Console::Types;
         _UpdateSystemMetrics();
         s_ReinitializeFontsForDPIChange();
 
-        if (IsInFullscreen())
-        {
-            // If we're a full screen window, completely ignore what the DPICHANGED says as it will be bigger than the monitor and
-            // instead just ensure that the window is still taking up the full screen.
-            SetIsFullscreen(true);
-        }
-        else
-        {
-            // this is the RECT that the system suggests.
-            RECT* const prcNewScale = (RECT*)lParam;
-            SetWindowPos(hWnd, HWND_TOP, prcNewScale->left, prcNewScale->top, RECT_WIDTH(prcNewScale), RECT_HEIGHT(prcNewScale), SWP_NOZORDER | SWP_NOACTIVATE);
-        }
+        // This is the RECT that the system suggests.
+        RECT* const prcNewScale = (RECT*)lParam;
+        SetWindowPos(hWnd,
+                     HWND_TOP,
+                     prcNewScale->left,
+                     prcNewScale->top,
+                     RECT_WIDTH(prcNewScale),
+                     RECT_HEIGHT(prcNewScale),
+                     SWP_NOZORDER | SWP_NOACTIVATE);
 
         _fInDPIChange = false;
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This change cleans up the Fullscreen implementation for both conhost and Terminal, improving the restore position (where the window goes when exiting fullscreen).

Prior to this change the window wasn't guaranteed to restore somewhere on the window's current monitor when exiting fullscreen. With this change the window will restore always to its current monitor, at a reasonable location (and will 'double restore' (to fullscreen->maximize->restore) after monitor changes while fullscreen, which is the expected user behavior.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #9746
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

A fullscreen window's monitor can change.
 - Win+Shift+left/right migrates a window between monitors.
 - User could open settings, display, and move the monitor or change its DPI.
 - The monitor could be unplugged.
 - The session could be remote and be disconnected.

A fullscreen window stores a 'restore position' when entering fullscreen, used to move the window back 'where it was'. BUT, its unexpected for the window to exit fullscreen and jump to another monitor. This means its previous position must be migrated from the old monitor's work area to the new monitor's work area.

If a window is maximized, it is sized to the work area. Like with fullscreen, a maximized window has a 'restore position', though unlike with fullscreen the restore position for maximized is stored by the system itself. Migration in cases where a maximized (or fullscreen) window's monitor changes is also taken care of by the system. To restore 'safely' to maximized (after changing window styles) a window must only `SetWindowPos(SWP_FRAMECHANGED)`. While technically a maximized window that becomes fullscreen 'is still maximized' (from Win32's perspective), its prudent to also `ShowWindow(SW_MAXIMIZED)` prior to `SWP_FRAMECHANGED` (to explicitly make the window maximized).

If not restoring to maximized, the restore position is adjusted by the new/ old work area. Additionally, the new/ old window DPI is used to adjust the size of the window by the DPI change (keeping the window's logical size the same).
 - The work area origin is checked first (shifting window rect by the change in origin)
 - The DPI is checked next, changing right/ bottom (size only)
 - Each edge of the window is compared against the corresponding edge of the work area, nudging the window back on-screen if hanging offscreen. By shifting right before left, bottom before top, the top-left is guaranteed on-screen. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Tried it out. Seemed to work on my machine.
Jk, ran conhost/ terminal on mixed DPI system, max (or not), fullscreen, win+shift+left/ exit fullscreen/ maximize. Monitor unplug, etc. 
