### PR TITLE
Make TabView padding equal

### DIFF
--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -45,7 +45,7 @@
                                      Color="{ThemeResource SystemErrorTextColor}" />
 
                     <!--  Suppress top padding  -->
-                    <Thickness x:Key="TabViewHeaderPadding">8,0,8,0</Thickness>
+                    <Thickness x:Key="TabViewHeaderPadding">9,0,8,0</Thickness>
 
                     <!--  Remove when implementing WinUI 2.6  -->
                     <Thickness x:Key="FlyoutContentPadding">12</Thickness>

--- a/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
+++ b/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
@@ -125,7 +125,7 @@
                 details.
             -->
             <x:Double x:Key="CaptionButtonHeightWindowed">40.0</x:Double>
-            <!-- 32 + 1 to compensate for GH#10746 -->
+            <!--  32 + 1 to compensate for GH#10746  -->
             <x:Double x:Key="CaptionButtonHeightMaximized">33.0</x:Double>
 
             <Style x:Key="CaptionButton"

--- a/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
+++ b/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
@@ -9,7 +9,7 @@
             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
             HorizontalAlignment="Left"
             VerticalAlignment="Top"
-            d:DesignHeight="36"
+            d:DesignHeight="40"
             d:DesignWidth="400"
             Background="Transparent"
             Orientation="Horizontal"
@@ -124,8 +124,9 @@
                 tabs will be flush with the top of the window. See GH#2541 for
                 details.
             -->
-            <x:Double x:Key="CaptionButtonHeightWindowed">36.0</x:Double>
-            <x:Double x:Key="CaptionButtonHeightMaximized">32.0</x:Double>
+            <x:Double x:Key="CaptionButtonHeightWindowed">40.0</x:Double>
+            <!-- 32 + 1 to compensate for GH#10746 -->
+            <x:Double x:Key="CaptionButtonHeightMaximized">33.0</x:Double>
 
             <Style x:Key="CaptionButton"
                    TargetType="Button">


### PR DESCRIPTION
Doing #10242 again.

The space around the tabs was made equal in windowed mode.
For maximized mode, I made the titlebar be 33px tall, to compensate for #10746.

![padding](https://user-images.githubusercontent.com/84711285/131723737-d63b015c-2134-465a-a15b-6b44538b95c5.png)
