### PR TITLE
Set keyword flags on all tracelog events

### DIFF
--- a/src/ConsolePerf.wprp
+++ b/src/ConsolePerf.wprp
@@ -43,6 +43,7 @@
         <EventProvider Id="EventProvider-Microsoft.Windows.Console.Server" Name="1A541C01-589A-496E-85A7-A9E02170166D"/>
         <EventProvider Id="EventProvider-Microsoft.Windows.Console.VirtualTerminal.Parser" Name="c9ba2a84-d3ca-5e19-2bd6-776a0910cb9d"/>
         <EventProvider Id="EventProvider-Microsoft.Windows.Console.Render.VtEngine" Name="c9ba2a95-d3ca-5e19-2bd6-776a0910cb9d"/>
+        <EventProvider Id="EventProvider-Microsoft.Windows.Console.UIA" Name="e7ebce59-2161-572d-b263-2f16a6afb9e5"/>
         <!-- Now define some profiles. We'll call them by ID when collecting. Also, the Base is where it is inheriting from and is a .wprpi file built... -->
         <!-- ... into WPR automatically. Go look in the WPR install directory or in the documentation to find it. -->
         <Profile Id="ConsolePerfProfile.Verbose.File" Base="GeneralProfile.Light.File" LoggingMode="File" Name="ConsolePerfProfile" DetailLevel="Verbose" Description="Console Performance default profile">
@@ -66,6 +67,7 @@
                         <EventProviderId Value="EventProvider-Microsoft.Windows.Console.Server"/>
                         <EventProviderId Value="EventProvider-Microsoft.Windows.Console.VirtualTerminal.Parser"/>
                         <EventProviderId Value="EventProvider-Microsoft.Windows.Console.Render.VtEngine"/>
+                        <EventProviderId Value="EventProvider-Microsoft.Windows.Console.UIA"/>
                     </EventProviders>
                 </EventCollectorId>
             </Collectors>

--- a/src/Terminal.wprp
+++ b/src/Terminal.wprp
@@ -11,6 +11,7 @@
     <EventProvider Id="EventProvider_TerminalApp" Name="24a1622f-7da7-5c77-3303-d850bd1ab2ed" />
     <EventProvider Id="EventProvider_TerminalWin32Host" Name="56c06166-2e2e-5f4d-7ff3-74f4b78c87d6" />
     <EventProvider Id="EventProvider_TerminalRemoting" Name="d6f04aad-629f-539a-77c1-73f5c3e4aa7b" />
+    <EventProvider Id="EventProvider_TerminalDirectX" Name="c93e739e-ae50-5a14-78e7-f171e947535d" />
     <Profile Id="Terminal.Verbose.File" Name="Terminal" Description="Terminal" LoggingMode="File" DetailLevel="Verbose">
       <Collectors>
         <EventCollectorId Value="EventCollector_Terminal">
@@ -21,6 +22,7 @@
             <EventProviderId Value="EventProvider_TerminalApp" />
             <EventProviderId Value="EventProvider_TerminalWin32Host" />
             <EventProviderId Value="EventProvider_TerminalRemoting" />
+            <EventProviderId Value="EventProvider_TerminalDirectX" />
           </EventProviders>
         </EventCollectorId>
       </Collectors>

--- a/src/cascadia/Remoting/Monarch.cpp
+++ b/src/cascadia/Remoting/Monarch.cpp
@@ -84,14 +84,16 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                               "Monarch_AddPeasant",
                               TraceLoggingUInt64(providedID, "providedID", "the provided ID for the peasant"),
                               TraceLoggingUInt64(newPeasantsId, "peasantID", "the ID of the new peasant"),
-                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
             return newPeasantsId;
         }
         catch (...)
         {
             TraceLoggingWrite(g_hRemotingProvider,
                               "Monarch_AddPeasant_Failed",
-                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 
             // We can only get into this try/catch if the peasant died on us. So
             // the return value doesn't _really_ matter. They're not about to
@@ -234,7 +236,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         {
             TraceLoggingWrite(g_hRemotingProvider,
                               "Monarch_HandleActivatePeasant_Failed",
-                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
         }
     }
 
@@ -260,7 +263,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                               "Monarch_RemovedPeasantFromDesktop",
                               TraceLoggingUInt64(peasantID, "peasantID", "The ID of the peasant"),
                               TraceLoggingGuid(result->DesktopID(), "desktopGuid", "The GUID of the previous desktop the window was on"),
-                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 
             _mruPeasants.erase(result);
         }
@@ -297,7 +301,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                           TraceLoggingUInt64(localArgs->PeasantID(), "peasantID", "the ID of the activated peasant"),
                           TraceLoggingGuid(desktopGuid, "desktopGuid", "The GUID of the desktop the window is on"),
                           TraceLoggingInt64(newLastActiveTime, "newLastActiveTime", "The provided localArgs->ActivatedTime()"),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 
     // Method Description:
@@ -334,7 +339,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
 
             TraceLoggingWrite(g_hRemotingProvider,
                               "Monarch_getMostRecentPeasantID_NoPeasants",
-                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
             return 0;
         }
 
@@ -368,7 +374,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                                                      "peasantID",
                                                      "We thought this peasant was the MRU one, but it was actually already dead."),
                                   TraceLoggingGuid(mruWindowArgs.DesktopID(), "desktopGuid", "The GUID of the desktop the window is on"),
-                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE));
                 // We'll go through the loop again. We removed the current one
                 // at positionInList, so the next one in positionInList will be
                 // a new, different peasant.
@@ -407,7 +414,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                                       TraceLoggingBool(onCurrentDesktop,
                                                        "onCurrentDesktop",
                                                        "true if this window was in fact on the current desktop"),
-                                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
                     return mruWindowArgs.PeasantID();
                 }
                 // If this window wasn't on the current desktop, another one
@@ -419,7 +427,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                 TraceLoggingWrite(g_hRemotingProvider,
                                   "Monarch_getMostRecentPeasantID_Found",
                                   TraceLoggingUInt64(mruWindowArgs.PeasantID(), "peasantID", "The ID of the MRU peasant"),
-                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 
                 return mruWindowArgs.PeasantID();
             }
@@ -431,7 +440,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         // will use this to create a new window.
         TraceLoggingWrite(g_hRemotingProvider,
                           "Monarch_getMostRecentPeasantID_NotFound",
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 
         return 0;
     }
@@ -466,7 +476,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         TraceLoggingWrite(g_hRemotingProvider,
                           "Monarch_ProposeCommandline",
                           TraceLoggingInt64(targetWindow, "targetWindow", "The window ID the args specified"),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 
         // If there's a valid ID returned, then let's try and find the peasant
         // that goes with it. Alternatively, if we were given a magic windowing
@@ -505,7 +516,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                               TraceLoggingInt64(windowID,
                                                 "windowID",
                                                 "The actual peasant ID we evaluated the window ID as"),
-                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 
             // If_getMostRecentPeasantID returns 0 above, then we couldn't find
             // a matching window for that style of windowing. _getPeasant will
@@ -544,7 +556,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                                   TraceLoggingBoolean(!result->ShouldCreateWindow(),
                                                       "succeeded",
                                                       "true if we successfully dispatched the commandline to the peasant"),
-                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE));
                 return *result;
             }
             else if (windowID > 0)
