### PR TITLE
Don't call flush when circling is triggered in VtRenderer

### DIFF
--- a/src/renderer/vt/paint.cpp
+++ b/src/renderer/vt/paint.cpp
@@ -73,7 +73,6 @@ using namespace Microsoft::Console::Types;
             _virtualTop--;
         }
     }
-    _circled = false;
 
     // If we deferred a cursor movement during the frame, make sure we put the
     //      cursor in the right place before we end the frame.
@@ -82,7 +81,12 @@ using namespace Microsoft::Console::Types;
         RETURN_IF_FAILED(_MoveCursor(_deferredCursorPos));
     }
 
-    RETURN_IF_FAILED(_Flush());
+    if (!_circled)
+    {
+        RETURN_IF_FAILED(_Flush());
+    }
+
+    _circled = false;
 
     return S_OK;
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Don't call flush when circling is triggered in VtRenderer.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

Currently every time `TriggerCircling` is called, `VtRenderer` will force paint the frame and then flush the internal buffer. This is not really necessary because the max drawing frequency for graphic renderers like DxRenderer is limited. This causes an exceptionally bad case for the "1 million yes" benchmark: every time a “y" is printed, a single line if flushed, which is `y(lot of spaces)\n`. With this fix, `VtRenderer` will not flush the buffer eagerly and wait for more text. This improves the throughput. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Supports #10563
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
