### PR TITLE
Teach CmdPal search to use user locale

### DIFF
--- a/src/cascadia/TerminalApp/FilteredCommand.cpp
+++ b/src/cascadia/TerminalApp/FilteredCommand.cpp
@@ -80,7 +80,7 @@ namespace winrt::TerminalApp::implementation
 
         for (const auto searchChar : _Filter)
         {
-            const auto lowerCaseSearchChar = std::towlower(searchChar);
+            const WCHAR searchCharAsString[] = { searchChar, L'\0' };
             while (true)
             {
                 if (currentOffset == commandName.size())
@@ -93,7 +93,10 @@ namespace winrt::TerminalApp::implementation
                     return winrt::make<HighlightedText>(segments);
                 }
 
-                auto isCurrentCharMatched = std::towlower(commandName[currentOffset]) == lowerCaseSearchChar;
+                // GH#9941: search should be locale-aware as well
+                // We use the same comparison method as upon sorting to guarantee consistent behavior
+                const WCHAR currentCharAsString[] = { commandName[currentOffset], L'\0' };
+                auto isCurrentCharMatched = lstrcmpi(searchCharAsString, currentCharAsString) == 0;
                 if (isProcessingMatchedSegment != isCurrentCharMatched)
                 {
                     // We reached the end of the region (matched character came after a series of unmatched or vice versa).


### PR DESCRIPTION
## PR Checklist
* [x] Closes https://github.com/microsoft/terminal/issues/9941
* [x] CLA signed.

## Detailed Description of the Pull Request / Additional comments
The bug is due to us using std::tolower, while the default locale is not user's locale.
The fix here is to use the same approach as upon sorting: lstrcmpi.
While there are additional methods to do locale aware comparison,
here we convert chars to string and call lstrcmpi.
While this approach seems somewhat inefficient it ensures consistency
(with the order of locales that lstrcmi tries to apply internally).