### PR TITLE
Remove the fallback to 50% opacity when only `useAcrylic` is set

### DIFF
--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
@@ -202,15 +202,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         _IntenseIsBold = WI_IsFlagSet(appearance.IntenseTextStyle(), Microsoft::Terminal::Settings::Model::IntenseStyle::Bold);
         _IntenseIsBright = WI_IsFlagSet(appearance.IntenseTextStyle(), Microsoft::Terminal::Settings::Model::IntenseStyle::Bright);
 
-        // If the user set an opacity, then just use that. Otherwise, change the
-        // default value based off of whether useAcrylic was set or not. If they
-        // want acrylic, then default to 50%. Otherwise, default to 100% (fully
-        // opaque)
-        _Opacity = appearance.HasOpacity() ?
-                       appearance.Opacity() :
-                       UseAcrylic() ?
-                       .5 :
-                       1.0;
+        _Opacity = appearance.Opacity();
     }
 
     // Method Description:


### PR DESCRIPTION
This logic was seemingly redundant. There's two cases I'm looking at here:

#### Case 1
```jsonc
    "defaults":
    {
        "opacity": 35
    },
    "list":
    [
        {
            "commandline": "cmd.exe",
            "name": "Command Prompt"
        },
```

In this case, we wouldn't set the `TerminalSettings` Opacity to .35, we'd set it to 1.0, because the profile didn't have an `opactity`.

#### Case 2
```jsonc
    "defaults":
    {
        "useAcrylic": true
    },
    "list":
    [
        {
            "commandline": "cmd.exe",
            "name": "Command Prompt"
        },
```

In this case we still want to have an acrylic effect. Previously, we'd default this effect to 50% opaque. I'm not sure that we can actually get that anymore. BUT it turns out, we _can_ have 100% opacity and HostBackdropAcrylic. It is very subtle, but is maybe something we should be allowing anyways. It kinda looks like:
![image](https://user-images.githubusercontent.com/18356694/135168469-35d1f55b-58d1-4ee3-a717-76000c2574b9.png)



* [x] Fixes #11355
* [x] Regressed in #11180 
* [x] I work here