### PR TITLE
Render "intense" text as bright by default

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -155,7 +155,7 @@
           "type": "string"
         },
         "intenseTextStyle": {
-          "default": "all",
+          "default": "bright",
           "description": "Controls how 'intense' text is rendered. Values are \"bold\", \"bright\", \"all\" and \"none\"",
           "enum": [
             "none",

--- a/src/cascadia/TerminalSettingsModel/AppearanceConfig.h
+++ b/src/cascadia/TerminalSettingsModel/AppearanceConfig.h
@@ -52,7 +52,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         INHERITABLE_SETTING(Model::IAppearanceConfig, bool, RetroTerminalEffect, false);
         INHERITABLE_SETTING(Model::IAppearanceConfig, hstring, PixelShaderPath, L"");
-        INHERITABLE_SETTING(Model::IAppearanceConfig, Model::IntenseStyle, IntenseTextStyle, Model::IntenseStyle::All);
+        INHERITABLE_SETTING(Model::IAppearanceConfig, Model::IntenseStyle, IntenseTextStyle, Model::IntenseStyle::Bright);
 
     private:
         winrt::weak_ref<Profile> _sourceProfile;


### PR DESCRIPTION
From discussion at #10678, we will ship with "intense" as bright for now until we fix text getting cut off by some bold fonts.