### PR TITLE
Include profile nav menu items to consider for retaining position

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -132,7 +132,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // refresh the current page using the SelectedItem data we collected before the refresh
         if (selectedItemTag)
         {
-            for (const auto& item : menuItemsSTL)
+            for (const auto& item : menuItems)
             {
                 if (const auto& menuItem{ item.try_as<MUX::Controls::NavigationViewItem>() })
                 {

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -169,14 +169,12 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             }
         }
 
-        // couldn't find the selected item,
-        // fallback to first menu item
-        const auto& firstItem{ menuItems.GetAt(0) };
+        // Couldn't find the selected item, fallback to first menu item
+        // This happens when the selected item was a profile which doesn't exist in the new configuration
+        // We can use menuItemsSTL here because the only things they miss are profile entries.
+        const auto& firstItem{ menuItemsSTL.at(0).as<MUX::Controls::NavigationViewItem>() };
         SettingsNav().SelectedItem(firstItem);
-        if (const auto& tag{ SettingsNav().SelectedItem().try_as<MUX::Controls::NavigationViewItem>().Tag() })
-        {
-            _Navigate(unbox_value<hstring>(tag));
-        }
+        _Navigate(unbox_value<hstring>(firstItem.Tag()));
     }
 
     void MainPage::SetHostingWindow(uint64_t hostingWindow) noexcept


### PR DESCRIPTION
## Summary of the Pull Request

When discarding or saving settings, the current navigation should be retained.

## References

Issue introduced by #10390

## PR Checklist

* [x] Closes #10617 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments

`menuItemsSTL` is filled with all _non_ profile navItems, then `menuItemsSTL` fills `menuItems`, then the profile navItems are added to `menuItems`. So to include the profile nav items in the iteration, `menuItems` needs to be used

## Validation Steps Performed

Spam discard and save buttons