### PR TITLE
Add a KeyChordListener to the Settings UI

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Actions.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Actions.cpp
@@ -38,7 +38,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             const auto viewModelProperty{ args.PropertyName() };
             if (viewModelProperty == L"CurrentKeys")
             {
-                _KeyChordText = Model::KeyChordSerialization::ToString(_CurrentKeys);
+                _KeyChordText = KeyChordSerialization::ToString(_CurrentKeys);
                 _NotifyChanges(L"KeyChordText");
             }
             else if (viewModelProperty == L"IsContainerFocused" ||
@@ -75,8 +75,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             // if we're in edit mode,
             // - pre-populate the text box with the current keys
             // - reset the combo box with the current action
-            ProposedKeys(CurrentKeys());
-            ProposedAction(box_value(CurrentAction()));
+            ProposedKeys(_CurrentKeys);
+            ProposedAction(box_value(_CurrentAction));
         }
     }
 

--- a/src/cascadia/TerminalSettingsEditor/Actions.h
+++ b/src/cascadia/TerminalSettingsEditor/Actions.h
@@ -60,9 +60,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void ToggleEditMode();
         void DisableEditMode() { IsInEditMode(false); }
         void AttemptAcceptChanges();
-        void AttemptAcceptChanges(hstring newKeyChordText);
+        void AttemptAcceptChanges(const Control::KeyChord newKeys);
         void CancelChanges();
-        void DeleteKeyBinding() { _DeleteKeyBindingRequestedHandlers(*this, _Keys); }
+        void DeleteKeyBinding() { _DeleteKeyBindingRequestedHandlers(*this, _CurrentKeys); }
 
         // ProposedAction:   the entry selected by the combo box; may disagree with the settings model.
         // CurrentAction:    the combo box item that maps to the settings model value.
@@ -77,10 +77,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         VIEW_MODEL_OBSERVABLE_PROPERTY(hstring, CurrentAction);
         WINRT_PROPERTY(Windows::Foundation::Collections::IObservableVector<hstring>, AvailableActions, nullptr);
 
-        // ProposedKeys: the text shown in the text box; may disagree with the settings model.
-        // Keys:         the key chord bound in the settings model.
-        VIEW_MODEL_OBSERVABLE_PROPERTY(hstring, ProposedKeys);
-        VIEW_MODEL_OBSERVABLE_PROPERTY(Control::KeyChord, Keys, nullptr);
+        // ProposedKeys: the keys proposed by the control; may disagree with the settings model.
+        // CurrentKeys:         the key chord bound in the settings model.
+        VIEW_MODEL_OBSERVABLE_PROPERTY(Control::KeyChord, ProposedKeys);
+        VIEW_MODEL_OBSERVABLE_PROPERTY(Control::KeyChord, CurrentKeys, nullptr);
 
         VIEW_MODEL_OBSERVABLE_PROPERTY(bool, IsInEditMode, false);
         VIEW_MODEL_OBSERVABLE_PROPERTY(bool, IsNewlyAdded, false);
@@ -114,7 +114,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         void OnNavigatedTo(const winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
         Windows::UI::Xaml::Automation::Peers::AutomationPeer OnCreateAutomationPeer();
-        void KeyChordEditor_KeyDown(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e);
         void AddNew_Click(const IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& eventArgs);
 
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);

--- a/src/cascadia/TerminalSettingsEditor/Actions.h
+++ b/src/cascadia/TerminalSettingsEditor/Actions.h
@@ -78,7 +78,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         WINRT_PROPERTY(Windows::Foundation::Collections::IObservableVector<hstring>, AvailableActions, nullptr);
 
         // ProposedKeys: the keys proposed by the control; may disagree with the settings model.
-        // CurrentKeys:         the key chord bound in the settings model.
+        // CurrentKeys:  the key chord bound in the settings model.
         VIEW_MODEL_OBSERVABLE_PROPERTY(Control::KeyChord, ProposedKeys);
         VIEW_MODEL_OBSERVABLE_PROPERTY(Control::KeyChord, CurrentKeys, nullptr);
 

--- a/src/cascadia/TerminalSettingsEditor/Actions.idl
+++ b/src/cascadia/TerminalSettingsEditor/Actions.idl
@@ -23,7 +23,7 @@ namespace Microsoft.Terminal.Settings.Editor
         Boolean ShowEditButton { get; };
         Boolean IsInEditMode { get; };
         Boolean IsNewlyAdded { get; };
