### PR TITLE
wpf: fix the TerminalTheme struct to marshal the same on all platforms

### DIFF
--- a/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
@@ -798,7 +798,7 @@ void _stdcall TerminalSetTheme(void* terminal, TerminalTheme theme, LPCWSTR font
         }
     }
 
-    publicTerminal->_terminal->SetCursorStyle(theme.CursorStyle);
+    publicTerminal->_terminal->SetCursorStyle(static_cast<DispatchTypes::CursorStyle>(theme.CursorStyle));
 
     publicTerminal->_desiredFont = { fontFamily, 0, DEFAULT_FONT_WEIGHT, { 0, fontSize }, CP_UTF8 };
     publicTerminal->_UpdateFont(newDpi);

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
@@ -19,7 +19,7 @@ typedef struct _TerminalTheme
     COLORREF DefaultForeground;
     COLORREF DefaultSelectionBackground;
     float SelectionBackgroundAlpha;
-    DispatchTypes::CursorStyle CursorStyle;
+    uint32_t CursorStyle; // This will be converted to DispatchTypes::CursorStyle (size_t), but C# cannot marshal an enum type and have it fit in a size_t.
     COLORREF ColorTable[16];
 } TerminalTheme, *LPTerminalTheme;
 

--- a/src/cascadia/WpfTerminalTestNetCore/MainWindow.xaml.cs
+++ b/src/cascadia/WpfTerminalTestNetCore/MainWindow.xaml.cs
@@ -96,6 +96,8 @@ namespace WpfTerminalTestNetCore
             {
                 DefaultBackground = 0x0c0c0c,
                 DefaultForeground = 0xcccccc,
+                DefaultSelectionBackground = 0xcccccc,
+                SelectionBackgroundAlpha = 0.5f,
                 CursorStyle = CursorStyle.BlinkingBar,
                 // This is Campbell.
                 ColorTable = new uint[] { 0x0C0C0C, 0x1F0FC5, 0x0EA113, 0x009CC1, 0xDA3700, 0x981788, 0xDD963A, 0xCCCCCC, 0x767676, 0x5648E7, 0x0CC616, 0xA5F1F9, 0xFF783B, 0x9E00B4, 0xD6D661, 0xF2F2F2 },


### PR DESCRIPTION
The CursorStyle enum is declared as being of type `uint` on the C# side,
but as `size_t` on the C++ side. There's a C# size_t impostor we could
use, System.UIntPtr, but I don't want to risk changing the public API of
TerminalTheme and I don't know if it can be used as a base type for an
enum.

Anyway, since we don't have more than four billion cursor types I chose
to narrow the field to a uint32_t and unpack it in TerminalSetTheme.

Fixes #10485