### PR TITLE
Fix the tab color, part III

### DIFF
--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -25,6 +25,15 @@ namespace winrt
 
 namespace winrt::TerminalApp::implementation
 {
+    WUX::Media::Brush _defaultTabBackground(const MUX::Controls::TabViewItem& tab)
+    {
+        static WUX::Media::Brush brush = [tab]() {
+            auto bg = tab.Background();
+            return bg;
+        }();
+        return brush;
+    }
+
     TerminalTab::TerminalTab(const Profile& profile, const TermControl& control)
     {
         _rootPane = std::make_shared<Pane>(profile, control, true);
@@ -143,7 +152,8 @@ namespace winrt::TerminalApp::implementation
     void TerminalTab::_MakeTabViewItem()
     {
         TabBase::_MakeTabViewItem();
-
+        // auto bg{ _defaultTabBackground(TabViewItem()) };
+        // TabViewItem().Background(bg);
         TabViewItem().DoubleTapped([weakThis = get_weak()](auto&& /*s*/, auto&& /*e*/) {
             if (auto tab{ weakThis.get() })
             {
@@ -1469,6 +1479,10 @@ namespace winrt::TerminalApp::implementation
         // We actually can't, because it will make the part of the tab that
         // doesn't contain the text totally transparent to hit tests. So we
         // actually _do_ still need to set TabViewItemHeaderBackground manually.
+        auto originalBg = TabViewItem().Background();
+        originalBg;
+        // TabViewItem().Background(WUX::Media::SolidColorBrush{ Windows::UI::Colors::Transparent() });
+        TabViewItem().Background(deselectedTabBrush);
         TabViewItem().Resources().Insert(winrt::box_value(L"TabViewItemHeaderBackground"), deselectedTabBrush);
         TabViewItem().Resources().Insert(winrt::box_value(L"TabViewItemHeaderBackgroundSelected"), selectedTabBrush);
         TabViewItem().Resources().Insert(winrt::box_value(L"TabViewItemHeaderBackgroundPointerOver"), hoverTabBrush);
@@ -1535,6 +1549,10 @@ namespace winrt::TerminalApp::implementation
                 TabViewItem().Resources().Remove(key);
             }
         }
+
+        // TabViewItem().Background(nullptr);
+        // TabViewItem().Background(_defaultTabBackground(TabViewItem()));
+        TabViewItem().Background(WUX::Media::SolidColorBrush{ Windows::UI::Colors::Transparent() });
 
         _RefreshVisualState();
         _colorCleared();

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -1461,16 +1461,10 @@ namespace winrt::TerminalApp::implementation
         // when the TabViewItem is unselected. So we still need to set the other
         // properties ourselves.
         //
-        // GH#11294: DESPITE the fact that there's a Background() API that we
-        // could just call like:
-        //
-        //     TabViewItem().Background(deselectedTabBrush);
-        //
-        // We actually can't, because it will make the part of the tab that
-        // doesn't contain the text totally transparent to hit tests. So we
-        // actually _do_ still need to set TabViewItemHeaderBackground manually.
+        // In GH#11294 we thought we'd still need to set
+        // TabViewItemHeaderBackground manually, but GH#11382 discovered that
+        // Background() was actually okay after all.
         TabViewItem().Background(deselectedTabBrush);
-        TabViewItem().Resources().Insert(winrt::box_value(L"TabViewItemHeaderBackground"), deselectedTabBrush);
         TabViewItem().Resources().Insert(winrt::box_value(L"TabViewItemHeaderBackgroundSelected"), selectedTabBrush);
         TabViewItem().Resources().Insert(winrt::box_value(L"TabViewItemHeaderBackgroundPointerOver"), hoverTabBrush);
         TabViewItem().Resources().Insert(winrt::box_value(L"TabViewItemHeaderBackgroundPressed"), selectedTabBrush);

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -25,15 +25,6 @@ namespace winrt
 
 namespace winrt::TerminalApp::implementation
 {
-    WUX::Media::Brush _defaultTabBackground(const MUX::Controls::TabViewItem& tab)
-    {
-        static WUX::Media::Brush brush = [tab]() {
-            auto bg = tab.Background();
-            return bg;
-        }();
-        return brush;
-    }
-
     TerminalTab::TerminalTab(const Profile& profile, const TermControl& control)
     {
         _rootPane = std::make_shared<Pane>(profile, control, true);
@@ -152,8 +143,7 @@ namespace winrt::TerminalApp::implementation
     void TerminalTab::_MakeTabViewItem()
     {
         TabBase::_MakeTabViewItem();
-        // auto bg{ _defaultTabBackground(TabViewItem()) };
-        // TabViewItem().Background(bg);
+
         TabViewItem().DoubleTapped([weakThis = get_weak()](auto&& /*s*/, auto&& /*e*/) {
             if (auto tab{ weakThis.get() })
             {
@@ -1479,9 +1469,6 @@ namespace winrt::TerminalApp::implementation
         // We actually can't, because it will make the part of the tab that
         // doesn't contain the text totally transparent to hit tests. So we
         // actually _do_ still need to set TabViewItemHeaderBackground manually.
-        auto originalBg = TabViewItem().Background();
-        originalBg;
-        // TabViewItem().Background(WUX::Media::SolidColorBrush{ Windows::UI::Colors::Transparent() });
         TabViewItem().Background(deselectedTabBrush);
         TabViewItem().Resources().Insert(winrt::box_value(L"TabViewItemHeaderBackground"), deselectedTabBrush);
         TabViewItem().Resources().Insert(winrt::box_value(L"TabViewItemHeaderBackgroundSelected"), selectedTabBrush);
@@ -1550,8 +1537,9 @@ namespace winrt::TerminalApp::implementation
             }
         }
 
-        // TabViewItem().Background(nullptr);
-        // TabViewItem().Background(_defaultTabBackground(TabViewItem()));
+        // GH#11382 DON'T set the background to null. If you do that, then the
+        // tab won't be hit testable at all. Transparent, however, is a totally
+        // valid hit test target. That makes sense.
         TabViewItem().Background(WUX::Media::SolidColorBrush{ Windows::UI::Colors::Transparent() });
 
         _RefreshVisualState();


### PR DESCRIPTION
I've had a hard time with the tab colors this week.

Turns out that setting the background to nullptr will make the tabviewitem invisible to hit tests. `Transparent`, on the other hand, is totally valid, and the expected default. 

Tabs as of this commit:

![tab-color-fix-3](https://user-images.githubusercontent.com/18356694/135915272-ff90b28b-f260-493e-bf0b-3450b4702dce.gif)

## PR Checklist
* [x] Closes #11382
* [x] I work here

This low-key reverts a bit of #11369, which fixed #11294, which regressed in #11240