### PR TITLE
Revert "Add the profile, page icons to the page headers (#10046)"

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.xaml
+++ b/src/cascadia/TerminalApp/CommandPalette.xaml
@@ -48,15 +48,8 @@
                           x:DataType="local:FilteredCommand">
                 <Grid HorizontalAlignment="Stretch"
                       ColumnSpacing="8">
-
-                    <!--
-                        Manually set the icon to 24x16. Why 24?
-                        If it's a BitmapIcon, then the icon will just get clamped to 16x16.
-                        However, if it's a FontIcon, then the icon might actually be double wide.
-                        Giving it a width of 24 will allow a 12pt font icon enough space, in a row height of 16 wide.
-                    -->
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="24" />
+                        <ColumnDefinition Width="16" />
                         <!--  icon  -->
                         <ColumnDefinition Width="Auto" />
                         <!--  command label  -->
@@ -67,7 +60,7 @@
                     </Grid.ColumnDefinitions>
 
                     <IconSourceElement Grid.Column="0"
-                                       Width="24"
+                                       Width="16"
                                        Height="16"
                                        IconSource="{x:Bind Item.Icon, Mode=OneWay, Converter={StaticResource IconSourceConverter}}" />
 
@@ -106,7 +99,7 @@
                 <Grid HorizontalAlignment="Stretch"
                       ColumnSpacing="8">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="24" />
+                        <ColumnDefinition Width="16" />
                         <!--  icon  -->
                         <ColumnDefinition Width="Auto" />
                         <!--  command label  -->
@@ -117,7 +110,7 @@
                     </Grid.ColumnDefinitions>
 
                     <IconSourceElement Grid.Column="0"
-                                       Width="24"
+                                       Width="16"
                                        Height="16"
                                        IconSource="{x:Bind Item.Icon, Mode=OneWay, Converter={StaticResource IconSourceConverter}}" />
 
@@ -169,7 +162,7 @@
                       AutomationProperties.Name="{x:Bind Item.Name, Mode=OneWay}"
                       ColumnSpacing="8">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="24" />
+                        <ColumnDefinition Width="16" />
                         <!--  icon / progress  -->
                         <ColumnDefinition Width="Auto" />
                         <!--  command label  -->
@@ -192,7 +185,7 @@
                                       Value="{x:Bind Item.(local:TabPaletteItem.TabStatus).ProgressValue, Mode=OneWay}" />
 
                     <IconSourceElement Grid.Column="0"
-                                       Width="24"
+                                       Width="16"
                                        Height="16"
                                        IconSource="{x:Bind Item.Icon, Mode=OneWay, Converter={StaticResource IconSourceConverter}}" />
 

--- a/src/cascadia/TerminalSettingsEditor/AddProfile.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AddProfile.xaml
@@ -45,21 +45,16 @@
                             <DataTemplate x:DataType="model:Profile">
                                 <Grid HorizontalAlignment="Stretch"
                                       ColumnSpacing="8">
+
                                     <Grid.ColumnDefinitions>
                                         <!--  icon  -->
-                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="16" />
                                         <!--  profile name  -->
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
 
-                                    <!--
-                                        Manually set the icon to 24x16. Why 24?
-                                        If it's a BitmapIcon, then the icon will just get clamped to 16x16.
-                                        However, if it's a FontIcon, then the icon might actually be double wide.
-                                        Giving it a width of 24 will allow a 12pt font icon enough space, in a row height of 16 wide.
-                                    -->
                                     <IconSourceElement Grid.Column="0"
-                                                       Width="24"
+                                                       Width="16"
                                                        Height="16"
                                                        IconSource="{x:Bind Icon, Mode=OneWay, Converter={StaticResource IconSourceConverter}}" />
 

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -377,13 +377,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         addProfileItem.Content(box_value(RS_(L"Nav_AddNewProfile/Content")));
         addProfileItem.Tag(box_value(addProfileTag));
 
-        // Wrap this icon up in a IconSourceElement, so we can bind to it in the
-        // Header above the Pivot.
-        WUX::Controls::IconSourceElement icon;
-        FontIconSource fontIcon;
+        FontIcon icon;
         // This is the "Add" symbol
-        fontIcon.Glyph(L"\xE710");
-        icon.IconSource(fontIcon);
+        icon.Glyph(L"\xE710");
         addProfileItem.Icon(icon);
 
         SettingsNav().MenuItems().Append(addProfileItem);

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -35,91 +35,54 @@
     </Page.Resources>
 
     <muxc:NavigationView x:Name="SettingsNav"
+                         Header="{Binding ElementName=SettingsNav, Path=SelectedItem.Content, Mode=OneWay}"
                          IsBackButtonVisible="Collapsed"
                          IsSettingsVisible="False"
                          ItemInvoked="SettingsNav_ItemInvoked"
                          Loaded="SettingsNav_Loaded"
                          TabFocusNavigation="Cycle">
 
