### PR TITLE
Consolidate the interfaces for setting VT input modes

### DIFF
--- a/src/cascadia/TerminalCore/ITerminalApi.hpp
+++ b/src/cascadia/TerminalCore/ITerminalApi.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "../../terminal/adapter/DispatchTypes.hpp"
+#include "../../terminal/input/terminalInput.hpp"
 #include "../../buffer/out/TextAttribute.hpp"
 #include "../../types/inc/Viewport.hpp"
 
@@ -47,16 +48,9 @@ namespace Microsoft::Terminal::Core
         virtual bool SetDefaultForeground(const DWORD color) noexcept = 0;
         virtual bool SetDefaultBackground(const DWORD color) noexcept = 0;
 
-        virtual bool EnableWin32InputMode(const bool win32InputMode) noexcept = 0;
-        virtual bool SetCursorKeysMode(const bool applicationMode) noexcept = 0;
-        virtual bool SetKeypadMode(const bool applicationMode) noexcept = 0;
+        virtual bool SetInputMode(const ::Microsoft::Console::VirtualTerminal::TerminalInput::Mode mode, const bool enabled) noexcept = 0;
+
         virtual bool SetScreenMode(const bool reverseMode) noexcept = 0;
-        virtual bool EnableVT200MouseMode(const bool enabled) noexcept = 0;
-        virtual bool EnableUTF8ExtendedMouseMode(const bool enabled) noexcept = 0;
-        virtual bool EnableSGRExtendedMouseMode(const bool enabled) noexcept = 0;
-        virtual bool EnableButtonEventMouseMode(const bool enabled) noexcept = 0;
-        virtual bool EnableAnyEventMouseMode(const bool enabled) noexcept = 0;
-        virtual bool EnableAlternateScrollMode(const bool enabled) noexcept = 0;
         virtual bool EnableXtermBracketedPasteMode(const bool enabled) noexcept = 0;
         virtual bool IsXtermBracketedPasteModeEnabled() const = 0;
 

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -112,16 +112,9 @@ public:
     bool SetDefaultForeground(const COLORREF color) noexcept override;
     bool SetDefaultBackground(const COLORREF color) noexcept override;
 
-    bool EnableWin32InputMode(const bool win32InputMode) noexcept override;
-    bool SetCursorKeysMode(const bool applicationMode) noexcept override;
-    bool SetKeypadMode(const bool applicationMode) noexcept override;
+    bool SetInputMode(const ::Microsoft::Console::VirtualTerminal::TerminalInput::Mode mode, const bool enabled) noexcept override;
+
     bool SetScreenMode(const bool reverseMode) noexcept override;
-    bool EnableVT200MouseMode(const bool enabled) noexcept override;
-    bool EnableUTF8ExtendedMouseMode(const bool enabled) noexcept override;
-    bool EnableSGRExtendedMouseMode(const bool enabled) noexcept override;
-    bool EnableButtonEventMouseMode(const bool enabled) noexcept override;
-    bool EnableAnyEventMouseMode(const bool enabled) noexcept override;
-    bool EnableAlternateScrollMode(const bool enabled) noexcept override;
     bool EnableXtermBracketedPasteMode(const bool enabled) noexcept override;
     bool IsXtermBracketedPasteModeEnabled() const noexcept override;
 

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -482,23 +482,13 @@ til::color Terminal::GetDefaultBackground() const noexcept
     return _defaultBg;
 }
 
-bool Terminal::EnableWin32InputMode(const bool win32InputMode) noexcept
+bool Terminal::SetInputMode(const TerminalInput::Mode mode, const bool enabled) noexcept
+try
 {
-    _terminalInput->SetInputMode(TerminalInput::Mode::Win32, win32InputMode);
+    _terminalInput->SetInputMode(mode, enabled);
     return true;
 }
-
-bool Terminal::SetCursorKeysMode(const bool applicationMode) noexcept
-{
-    _terminalInput->SetInputMode(TerminalInput::Mode::CursorKey, applicationMode);
-    return true;
-}
-
-bool Terminal::SetKeypadMode(const bool applicationMode) noexcept
-{
-    _terminalInput->SetInputMode(TerminalInput::Mode::Keypad, applicationMode);
-    return true;
-}
+CATCH_RETURN_FALSE()
 
 bool Terminal::SetScreenMode(const bool reverseMode) noexcept
 try
@@ -510,42 +500,6 @@ try
     return true;
 }
 CATCH_RETURN_FALSE()
-
-bool Terminal::EnableVT200MouseMode(const bool enabled) noexcept
-{
-    _terminalInput->SetInputMode(TerminalInput::Mode::DefaultMouseTracking, enabled);
-    return true;
-}
-
-bool Terminal::EnableUTF8ExtendedMouseMode(const bool enabled) noexcept
-{
-    _terminalInput->SetInputMode(TerminalInput::Mode::Utf8MouseEncoding, enabled);
-    return true;
-}
-
-bool Terminal::EnableSGRExtendedMouseMode(const bool enabled) noexcept
-{
-    _terminalInput->SetInputMode(TerminalInput::Mode::SgrMouseEncoding, enabled);
-    return true;
-}
-
-bool Terminal::EnableButtonEventMouseMode(const bool enabled) noexcept
-{
-    _terminalInput->SetInputMode(TerminalInput::Mode::ButtonEventMouseTracking, enabled);
-    return true;
-}
-
-bool Terminal::EnableAnyEventMouseMode(const bool enabled) noexcept
-{
-    _terminalInput->SetInputMode(TerminalInput::Mode::AnyEventMouseTracking, enabled);
-    return true;
-}
-
-bool Terminal::EnableAlternateScrollMode(const bool enabled) noexcept
-{
-    _terminalInput->SetInputMode(TerminalInput::Mode::AlternateScroll, enabled);
-    return true;
-}
 
 bool Terminal::EnableXtermBracketedPasteMode(const bool enabled) noexcept
 {

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -484,19 +484,19 @@ til::color Terminal::GetDefaultBackground() const noexcept
 
 bool Terminal::EnableWin32InputMode(const bool win32InputMode) noexcept
 {
-    _terminalInput->ChangeWin32InputMode(win32InputMode);
+    _terminalInput->SetInputMode(TerminalInput::Mode::Win32, win32InputMode);
     return true;
 }
 
 bool Terminal::SetCursorKeysMode(const bool applicationMode) noexcept
 {
-    _terminalInput->ChangeCursorKeysMode(applicationMode);
+    _terminalInput->SetInputMode(TerminalInput::Mode::CursorKey, applicationMode);
     return true;
 }
 
 bool Terminal::SetKeypadMode(const bool applicationMode) noexcept
 {
-    _terminalInput->ChangeKeypadMode(applicationMode);
+    _terminalInput->SetInputMode(TerminalInput::Mode::Keypad, applicationMode);
     return true;
 }
 

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -543,7 +543,7 @@ bool Terminal::EnableAnyEventMouseMode(const bool enabled) noexcept
 
 bool Terminal::EnableAlternateScrollMode(const bool enabled) noexcept
 {
-    _terminalInput->EnableAlternateScroll(enabled);
+    _terminalInput->SetInputMode(TerminalInput::Mode::AlternateScroll, enabled);
     return true;
 }
 

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -519,13 +519,13 @@ bool Terminal::EnableVT200MouseMode(const bool enabled) noexcept
 
 bool Terminal::EnableUTF8ExtendedMouseMode(const bool enabled) noexcept
 {
-    _terminalInput->SetUtf8ExtendedMode(enabled);
+    _terminalInput->SetInputMode(TerminalInput::Mode::Utf8MouseEncoding, enabled);
     return true;
 }
 
 bool Terminal::EnableSGRExtendedMouseMode(const bool enabled) noexcept
 {
-    _terminalInput->SetSGRExtendedMode(enabled);
+    _terminalInput->SetInputMode(TerminalInput::Mode::SgrMouseEncoding, enabled);
     return true;
 }
 

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -513,7 +513,7 @@ CATCH_RETURN_FALSE()
 
 bool Terminal::EnableVT200MouseMode(const bool enabled) noexcept
 {
-    _terminalInput->EnableDefaultTracking(enabled);
+    _terminalInput->SetInputMode(TerminalInput::Mode::DefaultMouseTracking, enabled);
     return true;
 }
 
@@ -531,13 +531,13 @@ bool Terminal::EnableSGRExtendedMouseMode(const bool enabled) noexcept
 
 bool Terminal::EnableButtonEventMouseMode(const bool enabled) noexcept
 {
-    _terminalInput->EnableButtonEventTracking(enabled);
+    _terminalInput->SetInputMode(TerminalInput::Mode::ButtonEventMouseTracking, enabled);
     return true;
 }
 
 bool Terminal::EnableAnyEventMouseMode(const bool enabled) noexcept
 {
-    _terminalInput->EnableAnyEventTracking(enabled);
+    _terminalInput->SetInputMode(TerminalInput::Mode::AnyEventMouseTracking, enabled);
     return true;
 }
 

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -321,9 +321,9 @@ CATCH_LOG_RETURN_FALSE()
 // - applicationMode - set to true to enable Application Mode Input, false for Numeric Mode Input.
 // Return Value:
 // - True if handled successfully. False otherwise.
-bool TerminalDispatch::SetKeypadMode(const bool fApplicationMode) noexcept
+bool TerminalDispatch::SetKeypadMode(const bool applicationMode) noexcept
 {
-    _terminalApi.SetKeypadMode(fApplicationMode);
+    _terminalApi.SetInputMode(TerminalInput::Mode::Keypad, applicationMode);
     return true;
 }
 
@@ -334,7 +334,7 @@ bool TerminalDispatch::SetKeypadMode(const bool fApplicationMode) noexcept
 // - True if handled successfully. False otherwise.
 bool TerminalDispatch::SetCursorKeysMode(const bool applicationMode) noexcept
 {
-    _terminalApi.SetCursorKeysMode(applicationMode);
+    _terminalApi.SetInputMode(TerminalInput::Mode::CursorKey, applicationMode);
     return true;
 }
 
@@ -359,7 +359,7 @@ bool TerminalDispatch::SetScreenMode(const bool reverseMode) noexcept
 // - True if handled successfully. False otherwise.
 bool TerminalDispatch::EnableWin32InputMode(const bool win32Mode) noexcept
 {
-    _terminalApi.EnableWin32InputMode(win32Mode);
+    _terminalApi.SetInputMode(TerminalInput::Mode::Win32, win32Mode);
     return true;
 }
 
@@ -371,7 +371,7 @@ bool TerminalDispatch::EnableWin32InputMode(const bool win32Mode) noexcept
 // True if handled successfully. False otherwise.
 bool TerminalDispatch::EnableVT200MouseMode(const bool enabled) noexcept
 {
-    _terminalApi.EnableVT200MouseMode(enabled);
+    _terminalApi.SetInputMode(TerminalInput::Mode::DefaultMouseTracking, enabled);
     return true;
 }
 
@@ -384,7 +384,7 @@ bool TerminalDispatch::EnableVT200MouseMode(const bool enabled) noexcept
 // True if handled successfully. False otherwise.
 bool TerminalDispatch::EnableUTF8ExtendedMouseMode(const bool enabled) noexcept
 {
-    _terminalApi.EnableUTF8ExtendedMouseMode(enabled);
+    _terminalApi.SetInputMode(TerminalInput::Mode::Utf8MouseEncoding, enabled);
     return true;
 }
 
@@ -397,7 +397,7 @@ bool TerminalDispatch::EnableUTF8ExtendedMouseMode(const bool enabled) noexcept
 // True if handled successfully. False otherwise.
 bool TerminalDispatch::EnableSGRExtendedMouseMode(const bool enabled) noexcept
 {
-    _terminalApi.EnableSGRExtendedMouseMode(enabled);
+    _terminalApi.SetInputMode(TerminalInput::Mode::SgrMouseEncoding, enabled);
     return true;
 }
 
@@ -409,7 +409,7 @@ bool TerminalDispatch::EnableSGRExtendedMouseMode(const bool enabled) noexcept
 // True if handled successfully. False otherwise.
 bool TerminalDispatch::EnableButtonEventMouseMode(const bool enabled) noexcept
 {
-    _terminalApi.EnableButtonEventMouseMode(enabled);
+    _terminalApi.SetInputMode(TerminalInput::Mode::ButtonEventMouseTracking, enabled);
     return true;
 }
 
@@ -422,7 +422,7 @@ bool TerminalDispatch::EnableButtonEventMouseMode(const bool enabled) noexcept
 // True if handled successfully. False otherwise.
 bool TerminalDispatch::EnableAnyEventMouseMode(const bool enabled) noexcept
 {
-    _terminalApi.EnableAnyEventMouseMode(enabled);
+    _terminalApi.SetInputMode(TerminalInput::Mode::AnyEventMouseTracking, enabled);
     return true;
 }
 
@@ -435,7 +435,7 @@ bool TerminalDispatch::EnableAnyEventMouseMode(const bool enabled) noexcept
 // True if handled successfully. False otherwise.
 bool TerminalDispatch::EnableAlternateScroll(const bool enabled) noexcept
 {
-    _terminalApi.EnableAlternateScrollMode(enabled);
+    _terminalApi.SetInputMode(TerminalInput::Mode::AlternateScroll, enabled);
     return true;
 }
 

--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -1477,18 +1477,6 @@ void DoSrvPrivateUseMainScreenBuffer(SCREEN_INFORMATION& screenInfo)
 }
 
 // Routine Description:
