### PR TITLE
Replace PolyTextOutW with ExtTextOutW

### DIFF
--- a/src/renderer/gdi/paint.cpp
+++ b/src/renderer/gdi/paint.cpp
@@ -436,9 +436,14 @@ using namespace Microsoft::Console::Render;
 
     if (_cPolyText > 0)
     {
-        if (!PolyTextOutW(_hdcMemoryContext, _pPolyText, (UINT)_cPolyText))
+        for (size_t i = 0; i != _cPolyText; ++i)
         {
-            hr = E_FAIL;
+            const auto& t = _pPolyText[i];
+            if (!ExtTextOutW(_hdcMemoryContext, t.x, t.y, t.uiFlags, &t.rcl, t.lpstr, t.n, t.pdx))
+            {
+                hr = E_FAIL;
+                break;
+            }
         }
 
         _polyStrings.clear();


### PR DESCRIPTION
Replace PolyTextOutW with ExtTextOutW to allow substitution of missing
glyphs from other fonts.

Why not let Windows substitute the glyphs that are missing in the
current font?  Currently the GDI renderer of conhost/OpenConsole uses
`PolyTextOutW` for drawing.  `PolyTextOutW` doesn't try to substitute
any missing glyphs, so the only way to see, say, Hiragana is to change
the _whole font_ to something like MS Gothic (which is eye-bleeding, to
be honest).

A trivial replace `PolyTextOutW` -> `ExtTextOutW` does the trick.

Switch to `PolyTextOutW` happened in Windows 7 along with introduction
of conhost.exe.  Substitution worked in previous Windows versions, where
internal NT interfaces were used.

# Before the change:
![image](https://user-images.githubusercontent.com/11453922/122759189-93ff3900-d291-11eb-89a9-b1d47aa22ed9.png)

# After the change:
![image](https://user-images.githubusercontent.com/11453922/122759316-b4c78e80-d291-11eb-87aa-7cdc2979ae28.png)

Closes #10472