### PR TITLE
Fix serialisation of findMatch action

### DIFF
--- a/src/cascadia/LocalTests_SettingsModel/SerializationTests.cpp
+++ b/src/cascadia/LocalTests_SettingsModel/SerializationTests.cpp
@@ -256,9 +256,13 @@ namespace SettingsModelLocalTests
                                             ])" };
 
         // complex command with key chords
-        const std::string actionsString4{ R"([
+        const std::string actionsString4A{ R"([
                                                 { "command": { "action": "adjustFontSize", "delta": 1 }, "keys": "ctrl+c" },
                                                 { "command": { "action": "adjustFontSize", "delta": 1 }, "keys": "ctrl+d" }
+                                            ])" };
+        const std::string actionsString4B{ R"([
+                                                { "command": { "action": "findMatch", "direction": "next" }, "keys": "ctrl+shift+s" },
+                                                { "command": { "action": "findMatch", "direction": "prev" }, "keys": "ctrl+shift+r" }
                                             ])" };
 
         // command with name and icon and multiple key chords
@@ -372,7 +376,8 @@ namespace SettingsModelLocalTests
         RoundtripTest<implementation::ActionMap>(actionsString3);
 
         Log::Comment(L"complex commands with key chords");
-        RoundtripTest<implementation::ActionMap>(actionsString4);
+        RoundtripTest<implementation::ActionMap>(actionsString4A);
+        RoundtripTest<implementation::ActionMap>(actionsString4B);
 
         Log::Comment(L"command with name and icon and multiple key chords");
         RoundtripTest<implementation::ActionMap>(actionsString5);

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -1417,7 +1417,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             }
             Json::Value json{ Json::ValueType::objectValue };
             const auto args{ get_self<FindMatchArgs>(val) };
-            JsonUtils::GetValueForKey(json, DirectionKey, args->_Direction);
+            JsonUtils::SetValueForKey(json, DirectionKey, args->_Direction);
             return json;
         }
         IActionArgs Copy() const


### PR DESCRIPTION
## Summary of the Pull Request
Fixes the serialisation of the findMatch action so that the direction is stored.

## PR Checklist
* [x] Closes #11225
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed
Added a test and tested manually.