### PR TITLE
Make sure we keep event handlers on the control when detaching a pane

### DIFF
--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -210,7 +210,7 @@ private:
                                             const winrt::Microsoft::Terminal::Settings::Model::FocusDirection& direction,
                                             const PanePoint offset);
 
-    void _CloseChild(const bool closeFirst);
+    void _CloseChild(const bool closeFirst, const bool isDetaching);
     winrt::fire_and_forget _CloseChildRoutine(const bool closeFirst);
 
     void _FocusFirstChild();


### PR DESCRIPTION
When moving a pane to a new tab previously we removed the event handlers
on it as if we were closing it, but we are just moving it so we need to
keep them.

I tried really hard to make sure all of the events were hooked up
correctly, but I guess I missed these originally since they are normally
created in the Pane constructor.

Closes #11035

## Validation Steps Performed
created panes, moved them to new tabs, confirmed that they close and
ding appropriately.