### PR TITLE
Fix drag and drop on '+' button for drive letters

### DIFF
--- a/src/cascadia/LocalTests_SettingsModel/CommandTests.cpp
+++ b/src/cascadia/LocalTests_SettingsModel/CommandTests.cpp
@@ -397,6 +397,10 @@ namespace SettingsModelLocalTests
                 "name":"action6",
                 "command": { "action": "newWindow", "startingDirectory":"C:\\foo", "commandline": "bar.exe" }
             },
+            {
+                "name":"action7_startingDirectoryWithTrailingSlash",
+                "command": { "action": "newWindow", "startingDirectory":"C:\\", "commandline": "bar.exe" }
+            },
         ])" };
 
         const auto commands0Json = VerifyParseSucceeded(commands0String);
@@ -405,7 +409,7 @@ namespace SettingsModelLocalTests
         VERIFY_ARE_EQUAL(0u, commands.Size());
         auto warnings = implementation::Command::LayerJson(commands, commands0Json);
         VERIFY_ARE_EQUAL(0u, warnings.size());
-        VERIFY_ARE_EQUAL(7u, commands.Size());
+        VERIFY_ARE_EQUAL(8u, commands.Size());
 
         {
             auto command = commands.Lookup(L"action0");
@@ -502,6 +506,21 @@ namespace SettingsModelLocalTests
             Log::Comment(NoThrowString().Format(
                 L"cmdline: \"%s\"", cmdline.c_str()));
             VERIFY_ARE_EQUAL(L"--startingDirectory \"C:\\foo\" -- \"bar.exe\"", terminalArgs.ToCommandline());
+        }
+
+        {
+            auto command = commands.Lookup(L"action7_startingDirectoryWithTrailingSlash");
+            VERIFY_IS_NOT_NULL(command);
+            VERIFY_IS_NOT_NULL(command.ActionAndArgs());
+            VERIFY_ARE_EQUAL(ShortcutAction::NewWindow, command.ActionAndArgs().Action());
+            const auto& realArgs = command.ActionAndArgs().Args().try_as<NewWindowArgs>();
+            VERIFY_IS_NOT_NULL(realArgs);
+            const auto& terminalArgs = realArgs.TerminalArgs();
+            VERIFY_IS_NOT_NULL(terminalArgs);
+            auto cmdline = terminalArgs.ToCommandline();
+            Log::Comment(NoThrowString().Format(
+                L"cmdline: \"%s\"", cmdline.c_str()));
+            VERIFY_ARE_EQUAL(L"--startingDirectory \"C:\\\\\" -- \"bar.exe\"", terminalArgs.ToCommandline());
         }
     }
 }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -255,10 +255,10 @@ namespace winrt::TerminalApp::implementation
 
             std::wstring pathText = path.wstring();
 
-            // Handle edge case of "C:\\", seems like the "StartingDirectory" doesn't like path which ends with '\'
+            // Handle edge case of "C:\" - add a '.' to the end
             if (pathText.back() == L'\\')
             {
-                pathText.erase(std::prev(pathText.end()));
+                pathText.push_back(L'.');
             }
 
             NewTerminalArgs args;

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -253,16 +253,8 @@ namespace winrt::TerminalApp::implementation
                 path = path.parent_path();
             }
 
-            std::wstring pathText = path.wstring();
-
-            // Handle edge case of "C:\" - add a '.' to the end
-            if (pathText.back() == L'\\')
-            {
-                pathText.push_back(L'.');
-            }
-
             NewTerminalArgs args;
-            args.StartingDirectory(winrt::hstring{ pathText });
+            args.StartingDirectory(winrt::hstring{ path.wstring() });
             this->_OpenNewTerminal(args);
 
             TraceLoggingWrite(

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
@@ -118,7 +118,10 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         if (!StartingDirectory().empty())
         {
-            ss << fmt::format(L"--startingDirectory \"{}\" ", StartingDirectory());
+            // If the directory ends in a '\', we need to add another one on so that the enclosing quote added
+            // afterwards isn't escaped
+            const auto trailingBackslashEscape = StartingDirectory().back() == L'\\' ? L"\\" : L"";
+            ss << fmt::format(L"--startingDirectory \"{}{}\" ", StartingDirectory(), trailingBackslashEscape);
         }
 
         if (!TabTitle().empty())


### PR DESCRIPTION
Fixes dragging and dropping drive letters onto the '+' button.

Manually tested - dragging and dropping the `C:\` drive onto the '+' button works when creating a new tab, splitting or creating a new window. Dragging and dropping a regular directory still works.

Closes #10723