### PR TITLE
Make the TerminalApi exception handler less garrulous

### DIFF
--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -16,7 +16,7 @@ try
     _WriteBuffer(stringView);
     return true;
 }
-CATCH_LOG_RETURN_FALSE()
+CATCH_RETURN_FALSE()
 
 bool Terminal::ExecuteChar(wchar_t wch) noexcept
 try
@@ -24,7 +24,7 @@ try
     _WriteBuffer({ &wch, 1 });
     return true;
 }
-CATCH_LOG_RETURN_FALSE()
+CATCH_RETURN_FALSE()
 
 TextAttribute Terminal::GetTextAttributes() const noexcept
 {
@@ -54,7 +54,7 @@ try
 
     return true;
 }
-CATCH_LOG_RETURN_FALSE()
+CATCH_RETURN_FALSE()
 
 COORD Terminal::GetCursorPosition() noexcept
 {
@@ -75,7 +75,7 @@ try
     _buffer->GetCursor().SetColor(color);
     return true;
 }
-CATCH_LOG_RETURN_FALSE()
+CATCH_RETURN_FALSE()
 
 // Method Description:
 // - Moves the cursor down one line, and possibly also to the leftmost column.
@@ -101,7 +101,7 @@ try
 
     return true;
 }
-CATCH_LOG_RETURN_FALSE()
+CATCH_RETURN_FALSE()
 
 // Method Description:
 // - deletes count characters starting from the cursor's current position
@@ -150,7 +150,7 @@ try
 
     return true;
 }
-CATCH_LOG_RETURN_FALSE()
+CATCH_RETURN_FALSE()
 
 // Method Description:
 // - Inserts count spaces starting from the cursor's current position, moving over the existing text
@@ -205,7 +205,7 @@ try
 
     return true;
 }
-CATCH_LOG_RETURN_FALSE()
+CATCH_RETURN_FALSE()
 
 bool Terminal::EraseCharacters(const size_t numChars) noexcept
 try
@@ -218,7 +218,7 @@ try
     _buffer->Write(eraseIter, absoluteCursorPos);
     return true;
 }
-CATCH_LOG_RETURN_FALSE()
+CATCH_RETURN_FALSE()
 
 // Method description:
 // - erases a line of text, either from
@@ -264,7 +264,7 @@ try
     _buffer->Write(eraseIter, startPos, false);
     return true;
 }
-CATCH_LOG_RETURN_FALSE()
+CATCH_RETURN_FALSE()
 
 // Method description:
 // - erases text in the buffer in two ways depending on erase type
@@ -348,7 +348,7 @@ try
 
     return true;
 }
-CATCH_LOG_RETURN_FALSE()
+CATCH_RETURN_FALSE()
 
 bool Terminal::WarningBell() noexcept
 try
@@ -356,7 +356,7 @@ try
     _pfnWarningBell();
     return true;
 }
-CATCH_LOG_RETURN_FALSE()
+CATCH_RETURN_FALSE()
 
 bool Terminal::SetWindowTitle(std::wstring_view title) noexcept
 try
@@ -368,7 +368,7 @@ try
     }
     return true;
 }
-CATCH_LOG_RETURN_FALSE()
+CATCH_RETURN_FALSE()
 
 // Method Description:
 // - Updates the value in the colortable at index tableIndex to the new color
@@ -387,7 +387,7 @@ try
     _buffer->GetRenderTarget().TriggerRedrawAll();
     return true;
 }
-CATCH_LOG_RETURN_FALSE()
+CATCH_RETURN_FALSE()
 
 // Method Description:
 // - Sets the cursor style to the given style.
@@ -457,7 +457,7 @@ try
     _buffer->GetRenderTarget().TriggerRedrawAll();
     return true;
 }
-CATCH_LOG_RETURN_FALSE()
+CATCH_RETURN_FALSE()
 
 // Method Description:
 // - Updates the default background color from a COLORREF, format 0x00BBGGRR.
@@ -475,7 +475,7 @@ try
     _buffer->GetRenderTarget().TriggerRedrawAll();
     return true;
 }
-CATCH_LOG_RETURN_FALSE()
+CATCH_RETURN_FALSE()
 
 til::color Terminal::GetDefaultBackground() const noexcept
 {
@@ -509,7 +509,7 @@ try
     _buffer->GetRenderTarget().TriggerRedrawAll();
     return true;
 }
-CATCH_LOG_RETURN_FALSE()
+CATCH_RETURN_FALSE()
 
 bool Terminal::EnableVT200MouseMode(const bool enabled) noexcept
 {
@@ -591,7 +591,7 @@ try
 
     return true;
 }
-CATCH_LOG_RETURN_FALSE()
+CATCH_RETURN_FALSE()
 
 // Method Description:
 // - Updates the buffer's current text attributes to start a hyperlink

--- a/src/inc/til.h
+++ b/src/inc/til.h
@@ -89,13 +89,22 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
         }                                           \
     } while (0, 0)
 
-// Due to a bug (DevDiv 441931), Warning 4297 (function marked noexcept throws exception) is detected even when the throwing code is unreachable, such as the end of scope after a return, in function-level catch.
+// Due to a bug (DevDiv 441931), Warning 4297 (function marked noexcept throws
+// exception) is detected even when the throwing code is unreachable, such as
+// the end of scope after a return, in function-level catch.
 #define CATCH_LOG_RETURN_FALSE()            \
     catch (...)                             \
     {                                       \
         __pragma(warning(suppress : 4297)); \
         LOG_CAUGHT_EXCEPTION();             \
         return false;                       \
+    }
+
+// This is like the above, but doesn't log any messages. This is for GH#10882.
+#define CATCH_RETURN_FALSE() \
+    catch (...)              \
+    {                        \
+        return false;        \
     }
 
 // MultiByteToWideChar has a bug in it where it can return 0 and then not set last error.


### PR DESCRIPTION
## Summary of the Pull Request

Apparently the exception handler in TerminalApi is far too talkative. We're apparently throwing in `TerminalApi::CursorLineFeed` way too often, and that's caused an internal bug to be filed on us.

This represents making the event less talkative, but doesn't actually fix the bug. It's just easier to get the OS bug cleared out quick this way. 

## References
* MSFT:33310649

## PR Checklist
* [x] Fixes the **A** portion of #10882, which closes MSFT:33310649
* [x] I work here
* [n/a] Tests added/passed
* [n/a] Requires documentation to be updated
