### PR TITLE
Add automation names to some controls that were missing them

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -72,13 +72,15 @@
                         two font lists causes a crash within the ComboBox code.
                         As a workaround, introduce two ComboBox controls and only display one at a time.
                     -->
-                    <ComboBox x:Uid="Profile_FontFaceBox" ItemTemplate="{StaticResource FontFaceComboBoxItemTemplate}"
+                    <ComboBox x:Uid="Profile_FontFaceBox"
+                              ItemTemplate="{StaticResource FontFaceComboBoxItemTemplate}"
                               ItemsSource="{x:Bind SourceProfile.MonospaceFontList, Mode=OneWay}"
                               SelectedItem="{x:Bind CurrentFontFace, Mode=OneWay}"
                               SelectionChanged="FontFace_SelectionChanged"
                               Style="{StaticResource ComboBoxSettingStyle}"
                               Visibility="{x:Bind local:Converters.InvertedBooleanToVisibility(ShowAllFonts), Mode=OneWay}" />
-                    <ComboBox x:Uid="Profile_FontFaceBox" ItemTemplate="{StaticResource FontFaceComboBoxItemTemplate}"
+                    <ComboBox x:Uid="Profile_FontFaceBox"
+                              ItemTemplate="{StaticResource FontFaceComboBoxItemTemplate}"
                               ItemsSource="{x:Bind SourceProfile.CompleteFontList, Mode=OneWay}"
                               SelectedItem="{x:Bind CurrentFontFace, Mode=OneWay}"
                               SelectionChanged="FontFace_SelectionChanged"
@@ -97,7 +99,8 @@
                                     HasSettingValue="{x:Bind Appearance.HasFontSize, Mode=OneWay}"
                                     SettingOverrideSource="{x:Bind Appearance.FontSizeOverrideSource, Mode=OneWay}"
                                     Visibility="{x:Bind Appearance.IsDefault, Mode=OneWay}">
-                <muxc:NumberBox x:Uid="Profile_FontSizeBox" AcceptsExpression="False"
+                <muxc:NumberBox x:Uid="Profile_FontSizeBox"
+                                AcceptsExpression="False"
                                 LargeChange="10"
                                 Maximum="128"
                                 Minimum="1"

--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -72,13 +72,13 @@
                         two font lists causes a crash within the ComboBox code.
                         As a workaround, introduce two ComboBox controls and only display one at a time.
                     -->
-                    <ComboBox ItemTemplate="{StaticResource FontFaceComboBoxItemTemplate}"
+                    <ComboBox x:Uid="Profile_FontFaceBox" ItemTemplate="{StaticResource FontFaceComboBoxItemTemplate}"
                               ItemsSource="{x:Bind SourceProfile.MonospaceFontList, Mode=OneWay}"
                               SelectedItem="{x:Bind CurrentFontFace, Mode=OneWay}"
                               SelectionChanged="FontFace_SelectionChanged"
                               Style="{StaticResource ComboBoxSettingStyle}"
                               Visibility="{x:Bind local:Converters.InvertedBooleanToVisibility(ShowAllFonts), Mode=OneWay}" />
-                    <ComboBox ItemTemplate="{StaticResource FontFaceComboBoxItemTemplate}"
+                    <ComboBox x:Uid="Profile_FontFaceBox" ItemTemplate="{StaticResource FontFaceComboBoxItemTemplate}"
                               ItemsSource="{x:Bind SourceProfile.CompleteFontList, Mode=OneWay}"
                               SelectedItem="{x:Bind CurrentFontFace, Mode=OneWay}"
                               SelectionChanged="FontFace_SelectionChanged"
@@ -97,7 +97,7 @@
                                     HasSettingValue="{x:Bind Appearance.HasFontSize, Mode=OneWay}"
                                     SettingOverrideSource="{x:Bind Appearance.FontSizeOverrideSource, Mode=OneWay}"
                                     Visibility="{x:Bind Appearance.IsDefault, Mode=OneWay}">
