### PR TITLE
Move commandline->title promotion into TerminalSettings

### DIFF
--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -603,13 +603,6 @@ NewTerminalArgs AppCommandlineArgs::_getNewTerminalArgs(AppCommandlineArgs::NewT
         args.Profile(winrt::to_hstring(_profileName));
     }
 
-    if (!*subcommand.profileNameOption && !_commandline.empty())
-    {
-        // If there's no profile, but there IS a command line, set the tab title to the first part of the command
-        // This will ensure that the tab we spawn has a name (since it didn't get one from its profile!)
-        args.TabTitle(winrt::to_hstring(til::at(_commandline, 0)));
-    }
-
     if (*subcommand.startingDirectoryOption)
     {
         args.StartingDirectory(winrt::to_hstring(_startingDirectory));


### PR DESCRIPTION
It was insufficient to only promote commandline components to titles
during commandline parsing, because we also have a whole complement of
actions that contain NewTerminalArgs. The tests caught me out a little
too late (sorry!). I decided it was better move promotion down to
TerminalSettings.

Fixes #6776
Re-implements #10998