### PR TITLE
[DRAFT] Use Font Set filtering/matching to better resolve complex name specifications

### DIFF
--- a/src/renderer/dx/DxFontInfo.cpp
+++ b/src/renderer/dx/DxFontInfo.cpp
@@ -228,9 +228,9 @@ void DxFontInfo::SetFromEngine(const std::wstring_view familyName,
         THROW_IF_FAILED(set.As(&set1));
 
         const std::array<DWRITE_FONT_PROPERTY, 3> fontProperties{
-            DWRITE_FONT_PROPERTY{ DWRITE_FONT_PROPERTY_ID_TYPOGRAPHIC_FAMILY_NAME, _familyName.data(), localeName.data() },
-            DWRITE_FONT_PROPERTY{ DWRITE_FONT_PROPERTY_ID_WIN32_FAMILY_NAME, _familyName.data(), localeName.data() },
-            DWRITE_FONT_PROPERTY{ DWRITE_FONT_PROPERTY_ID_FULL_NAME, _familyName.data(), localeName.data() }
+            DWRITE_FONT_PROPERTY{ DWRITE_FONT_PROPERTY_ID_TYPOGRAPHIC_FAMILY_NAME, _familyName.data(), nullptr },
+            DWRITE_FONT_PROPERTY{ DWRITE_FONT_PROPERTY_ID_WIN32_FAMILY_NAME, _familyName.data(), nullptr },
+            DWRITE_FONT_PROPERTY{ DWRITE_FONT_PROPERTY_ID_FULL_NAME, _familyName.data(), nullptr }
         };
 
         Microsoft::WRL::ComPtr<IDWriteFontSet1> filteredSet1;

--- a/src/renderer/dx/DxFontInfo.h
+++ b/src/renderer/dx/DxFontInfo.h
@@ -54,7 +54,10 @@ namespace Microsoft::Console::Render
                                                                                std::wstring& localeName,
                                                                                const bool withNearbyLookup);
 
-        [[nodiscard]] std::wstring _GetFontFamilyName(gsl::not_null<IDWriteFontFamily*> const fontFamily,
+        [[nodiscard]] ::Microsoft::WRL::ComPtr<IDWriteFontFace1> _TryWin10FontMatchingLogic(gsl::not_null<IDWriteFontCollection*> fontCollection,
+                                                                                            std::wstring& localeName);
+
+        [[nodiscard]] std::wstring _GetFontFamilyName(gsl::not_null<IDWriteLocalizedStrings*> const familyNames,
                                                       std::wstring& localeName);
 
         [[nodiscard]] const Microsoft::WRL::ComPtr<IDWriteFontCollection1>& _NearbyCollection(gsl::not_null<IDWriteFactory1*> dwriteFactory) const;


### PR DESCRIPTION
Not ready for review. Go away.  

TODO:
- [ ] - Check that invoking with names that contain weight suffixes works
- [ ] - Determine the proper hierarchy of weight/stretch/style versus the specified name when reducing font sets.
- [ ] - Chill out the fallback and warning messages when something appropriate is resolved but the names don't match quite right.

Closes #9744