### PR TITLE
Release unneeded memory more eagerly from conhost

### DIFF
--- a/src/inc/til/u8u16convert.h
+++ b/src/inc/til/u8u16convert.h
@@ -55,6 +55,14 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
                 RETURN_HR_IF(E_ABORT, !base::CheckAdd(in.length(), _partialsLen).AssignIfValid(&capacity));
 
                 _buffer.clear();
+
+                // If we were previously called with a huge buffer we have an equally large _buffer.
+                // We shouldn't just keep this huge buffer around, if no one needs it anymore.
+                if (_buffer.capacity() > 16 * 1024 && (_buffer.capacity() >> 1) > capacity)
+                {
+                    _buffer.shrink_to_fit();
+                }
+
                 _buffer.reserve(capacity);
 
                 // copy UTF-8 code units that were remaining from the previous call (if any)


### PR DESCRIPTION
The `_CONSOLE_API_MSG` buffer is resized to cover an entire message.
Later on any UTF-8 data is cached in a separate temporary
buffer inside `til::u8state` to prevent lone surrogate pairs.

Both cases are problematic as neither buffer is freed after the read
has finished. Passing a 100MB buffer to conhost once will thus cause it
to continue using ~220MB of physical memory until the conhost process exits.

This change releases unneeded memory as soon as the requested buffer
size has halved. In practice this means that once a command has returned
all buffers will shrink, as the shell commonly sends very small messages.

## PR Checklist
* [x] Closes #10731
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed

* Buffers aren't reallocated during printing ✔️
* Buffers shrink after printing finished ✔️