@@ -559,7 +572,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                                                      "peasantID",
                                                      "the ID of the peasant the commandline waws intended for"),
                                   TraceLoggingBoolean(false, "foundMatch", "true if we found a peasant with that ID"),
-                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 
                 auto result{ winrt::make_self<Remoting::implementation::ProposeCommandlineResult>(true) };
                 result->Id(windowID);
@@ -572,7 +586,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         TraceLoggingWrite(g_hRemotingProvider,
                           "Monarch_ProposeCommandline_NewWindow",
                           TraceLoggingInt64(targetWindow, "targetWindow", "The provided ID"),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 
         // In this case, no usable ID was provided. Return { true, nullopt }
         auto result = winrt::make_self<Remoting::implementation::ProposeCommandlineResult>(true);
@@ -634,7 +649,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
             TraceLoggingWrite(g_hRemotingProvider,
                               "Monarch_identifyWindows_Failed",
                               TraceLoggingInt64(id, "peasantID", "The ID of the peasant which we could not identify"),
-                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
         };
         _forAllPeasantsIgnoringTheDead(callback, onError);
     }
@@ -674,7 +690,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                               "Monarch_renameRequested",
                               TraceLoggingWideString(name.c_str(), "name", "The newly proposed name"),
                               TraceLoggingInt64(successfullyRenamed, "successfullyRenamed", "true if the peasant is allowed to rename themselves to that name."),
-                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
         }
         catch (...)
         {
@@ -683,7 +700,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
             // they're the only one who cares about the result.
             TraceLoggingWrite(g_hRemotingProvider,
                               "Monarch_renameRequested_Failed",
-                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
         }
     }
 
@@ -733,7 +751,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
             TraceLoggingWrite(g_hRemotingProvider,
                               "Monarch_SummonWindow_Failed",
                               TraceLoggingWideString(searchedForName.c_str(), "searchedForName", "The name of the window we tried to summon"),
-                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
         }
     }
 }

--- a/src/cascadia/Remoting/Peasant.cpp
+++ b/src/cascadia/Remoting/Peasant.cpp
@@ -55,7 +55,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                           "Peasant_ExecuteCommandline",
                           TraceLoggingUInt64(GetID(), "peasantID", "Our ID"),
                           TraceLoggingWideString(args.CurrentDirectory().c_str(), "directory", "the provided cwd"),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 
         // Raise an event with these args. The AppHost will listen for this
         // event to know when to take these args and dispatch them to a
@@ -102,7 +103,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                           "Peasant_ActivateWindow",
                           TraceLoggingUInt64(GetID(), "peasantID", "Our ID"),
                           TraceLoggingBoolean(successfullyNotified, "successfullyNotified", "true if we successfully notified the monarch"),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 
     // Method Description:
@@ -135,7 +137,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                           "Peasant_Summon",
                           TraceLoggingUInt64(GetID(), "peasantID", "Our ID"),
                           TraceLoggingUInt64(localCopy.MoveToCurrentDesktop(), "MoveToCurrentDesktop", "true if we should move to the current desktop"),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 
         _SummonRequestedHandlers(*this, localCopy);
     }
@@ -184,7 +187,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                           "Peasant_RequestIdentifyWindows",
                           TraceLoggingUInt64(GetID(), "peasantID", "Our ID"),
                           TraceLoggingBoolean(successfullyNotified, "successfullyNotified", "true if we successfully notified the monarch"),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 
     void Peasant::RequestRename(const winrt::Microsoft::Terminal::Remoting::RenameRequestArgs& args)
@@ -215,6 +219,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                           TraceLoggingWideString(args.NewName().c_str(), "newName", "The proposed name"),
                           TraceLoggingBoolean(args.Succeeded(), "succeeded", "true if the monarch ok'd this new name for us."),
                           TraceLoggingBoolean(successfullyNotified, "successfullyNotified", "true if we successfully notified the monarch"),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }

--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -40,7 +40,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                 // stay in this jail until we do.
                 TraceLoggingWrite(g_hRemotingProvider,
                                   "WindowManager_ExceptionInCtor",
-                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE));
             }
         }
     }
@@ -99,7 +100,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                                   TraceLoggingBoolean(_shouldCreateWindow, "CreateWindow", "true iff we should create a new window"),
                                   TraceLoggingUInt64(givenID.value(), "Id", "The ID we should assign our peasant"),
                                   TraceLoggingWideString(givenName.c_str(), "Name", "The name we should assign this window"),
-                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE));
             }
             else
             {
@@ -108,7 +110,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                                   TraceLoggingBoolean(_shouldCreateWindow, "CreateWindow", "true iff we should create a new window"),
                                   TraceLoggingPointer(nullptr, "Id", "No ID provided"),
                                   TraceLoggingWideString(givenName.c_str(), "Name", "The name we should assign this window"),
-                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE));
             }
         }
         else
@@ -140,7 +143,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                                   TraceLoggingBoolean(_shouldCreateWindow, "CreateWindow", "true iff we should create a new window"),
                                   TraceLoggingUInt64(givenID.value(), "Id", "The ID we should assign our peasant"),
                                   TraceLoggingWideString(givenName.c_str(), "Name", "The name we should assign this window"),
-                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE));
             }
             else if (responseId == WindowingBehaviorUseName)
             {
@@ -151,7 +155,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                                   TraceLoggingBoolean(_shouldCreateWindow, "CreateWindow", "true iff we should create a new window"),
                                   TraceLoggingUInt64(0, "Id", "The ID we should assign our peasant"),
                                   TraceLoggingWideString(givenName.c_str(), "Name", "The name we should assign this window"),
-                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE));
             }
             else
             {
@@ -160,7 +165,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                                   TraceLoggingBoolean(_shouldCreateWindow, "CreateWindow", "true iff we should create a new window"),
                                   TraceLoggingUInt64(0, "Id", "The ID we should assign our peasant"),
                                   TraceLoggingWideString(L"", "Name", "The name we should assign this window"),
-                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE));
             }
         }
 
