### PR TITLE
Add fast lookup path for DxFontInfo

### DIFF
--- a/src/renderer/dx/DxFontInfo.h
+++ b/src/renderer/dx/DxFontInfo.h
@@ -79,30 +79,3 @@ namespace Microsoft::Console::Render
         bool _didFallback;
     };
 }
-
-namespace std
-{
-    template<>
-    struct hash<Microsoft::Console::Render::DxFontInfo>
-    {
-        size_t operator()(const Microsoft::Console::Render::DxFontInfo& fontInfo) const noexcept
-        {
-            const size_t h1 = std::hash<std::wstring_view>{}(fontInfo.GetFamilyName());
-            const size_t h2 = std::hash<DWRITE_FONT_WEIGHT>{}(fontInfo.GetWeight());
-            const size_t h3 = std::hash<DWRITE_FONT_STYLE>{}(fontInfo.GetStyle());
-            const size_t h4 = std::hash<DWRITE_FONT_STRETCH>{}(fontInfo.GetStretch());
-            const size_t h5 = std::hash<bool>{}(fontInfo.GetFallback());
-
-            static const auto combine = [](std::initializer_list<size_t> list) {
-                size_t seed = 0;
-                for (auto hash : list)
-                {
-                    seed ^= hash + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-                }
-                return seed;
-            };
-
-            return combine({ h1, h2, h3, h4, h5 });
-        }
-    };
-}

--- a/src/renderer/dx/DxFontRenderData.cpp
+++ b/src/renderer/dx/DxFontRenderData.cpp
@@ -137,7 +137,7 @@ DxFontRenderData::DxFontRenderData(::Microsoft::WRL::ComPtr<IDWriteFactory1> dwr
         THROW_IF_FAILED(textFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_NEAR));
         THROW_IF_FAILED(textFormat->SetWordWrapping(DWRITE_WORD_WRAPPING_NO_WRAP));
 
-        _textFormatMap.emplace(_ToMapKey(weight, style, stretch), textFormat);
+        _textFormatMap.emplace(_ToMapKey(weight, style, stretch), std::move(textFormat));
         return textFormat;
     }
     else
@@ -161,7 +161,7 @@ DxFontRenderData::DxFontRenderData(::Microsoft::WRL::ComPtr<IDWriteFactory1> dwr
         std::wstring fontLocaleName = UserLocaleName();
         Microsoft::WRL::ComPtr<IDWriteFontFace1> fontFace = fontInfo.ResolveFontFaceWithFallback(_dwriteFactory.Get(), fontLocaleName);
 
-        _fontFaceMap.emplace(_ToMapKey(weight, style, stretch), fontFace);
+        _fontFaceMap.emplace(_ToMapKey(weight, style, stretch), std::move(fontFace));
         return fontFace;
     }
     else

--- a/src/renderer/dx/DxFontRenderData.cpp
+++ b/src/renderer/dx/DxFontRenderData.cpp
@@ -442,11 +442,6 @@ try
 }
 CATCH_RETURN()
 
-DxFontRenderData::MapKey DxFontRenderData::_ToMapKey(DWRITE_FONT_WEIGHT weight, DWRITE_FONT_STYLE style, DWRITE_FONT_STRETCH stretch) noexcept
-{
-    return static_cast<MapKey>((weight << 16) | (style << 8) | stretch);
-}
-
 // Routine Description:
 // - Build the needed data for rendering according to the font used
 // Arguments:

