### PR TITLE
Only attempt to focus if there is a control to focus

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -461,7 +461,10 @@ namespace winrt::TerminalApp::implementation
             // GH#6586: now that we're done processing all startup commands,
             // focus the active control. This will work as expected for both
             // commandline invocations and for `wt` action invocations.
-            _GetActiveControl().Focus(FocusState::Programmatic);
+            if (const auto control = _GetActiveControl())
+            {
+                control.Focus(FocusState::Programmatic);
+            }
         }
         if (initial)
         {


### PR DESCRIPTION
Only focus if there is a control to focus (which may be null if e.g. the focused tab is being destroyed)

Closes #11037 

## Additional comments
I tried to remove the _activePane = nullptr in `TerminalTab::DetachPane` but that actually completely broke being able to focus the control at all making the tab completely unusable. Focus does seem to transfer just fine here with this change.

## Validation Steps Performed
Used the command execution to move panes to and from existing panes, including new tabs and destroying tabs.