### PR TITLE
[A11y] Initialize and copy _blockRange in UIA Clone

### DIFF
--- a/src/interactivity/win32/ut_interactivity_win32/UiaTextRangeTests.cpp
+++ b/src/interactivity/win32/ut_interactivity_win32/UiaTextRangeTests.cpp
@@ -1346,4 +1346,27 @@ class UiaTextRangeTests
             VERIFY_SUCCEEDED(utr->ScrollIntoView(alignToTop));
         }
     }
+
+    TEST_METHOD(BlockRange)
+    {
+        // This test replicates GH#7960.
+        // It was caused by _blockRange being uninitialized, resulting in it occasionally being set to true.
+        // Additionally, all of the ctors _except_ the copy ctor initialized it. So this would be more apparent
+        // when calling Clone.
+        Microsoft::WRL::ComPtr<UiaTextRange> utr;
+        THROW_IF_FAILED(Microsoft::WRL::MakeAndInitialize<UiaTextRange>(&utr, _pUiaData, &_dummyProvider));
+        VERIFY_IS_FALSE(utr->_blockRange);
+
+        Microsoft::WRL::ComPtr<ITextRangeProvider> clone1;
+        THROW_IF_FAILED(utr->Clone(&clone1));
+
+        UiaTextRange* cloneUtr1 = static_cast<UiaTextRange*>(clone1.Get());
+        VERIFY_IS_FALSE(cloneUtr1->_blockRange);
+        cloneUtr1->_blockRange = true;
+
+        Microsoft::WRL::ComPtr<ITextRangeProvider> clone2;
+        cloneUtr1->Clone(&clone2);
+        UiaTextRange* cloneUtr2 = static_cast<UiaTextRange*>(clone2.Get());
+        VERIFY_IS_TRUE(cloneUtr2->_blockRange);
+    }
 };

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -117,6 +117,7 @@ try
     _end = a._end;
     _pData = a._pData;
     _wordDelimiters = a._wordDelimiters;
+    _blockRange = a._blockRange;
 
     UiaTracing::TextRange::Constructor(*this);
     return S_OK;

--- a/src/types/UiaTextRangeBase.hpp
+++ b/src/types/UiaTextRangeBase.hpp
@@ -125,7 +125,7 @@ namespace Microsoft::Console::Types
 
         IRawElementProviderSimple* _pProvider{ nullptr };
 
-        std::wstring _wordDelimiters{};
+        std::wstring _wordDelimiters{ L"" };
 
         virtual void _TranslatePointToScreen(LPPOINT clientPoint) const = 0;
         virtual void _TranslatePointFromScreen(LPPOINT screenPoint) const = 0;
@@ -135,9 +135,9 @@ namespace Microsoft::Console::Types
         // measure units in the form [_start, _end).
         // These are in the TextBuffer coordinate space.
         // NOTE: _start is inclusive, but _end is exclusive
-        COORD _start{};
-        COORD _end{};
-        bool _blockRange;
+        COORD _start{ 0, 0 };
+        COORD _end{ 0, 0 };
+        bool _blockRange{ false };
 
         // This is used by tracing to extract the text value
         // that the UiaTextRange currently encompasses.

--- a/src/types/UiaTextRangeBase.hpp
+++ b/src/types/UiaTextRangeBase.hpp
@@ -125,7 +125,7 @@ namespace Microsoft::Console::Types
 
         IRawElementProviderSimple* _pProvider{ nullptr };
 
-        std::wstring _wordDelimiters{ L"" };
+        std::wstring _wordDelimiters{};
 
         virtual void _TranslatePointToScreen(LPPOINT clientPoint) const = 0;
         virtual void _TranslatePointFromScreen(LPPOINT screenPoint) const = 0;
@@ -135,9 +135,9 @@ namespace Microsoft::Console::Types
         // measure units in the form [_start, _end).
         // These are in the TextBuffer coordinate space.
         // NOTE: _start is inclusive, but _end is exclusive
-        COORD _start{ 0, 0 };
-        COORD _end{ 0, 0 };
-        bool _blockRange{ false };
+        COORD _start{};
+        COORD _end{};
+        bool _blockRange{};
 
         // This is used by tracing to extract the text value
         // that the UiaTextRange currently encompasses.


### PR DESCRIPTION
## Summary of the Pull Request
#7960 was caused by `UiaTextRangeBase::_blockRange` not being initialized, thus pointing to random memory. In most cases, we initialize it properly in `RuntimeClassInitialize`, however, the copying version of `RuntimeClassInitialize` doesn't actually copy it over, resulting in it still containing random memory.

NVDA (and other screen readers) occasionally use `Clone` (really just the copy initializer), resulting in this bug occurring randomly.

## PR Checklist
* [X] Closes #7960 
* [X] Tests added/passed

## Validation Steps Performed
Test failed before the change, but passes after the change.