### PR TITLE
Allow reordering tabs when UAC is disabled

### DIFF
--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -144,8 +144,8 @@ try
     TOKEN_ELEVATION elevationState{ 0 };
 
     OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &hToken);
-    GetTokenInformation(hToken.get(), TokenElevationType, &elevationType, sizeof(elevationType), &dwSize);
-    GetTokenInformation(hToken.get(), TokenElevation, &elevationState, sizeof(elevationState), &dwSize);
+    THROW_IF_WIN32_BOOL_FALSE(GetTokenInformation(hToken.get(), TokenElevationType, &elevationType, sizeof(elevationType), &dwSize));
+    THROW_IF_WIN32_BOOL_FALSE(GetTokenInformation(hToken.get(), TokenElevation, &elevationState, sizeof(elevationState), &dwSize));
     if (elevationType == TokenElevationTypeDefault && elevationState.TokenIsElevated)
     {
         // In this case, the user has UAC entirely disabled. This is sort of

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -10,6 +10,7 @@
 
 #include <LibraryResources.h>
 #include <WtExeUtils.h>
+#include <wil/token_helpers.h >
 
 using namespace winrt::Windows::ApplicationModel;
 using namespace winrt::Windows::ApplicationModel::DataTransfer;
@@ -138,14 +139,9 @@ static Documents::Run _BuildErrorRun(const winrt::hstring& text, const ResourceD
 static bool _isUserAdmin() noexcept
 try
 {
-    DWORD dwSize;
-    wil::unique_handle hToken;
-    TOKEN_ELEVATION_TYPE elevationType;
-    TOKEN_ELEVATION elevationState{ 0 };
-
-    OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &hToken);
-    THROW_IF_WIN32_BOOL_FALSE(GetTokenInformation(hToken.get(), TokenElevationType, &elevationType, sizeof(elevationType), &dwSize));
-    THROW_IF_WIN32_BOOL_FALSE(GetTokenInformation(hToken.get(), TokenElevation, &elevationState, sizeof(elevationState), &dwSize));
+    wil::unique_handle processToken{ GetCurrentProcessToken() };
+    const auto elevationType = wil::get_token_information<TOKEN_ELEVATION_TYPE>(processToken.get());
+    const auto elevationState = wil::get_token_information<TOKEN_ELEVATION>(processToken.get());
     if (elevationType == TokenElevationTypeDefault && elevationState.TokenIsElevated)
     {
         // In this case, the user has UAC entirely disabled. This is sort of
@@ -157,12 +153,7 @@ try
         return false;
     }
 
-    SID_IDENTIFIER_AUTHORITY ntAuthority{ SECURITY_NT_AUTHORITY };
-    wil::unique_sid adminGroupSid{};
-    THROW_IF_WIN32_BOOL_FALSE(AllocateAndInitializeSid(&ntAuthority, 2, SECURITY_BUILTIN_DOMAIN_RID, DOMAIN_ALIAS_RID_ADMINS, 0, 0, 0, 0, 0, 0, &adminGroupSid));
-    BOOL b;
-    THROW_IF_WIN32_BOOL_FALSE(CheckTokenMembership(NULL, adminGroupSid.get(), &b));
-    return !!b;
+    return wil::test_token_membership(nullptr, SECURITY_NT_AUTHORITY, SECURITY_BUILTIN_DOMAIN_RID, DOMAIN_ALIAS_RID_ADMINS);
 }
 catch (...)
 {

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -148,7 +148,7 @@ try
     GetTokenInformation(hToken.get(), TokenElevation, &elevationState, sizeof(elevationState), &dwSize);
     if (elevationType == TokenElevationTypeDefault && elevationState.TokenIsElevated)
     {
-        // In this case, the user has UAC entirely disabled. This is sorta
+        // In this case, the user has UAC entirely disabled. This is sort of
         // weird, we treat this like the user isn't an admin at all. There's no
         // separation of powers, so the things we normally want to gate on
         // "having special powers" doesn't apply.


### PR DESCRIPTION
When we're elevated, we disable drag/dropping tabs when elevated, because of a platform limitation that causes the app to _crash_ (see #4874). However, if the user has UAC disabled, this actually works alright. So I'm adding it back in that case.

I'm not positive if this is the best way to check if UAC is disabled, but normally, you'll get a [`TokenElevationTypeFull`] when elevated, not `TokenElevationTypeDefault`. If the app is elevated, but there's not a split token, that kinda implies there's no user account separation. If I'm wrong, it's just code, let's replace this with something that does work.

## Validation Steps Performed

Booted up a Win10 VM, set `enableLUA` to `0`, rebooted, and checked if this exploded. It didn't.

References #4874 
References #3581
Work done in pursuit of #11096
Closes #7754

[`TokenElevationTypeFull`]: https://docs.microsoft.com/en-us/windows/win32/api/winnt/ne-winnt-token_elevation_type