### PR TITLE
Prevent deadlock in UIA Move API

### DIFF
--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -1006,6 +1006,7 @@ std::wstring UiaTextRangeBase::_getTextValue(std::optional<unsigned int> maxLeng
 IFACEMETHODIMP UiaTextRangeBase::Move(_In_ TextUnit unit,
                                       _In_ int count,
                                       _Out_ int* pRetVal) noexcept
+try
 {
     RETURN_HR_IF(E_INVALIDARG, pRetVal == nullptr);
     *pRetVal = 0;
@@ -1023,26 +1024,22 @@ IFACEMETHODIMP UiaTextRangeBase::Move(_In_ TextUnit unit,
     constexpr auto endpoint = TextPatternRangeEndpoint::TextPatternRangeEndpoint_Start;
     constexpr auto preventBufferEnd = true;
     const auto wasDegenerate = IsDegenerate();
-    try
+    if (unit == TextUnit::TextUnit_Character)
     {
-        if (unit == TextUnit::TextUnit_Character)
-        {
-            _moveEndpointByUnitCharacter(count, endpoint, pRetVal, preventBufferEnd);
-        }
-        else if (unit <= TextUnit::TextUnit_Word)
-        {
-            _moveEndpointByUnitWord(count, endpoint, pRetVal, preventBufferEnd);
-        }
-        else if (unit <= TextUnit::TextUnit_Line)
-        {
-            _moveEndpointByUnitLine(count, endpoint, pRetVal, preventBufferEnd);
-        }
-        else if (unit <= TextUnit::TextUnit_Document)
-        {
-            _moveEndpointByUnitDocument(count, endpoint, pRetVal, preventBufferEnd);
-        }
+        _moveEndpointByUnitCharacter(count, endpoint, pRetVal, preventBufferEnd);
     }
-    CATCH_RETURN();
+    else if (unit <= TextUnit::TextUnit_Word)
+    {
+        _moveEndpointByUnitWord(count, endpoint, pRetVal, preventBufferEnd);
+    }
+    else if (unit <= TextUnit::TextUnit_Line)
+    {
+        _moveEndpointByUnitLine(count, endpoint, pRetVal, preventBufferEnd);
+    }
+    else if (unit <= TextUnit::TextUnit_Document)
+    {
+        _moveEndpointByUnitDocument(count, endpoint, pRetVal, preventBufferEnd);
+    }
 
     // If we actually moved...
     if (*pRetVal != 0)
@@ -1063,6 +1060,7 @@ IFACEMETHODIMP UiaTextRangeBase::Move(_In_ TextUnit unit,
     UiaTracing::TextRange::Move(unit, count, *pRetVal, *this);
     return S_OK;
 }
+CATCH_RETURN();
 
 IFACEMETHODIMP UiaTextRangeBase::MoveEndpointByUnit(_In_ TextPatternRangeEndpoint endpoint,
                                                     _In_ TextUnit unit,

--- a/src/types/UiaTextRangeBase.hpp
+++ b/src/types/UiaTextRangeBase.hpp
@@ -153,6 +153,8 @@ namespace Microsoft::Console::Types
 
         void _getBoundingRect(const til::rectangle textRect, _Inout_ std::vector<double>& coords) const;
 
+        void _expandToEnclosingUnit(TextUnit unit);
+
         void
         _moveEndpointByUnitCharacter(_In_ const int moveCount,
                                      _In_ const TextPatternRangeEndpoint endpoint,


### PR DESCRIPTION
Fixes a bug where interacting with Windows Terminal when using Narrator causes Windows Terminal to hang.

`UiaTextRangeBase::Move()` locks, but later calls `UiaTextRangeBase::ExpandToEnclosingUnit()` which attempts to lock again. The workaround for this is to introduce a `_expandToEnclosingUnit()` that _does not_ lock the console. Then, `Move()` calls this new method, thus only allowing one lock to be established at a time.

This bug is observed to be in v1.11.2221.0 and _not_ in v1.9.1942.0.