### PR TITLE
Provide the focused tab title in the Tray Icon's context menu

### DIFF
--- a/src/cascadia/Remoting/Monarch.cpp
+++ b/src/cascadia/Remoting/Monarch.cpp
@@ -614,39 +614,6 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
     }
 
     // Method Description:
-    // - Helper for doing something on each and every peasant, with no regard
-    //   for if the peasant is living or dead.
-    // - We'll try calling callback on every peasant.
-    // - If any single peasant is dead, then we'll call errorCallback, and move on.
-    // - We're taking an errorCallback here, because the thing we usually want
-    //   to do is TraceLog a message, but TraceLoggingWrite is actually a macro
-    //   that _requires_ the second arg to be a string literal. It can't just be
-    //   a variable.
-    // Arguments:
-    // - callback: The function to call on each peasant
-    // - errorCallback: The function to call if a peasant is dead.
-    // Return Value:
-    // - <none>
-    void Monarch::_forAllPeasantsIgnoringTheDead(std::function<void(const Remoting::IPeasant&, const uint64_t)> callback,
-                                                 std::function<void(const uint64_t)> errorCallback)
-    {
-        for (const auto& [id, p] : _peasants)
-        {
-            try
-            {
-                callback(p, id);
-            }
-            catch (...)
-            {
-                LOG_CAUGHT_EXCEPTION();
-                // If this fails, we don't _really_ care. Just move on to the
-                // next one. Someone else will clean up the dead peasant.
-                errorCallback(id);
-            }
-        }
-    }
-
-    // Method Description:
     // - This is an event handler for the IdentifyWindowsRequested event. A
     //   Peasant may raise that event if they want _all_ windows to identify
     //   themselves.
