### PR TITLE
Lookup WSL distros in the registry

### DIFF
--- a/.github/actions/spelling/allow/microsoft.txt
+++ b/.github/actions/spelling/allow/microsoft.txt
@@ -25,6 +25,7 @@ DWINRT
 enablewttlogging
 Intelli
 LKG
+Lxss
 mfcribbon
 microsoft
 microsoftonline

--- a/src/cascadia/TerminalSettingsModel/WslDistroGenerator.cpp
+++ b/src/cascadia/TerminalSettingsModel/WslDistroGenerator.cpp
@@ -180,12 +180,12 @@ static std::vector<Profile> namesToProfiles(const std::vector<std::wstring>& nam
 // - <none>
 // Return Value:
 // - the HKEY if it exists and we can read it, else nullptr
-static HKEY openWslRegKey()
+static wil::unique_hkey openWslRegKey()
 {
     HKEY hKey{ nullptr };
     if (RegOpenKeyEx(HKEY_CURRENT_USER, RegKeyLxss, 0, KEY_READ, &hKey) == ERROR_SUCCESS)
     {
-        return hKey;
+        return wil::unique_hkey{ hKey };
     }
     return nullptr;
 }
@@ -197,12 +197,12 @@ static HKEY openWslRegKey()
 // - guid: the string representation of the GUID for the distro to inspect
 // Return Value:
 // - the HKEY if it exists and we can read it, else nullptr
-static HKEY openDistroKey(const wil::unique_hkey& wslRootKey, const std::wstring& guid)
+static wil::unique_hkey openDistroKey(const wil::unique_hkey& wslRootKey, const std::wstring& guid)
 {
     HKEY hKey{ nullptr };
     if (RegOpenKeyEx(wslRootKey.get(), guid.c_str(), 0, KEY_READ, &hKey) == ERROR_SUCCESS)
     {
-        return hKey;
+        return wil::unique_hkey{ hKey };
     }
     return nullptr;
 }
@@ -227,7 +227,7 @@ static bool getWslGuids(const wil::unique_hkey& wslRootKey,
     wchar_t buffer[39]; // a {GUID} is 38 chars long
     for (DWORD i = 0;; i++)
     {
-        DWORD length = std::size(buffer);
+        DWORD length = 39;
         const auto result = RegEnumKeyEx(wslRootKey.get(), i, &buffer[0], &length, nullptr, nullptr, nullptr, nullptr);
         if (result == ERROR_NO_MORE_ITEMS)
         {

--- a/src/cascadia/TerminalSettingsModel/WslDistroGenerator.cpp
+++ b/src/cascadia/TerminalSettingsModel/WslDistroGenerator.cpp
@@ -251,7 +251,7 @@ bool _getWslGuids(const wil::unique_hkey& wslRootKey,
     guidStrings.reserve(dwNumSubKeys);
     for (DWORD i = 0; i < dwNumSubKeys; i++)
     {
-        const auto cbName = maxSubKeyLen + 1;
+        auto cbName = maxSubKeyLen + 1;
         const auto result = RegEnumKeyEx(wslRootKey.get(), i, buffer.get(), &cbName, nullptr, nullptr, nullptr, nullptr);
         if (result == ERROR_SUCCESS)
         {

--- a/src/cascadia/TerminalSettingsModel/WslDistroGenerator.cpp
+++ b/src/cascadia/TerminalSettingsModel/WslDistroGenerator.cpp
@@ -35,7 +35,7 @@ std::wstring_view WslDistroGenerator::GetNamespace()
 // - <none>
 // Return Value:
 // - a vector with all distros for all the installed WSL distros
-std::vector<Profile> WslDistroGenerator::GenerateProfiles()
+std::vector<Profile> _legacyGenerate()
 {
     std::vector<Profile> profiles;
 
@@ -135,4 +135,9 @@ std::vector<Profile> WslDistroGenerator::GenerateProfiles()
     }
 
     return profiles;
+}
+
+std::vector<Profile> WslDistroGenerator::GenerateProfiles()
+{
+    return _legacyGenerate();
 }

--- a/src/cascadia/TerminalSettingsModel/WslDistroGenerator.cpp
+++ b/src/cascadia/TerminalSettingsModel/WslDistroGenerator.cpp
@@ -156,7 +156,7 @@ static std::vector<Profile> namesToProfiles(const std::vector<std::wstring>& nam
     std::vector<Profile> profiles;
     for (const auto& distName : names)
     {
-        if (distName.substr(0, std::min(distName.size(), DockerDistributionPrefix.size())) == DockerDistributionPrefix)
+        if (til::starts_with(distName, DockerDistributionPrefix))
         {
             // Docker for Windows creates some utility distributions to handle Docker commands.
             // Pursuant to GH#3556, because they are _not_ user-facing we want to hide them.
@@ -183,7 +183,7 @@ static std::vector<Profile> namesToProfiles(const std::vector<std::wstring>& nam
 static HKEY openWslRegKey()
 {
     HKEY hKey{ nullptr };
-    if (RegOpenKeyEx(HKEY_CURRENT_USER, RegKeyLxss, 0, KEY_ALL_ACCESS, &hKey) == ERROR_SUCCESS)
+    if (RegOpenKeyEx(HKEY_CURRENT_USER, RegKeyLxss, 0, KEY_READ, &hKey) == ERROR_SUCCESS)
     {
         return hKey;
     }
@@ -200,7 +200,7 @@ static HKEY openWslRegKey()
 static HKEY openDistroKey(const wil::unique_hkey& wslRootKey, const std::wstring& guid)
 {
     HKEY hKey{ nullptr };
-    if (RegOpenKeyEx(wslRootKey.get(), guid.c_str(), 0, KEY_ALL_ACCESS, &hKey) == ERROR_SUCCESS)
+    if (RegOpenKeyEx(wslRootKey.get(), guid.c_str(), 0, KEY_READ, &hKey) == ERROR_SUCCESS)
     {
         return hKey;
     }
@@ -227,7 +227,7 @@ static bool getWslGuids(const wil::unique_hkey& wslRootKey,
     wchar_t buffer[39]; // a {GUID} is 38 chars long
     for (DWORD i = 0;; i++)
     {
-        DWORD length;
+        DWORD length = std::size(buffer);
         const auto result = RegEnumKeyEx(wslRootKey.get(), i, &buffer[0], &length, nullptr, nullptr, nullptr, nullptr);
         if (result == ERROR_NO_MORE_ITEMS)
         {

--- a/src/cascadia/TerminalSettingsModel/WslDistroGenerator.cpp
+++ b/src/cascadia/TerminalSettingsModel/WslDistroGenerator.cpp
@@ -226,19 +226,18 @@ static bool getWslGuids(const wil::unique_hkey& wslRootKey,
 
     // Figure out how many subkeys we have, and what the longest name of these subkeys is.
     DWORD dwNumSubKeys = 0;
-    if (RegQueryInfoKey(wslRootKey.get(), // hKey,
-                        nullptr, // lpClass,
-                        nullptr, // lpcchClass,
-                        nullptr, // lpReserved,
-                        &dwNumSubKeys, // lpcSubKeys,
-                        nullptr, // lpcbMaxSubKeyLen,
-                        nullptr, // lpcbMaxClassLen,
-                        nullptr, // lpcValues,
-                        nullptr, // lpcbMaxValueNameLen,
-                        nullptr, // lpcbMaxValueLen,
-                        nullptr, // lpcbSecurityDescriptor,
-                        nullptr // lpftLastWriteTime
-                        ) != ERROR_SUCCESS)
+    if (RegQueryInfoKey(wslRootKey.get(),
+                        nullptr,
+                        nullptr,
+                        nullptr,
+                        &dwNumSubKeys,
+                        nullptr,
+                        nullptr,
+                        nullptr,
+                        nullptr,
+                        nullptr,
+                        nullptr,
+                        nullptr) != ERROR_SUCCESS)
     {
         return false;
     }
@@ -295,8 +294,8 @@ static bool getWslNames(const wil::unique_hkey& wslRootKey,
         auto result = wil::AdaptFixedSizeToAllocatedResult<std::wstring, 256>(buffer, [&](PWSTR value, size_t valueLength, size_t* valueLengthNeededWithNull) -> HRESULT {
             auto length = static_cast<DWORD>(valueLength);
             const auto status = RegQueryValueExW(distroKey.get(), RegKeyDistroName, 0, nullptr, reinterpret_cast<BYTE*>(value), &length);
-            // length will recieve the number of bytes - convert to a number of
-            // wchar_t's. AdaptFixedSizeToAllocatedResult wll resize buffer to
+            // length will receive the number of bytes - convert to a number of
+            // wchar_t's. AdaptFixedSizeToAllocatedResult will resize buffer to
             // valueLengthNeededWithNull
             *valueLengthNeededWithNull = (length / sizeof(wchar_t));
             // If you add one for another trailing null, then there'll actually


### PR DESCRIPTION
This PR converts the WSL distro generator to use the registry to lookup
WSL distros instead of trying to parse the results of `wsl.exe`.
`wsl.exe` sometimes takes a very long time to launch the WSL service,
which means that on the first launch of the Terminal, WSL distros can
sometimes be missing entirely!

## References
* Also related is #6160, but I feel that deserves a separate PR for
  warning when the default profile is a dynamic profile who's source
  indicated it was gone. 

## PR Checklist
* [x] Closes #9905
* [x] Closes #7199
* [x] I work here
* [ ] Tests added/passed
* [ ] Requires documentation to be updated

## Detailed Description of the Pull Request / Additional comments

This is maybe a little BODGY, but hey we get tons of reports of this
root cause.

## Validation Steps Performed

Ran it locally, it did well. Ran a `wsl --shutdown`, then booted the
terminal - seemed to do well. I never was able to repro the slowness
myself, but I'd suspect this'll fix it.