### PR TITLE
Add a setting for disabling rendering "intense" text as bold

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -155,6 +155,7 @@
           "type": "string"
         },
         "disableIntenseIsBold": {
+          "default": "false",
           "description": "When set to true, text formatted as 'intense' will not be rendered as 'bold'.",
           "type": "boolean"
         },

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -154,6 +154,10 @@
           "description": "Sets how the background image aligns to the boundaries of the window when unfocused. Possible values: \"center\", \"left\", \"top\", \"right\", \"bottom\", \"topLeft\", \"topRight\", \"bottomLeft\", \"bottomRight\"",
           "type": "string"
         },
+        "disableIntenseIsBold": {
+          "description": "When set to true, text formatted as 'intense' will not be rendered as 'bold'.",
+          "type": "boolean"
+        },
         "experimental.retroTerminalEffect": {
           "description": "When set to true, enable retro terminal effects when unfocused. This is an experimental feature, and its continued existence is not guaranteed.",
           "type": "boolean"

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -198,6 +198,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             dxEngine->SetPixelShaderPath(_settings.PixelShaderPath());
             dxEngine->SetForceFullRepaintRendering(_settings.ForceFullRepaintRendering());
             dxEngine->SetSoftwareRendering(_settings.SoftwareRendering());
+            dxEngine->SetIntenseIsBold(!_settings.DisableIntenseIsBold());
 
             _updateAntiAliasingMode(dxEngine.get());
 
@@ -526,6 +527,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         _renderEngine->SetForceFullRepaintRendering(_settings.ForceFullRepaintRendering());
         _renderEngine->SetSoftwareRendering(_settings.SoftwareRendering());
+        _renderEngine->SetIntenseIsBold(!_settings.DisableIntenseIsBold());
+
         _updateAntiAliasingMode(_renderEngine.get());
 
         // Refresh our font with the renderer

--- a/src/cascadia/TerminalControl/IControlAppearance.idl
+++ b/src/cascadia/TerminalControl/IControlAppearance.idl
@@ -12,6 +12,7 @@ namespace Microsoft.Terminal.Control
         Windows.UI.Xaml.HorizontalAlignment BackgroundImageHorizontalAlignment;
         Windows.UI.Xaml.VerticalAlignment BackgroundImageVerticalAlignment;
 
+        Boolean DisableIntenseIsBold;
         // Experimental settings
         Boolean RetroTerminalEffect;
         String PixelShaderPath;

--- a/src/cascadia/TerminalSettingsEditor/Appearances.h
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.h
@@ -78,6 +78,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         OBSERVABLE_PROJECTED_SETTING(_appearance, BackgroundImageOpacity);
         OBSERVABLE_PROJECTED_SETTING(_appearance, BackgroundImageStretchMode);
         OBSERVABLE_PROJECTED_SETTING(_appearance, BackgroundImageAlignment);
+        OBSERVABLE_PROJECTED_SETTING(_appearance, DisableIntenseIsBold);
 
     private:
         Model::AppearanceConfig _appearance;

--- a/src/cascadia/TerminalSettingsEditor/Appearances.idl
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.idl
@@ -39,6 +39,9 @@ namespace Microsoft.Terminal.Settings.Editor
         OBSERVABLE_PROJECTED_APPEARANCE_SETTING(Double, BackgroundImageOpacity);
         OBSERVABLE_PROJECTED_APPEARANCE_SETTING(Windows.UI.Xaml.Media.Stretch, BackgroundImageStretchMode);
         OBSERVABLE_PROJECTED_APPEARANCE_SETTING(Microsoft.Terminal.Settings.Model.ConvergedAlignment, BackgroundImageAlignment);
+
+        OBSERVABLE_PROJECTED_APPEARANCE_SETTING(Boolean, DisableIntenseIsBold);
+
     }
 
     [default_interface] runtimeclass Appearances : Windows.UI.Xaml.Controls.UserControl, Windows.UI.Xaml.Data.INotifyPropertyChanged

--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -44,6 +44,8 @@
             <local:PaddingConverter x:Key="PaddingConverter" />
             <local:StringIsNotDesktopConverter x:Key="StringIsNotDesktopConverter" />
             <local:DesktopWallpaperToEmptyStringConverter x:Key="DesktopWallpaperToEmptyStringConverter" />
+            <local:InvertedBooleanConverter x:Key="InvertedBooleanConverter" />
+
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -157,6 +159,14 @@
                                     SettingOverrideSource="{x:Bind Appearance.RetroTerminalEffectOverrideSource, Mode=OneWay}">
                 <ToggleSwitch IsOn="{x:Bind Appearance.RetroTerminalEffect, Mode=TwoWay}" />
             </local:SettingContainer>