@@ -660,17 +627,18 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                                    const winrt::Windows::Foundation::IInspectable& /*args*/)
     {
         // Notify all the peasants to display their ID.
-        auto callback = [](auto&& p, auto&& /*id*/) {
+        const auto callback = [&](const auto& /*id*/, const auto& p) {
             p.DisplayWindowId();
         };
-        auto onError = [](auto&& id) {
+        const auto onError = [&](const auto& id) {
             TraceLoggingWrite(g_hRemotingProvider,
                               "Monarch_identifyWindows_Failed",
                               TraceLoggingInt64(id, "peasantID", "The ID of the peasant which we could not identify"),
                               TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                               TraceLoggingKeyword(TIL_KEYWORD_TRACE));
         };
-        _forAllPeasantsIgnoringTheDead(callback, onError);
+
+        _forEachPeasant(callback, onError);
     }
 
     // Method Description:
@@ -812,78 +780,68 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
     // - <none>
     // Return Value:
     // - A map of peasant IDs to their names.
-    Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo> Monarch::GetAllPeasantInfo()
+    Windows::Foundation::Collections::IVectorView<PeasantInfo> Monarch::GetPeasantInfos()
     {
-        auto names = winrt::single_threaded_vector<winrt::Microsoft::Terminal::Remoting::PeasantInfo>();
+        std::vector<PeasantInfo> names;
+        names.reserve(_peasants.size());
 
-        std::vector<uint64_t> peasantsToErase{};
-        for (const auto& [id, p] : _peasants)
-        {
-            try
-            {
-                names.Append({ id, p.WindowName(), p.ActiveTabTitle() });
-            }
-            catch (...)
-            {
-                LOG_CAUGHT_EXCEPTION();
-                peasantsToErase.push_back(id);
-            }
-        }
+        const auto func = [&](const auto& id, const auto& p) -> void {
+            names.push_back({ id, p.WindowName(), p.ActiveTabTitle() });
+        };
 
-        // Remove the dead peasants we came across while iterating.
-        for (const auto& id : peasantsToErase)
-        {
-            _peasants.erase(id);
-            _clearOldMruEntries(id);
-        }
+        const auto onError = [&](const auto& id) {
+            TraceLoggingWrite(g_hRemotingProvider,
+                              "Monarch_identifyWindows_Failed",
+                              TraceLoggingInt64(id, "peasantID", "The ID of the peasant which we could not identify"),
+                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+        };
 
-        return names.GetView();
+        _forEachPeasant(func, onError);
+
+        return winrt::single_threaded_vector<PeasantInfo>(std::move(names)).GetView();
     }
 
     bool Monarch::DoesQuakeWindowExist()
     {
         bool result = false;
-        std::vector<uint64_t> peasantsToErase{};
-        for (const auto& [id, p] : _peasants)
-        {
-            try
+        const auto func = [&](const auto& /*id*/, const auto& p) {
+            if (p.WindowName() == QuakeWindowName)
             {
-                if (p.WindowName() == QuakeWindowName)
-                {
-                    result = true;
-                }
+                result = true;
             }
-            catch (...)
-            {
-                LOG_CAUGHT_EXCEPTION();
-                peasantsToErase.push_back(id);
-            }
-        }
+            // continue if we didn't get a positive result
+            return !result;
+        };
 
-        // Remove the dead peasants we came across while iterating.
-        for (const auto& id : peasantsToErase)
-        {
-            _peasants.erase(id);
-            _clearOldMruEntries(id);
-        }
+        const auto onError = [&](const auto& id) {
+            TraceLoggingWrite(g_hRemotingProvider,
+                              "Monarch_DoesQuakeWindowExist_Failed",
+                              TraceLoggingInt64(id, "peasantID", "The ID of the peasant which we could not ask for its name"),
+                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+        };
 
+        _forEachPeasant(func, onError);
         return result;
     }
 
     void Monarch::SummonAllWindows()
     {
-        auto callback = [](auto&& p, auto&& /*id*/) {
+        const auto func = [&](const auto& /*id*/, const auto& p) {
             SummonWindowBehavior args{};
             args.ToggleVisibility(false);
             p.Summon(args);
         };
-        auto onError = [](auto&& id) {
+
+        const auto onError = [&](const auto& id) {
             TraceLoggingWrite(g_hRemotingProvider,
                               "Monarch_SummonAll_Failed",
                               TraceLoggingInt64(id, "peasantID", "The ID of the peasant which we could not summon"),
                               TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                               TraceLoggingKeyword(TIL_KEYWORD_TRACE));
         };
-        _forAllPeasantsIgnoringTheDead(callback, onError);
+
+        _forEachPeasant(func, onError);
     }
 }

--- a/src/cascadia/Remoting/Monarch.cpp
+++ b/src/cascadia/Remoting/Monarch.cpp
@@ -812,16 +812,16 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
     // - <none>
     // Return Value:
     // - A map of peasant IDs to their names.
-    Windows::Foundation::Collections::IMapView<uint64_t, winrt::hstring> Monarch::GetPeasantNames()
+    Windows::Foundation::Collections::IMapView<uint64_t, winrt::Microsoft::Terminal::Remoting::IPeasant> Monarch::GetPeasants()
     {
-        auto names = winrt::single_threaded_map<uint64_t, winrt::hstring>();
+        auto names = winrt::single_threaded_map<uint64_t, winrt::Microsoft::Terminal::Remoting::IPeasant>();
 
         std::vector<uint64_t> peasantsToErase{};
         for (const auto& [id, p] : _peasants)
         {
             try
             {
-                names.Insert(id, p.WindowName());
+                names.Insert(id, p);
             }
             catch (...)
             {

--- a/src/cascadia/Remoting/Monarch.h
+++ b/src/cascadia/Remoting/Monarch.h
@@ -53,7 +53,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         void SummonWindow(const Remoting::SummonWindowSelectionArgs& args);
 
         void SummonAllWindows();
-        Windows::Foundation::Collections::IMapView<uint64_t, winrt::hstring> GetPeasantNames();
+        Windows::Foundation::Collections::IMapView<uint64_t, winrt::Microsoft::Terminal::Remoting::IPeasant> GetPeasants();
 
         TYPED_EVENT(FindTargetWindowRequested, winrt::Windows::Foundation::IInspectable, winrt::Microsoft::Terminal::Remoting::FindTargetWindowArgs);
         TYPED_EVENT(ShowTrayIconRequested, winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable);

--- a/src/cascadia/Remoting/Monarch.h
+++ b/src/cascadia/Remoting/Monarch.h
@@ -54,7 +54,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
 
         void SummonAllWindows();
         bool DoesQuakeWindowExist();
-        Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo> GetAllPeasantInfo();
+        Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo> GetPeasantInfos();
 
         TYPED_EVENT(FindTargetWindowRequested, winrt::Windows::Foundation::IInspectable, winrt::Microsoft::Terminal::Remoting::FindTargetWindowArgs);
         TYPED_EVENT(ShowTrayIconRequested, winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable);
@@ -89,6 +89,67 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
 
         void _renameRequested(const winrt::Windows::Foundation::IInspectable& sender,
                               const winrt::Microsoft::Terminal::Remoting::RenameRequestArgs& args);
+
+        // Method Description:
+        // - Helper for doing something on each and every peasant.
+        // - We'll try calling func on every peasant.
+        // - If the return type of func is void, it will perform it for all peasants.
+        // - If the return type is a boolean, we'll break out of the loop once func
+        //   returns false.
+        // - If any single peasant is dead, then we'll call onError and then add it to a
+        //   list of peasants to clean up once the loop ends.
+        // Arguments:
+        // - func: The function to call on each peasant
+        // - onError: The function to call if a peasant is dead.
+        // Return Value:
+        // - <none>
+        template<typename F, typename T>
+        void _forEachPeasant(F&& func, T&& onError)
+        {
+            using Map = decltype(_peasants);
+            using R = std::invoke_result_t<F, Map::key_type, Map::mapped_type>;
+            static constexpr auto IsVoid = std::is_void_v<R>;
+
+            std::vector<uint64_t> peasantsToErase;
+
+            for (const auto& [id, p] : _peasants)
+            {
+                try
+                {
+                    if constexpr (IsVoid)
+                    {
+                        func(id, p);
+                    }
+                    else
+                    {
+                        if (!func(id, p))
+                        {
+                            break;
+                        }
+                    }
+                }
+                catch (const winrt::hresult_error& exception)
+                {
+                    onError(id);
+
+                    if (exception.code() == 0x800706ba) // The RPC server is unavailable.
+                    {
+                        peasantsToErase.emplace_back(id);
+                    }
+                    else
+                    {
+                        LOG_CAUGHT_EXCEPTION();
+                        throw;
+                    }
+                }
+            }
+
+            for (const auto& id : peasantsToErase)
+            {
+                _peasants.erase(id);
+                _clearOldMruEntries(id);
+            }
+        }
 
         friend class RemotingUnitTests::RemotingTests;
     };

--- a/src/cascadia/Remoting/Monarch.h
+++ b/src/cascadia/Remoting/Monarch.h
@@ -53,7 +53,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         void SummonWindow(const Remoting::SummonWindowSelectionArgs& args);
 
         void SummonAllWindows();
-        Windows::Foundation::Collections::IMapView<uint64_t, winrt::Microsoft::Terminal::Remoting::IPeasant> GetPeasants();
+        bool DoesQuakeWindowExist();
+        Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo> GetAllPeasantInfo();
 
         TYPED_EVENT(FindTargetWindowRequested, winrt::Windows::Foundation::IInspectable, winrt::Microsoft::Terminal::Remoting::FindTargetWindowArgs);
         TYPED_EVENT(ShowTrayIconRequested, winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable);

--- a/src/cascadia/Remoting/Monarch.idl
+++ b/src/cascadia/Remoting/Monarch.idl
@@ -31,6 +31,12 @@ namespace Microsoft.Terminal.Remoting
         Windows.Foundation.IReference<UInt64> WindowID;
     }
 
+    struct PeasantInfo
+    {
+        UInt64 Id;
+        String Name;
+        String TabTitle;
+    };
 
     [default_interface] runtimeclass Monarch {
         Monarch();
@@ -42,7 +48,8 @@ namespace Microsoft.Terminal.Remoting
         void SummonWindow(SummonWindowSelectionArgs args);
 
         void SummonAllWindows();
-        Windows.Foundation.Collections.IMapView<UInt64, IPeasant> GetPeasants { get; };
+        Boolean DoesQuakeWindowExist();
+        Windows.Foundation.Collections.IVectorView<PeasantInfo> GetAllPeasantInfo { get; };
 
         event Windows.Foundation.TypedEventHandler<Object, FindTargetWindowArgs> FindTargetWindowRequested;
         event Windows.Foundation.TypedEventHandler<Object, Object> ShowTrayIconRequested;

--- a/src/cascadia/Remoting/Monarch.idl
+++ b/src/cascadia/Remoting/Monarch.idl
@@ -49,7 +49,7 @@ namespace Microsoft.Terminal.Remoting
 
         void SummonAllWindows();
         Boolean DoesQuakeWindowExist();
-        Windows.Foundation.Collections.IVectorView<PeasantInfo> GetAllPeasantInfo { get; };
+        Windows.Foundation.Collections.IVectorView<PeasantInfo> GetPeasantInfos { get; };
 
         event Windows.Foundation.TypedEventHandler<Object, FindTargetWindowArgs> FindTargetWindowRequested;
         event Windows.Foundation.TypedEventHandler<Object, Object> ShowTrayIconRequested;

--- a/src/cascadia/Remoting/Monarch.idl
+++ b/src/cascadia/Remoting/Monarch.idl
@@ -42,7 +42,7 @@ namespace Microsoft.Terminal.Remoting
         void SummonWindow(SummonWindowSelectionArgs args);
 
         void SummonAllWindows();
-        Windows.Foundation.Collections.IMapView<UInt64, String> GetPeasantNames { get; };
+        Windows.Foundation.Collections.IMapView<UInt64, IPeasant> GetPeasants { get; };
 
         event Windows.Foundation.TypedEventHandler<Object, FindTargetWindowArgs> FindTargetWindowRequested;
         event Windows.Foundation.TypedEventHandler<Object, Object> ShowTrayIconRequested;

--- a/src/cascadia/Remoting/Peasant.h
+++ b/src/cascadia/Remoting/Peasant.h
@@ -35,6 +35,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
 
         winrt::Microsoft::Terminal::Remoting::CommandlineArgs InitialArgs();
         WINRT_PROPERTY(winrt::hstring, WindowName);
+        WINRT_PROPERTY(winrt::hstring, ActiveTabTitle);
 
         TYPED_EVENT(WindowActivated, winrt::Windows::Foundation::IInspectable, winrt::Microsoft::Terminal::Remoting::WindowActivatedArgs);
         TYPED_EVENT(ExecuteCommandlineRequested, winrt::Windows::Foundation::IInspectable, winrt::Microsoft::Terminal::Remoting::CommandlineArgs);

--- a/src/cascadia/Remoting/Peasant.idl
+++ b/src/cascadia/Remoting/Peasant.idl
@@ -61,6 +61,7 @@ namespace Microsoft.Terminal.Remoting
         void DisplayWindowId(); // Tells us to display its own ID (which causes a DisplayWindowIdRequested to be raised)
 
         String WindowName { get; };
+        String ActiveTabTitle;
         void RequestIdentifyWindows(); // Tells us to raise a IdentifyWindowsRequested
         void RequestRename(RenameRequestArgs args); // Tells us to raise a RenameRequested
         void Summon(SummonWindowBehavior behavior);

--- a/src/cascadia/Remoting/Peasant.idl
+++ b/src/cascadia/Remoting/Peasant.idl
@@ -61,7 +61,7 @@ namespace Microsoft.Terminal.Remoting
         void DisplayWindowId(); // Tells us to display its own ID (which causes a DisplayWindowIdRequested to be raised)
 
         String WindowName { get; };
-        String ActiveTabTitle;
+        String ActiveTabTitle { get; };
         void RequestIdentifyWindows(); // Tells us to raise a IdentifyWindowsRequested
         void RequestRename(RenameRequestArgs args); // Tells us to raise a RenameRequested
         void Summon(SummonWindowBehavior behavior);

--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -519,11 +519,11 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         }
     }
 
-    Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo> WindowManager::GetAllPeasantInfo()
+    Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo> WindowManager::GetPeasantInfos()
     {
         // We should only get called when we're the monarch since the monarch
         // is the only one that knows about all peasants.
-        return _monarch.GetAllPeasantInfo();
+        return _monarch.GetPeasantInfos();
     }
 
     // Method Description:
@@ -558,6 +558,6 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
 
     void WindowManager::UpdateActiveTabTitle(winrt::hstring title)
     {
-        _peasant.ActiveTabTitle(title);
+        winrt::get_self<implementation::Peasant>(_peasant)->ActiveTabTitle(title);
     }
 }

--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -519,11 +519,11 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         }
     }
 
-    Windows::Foundation::Collections::IMapView<uint64_t, winrt::Microsoft::Terminal::Remoting::IPeasant> WindowManager::GetPeasants()
+    Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo> WindowManager::GetAllPeasantInfo()
     {
         // We should only get called when we're the monarch since the monarch
         // is the only one that knows about all peasants.
-        return _monarch.GetPeasants();
+        return _monarch.GetAllPeasantInfo();
     }
 
     // Method Description:
@@ -553,18 +553,10 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
 
     bool WindowManager::DoesQuakeWindowExist()
     {
-        const auto names = GetPeasants();
-        for (const auto [id, p] : names)
-        {
-            if (p.WindowName() == QuakeWindowName)
-            {
-                return true;
-            }
-        }
-        return false;
+        return _monarch.DoesQuakeWindowExist();
     }
 
-    void WindowManager::UpdateTitle(winrt::hstring title)
+    void WindowManager::UpdateActiveTabTitle(winrt::hstring title)
     {
         _peasant.ActiveTabTitle(title);
     }

--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -519,11 +519,11 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         }
     }
 
