### PR TITLE
Throttle cursor redrawing in outputStream.cpp

### DIFF
--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -76,8 +76,10 @@ void WriteBuffer::_DefaultStringCase(const std::wstring_view string)
 {
     size_t dwNumBytes = string.size() * sizeof(wchar_t);
 
-    _io.GetActiveOutputBuffer().GetTextBuffer().GetCursor().SetIsOn(true);
+    Cursor& cursor = _io.GetActiveOutputBuffer().GetTextBuffer().GetCursor();
+    cursor.SetIsOn(true);
 
+    //cursor.StartDeferDrawing();
     _ntstatus = WriteCharsLegacy(_io.GetActiveOutputBuffer(),
                                  string.data(),
                                  string.data(),
@@ -87,6 +89,7 @@ void WriteBuffer::_DefaultStringCase(const std::wstring_view string)
                                  _io.GetActiveOutputBuffer().GetTextBuffer().GetCursor().GetPosition().X,
                                  WC_LIMIT_BACKSPACE | WC_DELAY_EOL_WRAP,
                                  nullptr);
+    //cursor.EndDeferDrawing();
 }
 
 ConhostInternalGetSet::ConhostInternalGetSet(_In_ IIoProvider& io) :

--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -77,7 +77,10 @@ void WriteBuffer::_DefaultStringCase(const std::wstring_view string)
     size_t dwNumBytes = string.size() * sizeof(wchar_t);
 
     Cursor& cursor = _io.GetActiveOutputBuffer().GetTextBuffer().GetCursor();
-    cursor.SetIsOn(true);
+    if (!cursor.IsOn())
+    {
+        cursor.SetIsOn(true);
+    }
 
     //cursor.StartDeferDrawing();
     _ntstatus = WriteCharsLegacy(_io.GetActiveOutputBuffer(),

--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -82,7 +82,9 @@ void WriteBuffer::_DefaultStringCase(const std::wstring_view string)
         cursor.SetIsOn(true);
     }
 
-    //cursor.StartDeferDrawing();
+    // Defer the cursor drawing while we are iterating the string, for a better performance.
+    // We can not waste time displaying a cursor event when we know more text is coming right behind it.
+    cursor.StartDeferDrawing();
     _ntstatus = WriteCharsLegacy(_io.GetActiveOutputBuffer(),
                                  string.data(),
                                  string.data(),
@@ -92,7 +94,7 @@ void WriteBuffer::_DefaultStringCase(const std::wstring_view string)
                                  _io.GetActiveOutputBuffer().GetTextBuffer().GetCursor().GetPosition().X,
                                  WC_LIMIT_BACKSPACE | WC_DELAY_EOL_WRAP,
                                  nullptr);
-    //cursor.EndDeferDrawing();
+    cursor.EndDeferDrawing();
 }
 
 ConhostInternalGetSet::ConhostInternalGetSet(_In_ IIoProvider& io) :


### PR DESCRIPTION
Try to throttle the cursor redrawing in the conhost world.

The motivation of this is the high CPU usage of `TriggerRedrawCursor` (#10393).

This can be seen as the conhost version of #2960.

This saves 5%~8% of the CPU time.

Supports #10462.