### PR TITLE
Vectorize TextColor::GetColor

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -105,6 +105,7 @@ autoscrolling
 Autowrap
 AVerify
 AVI
+AVX
 awch
 azuredevopspodcast
 azzle
@@ -190,6 +191,7 @@ CARETBLINKINGENABLED
 CARRIAGERETURN
 cascadia
 cassert
+castsi
 catid
 cazamor
 CBash
@@ -270,6 +272,7 @@ Cmdlet
 cmdline
 CMOUSEBUTTONS
 cmp
+cmpeq
 cmt
 cmyk
 CNL
@@ -1260,6 +1263,7 @@ lnkd
 lnkfile
 LNM
 LOADONCALL
+loadu
 LOBYTE
 localappdata
 localhost
@@ -1420,6 +1424,7 @@ MOUSEFIRST
 MOUSEHWHEEL
 MOUSEMOVE
 mousewheel
+movemask
 MOVESTART
 msb
 msbuild
@@ -2530,6 +2535,7 @@ vcvarsall
 vcxitems
 vcxproj
 vec
+vectorized
 VERCTRL
 versioning
 VERTBAR

--- a/src/buffer/out/TextAttribute.cpp
+++ b/src/buffer/out/TextAttribute.cpp
@@ -98,7 +98,7 @@ bool TextAttribute::IsLegacy() const noexcept
 // - blinkingIsFaint: true if blinking should be interpreted as faint.
 // Return Value:
 // - the foreground and background colors that should be displayed.
