### PR TITLE
profile.schema: add missing actions and commands keys

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -873,11 +873,28 @@
             "string",
             "null"
           ]
+        },
+        "commands":{
+          "description": "list of commands to execute",
+          "items": {
+            "$ref": "#/definitions/Keybinding/properties/command"
+          },
+          "type": "array"
         }
       },
-      "required": [
-        "command",
-        "keys"
+      "allOf":[
+        {
+          "anyOf":[
+            {"required":["command"]},
+            {"required":["commands"]}
+          ]
+        },
+        {
+          "anyOf":[
+            {"required":["keys"]},
+            {"required":["name"]}
+          ]
+        }
       ],
       "type": "object"
     },
@@ -1011,8 +1028,16 @@
           "type": [ "integer", "string" ],
           "deprecated": true
         },
+		"actions": {
+			"description": "Properties are specific to each custom action.",
+			"items": {
+			  "$ref": "#/definitions/Keybinding"
+			},
+			"type": "array"
+		  },
         "keybindings": {
-          "description": "Properties are specific to each custom key binding.",
+          "description": "[deprecated] use actions instead",
+		  "deprecated": true,
           "items": {
             "$ref": "#/definitions/Keybinding"
           },

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -820,7 +820,7 @@
       ]
     },
     "GlobalSummonAction": {
-      "description": "Arguments corresponding to a focusPane Action",
+      "description": "This is a special action that works globally in the OS, rather than only in the context of the terminal window. When pressed, this action will summon the terminal window.",
       "allOf": [
         { "$ref": "#/definitions/ShortcutAction" },
         {
@@ -866,7 +866,7 @@
       ]
     },
     "QuakeModeAction": {
-      "description": "This action is a special variation of the globalSummon action. It specifically summons the quake window,If you'd like to change the behavior of the quakeMode action, we recommended creating a new globalSummon entry",
+      "description": "This action is a special variation of the globalSummon action, It specifically summons a window called \"_quake\". If you'd like to change the behavior of the quakeMode action, we recommended creating a new globalSummon entry.",
       "allOf": [
         { "$ref": "#/definitions/ShortcutAction" },
         {
@@ -929,10 +929,7 @@
         },
         "icon": { "$ref": "#/definitions/Icon" },
         "name": {
-          "description": "The name that will appear in the command palette. If one isn't provided, the terminal will attempt to automatically generate a name.",
-          "properties":{
-            "key":{
-              "type":"string"
+          "description": "The name that will appear in the command palette. If one isn't provided, the terminal will attempt to automatically generate a name.\nif name is a string, it  will be the name of the command.\nif name is a object, the key property of the object will be used to lookup a localized string resource for the command",
             }
           },
           "type": [
@@ -941,10 +938,10 @@
             "null"
           ]
         },
-        "iterateOn":{
-          "type":"string",
-          "description":"used to create iterable commands based on other object on your settings. possible values:\n- \"profiles\" \n- \"schemes\"",
-          "enum":[
+        "iterateOn": {
+          "type": "string",
+          "description": "used to create iterable commands based on other object on your settings. possible values:\n- \"profiles\" \n- \"schemes\"",
+          "enum": [
             "profiles",
             "schemes"
           ]

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -879,6 +879,7 @@
           "items": {
             "$ref": "#/definitions/Keybinding/properties/command"
           },
+          "minItems": 1,
           "type": "array"
         }
       },

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -191,6 +191,7 @@
         "find",
         "findMatch",
         "focusPane",
+        "globalSummon",
         "identifyWindow",
         "identifyWindows",
         "moveFocus",
@@ -206,6 +207,7 @@
         "prevTab",
         "renameTab",
         "openTabRenamer",
+        "quakeMode",
         "resetFontSize",
         "resizePane",
         "renameWindow",
@@ -817,6 +819,63 @@
         }
       ]
     },
+    "GlobalSummonAction": {
+      "description": "Arguments corresponding to a focusPane Action",
+      "allOf": [
+        { "$ref": "#/definitions/ShortcutAction" },
+        {
+          "properties": {
+            "action": { "type": "string", "pattern": "globalSummon" },
+            "desktop":{
+              "type":"string",
+              "default":"toCurrent",
+              "description":"This controls how the terminal should interact with virtual desktops.\n- \"any\": Leave the window on whichever desktop it's already on - will switch to that desktop as the window is activated.\n- \"toCurrent\" (default): Move the window to the current virtual desktop.\n- \"onCurrent\": Only summon the window if it's already on the current virtual desktop. ",
+              "enum":[
+                "any",
+                "toCurrent",
+                "onCurrent"
+              ]
+            },
+            "monitor":{
+              "type":"string",
+              "default":"toMouse",
+              "description":"This controls the monitor that the window will be summoned from/to.\n- \"any\": Summon the most recently used window, regardless of which monitor it's currently on.\n- \"toCurrent\": Summon the most recently used window to the monitor with the current foreground window.\n- \"toMouse\" (default): Summon the most recently used window to the monitor where the mouse cursor is.",
+              "enum":[
+                "any",
+                "toCurrent",
+                "toMouse"
+              ]
+            },
+            "name":{
+              "type":"string",
+              "description":"When provided, summon the window whose name or ID matches the given name value. If no such window exists, then create a new window with that name."
+            },
+            "dropdownDuration":{
+              "type":"number",
+              "minimum": 0,
+              "default":0,
+              "description":"When provided with a positive number, \"slide\" the window in from the top of the screen using an animation that lasts dropdownDuration milliseconds."
+            },
+            "toggleVisibility":{
+              "type":"boolean",
+              "default":true,
+              "description":"When true, pressing the assigned keys for this action will dismiss (minimize) the window when the window is currently the foreground window."
+            }
+          }
+        }
+      ]
+    },
+    "QuakeModeAction": {
+      "description": "Arguments corresponding to a focusPane Action",
+      "allOf": [
+        { "$ref": "#/definitions/ShortcutAction" },
+        {
+          "properties": {
+            "action": { "type": "string", "pattern": "quakeMode" }
+          }
+        }
+      ]
+    },
     "Keybinding": {
       "additionalProperties": false,
       "properties": {
@@ -848,6 +907,8 @@
               { "$ref": "#/definitions/RenameTabAction" },
               { "$ref": "#/definitions/RenameWindowAction" },
               { "$ref": "#/definitions/FocusPaneAction" },
+              { "$ref": "#/definitions/GlobalSummonAction" },
+              { "$ref": "#/definitions/QuakeModeAction" },
               { "type": "null" }
             ]
         },
@@ -897,7 +958,7 @@
           "type": "array"
         }
       },
