### PR TITLE
Fix code-format and test invocation through PowerShell

### DIFF
--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -193,7 +193,7 @@ function Invoke-OpenConsoleTests()
         return
     }
     $OpenConsolePlatform = $Platform
-    $TestHostAppPath = "$root\$OpenConsolePlatform\$Configuration\TestHostApp"
+    $TestHostAppPath = "$root\bin\$OpenConsolePlatform\$Configuration\TestHostApp"
     if ($Platform -eq 'x86')
     {
         $OpenConsolePlatform = 'Win32'
@@ -240,8 +240,10 @@ function Invoke-OpenConsoleTests()
             {
                 & $TaefExePath "$TestHostAppPath\$($t.binary)" $TaefArgs
             }
-
-            & $TaefExePath "$BinDir\$($t.binary)" $TaefArgs
+            else
+            {
+                & $TaefExePath "$BinDir\$($t.binary)" $TaefArgs
+            }
         }
         elseif ($t.type -eq "ft")
         {
@@ -393,10 +395,10 @@ function Invoke-XamlFormat() {
     dotnet tool run xstyler -- -c "$root\XamlStyler.json" -f "$xamlsForStyler"
 
     # Strip BOMs from all the .xaml files
-    $xamls = (git ls-files "$root/**/*.xaml")
-    foreach ($file in $xamls ) {
-        $content = Get-Content $file
-        [IO.File]::WriteAllLines("$file", $content)
+    $xamls = (git ls-files --full-name "$root/**/*.xaml")
+    foreach ($file in $xamls) {
+        $content = Get-Content "$root/$file"
+        [IO.File]::WriteAllLines("$root/$file", $content)
     }
 }
 

--- a/tools/tests.xml
+++ b/tools/tests.xml
@@ -6,8 +6,8 @@
   <test name="terminalApp" type="unit" binary="UnitTests_TerminalApp\Terminal.App.Unit.Tests.dll" />
   <test name="localTerminalApp" type="unit" runInHostApp="true" binary="TerminalApp.LocalTests.dll" />
   <test name="localSettingsModel" type="unit" runInHostApp="true" binary="SettingsModel.LocalTests.dll" />
-  <test name="unitRemoting" type="unit" binary="Remoting.Unit.Tests.dll" />
-  <test name="unitControl" type="unit" binary="Control.Unit.Tests.dll" />
+  <test name="unitRemoting" type="unit" binary="UnitTests_Remoting\Remoting.Unit.Tests.dll" />
+  <test name="unitControl" type="unit" binary="UnitTests_Control\Control.Unit.Tests.dll" />
   <test name="interactivityWin32" type="unit" binary="Conhost.Interactivity.Win32.Unit.Tests.dll" />
   <test name="terminal" type="unit" binary="ConParser.Unit.Tests.dll" />
   <test name="adapter" type="unit" binary="ConAdapter.Unit.Tests.dll" />


### PR DESCRIPTION
Fixes the `Invoke-CodeFormat` and `Invoke-OpenConsoleTests` functions in `OpenConsole.psm1` so that they can be run directly from PowerShell.

Addresses the issues found when creating #10447.

`Invoke-CodeFormat` did not work when invoked directly from PowerShell due to a relative path being passed into the .NET function `[IO.File]::WriteAllLines()`. The working directory for .NET objects does not change when you change directory in PowerShell, so the paths were being treated as relative to the initial working directory of the shell - which was not the terminal git repo.

`Invoke-OpenConsoleTests` had 3 issues:
1. The path to `TestHostApp` was wrong.
2. It would attempt to run the "in host app" tests both in the host app and not in the host app.
3. The test configuration in `tests.xml` wasn't in sync with the `runABC.cmd` files, so the remoting and control unit tests didn't run.

## Validation Steps Performed
1. Ran `Invoke-CodeFormat` and `runformat.cmd` from multiple directories and didn't see errors.
2. Ran `Invoke-OpenConsoleTests` and didn't see errors.