### PR TITLE
.editorconfig: add utf-8 encoding 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,7 @@
 root = true
 
 [*]
+charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 


### PR DESCRIPTION
This commit configures compliant text editors to save our code as UTF-8.