### PR TITLE
Minor typos in 1.12 features in SUI

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -496,7 +496,7 @@
     <comment>A description for what the "acrylic opacity" setting does. Presented near "Profile_AcrylicOpacity.Header".</comment>
   </data>
   <data name="Profile_Opacity.Header" xml:space="preserve">
-    <value>Background Opacity</value>
+    <value>Background opacity</value>
     <comment>Header for a control to determine the level of opacity for the background of the control. The user can choose to make the background of the app more or less opaque.</comment>
   </data>
   <data name="Profile_Opacity.HelpText" xml:space="preserve">
@@ -1227,7 +1227,7 @@
     <comment>Header for a control to how text is formatted</comment>
   </data>
   <data name="Appearance_IntenseTextStyle.Header" xml:space="preserve">
-    <value>Intense Text Style</value>
+    <value>Intense text style</value>
     <comment>Header for a control to select how "intense" text is formatted (bold, bright, both or none)</comment>
   </data>
   <data name="Appearance_IntenseTextStyleNone.Content" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsModel/JsonUtils.h
+++ b/src/cascadia/TerminalSettingsModel/JsonUtils.h
@@ -101,7 +101,7 @@ namespace Microsoft::Terminal::Settings::Model::JsonUtils
     {
     public:
         DeserializationError(const Json::Value& value) :
-            runtime_error(std::string("failed to deserialize ") + (value.isNull() ? "" : value.asCString())),
+            runtime_error(std::string("failed to deserialize ") + (value.isNull() ? "" : value.asString())),
             jsonValue{ value } {}
 
         void SetKey(std::string_view newKey)

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -433,7 +433,7 @@
     <value>Break into the debugger</value>
   </data>
   <data name="OpenSettingsUICommandKey" xml:space="preserve">
-    <value>Open Settings...</value>
+    <value>Open settings...</value>
   </data>
   <data name="RenameWindowCommandKey" xml:space="preserve">
     <value>Rename window to "{0}"</value>
@@ -456,15 +456,15 @@
     <comment>{0} will be replaced with a user-specified number</comment>
   </data>
   <data name="ClearAllCommandKey" xml:space="preserve">
-    <value>Clear Buffer</value>
+    <value>Clear buffer</value>
     <comment>A command to clear the entirety of the Terminal output buffer</comment>
   </data>
   <data name="ClearViewportCommandKey" xml:space="preserve">
-    <value>Clear Viewport</value>
+    <value>Clear viewport</value>
     <comment>A command to clear the active viewport of the Terminal</comment>
   </data>
   <data name="ClearScrollbackCommandKey" xml:space="preserve">
-    <value>Clear Scrollback</value>
+    <value>Clear scrollback</value>
     <comment>A command to clear the part of the buffer above the viewport</comment>
   </data>
   <data name="InboxWindowsConsoleAuthor" xml:space="preserve">


### PR DESCRIPTION
* [x] Fixes a bunch of the checkboxes in #11352
* [x] Fixes one of the boxes in #11353
* [x] The opacity warning -> error gibberish was fixed with the change to `DeserializationError` - `asCString` only works if the `JsonValue` is a string already.