--- a/src/renderer/dx/DxFontRenderData.cpp
+++ b/src/renderer/dx/DxFontRenderData.cpp
@@ -118,7 +118,6 @@ DxFontRenderData::DxFontRenderData(::Microsoft::WRL::ComPtr<IDWriteFactory1> dwr
                                                                                                   DWRITE_FONT_STYLE style,
                                                                                                   DWRITE_FONT_STRETCH stretch)
 {
-
     const auto textFormatIt = _textFormatMap.find(_ToMapKey(weight, style, stretch));
     if (textFormatIt == _textFormatMap.end())
     {

--- a/src/renderer/dx/DxFontRenderData.cpp
+++ b/src/renderer/dx/DxFontRenderData.cpp
@@ -137,7 +137,7 @@ DxFontRenderData::DxFontRenderData(::Microsoft::WRL::ComPtr<IDWriteFactory1> dwr
         THROW_IF_FAILED(textFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_NEAR));
         THROW_IF_FAILED(textFormat->SetWordWrapping(DWRITE_WORD_WRAPPING_NO_WRAP));
 
-        _textFormatMap.emplace(_ToMapKey(weight, style, stretch), std::move(textFormat));
+        _textFormatMap.emplace(_ToMapKey(weight, style, stretch), textFormat);
         return textFormat;
     }
     else
@@ -161,7 +161,7 @@ DxFontRenderData::DxFontRenderData(::Microsoft::WRL::ComPtr<IDWriteFactory1> dwr
         std::wstring fontLocaleName = UserLocaleName();
         Microsoft::WRL::ComPtr<IDWriteFontFace1> fontFace = fontInfo.ResolveFontFaceWithFallback(_dwriteFactory.Get(), fontLocaleName);
 
-        _fontFaceMap.emplace(_ToMapKey(weight, style, stretch), std::move(fontFace));
+        _fontFaceMap.emplace(_ToMapKey(weight, style, stretch), fontFace);
         return fontFace;
     }
     else

--- a/src/renderer/dx/DxFontRenderData.h
+++ b/src/renderer/dx/DxFontRenderData.h
@@ -75,17 +75,18 @@ namespace Microsoft::Console::Render
         [[nodiscard]] static HRESULT STDMETHODCALLTYPE s_CalculateBoxEffect(IDWriteTextFormat* format, size_t widthPixels, IDWriteFontFace1* face, float fontScale, IBoxDrawingEffect** effect) noexcept;
 
     private:
-        enum class MapKey : uint32_t
-        {
-        };
+        using FontAttributeMapKey = uint32_t;
 
-        static MapKey _ToMapKey(DWRITE_FONT_WEIGHT weight, DWRITE_FONT_STYLE style, DWRITE_FONT_STRETCH stretch) noexcept;
+        // We use this to identify font variants with different attributes.
+        static FontAttributeMapKey _ToMapKey(DWRITE_FONT_WEIGHT weight, DWRITE_FONT_STYLE style, DWRITE_FONT_STRETCH stretch) noexcept {
+            return static_cast<FontAttributeMapKey>((weight << 16) | (style << 8) | stretch);
+        };
 
         void _BuildFontRenderData(const FontInfoDesired& desired, FontInfo& actual, const int dpi);
         Microsoft::WRL::ComPtr<IDWriteTextFormat> _BuildTextFormat(const DxFontInfo fontInfo, const std::wstring_view localeName);
 
-        std::unordered_map<MapKey, ::Microsoft::WRL::ComPtr<IDWriteTextFormat>> _textFormatMap;
-        std::unordered_map<MapKey, ::Microsoft::WRL::ComPtr<IDWriteFontFace1>> _fontFaceMap;
+        std::unordered_map<FontAttributeMapKey, ::Microsoft::WRL::ComPtr<IDWriteTextFormat>> _textFormatMap;
+        std::unordered_map<FontAttributeMapKey, ::Microsoft::WRL::ComPtr<IDWriteFontFace1>> _fontFaceMap;
 
         ::Microsoft::WRL::ComPtr<IBoxDrawingEffect> _boxDrawingEffect;
         ::Microsoft::WRL::ComPtr<IDWriteFontFallback> _systemFontFallback;

--- a/src/renderer/dx/DxFontRenderData.h
+++ b/src/renderer/dx/DxFontRenderData.h
@@ -75,26 +75,28 @@ namespace Microsoft::Console::Render
         [[nodiscard]] static HRESULT STDMETHODCALLTYPE s_CalculateBoxEffect(IDWriteTextFormat* format, size_t widthPixels, IDWriteFontFace1* face, float fontScale, IBoxDrawingEffect** effect) noexcept;
 
     private:
+        enum class MapKey : uint32_t
+        {
+        };
+
+        static MapKey _ToMapKey(DWRITE_FONT_WEIGHT weight, DWRITE_FONT_STYLE style, DWRITE_FONT_STRETCH stretch) noexcept;
+
         void _BuildFontRenderData(const FontInfoDesired& desired, FontInfo& actual, const int dpi);
         Microsoft::WRL::ComPtr<IDWriteTextFormat> _BuildTextFormat(const DxFontInfo fontInfo, const std::wstring_view localeName);
 
-        ::Microsoft::WRL::ComPtr<IDWriteFactory1> _dwriteFactory;
-
-        ::Microsoft::WRL::ComPtr<IDWriteTextAnalyzer1> _dwriteTextAnalyzer;
-
-        std::unordered_map<DxFontInfo, ::Microsoft::WRL::ComPtr<IDWriteTextFormat>> _textFormatMap;
-        std::unordered_map<DxFontInfo, ::Microsoft::WRL::ComPtr<IDWriteFontFace1>> _fontFaceMap;
+        std::unordered_map<MapKey, ::Microsoft::WRL::ComPtr<IDWriteTextFormat>> _textFormatMap;
+        std::unordered_map<MapKey, ::Microsoft::WRL::ComPtr<IDWriteFontFace1>> _fontFaceMap;
 
         ::Microsoft::WRL::ComPtr<IBoxDrawingEffect> _boxDrawingEffect;
-
         ::Microsoft::WRL::ComPtr<IDWriteFontFallback> _systemFontFallback;
-        mutable ::Microsoft::WRL::ComPtr<IDWriteFontCollection1> _nearbyCollection;
+        ::Microsoft::WRL::ComPtr<IDWriteFactory1> _dwriteFactory;
+        ::Microsoft::WRL::ComPtr<IDWriteTextAnalyzer1> _dwriteTextAnalyzer;
+
         std::wstring _userLocaleName;
         DxFontInfo _defaultFontInfo;
-
-        float _fontSize;
         til::size _glyphCell;
         DWRITE_LINE_SPACING _lineSpacing;
         LineMetrics _lineMetrics;
+        float _fontSize;
     };
 }