@@ -228,7 +234,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                           "WindowManager_ConnectedToMonarch",
                           TraceLoggingUInt64(_monarch.GetPID(), "monarchPID", "The PID of the new Monarch"),
                           TraceLoggingBoolean(_isKing, "isKing", "true if we are the new monarch"),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 
         if (_peasant)
         {
@@ -296,7 +303,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         TraceLoggingWrite(g_hRemotingProvider,
                           "WindowManager_CreateOurPeasant",
                           TraceLoggingUInt64(_peasant.GetID(), "peasantID", "The ID of our new peasant"),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 
         return _peasant;
     }
@@ -371,7 +379,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                                       "WindowManager_FailedToOpenMonarch",
                                       TraceLoggingUInt64(peasantID, "peasantID", "Our peasant ID"),
                                       TraceLoggingUInt64(gle, "lastError", "The result of GetLastError"),
-                                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 
                     exitThreadRequested = _performElection();
                     continue;
@@ -387,7 +396,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                     TraceLoggingWrite(g_hRemotingProvider,
                                       "WindowManager_MonarchDied",
                                       TraceLoggingUInt64(peasantID, "peasantID", "Our peasant ID"),
-                                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
                     // Connect to the new monarch, which might be us!
                     // If we become the monarch, then we'll return true and exit this thread.
                     exitThreadRequested = _performElection();
@@ -398,7 +408,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                     TraceLoggingWrite(g_hRemotingProvider,
                                       "WindowManager_MonarchWaitInterrupted",
                                       TraceLoggingUInt64(peasantID, "peasantID", "Our peasant ID"),
-                                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
                     exitThreadRequested = true;
                     break;
 
@@ -407,7 +418,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                     TraceLoggingWrite(g_hRemotingProvider,
                                       "WindowManager_MonarchWaitTimeout",
                                       TraceLoggingUInt64(peasantID, "peasantID", "Our peasant ID"),
-                                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
                     exitThreadRequested = true;
                     break;
 
@@ -419,7 +431,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                                       "WindowManager_WaitFailed",
                                       TraceLoggingUInt64(peasantID, "peasantID", "Our peasant ID"),
                                       TraceLoggingUInt64(gle, "lastError", "The result of GetLastError"),
-                                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
                     ExitProcess(0);
                 }
                 }
@@ -443,7 +456,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                 TraceLoggingWrite(g_hRemotingProvider,
                                   "WindowManager_ExceptionInWaitThread",
                                   TraceLoggingUInt64(peasantID, "peasantID", "Our peasant ID"),
-                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE));
                 bool foundNewMonarch = false;
                 while (!foundNewMonarch)
                 {
@@ -463,7 +477,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                         TraceLoggingWrite(g_hRemotingProvider,
                                           "WindowManager_ExceptionInNestedWaitThread",
                                           TraceLoggingUInt64(peasantID, "peasantID", "Our peasant ID"),
-                                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
                     }
                 }
             }

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -954,7 +954,8 @@ void IslandWindow::UnsetHotkeys(const std::vector<winrt::Microsoft::Terminal::Co
                       "UnsetHotkeys",
                       TraceLoggingDescription("Emitted when clearing previously set hotkeys"),
                       TraceLoggingInt64(hotkeyList.size(), "numHotkeys", "The number of hotkeys to unset"),
-                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 
     for (int i = 0; i < ::base::saturated_cast<int>(hotkeyList.size()); i++)
     {
@@ -977,7 +978,8 @@ void IslandWindow::SetGlobalHotkeys(const std::vector<winrt::Microsoft::Terminal
                       "SetGlobalHotkeys",
                       TraceLoggingDescription("Emitted when setting hotkeys"),
                       TraceLoggingInt64(hotkeyList.size(), "numHotkeys", "The number of hotkeys to set"),
-                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     int index = 0;
     for (const auto& hotkey : hotkeyList)
     {

--- a/src/host/exe/exemain.cpp
+++ b/src/host/exe/exemain.cpp
@@ -146,7 +146,11 @@ static bool ShouldUseLegacyConhost(const ConsoleArguments& args)
     // because there's already a count of how many total processes were launched.
     // Total - legacy = new console.
     // We expect legacy launches to be infrequent enough to not cause an issue.
-    TraceLoggingWrite(g_ConhostLauncherProvider, "IsLegacyLoaded", TraceLoggingBool(true, "ConsoleLegacy"), TraceLoggingKeyword(MICROSOFT_KEYWORD_TELEMETRY));
+    TraceLoggingWrite(g_ConhostLauncherProvider,
+                      "IsLegacyLoaded",
+                      TraceLoggingBool(true, "ConsoleLegacy"),
+                      TraceLoggingKeyword(MICROSOFT_KEYWORD_TELEMETRY),
+                      TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
 
     const PCWSTR pszConhostDllName = L"ConhostV1.dll";
 

--- a/src/host/tracing.cpp
+++ b/src/host/tracing.cpp
@@ -8,6 +8,8 @@
 
 using namespace Microsoft::Console::Types;
 
+// NOTE: See `til.h` for which keyword flags are reserved
+// to ensure newly added ones do NOT overlap.
 enum TraceKeywords
 {
     //Font = 0x001, // _DBGFONTS
@@ -63,6 +65,7 @@ Tracing Tracing::s_TraceApiCall(const NTSTATUS& result, PCSTR traceName)
         TraceLoggingString(traceName, "ApiName"),
         TraceLoggingOpcode(WINEVENT_OPCODE_START),
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE),
         TraceLoggingKeyword(TraceKeywords::API));
 
     return Tracing([traceName, &result] {
@@ -73,6 +76,7 @@ Tracing Tracing::s_TraceApiCall(const NTSTATUS& result, PCSTR traceName)
             TraceLoggingHResult(result, "Result"),
             TraceLoggingOpcode(WINEVENT_OPCODE_STOP),
             TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE),
             TraceLoggingKeyword(TraceKeywords::API));
     });
     // clang-format on
@@ -89,6 +93,7 @@ void Tracing::s_TraceApi(const NTSTATUS status, const CONSOLE_GETLARGESTWINDOWSI
         TraceLoggingInt32(a->Size.X, "MaxWindowWidthInChars"),
         TraceLoggingInt32(a->Size.Y, "MaxWindowHeightInChars"),
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+        TraceLoggingKeyword(TIL_KEYWORD_TRACE),
         TraceLoggingKeyword(TraceKeywords::API));
 }
 
@@ -110,6 +115,7 @@ void Tracing::s_TraceApi(const NTSTATUS status, const CONSOLE_SCREENBUFFERINFO_M
             TraceLoggingInt32(a->MaximumWindowSize.X, "MaxWindowWidthInChars"),
             TraceLoggingInt32(a->MaximumWindowSize.Y, "MaxWindowHeightInChars"),
             TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE),
             TraceLoggingKeyword(TraceKeywords::API));
     }
     else
@@ -125,6 +131,7 @@ void Tracing::s_TraceApi(const NTSTATUS status, const CONSOLE_SCREENBUFFERINFO_M
             TraceLoggingInt32(a->MaximumWindowSize.X, "MaxWindowWidthInChars"),
             TraceLoggingInt32(a->MaximumWindowSize.Y, "MaxWindowHeightInChars"),
             TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE),
             TraceLoggingKeyword(TraceKeywords::API));
     }
 }
@@ -138,6 +145,7 @@ void Tracing::s_TraceApi(const NTSTATUS status, const CONSOLE_SETSCREENBUFFERSIZ
         TraceLoggingInt32(a->Size.X, "BufferWidthInChars"),
         TraceLoggingInt32(a->Size.Y, "BufferHeightInChars"),
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+        TraceLoggingKeyword(TIL_KEYWORD_TRACE),
         TraceLoggingKeyword(TraceKeywords::API));
 }
 
@@ -153,6 +161,7 @@ void Tracing::s_TraceApi(const NTSTATUS status, const CONSOLE_SETWINDOWINFO_MSG*
         TraceLoggingInt32(a->Window.Top, "WindowRectTop"),
         TraceLoggingInt32(a->Window.Bottom, "WindowRectBottom"),
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+        TraceLoggingKeyword(TIL_KEYWORD_TRACE),
         TraceLoggingKeyword(TraceKeywords::API));
 }
 
@@ -169,6 +178,7 @@ void Tracing::s_TraceApi(_In_ const void* const buffer, const CONSOLE_WRITECONSO
             TraceLoggingUInt32(a->NumBytes, "NumBytes"),
             TraceLoggingCountedWideString(buf, static_cast<UINT16>(a->NumBytes / sizeof(wchar_t)), "input buffer"),
             TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE),
             TraceLoggingKeyword(TraceKeywords::API));
     }
     else