-// - A private API call for enabling alternate scroll mode
-// Parameters:
-// - fEnable - true to enable alternate scroll mode, false to disable.
-// Return value:
-// None
-void DoSrvPrivateEnableAlternateScroll(const bool fEnable)
-{
-    CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
-    gci.GetActiveInputBuffer()->GetTerminalInput().EnableAlternateScroll(fEnable);
-}
-
-// Routine Description:
 // - A private API call for performing a VT-style erase all operation on the buffer.
 //      See SCREEN_INFORMATION::VtEraseAll's description for details.
 // Parameters:

--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -1249,55 +1249,6 @@ void ApiRoutines::GetConsoleDisplayModeImpl(ULONG& flags) noexcept
 }
 
 // Routine Description:
-// - A private API call for changing the cursor keys input mode between normal and application mode.
-//     The cursor keys are the arrows, plus Home and End.
-// Parameters:
-// - fApplicationMode - set to true to enable Application Mode Input, false for Numeric Mode Input.
-// Return value:
-// - True if handled successfully. False otherwise.
-[[nodiscard]] NTSTATUS DoSrvPrivateSetCursorKeysMode(_In_ bool fApplicationMode)
-{
-    CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
-    if (gci.pInputBuffer == nullptr)
-    {
-        return STATUS_UNSUCCESSFUL;
-    }
-    gci.pInputBuffer->GetTerminalInput().ChangeCursorKeysMode(fApplicationMode);
-    return STATUS_SUCCESS;
-}
-
-// Routine Description:
-// - A private API call for changing the keypad input mode between numeric and application mode.
-//     This controls what the keys on the numpad translate to.
-// Parameters:
-// - fApplicationMode - set to true to enable Application Mode Input, false for Numeric Mode Input.
-// Return value:
-// - True if handled successfully. False otherwise.
-[[nodiscard]] NTSTATUS DoSrvPrivateSetKeypadMode(_In_ bool fApplicationMode)
-{
-    CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
-    if (gci.pInputBuffer == nullptr)
-    {
-        return STATUS_UNSUCCESSFUL;
-    }
-    gci.pInputBuffer->GetTerminalInput().ChangeKeypadMode(fApplicationMode);
-    return STATUS_SUCCESS;
-}
-
-// Function Description:
-// - A private API call which enables/disables sending full input records
-//   encoded as a string of characters to the client application.
-// Parameters:
-// - win32InputMode - set to true to enable win32-input-mode, false to disable.
-// Return value:
-// - <none>
-void DoSrvPrivateEnableWin32InputMode(const bool win32InputMode)
-{
-    CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
-    gci.pInputBuffer->GetTerminalInput().ChangeWin32InputMode(win32InputMode);
-}
-
-// Routine Description:
 // - A private API call for changing the screen mode between normal and reverse.
 //    When in reverse screen mode, the background and foreground colors are switched.
 // Parameters:

--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -1489,30 +1489,6 @@ void DoSrvPrivateEnableVT200MouseMode(const bool fEnable)
 }
 
 // Routine Description:
-// - A private API call for enabling utf8 style mouse mode.
-// Parameters:
-// - fEnable - true to enable, false to disable.
-// Return value:
-// - None
-void DoSrvPrivateEnableUTF8ExtendedMouseMode(const bool fEnable)
-{
-    CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
-    gci.GetActiveInputBuffer()->GetTerminalInput().SetUtf8ExtendedMode(fEnable);
-}
-
-// Routine Description:
-// - A private API call for enabling SGR style mouse mode.
-// Parameters:
-// - fEnable - true to enable, false to disable.
-// Return value:
-// - None
-void DoSrvPrivateEnableSGRExtendedMouseMode(const bool fEnable)
-{
-    CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
-    gci.GetActiveInputBuffer()->GetTerminalInput().SetSGRExtendedMode(fEnable);
-}
-
-// Routine Description:
 // - A private API call for enabling button-event mouse mode.
 // Parameters:
 // - fEnable - true to enable button-event mode, false to disable mouse mode.

--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -1477,42 +1477,6 @@ void DoSrvPrivateUseMainScreenBuffer(SCREEN_INFORMATION& screenInfo)
 }
 
 // Routine Description:
-// - A private API call for enabling VT200 style mouse mode.
-// Parameters:
-// - fEnable - true to enable default tracking mode, false to disable mouse mode.
-// Return value:
-// - None
-void DoSrvPrivateEnableVT200MouseMode(const bool fEnable)
-{
-    CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
-    gci.GetActiveInputBuffer()->GetTerminalInput().EnableDefaultTracking(fEnable);
-}
-
-// Routine Description:
-// - A private API call for enabling button-event mouse mode.
-// Parameters:
-// - fEnable - true to enable button-event mode, false to disable mouse mode.
-// Return value:
-// - None
-void DoSrvPrivateEnableButtonEventMouseMode(const bool fEnable)
-{
-    CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
-    gci.GetActiveInputBuffer()->GetTerminalInput().EnableButtonEventTracking(fEnable);
-}
-
-// Routine Description:
-// - A private API call for enabling any-event mouse mode.
-// Parameters:
-// - fEnable - true to enable any-event mode, false to disable mouse mode.
-// Return value:
-// - None
-void DoSrvPrivateEnableAnyEventMouseMode(const bool fEnable)
-{
-    CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
-    gci.GetActiveInputBuffer()->GetTerminalInput().EnableAnyEventTracking(fEnable);
-}
-
-// Routine Description:
 // - A private API call for enabling alternate scroll mode
 // Parameters:
 // - fEnable - true to enable alternate scroll mode, false to disable.

--- a/src/host/getset.h
+++ b/src/host/getset.h
@@ -18,10 +18,6 @@ Revision History:
 #include "../inc/conattrs.hpp"
 class SCREEN_INFORMATION;
 
-[[nodiscard]] NTSTATUS DoSrvPrivateSetCursorKeysMode(_In_ bool fApplicationMode);
-[[nodiscard]] NTSTATUS DoSrvPrivateSetKeypadMode(_In_ bool fApplicationMode);
-void DoSrvPrivateEnableWin32InputMode(const bool win32InputMode);
-
 [[nodiscard]] NTSTATUS DoSrvPrivateSetScreenMode(const bool reverseMode);
 [[nodiscard]] NTSTATUS DoSrvPrivateSetAutoWrapMode(const bool wrapAtEOL);
 

