### PR TITLE
[DefApp] Move from Monarch multi instance servers to Peasant single instance servers

### DIFF
--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -257,12 +257,12 @@ namespace winrt::TerminalApp::implementation
     {
         if (args == nullptr)
         {
-            _OpenNewTab(nullptr);
+            LOG_IF_FAILED(_OpenNewTab(nullptr));
             args.Handled(true);
         }
         else if (const auto& realArgs = args.ActionArgs().try_as<NewTabArgs>())
         {
-            _OpenNewTab(realArgs.TerminalArgs());
+            LOG_IF_FAILED(_OpenNewTab(realArgs.TerminalArgs()));
             args.Handled(true);
         }
     }

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -1229,6 +1229,13 @@ namespace winrt::TerminalApp::implementation
             auto actions = winrt::single_threaded_vector<ActionAndArgs>(std::move(appArgs.GetStartupActions()));
 
             _root->ProcessStartupActions(actions, false, cwd);
+
+            // TODO: Comments - this is the function that peasants end up calling for handling the commandline
+            // hence why SetInboundListener is here.
+            if (_appArgs.IsHandoffListener())
+            {
+                _root->SetInboundListener(true);
+            }
         }
         // Return the result of parsing with commandline, though it may or may not be used.
         return result;

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -1230,9 +1230,7 @@ namespace winrt::TerminalApp::implementation
 
             _root->ProcessStartupActions(actions, false, cwd);
 
-            // TODO: Comments - this is the function that peasants end up calling for handling the commandline
-            // hence why SetInboundListener is here.
-            if (_appArgs.IsHandoffListener())
+            if (appArgs.IsHandoffListener())
             {
                 _root->SetInboundListener(true);
             }

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -56,7 +56,7 @@ namespace winrt::TerminalApp::implementation
     // - existingConnection: An optional connection that is already established to a PTY
     //   for this tab to host instead of creating one.
     //   If not defined, the tab will create the connection.
-    void TerminalPage::_OpenNewTab(const NewTerminalArgs& newTerminalArgs, winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection existingConnection)
+    HRESULT TerminalPage::_OpenNewTab(const NewTerminalArgs& newTerminalArgs, winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection existingConnection)
     try
     {
         const auto profileGuid{ _settings.GetProfileForArgs(newTerminalArgs) };
@@ -89,8 +89,10 @@ namespace winrt::TerminalApp::implementation
             TraceLoggingWideString(schemeName.data(), "SchemeName", "Color scheme set in the settings"),
             TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
             TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
+
+        return S_OK;
     }
-    CATCH_LOG();
+    CATCH_RETURN();
 
     // Method Description:
     // - Creates a new tab with the given settings. If the tab bar is not being

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2362,20 +2362,18 @@ namespace winrt::TerminalApp::implementation
         else
         {
             til::latch latch{ 1 };
-            std::optional<HRESULT> finalVal{};
+            HRESULT finalVal = S_OK;
 
             Dispatcher().RunAsync(CoreDispatcherPriority::Normal, [&]() {
-                auto hr = _OpenNewTab(nullptr, connection);
+                finalVal = _OpenNewTab(nullptr, connection);
 
                 _SummonWindowRequestedHandlers(*this, nullptr);
-
-                finalVal.emplace(std::move(hr));
 
                 latch.count_down();
             });
 
             latch.wait();
-            return *finalVal;
+            return finalVal;
         }
     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2368,8 +2368,11 @@ namespace winrt::TerminalApp::implementation
         return _isAlwaysOnTop;
     }
 
