### PR TITLE
Refresh frame margins when moving between monitors

### DIFF
--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -310,6 +310,12 @@ void NonClientIslandWindow::OnSize(const UINT width, const UINT height)
     {
         _UpdateIslandPosition(width, height);
     }
+
+    // GH#11367: We need to do this,
+    // otherwise the titlebar may still be partially visible
+    // when we move between different DPI monitors.
+    RefreshCurrentDPI();
+    _UpdateFrameMargins();
 }
 
 // Method Description:


### PR DESCRIPTION
## Summary of the Pull Request

Refresh the DPI and frame margins when we move the window between different DPI monitors.

## PR Checklist
Closes #11367 