### PR TITLE
Fix unfocused appearance editor not appearing/disappearing correctly

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Profiles.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.cpp
@@ -284,7 +284,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         _unfocusedAppearanceViewModel = nullptr;
 
-        _NotifyChanges(L"HasUnfocusedAppearance", L"ShowUnfocusedAppearance");
+        _NotifyChanges(L"UnfocusedAppearance", L"HasUnfocusedAppearance", L"ShowUnfocusedAppearance");
     }
 
     Editor::AppearanceViewModel ProfileViewModel::UnfocusedAppearance()

--- a/src/cascadia/TerminalSettingsEditor/Profiles.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.cpp
@@ -275,7 +275,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _unfocusedAppearanceViewModel.Schemes(schemes);
         _unfocusedAppearanceViewModel.WindowRoot(windowRoot);
 
-        _NotifyChanges(L"UnfocusedAppearance", L"HasUnfocusedAppearance");
+        _NotifyChanges(L"UnfocusedAppearance", L"HasUnfocusedAppearance", L"ShowUnfocusedAppearance");
     }
 
     void ProfileViewModel::DeleteUnfocusedAppearance()
@@ -284,7 +284,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         _unfocusedAppearanceViewModel = nullptr;
 
-        _NotifyChanges(L"HasUnfocusedAppearance");
+        _NotifyChanges(L"HasUnfocusedAppearance", L"ShowUnfocusedAppearance");
     }
 
     Editor::AppearanceViewModel ProfileViewModel::UnfocusedAppearance()


### PR DESCRIPTION
## Summary of the Pull Request
Sends the additional xaml notification when the user presses the '+' or delete button for unfocused appearances

## PR Checklist
* [x] Closes #10673
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I work here

## Validation Steps Performed
It works now