### PR TITLE
Fix mouse coordinates when viewport is scrolled for all events, not just pressed

### DIFF
--- a/src/cascadia/TerminalControl/ControlInteractivity.cpp
+++ b/src/cascadia/TerminalControl/ControlInteractivity.cpp
@@ -214,12 +214,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         }
         else if (_canSendVTMouseInput(modifiers))
         {
-            const auto adjustment = _core->ScrollOffset() > 0 ? _core->BufferHeight() - _core->ScrollOffset() - _core->ViewHeight() : 0;
-            // If the click happened outside the active region, just don't send any mouse event
-            if (const auto adjustedY = terminalPosition.y() - adjustment; adjustedY >= 0)
-            {
-                _core->SendMouseEvent({ terminalPosition.x(), adjustedY }, pointerUpdateKind, modifiers, 0, toInternalMouseState(buttonState));
-            }
+            _sendMouseEventHelper(terminalPosition, pointerUpdateKind, modifiers, 0, buttonState);
         }
         else if (WI_IsFlagSet(buttonState, MouseButtonState::IsLeftButtonDown))
         {
@@ -287,7 +282,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // Short-circuit isReadOnly check to avoid warning dialog
         if (focused && !_core->IsInReadOnlyMode() && _canSendVTMouseInput(modifiers))
         {
-            _core->SendMouseEvent(terminalPosition, pointerUpdateKind, modifiers, 0, toInternalMouseState(buttonState));
+            _sendMouseEventHelper(terminalPosition, pointerUpdateKind, modifiers, 0, buttonState);
         }
         // GH#4603 - don't modify the selection if the pointer press didn't
         // actually start _in_ the control bounds. Case in point - someone drags
@@ -370,7 +365,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // Short-circuit isReadOnly check to avoid warning dialog
         if (!_core->IsInReadOnlyMode() && _canSendVTMouseInput(modifiers))
         {
-            _core->SendMouseEvent(terminalPosition, pointerUpdateKind, modifiers, 0, toInternalMouseState(buttonState));
+            _sendMouseEventHelper(terminalPosition, pointerUpdateKind, modifiers, 0, buttonState);
             return;
         }
 
@@ -420,11 +415,11 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             // here with a PointerPoint. However, as of #979, we don't have a
             // PointerPoint to work with. So, we're just going to do a
             // mousewheel event manually
-            return _core->SendMouseEvent(terminalPosition,
+            return _sendMouseEventHelper(terminalPosition,
                                          WM_MOUSEWHEEL,
                                          modifiers,
                                          ::base::saturated_cast<short>(delta),
-                                         toInternalMouseState(buttonState));
+                                         buttonState);
         }
 
         const auto ctrlPressed = modifiers.IsCtrlPressed();
@@ -598,6 +593,21 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         const til::size fontSize{ _core->GetFont().GetSize() };
         // Convert the location in pixels to characters within the current viewport.
         return til::point{ pixelPosition / fontSize };
+    }
+
+    bool ControlInteractivity::_sendMouseEventHelper(const til::point terminalPosition,
+                                                     const unsigned int pointerUpdateKind,
+                                                     const ::Microsoft::Terminal::Core::ControlKeyStates modifiers,
+                                                     const SHORT wheelDelta,
+                                                     Control::MouseButtonState buttonState)
+    {
+        const auto adjustment = _core->ScrollOffset() > 0 ? _core->BufferHeight() - _core->ScrollOffset() - _core->ViewHeight() : 0;
+        // If the click happened outside the active region, just don't send any mouse event
+        if (const auto adjustedY = terminalPosition.y() - adjustment; adjustedY >= 0)
+        {
+            return _core->SendMouseEvent({ terminalPosition.x(), adjustedY }, pointerUpdateKind, modifiers, wheelDelta, toInternalMouseState(buttonState));
+        }
+        return false;
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/ControlInteractivity.h
+++ b/src/cascadia/TerminalControl/ControlInteractivity.h
@@ -142,6 +142,12 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void _sendPastedTextToConnection(std::wstring_view wstr);
         til::point _getTerminalPosition(const til::point& pixelPosition);
 
+        bool _sendMouseEventHelper(const til::point terminalPosition,
+                                   const unsigned int pointerUpdateKind,
+                                   const ::Microsoft::Terminal::Core::ControlKeyStates modifiers,
+                                   const SHORT wheelDelta,
+                                   Control::MouseButtonState buttonState);
+
         friend class ControlUnitTests::ControlCoreTests;
         friend class ControlUnitTests::ControlInteractivityTests;
     };


### PR DESCRIPTION
## Summary of the Pull Request
Does the mouse coordinate adjustment added in #10642 for all the other mouse events as well (moved, released, wheel)

## PR Checklist
* [x] Closes #10190 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I work here

## Validation Steps Performed
Cannot repro the issue anymore (for real this time hopefully)