--- a/src/renderer/dx/DxFontRenderData.h
+++ b/src/renderer/dx/DxFontRenderData.h
@@ -80,7 +80,7 @@ namespace Microsoft::Console::Render
         // We use this to identify font variants with different attributes.
         static FontAttributeMapKey _ToMapKey(DWRITE_FONT_WEIGHT weight, DWRITE_FONT_STYLE style, DWRITE_FONT_STRETCH stretch) noexcept
         {
-            return static_cast<FontAttributeMapKey>((weight << 16) | (style << 8) | stretch);
+            return (weight << 16) | (style << 8) | stretch;
         };
 
         void _BuildFontRenderData(const FontInfoDesired& desired, FontInfo& actual, const int dpi);

--- a/src/renderer/dx/DxFontRenderData.h
+++ b/src/renderer/dx/DxFontRenderData.h
@@ -78,7 +78,8 @@ namespace Microsoft::Console::Render
         using FontAttributeMapKey = uint32_t;
 
         // We use this to identify font variants with different attributes.
-        static FontAttributeMapKey _ToMapKey(DWRITE_FONT_WEIGHT weight, DWRITE_FONT_STYLE style, DWRITE_FONT_STRETCH stretch) noexcept {
+        static FontAttributeMapKey _ToMapKey(DWRITE_FONT_WEIGHT weight, DWRITE_FONT_STYLE style, DWRITE_FONT_STRETCH stretch) noexcept
+        {
             return static_cast<FontAttributeMapKey>((weight << 16) | (style << 8) | stretch);
         };
 


### PR DESCRIPTION
Fixes the performance regression caused by DxFontInfo.

DxFontInfo introduced in #9201