### PR TITLE
Add percentage sign to opacity slider values

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Converters.idl
+++ b/src/cascadia/TerminalSettingsEditor/Converters.idl
@@ -39,6 +39,11 @@ namespace Microsoft.Terminal.Settings.Editor
         PercentageConverter();
     };
 
+    runtimeclass PercentageSignConverter : [default] Windows.UI.Xaml.Data.IValueConverter
+    {
+        PercentageSignConverter();
+    };
+
     runtimeclass StringIsEmptyConverter : [default] Windows.UI.Xaml.Data.IValueConverter
     {
         StringIsEmptyConverter();

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
@@ -282,12 +282,10 @@
     <ProjectReference Include="$(OpenConsoleDir)src\types\lib\types.vcxproj">
       <Project>{18D09A24-8240-42D6-8CB6-236EEE820263}</Project>
     </ProjectReference>
-
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\WinRTUtils\WinRTUtils.vcxproj">
       <Project>{CA5CAD1A-039A-4929-BA2A-8BEB2E4106FE}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalConnection\TerminalConnection.vcxproj">
       <Private>false</Private>
     </ProjectReference>
@@ -324,11 +322,13 @@
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
     </Reference>
   </ItemGroup>
+
   <ItemDefinitionGroup>
     <Link>
       <AdditionalDependencies>shell32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
+
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.post.props" />
   <Import Project="..\..\..\packages\Microsoft.UI.Xaml.2.5.0-prerelease.201202003\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\..\..\packages\Microsoft.UI.Xaml.2.5.0-prerelease.201202003\build\native\Microsoft.UI.Xaml.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
@@ -60,6 +60,9 @@
     <ClInclude Include="InvertedBooleanToVisibilityConverter.h">
       <DependentUpon>Converters.idl</DependentUpon>
     </ClInclude>
+    <ClInclude Include="PercentageSignConverter.h">
+      <DependentUpon>Converters.idl</DependentUpon>
+    </ClInclude>
     <ClInclude Include="StringIsEmptyConverter.h">
       <DependentUpon>Converters.idl</DependentUpon>
     </ClInclude>
@@ -165,6 +168,9 @@
       <DependentUpon>Converters.idl</DependentUpon>
     </ClCompile>
     <ClCompile Include="InvertedBooleanToVisibilityConverter.cpp">
+      <DependentUpon>Converters.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="PercentageSignConverter.cpp">
       <DependentUpon>Converters.idl</DependentUpon>
     </ClCompile>
     <ClCompile Include="StringIsEmptyConverter.cpp">
@@ -283,7 +289,6 @@
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalConnection\TerminalConnection.vcxproj">
       <Private>false</Private>
     </ProjectReference>
-
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\dll\TerminalControl.vcxproj">
       <!-- Private:false and ReferenceOutputAssembly:false, in combination with
       the manual reference to TerminalControl.winmd below make sure that this
@@ -292,12 +297,10 @@
       <Private>true</Private>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalSettingsModel\dll\Microsoft.Terminal.Settings.Model.vcxproj">
       <Private>false</Private>
     </ProjectReference>
   </ItemGroup>
-
   <ItemGroup>
     <!-- Manually add a reference to TerminalControl here. We need this so
     MDMERGE will know where the TermControl types are defined. However, we need
@@ -316,13 +319,11 @@
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
     </Reference>
   </ItemGroup>
-
   <ItemDefinitionGroup>
     <Link>
       <AdditionalDependencies>shell32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.post.props" />
   <Import Project="..\..\..\packages\Microsoft.UI.Xaml.2.5.0-prerelease.201202003\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\..\..\packages\Microsoft.UI.Xaml.2.5.0-prerelease.201202003\build\native\Microsoft.UI.Xaml.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
@@ -282,13 +282,16 @@
     <ProjectReference Include="$(OpenConsoleDir)src\types\lib\types.vcxproj">
       <Project>{18D09A24-8240-42D6-8CB6-236EEE820263}</Project>
     </ProjectReference>
+
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\WinRTUtils\WinRTUtils.vcxproj">
       <Project>{CA5CAD1A-039A-4929-BA2A-8BEB2E4106FE}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
+
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalConnection\TerminalConnection.vcxproj">
       <Private>false</Private>
     </ProjectReference>
+
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\dll\TerminalControl.vcxproj">
       <!-- Private:false and ReferenceOutputAssembly:false, in combination with
       the manual reference to TerminalControl.winmd below make sure that this
@@ -297,10 +300,12 @@
       <Private>true</Private>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
+
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalSettingsModel\dll\Microsoft.Terminal.Settings.Model.vcxproj">
       <Private>false</Private>
     </ProjectReference>
   </ItemGroup>
+
   <ItemGroup>
     <!-- Manually add a reference to TerminalControl here. We need this so
     MDMERGE will know where the TermControl types are defined. However, we need

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj.filters
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj.filters
@@ -10,10 +10,16 @@
     <ClCompile Include="pch.cpp" />
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
     <ClCompile Include="Utils.cpp" />
+    <ClCompile Include="PercentageSignConverter.cpp">
+      <Filter>Converters</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
     <ClInclude Include="Utils.h" />
+    <ClInclude Include="PercentageSignConverter.h">
+      <Filter>Converters</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Midl Include="EnumEntry.idl" />

--- a/src/cascadia/TerminalSettingsEditor/PercentageSignConverter.cpp
+++ b/src/cascadia/TerminalSettingsEditor/PercentageSignConverter.cpp
@@ -11,18 +11,18 @@ using namespace winrt::Windows::UI::Xaml;
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
     Foundation::IInspectable PercentageSignConverter::Convert(Foundation::IInspectable const& value,
-                                                          Windows::UI::Xaml::Interop::TypeName const& /* targetType */,
-                                                          Foundation::IInspectable const& /* parameter */,
-                                                          hstring const& /* language */)
+                                                              Windows::UI::Xaml::Interop::TypeName const& /* targetType */,
+                                                              Foundation::IInspectable const& /* parameter */,
+                                                              hstring const& /* language */)
     {
         const auto number{ winrt::unbox_value<double>(value) };
         return winrt::box_value(to_hstring((int)number) + L"%");
     }
 
     Foundation::IInspectable PercentageSignConverter::ConvertBack(Foundation::IInspectable const& value,
-                                                              Windows::UI::Xaml::Interop::TypeName const& /* targetType */,
-                                                              Foundation::IInspectable const& /*parameter*/,
-                                                              hstring const& /* language */)
+                                                                  Windows::UI::Xaml::Interop::TypeName const& /* targetType */,
+                                                                  Foundation::IInspectable const& /*parameter*/,
+                                                                  hstring const& /* language */)
     {
         return value;
     }

