### PR TITLE
Don't auto-generate the hidden field when creating profile stubs

### DIFF
--- a/src/cascadia/TerminalSettingsModel/Profile.cpp
+++ b/src/cascadia/TerminalSettingsModel/Profile.cpp
@@ -237,8 +237,6 @@ Json::Value Profile::GenerateStub() const
         stub[JsonKey(SourceKey)] = winrt::to_string(source);
     }
 
-    stub[JsonKey(HiddenKey)] = Hidden();
-
     return stub;
 }
 


### PR DESCRIPTION
## Summary of the Pull Request
We no longer automatically write the 'hidden' field for profile stubs we create

**Note**: This does not retroactively remove the automatically generated hidden fields in current settings files

## PR Checklist
* [x] Closes #10539 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I work here

## Validation Steps Performed
Deleted the ubuntu stub in my settings file, booted up terminal, new created stub did not have the hidden field. Created a fragment that overrides the hidden field and it worked. 