### PR TITLE
Serialize stub for dynamic profiles

### DIFF
--- a/src/cascadia/TerminalSettingsModel/Profile.cpp
+++ b/src/cascadia/TerminalSettingsModel/Profile.cpp
@@ -499,7 +499,7 @@ Json::Value Profile::ToJson() const
     // GH #9962:
     //   If the settings.json was missing, when we load the dynamic profiles, they are completely empty.
     //   This caused us to serialize empty profiles "{}" on accident.
-    bool writeBasicSettings{ !Source().empty() };
+    const bool writeBasicSettings{ !Source().empty() };
 
     // Profile-specific Settings
     JsonUtils::SetValueForKey(json, NameKey, writeBasicSettings ? Name() : _Name);

--- a/src/cascadia/TerminalSettingsModel/Profile.cpp
+++ b/src/cascadia/TerminalSettingsModel/Profile.cpp
@@ -496,11 +496,16 @@ Json::Value Profile::ToJson() const
     // Initialize the json with the appearance settings
     Json::Value json{ winrt::get_self<implementation::AppearanceConfig>(_DefaultAppearance)->ToJson() };
 
+    // GH #9962:
+    //   If the settings.json was missing, when we load the dynamic profiles, they are completely empty.
+    //   This caused us to serialize empty profiles "{}" on accident.
+    bool writeBasicSettings{ !Source().empty() };
+
     // Profile-specific Settings
-    JsonUtils::SetValueForKey(json, NameKey, _Name);
-    JsonUtils::SetValueForKey(json, GuidKey, _Guid);
-    JsonUtils::SetValueForKey(json, HiddenKey, _Hidden);
-    JsonUtils::SetValueForKey(json, SourceKey, _Source);
+    JsonUtils::SetValueForKey(json, NameKey, writeBasicSettings ? Name() : _Name);
+    JsonUtils::SetValueForKey(json, GuidKey, writeBasicSettings ? Guid() : _Guid);
+    JsonUtils::SetValueForKey(json, HiddenKey, writeBasicSettings ? Hidden() : _Hidden);
+    JsonUtils::SetValueForKey(json, SourceKey, writeBasicSettings ? Source() : _Source);
 
     // TODO:MSFT:20642297 - Use a sentinel value (-1) for "Infinite scrollback"
     JsonUtils::SetValueForKey(json, HistorySizeKey, _HistorySize);


### PR DESCRIPTION
#9962 was caused by a serialization bug. _Technically_, `ToJson` works
as intended: if the current layer has any values set, write them out to
the json. However, on first load, the dynamic profile `Profile` objects
are actually empty (because they inherit from base layer, then the
dynamic profile generator). This means that `ToJson` writes the dynamic
profiles as empty objects `{}`. Then, on reload, we see that the dynamic
profiles aren't in the JSON, and we write them again.

To get around this issue, we added a simple check to `Profile::ToJson`:
if we have a source, make sure we write out the name, guid, hidden, and
source. This is intended to align with `Profile::GenerateStub`.

Closes #9962 