### PR TITLE
Propagate the hosting HWND to the new IFileDialogs

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -182,6 +182,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         return false;
     }
 
+    uint64_t MainPage::GetHostingWindow() const noexcept
+    {
+        return reinterpret_cast<uint64_t>(_hostingHwnd.value_or(nullptr));
+    }
+
     // Function Description:
     // - Called when the NavigationView is loaded. Navigates to the first item in the NavigationView, if no item is selected
     // Arguments:

--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -24,6 +24,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         void SetHostingWindow(uint64_t hostingWindow) noexcept;
         bool TryPropagateHostingWindow(IInspectable object) noexcept;
+        uint64_t GetHostingWindow() const noexcept;
 
         TYPED_EVENT(OpenJson, Windows::Foundation::IInspectable, Model::SettingsTarget);
 

--- a/src/cascadia/TerminalSettingsEditor/MainPage.idl
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.idl
@@ -10,6 +10,7 @@ namespace Microsoft.Terminal.Settings.Editor
     interface IHostedInWindow
     {
         Boolean TryPropagateHostingWindow(IInspectable i);
+        UInt64 GetHostingWindow();
     }
 
     [default_interface] runtimeclass MainPage : Windows.UI.Xaml.Controls.Page, IHostedInWindow


### PR DESCRIPTION
This is required to maintain the modality of the dialogs, which we lost
when we moved from Pickers to IFileDialog. The HWND hosting Window API
we dreamed up is incompatible with IModalDialog, because IModalDialog
requires the HWND immediately upon `Show`. We're smuggling it in a
uint64, as is tradition.

zadjii-msft noticed this in #9760.