### PR TITLE
Reload settings when the input method changes

### DIFF
--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -209,6 +209,10 @@ namespace winrt::TerminalApp::implementation
                 self->_ReloadSettings();
             }
         });
+
+        _languageProfileNotifier = winrt::make_self<LanguageProfileNotifier>([this]() {
+            _reloadSettings->Run();
+        });
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/AppLogic.h
+++ b/src/cascadia/TerminalApp/AppLogic.h
@@ -5,8 +5,9 @@
 
 #include "AppLogic.g.h"
 #include "FindTargetWindowResult.g.h"
-#include "TerminalPage.h"
 #include "Jumplist.h"
+#include "LanguageProfileNotifier.h"
+#include "TerminalPage.h"
 
 #include <inc/cppwinrt_utils.h>
 #include <ThrottledFunc.h>
@@ -110,12 +111,8 @@ namespace winrt::TerminalApp::implementation
         // ALSO: If you add any UIElements as roots here, make sure they're
         // updated in _ApplyTheme. The root currently is _root.
         winrt::com_ptr<TerminalPage> _root{ nullptr };
-
         Microsoft::Terminal::Settings::Model::CascadiaSettings _settings{ nullptr };
 
-        wil::unique_folder_change_reader_nothrow _reader;
-        std::shared_ptr<ThrottledFuncTrailing<>> _reloadSettings;
-        til::throttled_func_trailing<> _reloadState;
         winrt::hstring _settingsLoadExceptionText;
         HRESULT _settingsLoadedResult = S_OK;
         bool _loadedInitialSettings = false;
@@ -124,6 +121,15 @@ namespace winrt::TerminalApp::implementation
 
         ::TerminalApp::AppCommandlineArgs _appArgs;
         ::TerminalApp::AppCommandlineArgs _settingsAppArgs;
+
+        std::shared_ptr<ThrottledFuncTrailing<>> _reloadSettings;
+        til::throttled_func_trailing<> _reloadState;
+
+        // These fields invoke _reloadSettings and must be destroyed before _reloadSettings.
+        // (C++ destroys members in reverse-declaration-order.)
+        winrt::com_ptr<LanguageProfileNotifier> _languageProfileNotifier;
+        wil::unique_folder_change_reader_nothrow _reader;
+
         static TerminalApp::FindTargetWindowResult _doFindTargetWindow(winrt::array_view<const hstring> args,
                                                                        const Microsoft::Terminal::Settings::Model::WindowingMode& windowingBehavior);
 

--- a/src/cascadia/TerminalApp/LanguageProfileNotifier.cpp
+++ b/src/cascadia/TerminalApp/LanguageProfileNotifier.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "LanguageProfileNotifier.h"
+
+using namespace winrt::TerminalApp::implementation;
+
+LanguageProfileNotifier::LanguageProfileNotifier(std::function<void()>&& callback) :
+    _callback{ std::move(callback) },
+    _currentKeyboardLayout{ GetKeyboardLayout(0) }
+{
+    const auto manager = wil::CoCreateInstance<ITfThreadMgr>(CLSID_TF_ThreadMgr);
+    _source = manager.query<ITfSource>();
+    if (FAILED(_source->AdviseSink(IID_ITfInputProcessorProfileActivationSink, static_cast<ITfInputProcessorProfileActivationSink*>(this), &_cookie)))
+    {
+        _cookie = TF_INVALID_COOKIE;
+        THROW_LAST_ERROR();
+    }
+}
+
+LanguageProfileNotifier::~LanguageProfileNotifier()
+{
+    if (_cookie != TF_INVALID_COOKIE)
+    {
+        _source->UnadviseSink(_cookie);
+    }
+}
+
+STDMETHODIMP LanguageProfileNotifier::OnActivated(DWORD /*dwProfileType*/, LANGID /*langid*/, REFCLSID /*clsid*/, REFGUID /*catid*/, REFGUID /*guidProfile*/, HKL hkl, DWORD /*dwFlags*/)
+{
+    if (hkl && hkl != _currentKeyboardLayout)
+    {
+        _currentKeyboardLayout = hkl;
+        try
+        {
+            _callback();
+        }
+        CATCH_RETURN();
+    }
+    return S_OK;
+}

