### PR TITLE
Create a window process for the tray icon

### DIFF
--- a/src/cascadia/WindowsTerminal/TrayIcon.cpp
+++ b/src/cascadia/WindowsTerminal/TrayIcon.cpp
@@ -23,6 +23,7 @@ TrayIcon::TrayIcon(const HWND owningHwnd) :
 
 TrayIcon::~TrayIcon()
 {
+    DestroyWindow(_trayIconWndProc);
     RemoveIconFromTray();
 }
 
@@ -33,6 +34,7 @@ void TrayIcon::CreateWindowProcess()
     wc.hInstance = reinterpret_cast<HINSTANCE>(&__ImageBase);
     wc.lpszClassName = TRAY_ICON_HOSTING_WINDOW_CLASS;
     wc.style = CS_HREDRAW | CS_VREDRAW;
+    wc.lpfnWndProc = &TrayIcon::_WindowProc;
     wc.hIcon = static_cast<HICON>(GetActiveAppIconHandle(true));
     RegisterClass(&wc);
 

--- a/src/cascadia/WindowsTerminal/TrayIcon.cpp
+++ b/src/cascadia/WindowsTerminal/TrayIcon.cpp
@@ -13,7 +13,6 @@ using namespace winrt::Windows::Foundation::Collections;
 using namespace winrt::Microsoft::Terminal;
 
 extern "C" IMAGE_DOS_HEADER __ImageBase;
-#define TRAY_ICON_HOSTING_WINDOW_CLASS L"TRAY_ICON_HOSTING_WINDOW_CLASS"
 
 TrayIcon::TrayIcon(const HWND owningHwnd) :
     _owningHwnd{ owningHwnd }
@@ -32,15 +31,15 @@ void TrayIcon::CreateWindowProcess()
     WNDCLASSW wc{};
     wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
     wc.hInstance = reinterpret_cast<HINSTANCE>(&__ImageBase);
-    wc.lpszClassName = TRAY_ICON_HOSTING_WINDOW_CLASS;
+    wc.lpszClassName = L"TRAY_ICON_HOSTING_WINDOW_CLASS";
     wc.style = CS_HREDRAW | CS_VREDRAW;
     wc.lpfnWndProc = &TrayIcon::_WindowProc;
     wc.hIcon = static_cast<HICON>(GetActiveAppIconHandle(true));
     RegisterClass(&wc);
 
     _trayIconWndProc = CreateWindowW(wc.lpszClassName,
-                                     TRAY_ICON_HOSTING_WINDOW_CLASS,
-                                     WS_OVERLAPPEDWINDOW | WS_POPUP,
+                                     wc.lpszClassName,
+                                     WS_DISABLED,
                                      CW_USEDEFAULT,
                                      CW_USEDEFAULT,
                                      CW_USEDEFAULT,
@@ -70,9 +69,10 @@ void TrayIcon::CreateTrayIcon()
 {
     if (!_trayIconWndProc)
     {
-        // Creating a window proc just so we can set it as the foreground
-        // window when showing the context menu. This is done so that the
-        // menu can be dismissed by clicking outside of the menu.
+        // Creating a disabled, non visible window just so we can set it
+        // as the foreground window when showing the context menu.
+        // This is done so that the context menu can be dismissed
+        // when clicking outside of it.
         CreateWindowProcess();
     }
 

--- a/src/cascadia/WindowsTerminal/TrayIcon.cpp
+++ b/src/cascadia/WindowsTerminal/TrayIcon.cpp
@@ -44,7 +44,7 @@ void TrayIcon::CreateWindowProcess()
                                      CW_USEDEFAULT,
                                      CW_USEDEFAULT,
                                      CW_USEDEFAULT,
-                                     nullptr,
+                                     _owningHwnd,
                                      nullptr,
                                      wc.hInstance,
                                      nullptr);

--- a/src/cascadia/WindowsTerminal/TrayIcon.cpp
+++ b/src/cascadia/WindowsTerminal/TrayIcon.cpp
@@ -23,14 +23,14 @@ TrayIcon::~TrayIcon()
     RemoveIconFromTray();
 }
 
