### PR TITLE
Fix edit button color in light theme

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Actions.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Actions.xaml
@@ -240,16 +240,12 @@
                                 <ResourceDictionary>
                                     <ResourceDictionary.ThemeDictionaries>
                                         <ResourceDictionary x:Key="Light">
-                                            <SolidColorBrush x:Key="ButtonForeground"
-                                                             Color="White" />
                                             <SolidColorBrush x:Key="ButtonForegroundPointerOver"
                                                              Color="{StaticResource SystemAccentColor}" />
                                             <SolidColorBrush x:Key="ButtonForegroundPressed"
                                                              Color="{StaticResource SystemAccentColor}" />
                                         </ResourceDictionary>
                                         <ResourceDictionary x:Key="Dark">
-                                            <SolidColorBrush x:Key="ButtonForeground"
-                                                             Color="White" />
                                             <SolidColorBrush x:Key="ButtonForegroundPointerOver"
                                                              Color="{StaticResource SystemAccentColor}" />
                                             <SolidColorBrush x:Key="ButtonForegroundPressed"


### PR DESCRIPTION
## Summary of the Pull Request
Fixes a bug where the edit button in the actions page would have white text when in light theme. Now, we just fallback to XAML's built-in value (black in light theme and white in dark theme).

## References
#6900 - Epic
Closes #10406