-    Windows::Foundation::Collections::IMapView<uint64_t, winrt::hstring> WindowManager::GetPeasantNames()
+    Windows::Foundation::Collections::IMapView<uint64_t, winrt::Microsoft::Terminal::Remoting::IPeasant> WindowManager::GetPeasants()
     {
         // We should only get called when we're the monarch since the monarch
         // is the only one that knows about all peasants.
-        return _monarch.GetPeasantNames();
+        return _monarch.GetPeasants();
     }
 
     // Method Description:
@@ -553,10 +553,10 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
 
     bool WindowManager::DoesQuakeWindowExist()
     {
-        const auto names = GetPeasantNames();
-        for (const auto [id, name] : names)
+        const auto names = GetPeasants();
+        for (const auto [id, p] : names)
         {
-            if (name == QuakeWindowName)
+            if (p.WindowName() == QuakeWindowName)
             {
                 return true;
             }
@@ -564,4 +564,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         return false;
     }
 
+    void WindowManager::UpdateTitle(winrt::hstring title)
+    {
+        _peasant.ActiveTabTitle(title);
+    }
 }

--- a/src/cascadia/Remoting/WindowManager.h
+++ b/src/cascadia/Remoting/WindowManager.h
@@ -41,7 +41,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         void SummonWindow(const Remoting::SummonWindowSelectionArgs& args);
 
         void SummonAllWindows();
