### PR TITLE
Ensure automation peer is created regardless of terminal initialization

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -104,6 +104,32 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         auto pfnTerminalTaskbarProgressChanged = std::bind(&ControlCore::_terminalTaskbarProgressChanged, this);
         _terminal->TaskbarProgressChangedCallback(pfnTerminalTaskbarProgressChanged);
 
+        // MSFT 33353327: Initialize the renderer in the ctor instead of Initialize().
+        // We need the renderer to be ready to accept new engines before the SwapChainPanel is ready to go.
+        // If we wait, a screen reader may try to get the AutomationPeer (aka the UIA Engine), and we won't be able to attach
+        // the UIA Engine to the renderer. This prevents us from signaling changes to the cursor or buffer.
+        {
+            // First create the render thread.
+            // Then stash a local pointer to the render thread so we can initialize it and enable it
+            // to paint itself *after* we hand off its ownership to the renderer.
+            // We split up construction and initialization of the render thread object this way
+            // because the renderer and render thread have circular references to each other.
+            auto renderThread = std::make_unique<::Microsoft::Console::Render::RenderThread>();
+            auto* const localPointerToThread = renderThread.get();
+
+            // Now create the renderer and initialize the render thread.
+            _renderer = std::make_unique<::Microsoft::Console::Render::Renderer>(_terminal.get(), nullptr, 0, std::move(renderThread));
+
+            _renderer->SetRendererEnteredErrorStateCallback([weakThis = get_weak()]() {
+                if (auto strongThis{ weakThis.get() })
+                {
+                    strongThis->_RendererEnteredErrorStateHandlers(*strongThis, nullptr);
+                }
+            });
+
+            THROW_IF_FAILED(localPointerToThread->Initialize(_renderer.get()));
+        }
+
         // Get our dispatcher. If we're hosted in-proc with XAML, this will get
         // us the same dispatcher as TermControl::Dispatcher(). If we're out of
         // proc, this'll return null. We'll need to instead make a new
@@ -196,27 +222,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                 return false;
             }
 
-            // First create the render thread.
-            // Then stash a local pointer to the render thread so we can initialize it and enable it
-            // to paint itself *after* we hand off its ownership to the renderer.
-            // We split up construction and initialization of the render thread object this way
-            // because the renderer and render thread have circular references to each other.
-            auto renderThread = std::make_unique<::Microsoft::Console::Render::RenderThread>();
-            auto* const localPointerToThread = renderThread.get();
-
-            // Now create the renderer and initialize the render thread.
-            _renderer = std::make_unique<::Microsoft::Console::Render::Renderer>(_terminal.get(), nullptr, 0, std::move(renderThread));
-            ::Microsoft::Console::Render::IRenderTarget& renderTarget = *_renderer;
-
-            _renderer->SetRendererEnteredErrorStateCallback([weakThis = get_weak()]() {
-                if (auto strongThis{ weakThis.get() })
-                {
-                    strongThis->_RendererEnteredErrorStateHandlers(*strongThis, nullptr);
-                }
-            });
-
-            THROW_IF_FAILED(localPointerToThread->Initialize(_renderer.get()));
-
             // Set up the DX Engine
             auto dxEngine = std::make_unique<::Microsoft::Console::Render::DxEngine>();
             _renderer->AddRenderEngine(dxEngine.get());
@@ -248,7 +253,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             _settings.InitialCols(width);
             _settings.InitialRows(height);
 
-            _terminal->CreateFromSettings(_settings, renderTarget);
+            _terminal->CreateFromSettings(_settings, *_renderer);
 
             // IMPORTANT! Set this callback up sooner than later. If we do it
             // after Enable, then it'll be possible to paint the frame once
@@ -1465,10 +1470,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     void ControlCore::AttachUiaEngine(::Microsoft::Console::Render::IRenderEngine* const pEngine)
     {
-        if (_renderer)
-        {
-            _renderer->AddRenderEngine(pEngine);
-        }
+        // _renderer will always exist since it's introduced in the ctor
+        _renderer->AddRenderEngine(pEngine);
     }
 
     bool ControlCore::IsInReadOnlyMode() const

--- a/src/cascadia/TerminalControl/ControlInteractivity.cpp
+++ b/src/cascadia/TerminalControl/ControlInteractivity.cpp
@@ -614,7 +614,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     Control::InteractivityAutomationPeer ControlInteractivity::OnCreateAutomationPeer()
     try
     {
-        auto autoPeer = winrt::make_self<implementation::InteractivityAutomationPeer>(this);
+        const auto autoPeer = winrt::make_self<implementation::InteractivityAutomationPeer>(this);
 
         _uiaEngine = std::make_unique<::Microsoft::Console::Render::UiaEngine>(autoPeer.get());
         _core->AttachUiaEngine(_uiaEngine.get());

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -939,10 +939,11 @@ try
                                   std::nullopt :
                                   std::optional<unsigned int>{ maxLength };
     _pData->LockConsole();
-    auto Unlock = wil::scope_exit([&]() noexcept {
+    auto Unlock = wil::scope_exit([this]() noexcept {
         _pData->UnlockConsole();
     });
     const auto text = _getTextValue(maxLengthOpt);
+    Unlock.reset();
 
     *pRetVal = SysAllocString(text.c_str());
     RETURN_HR_IF_NULL(E_OUTOFMEMORY, *pRetVal);

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -938,6 +938,10 @@ try
     const auto maxLengthOpt = (maxLength == -1) ?
                                   std::nullopt :
                                   std::optional<unsigned int>{ maxLength };
+    _pData->LockConsole();
+    auto Unlock = wil::scope_exit([&]() noexcept {
+        _pData->UnlockConsole();
+    });
     const auto text = _getTextValue(maxLengthOpt);
 
     *pRetVal = SysAllocString(text.c_str());
@@ -958,11 +962,6 @@ CATCH_RETURN();
 #pragma warning(disable : 26447) // compiler isn't filtering throws inside the try/catch
 std::wstring UiaTextRangeBase::_getTextValue(std::optional<unsigned int> maxLength) const
 {
-    _pData->LockConsole();
-    auto Unlock = wil::scope_exit([&]() noexcept {
-        _pData->UnlockConsole();
-    });
-
     std::wstring textData{};
     if (!IsDegenerate())
     {


### PR DESCRIPTION
## Summary of the Pull Request
The bug was that Narrator would still read the content of the old tab/pane although a new tab/pane was introduced. This is caused by the automation peer not being created when XAML requests it. Normally, we would prevent the automation peer from being created if the terminal was not fully initialized.

This change allows the automation peer to be created regardless of the terminal being fully initialized by...
- `TermControl`: `_InitializeTerminal` updates the padding (dependent on the `SwapChainPanel`) upon full initialization
- `ControlCore`: initialize the `_renderer` in the ctor so that we can attach the UIA Engine before `ControlCore::Initialize()` is called (dependent on `SwapChainPanel` loading)

As a bonus, this also fixes a locking issue where logging would attempt to get the text range's text and lock twice. The locking fix is very similar to #10937.

## PR Checklist
Closes [MSFT 33353327](https://microsoft.visualstudio.com/OS/_workitems/edit/33353327)

## Validation Steps Performed
- New pane from key binding is announced by Narrator
- New tab from key binding is announced by Narrator