### PR TITLE
Fix focus-tab --previous/next to ignore tab switcher order

### DIFF
--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -380,6 +380,9 @@ void AppCommandlineArgs::_buildFocusTabParser()
             else if (_focusNextTab || _focusPrevTab)
             {
                 focusTabAction.Action(_focusNextTab ? ShortcutAction::NextTab : ShortcutAction::PrevTab);
+                focusTabAction.Args(_focusNextTab ?
+                                        static_cast<IActionArgs>(NextTabArgs(TabSwitcherMode::Disabled)) :
+                                        static_cast<IActionArgs>(PrevTabArgs(TabSwitcherMode::Disabled)));
                 _startupActions.push_back(std::move(focusTabAction));
             }
         });

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -380,7 +380,7 @@ void AppCommandlineArgs::_buildFocusTabParser()
             else if (_focusNextTab || _focusPrevTab)
             {
                 focusTabAction.Action(_focusNextTab ? ShortcutAction::NextTab : ShortcutAction::PrevTab);
-                // GH#10070 - make sure to not use the MRU order when switching 
+                // GH#10070 - make sure to not use the MRU order when switching
                 // tabs on the commandline. That wouldn't make any sense!
                 focusTabAction.Args(_focusNextTab ?
                                         static_cast<IActionArgs>(NextTabArgs(TabSwitcherMode::Disabled)) :

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -380,6 +380,8 @@ void AppCommandlineArgs::_buildFocusTabParser()
             else if (_focusNextTab || _focusPrevTab)
             {
                 focusTabAction.Action(_focusNextTab ? ShortcutAction::NextTab : ShortcutAction::PrevTab);
+                // GH#10070 - make sure to not use the MRU order when switching 
+                // tabs on the commandline. That wouldn't make any sense!
                 focusTabAction.Args(_focusNextTab ?
                                         static_cast<IActionArgs>(NextTabArgs(TabSwitcherMode::Disabled)) :
                                         static_cast<IActionArgs>(PrevTabArgs(TabSwitcherMode::Disabled)));

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -1475,6 +1475,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     struct PrevTabArgs : public PrevTabArgsT<PrevTabArgs>
     {
         PrevTabArgs() = default;
+        PrevTabArgs(TabSwitcherMode switcherMode) :
+            _SwitcherMode(switcherMode) {}
         ACTION_ARG(Windows::Foundation::IReference<TabSwitcherMode>, SwitcherMode, nullptr);
         static constexpr std::string_view SwitcherModeKey{ "tabSwitcherMode" };
 
@@ -1523,6 +1525,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     struct NextTabArgs : public NextTabArgsT<NextTabArgs>
     {
         NextTabArgs() = default;
+        NextTabArgs(TabSwitcherMode switcherMode) :
+            _SwitcherMode(switcherMode) {}
         ACTION_ARG(Windows::Foundation::IReference<TabSwitcherMode>, SwitcherMode, nullptr);
         static constexpr std::string_view SwitcherModeKey{ "tabSwitcherMode" };
 
@@ -1772,4 +1776,6 @@ namespace winrt::Microsoft::Terminal::Settings::Model::factory_implementation
     BASIC_FACTORY(FindMatchArgs);
     BASIC_FACTORY(NewWindowArgs);
     BASIC_FACTORY(FocusPaneArgs);
+    BASIC_FACTORY(PrevTabArgs);
+    BASIC_FACTORY(NextTabArgs);
 }

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -274,11 +274,15 @@ namespace Microsoft.Terminal.Settings.Model
 
     [default_interface] runtimeclass PrevTabArgs : IActionArgs
     {
+        PrevTabArgs();
+        PrevTabArgs(TabSwitcherMode SwitcherMode);
         Windows.Foundation.IReference<TabSwitcherMode> SwitcherMode;
     };
 
     [default_interface] runtimeclass NextTabArgs : IActionArgs
     {
+        NextTabArgs();
+        NextTabArgs(TabSwitcherMode SwitcherMode);
         Windows.Foundation.IReference<TabSwitcherMode> SwitcherMode;
     };
 


### PR DESCRIPTION
When creating `startupAction` use `TabSwitcherMode::Disabled` in action args
to disable the tab switcher and prevent MRU logic to be applied.

Closes #10070