### PR TITLE
Prevent the virtual viewport bottom being moved up unintentionally

### DIFF
--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -686,6 +686,17 @@ bool ConhostInternalGetSet::InsertLines(const size_t count)
 }
 
 // Method Description:
+// - Resets the internal "virtual bottom" tracker to the top of the buffer.
+// Arguments:
+// - <none>
+// Return Value:
+// - <none>
+void ConhostInternalGetSet::ResetBottom()
+{
+    _io.GetActiveOutputBuffer().ResetBottom();
+}
+
+// Method Description:
 // - Connects the MoveToBottom call directly into our Driver Message servicing
 //      call inside Conhost.exe
 // Arguments:

--- a/src/host/outputStream.hpp
+++ b/src/host/outputStream.hpp
@@ -126,6 +126,7 @@ public:
     bool DeleteLines(const size_t count) override;
     bool InsertLines(const size_t count) override;
 
+    void ResetBottom() override;
     bool MoveToBottom() const override;
 
     bool PrivateGetColorTableEntry(const size_t index, COLORREF& value) const noexcept override;

--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -113,13 +113,14 @@ SCREEN_INFORMATION::~SCREEN_INFORMATION()
         // Set up viewport
         pScreen->_viewport = Viewport::FromDimensions({ 0, 0 },
                                                       pScreen->_IsInPtyMode() ? coordScreenBufferSize : coordWindowSize);
-        pScreen->UpdateBottom();
 
         // Set up text buffer
         pScreen->_textBuffer = std::make_unique<TextBuffer>(coordScreenBufferSize,
                                                             defaultAttributes,
                                                             uiCursorSize,
                                                             pScreen->_renderTarget);
+
+        pScreen->UpdateBottom();
 
         const auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
         pScreen->_textBuffer->GetCursor().SetColor(gci.GetCursorColor());
@@ -2520,13 +2521,17 @@ TextBufferCellIterator SCREEN_INFORMATION::GetCellDataAt(const COORD at, const V
 
 // Method Description:
 // - Updates our internal "virtual bottom" tracker with wherever the viewport
-//      currently is.
+//      currently is. This is only used to move the bottom further down, unless
+//      the buffer has shrunk, and the viewport needs to be moved back up to
+//      fit within the new buffer range.
 // - <none>
 // Return Value:
 // - <none>
 void SCREEN_INFORMATION::UpdateBottom()
 {
-    _virtualBottom = _viewport.BottomInclusive();
+    // We clamp it so it's at least as low as the current viewport bottom,
+    // but no lower than the bottom of the buffer.
+    _virtualBottom = std::clamp(_virtualBottom, _viewport.BottomInclusive(), GetBufferSize().BottomInclusive());
 }
 
 // Method Description:

--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -2535,6 +2535,19 @@ void SCREEN_INFORMATION::UpdateBottom()
 }
 
 // Method Description:
+// - Resets the internal "virtual bottom" tracker to the top of the buffer.
+//      Used when the scrollback buffer has been completely cleared.
+// - <none>
+// Return Value:
+// - <none>
+void SCREEN_INFORMATION::ResetBottom()
+{
+    // The virtual bottom points to the last line of the viewport, so at the
+    // top of the buffer it should be one less than the viewport height.
+    _virtualBottom = _viewport.Height() - 1;
+}
+
+// Method Description:
 // - Initialize the row with the cursor on it to the standard erase attributes.
 //      This is executed when we move the cursor below the current viewport in
 //      VT mode. When that happens in a real terminal, the line is brand new,

--- a/src/host/screenInfo.hpp
+++ b/src/host/screenInfo.hpp
@@ -226,6 +226,7 @@ public:
     void SetTerminalConnection(_In_ Microsoft::Console::ITerminalOutputConnection* const pTtyConnection);
 
     void UpdateBottom();
+    void ResetBottom();
     void MoveToBottom();
 
     Microsoft::Console::Render::IRenderTarget& GetRenderTarget() noexcept;

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -2030,6 +2030,9 @@ bool AdaptDispatch::_EraseScrollback()
 
             if (success)
             {
+                // Reset the virtual viewport bottom to the top of the buffer.
+                _pConApi->ResetBottom();
+
                 // Move the viewport (CAN'T be done in one call with SetConsolescreenBufferInfoEx, because legacy)
                 SMALL_RECT newViewport;
                 newViewport.Left = screen.Left;

--- a/src/terminal/adapter/conGetSet.hpp
+++ b/src/terminal/adapter/conGetSet.hpp
@@ -90,6 +90,7 @@ namespace Microsoft::Console::VirtualTerminal
         virtual bool DeleteLines(const size_t count) = 0;
         virtual bool InsertLines(const size_t count) = 0;
 
+        virtual void ResetBottom() = 0;
         virtual bool MoveToBottom() const = 0;
 
         virtual bool PrivateGetColorTableEntry(const size_t index, COLORREF& value) const = 0;

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -518,6 +518,11 @@ public:
         return TRUE;
     }
 
+    void ResetBottom() override
+    {
+        Log::Comment(L"ResetBottom MOCK called...");
+    }
+
     bool MoveToBottom() const override
     {
         Log::Comment(L"MoveToBottom MOCK called...");


### PR DESCRIPTION
## Summary of the Pull Request

The "virtual bottom" marks the last line of the mutable viewport area, which is the part of the buffer that VT sequences can write to. This region should typically only move downwards, as new lines are added to the buffer, but there were a number of cases where it was incorrectly being moved up. This PR attempts to fix that.

## PR Checklist
* [x] Closes #9754
* [x] CLA signed.
* [x] Tests added/passed
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #9754

## Detailed Description of the Pull Request / Additional comments

When a call is made to `UpdateBottom`, we now clamp the value so it's at least as low as the current viewport bottom (i.e. if the viewport has moved down, we want the virtual bottom to move down too), but no lower than the bottom of the buffer (we don't want it to be out of range).

There is one special case where we do actually want the virtual bottom to move up - when the scrollback has been cleared with an `ED3` escape sequence. So in that case we needed a new `ConGetSet` API (`ResetBottom`) to reset the virtual bottom to the top of the buffer (essentially one less than the viewport height, since the virtual bottom points to the last line of the viewport).

## Validation Steps Performed

I had to reset the virtual bottom manually in some parts of the `ScreenBufferTests`, since some of the tests were relying on the virtual bottom being automatically reset when the viewport was reset, which is no longer the case.

I've also added a new test to verify that the virtual bottom doesn't move upwards if an update is triggered while the visible viewport is scrolled up. This essentially reproduces the test case from issue #9754, which I've also manually confirmed is fixed.