### PR TITLE
Fix font changes not resizing _invalidMap

### DIFF
--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1315,12 +1315,9 @@ try
 
             // And persist the new size.
             _displaySizePixels = clientSize;
-
-            _invalidMap.resize(clientSize / glyphCellSize);
-            RETURN_IF_FAILED(InvalidateAll());
         }
 
-        if (auto size = clientSize / glyphCellSize; size != _invalidMap.size())
+        if (const auto size = clientSize / glyphCellSize; size != _invalidMap.size())
         {
             _invalidMap.resize(size);
             RETURN_IF_FAILED(InvalidateAll());

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -582,9 +582,6 @@ try
 
     _displaySizePixels = _GetClientSize();
 
-    _invalidMap.resize(_displaySizePixels / _fontRenderData->GlyphCell());
-    RETURN_IF_FAILED(InvalidateAll());
-
     // Get the other device types so we have deeper access to more functionality
     // in our pipeline than by just walking straight from the D3D device.
 
@@ -1288,6 +1285,7 @@ try
     if (_isEnabled)
     {
         const auto clientSize = _GetClientSize();
+        const auto glyphCellSize = _fontRenderData->GlyphCell();
 
         // If we don't have device resources or if someone has requested that we
         // recreate the device... then make new resources. (Create will dump the old ones.)
@@ -1318,7 +1316,13 @@ try
             // And persist the new size.
             _displaySizePixels = clientSize;
 
-            _invalidMap.resize(clientSize / _fontRenderData->GlyphCell());
+            _invalidMap.resize(clientSize / glyphCellSize);
+            RETURN_IF_FAILED(InvalidateAll());
+        }
+
+        if (auto size = clientSize / glyphCellSize; size != _invalidMap.size())
+        {
+            _invalidMap.resize(size);
             RETURN_IF_FAILED(InvalidateAll());
         }
 
@@ -1337,7 +1341,7 @@ try
                                                                _ShouldForceGrayscaleAA(),
                                                                _dwriteFactory.Get(),
                                                                spacing,
-                                                               _fontRenderData->GlyphCell(),
+                                                               glyphCellSize,
                                                                _d2dDeviceContext->GetSize(),
                                                                std::nullopt,
                                                                D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT);


### PR DESCRIPTION
The `_invalidMap` size is dependent on both `clientSize` as well
as `glyphCellSize` and must be resized when either changes.

## PR Checklist
* [x] Closes #10855
* [x] I work here

## Validation Steps Performed
* Changing font size with Ctrl+Mousewheel in fullscreen works ✔️