-std::pair<COLORREF, COLORREF> TextAttribute::CalculateRgbColors(const gsl::span<const COLORREF> colorTable,
+std::pair<COLORREF, COLORREF> TextAttribute::CalculateRgbColors(const std::array<COLORREF, 256>& colorTable,
                                                                 const COLORREF defaultFgColor,
                                                                 const COLORREF defaultBgColor,
                                                                 const bool reverseScreenMode,

--- a/src/buffer/out/TextAttribute.hpp
+++ b/src/buffer/out/TextAttribute.hpp
@@ -64,7 +64,7 @@ public:
     static TextAttribute StripErroneousVT16VersionsOfLegacyDefaults(const TextAttribute& attribute) noexcept;
     WORD GetLegacyAttributes() const noexcept;
 
-    std::pair<COLORREF, COLORREF> CalculateRgbColors(const gsl::span<const COLORREF> colorTable,
+    std::pair<COLORREF, COLORREF> CalculateRgbColors(const std::array<COLORREF, 256>& colorTable,
                                                      const COLORREF defaultFgColor,
                                                      const COLORREF defaultBgColor,
                                                      const bool reverseScreenMode = false,

--- a/src/buffer/out/TextColor.cpp
+++ b/src/buffer/out/TextColor.cpp
@@ -50,6 +50,9 @@ constexpr std::array<BYTE, 256> Index256ToIndex16 = {
 
 // clang-format on
 
+// We should only need 4B for TextColor. Any more than that is just waste.
+static_assert(sizeof(TextColor) == 4);
+
 bool TextColor::CanBeBrightened() const noexcept
 {
     return IsIndex16() || IsDefault();
@@ -138,15 +141,12 @@ void TextColor::SetDefault() noexcept
 // - brighten: if true, we'll brighten a dark color table index.
 // Return Value:
 // - a COLORREF containing the real value of this TextColor.
-COLORREF TextColor::GetColor(gsl::span<const COLORREF> colorTable,
-                             const COLORREF defaultColor,
-                             bool brighten) const noexcept
+COLORREF TextColor::GetColor(const std::array<COLORREF, 256>& colorTable, const COLORREF defaultColor, bool brighten) const noexcept
 {
     if (IsDefault())
     {
         if (brighten)
         {
-            FAIL_FAST_IF(colorTable.size() < 16);
             // See MSFT:20266024 for context on this fix.
             //      Additionally todo MSFT:20271956 to fix this better for 19H2+
             // If we're a default color, check to see if the defaultColor exists
@@ -156,6 +156,58 @@ COLORREF TextColor::GetColor(gsl::span<const COLORREF> colorTable,
             //      (Settings::_DefaultForeground==INVALID_COLOR, and the index
             //      from _wFillAttribute is being used instead.)
             // If we find a match, return instead the bright version of this color
+
+            static_assert(sizeof(COLORREF) * 8 == 32, "The vectorized code broke. If you can't fix COLORREF, just remove the vectorized code.");
+
+#pragma warning(push)
+#pragma warning(disable : 26481) // Don't use pointer arithmetic. Use span instead (bounds.1).
+#pragma warning(disable : 26490) // Don't use reinterpret_cast (type.1).
+#ifdef __AVX2__
+            // I wrote this vectorized code one day, because the sun was shining so nicely.
+            // There's no other reason for this to exist here, except for being pretty.
+            // This code implements the exact same for loop you can find below, but is ~3x faster.
+            //
+            // A brief explanation for people unfamiliar with vectorized instructions:
+            //   Vectorized instructions, like "SSE" or "AVX", allow you to run
+            //   common operations like additions, multiplications, comparisons,
+            //   or bitwise operations concurrently on multiple values at once.
+            //
+            // We want to find the given defaultColor in the first 8 values of colorTable.
+            // Coincidentally a COLORREF is a DWORD and 8 of them are exactly 256 bits.
+            // -- The size of a single AVX register.
+            //
+            // Thus, the code works like this:
+            // 1. Load all 8 DWORDs at once into one register
+            // 2. Set the same defaultColor 8 times in another register
+            // 3. Compare all 8 values at once
+            //    The result is either 0xffffffff or 0x00000000.
+            // 4. Extract the most significant bit of each DWORD
+            //    Assuming that no duplicate colors exist in colorTable,
+            //    the result will be something like 0b00100000.
+            // 5. Use BitScanForward (bsf) to find the index of the most significant 1 bit.
+            const auto haystack = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(colorTable.data())); // 1.
+            const auto needle = _mm256_set1_epi32(__builtin_bit_cast(int, defaultColor)); // 2.
+            const auto result = _mm256_cmpeq_epi32(haystack, needle); // 3.
+            const auto mask = _mm256_movemask_ps(_mm256_castsi256_ps(result)); // 4.
+            unsigned long index;
+            return _BitScanForward(&index, mask) ? til::at(colorTable, static_cast<size_t>(index) + 8) : defaultColor; // 5.
+#elif _M_AMD64
+            // If you look closely this SSE2 algorithm is the exact same as the AVX one.
+            // The two differences are that we need to:
+            // * do everything twice, because SSE is limited to 128 bits and not 256.
+            // * use _mm_packs_epi32 to merge two 128 bits vectors into one in step 3.5.
+            //   _mm_packs_epi32 takes two SSE registers and truncates all 8 DWORDs into 8 WORDs,
+            //   the latter of which fits into a single register (which is then used in the identical step 4).
+            const auto haystack1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(colorTable.data() + 0));
+            const auto haystack2 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(colorTable.data() + 4));
+            const auto needle = _mm_set1_epi32(__builtin_bit_cast(int, defaultColor));
+            const auto result1 = _mm_cmpeq_epi32(haystack1, needle);
+            const auto result2 = _mm_cmpeq_epi32(haystack2, needle);
+            const auto result = _mm_packs_epi32(result1, result2); // 3.5
+            const auto mask = _mm_movemask_ps(_mm_castsi128_ps(result));
+            unsigned long index;
+            return _BitScanForward(&index, mask) ? til::at(colorTable, static_cast<size_t>(index) + 8) : defaultColor;
+#else
             for (size_t i = 0; i < 8; i++)
             {
                 if (til::at(colorTable, i) == defaultColor)
@@ -163,6 +215,8 @@ COLORREF TextColor::GetColor(gsl::span<const COLORREF> colorTable,
                     return til::at(colorTable, i + 8);
                 }
             }
+#endif
+#pragma warning(pop)
         }
 
         return defaultColor;
@@ -199,7 +253,7 @@ BYTE TextColor::GetLegacyIndex(const BYTE defaultIndex) const noexcept
     }
     else if (IsIndex256())
     {
-        return Index256ToIndex16.at(GetIndex());
+        return til::at(Index256ToIndex16, GetIndex());
     }
     else
     {
@@ -208,7 +262,7 @@ BYTE TextColor::GetLegacyIndex(const BYTE defaultIndex) const noexcept
         const BYTE compressedRgb = (_red & 0b11100000) +
                                    ((_green >> 3) & 0b00011100) +
                                    ((_blue >> 6) & 0b00000011);
-        return CompressedRgbToIndex16.at(compressedRgb);
+        return til::at(CompressedRgbToIndex16, compressedRgb);
     }
 }
 

--- a/src/buffer/out/TextColor.h
+++ b/src/buffer/out/TextColor.h
@@ -86,10 +86,7 @@ public:
     void SetIndex(const BYTE index, const bool isIndex256) noexcept;
     void SetDefault() noexcept;
 
-    COLORREF GetColor(gsl::span<const COLORREF> colorTable,
-                      const COLORREF defaultColor,
-                      const bool brighten = false) const noexcept;
-
+    COLORREF GetColor(const std::array<COLORREF, 256>& colorTable, const COLORREF defaultColor, bool brighten = false) const noexcept;
     BYTE GetLegacyIndex(const BYTE defaultIndex) const noexcept;
 
     constexpr BYTE GetIndex() const noexcept
@@ -157,5 +154,3 @@ namespace WEX
     }
 }
 #endif
-
-static_assert(sizeof(TextColor) <= 4 * sizeof(BYTE), "We should only need 4B for an entire TextColor. Any more than that is just waste");

--- a/src/buffer/out/lib/bufferout.vcxproj
+++ b/src/buffer/out/lib/bufferout.vcxproj
@@ -44,7 +44,7 @@
     <ClInclude Include="..\Row.hpp" />
     <ClInclude Include="..\search.h" />
     <ClInclude Include="..\TextColor.h" />
-    <ClInclude Include="..\TextAttribute.h" />
+    <ClInclude Include="..\TextAttribute.hpp" />
     <ClInclude Include="..\textBuffer.hpp" />
     <ClInclude Include="..\textBufferCellIterator.hpp" />
     <ClInclude Include="..\textBufferTextIterator.hpp" />

--- a/src/buffer/out/ut_textbuffer/TextColorTests.cpp
+++ b/src/buffer/out/ut_textbuffer/TextColorTests.cpp
@@ -23,11 +23,9 @@ class TextColorTests
     TEST_METHOD(TestRgbColor);
     TEST_METHOD(TestChangeColor);
 
-    static const int COLOR_TABLE_SIZE = 16;
-    COLORREF _colorTable[COLOR_TABLE_SIZE];
+    std::array<COLORREF, 256> _colorTable;
     COLORREF _defaultFg = RGB(1, 2, 3);
     COLORREF _defaultBg = RGB(4, 5, 6);
-    gsl::span<const COLORREF> _GetTableView();
 };
 
 bool TextColorTests::ClassSetup()
@@ -51,11 +49,6 @@ bool TextColorTests::ClassSetup()
     return true;
 }
 
