### PR TITLE
Enable incremental linking for debug builds

### DIFF
--- a/src/common.build.pre.props
+++ b/src/common.build.pre.props
@@ -136,7 +136,7 @@
   <!-- For Debug ONLY -->
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
-    <LinkIncremental>false</LinkIncremental>
+    <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
 
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">


### PR DESCRIPTION
## Summary of the Pull Request

Incremental linking was disabled for debug builds only by mistake in the past.
It can't hurt to have it enabled for debug builds.

## PR Checklist
* [x] I work here
* [x] Project still builds