### PR TITLE
Re-evaluate the size of the quake window when it's summoned to a monitor

### DIFF
--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -1406,6 +1406,13 @@ void IslandWindow::_moveToMonitor(const MONITORINFO activeMonitor)
                      currentWindowRect.width<int>(),
                      currentWindowRect.height<int>(),
                      SWP_NOZORDER | SWP_NOSIZE | SWP_NOACTIVATE);
+
+        // GH#10274, GH#10182: Re-evaluate the size of the quake window when we
+        // move to another monitor.
+        if (IsQuakeWindow())
+        {
+            _enterQuakeMode();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

When the quake window is moved to another monitor, re-evaluate it's size for that monitor.

## References
* megathread: #8888
* Similar, but not the same: #10274

## PR Checklist
* [x] Closes #10182
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated

## Detailed Description of the Pull Request / Additional comments

We'll probably need to do this in a few more places, but I'm breaking PRs into small chunks for easier reviews.

## Validation Steps Performed

Summoned the window to a bunch of different resolutions. Where it would use the wrong size before, it no longer does.