### PR TITLE
[DefApp] Teach connection and tab to negotiate initial size

### DIFF
--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -105,6 +105,14 @@ namespace winrt::TerminalApp::implementation
         // Create a connection based on the values in our settings object if we weren't given one.
         auto connection = existingConnection ? existingConnection : _CreateConnectionFromSettings(profileGuid, settings.DefaultSettings());
 
+        // If we had an `existingConnection`, then this is an inbound handoff from somewhere else.
+        // We need to tell it about our size information so it can match the dimensions of what
+        // we are about to present.
+        if (existingConnection)
+        {
+            connection.Resize(settings.DefaultSettings().InitialRows(), settings.DefaultSettings().InitialCols());
+        }
+
         TerminalConnection::ITerminalConnection debugConnection{ nullptr };
         if (_settings.GlobalSettings().DebugFeaturesEnabled())
         {


### PR DESCRIPTION
- For tabs started from the Terminal, the initial sizing information is
  passed into the connection and used to establish the PTY. Those
  parameters are given over to the `OpenConsole.exe` acting as PTY to
  establish the initial buffer/window size.
- However, for tabs started from outside, the PTY is created with some
  default buffer information FIRST as the Terminal hasn't even been
  involved yet. As such, when the Terminal gets that connection, it must
  tell the PTY to resize just as it connects to match the window size
  it's about to use.
- Ongoing resize operations in the Terminal did and still work fine
  because they transmitted the updated size with the
  `ResizePseudoConsole` API.

## Validation Steps Performed
- [x] Confirmed existing tabs opening have correct initial size in PTY
  (like with CMD `mode con` command)
- [x] Confirmed inbound cmd tabs have correct initial size in PTY via
  `mode con` command per bug repro

Closes #9811
