### PR TITLE
Ensure "Reset to inherited value" button works for opacity

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Profiles.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
 #pragma once
@@ -22,7 +22,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         void SetAcrylicOpacityPercentageValue(double value)
         {
-            _profile.DefaultAppearance().Opacity(winrt::Microsoft::Terminal::Settings::Editor::Converters::PercentageValueToPercentage(value));
+            Opacity(winrt::Microsoft::Terminal::Settings::Editor::Converters::PercentageValueToPercentage(value));
         };
 
         void SetPadding(double value)

--- a/src/cascadia/TerminalSettingsEditor/Profiles.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles.xaml
@@ -249,6 +249,7 @@
                             <!--  Opacity  -->
                             <local:SettingContainer x:Name="OpacityContainer"
                                                     x:Uid="Profile_Opacity"
+                                                    Margin="0"
                                                     ClearSettingValue="{x:Bind State.Profile.ClearOpacity}"
                                                     HasSettingValue="{x:Bind State.Profile.HasOpacity, Mode=OneWay}"
                                                     SettingOverrideSource="{x:Bind State.Profile.OpacityOverrideSource, Mode=OneWay}">


### PR DESCRIPTION
## Summary of the Pull Request
Fixes the "Reset to inherited value" button for the opacity slider and removes the unwanted padding between the header and the control.

## PR Checklist
* [x] Closes #11352
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed
Manually tested