### PR TITLE
Fix conhost UseDx mode

### DIFF
--- a/src/interactivity/win32/window.cpp
+++ b/src/interactivity/win32/window.cpp
@@ -31,9 +31,6 @@
 
 #if TIL_FEATURE_CONHOSTDXENGINE_ENABLED
 #include "../../renderer/dx/DxRenderer.hpp"
-#else
-// Forward-declare this so we don't blow up later.
-struct DxEngine;
 #endif
 
 #include "../inc/ServiceLocator.hpp"
@@ -214,7 +211,9 @@ void Window::_UpdateSystemMetrics() const
 
     const bool useDx = pSettings->GetUseDx();
     GdiEngine* pGdiEngine = nullptr;
+#if TIL_FEATURE_CONHOSTDXENGINE_ENABLED
     [[maybe_unused]] DxEngine* pDxEngine = nullptr;
+#endif
     try
     {
 #if TIL_FEATURE_CONHOSTDXENGINE_ENABLED

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -169,7 +169,6 @@ namespace Microsoft::Console::Render
         uint16_t _hyperlinkHoveredId;
 
         bool _firstFrame;
-        bool _invalidateFullRows;
         std::pmr::unsynchronized_pool_resource _pool;
         til::pmr::bitmap _invalidMap;
         til::point _invalidScroll;


### PR DESCRIPTION
This commit fixes the UseDx mode for conhost.
In order to add support for UseDx without calling `SetWindowSize`,
responsibility for resizing `_invalidMap` has been moved to occur
only when the renderer itself recognizes a new size. Furthermore
`InvalidateAll` is now the central point to invalidate `_invalidMap`.

## Validation Steps Performed

* Enabling `UseDx` enables the DxEngine for conhost ✔️
* Resizing windows in conhost works ✔️
* Resizing windows in WT works ✔️

Closes #5455