### PR TITLE
Fix for configuring starting directory in SUI when defaults sets it to null

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Profiles.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.cpp
@@ -362,7 +362,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             }
             BackgroundImagePath(L"desktopWallpaper");
         }
-        else if (HasBackgroundImagePath())
+        else
         {
             // Restore the path we had previously cached. This might be the
             // empty string.
@@ -399,7 +399,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             }
             StartingDirectory(L"");
         }
-        else if (HasStartingDirectory())
+        else
         {
             // Restore the path we had previously cached as long as it wasn't empty
             // If it was empty, set the starting directory to %USERPROFILE%


### PR DESCRIPTION
## Summary of the Pull Request
Remove an unnecessary check in `Profiles.cpp` that was preventing us from enabling the text box and browse button when the user unchecks 'use parent process directory'

## PR Checklist
* [x] Closes #9847 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I work here

## Validation Steps Performed
Played around with it and it works. 