### PR TITLE
Make sure we run CG component detection on main

### DIFF
--- a/build/pipelines/templates/build-console-ci.yml
+++ b/build/pipelines/templates/build-console-ci.yml
@@ -24,7 +24,7 @@ jobs:
   # when we renamed our main branch.
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
-    condition: and(succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
+    condition: and(succeededOrFailed(), not(eq(variables['Build.Reason'], 'PullRequest')))
 
 - template: helix-runtests-job.yml
   parameters:

--- a/build/pipelines/templates/build-console-ci.yml
+++ b/build/pipelines/templates/build-console-ci.yml
@@ -20,6 +20,12 @@ jobs:
     parameters:
       additionalBuildArguments: ${{ parameters.additionalBuildArguments }}
 
+  # It appears that the Component Governance build task that gets automatically injected stopped working
+  # when we renamed our main branch.
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+    displayName: 'Component Detection'
+    condition: and(succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
+
 - template: helix-runtests-job.yml
   parameters:
     name: 'RunTestsInHelix'


### PR DESCRIPTION
I believe that there is a hidden "default branch" setting in Azure
DevOps, and ours is set to "master". CG only attempts to automatically
inject to builds off the default branch... and because we're a GitHub
repo running builds in AzDO we _can't change what the default branch
is_. Oops.