### PR TITLE
Delay load call SetThreadDescription to restore WPF renderer on Win7

### DIFF
--- a/src/renderer/base/thread.cpp
+++ b/src/renderer/base/thread.cpp
@@ -136,7 +136,14 @@ RenderThread::~RenderThread()
         else
         {
             _hThread = hThread;
-            LOG_IF_FAILED(SetThreadDescription(hThread, L"Rendering Output Thread"));
+
+            // SetThreadDescription only works on 1607 and higher. If we cannot find it,
+            // then it's no big deal. Just skip setting the description.
+            auto func = GetProcAddressByFunctionDeclaration(GetModuleHandleW(L"kernel32.dll"), SetThreadDescription);
+            if (func)
+            {
+                LOG_IF_FAILED(func(hThread, L"Rendering Output Thread"));
+            }
         }
     }
 


### PR DESCRIPTION
Delay load call SetThreadDescription to restore WPF renderer on Win7

## PR Checklist
* [x] Closes something @DHowett asked me to do.
* [x] I work here
* [x] I F5'd it on a version with this function and it still works

## Detailed Description of the Pull Request / Additional comments

I keep forgetting that anything in the WPF control needs to keep working on Win7. Or more specifically... I remember this fact for the DX renderer, but not for the render thread base. Oops. Turns out this particular convenience method to set thread descriptions for visibility inside the debugger (to make my life easier) only works down to 1607 (see https://docs.microsoft.com/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreaddescription). Since it's just a debugging convenience... skipping it entirely when the procedure is not found should be fine. Also I don't try to load `kernel32.dll` and just get the handle of the existing module (which per the remarks at https://docs.microsoft.com/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulehandlew will not increment the module reference count) because `kernel32.dll` pretty much has to be there or we're already in hot water.