-    void TerminalPage::_OnNewConnection(winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection connection)
+    winrt::fire_and_forget TerminalPage::_OnNewConnection(winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection connection)
     {
+        // Handle it on a subsequent pass of the UI thread.
+        co_await winrt::resume_foreground(Dispatcher(), CoreDispatcherPriority::Normal);
+
         // TODO: GH 9458 will give us more context so we can try to choose a better profile.
         _OpenNewTab(nullptr, connection);
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -378,7 +378,12 @@ namespace winrt::TerminalApp::implementation
                 // tasks decide to clean up.
                 if (_isEmbeddingInboundListener)
                 {
-                    FAIL_FAST_CAUGHT_EXCEPTION();
+                    // Commenting out the fail fast because peasants will now become com servers
+                    // through receiving the -Embedded argument from the Monarch, and so we don't
+                    // want any peasants and all their tabs to die.
+                    // TODO: Get rid of the whole variable and just Log.
+                    /*FAIL_FAST_CAUGHT_EXCEPTION();*/
+                    LOG_CAUGHT_EXCEPTION();
                 }
                 else
                 {

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -356,39 +356,12 @@ namespace winrt::TerminalApp::implementation
                 winrt::Microsoft::Terminal::TerminalConnection::ConptyConnection::StartInboundListener();
             }
             // If we failed to start the listener, it will throw.
-            // We should fail fast here or the Terminal will be in a very strange state.
-            // We only start the listener if the Terminal was started with the COM server
-            // `-Embedding` flag and we make no tabs as a result.
-            // Therefore, if the listener cannot start itself up to make that tab with
-            // the inbound connection that caused the COM activation in the first place...
-            // we would be left with an empty terminal frame with no tabs.
-            // Instead, crash out so COM sees the server die and things unwind
-            // without a weird empty frame window.
+            // We don't want to fail fast here because if a peasant has some trouble with
+            // starting the listener, we don't want it to crash and take all its tabs down
+            // with it.
             catch (...)
             {
-                // However, we cannot always fail fast because of MSFT:33501832. Sometimes the COM catalog
-                // tears the state between old and new versions and fails here for that reason.
-                // As we're always becoming an inbound server in the monarch, even when COM didn't strictly
-                // ask us yet...we might just crash always.
-                // Instead... we're going to differentiate. If COM started us... we will fail fast
-                // so it sees the process die and falls back.
-                // If we were just starting normally as a Monarch and opportunistically listening for
-                // inbound connections... then we'll just log the failure and move on assuming
-                // the version state is torn and will fix itself whenever the packaging upgrade
-                // tasks decide to clean up.
-                //if (_isEmbeddingInboundListener)
-                //{
-                //    // Commenting out the fail fast because peasants will now become com servers
-                //    // through receiving the -Embedded argument from the Monarch, and so we don't
-                //    // want any peasants and all their tabs to die.
-                //    // TODO: Get rid of the whole variable and just Log.
-                //    /*FAIL_FAST_CAUGHT_EXCEPTION();*/
-                //    LOG_CAUGHT_EXCEPTION();
-                //}
-                //else
-                //{
-                    LOG_CAUGHT_EXCEPTION();
-                //}
+                LOG_CAUGHT_EXCEPTION();
             }
         }
     }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -376,19 +376,19 @@ namespace winrt::TerminalApp::implementation
                 // inbound connections... then we'll just log the failure and move on assuming
                 // the version state is torn and will fix itself whenever the packaging upgrade
                 // tasks decide to clean up.
-                if (_isEmbeddingInboundListener)
-                {
-                    // Commenting out the fail fast because peasants will now become com servers
-                    // through receiving the -Embedded argument from the Monarch, and so we don't
-                    // want any peasants and all their tabs to die.
-                    // TODO: Get rid of the whole variable and just Log.
-                    /*FAIL_FAST_CAUGHT_EXCEPTION();*/
+                //if (_isEmbeddingInboundListener)
+                //{
+                //    // Commenting out the fail fast because peasants will now become com servers
+                //    // through receiving the -Embedded argument from the Monarch, and so we don't
+                //    // want any peasants and all their tabs to die.
+                //    // TODO: Get rid of the whole variable and just Log.
+                //    /*FAIL_FAST_CAUGHT_EXCEPTION();*/
+                //    LOG_CAUGHT_EXCEPTION();
+                //}
+                //else
+                //{
                     LOG_CAUGHT_EXCEPTION();
-                }
-                else
-                {
-                    LOG_CAUGHT_EXCEPTION();
-                }
+                //}
             }
         }
     }

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -336,7 +336,7 @@ namespace winrt::TerminalApp::implementation
         winrt::Microsoft::Terminal::Settings::Model::Command _lastPreviewedCommand{ nullptr };
         winrt::Microsoft::Terminal::Settings::Model::TerminalSettings _originalSettings{ nullptr };
 
