### PR TITLE
Pass through double clicks and hover events in Win32 mouse mode

### DIFF
--- a/.github/actions/spelling/allow/apis.txt
+++ b/.github/actions/spelling/allow/apis.txt
@@ -16,6 +16,7 @@ CYICON
 dataobject
 dcomp
 DERR
+difftime
 dlldata
 DONTADDTORECENT
 DWORDLONG

--- a/.github/actions/spelling/allow/apis.txt
+++ b/.github/actions/spelling/allow/apis.txt
@@ -16,7 +16,6 @@ CYICON
 dataobject
 dcomp
 DERR
-difftime
 dlldata
 DONTADDTORECENT
 DWORDLONG

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -99,7 +99,9 @@ InputStateMachineEngine::InputStateMachineEngine(std::unique_ptr<IInteractDispat
 InputStateMachineEngine::InputStateMachineEngine(std::unique_ptr<IInteractDispatch> pDispatch, const bool lookingForDSR) :
     _pDispatch(std::move(pDispatch)),
     _lookingForDSR(lookingForDSR),
-    _pfnFlushToInputQueue(nullptr)
+    _pfnFlushToInputQueue(nullptr),
+    _doubleClickTime(GetDoubleClickTime()),
+    _lastMouseClickTime(time(nullptr))
 {
     THROW_HR_IF_NULL(E_INVALIDARG, _pDispatch.get());
 }
@@ -878,7 +880,7 @@ bool InputStateMachineEngine::_UpdateSGRMouseButtonState(const VTID id,
         {
             // difftime returns in seconds but double click time returns in milliseconds
             if (til::point(uiPos) == _lastMouseClickPos &&
-                (difftime(currentTime, _lastMouseClickTime) * 1000) < GetDoubleClickTime())
+                (difftime(currentTime, _lastMouseClickTime) * 1000) < _doubleClickTime)
             {
                 eventFlags |= DOUBLE_CLICK;
             }

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -884,7 +884,7 @@ bool InputStateMachineEngine::_UpdateSGRMouseButtonState(const VTID id,
                 eventFlags |= DOUBLE_CLICK;
             }
             _lastMouseClickPos = uiPos;
-            _lastMouseClickTime = currentTime;
+            //_lastMouseClickTime = currentTime;
         }
         break;
     case CsiMouseButtonCodes::Right:

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -885,8 +885,11 @@ bool InputStateMachineEngine::_UpdateSGRMouseButtonState(const VTID id,
                 _lastMouseClickPos.reset();
                 _lastMouseClickTime.reset();
             }
-            _lastMouseClickPos = uiPos;
-            _lastMouseClickTime = currentTime;
+            else
+            {
+                _lastMouseClickPos = uiPos;
+                _lastMouseClickTime = currentTime;
+            }
         }
         break;
     case CsiMouseButtonCodes::Right:

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -100,8 +100,7 @@ InputStateMachineEngine::InputStateMachineEngine(std::unique_ptr<IInteractDispat
     _pDispatch(std::move(pDispatch)),
     _lookingForDSR(lookingForDSR),
     _pfnFlushToInputQueue(nullptr),
-    _doubleClickTime(GetDoubleClickTime()),
-    _lastMouseClickTime(time(nullptr))
+    _doubleClickTime(std::chrono::milliseconds(GetDoubleClickTime()))
 {
     THROW_HR_IF_NULL(E_INVALIDARG, _pDispatch.get());
 }
@@ -865,7 +864,7 @@ bool InputStateMachineEngine::_UpdateSGRMouseButtonState(const VTID id,
     // This retrieves the 2 MSBs and concatenates them to the 2 LSBs to create BBBB in binary
     // This represents which button had a change in state
     const auto buttonID = (sgrEncoding & 0x3) | ((sgrEncoding & 0xC0) >> 4);
-    const auto currentTime = time(nullptr);
+    const auto currentTime = std::chrono::steady_clock::now();
     // Step 1: Translate which button was affected
     // NOTE: if scrolled, having buttonFlag = 0 means
     //       we don't actually update the buttonState
@@ -878,9 +877,9 @@ bool InputStateMachineEngine::_UpdateSGRMouseButtonState(const VTID id,
         // and also update our last clicked position and time
         if (id == CsiActionCodes::MouseDown)
         {
-            // difftime returns in seconds but double click time returns in milliseconds
-            if (til::point(uiPos) == _lastMouseClickPos &&
-                (difftime(currentTime, _lastMouseClickTime) * 1000) < _doubleClickTime)
+            if (_lastMouseClickPos && _lastMouseClickTime &&
+                til::point(uiPos) == _lastMouseClickPos &&
+                (currentTime - _lastMouseClickTime.value()) < _doubleClickTime)
             {
                 eventFlags |= DOUBLE_CLICK;
             }

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -877,14 +877,17 @@ bool InputStateMachineEngine::_UpdateSGRMouseButtonState(const VTID id,
         // and also update our last clicked position and time
         if (id == CsiActionCodes::MouseDown)
         {
-            if (_lastMouseClickPos && _lastMouseClickTime &&
-                til::point(uiPos) == _lastMouseClickPos &&
-                (currentTime - _lastMouseClickTime.value()) < _doubleClickTime)
+            if (_lastMouseClickPos && _lastMouseClickTime)
             {
-                eventFlags |= DOUBLE_CLICK;
+                const auto delta{ currentTime - _lastMouseClickTime.value() };
+                if (til::point(uiPos) == _lastMouseClickPos &&
+                    !(delta > _doubleClickTime))
+                {
+                    eventFlags |= DOUBLE_CLICK;
+                }
             }
             _lastMouseClickPos = uiPos;
-            //_lastMouseClickTime = currentTime;
+            _lastMouseClickTime = currentTime;
         }
         break;
     case CsiMouseButtonCodes::Right:

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -879,7 +879,7 @@ bool InputStateMachineEngine::_UpdateSGRMouseButtonState(const VTID id,
         {
             if (_lastMouseClickPos && _lastMouseClickTime &&
                 uiPos == _lastMouseClickPos &&
-                (std::chrono::steady_clock::now() - _lastMouseClickTime.value()) < _doubleClickTime)
+                (currentTime - _lastMouseClickTime.value()) < _doubleClickTime)
             {
                 // This was a double click, set the flag and reset our trackers
                 // for last clicked position and time (this is so we don't send

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -910,6 +910,10 @@ bool InputStateMachineEngine::_UpdateSGRMouseButtonState(const VTID id,
         eventFlags |= MOUSE_WHEELED;
         break;
     }
+    case CsiMouseButtonCodes::Released:
+        // hover event, we still want to send these but we don't
+        // need to do anything special here, so just break
+        break;
     default:
         // no detectable buttonID, so we can't update the state
         return false;

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -848,7 +848,7 @@ bool InputStateMachineEngine::_UpdateSGRMouseButtonState(const VTID id,
                                                          const size_t sgrEncoding,
                                                          DWORD& buttonState,
                                                          DWORD& eventFlags,
-                                                         COORD uiPos) noexcept
+                                                         COORD uiPos)
 {
     // Starting with the state from the last mouse event we received
     buttonState = _mouseButtonState;
@@ -877,14 +877,11 @@ bool InputStateMachineEngine::_UpdateSGRMouseButtonState(const VTID id,
         // and also update our last clicked position and time
         if (id == CsiActionCodes::MouseDown)
         {
-            if (_lastMouseClickPos && _lastMouseClickTime)
+            if (_lastMouseClickPos && _lastMouseClickTime &&
+                til::point(uiPos) == _lastMouseClickPos &&
+                (std::chrono::steady_clock::time_point() - _lastMouseClickTime.value()) > _doubleClickTime)
             {
-                const auto delta{ currentTime - _lastMouseClickTime.value() };
-                if (til::point(uiPos) == _lastMouseClickPos &&
-                    !(delta > _doubleClickTime))
-                {
-                    eventFlags |= DOUBLE_CLICK;
-                }
+                eventFlags |= DOUBLE_CLICK;
             }
             _lastMouseClickPos = uiPos;
             _lastMouseClickTime = currentTime;

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -881,12 +881,17 @@ bool InputStateMachineEngine::_UpdateSGRMouseButtonState(const VTID id,
                 uiPos == _lastMouseClickPos &&
                 (std::chrono::steady_clock::now() - _lastMouseClickTime.value()) < _doubleClickTime)
             {
+                // This was a double click, set the flag and reset our trackers
+                // for last clicked position and time (this is so we don't send
+                // another double click on a third click)
                 eventFlags |= DOUBLE_CLICK;
                 _lastMouseClickPos.reset();
                 _lastMouseClickTime.reset();
             }
             else
             {
+                // This was a single click, update our trackers for last
+                // clicked position and time
                 _lastMouseClickPos = uiPos;
                 _lastMouseClickTime = currentTime;
             }

--- a/src/terminal/parser/InputStateMachineEngine.cpp
+++ b/src/terminal/parser/InputStateMachineEngine.cpp
@@ -879,7 +879,7 @@ bool InputStateMachineEngine::_UpdateSGRMouseButtonState(const VTID id,
         {
             if (_lastMouseClickPos && _lastMouseClickTime &&
                 til::point(uiPos) == _lastMouseClickPos &&
-                (std::chrono::steady_clock::time_point() - _lastMouseClickTime.value()) > _doubleClickTime)
+                (std::chrono::steady_clock::time_point() - _lastMouseClickTime.value()) < _doubleClickTime)
             {
                 eventFlags |= DOUBLE_CLICK;
             }

--- a/src/terminal/parser/InputStateMachineEngine.hpp
+++ b/src/terminal/parser/InputStateMachineEngine.hpp
@@ -170,6 +170,8 @@ namespace Microsoft::Console::VirtualTerminal
         std::function<bool()> _pfnFlushToInputQueue;
         bool _lookingForDSR;
         DWORD _mouseButtonState = 0;
+        COORD _lastMouseClickPos{ 0, 0 };
+        std::time_t _lastMouseClickTime;
 
         DWORD _GetCursorKeysModifierState(const VTParameters parameters, const VTID id) noexcept;
         DWORD _GetGenericKeysModifierState(const VTParameters parameters) noexcept;
@@ -181,7 +183,8 @@ namespace Microsoft::Console::VirtualTerminal
         bool _UpdateSGRMouseButtonState(const VTID id,
                                         const size_t sgrEncoding,
                                         DWORD& buttonState,
-                                        DWORD& eventFlags) noexcept;
+                                        DWORD& eventFlags,
+                                        COORD uiPos) noexcept;
         bool _GetGenericVkey(const GenericKeyIdentifiers identifier, short& vkey) const;
         bool _GetCursorKeysVkey(const VTID id, short& vkey) const;
         bool _GetSs3KeysVkey(const wchar_t wch, short& vkey) const;
@@ -189,7 +192,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool _WriteSingleKey(const short vkey, const DWORD modifierState);
         bool _WriteSingleKey(const wchar_t wch, const short vkey, const DWORD modifierState);
 
-        bool _WriteMouseEvent(const size_t column, const size_t line, const DWORD buttonState, const DWORD controlKeyState, const DWORD eventFlags);
+        bool _WriteMouseEvent(const COORD uiPos, const DWORD buttonState, const DWORD controlKeyState, const DWORD eventFlags);
 
         void _GenerateWrappedSequence(const wchar_t wch,
                                       const short vkey,

--- a/src/terminal/parser/InputStateMachineEngine.hpp
+++ b/src/terminal/parser/InputStateMachineEngine.hpp
@@ -171,6 +171,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool _lookingForDSR;
         DWORD _mouseButtonState = 0;
         COORD _lastMouseClickPos{ 0, 0 };
+        uint64_t _doubleClickTime;
         std::time_t _lastMouseClickTime;
 
         DWORD _GetCursorKeysModifierState(const VTParameters parameters, const VTID id) noexcept;

--- a/src/terminal/parser/InputStateMachineEngine.hpp
+++ b/src/terminal/parser/InputStateMachineEngine.hpp
@@ -171,7 +171,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool _lookingForDSR;
         DWORD _mouseButtonState = 0;
         std::chrono::milliseconds _doubleClickTime;
-        std::optional<COORD> _lastMouseClickPos{};
+        std::optional<til::point> _lastMouseClickPos{};
         std::optional<std::chrono::steady_clock::time_point> _lastMouseClickTime{};
 
         DWORD _GetCursorKeysModifierState(const VTParameters parameters, const VTID id) noexcept;
@@ -185,7 +185,7 @@ namespace Microsoft::Console::VirtualTerminal
                                         const size_t sgrEncoding,
                                         DWORD& buttonState,
                                         DWORD& eventFlags,
-                                        COORD uiPos);
+                                        const til::point uiPos);
         bool _GetGenericVkey(const GenericKeyIdentifiers identifier, short& vkey) const;
         bool _GetCursorKeysVkey(const VTID id, short& vkey) const;
         bool _GetSs3KeysVkey(const wchar_t wch, short& vkey) const;
@@ -193,7 +193,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool _WriteSingleKey(const short vkey, const DWORD modifierState);
         bool _WriteSingleKey(const wchar_t wch, const short vkey, const DWORD modifierState);
 
-        bool _WriteMouseEvent(const COORD uiPos, const DWORD buttonState, const DWORD controlKeyState, const DWORD eventFlags);
+        bool _WriteMouseEvent(const til::point uiPos, const DWORD buttonState, const DWORD controlKeyState, const DWORD eventFlags);
 
         void _GenerateWrappedSequence(const wchar_t wch,
                                       const short vkey,

--- a/src/terminal/parser/InputStateMachineEngine.hpp
+++ b/src/terminal/parser/InputStateMachineEngine.hpp
@@ -170,9 +170,9 @@ namespace Microsoft::Console::VirtualTerminal
         std::function<bool()> _pfnFlushToInputQueue;
         bool _lookingForDSR;
         DWORD _mouseButtonState = 0;
-        COORD _lastMouseClickPos{ 0, 0 };
-        uint64_t _doubleClickTime;
-        std::time_t _lastMouseClickTime;
+        std::chrono::milliseconds _doubleClickTime;
+        std::optional<COORD> _lastMouseClickPos{};
+        std::optional<std::chrono::steady_clock::time_point> _lastMouseClickTime{};
 
         DWORD _GetCursorKeysModifierState(const VTParameters parameters, const VTID id) noexcept;
         DWORD _GetGenericKeysModifierState(const VTParameters parameters) noexcept;

--- a/src/terminal/parser/InputStateMachineEngine.hpp
+++ b/src/terminal/parser/InputStateMachineEngine.hpp
@@ -173,6 +173,7 @@ namespace Microsoft::Console::VirtualTerminal
         std::chrono::milliseconds _doubleClickTime;
         std::optional<til::point> _lastMouseClickPos{};
         std::optional<std::chrono::steady_clock::time_point> _lastMouseClickTime{};
+        std::optional<size_t> _lastMouseClickButton{};
 
         DWORD _GetCursorKeysModifierState(const VTParameters parameters, const VTID id) noexcept;
         DWORD _GetGenericKeysModifierState(const VTParameters parameters) noexcept;

--- a/src/terminal/parser/InputStateMachineEngine.hpp
+++ b/src/terminal/parser/InputStateMachineEngine.hpp
@@ -185,7 +185,7 @@ namespace Microsoft::Console::VirtualTerminal
                                         const size_t sgrEncoding,
                                         DWORD& buttonState,
                                         DWORD& eventFlags,
-                                        COORD uiPos) noexcept;
+                                        COORD uiPos);
         bool _GetGenericVkey(const GenericKeyIdentifiers identifier, short& vkey) const;
         bool _GetCursorKeysVkey(const VTID id, short& vkey) const;
         bool _GetSs3KeysVkey(const wchar_t wch, short& vkey) const;

--- a/src/terminal/parser/ut_parser/InputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/InputEngineTest.cpp
@@ -1271,7 +1271,7 @@ void InputEngineTest::SGRMouseTest_DoubleClick()
         {   { CsiMouseButtonCodes::Left, 0, { 1, 1 }, CsiActionCodes::MouseDown },         { FROM_LEFT_1ST_BUTTON_PRESSED, 0, { 0, 0 }, 0 } },
         {   { CsiMouseButtonCodes::Left, 0, { 1, 1 }, CsiActionCodes::MouseUp },           { 0, 0, { 0, 0 }, 0 } },
 
-        {   { CsiMouseButtonCodes::Left, 0, { 1, 1 }, CsiActionCodes::MouseDown },         { FROM_LEFT_1ST_BUTTON_PRESSED, 0, { 0, 0 }, 2 } },
+        {   { CsiMouseButtonCodes::Left, 0, { 1, 1 }, CsiActionCodes::MouseDown },         { FROM_LEFT_1ST_BUTTON_PRESSED, 0, { 0, 0 }, DOUBLE_CLICK } },
         {   { CsiMouseButtonCodes::Left, 0, { 1, 1 }, CsiActionCodes::MouseUp },           { 0, 0, { 0, 0 }, 0 } },
 
         {   { CsiMouseButtonCodes::Left, 0, { 1, 1 }, CsiActionCodes::MouseDown },         { FROM_LEFT_1ST_BUTTON_PRESSED, 0, { 0, 0 }, 0 } },
@@ -1299,8 +1299,8 @@ void InputEngineTest::SGRMouseTest_Hover()
     // clang-format off
     const std::vector<std::tuple<SGR_PARAMS, MOUSE_EVENT_PARAMS>> testData = {
         //  TEST INPUT                                                                     EXPECTED OUTPUT
-        {   { CsiMouseButtonCodes::Released, 0, { 1, 1 }, CsiActionCodes::MouseUp },         { 0, 0, { 0, 0 }, 0 } },
-        {   { CsiMouseButtonCodes::Released, 0, { 2, 2 }, CsiActionCodes::MouseUp },         { 0, 0, { 1, 1 }, 0 } },
+        {   { CsiMouseButtonCodes::Released, CsiMouseModifierCodes::Drag, { 1, 1 }, CsiActionCodes::MouseUp },         { 0, 0, { 0, 0 }, MOUSE_MOVED } },
+        {   { CsiMouseButtonCodes::Released, CsiMouseModifierCodes::Drag, { 2, 2 }, CsiActionCodes::MouseUp },         { 0, 0, { 1, 1 }, MOUSE_MOVED } },
     };
     // clang-format on
 

--- a/src/terminal/parser/ut_parser/InputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/InputEngineTest.cpp
@@ -1273,6 +1273,9 @@ void InputEngineTest::SGRMouseTest_DoubleClick()
 
         {   { CsiMouseButtonCodes::Left, 0, { 1, 1 }, CsiActionCodes::MouseDown },         { FROM_LEFT_1ST_BUTTON_PRESSED, 0, { 0, 0 }, 2 } },
         {   { CsiMouseButtonCodes::Left, 0, { 1, 1 }, CsiActionCodes::MouseUp },           { 0, 0, { 0, 0 }, 0 } },
+
+        {   { CsiMouseButtonCodes::Left, 0, { 1, 1 }, CsiActionCodes::MouseDown },         { FROM_LEFT_1ST_BUTTON_PRESSED, 0, { 0, 0 }, 0 } },
+        {   { CsiMouseButtonCodes::Left, 0, { 1, 1 }, CsiActionCodes::MouseUp },           { 0, 0, { 0, 0 }, 0 } },
     };
     // clang-format on
 

--- a/src/terminal/parser/ut_parser/InputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/InputEngineTest.cpp
@@ -272,6 +272,8 @@ class Microsoft::Console::VirtualTerminal::InputEngineTest
     TEST_METHOD(SGRMouseTest_Modifiers);
     TEST_METHOD(SGRMouseTest_Movement);
     TEST_METHOD(SGRMouseTest_Scroll);
+    TEST_METHOD(SGRMouseTest_DoubleClick);
+    TEST_METHOD(SGRMouseTest_Hover);
     TEST_METHOD(CtrlAltZCtrlAltXTest);
     TEST_METHOD(TestSs3Entry);
     TEST_METHOD(TestSs3Immediate);
@@ -1246,6 +1248,59 @@ void InputEngineTest::SGRMouseTest_Scroll()
         {   { CsiMouseButtonCodes::ScrollBack,    0, { 1, 1 }, CsiActionCodes::MouseDown },        { SCROLL_DELTA_BACKWARD, 0, { 0, 0 }, MOUSE_WHEELED } },
     };
     // clang-format on
+    VerifySGRMouseData(testData);
+}
+
+void InputEngineTest::SGRMouseTest_DoubleClick()
+{
+    // SGR_PARAMS serves as test input
+    // - the state of the buttons (constructed via InputStateMachineEngine::CsiMouseButtonCodes)
+    // - the modifiers for the mouse event (constructed via InputStateMachineEngine::CsiMouseModifierCodes)
+    // - the {x,y} position of the event on the viewport where the top-left is {1,1}
+    // - the direction of the mouse press (constructed via InputStateMachineEngine::CsiActionCodes)
+
+    // MOUSE_EVENT_PARAMS serves as expected output
+    // - buttonState
+    // - controlKeyState
+    // - mousePosition
+    // - eventFlags
+
+    // clang-format off
+    const std::vector<std::tuple<SGR_PARAMS, MOUSE_EVENT_PARAMS>> testData = {
+        //  TEST INPUT                                                                     EXPECTED OUTPUT
+        {   { CsiMouseButtonCodes::Left, 0, { 1, 1 }, CsiActionCodes::MouseDown },         { FROM_LEFT_1ST_BUTTON_PRESSED, 0, { 0, 0 }, 0 } },
+        {   { CsiMouseButtonCodes::Left, 0, { 1, 1 }, CsiActionCodes::MouseUp },           { 0, 0, { 0, 0 }, 0 } },
+
+        {   { CsiMouseButtonCodes::Left, 0, { 1, 1 }, CsiActionCodes::MouseDown },         { FROM_LEFT_1ST_BUTTON_PRESSED, 0, { 0, 0 }, 2 } },
+        {   { CsiMouseButtonCodes::Left, 0, { 1, 1 }, CsiActionCodes::MouseUp },           { 0, 0, { 0, 0 }, 0 } },
+    };
+    // clang-format on
+
+    VerifySGRMouseData(testData);
+}
+
+void InputEngineTest::SGRMouseTest_Hover()
+{
+    // SGR_PARAMS serves as test input
+    // - the state of the buttons (constructed via InputStateMachineEngine::CsiMouseButtonCodes)
+    // - the modifiers for the mouse event (constructed via InputStateMachineEngine::CsiMouseModifierCodes)
+    // - the {x,y} position of the event on the viewport where the top-left is {1,1}
+    // - the direction of the mouse press (constructed via InputStateMachineEngine::CsiActionCodes)
+
+    // MOUSE_EVENT_PARAMS serves as expected output
+    // - buttonState
+    // - controlKeyState
+    // - mousePosition
+    // - eventFlags
+
+    // clang-format off
+    const std::vector<std::tuple<SGR_PARAMS, MOUSE_EVENT_PARAMS>> testData = {
+        //  TEST INPUT                                                                     EXPECTED OUTPUT
+        {   { CsiMouseButtonCodes::Released, 0, { 1, 1 }, CsiActionCodes::MouseUp },         { 0, 0, { 0, 0 }, 0 } },
+        {   { CsiMouseButtonCodes::Released, 0, { 2, 2 }, CsiActionCodes::MouseUp },         { 0, 0, { 1, 1 }, 0 } },
+    };
+    // clang-format on
+
     VerifySGRMouseData(testData);
 }
 

--- a/src/terminal/parser/ut_parser/InputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/InputEngineTest.cpp
@@ -1276,6 +1276,24 @@ void InputEngineTest::SGRMouseTest_DoubleClick()
 
         {   { CsiMouseButtonCodes::Left, 0, { 1, 1 }, CsiActionCodes::MouseDown },         { FROM_LEFT_1ST_BUTTON_PRESSED, 0, { 0, 0 }, 0 } },
         {   { CsiMouseButtonCodes::Left, 0, { 1, 1 }, CsiActionCodes::MouseUp },           { 0, 0, { 0, 0 }, 0 } },
+
+        {   { CsiMouseButtonCodes::Middle, 0, { 1, 1 }, CsiActionCodes::MouseDown },       { FROM_LEFT_2ND_BUTTON_PRESSED, 0, { 0, 0 }, 0 } },
+        {   { CsiMouseButtonCodes::Middle, 0, { 1, 1 }, CsiActionCodes::MouseUp },         { 0, 0, { 0, 0 }, 0 } },
+
+        {   { CsiMouseButtonCodes::Middle, 0, { 1, 1 }, CsiActionCodes::MouseDown },       { FROM_LEFT_2ND_BUTTON_PRESSED, 0, { 0, 0 }, DOUBLE_CLICK } },
+        {   { CsiMouseButtonCodes::Middle, 0, { 1, 1 }, CsiActionCodes::MouseUp },         { 0, 0, { 0, 0 }, 0 } },
+
+        {   { CsiMouseButtonCodes::Middle, 0, { 1, 1 }, CsiActionCodes::MouseDown },       { FROM_LEFT_2ND_BUTTON_PRESSED, 0, { 0, 0 }, 0 } },
+        {   { CsiMouseButtonCodes::Middle, 0, { 1, 1 }, CsiActionCodes::MouseUp },         { 0, 0, { 0, 0 }, 0 } },
+
+        {   { CsiMouseButtonCodes::Right, 0, { 1, 1 }, CsiActionCodes::MouseDown },         { RIGHTMOST_BUTTON_PRESSED, 0, { 0, 0 }, 0 } },
+        {   { CsiMouseButtonCodes::Right, 0, { 1, 1 }, CsiActionCodes::MouseUp },           { 0, 0, { 0, 0 }, 0 } },
+
+        {   { CsiMouseButtonCodes::Right, 0, { 1, 1 }, CsiActionCodes::MouseDown },         { RIGHTMOST_BUTTON_PRESSED, 0, { 0, 0 }, DOUBLE_CLICK } },
+        {   { CsiMouseButtonCodes::Right, 0, { 1, 1 }, CsiActionCodes::MouseUp },           { 0, 0, { 0, 0 }, 0 } },
+
+        {   { CsiMouseButtonCodes::Right, 0, { 1, 1 }, CsiActionCodes::MouseDown },         { RIGHTMOST_BUTTON_PRESSED, 0, { 0, 0 }, 0 } },
+        {   { CsiMouseButtonCodes::Right, 0, { 1, 1 }, CsiActionCodes::MouseUp },           { 0, 0, { 0, 0 }, 0 } },
     };
     // clang-format on
 
@@ -1298,7 +1316,7 @@ void InputEngineTest::SGRMouseTest_Hover()
 
     // clang-format off
     const std::vector<std::tuple<SGR_PARAMS, MOUSE_EVENT_PARAMS>> testData = {
-        //  TEST INPUT                                                                     EXPECTED OUTPUT
+        //  TEST INPUT                                                                                                 EXPECTED OUTPUT
         {   { CsiMouseButtonCodes::Released, CsiMouseModifierCodes::Drag, { 1, 1 }, CsiActionCodes::MouseUp },         { 0, 0, { 0, 0 }, MOUSE_MOVED } },
         {   { CsiMouseButtonCodes::Released, CsiMouseModifierCodes::Drag, { 2, 2 }, CsiActionCodes::MouseUp },         { 0, 0, { 1, 1 }, MOUSE_MOVED } },
     };


### PR DESCRIPTION
Each mouse-down event's time and position is now stored, and if we
process a left-mouse-down event at the same position as the previous one
and within the double click time we set the double click flag. 

Also adds a case statement to `_UpdateSGRMouseButtonState` so that we
send hover events instead of ignoring them. 

Note: The 'right-click menu in far manager shows up at the wrong
location' bug still exists with this, as it seems to use the cursor
position as told by user32.

Related to #376

## Validation Steps Performed
Double click in far manager works, hover in far manager works (hovering
over items in the right-click menu correctly highlights them)