-        Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo> GetAllPeasantInfo();
+        Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo> GetPeasantInfos();
 
         winrt::fire_and_forget RequestShowTrayIcon();
         winrt::fire_and_forget RequestHideTrayIcon();

--- a/src/cascadia/Remoting/WindowManager.h
+++ b/src/cascadia/Remoting/WindowManager.h
@@ -41,12 +41,12 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         void SummonWindow(const Remoting::SummonWindowSelectionArgs& args);
 
         void SummonAllWindows();
-        Windows::Foundation::Collections::IMapView<uint64_t, winrt::Microsoft::Terminal::Remoting::IPeasant> GetPeasants();
+        Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo> GetAllPeasantInfo();
 
         winrt::fire_and_forget RequestShowTrayIcon();
         winrt::fire_and_forget RequestHideTrayIcon();
         bool DoesQuakeWindowExist();
-        void UpdateTitle(winrt::hstring title);
+        void UpdateActiveTabTitle(winrt::hstring title);
 
         TYPED_EVENT(FindTargetWindowRequested, winrt::Windows::Foundation::IInspectable, winrt::Microsoft::Terminal::Remoting::FindTargetWindowArgs);
         TYPED_EVENT(BecameMonarch, winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable);

--- a/src/cascadia/Remoting/WindowManager.h
+++ b/src/cascadia/Remoting/WindowManager.h
@@ -41,11 +41,12 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         void SummonWindow(const Remoting::SummonWindowSelectionArgs& args);
 
         void SummonAllWindows();
-        Windows::Foundation::Collections::IMapView<uint64_t, winrt::hstring> GetPeasantNames();
+        Windows::Foundation::Collections::IMapView<uint64_t, winrt::Microsoft::Terminal::Remoting::IPeasant> GetPeasants();
 
         winrt::fire_and_forget RequestShowTrayIcon();
         winrt::fire_and_forget RequestHideTrayIcon();
         bool DoesQuakeWindowExist();
+        void UpdateTitle(winrt::hstring title);
 
         TYPED_EVENT(FindTargetWindowRequested, winrt::Windows::Foundation::IInspectable, winrt::Microsoft::Terminal::Remoting::FindTargetWindowArgs);
         TYPED_EVENT(BecameMonarch, winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable);

--- a/src/cascadia/Remoting/WindowManager.idl
+++ b/src/cascadia/Remoting/WindowManager.idl
@@ -15,9 +15,9 @@ namespace Microsoft.Terminal.Remoting
         void SummonAllWindows();
         void RequestShowTrayIcon();
         void RequestHideTrayIcon();