--- a/src/cascadia/TerminalSettingsEditor/PercentageSignConverter.cpp
+++ b/src/cascadia/TerminalSettingsEditor/PercentageSignConverter.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "PercentageSignConverter.h"
+#include "PercentageSignConverter.g.cpp"
+
+using namespace winrt::Windows;
+using namespace winrt::Windows::UI::Xaml;
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
+{
+    Foundation::IInspectable PercentageSignConverter::Convert(Foundation::IInspectable const& value,
+                                                          Windows::UI::Xaml::Interop::TypeName const& /* targetType */,
+                                                          Foundation::IInspectable const& /* parameter */,
+                                                          hstring const& /* language */)
+    {
+        const auto number{ winrt::unbox_value<double>(value) };
+        return winrt::box_value(to_hstring((int)number) + L"%");
+    }
+
+    Foundation::IInspectable PercentageSignConverter::ConvertBack(Foundation::IInspectable const& value,
+                                                              Windows::UI::Xaml::Interop::TypeName const& /* targetType */,
+                                                              Foundation::IInspectable const& /*parameter*/,
+                                                              hstring const& /* language */)
+    {
+        return value;
+    }
+}

--- a/src/cascadia/TerminalSettingsEditor/PercentageSignConverter.cpp
+++ b/src/cascadia/TerminalSettingsEditor/PercentageSignConverter.cpp
@@ -24,6 +24,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                                                                   Foundation::IInspectable const& /*parameter*/,
                                                                   hstring const& /* language */)
     {
-        return value;
+        throw hresult_not_implemented();
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/PercentageSignConverter.cpp
+++ b/src/cascadia/TerminalSettingsEditor/PercentageSignConverter.cpp
@@ -19,7 +19,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         return winrt::box_value(to_hstring((int)number) + L"%");
     }
 