-void TrayIcon::CreateWindowProcess()
+void TrayIcon::_CreateWindow()
 {
     WNDCLASSW wc{};
     wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
     wc.hInstance = wil::GetModuleInstanceHandle();
     wc.lpszClassName = L"TRAY_ICON_HOSTING_WINDOW_CLASS";
     wc.style = CS_HREDRAW | CS_VREDRAW;
-    wc.lpfnWndProc = &TrayIcon::_WindowProc;
+    wc.lpfnWndProc = DefWindowProcW;
     wc.hIcon = static_cast<HICON>(GetActiveAppIconHandle(true));
     RegisterClass(&wc);
 
@@ -49,11 +49,6 @@ void TrayIcon::CreateWindowProcess()
     WINRT_VERIFY(_trayIconHwnd);
 }
 
-LRESULT CALLBACK TrayIcon::_WindowProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) noexcept
-{
-    return DefWindowProc(window, message, wparam, lparam);
-}
-
 // Method Description:
 // - Creates and adds an icon to the notification tray.
 // If an icon already exists, update the HWND associated
@@ -70,7 +65,7 @@ void TrayIcon::CreateTrayIcon()
         // as the foreground window when showing the context menu.
         // This is done so that the context menu can be dismissed
         // when clicking outside of it.
-        CreateWindowProcess();
+        _CreateWindow();
     }
 
     NOTIFYICONDATA nid{};

--- a/src/cascadia/WindowsTerminal/TrayIcon.h
+++ b/src/cascadia/WindowsTerminal/TrayIcon.h
@@ -19,9 +19,6 @@ public:
     TrayIcon(const HWND owningHwnd);
     ~TrayIcon();
 
-    void CreateWindowProcess();
-    static LRESULT CALLBACK _WindowProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) noexcept;
-
     void CreateTrayIcon();
     void RemoveIconFromTray();
     void ReAddTrayIcon();
@@ -33,6 +30,7 @@ public:
     WINRT_CALLBACK(SummonWindowRequested, winrt::delegate<void(winrt::Microsoft::Terminal::Remoting::SummonWindowSelectionArgs)>);
 
 private:
+    void _CreateWindow();
     HMENU _CreateTrayContextMenu(winrt::Windows::Foundation::Collections::IMapView<uint64_t, winrt::hstring> peasants);
 
     wil::unique_hwnd _trayIconHwnd;

--- a/src/cascadia/WindowsTerminal/TrayIcon.h
+++ b/src/cascadia/WindowsTerminal/TrayIcon.h
@@ -21,7 +21,6 @@ public:
 
     void CreateWindowProcess();
     static LRESULT CALLBACK _WindowProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) noexcept;
-    LRESULT MessageHandler(HWND window, UINT const message, WPARAM const wparam, LPARAM const lparam) noexcept;
 
     void CreateTrayIcon();
     void RemoveIconFromTray();

--- a/src/cascadia/WindowsTerminal/TrayIcon.h
+++ b/src/cascadia/WindowsTerminal/TrayIcon.h
@@ -35,7 +35,7 @@ public:
 private:
     HMENU _CreateTrayContextMenu(winrt::Windows::Foundation::Collections::IMapView<uint64_t, winrt::hstring> peasants);
 
-    HWND _trayIconWndProc;
+    wil::unique_hwnd _trayIconHwnd;
     HWND _owningHwnd;
     NOTIFYICONDATA _trayIconData;
 };

--- a/src/cascadia/WindowsTerminal/TrayIcon.h
+++ b/src/cascadia/WindowsTerminal/TrayIcon.h
@@ -19,6 +19,10 @@ public:
     TrayIcon(const HWND owningHwnd);
     ~TrayIcon();
 
+    void CreateWindowProcess();
+    static LRESULT CALLBACK _WindowProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) noexcept;
+    LRESULT MessageHandler(HWND window, UINT const message, WPARAM const wparam, LPARAM const lparam) noexcept;
+
     void CreateTrayIcon();
     void RemoveIconFromTray();
     void ReAddTrayIcon();
@@ -32,6 +36,7 @@ public:
 private:
     HMENU _CreateTrayContextMenu(winrt::Windows::Foundation::Collections::IMapView<uint64_t, winrt::hstring> peasants);
 
+    HWND _trayIconWndProc;
     HWND _owningHwnd;
     NOTIFYICONDATA _trayIconData;
 };


### PR DESCRIPTION
Currently, the monarch window will show itself when opening the tray icon context menu. This is because a window must be set as the foreground window when the context menu opens, otherwise the menu won't be able to be dismissed when clicking outside of the context menu.

This PR makes the tray icon create a non visible/interactable window for the sole purpose of being set as the foreground window when the tray icon's context menu is opened. Then none of the terminal windows should be set as the foreground window when opening the context menu.

Closes #10936