### PR TITLE
Shift the island up by 1px when maximized

### DIFF
--- a/.github/actions/spelling/allow/allow.txt
+++ b/.github/actions/spelling/allow/allow.txt
@@ -12,6 +12,7 @@ downsides
 dze
 dzhe
 Enum'd
+Fitt
 formattings
 ftp
 geeksforgeeks

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -374,7 +374,7 @@ void NonClientIslandWindow::_UpdateIslandPosition(const UINT windowWidth, const 
     // buttons, which will make them clickable. It's perhaps not the right fix,
     // but it works.
     // _GetTopBorderHeight() returns 0 when we're maximized.
-    const short topBorderHeight = (originalTopHeight == 0) ? -1 : originalTopHeight;
+    const short topBorderHeight = ::base::saturated_cast<short>((originalTopHeight == 0) ? -1 : originalTopHeight);
 
     const COORD newIslandPos = { 0, topBorderHeight };
 

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -365,10 +365,10 @@ void NonClientIslandWindow::_UpdateIslandPosition(const UINT windowWidth, const 
     // !! BODGY !!
     //
     // For inexplicable reasons, the top row of pixels on our tabs, new tab
-    // button, and caption buttons is totally unclickable. The mouse simply
+    // button, and caption buttons is totally un-clickable. The mouse simply
     // refuses to interact with them. So when we're maximized, on certain
     // monitor configurations, this results in the top row of pixels not
-    // reacting to clicks at all. To obey Fitt's Law, we're gonna hackily shift
+    // reacting to clicks at all. To obey Fitt's Law, we're gonna shift
     // the entire island up one pixel. That will result in the top row of pixels
     // in the window actually being the _second_ row of pixels for those
     // buttons, which will make them clickable. It's perhaps not the right fix,

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -360,7 +360,21 @@ void NonClientIslandWindow::_OnMaximizeChange() noexcept
 //   sizes of our child XAML Islands to match our new sizing.
 void NonClientIslandWindow::_UpdateIslandPosition(const UINT windowWidth, const UINT windowHeight)
 {
-    const auto topBorderHeight = Utils::ClampToShortMax(_GetTopBorderHeight(), 0);
+    const auto originalTopHeight = _GetTopBorderHeight();
+    // GH#7422
+    // !! BODGY !!
+    //
+    // For inexplicable reasons, the top row of pixels on our tabs, new tab
+    // button, and caption buttons is totally unclickable. The mouse simply
+    // refuses to interact with them. So when we're maximized, on certain
+    // monitor configurations, this results in the top row of pixels not
+    // reacting to clicks at all. To obey Fitt's Law, we're gonna hackily shift
+    // the entire island up one pixel. That will result in the top row of pixels
+    // in the window actually being the _second_ row of pixels for those
+    // buttons, which will make them clickable. It's perhaps not the right fix,
+    // but it works.
+    // _GetTopBorderHeight() returns 0 when we're maximized.
+    const short topBorderHeight = (originalTopHeight == 0) ? -1 : originalTopHeight;
 
     const COORD newIslandPos = { 0, topBorderHeight };
 


### PR DESCRIPTION
For inexplicable reasons, the top row of pixels on our tabs, new tab
button, and caption buttons is totally unclickable. The mouse simply
refuses to interact with them. So when we're maximized, on certain
monitor configurations, this results in the top row of pixels not
reacting to clicks at all.

To obey Fitt's Law, we're gonna hackily shift the entire island up one
pixel. That will result in the top row of pixels in the window actually
being the _second_ row of pixels for those buttons, which will make them
clickable. It's perhaps not the right fix, but it works.

After discussion, we think this is a fine fix for this. We don't think
anyone's going to miss the top row of pixels on the TabView. The original
bug is painful enough for the subset of users it impacts that this is an
acceptable trade. Should a better fix be found, we can absolutely do that
instead.

Closes #7422
