### PR TITLE
Specify sln file to use for razzle nuget restore

### DIFF
--- a/tools/razzle.cmd
+++ b/tools/razzle.cmd
@@ -21,7 +21,7 @@ rem Add nuget to PATH
 set PATH=%PATH%%OPENCON%\dep\nuget;
 
 rem Run nuget restore so you can use vswhere
-nuget restore %OPENCON% -Verbosity quiet
+nuget restore %OPENCON%\OpenConsole.sln -Verbosity quiet
 
 rem Find vswhere
 rem from https://github.com/microsoft/vs-setup-samples/blob/master/tools/vswhere.cmd


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
After the introduction of scratch.sln, the nuget restore in razzle.cmd fails. This fixes it by specifying the sln file to use.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #10605
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Ran razzle
