### PR TITLE
Set working directory when invoked from shell extension

### DIFF
--- a/src/cascadia/ShellExtension/OpenTerminalHere.cpp
+++ b/src/cascadia/ShellExtension/OpenTerminalHere.cpp
@@ -56,16 +56,17 @@ HRESULT OpenTerminalHere::Invoke(IShellItemArray* psiItemArray,
         siEx.StartupInfo.cb = sizeof(STARTUPINFOEX);
 
         // Append a "\." to the given path, so that this will work in "C:\"
-        auto cmdline{ wil::str_printf<std::wstring>(LR"-("%s" -d "%s\.")-", GetWtExePath().c_str(), pszName.get()) };
+        auto path{ wil::str_printf<std::wstring>(LR"-(%s\.)-", pszName.get()) };
+        auto cmdline{ wil::str_printf<std::wstring>(LR"-("%s" -d "%s")-", GetWtExePath().c_str(), path.c_str()) };
         RETURN_IF_WIN32_BOOL_FALSE(CreateProcessW(
-            nullptr,
+            nullptr, // lpApplicationName
             cmdline.data(),
             nullptr, // lpProcessAttributes
             nullptr, // lpThreadAttributes
             false, // bInheritHandles
             EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT, // dwCreationFlags
             nullptr, // lpEnvironment
-            nullptr,
+            path.data(),
             &siEx.StartupInfo, // lpStartupInfo
             &_piClient // lpProcessInformation
             ));


### PR DESCRIPTION
Sets the working directory of the terminal when invoked from the shell extension. This ensures that new tabs opened with a starting directory of `.` open in the directory that the terminal was invoked from.

Closes #8933

## Validation Steps Performed
Manually tested - default PowerShell profile set to use home directory, Windows PowerShell profile set to use current directory. Launched via the shell extension and the default profile opened in the explorer directory, as did a new Windows PowerShell tab.