### PR TITLE
[a11y] Ensure buffer is initialized before interacting with it

### DIFF
--- a/src/Terminal.wprp
+++ b/src/Terminal.wprp
@@ -12,6 +12,7 @@
     <EventProvider Id="EventProvider_TerminalWin32Host" Name="56c06166-2e2e-5f4d-7ff3-74f4b78c87d6" />
     <EventProvider Id="EventProvider_TerminalRemoting" Name="d6f04aad-629f-539a-77c1-73f5c3e4aa7b" />
     <EventProvider Id="EventProvider_TerminalDirectX" Name="c93e739e-ae50-5a14-78e7-f171e947535d" />
+    <EventProvider Id="EventProvider_TerminalUIA" Name="e7ebce59-2161-572d-b263-2f16a6afb9e5"/>
     <Profile Id="Terminal.Verbose.File" Name="Terminal" Description="Terminal" LoggingMode="File" DetailLevel="Verbose">
       <Collectors>
         <EventCollectorId Value="EventCollector_Terminal">
@@ -23,6 +24,7 @@
             <EventProviderId Value="EventProvider_TerminalWin32Host" />
             <EventProviderId Value="EventProvider_TerminalRemoting" />
             <EventProviderId Value="EventProvider_TerminalDirectX" />
+            <EventProviderId Value="EventProvider_TerminalUIA" />
           </EventProviders>
         </EventCollectorId>
       </Collectors>

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -199,6 +199,7 @@ public:
     const COORD GetSelectionEnd() const noexcept override;
     const std::wstring_view GetConsoleTitle() const noexcept override;
     void ColorSelection(const COORD coordSelectionStart, const COORD coordSelectionEnd, const TextAttribute) override;
+    const bool IsUiaDataInitialized() const noexcept override;
 #pragma endregion
 
     void SetWriteInputCallback(std::function<void(std::wstring&)> pfn) noexcept;

--- a/src/cascadia/TerminalCore/terminalrenderdata.cpp
+++ b/src/cascadia/TerminalCore/terminalrenderdata.cpp
@@ -250,3 +250,12 @@ bool Terminal::IsScreenReversed() const noexcept
 {
     return _screenReversed;
 }
+
+const bool Terminal::IsUiaDataInitialized() const noexcept
+{
+    // GH#11135: Windows Terminal needs to create and return an automation peer
+    // when a screen reader requests it. However, the terminal might not be fully
+    // initialized yet. So we use this to check if any crucial components of
+    // UiaData are not yet initialized.
+    return !!_buffer;
+}

--- a/src/host/renderData.hpp
+++ b/src/host/renderData.hpp
@@ -69,5 +69,6 @@ public:
     const COORD GetSelectionAnchor() const noexcept;
     const COORD GetSelectionEnd() const noexcept;
     void ColorSelection(const COORD coordSelectionStart, const COORD coordSelectionEnd, const TextAttribute attr);
+    const bool IsUiaDataInitialized() const noexcept override { return true; }
 #pragma endregion
 };

--- a/src/host/ut_host/VtIoTests.cpp
+++ b/src/host/ut_host/VtIoTests.cpp
@@ -392,6 +392,11 @@ public:
     {
     }
 
+    const bool IsUiaDataInitialized() const noexcept
+    {
+        return true;
+    }
+
     const std::wstring GetHyperlinkUri(uint16_t /*id*/) const noexcept
     {
         return {};

--- a/src/types/IUiaData.h
+++ b/src/types/IUiaData.h
@@ -40,6 +40,7 @@ namespace Microsoft::Console::Types
         virtual const COORD GetSelectionAnchor() const noexcept = 0;
         virtual const COORD GetSelectionEnd() const noexcept = 0;
         virtual void ColorSelection(const COORD coordSelectionStart, const COORD coordSelectionEnd, const TextAttribute attr) = 0;
+        virtual const bool IsUiaDataInitialized() const noexcept = 0;
     };
 
     // See docs/virtual-dtors.md for an explanation of why this is weird.