-                <muxc:NumberBox AcceptsExpression="False"
+                <muxc:NumberBox x:Uid="Profile_FontSizeBox" AcceptsExpression="False"
                                 LargeChange="10"
                                 Maximum="128"
                                 Minimum="1"

--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -166,12 +166,14 @@
                 <!--  Columns  -->
                 <local:SettingContainer x:Uid="Globals_InitialCols"
                                         Margin="0">
-                    <muxc:NumberBox Style="{StaticResource LaunchSizeNumberBoxStyle}"
+                    <muxc:NumberBox x:Uid="Globals_InitialColsBox"
+                                    Style="{StaticResource LaunchSizeNumberBoxStyle}"
                                     Value="{x:Bind State.Settings.GlobalSettings.InitialCols, Mode=TwoWay}" />
                 </local:SettingContainer>
                 <!--  Rows  -->
                 <local:SettingContainer x:Uid="Globals_InitialRows">
-                    <muxc:NumberBox Style="{StaticResource LaunchSizeNumberBoxStyle}"
+                    <muxc:NumberBox x:Uid="Globals_InitialRowsBox"
+                                    Style="{StaticResource LaunchSizeNumberBoxStyle}"
                                     Value="{x:Bind State.Settings.GlobalSettings.InitialRows, Mode=TwoWay}" />
                 </local:SettingContainer>
             </StackPanel>

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -81,9 +81,8 @@
                                                 SettingOverrideSource="{x:Bind State.Profile.CommandlineOverrideSource, Mode=OneWay}"
                                                 Visibility="{x:Bind local:Converters.InvertedBooleanToVisibility(State.Profile.IsBaseLayer), Mode=OneWay}">
                             <StackPanel Orientation="Horizontal">
-                                <TextBox
-                                            x:Uid="Profile_CommandlineBox"
-                                           IsSpellCheckEnabled="False"
+                                <TextBox x:Uid="Profile_CommandlineBox"
+                                         IsSpellCheckEnabled="False"
                                          Style="{StaticResource TextBoxSettingStyle}"
                                          Text="{x:Bind State.Profile.Commandline, Mode=TwoWay}" />
                                 <Button x:Uid="Profile_CommandlineBrowse"
@@ -101,9 +100,8 @@
                                                 SettingOverrideSource="{x:Bind State.Profile.StartingDirectoryOverrideSource, Mode=OneWay}">
                             <StackPanel Orientation="Vertical">
                                 <StackPanel Orientation="Horizontal">
-                                    <TextBox
-                                            x:Uid="Profile_StartingDirectoryBox"
-                                            IsEnabled="{x:Bind State.Profile.UseCustomStartingDirectory, Mode=OneWay}"
+                                    <TextBox x:Uid="Profile_StartingDirectoryBox"
+                                             IsEnabled="{x:Bind State.Profile.UseCustomStartingDirectory, Mode=OneWay}"
                                              IsSpellCheckEnabled="False"
                                              Style="{StaticResource TextBoxSettingStyle}"
                                              Text="{x:Bind State.Profile.StartingDirectory, Mode=TwoWay}" />
@@ -125,9 +123,8 @@
                                                 HasSettingValue="{x:Bind State.Profile.HasIcon, Mode=OneWay}"
                                                 SettingOverrideSource="{x:Bind State.Profile.IconOverrideSource, Mode=OneWay}">
                             <StackPanel Orientation="Horizontal">
-                                <TextBox
-                                            x:Uid="Profile_IconBox"
-                                            FontFamily="Segoe UI, Segoe MDL2 Assets"
+                                <TextBox x:Uid="Profile_IconBox"
+                                         FontFamily="Segoe UI, Segoe MDL2 Assets"
                                          IsSpellCheckEnabled="False"
                                          Style="{StaticResource TextBoxSettingStyle}"
                                          Text="{x:Bind State.Profile.Icon, Mode=TwoWay}" />
