### PR TITLE
Prevent the quake window's borders from hanging onto adjacent monitors

### DIFF
--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -1455,12 +1455,15 @@ void IslandWindow::_enterQuakeMode()
     const til::size ncSize{ GetTotalNonClientExclusiveSize(dpix) };
     const til::size availableSpace = desktopDimensions + ncSize;
 
+    // GH#10201 - The borders are still visible in quake mode, so make us 1px
+    // smaller on either side to account for that, so they don't hang onto
+    // adjacent monitors.
     const til::point origin{
-        ::base::ClampSub<long>(nearestMonitorInfo.rcWork.left, (ncSize.width() / 2)),
+        ::base::ClampSub<long>(nearestMonitorInfo.rcWork.left, (ncSize.width() / 2)) + 1,
         (nearestMonitorInfo.rcWork.top)
     };
     const til::size dimensions{
-        availableSpace.width(),
+        availableSpace.width() - 2,
         availableSpace.height() / 2
     };
 


### PR DESCRIPTION
## Summary of the Pull Request

We were making the quake window exactly the width of the monitor it was on, but that didn't account for the 1px of border on either side.		

## References
* megathread: #8888

## PR Checklist
* [x] Closes #10201
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated

## Validation Steps Performed

It happened before, it doesn't anymore.