### PR TITLE
Try to persist the Pane's working directory if we know what it is.

### DIFF
--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -128,7 +128,15 @@ NewTerminalArgs Pane::GetTerminalArgsForPane() const
     auto controlSettings = _control.Settings().as<TerminalSettings>();
 
     args.Profile(controlSettings.ProfileName());
-    args.StartingDirectory(controlSettings.StartingDirectory());
+    // If we know the user's working directory use it instead of the profile.
+    if (!_control.WorkingDirectory().empty())
+    {
+        args.StartingDirectory(_control.WorkingDirectory());
+    }
+    else
+    {
+        args.StartingDirectory(controlSettings.StartingDirectory());
+    }
     args.TabTitle(controlSettings.StartingTitle());
     args.Commandline(controlSettings.Commandline());
     args.SuppressApplicationTitle(controlSettings.SuppressApplicationTitle());

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -129,9 +129,9 @@ NewTerminalArgs Pane::GetTerminalArgsForPane() const
 
     args.Profile(controlSettings.ProfileName());
     // If we know the user's working directory use it instead of the profile.
-    if (!_control.WorkingDirectory().empty())
+    if (const auto dir = _control.WorkingDirectory(); !dir.empty())
     {
-        args.StartingDirectory(_control.WorkingDirectory());
+        args.StartingDirectory(dir);
     }
     else
     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Try to save the working directory if we know what it is (just copied what was done in duplicating a pane). I overlooked this in my original implementation that always used the settings StartingDirectory.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
#9800 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tried setting the working directory using the OSC 9;9 escape and confirmed that the directory saves correctly.
