### PR TITLE
Change exit code to hex; Fix format spec

### DIFF
--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -421,7 +421,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         const auto hr = wil::ResultFromCaughtException();
 
         winrt::hstring failureText{ fmt::format(std::wstring_view{ RS_(L"ProcessFailedToLaunch") },
-                                                gsl::narrow_cast<unsigned long>(hr),
+                                                fmt::format(_errorFormat, hr),
                                                 _commandline) };
         _TerminalOutputHandlers(failureText);
 
@@ -448,7 +448,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
     {
         try
         {
-            winrt::hstring exitText{ fmt::format(std::wstring_view{ RS_(L"ProcessExited") }, status) };
+            winrt::hstring exitText{ fmt::format(std::wstring_view{ RS_(L"ProcessExited") }, fmt::format(_errorFormat, status)) };
             _TerminalOutputHandlers(L"\r\n");
             _TerminalOutputHandlers(exitText);
         }

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -16,6 +16,10 @@
 #include "LibraryResources.h"
 
 using namespace ::Microsoft::Console;
+using namespace std::string_view_literals;
+
+// Format is: "DecimalResult (HexadecimalForm)"
+static constexpr auto _errorFormat = L"{0} ({0:#010x})"sv;
 
 // Notes:
 // There is a number of ways that the Conpty connection can be terminated (voluntarily or not):

--- a/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
@@ -204,11 +204,11 @@
     <comment>This is shorthand for "no". The user must enter this character to DECLINE a prompt.</comment>
   </data>
   <data name="ProcessExited" xml:space="preserve">
-    <value>[process exited with code {0}]</value>
-    <comment>The first argument {0} is the (positive) error code of the process. When there is no error, the number ZERO will be displayed.</comment>
+    <value>[process exited with code {0:#010x})]</value>
+    <comment>The first argument {0...} is the hexadecimal error code of the process. When there is no error, the number ZERO will be displayed. </comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">
-    <value>[error {0:#08x} when launching `{1}']</value>
+    <value>[error {0:#010x} when launching `{1}']</value>
     <comment>The first argument {0...} is the hexadecimal error code. The second argument {1} is the user-specified path to a program.
       If this string is broken to multiple lines, it will not be displayed properly.</comment>
   </data>

--- a/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
@@ -204,7 +204,7 @@
     <comment>This is shorthand for "no". The user must enter this character to DECLINE a prompt.</comment>
   </data>
   <data name="ProcessExited" xml:space="preserve">
-    <value>[process exited with code {0})]</value>
+    <value>[process exited with code {0}]</value>
     <comment>The first argument {0} is the error code of the process. When there is no error, the number ZERO will be displayed. </comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">

--- a/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalConnection/Resources/en-US/Resources.resw
@@ -204,12 +204,12 @@
     <comment>This is shorthand for "no". The user must enter this character to DECLINE a prompt.</comment>
   </data>
   <data name="ProcessExited" xml:space="preserve">
-    <value>[process exited with code {0:#010x})]</value>
-    <comment>The first argument {0...} is the hexadecimal error code of the process. When there is no error, the number ZERO will be displayed. </comment>
+    <value>[process exited with code {0})]</value>
+    <comment>The first argument {0} is the error code of the process. When there is no error, the number ZERO will be displayed. </comment>
   </data>
   <data name="ProcessFailedToLaunch" xml:space="preserve">
-    <value>[error {0:#010x} when launching `{1}']</value>
-    <comment>The first argument {0...} is the hexadecimal error code. The second argument {1} is the user-specified path to a program.
+    <value>[error {0} when launching `{1}']</value>
+    <comment>The first argument {0} is the error code. The second argument {1} is the user-specified path to a program.
       If this string is broken to multiple lines, it will not be displayed properly.</comment>
   </data>
   <data name="BadPathText" xml:space="preserve">

--- a/src/cascadia/TerminalConnection/TerminalConnection.vcxproj
+++ b/src/cascadia/TerminalConnection/TerminalConnection.vcxproj
@@ -56,7 +56,9 @@
     <Midl Include="AzureConnection.idl" />
   </ItemGroup>
   <ItemGroup>
-    <PRIResource Include="Resources\en-US\Resources.resw" />
+    <PRIResource Include="Resources\en-US\Resources.resw">
+      <SubType>Designer</SubType>
+    </PRIResource>
     <OCResourceDirectory Include="Resources" />
     <None Include="packages.config" />
   </ItemGroup>
@@ -88,7 +90,7 @@
   </Target>
   <ItemDefinitionGroup>
     <ClCompile>
-        <AdditionalIncludeDirectories>$(IntDir)..\OpenConsoleProxy;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(IntDir)..\OpenConsoleProxy;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(OpenConsoleCommonOutDir)\conptylib.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/cascadia/TerminalConnection/TerminalConnection.vcxproj.filters
+++ b/src/cascadia/TerminalConnection/TerminalConnection.vcxproj.filters
@@ -32,6 +32,7 @@
     <Midl Include="EchoConnection.idl" />
     <Midl Include="AzureConnection.idl" />
     <Midl Include="ConptyConnection.idl" />
+    <Midl Include="ConnectionInformation.idl" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
Process exit code now shows as hex not decimal. Format specification needs length "10" not "8" because the leading '0x' generated by the # symbol counts as part of the length.

## PR Checklist
* [x] Closes annoyance at looking up process exit codes
* [x] I work here.
* [x] Checked manually

## Validation Steps Performed
- [x] Ran it, opened tab, opened another CMD tab, ran `exit <code>` and observed hex pattern
