### PR TITLE
Replace `null` with `"null"` for types in the schema

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -110,7 +110,7 @@
           "description": "Sets the file location of the image to draw over the window background when unfocused.",
           "oneOf": [
             {
-              "type": ["string", null]
+              "type": ["string", "null"]
             },
             {
               "enum": [
@@ -529,13 +529,13 @@
               "type": "integer",
               "default": 0,
               "description": "Which tab to switch to, with the first being 0"
+            }
           }
         }
-      }
-    ],
-    "required": [ "index" ]
-  },
-  "MovePaneAction": {
+      ],
+      "required": [ "index" ]
+    },
+    "MovePaneAction": {
       "description": "Arguments corresponding to a Move Pane Action",
       "allOf": [
         { "$ref": "#/definitions/ShortcutAction" },
@@ -1442,7 +1442,7 @@
           "description": "Sets the file location of the image to draw over the window background.",
           "oneOf": [
             {
-              "type": ["string", null]
+              "type": ["string", "null"]
             },
             {
               "enum": [


### PR DESCRIPTION
* fixes #11349
* Fix these two nulls
* While I'm here, fix the indenting around `SwitchToTabAction` that would prevent nice code folding