-    Foundation::IInspectable PercentageSignConverter::ConvertBack(Foundation::IInspectable const& value,
+    Foundation::IInspectable PercentageSignConverter::ConvertBack(Foundation::IInspectable const& /*value*/,
                                                                   Windows::UI::Xaml::Interop::TypeName const& /* targetType */,
                                                                   Foundation::IInspectable const& /*parameter*/,
                                                                   hstring const& /* language */)

--- a/src/cascadia/TerminalSettingsEditor/PercentageSignConverter.h
+++ b/src/cascadia/TerminalSettingsEditor/PercentageSignConverter.h
@@ -6,25 +6,4 @@
 #include "PercentageSignConverter.g.h"
 #include "Utils.h"
 
-namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
-{
-    struct PercentageSignConverter : PercentageSignConverterT<PercentageSignConverter>
-    {
-        PercentageSignConverter() = default;
-
-        Windows::Foundation::IInspectable Convert(Windows::Foundation::IInspectable const& value,
-                                                  Windows::UI::Xaml::Interop::TypeName const& targetType,
-                                                  Windows::Foundation::IInspectable const& parameter,
-                                                  hstring const& language);
-
-        Windows::Foundation::IInspectable ConvertBack(Windows::Foundation::IInspectable const& value,
-                                                      Windows::UI::Xaml::Interop::TypeName const& targetType,
-                                                      Windows::Foundation::IInspectable const& parameter,
-                                                      hstring const& language);
-    };
-}
-
-namespace winrt::Microsoft::Terminal::Settings::Editor::factory_implementation
-{
-    BASIC_FACTORY(PercentageSignConverter);
-}
+DECLARE_CONVERTER(winrt::Microsoft::Terminal::Settings::Editor, PercentageSignConverter);

--- a/src/cascadia/TerminalSettingsEditor/PercentageSignConverter.h
+++ b/src/cascadia/TerminalSettingsEditor/PercentageSignConverter.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+#include "PercentageSignConverter.g.h"
+#include "Utils.h"
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
+{
+    struct PercentageSignConverter : PercentageSignConverterT<PercentageSignConverter>
+    {
+        PercentageSignConverter() = default;
+
+        Windows::Foundation::IInspectable Convert(Windows::Foundation::IInspectable const& value,
+                                                  Windows::UI::Xaml::Interop::TypeName const& targetType,
+                                                  Windows::Foundation::IInspectable const& parameter,
+                                                  hstring const& language);
+
+        Windows::Foundation::IInspectable ConvertBack(Windows::Foundation::IInspectable const& value,
+                                                      Windows::UI::Xaml::Interop::TypeName const& targetType,
+                                                      Windows::Foundation::IInspectable const& parameter,
+                                                      hstring const& language);
+    };
+}
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::factory_implementation
+{
+    BASIC_FACTORY(PercentageSignConverter);
+}

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -35,6 +35,7 @@
             </DataTemplate>
             <local:ColorToBrushConverter x:Key="ColorToBrushConverter" />
             <local:PercentageConverter x:Key="PercentageConverter" />
+            <local:PercentageSignConverter x:Key="PercentageSignConverter" />
             <local:FontWeightConverter x:Key="FontWeightConverter" />
             <local:InvertedBooleanToVisibilityConverter x:Key="InvertedBooleanToVisibilityConverter" />
             <local:StringIsEmptyConverter x:Key="StringIsEmptyConverter" />
@@ -626,7 +627,7 @@
                                             Value="{x:Bind State.Profile.BackgroundImageOpacity, Converter={StaticResource PercentageConverter}, Mode=TwoWay}" />
                                     <TextBlock Grid.Column="1"
                                                Style="{StaticResource SliderValueLabelStyle}"
-                                               Text="{Binding ElementName=BIOpacitySlider, Path=Value, Mode=OneWay}" />
+                                               Text="{Binding ElementName=BIOpacitySlider, Path=Value, Mode=OneWay, Converter={StaticResource PercentageSignConverter}}" />
                                 </Grid>
                             </local:SettingContainer>
                         </StackPanel>
@@ -664,7 +665,7 @@
                                                 Value="{x:Bind State.Profile.AcrylicOpacity, Converter={StaticResource PercentageConverter}, Mode=TwoWay}" />
                                         <TextBlock Grid.Column="1"
                                                    Style="{StaticResource SliderValueLabelStyle}"
-                                                   Text="{Binding ElementName=AcrylicOpacitySlider, Path=Value, Mode=OneWay}" />
+                                                   Text="{Binding ElementName=AcrylicOpacitySlider, Path=Value, Mode=OneWay, Converter={StaticResource PercentageSignConverter}}" />
                                     </Grid>
                                 </StackPanel>
                             </local:SettingContainer>


### PR DESCRIPTION
This PR adds a new PercentageSignConverter that appends the percentage sign to a number. The new converter is being used by the Acrylic opacity slider label and the Background image opacity slider label.

* [x] Closes #10289 