-          "anyOf":[
+      "anyOf":[
         {"required":["name","commands"]},
         {"required":["command"]}
       ],

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -826,40 +826,40 @@
         {
           "properties": {
             "action": { "type": "string", "pattern": "globalSummon" },
-            "desktop":{
-              "type":"string",
-              "default":"toCurrent",
-              "description":"This controls how the terminal should interact with virtual desktops.\n- \"any\": Leave the window on whichever desktop it's already on - will switch to that desktop as the window is activated.\n- \"toCurrent\" (default): Move the window to the current virtual desktop.\n- \"onCurrent\": Only summon the window if it's already on the current virtual desktop. ",
-              "enum":[
+            "desktop": {
+              "type": "string",
+              "default": "toCurrent",
+              "description": "This controls how the terminal should interact with virtual desktops.\n- \"any\": Leave the window on whichever desktop it's already on - will switch to that desktop as the window is activated.\n- \"toCurrent\" (default): Move the window to the current virtual desktop.\n- \"onCurrent\": Only summon the window if it's already on the current virtual desktop. ",
+              "enum": [
                 "any",
                 "toCurrent",
                 "onCurrent"
               ]
             },
-            "monitor":{
-              "type":"string",
-              "default":"toMouse",
-              "description":"This controls the monitor that the window will be summoned from/to.\n- \"any\": Summon the most recently used window, regardless of which monitor it's currently on.\n- \"toCurrent\": Summon the most recently used window to the monitor with the current foreground window.\n- \"toMouse\" (default): Summon the most recently used window to the monitor where the mouse cursor is.",
-              "enum":[
+            "monitor": {
+              "type": "string",
+              "default": "toMouse",
+              "description": "This controls the monitor that the window will be summoned from/to.\n- \"any\": Summon the most recently used window, regardless of which monitor it's currently on.\n- \"toCurrent\": Summon the most recently used window to the monitor with the current foreground window.\n- \"toMouse\" (default): Summon the most recently used window to the monitor where the mouse cursor is.",
+              "enum": [
                 "any",
                 "toCurrent",
                 "toMouse"
               ]
             },
-            "name":{
-              "type":"string",
-              "description":"When provided, summon the window whose name or ID matches the given name value. If no such window exists, then create a new window with that name."
+            "name": {
+              "type": "string",
+              "description": "When provided, summon the window whose name or ID matches the given name value. If no such window exists, then create a new window with that name."
             },
-            "dropdownDuration":{
-              "type":"number",
+            "dropdownDuration": {
+              "type": "number",
               "minimum": 0,
-              "default":0,
-              "description":"When provided with a positive number, \"slide\" the window in from the top of the screen using an animation that lasts dropdownDuration milliseconds."
+              "default": 0,
+              "description": "When provided with a positive number, \"slide\" the window in from the top of the screen using an animation that lasts dropdownDuration milliseconds."
             },
-            "toggleVisibility":{
-              "type":"boolean",
-              "default":true,
-              "description":"When true, pressing the assigned keys for this action will dismiss (minimize) the window when the window is currently the foreground window."
+            "toggleVisibility": {
+              "type": "boolean",
+              "default": true,
+              "description": "When true, pressing the assigned keys for this action will dismiss (minimize) the window when the window is currently the foreground window."
             }
           }
         }
@@ -930,6 +930,9 @@
         "icon": { "$ref": "#/definitions/Icon" },
         "name": {
           "description": "The name that will appear in the command palette. If one isn't provided, the terminal will attempt to automatically generate a name.\nif name is a string, it  will be the name of the command.\nif name is a object, the key property of the object will be used to lookup a localized string resource for the command",
+          "properties": {
+            "key": {
+              "type": "string"
             }
           },
           "type": [
@@ -946,7 +949,7 @@
             "schemes"
           ]
         },
-        "commands":{
+        "commands": {
           "description": "list of commands to execute",
           "items": {
             "$ref": "#/definitions/Keybinding/properties/command"
@@ -955,9 +958,9 @@
           "type": "array"
         }
       },
-      "anyOf":[
-        {"required":["name","commands"]},
-        {"required":["command"]}
+      "anyOf": [
+        {"required": ["name","commands"]},
+        {"required": ["command"]}
       ],
       "type": "object"
     },

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -869,8 +869,14 @@
         "icon": { "$ref": "#/definitions/Icon" },
         "name": {
           "description": "The name that will appear in the command palette. If one isn't provided, the terminal will attempt to automatically generate a name.",
+          "properties":{
+            "key":{
+              "type":"string"
+            }
+          },
           "type": [
             "string",
+            "object",
             "null"
           ]
         },

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -866,7 +866,7 @@
       ]
     },
     "QuakeModeAction": {
-      "description": "This action is a special variation of the globalSummon action. It specifically summons a window called \"_quake\". If you'd like to change the behavior of the quakeMode action, we recommended creating a new globalSummon entry.",
+      "description": "This action is a special variation of the globalSummon action. It specifically summons a window called \"_quake\". If you would like to change the behavior of the quakeMode action, we recommended creating a new globalSummon entry.",
       "allOf": [
         { "$ref": "#/definitions/ShortcutAction" },
         {
@@ -929,7 +929,7 @@
         },
         "icon": { "$ref": "#/definitions/Icon" },
         "name": {
-          "description": "The name that will appear in the command palette. If one isn't provided, the terminal will attempt to automatically generate a name.\nif name is a string, it  will be the name of the command.\nif name is a object, the key property of the object will be used to lookup a localized string resource for the command",
+          "description": "The name that will appear in the command palette. If one isn't provided, the terminal will attempt to automatically generate a name.\nIf name is a string, it will be the name of the command.\nIf name is a object, the key property of the object will be used to lookup a localized string resource for the command",
           "properties": {
             "key": {
               "type": "string"
@@ -943,14 +943,14 @@
         },
         "iterateOn": {
           "type": "string",
-          "description": "used to create iterable commands based on other object on your settings. possible values:\n- \"profiles\" \n- \"schemes\"",
+          "description": "Used to create iterable commands based on other objects in your settings. Possible values:\n- \"profiles\" \n- \"schemes\"",
           "enum": [
             "profiles",
             "schemes"
           ]
         },
         "commands": {
-          "description": "list of commands to execute",
+          "description": "List of commands to execute",
           "items": {
             "$ref": "#/definitions/Keybinding/properties/command"
           },
@@ -1102,7 +1102,7 @@
 			"type": "array"
 		  },
         "keybindings": {
-          "description": "[deprecated] use actions instead",
+          "description": "[deprecated] Use actions instead.",
           "deprecated": true,
           "items": {
             "$ref": "#/definitions/Keybinding"

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -1038,7 +1038,7 @@
 		  },
         "keybindings": {
           "description": "[deprecated] use actions instead",
-		  "deprecated": true,
+          "deprecated": true,
           "items": {
             "$ref": "#/definitions/Keybinding"
           },

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -866,7 +866,7 @@
       ]
     },
     "QuakeModeAction": {
-      "description": "Arguments corresponding to a focusPane Action",
+      "description": "This action is a special variation of the globalSummon action. It specifically summons the quake window,If you'd like to change the behavior of the quakeMode action, we recommended creating a new globalSummon entry",
       "allOf": [
         { "$ref": "#/definitions/ShortcutAction" },
         {

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -866,7 +866,7 @@
       ]
     },
     "QuakeModeAction": {
-      "description": "This action is a special variation of the globalSummon action, It specifically summons a window called \"_quake\". If you'd like to change the behavior of the quakeMode action, we recommended creating a new globalSummon entry.",
+      "description": "This action is a special variation of the globalSummon action. It specifically summons a window called \"_quake\". If you'd like to change the behavior of the quakeMode action, we recommended creating a new globalSummon entry.",
       "allOf": [
         { "$ref": "#/definitions/ShortcutAction" },
         {

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -897,19 +897,9 @@
           "type": "array"
         }
       },
-      "allOf":[
-        {
           "anyOf":[
-            {"required":["command"]},
-            {"required":["commands"]}
-          ]
-        },
-        {
-          "anyOf":[
-            {"required":["keys"]},
-            {"required":["name"]}
-          ]
-        }
+        {"required":["name","commands"]},
+        {"required":["command"]}
       ],
       "type": "object"
     },

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -880,6 +880,14 @@
             "null"
           ]
         },
+        "iterateOn":{
+          "type":"string",
+          "description":"used to create iterable commands based on other object on your settings. possible values:\n- \"profiles\" \n- \"schemes\"",
+          "enum":[
+            "profiles",
+            "schemes"
+          ]
+        },
         "commands":{
           "description": "list of commands to execute",
           "items": {


### PR DESCRIPTION
## Summary of the Pull Request
Add missing keys to the schema:
- globalSummon (and args: desktop, monitor, name, dropdownDuration, toggleVisibility)
- quakeMode
- iterateOn
- commands

Also enforces required keys for commands and deprecates "keybindings"

## PR Checklist
* [x] Closes #7443
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Schema updated.

## Detailed Description of the Pull Request / Additional comments
There were some other pending keys mentioned on the issue, but I don't think they are pending anymore.

## Validation Steps Performed
Changed the `"$schema"` value in my settings.json to point to the edited one.