### PR TITLE
Only iterate panes one time when updating settings

### DIFF
--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -1049,10 +1049,7 @@ void Pane::_FocusFirstChild()
 }
 
 // Method Description:
-// - Attempts to update the settings of this pane or any children of this pane.
-//   * If this pane is a leaf, and our profile guid matches the parameter, then
-//     we'll apply the new settings to our control.
-//   * If we're not a leaf, we'll recurse on our children.
+// - Updates the settings of this pane, presuming that it is a leaf.
 // Arguments:
 // - settings: The new TerminalSettings to apply to any matching controls
 // - profile: The profile from which these settings originated.

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -54,7 +54,14 @@ public:
     std::shared_ptr<Pane> GetActivePane();
     winrt::Microsoft::Terminal::Control::TermControl GetTerminalControl();
     winrt::Microsoft::Terminal::Settings::Model::Profile GetFocusedProfile();
-    winrt::Microsoft::Terminal::Settings::Model::Profile GetProfile() const { return _profile; }
+
+    // Method Description:
+    // - If this is a leaf pane, return its profile.
+    // - If this is a branch/root pane, return nullptr.
+    winrt::Microsoft::Terminal::Settings::Model::Profile GetProfile() const
+    {
+        return _profile;
+    }
 
     winrt::Windows::UI::Xaml::Controls::Grid GetRootElement();
 

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -54,6 +54,7 @@ public:
     std::shared_ptr<Pane> GetActivePane();
     winrt::Microsoft::Terminal::Control::TermControl GetTerminalControl();
     winrt::Microsoft::Terminal::Settings::Model::Profile GetFocusedProfile();
+    winrt::Microsoft::Terminal::Settings::Model::Profile GetProfile() const { return _profile; }
 
     winrt::Windows::UI::Xaml::Controls::Grid GetRootElement();
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1996,36 +1996,53 @@ namespace winrt::TerminalApp::implementation
         _HookupKeyBindings(_settings.ActionMap());
 
         // Refresh UI elements
