### PR TITLE
Add Tray Icon settings to the SettingsUI

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.cpp
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.cpp
@@ -198,4 +198,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             globals.Language(currentLanguage);
         }
     }
+
+    bool GlobalAppearance::FeatureTrayIconEnabled() const noexcept
+    {
+        return Feature_TrayIcon::IsEnabled();
+    }
 }

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.h
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.h
@@ -25,6 +25,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         void OnNavigatedTo(const winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
 
+        bool FeatureTrayIconEnabled() const noexcept;
+
         WINRT_PROPERTY(Editor::GlobalAppearancePageNavigationState, State, nullptr);
         GETSET_BINDABLE_ENUM_SETTING(Theme, winrt::Windows::UI::Xaml::ElementTheme, State().Globals, Theme);
         GETSET_BINDABLE_ENUM_SETTING(TabWidthMode, winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode, State().Globals, TabWidthMode);

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.idl
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.idl
@@ -25,5 +25,7 @@ namespace Microsoft.Terminal.Settings.Editor
 
         IInspectable CurrentTabWidthMode;
         Windows.Foundation.Collections.IObservableVector<Microsoft.Terminal.Settings.Editor.EnumEntry> TabWidthModeList { get; };
+
+        Boolean FeatureTrayIconEnabled { get; };
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
@@ -84,6 +84,16 @@
             <local:SettingContainer x:Uid="Globals_DisableAnimationsReversed">
                 <ToggleSwitch IsOn="{x:Bind local:Converters.InvertBoolean(State.Globals.DisableAnimations), BindBack=State.Globals.SetInvertedDisableAnimationsValue, Mode=TwoWay}" />
             </local:SettingContainer>
+
+            <!--  Always Show Tray Icon  -->
+            <local:SettingContainer x:Uid="Globals_AlwaysShowTrayIcon">
+                <ToggleSwitch IsOn="{x:Bind State.Globals.AlwaysShowTrayIcon, Mode=TwoWay}" />
+            </local:SettingContainer>
+
+            <!--  Minimize To Tray  -->
+            <local:SettingContainer x:Uid="Globals_MinimizeToTray">
+                <ToggleSwitch IsOn="{x:Bind State.Globals.MinimizeToTray, Mode=TwoWay}" />
+            </local:SettingContainer>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
@@ -86,12 +86,14 @@
             </local:SettingContainer>
 
             <!--  Always Show Tray Icon  -->
-            <local:SettingContainer x:Uid="Globals_AlwaysShowTrayIcon">
+            <local:SettingContainer x:Uid="Globals_AlwaysShowTrayIcon"
+                                    Visibility="{x:Bind FeatureTrayIconEnabled}">
                 <ToggleSwitch IsOn="{x:Bind State.Globals.AlwaysShowTrayIcon, Mode=TwoWay}" />
             </local:SettingContainer>
 
             <!--  Minimize To Tray  -->
-            <local:SettingContainer x:Uid="Globals_MinimizeToTray">
+            <local:SettingContainer x:Uid="Globals_MinimizeToTray"
+                                    Visibility="{x:Bind FeatureTrayIconEnabled}">
                 <ToggleSwitch IsOn="{x:Bind State.Globals.MinimizeToTray, Mode=TwoWay}" />
             </local:SettingContainer>
         </StackPanel>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1095,7 +1095,7 @@
     <comment>Header for a control to toggle whether the tray icon should always be shown.</comment>
   </data>
   <data name="Globals_MinimizeToTray.Header" xml:space="preserve">
-    <value>Hide the window in the tray when minimizing</value>
+    <value>Hide terminal in the system tray when minimized</value>
     <comment>Header for a control to toggle whether the terminal should hide itself in the tray instead of the taskbar when minimized.</comment>
   </data>
   <data name="SettingContainer_OverrideMessageBaseLayer" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1091,11 +1091,11 @@
     <comment>Header for a control to toggle animations on panes. "Enabled" value enables the animations.</comment>
   </data>
   <data name="Globals_AlwaysShowTrayIcon.Header" xml:space="preserve">
-    <value>Always show the Tray Icon</value>
+    <value>Always display an icon in the notification area</value>
     <comment>Header for a control to toggle whether the tray icon should always be shown.</comment>
   </data>
   <data name="Globals_MinimizeToTray.Header" xml:space="preserve">
-    <value>Hide terminal in the system tray when minimized</value>
+    <value>Hide Terminal in the notification area when it is minimized</value>
     <comment>Header for a control to toggle whether the terminal should hide itself in the tray instead of the taskbar when minimized.</comment>
   </data>
   <data name="SettingContainer_OverrideMessageBaseLayer" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1090,6 +1090,14 @@
     <value>Pane animations</value>
     <comment>Header for a control to toggle animations on panes. "Enabled" value enables the animations.</comment>
   </data>
+  <data name="Globals_AlwaysShowTrayIcon.Header" xml:space="preserve">
+    <value>Always show the Tray Icon</value>
+    <comment>Header for a control to toggle whether the tray icon should always be shown.</comment>
+  </data>
+  <data name="Globals_MinimizeToTray.Header" xml:space="preserve">
+    <value>Hide the window in the tray when minimizing</value>
+    <comment>Header for a control to toggle whether the terminal should hide itself in the tray instead of the taskbar when minimized.</comment>
+  </data>
   <data name="SettingContainer_OverrideMessageBaseLayer" xml:space="preserve">
     <value>Reset to inherited value.</value>
     <comment>This button will remove a user's customization from a given setting, restoring it to the value that the profile inherited. This is a text label on a button.</comment>


### PR DESCRIPTION
Adds toggle buttons to the settings UI for `minimizeToTray` and `alwaysShowTrayIcon` that I mistakenly left out.