--- a/src/host/getset.h
+++ b/src/host/getset.h
@@ -31,9 +31,6 @@ void DoSrvPrivateAllowCursorBlinking(SCREEN_INFORMATION& screenInfo, const bool 
 [[nodiscard]] NTSTATUS DoSrvPrivateUseAlternateScreenBuffer(SCREEN_INFORMATION& screenInfo);
 void DoSrvPrivateUseMainScreenBuffer(SCREEN_INFORMATION& screenInfo);
 
-void DoSrvPrivateEnableVT200MouseMode(const bool fEnable);
-void DoSrvPrivateEnableButtonEventMouseMode(const bool fEnable);
-void DoSrvPrivateEnableAnyEventMouseMode(const bool fEnable);
 void DoSrvPrivateEnableAlternateScroll(const bool fEnable);
 
 [[nodiscard]] HRESULT DoSrvPrivateEraseAll(SCREEN_INFORMATION& screenInfo);

--- a/src/host/getset.h
+++ b/src/host/getset.h
@@ -31,8 +31,6 @@ void DoSrvPrivateAllowCursorBlinking(SCREEN_INFORMATION& screenInfo, const bool 
 [[nodiscard]] NTSTATUS DoSrvPrivateUseAlternateScreenBuffer(SCREEN_INFORMATION& screenInfo);
 void DoSrvPrivateUseMainScreenBuffer(SCREEN_INFORMATION& screenInfo);
 
-void DoSrvPrivateEnableAlternateScroll(const bool fEnable);
-
 [[nodiscard]] HRESULT DoSrvPrivateEraseAll(SCREEN_INFORMATION& screenInfo);
 [[nodiscard]] HRESULT DoSrvPrivateClearBuffer(SCREEN_INFORMATION& screenInfo);
 

--- a/src/host/getset.h
+++ b/src/host/getset.h
@@ -32,8 +32,6 @@ void DoSrvPrivateAllowCursorBlinking(SCREEN_INFORMATION& screenInfo, const bool 
 void DoSrvPrivateUseMainScreenBuffer(SCREEN_INFORMATION& screenInfo);
 
 void DoSrvPrivateEnableVT200MouseMode(const bool fEnable);
-void DoSrvPrivateEnableUTF8ExtendedMouseMode(const bool fEnable);
-void DoSrvPrivateEnableSGRExtendedMouseMode(const bool fEnable);
 void DoSrvPrivateEnableButtonEventMouseMode(const bool fEnable);
 void DoSrvPrivateEnableAnyEventMouseMode(const bool fEnable);
 void DoSrvPrivateEnableAlternateScroll(const bool fEnable);

--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -238,48 +238,28 @@ bool ConhostInternalGetSet::SetConsoleWindowInfo(const bool absolute, const SMAL
 }
 
 // Routine Description:
-// - Connects the PrivateSetCursorKeysMode call directly into our Driver Message servicing call inside Conhost.exe
-//   PrivateSetCursorKeysMode is an internal-only "API" call that the vt commands can execute,
+// - Sets the various terminal input modes.
+//   SetInputMode is an internal-only "API" call that the vt commands can execute,
 //     but it is not represented as a function call on out public API surface.
 // Arguments:
-// - fApplicationMode - set to true to enable Application Mode Input, false for Normal Mode.
+// - mode - the input mode to change.
+// - enabled - set to true to enable the mode, false to disable it.
 // Return Value:
 // - true if successful. false otherwise.
-bool ConhostInternalGetSet::PrivateSetCursorKeysMode(const bool fApplicationMode)
+bool ConhostInternalGetSet::SetInputMode(const TerminalInput::Mode mode, const bool enabled)
 {
     auto& terminalInput = _io.GetActiveInputBuffer()->GetTerminalInput();
-    terminalInput.SetInputMode(TerminalInput::Mode::CursorKey, fApplicationMode);
-    return true;
-}
+    terminalInput.SetInputMode(mode, enabled);
 
-// Routine Description:
-// - Connects the PrivateSetKeypadMode call directly into our Driver Message servicing call inside Conhost.exe
-//   PrivateSetKeypadMode is an internal-only "API" call that the vt commands can execute,
-//     but it is not represented as a function call on out public API surface.
-// Arguments:
-// - fApplicationMode - set to true to enable Application Mode Input, false for Numeric Mode.
-// Return Value:
-// - true if successful. false otherwise.
-bool ConhostInternalGetSet::PrivateSetKeypadMode(const bool fApplicationMode)
-{
-    auto& terminalInput = _io.GetActiveInputBuffer()->GetTerminalInput();
-    terminalInput.SetInputMode(TerminalInput::Mode::Keypad, fApplicationMode);
-    return true;
-}
-
-// Routine Description:
-// - Connects the PrivateEnableWin32InputMode call directly into our Driver Message servicing call inside Conhost.exe
-//   PrivateEnableWin32InputMode is an internal-only "API" call that the vt commands can execute,
-//     but it is not represented as a function call on out public API surface.
-// Arguments:
-// - win32InputMode - set to true to enable win32-input-mode, false to disable.
-// Return Value:
-// - true always
-bool ConhostInternalGetSet::PrivateEnableWin32InputMode(const bool win32InputMode)
-{
-    auto& terminalInput = _io.GetActiveInputBuffer()->GetTerminalInput();
-    terminalInput.SetInputMode(TerminalInput::Mode::Win32, win32InputMode);
-    return true;
+    // If we're a conpty, AND WE'RE IN VT INPUT MODE, always pass input mode requests
+    // The VT Input mode check is to work around ssh.exe v7.7, which uses VT
+    // output, but not Input.
+    // The original comment said, "Once the conpty supports these types of input,
+    // this check can be removed. See GH#4911". Unfortunately, time has shown
+    // us that SSH 7.7 _also_ requests mouse input and that can have a user interface
+    // impact on the actual connected terminal. We can't remove this check,
+    // because SSH <=7.7 is out in the wild on all versions of Windows <=2004.
+    return !(IsConsolePty() && PrivateIsVtInputEnabled());
 }
 
 // Routine Description:

--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -15,6 +15,7 @@
 
 using namespace Microsoft::Console;
 using Microsoft::Console::Interactivity::ServiceLocator;
+using Microsoft::Console::VirtualTerminal::TerminalInput;
 
 WriteBuffer::WriteBuffer(_In_ Microsoft::Console::IIoProvider& io) :
     _io{ io },
@@ -243,10 +244,12 @@ bool ConhostInternalGetSet::SetConsoleWindowInfo(const bool absolute, const SMAL
 // Arguments:
 // - fApplicationMode - set to true to enable Application Mode Input, false for Normal Mode.
 // Return Value:
-// - true if successful (see DoSrvPrivateSetCursorKeysMode). false otherwise.
+// - true if successful. false otherwise.
 bool ConhostInternalGetSet::PrivateSetCursorKeysMode(const bool fApplicationMode)
 {
-    return NT_SUCCESS(DoSrvPrivateSetCursorKeysMode(fApplicationMode));
+    auto& terminalInput = _io.GetActiveInputBuffer()->GetTerminalInput();
+    terminalInput.SetInputMode(TerminalInput::Mode::CursorKey, fApplicationMode);
+    return true;
 }
 
 // Routine Description:
@@ -256,10 +259,12 @@ bool ConhostInternalGetSet::PrivateSetCursorKeysMode(const bool fApplicationMode
 // Arguments:
 // - fApplicationMode - set to true to enable Application Mode Input, false for Numeric Mode.
 // Return Value:
-// - true if successful (see DoSrvPrivateSetKeypadMode). false otherwise.
+// - true if successful. false otherwise.
 bool ConhostInternalGetSet::PrivateSetKeypadMode(const bool fApplicationMode)
 {
-    return NT_SUCCESS(DoSrvPrivateSetKeypadMode(fApplicationMode));
+    auto& terminalInput = _io.GetActiveInputBuffer()->GetTerminalInput();
+    terminalInput.SetInputMode(TerminalInput::Mode::Keypad, fApplicationMode);
+    return true;
 }
 
 // Routine Description:
@@ -272,7 +277,8 @@ bool ConhostInternalGetSet::PrivateSetKeypadMode(const bool fApplicationMode)
 // - true always
 bool ConhostInternalGetSet::PrivateEnableWin32InputMode(const bool win32InputMode)
 {
-    DoSrvPrivateEnableWin32InputMode(win32InputMode);
+    auto& terminalInput = _io.GetActiveInputBuffer()->GetTerminalInput();
+    terminalInput.SetInputMode(TerminalInput::Mode::Win32, win32InputMode);
     return true;
 }
 
@@ -289,7 +295,7 @@ bool ConhostInternalGetSet::PrivateSetAnsiMode(const bool ansiMode)
     auto& stateMachine = _io.GetActiveOutputBuffer().GetStateMachine();
     stateMachine.SetAnsiMode(ansiMode);
     auto& terminalInput = _io.GetActiveInputBuffer()->GetTerminalInput();
-    terminalInput.ChangeAnsiMode(ansiMode);
+    terminalInput.SetInputMode(TerminalInput::Mode::Ansi, ansiMode);
     return true;
 }
 

--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -435,48 +435,6 @@ bool ConhostInternalGetSet::PrivateUseMainScreenBuffer()
 }
 
 // Routine Description:
-// - Connects the PrivateEnableVT200MouseMode call directly into our Driver Message servicing call inside Conhost.exe
-//   PrivateEnableVT200MouseMode is an internal-only "API" call that the vt commands can execute,
-//     but it is not represented as a function call on out public API surface.
-// Arguments:
-// - enabled - set to true to enable vt200 mouse mode, false to disable
-// Return Value:
-// - true if successful (see DoSrvPrivateEnableVT200MouseMode). false otherwise.
-bool ConhostInternalGetSet::PrivateEnableVT200MouseMode(const bool enabled)
-{
-    DoSrvPrivateEnableVT200MouseMode(enabled);
-    return true;
-}
-
-// Routine Description:
-// - Connects the PrivateEnableButtonEventMouseMode call directly into our Driver Message servicing call inside Conhost.exe
-//   PrivateEnableButtonEventMouseMode is an internal-only "API" call that the vt commands can execute,
-//     but it is not represented as a function call on out public API surface.
-// Arguments:
-// - enabled - set to true to enable button-event mouse mode, false to disable
-// Return Value:
-// - true if successful (see DoSrvPrivateEnableButtonEventMouseMode). false otherwise.
-bool ConhostInternalGetSet::PrivateEnableButtonEventMouseMode(const bool enabled)
-{
-    DoSrvPrivateEnableButtonEventMouseMode(enabled);
-    return true;
-}
-
-// Routine Description:
-// - Connects the PrivateEnableAnyEventMouseMode call directly into our Driver Message servicing call inside Conhost.exe
-//   PrivateEnableAnyEventMouseMode is an internal-only "API" call that the vt commands can execute,
-//     but it is not represented as a function call on out public API surface.
-// Arguments:
-// - enabled - set to true to enable any-event mouse mode, false to disable
-// Return Value:
-// - true if successful (see DoSrvPrivateEnableAnyEventMouseMode). false otherwise.
-bool ConhostInternalGetSet::PrivateEnableAnyEventMouseMode(const bool enabled)
-{
-    DoSrvPrivateEnableAnyEventMouseMode(enabled);
-    return true;
-}
-
-// Routine Description:
 // - Connects the PrivateEnableAlternateScroll call directly into our Driver Message servicing call inside Conhost.exe
 //   PrivateEnableAlternateScroll is an internal-only "API" call that the vt commands can execute,
 //     but it is not represented as a function call on out public API surface.

--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -449,34 +449,6 @@ bool ConhostInternalGetSet::PrivateEnableVT200MouseMode(const bool enabled)
 }
 
 // Routine Description:
-// - Connects the PrivateEnableUTF8ExtendedMouseMode call directly into our Driver Message servicing call inside Conhost.exe
-//   PrivateEnableUTF8ExtendedMouseMode is an internal-only "API" call that the vt commands can execute,
-//     but it is not represented as a function call on out public API surface.
-// Arguments:
-// - enabled - set to true to enable utf8 extended mouse mode, false to disable
-// Return Value:
-// - true if successful (see DoSrvPrivateEnableUTF8ExtendedMouseMode). false otherwise.
-bool ConhostInternalGetSet::PrivateEnableUTF8ExtendedMouseMode(const bool enabled)
-{
-    DoSrvPrivateEnableUTF8ExtendedMouseMode(enabled);
-    return true;
-}
-
-// Routine Description:
-// - Connects the PrivateEnableSGRExtendedMouseMode call directly into our Driver Message servicing call inside Conhost.exe
-//   PrivateEnableSGRExtendedMouseMode is an internal-only "API" call that the vt commands can execute,
-//     but it is not represented as a function call on out public API surface.
-// Arguments:
-// - enabled - set to true to enable SGR extended mouse mode, false to disable
-// Return Value:
-// - true if successful (see DoSrvPrivateEnableSGRExtendedMouseMode). false otherwise.
-bool ConhostInternalGetSet::PrivateEnableSGRExtendedMouseMode(const bool enabled)
-{
-    DoSrvPrivateEnableSGRExtendedMouseMode(enabled);
-    return true;
-}
-
-// Routine Description:
 // - Connects the PrivateEnableButtonEventMouseMode call directly into our Driver Message servicing call inside Conhost.exe
 //   PrivateEnableButtonEventMouseMode is an internal-only "API" call that the vt commands can execute,
 //     but it is not represented as a function call on out public API surface.

--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -435,20 +435,6 @@ bool ConhostInternalGetSet::PrivateUseMainScreenBuffer()
 }
 
 // Routine Description:
-// - Connects the PrivateEnableAlternateScroll call directly into our Driver Message servicing call inside Conhost.exe
-//   PrivateEnableAlternateScroll is an internal-only "API" call that the vt commands can execute,
-//     but it is not represented as a function call on out public API surface.
-// Arguments:
-// - enabled - set to true to enable alternate scroll mode, false to disable
-// Return Value:
-// - true if successful (see DoSrvPrivateEnableAnyEventMouseMode). false otherwise.
-bool ConhostInternalGetSet::PrivateEnableAlternateScroll(const bool enabled)
-{
-    DoSrvPrivateEnableAlternateScroll(enabled);
-    return true;
-}
-
-// Routine Description:
 // - Connects the PrivateEraseAll call directly into our Driver Message servicing call inside Conhost.exe
 //   PrivateEraseAll is an internal-only "API" call that the vt commands can execute,
 //     but it is not represented as a function call on our public API surface.

--- a/src/host/outputStream.hpp
+++ b/src/host/outputStream.hpp
@@ -96,8 +96,6 @@ public:
     bool PrivateUseMainScreenBuffer() override;
 
     bool PrivateEnableVT200MouseMode(const bool enabled) override;
-    bool PrivateEnableUTF8ExtendedMouseMode(const bool enabled) override;
-    bool PrivateEnableSGRExtendedMouseMode(const bool enabled) override;
     bool PrivateEnableButtonEventMouseMode(const bool enabled) override;
     bool PrivateEnableAnyEventMouseMode(const bool enabled) override;
     bool PrivateEnableAlternateScroll(const bool enabled) override;

--- a/src/host/outputStream.hpp
+++ b/src/host/outputStream.hpp
@@ -72,9 +72,7 @@ public:
     bool SetConsoleWindowInfo(bool const absolute,
                               const SMALL_RECT& window) override;
 
-    bool PrivateSetCursorKeysMode(const bool applicationMode) override;
-    bool PrivateSetKeypadMode(const bool applicationMode) override;
-    bool PrivateEnableWin32InputMode(const bool win32InputMode) override;
+    bool SetInputMode(const Microsoft::Console::VirtualTerminal::TerminalInput::Mode mode, const bool enabled) override;
 
     bool PrivateSetAnsiMode(const bool ansiMode) override;
     bool PrivateSetScreenMode(const bool reverseMode) override;

--- a/src/host/outputStream.hpp
+++ b/src/host/outputStream.hpp
@@ -95,9 +95,6 @@ public:
 
     bool PrivateUseMainScreenBuffer() override;
 
-    bool PrivateEnableVT200MouseMode(const bool enabled) override;
-    bool PrivateEnableButtonEventMouseMode(const bool enabled) override;
-    bool PrivateEnableAnyEventMouseMode(const bool enabled) override;
     bool PrivateEnableAlternateScroll(const bool enabled) override;
     bool PrivateEraseAll() override;
     bool PrivateClearBuffer() override;

--- a/src/host/outputStream.hpp
+++ b/src/host/outputStream.hpp
@@ -95,7 +95,6 @@ public:
 
     bool PrivateUseMainScreenBuffer() override;
 
-    bool PrivateEnableAlternateScroll(const bool enabled) override;
     bool PrivateEraseAll() override;
     bool PrivateClearBuffer() override;
 

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -2131,15 +2131,7 @@ bool AdaptDispatch::EnableAnyEventMouseMode(const bool enabled)
 // True if handled successfully. False otherwise.
 bool AdaptDispatch::EnableAlternateScroll(const bool enabled)
 {
-    bool success = true;
-    success = _pConApi->PrivateEnableAlternateScroll(enabled);
-
-    if (_ShouldPassThroughInputModeChange())
-    {
-        return false;
-    }
-
-    return success;
+    return _pConApi->SetInputMode(TerminalInput::Mode::AlternateScroll, enabled);
 }
 
 //Routine Description:
@@ -2607,23 +2599,4 @@ void AdaptDispatch::_ReportDECSTBMSetting() const
     // The 'r' indicates this is an DECSTBM response, and ST ends the sequence.
     response += L"r\033\\";
     _WriteResponse(response);
-}
-
-// Routine Description:
-// - Determines whether we should pass any sequence that manipulates
-//   TerminalInput's input generator through the PTY. It encapsulates
-//   a check for whether the PTY is in use.
-// Return value:
-// True if the request should be passed.
-bool AdaptDispatch::_ShouldPassThroughInputModeChange() const
-{
-    // If we're a conpty, AND WE'RE IN VT INPUT MODE, always pass input mode requests
-    // The VT Input mode check is to work around ssh.exe v7.7, which uses VT
-    // output, but not Input.
-    // The original comment said, "Once the conpty supports these types of input,
-    // this check can be removed. See GH#4911". Unfortunately, time has shown
-    // us that SSH 7.7 _also_ requests mouse input and that can have a user interface
-    // impact on the actual connected terminal. We can't remove this check,
-    // because SSH <=7.7 is out in the wild on all versions of Windows <=2004.
-    return _pConApi->IsConsolePty() && _pConApi->PrivateIsVtInputEnabled();
 }

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -2072,15 +2072,7 @@ bool AdaptDispatch::EnableDECCOLMSupport(const bool enabled) noexcept
 // True if handled successfully. False otherwise.
 bool AdaptDispatch::EnableVT200MouseMode(const bool enabled)
 {
-    bool success = true;
-    success = _pConApi->PrivateEnableVT200MouseMode(enabled);
-
-    if (_ShouldPassThroughInputModeChange())
-    {
-        return false;
-    }
-
-    return success;
+    return _pConApi->SetInputMode(TerminalInput::Mode::DefaultMouseTracking, enabled);
 }
 
 //Routine Description:
