### PR TITLE
Smoothen close caption button animation

### DIFF
--- a/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
+++ b/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
@@ -43,6 +43,9 @@
                                      Color="#f1707a" />
                     <SolidColorBrush x:Key="CloseButtonStrokePressed"
                                      Color="Black" />
+                    <SolidColorBrush x:Key="CloseButtonBackground"
+                                     Color="#00e81123" />
+                    <Color x:Key="CloseButtonBackgroundColor">#00e81123</Color>
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Dark">
                     <x:Double x:Key="CaptionButtonStrokeWidth">1.0</x:Double>
@@ -69,6 +72,9 @@
                                      Color="#f1707a" />
                     <SolidColorBrush x:Key="CloseButtonStrokePressed"
                                      Color="Black" />
+                    <SolidColorBrush x:Key="CloseButtonBackground"
+                                     Color="#00e81123" />
+                    <Color x:Key="CloseButtonBackgroundColor">#00e81123</Color>
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="HighContrast">
                     <x:Double x:Key="CaptionButtonStrokeWidth">3.0</x:Double>
@@ -268,9 +274,10 @@
                                         ResourceKey="CloseButtonStrokePointerOver" />
                         <StaticResource x:Key="CaptionButtonStrokePressed"
                                         ResourceKey="CloseButtonStrokePressed" />
-                        <SolidColorBrush x:Key="CaptionButtonBackground"
-                                     Color="#00e81123" />
-                        <Color x:Key="CaptionButtonBackgroundColor">#00e81123</Color>
+                        <StaticResource x:Key="CaptionButtonBackground"
+                                        ResourceKey="CloseButtonBackground" />
+                        <StaticResource x:Key="CaptionButtonBackgroundColor"
+                                        ResourceKey="CloseButtonBackgroundColor" />
                     </ResourceDictionary>
                     <ResourceDictionary x:Key="Dark">
                         <StaticResource x:Key="CaptionButtonBackgroundPointerOver"
@@ -281,9 +288,10 @@
                                         ResourceKey="CloseButtonStrokePointerOver" />
                         <StaticResource x:Key="CaptionButtonStrokePressed"
                                         ResourceKey="CloseButtonStrokePressed" />
-                        <SolidColorBrush x:Key="CaptionButtonBackground"
-                                     Color="#00e81123" />
-                        <Color x:Key="CaptionButtonBackgroundColor">#00e81123</Color>
+                        <StaticResource x:Key="CaptionButtonBackground"
+                                        ResourceKey="CloseButtonBackground" />
+                        <StaticResource x:Key="CaptionButtonBackgroundColor"
+                                        ResourceKey="CloseButtonBackgroundColor" />
                     </ResourceDictionary>
                     <ResourceDictionary x:Key="HighContrast">
                         <StaticResource x:Key="CaptionButtonBackgroundPointerOver"

--- a/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
+++ b/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
@@ -268,6 +268,9 @@
                                         ResourceKey="CloseButtonStrokePointerOver" />
                         <StaticResource x:Key="CaptionButtonStrokePressed"
                                         ResourceKey="CloseButtonStrokePressed" />
+                        <SolidColorBrush x:Key="CaptionButtonBackground"
+                                     Color="#00e81123" />
+                        <Color x:Key="CaptionButtonBackgroundColor">#00e81123</Color>
                     </ResourceDictionary>
                     <ResourceDictionary x:Key="Dark">
                         <StaticResource x:Key="CaptionButtonBackgroundPointerOver"
@@ -278,6 +281,9 @@
                                         ResourceKey="CloseButtonStrokePointerOver" />
                         <StaticResource x:Key="CaptionButtonStrokePressed"
                                         ResourceKey="CloseButtonStrokePressed" />
+                        <SolidColorBrush x:Key="CaptionButtonBackground"
+                                     Color="#00e81123" />
+                        <Color x:Key="CaptionButtonBackgroundColor">#00e81123</Color>
                     </ResourceDictionary>
                     <ResourceDictionary x:Key="HighContrast">
                         <StaticResource x:Key="CaptionButtonBackgroundPointerOver"


### PR DESCRIPTION
The red close button animation fades to gray then to transparent, when
standard behavior skips the gray part. I manually tested in light/dark/high
contrast mode.

Closes #9762