### PR TITLE
Fix a crash when there aren't any `recentCommands` yet

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -1255,7 +1255,7 @@ namespace winrt::TerminalApp::implementation
         const auto recentCommands = ApplicationState::SharedInstance().RecentCommands();
         // If there aren't and recent commands already in the state, then we
         // don't need to copy any.
-        const auto countToCopy = std::min(recentCommands? recentCommands.Size() : 0, CommandLineHistoryLength - 1);
+        const auto countToCopy = std::min(recentCommands ? recentCommands.Size() : 0, CommandLineHistoryLength - 1);
         std::vector<hstring> newRecentCommands{ countToCopy + 1 };
         til::at(newRecentCommands, 0) = command;
         if (countToCopy)

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -1219,6 +1219,13 @@ namespace winrt::TerminalApp::implementation
     IVector<TerminalApp::FilteredCommand> CommandPalette::_loadRecentCommands()
     {
         const auto recentCommands = ApplicationState::SharedInstance().RecentCommands();
+        // If this is ter first time we've opened the commandline mode and
+        // there aren't any recent commands, then just return an emptry vector.
+        if (!recentCommands)
+        {
+            return single_threaded_vector<TerminalApp::FilteredCommand>();
+        }
+
         std::vector<TerminalApp::FilteredCommand> parsedCommands;
         parsedCommands.reserve(std::min(recentCommands.Size(), CommandLineHistoryLength));
 
@@ -1246,7 +1253,9 @@ namespace winrt::TerminalApp::implementation
     void CommandPalette::_updateRecentCommands(const hstring& command)
     {
         const auto recentCommands = ApplicationState::SharedInstance().RecentCommands();
-        const auto countToCopy = std::min(recentCommands.Size(), CommandLineHistoryLength - 1);
+        // If there aren't and recent commands already in the state, then we
+        // don't need to copy any.
+        const auto countToCopy = std::min(recentCommands? recentCommands.Size() : 0, CommandLineHistoryLength - 1);
         std::vector<hstring> newRecentCommands{ countToCopy + 1 };
         til::at(newRecentCommands, 0) = command;
         if (countToCopy)

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -1219,8 +1219,8 @@ namespace winrt::TerminalApp::implementation
     IVector<TerminalApp::FilteredCommand> CommandPalette::_loadRecentCommands()
     {
         const auto recentCommands = ApplicationState::SharedInstance().RecentCommands();
-        // If this is ter first time we've opened the commandline mode and
-        // there aren't any recent commands, then just return an emptry vector.
+        // If this is the first time we've opened the commandline mode and
+        // there aren't any recent commands, then just return an empty vector.
         if (!recentCommands)
         {
             return single_threaded_vector<TerminalApp::FilteredCommand>();


### PR DESCRIPTION
The first time you open commandline mode, `recentCommands` doesn't exist yet. However, we immediately try to read the `Size()` in a couple places. This'll A/V and we'll crash 😨 

The fix is easy - don't try and read the size of the non-existent `recentCommands`

Found this while playing with #11069
Regressed in #11030 
Didn't bother filing an issue for it when I have the fix in hand