### PR TITLE
Disable autocorrect for command, path and find text inputs

### DIFF
--- a/src/cascadia/TerminalControl/SearchBoxControl.xaml
+++ b/src/cascadia/TerminalControl/SearchBoxControl.xaml
@@ -239,8 +239,8 @@
                  VerticalAlignment="Center"
                  CornerRadius="2"
                  FontSize="15"
-                 KeyDown="TextBoxKeyDown"
                  IsSpellCheckEnabled="False"
+                 KeyDown="TextBoxKeyDown"
                  PlaceholderForeground="{ThemeResource TextBoxPlaceholderTextThemeBrush}" />
 
         <ToggleButton x:Name="GoBackwardButton"

--- a/src/cascadia/TerminalControl/SearchBoxControl.xaml
+++ b/src/cascadia/TerminalControl/SearchBoxControl.xaml
@@ -240,6 +240,7 @@
                  CornerRadius="2"
                  FontSize="15"
                  KeyDown="TextBoxKeyDown"
+                 IsSpellCheckEnabled="False"
                  PlaceholderForeground="{ThemeResource TextBoxPlaceholderTextThemeBrush}" />
 
         <ToggleButton x:Name="GoBackwardButton"

--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -207,6 +207,7 @@
                     <StackPanel Orientation="Horizontal">
                         <TextBox IsEnabled="{x:Bind local:Converters.StringsAreNotEqual('desktopWallpaper', Appearance.BackgroundImagePath), Mode=OneWay}"
                                  Style="{StaticResource TextBoxSettingStyle}"
+                                 IsSpellCheckEnabled="False"
                                  Text="{x:Bind local:Converters.StringFallBackToEmptyString('desktopWallpaper', Appearance.BackgroundImagePath), Mode=TwoWay, BindBack=Appearance.SetBackgroundImagePath}" />
                         <Button x:Uid="Profile_BackgroundImageBrowse"
                                 Click="BackgroundImage_Click"

--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -206,8 +206,8 @@
                 <StackPanel Orientation="Vertical">
                     <StackPanel Orientation="Horizontal">
                         <TextBox IsEnabled="{x:Bind local:Converters.StringsAreNotEqual('desktopWallpaper', Appearance.BackgroundImagePath), Mode=OneWay}"
-                                 Style="{StaticResource TextBoxSettingStyle}"
                                  IsSpellCheckEnabled="False"
+                                 Style="{StaticResource TextBoxSettingStyle}"
                                  Text="{x:Bind local:Converters.StringFallBackToEmptyString('desktopWallpaper', Appearance.BackgroundImagePath), Mode=TwoWay, BindBack=Appearance.SetBackgroundImagePath}" />
                         <Button x:Uid="Profile_BackgroundImageBrowse"
                                 Click="BackgroundImage_Click"

--- a/src/cascadia/TerminalSettingsEditor/Interaction.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.xaml
@@ -46,8 +46,8 @@
 
             <!--  Word Delimiters  -->
             <local:SettingContainer x:Uid="Globals_WordDelimiters">
-                <TextBox Style="{StaticResource TextBoxSettingStyle}"
-                         IsSpellCheckEnabled="False"
+                <TextBox IsSpellCheckEnabled="False"
+                         Style="{StaticResource TextBoxSettingStyle}"
                          Text="{x:Bind State.Globals.WordDelimiters, Mode=TwoWay}" />
             </local:SettingContainer>
 

--- a/src/cascadia/TerminalSettingsEditor/Interaction.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Interaction.xaml
@@ -47,6 +47,7 @@
             <!--  Word Delimiters  -->
             <local:SettingContainer x:Uid="Globals_WordDelimiters">
                 <TextBox Style="{StaticResource TextBoxSettingStyle}"
+                         IsSpellCheckEnabled="False"
                          Text="{x:Bind State.Globals.WordDelimiters, Mode=TwoWay}" />
             </local:SettingContainer>
 

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -82,6 +82,7 @@
                                                 Visibility="{x:Bind local:Converters.InvertedBooleanToVisibility(State.Profile.IsBaseLayer), Mode=OneWay}">
                             <StackPanel Orientation="Horizontal">
                                 <TextBox Style="{StaticResource TextBoxSettingStyle}"
