### PR TITLE
Refactor `u8u16` and `u16u8` conversion functions

### DIFF
--- a/.github/actions/spelling/allow/names.txt
+++ b/.github/actions/spelling/allow/names.txt
@@ -31,6 +31,7 @@ Kourosh
 kowalczyk
 leonmsft
 Lepilleur
+lhecker
 lukesampson
 Manandhar
 mbadolato
@@ -66,6 +67,7 @@ sonpham
 stakx
 thereses
 Walisch
+Wellons
 Wirt
 Wojciech
 zadjii

--- a/src/inc/til/u8u16convert.h
+++ b/src/inc/til/u8u16convert.h
@@ -56,7 +56,8 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
     // - S_OK          - the conversion succeeded
     // - E_OUTOFMEMORY - the function failed to allocate memory for the resulting string
     // - E_ABORT       - the resulting string length would exceed the upper boundary of an int and thus, the conversion was aborted before the conversion has been completed
-    // - E_UNEXPECTED  - an unexpected error occurred
+    // - E_UNEXPECTED  - the underlying conversion function failed
+    // - HRESULT value converted from a caught exception
     template<class outT>
     [[nodiscard]] HRESULT u8u16(const std::string_view& in, outT& out) noexcept
     {
@@ -74,18 +75,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
 
             return lengthOut == 0 ? E_UNEXPECTED : S_OK;
         }
-        catch (std::length_error&)
-        {
-            return E_ABORT;
-        }
-        catch (std::bad_alloc&)
-        {
-            return E_OUTOFMEMORY;
-        }
-        catch (...)
-        {
-            return E_UNEXPECTED;
-        }
+        CATCH_RETURN();
     }
 
 #pragma warning(push)
@@ -100,7 +90,8 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
     // - S_OK          - the conversion succeeded
     // - E_OUTOFMEMORY - the function failed to allocate memory for the resulting string
     // - E_ABORT       - the resulting string length would exceed the upper boundary of an int and thus, the conversion was aborted before the conversion has been completed
-    // - E_UNEXPECTED  - an unexpected error occurred
+    // - E_UNEXPECTED  - the underlying conversion function failed
+    // - HRESULT value converted from a caught exception
     template<class outT>
     [[nodiscard]] HRESULT u8u16(const std::string_view& in, outT& out, u8state& state) noexcept
     {
@@ -175,18 +166,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             out.resize(gsl::narrow_cast<size_t>(len16));
             return S_OK;
         }
-        catch (std::length_error&)
-        {
-            return E_ABORT;
-        }
-        catch (std::bad_alloc&)
-        {
-            return E_OUTOFMEMORY;
-        }
-        catch (...)
-        {
-            return E_UNEXPECTED;
-        }
+        CATCH_RETURN();
     }
 #pragma warning(pop)
 
@@ -199,7 +179,8 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
     // - S_OK          - the conversion succeeded
     // - E_OUTOFMEMORY - the function failed to allocate memory for the resulting string
     // - E_ABORT       - the resulting string length would exceed the upper boundary of an int and thus, the conversion was aborted before the conversion has been completed
-    // - E_UNEXPECTED  - an unexpected error occurred
+    // - E_UNEXPECTED  - the underlying conversion function failed
+    // - HRESULT value converted from a caught exception
     template<class outT>
     [[nodiscard]] HRESULT u16u8(const std::wstring_view& in, outT& out) noexcept
     {
@@ -220,18 +201,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
 
             return lengthOut == 0 ? E_UNEXPECTED : S_OK;
         }
-        catch (std::length_error&)
-        {
-            return E_ABORT;
-        }
-        catch (std::bad_alloc&)
-        {
-            return E_OUTOFMEMORY;
-        }
-        catch (...)
-        {
-            return E_UNEXPECTED;
-        }
+        CATCH_RETURN();
     }
 
 #pragma warning(push)
@@ -246,7 +216,8 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
     // - S_OK          - the conversion succeeded without any change of the represented code points
     // - E_OUTOFMEMORY - the function failed to allocate memory for the resulting string
     // - E_ABORT       - the resulting string length would exceed the upper boundary of an int and thus, the conversion was aborted before the conversion has been completed
