### PR TITLE
Force the execution policy on the til::feature powershell script

### DIFF
--- a/build/rules/GenerateFeatureFlags.proj
+++ b/build/rules/GenerateFeatureFlags.proj
@@ -64,7 +64,7 @@
     DependsOnTargets="_GenerateBranchAndBrandingCache">
     <MakeDir Directories="$(OpenConsoleCommonOutDir)\inc" />
     <Exec
-      Command="powershell -NoProfile -Command &quot;$(SolutionDir)\tools\Generate-FeatureStagingHeader.ps1&quot; -Path &quot;%(FeatureFlagFile.FullPath)&quot; -Branding $(_WTBrandingName)"
+      Command="powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy ByPass -Command &quot;$(SolutionDir)\tools\Generate-FeatureStagingHeader.ps1&quot; -Path &quot;%(FeatureFlagFile.FullPath)&quot; -Branding $(_WTBrandingName)"
       ConsoleToMsBuild="true"
       StandardOutputImportance="low">
       <Output TaskParameter="ConsoleOutput" ItemName="_FeatureFlagFileLines" />


### PR DESCRIPTION
It was not set to `bypass`, which gave @carlos-zamora some trouble.

This commit brings it in line with the Windows build rule.