### PR TITLE
Make top titlebar padding consistent with WinUI and other apps

### DIFF
--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
     Copyright (c) Microsoft Corporation. All rights reserved. Licensed under
     the MIT License. See LICENSE in the project root for license information.
 -->
@@ -45,7 +45,7 @@
                                      Color="{ThemeResource SystemErrorTextColor}" />
 
                     <!--  Suppress top padding  -->
-                    <Thickness x:Key="TabViewHeaderPadding">8,0,8,0</Thickness>
+                    <Thickness x:Key="TabViewHeaderPadding">9,0,4,0</Thickness>
 
                     <ResourceDictionary.ThemeDictionaries>
                         <ResourceDictionary x:Key="Dark">

--- a/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
+++ b/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
@@ -9,7 +9,7 @@
             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
             HorizontalAlignment="Left"
             VerticalAlignment="Top"
-            d:DesignHeight="36"
+            d:DesignHeight="40"
             d:DesignWidth="400"
             Background="Transparent"
             Orientation="Horizontal"
@@ -124,7 +124,7 @@
                 tabs will be flush with the top of the window. See GH#2541 for
                 details.
             -->
-            <x:Double x:Key="CaptionButtonHeightWindowed">36.0</x:Double>
+            <x:Double x:Key="CaptionButtonHeightWindowed">40.0</x:Double>
             <x:Double x:Key="CaptionButtonHeightMaximized">32.0</x:Double>
 
             <Style x:Key="CaptionButton"


### PR DESCRIPTION
The current titlebar padding of 4px on the top was decided in #3513, and it was chosen because it persisted even in maximized mode. That was over a year and a half ago, and in the meantime with #5881 the issue was fixed.

WinUI and other tabbed apps like Chrome and Edge have the left padding equal to the one on top, because it looks more balanced.

This fix increases the height of the caption buttons in windowed mode by 4px, which in turn makes the effective top padding be 8px. (that's how it worked before as well)

![top-padding](https://user-images.githubusercontent.com/84711285/119894136-e5dbca00-bf44-11eb-9776-d78f61ec17e3.png)

