### PR TITLE
Make whitespace trimming in block selection configurable

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -902,7 +902,7 @@
         },
         "trimBlockSelection": {
           "default": false,
-          "description": "When set to true, trailing whitespaces will be removed from text in rectangular (block) selection while copied to your clipboard. When set to false, the white-spaces will be preserved.",
+          "description": "When set to true, trailing white-spaces will be removed from text in rectangular (block) selection while copied to your clipboard. When set to false, the white-spaces will be preserved.",
           "type": "boolean"
         },
         "disableAnimations": {

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -900,6 +900,11 @@
           "description": "When set to `true`, the color and font formatting of selected text is also copied to your clipboard. When set to `false`, only plain text is copied to your clipboard. An array of specific formats can also be used. Supported array values include `html` and `rtf`. Plain text is always copied.",
           "$ref": "#/definitions/CopyFormat"
         },
+        "trimBlockSelection": {
+          "default": false,
+          "description": "When set to true, trailing whitespaces will be removed from text in rectangular (block) selection while copied to your clipboard. When set to false, the white-spaces will be preserved.",
+          "type": "boolean"
+        },
         "disableAnimations": {
           "default": false,
           "description": "When set to `true`, visual animations will be disabled across the application.",

--- a/src/cascadia/TerminalCore/ICoreSettings.idl
+++ b/src/cascadia/TerminalCore/ICoreSettings.idl
@@ -20,6 +20,7 @@ namespace Microsoft.Terminal.Core
         String WordDelimiters;
 
         Boolean ForceVTInput;
+        Boolean TrimBlockSelection;
 
         Windows.Foundation.IReference<Microsoft.Terminal.Core.Color> TabColor;
         Windows.Foundation.IReference<Microsoft.Terminal.Core.Color> StartingTabColor;

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -52,7 +52,8 @@ Terminal::Terminal() :
     _blockSelection{ false },
     _selection{ std::nullopt },
     _taskbarState{ 0 },
-    _taskbarProgress{ 0 }
+    _taskbarProgress{ 0 },
+    _trimBlockSelection{ false }
 {
     auto dispatch = std::make_unique<TerminalDispatch>(*this);
     auto engine = std::make_unique<OutputStateMachineEngine>(std::move(dispatch));
@@ -119,6 +120,7 @@ void Terminal::UpdateSettings(ICoreSettings settings)
     _wordDelimiters = settings.WordDelimiters();
     _suppressApplicationTitle = settings.SuppressApplicationTitle();
     _startingTitle = settings.StartingTitle();
+    _trimBlockSelection = settings.TrimBlockSelection();
 
     _terminalInput->ForceDisableWin32InputMode(settings.ForceVTInput());
 

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -263,6 +263,7 @@ private:
     bool _altGrAliasing;
     bool _suppressApplicationTitle;
     bool _bracketedPasteMode;
+    bool _trimBlockSelection;
 
     size_t _taskbarState;
     size_t _taskbarProgress;

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -255,15 +255,14 @@ const TextBuffer::TextAndColor Terminal::RetrieveSelectedTextFromBuffer(bool sin
 
     const auto GetAttributeColors = std::bind(&Terminal::GetAttributeColors, this, std::placeholders::_1);
 
-    // GH#6740: Block selection should preserve the text block as is:
-    // - No trailing white-spaces should be removed.
+    // GH#6740: Block selection should preserve the visual structure:
     // - CRLFs need to be added - so the lines structure is preserved
     // - We should apply formatting above to wrapped rows as well (newline should be added).
-    return _buffer->GetText(!singleLine || _blockSelection,
-                            !singleLine && !_blockSelection,
-                            selectionRects,
-                            GetAttributeColors,
-                            _blockSelection);
+    // GH#9706: Trimming of trailing white-spaces in block selection is configurable.
+    const auto includeCRLF = !singleLine || _blockSelection;
+    const auto trimTrailingWhitespace = !singleLine && (!_blockSelection || _trimBlockSelection);
+    const auto formatWrappedRows = _blockSelection;
+    return _buffer->GetText(includeCRLF, trimTrailingWhitespace, selectionRects, GetAttributeColors, formatWrappedRows);
 }
 
 // Method Description:

--- a/src/cascadia/TerminalSettingsEditor/Interaction.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.xaml
@@ -39,6 +39,11 @@
                                    SelectedItem="{x:Bind CurrentCopyFormat, Mode=TwoWay}" />
             </local:SettingContainer>
 
+            <!--  Trim Block Selection  -->
+            <local:SettingContainer x:Uid="Globals_TrimBlockSelection">
+                <ToggleSwitch IsOn="{x:Bind State.Globals.TrimBlockSelection, Mode=TwoWay}" />
+            </local:SettingContainer>
+
             <!--  Word Delimiters  -->
             <local:SettingContainer x:Uid="Globals_WordDelimiters">
                 <TextBox Style="{StaticResource TextBoxSettingStyle}"

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -210,7 +210,7 @@
     <comment>Header for a control to toggle whether selected text should be copied to the clipboard automatically, or not.</comment>
   </data>
   <data name="Globals_TrimBlockSelection.Header" xml:space="preserve">
-    <value>Remove trailing white-spaces when copying text in rectangular selection to clipboard</value>
+    <value>Remove trailing white-space in rectangular selection</value>
     <comment>Header for a control to toggle whether a text selected with block selection should be trimmed of white spaces when copied to the clipboard, or not.</comment>
   </data>
   <data name="Globals_KeybindingsDisclaimer.Text" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -209,6 +209,10 @@
     <value>Automatically copy selection to clipboard</value>
     <comment>Header for a control to toggle whether selected text should be copied to the clipboard automatically, or not.</comment>
   </data>
+  <data name="Globals_TrimBlockSelection.Header" xml:space="preserve">
+    <value>Remove trailing white-spaces when copying text in rectangular selection to clipboard</value>
+    <comment>Header for a control to toggle whether a text selected with block selection should be trimmed of white spaces when copied to the clipboard, or not.</comment>
+  </data>
   <data name="Globals_KeybindingsDisclaimer.Text" xml:space="preserve">
     <value>Below are the currently bound keys, which can be modified by editing the JSON settings file.</value>
     <comment>A disclaimer located at the top of the actions page that presents the list of keybindings.</comment>

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -45,6 +45,7 @@ static constexpr std::string_view DisableAnimationsKey{ "disableAnimations" };
 static constexpr std::string_view StartupActionsKey{ "startupActions" };
 static constexpr std::string_view FocusFollowMouseKey{ "focusFollowMouse" };
 static constexpr std::string_view WindowingBehaviorKey{ "windowingBehavior" };
+static constexpr std::string_view TrimBlockSelectionKey{ "trimBlockSelection" };
 
 static constexpr std::string_view DebugFeaturesKey{ "debugFeatures" };
 
@@ -124,6 +125,7 @@ winrt::com_ptr<GlobalAppSettings> GlobalAppSettings::Copy() const
     globals->_StartupActions = _StartupActions;
     globals->_FocusFollowMouse = _FocusFollowMouse;
     globals->_WindowingBehavior = _WindowingBehavior;
+    globals->_TrimBlockSelection = _TrimBlockSelection;
 
     globals->_UnparsedDefaultProfile = _UnparsedDefaultProfile;
     globals->_validDefaultProfile = _validDefaultProfile;
@@ -320,6 +322,8 @@ void GlobalAppSettings::LayerJson(const Json::Value& json)
 
     JsonUtils::GetValueForKey(json, WindowingBehaviorKey, _WindowingBehavior);
 
+    JsonUtils::GetValueForKey(json, TrimBlockSelectionKey, _TrimBlockSelection);
+
     // This is a helper lambda to get the keybindings and commands out of both
     // and array of objects. We'll use this twice, once on the legacy
     // `keybindings` key, and again on the newer `bindings` key.
@@ -426,6 +430,7 @@ Json::Value GlobalAppSettings::ToJson() const
     JsonUtils::SetValueForKey(json, StartupActionsKey,              _StartupActions);
     JsonUtils::SetValueForKey(json, FocusFollowMouseKey,            _FocusFollowMouse);
     JsonUtils::SetValueForKey(json, WindowingBehaviorKey,           _WindowingBehavior);
+    JsonUtils::SetValueForKey(json, TrimBlockSelectionKey,          _TrimBlockSelection);
     // clang-format on
 
     // TODO GH#8100: keymap needs to be serialized here

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.h
@@ -91,6 +91,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         INHERITABLE_SETTING(Model::GlobalAppSettings, hstring, StartupActions, L"");
         INHERITABLE_SETTING(Model::GlobalAppSettings, bool, FocusFollowMouse, false);
         INHERITABLE_SETTING(Model::GlobalAppSettings, Model::WindowingMode, WindowingBehavior, Model::WindowingMode::UseNew);
+        INHERITABLE_SETTING(Model::GlobalAppSettings, bool, TrimBlockSelection, false);
 
     private:
         guid _defaultProfile;

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -68,6 +68,7 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_SETTING(String, StartupActions);
         INHERITABLE_SETTING(Boolean, FocusFollowMouse);
         INHERITABLE_SETTING(WindowingMode, WindowingBehavior);
+        INHERITABLE_SETTING(Boolean, TrimBlockSelection);
 
         Windows.Foundation.Collections.IMapView<String, ColorScheme> ColorSchemes();
         void AddColorScheme(ColorScheme scheme);

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
@@ -296,6 +296,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         _ForceFullRepaintRendering = globalSettings.ForceFullRepaintRendering();
         _SoftwareRendering = globalSettings.SoftwareRendering();
         _ForceVTInput = globalSettings.ForceVTInput();
+        _TrimBlockSelection = globalSettings.TrimBlockSelection();
     }
 
     // Method Description:

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -87,6 +87,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         INHERITABLE_SETTING(Model::TerminalSettings, bool, CopyOnSelect, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, InputServiceWarning, true);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, FocusFollowMouse, false);
+        INHERITABLE_SETTING(Model::TerminalSettings, bool, TrimBlockSelection, false);
 
         INHERITABLE_SETTING(Model::TerminalSettings, Windows::Foundation::IReference<Microsoft::Terminal::Core::Color>, TabColor, nullptr);
 

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -11,6 +11,7 @@
     // Selection
     "copyOnSelect": false,
     "copyFormatting": true,