-        <muxc:NavigationView.Header>
-            <StackPanel Orientation="Horizontal">
-                <!--
-                    This height is taken from NavigationViewTitleHeaderContentControlTextStyle's
-                    FontSize. Our icons may or may not be font icons, so we want to make sure to clamp them to this size.
-                -->
-                <IconSourceElement Height="28"
-                                   Margin="{ThemeResource NavigationViewHeaderMargin}"
-                                   IconSource="{Binding ElementName=SettingsNav, Path=SelectedItem.Icon.IconSource, Mode=OneWay}" />
-                <TextBlock Margin="{ThemeResource NavigationViewHeaderMargin}"
-                           Text="{Binding ElementName=SettingsNav, Path=SelectedItem.Content, Mode=OneWay}" />
-            </StackPanel>
-        </muxc:NavigationView.Header>
-
         <muxc:NavigationView.MenuItems>
 
             <muxc:NavigationViewItem x:Uid="Nav_Launch"
                                      Tag="Launch_Nav">
                 <muxc:NavigationViewItem.Icon>
-                    <IconSourceElement>
-                        <IconSourceElement.IconSource>
-                            <FontIconSource Glyph="&#xE7B5;" />
-                        </IconSourceElement.IconSource>
-                    </IconSourceElement>
+                    <FontIcon Glyph="&#xE7B5;" />
                 </muxc:NavigationViewItem.Icon>
             </muxc:NavigationViewItem>
 
             <muxc:NavigationViewItem x:Uid="Nav_Interaction"
                                      Tag="Interaction_Nav">
                 <muxc:NavigationViewItem.Icon>
-                    <IconSourceElement>
-                        <IconSourceElement.IconSource>
-                            <FontIconSource Glyph="&#xE7C9;" />
-                        </IconSourceElement.IconSource>
-                    </IconSourceElement>
+                    <FontIcon Glyph="&#xE7C9;" />
                 </muxc:NavigationViewItem.Icon>
             </muxc:NavigationViewItem>
 
             <muxc:NavigationViewItem x:Uid="Nav_Appearance"
                                      Tag="GlobalAppearance_Nav">
                 <muxc:NavigationViewItem.Icon>
-                    <IconSourceElement>
-                        <IconSourceElement.IconSource>
-                            <FontIconSource Glyph="&#xE771;" />
-                        </IconSourceElement.IconSource>
-                    </IconSourceElement>
+                    <FontIcon Glyph="&#xE771;" />
                 </muxc:NavigationViewItem.Icon>
             </muxc:NavigationViewItem>
 
             <muxc:NavigationViewItem x:Uid="Nav_ColorSchemes"
                                      Tag="ColorSchemes_Nav">
                 <muxc:NavigationViewItem.Icon>
-                    <IconSourceElement>
-                        <IconSourceElement.IconSource>
-                            <FontIconSource Glyph="&#xE790;" />
-                        </IconSourceElement.IconSource>
-                    </IconSourceElement>
+                    <FontIcon Glyph="&#xE790;" />
                 </muxc:NavigationViewItem.Icon>
             </muxc:NavigationViewItem>
 
             <muxc:NavigationViewItem x:Uid="Nav_Rendering"
                                      Tag="Rendering_Nav">
                 <muxc:NavigationViewItem.Icon>
-                    <IconSourceElement>
-                        <IconSourceElement.IconSource>
-                            <FontIconSource Glyph="&#xE7F8;" />
-                        </IconSourceElement.IconSource>
-                    </IconSourceElement>
+                    <FontIcon Glyph="&#xE7F8;" />
                 </muxc:NavigationViewItem.Icon>
             </muxc:NavigationViewItem>
 
             <muxc:NavigationViewItem x:Uid="Nav_Actions"
                                      Tag="Actions_Nav">
                 <muxc:NavigationViewItem.Icon>
-                    <IconSourceElement>
-                        <IconSourceElement.IconSource>
-                            <FontIconSource Glyph="&#xE765;" />
-                        </IconSourceElement.IconSource>
-                    </IconSourceElement>
+                    <FontIcon Glyph="&#xE765;" />
                 </muxc:NavigationViewItem.Icon>
             </muxc:NavigationViewItem>
 
@@ -134,11 +97,7 @@
                                      KeyDown="OpenJsonKeyDown"
                                      Tapped="OpenJsonTapped">
                 <muxc:NavigationViewItem.Icon>
-                    <IconSourceElement>
-                        <IconSourceElement.IconSource>
-                            <FontIconSource Glyph="&#xE713;" />
-                        </IconSourceElement.IconSource>
-                    </IconSourceElement>
+                    <FontIcon Glyph="&#xE713;" />
                 </muxc:NavigationViewItem.Icon>
             </muxc:NavigationViewItem>
         </muxc:NavigationView.PaneFooter>

--- a/src/cascadia/TerminalSettingsModel/IconPathConverter.cpp
+++ b/src/cascadia/TerminalSettingsModel/IconPathConverter.cpp
@@ -131,6 +131,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                         // Note: you _do_ need to manually set the font here.
                         icon.FontFamily(winrt::Windows::UI::Xaml::Media::FontFamily{ L"Segoe UI" });
                     }
+                    icon.FontSize(12);
                     icon.Glyph(iconPath);
                     iconSource = icon;
                 }


### PR DESCRIPTION
This reverts commit a3a2a4102dff785ac84f0d37397113fae3ef2033.

#10046 causes a crash on save. `MainPage::UpdateSettings()` is unable to update the navigation view's selected item due to an "incorrect parameter". This is particularly strange to see because #10046 only modifies the navigation view's header, not the menu items themselves. Reverting this change fixes that crash (verified).

Reopens #9694