-        String ProposedKeys;
+        Microsoft.Terminal.Control.KeyChord ProposedKeys;
         Object ProposedAction;
         Windows.UI.Xaml.Controls.Flyout AcceptChangesFlyout;
         String EditButtonName { get; };

--- a/src/cascadia/TerminalSettingsEditor/Actions.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Actions.xaml
@@ -133,13 +133,9 @@
                 <Setter Property="TextWrapping" Value="WrapWholeWords" />
             </Style>
             <Style x:Key="KeyChordEditorStyle"
-                   BasedOn="{StaticResource DefaultTextBoxStyle}"
-                   TargetType="TextBox">
+                   TargetType="local:KeyChordListener">
                 <Setter Property="HorizontalAlignment" Value="Right" />
                 <Setter Property="VerticalAlignment" Value="Center" />
-                <Setter Property="TextAlignment" Value="Right" />
-                <Setter Property="TextWrapping" Value="Wrap" />
-                <Setter Property="IsSpellCheckEnabled" Value="False" />
             </Style>
             <x:Int32 x:Key="EditButtonSize">32</x:Int32>
             <x:Double x:Key="EditButtonIconSize">15</x:Double>
@@ -222,13 +218,11 @@
                                        TextWrapping="WrapWholeWords" />
                         </Border>
 
-                        <!--  Edit Mode: Key Chord Text Box  -->
-                        <TextBox Grid.Column="1"
-                                 DataContext="{x:Bind Mode=OneWay}"
-                                 KeyDown="KeyChordEditor_KeyDown"
-                                 Style="{StaticResource KeyChordEditorStyle}"
-                                 Text="{x:Bind ProposedKeys, Mode=TwoWay}"
-                                 Visibility="{x:Bind IsInEditMode, Mode=OneWay}" />
+                        <!--  Edit Mode: Key Chord Listener  -->
+                        <local:KeyChordListener Grid.Column="1"
+                                                CurrentKeys="{x:Bind ProposedKeys, Mode=TwoWay}"
+                                                Style="{StaticResource KeyChordEditorStyle}"
+                                                Visibility="{x:Bind IsInEditMode, Mode=OneWay}" />
 
                         <!--  Edit Button  -->
                         <Button x:Uid="Actions_EditButton"

--- a/src/cascadia/TerminalSettingsEditor/Actions.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Actions.xaml
@@ -198,7 +198,8 @@
                                    Visibility="{x:Bind IsInEditMode, Mode=OneWay, Converter={StaticResource InvertedBooleanToVisibilityConverter}}" />
 
                         <!--  Edit Mode: Action Combo-box  -->
-                        <ComboBox Grid.Column="0"
+                        <ComboBox x:Uid="Actions_ActionComboBox"
+                                  Grid.Column="0"
                                   VerticalAlignment="Center"
                                   ItemsSource="{x:Bind AvailableActions, Mode=OneWay}"
                                   SelectedItem="{x:Bind ProposedAction, Mode=TwoWay}"
@@ -220,7 +221,7 @@
 
                         <!--  Edit Mode: Key Chord Listener  -->
                         <local:KeyChordListener Grid.Column="1"
-                                                CurrentKeys="{x:Bind ProposedKeys, Mode=TwoWay}"
+                                                Keys="{x:Bind ProposedKeys, Mode=TwoWay}"
                                                 Style="{StaticResource KeyChordEditorStyle}"
                                                 Visibility="{x:Bind IsInEditMode, Mode=OneWay}" />
 