-        void _OnNewConnection(winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection connection);
+        winrt::fire_and_forget _OnNewConnection(winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection connection);
         void _HandleToggleInboundPty(const IInspectable& sender, const Microsoft::Terminal::Settings::Model::ActionEventArgs& args);
 
         void _WindowRenamerActionClick(const IInspectable& sender, const IInspectable& eventArgs);

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -188,7 +188,7 @@ namespace winrt::TerminalApp::implementation
 
         void _CreateNewTabFlyout();
         void _OpenNewTabDropdown();
-        void _OpenNewTab(const Microsoft::Terminal::Settings::Model::NewTerminalArgs& newTerminalArgs, winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection existingConnection = nullptr);
+        HRESULT _OpenNewTab(const Microsoft::Terminal::Settings::Model::NewTerminalArgs& newTerminalArgs, winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection existingConnection = nullptr);
         void _CreateNewTabFromSettings(GUID profileGuid, const Microsoft::Terminal::Settings::Model::TerminalSettingsCreateResult& settings, winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection existingConnection = nullptr);
         winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection _CreateConnectionFromSettings(GUID profileGuid, Microsoft::Terminal::Settings::Model::TerminalSettings settings);
 
@@ -336,7 +336,7 @@ namespace winrt::TerminalApp::implementation
         winrt::Microsoft::Terminal::Settings::Model::Command _lastPreviewedCommand{ nullptr };
         winrt::Microsoft::Terminal::Settings::Model::TerminalSettings _originalSettings{ nullptr };
 
-        winrt::fire_and_forget _OnNewConnection(winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection connection);
+        HRESULT _OnNewConnection(winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection connection);
         void _HandleToggleInboundPty(const IInspectable& sender, const Microsoft::Terminal::Settings::Model::ActionEventArgs& args);
 
         void _WindowRenamerActionClick(const IInspectable& sender, const IInspectable& eventArgs);

--- a/src/cascadia/TerminalConnection/CTerminalHandoff.cpp
+++ b/src/cascadia/TerminalConnection/CTerminalHandoff.cpp
@@ -31,7 +31,7 @@ try
     ComPtr<IUnknown> unk;
     RETURN_IF_FAILED(classFactory.As(&unk));
 
-    RETURN_IF_FAILED(CoRegisterClassObject(__uuidof(CTerminalHandoff), unk.Get(), CLSCTX_LOCAL_SERVER, REGCLS_MULTIPLEUSE, &g_cTerminalHandoffRegistration));
+    RETURN_IF_FAILED(CoRegisterClassObject(__uuidof(CTerminalHandoff), unk.Get(), CLSCTX_LOCAL_SERVER, REGCLS_SINGLEUSE, &g_cTerminalHandoffRegistration));
 
     _pfnHandoff = pfnHandoff;
 

