### PR TITLE
When there's no profile or title, invent a title from the commandline

### DIFF
--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -598,6 +598,13 @@ NewTerminalArgs AppCommandlineArgs::_getNewTerminalArgs(AppCommandlineArgs::NewT
         args.Profile(winrt::to_hstring(_profileName));
     }
 
+    if (!*subcommand.profileNameOption && !_commandline.empty())
+    {
+        // If there's no profile, but there IS a command line, set the tab title to the first part of the command
+        // This will ensure that the tab we spawn has a name (since it didn't get one from its profile!)
+        args.TabTitle(winrt::to_hstring(til::at(_commandline, 0)));
+    }
+
     if (*subcommand.startingDirectoryOption)
     {
         args.StartingDirectory(winrt::to_hstring(_startingDirectory));


### PR DESCRIPTION
This supports a future world where we give commandline-only invocations
their own tabs. It was easier to promote the commandline to a title at
the time of argument parsing, rather than later, but I am happy to
change this if anyone disagrees.