### PR TITLE
Enable /Zc:preprocessor

### DIFF
--- a/build/Helix/PrepareHelixPayload.ps1
+++ b/build/Helix/PrepareHelixPayload.ps1
@@ -9,7 +9,7 @@ $payloadDir = "HelixPayload\$Configuration\$Platform"
 
 $repoDirectory = Join-Path (Split-Path -Parent $script:MyInvocation.MyCommand.Path) "..\..\"
 $nugetPackagesDir = Join-Path (Split-Path -Parent $script:MyInvocation.MyCommand.Path) "packages"
- 
+
 # Create the payload directory. Remove it if it already exists.
 If(test-path $payloadDir)
 {
@@ -19,8 +19,8 @@ New-Item -ItemType Directory -Force -Path $payloadDir
 
 # Copy files from nuget packages
 Copy-Item "$nugetPackagesDir\microsoft.windows.apps.test.1.0.181203002\lib\netcoreapp2.1\*.dll" $payloadDir
-Copy-Item "$nugetPackagesDir\Microsoft.Taef.10.58.210305002\build\Binaries\$Platform\*" $payloadDir
-Copy-Item "$nugetPackagesDir\Microsoft.Taef.10.58.210305002\build\Binaries\$Platform\NetFx4.5\*" $payloadDir
+Copy-Item "$nugetPackagesDir\Microsoft.Taef.10.60.210621002\build\Binaries\$Platform\*" $payloadDir
+Copy-Item "$nugetPackagesDir\Microsoft.Taef.10.60.210621002\build\Binaries\$Platform\NetFx4.5\*" $payloadDir
 New-Item -ItemType Directory -Force -Path "$payloadDir\.NETCoreApp2.1\"
 Copy-Item "$nugetPackagesDir\runtime.win-$Platform.microsoft.netcore.app.2.1.0\runtimes\win-$Platform\lib\netcoreapp2.1\*" "$payloadDir\.NETCoreApp2.1\"
 Copy-Item "$nugetPackagesDir\runtime.win-$Platform.microsoft.netcore.app.2.1.0\runtimes\win-$Platform\native\*" "$payloadDir\.NETCoreApp2.1\"
@@ -59,7 +59,7 @@ Copy-Item "build\Helix\EnsureMachineState.ps1" "$payloadDir"
 Copy-Item "$repoDirectory\Artifacts\$ArtifactName\appx\CascadiaPackage_0.0.1.0_$Platform.msix" $payloadDir\CascadiaPackage.zip
 
 # Rename it to extension of ZIP because Expand-Archive is real sassy on the build machines
-# and refuses to unzip it because of its file extension while on a desktop, it just 
+# and refuses to unzip it because of its file extension while on a desktop, it just
 # does the job without complaining.
 
 # Extract the APPX package

--- a/build/Helix/packages.config
+++ b/build/Helix/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="MUXCustomBuildTasks" version="1.0.48" targetFramework="native" />
   <package id="Microsoft.Internal.Windows.Terminal.TestContent" version="1.0.1" />
-  <package id="Microsoft.Taef" version="10.58.210305002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.60.210621002" targetFramework="native" />
   <package id="microsoft.windows.apps.test" version="1.0.181203002" targetFramework="native" />
   <package id="runtime.win-x86.microsoft.netcore.app" version="2.1.0" targetFramework="native" />
   <package id="runtime.win-x64.microsoft.netcore.app" version="2.1.0" targetFramework="native" />

--- a/build/packages.config
+++ b/build/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MUXCustomBuildTasks" version="1.0.48" targetFramework="native" />
-  <package id="Microsoft.Taef" version="10.58.210305002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.60.210621002" targetFramework="native" />
 </packages>

--- a/build/pipelines/templates/helix-createprojfile-steps.yml
+++ b/build/pipelines/templates/helix-createprojfile-steps.yml
@@ -12,4 +12,4 @@ steps:
     inputs:
       targetType: filePath
       filePath: build\Helix\GenerateTestProjFile.ps1
-      arguments: -TestFile '${{ parameters.testFilePath }}' -OutputProjFile '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\$(BuildPlatform)\${{ parameters.outputProjFileName }}' -JobTestSuiteName '${{ parameters.testSuite }}' -TaefPath '$(Build.SourcesDirectory)\build\Helix\packages\Microsoft.Taef.10.58.210305002\build\Binaries\x86' -TaefQuery '${{ parameters.taefQuery }}'
+      arguments: -TestFile '${{ parameters.testFilePath }}' -OutputProjFile '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\$(BuildPlatform)\${{ parameters.outputProjFileName }}' -JobTestSuiteName '${{ parameters.testSuite }}' -TaefPath '$(Build.SourcesDirectory)\build\Helix\packages\Microsoft.Taef.10.60.210621002\build\Binaries\x86' -TaefQuery '${{ parameters.taefQuery }}'

--- a/build/pipelines/templates/helix-runtests-job.yml
+++ b/build/pipelines/templates/helix-runtests-job.yml
@@ -30,7 +30,7 @@ jobs:
     buildPlatform: ${{ parameters.platform }}
     openHelixTargetQueues: ${{ parameters.openHelixTargetQueues }}
     artifactsDir: $(Build.SourcesDirectory)\Artifacts
-    taefPath: $(Build.SourcesDirectory)\build\Helix\packages\Microsoft.Taef.10.58.210305002\build\Binaries\$(buildPlatform)
+    taefPath: $(Build.SourcesDirectory)\build\Helix\packages\Microsoft.Taef.10.60.210621002\build\Binaries\$(buildPlatform)
     helixCommonArgs: '/binaryLogger:$(Build.SourcesDirectory)/${{parameters.name}}.$(buildPlatform).$(buildConfiguration).binlog /p:HelixBuild=$(Build.BuildId).$(buildPlatform).$(buildConfiguration) /p:Platform=$(buildPlatform) /p:Configuration=$(buildConfiguration) /p:HelixType=${{parameters.helixType}} /p:TestSuite=${{parameters.testSuite}} /p:ProjFilesPath=$(Build.ArtifactStagingDirectory) /p:rerunPassesRequiredToAvoidFailure=${{parameters.rerunPassesRequiredToAvoidFailure}}'
 
 
@@ -147,4 +147,3 @@ jobs:
       projects: build\Helix\RunTestsInHelix.proj
       custom: msbuild
       arguments: '$(helixCommonArgs) /p:IsExternal=true /p:Creator=Terminal /p:HelixTargetQueues=$(openHelixTargetQueues)'
-

--- a/src/buffer/out/TextAttribute.hpp
+++ b/src/buffer/out/TextAttribute.hpp
@@ -212,7 +212,7 @@ constexpr bool operator!=(const TextAttribute& a, const TextAttribute& b) noexce
 #ifdef UNIT_TESTING
 
 #define LOG_ATTR(attr) (Log::Comment(NoThrowString().Format( \
-    L#attr L"=%s", VerifyOutputTraits<TextAttribute>::ToString(attr).GetBuffer())))
+    L## #attr L"=%s", VerifyOutputTraits<TextAttribute>::ToString(attr).GetBuffer())))
 
 namespace WEX
 {

--- a/src/cascadia/LocalTests_TerminalApp/TestHostApp/TestHostApp.vcxproj
+++ b/src/cascadia/LocalTests_TerminalApp/TestHostApp/TestHostApp.vcxproj
@@ -115,7 +115,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestExecutor.WinRTCore">
-      <HintPath>$(OpenConsoleDir)\packages\Microsoft.Taef.10.58.210305002\lib\Microsoft.VisualStudio.TestPlatform.TestExecutor.WinRTCore.winmd</HintPath>
+      <HintPath>$(OpenConsoleDir)\packages\Microsoft.Taef.10.60.210621002\lib\Microsoft.VisualStudio.TestPlatform.TestExecutor.WinRTCore.winmd</HintPath>
       <IsWinMDFile>true</IsWinMDFile>
 
       <!-- This path is _relative to the .winmd_ -->

--- a/src/cascadia/TerminalSettingsEditor/Utils.h
+++ b/src/cascadia/TerminalSettingsEditor/Utils.h
@@ -11,33 +11,39 @@
 // being its localized name, and also initializes the enum to EnumEntry
 // map that's required to tell XAML what enum value the currently active
 // setting has.
-#define INITIALIZE_BINDABLE_ENUM_SETTING(name, enumMappingsName, enumType, resourceSectionAndType, resourceProperty)                                    \
-    std::vector<winrt::Microsoft::Terminal::Settings::Editor::EnumEntry> name##List;                                                                    \
-    _##name##Map = winrt::single_threaded_map<enumType, winrt::Microsoft::Terminal::Settings::Editor::EnumEntry>();                                     \
-    auto enumMapping##name = winrt::Microsoft::Terminal::Settings::Model::EnumMappings::##enumMappingsName();                                           \
-    for (auto [key, value] : enumMapping##name)                                                                                                         \
-    {                                                                                                                                                   \
-        auto enumName = LocalizedNameForEnumName(resourceSectionAndType, key, resourceProperty);                                                        \
-        auto entry = winrt::make<winrt::Microsoft::Terminal::Settings::Editor::implementation::EnumEntry>(enumName, winrt::box_value<enumType>(value)); \
-        name##List.emplace_back(entry);                                                                                                                 \
-        _##name##Map.Insert(value, entry);                                                                                                              \
-    }                                                                                                                                                   \
-    std::sort(begin(name##List), end(name##List), EnumEntryComparator<enumType>());                                                                     \
-    _##name##List = winrt::single_threaded_observable_vector<winrt::Microsoft::Terminal::Settings::Editor::EnumEntry>(std::move(name##List));
+#define INITIALIZE_BINDABLE_ENUM_SETTING(name, enumMappingsName, enumType, resourceSectionAndType, resourceProperty)                                        \
+    do                                                                                                                                                      \
+    {                                                                                                                                                       \
+        std::vector<winrt::Microsoft::Terminal::Settings::Editor::EnumEntry> name##List;                                                                    \
+        _##name##Map = winrt::single_threaded_map<enumType, winrt::Microsoft::Terminal::Settings::Editor::EnumEntry>();                                     \
+        auto enumMapping##name = winrt::Microsoft::Terminal::Settings::Model::EnumMappings::enumMappingsName();                                             \
+        for (auto [key, value] : enumMapping##name)                                                                                                         \
+        {                                                                                                                                                   \
+            auto enumName = LocalizedNameForEnumName(resourceSectionAndType, key, resourceProperty);                                                        \
+            auto entry = winrt::make<winrt::Microsoft::Terminal::Settings::Editor::implementation::EnumEntry>(enumName, winrt::box_value<enumType>(value)); \
+            name##List.emplace_back(entry);                                                                                                                 \
+            _##name##Map.Insert(value, entry);                                                                                                              \
+        }                                                                                                                                                   \
+        std::sort(name##List.begin(), name##List.end(), EnumEntryComparator<enumType>());                                                                   \
+        _##name##List = winrt::single_threaded_observable_vector<winrt::Microsoft::Terminal::Settings::Editor::EnumEntry>(std::move(name##List));           \
+    } while (0);
 
-#define INITIALIZE_BINDABLE_ENUM_SETTING_REVERSE_ORDER(name, enumMappingsName, enumType, resourceSectionAndType, resourceProperty)                      \
-    std::vector<winrt::Microsoft::Terminal::Settings::Editor::EnumEntry> name##List;                                                                    \
-    _##name##Map = winrt::single_threaded_map<enumType, winrt::Microsoft::Terminal::Settings::Editor::EnumEntry>();                                     \
-    auto enumMapping##name = winrt::Microsoft::Terminal::Settings::Model::EnumMappings::##enumMappingsName();                                           \
-    for (auto [key, value] : enumMapping##name)                                                                                                         \
-    {                                                                                                                                                   \
-        auto enumName = LocalizedNameForEnumName(resourceSectionAndType, key, resourceProperty);                                                        \
-        auto entry = winrt::make<winrt::Microsoft::Terminal::Settings::Editor::implementation::EnumEntry>(enumName, winrt::box_value<enumType>(value)); \
-        name##List.emplace_back(entry);                                                                                                                 \
-        _##name##Map.Insert(value, entry);                                                                                                              \
-    }                                                                                                                                                   \
-    std::sort(begin(name##List), end(name##List), EnumEntryReverseComparator<enumType>());                                                              \
-    _##name##List = winrt::single_threaded_observable_vector<winrt::Microsoft::Terminal::Settings::Editor::EnumEntry>(std::move(name##List));
+#define INITIALIZE_BINDABLE_ENUM_SETTING_REVERSE_ORDER(name, enumMappingsName, enumType, resourceSectionAndType, resourceProperty)                          \
+    do                                                                                                                                                      \
+    {                                                                                                                                                       \
+        std::vector<winrt::Microsoft::Terminal::Settings::Editor::EnumEntry> name##List;                                                                    \
+        _##name##Map = winrt::single_threaded_map<enumType, winrt::Microsoft::Terminal::Settings::Editor::EnumEntry>();                                     \
+        auto enumMapping##name = winrt::Microsoft::Terminal::Settings::Model::EnumMappings::enumMappingsName();                                             \
+        for (auto [key, value] : enumMapping##name)                                                                                                         \
+        {                                                                                                                                                   \
+            auto enumName = LocalizedNameForEnumName(resourceSectionAndType, key, resourceProperty);                                                        \
+            auto entry = winrt::make<winrt::Microsoft::Terminal::Settings::Editor::implementation::EnumEntry>(enumName, winrt::box_value<enumType>(value)); \
+            name##List.emplace_back(entry);                                                                                                                 \
+            _##name##Map.Insert(value, entry);                                                                                                              \
+        }                                                                                                                                                   \
+        std::sort(name##List.begin(), name##List.end(), EnumEntryReverseComparator<enumType>());                                                            \
+        _##name##List = winrt::single_threaded_observable_vector<winrt::Microsoft::Terminal::Settings::Editor::EnumEntry>(std::move(name##List));           \
+    } while (0);
 
 // This macro must be used alongside INITIALIZE_BINDABLE_ENUM_SETTING.
 // It declares the needed data structures, getters, and setters to make
@@ -45,29 +51,29 @@
 // of EnumEntries so that we may display all possible values of the given
 // enum type and its localized names. It also provides a getter and setter
 // for the setting we wish to bind to.
-#define GETSET_BINDABLE_ENUM_SETTING(name, enumType, settingsModelName, settingNameInModel)                                                                  \
-public:                                                                                                                                                      \
-    winrt::Windows::Foundation::Collections::IObservableVector<winrt::Microsoft::Terminal::Settings::Editor::EnumEntry>##name##List()                        \
-    {                                                                                                                                                        \
-        return _##name##List;                                                                                                                                \
-    }                                                                                                                                                        \
-                                                                                                                                                             \
-    winrt::Windows::Foundation::IInspectable Current##name()                                                                                                 \
-    {                                                                                                                                                        \
-        return winrt::box_value<winrt::Microsoft::Terminal::Settings::Editor::EnumEntry>(_##name##Map.Lookup(##settingsModelName().##settingNameInModel())); \
-    }                                                                                                                                                        \
-                                                                                                                                                             \
-    void Current##name(const winrt::Windows::Foundation::IInspectable& enumEntry)                                                                            \
-    {                                                                                                                                                        \
-        if (auto ee = enumEntry.try_as<winrt::Microsoft::Terminal::Settings::Editor::EnumEntry>())                                                           \
-        {                                                                                                                                                    \
-            auto setting = winrt::unbox_value<enumType>(ee.EnumValue());                                                                                     \
-            ##settingsModelName().##settingNameInModel(setting);                                                                                             \
-        }                                                                                                                                                    \
-    }                                                                                                                                                        \
-                                                                                                                                                             \
-private:                                                                                                                                                     \
-    winrt::Windows::Foundation::Collections::IObservableVector<winrt::Microsoft::Terminal::Settings::Editor::EnumEntry> _##name##List;                       \
+#define GETSET_BINDABLE_ENUM_SETTING(name, enumType, settingsModelName, settingNameInModel)                                                              \
+public:                                                                                                                                                  \
+    winrt::Windows::Foundation::Collections::IObservableVector<winrt::Microsoft::Terminal::Settings::Editor::EnumEntry> name##List()                     \
+    {                                                                                                                                                    \
+        return _##name##List;                                                                                                                            \
+    }                                                                                                                                                    \
+                                                                                                                                                         \
+    winrt::Windows::Foundation::IInspectable Current##name()                                                                                             \
+    {                                                                                                                                                    \
+        return winrt::box_value<winrt::Microsoft::Terminal::Settings::Editor::EnumEntry>(_##name##Map.Lookup(settingsModelName().settingNameInModel())); \
+    }                                                                                                                                                    \
+                                                                                                                                                         \
+    void Current##name(const winrt::Windows::Foundation::IInspectable& enumEntry)                                                                        \
+    {                                                                                                                                                    \
+        if (auto ee = enumEntry.try_as<winrt::Microsoft::Terminal::Settings::Editor::EnumEntry>())                                                       \
+        {                                                                                                                                                \
+            auto setting = winrt::unbox_value<enumType>(ee.EnumValue());                                                                                 \
+            settingsModelName().settingNameInModel(setting);                                                                                             \
+        }                                                                                                                                                \
+    }                                                                                                                                                    \
+                                                                                                                                                         \
+private:                                                                                                                                                 \
+    winrt::Windows::Foundation::Collections::IObservableVector<winrt::Microsoft::Terminal::Settings::Editor::EnumEntry> _##name##List;                   \
     winrt::Windows::Foundation::Collections::IMap<enumType, winrt::Microsoft::Terminal::Settings::Editor::EnumEntry> _##name##Map;
 
 // This macro defines a dependency property for a WinRT class.

--- a/src/cascadia/TerminalSettingsEditor/ViewModelHelpers.h
+++ b/src/cascadia/TerminalSettingsEditor/ViewModelHelpers.h
@@ -48,7 +48,7 @@ public:                                                   \
         if (name() != value)                              \
         {                                                 \
             target.name(value);                           \
-            _NotifyChanges(L"Has" #name, L#name);         \
+            _NotifyChanges(L"Has" #name, L## #name);      \
         }                                                 \
     }                                                     \
     bool Has##name() { return target.Has##name(); }
@@ -63,7 +63,7 @@ public:                                                   \
         target.Clear##name();                        \
         if (hadValue)                                \
         {                                            \
-            _NotifyChanges(L"Has" #name, L#name);    \
+            _NotifyChanges(L"Has" #name, L## #name); \
         }                                            \
     }                                                \
     auto name##OverrideSource() { return target.name##OverrideSource(); }
@@ -84,7 +84,7 @@ public:                                                 \
         if (_##name != value)                           \
         {                                               \
             _##name = value;                            \
-            _NotifyChanges(L#name);                     \
+            _NotifyChanges(L## #name);                  \
         }                                               \
     };                                                  \
                                                         \

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -98,7 +98,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         winrt::guid GetProfileForArgs(const Model::NewTerminalArgs& newTerminalArgs) const;
 
-        Model::Profile DuplicateProfile(Model::Profile source);
+        Model::Profile DuplicateProfile(const Model::Profile& source);
         void RefreshDefaultTerminals();
 
         static bool IsDefaultTerminalAvailable() noexcept;

--- a/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj
+++ b/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj
@@ -15,8 +15,8 @@
 
   <!-- ========================= Headers ======================== -->
   <ItemGroup>
-    <ClInclude Include="DefaultTerminal.h" >
-        <DependentUpon>DefaultTerminal.idl</DependentUpon>
+    <ClInclude Include="DefaultTerminal.h">
+      <DependentUpon>DefaultTerminal.idl</DependentUpon>
     </ClInclude>
     <ClInclude Include="IconPathConverter.h">
       <DependentUpon>IconPathConverter.idl</DependentUpon>
@@ -82,8 +82,8 @@
   <!-- ========================= Cpp Files ======================== -->
   <ItemGroup>
     <ClCompile Include="DefaultTerminal.cpp">
-        <DependentUpon>DefaultTerminal.idl</DependentUpon>
-      </ClCompile>
+      <DependentUpon>DefaultTerminal.idl</DependentUpon>
+    </ClCompile>
     <ClCompile Include="IconPathConverter.cpp">
       <DependentUpon>IconPathConverter.idl</DependentUpon>
     </ClCompile>

--- a/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj.filters
+++ b/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj.filters
@@ -18,7 +18,6 @@
     <ClCompile Include="WslDistroGenerator.cpp">
       <Filter>profileGeneration</Filter>
     </ClCompile>
-    <ClCompile Include="KeyMappingSerialization.cpp" />
     <ClCompile Include="CascadiaSettings.cpp" />
     <ClCompile Include="CascadiaSettingsSerialization.cpp" />
     <ClCompile Include="GlobalAppSettings.cpp" />
@@ -34,6 +33,7 @@
     <ClCompile Include="init.cpp" />
     <ClCompile Include="IconPathConverter.cpp" />
     <ClCompile Include="DefaultTerminal.cpp" />
+    <ClCompile Include="FileUtils.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -66,6 +66,8 @@
     <ClInclude Include="IInheritable.h" />
     <ClInclude Include="IconPathConverter.h" />
     <ClInclude Include="DefaultTerminal.h" />
+    <ClInclude Include="FileUtils.h" />
+    <ClInclude Include="HashUtils.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="ActionArgs.idl" />
@@ -84,6 +86,7 @@
     <Midl Include="IAppearanceConfig.idl" />
     <Midl Include="FontConfig.idl" />
     <Midl Include="DefaultTerminal.idl" />
+    <Midl Include="ApplicationState.idl" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/cascadia/UnitTests_Remoting/RemotingTests.cpp
+++ b/src/cascadia/UnitTests_Remoting/RemotingTests.cpp
@@ -165,7 +165,7 @@ namespace RemotingUnitTests
             return;
         }
 
-        m->_peasants[peasantID] = *winrt::make_self<DeadPeasant>();
+        m->_peasants[peasantID] = winrt::make<DeadPeasant>();
     }
 
     // Helper to get the first argument out of the commandline, and try to

--- a/src/cascadia/UnitTests_Remoting/RemotingTests.cpp
+++ b/src/cascadia/UnitTests_Remoting/RemotingTests.cpp
@@ -16,24 +16,6 @@ using namespace WEX::Common;
 using namespace winrt;
 using namespace winrt::Microsoft::Terminal;
 
-// These are some gross macros that let us call a private ctor for
-// Monarch/Peasant. We can't just use make_self, because that doesn't let us
-// call a private ctor. We can use com_ptr::attach, but since we're allocating
-// the thing on the stack, we need to make sure to call detach before the object
-// is destructed.
-
-#define MAKE_MONARCH(name, pid)                               \
-    Remoting::implementation::Monarch _local_##name##{ pid }; \
-    com_ptr<Remoting::implementation::Monarch> name;          \
-    name.attach(&_local_##name##);                            \
-    auto cleanup_##name## = wil::scope_exit([&]() { name.detach(); });
-
-#define MAKE_PEASANT(name, pid)                               \
-    Remoting::implementation::Peasant _local_##name##{ pid }; \
-    com_ptr<Remoting::implementation::Peasant> name;          \
-    name.attach(&_local_##name##);                            \
-    auto cleanup_##name## = wil::scope_exit([&]() { name.detach(); });
-
 namespace RemotingUnitTests
 {
     struct MockDesktopManager : implements<MockDesktopManager, IVirtualDesktopManager>
@@ -161,6 +143,15 @@ namespace RemotingUnitTests
 
         static void _findTargetWindowByNameHelper(const winrt::Windows::Foundation::IInspectable& sender,
                                                   const winrt::Microsoft::Terminal::Remoting::FindTargetWindowArgs& args);
+
+        // This template that lets us call a private ctor for Monarch/Peasant, unlike make_self.
+        // Currently I use a private implementation detail of winrt::make_self,
+        // which is bad, but I didn't want to deal with the alternatives.
+        template<typename T, typename... Args>
+        static winrt::com_ptr<T> make_private(Args&&... args)
+        {
+            return { new winrt::impl::heap_implements<T>(std::forward<Args>(args)...), winrt::take_ownership_from_abi };
+        }
     };
 
     // Helper to replace the specified peasant in a monarch with a
@@ -174,9 +165,7 @@ namespace RemotingUnitTests
             return;
         }
 
-        com_ptr<DeadPeasant> tombstone;
-        tombstone.attach(new DeadPeasant());
-        m->_peasants[peasantID] = *tombstone;
+        m->_peasants[peasantID] = *winrt::make_self<DeadPeasant>();
     }
 
     // Helper to get the first argument out of the commandline, and try to
@@ -207,8 +196,7 @@ namespace RemotingUnitTests
 
     void RemotingTests::CreateMonarch()
     {
-        auto m1 = winrt::make_self<Remoting::implementation::Monarch>();
-        VERIFY_IS_NOT_NULL(m1);
+        auto m1 = make_private<Remoting::implementation::Monarch>();
         VERIFY_ARE_EQUAL(GetCurrentProcessId(),
                          m1->GetPID(),
                          L"A Monarch without an explicit PID should use the current PID");
@@ -216,9 +204,7 @@ namespace RemotingUnitTests
         Log::Comment(L"That's what we need for window process management, but for tests, it'll be more useful to fake the PIDs.");
 
         auto expectedFakePID = 1234u;
-        MAKE_MONARCH(m2, expectedFakePID);
-
-        VERIFY_IS_NOT_NULL(m2);
+        auto m2 = make_private<Remoting::implementation::Monarch>(expectedFakePID);
         VERIFY_ARE_EQUAL(expectedFakePID,
                          m2->GetPID(),
                          L"A Monarch with an explicit PID should use the one we provided");
@@ -226,8 +212,7 @@ namespace RemotingUnitTests
 
     void RemotingTests::CreatePeasant()
     {
-        auto p1 = winrt::make_self<Remoting::implementation::Peasant>();
-        VERIFY_IS_NOT_NULL(p1);
+        auto p1 = make_private<Remoting::implementation::Peasant>();
         VERIFY_ARE_EQUAL(GetCurrentProcessId(),
                          p1->GetPID(),
                          L"A Peasant without an explicit PID should use the current PID");
@@ -235,9 +220,7 @@ namespace RemotingUnitTests
         Log::Comment(L"That's what we need for window process management, but for tests, it'll be more useful to fake the PIDs.");
 
         auto expectedFakePID = 2345u;
-        MAKE_PEASANT(p2, expectedFakePID);
-
-        VERIFY_IS_NOT_NULL(p2);
+        auto p2 = make_private<Remoting::implementation::Monarch>(expectedFakePID);
         VERIFY_ARE_EQUAL(expectedFakePID,
                          p2->GetPID(),
                          L"A Peasant with an explicit PID should use the one we provided");
@@ -247,19 +230,14 @@ namespace RemotingUnitTests
     {
         Log::Comment(L"The same thing as the above test, but with `new` instead of insanity on the stack");
 
-        auto p1 = winrt::make_self<Remoting::implementation::Peasant>();
-        VERIFY_IS_NOT_NULL(p1);
+        auto p1 = make_private<Remoting::implementation::Peasant>();
         VERIFY_ARE_EQUAL(GetCurrentProcessId(),
                          p1->GetPID(),
                          L"A Peasant without an explicit PID should use the current PID");
 
         auto expectedFakePID = 2345u;
 
-        com_ptr<Remoting::implementation::Peasant> p2;
-        VERIFY_IS_NULL(p2);
-        p2.attach(new Remoting::implementation::Peasant(expectedFakePID));
-
-        VERIFY_IS_NOT_NULL(p2);
+        auto p2 = make_private<Remoting::implementation::Peasant>(expectedFakePID);
         VERIFY_ARE_EQUAL(expectedFakePID,
                          p2->GetPID(),
                          L"A Peasant with an explicit PID should use the one we provided");
@@ -271,18 +249,9 @@ namespace RemotingUnitTests
         const auto peasant1PID = 23456u;
         const auto peasant2PID = 34567u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
-
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
 
         VERIFY_ARE_EQUAL(0, p1->GetID());
         VERIFY_ARE_EQUAL(0, p2->GetID());
@@ -300,18 +269,9 @@ namespace RemotingUnitTests
         const auto peasant1PID = 23456u;
         const auto peasant2PID = 34567u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
-
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
 
         VERIFY_ARE_EQUAL(0, p1->GetID());
         VERIFY_ARE_EQUAL(0, p2->GetID());
@@ -323,11 +283,9 @@ namespace RemotingUnitTests
         VERIFY_ARE_EQUAL(2, p2->GetID());
 
         auto maybeP1 = m0->_getPeasant(1);
-        VERIFY_IS_NOT_NULL(maybeP1);
         VERIFY_ARE_EQUAL(peasant1PID, maybeP1.GetPID());
 
         auto maybeP2 = m0->_getPeasant(2);
-        VERIFY_IS_NOT_NULL(maybeP2);
         VERIFY_ARE_EQUAL(peasant2PID, maybeP2.GetPID());
     }
 
@@ -338,22 +296,10 @@ namespace RemotingUnitTests
         const auto peasant2PID = 34567u;
         const auto monarch3PID = 45678u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
-
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        com_ptr<Remoting::implementation::Monarch> m3;
-        m3.attach(new Remoting::implementation::Monarch(monarch3PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
-        VERIFY_IS_NOT_NULL(m3);
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
+        auto m3 = make_private<Remoting::implementation::Monarch>(monarch3PID);
 
         VERIFY_ARE_EQUAL(0, p1->GetID());
         VERIFY_ARE_EQUAL(0, p2->GetID());
@@ -377,18 +323,9 @@ namespace RemotingUnitTests
         const auto peasant1PID = 23456u;
         const auto peasant2PID = 34567u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
-
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
 
         VERIFY_ARE_EQUAL(0, p1->GetID());
         VERIFY_ARE_EQUAL(0, p2->GetID());
@@ -405,7 +342,6 @@ namespace RemotingUnitTests
         RemotingTests::_killPeasant(m0, p1->GetID());
 
         auto maybeP2 = m0->_getPeasant(2);
-        VERIFY_IS_NOT_NULL(maybeP2);
         VERIFY_ARE_EQUAL(peasant2PID, maybeP2.GetPID());
 
         auto maybeP1 = m0->_getPeasant(1);
@@ -420,9 +356,7 @@ namespace RemotingUnitTests
 
         const auto monarch0PID = 12345u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
-        VERIFY_IS_NOT_NULL(m0);
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
         m0->FindTargetWindowRequested(&RemotingTests::_findTargetWindowHelper);
 
         std::vector<winrt::hstring> args{};
@@ -434,9 +368,7 @@ namespace RemotingUnitTests
 
         Log::Comment(L"Add a peasant");
         const auto peasant1PID = 23456u;
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-        VERIFY_IS_NOT_NULL(p1);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
         m0->AddPeasant(*p1);
 
         Log::Comment(L"Propose the same args again after adding a peasant - we should still return {create new window, no ID}");
@@ -450,16 +382,12 @@ namespace RemotingUnitTests
         Log::Comment(L"Test proposing a commandline for a window that currently exists");
 
         const auto monarch0PID = 12345u;
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
-        VERIFY_IS_NOT_NULL(m0);
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
         m0->FindTargetWindowRequested(&RemotingTests::_findTargetWindowHelper);
 
         Log::Comment(L"Add a peasant");
         const auto peasant1PID = 23456u;
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-        VERIFY_IS_NOT_NULL(p1);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
         m0->AddPeasant(*p1);
 
         p1->ExecuteCommandlineRequested([&](auto&&, const Remoting::CommandlineArgs& cmdlineArgs) {
@@ -480,16 +408,12 @@ namespace RemotingUnitTests
         Log::Comment(L"Test proposing a commandline for an invalid window ID, like -1");
 
         const auto monarch0PID = 12345u;
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
-        VERIFY_IS_NOT_NULL(m0);
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
         m0->FindTargetWindowRequested(&RemotingTests::_findTargetWindowHelper);
 
         Log::Comment(L"Add a peasant");
         const auto peasant1PID = 23456u;
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-        VERIFY_IS_NOT_NULL(p1);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
         m0->AddPeasant(*p1);
 
         {
@@ -514,16 +438,12 @@ namespace RemotingUnitTests
         Log::Comment(L"Test proposing a commandline for the current window (ID=0)");
 
         const auto monarch0PID = 12345u;
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
-        VERIFY_IS_NOT_NULL(m0);
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
         m0->FindTargetWindowRequested(&RemotingTests::_findTargetWindowHelper);
 
         Log::Comment(L"Add a peasant");
         const auto peasant1PID = 23456u;
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-        VERIFY_IS_NOT_NULL(p1);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
         m0->AddPeasant(*p1);
         p1->ExecuteCommandlineRequested([&](auto&&, const Remoting::CommandlineArgs& cmdlineArgs) {
             Log::Comment(L"Commandline dispatched to p1");
@@ -552,9 +472,7 @@ namespace RemotingUnitTests
 
         Log::Comment(L"Add a second peasant");
         const auto peasant2PID = 34567u;
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-        VERIFY_IS_NOT_NULL(p2);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
         m0->AddPeasant(*p2);
         p2->ExecuteCommandlineRequested([&](auto&&, const Remoting::CommandlineArgs& cmdlineArgs) {
             Log::Comment(L"Commandline dispatched to p2");
@@ -594,16 +512,12 @@ namespace RemotingUnitTests
         Log::Comment(L"Test proposing a commandline for an ID that doesn't have a current peasant");
 
         const auto monarch0PID = 12345u;
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
-        VERIFY_IS_NOT_NULL(m0);
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
         m0->FindTargetWindowRequested(&RemotingTests::_findTargetWindowHelper);
 
         Log::Comment(L"Add a peasant");
         const auto peasant1PID = 23456u;
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-        VERIFY_IS_NOT_NULL(p1);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
         m0->AddPeasant(*p1);
 
         {
@@ -631,16 +545,12 @@ namespace RemotingUnitTests
         Log::Comment(L"Test proposing a commandline for a peasant that previously died");
 
         const auto monarch0PID = 12345u;
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
-        VERIFY_IS_NOT_NULL(m0);
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
         m0->FindTargetWindowRequested(&RemotingTests::_findTargetWindowHelper);
 
         Log::Comment(L"Add a peasant");
         const auto peasant1PID = 23456u;
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-        VERIFY_IS_NOT_NULL(p1);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
         m0->AddPeasant(*p1);
         p1->ExecuteCommandlineRequested([&](auto&&, const Remoting::CommandlineArgs& /*cmdlineArgs*/) {
             Log::Comment(L"Commandline dispatched to p1");
@@ -649,9 +559,7 @@ namespace RemotingUnitTests
 
         Log::Comment(L"Add a second peasant");
         const auto peasant2PID = 34567u;
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-        VERIFY_IS_NOT_NULL(p2);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
         m0->AddPeasant(*p2);
         p2->ExecuteCommandlineRequested([&](auto&&, const Remoting::CommandlineArgs& cmdlineArgs) {
             Log::Comment(L"Commandline dispatched to p2");
@@ -702,23 +610,17 @@ namespace RemotingUnitTests
         const winrt::guid guid2{ Utils::GuidFromString(L"{22222222-2222-2222-2222-222222222222}") };
 
         const auto monarch0PID = 12345u;
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
-        VERIFY_IS_NOT_NULL(m0);
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
         m0->FindTargetWindowRequested(&RemotingTests::_findTargetWindowHelper);
 
         Log::Comment(L"Add a peasant");
         const auto peasant1PID = 23456u;
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-        VERIFY_IS_NOT_NULL(p1);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
         m0->AddPeasant(*p1);
 
         Log::Comment(L"Add a second peasant");
         const auto peasant2PID = 34567u;
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-        VERIFY_IS_NOT_NULL(p2);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
         m0->AddPeasant(*p2);
 
         {
@@ -759,23 +661,17 @@ namespace RemotingUnitTests
         const winrt::guid guid2{ Utils::GuidFromString(L"{22222222-2222-2222-2222-222222222222}") };
 
         const auto monarch0PID = 12345u;
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
-        VERIFY_IS_NOT_NULL(m0);
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
         m0->FindTargetWindowRequested(&RemotingTests::_findTargetWindowHelper);
 
         Log::Comment(L"Add a peasant");
         const auto peasant1PID = 23456u;
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-        VERIFY_IS_NOT_NULL(p1);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
         m0->AddPeasant(*p1);
 
         Log::Comment(L"Add a second peasant");
         const auto peasant2PID = 34567u;
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-        VERIFY_IS_NOT_NULL(p2);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
         m0->AddPeasant(*p2);
 
         {
@@ -798,9 +694,7 @@ namespace RemotingUnitTests
 
         Log::Comment(L"Add a third peasant");
         const auto peasant3PID = 45678u;
-        com_ptr<Remoting::implementation::Peasant> p3;
-        p3.attach(new Remoting::implementation::Peasant(peasant3PID));
-        VERIFY_IS_NOT_NULL(p3);
+        auto p3 = make_private<Remoting::implementation::Peasant>(peasant3PID);
         m0->AddPeasant(*p3);
         {
             Log::Comment(L"Activate the third peasant, first desktop");
@@ -836,23 +730,17 @@ namespace RemotingUnitTests
         const winrt::guid guid2{ Utils::GuidFromString(L"{22222222-2222-2222-2222-222222222222}") };
 
         const auto monarch0PID = 12345u;
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
-        VERIFY_IS_NOT_NULL(m0);
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
         m0->FindTargetWindowRequested(&RemotingTests::_findTargetWindowHelper);
 
         Log::Comment(L"Add a peasant");
         const auto peasant1PID = 23456u;
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-        VERIFY_IS_NOT_NULL(p1);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
         m0->AddPeasant(*p1);
 
         Log::Comment(L"Add a second peasant");
         const auto peasant2PID = 34567u;
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-        VERIFY_IS_NOT_NULL(p2);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
         m0->AddPeasant(*p2);
 
         {
@@ -875,9 +763,7 @@ namespace RemotingUnitTests
 
         Log::Comment(L"Add a third peasant");
         const auto peasant3PID = 45678u;
-        com_ptr<Remoting::implementation::Peasant> p3;
-        p3.attach(new Remoting::implementation::Peasant(peasant3PID));
-        VERIFY_IS_NOT_NULL(p3);
+        auto p3 = make_private<Remoting::implementation::Peasant>(peasant3PID);
         m0->AddPeasant(*p3);
         {
             Log::Comment(L"Activate the third peasant, first desktop");
@@ -937,23 +823,17 @@ namespace RemotingUnitTests
         const winrt::guid guid2{ Utils::GuidFromString(L"{22222222-2222-2222-2222-222222222222}") };
 
         const auto monarch0PID = 12345u;
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
-        VERIFY_IS_NOT_NULL(m0);
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
         m0->FindTargetWindowRequested(&RemotingTests::_findTargetWindowHelper);
 
         Log::Comment(L"Add a peasant");
         const auto peasant1PID = 23456u;
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-        VERIFY_IS_NOT_NULL(p1);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
         m0->AddPeasant(*p1);
 
         Log::Comment(L"Add a second peasant");
         const auto peasant2PID = 34567u;
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-        VERIFY_IS_NOT_NULL(p2);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
         m0->AddPeasant(*p2);
 
         {
@@ -974,9 +854,7 @@ namespace RemotingUnitTests
 
         Log::Comment(L"Add a third peasant");
         const auto peasant3PID = 45678u;
-        com_ptr<Remoting::implementation::Peasant> p3;
-        p3.attach(new Remoting::implementation::Peasant(peasant3PID));
-        VERIFY_IS_NOT_NULL(p3);
+        auto p3 = make_private<Remoting::implementation::Peasant>(peasant3PID);
         m0->AddPeasant(*p3);
         {
             Log::Comment(L"Activate the third peasant, first desktop");
@@ -1006,23 +884,17 @@ namespace RemotingUnitTests
         const winrt::guid guid2{ Utils::GuidFromString(L"{22222222-2222-2222-2222-222222222222}") };
 
         const auto monarch0PID = 12345u;
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
-        VERIFY_IS_NOT_NULL(m0);
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
         m0->FindTargetWindowRequested(&RemotingTests::_findTargetWindowHelper);
 
         Log::Comment(L"Add a peasant");
         const auto peasant1PID = 23456u;
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-        VERIFY_IS_NOT_NULL(p1);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
         m0->AddPeasant(*p1);
 
         Log::Comment(L"Add a second peasant");
         const auto peasant2PID = 34567u;
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-        VERIFY_IS_NOT_NULL(p2);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
         m0->AddPeasant(*p2);
 
         {
@@ -1066,18 +938,10 @@ namespace RemotingUnitTests
         const auto peasant1PID = 23456u;
         const auto peasant2PID = 34567u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
 
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
         p1->WindowName(L"one");
         p2->WindowName(L"_quake");
 
@@ -1165,18 +1029,9 @@ namespace RemotingUnitTests
         const auto peasant1PID = 23456u;
         const auto peasant2PID = 34567u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
-
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
 
         p1->WindowName(L"one");
         p2->WindowName(L"two");
@@ -1214,22 +1069,10 @@ namespace RemotingUnitTests
         const auto peasant2PID = 34567u;
         const auto monarch3PID = 45678u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
-
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        com_ptr<Remoting::implementation::Monarch> m3;
-        m3.attach(new Remoting::implementation::Monarch(monarch3PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
-        VERIFY_IS_NOT_NULL(m3);
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
+        auto m3 = make_private<Remoting::implementation::Monarch>(monarch3PID);
 
         p1->WindowName(L"one");
         p2->WindowName(L"two");
@@ -1271,18 +1114,10 @@ namespace RemotingUnitTests
         const auto peasant1PID = 23456u;
         const auto peasant2PID = 34567u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
 
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
         p1->WindowName(L"one");
         p2->WindowName(L"two");
 
@@ -1323,18 +1158,10 @@ namespace RemotingUnitTests
         const auto peasant1PID = 23456u;
         const auto peasant2PID = 34567u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
 
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
         p1->WindowName(L"one");
         p2->WindowName(L"two");
 
@@ -1377,18 +1204,10 @@ namespace RemotingUnitTests
         const auto peasant1PID = 23456u;
         const auto peasant2PID = 34567u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
 
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
         p1->WindowName(L"one");
         p2->WindowName(L"two");
 
@@ -1437,20 +1256,11 @@ namespace RemotingUnitTests
         const auto peasant1PID = 23456u;
         const auto peasant2PID = 34567u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
-        VERIFY_IS_NOT_NULL(m0);
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
         m0->FindTargetWindowRequested(&RemotingTests::_findTargetWindowByNameHelper);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
 
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
         p1->WindowName(L"one");
         p2->WindowName(L"two");
 
@@ -1515,18 +1325,10 @@ namespace RemotingUnitTests
         const auto peasant1PID = 23456u;
         const auto peasant2PID = 34567u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
 
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
         p1->WindowName(L"one");
         p2->WindowName(L"two");
 
@@ -1561,18 +1363,10 @@ namespace RemotingUnitTests
         const auto peasant1PID = 23456u;
         const auto peasant2PID = 34567u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
 
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
         p1->WindowName(L"one");
         p2->WindowName(L"two");
 
@@ -1605,18 +1399,10 @@ namespace RemotingUnitTests
         const auto peasant1PID = 23456u;
         const auto peasant2PID = 34567u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
 
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
         p1->WindowName(L"one");
         p2->WindowName(L"two");
 
@@ -1659,18 +1445,10 @@ namespace RemotingUnitTests
         const auto peasant1PID = 23456u;
         const auto peasant2PID = 34567u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
 
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
         p1->WindowName(L"one");
         p2->WindowName(L"two");
 
@@ -1746,18 +1524,10 @@ namespace RemotingUnitTests
         const auto peasant1PID = 23456u;
         const auto peasant2PID = 34567u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
 
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
         p1->WindowName(L"one");
         p2->WindowName(L"two");
 
@@ -1816,18 +1586,10 @@ namespace RemotingUnitTests
         const auto peasant1PID = 23456u;
         const auto peasant2PID = 34567u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
 
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
         p1->WindowName(L"one");
         p2->WindowName(L"two");
 
@@ -1892,18 +1654,10 @@ namespace RemotingUnitTests
         const auto peasant1PID = 23456u;
         const auto peasant2PID = 34567u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant1PID);
 
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
         p1->WindowName(L"one");
         p2->WindowName(L"two");
 
@@ -1992,22 +1746,11 @@ namespace RemotingUnitTests
         constexpr auto peasant2PID = 34567u;
         constexpr auto peasant3PID = 45678u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
+        auto p3 = make_private<Remoting::implementation::Peasant>(peasant3PID);
 
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        com_ptr<Remoting::implementation::Peasant> p3;
-        p3.attach(new Remoting::implementation::Peasant(peasant3PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
-        VERIFY_IS_NOT_NULL(p3);
         p1->WindowName(L"one");
         p2->WindowName(L"two");
         p3->WindowName(L"three");
@@ -2069,8 +1812,7 @@ namespace RemotingUnitTests
         }
 
         Log::Comment(L"Create a mock IVirtualDesktopManager to handle checking if a window is on a given desktop");
-        winrt::com_ptr<MockDesktopManager> manager;
-        manager.attach(new MockDesktopManager());
+        auto manager = winrt::make_self<MockDesktopManager>();
         m0->_desktopManager = manager.try_as<IVirtualDesktopManager>();
 
         auto firstCallback = [&](HWND h, BOOL* result) -> HRESULT {
@@ -2255,22 +1997,11 @@ namespace RemotingUnitTests
         constexpr auto peasant2PID = 34567u;
         constexpr auto peasant3PID = 45678u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
+        auto p3 = make_private<Remoting::implementation::Peasant>(peasant3PID);
 
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        com_ptr<Remoting::implementation::Peasant> p3;
-        p3.attach(new Remoting::implementation::Peasant(peasant3PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
-        VERIFY_IS_NOT_NULL(p3);
         p1->WindowName(L"one");
         p2->WindowName(L"two");
         p3->WindowName(L"three");
@@ -2332,8 +2063,7 @@ namespace RemotingUnitTests
         }
 
         Log::Comment(L"Create a mock IVirtualDesktopManager to handle checking if a window is on a given desktop");
-        winrt::com_ptr<MockDesktopManager> manager;
-        manager.attach(new MockDesktopManager());
+        auto manager = winrt::make_self<MockDesktopManager>();
         m0->_desktopManager = manager.try_as<IVirtualDesktopManager>();
 
         auto firstCallback = [&](HWND h, BOOL* result) -> HRESULT {
@@ -2408,22 +2138,11 @@ namespace RemotingUnitTests
         constexpr auto peasant2PID = 34567u;
         constexpr auto peasant3PID = 45678u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
+        auto p3 = make_private<Remoting::implementation::Peasant>(peasant3PID);
 
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        com_ptr<Remoting::implementation::Peasant> p3;
-        p3.attach(new Remoting::implementation::Peasant(peasant3PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
-        VERIFY_IS_NOT_NULL(p3);
         p1->WindowName(L"one");
         p2->WindowName(L"two");
         p3->WindowName(L"three");
@@ -2485,8 +2204,7 @@ namespace RemotingUnitTests
         }
 
         Log::Comment(L"Create a mock IVirtualDesktopManager to handle checking if a window is on a given desktop");
-        winrt::com_ptr<MockDesktopManager> manager;
-        manager.attach(new MockDesktopManager());
+        auto manager = winrt::make_self<MockDesktopManager>();
         m0->_desktopManager = manager.try_as<IVirtualDesktopManager>();
 
         auto firstCallback = [&](HWND h, BOOL* result) -> HRESULT {
@@ -2541,18 +2259,10 @@ namespace RemotingUnitTests
         const auto peasant1PID = 23456u;
         const auto peasant2PID = 34567u;
 
-        com_ptr<Remoting::implementation::Monarch> m0;
-        m0.attach(new Remoting::implementation::Monarch(monarch0PID));
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        auto p2 = make_private<Remoting::implementation::Peasant>(peasant2PID);
 
-        com_ptr<Remoting::implementation::Peasant> p1;
-        p1.attach(new Remoting::implementation::Peasant(peasant1PID));
-
-        com_ptr<Remoting::implementation::Peasant> p2;
-        p2.attach(new Remoting::implementation::Peasant(peasant2PID));
-
-        VERIFY_IS_NOT_NULL(m0);
-        VERIFY_IS_NOT_NULL(p1);
-        VERIFY_IS_NOT_NULL(p2);
         p1->WindowName(L"one");
         p2->WindowName(L"_quake");
 

--- a/src/cascadia/UnitTests_TerminalCore/ScreenSizeLimitsTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ScreenSizeLimitsTest.cpp
@@ -18,7 +18,7 @@ using namespace WEX::Common;
 namespace TerminalCoreUnitTests
 {
 #define WCS(x) WCSHELPER(x)
-#define WCSHELPER(x) L#x
+#define WCSHELPER(x) L## #x
 
     class ScreenSizeLimitsTest
     {

--- a/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
@@ -18,7 +18,7 @@ using namespace WEX::TestExecution;
 namespace TerminalCoreUnitTests
 {
 #define WCS(x) WCSHELPER(x)
-#define WCSHELPER(x) L#x
+#define WCSHELPER(x) L## #x
 
     class TerminalApiTest
     {

--- a/src/cascadia/WindowsTerminal_UIATests/WindowsTerminal.UIA.Tests.csproj
+++ b/src/cascadia/WindowsTerminal_UIATests/WindowsTerminal.UIA.Tests.csproj
@@ -54,10 +54,10 @@
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="TE.Managed, Version=10.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Taef.10.58.210305002\lib\net45\TE.Managed.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Taef.10.60.210621002\lib\net45\TE.Managed.dll</HintPath>
     </Reference>
     <Reference Include="TE.Model.Managed, Version=10.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Taef.10.58.210305002\lib\net45\TE.Model.Managed.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Taef.10.60.210621002\lib\net45\TE.Model.Managed.dll</HintPath>
     </Reference>
     <Reference Include="UIAutomationClient" />
     <Reference Include="UIAutomationTypes" />
@@ -68,10 +68,10 @@
       <HintPath>..\..\..\packages\Selenium.Support.3.5.0\lib\net40\WebDriver.Support.dll</HintPath>
     </Reference>
     <Reference Include="Wex.Common.Managed, Version=10.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Taef.10.58.210305002\lib\net45\Wex.Common.Managed.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Taef.10.60.210621002\lib\net45\Wex.Common.Managed.dll</HintPath>
     </Reference>
     <Reference Include="Wex.Logger.Interop, Version=10.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Taef.10.58.210305002\lib\net45\Wex.Logger.Interop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Taef.10.60.210621002\lib\net45\Wex.Logger.Interop.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>
@@ -122,11 +122,11 @@
   <PropertyGroup>
     <PostBuildEvent>copy $(SolutionDir)\dep\WinAppDriver\* $(OutDir)\</PostBuildEvent>
   </PropertyGroup>
-  <Import Project="..\..\..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets" Condition="Exists('..\..\..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets')" />
+  <Import Project="..\..\..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets" Condition="Exists('..\..\..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets'))" />
   </Target>
 </Project>

--- a/src/cascadia/WindowsTerminal_UIATests/packages.config
+++ b/src/cascadia/WindowsTerminal_UIATests/packages.config
@@ -5,5 +5,5 @@
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
   <package id="Selenium.Support" version="3.5.0" targetFramework="net45" />
   <package id="Selenium.WebDriver" version="3.5.0" targetFramework="net45" />
-  <package id="Microsoft.Taef" version="10.58.210305002" targetFramework="net45" />
+  <package id="Microsoft.Taef" version="10.60.210621002" targetFramework="net45" />
 </packages>

--- a/src/cascadia/inc/cppwinrt_utils.h
+++ b/src/cascadia/inc/cppwinrt_utils.h
@@ -114,23 +114,23 @@ private:                                                       \
 // private _setName() method, that the class can internally use to change the
 // value when it _knows_ it doesn't need to raise the PropertyChanged event
 // (like when the class is being initialized).
-#define WINRT_OBSERVABLE_PROPERTY(type, name, event, ...)                              \
-public:                                                                                \
-    type name() const noexcept { return _##name; };                                    \
-    void name(const type& value)                                                       \
-    {                                                                                  \
-        if (_##name != value)                                                          \
-        {                                                                              \
-            _##name = value;                                                           \
-            event(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L#name }); \
-        }                                                                              \
-    };                                                                                 \
-                                                                                       \
-private:                                                                               \
-    type _##name{ __VA_ARGS__ };                                                       \
-    void _set##name(const type& value)                                                 \
-    {                                                                                  \
-        const_cast<type&>(_##name) = value;                                            \
+#define WINRT_OBSERVABLE_PROPERTY(type, name, event, ...)                                 \
+public:                                                                                   \
+    type name() const noexcept { return _##name; };                                       \
+    void name(const type& value)                                                          \
+    {                                                                                     \
+        if (_##name != value)                                                             \
+        {                                                                                 \
+            _##name = value;                                                              \
+            event(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L## #name }); \
+        }                                                                                 \
+    };                                                                                    \
+                                                                                          \
+private:                                                                                  \
+    type _##name{ __VA_ARGS__ };                                                          \
+    void _set##name(const type& value)                                                    \
+    {                                                                                     \
+        _##name = value;                                                                  \
     };
 
 // Use this macro for quickly defining the factory_implementation part of a

--- a/src/common.build.tests.props
+++ b/src/common.build.tests.props
@@ -5,11 +5,11 @@
       <PreprocessorDefinitions>INLINE_TEST_METHOD_MARKUP;UNIT_TESTING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
-  <Import Project="$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets" Condition="Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets')" />
+  <Import Project="$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets" Condition="Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets'))" />
+    <Error Condition="!Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets'))" />
   </Target>
 </Project>

--- a/src/cppwinrt.build.pre.props
+++ b/src/cppwinrt.build.pre.props
@@ -72,8 +72,10 @@
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
 
       <!-- All new code should be in non-permissive mode. Big objects for C++/WinRT. -->
-      <AdditionalOptions>%(AdditionalOptions) /permissive- /bigobj /Zc:twoPhase-</AdditionalOptions>
-      <DisableSpecificWarnings>28204;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <ConformanceMode>true</ConformanceMode>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /bigobj /Zc:twoPhase-</AdditionalOptions>
+      <DisableSpecificWarnings>5104;5105;28204;%(DisableSpecificWarnings)</DisableSpecificWarnings>
 
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
     </ClCompile>

--- a/src/host/ft_uia/Host.Tests.UIA.csproj
+++ b/src/host/ft_uia/Host.Tests.UIA.csproj
@@ -53,10 +53,10 @@
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="TE.Managed, Version=10.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Taef.10.58.210305002\lib\net45\TE.Managed.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Taef.10.60.210621002\lib\net45\TE.Managed.dll</HintPath>
     </Reference>
     <Reference Include="TE.Model.Managed, Version=10.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Taef.10.58.210305002\lib\net45\TE.Model.Managed.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Taef.10.60.210621002\lib\net45\TE.Model.Managed.dll</HintPath>
     </Reference>
     <Reference Include="UIAutomationClient" />
     <Reference Include="UIAutomationTypes" />
@@ -67,10 +67,10 @@
       <HintPath>..\..\..\packages\Selenium.Support.3.5.0\lib\net40\WebDriver.Support.dll</HintPath>
     </Reference>
     <Reference Include="Wex.Common.Managed, Version=10.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Taef.10.58.210305002\lib\net45\Wex.Common.Managed.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Taef.10.60.210621002\lib\net45\Wex.Common.Managed.dll</HintPath>
     </Reference>
     <Reference Include="Wex.Logger.Interop, Version=10.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Taef.10.58.210305002\lib\net45\Wex.Logger.Interop.dll</HintPath>
+      <HintPath>..\..\..\packages\Microsoft.Taef.10.60.210621002\lib\net45\Wex.Logger.Interop.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>
@@ -145,11 +145,11 @@
   <PropertyGroup>
     <PostBuildEvent>copy $(SolutionDir)\dep\WinAppDriver\* $(OutDir)\</PostBuildEvent>
   </PropertyGroup>
-  <Import Project="..\..\..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets" Condition="Exists('..\..\..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets')" />
+  <Import Project="..\..\..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets" Condition="Exists('..\..\..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Taef.10.58.210305002\build\Microsoft.Taef.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets'))" />
   </Target>
 </Project>

--- a/src/host/ft_uia/packages.config
+++ b/src/host/ft_uia/packages.config
@@ -5,5 +5,5 @@
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
   <package id="Selenium.Support" version="3.5.0" targetFramework="net45" />
   <package id="Selenium.WebDriver" version="3.5.0" targetFramework="net45" />
-  <package id="Microsoft.Taef" version="10.58.210305002" targetFramework="net45" />
+  <package id="Microsoft.Taef" version="10.60.210621002" targetFramework="net45" />
 </packages>

--- a/src/inc/WilErrorReporting.h
+++ b/src/inc/WilErrorReporting.h
@@ -10,27 +10,6 @@ Module Name:
 #include <winmeta.h>
 #include <wil/common.h>
 
-#define CONSOLE_WIL_TRACELOGGING_COMMON_FAILURE_PARAMS(failure)                                                                                                                                    \
-    TraceLoggingUInt32((failure).hr, "hresult", "Failure error code"),                                                                                                                             \
-        TraceLoggingString((failure).pszFile, "fileName", "Source code file name where the error occurred"),                                                                                       \
-        TraceLoggingUInt32((failure).uLineNumber, "lineNumber", "Line number within the source code file where the error occurred"),                                                               \
-        TraceLoggingString((failure).pszModule, "module", "Name of the binary where the error occurred"),                                                                                          \
-        TraceLoggingUInt32(static_cast<DWORD>((failure).type), "failureType", "Indicates what type of failure was observed (exception, returned error, logged error or fail fast"),                \
-        TraceLoggingWideString((failure).pszMessage, "message", "Custom message associated with the failure (if any)"),                                                                            \
-        TraceLoggingUInt32((failure).threadId, "threadId", "Identifier of the thread the error occurred on"),                                                                                      \
-        TraceLoggingString((failure).pszCallContext, "callContext", "List of containing this error"),                                                                                              \
-        TraceLoggingUInt32((failure).callContextOriginating.contextId, "originatingContextId", "Identifier for the oldest activity containing this error"),                                        \
-        TraceLoggingString((failure).callContextOriginating.contextName, "originatingContextName", "Name of the oldest activity containing this error"),                                           \
-        TraceLoggingWideString((failure).callContextOriginating.contextMessage, "originatingContextMessage", "Custom message associated with the oldest activity containing this error (if any)"), \
-        TraceLoggingUInt32((failure).callContextCurrent.contextId, "currentContextId", "Identifier for the newest activity containing this error"),                                                \
-        TraceLoggingString((failure).callContextCurrent.contextName, "currentContextName", "Name of the newest activity containing this error"),                                                   \
-        TraceLoggingWideString((failure).callContextCurrent.contextMessage, "currentContextMessage", "Custom message associated with the newest activity containing this error (if any)")
-
-#define CONSOLE_WIL_TRACELOGGING_FAILURE_PARAMS(failure)       \
-    TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance), \
-        TraceLoggingStruct(14, "wilResult"),                   \
-        CONSOLE_WIL_TRACELOGGING_COMMON_FAILURE_PARAMS(failure)
-
 namespace Microsoft::Console::ErrorReporting
 {
     __declspec(selectany) TraceLoggingHProvider FallbackProvider;
@@ -39,13 +18,29 @@ namespace Microsoft::Console::ErrorReporting
     {
         if (!alreadyReported && FallbackProvider)
         {
-#pragma warning(suppress : 26477 26485 26494 26482 26446) // We don't control TraceLoggingWrite
-            TraceLoggingWrite(FallbackProvider,
-                              "FallbackError",
-                              TraceLoggingKeyword(MICROSOFT_KEYWORD_TELEMETRY),
-                              TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
-                              TraceLoggingLevel(WINEVENT_LEVEL_ERROR),
-                              CONSOLE_WIL_TRACELOGGING_FAILURE_PARAMS(failure));
+#pragma warning(suppress : 26477) // Use 'nullptr' rather than 0 or NULL
+            TraceLoggingWrite(
+                FallbackProvider,
+                "FallbackError",
+                TraceLoggingKeyword(MICROSOFT_KEYWORD_TELEMETRY),
+                TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage),
+                TraceLoggingLevel(WINEVENT_LEVEL_ERROR),
+                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance),
+                TraceLoggingStruct(14, "wilResult", "wilResult"),
+                TraceLoggingUInt32(failure.hr, "hresult", "Failure error code"),
+                TraceLoggingString(failure.pszFile, "fileName", "Source code file name where the error occurred"),
+                TraceLoggingUInt32(failure.uLineNumber, "lineNumber", "Line number within the source code file where the error occurred"),
+                TraceLoggingString(failure.pszModule, "module", "Name of the binary where the error occurred"),
+                TraceLoggingUInt32(static_cast<DWORD>(failure.type), "failureType", "Indicates what type of failure was observed (exception, returned error, logged error or fail fast"),
+                TraceLoggingWideString(failure.pszMessage, "message", "Custom message associated with the failure (if any)"),
+                TraceLoggingUInt32(failure.threadId, "threadId", "Identifier of the thread the error occurred on"),
+                TraceLoggingString(failure.pszCallContext, "callContext", "List of containing this error"),
+                TraceLoggingUInt32(failure.callContextOriginating.contextId, "originatingContextId", "Identifier for the oldest activity containing this error"),
+                TraceLoggingString(failure.callContextOriginating.contextName, "originatingContextName", "Name of the oldest activity containing this error"),
+                TraceLoggingWideString(failure.callContextOriginating.contextMessage, "originatingContextMessage", "Custom message associated with the oldest activity containing this error (if any)"),
+                TraceLoggingUInt32(failure.callContextCurrent.contextId, "currentContextId", "Identifier for the newest activity containing this error"),
+                TraceLoggingString(failure.callContextCurrent.contextName, "currentContextName", "Name of the newest activity containing this error"),
+                TraceLoggingWideString(failure.callContextCurrent.contextMessage, "currentContextMessage", "Custom message associated with the newest activity containing this error (if any)"));
         }
     }
     catch (...)

--- a/src/inc/consoletaeftemplates.hpp
+++ b/src/inc/consoletaeftemplates.hpp
@@ -20,7 +20,7 @@ Revision History:
 // Helper for declaring a variable to store a TEST_METHOD_PROPERTY and get it's value from the test metadata
 #define INIT_TEST_PROPERTY(type, identifer, description) \
     type identifer;                                      \
-    VERIFY_SUCCEEDED(TestData::TryGetValue(L#identifer, identifer), description);
+    VERIFY_SUCCEEDED(TestData::TryGetValue(L## #identifer, identifer), description);
 
 // Thinking of adding a new VerifyOutputTraits for a new type? MAKE SURE that
 // you include this header (or at least the relevant definition) before _every_
@@ -270,73 +270,60 @@ namespace WEX::TestExecution
         static WEX::Common::NoThrowString ToString(const INPUT_RECORD& ir)
         {
             SetVerifyOutput verifySettings(VerifyOutputSettings::LogOnlyFailures);
-            WCHAR szBuf[1024];
-            VERIFY_SUCCEEDED(StringCchCopy(szBuf, ARRAYSIZE(szBuf), L"(ev: "));
+
+            WEX::Common::NoThrowString str;
+            str.Append(L"(ev: ");
+
             switch (ir.EventType)
             {
             case FOCUS_EVENT:
             {
-                WCHAR szFocus[512];
-                VERIFY_SUCCEEDED(StringCchPrintf(szFocus,
-                                                 ARRAYSIZE(szFocus),
-                                                 L"FOCUS set: %s)",
-                                                 ir.Event.FocusEvent.bSetFocus ? L"T" : L"F"));
-                VERIFY_SUCCEEDED(StringCchCat(szBuf, ARRAYSIZE(szBuf), szFocus));
+                str.AppendFormat(
+                    L"FOCUS set: %s)",
+                    ir.Event.FocusEvent.bSetFocus ? L"T" : L"F");
                 break;
             }
 
             case KEY_EVENT:
             {
-                WCHAR szKey[512];
-                VERIFY_SUCCEEDED(StringCchPrintf(szKey,
-                                                 ARRAYSIZE(szKey),
-                                                 L"KEY down: %s reps: %d kc: 0x%x sc: 0x%x uc: %d ctl: 0x%x)",
-                                                 ir.Event.KeyEvent.bKeyDown ? L"T" : L"F",
-                                                 ir.Event.KeyEvent.wRepeatCount,
-                                                 ir.Event.KeyEvent.wVirtualKeyCode,
-                                                 ir.Event.KeyEvent.wVirtualScanCode,
-                                                 ir.Event.KeyEvent.uChar.UnicodeChar,
-                                                 ir.Event.KeyEvent.dwControlKeyState));
-                VERIFY_SUCCEEDED(StringCchCat(szBuf, ARRAYSIZE(szBuf), szKey));
+                str.AppendFormat(
+                    L"KEY down: %s reps: %d kc: 0x%x sc: 0x%x uc: %d ctl: 0x%x)",
+                    ir.Event.KeyEvent.bKeyDown ? L"T" : L"F",
+                    ir.Event.KeyEvent.wRepeatCount,
+                    ir.Event.KeyEvent.wVirtualKeyCode,
+                    ir.Event.KeyEvent.wVirtualScanCode,
+                    ir.Event.KeyEvent.uChar.UnicodeChar,
+                    ir.Event.KeyEvent.dwControlKeyState);
                 break;
             }
 
             case MENU_EVENT:
             {
-                WCHAR szMenu[512];
-                VERIFY_SUCCEEDED(StringCchPrintf(szMenu,
-                                                 ARRAYSIZE(szMenu),
-                                                 L"MENU cmd: %d (0x%x))",
-                                                 ir.Event.MenuEvent.dwCommandId,
-                                                 ir.Event.MenuEvent.dwCommandId));
-                VERIFY_SUCCEEDED(StringCchCat(szBuf, ARRAYSIZE(szBuf), szMenu));
+                str.AppendFormat(
+                    L"MENU cmd: %d (0x%x))",
+                    ir.Event.MenuEvent.dwCommandId,
+                    ir.Event.MenuEvent.dwCommandId);
                 break;
             }
 
             case MOUSE_EVENT:
             {
-                WCHAR szMouse[512];
-                VERIFY_SUCCEEDED(StringCchPrintf(szMouse,
-                                                 ARRAYSIZE(szMouse),
-                                                 L"MOUSE pos: (%d, %d) buttons: 0x%x ctl: 0x%x evflags: 0x%x)",
-                                                 ir.Event.MouseEvent.dwMousePosition.X,
-                                                 ir.Event.MouseEvent.dwMousePosition.Y,
-                                                 ir.Event.MouseEvent.dwButtonState,
-                                                 ir.Event.MouseEvent.dwControlKeyState,
-                                                 ir.Event.MouseEvent.dwEventFlags));
-                VERIFY_SUCCEEDED(StringCchCat(szBuf, ARRAYSIZE(szBuf), szMouse));
+                str.AppendFormat(
+                    L"MOUSE pos: (%d, %d) buttons: 0x%x ctl: 0x%x evflags: 0x%x)",
+                    ir.Event.MouseEvent.dwMousePosition.X,
+                    ir.Event.MouseEvent.dwMousePosition.Y,
+                    ir.Event.MouseEvent.dwButtonState,
+                    ir.Event.MouseEvent.dwControlKeyState,
+                    ir.Event.MouseEvent.dwEventFlags);
                 break;
             }
 
             case WINDOW_BUFFER_SIZE_EVENT:
             {
-                WCHAR szBufferSize[512];
-                VERIFY_SUCCEEDED(StringCchPrintf(szBufferSize,
-                                                 ARRAYSIZE(szBufferSize),
-                                                 L"WINDOW_BUFFER_SIZE (%d, %d)",
-                                                 ir.Event.WindowBufferSizeEvent.dwSize.X,
-                                                 ir.Event.WindowBufferSizeEvent.dwSize.Y));
-                VERIFY_SUCCEEDED(StringCchCat(szBuf, ARRAYSIZE(szBuf), szBufferSize));
+                str.AppendFormat(
+                    L"WINDOW_BUFFER_SIZE (%d, %d)",
+                    ir.Event.WindowBufferSizeEvent.dwSize.X,
+                    ir.Event.WindowBufferSizeEvent.dwSize.Y);
                 break;
             }
 
@@ -344,7 +331,7 @@ namespace WEX::TestExecution
                 VERIFY_FAIL(L"ERROR: unknown input event type encountered");
             }
 
-            return WEX::Common::NoThrowString(szBuf);
+            return str;
         }
     };
 

--- a/src/terminal/parser/ut_parser/packages.config
+++ b/src/terminal/parser/ut_parser/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Taef" version="10.58.210305002" targetFramework="native" />
+  <package id="Microsoft.Taef" version="10.60.210621002" targetFramework="native" />
 </packages>

--- a/tools/OpenConsole.psm1
+++ b/tools/OpenConsole.psm1
@@ -200,7 +200,7 @@ function Invoke-OpenConsoleTests()
         $TestHostAppPath = "$root\$Configuration\TestHostApp"
     }
     $OpenConsolePath = "$env:OpenConsoleroot\bin\$OpenConsolePlatform\$Configuration\OpenConsole.exe"
-    $TaefExePath = "$root\packages\Microsoft.Taef.10.58.210305002\build\Binaries\$Platform\te.exe"
+    $TaefExePath = "$root\packages\Microsoft.Taef.10.60.210621002\build\Binaries\$Platform\te.exe"
     $BinDir = "$root\bin\$OpenConsolePlatform\$Configuration"
 
     [xml]$TestConfig = Get-Content "$root\tools\tests.xml"

--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -104,7 +104,7 @@ shift
 goto :ARGS_LOOP
 
 :POST_ARGS_LOOP
-set TAEF=%OPENCON%\packages\Microsoft.Taef.10.58.210305002\build\Binaries\%ARCH%\TE.exe
+set TAEF=%OPENCON%\packages\Microsoft.Taef.10.60.210621002\build\Binaries\%ARCH%\TE.exe
 rem Set this envvar so setup won't repeat itself
 set OpenConBuild=true
 


### PR DESCRIPTION
This commit is a preparation for upcoming changes to KeyChordSerialization for #7539 and #10203.
In order to support variadic macros, /Zc:preprocessor was enabled, which required changing unrelated parts of the project.

## PR Checklist
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed

* Project still compiles ✔️