### PR TITLE
Add `useAcrylicInTabRow` to JSON schema

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -1261,6 +1261,11 @@
           "description": "When set to true, the Terminal's tray icon will always be shown in the system tray.",
           "type": "boolean"
         },
+        "useAcrylicInTabRow": {
+          "default": "false",
+          "description": "When set to true, the tab row will have an acrylic background with 50% opacity.",
+          "type": "boolean"
+        },
 		"actions": {
 			"description": "Properties are specific to each custom action.",
 			"items": {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
`useAcrylicInTabRow` was missing from the JSON schema, so I added it in.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
#10864 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #11087 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [x] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx