### PR TITLE
Lock for writing in `ControlCore::SetBackgroundOpacity`

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1126,6 +1126,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
         if (_renderEngine)
         {
+            auto lock = _terminal->LockForWriting();
             _renderEngine->SetDefaultTextBackgroundOpacity(::base::saturated_cast<float>(opacity));
         }
     }


### PR DESCRIPTION
## PR Checklist
* [x] Closes random crash that @lhecker sent me on Teams
* [x] I work here.

## Detailed Description of the Pull Request / Additional comments
- Any change to the renderer engine has to be done under lock. Leonard gave me a crash where the dirty rectangles changed out from under the renderer thread. By inspection, only one spot in `ControlCore` is modifying the engine outside of lock.... here. The dump is too far along to definitively prove the issue and it's sort of a race so its difficult to repro. But the theory is sound that all writes to the dirty regions must be done under lock. So here's a fix.