-gsl::span<const COLORREF> TextColorTests::_GetTableView()
-{
-    return gsl::span<const COLORREF>(&_colorTable[0], COLOR_TABLE_SIZE);
-}
-
 void TextColorTests::TestDefaultColor()
 {
     TextColor defaultColor;
@@ -64,18 +57,16 @@ void TextColorTests::TestDefaultColor()
     VERIFY_IS_FALSE(defaultColor.IsLegacy());
     VERIFY_IS_FALSE(defaultColor.IsRgb());
 
-    auto view = _GetTableView();
-
-    auto color = defaultColor.GetColor(view, _defaultFg, false);
+    auto color = defaultColor.GetColor(_colorTable, _defaultFg, false);
     VERIFY_ARE_EQUAL(_defaultFg, color);
 
-    color = defaultColor.GetColor(view, _defaultFg, true);
+    color = defaultColor.GetColor(_colorTable, _defaultFg, true);
     VERIFY_ARE_EQUAL(_defaultFg, color);
 
-    color = defaultColor.GetColor(view, _defaultBg, false);
+    color = defaultColor.GetColor(_colorTable, _defaultBg, false);
     VERIFY_ARE_EQUAL(_defaultBg, color);
 
-    color = defaultColor.GetColor(view, _defaultBg, true);
+    color = defaultColor.GetColor(_colorTable, _defaultBg, true);
     VERIFY_ARE_EQUAL(_defaultBg, color);
 }
 