@@ -2115,15 +2107,7 @@ bool AdaptDispatch::EnableSGRExtendedMouseMode(const bool enabled)
 // True if handled successfully. False otherwise.
 bool AdaptDispatch::EnableButtonEventMouseMode(const bool enabled)
 {
-    bool success = true;
-    success = _pConApi->PrivateEnableButtonEventMouseMode(enabled);
-
-    if (_ShouldPassThroughInputModeChange())
-    {
-        return false;
-    }
-
-    return success;
+    return _pConApi->SetInputMode(TerminalInput::Mode::ButtonEventMouseTracking, enabled);
 }
 
 //Routine Description:
@@ -2135,15 +2119,7 @@ bool AdaptDispatch::EnableButtonEventMouseMode(const bool enabled)
 // True if handled successfully. False otherwise.
 bool AdaptDispatch::EnableAnyEventMouseMode(const bool enabled)
 {
-    bool success = true;
-    success = _pConApi->PrivateEnableAnyEventMouseMode(enabled);
-
-    if (_ShouldPassThroughInputModeChange())
-    {
-        return false;
-    }
-
-    return success;
+    return _pConApi->SetInputMode(TerminalInput::Mode::AnyEventMouseTracking, enabled);
 }
 
 //Routine Description:

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1167,15 +1167,7 @@ bool AdaptDispatch::ResetMode(const DispatchTypes::ModeParams param)
 // - True if handled successfully. False otherwise.
 bool AdaptDispatch::SetKeypadMode(const bool fApplicationMode)
 {
-    bool success = true;
-    success = _pConApi->PrivateSetKeypadMode(fApplicationMode);
-
-    if (_ShouldPassThroughInputModeChange())
-    {
-        return false;
-    }
-
-    return success;
+    return _pConApi->SetInputMode(TerminalInput::Mode::Keypad, fApplicationMode);
 }
 
 // Method Description:
@@ -1187,15 +1179,7 @@ bool AdaptDispatch::SetKeypadMode(const bool fApplicationMode)
 // - True if handled successfully. False otherwise.
 bool AdaptDispatch::EnableWin32InputMode(const bool win32InputMode)
 {
-    bool success = true;
-    success = _pConApi->PrivateEnableWin32InputMode(win32InputMode);
-
-    if (_ShouldPassThroughInputModeChange())
-    {
-        return false;
-    }
-
-    return success;
+    return _pConApi->SetInputMode(TerminalInput::Mode::Win32, win32InputMode);
 }
 
 // - DECCKM - Sets the cursor keys input mode to either Application mode or Normal mode (true, false respectively)
@@ -1205,15 +1189,7 @@ bool AdaptDispatch::EnableWin32InputMode(const bool win32InputMode)
 // - True if handled successfully. False otherwise.
 bool AdaptDispatch::SetCursorKeysMode(const bool applicationMode)
 {
-    bool success = true;
-    success = _pConApi->PrivateSetCursorKeysMode(applicationMode);
-
-    if (_ShouldPassThroughInputModeChange())
-    {
-        return false;
-    }
-
-    return success;
+    return _pConApi->SetInputMode(TerminalInput::Mode::CursorKey, applicationMode);
 }
 
 // - att610 - Enables or disables the cursor blinking.

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -2092,15 +2092,7 @@ bool AdaptDispatch::EnableVT200MouseMode(const bool enabled)
 // True if handled successfully. False otherwise.
 bool AdaptDispatch::EnableUTF8ExtendedMouseMode(const bool enabled)
 {
-    bool success = true;
-    success = _pConApi->PrivateEnableUTF8ExtendedMouseMode(enabled);
-
-    if (_ShouldPassThroughInputModeChange())
-    {
-        return false;
-    }
-
-    return success;
+    return _pConApi->SetInputMode(TerminalInput::Mode::Utf8MouseEncoding, enabled);
 }
 
 //Routine Description:
@@ -2112,15 +2104,7 @@ bool AdaptDispatch::EnableUTF8ExtendedMouseMode(const bool enabled)
 // True if handled successfully. False otherwise.
 bool AdaptDispatch::EnableSGRExtendedMouseMode(const bool enabled)
 {
-    bool success = true;
-    success = _pConApi->PrivateEnableSGRExtendedMouseMode(enabled);
-
-    if (_ShouldPassThroughInputModeChange())
-    {
-        return false;
-    }
-
-    return success;
+    return _pConApi->SetInputMode(TerminalInput::Mode::SgrMouseEncoding, enabled);
 }
 
 //Routine Description:

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -194,8 +194,6 @@ namespace Microsoft::Console::VirtualTerminal
         void _ReportSGRSetting() const;
         void _ReportDECSTBMSetting() const;
 
-        bool _ShouldPassThroughInputModeChange() const;
-
         std::vector<bool> _tabStopColumns;
         bool _initDefaultTabStops = true;
 

--- a/src/terminal/adapter/conGetSet.hpp
+++ b/src/terminal/adapter/conGetSet.hpp
@@ -67,8 +67,6 @@ namespace Microsoft::Console::VirtualTerminal
         virtual bool PrivateUseMainScreenBuffer() = 0;
 
         virtual bool PrivateEnableVT200MouseMode(const bool enabled) = 0;
-        virtual bool PrivateEnableUTF8ExtendedMouseMode(const bool enabled) = 0;
-        virtual bool PrivateEnableSGRExtendedMouseMode(const bool enabled) = 0;
         virtual bool PrivateEnableButtonEventMouseMode(const bool enabled) = 0;
         virtual bool PrivateEnableAnyEventMouseMode(const bool enabled) = 0;
         virtual bool PrivateEnableAlternateScroll(const bool enabled) = 0;

--- a/src/terminal/adapter/conGetSet.hpp
+++ b/src/terminal/adapter/conGetSet.hpp
@@ -66,9 +66,6 @@ namespace Microsoft::Console::VirtualTerminal
         virtual bool PrivateUseAlternateScreenBuffer() = 0;
         virtual bool PrivateUseMainScreenBuffer() = 0;
 
-        virtual bool PrivateEnableVT200MouseMode(const bool enabled) = 0;
-        virtual bool PrivateEnableButtonEventMouseMode(const bool enabled) = 0;
-        virtual bool PrivateEnableAnyEventMouseMode(const bool enabled) = 0;
         virtual bool PrivateEnableAlternateScroll(const bool enabled) = 0;
         virtual bool PrivateEraseAll() = 0;
         virtual bool PrivateClearBuffer() = 0;