--- a/src/cascadia/TerminalConnection/CTerminalHandoff.cpp
+++ b/src/cascadia/TerminalConnection/CTerminalHandoff.cpp
@@ -95,9 +95,7 @@ HRESULT CTerminalHandoff::EstablishPtyHandoff(HANDLE in, HANDLE out, HANDLE sign
 {
     // Because we are REGCLS_SINGLEUSE... we need to `CoRevokeClassObject` after we handle this ONE call.
     // COM does not automatically clean that up for us. We must do it.
-    auto cleanup = wil::scope_exit([] {
-        s_StopListening();
-    });
+    s_StopListening();
 
     // Report an error if no one registered a handoff function before calling this.
     RETURN_HR_IF_NULL(E_NOT_VALID_STATE, _pfnHandoff);

--- a/src/cascadia/TerminalConnection/CTerminalHandoff.cpp
+++ b/src/cascadia/TerminalConnection/CTerminalHandoff.cpp
@@ -93,6 +93,12 @@ static HRESULT _duplicateHandle(const HANDLE in, HANDLE& out) noexcept
 //   from the registered handler event function.
 HRESULT CTerminalHandoff::EstablishPtyHandoff(HANDLE in, HANDLE out, HANDLE signal, HANDLE ref, HANDLE server, HANDLE client) noexcept
 {
+    // Because we are REGCLS_SINGLEUSE... we need to `CoRevokeClassObject` after we handle this ONE call.
+    // COM does not automatically clean that up for us. We must do it.
+    auto cleanup = wil::scope_exit([] {
+        s_StopListening();
+    });
+
     // Report an error if no one registered a handoff function before calling this.
     RETURN_HR_IF_NULL(E_NOT_VALID_STATE, _pfnHandoff);
 

--- a/src/cascadia/TerminalConnection/CTerminalHandoff.h
+++ b/src/cascadia/TerminalConnection/CTerminalHandoff.h
@@ -37,12 +37,12 @@ struct __declspec(uuid(__CLSID_CTerminalHandoff))
                                      HANDLE signal,
                                      HANDLE ref,
                                      HANDLE server,
-                                     HANDLE client) noexcept override;
+                                     HANDLE client) override;
 
 #pragma endregion
 
-    static HRESULT s_StartListening(NewHandoffFunction pfnHandoff) noexcept;
-    static HRESULT s_StopListening() noexcept;
+    static HRESULT s_StartListening(NewHandoffFunction pfnHandoff);
+    static HRESULT s_StopListening();
 };
 
 // Disable warnings from the CoCreatableClass macro as the value it provides for

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -656,14 +656,6 @@ void AppHost::_BecomeMonarch(const winrt::Windows::Foundation::IInspectable& /*s
                              const winrt::Windows::Foundation::IInspectable& /*args*/)
 {
     _setupGlobalHotkeys();
-
-    // Originally, the monarch is THE listener for inbound connections, but
-    // now the model has changed where the monarch will first decide whether
-    // the monarch or one of its peasants should be the listener to receive
-    // the new tab event.
-    // 
-    // The monarch is just going to be THE listener for inbound connections.
-    //_listenForInboundConnections();
 }
 
 void AppHost::_listenForInboundConnections()

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -657,8 +657,13 @@ void AppHost::_BecomeMonarch(const winrt::Windows::Foundation::IInspectable& /*s
 {
     _setupGlobalHotkeys();
 
+    // Originally, the monarch is THE listener for inbound connections, but
+    // now the model has changed where the monarch will first decide whether
+    // the monarch or one of its peasants should be the listener to receive
+    // the new tab event.
+    // 
     // The monarch is just going to be THE listener for inbound connections.
-    _listenForInboundConnections();
+    //_listenForInboundConnections();
 }
 
 void AppHost::_listenForInboundConnections()


### PR DESCRIPTION
- Monarch no longer sets itself up as a `CTerminalHandoff` multi instance server by default
- In fact, `CTerminalHandoff` will only ever be a single instance server 
- When COM needs a `CTerminalHandoff`, it launches `wt.exe -embedding`, which gets picked up by the Monarch and then gets handed off to itself/peasant depending on user settings.
- Peasant now recognizes the `-embedding` commandline and will start a `CTerminalHandoff` single instance listener, and receives the connection into a new tab.

Closes #10358