@@ -87,18 +78,16 @@ void TextColorTests::TestDarkIndexColor()
     VERIFY_IS_TRUE(indexColor.IsLegacy());
     VERIFY_IS_FALSE(indexColor.IsRgb());
 
-    auto view = _GetTableView();
-
-    auto color = indexColor.GetColor(view, _defaultFg, false);
+    auto color = indexColor.GetColor(_colorTable, _defaultFg, false);
     VERIFY_ARE_EQUAL(_colorTable[7], color);
 
-    color = indexColor.GetColor(view, _defaultFg, true);
+    color = indexColor.GetColor(_colorTable, _defaultFg, true);
     VERIFY_ARE_EQUAL(_colorTable[15], color);
 
-    color = indexColor.GetColor(view, _defaultBg, false);
+    color = indexColor.GetColor(_colorTable, _defaultBg, false);
     VERIFY_ARE_EQUAL(_colorTable[7], color);
 
-    color = indexColor.GetColor(view, _defaultBg, true);
+    color = indexColor.GetColor(_colorTable, _defaultBg, true);
     VERIFY_ARE_EQUAL(_colorTable[15], color);
 }
 
@@ -110,18 +99,16 @@ void TextColorTests::TestBrightIndexColor()
     VERIFY_IS_TRUE(indexColor.IsLegacy());
     VERIFY_IS_FALSE(indexColor.IsRgb());
 
-    auto view = _GetTableView();
-
-    auto color = indexColor.GetColor(view, _defaultFg, false);
+    auto color = indexColor.GetColor(_colorTable, _defaultFg, false);
     VERIFY_ARE_EQUAL(_colorTable[15], color);
 
-    color = indexColor.GetColor(view, _defaultFg, true);
+    color = indexColor.GetColor(_colorTable, _defaultFg, true);
     VERIFY_ARE_EQUAL(_colorTable[15], color);
 
-    color = indexColor.GetColor(view, _defaultBg, false);
+    color = indexColor.GetColor(_colorTable, _defaultBg, false);
     VERIFY_ARE_EQUAL(_colorTable[15], color);
 
-    color = indexColor.GetColor(view, _defaultBg, true);
+    color = indexColor.GetColor(_colorTable, _defaultBg, true);
     VERIFY_ARE_EQUAL(_colorTable[15], color);
 }
 
@@ -134,18 +121,16 @@ void TextColorTests::TestRgbColor()
     VERIFY_IS_FALSE(rgbColor.IsLegacy());
     VERIFY_IS_TRUE(rgbColor.IsRgb());
 
-    auto view = _GetTableView();
-
-    auto color = rgbColor.GetColor(view, _defaultFg, false);
+    auto color = rgbColor.GetColor(_colorTable, _defaultFg, false);
     VERIFY_ARE_EQUAL(myColor, color);
 
-    color = rgbColor.GetColor(view, _defaultFg, true);
+    color = rgbColor.GetColor(_colorTable, _defaultFg, true);
     VERIFY_ARE_EQUAL(myColor, color);
 
-    color = rgbColor.GetColor(view, _defaultBg, false);
+    color = rgbColor.GetColor(_colorTable, _defaultBg, false);
     VERIFY_ARE_EQUAL(myColor, color);
 
-    color = rgbColor.GetColor(view, _defaultBg, true);
+    color = rgbColor.GetColor(_colorTable, _defaultBg, true);
     VERIFY_ARE_EQUAL(myColor, color);
 }
 
@@ -158,57 +143,55 @@ void TextColorTests::TestChangeColor()
     VERIFY_IS_FALSE(rgbColor.IsLegacy());
     VERIFY_IS_TRUE(rgbColor.IsRgb());
 
-    auto view = _GetTableView();
-
-    auto color = rgbColor.GetColor(view, _defaultFg, false);
+    auto color = rgbColor.GetColor(_colorTable, _defaultFg, false);
     VERIFY_ARE_EQUAL(myColor, color);
 
-    color = rgbColor.GetColor(view, _defaultFg, true);
+    color = rgbColor.GetColor(_colorTable, _defaultFg, true);
     VERIFY_ARE_EQUAL(myColor, color);
 
-    color = rgbColor.GetColor(view, _defaultBg, false);
+    color = rgbColor.GetColor(_colorTable, _defaultBg, false);
     VERIFY_ARE_EQUAL(myColor, color);
 
