### PR TITLE
Fix globalSummon.dropdownDuration not saving correctly

### DIFF
--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -1683,7 +1683,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             JsonUtils::SetValueForKey(json, NameKey, args->_Name);
             JsonUtils::SetValueForKey(json, DesktopKey, args->_Desktop);
             JsonUtils::SetValueForKey(json, MonitorKey, args->_Monitor);
-            JsonUtils::GetValueForKey(json, DropdownDurationKey, args->_DropdownDuration);
+            JsonUtils::SetValueForKey(json, DropdownDurationKey, args->_DropdownDuration);
             JsonUtils::SetValueForKey(json, ToggleVisibilityKey, args->_ToggleVisibility);
             return json;
         }


### PR DESCRIPTION
## Summary of the Pull Request

In `settings.json` there's an `actions` array to configure keybindings.
The action `globalSummon` has an argument called `dropdownDuration`.
The settings editor deleted this argument from the settings because of a typo in `ActionArgs.h`.

## PR Checklist
* [x] Closes #11400
* [x] CLA signed
* [ ] Tests added/passed
* [ ] Documentation updated
* [ ] Schema updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.

## Detailed Description of the Pull Request / Additional comments

There was a `JsonUtils::GetValueForKey` instead of a `JsonUtils::SetValueForKey`.
This is what happens when such code is not autogenerated.

## Validation Steps Performed

None