### PR TITLE
Tray Icon PR followup

### DIFF
--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -546,7 +546,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
     // - <none>
     winrt::fire_and_forget WindowManager::RequestHideTrayIcon()
     {
-        auto strongThis { get_strong() };
+        auto strongThis{ get_strong() };
         co_await winrt::resume_background();
         _peasant.RequestHideTrayIcon();
     }

--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -532,8 +532,9 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
     // - <none>
     // Return Value:
     // - <none>
-    void WindowManager::RequestShowTrayIcon()
+    winrt::fire_and_forget WindowManager::RequestShowTrayIcon()
     {
+        co_await winrt::resume_background();
         _peasant.RequestShowTrayIcon();
     }
 
@@ -543,8 +544,10 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
     // - <none>
     // Return Value:
     // - <none>
-    void WindowManager::RequestHideTrayIcon()
+    winrt::fire_and_forget WindowManager::RequestHideTrayIcon()
     {
+        auto strongThis { get_strong() };
+        co_await winrt::resume_background();
         _peasant.RequestHideTrayIcon();
     }
 

--- a/src/cascadia/Remoting/WindowManager.h
+++ b/src/cascadia/Remoting/WindowManager.h
@@ -43,8 +43,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         void SummonAllWindows();
         Windows::Foundation::Collections::IMapView<uint64_t, winrt::hstring> GetPeasantNames();
 
-        void RequestShowTrayIcon();
-        void RequestHideTrayIcon();
+        winrt::fire_and_forget RequestShowTrayIcon();
+        winrt::fire_and_forget RequestHideTrayIcon();
         bool DoesQuakeWindowExist();
 
         TYPED_EVENT(FindTargetWindowRequested, winrt::Windows::Foundation::IInspectable, winrt::Microsoft::Terminal::Remoting::FindTargetWindowArgs);

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -92,15 +92,6 @@ AppHost::AppHost() noexcept :
 
 AppHost::~AppHost()
 {
-    if (_windowManager.IsMonarch())
-    {
-        _DestroyTrayIcon();
-    }
-    else if (_window->IsQuakeWindow())
-    {
-        _HideTrayIconRequested();
-    }
-
     // destruction order is important for proper teardown here
     _window = nullptr;
     _app.Close();
@@ -328,6 +319,15 @@ void AppHost::AppTitleChanged(const winrt::Windows::Foundation::IInspectable& /*
 // - <none>
 void AppHost::LastTabClosed(const winrt::Windows::Foundation::IInspectable& /*sender*/, const winrt::TerminalApp::LastTabClosedEventArgs& /*args*/)
 {
+    if (_windowManager.IsMonarch() && _trayIcon)
+    {
+        _DestroyTrayIcon();
+    }
+    else if (_window->IsQuakeWindow())
+    {
+        _HideTrayIconRequested();
+    }
+
     _window->Close();
 }
 

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -1056,11 +1056,10 @@ void AppHost::_DestroyTrayIcon()
     }
 }
 
-winrt::fire_and_forget AppHost::_ShowTrayIconRequested()
+void AppHost::_ShowTrayIconRequested()
 {
     if constexpr (Feature_TrayIcon::IsEnabled())
     {
-        co_await winrt::resume_background();
         if (_windowManager.IsMonarch())
         {
             if (!_trayIcon)
@@ -1075,11 +1074,10 @@ winrt::fire_and_forget AppHost::_ShowTrayIconRequested()
     }
 }
 
-winrt::fire_and_forget AppHost::_HideTrayIconRequested()
+void AppHost::_HideTrayIconRequested()
 {
     if constexpr (Feature_TrayIcon::IsEnabled())
     {
-        co_await winrt::resume_background();
         if (_windowManager.IsMonarch())
         {
             // Destroy it only if our settings allow it

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -92,9 +92,13 @@ AppHost::AppHost() noexcept :
 
 AppHost::~AppHost()
 {
-    if (_window->IsQuakeWindow())
+    if (_windowManager.IsMonarch())
     {
-        _windowManager.RequestHideTrayIcon();
+        _DestroyTrayIcon();
+    }
+    else if (_window->IsQuakeWindow())
+    {
+        _HideTrayIconRequested();
     }
 
     // destruction order is important for proper teardown here
@@ -655,9 +659,6 @@ void AppHost::_BecomeMonarch(const winrt::Windows::Foundation::IInspectable& /*s
                              const winrt::Windows::Foundation::IInspectable& /*args*/)
 {
     _setupGlobalHotkeys();
-
-    // The monarch is just going to be THE listener for inbound connections.
-    _listenForInboundConnections();
 
     if (_windowManager.DoesQuakeWindowExist() ||
         _window->IsQuakeWindow() ||

--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -86,8 +86,8 @@ private:
 
     void _CreateTrayIcon();
     void _DestroyTrayIcon();
-    winrt::fire_and_forget _ShowTrayIconRequested();
-    winrt::fire_and_forget _HideTrayIconRequested();
+    void _ShowTrayIconRequested();
+    void _HideTrayIconRequested();
     std::unique_ptr<TrayIcon> _trayIcon;
     winrt::event_token _ReAddTrayIconToken;
     winrt::event_token _TrayIconPressedToken;


### PR DESCRIPTION
Some followups to #10368:
- Accidentally reverted a defapp change where the Monarch should not by default register itself as a handoff server.
- Destroy the tray icon if we're a monarch otherwise if we're a quake window we request the monarch to hide the icon.