### PR TITLE
Convert four INSIDE_WINDOWS blocks to til features

### DIFF
--- a/.github/actions/spelling/patterns/patterns.txt
+++ b/.github/actions/spelling/patterns/patterns.txt
@@ -23,3 +23,4 @@ VERIFY_ARE_EQUAL\(L"[^"]+"
 "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789\+/"
 std::memory_order_[\w]+
 D2DERR_SHADER_COMPILE_FAILED
+TIL_FEATURE_[0-9A-Z_]+

--- a/src/features.xml
+++ b/src/features.xml
@@ -35,4 +35,18 @@
             <brandingToken>WindowsInbox</brandingToken>
         </alwaysDisabledBrandingTokens>
     </feature>
+
+    <feature>
+        <name>Feature_UseNumpadEventsForClipboardInput</name>
+        <description>Controls whether the clipboard converter (and ConPTY InputStateMachine) uses Numpad events instead of UChar</description>
+        <stage>AlwaysDisabled</stage>
+        <alwaysEnabledBrandingTokens>
+            <!--
+                To reduce the risk of compatibility issues inside Windows, we're going to continue using the old
+                version of GetQuickCharWidth to determine whether a character should be synthesized into numpad
+                events.
+            -->
+            <brandingToken>WindowsInbox</brandingToken>
+        </alwaysEnabledBrandingTokens>
+    </feature>
 </featureStaging>

--- a/src/features.xml
+++ b/src/features.xml
@@ -18,4 +18,21 @@
             <brandingToken>WindowsInbox</brandingToken>
         </alwaysEnabledBrandingTokens>
     </feature>
+
+    <feature>
+        <name>Feature_ConhostDxEngine</name>
+        <description>Controls whether conhost supports the DX engine and the UseDx registry key</description>
+        <stage>AlwaysEnabled</stage>
+        <alwaysDisabledBrandingTokens>
+            <brandingToken>WindowsInbox</brandingToken>
+        </alwaysDisabledBrandingTokens>
+    </feature>
+    <feature>
+        <name>Feature_DxEngineShaderSupport</name>
+        <description>Controls whether the DX engine is built with shader support.</description>
+        <stage>AlwaysEnabled</stage>
+        <alwaysDisabledBrandingTokens>
+            <brandingToken>WindowsInbox</brandingToken>
+        </alwaysDisabledBrandingTokens>
+    </feature>
 </featureStaging>

--- a/src/features.xml
+++ b/src/features.xml
@@ -9,4 +9,13 @@
             <brandingToken>WindowsInbox</brandingToken>
         </alwaysDisabledBrandingTokens>
     </feature>
+
+    <feature>
+        <name>Feature_AttemptHandoff</name>
+        <description>conhost should try to hand connections over to OpenConsole</description>
+        <stage>AlwaysDisabled</stage>
+        <alwaysEnabledBrandingTokens>
+            <brandingToken>WindowsInbox</brandingToken>
+        </alwaysEnabledBrandingTokens>
+    </feature>
 </featureStaging>

--- a/src/features.xml
+++ b/src/features.xml
@@ -2,11 +2,10 @@
 <featureStaging xmlns="http://microsoft.com/TilFeatureStaging-Schema.xsd">
     <!-- See doc/feature_flags.md for more info.  -->
     <feature>
-        <name>Feature_ExampleFeat</name>
-        <description>This feature will be replaced in the next pull request.</description>
+        <name>Feature_ReceiveIncomingHandoff</name>
+        <description>OpenConsole should be able to receive incoming connections</description>
         <stage>AlwaysEnabled</stage>
         <alwaysDisabledBrandingTokens>
-            <brandingToken>Preview</brandingToken>
             <brandingToken>WindowsInbox</brandingToken>
         </alwaysDisabledBrandingTokens>
     </feature>

--- a/src/host/exe/exemain.cpp
+++ b/src/host/exe/exemain.cpp
@@ -9,7 +9,7 @@
 #include "../interactivity/inc/ServiceLocator.hpp"
 #include "../inc/conint.h"
 
-#ifndef __INSIDE_WINDOWS
+#if TIL_FEATURE_RECEIVEINCOMINGHANDOFF_ENABLED
 #include "CConsoleHandoff.h"
 #endif
 
