### PR TITLE
[Quick and Dirty] Copy runtime tab title when duplicating tabs

### DIFF
--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -323,6 +323,15 @@ namespace winrt::TerminalApp::implementation
                 }
 
                 _CreateNewTabFromSettings(profileGuid.value(), settingsCreateResult);
+
+                const auto runtimeTabText{ tab.GetTabText() };
+                if (!runtimeTabText.empty())
+                {
+                    if (auto newTab{ _GetFocusedTabImpl() })
+                    {
+                        newTab->SetTabText(runtimeTabText);
+                    }
+                }
             }
         }
         CATCH_LOG();

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -510,6 +510,11 @@ namespace winrt::TerminalApp::implementation
         UpdateTitle();
     }
 
+    winrt::hstring TerminalTab::GetTabText() const
+    {
+        return _runtimeTabText;
+    }
+
     void TerminalTab::ResetTabText()
     {
         _runtimeTabText = L"";

--- a/src/cascadia/TerminalApp/TerminalTab.h
+++ b/src/cascadia/TerminalApp/TerminalTab.h
@@ -61,6 +61,7 @@ namespace winrt::TerminalApp::implementation
         void ClosePane();
 
         void SetTabText(winrt::hstring title);
+        winrt::hstring GetTabText() const;
         void ResetTabText();
         void ActivateTabRenamer();
 


### PR DESCRIPTION
## PR Checklist
* [x] Closes https://github.com/microsoft/terminal/issues/9723
* [x] CLA signed. 
* [ ] Tests added/passed
* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already.

## Detailed Description of the Pull Request / Additional comments
Quick and dirty. 
A better solution is to allow passing all "runtime settings" upon tab creation.