### PR TITLE
Hide `_quake` window on minimize ALWAYS

### DIFF
--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -447,6 +447,15 @@ long IslandWindow::_calculateTotalSize(const bool isWidth, const long clientSize
     {
         return _OnSizing(wparam, lparam);
     }
+    case WM_SIZE:
+    {
+        if (wparam == SIZE_MINIMIZED && _isQuakeWindow)
+        {
+            ShowWindow(GetHandle(), SW_HIDE);
+            return 0;
+        }
+        break;
+    }
     case WM_MOVING:
     {
         return _OnMoving(wparam, lparam);
@@ -1113,6 +1122,13 @@ void IslandWindow::_dropdownWindow(const uint32_t dropdownDuration)
     WINDOWPLACEMENT wpc{};
     wpc.length = sizeof(WINDOWPLACEMENT);
     GetWindowPlacement(_window.get(), &wpc);
+
+    // If the window is hidden, SW_SHOW it first.
+    if (!IsWindowVisible(GetHandle()))
+    {
+        wpc.showCmd = SW_SHOW;
+        SetWindowPlacement(_window.get(), &wpc);
+    }
     wpc.showCmd = SW_RESTORE;
     SetWindowPlacement(_window.get(), &wpc);
 
@@ -1162,7 +1178,15 @@ void IslandWindow::_globalActivateWindow(const uint32_t dropdownDuration)
         }
         else
         {
-            LOG_IF_WIN32_BOOL_FALSE(ShowWindow(_window.get(), SW_RESTORE));
+            // If the window is hidden, SW_SHOW it first. Note that hidden !=
+            // minimized. A hidden window doesn't appear in the taskbar, while a
+            // minimized window will. If you don't do this, then we won't be
+            // able to properly set this as the foreground window.
+            if (!IsWindowVisible(GetHandle()))
+            {
+                ShowWindow(_window.get(), SW_SHOW);
+            }
+            ShowWindow(_window.get(), SW_RESTORE);
         }
     }
     else
@@ -1176,7 +1200,7 @@ void IslandWindow::_globalActivateWindow(const uint32_t dropdownDuration)
             LOG_IF_WIN32_BOOL_FALSE(AttachThreadInput(windowThreadProcessId, currentThreadId, false));
         });
         LOG_IF_WIN32_BOOL_FALSE(BringWindowToTop(_window.get()));
-        LOG_IF_WIN32_BOOL_FALSE(ShowWindow(_window.get(), SW_SHOW));
+        ShowWindow(_window.get(), SW_SHOW);
 
         // Activate the window too. This will force us to the virtual desktop this
         // window is on, if it's on another virtual desktop.
@@ -1202,7 +1226,7 @@ void IslandWindow::_globalDismissWindow(const uint32_t dropdownDuration)
     }
     else
     {
-        LOG_IF_WIN32_BOOL_FALSE(ShowWindow(_window.get(), SW_MINIMIZE));
+        ShowWindow(_window.get(), SW_MINIMIZE);
     }
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

This is a scoped implementation of "hide on minimize", only to the `_quake` window. When minimized, the `_quake` window won't appear in the taskbar. IT ALSO WON'T APPEAR IN THE TRAY, BECAUSE WE DON'T HAVE ONE YET.

I talked about this with @DHowett, and it seemed cool. Other windows will still minimize normally.

## References
* Original thread: #653
* Spec: #9274 
* megathread: #8888
* minimize to tray: #5727 

## PR Checklist
* [x] Closes https://github.com/microsoft/terminal/projects/5#card-61246940
* [x] I work here
* [ ] Tests added/passed
* [ ] Requires documentation to be updated - probably yea, but something <sub>something <sub>something</sub></sub>

## Detailed Description of the Pull Request / Additional comments

After playing with it, it is in fact, cool.

ALSO `LOG_IF_WIN32_BOOL_FALSE` should DEFINITELY not be used with `ShowWindow`. [`ShowWindow`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow#return-value) returns false if the window was previously hidden, but doesn't `SetLastError`, so that macro will _throw_.

## Validation Steps Performed


```jsonc
        { "keys": "ctrl+`", "command": { "action": "quakeMode" } },
        { "keys": "ctrl+1", "command": { "action": "globalSummon", "name": "_quake" } },
        // { "keys": "ctrl+1", "command": { "action": "globalSummon" } },
        // { "keys": "ctrl+2", "command": { "action": "globalSummon", "desktop": "toCurrent" } },
        // { "keys": "ctrl+2", "command": { "action": "globalSummon", "toggleVisibility": false } },
        // { "keys": "ctrl+2", "command": { "action": "globalSummon", "dropdownDuration": 2000 } },
        { "keys": "ctrl+2", "command": { "action": "globalSummon", "monitor": "any" } },
        // { "keys": "ctrl+3", "command": { "action": "globalSummon", "desktop": "onCurrent" } },
        { "keys": "ctrl+3", "command": { "action": "globalSummon", "monitor": "toMouse" } },
        // { "keys": "ctrl+4", "command": { "action": "globalSummon", "desktop": "any" } },
        { "keys": "ctrl+4", "command": { "action": "globalSummon", "monitor": "toMouse", "dropdownDuration": 500 } },
        { "keys": "ctrl+5", "command": { "action": "globalSummon", "dropdownDuration": 500 } },
```