### PR TITLE
Don't notify a11y event when in ConPTY mode

### DIFF
--- a/src/host/_stream.cpp
+++ b/src/host/_stream.cpp
@@ -556,11 +556,9 @@ constexpr unsigned int LOCAL_BUFFER_SIZE = 100;
             OutputCellIterator it(std::wstring_view(LocalBuffer, i), Attributes);
             const auto itEnd = screenInfo.Write(it);
 
-            // Notify accessibility if we're not in conpty mode.
-            if (!gci.IsInVtIoMode())
-            {
-                screenInfo.NotifyAccessibilityEventing(CursorPosition.X, CursorPosition.Y, CursorPosition.X + gsl::narrow<SHORT>(i - 1), CursorPosition.Y);
-            }
+            // Notify accessibility
+            screenInfo.NotifyAccessibilityEventing(CursorPosition.X, CursorPosition.Y, CursorPosition.X + gsl::narrow<SHORT>(i - 1), CursorPosition.Y);
+
 
             // The number of "spaces" or "cells" we have consumed needs to be reported and stored for later
             // when/if we need to erase the command line.

--- a/src/host/_stream.cpp
+++ b/src/host/_stream.cpp
@@ -556,8 +556,11 @@ constexpr unsigned int LOCAL_BUFFER_SIZE = 100;
             OutputCellIterator it(std::wstring_view(LocalBuffer, i), Attributes);
             const auto itEnd = screenInfo.Write(it);
 
-            // Notify accessibility
-            screenInfo.NotifyAccessibilityEventing(CursorPosition.X, CursorPosition.Y, CursorPosition.X + gsl::narrow<SHORT>(i - 1), CursorPosition.Y);
+            // Notify accessibility if we're not in conpty mode.
+            if (!gci.IsInVtIoMode())
+            {
+                screenInfo.NotifyAccessibilityEventing(CursorPosition.X, CursorPosition.Y, CursorPosition.X + gsl::narrow<SHORT>(i - 1), CursorPosition.Y);
+            }
 
             // The number of "spaces" or "cells" we have consumed needs to be reported and stored for later
             // when/if we need to erase the command line.

--- a/src/host/_stream.cpp
+++ b/src/host/_stream.cpp
@@ -559,7 +559,6 @@ constexpr unsigned int LOCAL_BUFFER_SIZE = 100;
             // Notify accessibility
             screenInfo.NotifyAccessibilityEventing(CursorPosition.X, CursorPosition.Y, CursorPosition.X + gsl::narrow<SHORT>(i - 1), CursorPosition.Y);
 
-
             // The number of "spaces" or "cells" we have consumed needs to be reported and stored for later
             // when/if we need to erase the command line.
             TempNumSpaces += itEnd.GetCellDistance(it);

--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -573,6 +573,12 @@ void SCREEN_INFORMATION::NotifyAccessibilityEventing(const short sStartX,
                                                      const short sEndX,
                                                      const short sEndY)
 {
+    CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
+    if (gci.IsInVtIoMode())
+    {
+        return;
+    }
+
     // Fire off a winevent to let accessibility apps know what changed.
     if (IsActiveScreenBuffer())
     {


### PR DESCRIPTION
Don't notify a11y event when in ConPTY mode

In support of #10528