### PR TITLE
Optimize hot path in textBufferCellIterator

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -1021,6 +1021,7 @@ IAction
 IApi
 IApplication
 IBase
+ICache
 icacls
 iccex
 icch

--- a/src/buffer/out/OutputCellView.hpp
+++ b/src/buffer/out/OutputCellView.hpp
@@ -36,6 +36,21 @@ public:
     TextAttribute TextAttr() const noexcept;
     TextAttributeBehavior TextAttrBehavior() const noexcept;
 
+    void UpdateText(const std::wstring_view& view) noexcept
+    {
+        _view = view;
+    };
+
+    void UpdateDbcsAttribute(const DbcsAttribute& dbcsAttr) noexcept
+    {
+        _dbcsAttr = dbcsAttr;
+    }
+
+    void UpdateTextAttribute(const TextAttribute& textAttr) noexcept
+    {
+        _textAttr = textAttr;
+    }
+
     bool operator==(const OutputCellView& view) const noexcept;
     bool operator!=(const OutputCellView& view) const noexcept;
 

--- a/src/buffer/out/OutputCellView.hpp
+++ b/src/buffer/out/OutputCellView.hpp
@@ -6,7 +6,7 @@ Module Name:
 - OutputCellView.hpp
 
 Abstract:
-- Read-only view into a single cell of data that someone is attempting to write into the output buffer.
+- Read view into a single cell of data that someone is attempting to write into the output buffer.
 - This is done for performance reasons (avoid heap allocs and copies).
 
 Author:

--- a/src/buffer/out/textBufferCellIterator.cpp
+++ b/src/buffer/out/textBufferCellIterator.cpp
@@ -137,7 +137,7 @@ TextBufferCellIterator& TextBufferCellIterator::operator+=(const ptrdiff_t& move
 
     if (yChanged)
     {
-        _pRow = s_GetRow(_buffer, {newX, newY});
+        _pRow = s_GetRow(_buffer, { newX, newY });
         _attrIter = _pRow->GetAttrRow().cbegin() + newX;
         _pos.X = newX;
         _pos.Y = newY;

--- a/src/buffer/out/textBufferCellIterator.cpp
+++ b/src/buffer/out/textBufferCellIterator.cpp
@@ -95,12 +95,12 @@ bool TextBufferCellIterator::operator!=(const TextBufferCellIterator& it) const 
 TextBufferCellIterator& TextBufferCellIterator::operator+=(const ptrdiff_t& movement)
 {
     // Note that this method is called intensively when the terminal is under heavy load.
-    // We need to aggresively optimize it, comparing to the -= operator.
+    // We need to aggressively optimize it, comparing to the -= operator.
     ptrdiff_t move = movement;
     if (move < 0)
     {
         // Early branching to leave the rare case to -= operator.
-        // This helps reducing the intruction count within this method, which is good for instruction cache.
+        // This helps reducing the instruction count within this method, which is good for instruction cache.
         return (*this) -= (-move);
     }
 

--- a/src/buffer/out/textBufferCellIterator.hpp
+++ b/src/buffer/out/textBufferCellIterator.hpp
@@ -50,7 +50,6 @@ public:
     COORD Pos() const noexcept;
 
 protected:
-    void _SetPos(const COORD newPos);
     void _GenerateView();
     static const ROW* s_GetRow(const TextBuffer& buffer, const COORD pos);
 

--- a/src/buffer/out/textBufferCellIterator.hpp
+++ b/src/buffer/out/textBufferCellIterator.hpp
@@ -50,6 +50,7 @@ public:
     COORD Pos() const noexcept;
 
 protected:
+    void _SetPos(const COORD newPos);
     void _GenerateView();
     static const ROW* s_GetRow(const TextBuffer& buffer, const COORD pos);
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

The `+=` operator is an extremely hot path under heavily output load. This PR aims to optimize its speed.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Supports #10563
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
