### PR TITLE
Localize the shell extension's menu item

### DIFF
--- a/src/cascadia/ShellExtension/OpenTerminalHere.cpp
+++ b/src/cascadia/ShellExtension/OpenTerminalHere.cpp
@@ -4,11 +4,11 @@
 #include "pch.h"
 #include "OpenTerminalHere.h"
 #include "../WinRTUtils/inc/WtExeUtils.h"
+#include "../WinRTUtils/inc/LibraryResources.h"
+
+#include <winrt/Windows.ApplicationModel.Resources.Core.h>
 #include <ShlObj.h>
 
-// TODO GH#6112: Localize these strings
-static constexpr std::wstring_view VerbDisplayName{ L"Open in Windows Terminal" };
-static constexpr std::wstring_view VerbDevBuildDisplayName{ L"Open in Windows Terminal (Dev Build)" };
 static constexpr std::wstring_view VerbName{ L"WindowsTerminalOpenHere" };
 
 // This code is aggressively copied from
@@ -87,8 +87,15 @@ HRESULT OpenTerminalHere::GetTitle(IShellItemArray* /*psiItemArray*/,
 {
     // Change the string we return depending on if we're running from the dev
     // build package or not.
-    const bool isDevBuild = IsDevBuild();
-    return SHStrDup(isDevBuild ? VerbDevBuildDisplayName.data() : VerbDisplayName.data(), ppszName);
+    const auto resource =
+#if defined(WT_BRANDING_RELEASE)
+        RS_(L"ShellExtension_OpenInTerminalMenuItem");
+#elif defined(WT_BRANDING_PREVIEW)
+        RS_(L"ShellExtension_OpenInTerminalMenuItem_Preview");
+#else
+        RS_(L"ShellExtension_OpenInTerminalMenuItem_Dev");
+#endif
+    return SHStrDup(resource.data(), ppszName);
 }
 
 HRESULT OpenTerminalHere::GetState(IShellItemArray* /*psiItemArray*/,

--- a/src/cascadia/ShellExtension/dllmain.cpp
+++ b/src/cascadia/ShellExtension/dllmain.cpp
@@ -4,6 +4,8 @@
 #include "pch.h"
 #include "OpenTerminalHere.h"
 
+#include "../WinRTUtils/inc/LibraryResources.h"
+
 using namespace Microsoft::WRL;
 
 STDAPI DllCanUnloadNow()
@@ -30,3 +32,6 @@ DllMain(_In_opt_ HINSTANCE hinst, DWORD reason, _In_opt_ void*)
     }
     return TRUE;
 }
+
+// Usurp the TerminalApp's resource group.
+UTILS_DEFINE_LIBRARY_RESOURCE_SCOPE(L"TerminalApp/Resources")

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -637,4 +637,16 @@
   <data name="CommandPaletteMenuItem" xml:space="preserve">
     <value>Command Palette</value>
   </data>
+  <data name="ShellExtension_OpenInTerminalMenuItem_Dev" xml:space="preserve">
+    <value>Open in Windows Terminal (Dev)</value>
+    <comment>{Locked} The dev build will never be seen in multiple languages</comment>
+  </data>
+  <data name="ShellExtension_OpenInTerminalMenuItem_Preview" xml:space="preserve">
+    <value>Open in Windows Terminal Preview</value>
+    <comment>{Locked="Windows"} This is a menu item that will be displayed in the Windows File Explorer that launches the Preview version of Windows Terminal</comment>
+  </data>
+  <data name="ShellExtension_OpenInTerminalMenuItem" xml:space="preserve">
+    <value>Open in Windows Terminal</value>
+    <comment>{Locked="Windows"} This is a menu item that will be displayed in the Windows File Explorer that launches the non-preview version of Windows Terminal</comment>
+  </data>
 </root>


### PR DESCRIPTION
This commit introduces localization for the "Open in Windows Terminal"
menu item and differentiates it based on compile-time branding (rather
than runtime detection!).

@leonMSFT's tray icon pull request had the excellent idea to use the
TerminalApp's resource compartment for auxiliary resources for projects
that can't otherwise be localized the same way. Doing localization in
the shell extension (or WindowsTerminal.exe) would require us to use
MUIRCT and split the build process up to support mui files. That's a
huge amount of work... but this is *not* a huge amount of work.

Fixes #6112