### PR TITLE
Make sure we terminate the expected title string

### DIFF
--- a/OpenConsole.sln
+++ b/OpenConsole.sln
@@ -73,6 +73,7 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Host.unittest", "src\host\ut_lib\host.unittest.vcxproj", "{06EC74CB-9A12-429C-B551-8562EC954747}"
 	ProjectSection(ProjectDependencies) = postProject
 		{18D09A24-8240-42D6-8CB6-236EEE820263} = {18D09A24-8240-42D6-8CB6-236EEE820263}
+		{71CC9D78-BA29-4D93-946F-BEF5D9A3A6EF} = {71CC9D78-BA29-4D93-946F-BEF5D9A3A6EF}
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Host.Tests.Unit", "src\host\ut_host\Host.UnitTests.vcxproj", "{531C23E7-4B76-4C08-8AAD-04164CB628C9}"

--- a/src/host/ut_host/ApiRoutinesTests.cpp
+++ b/src/host/ut_host/ApiRoutinesTests.cpp
@@ -278,7 +278,7 @@ class ApiRoutinesTests
                                                      nullptr,
                                                      nullptr);
 
-        wistd::unique_ptr<char[]> pszExpected = wil::make_unique_nothrow<char[]>(iBytesNeeded);
+        wistd::unique_ptr<char[]> pszExpected = wil::make_unique_nothrow<char[]>(iBytesNeeded + 1);
         VERIFY_IS_NOT_NULL(pszExpected);
 
         VERIFY_WIN32_BOOL_SUCCEEDED(WideCharToMultiByte(gci.OutputCP,
@@ -289,6 +289,9 @@ class ApiRoutinesTests
                                                         iBytesNeeded,
                                                         nullptr,
                                                         nullptr));
+
+        // Make sure we terminate the expected title -- WC2MB does not add the \0 if we use the size variant
+        pszExpected[iBytesNeeded] = '\0';
 
         char pszTitle[MAX_PATH]; // most applications use MAX_PATH
         size_t cchWritten = 0;


### PR DESCRIPTION
When you use the size parameter to WideCharToMultiByte, it only
null-terminates the output string if the input string was
null-terminated within the specified range.

Burned in for 1k runs-

BEFORE

    Summary: Total=1000, Passed=997, Failed=3

AFTER

    Summary: Total=1000, Passed=1000, Failed=0

Fixes MSFT-34656993