### PR TITLE
Don't yeet focus to the control when the tab renamer is opened

### DIFF
--- a/src/cascadia/TerminalApp/TabHeaderControl.cpp
+++ b/src/cascadia/TerminalApp/TabHeaderControl.cpp
@@ -56,6 +56,18 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Method Description:
+    // - Returns true if we're in the middle of a tab rename. This is used to
+    //   mitigate GH#10112.
+    // Arguments:
+    // - <none>
+    // Return Value:
+    // - true if the renamer is open.
+    bool TabHeaderControl::InRename()
+    {
+        return Windows::UI::Xaml::Visibility::Visible == HeaderRenamerTextBox().Visibility();
+    }
+
+    // Method Description:
     // - Show the tab rename box for the user to rename the tab title
     // - We automatically use the previous title as the initial text of the box
     void TabHeaderControl::BeginRename()

--- a/src/cascadia/TerminalApp/TabHeaderControl.cpp
+++ b/src/cascadia/TerminalApp/TabHeaderControl.cpp
@@ -62,7 +62,7 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     // Return Value:
     // - true if the renamer is open.
-    bool TabHeaderControl::InRename()
+    bool TabHeaderControl::InRename() const noexcept
     {
         return Windows::UI::Xaml::Visibility::Visible == HeaderRenamerTextBox().Visibility();
     }

--- a/src/cascadia/TerminalApp/TabHeaderControl.cpp
+++ b/src/cascadia/TerminalApp/TabHeaderControl.cpp
@@ -62,7 +62,7 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     // Return Value:
     // - true if the renamer is open.
-    bool TabHeaderControl::InRename() const noexcept
+    bool TabHeaderControl::InRename()
     {
         return Windows::UI::Xaml::Visibility::Visible == HeaderRenamerTextBox().Visibility();
     }

--- a/src/cascadia/TerminalApp/TabHeaderControl.h
+++ b/src/cascadia/TerminalApp/TabHeaderControl.h
@@ -18,6 +18,8 @@ namespace winrt::TerminalApp::implementation
         void RenameBoxLostFocusHandler(winrt::Windows::Foundation::IInspectable const& sender,
                                        winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
 
+        bool InRename();
+
         WINRT_CALLBACK(TitleChangeRequested, TerminalApp::TitleChangeRequestedArgs);
 
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);

--- a/src/cascadia/TerminalApp/TabHeaderControl.h
+++ b/src/cascadia/TerminalApp/TabHeaderControl.h
@@ -18,7 +18,7 @@ namespace winrt::TerminalApp::implementation
         void RenameBoxLostFocusHandler(winrt::Windows::Foundation::IInspectable const& sender,
                                        winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
 
-        bool InRename() const noexcept;
+        bool InRename();
 
         WINRT_CALLBACK(TitleChangeRequested, TerminalApp::TitleChangeRequestedArgs);
 

--- a/src/cascadia/TerminalApp/TabHeaderControl.h
+++ b/src/cascadia/TerminalApp/TabHeaderControl.h
@@ -18,7 +18,7 @@ namespace winrt::TerminalApp::implementation
         void RenameBoxLostFocusHandler(winrt::Windows::Foundation::IInspectable const& sender,
                                        winrt::Windows::UI::Xaml::RoutedEventArgs const& e);
 
-        bool InRename();
+        bool InRename() const noexcept;
 
         WINRT_CALLBACK(TitleChangeRequested, TerminalApp::TitleChangeRequestedArgs);
 

--- a/src/cascadia/TerminalApp/TabHeaderControl.idl
+++ b/src/cascadia/TerminalApp/TabHeaderControl.idl
@@ -14,6 +14,8 @@ namespace TerminalApp
         TabHeaderControl();
         void BeginRename();
 
+        Boolean InRename { get; };
+
         TerminalTabStatus TabStatus { get;  set; };
 
         event TitleChangeRequestedArgs TitleChangeRequested;

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -899,7 +899,13 @@ namespace winrt::TerminalApp::implementation
         contextMenuFlyout.Closed([weakThis](auto&&, auto&&) {
             if (auto tab{ weakThis.get() })
             {
-                tab->_RequestFocusActiveControlHandlers();
+                // GH#10112 - if we're opening the tab renamer, don't
+                // immediately toss focus to the control. We don't want to steal
+                // focus from the tab renamer.
+                if (!tab->_headerControl.InRename())
+                {
+                    tab->_RequestFocusActiveControlHandlers();
+                }
             }
         });
         _AppendCloseMenuItems(contextMenuFlyout);


### PR DESCRIPTION
This is a hotfix to #10048. When the tab renamer is opened, we need to make sure to not immediately steal focus from it.

* [x] closes #10112
* [x] I work here
* [x] tested manually