### PR TITLE
Work around an ARM64 compiler crash by splitting a coroutine up

### DIFF
--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -1023,7 +1023,15 @@ winrt::fire_and_forget IslandWindow::SummonWindow(Remoting::SummonWindowBehavior
 {
     // On the foreground thread:
     co_await winrt::resume_foreground(_rootGrid.Dispatcher());
+    _summonWindowRoutineBody(args);
+}
 
+// Method Description:
+// - As above.
+//   BODGY: ARM64 BUILD FAILED WITH fatal error C1001: Internal compiler error
+//   when this was part of the coroutine body.
+void IslandWindow::_summonWindowRoutineBody(Remoting::SummonWindowBehavior args)
+{
     uint32_t actualDropdownDuration = args.DropdownDuration();
     // If the user requested an animation, let's check if animations are enabled in the OS.
     if (args.DropdownDuration() > 0)

--- a/src/cascadia/WindowsTerminal/IslandWindow.h
+++ b/src/cascadia/WindowsTerminal/IslandWindow.h
@@ -111,6 +111,8 @@ protected:
     bool _isQuakeWindow{ false };
     void _enterQuakeMode();
 
+    void _summonWindowRoutineBody(winrt::Microsoft::Terminal::Remoting::SummonWindowBehavior args);
+
 private:
     // This minimum width allows for width the tabs fit
     static constexpr long minimumWidth = 460L;


### PR DESCRIPTION
Built and tested in PackageES