### PR TITLE
Bind resetFontSize to numpad_0

### DIFF
--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -393,6 +393,7 @@
         { "command": { "action": "adjustFontSize", "delta": 1 }, "keys": "ctrl+numpad_plus" },
         { "command": { "action": "adjustFontSize", "delta": -1 }, "keys": "ctrl+numpad_minus" },
         { "command": "resetFontSize", "keys": "ctrl+0" },
+        { "command": "resetFontSize", "keys": "ctrl+numpad_0" },
 
         // Other commands
         {


### PR DESCRIPTION
We already had resetFontSize bound to ctrl+0. As discussed in
#11239 it should be possible to do the same with ctrl+numpad_0.

## PR Checklist
* [x] Closes #11239
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [x] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: https://github.com/MicrosoftDocs/terminal/pull/412

## Validation Steps Performed

* Resetting the font size with ctrl+numpad_0 works