### PR TITLE
Don't override success value when resetting mouse mode in hard reset

### DIFF
--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -734,8 +734,8 @@ bool TerminalDispatch::HardReset() noexcept
     success = CursorPosition(1, 1) && success;
 
     // Reset the mouse mode
-    success = EnableSGRExtendedMouseMode(false);
-    success = EnableAnyEventMouseMode(false);
+    success = EnableSGRExtendedMouseMode(false) && success;
+    success = EnableAnyEventMouseMode(false) && success;
 
     // Delete all current tab stops and reapply
     _ResetTabStops();

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1923,8 +1923,8 @@ bool AdaptDispatch::HardReset()
     success = CursorPosition(1, 1) && success;
 
     // Reset the mouse mode
-    success = EnableSGRExtendedMouseMode(false);
-    success = EnableAnyEventMouseMode(false);
+    success = EnableSGRExtendedMouseMode(false) && success;
+    success = EnableAnyEventMouseMode(false) && success;
 
     // Delete all current tab stops and reapply
     _ResetTabStops();


### PR DESCRIPTION
Quick fix for an error made in #10602 

References #8613
Closes #10658