@@ -247,7 +247,7 @@ int CALLBACK wWinMain(
     //    messages going forward.
     // 7. The out-of-box `OpenConsole.exe` can then attempt to lookup and invoke a `CTerminalHandoff` to ask a registered
     //    Terminal to become the UI. This OpenConsole.exe will put itself in PTY mode and let the Terminal handle user interaction.
-#ifndef __INSIDE_WINDOWS
+#if TIL_FEATURE_RECEIVEINCOMINGHANDOFF_ENABLED
     auto& module = OutOfProcModuleWithRegistrationFlag<REGCLS_SINGLEUSE>::Create(&_releaseNotifier);
 #endif
 
@@ -264,7 +264,7 @@ int CALLBACK wWinMain(
     if (SUCCEEDED(hr))
     {
         // Only try to register as a handoff target if we are NOT a part of Windows.
-#ifndef __INSIDE_WINDOWS
+#if TIL_FEATURE_RECEIVEINCOMINGHANDOFF_ENABLED
         bool defAppEnabled = false;
         if (args.ShouldRunAsComServer() && SUCCEEDED(Microsoft::Console::Internal::DefaultApp::CheckDefaultAppPolicy(defAppEnabled)) && defAppEnabled)
         {

--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -27,9 +27,9 @@
 #include "../inc/conint.h"
 #include "../propslib/DelegationConfig.hpp"
 
-#ifndef __INSIDE_WINDOWS
+#if TIL_FEATURE_RECEIVEINCOMINGHANDOFF_ENABLED
 #include "ITerminalHandoff.h"
-#endif // __INSIDE_WINDOWS
+#endif // TIL_FEATURE_RECEIVEINCOMINGHANDOFF_ENABLED
 
 #pragma hdrstop
 
@@ -367,9 +367,9 @@ HRESULT ConsoleCreateIoThread(_In_ HANDLE Server,
                                               [[maybe_unused]] PCONSOLE_API_MSG connectMessage)
 try
 {
-#ifdef __INSIDE_WINDOWS
+#if !TIL_FEATURE_RECEIVEINCOMINGHANDOFF_ENABLED
     return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
-#else // !__INSIDE_WINDOWS
+#else // TIL_FEATURE_RECEIVEINCOMINGHANDOFF_ENABLED
     auto& g = ServiceLocator::LocateGlobals();
     g.handoffTarget = true;
 
@@ -444,7 +444,7 @@ try
     RETURN_IF_FAILED(consoleArgs.ParseCommandline());
 
     return ConsoleCreateIoThread(Server, &consoleArgs, driverInputEvent, connectMessage);
-#endif // __INSIDE_WINDOWS
+#endif // TIL_FEATURE_RECEIVEINCOMINGHANDOFF_ENABLED
 }
 CATCH_RETURN()
 

--- a/src/host/ut_host/ClipboardTests.cpp
+++ b/src/host/ut_host/ClipboardTests.cpp
@@ -308,26 +308,29 @@ class ClipboardTests
                                                                                                 wstr.size());
 
         std::deque<KeyEvent> expectedEvents;
-#ifdef __INSIDE_WINDOWS
-        // Inside Windows, where numpad events are enabled, this generated numpad events.
-        // should be converted to:
-        // 1. left alt keydown
-        // 2. 1st numpad keydown
-        // 3. 1st numpad keyup
-        // 4. 2nd numpad keydown
-        // 5. 2nd numpad keyup
-        // 6. left alt keyup
-        expectedEvents.push_back({ TRUE, 1, VK_MENU, altScanCode, L'\0', LEFT_ALT_PRESSED });
-        expectedEvents.push_back({ TRUE, 1, 0x66, 0x4D, L'\0', LEFT_ALT_PRESSED });
-        expectedEvents.push_back({ FALSE, 1, 0x66, 0x4D, L'\0', LEFT_ALT_PRESSED });
-        expectedEvents.push_back({ TRUE, 1, 0x63, 0x51, L'\0', LEFT_ALT_PRESSED });
-        expectedEvents.push_back({ FALSE, 1, 0x63, 0x51, L'\0', LEFT_ALT_PRESSED });
-        expectedEvents.push_back({ FALSE, 1, VK_MENU, altScanCode, wstr[0], 0 });
-#else
-        // Outside Windows, without numpad events, we just emit the key with a nonzero UnicodeChar
-        expectedEvents.push_back({ TRUE, 1, 0, 0, wstr[0], 0 });
-        expectedEvents.push_back({ FALSE, 1, 0, 0, wstr[0], 0 });
-#endif
+        if constexpr (Feature_UseNumpadEventsForClipboardInput::IsEnabled())
+        {
+            // Inside Windows, where numpad events are enabled, this generated numpad events.
+            // should be converted to:
+            // 1. left alt keydown
+            // 2. 1st numpad keydown
+            // 3. 1st numpad keyup
+            // 4. 2nd numpad keydown
+            // 5. 2nd numpad keyup
+            // 6. left alt keyup
+            expectedEvents.push_back({ TRUE, 1, VK_MENU, altScanCode, L'\0', LEFT_ALT_PRESSED });
+            expectedEvents.push_back({ TRUE, 1, 0x66, 0x4D, L'\0', LEFT_ALT_PRESSED });
+            expectedEvents.push_back({ FALSE, 1, 0x66, 0x4D, L'\0', LEFT_ALT_PRESSED });
+            expectedEvents.push_back({ TRUE, 1, 0x63, 0x51, L'\0', LEFT_ALT_PRESSED });
+            expectedEvents.push_back({ FALSE, 1, 0x63, 0x51, L'\0', LEFT_ALT_PRESSED });
+            expectedEvents.push_back({ FALSE, 1, VK_MENU, altScanCode, wstr[0], 0 });
+        }
+        else
+        {
+            // Outside Windows, without numpad events, we just emit the key with a nonzero UnicodeChar
+            expectedEvents.push_back({ TRUE, 1, 0, 0, wstr[0], 0 });
+            expectedEvents.push_back({ FALSE, 1, 0, 0, wstr[0], 0 });
+        }
 
         VERIFY_ARE_EQUAL(expectedEvents.size(), events.size());
 

--- a/src/host/ut_host/VtIoTests.cpp
+++ b/src/host/ut_host/VtIoTests.cpp
@@ -12,7 +12,7 @@
 #include "../Settings.hpp"
 #include "../VtIo.hpp"
 
-#ifndef __INSIDE_WINDOWS
+#if TIL_FEATURE_CONHOSTDXENGINE_ENABLED
 #include "../../renderer/dx/DxRenderer.hpp"
 #endif
 
@@ -38,7 +38,7 @@ class Microsoft::Console::VirtualTerminal::VtIoTests
 
     TEST_METHOD(RendererDtorAndThread);
 
-#ifndef __INSIDE_WINDOWS
+#if TIL_FEATURE_CONHOSTDXENGINE_ENABLED
     TEST_METHOD(RendererDtorAndThreadAndDx);
 #endif
 
@@ -433,7 +433,7 @@ void VtIoTests::RendererDtorAndThread()
     }
 }
 
-#ifndef __INSIDE_WINDOWS
+#if TIL_FEATURE_CONHOSTDXENGINE_ENABLED
 void VtIoTests::RendererDtorAndThreadAndDx()
 {
     Log::Comment(NoThrowString().Format(

--- a/src/interactivity/base/EventSynthesis.cpp
+++ b/src/interactivity/base/EventSynthesis.cpp
@@ -16,19 +16,9 @@
 static constexpr WORD altScanCode = 0x38;
 static constexpr WORD leftShiftScanCode = 0x2A;
 
-#ifdef __INSIDE_WINDOWS
-// To reduce the risk of compatibility issues inside Windows, we're going to continue using the old
-// version of GetQuickCharWidth to determine whether a character should be synthesized into numpad
-// events.
-static constexpr bool useNumpadEvents{ true };
-#else // !defined(__INSIDE_WINDOWS)
-// In Terminal, however, we will *always* use normal key events (!)
-static constexpr bool useNumpadEvents{ false };
-#endif // __INSIDE_WINDOWS
-
 // Routine Description:
 // - naively determines the width of a UCS2 encoded wchar (with caveats noted above)
-#pragma warning(suppress : 4505) // this function will be deleted if useNumpadEvents is false
+#pragma warning(suppress : 4505) // this function will be deleted if numpad events are disabled
 static CodepointWidth GetQuickCharWidthLegacyForNumpadEventSynthesis(const wchar_t wch) noexcept
 {
     if ((0x1100 <= wch && wch <= 0x115f) // From Unicode 9.0, Hangul Choseong is wide
@@ -62,7 +52,7 @@ std::deque<std::unique_ptr<KeyEvent>> Microsoft::Console::Interactivity::CharToK
 
     if (keyState == invalidKey)
     {
-        if constexpr (useNumpadEvents)
+        if constexpr (Feature_UseNumpadEventsForClipboardInput::IsEnabled())
         {
             // Determine DBCS character because these character does not know by VkKeyScan.
             // GetStringTypeW(CT_CTYPE3) & C3_ALPHA can determine all linguistic characters. However, this is

--- a/src/interactivity/win32/window.cpp
+++ b/src/interactivity/win32/window.cpp
@@ -29,7 +29,7 @@
 #include "../../renderer/base/renderer.hpp"
 #include "../../renderer/gdi/gdirenderer.hpp"
 
-#ifndef __INSIDE_WINDOWS
+#if TIL_FEATURE_CONHOSTDXENGINE_ENABLED
 #include "../../renderer/dx/DxRenderer.hpp"
 #else
 // Forward-declare this so we don't blow up later.
@@ -217,7 +217,7 @@ void Window::_UpdateSystemMetrics() const
     [[maybe_unused]] DxEngine* pDxEngine = nullptr;
     try
     {
-#ifndef __INSIDE_WINDOWS
+#if TIL_FEATURE_CONHOSTDXENGINE_ENABLED
         if (useDx)
         {
             pDxEngine = new DxEngine();
@@ -324,7 +324,7 @@ void Window::_UpdateSystemMetrics() const
         {
             _hWnd = hWnd;
 
-#ifndef __INSIDE_WINDOWS
+#if TIL_FEATURE_CONHOSTDXENGINE_ENABLED
             if (useDx)
             {
                 status = NTSTATUS_FROM_WIN32(HRESULT_CODE((pDxEngine->SetHwnd(hWnd))));

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -194,7 +194,7 @@ _CompileShader(
     std::string target,
     std::string entry = "main")
 {
-#ifdef __INSIDE_WINDOWS
+#if !TIL_FEATURE_DXENGINESHADERSUPPORT_ENABLED
     THROW_HR(E_UNEXPECTED);
     return 0;
 #else

--- a/src/renderer/dx/ScreenPixelShader.h
+++ b/src/renderer/dx/ScreenPixelShader.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef __INSIDE_WINDOWS
+#if !TIL_FEATURE_DXENGINESHADERSUPPORT_ENABLED
 constexpr std::string_view retroPixelShaderString{ "" };
 #else
 constexpr std::string_view retroPixelShaderString{ R"(

--- a/src/renderer/dx/ScreenVertexShader.h
+++ b/src/renderer/dx/ScreenVertexShader.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef __INSIDE_WINDOWS
+#if !TIL_FEATURE_DXENGINESHADERSUPPORT_ENABLED
 const char screenVertexShaderString[] = "";
 #else
 const char screenVertexShaderString[] = R"(

--- a/src/server/IoDispatchers.cpp
+++ b/src/server/IoDispatchers.cpp
@@ -146,7 +146,7 @@ static bool _shouldAttemptHandoff(const Globals& globals,
                                   const CONSOLE_INFORMATION& gci,
                                   CONSOLE_API_CONNECTINFO& cac)
 {
-#ifndef __INSIDE_WINDOWS
+#if !TIL_FEATURE_ATTEMPTHANDOFF_ENABLED
 
     UNREFERENCED_PARAMETER(globals);
     UNREFERENCED_PARAMETER(gci);


### PR DESCRIPTION
This pull request converts four of our existing `#ifdef` (or `#ifndef`)
`INSIDE_WINDOWS` blocks to til::features:

* Attempting to establish a handoff session (inside Windows only)
* The ability to *receive* a handoff session (outside Windows only)
* The DX engine (outside Windows only) and shaders (also outside only)
* Whether we use numpad event synthesis for clipboard/conpty (inside
  Windows only)

Most of these are using the preprocessor verison of til::feature, only
because it is more difficult to gate the inclusion of headers on
constant expressions. I'd love to prefer the compile time version.
