### PR TITLE
Add names to threads to make debugging a slight bit easier

### DIFF
--- a/src/cascadia/TerminalConnection/AzureConnection.cpp
+++ b/src/cascadia/TerminalConnection/AzureConnection.cpp
@@ -132,6 +132,8 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 
         THROW_LAST_ERROR_IF_NULL(_hOutputThread);
 
+        LOG_IF_FAILED(SetThreadDescription(_hOutputThread.get(), L"AzureConnection Output Thread"));
+
         _transitionToState(ConnectionState::Connecting);
     }
 

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -278,6 +278,8 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 
         THROW_LAST_ERROR_IF_NULL(_hOutputThread);
 
+        LOG_IF_FAILED(SetThreadDescription(_hOutputThread.get(), L"ConptyConnection Output Thread"));
+
         _clientExitWait.reset(CreateThreadpoolWait(
             [](PTP_CALLBACK_INSTANCE /*callbackInstance*/, PVOID context, PTP_WAIT /*wait*/, TP_WAIT_RESULT /*waitResult*/) noexcept {
                 ConptyConnection* const pInstance = static_cast<ConptyConnection*>(context);

--- a/src/host/PtySignalInputThread.cpp
+++ b/src/host/PtySignalInputThread.cpp
@@ -182,6 +182,7 @@ bool PtySignalInputThread::_GetData(_Out_writes_bytes_(cbBuffer) void* const pBu
     RETURN_LAST_ERROR_IF_NULL(hThread);
     _hThread.reset(hThread);
     _dwThreadId = dwThreadId;
+    LOG_IF_FAILED(SetThreadDescription(hThread, L"ConPTY Signal Handler Thread"));
 
     return S_OK;
 }

--- a/src/host/VtInputThread.cpp
+++ b/src/host/VtInputThread.cpp
@@ -176,6 +176,7 @@ DWORD VtInputThread::_InputThread()
     RETURN_LAST_ERROR_IF_NULL(hThread);
     _hThread.reset(hThread);
     _dwThreadId = dwThreadId;
+    LOG_IF_FAILED(SetThreadDescription(hThread, L"ConPTY Input Handler Thread"));
 
     return S_OK;
 }

--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -322,6 +322,7 @@ HRESULT ConsoleCreateIoThread(_In_ HANDLE Server,
 
     HANDLE const hThread = CreateThread(nullptr, 0, ConsoleIoThread, connectMessage, 0, nullptr);
     RETURN_HR_IF(E_HANDLE, hThread == nullptr);
+    LOG_IF_FAILED(SetThreadDescription(hThread, L"Console Driver Message IO Thread"));
     LOG_IF_WIN32_BOOL_FALSE(CloseHandle(hThread)); // The thread will run on its own and close itself. Free the associated handle.
 
     // See MSFT:19918626

--- a/src/interactivity/win32/ConsoleInputThread.cpp
+++ b/src/interactivity/win32/ConsoleInputThread.cpp
@@ -27,6 +27,7 @@ HANDLE ConsoleInputThread::Start()
     {
         _hThread = hThread;
         _dwThreadId = dwThreadId;
+        LOG_IF_FAILED(SetThreadDescription(hThread, L"Win32 Window Message Input Thread"));
     }
 
     return hThread;

--- a/src/renderer/base/thread.cpp
+++ b/src/renderer/base/thread.cpp
@@ -136,6 +136,7 @@ RenderThread::~RenderThread()
         else
         {
             _hThread = hThread;
+            LOG_IF_FAILED(SetThreadDescription(hThread, L"Rendering Output Thread"));
         }
     }
 


### PR DESCRIPTION
Add names to threads to make debugging a slight bit easier.

## PR Checklist
* [x] Closes personal todo item.
* [x] I work here.
* [x] Tested manually.

## Detailed Description of the Pull Request / Additional comments
Thread descriptions show up as names in both the Visual Studio debugger, WinDBG debugger, and Windows Performance Analyzer. This makes it faster and easier to identify threads of interest in our processes.

## Validation Steps Performed
* [x] Checked threads were named in OpenConsole.exe running in classic conhost window mode under VS debug
* [x] Checked threads were named in OpenConsole.exe running in conpty mode under VS debug
* [x] Checked threads were named in WindowsTerminal.exe (for a few of the threads around connections)
* [x] Checked that we could also see it in WinDBG