--- a/src/terminal/adapter/conGetSet.hpp
+++ b/src/terminal/adapter/conGetSet.hpp
@@ -15,6 +15,7 @@ Author(s):
 
 #pragma once
 
+#include "../input/terminalInput.hpp"
 #include "../../types/inc/IInputEvent.hpp"
 #include "../../buffer/out/LineRendition.hpp"
 #include "../../buffer/out/TextAttribute.hpp"
@@ -46,9 +47,8 @@ namespace Microsoft::Console::VirtualTerminal
                                                size_t& eventsWritten) = 0;
         virtual bool SetConsoleWindowInfo(const bool absolute,
                                           const SMALL_RECT& window) = 0;
-        virtual bool PrivateSetCursorKeysMode(const bool applicationMode) = 0;
-        virtual bool PrivateSetKeypadMode(const bool applicationMode) = 0;
-        virtual bool PrivateEnableWin32InputMode(const bool win32InputMode) = 0;
+
+        virtual bool SetInputMode(const TerminalInput::Mode mode, const bool enabled) = 0;
 
         virtual bool PrivateSetAnsiMode(const bool ansiMode) = 0;
         virtual bool PrivateSetScreenMode(const bool reverseMode) = 0;

--- a/src/terminal/adapter/conGetSet.hpp
+++ b/src/terminal/adapter/conGetSet.hpp
@@ -66,7 +66,6 @@ namespace Microsoft::Console::VirtualTerminal
         virtual bool PrivateUseAlternateScreenBuffer() = 0;
         virtual bool PrivateUseMainScreenBuffer() = 0;
 
-        virtual bool PrivateEnableAlternateScroll(const bool enabled) = 0;
         virtual bool PrivateEraseAll() = 0;
         virtual bool PrivateClearBuffer() = 0;
         virtual bool GetUserDefaultCursorStyle(CursorType& style) = 0;

--- a/src/terminal/adapter/ut_adapter/MouseInputTest.cpp
+++ b/src/terminal/adapter/ut_adapter/MouseInputTest.cpp
@@ -381,7 +381,7 @@ public:
         s_pwszInputExpected = L"\x0";
         VERIFY_ARE_EQUAL(fExpectedKeyHandled, mouseInput->HandleMouse({ 0, 0 }, uiButton, sModifierKeystate, sScrollDelta, {}));
 
-        mouseInput->SetUtf8ExtendedMode(true);
+        mouseInput->SetInputMode(TerminalInput::Mode::Utf8MouseEncoding, true);
 
         short MaxCoord = SHORT_MAX - 33;
 
@@ -467,7 +467,7 @@ public:
         s_pwszInputExpected = L"\x0";
         VERIFY_ARE_EQUAL(fExpectedKeyHandled, mouseInput->HandleMouse({ 0, 0 }, uiButton, sModifierKeystate, sScrollDelta, {}));
 
-        mouseInput->SetSGRExtendedMode(true);
+        mouseInput->SetInputMode(TerminalInput::Mode::SgrMouseEncoding, true);
 
         // SGR Mode should be able to handle any arbitrary coords.
         // However, mouse moves are only handled in Any Event mode
@@ -571,7 +571,7 @@ public:
         }
 
         // Default Tracking, UTF8 Encoding
-        mouseInput->SetUtf8ExtendedMode(true);
+        mouseInput->SetInputMode(TerminalInput::Mode::Utf8MouseEncoding, true);
         short MaxCoord = SHORT_MAX - 33;
         for (int i = 0; i < s_iTestCoordsLength; i++)
         {
@@ -592,7 +592,7 @@ public:
         }
 
         // Default Tracking, SGR Encoding
-        mouseInput->SetSGRExtendedMode(true);
+        mouseInput->SetInputMode(TerminalInput::Mode::SgrMouseEncoding, true);
         fExpectedKeyHandled = true; // SGR Mode should be able to handle any arbitrary coords.
         for (int i = 0; i < s_iTestCoordsLength; i++)
         {

--- a/src/terminal/adapter/ut_adapter/MouseInputTest.cpp
+++ b/src/terminal/adapter/ut_adapter/MouseInputTest.cpp
@@ -620,7 +620,7 @@ public:
 
         Log::Comment(L"Enable alternate scroll mode in the alt screen buffer");
         mouseInput->UseAlternateScreenBuffer();
-        mouseInput->EnableAlternateScroll(true);
+        mouseInput->SetInputMode(TerminalInput::Mode::AlternateScroll, true);
 
         Log::Comment(L"Test mouse wheel scrolling up");
         s_pwszInputExpected = L"\x1B[A";
@@ -643,12 +643,12 @@ public:
 
         Log::Comment(L"Confirm no effect when scroll mode is disabled");
         mouseInput->UseAlternateScreenBuffer();
-        mouseInput->EnableAlternateScroll(false);
+        mouseInput->SetInputMode(TerminalInput::Mode::AlternateScroll, false);
         VERIFY_IS_FALSE(mouseInput->HandleMouse({ 0, 0 }, WM_MOUSEWHEEL, noModifierKeys, WHEEL_DELTA, {}));
 
         Log::Comment(L"Confirm no effect when using the main buffer");
         mouseInput->UseMainScreenBuffer();
-        mouseInput->EnableAlternateScroll(true);
+        mouseInput->SetInputMode(TerminalInput::Mode::AlternateScroll, true);
         VERIFY_IS_FALSE(mouseInput->HandleMouse({ 0, 0 }, WM_MOUSEWHEEL, noModifierKeys, WHEEL_DELTA, {}));
     }
 };

--- a/src/terminal/adapter/ut_adapter/MouseInputTest.cpp
+++ b/src/terminal/adapter/ut_adapter/MouseInputTest.cpp
@@ -631,7 +631,7 @@ public:
         VERIFY_IS_TRUE(mouseInput->HandleMouse({ 0, 0 }, WM_MOUSEWHEEL, noModifierKeys, -WHEEL_DELTA, {}));
 
         Log::Comment(L"Enable cursor keys mode");
-        mouseInput->ChangeCursorKeysMode(true);
+        mouseInput->SetInputMode(TerminalInput::Mode::CursorKey, true);
 
         Log::Comment(L"Test mouse wheel scrolling up");
         s_pwszInputExpected = L"\x1BOA";

--- a/src/terminal/adapter/ut_adapter/MouseInputTest.cpp
+++ b/src/terminal/adapter/ut_adapter/MouseInputTest.cpp
@@ -298,7 +298,7 @@ public:
         s_pwszInputExpected = L"\x0";
         VERIFY_ARE_EQUAL(fExpectedKeyHandled, mouseInput->HandleMouse({ 0, 0 }, uiButton, sModifierKeystate, sScrollDelta, {}));
 
-        mouseInput->EnableDefaultTracking(true);
+        mouseInput->SetInputMode(TerminalInput::Mode::DefaultMouseTracking, true);
 
         for (int i = 0; i < s_iTestCoordsLength; i++)
         {
@@ -318,7 +318,7 @@ public:
                              NoThrowString().Format(L"(x,y)=(%d,%d)", Coord.X, Coord.Y));
         }
 
-        mouseInput->EnableButtonEventTracking(true);
+        mouseInput->SetInputMode(TerminalInput::Mode::ButtonEventMouseTracking, true);
         for (int i = 0; i < s_iTestCoordsLength; i++)
         {
             COORD Coord = s_rgTestCoords[i];
@@ -337,7 +337,7 @@ public:
                              NoThrowString().Format(L"(x,y)=(%d,%d)", Coord.X, Coord.Y));
         }
 
-        mouseInput->EnableAnyEventTracking(true);
+        mouseInput->SetInputMode(TerminalInput::Mode::AnyEventMouseTracking, true);
         for (int i = 0; i < s_iTestCoordsLength; i++)
         {
             COORD Coord = s_rgTestCoords[i];
@@ -385,7 +385,7 @@ public:
 
         short MaxCoord = SHORT_MAX - 33;
 
-        mouseInput->EnableDefaultTracking(true);
+        mouseInput->SetInputMode(TerminalInput::Mode::DefaultMouseTracking, true);
         for (int i = 0; i < s_iTestCoordsLength; i++)
         {
             COORD Coord = s_rgTestCoords[i];
@@ -404,7 +404,7 @@ public:
                              NoThrowString().Format(L"(x,y)=(%d,%d)", Coord.X, Coord.Y));
         }
 
-        mouseInput->EnableButtonEventTracking(true);
+        mouseInput->SetInputMode(TerminalInput::Mode::ButtonEventMouseTracking, true);
         for (int i = 0; i < s_iTestCoordsLength; i++)
         {
             COORD Coord = s_rgTestCoords[i];
@@ -423,7 +423,7 @@ public:
                              NoThrowString().Format(L"(x,y)=(%d,%d)", Coord.X, Coord.Y));
         }
 
-        mouseInput->EnableAnyEventTracking(true);
+        mouseInput->SetInputMode(TerminalInput::Mode::AnyEventMouseTracking, true);
         for (int i = 0; i < s_iTestCoordsLength; i++)
         {
             COORD Coord = s_rgTestCoords[i];
@@ -473,7 +473,7 @@ public:
         // However, mouse moves are only handled in Any Event mode
         fExpectedKeyHandled = uiButton != WM_MOUSEMOVE;
 
-        mouseInput->EnableDefaultTracking(true);
+        mouseInput->SetInputMode(TerminalInput::Mode::DefaultMouseTracking, true);
         for (int i = 0; i < s_iTestCoordsLength; i++)
         {
             COORD Coord = s_rgTestCoords[i];
@@ -487,7 +487,7 @@ public:
                              NoThrowString().Format(L"(x,y)=(%d,%d)", Coord.X, Coord.Y));
         }
 
-        mouseInput->EnableButtonEventTracking(true);
+        mouseInput->SetInputMode(TerminalInput::Mode::ButtonEventMouseTracking, true);
         for (int i = 0; i < s_iTestCoordsLength; i++)
         {
             COORD Coord = s_rgTestCoords[i];
@@ -506,7 +506,7 @@ public:
         }
 
         fExpectedKeyHandled = true;
