### PR TITLE
Backport hotfix ac265aa to v1.8

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -640,6 +640,29 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     TermControl::~TermControl()
     {
         Close();
+
+        // Before destroying this instance we must ensure that we destroy the _renderer
+        // before the _renderEngine, as well as calling _renderer->TriggerTeardown().
+        // _renderEngine will be destroyed naturally after this ~destructor() returns.
+
+        decltype(_renderer) renderer;
+        {
+            // GH#8734:
+            // We lock the terminal here to make sure it isn't still being
+            // used in the connection thread before we destroy the renderer.
+            // However, we must unlock it again prior to triggering the
+            // teardown, to avoid the render thread being deadlocked. The
+            // renderer may be waiting to acquire the terminal lock, while
+            // we're waiting for the renderer to finish.
+            auto lock = _terminal->LockForWriting();
+
+            _renderer.swap(renderer);
+        }
+
+        if (renderer)
+        {
+            renderer->TriggerTeardown();
+        }
     }
 
     // Method Description:
@@ -2670,30 +2693,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             // don't really care to wait for the connection to be completely
             // closed. We can just do it whenever.
             _AsyncCloseConnection();
-
-            {
-                // GH#8734:
-                // We lock the terminal here to make sure it isn't still being
-                // used in the connection thread before we destroy the renderer.
-                // However, we must unlock it again prior to triggering the
-                // teardown, to avoid the render thread being deadlocked. The
-                // renderer may be waiting to acquire the terminal lock, while
-                // we're waiting for the renderer to finish.
-                auto lock = _terminal->LockForWriting();
-            }
-
-            if (auto localRenderEngine{ std::exchange(_renderEngine, nullptr) })
-            {
-                if (auto localRenderer{ std::exchange(_renderer, nullptr) })
-                {
-                    localRenderer->TriggerTeardown();
-                    // renderer is destroyed
-                }
-                // renderEngine is destroyed
-            }
-
-            // we don't destroy _terminal here; it now has the same lifetime as the
-            // control.
         }
     }
 


### PR DESCRIPTION
This backports ac265aab99d5f79345074fbff66c54a816120de1 to v1.8.

ControlCore's _renderer (IRenderTarget) is allocated as std::unique_ptr,
but is given to Terminal::CreateFromSettings as a reference.
ControlCore::Close deallocates the _renderer, but if ThrottledFuncs
are still scheduled to call ControlCore::UpdatePatternLocations
it'll cause Terminal::UpdatePatterns to be called, which in turn ends up
accessing the deallocated IRenderTarget reference and lead to a crash.

A proper solution with shared pointers is nontrivial and should be
attempted at a later point in time. This solution moves the teardown of
the _renderer into ControlCore::~ControlCore, where we can be certain
that no further strong references are held by ThrottledFuncs.