### PR TITLE
Render SGR 1 ("intensity") as bold in the DX engine

### DIFF
--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -137,9 +137,15 @@ try
 {
     const auto drawingContext = static_cast<const DrawingContext*>(clientDrawingContext);
 
-    const DWRITE_FONT_WEIGHT weight = _fontRenderData->DefaultFontWeight();
+    DWRITE_FONT_WEIGHT weight = _fontRenderData->DefaultFontWeight();
     DWRITE_FONT_STYLE style = _fontRenderData->DefaultFontStyle();
     const DWRITE_FONT_STRETCH stretch = _fontRenderData->DefaultFontStretch();
+
+    if (drawingContext->useBoldFont)
+    {
+        // TODO: "relative" bold?
+        weight = DWRITE_FONT_WEIGHT_BOLD;
+    }
 
     if (drawingContext->useItalicFont)
     {

--- a/src/renderer/dx/CustomTextRenderer.h
+++ b/src/renderer/dx/CustomTextRenderer.h
@@ -24,6 +24,7 @@ namespace Microsoft::Console::Render
             renderTarget(renderTarget),
             foregroundBrush(foregroundBrush),
             backgroundBrush(backgroundBrush),
+            useBoldFont(false),
             useItalicFont(false),
             forceGrayscaleAA(forceGrayscaleAA),
             dwriteFactory(dwriteFactory),
@@ -38,6 +39,7 @@ namespace Microsoft::Console::Render
         ID2D1RenderTarget* renderTarget;
         ID2D1SolidColorBrush* foregroundBrush;
         ID2D1SolidColorBrush* backgroundBrush;
+        bool useBoldFont;
         bool useItalicFont;
         bool forceGrayscaleAA;
         IDWriteFactory* dwriteFactory;

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1961,6 +1961,7 @@ CATCH_RETURN()
     if (_drawingContext)
     {
         _drawingContext->forceGrayscaleAA = _ShouldForceGrayscaleAA();
+        _drawingContext->useBoldFont = textAttributes.IsBold();
         _drawingContext->useItalicFont = textAttributes.IsItalic();
     }
 


### PR DESCRIPTION
This commit adds support for bold text in DxRenderer.

For now, bold fonts are always rendered using DWRITE_FONT_WEIGHT_BOLD
regardless of the base weight.

As yet, this behavior is unconfigurable.

References
Previous refactoring PRs: #9096 (DxFontRenderData) #9201 (DxFontInfo) 
SGR support tracking issue: #6879

Closes #109