### PR TITLE
Trigger taskbar progress evaluation upon pane activation

### DIFF
--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -665,7 +665,7 @@ namespace winrt::TerminalApp::implementation
 
         _RecalculateAndApplyReadOnly();
 
-        if (const auto control = pane->GetTerminalControl())
+        if (const auto control{ pane->GetTerminalControl() })
         {
             control.TaskbarProgressChanged();
         }

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -167,7 +167,6 @@ namespace winrt::TerminalApp::implementation
             if (lastFocusedControl)
             {
                 lastFocusedControl.Focus(_focusState);
-                lastFocusedControl.TaskbarProgressChanged();
             }
             // When we gain focus, remove the bell indicator if it is active
             if (_tabStatus.BellIndicator())
@@ -665,6 +664,11 @@ namespace winrt::TerminalApp::implementation
         }
 
         _RecalculateAndApplyReadOnly();
+
+        if (const auto control = pane->GetTerminalControl())
+        {
+            control.TaskbarProgressChanged();
+        }
 
         // Raise our own ActivePaneChanged event.
         _ActivePaneChangedHandlers();

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -167,6 +167,7 @@ namespace winrt::TerminalApp::implementation
             if (lastFocusedControl)
             {
                 lastFocusedControl.Focus(_focusState);
+                lastFocusedControl.TaskbarProgressChanged();
             }
             // When we gain focus, remove the bell indicator if it is active
             if (_tabStatus.BellIndicator())


### PR DESCRIPTION
Trigger TaskbarProgressChanged every time we switch between active panes
(to update the tab header if required).

Closes #9743