+            <!--  Intense is bold  -->
+            <local:SettingContainer x:Uid="Profile_DisableIntenseIsBold"
+                                    ClearSettingValue="{x:Bind Appearance.ClearDisableIntenseIsBold}"
+                                    HasSettingValue="{x:Bind Appearance.HasDisableIntenseIsBold, Mode=OneWay}"
+                                    SettingOverrideSource="{x:Bind Appearance.DisableIntenseIsBoldOverrideSource, Mode=OneWay}">
+                <ToggleSwitch IsOn="{x:Bind Appearance.DisableIntenseIsBold, Mode=TwoWay, Converter={StaticResource InvertedBooleanConverter}}" />
+            </local:SettingContainer>
+
         </StackPanel>
 
         <!--  Grouping: Cursor  -->

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -402,6 +402,7 @@
                                           IsChecked="{x:Bind IsBellStyleFlagSet(4), BindBack=SetBellStyleTaskbar, Mode=TwoWay}" />
                             </StackPanel>
                         </local:SettingContainer>
+
                     </StackPanel>
                 </ScrollViewer>
             </PivotItem>

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -481,7 +481,6 @@
                                           IsChecked="{x:Bind IsBellStyleFlagSet(4), BindBack=SetBellStyleTaskbar, Mode=TwoWay}" />
                             </StackPanel>
                         </local:SettingContainer>
-
                     </StackPanel>
                 </ScrollViewer>
             </PivotItem>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -926,6 +926,10 @@
     <value>Flash window</value>
     <comment>An option to choose from for the "bell style" setting. When selected, a visual notification is used to notify the user. In this case, the window is flashed.</comment>
   </data>
+  <data name="Profile_DisableIntenseIsBold.Header" xml:space="preserve">
+    <value>Render "intense" text as bold</value>
+    <comment>Header for a control to toggle if text formatted as "intense" should be rendered with a bold font weight or not.</comment>
+  </data>
   <data name="ColorScheme_AddNewButton.Text" xml:space="preserve">
     <value>Add new</value>
     <comment>Button label that creates a new color scheme.</comment>

--- a/src/cascadia/TerminalSettingsModel/AppearanceConfig.cpp
+++ b/src/cascadia/TerminalSettingsModel/AppearanceConfig.cpp
@@ -25,6 +25,7 @@ static constexpr std::string_view BackgroundImageStretchModeKey{ "backgroundImag
 static constexpr std::string_view BackgroundImageAlignmentKey{ "backgroundImageAlignment" };
 static constexpr std::string_view RetroTerminalEffectKey{ "experimental.retroTerminalEffect" };
 static constexpr std::string_view PixelShaderPathKey{ "experimental.pixelShaderPath" };
+static constexpr std::string_view DisableIntenseIsBoldKey{ "disableIntenseIsBold" };
 
 winrt::Microsoft::Terminal::Settings::Model::implementation::AppearanceConfig::AppearanceConfig(const winrt::weak_ref<Profile> sourceProfile) :
     _sourceProfile(sourceProfile)
@@ -48,6 +49,7 @@ winrt::com_ptr<AppearanceConfig> AppearanceConfig::CopyAppearance(const winrt::c
     appearance->_BackgroundImageAlignment = sourceAppearance->_BackgroundImageAlignment;
     appearance->_RetroTerminalEffect = sourceAppearance->_RetroTerminalEffect;
     appearance->_PixelShaderPath = sourceAppearance->_PixelShaderPath;
+    appearance->_DisableIntenseIsBold = sourceAppearance->_DisableIntenseIsBold;
     return appearance;
 }
 
@@ -68,6 +70,7 @@ Json::Value AppearanceConfig::ToJson() const
     JsonUtils::SetValueForKey(json, BackgroundImageAlignmentKey, _BackgroundImageAlignment);
     JsonUtils::SetValueForKey(json, RetroTerminalEffectKey, _RetroTerminalEffect);
     JsonUtils::SetValueForKey(json, PixelShaderPathKey, _PixelShaderPath);
+    JsonUtils::SetValueForKey(json, DisableIntenseIsBoldKey, _DisableIntenseIsBold);
 
     return json;
 }
@@ -98,6 +101,7 @@ void AppearanceConfig::LayerJson(const Json::Value& json)
     JsonUtils::GetValueForKey(json, BackgroundImageAlignmentKey, _BackgroundImageAlignment);
     JsonUtils::GetValueForKey(json, RetroTerminalEffectKey, _RetroTerminalEffect);
     JsonUtils::GetValueForKey(json, PixelShaderPathKey, _PixelShaderPath);
+    JsonUtils::GetValueForKey(json, DisableIntenseIsBoldKey, _DisableIntenseIsBold);
 }
 
 winrt::Microsoft::Terminal::Settings::Model::Profile AppearanceConfig::SourceProfile()

--- a/src/cascadia/TerminalSettingsModel/AppearanceConfig.h
+++ b/src/cascadia/TerminalSettingsModel/AppearanceConfig.h
@@ -53,6 +53,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         INHERITABLE_SETTING(Model::IAppearanceConfig, bool, RetroTerminalEffect, false);
         INHERITABLE_SETTING(Model::IAppearanceConfig, hstring, PixelShaderPath, L"");
 
+        INHERITABLE_SETTING(Model::IAppearanceConfig, bool, DisableIntenseIsBold, false);
+
     private:
         winrt::weak_ref<Profile> _sourceProfile;
     };

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -340,6 +340,7 @@ winrt::Microsoft::Terminal::Settings::Model::Profile CascadiaSettings::Duplicate
     DUPLICATE_APPEARANCE_SETTING_MACRO(SelectionBackground);
     DUPLICATE_APPEARANCE_SETTING_MACRO(CursorColor);
     DUPLICATE_APPEARANCE_SETTING_MACRO(PixelShaderPath);
