### PR TITLE
releng: add New-TerminalStackedChangelog

### DIFF
--- a/.github/actions/spelling/allow/allow.txt
+++ b/.github/actions/spelling/allow/allow.txt
@@ -1,6 +1,7 @@
 apc
 calt
 ccmp
+changelog
 cybersecurity
 Apc
 clickable
@@ -38,6 +39,7 @@ lorem
 maxed
 mkmk
 mru
+noreply
 nje
 ogonek
 ok'd

--- a/.github/actions/spelling/allow/names.txt
+++ b/.github/actions/spelling/allow/names.txt
@@ -53,6 +53,7 @@ oldnewthing
 opengl
 osgwiki
 pabhojwa
+panos
 paulcam
 pauldotknopf
 PGP

--- a/tools/ReleaseEngineering/New-TerminalStackedChangelog.ps1
+++ b/tools/ReleaseEngineering/New-TerminalStackedChangelog.ps1
@@ -11,10 +11,15 @@
 ## The output will be a markdown-like document. Each commit will be converted into a
 ## single-line entry with attribution and an optional count:
 #
-# * Frob the foo (thanks @PanosP!)
+# * Foo the bar (thanks @PanosP!)
 # * [2] Fix the bug
 #
 # Entries with a count were present in both changelists.
+#
+# If you don't have the release tags/branches checked out locally, you might
+# need to do something like:
+#
+# $ New-TerminalStackedChangelog origin/release-1.8..origin/release-1.9
 
 [CmdletBinding()]
 Param(
@@ -26,45 +31,52 @@ Function Test-MicrosoftPerson($email) {
 }
 
 Function Generate-Thanks($Entry) {
-	If ($_.Microsoft) {
-		""
-	} ElseIf (-Not [string]::IsNullOrEmpty($_.PossibleUsername)) {
-		" (thanks @{0}!)" -f $_.PossibleUsername
-	} Else {
-		" (thanks @<{0}>!)" -f $_.Email
-	}
+    # We don't need to thank ourselves for doing our jobs
+    If ($_.Microsoft) {
+        ""
+    } ElseIf (-Not [string]::IsNullOrEmpty($_.PossibleUsername)) {
+        " (thanks @{0}!)" -f $_.PossibleUsername
+    } Else {
+        " (thanks @<{0}>!)" -f $_.Email
+    }
 }
 
 $usernameRegex = [regex]::new("(?:\d+\+)?(?<name>[^@]+)@users.noreply.github.com")
 Function Get-PossibleUserName($email) {
-	$match = $usernameRegex.Match($email)
-	if ($null -Ne $match) {
-		return $match.Groups["name"].Value
-	}
-	return $null
+    $match = $usernameRegex.Match($email)
+    if ($null -Ne $match) {
+        return $match.Groups["name"].Value
+    }
+    return $null
 }
 
 $Entries = @()
 
 ForEach ($RevisionRange in $RevisionRanges) {
-	$NewEntries = & git log $RevisionRange "--pretty=format:%an%x1C%ae%x1C%s" |
-	    ConvertFrom-CSV -Delimiter "`u{001C}" -Header Author,Email,Subject
+    # --pretty=format notes:
+    #   - %an: author name
+    #   - %x1C: print a literal FS (0x1C), which will be used as a delimiter
+    #   - %ae: author email
+    #   - %x1C: another FS
+    #   - %s: subject, the title of the commit
+    $NewEntries = & git log $RevisionRange "--pretty=format:%an%x1C%ae%x1C%s" |
+        ConvertFrom-CSV -Delimiter "`u{001C}" -Header Author,Email,Subject
 
-	$Entries += $NewEntries | % { [PSCustomObject]@{
-		Author = $_.Author;
-		Email = $_.Email;
-		Subject = $_.Subject;
-		Microsoft = (Test-MicrosoftPerson $_.Email);
-		PossibleUsername = (Get-PossibleUserName $_.Email);
-	} }
+    $Entries += $NewEntries | % { [PSCustomObject]@{
+        Author = $_.Author;
+        Email = $_.Email;
+        Subject = $_.Subject;
+        Microsoft = (Test-MicrosoftPerson $_.Email);
+        PossibleUsername = (Get-PossibleUserName $_.Email);
+    } }
 }
 
-$Uniq = $Entries | Group-Object Subject | %{ $_.Group[0] | Add-Member Count $_.Count -Force -PassThru }
+$Unique = $Entries | Group-Object Subject | %{ $_.Group[0] | Add-Member Count $_.Count -Force -PassThru }
 
-$Uniq | % {
-	$c = ""
-	If ($_.Count -Gt 1) {
-		$c = "[{0}] " -f $_.Count
-	}
-	"* {0}{1}{2}" -f ($c, $_.Subject, (Generate-Thanks $_))
+$Unique | % {
+    $c = ""
+    If ($_.Count -Gt 1) {
+        $c = "[{0}] " -f $_.Count
+    }
+    "* {0}{1}{2}" -f ($c, $_.Subject, (Generate-Thanks $_))
 }

--- a/tools/ReleaseEngineering/New-TerminalStackedChangelog.ps1
+++ b/tools/ReleaseEngineering/New-TerminalStackedChangelog.ps1
@@ -7,7 +7,7 @@
 # Dustin uses it when he's writing changelogs.
 # 
 ## For example, generating the changelogs for both 1.9 and 1.10 might look like this:
-# $ New-TerminalStackedChangelog 1.9..release-1.9 1.10..release-1.10
+# $ New-TerminalStackedChangelog 1.9..release-1.9, 1.10..release-1.10
 ## The output will be a markdown-like document. Each commit will be converted into a
 ## single-line entry with attribution and an optional count:
 #

--- a/tools/ReleaseEngineering/New-TerminalStackedChangelog.ps1
+++ b/tools/ReleaseEngineering/New-TerminalStackedChangelog.ps1
@@ -1,0 +1,70 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+#################################
+# New-TerminalStackedChangelog generates a markdown file with attribution
+# over a set of revision ranges.
+# Dustin uses it when he's writing changelogs.
+# 
+## For example, generating the changelogs for both 1.9 and 1.10 might look like this:
+# $ New-TerminalStackedChangelog 1.9..release-1.9 1.10..release-1.10
+## The output will be a markdown-like document. Each commit will be converted into a
+## single-line entry with attribution and an optional count:
+#
+# * Frob the foo (thanks @PanosP!)
+# * [2] Fix the bug
+#
+# Entries with a count were present in both changelists.
+
+[CmdletBinding()]
+Param(
+    [string[]]$RevisionRanges
+)
+
+Function Test-MicrosoftPerson($email) {
+    Return $email -like "*@microsoft.com" -Or $email -like "pankaj.d*"
+}
+
+Function Generate-Thanks($Entry) {
+	If ($_.Microsoft) {
+		""
+	} ElseIf (-Not [string]::IsNullOrEmpty($_.PossibleUsername)) {
+		" (thanks @{0}!)" -f $_.PossibleUsername
+	} Else {
+		" (thanks @<{0}>!)" -f $_.Email
+	}
+}
+
+$usernameRegex = [regex]::new("(?:\d+\+)?(?<name>[^@]+)@users.noreply.github.com")
+Function Get-PossibleUserName($email) {
+	$match = $usernameRegex.Match($email)
+	if ($null -Ne $match) {
+		return $match.Groups["name"].Value
+	}
+	return $null
+}
+
+$Entries = @()
+
+ForEach ($RevisionRange in $RevisionRanges) {
+	$NewEntries = & git log $RevisionRange "--pretty=format:%an%x1C%ae%x1C%s" |
+	    ConvertFrom-CSV -Delimiter "`u{001C}" -Header Author,Email,Subject
+
+	$Entries += $NewEntries | % { [PSCustomObject]@{
+		Author = $_.Author;
+		Email = $_.Email;
+		Subject = $_.Subject;
+		Microsoft = (Test-MicrosoftPerson $_.Email);
+		PossibleUsername = (Get-PossibleUserName $_.Email);
+	} }
+}
+
+$Uniq = $Entries | Group-Object Subject | %{ $_.Group[0] | Add-Member Count $_.Count -Force -PassThru }
+
+$Uniq | % {
+	$c = ""
+	If ($_.Count -Gt 1) {
+		$c = "[{0}] " -f $_.Count
+	}
+	"* {0}{1}{2}" -f ($c, $_.Subject, (Generate-Thanks $_))
+}

--- a/tools/ReleaseEngineering/New-TerminalStackedChangelog.ps1
+++ b/tools/ReleaseEngineering/New-TerminalStackedChangelog.ps1
@@ -4,9 +4,9 @@
 #################################
 # New-TerminalStackedChangelog generates a markdown file with attribution
 # over a set of revision ranges.
-# Dustin uses it when he's writing changelogs.
+# Dustin uses it when he's writing the changelog.
 # 
-## For example, generating the changelogs for both 1.9 and 1.10 might look like this:
+## For example, generating the changelog for both 1.9 and 1.10 might look like this:
 # $ New-TerminalStackedChangelog 1.9..release-1.9, 1.10..release-1.10
 ## The output will be a markdown-like document. Each commit will be converted into a
 ## single-line entry with attribution and an optional count:


### PR DESCRIPTION
I've done this process enough times that I should have written a script
to do it a while ago. This one is rough, but the whole changelog process
is pretty rough.

This script takes multiple revision ranges and produces something that
looks like a rough untranslated changelog, with indicators for how many
of the provided ranges had the same change (deduplicated by title.)

I use a process like this to build the Stable and Preview release notes
out of a set of revision ranges.