+    "trimBlockSelection": false,
     "wordDelimiters": " /\\()\"'-.,:;<>~!@#$%^&*|+=[]{}~?\u2502",
 
     // Tab UI

--- a/src/cascadia/UnitTests_TerminalCore/MockTermSettings.h
+++ b/src/cascadia/UnitTests_TerminalCore/MockTermSettings.h
@@ -43,6 +43,7 @@ namespace TerminalCoreUnitTests
         ICoreAppearance UnfocusedAppearance() { return {}; };
         winrt::Windows::Foundation::IReference<winrt::Microsoft::Terminal::Core::Color> TabColor() { return nullptr; }
         winrt::Windows::Foundation::IReference<winrt::Microsoft::Terminal::Core::Color> StartingTabColor() { return nullptr; }
+        bool TrimBlockSelection() { return false; }
 
         // other implemented methods
         til::color GetColorTableEntry(int32_t) const { return 123; }
@@ -68,6 +69,7 @@ namespace TerminalCoreUnitTests
         void UnfocusedAppearance(ICoreAppearance) {}
         void TabColor(const IInspectable&) {}
         void StartingTabColor(const IInspectable&) {}
+        void TrimBlockSelection(bool) {}
 
     private:
         int32_t _historySize;


### PR DESCRIPTION
## PR Checklist
* [x] Closes https://github.com/microsoft/terminal/issues/9706
* [x] CLA signed.
* [ ] Tests added/passed
* [x] Documentation updated here: https://github.com/MicrosoftDocs/terminal/pull/313
* [x] Schema updated.
* [ ] I've discussed this with core contributors already. 

## Detailed Description of the Pull Request / Additional comments
Added global flag named `trimBlockSelection` set to `false` by default.
The setting was added to Interactions menu of the SUI.