### PR TITLE
Introduce feature flag for editable actions page

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -8,6 +8,7 @@
 #include "Interaction.h"
 #include "Rendering.h"
 #include "Actions.h"
+#include "ReadOnlyActions.h"
 #include "Profiles.h"
 #include "GlobalAppearance.h"
 #include "ColorSchemes.h"
@@ -293,7 +294,21 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
         else if (clickedItemTag == actionsTag)
         {
-            contentFrame().Navigate(xaml_typename<Editor::Actions>(), winrt::make<ActionsPageNavigationState>(_settingsClone));
+            if constexpr (Feature_EditableActionsPage::IsEnabled())
+            {
+                contentFrame().Navigate(xaml_typename<Editor::Actions>(), winrt::make<ActionsPageNavigationState>(_settingsClone));
+            }
+            else
+            {
+                auto actionsState{ winrt::make<ReadOnlyActionsPageNavigationState>(_settingsClone) };
+                actionsState.OpenJson([weakThis = get_weak()](auto&&, auto&& arg) {
+                    if (auto self{ weakThis.get() })
+                    {
+                        self->_OpenJsonHandlers(nullptr, arg);
+                    }
+                });
+                contentFrame().Navigate(xaml_typename<Editor::ReadOnlyActions>(), actionsState);
+            }
         }
         else if (clickedItemTag == colorSchemesTag)
         {

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
@@ -99,6 +99,9 @@
       <DependentUpon>Profiles.xaml</DependentUpon>
       <SubType>Code</SubType>
     </ClInclude>
+    <ClInclude Include="ReadOnlyActions.h">
+      <DependentUpon>ReadOnlyActions.xaml</DependentUpon>
+    </ClInclude>
     <ClInclude Include="Rendering.h">
       <DependentUpon>Rendering.xaml</DependentUpon>
     </ClInclude>
@@ -135,6 +138,9 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Profiles.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="ReadOnlyActions.xaml">
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Rendering.xaml">
@@ -209,6 +215,9 @@
       <DependentUpon>Profiles.xaml</DependentUpon>
       <SubType>Code</SubType>
     </ClCompile>
+    <ClCompile Include="ReadOnlyActions.cpp">
+      <DependentUpon>ReadOnlyActions.xaml</DependentUpon>
+    </ClCompile>
     <ClCompile Include="Rendering.cpp">
       <DependentUpon>Rendering.xaml</DependentUpon>
     </ClCompile>
@@ -246,6 +255,10 @@
     </Midl>
     <Midl Include="Interaction.idl">
       <DependentUpon>Interaction.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Midl>
+    <Midl Include="ReadOnlyActions.idl">
+      <DependentUpon>ReadOnlyActions.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Midl>
     <Midl Include="Rendering.idl">

--- a/src/cascadia/TerminalSettingsEditor/ReadOnlyActions.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ReadOnlyActions.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "ReadOnlyActions.h"
+#include "ReadOnlyActions.g.cpp"
+#include "ReadOnlyActionsPageNavigationState.g.cpp"
+#include "EnumEntry.h"
+
+using namespace winrt::Windows::Foundation;
+using namespace winrt::Windows::System;
+using namespace winrt::Windows::UI::Core;
+using namespace winrt::Windows::UI::Xaml::Navigation;
+using namespace winrt::Microsoft::Terminal::Settings::Model;
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
+{
+    ReadOnlyActions::ReadOnlyActions()
+    {
+        InitializeComponent();
+
+        _filteredActions = winrt::single_threaded_observable_vector<Command>();
+    }
+
+    void ReadOnlyActions::OnNavigatedTo(const NavigationEventArgs& e)
+    {
+        _State = e.Parameter().as<Editor::ReadOnlyActionsPageNavigationState>();
+
+        std::vector<Command> keyBindingList;
+        for (const auto& [_, command] : _State.Settings().GlobalSettings().ActionMap().NameMap())
+        {
+            // Filter out nested commands, and commands that aren't bound to a
+            // key. This page is currently just for displaying the actions that
+            // _are_ bound to keys.
+            if (command.HasNestedCommands() || !command.Keys())
+            {
+                continue;
+            }
+            keyBindingList.push_back(command);
+        }
+        std::sort(begin(keyBindingList), end(keyBindingList), CommandComparator{});
+        _filteredActions = single_threaded_observable_vector<Command>(std::move(keyBindingList));
+    }
+
+    Collections::IObservableVector<Command> ReadOnlyActions::FilteredActions()
+    {
+        return _filteredActions;
+    }
+
+    void ReadOnlyActions::_OpenSettingsClick(const IInspectable& /*sender*/,
+                                             const Windows::UI::Xaml::RoutedEventArgs& /*eventArgs*/)
+    {
+        const CoreWindow window = CoreWindow::GetForCurrentThread();
+        const auto rAltState = window.GetKeyState(VirtualKey::RightMenu);
+        const auto lAltState = window.GetKeyState(VirtualKey::LeftMenu);
+        const bool altPressed = WI_IsFlagSet(lAltState, CoreVirtualKeyStates::Down) ||
+                                WI_IsFlagSet(rAltState, CoreVirtualKeyStates::Down);
+
+        const auto target = altPressed ? SettingsTarget::DefaultsFile : SettingsTarget::SettingsFile;
+
+        _State.RequestOpenJson(target);
+    }
+
+}

--- a/src/cascadia/TerminalSettingsEditor/ReadOnlyActions.h
+++ b/src/cascadia/TerminalSettingsEditor/ReadOnlyActions.h
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+#include "ReadOnlyActions.g.h"
+#include "ReadOnlyActionsPageNavigationState.g.h"
+#include "Utils.h"
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
+{
+    struct CommandComparator
+    {
+        bool operator()(const Model::Command& lhs, const Model::Command& rhs) const
+        {
+            return lhs.Name() < rhs.Name();
+        }
+    };
+
+    struct ReadOnlyActionsPageNavigationState : ReadOnlyActionsPageNavigationStateT<ReadOnlyActionsPageNavigationState>
+    {
+    public:
+        ReadOnlyActionsPageNavigationState(const Model::CascadiaSettings& settings) :
+            _Settings{ settings } {}
+
+        void RequestOpenJson(const Model::SettingsTarget target)
+        {
+            _OpenJsonHandlers(nullptr, target);
+        }
+
+        WINRT_PROPERTY(Model::CascadiaSettings, Settings, nullptr)
+        TYPED_EVENT(OpenJson, Windows::Foundation::IInspectable, Model::SettingsTarget);
+    };
+
+    struct ReadOnlyActions : ReadOnlyActionsT<ReadOnlyActions>
+    {
+    public:
+        ReadOnlyActions();
+
+        void OnNavigatedTo(const winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
+
+        Windows::Foundation::Collections::IObservableVector<winrt::Microsoft::Terminal::Settings::Model::Command> FilteredActions();
+
+        WINRT_PROPERTY(Editor::ReadOnlyActionsPageNavigationState, State, nullptr);
+
+    private:
+        friend struct ReadOnlyActionsT<ReadOnlyActions>; // for Xaml to bind events
+        Windows::Foundation::Collections::IObservableVector<winrt::Microsoft::Terminal::Settings::Model::Command> _filteredActions{ nullptr };
+
+        void _OpenSettingsClick(const IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& eventArgs);
+    };
+}
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::factory_implementation
+{
+    BASIC_FACTORY(ReadOnlyActions);
+}

--- a/src/cascadia/TerminalSettingsEditor/ReadOnlyActions.idl
+++ b/src/cascadia/TerminalSettingsEditor/ReadOnlyActions.idl
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "EnumEntry.idl";
+
+namespace Microsoft.Terminal.Settings.Editor
+{
+    runtimeclass ReadOnlyActionsPageNavigationState
+    {
+        Microsoft.Terminal.Settings.Model.CascadiaSettings Settings;
+        void RequestOpenJson(Microsoft.Terminal.Settings.Model.SettingsTarget target);
+        event Windows.Foundation.TypedEventHandler<Object, Microsoft.Terminal.Settings.Model.SettingsTarget> OpenJson;
+    };
+
+    [default_interface] runtimeclass ReadOnlyActions : Windows.UI.Xaml.Controls.Page
+    {
+        ReadOnlyActions();
+        ReadOnlyActionsPageNavigationState State { get; };
+
+        IObservableVector<Microsoft.Terminal.Settings.Model.Command> FilteredActions { get; };
+
+    }
+}

--- a/src/cascadia/TerminalSettingsEditor/ReadOnlyActions.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ReadOnlyActions.xaml
@@ -1,0 +1,225 @@
+<!--
+    Copyright (c) Microsoft Corporation. All rights reserved. Licensed under
+    the MIT License. See LICENSE in the project root for license information.
+-->
+<Page x:Class="Microsoft.Terminal.Settings.Editor.ReadOnlyActions"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:SettingsModel="using:Microsoft.Terminal.Settings.Model"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:local="using:Microsoft.Terminal.Settings.Editor"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+      mc:Ignorable="d">
+
+    <Page.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="CommonResources.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+
+            <local:StringIsEmptyConverter x:Key="CommandKeyChordVisibilityConverter" />
+
+            <!--
+                Template for actions. This is _heavily_ copied from the command
+                palette, with modifications:
+                * We don't need to use a HighlightedTextControl, because we're
+                not filtering this list
+                * We don't need the chevron for nested commands
+                * We're not displaying the icon
+                * We're binding directly to a Command, not a FilteredCommand
+                
+                If we wanted to reuse the command palette's list more directly,
+                that's theoretically possible, but then it would need to be
+                lifted out of TerminalApp and either moved into the
+                TerminalSettingsEditor or moved to it's own project consumed by
+                both TSE and TerminalApp.
+            -->
+            <DataTemplate x:Key="GeneralItemTemplate"
+                          x:DataType="SettingsModel:Command">
+
+                <!--
+                    This HorizontalContentAlignment="Stretch" is important
+                    to make sure it takes the entire width of the line
+                -->
+                <ListViewItem HorizontalContentAlignment="Stretch"
+                              AutomationProperties.AcceleratorKey="{x:Bind KeyChordText, Mode=OneWay}"
+                              AutomationProperties.Name="{x:Bind Name, Mode=OneWay}">
+
+                    <Grid HorizontalAlignment="Stretch"
+                          ColumnSpacing="8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <!--  command label  -->
+                            <ColumnDefinition Width="*" />
+                            <!--  key chord  -->
+                            <ColumnDefinition Width="32" />
+                            <!--  gutter for scrollbar  -->
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Grid.Column="0"
+                                   HorizontalAlignment="Left"
+                                   Text="{x:Bind Name, Mode=OneWay}" />
+
+                        <!--
+                            Inexplicably, we don't need to set the
+                            AutomationProperties to Raw here, unlike in the
+                            CommandPalette. We're not quite sure why.
+                        -->
+                        <Border Grid.Column="1"
+                                Padding="2,0,2,0"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Center"
+                                Style="{ThemeResource KeyChordBorderStyle}">
+
+                            <TextBlock FontSize="12"
+                                       Style="{ThemeResource KeyChordTextBlockStyle}"
+                                       Text="{x:Bind KeyChordText, Mode=OneWay}" />
+                        </Border>
+                    </Grid>
+                </ListViewItem>
+            </DataTemplate>
+
+            <!--  These resources again, HEAVILY copied from the command palette  -->
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Dark">
+                    <!--  TextBox colors !  -->
+                    <SolidColorBrush x:Key="TextControlBackground"
+                                     Color="#333333" />
+                    <SolidColorBrush x:Key="TextBoxPlaceholderTextThemeBrush"
+                                     Color="#B5B5B5" />
+                    <SolidColorBrush x:Key="TextControlForeground"
+                                     Color="#B5B5B5" />
+                    <SolidColorBrush x:Key="TextControlBorderBrush"
+                                     Color="#404040" />
+                    <SolidColorBrush x:Key="TextControlButtonForeground"
+                                     Color="#B5B5B5" />
+
+                    <SolidColorBrush x:Key="TextControlBackgroundPointerOver"
+                                     Color="#404040" />
+                    <SolidColorBrush x:Key="TextControlForegroundPointerOver"
+                                     Color="#FFFFFF" />
+                    <SolidColorBrush x:Key="TextControlBorderBrushPointerOver"
+                                     Color="#404040" />
+                    <SolidColorBrush x:Key="TextControlButtonForegroundPointerOver"
+                                     Color="#FF4343" />
+
+                    <SolidColorBrush x:Key="TextControlBackgroundFocused"
+                                     Color="#333333" />
+                    <SolidColorBrush x:Key="TextControlForegroundFocused"
+                                     Color="#FFFFFF" />
+                    <SolidColorBrush x:Key="TextControlBorderBrushFocused"
+                                     Color="#404040" />
+                    <SolidColorBrush x:Key="TextControlButtonForegroundPressed"
+                                     Color="#FFFFFF" />
+                    <SolidColorBrush x:Key="TextControlButtonBackgroundPressed"
+                                     Color="#FF4343" />
+
+                    <!--  KeyChordText styles  -->
+                    <Style x:Key="KeyChordBorderStyle"
+                           TargetType="Border">
+                        <Setter Property="BorderThickness" Value="1" />
+                        <Setter Property="CornerRadius" Value="1" />
+                        <Setter Property="Background" Value="{ThemeResource SystemAltMediumLowColor}" />
+                        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+                    </Style>
+                    <Style x:Key="KeyChordTextBlockStyle"
+                           TargetType="TextBlock">
+                        <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+                    </Style>
+
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Light">
+                    <!--  TextBox colors !  -->
+                    <SolidColorBrush x:Key="TextControlBackground"
+                                     Color="#CCCCCC" />
+                    <SolidColorBrush x:Key="TextBoxPlaceholderTextThemeBrush"
+                                     Color="#636363" />
+                    <SolidColorBrush x:Key="TextControlBorderBrush"
+                                     Color="#636363" />
+                    <SolidColorBrush x:Key="TextControlButtonForeground"
+                                     Color="#636363" />
+
+                    <SolidColorBrush x:Key="TextControlBackgroundPointerOver"
+                                     Color="#DADADA" />
+                    <SolidColorBrush x:Key="TextControlBorderBrushPointerOver"
+                                     Color="#636363" />
+                    <SolidColorBrush x:Key="TextControlButtonForegroundPointerOver"
+                                     Color="#FF4343" />
+
+                    <SolidColorBrush x:Key="TextControlBackgroundFocused"
+                                     Color="#CCCCCC" />
+                    <SolidColorBrush x:Key="TextControlBorderBrushFocused"
+                                     Color="#636363" />
+                    <SolidColorBrush x:Key="TextControlButtonForegroundPressed"
+                                     Color="#FFFFFF" />
+                    <SolidColorBrush x:Key="TextControlButtonBackgroundPressed"
+                                     Color="#FF4343" />
+
+                    <!--  KeyChordText styles  -->
+                    <Style x:Key="KeyChordBorderStyle"
+                           TargetType="Border">
+                        <Setter Property="BorderThickness" Value="1" />
+                        <Setter Property="CornerRadius" Value="1" />
+                        <Setter Property="Background" Value="{ThemeResource SystemAltMediumLowColor}" />
+                        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+                    </Style>
+                    <Style x:Key="KeyChordTextBlockStyle"
+                           TargetType="TextBlock">
+                        <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+                    </Style>
+
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="HighContrast">
+
+                    <!--  KeyChordText styles (use XAML defaults for High Contrast theme)  -->
+                    <Style x:Key="KeyChordBorderStyle"
+                           TargetType="Border" />
+                    <Style x:Key="KeyChordTextBlockStyle"
+                           TargetType="TextBlock" />
+
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+
+
+        </ResourceDictionary>
+    </Page.Resources>
+
+    <ScrollViewer>
+        <StackPanel Style="{StaticResource SettingsStackStyle}">
+            <TextBlock x:Uid="Globals_KeybindingsDisclaimer"
+                       Style="{StaticResource DisclaimerStyle}" />
+
+            <!--
+                The Nav_OpenJSON resource just so happens to have a .Content
+                and .Tooltip that are _exactly_ what we're looking for here.
+            -->
+
+            <HyperlinkButton x:Uid="Nav_OpenJSON"
+                             Click="_OpenSettingsClick" />
+
+            <!--  Keybindings  -->
+
+            <!--
+                NOTE: Globals_Keybindings.Header is not defined, because that
+                would result in the page having "Keybindings" displayed twice, which
+                looks quite redundant
+            -->
+            <ContentPresenter x:Uid="Globals_Keybindings"
+                              Margin="0">
+
+                <ListView HorizontalAlignment="Stretch"
+                          VerticalAlignment="Stretch"
+                          AllowDrop="False"
+                          CanReorderItems="False"
+                          IsItemClickEnabled="False"
+                          ItemTemplate="{StaticResource GeneralItemTemplate}"
+                          ItemsSource="{x:Bind FilteredActions, Mode=OneWay}"
+                          SelectionMode="None" />
+
+            </ContentPresenter>
+
+        </StackPanel>
+
+    </ScrollViewer>
+</Page>

--- a/src/features.xml
+++ b/src/features.xml
@@ -11,6 +11,13 @@
     </feature>
 
     <feature>
+        <name>Feature_EditableActionsPage</name>
+        <description>The Actions page in the settings UI should allow users to edit actions.</description>
+        <stage>AlwaysEnabled</stage>
+        <alwaysDisabledReleaseTokens/>
+    </feature>
+
+    <feature>
         <name>Feature_AttemptHandoff</name>
         <description>conhost should try to hand connections over to OpenConsole</description>
         <stage>AlwaysDisabled</stage>


### PR DESCRIPTION
## Summary of the Pull Request
Adds a feature flag `Feature_EditableActionsPage` that controls whether the Actions page in the Settings UI is read-only vs editable. The editable version is disabled for `Release` builds and enabled everywhere else (i.e. Dev, Preview, etc...).

Validated using `<stage>` `AlwaysEnabled` and `AlwaysDisabled`.

## References
#6900 - Actions Page Epic

## PR Checklist
Closes #10578 
