### PR TITLE
Keep the last selected pivot active when navigating over profile pages

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Profiles.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.h
@@ -136,16 +136,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             _Schemes{ schemes },
             _WindowRoot{ windowRoot }
         {
-            // If there was a previous nav state, and it was for the same
-            // profile, then copy the selected pivot from it.
+            // If there was a previous nav state copy the selected pivot from it.
             if (lastState)
             {
-                const auto& oldGuid = lastState.Profile().Guid();
-                const auto& newGuid = _Profile.Guid();
-                if (oldGuid == newGuid)
-                {
-                    _LastActivePivot = lastState.LastActivePivot();
-                }
+                _LastActivePivot = lastState.LastActivePivot();
             }
         }
 


### PR DESCRIPTION
## PR Checklist
* [x] Closes #9920 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA

## Validation Steps Performed

- When opening a profile page and selecting a random pivot, when then navigating away from the profile page to another item and navigating back to the same profile the last selected pivot was still active.
- When opening a profile page and selecting a random pivot, when then navigating away from the profile page to a second profile the last selected pivot was immediately active on the second profile.
- When selecting random pivots and navigating only between other profile pages the last selected pivot was always active on the opened profile page.

What felt a bit strange at first sight was:
- open a profile page, select a random pivot
- start adding a new profile
- the last selected pivot is immediately active and not the "General" pivot what might be the obvious pivot to show when a user  wants to add a new profile.

After playing a bit more with this this started to feel ok. Since as a user you might go to "Add new profile" immediately anyway instead of opening other profiles first.  

Just explicitly highlighting this last point since maybe someone prefers that we need to make sure to always start with the 'General' pivot when adding a new profile and then this fix is not correct.





