### PR TITLE
Fix version specification because nuget only likes dashes

### DIFF
--- a/tools/PGODatabase/version.ps1
+++ b/tools/PGODatabase/version.ps1
@@ -1,6 +1,6 @@
 function MakeVersion ( $major, $minor, $datetimeStamp )
 {
-    $revision, $branch = $datetimeStamp.Split("-")
+    $revision, $branch = $datetimeStamp.Split("-", 2)
 
     if ( $branch -eq $null )
     {
@@ -71,5 +71,5 @@ function GetDatetimeStamp ( $pgoBranch )
         throw "FAILED: Get forkDate"
     }
 
-    return $forkDate + "-" + $pgoBranch.Replace("/", "_").Replace("-", "_").Replace(".", "_")
+    return $forkDate + "-" + ( $pgoBranch -replace "(/|\.|@|>|<)", "-" )
 }


### PR DESCRIPTION
Fix version specification because nuget only likes dashes.

We had an old edition of this script that was using underscores as the safe character, but that's not valid for SemVer.

This uses dash instead which is valid.