@@ -444,10 +441,10 @@
                                                 ClearSettingValue="{x:Bind State.Profile.ClearHistorySize}"
                                                 HasSettingValue="{x:Bind State.Profile.HasHistorySize, Mode=OneWay}"
                                                 SettingOverrideSource="{x:Bind State.Profile.HistorySizeOverrideSource, Mode=OneWay}">
-                            <muxc:NumberBox LargeChange="100"
+                            <muxc:NumberBox x:Uid="Profile_HistorySizeBox"
+                                            LargeChange="100"
                                             Minimum="0"
                                             SmallChange="10"
-                                             x:Uid="Profile_HistorySizeBox"
                                             Style="{StaticResource NumberBoxSettingStyle}"
                                             Value="{x:Bind State.Profile.HistorySize, Mode=TwoWay}" />
                         </local:SettingContainer>

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -81,7 +81,9 @@
                                                 SettingOverrideSource="{x:Bind State.Profile.CommandlineOverrideSource, Mode=OneWay}"
                                                 Visibility="{x:Bind local:Converters.InvertedBooleanToVisibility(State.Profile.IsBaseLayer), Mode=OneWay}">
                             <StackPanel Orientation="Horizontal">
-                                <TextBox IsSpellCheckEnabled="False"
+                                <TextBox
+                                            x:Uid="Profile_CommandlineBox"
+                                           IsSpellCheckEnabled="False"
                                          Style="{StaticResource TextBoxSettingStyle}"
                                          Text="{x:Bind State.Profile.Commandline, Mode=TwoWay}" />
                                 <Button x:Uid="Profile_CommandlineBrowse"
@@ -99,7 +101,9 @@
                                                 SettingOverrideSource="{x:Bind State.Profile.StartingDirectoryOverrideSource, Mode=OneWay}">
                             <StackPanel Orientation="Vertical">
                                 <StackPanel Orientation="Horizontal">
-                                    <TextBox IsEnabled="{x:Bind State.Profile.UseCustomStartingDirectory, Mode=OneWay}"
+                                    <TextBox
+                                            x:Uid="Profile_StartingDirectoryBox"
+                                            IsEnabled="{x:Bind State.Profile.UseCustomStartingDirectory, Mode=OneWay}"
                                              IsSpellCheckEnabled="False"
                                              Style="{StaticResource TextBoxSettingStyle}"
                                              Text="{x:Bind State.Profile.StartingDirectory, Mode=TwoWay}" />
@@ -121,7 +125,9 @@
                                                 HasSettingValue="{x:Bind State.Profile.HasIcon, Mode=OneWay}"
                                                 SettingOverrideSource="{x:Bind State.Profile.IconOverrideSource, Mode=OneWay}">
                             <StackPanel Orientation="Horizontal">
-                                <TextBox FontFamily="Segoe UI, Segoe MDL2 Assets"
+                                <TextBox
+                                            x:Uid="Profile_IconBox"
+                                            FontFamily="Segoe UI, Segoe MDL2 Assets"
                                          IsSpellCheckEnabled="False"
                                          Style="{StaticResource TextBoxSettingStyle}"
                                          Text="{x:Bind State.Profile.Icon, Mode=TwoWay}" />
@@ -441,6 +447,7 @@
                             <muxc:NumberBox LargeChange="100"
                                             Minimum="0"
                                             SmallChange="10"
+                                             x:Uid="Profile_HistorySizeBox"
                                             Style="{StaticResource NumberBoxSettingStyle}"
                                             Value="{x:Bind State.Profile.HistorySize, Mode=TwoWay}" />
                         </local:SettingContainer>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -291,6 +291,14 @@
     <value>The number of rows displayed in the window upon first load. Measured in characters.</value>
     <comment>A description for what the "rows" setting does. Presented near "Globals_InitialRows.Header".</comment>
   </data>