+    DUPLICATE_APPEARANCE_SETTING_MACRO(DisableIntenseIsBold);
     DUPLICATE_APPEARANCE_SETTING_MACRO(BackgroundImagePath);
     DUPLICATE_APPEARANCE_SETTING_MACRO(BackgroundImageOpacity);
     DUPLICATE_APPEARANCE_SETTING_MACRO(BackgroundImageStretchMode);

--- a/src/cascadia/TerminalSettingsModel/IAppearanceConfig.idl
+++ b/src/cascadia/TerminalSettingsModel/IAppearanceConfig.idl
@@ -42,5 +42,7 @@ namespace Microsoft.Terminal.Settings.Model
 
         INHERITABLE_APPEARANCE_SETTING(Boolean, RetroTerminalEffect);
         INHERITABLE_APPEARANCE_SETTING(String, PixelShaderPath);
+
+        INHERITABLE_APPEARANCE_SETTING(Boolean, DisableIntenseIsBold);
     };
 }

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
@@ -202,6 +202,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         _RetroTerminalEffect = appearance.RetroTerminalEffect();
         _PixelShaderPath = winrt::hstring{ wil::ExpandEnvironmentStringsW<std::wstring>(appearance.PixelShaderPath().c_str()) };
+
+        _DisableIntenseIsBold = appearance.DisableIntenseIsBold();
     }
 
     // Method Description:

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -150,6 +150,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         INHERITABLE_SETTING(Model::TerminalSettings, hstring, PixelShaderPath);
 
+        INHERITABLE_SETTING(Model::TerminalSettings, bool, DisableIntenseIsBold, false);
+
     private:
         std::optional<std::array<Microsoft::Terminal::Core::Color, COLOR_TABLE_SIZE>> _ColorTable;
         gsl::span<Microsoft::Terminal::Core::Color> _getColorTableImpl();

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1035,6 +1035,17 @@ try
 }
 CATCH_LOG()
 
+void DxEngine::SetIntenseIsBold(bool enable) noexcept
+try
+{
+    if (_intenseIsBold != enable)
+    {
+        _intenseIsBold = enable;
+        LOG_IF_FAILED(InvalidateAll());
+    }
+}
+CATCH_LOG()
+
 HANDLE DxEngine::GetSwapChainHandle()
 {
     if (!_swapChainHandle)
@@ -1961,7 +1972,7 @@ CATCH_RETURN()
     if (_drawingContext)
     {
         _drawingContext->forceGrayscaleAA = _ShouldForceGrayscaleAA();
-        _drawingContext->useBoldFont = textAttributes.IsBold();
+        _drawingContext->useBoldFont = _intenseIsBold && textAttributes.IsBold();
         _drawingContext->useItalicFont = textAttributes.IsItalic();
     }
 

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -95,6 +95,7 @@ DxEngine::DxEngine() :
     _dpi{ USER_DEFAULT_SCREEN_DPI },
     _scale{ 1.0f },
     _prevScale{ 1.0f },
+    _intenseIsBold{ true },
     _chainMode{ SwapChainMode::ForComposition },
     _customLayout{},
     _customRenderer{ ::Microsoft::WRL::Make<CustomTextRenderer>() },

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -70,6 +70,8 @@ namespace Microsoft::Console::Render
 
         void SetSoftwareRendering(bool enable) noexcept;
 
+        void SetIntenseIsBold(bool enable) noexcept;
+
         HANDLE GetSwapChainHandle();
 
         // IRenderEngine Members
@@ -252,6 +254,7 @@ namespace Microsoft::Console::Render
         // Preferences and overrides
         bool _softwareRendering;
         bool _forceFullRepaintRendering;
+        bool _intenseIsBold{ true };
 
         D2D1_TEXT_ANTIALIAS_MODE _antialiasingMode;
 

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -254,7 +254,7 @@ namespace Microsoft::Console::Render
         // Preferences and overrides
         bool _softwareRendering;
         bool _forceFullRepaintRendering;
-        bool _intenseIsBold{ true };
+        bool _intenseIsBold;
 
         D2D1_TEXT_ANTIALIAS_MODE _antialiasingMode;
 


### PR DESCRIPTION
## Summary of the Pull Request

This adds a new setting `disableIntenseIsBold`. It's a per-appearance, control setting, defaulting to `false`.
* When set to false, we'll render text formatted with `^[[1m` as **bold**. (the 1.10+ default)
* When set to true, we won't. (the pre-1.10 behavior)

## PR Checklist
* [x] Closes #10576 
* [x] I work here
* [ ] Tests added/passed - nah I didn't do that
* [n/a] Requires documentation to be updated

## Validation Steps Performed

![image](https://user-images.githubusercontent.com/18356694/125480327-07f6b711-6bca-4c1b-9a76-75fc978c702d.png)

Yea that works. Printed some bold text, toggled it on, the text was no longer bold. hooray.