### PR TITLE
Give our NavigationView's acrylic a fallback color

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -18,14 +18,17 @@
 
             <AcrylicBrush x:Key="NavigationViewDefaultPaneBackground"
                           BackgroundSource="Backdrop"
+                          FallbackColor="{ThemeResource SystemChromeMediumLowColor}"
                           TintColor="{ThemeResource SystemChromeMediumColor}"
                           TintOpacity="0.5" />
             <AcrylicBrush x:Key="NavigationViewTopPaneBackground"
                           BackgroundSource="Backdrop"
+                          FallbackColor="{ThemeResource SystemChromeMediumLowColor}"
                           TintColor="{ThemeResource SystemChromeMediumColor}"
                           TintOpacity="0.5" />
             <AcrylicBrush x:Key="NavigationViewExpandedPaneBackground"
                           BackgroundSource="HostBackdrop"
+                          FallbackColor="{ThemeResource SystemChromeMediumLowColor}"
                           TintColor="{ThemeResource SystemChromeMediumColor}"
                           TintOpacity="0.7" />
         </ResourceDictionary>


### PR DESCRIPTION
It will be a different color than the background, so it will look less
weird when it's unfocused. It also fixes the bug where the navigation
menu is transparent when acrylic is disabled systemwide.

Fixes #9337