### PR TITLE
Restore embedded manifests to say 18362

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/TerminalApp.LocalTests.manifest
+++ b/src/cascadia/LocalTests_TerminalApp/TerminalApp.LocalTests.manifest
@@ -7,10 +7,13 @@
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-        <!-- Windows 10 20H1 -->
+        <!-- Windows 10 1903 -->
         <!-- See https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/xaml-islands -->
         <!-- "maxversiontested" is CASE SENSITIVE. Do not change this.-->
-        <maxversiontested Id="10.0.19041.0"/>
+        <!-- DO NOT ADVANCE PAST 18362. The OS has a bug where it won't recognize 19041 as bigger. -->
+        <!-- This will cause unpackaged activation failures in XAML Islands. -->
+        <!-- (We use unpackaged activation in test scenarios.) See GH#10265. -->
+        <maxversiontested Id="10.0.18362.0"/>
         <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
     </application>
   </compatibility>

--- a/src/cascadia/WindowsTerminal/WindowsTerminal.manifest
+++ b/src/cascadia/WindowsTerminal/WindowsTerminal.manifest
@@ -10,7 +10,10 @@
         <!-- Windows 10 1903 -->
         <!-- See https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/xaml-islands -->
         <!-- "maxversiontested" is CASE SENSITIVE. Do not change this.-->
-        <maxversiontested Id="10.0.19041.0"/>
+        <!-- DO NOT ADVANCE PAST 18362. The OS has a bug where it won't recognize 19041 as bigger. -->
+        <!-- This will cause unpackaged activation failures in XAML Islands. -->
+        <!-- (We use unpackaged activation in test scenarios.) See GH#10265. -->
+        <maxversiontested Id="10.0.18362.0"/>
         <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
     </application>
   </compatibility>

--- a/src/cascadia/ut_app/TerminalApp.Unit.Tests.manifest
+++ b/src/cascadia/ut_app/TerminalApp.Unit.Tests.manifest
@@ -10,7 +10,10 @@
         <!-- Windows 10 1903 -->
         <!-- See https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/xaml-islands -->
         <!-- "maxversiontested" is CASE SENSITIVE. Do not change this.-->
-        <maxversiontested Id="10.0.19041.0"/>
+        <!-- DO NOT ADVANCE PAST 18362. The OS has a bug where it won't recognize 19041 as bigger. -->
+        <!-- This will cause unpackaged activation failures in XAML Islands. -->
+        <!-- (We use unpackaged activation in test scenarios.) See GH#10265. -->
+        <maxversiontested Id="10.0.18362.0"/>
         <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
     </application>
   </compatibility>


### PR DESCRIPTION
Restore embedded manifests to say 18362 or unpackaged activation won't work (for helix testing.)

## PR Checklist
* [x] Closes #10265 
* [x] I work here
* [x] Tests now pass

## Detailed Description of the Pull Request / Additional comments
- Unpackaged activation uses the embedded manifest inside the exe. We use unpackaged activation to run our tests in Helix as it's easier that way. Turns out the 1903/19h1 OS thinks 19041 isn't greater than the minimum XAML islands version of 18226 and blocks the load of `TerminalApp.dll` causing a crash (fail fast) on launch. For **REASONS**, 18362 is considered greater than 18226. 
- Packaged activation will use the value in the .appxmanifest and everything is somehow still fine there even with it saying 19041 now.

## Validation Steps Performed
- Kicking a Helix-run off on this branch: https://dev.azure.com/ms/terminal/_build/results?buildId=177336&view=results