-        mouseInput->EnableAnyEventTracking(true);
+        mouseInput->SetInputMode(TerminalInput::Mode::AnyEventMouseTracking, true);
         for (int i = 0; i < s_iTestCoordsLength; i++)
         {
             COORD Coord = s_rgTestCoords[i];
@@ -550,7 +550,7 @@ public:
         VERIFY_ARE_EQUAL(fExpectedKeyHandled, mouseInput->HandleMouse({ 0, 0 }, uiButton, sModifierKeystate, sScrollDelta, {}));
 
         // Default Tracking, Default Encoding
-        mouseInput->EnableDefaultTracking(true);
+        mouseInput->SetInputMode(TerminalInput::Mode::DefaultMouseTracking, true);
 
         for (int i = 0; i < s_iTestCoordsLength; i++)
         {

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -334,16 +334,6 @@ public:
         return true;
     }
 
-    bool PrivateEnableAlternateScroll(const bool enabled) override
-    {
-        Log::Comment(L"PrivateEnableAlternateScroll MOCK called...");
-        if (_privateEnableAlternateScrollResult)
-        {
-            VERIFY_ARE_EQUAL(_expectedAlternateScrollEnabled, enabled);
-        }
-        return _privateEnableAlternateScrollResult;
-    }
-
     bool PrivateEraseAll() override
     {
         Log::Comment(L"PrivateEraseAll MOCK called...");
@@ -734,8 +724,6 @@ public:
 
     bool _setConsoleTitleWResult = false;
     std::wstring_view _expectedWindowTitle{};
-    bool _expectedAlternateScrollEnabled = false;
-    bool _privateEnableAlternateScrollResult = false;
     bool _setCursorStyleResult = false;
     CursorType _expectedCursorStyle;
     bool _setCursorColorResult = false;
@@ -2285,10 +2273,11 @@ public:
         VERIFY_IS_TRUE(_pDispatch.get()->EnableAnyEventMouseMode(false));
 
         Log::Comment(L"Test 6: Test Alt Scroll Mouse Mode");
-        _testGetSet->_expectedAlternateScrollEnabled = true;
-        _testGetSet->_privateEnableAlternateScrollResult = TRUE;
+        _testGetSet->_expectedInputModeEnabled = true;
+        _testGetSet->_expectedInputMode = TerminalInput::Mode::AlternateScroll;
+        _testGetSet->_setInputModeResult = true;
         VERIFY_IS_TRUE(_pDispatch.get()->EnableAlternateScroll(true));
-        _testGetSet->_expectedAlternateScrollEnabled = false;
+        _testGetSet->_expectedInputModeEnabled = false;
         VERIFY_IS_TRUE(_pDispatch.get()->EnableAlternateScroll(false));
     }
 

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -334,36 +334,6 @@ public:
         return true;
     }
 
-    bool PrivateEnableVT200MouseMode(const bool enabled) override
-    {
-        Log::Comment(L"PrivateEnableVT200MouseMode MOCK called...");
-        if (_privateEnableVT200MouseModeResult)
-        {
-            VERIFY_ARE_EQUAL(_expectedMouseEnabled, enabled);
-        }
-        return _privateEnableVT200MouseModeResult;
-    }
-
-    bool PrivateEnableButtonEventMouseMode(const bool enabled) override
-    {
-        Log::Comment(L"PrivateEnableButtonEventMouseMode MOCK called...");
-        if (_privateEnableButtonEventMouseModeResult)
-        {
-            VERIFY_ARE_EQUAL(_expectedMouseEnabled, enabled);
-        }
-        return _privateEnableButtonEventMouseModeResult;
-    }
-
-    bool PrivateEnableAnyEventMouseMode(const bool enabled) override
-    {
-        Log::Comment(L"PrivateEnableAnyEventMouseMode MOCK called...");
-        if (_privateEnableAnyEventMouseModeResult)
-        {
-            VERIFY_ARE_EQUAL(_expectedMouseEnabled, enabled);
-        }
-        return _privateEnableAnyEventMouseModeResult;
-    }
-
     bool PrivateEnableAlternateScroll(const bool enabled) override
     {
         Log::Comment(L"PrivateEnableAlternateScroll MOCK called...");
@@ -764,11 +734,7 @@ public:
 
     bool _setConsoleTitleWResult = false;
     std::wstring_view _expectedWindowTitle{};
-    bool _expectedMouseEnabled = false;
     bool _expectedAlternateScrollEnabled = false;
-    bool _privateEnableVT200MouseModeResult = false;
-    bool _privateEnableButtonEventMouseModeResult = false;
-    bool _privateEnableAnyEventMouseModeResult = false;
     bool _privateEnableAlternateScrollResult = false;
     bool _setCursorStyleResult = false;
     CursorType _expectedCursorStyle;
@@ -2279,10 +2245,11 @@ public:
         Log::Comment(L"Starting test...");
 
         Log::Comment(L"Test 1: Test Default Mouse Mode");
-        _testGetSet->_expectedMouseEnabled = true;
-        _testGetSet->_privateEnableVT200MouseModeResult = TRUE;
+        _testGetSet->_expectedInputModeEnabled = true;
+        _testGetSet->_expectedInputMode = TerminalInput::Mode::DefaultMouseTracking;
+        _testGetSet->_setInputModeResult = true;
         VERIFY_IS_TRUE(_pDispatch.get()->EnableVT200MouseMode(true));
-        _testGetSet->_expectedMouseEnabled = false;
+        _testGetSet->_expectedInputModeEnabled = false;
         VERIFY_IS_TRUE(_pDispatch.get()->EnableVT200MouseMode(false));
 
         Log::Comment(L"Test 2: Test UTF-8 Extended Mouse Mode");
@@ -2302,17 +2269,19 @@ public:
         VERIFY_IS_TRUE(_pDispatch.get()->EnableSGRExtendedMouseMode(false));
 
         Log::Comment(L"Test 4: Test Button-Event Mouse Mode");
-        _testGetSet->_expectedMouseEnabled = true;
-        _testGetSet->_privateEnableButtonEventMouseModeResult = TRUE;
+        _testGetSet->_expectedInputModeEnabled = true;
+        _testGetSet->_expectedInputMode = TerminalInput::Mode::ButtonEventMouseTracking;
+        _testGetSet->_setInputModeResult = true;
         VERIFY_IS_TRUE(_pDispatch.get()->EnableButtonEventMouseMode(true));
-        _testGetSet->_expectedMouseEnabled = false;
+        _testGetSet->_expectedInputModeEnabled = false;
         VERIFY_IS_TRUE(_pDispatch.get()->EnableButtonEventMouseMode(false));
 
         Log::Comment(L"Test 5: Test Any-Event Mouse Mode");
-        _testGetSet->_expectedMouseEnabled = true;
-        _testGetSet->_privateEnableAnyEventMouseModeResult = TRUE;
+        _testGetSet->_expectedInputModeEnabled = true;
+        _testGetSet->_expectedInputMode = TerminalInput::Mode::AnyEventMouseTracking;
+        _testGetSet->_setInputModeResult = true;
         VERIFY_IS_TRUE(_pDispatch.get()->EnableAnyEventMouseMode(true));
-        _testGetSet->_expectedMouseEnabled = false;
+        _testGetSet->_expectedInputModeEnabled = false;
         VERIFY_IS_TRUE(_pDispatch.get()->EnableAnyEventMouseMode(false));
 
         Log::Comment(L"Test 6: Test Alt Scroll Mouse Mode");

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -344,26 +344,6 @@ public:
         return _privateEnableVT200MouseModeResult;
     }
 
-    bool PrivateEnableUTF8ExtendedMouseMode(const bool enabled) override
-    {
-        Log::Comment(L"PrivateEnableUTF8ExtendedMouseMode MOCK called...");
-        if (_privateEnableUTF8ExtendedMouseModeResult)
-        {
-            VERIFY_ARE_EQUAL(_expectedMouseEnabled, enabled);
-        }
-        return _privateEnableUTF8ExtendedMouseModeResult;
-    }
-
-    bool PrivateEnableSGRExtendedMouseMode(const bool enabled) override
-    {
-        Log::Comment(L"PrivateEnableSGRExtendedMouseMode MOCK called...");
-        if (_privateEnableSGRExtendedMouseModeResult)
-        {
-            VERIFY_ARE_EQUAL(_expectedMouseEnabled, enabled);
-        }
-        return _privateEnableSGRExtendedMouseModeResult;
-    }
-
     bool PrivateEnableButtonEventMouseMode(const bool enabled) override
     {
         Log::Comment(L"PrivateEnableButtonEventMouseMode MOCK called...");
@@ -787,8 +767,6 @@ public:
     bool _expectedMouseEnabled = false;
     bool _expectedAlternateScrollEnabled = false;
     bool _privateEnableVT200MouseModeResult = false;
-    bool _privateEnableUTF8ExtendedMouseModeResult = false;
-    bool _privateEnableSGRExtendedMouseModeResult = false;
     bool _privateEnableButtonEventMouseModeResult = false;
     bool _privateEnableAnyEventMouseModeResult = false;
     bool _privateEnableAlternateScrollResult = false;
@@ -2308,17 +2286,19 @@ public:
         VERIFY_IS_TRUE(_pDispatch.get()->EnableVT200MouseMode(false));
 
         Log::Comment(L"Test 2: Test UTF-8 Extended Mouse Mode");
-        _testGetSet->_expectedMouseEnabled = true;
-        _testGetSet->_privateEnableUTF8ExtendedMouseModeResult = TRUE;
+        _testGetSet->_expectedInputModeEnabled = true;
+        _testGetSet->_expectedInputMode = TerminalInput::Mode::Utf8MouseEncoding;
+        _testGetSet->_setInputModeResult = true;
         VERIFY_IS_TRUE(_pDispatch.get()->EnableUTF8ExtendedMouseMode(true));
-        _testGetSet->_expectedMouseEnabled = false;
+        _testGetSet->_expectedInputModeEnabled = false;
         VERIFY_IS_TRUE(_pDispatch.get()->EnableUTF8ExtendedMouseMode(false));
 
         Log::Comment(L"Test 3: Test SGR Extended Mouse Mode");
-        _testGetSet->_expectedMouseEnabled = true;
-        _testGetSet->_privateEnableSGRExtendedMouseModeResult = TRUE;
+        _testGetSet->_expectedInputModeEnabled = true;
+        _testGetSet->_expectedInputMode = TerminalInput::Mode::SgrMouseEncoding;
+        _testGetSet->_setInputModeResult = true;
         VERIFY_IS_TRUE(_pDispatch.get()->EnableSGRExtendedMouseMode(true));
-        _testGetSet->_expectedMouseEnabled = false;
+        _testGetSet->_expectedInputModeEnabled = false;
         VERIFY_IS_TRUE(_pDispatch.get()->EnableSGRExtendedMouseMode(false));
 
         Log::Comment(L"Test 4: Test Button-Event Mouse Mode");

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -112,35 +112,17 @@ public:
         return _setConsoleWindowInfoResult;
     }
 
-    bool PrivateSetCursorKeysMode(const bool applicationMode) override
+    bool SetInputMode(const TerminalInput::Mode mode, const bool enabled) override
     {
-        Log::Comment(L"PrivateSetCursorKeysMode MOCK called...");
+        Log::Comment(L"SetInputMode MOCK called...");
 
-        if (_privateSetCursorKeysModeResult)
+        if (_setInputModeResult)
         {
-            VERIFY_ARE_EQUAL(_cursorKeysApplicationMode, applicationMode);
+            VERIFY_ARE_EQUAL(_expectedInputMode, mode);
+            VERIFY_ARE_EQUAL(_expectedInputModeEnabled, enabled);
         }
 
-        return _privateSetCursorKeysModeResult;
-    }
-
-    bool PrivateSetKeypadMode(const bool applicationMode) override
-    {
-        Log::Comment(L"PrivateSetKeypadMode MOCK called...");
-
-        if (_privateSetKeypadModeResult)
-        {
-            VERIFY_ARE_EQUAL(_keypadApplicationMode, applicationMode);
-        }
-
-        return _privateSetKeypadModeResult;
-    }
-
-    bool PrivateEnableWin32InputMode(const bool /*win32InputMode*/) override
-    {
-        Log::Comment(L"PrivateEnableWin32InputMode MOCK called...");
-
-        return true;
+        return _setInputModeResult;
     }
 
     bool PrivateSetAnsiMode(const bool ansiMode) override
@@ -787,10 +769,9 @@ public:
 
     COORD _expectedScreenBufferSize = { 0, 0 };
     SMALL_RECT _expectedScreenBufferViewport{ 0, 0, 0, 0 };