--- a/src/cascadia/TerminalSettingsEditor/KeyChordListener.cpp
+++ b/src/cascadia/TerminalSettingsEditor/KeyChordListener.cpp
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "KeyChordListener.h"
+#include "KeyChordListener.g.cpp"
+#include "LibraryResources.h"
+
+using namespace winrt::Windows::UI::Core;
+using namespace winrt::Windows::UI::Xaml;
+using namespace winrt::Windows::UI::Xaml::Controls;
+using namespace winrt::Windows::UI::Xaml::Data;
+using namespace winrt::Windows::Foundation;
+using namespace winrt::Windows::System;
+using namespace winrt::Windows::UI::Xaml::Input;
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
+{
+    DependencyProperty KeyChordListener::_CurrentKeysProperty{ nullptr };
+
+    static constexpr std::array<VirtualKey, 10> ModifierKeys{
+        VirtualKey::Menu,
+        VirtualKey::RightMenu,
+        VirtualKey::LeftMenu,
+        VirtualKey::Control,
+        VirtualKey::RightControl,
+        VirtualKey::LeftControl,
+        VirtualKey::Shift,
+        VirtualKey::LeftShift,
+        VirtualKey::RightWindows,
+        VirtualKey::LeftWindows
+    };
+
+    static VirtualKeyModifiers _GetModifiers()
+    {
+        const auto window{ CoreWindow::GetForCurrentThread() };
+
+        VirtualKeyModifiers flags = VirtualKeyModifiers::None;
+        for (const auto mod : ModifierKeys)
+        {
+            const auto state = window.GetKeyState(mod);
+            const auto isDown = WI_IsFlagSet(state, CoreVirtualKeyStates::Down);
+
+            if (isDown)
+            {
+                switch (mod)
+                {
+                case VirtualKey::Control:
+                case VirtualKey::LeftControl:
+                case VirtualKey::RightControl:
+                {
+                    flags |= VirtualKeyModifiers::Control;
+                    break;
+                }
+                case VirtualKey::Menu:
+                case VirtualKey::LeftMenu:
+                case VirtualKey::RightMenu:
+                {
+                    flags |= VirtualKeyModifiers::Menu;
+                    break;
+                }
+                case VirtualKey::Shift:
+                case VirtualKey::LeftShift:
+                {
+                    flags |= VirtualKeyModifiers::Shift;
+                    break;
+                }
+                case VirtualKey::LeftWindows:
+                case VirtualKey::RightWindows:
+                {
+                    flags |= VirtualKeyModifiers::Windows;
+                    break;
+                }
+                }
+            }
+        }
+        return flags;
+    }
+
+    KeyChordListener::KeyChordListener()
+    {
+        InitializeComponent();
+        _InitializeProperties();
+
+        PropertyChanged([this](auto&&, const PropertyChangedEventArgs& args) {
+            if (args.PropertyName() == L"ProposedKeys")
+            {
+                KeyChordTextBox().Text(Model::KeyChordSerialization::ToString(_ProposedKeys));
+            }
+        });
+    }
+
+    void KeyChordListener::_InitializeProperties()
+    {
+        // Initialize any KeyChordListener dependency properties here.
+        // This performs a lazy load on these properties, instead of
+        // initializing them when the DLL loads.
+        if (!_CurrentKeysProperty)
+        {
+            _CurrentKeysProperty =
+                DependencyProperty::Register(
+                    L"CurrentKeys",
+                    xaml_typename<Control::KeyChord>(),
+                    xaml_typename<Editor::KeyChordListener>(),
+                    PropertyMetadata{ nullptr, PropertyChangedCallback{ &KeyChordListener::_OnCurrentKeysChanged } });
+        }
+    }
+
+    void KeyChordListener::_OnCurrentKeysChanged(DependencyObject const& d, DependencyPropertyChangedEventArgs const& e)
+    {
+        if (auto control{ d.try_as<Editor::KeyChordListener>() })
+        {
+            auto controlImpl{ get_self<KeyChordListener>(control) };
+            controlImpl->ProposedKeys(unbox_value<Control::KeyChord>(e.NewValue()));
+        }
+    }
+
+    void KeyChordListener::KeyChordTextBox_LosingFocus(IInspectable const& /*sender*/, LosingFocusEventArgs const& /*e*/)
+    {
+        // export our key chord into the attached view model
+        SetValue(_CurrentKeysProperty, _ProposedKeys);
+    }
+
+    void KeyChordListener::KeyChordTextBox_KeyDown(IInspectable const& /*sender*/, KeyRoutedEventArgs const& e)
+    {
+        const auto key{ e.OriginalKey() };
+        for (const auto mod : ModifierKeys)
+        {
+            if (key == mod)
+            {
+                // Ignore modifier keys
+                return;
+            }
+        }
+
+        const auto modifiers{ _GetModifiers() };
+        if (key == VirtualKey::Tab && (modifiers == VirtualKeyModifiers::None || modifiers == VirtualKeyModifiers::Shift))
+        {
+            // [Shift]+[Tab] && [Tab] are needed for keyboard navigation
+            return;
+        }
+
+        // Permitted key events are used to update _ProposedKeys
+        ProposedKeys({ modifiers, static_cast<int32_t>(key) });
+        e.Handled(true);
+    }
+}

--- a/src/cascadia/TerminalSettingsEditor/KeyChordListener.cpp
+++ b/src/cascadia/TerminalSettingsEditor/KeyChordListener.cpp
@@ -18,17 +18,17 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
     DependencyProperty KeyChordListener::_KeysProperty{ nullptr };
 
