### PR TITLE
Fix fragments that update other profiles

### DIFF
--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -553,9 +553,11 @@ Model::Profile CascadiaSettings::GetProfileForArgs(const Model::NewTerminalArgs&
                    FindProfile(GlobalSettings().DefaultProfile()) :
                    ProfileDefaults();
     }
-
-    // For compatibility with the stable version's behavior, return the default by GUID in all other cases.
-    return FindProfile(GlobalSettings().DefaultProfile());
+    else
+    {
+        // For compatibility with the stable version's behavior, return the default by GUID in all other cases.
+        return FindProfile(GlobalSettings().DefaultProfile());
+    }
 }
 
 // Method Description:

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -67,9 +67,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static void _rethrowSerializationExceptionWithLocationInfo(const JsonUtils::DeserializationError& e, const std::string_view& settingsString);
         static Json::Value _parseJSON(const std::string_view& content);
         static const Json::Value& _getJSONValue(const Json::Value& json, const std::string_view& key) noexcept;
-        static bool _isValidProfileObject(const Json::Value& profileJson);
         gsl::span<const winrt::com_ptr<implementation::Profile>> _getNonUserOriginProfiles() const;
-        void _parse(const OriginTag origin, const winrt::hstring& source, const std::string_view& content, ParsedSettings& settings);
+        void _parse(const OriginTag origin, const winrt::hstring& source, const std::string_view& content, ParsedSettings& settings, bool updatesKeyAllowed = false);
         void _appendProfile(winrt::com_ptr<implementation::Profile>&& profile, ParsedSettings& settings);
         static void _addParentProfile(const winrt::com_ptr<implementation::Profile>& profile, ParsedSettings& settings);
         void _executeGenerator(const IDynamicProfileGenerator& generator);


### PR DESCRIPTION
`SettingsLoader::_parse` used to skip profiles which didn't have either a "guid"
or "name" field, due to #9962. This is however wrong for fragment loading, as
fragments can alternatively use an "updates" field instead of guid/name.

`SettingsLoader::_parse` was updated to allow profiles with this alternative
field during fragment loading.

## PR Checklist
* [x] Closes #11331
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed

* Wrote the following to
  `%LOCALAPPDATA%\Microsoft\Windows Terminal\Fragments\test\test.json`:
  ```json
  {
    "profiles": [
      {
        "updates": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
        "background": "#FFD700"
      }
    ]
  }
  ```