-        auto profiles = _settings.ActiveProfiles();
-        for (const auto& profile : profiles)
-        {
-            try
-            {
-                auto settings{ TerminalSettings::CreateWithProfile(_settings, profile, *_bindings) };
 
-                for (auto tab : _tabs)
-                {
-                    if (auto terminalTab = _GetTerminalTabImpl(tab))
-                    {
-                        terminalTab->UpdateSettings(settings, profile);
-                    }
-                }
-            }
-            CATCH_LOG();
+        // Mapping by GUID isn't _excellent_ because the defaults profile doesn't have a stable GUID; however,
+        // when we stabilize its guid this will become fully safe.
+        std::unordered_map<winrt::guid, std::pair<Profile, TerminalSettingsCreateResult>> _profileGuidSettingsMap;
+
+        // Include the Defaults profile for consideration
+        const auto profileDefaults{ _settings.ProfileDefaults() };
+        _profileGuidSettingsMap.insert_or_assign(profileDefaults.Guid(), std::pair<Profile, TerminalSettingsCreateResult>{ profileDefaults, nullptr });
+        for (const auto& newProfile : _settings.AllProfiles())
+        {
+            // Avoid creating a TerminalSettings right now. They're not totally cheap, and we suspect that users with many
+            // panes may not be using all of their profiles at the same time. Lazy evaluation is king!
+            _profileGuidSettingsMap.insert_or_assign(newProfile.Guid(), std::pair<Profile, TerminalSettingsCreateResult>{ newProfile, nullptr });
         }
 
-        // GH#2455: If there are any panes with controls that had been
-        // initialized with a Profile that no longer exists in our list of
-        // profiles, we'll leave it unmodified. The profile doesn't exist
-        // anymore, so we can't possibly update its settings.
-
-        // Update the icon of the tab for the currently focused profile in that tab.
-        // Only do this for TerminalTabs. Other types of tabs won't have multiple panes
-        // and profiles so the Title and Icon will be set once and only once on init.
-        for (auto tab : _tabs)
+        for (const auto& tab : _tabs)
         {
-            if (auto terminalTab = _GetTerminalTabImpl(tab))
+            if (auto terminalTab{ _GetTerminalTabImpl(tab) })
             {
+                terminalTab->UpdateSettings();
+
+                // Manually enumerate the panes in each tab; this will let us recycle TerminalSettings
+                // objects but only have to iterate one time.
+                terminalTab->GetRootPane()->WalkTree([&](auto&& pane) {
+                    if (const auto profile{ pane->GetProfile() })
+                    {
+                        const auto found{ _profileGuidSettingsMap.find(profile.Guid()) };
+                        // GH#2455: If there are any panes with controls that had been
+                        // initialized with a Profile that no longer exists in our list of
+                        // profiles, we'll leave it unmodified. The profile doesn't exist
+                        // anymore, so we can't possibly update its settings.
+                        if (found != _profileGuidSettingsMap.cend())
+                        {
+                            auto& pair{ found->second };
+                            if (!pair.second)
+                            {
+                                pair.second = TerminalSettings::CreateWithProfile(_settings, pair.first, *_bindings);
+                            }
+                            pane->UpdateSettings(pair.second, pair.first);
+                        }
+                    }
+                    return false;
+                });
+
+                // Update the icon of the tab for the currently focused profile in that tab.
+                // Only do this for TerminalTabs. Other types of tabs won't have multiple panes
+                // and profiles so the Title and Icon will be set once and only once on init.
                 _UpdateTabIcon(*terminalTab);
 
                 // Force the TerminalTab to re-grab its currently active control's title.

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2003,12 +2003,12 @@ namespace winrt::TerminalApp::implementation
 
         // Include the Defaults profile for consideration
         const auto profileDefaults{ _settings.ProfileDefaults() };
-        _profileGuidSettingsMap.insert_or_assign(profileDefaults.Guid(), std::pair<Profile, TerminalSettingsCreateResult>{ profileDefaults, nullptr });
+        _profileGuidSettingsMap.insert_or_assign(profileDefaults.Guid(), std::pair{ profileDefaults, nullptr });
         for (const auto& newProfile : _settings.AllProfiles())
         {
             // Avoid creating a TerminalSettings right now. They're not totally cheap, and we suspect that users with many
             // panes may not be using all of their profiles at the same time. Lazy evaluation is king!
-            _profileGuidSettingsMap.insert_or_assign(newProfile.Guid(), std::pair<Profile, TerminalSettingsCreateResult>{ newProfile, nullptr });
+            _profileGuidSettingsMap.insert_or_assign(newProfile.Guid(), std::pair{ newProfile, nullptr });
         }
 
         for (const auto& tab : _tabs)

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -263,10 +263,9 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Method Description:
-    // - Attempts to update the settings of this tab's tree of panes.
-    // Arguments:
-    // - settings: The new TerminalSettingsCreateResult to apply to any matching controls
-    // - profile: The GUID of the profile these settings should apply to.
+    // - Attempts to update the settings that apply to this tab.
+    // - Panes are handled elsewhere, by somebody who can establish broader knowledge
+    //   of the settings that apply to all tabs.
     // Return Value:
     // - <none>
     void TerminalTab::UpdateSettings()

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -269,10 +269,8 @@ namespace winrt::TerminalApp::implementation
     // - profile: The GUID of the profile these settings should apply to.
     // Return Value:
     // - <none>
-    void TerminalTab::UpdateSettings(const TerminalSettingsCreateResult& settings, const Profile& profile)
+    void TerminalTab::UpdateSettings()
     {
-        _rootPane->UpdateSettings(settings, profile);
-
         // The tabWidthMode may have changed, update the header control accordingly
         _UpdateHeaderControlMaxWidth();
     }

--- a/src/cascadia/TerminalApp/TerminalTab.h
+++ b/src/cascadia/TerminalApp/TerminalTab.h
@@ -62,7 +62,7 @@ namespace winrt::TerminalApp::implementation
         bool SwapPane(const winrt::Microsoft::Terminal::Settings::Model::FocusDirection& direction);
         bool FocusPane(const uint32_t id);
 
-        void UpdateSettings(const Microsoft::Terminal::Settings::Model::TerminalSettingsCreateResult& settings, const winrt::Microsoft::Terminal::Settings::Model::Profile& profile);
+        void UpdateSettings();
         winrt::fire_and_forget UpdateTitle();
 
         void Shutdown() override;
@@ -89,6 +89,8 @@ namespace winrt::TerminalApp::implementation
         void TogglePaneReadOnly();
         std::shared_ptr<Pane> GetActivePane() const;
         winrt::TerminalApp::TaskbarState GetCombinedTaskbarState() const;
+
+        std::shared_ptr<Pane> GetRootPane() const { return _rootPane; }
 
         winrt::TerminalApp::TerminalTabStatus TabStatus()
         {


### PR DESCRIPTION
The original code for settings reload iterated the entire tree of panes
for every profile in the new settings (O(mn)) and constructed a
TerminalSettings object for every profile even if it later went unused.

This implementation:

1. Collects all new profiles keyed by guid
1.a. Adds the "defaults" profile to the map
2. Iterates every pane, just once, and updates its profile if it shows
   up in the list by GUID.

I've merged all of the per-tab code into a single loop.

Because of 1.a., this code can now update panes that are hosting the
"base" profile.