### PR TITLE
Initialize the padding for the Control UIA provider

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -542,7 +542,13 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             // (https://docs.microsoft.com/en-us/windows/uwp/design/accessibility/custom-automation-peers)
             if (const auto& interactivityAutoPeer = _interactivity.OnCreateAutomationPeer())
             {
-                _automationPeer = winrt::make<implementation::TermControlAutomationPeer>(this, interactivityAutoPeer);
+                auto margins{ SwapChainPanel().Margin() };
+
+                Core::Padding padding{ margins.Left,
+                                       margins.Top,
+                                       margins.Right,
+                                       margins.Bottom };
+                _automationPeer = winrt::make<implementation::TermControlAutomationPeer>(this, padding, interactivityAutoPeer);
                 return _automationPeer;
             }
         }

--- a/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
+++ b/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
@@ -31,13 +31,14 @@ namespace XamlAutomation
 namespace winrt::Microsoft::Terminal::Control::implementation
 {
     TermControlAutomationPeer::TermControlAutomationPeer(TermControl* owner,
+                                                         const Core::Padding padding,
                                                          Control::InteractivityAutomationPeer impl) :
         TermControlAutomationPeerT<TermControlAutomationPeer>(*owner), // pass owner to FrameworkElementAutomationPeer
         _termControl{ owner },
         _contentAutomationPeer{ impl }
     {
         UpdateControlBounds();
-
+        SetControlPadding(padding);
         // Listen for UIA signalling events from the implementation. We need to
         // be the one to actually raise these automation events, so they go
         // through the UI tree correctly.

--- a/src/cascadia/TerminalControl/TermControlAutomationPeer.h
+++ b/src/cascadia/TerminalControl/TermControlAutomationPeer.h
@@ -43,6 +43,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
     public:
         TermControlAutomationPeer(Microsoft::Terminal::Control::implementation::TermControl* owner,
+                                  const Core::Padding padding,
                                   Control::InteractivityAutomationPeer implementation);
 
         void UpdateControlBounds();


### PR DESCRIPTION
## Summary of the Pull Request

This was missed in #10051. We need to make sure that the UIA provider can immediately know about the padding in the control, not just after the settings reload.

## PR Checklist
* [x] Closes #9955.e
  * [x] Additionally, this just closes #9955. The only remaining box in there never repro'd, so probably wasn't even root caused by #9820. I think we can close that issue for now, and reactivate if something else was broken.
* [x] I work here
* [ ] Tests added/passed
* [n/a] Requires documentation to be updated

## Validation Steps Performed

Checked before/after in Accessibility Insights. Before the row rectangles were the full width of the control initially. Now they're properly padded.