### PR TITLE
[WPF] Allows setting the WPF control background when setting the terminal theme

### DIFF
--- a/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
@@ -76,7 +76,8 @@ namespace Microsoft.Terminal.Wpf
         /// <param name="theme">The color theme to use in the terminal.</param>
         /// <param name="fontFamily">The font family to use in the terminal.</param>
         /// <param name="fontSize">The font size to use in the terminal.</param>
-        public void SetTheme(TerminalTheme theme, string fontFamily, short fontSize)
+        /// <param name="externalBackground">Color for the control background when the terminal window is smaller than the hosting WPF window.</param>
+        public void SetTheme(TerminalTheme theme, string fontFamily, short fontSize, Color externalBackground = default)
         {
             PresentationSource source = PresentationSource.FromVisual(this);
 
@@ -92,7 +93,12 @@ namespace Microsoft.Terminal.Wpf
             byte g = Convert.ToByte((theme.DefaultBackground >> 8) & 0xff);
             byte r = Convert.ToByte(theme.DefaultBackground & 0xff);
 
-            this.terminalGrid.Background = new SolidColorBrush(Color.FromRgb(r, g, b));
+            // Set the background color for the control only if one is provided.
+            // This is only shown when the terminal renderer is smaller than the enclosing WPF window.
+            if (externalBackground != default)
+            {
+                this.Background = new SolidColorBrush(externalBackground);
+            }
         }
 
         /// <summary>

--- a/src/cascadia/WpfTerminalControl/TerminalTheme.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalTheme.cs
@@ -5,7 +5,6 @@
 
 namespace Microsoft.Terminal.Wpf
 {
-    using System;
     using System.Runtime.InteropServices;
 
     /// <summary>


### PR DESCRIPTION
When syncing terminals across users (i.e. Liveshare shared terminals),
the terminal size is synced. This leads to having unused space around
the terminal which is the same color as the terminal's background
causing confusion as to what space is usable within the terminal.

Instead this change allows consumers to set the background color of the
control, separate from the terminal renderer's background, which makes
it easier to identify the edges of the terminal.