--- a/src/cascadia/TerminalApp/LanguageProfileNotifier.h
+++ b/src/cascadia/TerminalApp/LanguageProfileNotifier.h
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+namespace winrt::TerminalApp::implementation
+{
+    class LanguageProfileNotifier : public winrt::implements<LanguageProfileNotifier, ITfInputProcessorProfileActivationSink>
+    {
+    public:
+        explicit LanguageProfileNotifier(std::function<void()>&& callback);
+        ~LanguageProfileNotifier();
+        STDMETHODIMP OnActivated(DWORD dwProfileType, LANGID langid, REFCLSID clsid, REFGUID catid, REFGUID guidProfile, HKL hkl, DWORD dwFlags);
+
+    private:
+        std::function<void()> _callback;
+        wil::com_ptr<ITfSource> _source;
+        DWORD _cookie = TF_INVALID_COOKIE;
+        HKL _currentKeyboardLayout;
+    };
+}

--- a/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
@@ -53,7 +53,7 @@
     <Page Include="TabRowControl.xaml">
       <SubType>Designer</SubType>
     </Page>
-        <Page Include="TabHeaderControl.xaml">
+    <Page Include="TabHeaderControl.xaml">
       <SubType>Designer</SubType>
     </Page>
     <Page Include="HighlightedTextControl.xaml">
@@ -74,6 +74,7 @@
     <ClInclude Include="Commandline.h" />
     <ClInclude Include="CommandLinePaletteItem.h" />
     <ClInclude Include="Jumplist.h" />
+    <ClInclude Include="LanguageProfileNotifier.h" />
     <ClInclude Include="MinMaxCloseControl.h">
       <DependentUpon>MinMaxCloseControl.xaml</DependentUpon>
     </ClInclude>
@@ -112,7 +113,7 @@
     <ClInclude Include="HighlightedTextControl.h">
       <DependentUpon>HighlightedTextControl.xaml</DependentUpon>
     </ClInclude>
-	<ClInclude Include="HighlightedText.h" />
+    <ClInclude Include="HighlightedText.h" />
     <ClInclude Include="ColorPickupFlyout.h">
       <DependentUpon>ColorPickupFlyout.xaml</DependentUpon>
     </ClInclude>
@@ -139,7 +140,7 @@
     <ClInclude Include="AppLogic.h">
       <DependentUpon>AppLogic.idl</DependentUpon>
     </ClInclude>
-    <ClInclude Include="Toast.h"/>
+    <ClInclude Include="Toast.h" />
   </ItemGroup>
   <!-- ========================= Cpp Files ======================== -->
   <ItemGroup>
@@ -149,6 +150,7 @@
     <ClCompile Include="AppCommandlineArgs.cpp" />
     <ClCompile Include="Commandline.cpp" />
     <ClCompile Include="Jumplist.cpp" />
+    <ClCompile Include="LanguageProfileNotifier.cpp" />
     <ClCompile Include="MinMaxCloseControl.cpp">
       <DependentUpon>MinMaxCloseControl.xaml</DependentUpon>
     </ClCompile>
@@ -195,7 +197,7 @@
     <ClCompile Include="HighlightedTextControl.cpp">
       <DependentUpon>HighlightedTextControl.xaml</DependentUpon>
     </ClCompile>
-	<ClCompile Include="HighlightedText.cpp" />
+    <ClCompile Include="HighlightedText.cpp" />
     <ClCompile Include="ColorPickupFlyout.cpp">
       <DependentUpon>ColorPickupFlyout.xaml</DependentUpon>
     </ClCompile>
@@ -280,7 +282,7 @@
       <DependentUpon>HighlightedTextControl.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Midl>
-	<Midl Include="HighlightedText.idl" />
+    <Midl Include="HighlightedText.idl" />
     <Midl Include="ColorPickupFlyout.idl">
       <DependentUpon>ColorPickupFlyout.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/src/cascadia/TerminalApp/TerminalAppLib.vcxproj.filters
+++ b/src/cascadia/TerminalApp/TerminalAppLib.vcxproj.filters
@@ -13,9 +13,6 @@
     <ClCompile Include="Pane.cpp">
       <Filter>pane</Filter>
     </ClCompile>
