### PR TITLE
Add tracelogging for drag&drop on the new tab button

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -264,6 +264,13 @@ namespace winrt::TerminalApp::implementation
             NewTerminalArgs args;
             args.StartingDirectory(winrt::hstring{ pathText });
             this->_OpenNewTerminal(args);
+
+            TraceLoggingWrite(
+                g_hTerminalAppProvider,
+                "NewTabByDragDrop",
+                TraceLoggingDescription("Event emitted when the user drag&drops onto the new tab button"),
+                TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+                TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         }
     }
 


### PR DESCRIPTION
As discussed in team sync. Is this a mysterious dark pattern we didn't know about? 

* [x] closes #10721
* [x] I work here
* [x] doesn't need tests
* [x] doesn't need docs
* see also #10160 