@@ -181,6 +191,7 @@ void Tracing::s_TraceApi(_In_ const void* const buffer, const CONSOLE_WRITECONSO
             TraceLoggingUInt32(a->NumBytes, "NumBytes"),
             TraceLoggingCountedString(buf, static_cast<UINT16>(a->NumBytes / sizeof(char)), "input buffer"),
             TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE),
             TraceLoggingKeyword(TraceKeywords::API));
     }
     // clang-format on
@@ -206,6 +217,7 @@ void Tracing::s_TraceApi(const CONSOLE_SCREENBUFFERINFO_MSG* const a)
         TraceLoggingBoolean(a->FullscreenSupported, "FullscreenSupported"),
         TraceLoggingHexUInt32FixedArray((UINT32 const*)a->ColorTable, _countof(a->ColorTable), "ColorTable"),
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+        TraceLoggingKeyword(TIL_KEYWORD_TRACE),
         TraceLoggingKeyword(TraceKeywords::API));
     static_assert(sizeof(UINT32) == sizeof(*a->ColorTable), "a->ColorTable");
 }
@@ -218,6 +230,7 @@ void Tracing::s_TraceApi(const CONSOLE_MODE_MSG* const a, const std::wstring_vie
         TraceLoggingHexUInt32(a->Mode, "Mode"),
         TraceLoggingCountedWideString(handleType.data(), gsl::narrow_cast<ULONG>(handleType.size()), "Handle type"),
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+        TraceLoggingKeyword(TIL_KEYWORD_TRACE),
         TraceLoggingKeyword(TraceKeywords::API));
 }
 
@@ -228,6 +241,7 @@ void Tracing::s_TraceApi(const CONSOLE_SETTEXTATTRIBUTE_MSG* const a)
         "API_SetConsoleTextAttribute",
         TraceLoggingHexUInt16(a->Attributes, "Attributes"),
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+        TraceLoggingKeyword(TIL_KEYWORD_TRACE),
         TraceLoggingKeyword(TraceKeywords::API));
 }
 
@@ -241,6 +255,7 @@ void Tracing::s_TraceApi(const CONSOLE_WRITECONSOLEOUTPUTSTRING_MSG* const a)
         TraceLoggingHexUInt32(a->StringType, "StringType"),
         TraceLoggingUInt32(a->NumRecords, "NumRecords"),
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+        TraceLoggingKeyword(TIL_KEYWORD_TRACE),
         TraceLoggingKeyword(TraceKeywords::API));
 }
 
@@ -254,6 +269,7 @@ void Tracing::s_TraceWindowViewport(const Viewport& viewport)
         TraceLoggingInt32(viewport.Top(), "OriginTop"),
         TraceLoggingInt32(viewport.Left(), "OriginLeft"),
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+        TraceLoggingKeyword(TIL_KEYWORD_TRACE),
         TraceLoggingKeyword(TraceKeywords::General));
 }
 
@@ -270,6 +286,7 @@ void Tracing::s_TraceChars(_In_z_ const char* pszMessage, ...)
         "CharsTrace",
         TraceLoggingString(szBuffer),
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+        TraceLoggingKeyword(TIL_KEYWORD_TRACE),
         TraceLoggingKeyword(TraceKeywords::Chars));
 
     if (s_ulDebugFlag & TraceKeywords::Chars)
@@ -291,6 +308,7 @@ void Tracing::s_TraceOutput(_In_z_ const char* pszMessage, ...)
         "OutputTrace",
         TraceLoggingString(szBuffer),
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+        TraceLoggingKeyword(TIL_KEYWORD_TRACE),
         TraceLoggingKeyword(TraceKeywords::Output));
 
     if (s_ulDebugFlag & TraceKeywords::Output)
@@ -308,6 +326,7 @@ void Tracing::s_TraceWindowMessage(const MSG& msg)
         TraceLoggingHexUInt64(msg.wParam, "wParam"),
         TraceLoggingHexUInt64(msg.lParam, "lParam"),
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+        TraceLoggingKeyword(TIL_KEYWORD_TRACE),
         TraceLoggingKeyword(TraceKeywords::Input));
 }
 
@@ -329,6 +348,7 @@ void Tracing::s_TraceInputRecord(const INPUT_RECORD& inputRecord)
             TraceLoggingHexUInt8(inputRecord.Event.KeyEvent.uChar.AsciiChar, "Hex AsciiChar"),
             TraceLoggingHexUInt32(inputRecord.Event.KeyEvent.dwControlKeyState, "dwControlKeyState"),
             TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE),
             TraceLoggingKeyword(TraceKeywords::Input));
         break;
     case MOUSE_EVENT:
@@ -341,6 +361,7 @@ void Tracing::s_TraceInputRecord(const INPUT_RECORD& inputRecord)
             TraceLoggingHexUInt32(inputRecord.Event.MouseEvent.dwControlKeyState, "dwControlKeyState"),
             TraceLoggingHexUInt32(inputRecord.Event.MouseEvent.dwEventFlags, "dwEventFlags"),
             TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE),
             TraceLoggingKeyword(TraceKeywords::Input));
         break;
     case WINDOW_BUFFER_SIZE_EVENT:
@@ -350,6 +371,7 @@ void Tracing::s_TraceInputRecord(const INPUT_RECORD& inputRecord)
             TraceLoggingInt16(inputRecord.Event.WindowBufferSizeEvent.dwSize.X, "dwSize.X"),
             TraceLoggingInt16(inputRecord.Event.WindowBufferSizeEvent.dwSize.Y, "dwSize.Y"),
             TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE),
             TraceLoggingKeyword(TraceKeywords::Input));
         break;
     case MENU_EVENT:
@@ -358,6 +380,7 @@ void Tracing::s_TraceInputRecord(const INPUT_RECORD& inputRecord)
             "Menu Event Input Record",
             TraceLoggingHexUInt64(inputRecord.Event.MenuEvent.dwCommandId, "dwCommandId"),
             TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE),
             TraceLoggingKeyword(TraceKeywords::Input));
         break;
     case FOCUS_EVENT:
@@ -366,6 +389,7 @@ void Tracing::s_TraceInputRecord(const INPUT_RECORD& inputRecord)
             "Focus Event Input Record",
             TraceLoggingBool(inputRecord.Event.FocusEvent.bSetFocus, "bSetFocus"),
             TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE),
             TraceLoggingKeyword(TraceKeywords::Input));
         break;
     default:

--- a/src/host/tracing.cpp
+++ b/src/host/tracing.cpp
@@ -65,7 +65,7 @@ Tracing Tracing::s_TraceApiCall(const NTSTATUS& result, PCSTR traceName)
         TraceLoggingString(traceName, "ApiName"),
         TraceLoggingOpcode(WINEVENT_OPCODE_START),
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-            TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+        TraceLoggingKeyword(TIL_KEYWORD_TRACE),
         TraceLoggingKeyword(TraceKeywords::API));
 
     return Tracing([traceName, &result] {
@@ -398,6 +398,7 @@ void Tracing::s_TraceInputRecord(const INPUT_RECORD& inputRecord)
             "Unknown Input Record",
             TraceLoggingHexUInt16(inputRecord.EventType, "EventType"),
             TraceLoggingLevel(WINEVENT_LEVEL_ERROR),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE),
             TraceLoggingKeyword(TraceKeywords::Input));
         break;
     }
