### PR TITLE
Replicate winrt::make<> changes in ScratchIslandApp SampleAppLib

### DIFF
--- a/scratch/ScratchIslandApp/SampleApp/App.base.h
+++ b/scratch/ScratchIslandApp/SampleApp/App.base.h
@@ -9,30 +9,22 @@ namespace winrt::SampleApp::implementation
 
         IXamlType GetXamlType(::winrt::Windows::UI::Xaml::Interop::TypeName const& type)
         {
-            return AppProvider()->GetXamlType(type);
+            return _appProvider.GetXamlType(type);
         }
 
         IXamlType GetXamlType(::winrt::hstring const& fullName)
         {
-            return AppProvider()->GetXamlType(fullName);
+            return _appProvider.GetXamlType(fullName);
         }
 
         ::winrt::com_array<::winrt::Windows::UI::Xaml::Markup::XmlnsDefinition> GetXmlnsDefinitions()
         {
-            return AppProvider()->GetXmlnsDefinitions();
+            return _appProvider.GetXmlnsDefinitions();
         }
 
     private:
         bool _contentLoaded{ false };
-        std::shared_ptr<XamlMetaDataProvider> _appProvider;
-        std::shared_ptr<XamlMetaDataProvider> AppProvider()
-        {
-            if (!_appProvider)
-            {
-                _appProvider = std::make_shared<XamlMetaDataProvider>();
-            }
-            return _appProvider;
-        }
+        winrt::SampleApp::XamlMetaDataProvider _appProvider;
     };
 
     template<typename D, typename... I>


### PR DESCRIPTION
Sample scratch app would not compile. It does if we apply #10335 to App.base.h in the scratch app.

Closes #10493