### PR TITLE
#10497: Do not force the font on output codepage change

### DIFF
--- a/src/host/misc.cpp
+++ b/src/host/misc.cpp
@@ -34,27 +34,6 @@ void SetConsoleCPInfo(const BOOL fOutput)
     CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     if (fOutput)
     {
-        // If we're changing the output codepage, we want to update the font as well to give the engine an opportunity
-        // to pick a more appropriate font should the current one be unable to render in the new codepage.
-        // To do this, we create a copy of the existing font but we change the codepage value to be the new one that was just set in the global structures.
-        // NOTE: We need to do this only if everything is set up. This can get called while we're still initializing, so carefully check things for nullptr.
-        if (gci.HasActiveOutputBuffer())
-        {
-            SCREEN_INFORMATION& screenInfo = gci.GetActiveOutputBuffer();
-            const FontInfo& fiOld = screenInfo.GetCurrentFont();
-
-            // Use the desired face name when updating the font.
-            // This ensures that if we had a fall back operation last time (the desired
-            // face name didn't support the code page and we have a different less-desirable font currently)
-            // that we'll now give it another shot to use the desired face name in the new code page.
-            FontInfo fiNew(screenInfo.GetDesiredFont().GetFaceName(),
-                           fiOld.GetFamily(),
-                           fiOld.GetWeight(),
-                           fiOld.GetUnscaledSize(),
-                           gci.OutputCP);
-            screenInfo.UpdateFont(&fiNew);
-        }
-
         if (!GetCPInfo(gci.OutputCP, &gci.OutputCPInfo))
         {
             gci.OutputCPInfo.LeadByte[0] = 0;


### PR DESCRIPTION
Currently, when the user changes the console codepage (manually or via a script) the GDI engine tries to find and set the "best possible" font. The "best possible" here is charset-wise, it doesn't mean that the font is actually better or more eye-candy for the user.

Example:
- Open cmd
- Set the font to Consolas
- Enter `chcp 932`
- Suddenly, a wild MS Gothic appears!

This kind of makes sense (*"if I'm changing the codepage I probably want to see the national characters"*) but it doesn't happen anywhere else - all other apps just substitute the missing glyphs.

After #10472 / #10478 this magic should finally work here as well. So, do we still need to change the whole font? Terminal doesn't do that after all.

## Validation Steps Performed
Download [932.cmd.txt](https://github.com/microsoft/terminal/files/6697577/932.cmd.txt),
rename to 932.cmd, run it, check if the output is still readable.

Closes #10497