@@ -417,5 +418,6 @@ void __stdcall Tracing::TraceFailure(const wil::FailureInfo& failure) noexcept
         TraceLoggingString(failure.pszModule, "Module"),
         TraceLoggingPointer(failure.returnAddress, "Site"),
         TraceLoggingString(failure.pszCode, "Code"),
-        TraceLoggingLevel(WINEVENT_LEVEL_ERROR));
+        TraceLoggingLevel(WINEVENT_LEVEL_ERROR),
+        TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 }

--- a/src/inc/WilErrorReporting.h
+++ b/src/inc/WilErrorReporting.h
@@ -40,7 +40,12 @@ namespace Microsoft::Console::ErrorReporting
         if (!alreadyReported && FallbackProvider)
         {
 #pragma warning(suppress : 26477 26485 26494 26482 26446) // We don't control TraceLoggingWrite
-            TraceLoggingWrite(FallbackProvider, "FallbackError", TraceLoggingKeyword(MICROSOFT_KEYWORD_TELEMETRY), TraceLoggingLevel(WINEVENT_LEVEL_ERROR), CONSOLE_WIL_TRACELOGGING_FAILURE_PARAMS(failure));
+            TraceLoggingWrite(FallbackProvider,
+                              "FallbackError",
+                              TraceLoggingKeyword(MICROSOFT_KEYWORD_TELEMETRY),
+                              TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+                              TraceLoggingLevel(WINEVENT_LEVEL_ERROR),
+                              CONSOLE_WIL_TRACELOGGING_FAILURE_PARAMS(failure));
         }
     }
     catch (...)

--- a/src/inc/til.h
+++ b/src/inc/til.h
@@ -21,6 +21,34 @@
 #include "til/visualize_control_codes.h"
 #include "til/pmr.h"
 
+// Use keywords on TraceLogging providers to specify the category
+// of event that we are emitting for filtering purposes.
+// The bottom 48 bits (0..47) are definable by each provider.
+// The top 16 bits are reserved by Microsoft.
+// NOTE: Any provider registering TraceLoggingOptionMicrosoftTelemetry
+// should also reserve bits 43..47 for telemetry controls.
+//
+// To ensure that providers that transmit both telemetry
+// and diagnostic information do not do excess work when only
+// a telemetry listener is attached, please set a keyword
+// on all TraceLoggingWrite statements.
+//
+// Use TIL_KEYWORD_TRACE if you are basically
+// using it as a printf-like debugging tool for super
+// deep diagnostics reasons only.
+//
+// Please do NOT leave events marked without a keyword
+// or filtering on intent will not be possible.
+//
+// See also https://osgwiki.com/wiki/TraceLogging#Semantics
+//
+// Note that Conhost had already defined some keywords
+// between bits 0..11 so be sure to not overlap those.
+// See `TraceKeywords`.
+// We will therefore try to reserve 32..42 for TIL
+// as common flags for the entire Terminal team projects.
+#define TIL_KEYWORD_TRACE 0x0000000100000000 // bit 32
+
 namespace til // Terminal Implementation Library. Also: "Today I Learned"
 {
     template<typename T>

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1276,7 +1276,7 @@ try
         _invalidMap.set_all();
     }
 