--- a/src/types/ScreenInfoUiaProviderBase.cpp
+++ b/src/types/ScreenInfoUiaProviderBase.cpp
@@ -235,6 +235,10 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::GetSelection(_Outptr_result_maybenull_
     {
         return E_OUTOFMEMORY;
     }
+    else if (!_pData->IsUiaDataInitialized())
+    {
+        return E_FAIL;
+    }
 
     WRL::ComPtr<UiaTextRangeBase> range;
     if (!_pData->IsSelectionActive())
@@ -272,12 +276,16 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::GetSelection(_Outptr_result_maybenull_
 
 IFACEMETHODIMP ScreenInfoUiaProviderBase::GetVisibleRanges(_Outptr_result_maybenull_ SAFEARRAY** ppRetVal)
 {
+    RETURN_HR_IF_NULL(E_INVALIDARG, ppRetVal);
+    if (!_pData->IsUiaDataInitialized())
+    {
+        return E_FAIL;
+    }
+
     _LockConsole();
     auto Unlock = wil::scope_exit([&]() noexcept {
         _UnlockConsole();
     });
-
-    RETURN_HR_IF_NULL(E_INVALIDARG, ppRetVal);
 
     // make a safe array
     *ppRetVal = SafeArrayCreateVector(VT_UNKNOWN, 0, 1);

--- a/src/types/ScreenInfoUiaProviderBase.cpp
+++ b/src/types/ScreenInfoUiaProviderBase.cpp
@@ -220,25 +220,19 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::SetFocus()
 
 IFACEMETHODIMP ScreenInfoUiaProviderBase::GetSelection(_Outptr_result_maybenull_ SAFEARRAY** ppRetVal)
 {
+    RETURN_HR_IF_NULL(E_INVALIDARG, ppRetVal);
+    *ppRetVal = nullptr;
+
     _LockConsole();
     auto Unlock = wil::scope_exit([&]() noexcept {
         _UnlockConsole();
     });
-
-    RETURN_HR_IF_NULL(E_INVALIDARG, ppRetVal);
-    *ppRetVal = nullptr;
-    HRESULT hr = S_OK;
+    RETURN_HR_IF(E_FAIL, !_pData->IsUiaDataInitialized());
 
     // make a safe array
+    HRESULT hr = S_OK;
     *ppRetVal = SafeArrayCreateVector(VT_UNKNOWN, 0, 1);
-    if (*ppRetVal == nullptr)
-    {
-        return E_OUTOFMEMORY;
-    }
-    else if (!_pData->IsUiaDataInitialized())
-    {
-        return E_FAIL;
-    }
+    RETURN_HR_IF_NULL(E_OUTOFMEMORY, *ppRetVal);
 
     WRL::ComPtr<UiaTextRangeBase> range;
     if (!_pData->IsSelectionActive())
@@ -277,22 +271,17 @@ IFACEMETHODIMP ScreenInfoUiaProviderBase::GetSelection(_Outptr_result_maybenull_
 IFACEMETHODIMP ScreenInfoUiaProviderBase::GetVisibleRanges(_Outptr_result_maybenull_ SAFEARRAY** ppRetVal)
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppRetVal);
-    if (!_pData->IsUiaDataInitialized())
-    {
-        return E_FAIL;
-    }
+    *ppRetVal = nullptr;
 
     _LockConsole();
     auto Unlock = wil::scope_exit([&]() noexcept {
         _UnlockConsole();
     });
+    RETURN_HR_IF(E_FAIL, !_pData->IsUiaDataInitialized());
 
     // make a safe array
     *ppRetVal = SafeArrayCreateVector(VT_UNKNOWN, 0, 1);
-    if (*ppRetVal == nullptr)
-    {
-        return E_OUTOFMEMORY;
-    }
+    RETURN_HR_IF_NULL(E_OUTOFMEMORY, *ppRetVal);
 
     WRL::ComPtr<UiaTextRangeBase> range;
     const auto bufferSize = _pData->GetTextBuffer().GetSize();

--- a/src/types/TermControlUiaProvider.cpp
+++ b/src/types/TermControlUiaProvider.cpp
@@ -16,9 +16,6 @@ HRESULT TermControlUiaProvider::RuntimeClassInitialize(_In_ ::Microsoft::Console
     RETURN_IF_FAILED(ScreenInfoUiaProviderBase::RuntimeClassInitialize(uiaData));
 
     _controlInfo = controlInfo;
-
-    // TODO GitHub #1914: Re-attach Tracing to UIA Tree
-    //Tracing::s_TraceUia(nullptr, ApiCall::Constructor, nullptr);
     return S_OK;
 }
 
@@ -26,11 +23,6 @@ IFACEMETHODIMP TermControlUiaProvider::Navigate(_In_ NavigateDirection direction
                                                 _COM_Outptr_result_maybenull_ IRawElementProviderFragment** ppProvider) noexcept
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppProvider);
-
-    // TODO GitHub #1914: Re-attach Tracing to UIA Tree
-    /*ApiMsgNavigate apiMsg;
-    apiMsg.Direction = direction;
-    Tracing::s_TraceUia(this, ApiCall::Navigate, &apiMsg);*/
     *ppProvider = nullptr;
 
     if (direction == NavigateDirection_Parent)
@@ -121,6 +113,10 @@ HRESULT TermControlUiaProvider::GetSelectionRange(_In_ IRawElementProviderSimple
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
+    if (!_pData->IsUiaDataInitialized() || !_pData->IsSelectionActive())
+    {
+        return E_FAIL;
+    }
 
     const auto start = _pData->GetSelectionAnchor();
 

--- a/src/types/TermControlUiaProvider.cpp
+++ b/src/types/TermControlUiaProvider.cpp
@@ -113,10 +113,12 @@ HRESULT TermControlUiaProvider::GetSelectionRange(_In_ IRawElementProviderSimple
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, ppUtr);
     *ppUtr = nullptr;
-    if (!_pData->IsUiaDataInitialized() || !_pData->IsSelectionActive())
-    {
-        return E_FAIL;
-    }
+
+    _pData->LockConsole();
+    auto Unlock = wil::scope_exit([&]() noexcept {
+        _pData->UnlockConsole();
+    });
+    RETURN_HR_IF(E_FAIL, !_pData->IsUiaDataInitialized() || !_pData->IsSelectionActive());
 
     const auto start = _pData->GetSelectionAnchor();
 

--- a/src/types/TermControlUiaTextRange.cpp
+++ b/src/types/TermControlUiaTextRange.cpp
@@ -63,20 +63,6 @@ IFACEMETHODIMP TermControlUiaTextRange::Clone(_Outptr_result_maybenull_ ITextRan
         return hr;
     }
 
-#if defined(_DEBUG) && defined(UiaTextRangeBase_DEBUG_MSGS)
-    OutputDebugString(L"Clone\n");
-    std::wstringstream ss;
-    ss << _id << L" cloned to " << (static_cast<UiaTextRangeBase*>(*ppRetVal))->_id;
-    std::wstring str = ss.str();
-    OutputDebugString(str.c_str());
-    OutputDebugString(L"\n");
-#endif
-    // TODO GitHub #1914: Re-attach Tracing to UIA Tree
-    // tracing
-    /*ApiMsgClone apiMsg;
-    apiMsg.CloneId = static_cast<UiaTextRangeBase*>(*ppRetVal)->GetId();
-    Tracing::s_TraceUia(this, ApiCall::Clone, &apiMsg);*/
-
     return S_OK;
 }
 

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -223,6 +223,11 @@ try
     RETURN_HR_IF(E_INVALIDARG, pRetVal == nullptr);
     *pRetVal = 0;
 
+    if (!_pData->IsUiaDataInitialized())
+    {
+        return E_FAIL;
+    }
+
     // get the text range that we're comparing to
     const UiaTextRangeBase* range = static_cast<UiaTextRangeBase*>(pTargetRange);
     if (range == nullptr)
@@ -259,6 +264,11 @@ IFACEMETHODIMP UiaTextRangeBase::ExpandToEnclosingUnit(_In_ TextUnit unit) noexc
     auto Unlock = wil::scope_exit([&]() noexcept {
         _pData->UnlockConsole();
     });
+
+    if (!_pData->IsUiaDataInitialized())
+    {
+        return E_FAIL;
+    }
 
     try
     {
@@ -444,6 +454,11 @@ try
     RETURN_HR_IF(E_INVALIDARG, ppRetVal == nullptr);
     *ppRetVal = nullptr;
 
+    if (!_pData->IsUiaDataInitialized())
+    {
+        return E_FAIL;
+    }
+
     // AttributeIDs that require special handling
     switch (attributeId)
     {
@@ -605,6 +620,11 @@ try
     RETURN_HR_IF(E_INVALIDARG, ppRetVal == nullptr);
     *ppRetVal = nullptr;
 
+    if (!_pData->IsUiaDataInitialized())
+    {
+        return E_FAIL;
+    }
+
     const std::wstring queryText{ text, SysStringLen(text) };
     const auto bufferSize = _getOptimizedBufferSize();
     const auto sensitivity = ignoreCase ? Search::Sensitivity::CaseInsensitive : Search::Sensitivity::CaseSensitive;
@@ -730,6 +750,11 @@ try
     RETURN_HR_IF(E_INVALIDARG, pRetVal == nullptr);
     VariantInit(pRetVal);
 
+    if (!_pData->IsUiaDataInitialized())
+    {
+        return E_FAIL;
+    }
+
     // AttributeIDs that require special handling
     switch (attributeId)
     {
@@ -824,6 +849,11 @@ IFACEMETHODIMP UiaTextRangeBase::GetBoundingRectangles(_Outptr_result_maybenull_
 
     RETURN_HR_IF(E_INVALIDARG, ppRetVal == nullptr);
     *ppRetVal = nullptr;
+
+    if (!_pData->IsUiaDataInitialized())
+    {
+        return E_FAIL;
+    }
 
     try
     {
@@ -933,6 +963,11 @@ try
         return E_INVALIDARG;
     }
 
+    if (!_pData->IsUiaDataInitialized())
+    {
+        return E_FAIL;
+    }
+
     const auto maxLengthOpt = (maxLength == -1) ?
                                   std::nullopt :
                                   std::optional<unsigned int>{ maxLength };
@@ -1009,6 +1044,11 @@ try
     RETURN_HR_IF(E_INVALIDARG, pRetVal == nullptr);
     *pRetVal = 0;
 
+    if (!_pData->IsUiaDataInitialized())
+    {
+        return E_FAIL;
+    }
+
     _pData->LockConsole();
     auto Unlock = wil::scope_exit([&]() noexcept {
         _pData->UnlockConsole();
@@ -1075,7 +1115,11 @@ IFACEMETHODIMP UiaTextRangeBase::MoveEndpointByUnit(_In_ TextPatternRangeEndpoin
 {
     RETURN_HR_IF(E_INVALIDARG, pRetVal == nullptr);
     *pRetVal = 0;
-    if (count == 0)
+    if (!_pData->IsUiaDataInitialized())
+    {
+        return E_FAIL;
+    }
+    else if (count == 0)
     {
         return S_OK;
     }
@@ -1145,6 +1189,10 @@ try
     {
         return E_INVALIDARG;
     }
+    else if (!_pData->IsUiaDataInitialized())
+    {
+        return E_FAIL;
+    }
 
     // TODO GH#5406: create a different UIA parent object for each TextBuffer
     //   This is a temporary solution to comparing two UTRs from different TextBuffers
@@ -1167,6 +1215,11 @@ CATCH_RETURN();
 IFACEMETHODIMP UiaTextRangeBase::Select() noexcept
 try
 {
+    if (!_pData->IsUiaDataInitialized())
+    {
+        return E_FAIL;
+    }
+
     _pData->LockConsole();
     auto Unlock = wil::scope_exit([&]() noexcept {
         _pData->UnlockConsole();
@@ -1211,6 +1264,11 @@ IFACEMETHODIMP UiaTextRangeBase::RemoveFromSelection() noexcept
 IFACEMETHODIMP UiaTextRangeBase::ScrollIntoView(_In_ BOOL alignToTop) noexcept
 try
 {
+    if (!_pData->IsUiaDataInitialized())
+    {
+        return E_FAIL;
+    }
+
     _pData->LockConsole();
     auto Unlock = wil::scope_exit([&]() noexcept {
         _pData->UnlockConsole();


### PR DESCRIPTION
## Summary of the Pull Request
Adds a check before every UIA function call to ensure the terminal (specifically the buffer) is initialized before doing work. Both the `ScreenInfoUiaProvider` and the `UiaTextRange` are now covered.

## References
Closes #11135 
#10971 & #11042

## Detailed Description of the Pull Request / Additional comments
Originally, I tried applying this heuristic to all the `RuntimeClassInitialize` on `UiaTextRangeBase` with the philosophy of "a range pointing to an invalid buffer is invalid itself", but that caused a regression on [MSFT 33353327](https://microsoft.visualstudio.com/OS/_workitems/edit/33353327).

`IUiaData` also has `GetTextBuffer()` return a `TextBuffer&`, which cannot be checked for nullness. Instead, I decided to add a function to `IUiaData` that checks if we have a valid state. Since this is shared with Conhost and Conhost doesn't have this issue, I simply make that function say that it's always in a valid state.

## Validation Steps Performed
- [X] Narrator can detect newly created terminals
- [X] (On Windows Server 2022) Windows Terminal does not hang on launch