### PR TITLE
Clear all state tracking nested commands when switching command mode

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -933,6 +933,10 @@ namespace winrt::TerminalApp::implementation
         ParsedCommandLineText(L"");
         _searchBox().Text(L"");
         _searchBox().Select(_searchBox().Text().size(), 0);
+
+        _nestedActionStack.Clear();
+        ParentCommandName(L"");
+        _currentNestedCommands.Clear();
         // Leaving this block of code outside the above if-statement
         // guarantees that the correct text is shown for the mode
         // whenever _switchToMode is called.


### PR DESCRIPTION
Went for option 2 proposed here:
https://github.com/microsoft/terminal/issues/10140#issuecomment-845193132. 

Disabling back space in the nested entry didn't felt as the nicest
solution.  Instead now all state that keeps track of nested commands is
cleared when switching beteen modes.

## Validation Steps Performed
- Validated the specified issue is fixed by this change:. now after
  entering a sub command and hitting backspace the palette no longer
  shows the sub command item (here `< Select color scheme...` ).
- Validated that switching between all modes (command line, actions, tab
  search & tab switch) still work as expected.
- Validated as well that all modes still work as expected.

Didn't add unit tests, but happy to try that out if this would be
required. 

Closes #10140