### PR TITLE
Set drag and drop on '+' tooltip text based on keyboard modifiers

### DIFF
--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -662,4 +662,10 @@
   <data name="DropPathTabRun.Text" xml:space="preserve">
     <value>Open a new tab in given starting directory</value>
   </data>
+  <data name="DropPathTabNewWindow.Text" xml:space="preserve">
+    <value>Open a new window with given starting directory</value>
+  </data>
+  <data name="DropPathTabSplit.Text" xml:space="preserve">
+    <value>Split the window and start in given directory</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/TabRowControl.cpp
+++ b/src/cascadia/TerminalApp/TabRowControl.cpp
@@ -61,8 +61,19 @@ namespace winrt::TerminalApp::implementation
         // Make sure to set the AcceptedOperation, so that we can later receive the path in the Drop event
         e.AcceptedOperation(DataPackageOperation::Copy);
 
-        // Sets custom UI text
-        e.DragUIOverride().Caption(RS_(L"DropPathTabRun/Text"));
+        const auto modifiers = static_cast<uint32_t>(e.Modifiers());
+        if (WI_IsFlagSet(modifiers, static_cast<uint32_t>(DragDrop::DragDropModifiers::Alt)))
+        {
+            e.DragUIOverride().Caption(RS_(L"DropPathTabSplit/Text"));
+        }
+        else if (WI_IsFlagSet(modifiers, static_cast<uint32_t>(DragDrop::DragDropModifiers::Shift)))
+        {
+            e.DragUIOverride().Caption(RS_(L"DropPathTabNewWindow/Text"));
+        }
+        else
+        {
+            e.DragUIOverride().Caption(RS_(L"DropPathTabRun/Text"));
+        }
 
         // Sets if the caption is visible
         e.DragUIOverride().IsCaptionVisible(true);


### PR DESCRIPTION
Sets the tooltip text on the '+' button based on the keyboard modifiers
when dragging and dropping.

## Validation Steps Performed
Manually tested - dragged a directory onto the '+ button and saw that
* The text changed when `shift` was pressed
* The text changed when `alt` was pressed
* The text changed back when `shift` or `alt` were released

Closes #10722