### PR TITLE
Fix the cursor blink VT sequence being ignored

### DIFF
--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -348,7 +348,11 @@ bool ConhostInternalGetSet::PrivateAllowCursorBlinking(const bool fEnable)
     bool isPty;
     DoSrvIsConsolePty(isPty);
     // If we are connected to a pty, return that we could not handle this
-    // so that the VT sequence gets flushed to terminal
+    // so that the VT sequence gets flushed to terminal.
+    // Note: we technically don't need to handle it ourselves at all if
+    // we are connected to a pty (i.e. we could have just returned false
+    // immediately without needing to call DoSrvPrivateAllowCursorBlinking),
+    // but we call it anyway for consistency, just in case.
     return !isPty;
 }
 

--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -344,7 +344,12 @@ bool ConhostInternalGetSet::PrivateShowCursor(const bool show) noexcept
 bool ConhostInternalGetSet::PrivateAllowCursorBlinking(const bool fEnable)
 {
     DoSrvPrivateAllowCursorBlinking(_io.GetActiveOutputBuffer(), fEnable);
-    return true;
+
+    bool isPty;
+    DoSrvIsConsolePty(isPty);
+    // If we are connected to a pty, return that we could not handle this
+    // so that the VT sequence gets flushed to terminal
+    return !isPty;
 }
 
 // Routine Description:


### PR DESCRIPTION
Ensure that the cursor blink VT sequence gets flushed to terminal when conhost is attached to a pty

Closes #10543 