### PR TITLE
Prevent crashes in Settings UI launch on OS versions before package management extensions

### DIFF
--- a/src/cascadia/TerminalSettingsModel/DefaultTerminal.cpp
+++ b/src/cascadia/TerminalSettingsModel/DefaultTerminal.cpp
@@ -11,7 +11,7 @@ using namespace winrt::Microsoft::Terminal::Settings;
 using namespace winrt::Microsoft::Terminal::Settings::Model::implementation;
 
 winrt::Windows::Foundation::Collections::IVector<Model::DefaultTerminal> DefaultTerminal::_available = winrt::single_threaded_vector<Model::DefaultTerminal>();
-std::optional<Model::DefaultTerminal> DefaultTerminal::_current;
+Model::DefaultTerminal DefaultTerminal::_current = nullptr;
 
 DefaultTerminal::DefaultTerminal(DelegationConfig::DelegationPackage pkg) :
     _pkg(pkg)
@@ -81,7 +81,10 @@ Model::DefaultTerminal DefaultTerminal::Current()
     {
         Refresh();
     }
-    return _current.value();
+
+    // The potential of returning nullptr feels weird, but XAML can handle that appropriately
+    // and will select nothing as current in the dropdown.
+    return _current;
 }
 
 void DefaultTerminal::Current(const Model::DefaultTerminal& term)

--- a/src/cascadia/TerminalSettingsModel/DefaultTerminal.h
+++ b/src/cascadia/TerminalSettingsModel/DefaultTerminal.h
@@ -42,7 +42,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     private:
         DelegationConfig::DelegationPackage _pkg;
         static Windows::Foundation::Collections::IVector<Model::DefaultTerminal> _available;
-        static std::optional<Model::DefaultTerminal> _current;
+        static Model::DefaultTerminal _current;
     };
 }
 

--- a/src/propslib/DelegationConfig.cpp
+++ b/src/propslib/DelegationConfig.cpp
@@ -185,11 +185,14 @@ try
 {
     packages.clear();
 
+    // Get consoles and terminals.
+    // If we fail to look up any, we should still have ONE come back to us as the hardcoded default console host.
+    // The errors aren't really useful except for debugging, so log only.
     std::vector<DelegationConsole> consoles;
-    RETURN_IF_FAILED(s_GetAvailableConsoles(consoles));
+    LOG_IF_FAILED(s_GetAvailableConsoles(consoles));
 
     std::vector<DelegationTerminal> terminals;
-    RETURN_IF_FAILED(s_GetAvailableTerminals(terminals));
+    LOG_IF_FAILED(s_GetAvailableTerminals(terminals));
 
     // TODO: I hate this algorithm (it's bad performance), but I couldn't
     // find an AppModel interface that would let me look up all the extensions


### PR DESCRIPTION
Prevent crashes in Settings UI launch on OS versions before package management extensions

## PR Checklist
* [x] Closes #10106 
* [x] I work here
* [x] Manual tests passed.

## Detailed Description of the Pull Request / Additional comments
- On older OS versions like 18363, some of the COM interfaces we use to look up information from the OS application package management catalog (to find default terminals) are unavailable. This returns `E_NOINTERFACE`. This then ends up returning an empty list of items and null as a selected item. 
- I had intended for that to not return that particular error all the way up and just log it because the console and terminal lookup functions always return at least one element: the one representing the `conhost.exe` that is already on the machine.
- I have changed the "default packages" lookup to log instead of return failures like E_NOINTERFACE such that it can continue processing and make the "package" of the hardcoded `conhost.exe` default no matter what. (It will still return an error if there are somehow 0 packages because that code changed or some other catastrophic event happened...)
- I have also changed the Model to have a nulled DefaultTerminal model object (as all winrt objects are nullable) instead of using an optional. I did this because XAML is perfectly happy receiving a `nullptr` for a selected item and will just not select anything. By contrast, if it has an exception occur... it will just bubble that out and crash.

## Validation Steps Performed
- Simulated no items returned from list and nullptr returned to XAML on Current() method of Model. Validated XAML will happily select no item from list (and is fine with an empty list of items... that is it doesn't crash).
- Simulated downlevel OS returning package management errors in lookup catalog functions after the hardcoded default is added to the list. Ensured that this error is only logged, the remainder of the package identification functions make the hardcoded default package, and it is presented as your one and only option in the XAML.