-    color = rgbColor.GetColor(view, _defaultBg, true);
+    color = rgbColor.GetColor(_colorTable, _defaultBg, true);
     VERIFY_ARE_EQUAL(myColor, color);
 
     rgbColor.SetDefault();
 
-    color = rgbColor.GetColor(view, _defaultFg, false);
+    color = rgbColor.GetColor(_colorTable, _defaultFg, false);
     VERIFY_ARE_EQUAL(_defaultFg, color);
 
-    color = rgbColor.GetColor(view, _defaultFg, true);
+    color = rgbColor.GetColor(_colorTable, _defaultFg, true);
     VERIFY_ARE_EQUAL(_defaultFg, color);
 
-    color = rgbColor.GetColor(view, _defaultBg, false);
+    color = rgbColor.GetColor(_colorTable, _defaultBg, false);
     VERIFY_ARE_EQUAL(_defaultBg, color);
 
-    color = rgbColor.GetColor(view, _defaultBg, true);
+    color = rgbColor.GetColor(_colorTable, _defaultBg, true);
     VERIFY_ARE_EQUAL(_defaultBg, color);
 
     rgbColor.SetIndex(7, false);
-    color = rgbColor.GetColor(view, _defaultFg, false);
+    color = rgbColor.GetColor(_colorTable, _defaultFg, false);
     VERIFY_ARE_EQUAL(_colorTable[7], color);
 
-    color = rgbColor.GetColor(view, _defaultFg, true);
+    color = rgbColor.GetColor(_colorTable, _defaultFg, true);
     VERIFY_ARE_EQUAL(_colorTable[15], color);
 
-    color = rgbColor.GetColor(view, _defaultBg, false);
+    color = rgbColor.GetColor(_colorTable, _defaultBg, false);
     VERIFY_ARE_EQUAL(_colorTable[7], color);
 
-    color = rgbColor.GetColor(view, _defaultBg, true);
+    color = rgbColor.GetColor(_colorTable, _defaultBg, true);
     VERIFY_ARE_EQUAL(_colorTable[15], color);
 
     rgbColor.SetIndex(15, false);
-    color = rgbColor.GetColor(view, _defaultFg, false);
+    color = rgbColor.GetColor(_colorTable, _defaultFg, false);
     VERIFY_ARE_EQUAL(_colorTable[15], color);
 
-    color = rgbColor.GetColor(view, _defaultFg, true);
+    color = rgbColor.GetColor(_colorTable, _defaultFg, true);
     VERIFY_ARE_EQUAL(_colorTable[15], color);
 
-    color = rgbColor.GetColor(view, _defaultBg, false);
+    color = rgbColor.GetColor(_colorTable, _defaultBg, false);
     VERIFY_ARE_EQUAL(_colorTable[15], color);
 
-    color = rgbColor.GetColor(view, _defaultBg, true);
+    color = rgbColor.GetColor(_colorTable, _defaultBg, true);
     VERIFY_ARE_EQUAL(_colorTable[15], color);
 }

--- a/src/cascadia/TerminalCore/terminalrenderdata.cpp
+++ b/src/cascadia/TerminalCore/terminalrenderdata.cpp
@@ -45,11 +45,12 @@ const TextAttribute Terminal::GetDefaultBrushColors() noexcept
 std::pair<COLORREF, COLORREF> Terminal::GetAttributeColors(const TextAttribute& attr) const noexcept
 {
     _blinkingState.RecordBlinkingUsage(attr);
-    auto colors = attr.CalculateRgbColors({ _colorTable.data(), _colorTable.size() },
-                                          _defaultFg,
-                                          _defaultBg,
-                                          _screenReversed,
-                                          _blinkingState.IsBlinkingFaint());
+    auto colors = attr.CalculateRgbColors(
+        _colorTable,
+        _defaultFg,
+        _defaultBg,
+        _screenReversed,
+        _blinkingState.IsBlinkingFaint());
     colors.first |= 0xff000000;
     // We only care about alpha for the default BG (which enables acrylic)
     // If the bg isn't the default bg color, or reverse video is enabled, make it fully opaque.

--- a/src/host/consoleInformation.cpp
+++ b/src/host/consoleInformation.cpp
@@ -259,11 +259,12 @@ COLORREF CONSOLE_INFORMATION::GetDefaultBackground() const noexcept
 std::pair<COLORREF, COLORREF> CONSOLE_INFORMATION::LookupAttributeColors(const TextAttribute& attr) const noexcept
 {
     _blinkingState.RecordBlinkingUsage(attr);
-    return attr.CalculateRgbColors(Get256ColorTable(),
-                                   GetDefaultForeground(),
-                                   GetDefaultBackground(),
-                                   IsScreenReversed(),
-                                   _blinkingState.IsBlinkingFaint());
+    return attr.CalculateRgbColors(
+        GetColorTable(),
+        GetDefaultForeground(),
+        GetDefaultBackground(),
+        IsScreenReversed(),
+        _blinkingState.IsBlinkingFaint());
 }
 
 // Method Description:

--- a/src/host/settings.cpp
+++ b/src/host/settings.cpp
@@ -726,16 +726,6 @@ void Settings::SetHistoryNoDup(const bool bHistoryNoDup)
     _bHistoryNoDup = bHistoryNoDup;
 }
 
