### PR TITLE
Fix WriteUTF8FileAtomic to preserve symlinks

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -2253,6 +2253,7 @@ SWMR
 SWP
 swprintf
 SYMED
+symlink
 SYNCPAINT
 sys
 syscalls

--- a/src/cascadia/TerminalSettingsModel/FileUtils.cpp
+++ b/src/cascadia/TerminalSettingsModel/FileUtils.cpp
@@ -148,6 +148,7 @@ namespace Microsoft::Terminal::Settings::Model
 
         // Writing to a file isn't atomic, but...
         WriteUTF8File(tmpPath, content);
+
         // renaming one is (supposed to be) atomic.
         // Wait... "supposed to be"!? Well it's technically not always atomic,
         // but it's pretty darn close to it, so... better than nothing.

--- a/src/cascadia/TerminalSettingsModel/FileUtils.cpp
+++ b/src/cascadia/TerminalSettingsModel/FileUtils.cpp
@@ -125,7 +125,11 @@ namespace Microsoft::Terminal::Settings::Model
     {
         // GH#10787: In the case of symbolic link, ensure that we modify the target rather than the link itself.
         // We append the paths manually rather than using "canonical" method to support scenario in which link target doesn't exist
-        const auto resolvedPath = std::filesystem::is_symlink(path) ? path.parent_path() / std::filesystem::read_symlink(path) : path;
+        auto resolvedPath = path;
+        while (std::filesystem::is_symlink(resolvedPath))
+        {
+            resolvedPath = resolvedPath.parent_path() / std::filesystem::read_symlink(resolvedPath);
+        }
 
         auto tmpPath = resolvedPath;
         tmpPath += L".tmp";


### PR DESCRIPTION

WriteUTF8FileAtomic  overrides the content of the file "atomically"
by creating a temp file and then renaming it to the original path.
The problem arises when the original path is symbolic link,
as the link itself gets overridden by a file (rather than the link target).
This PR introduces a special handling of the symlinks:
if the path as a symlink we resolve the path and use:
1. target's directory to create a temp-file in
2. target itself to be replaced with the tempfile.

Symlink resolution is problematic when the target path does not exist,
as there is no good utility that resolves such link (canonical() fails).
In this corner case we skip the "atomic" approach of renaming the file
and write the link target directly.

Closes #10787