### PR TITLE
Fix type of id in focusPane action in setttings schema

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -1184,7 +1184,7 @@
               "pattern": "focusPane"
             },
             "id": {
-              "type": "number",
+              "type": "integer",
               "minimum": 0,
               "default": 0,
               "description": "The ID of the pane to focus"
@@ -1230,7 +1230,7 @@
               "description": "When provided, summon the window whose name or ID matches the given name value. If no such window exists, then create a new window with that name."
             },
             "dropdownDuration": {
-              "type": "number",
+              "type": "integer",
               "minimum": 0,
               "default": 0,
               "description": "When provided with a positive number, \"slide\" the window in from the top of the screen using an animation that lasts dropdownDuration milliseconds."

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -1184,8 +1184,9 @@
               "pattern": "focusPane"
             },
             "id": {
-              "type": "string",
-              "default": "",
+              "type": "number",
+              "minimum": 0,
+              "default": 0,
               "description": "The ID of the pane to focus"
             }
           }


### PR DESCRIPTION
## Summary of the Pull Request

The type of the `"id"` argument of the `focusPane` action under `"actions"` in the `settings.json` schema was incorrectly set to a string.
It's actually expecting a non-negative number, and defaults to 0.
So I fixed the schema.

## PR Checklist
* [x] Closes #11393
* [x] CLA signed
* [ ] Tests added/passed
* [ ] Documentation updated
* [x] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.

## Detailed Description of the Pull Request / Additional comments



## Validation Steps Performed

I've validated that a string makes Windows Terminal complain it's a string and not a number, and that a number works as expected, and that the default is indeed zero.