### PR TITLE
Add `experimental.input.forceVT` to JSON schema

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -1116,6 +1116,10 @@
           "description": "When set to true, we will use the software renderer (a.k.a. WARP) instead of the hardware one.",
           "type": "boolean"
         },
+        "experimental.input.forceVT": {
+          "description": "Force the terminal to use the legacy input encoding. Certain keys in some applications may stop working when enabling this setting.",
+          "type": "boolean"
+        },
         "initialCols": {
           "default": 120,
           "description": "The number of columns displayed in the window upon first load. If \"launchMode\" is set to \"maximized\" (or \"maximizedFocus\"), this property is ignored.",


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Looks like we forgot to add `experimental.input.forceVT` to the JSON schema when it was implemented in #6309 