-    bool _privateSetCursorKeysModeResult = false;
-    bool _privateSetKeypadModeResult = false;
-    bool _cursorKeysApplicationMode = false;
-    bool _keypadApplicationMode = false;
+    bool _setInputModeResult = false;
+    TerminalInput::Mode _expectedInputMode;
+    bool _expectedInputModeEnabled = false;
     bool _privateSetAnsiModeResult = false;
     bool _expectedAnsiMode = false;
     bool _privateAllowCursorBlinkingResult = false;
@@ -2100,15 +2081,17 @@ public:
         // success cases
         // set numeric mode = true
         Log::Comment(L"Test 1: application mode = false");
-        _testGetSet->_privateSetCursorKeysModeResult = TRUE;
-        _testGetSet->_cursorKeysApplicationMode = false;
+        _testGetSet->_setInputModeResult = true;
+        _testGetSet->_expectedInputMode = TerminalInput::Mode::CursorKey;
+        _testGetSet->_expectedInputModeEnabled = false;
 
         VERIFY_IS_TRUE(_pDispatch.get()->SetCursorKeysMode(false));
 
         // set numeric mode = false
         Log::Comment(L"Test 2: application mode = true");
-        _testGetSet->_privateSetCursorKeysModeResult = TRUE;
-        _testGetSet->_cursorKeysApplicationMode = true;
+        _testGetSet->_setInputModeResult = true;
+        _testGetSet->_expectedInputMode = TerminalInput::Mode::CursorKey;
+        _testGetSet->_expectedInputModeEnabled = true;
 
         VERIFY_IS_TRUE(_pDispatch.get()->SetCursorKeysMode(true));
     }
@@ -2120,15 +2103,17 @@ public:
         // success cases
         // set numeric mode = true
         Log::Comment(L"Test 1: application mode = false");
-        _testGetSet->_privateSetKeypadModeResult = TRUE;
-        _testGetSet->_keypadApplicationMode = false;
+        _testGetSet->_setInputModeResult = true;
+        _testGetSet->_expectedInputMode = TerminalInput::Mode::Keypad;
+        _testGetSet->_expectedInputModeEnabled = false;
 
         VERIFY_IS_TRUE(_pDispatch.get()->SetKeypadMode(false));
 
         // set numeric mode = false
         Log::Comment(L"Test 2: application mode = true");
-        _testGetSet->_privateSetKeypadModeResult = TRUE;
-        _testGetSet->_keypadApplicationMode = true;
+        _testGetSet->_setInputModeResult = true;
+        _testGetSet->_expectedInputMode = TerminalInput::Mode::Keypad;
+        _testGetSet->_expectedInputModeEnabled = true;
 
         VERIFY_IS_TRUE(_pDispatch.get()->SetKeypadMode(true));
     }