-        void UpdateTitle(String title);
+        void UpdateActiveTabTitle(String title);
         Boolean DoesQuakeWindowExist();
-        Windows.Foundation.Collections.IMapView<UInt64, IPeasant> GetPeasants();
+        Windows.Foundation.Collections.IVectorView<PeasantInfo> GetAllPeasantInfo();
         event Windows.Foundation.TypedEventHandler<Object, FindTargetWindowArgs> FindTargetWindowRequested;
         event Windows.Foundation.TypedEventHandler<Object, Object> BecameMonarch;
         event Windows.Foundation.TypedEventHandler<Object, Object> ShowTrayIconRequested;

--- a/src/cascadia/Remoting/WindowManager.idl
+++ b/src/cascadia/Remoting/WindowManager.idl
@@ -17,7 +17,7 @@ namespace Microsoft.Terminal.Remoting
         void RequestHideTrayIcon();
         void UpdateActiveTabTitle(String title);
         Boolean DoesQuakeWindowExist();
-        Windows.Foundation.Collections.IVectorView<PeasantInfo> GetAllPeasantInfo();
+        Windows.Foundation.Collections.IVectorView<PeasantInfo> GetPeasantInfos();
         event Windows.Foundation.TypedEventHandler<Object, FindTargetWindowArgs> FindTargetWindowRequested;
         event Windows.Foundation.TypedEventHandler<Object, Object> BecameMonarch;
         event Windows.Foundation.TypedEventHandler<Object, Object> ShowTrayIconRequested;

--- a/src/cascadia/Remoting/WindowManager.idl
+++ b/src/cascadia/Remoting/WindowManager.idl
@@ -15,8 +15,9 @@ namespace Microsoft.Terminal.Remoting
         void SummonAllWindows();
         void RequestShowTrayIcon();
         void RequestHideTrayIcon();
+        void UpdateTitle(String title);
         Boolean DoesQuakeWindowExist();
-        Windows.Foundation.Collections.IMapView<UInt64, String> GetPeasantNames();
+        Windows.Foundation.Collections.IMapView<UInt64, IPeasant> GetPeasants();
         event Windows.Foundation.TypedEventHandler<Object, FindTargetWindowArgs> FindTargetWindowRequested;
         event Windows.Foundation.TypedEventHandler<Object, Object> BecameMonarch;
         event Windows.Foundation.TypedEventHandler<Object, Object> ShowTrayIconRequested;

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -1477,4 +1477,9 @@ namespace winrt::TerminalApp::implementation
             return false;
         }
     }
+
+    bool AppLogic::GetShowTitleInTitlebar()
+    {
+        return _settings.GlobalSettings().ShowTitleInTitlebar();
+    }
 }

--- a/src/cascadia/TerminalApp/AppLogic.h
+++ b/src/cascadia/TerminalApp/AppLogic.h
@@ -94,6 +94,7 @@ namespace winrt::TerminalApp::implementation
 
         bool GetMinimizeToTray();
         bool GetAlwaysShowTrayIcon();
+        bool GetShowTitleInTitlebar();
 
         winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::UI::Xaml::Controls::ContentDialogResult> ShowDialog(winrt::Windows::UI::Xaml::Controls::ContentDialog dialog);
 

--- a/src/cascadia/TerminalApp/AppLogic.idl
+++ b/src/cascadia/TerminalApp/AppLogic.idl
@@ -72,6 +72,7 @@ namespace TerminalApp
 
         Boolean GetMinimizeToTray();
         Boolean GetAlwaysShowTrayIcon();
+        Boolean GetShowTitleInTitlebar();
 
         FindTargetWindowResult FindTargetWindow(String[] args);
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1022,7 +1022,7 @@ namespace winrt::TerminalApp::implementation
     {
         auto newTabTitle = tab.Title();
 
-        if (_settings.GlobalSettings().ShowTitleInTitlebar() && tab == _GetFocusedTab())
+        if (tab == _GetFocusedTab())
         {
             _TitleChangedHandlers(*this, newTabTitle);
         }

--- a/src/cascadia/UnitTests_Remoting/RemotingTests.cpp
+++ b/src/cascadia/UnitTests_Remoting/RemotingTests.cpp
@@ -62,6 +62,8 @@ namespace RemotingUnitTests
         void AssignID(uint64_t /*id*/) { throw winrt::hresult_error{}; };
         uint64_t GetID() { throw winrt::hresult_error{}; };
         winrt::hstring WindowName() { throw winrt::hresult_error{}; };
+        winrt::hstring ActiveTabTitle() { throw winrt::hresult_error{}; };
+        void ActiveTabTitle(const winrt::hstring& /*value*/) { throw winrt::hresult_error{}; };
         uint64_t GetPID() { throw winrt::hresult_error{}; };
         bool ExecuteCommandline(const Remoting::CommandlineArgs& /*args*/) { throw winrt::hresult_error{}; }
         void ActivateWindow(const Remoting::WindowActivatedArgs& /*args*/) { throw winrt::hresult_error{}; }

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -308,7 +308,11 @@ void AppHost::Initialize()
 // - <none>
 void AppHost::AppTitleChanged(const winrt::Windows::Foundation::IInspectable& /*sender*/, winrt::hstring newTitle)
 {
-    _window->UpdateTitle(newTitle);
+    if (_logic.GetShowTitleInTitlebar())
+    {
+        _window->UpdateTitle(newTitle);
+    }
+    _windowManager.UpdateTitle(newTitle);
 }
 
 // Method Description:
@@ -1031,7 +1035,7 @@ void AppHost::_CreateTrayIcon()
         // Hookup the handlers, save the tokens for revoking if settings change.
         _ReAddTrayIconToken = _window->NotifyReAddTrayIcon([this]() { _trayIcon->ReAddTrayIcon(); });
         _TrayIconPressedToken = _window->NotifyTrayIconPressed([this]() { _trayIcon->TrayIconPressed(); });
-        _ShowTrayContextMenuToken = _window->NotifyShowTrayContextMenu([this](til::point coord) { _trayIcon->ShowTrayContextMenu(coord, _windowManager.GetPeasantNames()); });
+        _ShowTrayContextMenuToken = _window->NotifyShowTrayContextMenu([this](til::point coord) { _trayIcon->ShowTrayContextMenu(coord, _windowManager.GetPeasants()); });
         _TrayMenuItemSelectedToken = _window->NotifyTrayMenuItemSelected([this](HMENU hm, UINT idx) { _trayIcon->TrayMenuItemSelected(hm, idx); });
         _trayIcon->SummonWindowRequested([this](auto& args) { _windowManager.SummonWindow(args); });
     }

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -1036,7 +1036,7 @@ void AppHost::_CreateTrayIcon()
         // Hookup the handlers, save the tokens for revoking if settings change.
         _ReAddTrayIconToken = _window->NotifyReAddTrayIcon([this]() { _trayIcon->ReAddTrayIcon(); });
         _TrayIconPressedToken = _window->NotifyTrayIconPressed([this]() { _trayIcon->TrayIconPressed(); });