-    static constexpr std::array<VirtualKey, 10> ModifierKeys{
-        VirtualKey::Menu,
-        VirtualKey::RightMenu,
-        VirtualKey::LeftMenu,
-        VirtualKey::Control,
-        VirtualKey::RightControl,
-        VirtualKey::LeftControl,
+    static constexpr std::array ModifierKeys{
         VirtualKey::Shift,
-        VirtualKey::LeftShift,
+        VirtualKey::Control,
+        VirtualKey::Menu,
+        VirtualKey::LeftWindows,
         VirtualKey::RightWindows,
-        VirtualKey::LeftWindows
+        VirtualKey::LeftShift,
+        VirtualKey::LeftControl,
+        VirtualKey::RightControl,
+        VirtualKey::LeftMenu,
+        VirtualKey::RightMenu
     };
 
     static VirtualKeyModifiers _GetModifiers()
@@ -48,29 +48,21 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 case VirtualKey::Control:
                 case VirtualKey::LeftControl:
                 case VirtualKey::RightControl:
-                {
                     flags |= VirtualKeyModifiers::Control;
                     break;
-                }
                 case VirtualKey::Menu:
                 case VirtualKey::LeftMenu:
                 case VirtualKey::RightMenu:
-                {
                     flags |= VirtualKeyModifiers::Menu;
                     break;
-                }
                 case VirtualKey::Shift:
                 case VirtualKey::LeftShift:
-                {
                     flags |= VirtualKeyModifiers::Shift;
                     break;
-                }
                 case VirtualKey::LeftWindows:
                 case VirtualKey::RightWindows:
-                {
                     flags |= VirtualKeyModifiers::Windows;
                     break;
-                }
                 }
             }
         }

--- a/src/cascadia/TerminalSettingsEditor/KeyChordListener.h
+++ b/src/cascadia/TerminalSettingsEditor/KeyChordListener.h
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+#include "KeyChordListener.g.h"
+#include "Utils.h"
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
+{
+    struct KeyChordListener : KeyChordListenerT<KeyChordListener>
+    {
+    public:
+        KeyChordListener();
+
+        void KeyChordTextBox_LosingFocus(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::LosingFocusEventArgs const& e);
+        void KeyChordTextBox_KeyDown(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e);
+
+        WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
+        DEPENDENCY_PROPERTY(Control::KeyChord, CurrentKeys);
+        WINRT_OBSERVABLE_PROPERTY(Control::KeyChord, ProposedKeys, _PropertyChangedHandlers, nullptr);
+
+    private:
+        static void _InitializeProperties();
+        static void _OnCurrentKeysChanged(Windows::UI::Xaml::DependencyObject const& d, Windows::UI::Xaml::DependencyPropertyChangedEventArgs const& e);
+    };
+}
+
+namespace winrt::Microsoft::Terminal::Settings::Editor::factory_implementation
+{
+    BASIC_FACTORY(KeyChordListener);
+}

--- a/src/cascadia/TerminalSettingsEditor/KeyChordListener.h
+++ b/src/cascadia/TerminalSettingsEditor/KeyChordListener.h
@@ -13,16 +13,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     public:
         KeyChordListener();
 
-        void KeyChordTextBox_LosingFocus(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::LosingFocusEventArgs const& e);
         void KeyChordTextBox_KeyDown(Windows::Foundation::IInspectable const& sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e);
 
-        WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
-        DEPENDENCY_PROPERTY(Control::KeyChord, CurrentKeys);
-        WINRT_OBSERVABLE_PROPERTY(Control::KeyChord, ProposedKeys, _PropertyChangedHandlers, nullptr);
+        DEPENDENCY_PROPERTY(Control::KeyChord, Keys);
 
     private:
         static void _InitializeProperties();
-        static void _OnCurrentKeysChanged(Windows::UI::Xaml::DependencyObject const& d, Windows::UI::Xaml::DependencyPropertyChangedEventArgs const& e);
+        static void _OnKeysChanged(Windows::UI::Xaml::DependencyObject const& d, Windows::UI::Xaml::DependencyPropertyChangedEventArgs const& e);
     };
 }
 

