### PR TITLE
Add background color to grid to prevent animation overflow

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -116,13 +116,14 @@
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
-            <ScrollViewer Grid.Row="0">
-                <Frame x:Name="contentFrame" />
-            </ScrollViewer>
+            <Frame x:Name="contentFrame"
+                   Grid.Row="0"/>
+            <!-- Explictly set the background color on grid to prevent the navigation animation from overflowing it -->
             <Grid Grid.Row="1"
                   Height="100"
                   BorderBrush="{ThemeResource SystemBaseLowColor}"
-                  BorderThickness="0,1,0,0">
+                  BorderThickness="0,1,0,0"
+                  Background="{ThemeResource SystemAltHighColor}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -118,7 +118,7 @@
             </Grid.RowDefinitions>
             <Frame x:Name="contentFrame"
                    Grid.Row="0"/>
-            <!-- Explictly set the background color on grid to prevent the navigation animation from overflowing it -->
+            <!-- Explicitly set the background color on grid to prevent the navigation animation from overflowing it -->
             <Grid Grid.Row="1"
                   Height="100"
                   BorderBrush="{ThemeResource SystemBaseLowColor}"

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -117,13 +117,13 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Frame x:Name="contentFrame"
-                   Grid.Row="0"/>
-            <!-- Explicitly set the background color on grid to prevent the navigation animation from overflowing it -->
+                   Grid.Row="0" />
+            <!--  Explicitly set the background color on grid to prevent the navigation animation from overflowing it  -->
             <Grid Grid.Row="1"
                   Height="100"
+                  Background="{ThemeResource SystemAltHighColor}"
                   BorderBrush="{ThemeResource SystemBaseLowColor}"
-                  BorderThickness="0,1,0,0"
-                  Background="{ThemeResource SystemAltHighColor}">
+                  BorderThickness="0,1,0,0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>


### PR DESCRIPTION
## Summary of the Pull Request
Add an explicit background color to part of the settings UI to prevent animation overflow. The previous solution (adding a ScrollViewer) caused problems.

## References
#10619 adds a ScrollViewer for one of the issues in #10609

## PR Checklist
* [x] Closes #10664
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed
Visually confirmed the animation doesn't overflow, changed the theme and confirmed the colors are responsive. Confirmed the extra scrollbar is gone.