+                                         IsSpellCheckEnabled="False"
                                          Text="{x:Bind State.Profile.Commandline, Mode=TwoWay}" />
                                 <Button x:Uid="Profile_CommandlineBrowse"
                                         Click="Commandline_Click"
@@ -100,6 +101,7 @@
                                 <StackPanel Orientation="Horizontal">
                                     <TextBox IsEnabled="{x:Bind State.Profile.UseCustomStartingDirectory, Mode=OneWay}"
                                              Style="{StaticResource TextBoxSettingStyle}"
+                                             IsSpellCheckEnabled="False"
                                              Text="{x:Bind State.Profile.StartingDirectory, Mode=TwoWay}" />
                                     <Button x:Name="StartingDirectoryBrowse"
                                             x:Uid="Profile_StartingDirectoryBrowse"
@@ -121,6 +123,7 @@
                             <StackPanel Orientation="Horizontal">
                                 <TextBox FontFamily="Segoe UI, Segoe MDL2 Assets"
                                          Style="{StaticResource TextBoxSettingStyle}"
+                                         IsSpellCheckEnabled="False"
                                          Text="{x:Bind State.Profile.Icon, Mode=TwoWay}" />
                                 <Button x:Uid="Profile_IconBrowse"
                                         Click="Icon_Click"

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -81,8 +81,8 @@
                                                 SettingOverrideSource="{x:Bind State.Profile.CommandlineOverrideSource, Mode=OneWay}"
                                                 Visibility="{x:Bind local:Converters.InvertedBooleanToVisibility(State.Profile.IsBaseLayer), Mode=OneWay}">
                             <StackPanel Orientation="Horizontal">
-                                <TextBox Style="{StaticResource TextBoxSettingStyle}"
-                                         IsSpellCheckEnabled="False"
+                                <TextBox IsSpellCheckEnabled="False"
+                                         Style="{StaticResource TextBoxSettingStyle}"
                                          Text="{x:Bind State.Profile.Commandline, Mode=TwoWay}" />
                                 <Button x:Uid="Profile_CommandlineBrowse"
                                         Click="Commandline_Click"
@@ -100,8 +100,8 @@
                             <StackPanel Orientation="Vertical">
                                 <StackPanel Orientation="Horizontal">
                                     <TextBox IsEnabled="{x:Bind State.Profile.UseCustomStartingDirectory, Mode=OneWay}"
-                                             Style="{StaticResource TextBoxSettingStyle}"
                                              IsSpellCheckEnabled="False"
+                                             Style="{StaticResource TextBoxSettingStyle}"
                                              Text="{x:Bind State.Profile.StartingDirectory, Mode=TwoWay}" />
                                     <Button x:Name="StartingDirectoryBrowse"
                                             x:Uid="Profile_StartingDirectoryBrowse"
@@ -122,8 +122,8 @@
                                                 SettingOverrideSource="{x:Bind State.Profile.IconOverrideSource, Mode=OneWay}">
                             <StackPanel Orientation="Horizontal">
                                 <TextBox FontFamily="Segoe UI, Segoe MDL2 Assets"
-                                         Style="{StaticResource TextBoxSettingStyle}"
                                          IsSpellCheckEnabled="False"
+                                         Style="{StaticResource TextBoxSettingStyle}"
                                          Text="{x:Bind State.Profile.Icon, Mode=TwoWay}" />
                                 <Button x:Uid="Profile_IconBrowse"
                                         Click="Icon_Click"


### PR DESCRIPTION
## Summary of the Pull Request
Disables autocorrect for command, path and find text inputs. Does not disable it for profile names, tab titles or colour scheme names.

## PR Checklist
* [x] Closes #11133
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed
Manually typed `bash -i -l` into the profile command text input and found it no longer auto-capitalised the I.