-    // - E_UNEXPECTED  - an unexpected error occurred
+    // - E_UNEXPECTED  - the underlying conversion function failed
+    // - HRESULT value converted from a caught exception
     template<class outT>
     [[nodiscard]] HRESULT u16u8(const std::wstring_view& in, outT& out, u16state& state) noexcept
     {
@@ -296,18 +267,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             out.resize(gsl::narrow_cast<size_t>(len8));
             return S_OK;
         }
-        catch (std::length_error&)
-        {
-            return E_ABORT;
-        }
-        catch (std::bad_alloc&)
-        {
-            return E_OUTOFMEMORY;
-        }
-        catch (...)
-        {
-            return E_UNEXPECTED;
-        }
+        CATCH_RETURN();
     }
 #pragma warning(pop)
 

--- a/src/inc/til/u8u16convert.h
+++ b/src/inc/til/u8u16convert.h
@@ -143,6 +143,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
                 }
 
                 // credits go to Christopher Wellons for this algorithm to determine the length of a UTF-8 code point
+                // it is released into the Public Domain. https://github.com/skeeto/branchless-utf8
                 static constexpr uint8_t lengths[]{ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 3, 3, 4, 0 };
                 const auto codePointLen{ lengths[gsl::narrow_cast<uint8_t>(*backIter) >> 3] };
 

--- a/src/inc/til/u8u16convert.h
+++ b/src/inc/til/u8u16convert.h
@@ -151,20 +151,16 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
                     ++sequenceLen;
                 }
 
-                // we found a Lead Byte if at least 2 high-order bits are set
-                if ((*backIter & 0b11'000000) == 0b11'000000)
-                {
-                    // credits go to Christopher Wellons for this algorithm to determine the length of a UTF-8 code point
-                    static constexpr uint8_t lengths[]{ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 3, 3, 4, 0 };
-                    const auto codePointLen{ lengths[gsl::narrow_cast<uint8_t>(*backIter) >> 3] };
+                // credits go to Christopher Wellons for this algorithm to determine the length of a UTF-8 code point
+                static constexpr uint8_t lengths[]{ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 3, 3, 4, 0 };
+                const auto codePointLen{ lengths[gsl::narrow_cast<uint8_t>(*backIter) >> 3] };
 
-                    if (codePointLen > sequenceLen)
-                    {
-                        std::move(backIter, backIter + sequenceLen, &state.partials[0]);
-                        len8 -= sequenceLen;
-                        state.have = gsl::narrow_cast<uint8_t>(sequenceLen);
-                        state.want = gsl::narrow_cast<uint8_t>(codePointLen - sequenceLen);
-                    }
+                if (codePointLen > sequenceLen)
+                {
+                    std::move(backIter, backIter + sequenceLen, &state.partials[0]);
+                    len8 -= sequenceLen;
+                    state.have = gsl::narrow_cast<uint8_t>(sequenceLen);
+                    state.want = gsl::narrow_cast<uint8_t>(codePointLen - sequenceLen);
                 }
             }
 


### PR DESCRIPTION
* Perform the handling of partial code points in the `u8u16` and `u16u8`
  conversion functions without preparation in a preliminary buffer.
* Simplify partials handling in `u8u16` (perf).
* Declare the parameters for the incoming data as referenced
  string_views.
* Simplify templatization.
* Simplify exception handling.

We complete the partial codepoint in the 4-bytes long cache and convert
it separately. This makes the cache ready for capturing the next
partials before the remaining string is converted. This way, we neither
need to copy the whole string into a buffer which contains complete
codepoints, nor do we need to allocate an unnecessarily long buffer
which exists for the life time of the state class instance.

Finding and capturing of partials is performed in a more linear code
using the evaluation of the length of a code point.

The parameters for the incoming data are now explicitely declared to be
referenced string_views.

`CATCH_RETURN` is used to improve the readability of the code.

## Validation Steps Performed
* manually tested
* unit tests passed

Closes #10946

Co-authored-by: Leonard Hecker <lhecker@microsoft.com>