-gsl::span<const COLORREF> Settings::Get16ColorTable() const
-{
-    return Get256ColorTable().subspan(0, 16);
-}
-
-gsl::span<const COLORREF> Settings::Get256ColorTable() const
-{
-    return { _colorTable.data(), _colorTable.size() };
-}
-
 void Settings::SetColorTableEntry(const size_t index, const COLORREF ColorValue)
 {
     _colorTable.at(index) = ColorValue;

--- a/src/host/settings.hpp
+++ b/src/host/settings.hpp
@@ -159,8 +159,12 @@ public:
     bool GetHistoryNoDup() const;
     void SetHistoryNoDup(const bool fHistoryNoDup);
 
-    gsl::span<const COLORREF> Get16ColorTable() const;
-    gsl::span<const COLORREF> Get256ColorTable() const;
+    // The first 16 items of the color table are the same as the 16-color palette.
+    inline const std::array<COLORREF, XTERM_COLOR_TABLE_SIZE>& GetColorTable() const noexcept
+    {
+        return _colorTable;
+    }
+
     void SetColorTableEntry(const size_t index, const COLORREF ColorValue);
     COLORREF GetColorTableEntry(const size_t index) const;
 

--- a/src/host/telemetry.cpp
+++ b/src/host/telemetry.cpp
@@ -419,7 +419,7 @@ void Telemetry::WriteFinalTraceLog()
                                     TraceLoggingBool(gci.GetQuickEdit(), "QuickEdit"),
                                     TraceLoggingValue(gci.GetWindowAlpha(), "WindowAlpha"),
                                     TraceLoggingBool(gci.GetWrapText(), "WrapText"),
-                                    TraceLoggingUInt32Array((UINT32 const*)gci.Get16ColorTable().data(), (UINT16)gci.Get16ColorTable().size(), "ColorTable"),
+                                    TraceLoggingUInt32Array((UINT32 const*)gci.GetColorTable().data(), 16, "ColorTable"),
                                     TraceLoggingValue(gci.CP, "CodePageInput"),
                                     TraceLoggingValue(gci.OutputCP, "CodePageOutput"),
                                     TraceLoggingValue(gci.GetFontSize().X, "FontSizeX"),
@@ -453,7 +453,7 @@ void Telemetry::WriteFinalTraceLog()
                                     TraceLoggingValue(gci.GetShowWindow(), "ShowWindow"),
                                     TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
                                     TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
-            static_assert(sizeof(UINT32) == sizeof(gci.Get16ColorTable()[0]), "gci.Get16ColorTable()");
+            static_assert(sizeof(UINT32) == sizeof(gci.GetColorTable()[0]), "gci.Get16ColorTable()");
 
             // I could use the TraceLoggingUIntArray, but then we would have to know the order of the enums on the backend.
             // So just log each enum count separately with its string representation which makes it more human readable.


### PR DESCRIPTION
I was watching a video about vectorized instructions and I wanted to
try out some new things, as I had never written AVX code before.
This commit is the result of this tiny Thursday morning detour into
AVX land. It improves performance of `TextColor::GetColor` by about 3x.

## Validation Steps Performed

* Default colors are still properly shifted +8 ✔️