### PR TITLE
Delete button Styling moved to CommonResource.xaml ;  Issue #10454

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -159,4 +159,58 @@
         <Setter Property="Width" Value="{StaticResource StandardBoxMinWidth}" />
         <Setter Property="HorizontalAlignment" Value="Left" />
     </Style>
+    <!-- DELETE BUTTON STYLING IN COLORSCHEMES.XAML FILE -->
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Light">
+            <Style x:Key="SecondaryTextBlockStyle" TargetType="TextBlock">
+                <Setter Property="Foreground" Value="{ThemeResource SystemBaseMediumColor"/>
+                <SolidColorBrush x:Key="ButtonBackground"
+                                    Color="Firebrick" />
+                <SolidColorBrush x:Key="ButtonBackgroundPointerOver"
+                                    Color="#C23232" />
+                <SolidColorBrush x:Key="ButtonBackgroundPressed"
+                                    Color="#A21212" />
+                <SolidColorBrush x:Key="ButtonForeground"
+                                    Color="White" />
+                <SolidColorBrush x:Key="ButtonForegroundPointerOver"
+                                    Color="White" />
+                <SolidColorBrush x:Key="ButtonForegroundPressed"
+                                    Color="White" />
+            </Style>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="Dark">
+            <Style x:Key="SecondaryTextBlockStyle" TargetType="TextBlock">
+                <Setter Property="Foreground" Value="{ThemeResource SystemBaseMediumColor"/>
+                <SolidColorBrush x:Key="ButtonBackground"
+                                    Color="Firebrick" />
+                <SolidColorBrush x:Key="ButtonBackgroundPointerOver"
+                                    Color="#C23232" />
+                <SolidColorBrush x:Key="ButtonBackgroundPressed"
+                                    Color="#A21212" />
+                <SolidColorBrush x:Key="ButtonForeground"
+                                    Color="White" />
+                <SolidColorBrush x:Key="ButtonForegroundPointerOver"
+                                    Color="White" />
+                <SolidColorBrush x:Key="ButtonForegroundPressed"
+                                    Color="White" />
+            </Style>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="HighContrast">
+        <Style x:Key="SecondaryTextBlockStyle" 
+                TargetType="TextBlock" /> 
+            <SolidColorBrush x:Key="ButtonBackground"
+                                Color="{ThemeResource SystemColorButtonFaceColor}" />
+            <SolidColorBrush x:Key="ButtonBackgroundPointerOver"
+                                Color="{ThemeResource SystemColorHighlightColor}" />
+            <SolidColorBrush x:Key="ButtonBackgroundPressed"
+                                Color="{ThemeResource SystemColorHighlightColor}" />
+            <SolidColorBrush x:Key="ButtonForeground"
+                                Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="ButtonForegroundPointerOver"
+                                Color="{ThemeResource SystemColorHighlightTextColor}" />
+            <SolidColorBrush x:Key="ButtonForegroundPressed"
+                                Color="{ThemeResource SystemColorHighlightTextColor}" />
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+
 </ResourceDictionary>


### PR DESCRIPTION
Issue #10454 

There are a few places in the Settings UI where we have a "delete button":

Actions Page
Color Schemes Page
Profiles Page - Delete Profile
(PR Allow creating and editing unfocused appearances in the SUI #10317) Profiles Page - Delete Appearance: (just look up "Firebrick")
I moved these over to CommonResources.xaml.






I referred https://github.com/microsoft/microsoft-ui-xaml/blob/main/dev/CommonStyles/Common_themeresources.xaml
as a reference for the code modification.
The styling code for "delete button" where moved to Common Resource.xaml file


