### PR TITLE
Make the xaml formatting script work outside the root directory

### DIFF
--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -370,7 +370,7 @@ function Test-XamlFormat() {
     $root = Find-OpenConsoleRoot
     & dotnet tool restore --add-source https://api.nuget.org/v3/index.json
 
-    $xamlsForStyler = (git ls-files **/*.xaml) -join ","
+    $xamlsForStyler = (git ls-files "$root/**/*.xaml") -join ","
     dotnet tool run xstyler -- -c "$root\XamlStyler.json" -f "$xamlsForStyler" --passive
 
     if ($lastExitCode -eq 1) {
@@ -389,14 +389,14 @@ function Invoke-XamlFormat() {
     # xstyler lets you pass multiple xaml files in the -f param if they're all
     # joined by commas. The `git ls-files` command will only get us the .xaml
     # files actually in the git repo, ignoring ones in "Generated Files/"
-    $xamlsForStyler = (git ls-files **/*.xaml) -join ","
+    $xamlsForStyler = (git ls-files "$root/**/*.xaml") -join ","
     dotnet tool run xstyler -- -c "$root\XamlStyler.json" -f "$xamlsForStyler"
 
     # Strip BOMs from all the .xaml files
-    $xamls = (git ls-files **/*.xaml)
+    $xamls = (git ls-files "$root/**/*.xaml")
     foreach ($file in $xamls ) {
         $content = Get-Content $file
-        [IO.File]::WriteAllLines("$root/$file", $content)
+        [IO.File]::WriteAllLines("$file", $content)
     }
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

When the `runformat` script was updated to include xaml formatting, the new code failed to work if run from anywhere other than the project root. This PR updates the script so it can be run from anywhere.

## PR Checklist
* [x] Closes #9768
* [x] CLA signed.
* [ ] Tests added/passed
* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments

There were a couple of places in the script where it was collecting the list of xaml files by doing `git ls-files **/*.xaml`. That obviously relies on the code being executed from within the root of the project. I've now updated those queries to prefix the path with the `$root` variable, which points to the project root.

## Validation Steps Performed

I've run the `runformat` script from within the tools directory and confirmed that it now works correctly from there. I've tested by changing some formatting in both .cpp and .xaml files, and also saved some .xaml files with a BOM to make sure those were appropriately stripped.