### PR TITLE
doc, tools: Improve docs around using clang-format with VS

### DIFF
--- a/doc/building.md
+++ b/doc/building.md
@@ -9,7 +9,13 @@ git submodule update --init --recursive
 
 OpenConsole.sln may be built from within Visual Studio or from the command-line using a set of convenience scripts & tools in the **/tools** directory:
 
-When using Visual Studio, be sure to set up the path for code formatting. To generate the required clang-format.exe file, follow one of the building instructions below and run `Invoke-CodeFormat` or `runformat`. After, go to Tools > Options > Text Editor > C++ > Formatting and checking "Use custom clang-format.exe file" in Visual Studio and choose the clang-format.exe in the repository at /packages/clang-format.win-x86.10.0.0/tools/clang-format.exe by clicking "browse" right under the check box.
+When using Visual Studio, be sure to set up the path for code formatting. To download the required clang-format.exe file, follow one of the building instructions below and run:
+```powershell
+Import-Module .\tools\OpenConsole.psm1
+Set-MsBuildDevEnvironment
+Get-Format
+```
+After, go to Tools > Options > Text Editor > C++ > Formatting and checking "Use custom clang-format.exe file" in Visual Studio and choose the clang-format.exe in the repository at /packages/clang-format.win-x86.10.0.0/tools/clang-format.exe by clicking "browse" right under the check box.
 
 ### Building in PowerShell
 

--- a/doc/building.md
+++ b/doc/building.md
@@ -9,7 +9,7 @@ git submodule update --init --recursive
 
 OpenConsole.sln may be built from within Visual Studio or from the command-line using a set of convenience scripts & tools in the **/tools** directory:
 
-When using Visual Studio, be sure to set up the path for code formatting. This can be done in Visual Studio by going to Tools > Options > Text Editor > C++ > Formatting and checking "Use custom clang-format.exe file" and choosing the clang-format.exe in the repository at /dep/llvm/clang-format.exe by clicking "browse" right under the check box.
+When using Visual Studio, be sure to set up the path for code formatting. To generate the required clang-format.exe file, follow one of the building instructions below and run `Invoke-CodeFormat` or `runformat`. After, go to Tools > Options > Text Editor > C++ > Formatting and checking "Use custom clang-format.exe file" in Visual Studio and choose the clang-format.exe in the repository at /packages/clang-format.win-x86.10.0.0/tools/clang-format.exe by clicking "browse" right under the check box.
 
 ### Building in PowerShell
 

--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -430,4 +430,12 @@ function Invoke-CodeFormat() {
     }
 }
 
-Export-ModuleMember -Function Set-MsbuildDevEnvironment,Invoke-OpenConsoleTests,Invoke-OpenConsoleBuild,Start-OpenConsole,Debug-OpenConsole,Invoke-CodeFormat,Invoke-XamlFormat,Verify-XamlFormat
+#.SYNOPSIS
+# Download clang-format.exe required for code formatting
+function Get-Format()
+{
+    $root = Find-OpenConsoleRoot
+    & "$root\dep\nuget\nuget.exe" restore "$root\tools\packages.config"
+}
+
+Export-ModuleMember -Function Set-MsbuildDevEnvironment,Invoke-OpenConsoleTests,Invoke-OpenConsoleBuild,Start-OpenConsole,Debug-OpenConsole,Invoke-CodeFormat,Invoke-XamlFormat,Verify-XamlFormat,Get-Format


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Commit https://github.com/microsoft/terminal/commit/dbbe820ae40d208c07c45b700fcc99063e68d1eb seems to change where OpenConsole.psm1 puts clang-format.exe but /doc/building.md still uses the path from commit https://github.com/microsoft/terminal/commit/9b92986b49bed8cc41fde4d6ef080921c41e6d9e.
Updated clang-format.exe's path and added the required steps to generate a clang-format.exe file.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes https://github.com/microsoft/terminal/issues/9777
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [x] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx (building.md doesn't exist in [docs repo](https://github.com/MicrosoftDocs/terminal))
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx