### PR TITLE
Fix: Multimedia Key Hotkey Support

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -4,7 +4,7 @@
   "title": "Microsoft's Windows Terminal Settings Profile Schema",
   "definitions": {
     "KeyChordSegment": {
-      "pattern": "^(?:(?:ctrl|alt|shift|win)\\+)*(?:app|backspace|comma|delete|down|end|enter|esc|escape|home|insert|left|menu|minus|pagedown|pageup|period|pgdn|pgup|plus|right|space|tab|up|f(?:1\\d?|2[0-4]?|[3-9])|numpad\\d|numpad_(?:\\d|add|decimal|divide|minus|multiply|period|plus|subtract)|(?:vk|sc)\\((?:[1-9]|1?\\d{2}|2[0-4]\\d|25[0-5])\\)|[^\\s+])(?:\\+(?:ctrl|alt|shift|win))*$",
+      "pattern": "^(?:(?:ctrl|alt|shift|win)\\+)*(?:app|backspace|browser_(?:back|forward|refresh|stop|search|favorites|home)|comma|delete|down|end|enter|esc|escape|home|insert|left|menu|minus|pagedown|pageup|period|pgdn|pgup|plus|right|space|tab|up|f(?:1\\d?|2[0-4]?|[3-9])|numpad\\d|numpad_(?:\\d|add|decimal|divide|minus|multiply|period|plus|subtract)|(?:vk|sc)\\((?:[1-9]|1?\\d{2}|2[0-4]\\d|25[0-5])\\)|[^\\s+])(?:\\+(?:ctrl|alt|shift|win))*$",
       "type": "string",
       "description": "The string should fit the format \"[ctrl+][alt+][shift+][win+]<KeyName>\", where each modifier is optional. KeyName is either any single key character, an explicit virtual key or scan code in the form vk(nnn) and sc(nnn) respectively, or one of the special names listed at https://docs.microsoft.com/en-us/windows/terminal/customize-settings/actions#accepted-modifiers-and-keys"
     },

--- a/src/cascadia/TerminalSettingsModel/KeyChordSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/KeyChordSerialization.cpp
@@ -85,9 +85,7 @@ constexpr std::wstring_view WIN_KEY{ L"win" };
     XX(VK_BROWSER_STOP, L"browser_stop")                 \
     XX(VK_BROWSER_SEARCH, L"browser_search")             \
     XX(VK_BROWSER_FAVORITES, L"browser_favorites")       \
-    XX(VK_BROWSER_HOME, L"browser_home")                 \
-    XX(VK_XBUTTON1, L"mouse_back")                       \
-    XX(VK_XBUTTON2, L"mouse_forward")
+    XX(VK_BROWSER_HOME, L"browser_home")
 
 constexpr std::wstring_view vkeyPrefix{ L"vk(" };
 constexpr std::wstring_view scanCodePrefix{ L"sc(" };

--- a/src/cascadia/TerminalSettingsModel/KeyChordSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/KeyChordSerialization.cpp
@@ -78,7 +78,16 @@ constexpr std::wstring_view WIN_KEY{ L"win" };
     XX(VK_OEM_PLUS, L"plus") /* '+' any country */       \
     XX(VK_OEM_COMMA, L"comma") /* ',' any country */     \
     XX(VK_OEM_MINUS, L"minus") /* '-' any country */     \
-    XX(VK_OEM_PERIOD, L"period") /* '.' any country */
+    XX(VK_OEM_PERIOD, L"period") /* '.' any country */   \
+    XX(VK_BROWSER_BACK, L"browser_back")                 \
+    XX(VK_BROWSER_FORWARD, L"browser_forward")           \
+    XX(VK_BROWSER_REFRESH, L"browser_refresh")           \
+    XX(VK_BROWSER_STOP, L"browser_stop")                 \
+    XX(VK_BROWSER_SEARCH, L"browser_search")             \
+    XX(VK_BROWSER_FAVORITES, L"browser_favorites")       \
+    XX(VK_BROWSER_HOME, L"browser_home")                 \
+    XX(VK_XBUTTON1, L"mouse_back")                       \
+    XX(VK_XBUTTON2, L"mouse_forward")
 
 constexpr std::wstring_view vkeyPrefix{ L"vk(" };
 constexpr std::wstring_view scanCodePrefix{ L"sc(" };


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fixes/implements #10058 according to directions in that issue: added support for browser navigation keys to be used in actions.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #10058
* [x] CLA signed.
* [x] Tests added/passed
* [x] Documentation updated: . If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: https://github.com/MicrosoftDocs/terminal/pull/371
* [x] Schema updated.
* [x] I've discussed this with core contributors already. According to instructions in #10058

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The mouse back/forward keys do not correspond to the keys added here. That would be a nice (but more complicated) addition, I'll add an issue for it.