### PR TITLE
Upgrade to C++/WinRT 2.0.210825.3

### DIFF
--- a/scratch/ScratchIslandApp/SampleApp/packages.config
+++ b/scratch/ScratchIslandApp/SampleApp/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Toolkit.Win32.UI.XamlApplication" version="6.1.3" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.5.0-prerelease.201202003" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />
 </packages>

--- a/scratch/ScratchIslandApp/WindowExe/packages.config
+++ b/scratch/ScratchIslandApp/WindowExe/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />
   <package id="Microsoft.Toolkit.Win32.UI.XamlApplication" version="6.1.3" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.5.0-prerelease.201202003" targetFramework="native" />
   <package id="Microsoft.VCRTForwarders.140" version="1.0.4" targetFramework="native" />

--- a/src/cascadia/Remoting/packages.config
+++ b/src/cascadia/Remoting/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />
 </packages>

--- a/src/cascadia/ShellExtension/packages.config
+++ b/src/cascadia/ShellExtension/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />
 </packages>

--- a/src/cascadia/TerminalApp/packages.config
+++ b/src/cascadia/TerminalApp/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Toolkit.Win32.UI.XamlApplication" version="6.1.3" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.5.0-prerelease.201202003" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />
 </packages>

--- a/src/cascadia/TerminalAzBridge/packages.config
+++ b/src/cascadia/TerminalAzBridge/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />
 </packages>

--- a/src/cascadia/TerminalConnection/packages.config
+++ b/src/cascadia/TerminalConnection/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />
   <package id="vcpkg-cpprestsdk" version="2.10.14" targetFramework="native" />
 </packages>

--- a/src/cascadia/TerminalControl/packages.config
+++ b/src/cascadia/TerminalControl/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />
 </packages>

--- a/src/cascadia/TerminalCore/packages.config
+++ b/src/cascadia/TerminalCore/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />
 </packages>

--- a/src/cascadia/TerminalSettingsEditor/packages.config
+++ b/src/cascadia/TerminalSettingsEditor/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.UI.Xaml" version="2.5.0-prerelease.201202003" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />
 </packages>

--- a/src/cascadia/TerminalSettingsModel/packages.config
+++ b/src/cascadia/TerminalSettingsModel/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />
 </packages>

--- a/src/cascadia/WinRTUtils/packages.config
+++ b/src/cascadia/WinRTUtils/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />
 </packages>

--- a/src/cascadia/WindowsTerminal/packages.config
+++ b/src/cascadia/WindowsTerminal/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />
   <package id="Microsoft.Toolkit.Win32.UI.XamlApplication" version="6.1.3" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.5.0-prerelease.201202003" targetFramework="native" />
   <package id="Microsoft.VCRTForwarders.140" version="1.0.4" targetFramework="native" />

--- a/src/cascadia/WindowsTerminalUniversal/packages.config
+++ b/src/cascadia/WindowsTerminalUniversal/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Toolkit.Win32.UI.XamlApplication" version="6.1.3" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />
 </packages>

--- a/src/cppwinrt.build.post.props
+++ b/src/cppwinrt.build.post.props
@@ -3,13 +3,13 @@
   <Import Project="$(MSBuildThisFileDirectory)common.build.post.props" />
 
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210825.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210825.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210825.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210825.3\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210825.3\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210825.3\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>
 </Project>

--- a/src/cppwinrt.build.pre.props
+++ b/src/cppwinrt.build.pre.props
@@ -8,7 +8,7 @@
 
   <Import Project="..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
 
-  <Import Project="$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210825.3\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(OpenConsoleDir)\packages\Microsoft.Windows.CppWinRT.2.0.210825.3\build\native\Microsoft.Windows.CppWinRT.props')" />
 
   <PropertyGroup Label="Globals">
     <CppWinRTHeapEnforcement>AnyValueHereWillDisableTheOptOut</CppWinRTHeapEnforcement>


### PR DESCRIPTION
This pull request moves us to Microsoft.Windows.CppWinRT 2.0.210825.3.

Notable improvements from 2.0.210309.3:
* Restored Windows 7 functionality
* C++20 ranges support
* `capture` now works with a raw pointer
* `hstring::starts_with` and `hstring::ends_with` (C++20)

Unit/Functional Tests:
Summary: Total=7728, Passed=7571, Failed=10, Blocked=0, Not Run=0, Skipped=147

Local Tests:
Summary: Total=163, Passed=158, Failed=5, Blocked=0, Not Run=0, Skipped=0

The above failures are (1) in UIA tests for conhost/WT (which do not work here) or
(2) in already known-broken local tests.