### PR TITLE
Fix crash on saving the settings twice

### DIFF
--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -19,6 +19,7 @@
 #include "CascadiaSettings.g.cpp"
 
 using namespace ::Microsoft::Terminal::Settings::Model;
+using namespace winrt::Microsoft::Terminal;
 using namespace winrt::Microsoft::Terminal::Control;
 using namespace winrt::Microsoft::Terminal::Settings::Model::implementation;
 using namespace winrt::Windows::Foundation::Collections;
@@ -1137,7 +1138,8 @@ winrt::hstring CascadiaSettings::ApplicationVersion()
 }
 
 // Method Description:
-// - Forces a refresh of all default terminal state
+// - Forces a refresh of all default terminal state. This hits the registry to
+//   read off the disk, so best to not do it on the UI thread.
 // Arguments:
 // - <none>
 // Return Value:
@@ -1187,18 +1189,22 @@ bool CascadiaSettings::IsDefaultTerminalAvailable() noexcept
 // - <none>
 // Return Value:
 // - an iterable collection of all available terminals that could be the default.
-IObservableVector<winrt::Microsoft::Terminal::Settings::Model::DefaultTerminal> CascadiaSettings::DefaultTerminals() const noexcept
+IObservableVector<Settings::Model::DefaultTerminal> CascadiaSettings::DefaultTerminals() const noexcept
 {
     return _defaultTerminals;
 }
 
 // Method Description:
-// - Returns the currently selected default terminal application
+// - Returns the currently selected default terminal application.
+// - DANGER! This will be null unless you've called
+//   CascadiaSettings::RefreshDefaultTerminals. At te time of this comment (May
+//   2021), only the Launch page in the settings UI calls that method, so this
+//   value is unset unless you've navigated to that page.
 // Arguments:
 // - <none>
 // Return Value:
 // - the selected default terminal application
-winrt::Microsoft::Terminal::Settings::Model::DefaultTerminal CascadiaSettings::CurrentDefaultTerminal() const noexcept
+Settings::Model::DefaultTerminal CascadiaSettings::CurrentDefaultTerminal() const noexcept
 {
     return _currentDefaultTerminal;
 }
@@ -1209,7 +1215,7 @@ winrt::Microsoft::Terminal::Settings::Model::DefaultTerminal CascadiaSettings::C
 // - terminal - Terminal from `DefaultTerminals` list to set as default
 // Return Value:
 // - <none>
-void CascadiaSettings::CurrentDefaultTerminal(winrt::Microsoft::Terminal::Settings::Model::DefaultTerminal terminal)
+void CascadiaSettings::CurrentDefaultTerminal(Settings::Model::DefaultTerminal terminal)
 {
     _currentDefaultTerminal = terminal;
 }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -1197,7 +1197,8 @@ IObservableVector<Settings::Model::DefaultTerminal> CascadiaSettings::DefaultTer
 // Method Description:
 // - Returns the currently selected default terminal application.
 // - DANGER! This will be null unless you've called
-//   CascadiaSettings::RefreshDefaultTerminals. At te time of this comment (May
+//   CascadiaSettings::RefreshDefaultTerminals. At the time of this comment (May
+
 //   2021), only the Launch page in the settings UI calls that method, so this
 //   value is unset unless you've navigated to that page.
 // Arguments:

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -1301,7 +1301,15 @@ void CascadiaSettings::WriteSettingsToDisk() const
     _WriteSettings(styledString, settingsPath);
 
     // Persists the default terminal choice
-    Model::DefaultTerminal::Current(_currentDefaultTerminal);
+    //
+    // GH#10003 - Only do this if _currentDefaultTerminal was actually
+    // initialized. It's only initialized when Launch.cpp calls
+    // `CascadiaSettings::RefreshDefaultTerminals`. We really don't need it
+    // otherwise.
+    if (_currentDefaultTerminal)
+    {
+        Model::DefaultTerminal::Current(_currentDefaultTerminal);
+    }
 }
 
 // Method Description:


### PR DESCRIPTION
## Summary of the Pull Request

Check for null before serializing the default terminal. Because the _currentDefaultTerminal is only initialized when the `Launch` page is navigated to, this _could_ be null if you navigate to another page, save, then save again. 


## PR Checklist
* [x] Closes #10003
* [x] I work here
* [n/a] Tests added/passed
* [n/a] Requires documentation to be updated

## Validation Steps Performed

It crashed consistently before, it doesn't now.