### PR TITLE
Always init the BG opacity with the renderer

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -274,10 +274,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             _updateAntiAliasingMode(_renderEngine.get());
 
             // GH#5098: Inform the engine of the opacity of the default text background.
-            if (_settings.UseAcrylic())
-            {
-                _renderEngine->SetDefaultTextBackgroundOpacity(::base::saturated_cast<float>(_settings.Opacity()));
-            }
+            // GH#11315: Always do this, even if they don't have acrylic on.
+            _renderEngine->SetDefaultTextBackgroundOpacity(::base::saturated_cast<float>(_settings.Opacity()));
 
             THROW_IF_FAILED(_renderEngine->Enable());
 

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -459,7 +459,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             }
 
             // GH#5098: Inform the engine of the new opacity of the default text background.
-            _core.SetBackgroundOpacity(::base::saturated_cast<float>(appearance.Opacity()));
+            _core.SetBackgroundOpacity(appearance.Opacity());
         }
         else
         {


### PR DESCRIPTION
Missed this in #11180. I forgot to init the BG opacity with the renderer on startup, because that matters when you have `"antialiasingMode": "cleartype",`.

Repro json
```json
{
    "commandline": "cmd.exe",
    "guid": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
    "hidden": false,
    "opacity": 35,
    "antialiasingMode": "cleartype",
    "padding": "0",
    "name": "Command Prompt"
},
```

* [x] Fixes #11315
