### PR TITLE
[A11y] Treat last character as 'end of buffer'

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -184,6 +184,20 @@ TextBufferCellIterator TextBuffer::GetCellDataAt(const COORD at, const Viewport 
     return TextBufferCellIterator(*this, at, limit);
 }
 
+// Routine Description:
+// - Retrieves read-only cell iterator at the given buffer location
+//   but restricted to operate only inside the given viewport.
+// Arguments:
+// - at - X,Y position in buffer for iterator start position
+// - limit - boundaries for the iterator to operate within
+// - until - X,Y position in buffer for last position for the iterator to read (inclusive)
+// Return Value:
+// - Read-only iterator of cell data.
+TextBufferCellIterator TextBuffer::GetCellDataAt(const COORD at, const Viewport limit, const COORD until) const
+{
+    return TextBufferCellIterator(*this, at, limit, until);
+}
+
 //Routine Description:
 // - Corrects and enforces consistent double byte character state (KAttrs line) within a row of the text buffer.
 // - This will take the given double byte information and check that it will be consistent when inserted into the buffer

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1074,9 +1074,10 @@ const DelimiterClass TextBuffer::_GetDelimiterClassAt(const COORD pos, const std
 // - accessibilityMode - when enabled, we continue expanding left until we are at the beginning of a readable word.
 //                        Otherwise, expand left until a character of a new delimiter class is found
 //                        (or a row boundary is encountered)
+// - limit - (optional) the last possible position that could be populated. This can be used to improve performance.
 // Return Value:
 // - The COORD for the first character on the "word" (inclusive)
-const COORD TextBuffer::GetWordStart(const COORD target, const std::wstring_view wordDelimiters, bool accessibilityMode) const
+const COORD TextBuffer::GetWordStart(const COORD target, const std::wstring_view wordDelimiters, bool accessibilityMode, std::optional<til::point> limit) const
 {
     // Consider a buffer with this text in it:
     // "  word   other  "
@@ -1097,6 +1098,10 @@ const COORD TextBuffer::GetWordStart(const COORD target, const std::wstring_view
     {
         // can't expand left
         return target;
+    }
+    else if (limit && bufferSize.CompareInBounds(target, *limit, true) >= 0)
+    {
+        copy = { limit->operator COORD() };
     }
     else if (target == bufferSize.EndExclusive())
     {
@@ -1196,9 +1201,10 @@ const COORD TextBuffer::_GetWordStartForSelection(const COORD target, const std:
 // - accessibilityMode - when enabled, we continue expanding right until we are at the beginning of the next READABLE word
 //                        Otherwise, expand right until a character of a new delimiter class is found
 //                        (or a row boundary is encountered)
+// - limit - (optional) the last possible position that could be populated. This can be used to improve performance.
 // Return Value:
 // - The COORD for the last character on the "word" (inclusive)
-const COORD TextBuffer::GetWordEnd(const COORD target, const std::wstring_view wordDelimiters, bool accessibilityMode) const
+const COORD TextBuffer::GetWordEnd(const COORD target, const std::wstring_view wordDelimiters, bool accessibilityMode, std::optional<til::point> limit) const
 {
     // Consider a buffer with this text in it:
     // "  word   other  "
@@ -1211,15 +1217,19 @@ const COORD TextBuffer::GetWordEnd(const COORD target, const std::wstring_view w
     // NOTE: the end anchor (this one) is exclusive, whereas the start anchor (GetWordStart) is inclusive
 
     // Already at the end. Can't move forward.
-    if (target == GetSize().EndExclusive())
+    if (limit && GetSize().CompareInBounds(target, *limit, true) >= 0)
+    {
+        return target;
+    }
+    else if (target == GetSize().EndExclusive())
     {
         return target;
     }
 
     if (accessibilityMode)
     {
-        const auto lastCharPos{ GetLastNonSpaceCharacter() };
-        return _GetWordEndForAccessibility(target, wordDelimiters, lastCharPos);
+        const auto lastCharPosLimit{ limit ? *limit : GetLastNonSpaceCharacter(GetSize()) };
+        return _GetWordEndForAccessibility(target, wordDelimiters, lastCharPosLimit);
     }
     else
     {
@@ -1237,40 +1247,34 @@ const COORD TextBuffer::GetWordEnd(const COORD target, const std::wstring_view w
 // - The COORD for the first character of the next readable "word". If no next word, return one past the end of the buffer
 const COORD TextBuffer::_GetWordEndForAccessibility(const COORD target, const std::wstring_view wordDelimiters, const COORD lastCharPos) const
 {
-    const auto bufferSize = GetSize();
-    COORD result = target;
+    const auto bufferSize{ GetSize() };
+    COORD result{ target };
 
-    // Check if we're already on/past the last RegularChar
-    if (bufferSize.CompareInBounds(result, lastCharPos, true) >= 0)
+    if (bufferSize.CompareInBounds(target, lastCharPos, true) >= 0)
     {
-        return bufferSize.EndExclusive();
+        // if we're already on/past the last RegularChar,
+        // clamp result to that position
+        result = lastCharPos;
+
+        // make the result exclusive
+        bufferSize.IncrementInBounds(result, true);
     }
-
-    // ignore right boundary. Continue through readable text found
-    while (_GetDelimiterClassAt(result, wordDelimiters) == DelimiterClass::RegularChar)
+    else
     {
-        if (!bufferSize.IncrementInBounds(result, true))
+        auto iter{ GetCellDataAt(result, bufferSize, lastCharPos) };
+        while (iter && _GetDelimiterClassAt(iter.Pos(), wordDelimiters) == DelimiterClass::RegularChar)
         {
-            break;
+            // Iterate through readable text
+            iter++;
         }
-    }
 
-    // we are already on/past the last RegularChar
-    if (bufferSize.CompareInBounds(result, lastCharPos, true) >= 0)
-    {
-        return bufferSize.EndExclusive();
-    }
-
-    // make sure we expand to the beginning of the NEXT word
-    while (_GetDelimiterClassAt(result, wordDelimiters) != DelimiterClass::RegularChar)
-    {
-        if (!bufferSize.IncrementInBounds(result, true))
+        while (iter && _GetDelimiterClassAt(iter.Pos(), wordDelimiters) != DelimiterClass::RegularChar)
         {
-            // we are at the EndInclusive COORD
-            // this signifies that we must include the last char in the buffer
-            // but the position of the COORD points to nothing
-            break;
+            // expand to the beginning of the NEXT word
+            iter++;
         }
+
+        result = iter.Pos();
     }
 
     return result;
@@ -1366,14 +1370,15 @@ void TextBuffer::_PruneHyperlinks()
 // Return Value:
 // - true, if successfully updated pos. False, if we are unable to move (usually due to a buffer boundary)
 // - pos - The COORD for the first character on the "word" (inclusive)
-bool TextBuffer::MoveToNextWord(COORD& pos, const std::wstring_view wordDelimiters, COORD lastCharPos) const
+bool TextBuffer::MoveToNextWord(COORD& pos, const std::wstring_view wordDelimiters, std::optional<til::point> limitOptional) const
 {
     // move to the beginning of the next word
     // NOTE: _GetWordEnd...() returns the exclusive position of the "end of the word"
     //       This is also the inclusive start of the next word.
-    auto copy{ _GetWordEndForAccessibility(pos, wordDelimiters, lastCharPos) };
+    const auto limit{ limitOptional ? *limitOptional : GetLastNonSpaceCharacter() };
+    auto copy{ _GetWordEndForAccessibility(pos, wordDelimiters, limit) };
 
-    if (copy == GetSize().EndExclusive())
+    if (GetSize().CompareInBounds(pos, limit, true) > 0)
     {
         return false;
     }
@@ -1412,17 +1417,19 @@ bool TextBuffer::MoveToPreviousWord(COORD& pos, std::wstring_view wordDelimiters
 // - pos - a COORD on the word you are currently on
 // Return Value:
 // - pos - The COORD for the first cell of the current glyph (inclusive)
-const til::point TextBuffer::GetGlyphStart(const til::point pos) const
+const til::point TextBuffer::GetGlyphStart(const til::point pos, std::optional<til::point> limitOptional) const
 {
     COORD resultPos = pos;
     const auto bufferSize = GetSize();
+    const auto limit{ limitOptional ? *limitOptional : bufferSize.EndInclusive() };
 
-    if (resultPos == bufferSize.EndExclusive())
+    // Clamp pos to limit
+    if (bufferSize.CompareInBounds(resultPos, limit, true) > 0)
     {
-        bufferSize.DecrementInBounds(resultPos, true);
+        resultPos = limit;
     }
 
-    if (resultPos != bufferSize.EndExclusive() && GetCellDataAt(resultPos)->DbcsAttr().IsTrailing())
+    if (resultPos != limit && GetCellDataAt(resultPos)->DbcsAttr().IsTrailing())
     {
         bufferSize.DecrementInBounds(resultPos, true);
     }
@@ -1436,12 +1443,19 @@ const til::point TextBuffer::GetGlyphStart(const til::point pos) const
 // - pos - a COORD on the word you are currently on
 // Return Value:
 // - pos - The COORD for the last cell of the current glyph (exclusive)
-const til::point TextBuffer::GetGlyphEnd(const til::point pos) const
+const til::point TextBuffer::GetGlyphEnd(const til::point pos, std::optional<til::point> limitOptional) const
 {
     COORD resultPos = pos;
-
     const auto bufferSize = GetSize();
-    if (resultPos != bufferSize.EndExclusive() && GetCellDataAt(resultPos)->DbcsAttr().IsLeading())
+    const auto limit{ limitOptional ? *limitOptional : bufferSize.EndInclusive() };
+
+    // Clamp pos to limit
+    if (bufferSize.CompareInBounds(resultPos, limit, true) > 0)
+    {
+        resultPos = limit;
+    }
+
+    if (resultPos != limit && GetCellDataAt(resultPos)->DbcsAttr().IsLeading())
     {
         bufferSize.IncrementInBounds(resultPos, true);
     }
@@ -1456,17 +1470,26 @@ const til::point TextBuffer::GetGlyphEnd(const til::point pos) const
 // Arguments:
 // - pos - a COORD on the word you are currently on
 // - allowBottomExclusive - allow the nonexistent end-of-buffer cell to be encountered
+// - limit - boundaries for the iterator to operate within
 // Return Value:
 // - true, if successfully updated pos. False, if we are unable to move (usually due to a buffer boundary)
 // - pos - The COORD for the first cell of the current glyph (inclusive)
-bool TextBuffer::MoveToNextGlyph(til::point& pos, bool allowBottomExclusive) const
+bool TextBuffer::MoveToNextGlyph(til::point& pos, bool allowBottomExclusive, std::optional<til::point> limitOptional) const
 {
     COORD resultPos = pos;
     const auto bufferSize = GetSize();
+    const auto limit{ limitOptional ? *limitOptional : bufferSize.EndInclusive() };
 
-    if (resultPos == GetSize().EndExclusive())
+    if (bufferSize.CompareInBounds(pos, limit, allowBottomExclusive) >= 0)
     {
-        // we're already at the end
+        // we're already at/past the end
+        // clamp us to the limit
+        resultPos = limit;
+        if (allowBottomExclusive)
+        {
+            bufferSize.IncrementInBounds(resultPos, allowBottomExclusive);
+        }
+        pos = resultPos;
         return false;
     }
 
@@ -1488,12 +1511,21 @@ bool TextBuffer::MoveToNextGlyph(til::point& pos, bool allowBottomExclusive) con
 // Return Value:
 // - true, if successfully updated pos. False, if we are unable to move (usually due to a buffer boundary)
 // - pos - The COORD for the first cell of the previous glyph (inclusive)
-bool TextBuffer::MoveToPreviousGlyph(til::point& pos) const
+bool TextBuffer::MoveToPreviousGlyph(til::point& pos, std::optional<til::point> limitOptional) const
 {
     COORD resultPos = pos;
+    const auto bufferSize = GetSize();
+    const auto limit{ limitOptional ? *limitOptional : bufferSize.EndInclusive() };
+
+    if (bufferSize.CompareInBounds(pos, limit, true) > 0)
+    {
+        // we're past the end
+        // clamp us to the limit
+        pos = limit;
+        return true;
+    }
 
     // try to move. If we can't, we're done.
-    const auto bufferSize = GetSize();
     const bool success = bufferSize.DecrementInBounds(resultPos, true);
     if (resultPos != bufferSize.EndExclusive() && GetCellDataAt(resultPos)->DbcsAttr().IsLeading())
     {

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -149,13 +149,13 @@ TextBufferTextIterator TextBuffer::GetTextLineDataAt(const COORD at) const
 // - Read-only iterator of cell data.
 TextBufferCellIterator TextBuffer::GetCellLineDataAt(const COORD at) const
 {
-    SMALL_RECT limit;
-    limit.Top = at.Y;
-    limit.Bottom = at.Y;
-    limit.Left = 0;
-    limit.Right = GetSize().RightInclusive();
+    SMALL_RECT bounds;
+    bounds.Top = at.Y;
+    bounds.Bottom = at.Y;
+    bounds.Left = 0;
+    bounds.Right = GetSize().RightInclusive();
 
-    return TextBufferCellIterator(*this, at, Viewport::FromInclusive(limit));
+    return TextBufferCellIterator(*this, at, Viewport::FromInclusive(bounds));
 }
 
 // Routine Description:
@@ -163,12 +163,12 @@ TextBufferCellIterator TextBuffer::GetCellLineDataAt(const COORD at) const
 //   but restricted to operate only inside the given viewport.
 // Arguments:
 // - at - X,Y position in buffer for iterator start position
-// - limit - boundaries for the iterator to operate within
+// - bounds - boundaries for the iterator to operate within
 // Return Value:
 // - Read-only iterator of text data only.
-TextBufferTextIterator TextBuffer::GetTextDataAt(const COORD at, const Viewport limit) const
+TextBufferTextIterator TextBuffer::GetTextDataAt(const COORD at, const Viewport bounds) const
 {
-    return TextBufferTextIterator(GetCellDataAt(at, limit));
+    return TextBufferTextIterator(GetCellDataAt(at, bounds));
 }
 
 // Routine Description:
@@ -176,12 +176,12 @@ TextBufferTextIterator TextBuffer::GetTextDataAt(const COORD at, const Viewport 
 //   but restricted to operate only inside the given viewport.
 // Arguments:
 // - at - X,Y position in buffer for iterator start position
-// - limit - boundaries for the iterator to operate within
+// - bounds - boundaries for the iterator to operate within
 // Return Value:
 // - Read-only iterator of cell data.
-TextBufferCellIterator TextBuffer::GetCellDataAt(const COORD at, const Viewport limit) const
+TextBufferCellIterator TextBuffer::GetCellDataAt(const COORD at, const Viewport bounds) const
 {
-    return TextBufferCellIterator(*this, at, limit);
+    return TextBufferCellIterator(*this, at, bounds);
 }
 
 // Routine Description:
@@ -189,13 +189,15 @@ TextBufferCellIterator TextBuffer::GetCellDataAt(const COORD at, const Viewport 
 //   but restricted to operate only inside the given viewport.
 // Arguments:
 // - at - X,Y position in buffer for iterator start position
-// - limit - boundaries for the iterator to operate within
-// - until - X,Y position in buffer for last position for the iterator to read (inclusive)
+// - bounds - viewport boundaries for the iterator to operate within.
+//            Allows for us to iterate over a sub-grid of the buffer.
+// - limit - X,Y position in buffer for the iterator end position (inclusive).
+//           Allows for us to iterate through "bounds" until we hit the end of "bounds" or the limit.
 // Return Value:
 // - Read-only iterator of cell data.
-TextBufferCellIterator TextBuffer::GetCellDataAt(const COORD at, const Viewport limit, const COORD until) const
+TextBufferCellIterator TextBuffer::GetCellDataAt(const COORD at, const Viewport bounds, const COORD limit) const
 {
-    return TextBufferCellIterator(*this, at, limit, until);
+    return TextBufferCellIterator(*this, at, bounds, limit);
 }
 
 //Routine Description:

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -81,6 +81,7 @@ public:
     TextBufferCellIterator GetCellDataAt(const COORD at) const;
     TextBufferCellIterator GetCellLineDataAt(const COORD at) const;
     TextBufferCellIterator GetCellDataAt(const COORD at, const Microsoft::Console::Types::Viewport limit) const;
+    TextBufferCellIterator GetCellDataAt(const COORD at, const Microsoft::Console::Types::Viewport limit, const COORD until) const;
     TextBufferTextIterator GetTextDataAt(const COORD at) const;
     TextBufferTextIterator GetTextLineDataAt(const COORD at) const;
     TextBufferTextIterator GetTextDataAt(const COORD at, const Microsoft::Console::Types::Viewport limit) const;

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -142,15 +142,15 @@ public:
 
     Microsoft::Console::Render::IRenderTarget& GetRenderTarget() noexcept;
 
-    const COORD GetWordStart(const COORD target, const std::wstring_view wordDelimiters, bool accessibilityMode = false) const;
-    const COORD GetWordEnd(const COORD target, const std::wstring_view wordDelimiters, bool accessibilityMode = false) const;
-    bool MoveToNextWord(COORD& pos, const std::wstring_view wordDelimiters, COORD lastCharPos) const;
+    const COORD GetWordStart(const COORD target, const std::wstring_view wordDelimiters, bool accessibilityMode = false, std::optional<til::point> limitOptional = std::nullopt) const;
+    const COORD GetWordEnd(const COORD target, const std::wstring_view wordDelimiters, bool accessibilityMode = false, std::optional<til::point> limitOptional = std::nullopt) const;
+    bool MoveToNextWord(COORD& pos, const std::wstring_view wordDelimiters, std::optional<til::point> limitOptional = std::nullopt) const;
     bool MoveToPreviousWord(COORD& pos, const std::wstring_view wordDelimiters) const;
 
-    const til::point GetGlyphStart(const til::point pos) const;
-    const til::point GetGlyphEnd(const til::point pos) const;
-    bool MoveToNextGlyph(til::point& pos, bool allowBottomExclusive = false) const;
-    bool MoveToPreviousGlyph(til::point& pos) const;
+    const til::point GetGlyphStart(const til::point pos, std::optional<til::point> limitOptional = std::nullopt) const;
+    const til::point GetGlyphEnd(const til::point pos, std::optional<til::point> limitOptional = std::nullopt) const;
+    bool MoveToNextGlyph(til::point& pos, bool allowBottomExclusive = false, std::optional<til::point> limitOptional = std::nullopt) const;
+    bool MoveToPreviousGlyph(til::point& pos, std::optional<til::point> limitOptional = std::nullopt) const;
 
     const std::vector<SMALL_RECT> GetTextRects(COORD start, COORD end, bool blockSelection, bool bufferCoordinates) const;
 

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -80,11 +80,11 @@ public:
 
     TextBufferCellIterator GetCellDataAt(const COORD at) const;
     TextBufferCellIterator GetCellLineDataAt(const COORD at) const;
-    TextBufferCellIterator GetCellDataAt(const COORD at, const Microsoft::Console::Types::Viewport limit) const;
-    TextBufferCellIterator GetCellDataAt(const COORD at, const Microsoft::Console::Types::Viewport limit, const COORD until) const;
+    TextBufferCellIterator GetCellDataAt(const COORD at, const Microsoft::Console::Types::Viewport bounds) const;
+    TextBufferCellIterator GetCellDataAt(const COORD at, const Microsoft::Console::Types::Viewport bounds, const COORD limit) const;
     TextBufferTextIterator GetTextDataAt(const COORD at) const;
     TextBufferTextIterator GetTextLineDataAt(const COORD at) const;
-    TextBufferTextIterator GetTextDataAt(const COORD at, const Microsoft::Console::Types::Viewport limit) const;
+    TextBufferTextIterator GetTextDataAt(const COORD at, const Microsoft::Console::Types::Viewport bounds) const;
 
     // Text insertion functions
     OutputCellIterator Write(const OutputCellIterator givenIt);

--- a/src/buffer/out/textBufferCellIterator.hpp
+++ b/src/buffer/out/textBufferCellIterator.hpp
@@ -27,6 +27,7 @@ class TextBufferCellIterator
 public:
     TextBufferCellIterator(const TextBuffer& buffer, COORD pos);
     TextBufferCellIterator(const TextBuffer& buffer, COORD pos, const Microsoft::Console::Types::Viewport limits);
+    TextBufferCellIterator(const TextBuffer& buffer, COORD pos, const Microsoft::Console::Types::Viewport limits, const COORD endPosInclusive);
 
     operator bool() const noexcept;
 
@@ -47,6 +48,8 @@ public:
     const OutputCellView& operator*() const noexcept;
     const OutputCellView* operator->() const noexcept;
 
+    COORD Pos() const noexcept;
+
 protected:
     void _SetPos(const COORD newPos);
     void _GenerateView();
@@ -60,6 +63,7 @@ protected:
     const Microsoft::Console::Types::Viewport _bounds;
     bool _exceeded;
     COORD _pos;
+    std::optional<COORD> _endPosInclusive;
 
 #if UNIT_TESTING
     friend class TextBufferIteratorTests;

--- a/src/buffer/out/textBufferCellIterator.hpp
+++ b/src/buffer/out/textBufferCellIterator.hpp
@@ -26,8 +26,8 @@ class TextBufferCellIterator
 {
 public:
     TextBufferCellIterator(const TextBuffer& buffer, COORD pos);
-    TextBufferCellIterator(const TextBuffer& buffer, COORD pos, const Microsoft::Console::Types::Viewport limits);
-    TextBufferCellIterator(const TextBuffer& buffer, COORD pos, const Microsoft::Console::Types::Viewport limits, const COORD endPosInclusive);
+    TextBufferCellIterator(const TextBuffer& buffer, COORD pos, const Microsoft::Console::Types::Viewport bounds);
+    TextBufferCellIterator(const TextBuffer& buffer, COORD pos, const Microsoft::Console::Types::Viewport bounds, const COORD limit);
 
     operator bool() const noexcept;
 
@@ -63,7 +63,7 @@ protected:
     const Microsoft::Console::Types::Viewport _bounds;
     bool _exceeded;
     COORD _pos;
-    std::optional<COORD> _endPosInclusive;
+    std::optional<COORD> _limit;
 
 #if UNIT_TESTING
     friend class TextBufferIteratorTests;

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -592,6 +592,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         const int newDpi = static_cast<int>(static_cast<double>(USER_DEFAULT_SCREEN_DPI) *
                                             _compositionScale);
 
+        _terminal->SetFontInfo(_actualFont);
+
         // TODO: MSFT:20895307 If the font doesn't exist, this doesn't
         //      actually fail. We need a way to gracefully fallback.
         _renderer->TriggerFontChange(newDpi, _desiredFont, _actualFont);

--- a/src/cascadia/TerminalControl/XamlUiaTextRange.cpp
+++ b/src/cascadia/TerminalControl/XamlUiaTextRange.cpp
@@ -5,6 +5,7 @@
 #include "XamlUiaTextRange.h"
 #include "../types/TermControlUiaTextRange.hpp"
 #include <UIAutomationClient.h>
+#include <UIAutomationCoreApi.h>
 
 // the same as COR_E_NOTSUPPORTED
 // we don't want to import the CLR headers to get it
@@ -89,12 +90,56 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     winrt::Windows::Foundation::IInspectable XamlUiaTextRange::GetAttributeValue(int32_t textAttributeId) const
     {
-        // Copied functionality from Types::UiaTextRange.cpp
-        if (textAttributeId == UIA_IsReadOnlyAttributeId)
+        // Call the function off of the underlying UiaTextRange.
+        VARIANT result;
+        THROW_IF_FAILED(_uiaProvider->GetAttributeValue(textAttributeId, &result));
+
+        // Convert the resulting VARIANT into a format that is consumable by XAML.
+        switch (result.vt)
         {
-            return winrt::box_value(false);
+        case VT_BSTR:
+        {
+            return box_value(result.bstrVal);
         }
-        else
+        case VT_I4:
+        {
+            return box_value(result.iVal);
+        }
+        case VT_R8:
+        {
+            return box_value(result.dblVal);
+        }
+        case VT_BOOL:
+        {
+            return box_value(result.boolVal);
+        }
+        case VT_UNKNOWN:
+        {
+            // This one is particularly special.
+            // We might return a special value like UiaGetReservedMixedAttributeValue
+            //  or UiaGetReservedNotSupportedValue.
+            // Some text attributes may return a real value, however, none of those
+            //  are supported at this time.
+            // So we need to figure out what was actually intended to be returned.
+
+            IUnknown* notSupportedVal;
+            UiaGetReservedNotSupportedValue(&notSupportedVal);
+            if (result.punkVal == notSupportedVal)
+            {
+                // See below for why we need to throw this special value.
+                winrt::throw_hresult(XAML_E_NOT_SUPPORTED);
+            }
+
+            IUnknown* mixedAttributeVal;
+            UiaGetReservedMixedAttributeValue(&mixedAttributeVal);
+            if (result.punkVal == mixedAttributeVal)
+            {
+                return Windows::UI::Xaml::DependencyProperty::UnsetValue();
+            }
+
+            __fallthrough;
+        }
+        default:
         {
             // We _need_ to return XAML_E_NOT_SUPPORTED here.
             // Returning nullptr is an improper implementation of it being unsupported.
@@ -102,6 +147,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             // Anything else will result in the UIA Client refusing to read when navigating by word
             // Magically, this doesn't affect other forms of navigation...
             winrt::throw_hresult(XAML_E_NOT_SUPPORTED);
+        }
         }
     }
 

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -68,6 +68,7 @@ public:
 
     void UpdateSettings(winrt::Microsoft::Terminal::Core::ICoreSettings settings);
     void UpdateAppearance(const winrt::Microsoft::Terminal::Core::ICoreAppearance& appearance);
+    void SetFontInfo(const FontInfo& fontInfo);
 
     // Write goes through the parser
     void Write(std::wstring_view stringView);
@@ -160,6 +161,7 @@ public:
     COORD GetTextBufferEndPosition() const noexcept override;
     const TextBuffer& GetTextBuffer() noexcept override;
     const FontInfo& GetFontInfo() noexcept override;
+    std::pair<COLORREF, COLORREF> GetAttributeColors(const TextAttribute& attr) const noexcept override;
 
     void LockConsole() noexcept override;
     void UnlockConsole() noexcept override;
@@ -168,7 +170,6 @@ public:
 #pragma region IRenderData
     // These methods are defined in TerminalRenderData.cpp
     const TextAttribute GetDefaultBrushColors() noexcept override;
-    std::pair<COLORREF, COLORREF> GetAttributeColors(const TextAttribute& attr) const noexcept override;
     COORD GetCursorPosition() const noexcept override;
     bool IsCursorVisible() const noexcept override;
     bool IsCursorOn() const noexcept override;
@@ -276,6 +277,7 @@ private:
     size_t _hyperlinkPatternId;
 
     std::wstring _workingDirectory;
+    std::optional<FontInfo> _fontInfo;
 #pragma region Text Selection
     // a selection is represented as a range between two COORDs (start and end)
     // the pivot is the COORD that remains selected when you extend a selection in any direction

--- a/src/cascadia/TerminalCore/terminalrenderdata.cpp
+++ b/src/cascadia/TerminalCore/terminalrenderdata.cpp
@@ -34,6 +34,11 @@ const TextBuffer& Terminal::GetTextBuffer() noexcept
 #pragma warning(disable : 26447)
 const FontInfo& Terminal::GetFontInfo() noexcept
 {
+    if (_fontInfo)
+    {
+        return *_fontInfo;
+    }
+
     // TODO: This font value is only used to check if the font is a raster font.
     // Otherwise, the font is changed with the renderer via TriggerFontChange.
     // The renderer never uses any of the other members from the value returned
@@ -44,6 +49,11 @@ const FontInfo& Terminal::GetFontInfo() noexcept
     return _fakeFontInfo;
 }
 #pragma warning(pop)
+
+void Terminal::SetFontInfo(const FontInfo& fontInfo)
+{
+    _fontInfo = fontInfo;
+}
 
 const TextAttribute Terminal::GetDefaultBrushColors() noexcept
 {

--- a/src/host/renderData.hpp
+++ b/src/host/renderData.hpp
@@ -27,6 +27,7 @@ public:
     COORD GetTextBufferEndPosition() const noexcept override;
     const TextBuffer& GetTextBuffer() noexcept override;
     const FontInfo& GetFontInfo() noexcept override;
+    std::pair<COLORREF, COLORREF> GetAttributeColors(const TextAttribute& attr) const noexcept override;
 
     std::vector<Microsoft::Console::Types::Viewport> GetSelectionRects() noexcept override;
 
@@ -36,8 +37,6 @@ public:
 
 #pragma region IRenderData
     const TextAttribute GetDefaultBrushColors() noexcept override;
-
-    std::pair<COLORREF, COLORREF> GetAttributeColors(const TextAttribute& attr) const noexcept override;
 
     COORD GetCursorPosition() const noexcept override;
     bool IsCursorVisible() const noexcept override;

--- a/src/interactivity/win32/ut_interactivity_win32/UiaTextRangeTests.cpp
+++ b/src/interactivity/win32/ut_interactivity_win32/UiaTextRangeTests.cpp
@@ -9,6 +9,7 @@
 #include "uiaTextRange.hpp"
 #include "../types/ScreenInfoUiaProviderBase.h"
 #include "../../../buffer/out/textBuffer.hpp"
+#include "../types/UiaTracing.h"
 
 using namespace WEX::Common;
 using namespace WEX::Logging;
@@ -130,6 +131,20 @@ class UiaTextRangeTests
     {
         std::wstring comment;
         short yPos;
+    };
+
+    enum SupportedTextAttributes
+    {
+        FontName = UIA_FontNameAttributeId, // special handling
+        FontSize = UIA_FontSizeAttributeId, // special handling
+        FontWeight = UIA_FontWeightAttributeId,
+        ForegroundColor = UIA_ForegroundColorAttributeId,
+        Italic = UIA_IsItalicAttributeId,
+        IsReadOnly = UIA_IsReadOnlyAttributeId, // special handling (always false)
+        StrikethroughColor = UIA_StrikethroughColorAttributeId,
+        StrikethroughStyle = UIA_StrikethroughStyleAttributeId,
+        UnderlineColor = UIA_UnderlineColorAttributeId,
+        UnderlineStyle = UIA_UnderlineStyleAttributeId
     };
 
     static constexpr wchar_t* toString(TextUnit unit) noexcept
@@ -1344,6 +1359,314 @@ class UiaTextRangeTests
             const til::point pos{ bufferSize.Left(), test.yPos };
             THROW_IF_FAILED(Microsoft::WRL::MakeAndInitialize<UiaTextRange>(&utr, _pUiaData, &_dummyProvider, pos, pos));
             VERIFY_SUCCEEDED(utr->ScrollIntoView(alignToTop));
+        }
+    }
+
+    TEST_METHOD(GetAttributeValue)
+    {
+        Log::Comment(L"Check supported attributes");
+        IUnknown* notSupportedVal;
+        UiaGetReservedNotSupportedValue(&notSupportedVal);
+        for (long uiaAttributeId = 40000; uiaAttributeId <= 40042; ++uiaAttributeId)
+        {
+            Microsoft::WRL::ComPtr<UiaTextRange> utr;
+            THROW_IF_FAILED(Microsoft::WRL::MakeAndInitialize<UiaTextRange>(&utr, _pUiaData, &_dummyProvider));
+
+            Log::Comment(UiaTracing::convertAttributeId(uiaAttributeId).c_str());
+            VARIANT result;
+            VERIFY_SUCCEEDED(utr->GetAttributeValue(uiaAttributeId, &result));
+
+            switch (uiaAttributeId)
+            {
+            case FontName:
+            {
+                VERIFY_ARE_EQUAL(VT_BSTR, result.vt);
+                break;
+            }
+            case FontSize:
+            {
+                VERIFY_ARE_EQUAL(VT_R8, result.vt);
+                break;
+            }
+            case FontWeight:
+            case ForegroundColor:
+            case StrikethroughColor:
+            case StrikethroughStyle:
+            case UnderlineColor:
+            case UnderlineStyle:
+            {
+                VERIFY_ARE_EQUAL(VT_I4, result.vt);
+                break;
+            }
+            case Italic:
+            case IsReadOnly:
+            {
+                VERIFY_ARE_EQUAL(VT_BOOL, result.vt);
+                break;
+            }
+            default:
+            {
+                // Expected: not supported
+                VERIFY_ARE_EQUAL(VT_UNKNOWN, result.vt);
+                VERIFY_ARE_EQUAL(notSupportedVal, result.punkVal);
+                break;
+            }
+            }
+        }
+
+        // This is the text attribute we'll use to update the text buffer.
+        // We'll modify it, then test if the UiaTextRange can extract/interpret the data properly.
+        // updateBuffer() will write that text attribute to the first cell in the buffer.
+        TextAttribute attr;
+        auto updateBuffer = [&](TextAttribute outputAttr) {
+            _pTextBuffer->Write({ outputAttr }, { 0, 0 });
+        };
+
+        Microsoft::WRL::ComPtr<UiaTextRange> utr;
+        THROW_IF_FAILED(Microsoft::WRL::MakeAndInitialize<UiaTextRange>(&utr, _pUiaData, &_dummyProvider));
+        {
+            Log::Comment(L"Test Font Weight");
+            attr.SetBold(true);
+            updateBuffer(attr);
+            VARIANT result;
+            VERIFY_SUCCEEDED(utr->GetAttributeValue(FontWeight, &result));
+            VERIFY_ARE_EQUAL(FW_BOLD, result.iVal);
+
+            attr.SetBold(false);
+            updateBuffer(attr);
+            VERIFY_SUCCEEDED(utr->GetAttributeValue(FontWeight, &result));
+            VERIFY_ARE_EQUAL(FW_NORMAL, result.iVal);
+
+            attr.SetFaint(true);
+            updateBuffer(attr);
+            VERIFY_SUCCEEDED(utr->GetAttributeValue(FontWeight, &result));
+            VERIFY_ARE_EQUAL(FW_LIGHT, result.iVal);
+
+            attr.SetFaint(false);
+            updateBuffer(attr);
+            VERIFY_SUCCEEDED(utr->GetAttributeValue(FontWeight, &result));
+            VERIFY_ARE_EQUAL(FW_NORMAL, result.iVal);
+        }
+        {
+            Log::Comment(L"Test Foreground");
+            const auto foregroundColor{ RGB(255, 0, 0) };
+            attr.SetForeground(foregroundColor);
+            updateBuffer(attr);
+            VARIANT result;
+            VERIFY_SUCCEEDED(utr->GetAttributeValue(ForegroundColor, &result));
+            VERIFY_ARE_EQUAL(foregroundColor, static_cast<COLORREF>(result.iVal));
+        }
+        {
+            Log::Comment(L"Test Italic");
+            attr.SetItalic(true);
+            updateBuffer(attr);
+            VARIANT result;
+            VERIFY_SUCCEEDED(utr->GetAttributeValue(Italic, &result));
+            VERIFY_IS_TRUE(result.boolVal);
+
+            attr.SetItalic(false);
+            updateBuffer(attr);
+            VERIFY_SUCCEEDED(utr->GetAttributeValue(Italic, &result));
+            VERIFY_IS_FALSE(result.boolVal);
+        }
+        {
+            Log::Comment(L"Test Strikethrough");
+            const auto foregroundColor{ attr.GetForeground().GetRGB() };
+            attr.SetCrossedOut(true);
+            updateBuffer(attr);
+            VARIANT result;
+            VERIFY_SUCCEEDED(utr->GetAttributeValue(StrikethroughColor, &result));
+            VERIFY_ARE_EQUAL(foregroundColor, static_cast<COLORREF>(result.iVal));
+            VERIFY_SUCCEEDED(utr->GetAttributeValue(StrikethroughStyle, &result));
+            VERIFY_ARE_EQUAL(TextDecorationLineStyle_Single, result.iVal);
+
+            attr.SetCrossedOut(false);
+            updateBuffer(attr);
+            VERIFY_SUCCEEDED(utr->GetAttributeValue(StrikethroughColor, &result));
+            VERIFY_ARE_EQUAL(0, result.iVal);
+            VERIFY_SUCCEEDED(utr->GetAttributeValue(StrikethroughStyle, &result));
+            VERIFY_ARE_EQUAL(TextDecorationLineStyle_None, result.iVal);
+        }
+        {
+            Log::Comment(L"Test Underline");
+            const auto foregroundColor{ attr.GetForeground().GetRGB() };
+            attr.SetUnderlined(true);
+            updateBuffer(attr);
+            VARIANT result;
+            VERIFY_SUCCEEDED(utr->GetAttributeValue(UnderlineColor, &result));
+            VERIFY_ARE_EQUAL(foregroundColor, static_cast<COLORREF>(result.iVal));
+            VERIFY_SUCCEEDED(utr->GetAttributeValue(UnderlineStyle, &result));
+            VERIFY_ARE_EQUAL(TextDecorationLineStyle_Single, result.iVal);
+
+            attr.SetUnderlined(false);
+            updateBuffer(attr);
+            VERIFY_SUCCEEDED(utr->GetAttributeValue(UnderlineColor, &result));
+            VERIFY_ARE_EQUAL(0, result.iVal);
+            VERIFY_SUCCEEDED(utr->GetAttributeValue(UnderlineStyle, &result));
+            VERIFY_ARE_EQUAL(TextDecorationLineStyle_None, result.iVal);
+        }
+        {
+            Log::Comment(L"Test Font Name (special)");
+            VARIANT result;
+            VERIFY_SUCCEEDED(utr->GetAttributeValue(FontName, &result));
+            const std::wstring actualFontName{ result.bstrVal };
+            const auto expectedFontName{ _pUiaData->GetFontInfo().GetFaceName() };
+            VERIFY_ARE_EQUAL(expectedFontName, actualFontName);
+        }
+        {
+            Log::Comment(L"Test Font Size (special)");
+            VARIANT result;
+            VERIFY_SUCCEEDED(utr->GetAttributeValue(FontSize, &result));
+            const auto actualFontSize{ result.dblVal };
+            const auto expectedFontSize{ 0 }; //_pUiaData->GetFontInfo().GetUnscaledSize() };
+            VERIFY_ARE_EQUAL(expectedFontSize, actualFontSize);
+
+            // TODO CARLOS: Fix this test when we actually know how to convert the font size into points
+            VERIFY_IS_TRUE(false);
+        }
+        {
+            Log::Comment(L"Test Read Only (special)");
+            VARIANT result;
+            VERIFY_SUCCEEDED(utr->GetAttributeValue(IsReadOnly, &result));
+            VERIFY_IS_FALSE(result.boolVal);
+        }
+    }
+
+    TEST_METHOD(FindAttribute)
+    {
+        Microsoft::WRL::ComPtr<UiaTextRange> utr;
+        const COORD startPos{ 0, 0 };
+        const COORD endPos{ 0, 2 };
+        THROW_IF_FAILED(Microsoft::WRL::MakeAndInitialize<UiaTextRange>(&utr, _pUiaData, &_dummyProvider, startPos, endPos));
+        {
+            Log::Comment(L"Test Font Name (special)");
+
+            // Populate query with font name currently in use.
+            const auto fontName{ _pUiaData->GetFontInfo().GetFaceName() };
+            VARIANT var{};
+            var.vt = VT_BSTR;
+            var.bstrVal = SysAllocString(fontName.data());
+
+            Microsoft::WRL::ComPtr<ITextRangeProvider> result;
+            VERIFY_SUCCEEDED(utr->FindAttribute(FontName, var, false, result.GetAddressOf()));
+
+            // Expecting the same text range endpoints
+            BOOL isEqual;
+            THROW_IF_FAILED(utr->Compare(result.Get(), &isEqual));
+            VERIFY_IS_TRUE(isEqual);
+
+            // Now perform the same test, but searching backwards
+            Log::Comment(L"Test Font Name (special) - Backwards");
+            Microsoft::WRL::ComPtr<ITextRangeProvider> resultBackwards;
+            VERIFY_SUCCEEDED(utr->FindAttribute(FontName, var, true, resultBackwards.GetAddressOf()));
+
+            // Expecting the same text range endpoints
+            THROW_IF_FAILED(result->Compare(resultBackwards.Get(), &isEqual));
+            VERIFY_IS_TRUE(isEqual);
+        }
+        {
+            Log::Comment(L"Test Font Size (special)");
+
+            // Populate query with font size currently in use.
+            const auto fontSize{ 0.0 }; //{ _pUiaData->GetFontInfo().GetUnscaledSize() };
+            VARIANT var{};
+            var.vt = VT_R8;
+            var.dblVal = 0;
+
+            Microsoft::WRL::ComPtr<ITextRangeProvider> result;
+            VERIFY_SUCCEEDED(utr->FindAttribute(FontSize, var, false, result.GetAddressOf()));
+
+            // Expecting the same text range endpoints
+            BOOL isEqual;
+            THROW_IF_FAILED(utr->Compare(result.Get(), &isEqual));
+            VERIFY_IS_TRUE(isEqual);
+
+            // Now perform the same test, but searching backwards
+            Log::Comment(L"Test Font Size (special) - Backwards");
+            Microsoft::WRL::ComPtr<ITextRangeProvider> resultBackwards;
+            VERIFY_SUCCEEDED(utr->FindAttribute(FontSize, var, true, resultBackwards.GetAddressOf()));
+
+            // Expecting the same text range endpoints
+            THROW_IF_FAILED(result->Compare(resultBackwards.Get(), &isEqual));
+            VERIFY_IS_TRUE(isEqual);
+
+            // TODO CARLOS: Fix this test when we actually know how to convert the font size into points
+            VERIFY_IS_TRUE(false);
+        }
+        {
+            Log::Comment(L"Test Read Only (special)");
+
+            VARIANT var{};
+            var.vt = VT_BOOL;
+            var.boolVal = false;
+
+            Microsoft::WRL::ComPtr<ITextRangeProvider> result;
+            VERIFY_SUCCEEDED(utr->FindAttribute(IsReadOnly, var, false, result.GetAddressOf()));
+
+            // Expecting the same text range endpoints
+            BOOL isEqual;
+            THROW_IF_FAILED(utr->Compare(result.Get(), &isEqual));
+            VERIFY_IS_TRUE(isEqual);
+
+            // Now perform the same test, but searching backwards
+            Log::Comment(L"Test Read Only (special) - Backwards");
+            Microsoft::WRL::ComPtr<ITextRangeProvider> resultBackwards;
+            VERIFY_SUCCEEDED(utr->FindAttribute(IsReadOnly, var, true, resultBackwards.GetAddressOf()));
+
+            // Expecting the same text range endpoints
+            THROW_IF_FAILED(result->Compare(resultBackwards.Get(), &isEqual));
+            VERIFY_IS_TRUE(isEqual);
+        }
+        {
+            Log::Comment(L"Test IsItalic (standard attribute)");
+
+            // Since all of the other attributes operate very similarly,
+            //  we're just going to pick one of them and test that.
+            // The "GetAttribute" tests provide code coverage for
+            //  retrieving an attribute verification function.
+            // This test is intended to provide code coverage for
+            //  finding a text range with the desired attribute.
+
+            // Set up the buffer's attributes.
+            TextAttribute italicAttr;
+            italicAttr.SetItalic(true);
+            auto iter{ _pUiaData->GetTextBuffer().GetCellDataAt(startPos) };
+            for (auto i = 0; i < 5; ++i)
+            {
+                _pTextBuffer->Write({ italicAttr }, iter.Pos());
+                ++iter;
+            }
+
+            // set the expected end (exclusive)
+            auto expectedEndPos{ iter.Pos() };
+            _pUiaData->GetTextBuffer().GetSize().IncrementInBounds(expectedEndPos);
+
+            VARIANT var{};
+            var.vt = VT_BOOL;
+            var.boolVal = true;
+
+            Microsoft::WRL::ComPtr<ITextRangeProvider> result;
+            VERIFY_SUCCEEDED(utr->FindAttribute(Italic, var, false, result.GetAddressOf()));
+
+            // TODO CARLOS: The "end" verification is failing. Here's a trace of what's going on:
+            // - UiaTextRangeBase:
+            //   - checkIfAttrFound is properly set and used
+            //   - the search loop properly sets the "start"
+            //   - the search loop iterates through the entire utr because checkIfAttrFound
+            //      continues to return true for the whole range
+            // I have no clue why this is happening. A fresh pair of eyes would be appreciated here :)
+            VERIFY_ARE_EQUAL(startPos, utr->_start);
+            VERIFY_ARE_EQUAL(expectedEndPos, utr->_end);
+
+            // Now perform the same test, but searching backwards
+            Log::Comment(L"Test IsItalic (standard attribute) - Backwards");
+            Microsoft::WRL::ComPtr<ITextRangeProvider> resultBackwards;
+            VERIFY_SUCCEEDED(utr->FindAttribute(Italic, var, true, resultBackwards.GetAddressOf()));
+
+            // Expecting the same text range endpoints
+            BOOL isEqual;
+            THROW_IF_FAILED(result->Compare(resultBackwards.Get(), &isEqual));
+            VERIFY_IS_TRUE(isEqual);
         }
     }
 };

--- a/src/renderer/inc/IRenderData.hpp
+++ b/src/renderer/inc/IRenderData.hpp
@@ -48,8 +48,6 @@ namespace Microsoft::Console::Render
 
         virtual const TextAttribute GetDefaultBrushColors() noexcept = 0;
 
-        virtual std::pair<COLORREF, COLORREF> GetAttributeColors(const TextAttribute& attr) const noexcept = 0;
-
         virtual COORD GetCursorPosition() const noexcept = 0;
         virtual bool IsCursorVisible() const noexcept = 0;
         virtual bool IsCursorOn() const noexcept = 0;

--- a/src/types/IBaseData.h
+++ b/src/types/IBaseData.h
@@ -37,6 +37,7 @@ namespace Microsoft::Console::Types
         virtual COORD GetTextBufferEndPosition() const noexcept = 0;
         virtual const TextBuffer& GetTextBuffer() noexcept = 0;
         virtual const FontInfo& GetFontInfo() noexcept = 0;
+        virtual std::pair<COLORREF, COLORREF> GetAttributeColors(const TextAttribute& attr) const noexcept = 0;
 
         virtual std::vector<Microsoft::Console::Types::Viewport> GetSelectionRects() noexcept = 0;
 

--- a/src/types/UiaTextRangeBase.hpp
+++ b/src/types/UiaTextRangeBase.hpp
@@ -177,6 +177,11 @@ namespace Microsoft::Console::Types
                                     gsl::not_null<int*> const pAmountMoved,
                                     _In_ const bool preventBufferEnd = false) noexcept;
 
+        std::function<bool(const TextAttribute&)> _getAttrVerificationFn(TEXTATTRIBUTEID attributeId, VARIANT val) const;
+        std::function<bool(const TextAttribute&)> _getAttrVerificationFnForFirstAttr(TEXTATTRIBUTEID attributeId, VARIANT* pRetVal) const;
+
+        COORD _getInclusiveEnd();
+
 #ifdef UNIT_TESTING
         friend class ::UiaTextRangeTests;
 #endif

--- a/src/types/UiaTextRangeBase.hpp
+++ b/src/types/UiaTextRangeBase.hpp
@@ -137,7 +137,7 @@ namespace Microsoft::Console::Types
         // NOTE: _start is inclusive, but _end is exclusive
         COORD _start{};
         COORD _end{};
-        bool _blockRange;
+        bool _blockRange{ false };
 
         // This is used by tracing to extract the text value
         // that the UiaTextRange currently encompasses.
@@ -150,6 +150,7 @@ namespace Microsoft::Console::Types
 
         const unsigned int _getViewportHeight(const SMALL_RECT viewport) const noexcept;
         const Viewport _getBufferSize() const noexcept;
+        const til::point _getDocumentEnd() const noexcept;
 
         void _getBoundingRect(const til::rectangle textRect, _Inout_ std::vector<double>& coords) const;
 

--- a/src/types/UiaTracing.h
+++ b/src/types/UiaTracing.h
@@ -29,6 +29,16 @@ namespace Microsoft::Console::Types
     class UiaTracing final
     {
     public:
+        static std::wstring convertAttributeId(const TEXTATTRIBUTEID attrId) noexcept;
+
+        enum class AttributeType
+        {
+            Standard,
+            Mixed,
+            Unsupported,
+            Error
+        };
+
         class TextRange final
         {
         public:
@@ -37,9 +47,9 @@ namespace Microsoft::Console::Types
             static void Compare(const UiaTextRangeBase& base, const UiaTextRangeBase& other, bool result) noexcept;
             static void CompareEndpoints(const UiaTextRangeBase& base, const TextPatternRangeEndpoint endpoint, const UiaTextRangeBase& other, TextPatternRangeEndpoint otherEndpoint, int result) noexcept;
             static void ExpandToEnclosingUnit(TextUnit unit, const UiaTextRangeBase& result) noexcept;
-            static void FindAttribute(const UiaTextRangeBase& base) noexcept;
+            static void FindAttribute(const UiaTextRangeBase& base, TEXTATTRIBUTEID attributeId, VARIANT val, BOOL searchBackwards, const UiaTextRangeBase& result, AttributeType attrType = AttributeType::Standard) noexcept;
             static void FindText(const UiaTextRangeBase& base, std::wstring text, bool searchBackward, bool ignoreCase, const UiaTextRangeBase& result) noexcept;
-            static void GetAttributeValue(const UiaTextRangeBase& base, TEXTATTRIBUTEID id, VARIANT result) noexcept;
+            static void GetAttributeValue(const UiaTextRangeBase& base, TEXTATTRIBUTEID id, VARIANT result, AttributeType attrType = AttributeType::Standard) noexcept;
             static void GetBoundingRectangles(const UiaTextRangeBase& base) noexcept;
             static void GetEnclosingElement(const UiaTextRangeBase& base) noexcept;
             static void GetText(const UiaTextRangeBase& base, int maxLength, std::wstring result) noexcept;
@@ -100,6 +110,9 @@ namespace Microsoft::Console::Types
         static inline std::wstring _getValue(const UiaTextRangeBase& utr) noexcept;
         static inline std::wstring _getValue(const TextPatternRangeEndpoint endpoint) noexcept;
         static inline std::wstring _getValue(const TextUnit unit) noexcept;
+
+        static inline std::wstring _getValue(const AttributeType attrType) noexcept;
+        static inline std::wstring _getValue(const VARIANT val) noexcept;
 
         // these are used to assign IDs to new UiaTextRanges and ScreenInfoUiaProviders respectively
         static IdType _utrId;

--- a/src/types/inc/viewport.hpp
+++ b/src/types/inc/viewport.hpp
@@ -59,6 +59,7 @@ namespace Microsoft::Console::Types
         COORD Origin() const noexcept;
         COORD BottomRightExclusive() const noexcept;
         COORD EndExclusive() const noexcept;
+        COORD EndInclusive() const noexcept;
         COORD Dimensions() const noexcept;
 
         bool IsInBounds(const Viewport& other) const noexcept;

--- a/src/types/viewport.cpp
+++ b/src/types/viewport.cpp
@@ -161,6 +161,11 @@ COORD Viewport::EndExclusive() const noexcept
     return { Left(), BottomExclusive() };
 }
 
+COORD Viewport::EndInclusive() const noexcept
+{
+    return { RightInclusive(), BottomInclusive() };
+}
+
 // Method Description:
 // - Get a coord representing the dimensions of this viewport.
 // Arguments:


### PR DESCRIPTION
## Summary of the Pull Request
Updates our `UiaTextRange` to treat the last legible character as the end of the buffer. Doing so significantly improves performance of word navigation because screen readers no longer have to take into account the whitespace following the end of the prompt.

This also fixes #7960. This bug was caused by the `UiaTextRange` occasionally having its `_blockRange` member set to `true`. As a result, the screen reader would read the block range of text from "start" to "end" as if it was a block selection created by Alt+Mouse.

## References
#7000 - Epic
Closes #6986 
Closes #7960 

## Detailed Description of the Pull Request / Additional comments
_Coming soon!_

## Validation Steps Performed
- [ ] Tests added/passed
- [x] NVDA - manual testing
- [x] Accessibility Insights - manual testing
- [ ] Narrator - manual testing