### PR TITLE
Bind `quakeMode` to "win+`" by default

### DIFF
--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -298,6 +298,7 @@
         { "command": "commandPalette", "keys":"ctrl+shift+p" },
         { "command": "identifyWindow" },
         { "command": "openWindowRenamer" },
+        { "command": "quakeMode", "keys":"win+`" },
 
         // Tab Management
         // "command": "closeTab" is unbound by default.


### PR DESCRIPTION
I'd personally chose to just bind `globalSummon` to <kbd>win+`</kbd>, but _I do as I'm told_.

* [x] I work here
* [x] @cinnamon-msft mentioned this
* [x] Docs