--- a/src/terminal/input/mouseInput.cpp
+++ b/src/terminal/input/mouseInput.cpp
@@ -542,10 +542,10 @@ std::wstring TerminalInput::_GenerateSGRSequence(const COORD position,
 // - delta: The scroll wheel delta of the input event
 // Return value:
 // True iff the alternate buffer is active and alternate scroll mode is enabled and the event is a mouse wheel event.
-bool TerminalInput::_ShouldSendAlternateScroll(const unsigned int button, const short delta) const noexcept
+bool TerminalInput::_ShouldSendAlternateScroll(const unsigned int button, const short delta) const
 {
     return _mouseInputState.inAlternateBuffer &&
-           _mouseInputState.alternateScroll &&
+           _inputMode.test(Mode::AlternateScroll) &&
            (button == WM_MOUSEWHEEL || button == WM_MOUSEHWHEEL) && delta != 0;
 }
 

--- a/src/terminal/input/mouseInput.cpp
+++ b/src/terminal/input/mouseInput.cpp
@@ -560,15 +560,15 @@ bool TerminalInput::_ShouldSendAlternateScroll(const unsigned int button, const 
 // - delta: The scroll wheel delta of the input event
 // Return value:
 // True iff the input sequence was sent successfully.
-bool TerminalInput::_SendAlternateScroll(const short delta) const noexcept
+bool TerminalInput::_SendAlternateScroll(const short delta) const
 {
     if (delta > 0)
     {
-        _SendInputSequence(_cursorApplicationMode ? ApplicationUpSequence : CursorUpSequence);
+        _SendInputSequence(_inputMode.test(Mode::CursorKey) ? ApplicationUpSequence : CursorUpSequence);
     }
     else
     {
-        _SendInputSequence(_cursorApplicationMode ? ApplicationDownSequence : CursorDownSequence);
+        _SendInputSequence(_inputMode.test(Mode::CursorKey) ? ApplicationDownSequence : CursorDownSequence);
     }
     return true;
 }

--- a/src/terminal/input/mouseInputState.cpp
+++ b/src/terminal/input/mouseInputState.cpp
@@ -8,34 +8,6 @@
 using namespace Microsoft::Console::VirtualTerminal;
 
 // Routine Description:
-// - Either enables or disables UTF-8 extended mode encoding. This *should* cause
-//      the coordinates of a mouse event to be encoded as a UTF-8 byte stream, however, because windows' input is
-//      typically UTF-16 encoded, it emits a UTF-16 stream.
-//   Does NOT enable or disable mouse mode by itself. This matches the behavior I found in Ubuntu terminals.
-// Parameters:
-// - enable - either enable or disable.
-// Return value:
-// <none>
-void TerminalInput::SetUtf8ExtendedMode(const bool enable) noexcept
-{
-    _mouseInputState.extendedMode = enable ? ExtendedMode::Utf8 : ExtendedMode::None;
-}
-
-// Routine Description:
-// - Either enables or disables SGR extended mode encoding. This causes the
-//      coordinates of a mouse event to be emitted in a human readable format,
-//      eg, x,y=203,504 -> "^[[<B;203;504M". This way, applications don't need to worry about character encoding.
-//   Does NOT enable or disable mouse mode by itself. This matches the behavior I found in Ubuntu terminals.
-// Parameters:
-// - enable - either enable or disable.
-// Return value:
-// <none>
-void TerminalInput::SetSGRExtendedMode(const bool enable) noexcept
-{
-    _mouseInputState.extendedMode = enable ? ExtendedMode::Sgr : ExtendedMode::None;
-}
-
-// Routine Description:
 // - Either enables or disables mouse mode handling. Leaves the extended mode alone,
 //      so if we disable then re-enable mouse mode without toggling an extended mode, the mode will persist.
 // Parameters:

--- a/src/terminal/input/mouseInputState.cpp
+++ b/src/terminal/input/mouseInputState.cpp
@@ -8,17 +8,6 @@
 using namespace Microsoft::Console::VirtualTerminal;
 
 // Routine Description:
-// - Enables alternate scroll mode. This sends Cursor Up/down sequences when in the alternate buffer
-// Parameters:
-// - enable - either enable or disable.
-// Return value:
-// <none>
-void TerminalInput::EnableAlternateScroll(const bool enable) noexcept
-{
-    _mouseInputState.alternateScroll = enable;
-}
-
-// Routine Description:
 // - Notify the MouseInput handler that the screen buffer has been swapped to the alternate buffer
 // Parameters:
 // <none>

--- a/src/terminal/input/mouseInputState.cpp
+++ b/src/terminal/input/mouseInputState.cpp
@@ -8,52 +8,6 @@
 using namespace Microsoft::Console::VirtualTerminal;
 
 // Routine Description:
-// - Either enables or disables mouse mode handling. Leaves the extended mode alone,
-//      so if we disable then re-enable mouse mode without toggling an extended mode, the mode will persist.
-// Parameters:
-// - enable - either enable or disable.
-// Return value:
-// <none>
-void TerminalInput::EnableDefaultTracking(const bool enable) noexcept
-{
-    _mouseInputState.trackingMode = enable ? TrackingMode::Default : TrackingMode::None;
-    _mouseInputState.lastPos = { -1, -1 }; // Clear out the last saved mouse position & button.
-    _mouseInputState.lastButton = 0;
-}
-
-// Routine Description:
-// - Either enables or disables ButtonEvent mouse handling. Button Event mode
-//      sends additional sequences when a button is pressed and the mouse changes character cells.
-//   Leaves the extended mode alone, so if we disable then re-enable mouse mode
-//      without toggling an extended mode, the mode will persist.
-// Parameters:
-// - enable - either enable or disable.
-// Return value:
-// <none>
-void TerminalInput::EnableButtonEventTracking(const bool enable) noexcept
-{
-    _mouseInputState.trackingMode = enable ? TrackingMode::ButtonEvent : TrackingMode::None;
-    _mouseInputState.lastPos = { -1, -1 }; // Clear out the last saved mouse position & button.
-    _mouseInputState.lastButton = 0;
-}
-
-// Routine Description:
-// - Either enables or disables AnyEvent mouse handling. Any Event mode sends sequences
-//      for any and every mouse event, regardless if a button is pressed or not.
-//   Leaves the extended mode alone, so if we disable then re-enable mouse mode
-//      without toggling an extended mode, the mode will persist.
-// Parameters:
-// - enable - either enable or disable.
-// Return value:
-// <none>
-void TerminalInput::EnableAnyEventTracking(const bool enable) noexcept
-{
-    _mouseInputState.trackingMode = enable ? TrackingMode::AnyEvent : TrackingMode::None;
-    _mouseInputState.lastPos = { -1, -1 }; // Clear out the last saved mouse position & button.
-    _mouseInputState.lastButton = 0;
-}
-
-// Routine Description:
 // - Enables alternate scroll mode. This sends Cursor Up/down sequences when in the alternate buffer
 // Parameters:
 // - enable - either enable or disable.

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -250,25 +250,16 @@ const wchar_t* const CTRL_QUESTIONMARK_SEQUENCE = L"\x7F";
 const wchar_t* const CTRL_ALT_SLASH_SEQUENCE = L"\x1b\x1f";
 const wchar_t* const CTRL_ALT_QUESTIONMARK_SEQUENCE = L"\x1b\x7F";
 
-void TerminalInput::ChangeAnsiMode(const bool ansiMode) noexcept
+void TerminalInput::SetInputMode(const Mode mode, const bool enabled)
 {
-    _ansiMode = ansiMode;
+    _inputMode.set(mode, enabled);
 }
 
-void TerminalInput::ChangeKeypadMode(const bool applicationMode) noexcept
+bool TerminalInput::GetInputMode(const Mode mode) const
 {
-    _keypadApplicationMode = applicationMode;
+    return _inputMode.test(mode);
 }
 
-void TerminalInput::ChangeCursorKeysMode(const bool applicationMode) noexcept
-{
-    _cursorApplicationMode = applicationMode;
-}
-
-void TerminalInput::ChangeWin32InputMode(const bool win32InputMode) noexcept
-{
-    _win32InputMode = win32InputMode;
-}
 void TerminalInput::ForceDisableWin32InputMode(const bool win32InputMode) noexcept
 {
     _forceDisableWin32InputMode = win32InputMode;
@@ -530,7 +521,7 @@ bool TerminalInput::HandleKey(const IInputEvent* const pInEvent)
     // GH#4999 - If we're in win32-input mode, skip straight to doing that.
     // Since this mode handles all types of key events, do nothing else.
     // Only do this if win32-input-mode support isn't manually disabled.
-    if (_win32InputMode && !_forceDisableWin32InputMode)
+    if (_inputMode.test(Mode::Win32) && !_forceDisableWin32InputMode)
     {
         const auto seq = _GenerateWin32KeySequence(keyEvent);
         _SendInputSequence(seq);
@@ -655,7 +646,7 @@ bool TerminalInput::HandleKey(const IInputEvent* const pInEvent)
     // Check any other key mappings (like those for the F1-F12 keys).
     // These mappings will kick in no matter which modifiers are pressed and as such
     // must be checked last, or otherwise we'd override more complex key combinations.
-    const auto mapping = _getKeyMapping(keyEvent, _ansiMode, _cursorApplicationMode, _keypadApplicationMode);
+    const auto mapping = _getKeyMapping(keyEvent, _inputMode.test(Mode::Ansi), _inputMode.test(Mode::CursorKey), _inputMode.test(Mode::Keypad));
     if (_translateDefaultMapping(keyEvent, mapping, senderFunc))
     {
         return true;

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -252,10 +252,22 @@ const wchar_t* const CTRL_ALT_QUESTIONMARK_SEQUENCE = L"\x1b\x7F";
 
 void TerminalInput::SetInputMode(const Mode mode, const bool enabled)
 {
+    // If we're changing a tracking mode, we always clear other tracking modes first.
+    // We also clear out the last saved mouse position & button.
+    if (mode == Mode::DefaultMouseTracking || mode == Mode::ButtonEventMouseTracking || mode == Mode::AnyEventMouseTracking)
+    {
+        _inputMode.reset_all(Mode::DefaultMouseTracking, Mode::ButtonEventMouseTracking, Mode::AnyEventMouseTracking);
+        _mouseInputState.lastPos = { -1, -1 };
+        _mouseInputState.lastButton = 0;
+    }
+
+    // But if we're changing the encoding, we only clear out the other encoding modes
+    // when enabling a new encoding - not when disabling.
     if ((mode == Mode::Utf8MouseEncoding || mode == Mode::SgrMouseEncoding) && enabled)
     {
         _inputMode.reset_all(Mode::Utf8MouseEncoding, Mode::SgrMouseEncoding);
     }
+
     _inputMode.set(mode, enabled);
 }
 

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -252,6 +252,10 @@ const wchar_t* const CTRL_ALT_QUESTIONMARK_SEQUENCE = L"\x1b\x7F";
 
 void TerminalInput::SetInputMode(const Mode mode, const bool enabled)
 {
+    if ((mode == Mode::Utf8MouseEncoding || mode == Mode::SgrMouseEncoding) && enabled)
+    {
+        _inputMode.reset_all(Mode::Utf8MouseEncoding, Mode::SgrMouseEncoding);
+    }
     _inputMode.set(mode, enabled);
 }
 

--- a/src/terminal/input/terminalInput.hpp
+++ b/src/terminal/input/terminalInput.hpp
@@ -40,7 +40,10 @@ namespace Microsoft::Console::VirtualTerminal
             Ansi,
             Keypad,
             CursorKey,
-            Win32
+            Win32,
+
+            Utf8MouseEncoding,
+            SgrMouseEncoding
         };
 
         void SetInputMode(const Mode mode, const bool enabled);
@@ -68,9 +71,6 @@ namespace Microsoft::Console::VirtualTerminal
 
 #pragma region MouseInputState Management
         // These methods are defined in mouseInputState.cpp
-        void SetUtf8ExtendedMode(const bool enable) noexcept;
-        void SetSGRExtendedMode(const bool enable) noexcept;
-
         void EnableDefaultTracking(const bool enable) noexcept;
         void EnableButtonEventTracking(const bool enable) noexcept;
         void EnableAnyEventTracking(const bool enable) noexcept;
@@ -97,14 +97,6 @@ namespace Microsoft::Console::VirtualTerminal
 
 #pragma region MouseInputState Management
         // These methods are defined in mouseInputState.cpp
-        enum class ExtendedMode : unsigned int
-        {
-            None,
-            Utf8,
-            Sgr,
-            Urxvt
-        };
-
         enum class TrackingMode : unsigned int
         {
             None,
@@ -115,7 +107,6 @@ namespace Microsoft::Console::VirtualTerminal
 
         struct MouseInputState
         {
-            ExtendedMode extendedMode{ ExtendedMode::None };
             TrackingMode trackingMode{ TrackingMode::None };
             bool alternateScroll{ false };
             bool inAlternateBuffer{ false };

--- a/src/terminal/input/terminalInput.hpp
+++ b/src/terminal/input/terminalInput.hpp
@@ -47,7 +47,9 @@ namespace Microsoft::Console::VirtualTerminal
 
             DefaultMouseTracking,
             ButtonEventMouseTracking,
-            AnyEventMouseTracking
+            AnyEventMouseTracking,
+
+            AlternateScroll
         };
 
         void SetInputMode(const Mode mode, const bool enabled);
@@ -75,7 +77,6 @@ namespace Microsoft::Console::VirtualTerminal
 
 #pragma region MouseInputState Management
         // These methods are defined in mouseInputState.cpp
-        void EnableAlternateScroll(const bool enable) noexcept;
         void UseAlternateScreenBuffer() noexcept;
         void UseMainScreenBuffer() noexcept;
 #pragma endregion
@@ -99,7 +100,6 @@ namespace Microsoft::Console::VirtualTerminal
         // These methods are defined in mouseInputState.cpp
         struct MouseInputState
         {
-            bool alternateScroll{ false };
             bool inAlternateBuffer{ false };
             COORD lastPos{ -1, -1 };
             unsigned int lastButton{ 0 };
@@ -127,7 +127,7 @@ namespace Microsoft::Console::VirtualTerminal
                                                  const short modifierKeyState,
                                                  const short delta);
 
-        bool _ShouldSendAlternateScroll(const unsigned int button, const short delta) const noexcept;
+        bool _ShouldSendAlternateScroll(const unsigned int button, const short delta) const;
         bool _SendAlternateScroll(const short delta) const;
 
         static constexpr unsigned int s_GetPressedButton(const MouseButtonState state) noexcept;

--- a/src/terminal/input/terminalInput.hpp
+++ b/src/terminal/input/terminalInput.hpp
@@ -34,11 +34,17 @@ namespace Microsoft::Console::VirtualTerminal
         ~TerminalInput() = default;
 
         bool HandleKey(const IInputEvent* const pInEvent);
-        void ChangeAnsiMode(const bool ansiMode) noexcept;
-        void ChangeKeypadMode(const bool applicationMode) noexcept;
-        void ChangeCursorKeysMode(const bool applicationMode) noexcept;
 
-        void ChangeWin32InputMode(const bool win32InputMode) noexcept;
+        enum class Mode : size_t
+        {
+            Ansi,
+            Keypad,
+            CursorKey,
+            Win32
+        };
+
+        void SetInputMode(const Mode mode, const bool enabled);
+        bool GetInputMode(const Mode mode) const;
         void ForceDisableWin32InputMode(const bool win32InputMode) noexcept;
 
 #pragma region MouseInput
@@ -80,10 +86,7 @@ namespace Microsoft::Console::VirtualTerminal
         // storage location for the leading surrogate of a utf-16 surrogate pair
         std::optional<wchar_t> _leadingSurrogate;
 
-        bool _ansiMode{ true };
-        bool _keypadApplicationMode{ false };
-        bool _cursorApplicationMode{ false };
-        bool _win32InputMode{ false };
+        til::enumset<Mode> _inputMode{ Mode::Ansi };
         bool _forceDisableWin32InputMode{ false };
 
         void _SendChar(const wchar_t ch);
@@ -143,7 +146,7 @@ namespace Microsoft::Console::VirtualTerminal
                                                  const short delta);
 
         bool _ShouldSendAlternateScroll(const unsigned int button, const short delta) const noexcept;
-        bool _SendAlternateScroll(const short delta) const noexcept;
+        bool _SendAlternateScroll(const short delta) const;
 
         static constexpr unsigned int s_GetPressedButton(const MouseButtonState state) noexcept;
 #pragma endregion

--- a/src/terminal/input/terminalInput.hpp
+++ b/src/terminal/input/terminalInput.hpp
@@ -43,7 +43,11 @@ namespace Microsoft::Console::VirtualTerminal
             Win32,
 
             Utf8MouseEncoding,
-            SgrMouseEncoding
+            SgrMouseEncoding,
+
+            DefaultMouseTracking,
+            ButtonEventMouseTracking,
+            AnyEventMouseTracking
         };
 
         void SetInputMode(const Mode mode, const bool enabled);
@@ -71,10 +75,6 @@ namespace Microsoft::Console::VirtualTerminal
 
 #pragma region MouseInputState Management
         // These methods are defined in mouseInputState.cpp
-        void EnableDefaultTracking(const bool enable) noexcept;
-        void EnableButtonEventTracking(const bool enable) noexcept;
-        void EnableAnyEventTracking(const bool enable) noexcept;
-
         void EnableAlternateScroll(const bool enable) noexcept;
         void UseAlternateScreenBuffer() noexcept;
         void UseMainScreenBuffer() noexcept;
@@ -97,17 +97,8 @@ namespace Microsoft::Console::VirtualTerminal
 
 #pragma region MouseInputState Management
         // These methods are defined in mouseInputState.cpp
-        enum class TrackingMode : unsigned int
-        {
-            None,
-            Default,
-            ButtonEvent,
-            AnyEvent
-        };
-
         struct MouseInputState
         {
-            TrackingMode trackingMode{ TrackingMode::None };
             bool alternateScroll{ false };
             bool inAlternateBuffer{ false };
             COORD lastPos{ -1, -1 };


### PR DESCRIPTION
## Summary of the Pull Request

Instead of having a separate method for setting each mouse and keyboard mode, this PR consolidates them all into a single method which takes a mode parameter, and stores the modes in a `til::enumset` rather than having a separate `bool` for each mode.

This enables us to get rid of a lot of boilerplate code, and makes the code easier to extend when we want to introduce additional modes in the future. It'll also makes it easier to read back the state of the various modes when implementing the `DECRQM` query.

## References

Simplifying the `ConGetSet` and `ITerminalApi` is also part of the plan to de-duplicate the `AdaptDispatch` and `TerminalDispatch` implementation (#3849).

## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed.
* [ ] Tests added/passed
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] I've discussed this with core contributors already. Issue number where discussion took place: #3849

## Detailed Description of the Pull Request / Additional comments

Most of the complication is in the `TerminalInput` class, which had to be adjusted to work with an `enumset` in place of all the `bool` fields. For the rest, it was largely a matter of replacing calls to all the old mode setting methods with the new `SetInputMode` method, and deleting a bunch of unused code.

One thing worth mentioning is that the `AdaptDispatch` implementation used to have a `_ShouldPassThroughInputModeChange` method that was called after every mode change. This code has now been moved up into the `SetInputMode` implementation in `ConhostInternalGetSet` so it's just handled in one place. Keeping this out of the dispatch class will also be beneficial for sharing the implementation with `TerminalDispatch`.

## Validation Steps Performed

The updated interface necessitated some adjustments to the tests in `AdapterTest` and `MouseInputTest`, but the essential structure of the tests remains unchanged, and everything still passes.

I've also tested the keyboard and mouse modes in Vttest and confirmed they still work at least as well as they did before (both conhost and Windows Terminal), and I tested the alternate scroll mode manually (conhost only).