-    if (TraceLoggingProviderEnabled(g_hDxRenderProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_hDxRenderProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         const auto invalidatedStr = _invalidMap.to_string();
         const auto invalidated = invalidatedStr.c_str();
@@ -1285,7 +1285,8 @@ try
         TraceLoggingWrite(g_hDxRenderProvider,
                           "Invalid",
                           TraceLoggingWideString(invalidated),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 
     if (_isEnabled)

--- a/src/renderer/vt/tracing.cpp
+++ b/src/renderer/vt/tracing.cpp
@@ -67,14 +67,15 @@ std::string toPrintableString(const std::string_view& inString)
 void RenderTracing::TraceString(const std::string_view& instr) const
 {
 #ifndef UNIT_TESTING
-    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         const std::string _seq = toPrintableString(instr);
         const char* const seq = _seq.c_str();
         TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
                           "VtEngine_TraceString",
                           TraceLoggingUtf8String(seq),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 #else
     UNREFERENCED_PARAMETER(instr);
@@ -84,14 +85,15 @@ void RenderTracing::TraceString(const std::string_view& instr) const
 void RenderTracing::TraceInvalidate(const til::rectangle invalidRect) const
 {
 #ifndef UNIT_TESTING
-    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         const auto invalidatedStr = invalidRect.to_string();
         const auto invalidated = invalidatedStr.c_str();
         TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
                           "VtEngine_TraceInvalidate",
                           TraceLoggingWideString(invalidated),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 #else
     UNREFERENCED_PARAMETER(invalidRect);
@@ -101,14 +103,15 @@ void RenderTracing::TraceInvalidate(const til::rectangle invalidRect) const
 void RenderTracing::TraceInvalidateAll(const til::rectangle viewport) const
 {
 #ifndef UNIT_TESTING
-    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         const auto invalidatedStr = viewport.to_string();
         const auto invalidatedAll = invalidatedStr.c_str();
         TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
                           "VtEngine_TraceInvalidateAll",
                           TraceLoggingWideString(invalidatedAll),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 #else
     UNREFERENCED_PARAMETER(viewport);
@@ -121,7 +124,8 @@ void RenderTracing::TraceTriggerCircling(const bool newFrame) const
     TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
                       "VtEngine_TraceTriggerCircling",
                       TraceLoggingBool(newFrame),
-                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 #else
     UNREFERENCED_PARAMETER(newFrame);
 #endif UNIT_TESTING
@@ -130,14 +134,15 @@ void RenderTracing::TraceTriggerCircling(const bool newFrame) const
 void RenderTracing::TraceInvalidateScroll(const til::point scroll) const
 {
 #ifndef UNIT_TESTING
-    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         const auto scrollDeltaStr = scroll.to_string();
         const auto scrollDelta = scrollDeltaStr.c_str();
         TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
                           "VtEngine_TraceInvalidateScroll",
                           TraceLoggingWideString(scrollDelta),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 #else
     UNREFERENCED_PARAMETER(scroll);
@@ -152,7 +157,7 @@ void RenderTracing::TraceStartPaint(const bool quickReturn,
                                     const std::optional<short>& wrappedRow) const
 {
 #ifndef UNIT_TESTING
-    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         const auto invalidatedStr = invalidMap.to_string();
         const auto invalidated = invalidatedStr.c_str();
@@ -170,7 +175,8 @@ void RenderTracing::TraceStartPaint(const bool quickReturn,
                               TraceLoggingWideString(scrollDelta),
                               TraceLoggingBool(cursorMoved),
                               TraceLoggingValue(wrappedRow.value()),
-                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
         }
         else
         {
@@ -181,7 +187,8 @@ void RenderTracing::TraceStartPaint(const bool quickReturn,
                               TraceLoggingWideString(lastView),
                               TraceLoggingWideString(scrollDelta),
                               TraceLoggingBool(cursorMoved),
-                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
         }
     }
 #else
@@ -199,7 +206,8 @@ void RenderTracing::TraceEndPaint() const
 #ifndef UNIT_TESTING
     TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
                       "VtEngine_TraceEndPaint",
-                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 #else
 #endif UNIT_TESTING
 }
@@ -207,14 +215,15 @@ void RenderTracing::TraceEndPaint() const
 void RenderTracing::TraceLastText(const til::point lastTextPos) const
 {
 #ifndef UNIT_TESTING
-    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         const auto lastTextStr = lastTextPos.to_string();
         const auto lastText = lastTextStr.c_str();
         TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
                           "VtEngine_TraceLastText",
                           TraceLoggingWideString(lastText),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 #else
     UNREFERENCED_PARAMETER(lastTextPos);
@@ -224,14 +233,15 @@ void RenderTracing::TraceLastText(const til::point lastTextPos) const
 void RenderTracing::TraceScrollFrame(const til::point scrollDeltaPos) const
 {
 #ifndef UNIT_TESTING
-    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         const auto scrollDeltaStr = scrollDeltaPos.to_string();
         const auto scrollDelta = scrollDeltaStr.c_str();
         TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
                           "VtEngine_TraceScrollFrame",
                           TraceLoggingWideString(scrollDelta),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 #else
     UNREFERENCED_PARAMETER(scrollDeltaPos);
@@ -241,7 +251,7 @@ void RenderTracing::TraceScrollFrame(const til::point scrollDeltaPos) const
 void RenderTracing::TraceMoveCursor(const til::point lastTextPos, const til::point cursor) const
 {
 #ifndef UNIT_TESTING
-    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         const auto lastTextStr = lastTextPos.to_string();
         const auto lastText = lastTextStr.c_str();
@@ -253,7 +263,8 @@ void RenderTracing::TraceMoveCursor(const til::point lastTextPos, const til::poi
                           "VtEngine_TraceMoveCursor",
                           TraceLoggingWideString(lastText),
                           TraceLoggingWideString(cursorPos),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 #else
     UNREFERENCED_PARAMETER(lastTextPos);
@@ -264,13 +275,14 @@ void RenderTracing::TraceMoveCursor(const til::point lastTextPos, const til::poi
 void RenderTracing::TraceWrapped() const
 {
 #ifndef UNIT_TESTING
-    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         const auto* const msg = "Wrapped instead of \\r\\n";
         TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
                           "VtEngine_TraceWrapped",
                           TraceLoggingString(msg),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 #else
 #endif UNIT_TESTING
@@ -279,12 +291,13 @@ void RenderTracing::TraceWrapped() const
 void RenderTracing::TraceSetWrapped(const short wrappedRow) const
 {
 #ifndef UNIT_TESTING
-    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
                           "VtEngine_TraceSetWrapped",
                           TraceLoggingValue(wrappedRow),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 #else
     UNREFERENCED_PARAMETER(wrappedRow);
@@ -294,13 +307,14 @@ void RenderTracing::TraceSetWrapped(const short wrappedRow) const
 void RenderTracing::TraceClearWrapped() const
 {
 #ifndef UNIT_TESTING
-    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         const auto* const msg = "Cleared wrap state";
         TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
                           "VtEngine_TraceClearWrapped",
                           TraceLoggingString(msg),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 #else
 #endif UNIT_TESTING
@@ -309,14 +323,15 @@ void RenderTracing::TraceClearWrapped() const
 void RenderTracing::TracePaintCursor(const til::point coordCursor) const
 {
 #ifndef UNIT_TESTING
-    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_hConsoleVtRendererTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         const auto cursorPosString = coordCursor.to_string();
         const auto cursorPos = cursorPosString.c_str();
         TraceLoggingWrite(g_hConsoleVtRendererTraceProvider,
                           "VtEngine_TracePaintCursor",
                           TraceLoggingWideString(cursorPos),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 #else
     UNREFERENCED_PARAMETER(coordCursor);

--- a/src/server/ApiDispatchers.cpp
+++ b/src/server/ApiDispatchers.cpp
@@ -40,6 +40,7 @@
     TraceLoggingWrite(g_hConhostV2EventTraceProvider,
                       "API_GetConsoleMode",
                       TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                      TraceLoggingKeyword(TIL_KEYWORD_TRACE),
                       TraceLoggingOpcode(WINEVENT_OPCODE_START));
 
     auto tracing = wil::scope_exit([&]() {
@@ -47,6 +48,7 @@
         TraceLoggingWrite(g_hConhostV2EventTraceProvider,
                           "API_GetConsoleMode",
                           TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE),
                           TraceLoggingOpcode(WINEVENT_OPCODE_STOP));
     });
 

--- a/src/terminal/parser/tracing.cpp
+++ b/src/terminal/parser/tracing.cpp
@@ -23,7 +23,8 @@ void ParserTracing::TraceStateChange(const std::wstring_view name) const noexcep
     TraceLoggingWrite(g_hConsoleVirtTermParserEventTraceProvider,
                       "StateMachine_EnterState",
                       TraceLoggingCountedWideString(name.data(), gsl::narrow_cast<ULONG>(name.size())),
-                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 }
 
 void ParserTracing::TraceOnAction(const std::wstring_view name) const noexcept
@@ -31,7 +32,8 @@ void ParserTracing::TraceOnAction(const std::wstring_view name) const noexcept
     TraceLoggingWrite(g_hConsoleVirtTermParserEventTraceProvider,
                       "StateMachine_Action",
                       TraceLoggingCountedWideString(name.data(), gsl::narrow_cast<ULONG>(name.size())),
-                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 }
 
 void ParserTracing::TraceOnExecute(const wchar_t wch) const
@@ -41,7 +43,8 @@ void ParserTracing::TraceOnExecute(const wchar_t wch) const
                       "StateMachine_Execute",
                       TraceLoggingWChar(wch),
                       TraceLoggingHexInt16(sch),
-                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 }
 
 void ParserTracing::TraceOnExecuteFromEscape(const wchar_t wch) const
@@ -51,7 +54,8 @@ void ParserTracing::TraceOnExecuteFromEscape(const wchar_t wch) const
                       "StateMachine_ExecuteFromEscape",
                       TraceLoggingWChar(wch),
                       TraceLoggingHexInt16(sch),
-                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 }
 
 void ParserTracing::TraceOnEvent(const std::wstring_view name) const noexcept
@@ -59,7 +63,8 @@ void ParserTracing::TraceOnEvent(const std::wstring_view name) const noexcept
     TraceLoggingWrite(g_hConsoleVirtTermParserEventTraceProvider,
                       "StateMachine_Event",
                       TraceLoggingCountedWideString(name.data(), gsl::narrow_cast<ULONG>(name.size())),
-                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 }
 
 void ParserTracing::TraceCharInput(const wchar_t wch)
@@ -71,13 +76,14 @@ void ParserTracing::TraceCharInput(const wchar_t wch)
                       "StateMachine_NewChar",
                       TraceLoggingWChar(wch),
                       TraceLoggingHexInt16(sch),
-                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 }
 
 void ParserTracing::AddSequenceTrace(const wchar_t wch)
 {
     // Don't waste time storing this if no one is listening.
-    if (TraceLoggingProviderEnabled(g_hConsoleVirtTermParserEventTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_hConsoleVirtTermParserEventTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         _sequenceTrace.push_back(wch);
     }
@@ -90,14 +96,16 @@ void ParserTracing::DispatchSequenceTrace(const bool fSuccess) noexcept
         TraceLoggingWrite(g_hConsoleVirtTermParserEventTraceProvider,
                           "StateMachine_Sequence_OK",
                           TraceLoggingWideString(_sequenceTrace.c_str()),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
     else
     {
         TraceLoggingWrite(g_hConsoleVirtTermParserEventTraceProvider,
                           "StateMachine_Sequence_FAIL",
                           TraceLoggingWideString(_sequenceTrace.c_str()),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 
     ClearSequenceTrace();
@@ -119,7 +127,8 @@ void ParserTracing::DispatchPrintRunTrace(const std::wstring_view string) const
                           "StateMachine_PrintRun",
                           TraceLoggingWChar(wch),
                           TraceLoggingHexInt16(sch),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
     else
     {
@@ -129,7 +138,8 @@ void ParserTracing::DispatchPrintRunTrace(const std::wstring_view string) const
                           "StateMachine_PrintRun",
                           TraceLoggingCountedWideString(string.data(), length),
                           TraceLoggingValue(length),
-                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 

--- a/src/types/UiaTracing.cpp
+++ b/src/types/UiaTracing.cpp
@@ -129,21 +129,22 @@ inline std::wstring UiaTracing::_getValue(const TextUnit unit) noexcept
 void UiaTracing::TextRange::Constructor(UiaTextRangeBase& result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         _assignId(result);
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::Constructor",
             TraceLoggingValue(_getValue(result).c_str(), "UiaTextRange"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextRange::Clone(const UiaTextRangeBase& utr, UiaTextRangeBase& result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         _assignId(result);
         TraceLoggingWrite(
@@ -151,14 +152,15 @@ void UiaTracing::TextRange::Clone(const UiaTextRangeBase& utr, UiaTextRangeBase&
             "UiaTextRange::Clone",
             TraceLoggingValue(_getValue(utr).c_str(), "base"),
             TraceLoggingValue(_getValue(result).c_str(), "clone"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextRange::Compare(const UiaTextRangeBase& utr, const UiaTextRangeBase& other, bool result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
@@ -166,14 +168,15 @@ void UiaTracing::TextRange::Compare(const UiaTextRangeBase& utr, const UiaTextRa
             TraceLoggingValue(_getValue(utr).c_str(), "base"),
             TraceLoggingValue(_getValue(other).c_str(), "other"),
             TraceLoggingValue(result, "result"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextRange::CompareEndpoints(const UiaTextRangeBase& utr, const TextPatternRangeEndpoint endpoint, const UiaTextRangeBase& other, TextPatternRangeEndpoint otherEndpoint, int result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
@@ -183,41 +186,44 @@ void UiaTracing::TextRange::CompareEndpoints(const UiaTextRangeBase& utr, const 
             TraceLoggingValue(_getValue(other).c_str(), "other"),
             TraceLoggingValue(_getValue(otherEndpoint).c_str(), "otherEndpoint"),
             TraceLoggingValue(result, "result"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextRange::ExpandToEnclosingUnit(TextUnit unit, const UiaTextRangeBase& utr) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::ExpandToEnclosingUnit",
             TraceLoggingValue(_getValue(unit).c_str(), "textUnit"),
             TraceLoggingValue(_getValue(utr).c_str(), "result"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextRange::FindAttribute(const UiaTextRangeBase& utr) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::FindAttribute (UNSUPPORTED)",
             TraceLoggingValue(_getValue(utr).c_str(), "base"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextRange::FindText(const UiaTextRangeBase& base, std::wstring text, bool searchBackward, bool ignoreCase, const UiaTextRangeBase& result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
@@ -227,14 +233,15 @@ void UiaTracing::TextRange::FindText(const UiaTextRangeBase& base, std::wstring 
             TraceLoggingValue(searchBackward, "searchBackward"),
             TraceLoggingValue(ignoreCase, "ignoreCase"),
             TraceLoggingValue(_getValue(result).c_str(), "result"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextRange::GetAttributeValue(const UiaTextRangeBase& base, TEXTATTRIBUTEID id, VARIANT result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
@@ -242,40 +249,43 @@ void UiaTracing::TextRange::GetAttributeValue(const UiaTextRangeBase& base, TEXT
             TraceLoggingValue(_getValue(base).c_str(), "base"),
             TraceLoggingValue(id, "textAttributeId"),
             TraceLoggingValue(result.vt, "result (type)"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextRange::GetBoundingRectangles(const UiaTextRangeBase& utr) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::GetBoundingRectangles",
             TraceLoggingValue(_getValue(utr).c_str(), "base"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextRange::GetEnclosingElement(const UiaTextRangeBase& utr) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::GetEnclosingElement",
             TraceLoggingValue(_getValue(utr).c_str(), "base"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextRange::GetText(const UiaTextRangeBase& utr, int maxLength, std::wstring result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
@@ -283,14 +293,15 @@ void UiaTracing::TextRange::GetText(const UiaTextRangeBase& utr, int maxLength, 
             TraceLoggingValue(_getValue(utr).c_str(), "base"),
             TraceLoggingValue(maxLength, "maxLength"),
             TraceLoggingValue(result.c_str(), "result"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextRange::Move(TextUnit unit, int count, int resultCount, const UiaTextRangeBase& result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
@@ -299,14 +310,15 @@ void UiaTracing::TextRange::Move(TextUnit unit, int count, int resultCount, cons
             TraceLoggingValue(count, "count"),
             TraceLoggingValue(resultCount, "resultCount"),
             TraceLoggingValue(_getValue(result).c_str(), "result"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextRange::MoveEndpointByUnit(TextPatternRangeEndpoint endpoint, TextUnit unit, int count, int resultCount, const UiaTextRangeBase& result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
@@ -316,14 +328,15 @@ void UiaTracing::TextRange::MoveEndpointByUnit(TextPatternRangeEndpoint endpoint
             TraceLoggingValue(count, "count"),
             TraceLoggingValue(resultCount, "resultCount"),
             TraceLoggingValue(_getValue(result).c_str(), "result"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextRange::MoveEndpointByRange(TextPatternRangeEndpoint endpoint, const UiaTextRangeBase& other, TextPatternRangeEndpoint otherEndpoint, const UiaTextRangeBase& result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
@@ -332,94 +345,101 @@ void UiaTracing::TextRange::MoveEndpointByRange(TextPatternRangeEndpoint endpoin
             TraceLoggingValue(_getValue(other).c_str(), "other"),
             TraceLoggingValue(_getValue(otherEndpoint).c_str(), "otherEndpoint"),
             TraceLoggingValue(_getValue(result).c_str(), "result"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextRange::Select(const UiaTextRangeBase& result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::Select",
             TraceLoggingValue(_getValue(result).c_str(), "base"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextRange::AddToSelection(const UiaTextRangeBase& result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::AddToSelection (UNSUPPORTED)",
             TraceLoggingValue(_getValue(result).c_str(), "base"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextRange::RemoveFromSelection(const UiaTextRangeBase& result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::RemoveFromSelection (UNSUPPORTED)",
             TraceLoggingValue(_getValue(result).c_str(), "base"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextRange::ScrollIntoView(bool alignToTop, const UiaTextRangeBase& result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::ScrollIntoView",
             TraceLoggingValue(alignToTop, "alignToTop"),
             TraceLoggingValue(_getValue(result).c_str(), "result"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextRange::GetChildren(const UiaTextRangeBase& result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "UiaTextRange::AddToSelection (UNSUPPORTED)",
             TraceLoggingValue(_getValue(result).c_str(), "base"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextProvider::Constructor(ScreenInfoUiaProviderBase& result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         _assignId(result);
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::Constructor",
             TraceLoggingValue(_getValue(result).c_str(), "ScreenInfoUiaProvider"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextProvider::get_ProviderOptions(const ScreenInfoUiaProviderBase& siup, ProviderOptions options) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         auto getOptions = [options]() {
             switch (options)
@@ -436,14 +456,15 @@ void UiaTracing::TextProvider::get_ProviderOptions(const ScreenInfoUiaProviderBa
             "ScreenInfoUiaProvider::get_ProviderOptions",
             TraceLoggingValue(_getValue(siup).c_str(), "base"),
             TraceLoggingValue(getOptions(), "providerOptions"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextProvider::GetPatternProvider(const ScreenInfoUiaProviderBase& siup, PATTERNID patternId) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         auto getPattern = [patternId]() {
             switch (patternId)
@@ -460,14 +481,15 @@ void UiaTracing::TextProvider::GetPatternProvider(const ScreenInfoUiaProviderBas
             "ScreenInfoUiaProvider::get_ProviderOptions",
             TraceLoggingValue(_getValue(siup).c_str(), "base"),
             TraceLoggingValue(getPattern(), "patternId"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextProvider::GetPropertyValue(const ScreenInfoUiaProviderBase& siup, PROPERTYID propertyId) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         auto getProperty = [propertyId]() {
             switch (propertyId)
@@ -500,108 +522,116 @@ void UiaTracing::TextProvider::GetPropertyValue(const ScreenInfoUiaProviderBase&
             "ScreenInfoUiaProvider::GetPropertyValue",
             TraceLoggingValue(_getValue(siup).c_str(), "base"),
             TraceLoggingValue(getProperty(), "propertyId"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextProvider::get_HostRawElementProvider(const ScreenInfoUiaProviderBase& siup) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::get_HostRawElementProvider (UNSUPPORTED)",
             TraceLoggingValue(_getValue(siup).c_str(), "base"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextProvider::GetRuntimeId(const ScreenInfoUiaProviderBase& siup) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::GetRuntimeId",
             TraceLoggingValue(_getValue(siup).c_str(), "base"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextProvider::GetEmbeddedFragmentRoots(const ScreenInfoUiaProviderBase& siup) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::GetEmbeddedFragmentRoots (UNSUPPORTED)",
             TraceLoggingValue(_getValue(siup).c_str(), "base"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextProvider::SetFocus(const ScreenInfoUiaProviderBase& siup) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::SetFocus",
             TraceLoggingValue(_getValue(siup).c_str(), "base"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextProvider::GetSelection(const ScreenInfoUiaProviderBase& siup, const UiaTextRangeBase& result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::GetSelection",
             TraceLoggingValue(_getValue(siup).c_str(), "base"),
             TraceLoggingValue(_getValue(result).c_str(), "result (utr)"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextProvider::GetVisibleRanges(const ScreenInfoUiaProviderBase& siup, const UiaTextRangeBase& result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::GetVisibleRanges",
             TraceLoggingValue(_getValue(siup).c_str(), "base"),
             TraceLoggingValue(_getValue(result).c_str(), "result (utr)"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextProvider::RangeFromChild(const ScreenInfoUiaProviderBase& siup, const UiaTextRangeBase& result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::GetVisibleRanges",
             TraceLoggingValue(_getValue(siup).c_str(), "base"),
             TraceLoggingValue(_getValue(result).c_str(), "result (utr)"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextProvider::RangeFromPoint(const ScreenInfoUiaProviderBase& siup, UiaPoint point, const UiaTextRangeBase& result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         auto getPoint = [point]() {
             std::wstringstream stream;
@@ -615,28 +645,30 @@ void UiaTracing::TextProvider::RangeFromPoint(const ScreenInfoUiaProviderBase& s
             TraceLoggingValue(_getValue(siup).c_str(), "base"),
             TraceLoggingValue(getPoint().c_str(), "uiaPoint"),
             TraceLoggingValue(_getValue(result).c_str(), "result (utr)"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextProvider::get_DocumentRange(const ScreenInfoUiaProviderBase& siup, const UiaTextRangeBase& result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "ScreenInfoUiaProvider::GetVisibleRanges",
             TraceLoggingValue(_getValue(siup).c_str(), "base"),
             TraceLoggingValue(_getValue(result).c_str(), "result (utr)"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::TextProvider::get_SupportedTextSelection(const ScreenInfoUiaProviderBase& siup, SupportedTextSelection result) noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         auto getResult = [result]() {
             switch (result)
@@ -653,43 +685,47 @@ void UiaTracing::TextProvider::get_SupportedTextSelection(const ScreenInfoUiaPro
             "ScreenInfoUiaProvider::get_SupportedTextSelection",
             TraceLoggingValue(_getValue(siup).c_str(), "base"),
             TraceLoggingValue(getResult(), "result"),
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::Signal::SelectionChanged() noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "Signal::SelectionChanged",
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::Signal::TextChanged() noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "Signal::TextChanged",
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 
 void UiaTracing::Signal::CursorChanged() noexcept
 {
     EnsureRegistration();
-    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, 0))
+    if (TraceLoggingProviderEnabled(g_UiaProviderTraceProvider, WINEVENT_LEVEL_VERBOSE, TIL_KEYWORD_TRACE))
     {
         TraceLoggingWrite(
             g_UiaProviderTraceProvider,
             "Signal::CursorChanged",
-            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 }
 


### PR DESCRIPTION
Set keyword flags on all events so those sharing a provider with
telemetry do not fire unless tracing is enabled

## PR Checklist
* [x] Closes #10093 
* [x] I work here
* [x] Tests passed
* [x] Documentation added in `til.h` about how keywords work and at the
  only other site of keywords we define in the Host project tracing
  files.

## Detailed Description of the Pull Request / Additional comments
I initially thought that we would need to split providers here to
accomplish this... but @DHowett helped me realize that might be a lot of
additional metadata and bloat binary size. So with help from a friend
from fundamentals, I realized that we could use Keywords to
differentiate here. We can no longer define 0 keywords as that
represents an any/all scenario. Every `TraceLoggingWrite` event now
needs a keyword. When our events have a keyword, they're not included in
any trace. Additionally, when we have an explicit keyword to check that
is different from the ones used for the telemetry pipeline, we can
ensure that we only do "hard work" to generate debug trace data when an
"ALL" type listener like TraceView or Windows Performance Recorder with
our profiles is listening to these providers for ALL keyworded events. 

## Validation Steps Performed
- [x] - Built with full release build config to confirm performance is
  worse than dev builds BECAUSE of the telemetry event collector camping
  our provider and triggering full trace event generation on shared
  providers.
- [x] - Built with full release build config to enable statistics
  collection and validated trace event collection is excluded and trace
  event short-circuits work with this change.
- [x] - Checked that TraceView still sees both telemetry and tracing
  events
- [x] - Checked that WPR with our .wprp profile sees both telemetry and
  tracing events