-        _ShowTrayContextMenuToken = _window->NotifyShowTrayContextMenu([this](til::point coord) { _trayIcon->ShowTrayContextMenu(coord, _windowManager.GetAllPeasantInfo()); });
+        _ShowTrayContextMenuToken = _window->NotifyShowTrayContextMenu([this](til::point coord) { _trayIcon->ShowTrayContextMenu(coord, _windowManager.GetPeasantInfos()); });
         _TrayMenuItemSelectedToken = _window->NotifyTrayMenuItemSelected([this](HMENU hm, UINT idx) { _trayIcon->TrayMenuItemSelected(hm, idx); });
         _trayIcon->SummonWindowRequested([this](auto& args) { _windowManager.SummonWindow(args); });
     }

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -299,8 +299,9 @@ void AppHost::Initialize()
 }
 
 // Method Description:
-// - Called when the app's title changes. Fires off a window message so we can
-//   update the window's title on the main thread.
+// - Called everytime when the active tab's title changes. We'll also fire off
+//   a window message so we can update the window's title on the main thread,
+//   though we'll only do so if the settings are configured for that.
 // Arguments:
 // - sender: unused
 // - newTitle: the string to use as the new window title
@@ -312,7 +313,7 @@ void AppHost::AppTitleChanged(const winrt::Windows::Foundation::IInspectable& /*
     {
         _window->UpdateTitle(newTitle);
     }
-    _windowManager.UpdateTitle(newTitle);
+    _windowManager.UpdateActiveTabTitle(newTitle);
 }
 
 // Method Description:
@@ -1035,7 +1036,7 @@ void AppHost::_CreateTrayIcon()
         // Hookup the handlers, save the tokens for revoking if settings change.
         _ReAddTrayIconToken = _window->NotifyReAddTrayIcon([this]() { _trayIcon->ReAddTrayIcon(); });
         _TrayIconPressedToken = _window->NotifyTrayIconPressed([this]() { _trayIcon->TrayIconPressed(); });
-        _ShowTrayContextMenuToken = _window->NotifyShowTrayContextMenu([this](til::point coord) { _trayIcon->ShowTrayContextMenu(coord, _windowManager.GetPeasants()); });
+        _ShowTrayContextMenuToken = _window->NotifyShowTrayContextMenu([this](til::point coord) { _trayIcon->ShowTrayContextMenu(coord, _windowManager.GetAllPeasantInfo()); });
         _TrayMenuItemSelectedToken = _window->NotifyTrayMenuItemSelected([this](HMENU hm, UINT idx) { _trayIcon->TrayMenuItemSelected(hm, idx); });
         _trayIcon->SummonWindowRequested([this](auto& args) { _windowManager.SummonWindow(args); });
     }

--- a/src/cascadia/WindowsTerminal/TrayIcon.cpp
+++ b/src/cascadia/WindowsTerminal/TrayIcon.cpp
@@ -110,7 +110,7 @@ void TrayIcon::CreateTrayIcon()
 // Return Value:
 // - <none>
 void TrayIcon::ShowTrayContextMenu(const til::point coord,
-                                   IMapView<uint64_t, winrt::hstring> peasants)
+                                   IMapView<uint64_t, winrt::Microsoft::Terminal::Remoting::IPeasant> peasants)
 {
     if (const auto hMenu = _CreateTrayContextMenu(peasants))
     {
@@ -142,7 +142,7 @@ void TrayIcon::ShowTrayContextMenu(const til::point coord,
 // - peasants: A map of all peasants' ID to their window name.
 // Return Value:
 // - The handle to the newly created context menu.
-HMENU TrayIcon::_CreateTrayContextMenu(IMapView<uint64_t, winrt::hstring> peasants)
+HMENU TrayIcon::_CreateTrayContextMenu(IMapView<uint64_t, winrt::Microsoft::Terminal::Remoting::IPeasant> peasants)
 {
     auto hMenu = CreatePopupMenu();
     if (hMenu)
@@ -161,14 +161,18 @@ HMENU TrayIcon::_CreateTrayContextMenu(IMapView<uint64_t, winrt::hstring> peasan
         // Submenu for Windows
         if (auto submenu = CreatePopupMenu())
         {
-            const auto locWindow = RS_(L"WindowIdLabel");
-            const auto locUnnamed = RS_(L"UnnamedWindowName");
-            for (const auto [id, name] : peasants)
+            for (const auto [id, p] : peasants)
             {
-                winrt::hstring displayText = name;
-                if (name.empty())
+                winrt::hstring displayText{ fmt::format(L"#{} : ", id) };
+
+                if (!p.ActiveTabTitle().empty())
                 {
-                    displayText = fmt::format(L"{} {} - <{}>", locWindow, id, locUnnamed);
+                    displayText = fmt::format(L"{} {}", displayText, p.ActiveTabTitle());
+                }
+
+                if (!p.WindowName().empty())
+                {
+                    displayText = fmt::format(L"{} [{}]", displayText, p.WindowName());
                 }
 
                 AppendMenu(submenu, MF_STRING, gsl::narrow<UINT_PTR>(id), displayText.c_str());

--- a/src/cascadia/WindowsTerminal/TrayIcon.cpp
+++ b/src/cascadia/WindowsTerminal/TrayIcon.cpp
@@ -110,7 +110,7 @@ void TrayIcon::CreateTrayIcon()
 // Return Value:
 // - <none>
 void TrayIcon::ShowTrayContextMenu(const til::point coord,
-                                   IMapView<uint64_t, winrt::Microsoft::Terminal::Remoting::IPeasant> peasants)
+                                   IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo> peasants)
 {
     if (const auto hMenu = _CreateTrayContextMenu(peasants))
     {
@@ -142,7 +142,7 @@ void TrayIcon::ShowTrayContextMenu(const til::point coord,
 // - peasants: A map of all peasants' ID to their window name.
 // Return Value:
 // - The handle to the newly created context menu.
-HMENU TrayIcon::_CreateTrayContextMenu(IMapView<uint64_t, winrt::Microsoft::Terminal::Remoting::IPeasant> peasants)
+HMENU TrayIcon::_CreateTrayContextMenu(IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo> peasants)
 {
     auto hMenu = CreatePopupMenu();
     if (hMenu)
@@ -161,21 +161,21 @@ HMENU TrayIcon::_CreateTrayContextMenu(IMapView<uint64_t, winrt::Microsoft::Term
         // Submenu for Windows
         if (auto submenu = CreatePopupMenu())
         {
-            for (const auto [id, p] : peasants)
+            for (const auto& p : peasants)
             {
-                winrt::hstring displayText{ fmt::format(L"#{} : ", id) };
+                winrt::hstring displayText{ fmt::format(L"#{} : ", p.Id) };
 
-                if (!p.ActiveTabTitle().empty())
+                if (!p.TabTitle.empty())
                 {
-                    displayText = fmt::format(L"{} {}", displayText, p.ActiveTabTitle());
+                    displayText = fmt::format(L"{} {}", displayText, p.TabTitle);
                 }
 
-                if (!p.WindowName().empty())
+                if (!p.Name.empty())
                 {
-                    displayText = fmt::format(L"{} [{}]", displayText, p.WindowName());
+                    displayText = fmt::format(L"{} [{}]", displayText, p.Name);
                 }
 
-                AppendMenu(submenu, MF_STRING, gsl::narrow<UINT_PTR>(id), displayText.c_str());
+                AppendMenu(submenu, MF_STRING, gsl::narrow<UINT_PTR>(p.Id), displayText.c_str());
             }
 
             MENUINFO submenuInfo{};

--- a/src/cascadia/WindowsTerminal/TrayIcon.cpp
+++ b/src/cascadia/WindowsTerminal/TrayIcon.cpp
@@ -109,8 +109,8 @@ void TrayIcon::CreateTrayIcon()
 // - peasants: The map of all peasants that should be available in the context menu.
 // Return Value:
 // - <none>
-void TrayIcon::ShowTrayContextMenu(const til::point coord,
-                                   IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo> peasants)
+void TrayIcon::ShowTrayContextMenu(const til::point& coord,
+                                   const IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo>& peasants)
 {
     if (const auto hMenu = _CreateTrayContextMenu(peasants))
     {
@@ -142,7 +142,7 @@ void TrayIcon::ShowTrayContextMenu(const til::point coord,
 // - peasants: A map of all peasants' ID to their window name.
 // Return Value:
 // - The handle to the newly created context menu.
-HMENU TrayIcon::_CreateTrayContextMenu(IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo> peasants)
+HMENU TrayIcon::_CreateTrayContextMenu(const IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo>& peasants)
 {
     auto hMenu = CreatePopupMenu();
     if (hMenu)
@@ -163,19 +163,20 @@ HMENU TrayIcon::_CreateTrayContextMenu(IVectorView<winrt::Microsoft::Terminal::R
         {
             for (const auto& p : peasants)
             {
-                winrt::hstring displayText{ fmt::format(L"#{} : ", p.Id) };
+                std::wstringstream displayText;
+                displayText << "#" << p.Id;
 
                 if (!p.TabTitle.empty())
                 {
-                    displayText = fmt::format(L"{} {}", displayText, p.TabTitle);
+                    displayText << ":" << p.TabTitle.c_str();
                 }
 
                 if (!p.Name.empty())
                 {
-                    displayText = fmt::format(L"{} [{}]", displayText, p.Name);
+                    displayText << " [" << p.Name.c_str() << "]";
                 }
 
-                AppendMenu(submenu, MF_STRING, gsl::narrow<UINT_PTR>(p.Id), displayText.c_str());
+                AppendMenu(submenu, MF_STRING, gsl::narrow<UINT_PTR>(p.Id), displayText.str().c_str());
             }
 
             MENUINFO submenuInfo{};

--- a/src/cascadia/WindowsTerminal/TrayIcon.cpp
+++ b/src/cascadia/WindowsTerminal/TrayIcon.cpp
@@ -164,16 +164,16 @@ HMENU TrayIcon::_CreateTrayContextMenu(const IVectorView<winrt::Microsoft::Termi
             for (const auto& p : peasants)
             {
                 std::wstringstream displayText;
-                displayText << "#" << p.Id;
+                displayText << L"#" << p.Id;
 
                 if (!p.TabTitle.empty())
                 {
-                    displayText << ":" << p.TabTitle.c_str();
+                    displayText << L": " << std::wstring_view{ p.TabTitle };
                 }
 
                 if (!p.Name.empty())
                 {
-                    displayText << " [" << p.Name.c_str() << "]";
+                    displayText << L" [" << std::wstring_view{ p.Name } << L"]";
                 }
 
                 AppendMenu(submenu, MF_STRING, gsl::narrow<UINT_PTR>(p.Id), displayText.str().c_str());

--- a/src/cascadia/WindowsTerminal/TrayIcon.h
+++ b/src/cascadia/WindowsTerminal/TrayIcon.h
@@ -24,14 +24,14 @@ public:
     void ReAddTrayIcon();
 
     void TrayIconPressed();
-    void ShowTrayContextMenu(const til::point coord, winrt::Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo> peasants);
+    void ShowTrayContextMenu(const til::point& coord, const winrt::Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo>& peasants);
     void TrayMenuItemSelected(const HMENU menu, const UINT menuItemIndex);
 
     WINRT_CALLBACK(SummonWindowRequested, winrt::delegate<void(winrt::Microsoft::Terminal::Remoting::SummonWindowSelectionArgs)>);
 
 private:
     void _CreateWindow();
-    HMENU _CreateTrayContextMenu(winrt::Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo> peasants);
+    HMENU _CreateTrayContextMenu(const winrt::Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo>& peasants);
 
     wil::unique_hwnd _trayIconHwnd;
     HWND _owningHwnd;

--- a/src/cascadia/WindowsTerminal/TrayIcon.h
+++ b/src/cascadia/WindowsTerminal/TrayIcon.h
@@ -24,14 +24,14 @@ public:
     void ReAddTrayIcon();
 
     void TrayIconPressed();
-    void ShowTrayContextMenu(const til::point coord, winrt::Windows::Foundation::Collections::IMapView<uint64_t, winrt::hstring> peasants);
+    void ShowTrayContextMenu(const til::point coord, winrt::Windows::Foundation::Collections::IMapView<uint64_t, winrt::Microsoft::Terminal::Remoting::IPeasant> peasants);
     void TrayMenuItemSelected(const HMENU menu, const UINT menuItemIndex);
 
     WINRT_CALLBACK(SummonWindowRequested, winrt::delegate<void(winrt::Microsoft::Terminal::Remoting::SummonWindowSelectionArgs)>);
 
 private:
     void _CreateWindow();
-    HMENU _CreateTrayContextMenu(winrt::Windows::Foundation::Collections::IMapView<uint64_t, winrt::hstring> peasants);
+    HMENU _CreateTrayContextMenu(winrt::Windows::Foundation::Collections::IMapView<uint64_t, winrt::Microsoft::Terminal::Remoting::IPeasant> peasants);
 
     wil::unique_hwnd _trayIconHwnd;
     HWND _owningHwnd;

--- a/src/cascadia/WindowsTerminal/TrayIcon.h
+++ b/src/cascadia/WindowsTerminal/TrayIcon.h
@@ -24,14 +24,14 @@ public:
     void ReAddTrayIcon();
 
     void TrayIconPressed();
-    void ShowTrayContextMenu(const til::point coord, winrt::Windows::Foundation::Collections::IMapView<uint64_t, winrt::Microsoft::Terminal::Remoting::IPeasant> peasants);
+    void ShowTrayContextMenu(const til::point coord, winrt::Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo> peasants);
     void TrayMenuItemSelected(const HMENU menu, const UINT menuItemIndex);
 
     WINRT_CALLBACK(SummonWindowRequested, winrt::delegate<void(winrt::Microsoft::Terminal::Remoting::SummonWindowSelectionArgs)>);
 
 private:
     void _CreateWindow();
-    HMENU _CreateTrayContextMenu(winrt::Windows::Foundation::Collections::IMapView<uint64_t, winrt::Microsoft::Terminal::Remoting::IPeasant> peasants);
+    HMENU _CreateTrayContextMenu(winrt::Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo> peasants);
 
     wil::unique_hwnd _trayIconHwnd;
     HWND _owningHwnd;


### PR DESCRIPTION
This PR adds a bit more information to each item in the Tray Icon's  window selection submenu. 
Currently it only shows the window ID and window name if given one. 
Now each item will instead show`{Window ID} : {Active Tab Title} [{Window Name}]`

![image](https://user-images.githubusercontent.com/57155886/130883675-7a76e674-2429-4b26-b869-2455a9e4b4f6.png)
