### PR TITLE
doc: Add tabColor to JSON schema

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -1347,6 +1347,11 @@
           "type": "boolean",
           "default": false
         },
+        "tabColor": {
+          "$ref": "#/definitions/Color",
+          "description": "Sets the color of the profile's tab. Using the tab color picker will override this color.",
+          "type": ["string", "null"]
+        },
         "tabTitle": {
           "description": "If set, will replace the name as the title to pass to the shell on startup. Some shells (like bash) may choose to ignore this initial value, while others (cmd, powershell) may use this value over the lifetime of the application.",
           "type": ["string", "null"]


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Turns out we forgot to add `tabColor` to the JSON schema.