### PR TITLE
Remove CONSOLE_API_MSG::UpdateUserBufferPointers hack

### DIFF
--- a/.github/actions/spelling/allow/apis.txt
+++ b/.github/actions/spelling/allow/apis.txt
@@ -89,6 +89,7 @@ ntprivapi
 oaidl
 ocidl
 ODR
+offsetof
 osver
 OSVERSIONINFOEXW
 otms

--- a/src/server/ApiMessage.cpp
+++ b/src/server/ApiMessage.cpp
@@ -8,7 +8,7 @@
 #include "ApiMessage.h"
 #include "DeviceComm.h"
 
-inline constexpr size_t structPacketDataSize = sizeof(_CONSOLE_API_MSG) - offsetof(_CONSOLE_API_MSG, Descriptor);
+constexpr size_t structPacketDataSize = sizeof(_CONSOLE_API_MSG) - offsetof(_CONSOLE_API_MSG, Descriptor);
 
 _CONSOLE_API_MSG::_CONSOLE_API_MSG()
 {

--- a/src/server/ApiMessage.h
+++ b/src/server/ApiMessage.h
@@ -29,17 +29,42 @@ typedef struct _CONSOLE_API_MSG
 {
     _CONSOLE_API_MSG();
 
-    CD_IO_COMPLETE Complete;
-    CONSOLE_API_STATE State;
+    _CONSOLE_API_MSG(_CONSOLE_API_MSG&&) = delete;
+    _CONSOLE_API_MSG& operator=(_CONSOLE_API_MSG&&) = delete;
 
-    IDeviceComm* _pDeviceComm;
-    IApiRoutines* _pApiRoutines;
+    _CONSOLE_API_MSG(const _CONSOLE_API_MSG& other);
+    _CONSOLE_API_MSG& operator=(const _CONSOLE_API_MSG&);
 
-private:
+    ConsoleProcessHandle* GetProcessHandle() const;
+    ConsoleHandleData* GetObjectHandle() const;
+
+    [[nodiscard]] HRESULT ReadMessageInput(const ULONG cbOffset, _Out_writes_bytes_(cbSize) PVOID pvBuffer, const ULONG cbSize);
+    [[nodiscard]] HRESULT GetAugmentedOutputBuffer(const ULONG cbFactor,
+                                                   _Outptr_result_bytebuffer_(*pcbSize) PVOID* ppvBuffer,
+                                                   _Out_ PULONG pcbSize);
+    [[nodiscard]] HRESULT GetOutputBuffer(_Outptr_result_bytebuffer_(*pcbSize) void** const ppvBuffer, _Out_ ULONG* const pcbSize);
+    [[nodiscard]] HRESULT GetInputBuffer(_Outptr_result_bytebuffer_(*pcbSize) void** const ppvBuffer, _Out_ ULONG* const pcbSize);
+
+    [[nodiscard]] HRESULT ReleaseMessageBuffers();
+
+    void SetReplyStatus(const NTSTATUS Status);
+    void SetReplyInformation(const ULONG_PTR pInformation);
+
+    // DO NOT PUT ACCESS SPECIFIERS HERE.
+    // The tail end of this structure is overwritten with console driver packet.
+    // It's important that we have a deterministic, C-like field ordering
+    // as this ensures that the packet data fields are last.
+    // Putting access specifiers here ("private:") would break this.
+
+    CD_IO_COMPLETE Complete{};
+    CONSOLE_API_STATE State{};
+
+    IDeviceComm* _pDeviceComm{ nullptr };
+    IApiRoutines* _pApiRoutines{ nullptr };
+
     boost::container::small_vector<BYTE, 128> _inputBuffer;
     boost::container::small_vector<BYTE, 128> _outputBuffer;
 
-public:
     // From here down is the actual packet data sent/received.
     CD_IO_DESCRIPTOR Descriptor;
     union
@@ -61,33 +86,6 @@ public:
         };
     };
     // End packet data
-
-public:
-    // DO NOT PUT MORE FIELDS DOWN HERE.
-    // The tail end of this structure will have a console driver packet
-    // copied over it and it will overwrite any fields declared here.
-
-    ConsoleProcessHandle* GetProcessHandle() const;
-    ConsoleHandleData* GetObjectHandle() const;
-
-    [[nodiscard]] HRESULT ReadMessageInput(const ULONG cbOffset, _Out_writes_bytes_(cbSize) PVOID pvBuffer, const ULONG cbSize);
-    [[nodiscard]] HRESULT GetAugmentedOutputBuffer(const ULONG cbFactor,
-                                                   _Outptr_result_bytebuffer_(*pcbSize) PVOID* ppvBuffer,
-                                                   _Out_ PULONG pcbSize);
-    [[nodiscard]] HRESULT GetOutputBuffer(_Outptr_result_bytebuffer_(*pcbSize) void** const ppvBuffer, _Out_ ULONG* const pcbSize);
-    [[nodiscard]] HRESULT GetInputBuffer(_Outptr_result_bytebuffer_(*pcbSize) void** const ppvBuffer, _Out_ ULONG* const pcbSize);
-
-    [[nodiscard]] HRESULT ReleaseMessageBuffers();
-
-    void SetReplyStatus(const NTSTATUS Status);
-    void SetReplyInformation(const ULONG_PTR pInformation);
-
-    // MSFT-33127449, GH#9692
-    // We are not writing a copy constructor for this class
-    // so as to scope a fix as narrowly as possible to the
-    // "invalid user buffer" crash.
-    // TODO GH#10076: remove this.
-    void UpdateUserBufferPointers();
 
     // DO NOT PUT MORE FIELDS DOWN HERE.
     // The tail end of this structure will have a console driver packet


### PR DESCRIPTION
## Summary of the Pull Request

This commit introduces a copy constructor/operator for
`_CONSOLE_API_MSG`. The change is not trivial as the struct contains a
union of unnamed structs that cannot be copied using regular language
features. As such a copy operator using `memcpy` was implemented.
Additionally all access specifiers were removed, as those allow a C++
compiler to reorder struct members. This would break message passing.
This commit is a good opportunity to prevent such miscompilations
proactively.

## Validation Steps Performed

* Command prompts of WSL2 fish-shell and pwsh still work ✔️

Closes #10076