### PR TITLE
Limit terminal warning bells to one per second

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -145,6 +145,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         std::shared_ptr<ThrottledFunc<>> _updatePatternLocations;
 
+        std::shared_ptr<ThrottledFunc<>> _playWarningBell;
+
         struct ScrollBarUpdate
         {
             std::optional<double> newValue;


### PR DESCRIPTION
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes https://github.com/microsoft/terminal/issues/9776
* [x] CLA signed.
* [ ] Tests added/passed
* [ ] Documentation updated. 
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. 

## Detailed Description of the Pull Request / Additional comments
Use `ThrottledFunc` in `TermControl` to limit bell emission callback to one per second.