### PR TITLE
Remove unused methods in ConGetSet and SCREEN_INFORMATION

### DIFF
--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -130,35 +130,6 @@ bool ConhostInternalGetSet::SetConsoleCursorPosition(const COORD position)
     return SUCCEEDED(ServiceLocator::LocateGlobals().api.SetConsoleCursorPositionImpl(info, clampedPosition));
 }
 
-// Routine Description:
-// - Connects the GetConsoleCursorInfo API call directly into our Driver Message servicing call inside Conhost.exe
-// Arguments:
-// - cursorInfo - Structure to receive console cursor rendering info
-// Return Value:
-// - true if successful (see DoSrvGetConsoleCursorInfo). false otherwise.
-bool ConhostInternalGetSet::GetConsoleCursorInfo(CONSOLE_CURSOR_INFO& cursorInfo) const
-{
-    bool visible;
-    DWORD size;
-
-    ServiceLocator::LocateGlobals().api.GetConsoleCursorInfoImpl(_io.GetActiveOutputBuffer(), size, visible);
-    cursorInfo.bVisible = visible;
-    cursorInfo.dwSize = size;
-    return true;
-}
-
-// Routine Description:
-// - Connects the SetConsoleCursorInfo API call directly into our Driver Message servicing call inside Conhost.exe
-// Arguments:
-// - cursorInfo - Updated size/visibility information to modify the cursor rendering behavior.
-// Return Value:
-// - true if successful (see DoSrvSetConsoleCursorInfo). false otherwise.
-bool ConhostInternalGetSet::SetConsoleCursorInfo(const CONSOLE_CURSOR_INFO& cursorInfo)
-{
-    const bool visible = !!cursorInfo.bVisible;
-    return SUCCEEDED(ServiceLocator::LocateGlobals().api.SetConsoleCursorInfoImpl(_io.GetActiveOutputBuffer(), cursorInfo.dwSize, visible));
-}
-
 // Method Description:
 // - Retrieves the current TextAttribute of the active screen buffer.
 // Arguments:

--- a/src/host/outputStream.hpp
+++ b/src/host/outputStream.hpp
@@ -59,9 +59,6 @@ public:
 
     bool SetConsoleCursorPosition(const COORD position) override;
 
-    bool GetConsoleCursorInfo(CONSOLE_CURSOR_INFO& cursorInfo) const override;
-    bool SetConsoleCursorInfo(const CONSOLE_CURSOR_INFO& cursorInfo) override;
-
     bool PrivateGetTextAttributes(TextAttribute& attrs) const override;
     bool PrivateSetTextAttributes(const TextAttribute& attrs) override;
 

--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -2684,26 +2684,6 @@ bool SCREEN_INFORMATION::IsCursorInMargins(const COORD cursorPosition) const noe
     return cursorPosition.Y <= margins.Bottom && cursorPosition.Y >= margins.Top;
 }
 
-// Method Description:
-// - Gets the region of the buffer that should be used for scrolling within the
-//      scroll margins. If the scroll margins aren't set, it returns the entire
-//      buffer size.
-// Arguments:
-// - <none>
-// Return Value:
-// - The area of the buffer within the scroll margins
-Viewport SCREEN_INFORMATION::GetScrollingRegion() const noexcept
-{
-    const auto buffer = GetBufferSize();
-    const bool marginsSet = AreMarginsSet();
-    const auto marginRect = GetAbsoluteScrollMargins().ToInclusive();
-    const auto margin = Viewport::FromInclusive({ buffer.Left(),
-                                                  marginsSet ? marginRect.Top : buffer.Top(),
-                                                  buffer.RightInclusive(),
-                                                  marginsSet ? marginRect.Bottom : buffer.BottomInclusive() });
-    return margin;
-}
-
 // Routine Description:
 // - Engages the legacy VT handling quirk; see TextAttribute::StripErroneousVT16VersionsOfLegacyDefaults
 void SCREEN_INFORMATION::SetIgnoreLegacyEquivalentVTAttributes() noexcept

--- a/src/host/screenInfo.hpp
+++ b/src/host/screenInfo.hpp
@@ -202,7 +202,6 @@ public:
     void SetScrollMargins(const Microsoft::Console::Types::Viewport margins);
     bool AreMarginsSet() const noexcept;
     bool IsCursorInMargins(const COORD cursorPosition) const noexcept;
-    Microsoft::Console::Types::Viewport GetScrollingRegion() const noexcept;
 
     [[nodiscard]] NTSTATUS UseAlternateScreenBuffer();
     void UseMainScreenBuffer();