+  <data name="Globals_InitialColsBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Initial Columns</value>
+    <comment>Name for a control to choose the number of columns in the terminal's text grid.</comment>
+  </data>
+  <data name="Globals_InitialRowsBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Initial Rows</value>
+    <comment>Name for a control to choose the number of rows in the terminal's text grid.</comment>
+  </data>
   <data name="Globals_FirstWindowPreference.Header" xml:space="preserve">
     <value>When Terminal starts</value>
     <comment>Header for a control to select how the terminal should load its first window.</comment>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -663,6 +663,10 @@
     <value>Command line</value>
     <comment>Header for a control to determine commandline executable (i.e. a .exe file) to run when a terminal session of this profile is launched.</comment>
   </data>
+  <data name="Profile_CommandlineBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Command line</value>
+    <comment>Name for a control to determine commandline executable (i.e. a .exe file) to run when a terminal session of this profile is launched.</comment>
+  </data>
   <data name="Profile_Commandline.HelpText" xml:space="preserve">
     <value>Executable used in the profile.</value>
     <comment>A description for what the "command line" setting does. Presented near "Profile_Commandline".</comment>
@@ -711,6 +715,10 @@
     <value>Font face</value>
     <comment>Header for a control to select the font for text in the app.</comment>
   </data>
+  <data name="Profile_FontFaceBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Font face</value>
+    <comment>Name for a control to select the font for text in the app.</comment>
+  </data>
   <data name="Profile_FontFace.HelpText" xml:space="preserve">
     <value>Name of the font face used in the profile.</value>
     <comment>A description for what the "font face" setting does. Presented near "Profile_FontFace".</comment>
@@ -718,6 +726,10 @@
   <data name="Profile_FontSize.Header" xml:space="preserve">
     <value>Font size</value>
     <comment>Header for a control to determine the size of the text in the app.</comment>
+  </data>
+  <data name="Profile_FontSizeBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Font size</value>
+    <comment>Name for a control to determine the size of the text in the app.</comment>
   </data>
   <data name="Profile_FontSize.HelpText" xml:space="preserve">
     <value>Size of the font in points.</value>
@@ -747,6 +759,10 @@
     <value>History size</value>
     <comment>Header for a control to determine how many lines of text can be saved in a session. In terminals, the "history" is the output generated within your session.</comment>
   </data>
+  <data name="Profile_HistorySizeBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>History size</value>
+    <comment>Name for a control to determine how many lines of text can be saved in a session. In terminals, the "history" is the output generated within your session.</comment>
+  </data>
   <data name="Profile_HistorySize.HelpText" xml:space="preserve">
     <value>The number of lines above the ones displayed in the window you can scroll back to.</value>
     <comment>A description for what the "history size" setting does. Presented near "Profile_HistorySize".</comment>
@@ -754,6 +770,10 @@
   <data name="Profile_Icon.Header" xml:space="preserve">
     <value>Icon</value>
     <comment>Header for a control to determine what icon can be used to represent this profile. This is not necessarily a file path, but can be one.</comment>
+  </data>
+  <data name="Profile_IconBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Icon</value>
+    <comment>Name for a control to determine what icon can be used to represent this profile. This is not necessarily a file path, but can be one.</comment>
   </data>
   <data name="Profile_Icon.HelpText" xml:space="preserve">
     <value>Emoji or image file location of the icon used in the profile.</value>
@@ -798,6 +818,10 @@
   <data name="Profile_StartingDirectory.Header" xml:space="preserve">
     <value>Starting directory</value>
     <comment>Header for a control to determine the directory the session opens it at launch. This is on a text box that accepts folder paths.</comment>
+  </data>
+  <data name="Profile_StartingDirectoryBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Starting directory</value>
+    <comment>Name for a control to determine the directory the session opens it at launch. This is on a text box that accepts folder paths.</comment>
   </data>
   <data name="Profile_StartingDirectory.HelpText" xml:space="preserve">
     <value>The directory the profile starts in when it is loaded.</value>


### PR DESCRIPTION
All these controls didn't have `Name`s assigned, and Accessibility Insights doesn't like that. Their parents did, but the actual focusable elements themselves didn't. So I've just taken the nearby headers for these things and slapped them in as the Automation names for these controls.

I verified that each of these automated tests in Accessibility Insights pass again. 

* Will do the thing to #11155 but we need confirmation before that can be closed.