-    <ClCompile Include="Tab.cpp">
-      <Filter>tab</Filter>
-    </ClCompile>
     <ClCompile Include="Pane.LayoutSizeNode.cpp">
       <Filter>pane</Filter>
     </ClCompile>
@@ -23,7 +20,6 @@
     <ClCompile Include="Commandline.cpp" />
     <ClCompile Include="ColorHelper.cpp" />
     <ClCompile Include="DebugTapConnection.cpp" />
-    <ClCompile Include="Utils.cpp" />
     <ClCompile Include="Jumplist.cpp" />
     <ClCompile Include="Tab.cpp">
       <Filter>tab</Filter>
@@ -49,19 +45,16 @@
     <ClCompile Include="HighlightedText.cpp">
       <Filter>highlightedText</Filter>
     </ClCompile>
+    <ClCompile Include="Toast.cpp" />
+    <ClCompile Include="LanguageProfileNotifier.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Utils.h" />
-    <ClInclude Include="TerminalWarnings.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="App.base.h">
       <Filter>app</Filter>
     </ClInclude>
     <ClInclude Include="Pane.h">
       <Filter>pane</Filter>
-    </ClInclude>
-    <ClInclude Include="Tab.h">
-      <Filter>tab</Filter>
     </ClInclude>
     <ClInclude Include="AppCommandlineArgs.h" />
     <ClInclude Include="Commandline.h" />
@@ -92,13 +85,12 @@
     <ClInclude Include="HighlightedText.h">
       <Filter>highlightedText</Filter>
     </ClInclude>
+    <ClInclude Include="Toast.h" />
+    <ClInclude Include="LanguageProfileNotifier.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="AppLogic.idl">
       <Filter>app</Filter>
-    </Midl>
-    <Midl Include="ActionArgs.idl">
-      <Filter>settings</Filter>
     </Midl>
     <Midl Include="AppKeyBindings.idl">
       <Filter>settings</Filter>
@@ -107,9 +99,6 @@
       <Filter>settings</Filter>
     </Midl>
     <Midl Include="IDirectKeyListener.idl" />
-    <Midl Include="ITab.idl">
-      <Filter>tab</Filter>
-    </Midl>
     <Midl Include="SettingsTab.idl">
       <Filter>tab</Filter>
     </Midl>
@@ -125,6 +114,9 @@
     <Midl Include="TerminalTabStatus.idl">
       <Filter>tab</Filter>
     </Midl>
+    <Midl Include="PaletteItemTemplateSelector.idl" />
+    <Midl Include="TabBase.idl" />
+    <Midl Include="EmptyStringVisibilityConverter.idl" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -158,9 +150,6 @@
       <Filter>commandPalette</Filter>
     </Midl>
     <Midl Include="ActionPaletteItem.idl">
-      <Filter>commandPalette</Filter>
-    </Midl>
-    <Midl Include="FilterableListItem.idl">
       <Filter>commandPalette</Filter>
     </Midl>
     <Midl Include="CommandLinePaletteItem.idl">

--- a/src/cascadia/TerminalApp/pch.h
+++ b/src/cascadia/TerminalApp/pch.h
@@ -66,6 +66,7 @@ TRACELOGGING_DECLARE_PROVIDER(g_hTerminalAppProvider);
 #include <telemetry/ProjectTelemetry.h>
 #include <TraceLoggingActivity.h>
 
+#include <msctf.h>
 #include <shellapi.h>
 #include <shobjidl_core.h>
 


### PR DESCRIPTION
`VkKeyScanW` as well as `MapVirtualKeyW` are used throughout
the project, but are input method sensitive functions.

Since #10666 `win+sc(41)` is used as the quake mode keybinding,
which is then mapped to a virtual key in order to call `RegisterHotKey`.
This mapping is highly dependent on the input method and the quake mode
key binding will fail to work once the input method was changed.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #10729
* [x] I work here
* [ ] Tests added/passed

## Validation Steps Performed

* win+` opens quake window before & after changing keyboard layout ✔️
* keyboard layout changes while WT is minimized trigger reloaded ✔️