### PR TITLE
Prevent redraw upon resize if new size is equal to old

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -739,6 +739,18 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             return;
         }
 
+        // Convert our new dimensions to characters
+        const auto viewInPixels = Viewport::FromDimensions({ 0, 0 },
+                                                           { static_cast<short>(size.cx), static_cast<short>(size.cy) });
+        const auto vp = _renderEngine->GetViewportInCharacters(viewInPixels);
+        const auto currentVP = _terminal->GetViewport();
+
+        // Don't actually resize if viewport dimensions didn't change
+        if (vp.Height() == currentVP.Height() && vp.Width() == currentVP.Width())
+        {
+            return;
+        }
+
         _terminal->ClearSelection();
 
         // Tell the dx engine that our window is now the new size.
@@ -746,11 +758,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         // Invalidate everything
         _renderer->TriggerRedrawAll();
-
-        // Convert our new dimensions to characters
-        const auto viewInPixels = Viewport::FromDimensions({ 0, 0 },
-                                                           { static_cast<short>(size.cx), static_cast<short>(size.cy) });
-        const auto vp = _renderEngine->GetViewportInCharacters(viewInPixels);
 
         // If this function succeeds with S_FALSE, then the terminal didn't
         // actually change size. No need to notify the connection of this no-op.


### PR DESCRIPTION
## Summary of the Pull Request
Do not invoke terminal resize logic if view port dimensions didn't change

## PR Checklist
* [x] Closes #10857 
* [x] CLA signed. 
* [ ] Tests added/passed
* [ ] Documentation updated. 
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. 

## Detailed Description of the Pull Request / Additional comments
Short-circuit `ControlCore::_doResizeUnderLock` if the dimensions of the
required view port are equal to the dimensions of the current view port