--- a/src/cascadia/TerminalSettingsEditor/KeyChordListener.idl
+++ b/src/cascadia/TerminalSettingsEditor/KeyChordListener.idl
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+namespace Microsoft.Terminal.Settings.Editor
+{
+    [default_interface] runtimeclass KeyChordListener : Windows.UI.Xaml.Controls.UserControl
+    {
+        KeyChordListener();
+
+        Microsoft.Terminal.Control.KeyChord CurrentKeys;
+        static Windows.UI.Xaml.DependencyProperty CurrentKeysProperty { get; };
+    }
+}

--- a/src/cascadia/TerminalSettingsEditor/KeyChordListener.idl
+++ b/src/cascadia/TerminalSettingsEditor/KeyChordListener.idl
@@ -7,7 +7,7 @@ namespace Microsoft.Terminal.Settings.Editor
     {
         KeyChordListener();
 
-        Microsoft.Terminal.Control.KeyChord CurrentKeys;
-        static Windows.UI.Xaml.DependencyProperty CurrentKeysProperty { get; };
+        Microsoft.Terminal.Control.KeyChord Keys;
+        static Windows.UI.Xaml.DependencyProperty KeysProperty { get; };
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/KeyChordListener.xaml
+++ b/src/cascadia/TerminalSettingsEditor/KeyChordListener.xaml
@@ -1,0 +1,18 @@
+<UserControl x:Class="Microsoft.Terminal.Settings.Editor.KeyChordListener"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+
+    <!--  Use PreviewKeyDown to prevent ctrl+a from selecting  -->
+    <TextBox x:Name="KeyChordTextBox"
+             x:Uid="KeyChordListener_KeyChordTextBox"
+             IsReadOnly="True"
+             IsSpellCheckEnabled="False"
+             IsTabStop="True"
+             LosingFocus="KeyChordTextBox_LosingFocus"
+             PreviewKeyDown="KeyChordTextBox_KeyDown"
+             TextAlignment="Right"
+             TextWrapping="Wrap" />
+</UserControl>

--- a/src/cascadia/TerminalSettingsEditor/KeyChordListener.xaml
+++ b/src/cascadia/TerminalSettingsEditor/KeyChordListener.xaml
@@ -7,11 +7,10 @@
 
     <!--  Use PreviewKeyDown to prevent ctrl+a from selecting  -->
     <TextBox x:Name="KeyChordTextBox"
-             x:Uid="KeyChordListener_KeyChordTextBox"
+             x:Uid="KeyChordListener"
              IsReadOnly="True"
              IsSpellCheckEnabled="False"
              IsTabStop="True"
-             LosingFocus="KeyChordTextBox_LosingFocus"
              PreviewKeyDown="KeyChordTextBox_KeyDown"
              TextAlignment="Right"
              TextWrapping="Wrap" />

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
@@ -60,6 +60,9 @@
     <ClInclude Include="InvertedBooleanToVisibilityConverter.h">
       <DependentUpon>Converters.idl</DependentUpon>
     </ClInclude>
+    <ClInclude Include="KeyChordListener.h">
+      <DependentUpon>KeyChordListener.xaml</DependentUpon>
+    </ClInclude>
     <ClInclude Include="PercentageSignConverter.h">
       <DependentUpon>Converters.idl</DependentUpon>
     </ClInclude>
@@ -135,6 +138,9 @@
     <Page Include="Interaction.xaml">
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="KeyChordListener.xaml">
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Launch.xaml">
       <SubType>Designer</SubType>
     </Page>
@@ -182,6 +188,9 @@
     </ClCompile>
     <ClCompile Include="InvertedBooleanToVisibilityConverter.cpp">
       <DependentUpon>Converters.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="KeyChordListener.cpp">
+      <DependentUpon>KeyChordListener.xaml</DependentUpon>
     </ClCompile>
     <ClCompile Include="PercentageSignConverter.cpp">
       <DependentUpon>Converters.idl</DependentUpon>
@@ -258,6 +267,10 @@
     </Midl>
     <Midl Include="ColorSchemes.idl">
       <DependentUpon>ColorSchemes.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Midl>
+    <Midl Include="KeyChordListener.idl">
+      <DependentUpon>KeyChordListener.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Midl>
     <Midl Include="Launch.idl">

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj.filters
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj.filters
@@ -20,6 +20,7 @@
     <ClInclude Include="PercentageSignConverter.h">
       <Filter>Converters</Filter>
     </ClInclude>
+    <ClInclude Include="PreviewConnection.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="EnumEntry.idl" />
@@ -44,6 +45,9 @@
     <Page Include="Rendering.xaml" />
     <Page Include="Actions.xaml" />
     <Page Include="SettingContainerStyle.xaml" />
+    <Page Include="AddProfile.xaml" />
+    <Page Include="ReadOnlyActions.xaml" />
+    <Page Include="KeyChordListener.xaml" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Converters">

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1158,4 +1158,20 @@
     <value>Add new</value>
     <comment>Button label that creates a new action on the actions page.</comment>
   </data>
+  <data name="Actions_ActionComboBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Action</value>
+    <comment>Label for a control that sets the action of a key binding.</comment>
+  </data>
+  <data name="KeyChordListener.[using:Windows.UI.Xaml.Automation]AutomationProperties.HelpText" xml:space="preserve">
+    <value>Input your desired keyboard shortcut.</value>
+    <comment>Help text directing users how to use the "KeyChordListener" control. Pressing a keyboard shortcut will be recorded by this control.</comment>
+  </data>
+  <data name="KeyChordListener.[using:Windows.UI.Xaml.Automation]AutomationProperties.LocalizedControlType" xml:space="preserve">
+    <value>shortcut listener</value>
+    <comment>The control type for a control that awaits keyboard input and records it.</comment>
+  </data>
+  <data name="KeyChordListener.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Shortcut</value>
+    <comment>The label for a "key chord listener" control that sets the keys a key binding is bound to.</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsEditor/pch.h
+++ b/src/cascadia/TerminalSettingsEditor/pch.h
@@ -24,6 +24,7 @@
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Globalization.h>
+#include <winrt/Windows.System.h>
 #include <winrt/Windows.UI.h>
 #include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Input.h>

--- a/src/cascadia/TerminalSettingsEditor/pch.h
+++ b/src/cascadia/TerminalSettingsEditor/pch.h
@@ -32,6 +32,7 @@
 #include <winrt/Windows.UI.Text.h>
 #include <winrt/Windows.UI.Xaml.h>
 #include <winrt/Windows.UI.Xaml.Automation.h>
+#include <winrt/Windows.UI.Xaml.Automation.Peers.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
 #include <winrt/Windows.UI.Xaml.Data.h>


### PR DESCRIPTION
## Summary of the Pull Request
Replaces the key chord editor in the actions page with a listener instead of a plain text box.

## References
#6900 - Settings UI Epic

## Detailed Description of the Pull Request / Additional comments
- `Actions` page:
   - Replace `Keys` with `CurrentKeys` for consistency with `Action`/`CurrentAction`
   - `ProposedKeys` is now a `Control::KeyChord`
   - removes key chord validation (now we don't need it)
   - removes accept/cancel shortcuts (nowhere we could use it now)
- `KeyChordListener`:
   - `Keys`: dependency property that hooks us up to a system to the committed setting value
      - this is the key binding view model, which propagates the change to the settings model clone on "accept changes"
   - We bind to `PreviewKeyDown` to intercept the key event _before_ some special key bindings are handled (i.e. "select all" in the text box)
   - `CoreWindow` is used to get the modifier keys because (1) it's easier than updating on each key press and (2) that approach resulted in a strange bug where the <kbd>Alt</kbd> key-up event was not detected
   - `LosingFocus` means that we have completed our operation and want to commit our changes to the key binding view model
   - `KeyDown` does most of the magic of updating `Keys`. We filter out any key chords that could be problematic (i.e. <kbd>Shift</kbd>+<kbd>Tab</kbd> and <kbd>Tab</kbd> for keyboard navigation)

## Validation Steps Performed
- Tested a few key chords:
   - ✅single key: <kbd>X</kbd>
   - ✅key with modifier(s): <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>X</kbd>
   - ❌plain modifier: <kbd>Ctrl</kbd>
   - ✅key that is used by text box: <kbd>Ctrl+A</kbd>
   - ✅key that is used by Windows Terminal: <kbd>Alt</kbd>+<kbd>F4</kbd>
   - ❌key that is taken by Windows OS: <kbd>Windows</kbd>+<kbd>X</kbd>
   - ✅key that is not taken by Windows OS: <kbd>Windows</kbd>+<kbd>Shift</kbd>+<kbd>X</kbd>
- Known issue:
   - global key taken by Windows Terminal: (i.e. quake mode keybinding)
      - Behavior: global key binding executed
      - Expected: key chord recorded

## Demo
![Key Chord Listener Demo](https://user-images.githubusercontent.com/11050425/125538094-08ea4eaa-21eb-4488-a74c-6ce65324cdf1.gif)
