### PR TITLE
Fix profile selection upon discarding changes in SUI

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -146,7 +146,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                         {
                             if (const auto& selectedItemProfileTag{ selectedItemTag.try_as<ProfileViewModel>() })
                             {
-                                if (profileTag->Guid() == selectedItemProfileTag->Guid())
+                                if (profileTag->OriginalProfileGuid() == selectedItemProfileTag->OriginalProfileGuid())
                                 {
                                     // found the one that was selected before the refresh
                                     SettingsNav().SelectedItem(item);

--- a/src/cascadia/TerminalSettingsEditor/Profiles.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.cpp
@@ -88,6 +88,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     ProfileViewModel::ProfileViewModel(const Model::Profile& profile, const Model::CascadiaSettings& appSettings) :
         _profile{ profile },
+        _originalProfileGuid{ profile.Guid() },
         _ShowAllFonts{ false },
         _appSettings{ appSettings }
     {
@@ -323,6 +324,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             _ShowAllFonts = value;
             _NotifyChanges(L"ShowAllFonts");
         }
+    }
+
+    winrt::guid ProfileViewModel::OriginalProfileGuid() const noexcept
+    {
+        return _originalProfileGuid;
     }
 
     bool ProfileViewModel::CanDeleteProfile() const

--- a/src/cascadia/TerminalSettingsEditor/Profiles.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.h
@@ -60,6 +60,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void ShowAllFonts(const bool& value);
 
         // general profile knowledge
+        winrt::guid OriginalProfileGuid() const noexcept;
         bool CanDeleteProfile() const;
         WINRT_PROPERTY(bool, IsBaseLayer, false);
 
@@ -104,6 +105,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     private:
         Model::Profile _profile;
+        winrt::guid _originalProfileGuid;
         winrt::hstring _lastBgImagePath;
         winrt::hstring _lastStartingDirectoryPath;
         bool _ShowAllFonts;

--- a/src/cascadia/TerminalSettingsEditor/Profiles.idl
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.idl
@@ -32,6 +32,7 @@ namespace Microsoft.Terminal.Settings.Editor
         Boolean ShowAllFonts;
         Boolean UseCustomStartingDirectory { get; };
         Boolean BackgroundImageSettingsVisible { get; };
+        Guid OriginalProfileGuid { get; };
 
         OBSERVABLE_PROJECTED_PROFILE_SETTING(String, Name);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Guid, Guid);


### PR DESCRIPTION
## PR Checklist
* [x] Closes https://github.com/microsoft/terminal/issues/8881
* [x] CLA signed. 
* [ ] Tests added/passed
* [ ] Documentation updated. 
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already.

## Detailed Description of the Pull Request / Additional comments
* Preserve profile GUID upon item Tag creation. 
* Use this GUID rather than the current profile GUID to select an item
upon settings update.

So even if the profile was renamed and the GUID has changed,
the GUID in the tag remains unchanged and can be found
upon discarding.