### PR TITLE
Use the "base" profile for incoming handoff and new commands

### DIFF
--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -350,8 +350,10 @@ namespace winrt::TerminalApp::implementation
             // current control's live settings (which will include changes
             // made through VT).
 
-            if (const auto profile = tab.GetFocusedProfile())
+            if (auto profile = tab.GetFocusedProfile())
             {
+                // TODO GH#5047 If we cache the NewTerminalArgs, we no longer need to do this.
+                profile = GetClosestProfileForDuplicationOfProfile(profile);
                 const auto settingsCreateResult{ TerminalSettings::CreateWithProfile(_settings, profile, *_bindings) };
                 const auto workingDirectory = tab.GetActiveTerminalControl().WorkingDirectory();
                 const auto validWorkingDirectory = !workingDirectory.empty();

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -358,6 +358,8 @@ namespace winrt::TerminalApp::implementation
 
         void _SetFocusMode(const bool inFocusMode);
 
+        winrt::Microsoft::Terminal::Settings::Model::Profile GetClosestProfileForDuplicationOfProfile(const winrt::Microsoft::Terminal::Settings::Model::Profile& profile) const noexcept;
+
 #pragma region ActionHandlers
         // These are all defined in AppActionHandlers.cpp
 #define ON_ALL_ACTIONS(action) DECLARE_ACTION_HANDLER(action);

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -827,12 +827,22 @@ winrt::Microsoft::Terminal::Settings::Model::Profile CascadiaSettings::GetProfil
         return FindProfile(*profileByIndex);
     }
 
-    // No profile was specified; what we do now is dependent on whether there was a commandline.
-    // If there was a command line, we want to use the generic profile. If there wasn't, the user
-    // probably wants their specified default profile.
-    return (!newTerminalArgs || newTerminalArgs.Commandline().empty()) ?
-               FindProfile(GlobalSettings().DefaultProfile()) :
-               ProfileDefaults();
+    if constexpr (Feature_ShowProfileDefaultsInSettings::IsEnabled())
+    {
+        // If the user has access to the "Defaults" profile, and no profile was otherwise specified,
+        // what we do is dependent on whether there was a commandline.
+        // If there was a commandline (case 1), we we'll launch in the "Defaults" profile.
+        // If there wasn't a commandline or there wasn't a NewTerminalArgs (case 2), we'll
+        //   launch in the user's actual default profile.
+        // Case 2 above could be the result of a "nt" or "sp" invocation that doesn't specify anything.
+        // TODO GH#XXXXX: Detect the profile based on the commandline (add matching support)
+        return (!newTerminalArgs || newTerminalArgs.Commandline().empty()) ?
+                   FindProfile(GlobalSettings().DefaultProfile()) :
+                   ProfileDefaults();
+    }
+
+    // For compatibility with the stable version's behavior, return the default by GUID in all other cases.
+    return FindProfile(GlobalSettings().DefaultProfile());
 }
 
 // Method Description:

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -817,7 +817,22 @@ winrt::Microsoft::Terminal::Settings::Model::Profile CascadiaSettings::GetProfil
         profileByName = _GetProfileGuidByName(newTerminalArgs.Profile());
     }
 
-    return FindProfile(til::coalesce_value(profileByName, profileByIndex, _globals->DefaultProfile()));
+    if (profileByName)
+    {
+        return FindProfile(*profileByName);
+    }
+
+    if (profileByIndex)
+    {
+        return FindProfile(*profileByIndex);
+    }
+
+    // No profile was specified; what we do now is dependent on whether there was a commandline.
+    // If there was a command line, we want to use the generic profile. If there wasn't, the user
+    // probably wants their specified default profile.
+    return (!newTerminalArgs || newTerminalArgs.Commandline().empty()) ?
+               FindProfile(GlobalSettings().DefaultProfile()) :
+               ProfileDefaults();
 }
 
 // Method Description:


### PR DESCRIPTION
This pull request introduces our first use of the "base" profile as an
actual profile. Incoming commandlines from `wt foo` *and* default
terminal handoffs will be hosted in the base profile.

**THIS IS A BREAKING CHANGE** for user behavior.

The original behavior where commandlines were hosted in the "default"
profile (in most cases, Windows PowerShell) led to user confusion: "why
does cmd use my powershell icon?" and "why does the title say
PowerShell?". Making this change unifies the user experience so that we
can land commandline detection in #XXXXX.

Users who want the original behavior can get it back for commandline
invocation by specifying a profile using the `-p` argument, as in `wt -p
PowerShell -- cmd`.

As a temporary stopgap, users who attempt to duplicate the base profile
will get their specified default profile until we land #5047.

This feature is hidden behind the same feature flag that controls the
visibility of base/"Defaults" in the settings UI.

Fixes #xxx
Fixes #yyy
Fixes #zzz  (i think there are three)