--- a/src/terminal/adapter/conGetSet.hpp
+++ b/src/terminal/adapter/conGetSet.hpp
@@ -29,10 +29,8 @@ namespace Microsoft::Console::VirtualTerminal
     {
     public:
         virtual ~ConGetSet() = default;
-        virtual bool GetConsoleCursorInfo(CONSOLE_CURSOR_INFO& cursorInfo) const = 0;
         virtual bool GetConsoleScreenBufferInfoEx(CONSOLE_SCREEN_BUFFER_INFOEX& screenBufferInfo) const = 0;
         virtual bool SetConsoleScreenBufferInfoEx(const CONSOLE_SCREEN_BUFFER_INFOEX& screenBufferInfo) = 0;
-        virtual bool SetConsoleCursorInfo(const CONSOLE_CURSOR_INFO& cursorInfo) = 0;
         virtual bool SetConsoleCursorPosition(const COORD position) = 0;
 
         virtual bool PrivateIsVtInputEnabled() const = 0;

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -98,32 +98,6 @@ public:
         return _setConsoleCursorPositionResult;
     }
 
-    bool GetConsoleCursorInfo(CONSOLE_CURSOR_INFO& cursorInfo) const override
-    {
-        Log::Comment(L"GetConsoleCursorInfo MOCK called...");
-
-        if (_getConsoleCursorInfoResult)
-        {
-            cursorInfo.dwSize = _cursorSize;
-            cursorInfo.bVisible = _cursorVisible;
-        }
-
-        return _getConsoleCursorInfoResult;
-    }
-
-    bool SetConsoleCursorInfo(const CONSOLE_CURSOR_INFO& cursorInfo) override
-    {
-        Log::Comment(L"SetConsoleCursorInfo MOCK called...");
-
-        if (_setConsoleCursorInfoResult)
-        {
-            VERIFY_ARE_EQUAL(_expectedCursorSize, cursorInfo.dwSize);
-            VERIFY_ARE_EQUAL(_expectedCursorVisible, !!cursorInfo.bVisible);
-        }
-
-        return _setConsoleCursorInfoResult;
-    }
-
     bool SetConsoleWindowInfo(const bool absolute, const SMALL_RECT& window) override
     {
         Log::Comment(L"SetConsoleWindowInfo MOCK called...");
@@ -624,8 +598,6 @@ public:
         // APIs succeed by default
         _setConsoleCursorPositionResult = TRUE;
         _getConsoleScreenBufferInfoExResult = TRUE;
-        _getConsoleCursorInfoResult = TRUE;
-        _setConsoleCursorInfoResult = TRUE;
         _privateGetTextAttributesResult = TRUE;
         _privateSetTextAttributesResult = TRUE;
         _privateWriteConsoleInputWResult = TRUE;
@@ -645,11 +617,7 @@ public:
         // Call cursor positions separately
         PrepCursor(xact, yact);
 
-        _cursorSize = 33;
-        _expectedCursorSize = _cursorSize;
-
         _cursorVisible = TRUE;
-        _expectedCursorVisible = _cursorVisible;
 
         // Attribute default is gray on black.
         _attribute = TextAttribute{ FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED };
@@ -775,12 +743,9 @@ public:
     COORD _cursorPos = { 0, 0 };
     SMALL_RECT _expectedScrollRegion = { 0, 0, 0, 0 };
 
-    DWORD _cursorSize = 0;
     bool _cursorVisible = false;
 
     COORD _expectedCursorPos = { 0, 0 };
-    DWORD _expectedCursorSize = 0;
-    bool _expectedCursorVisible = false;
 
     TextAttribute _attribute = {};
     TextAttribute _expectedAttribute = {};
@@ -792,8 +757,6 @@ public:
 
     bool _getConsoleScreenBufferInfoExResult = false;
     bool _setConsoleCursorPositionResult = false;
-    bool _getConsoleCursorInfoResult = false;
-    bool _setConsoleCursorInfoResult = false;
     bool _privateGetTextAttributesResult = false;
     bool _privateSetTextAttributesResult = false;
     bool _privateWriteConsoleInputWResult = false;


### PR DESCRIPTION
This PR removes the `GetConsoleCursorInfo` and `SetConsoleCursorInfo`
methods from the `ConGetSet` interface, and the `GetScrollingRegion`
method from the `SCREEN_INFORMATION` class. None of these methods are
used anymore.

PR #2764 removed the last usage of `GetScrollingRegion`. 

The `Get/SetConsoleCursorInfo` methods don't seem to have ever been used
in the time that the terminal code has been open source, so whatever
purpose they originally served must have been replaced a long time ago.

The `GetScrollingRegion` method was originally called from the
`ScrollRegion` function, but that usage was removed in PR #2764 when the
margin handling was moved to a higher level.

I've checked that the code still compiles.

Closes #9771