### PR TITLE
Fix null pointer exceptions for default constructed CascadiaSettings instances

### DIFF
--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -153,13 +153,13 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         bool _hasInvalidColorScheme(const Model::Command& command) const;
 
         // user settings
-        winrt::com_ptr<implementation::GlobalAppSettings> _globals;
-        winrt::com_ptr<implementation::Profile> _baseLayerProfile;
-        winrt::Windows::Foundation::Collections::IObservableVector<Model::Profile> _allProfiles;
-        winrt::Windows::Foundation::Collections::IObservableVector<Model::Profile> _activeProfiles;
+        winrt::com_ptr<implementation::GlobalAppSettings> _globals = winrt::make_self<implementation::GlobalAppSettings>();
+        winrt::com_ptr<implementation::Profile> _baseLayerProfile = winrt::make_self<implementation::Profile>();
+        winrt::Windows::Foundation::Collections::IObservableVector<Model::Profile> _allProfiles = winrt::single_threaded_observable_vector<Model::Profile>();
+        winrt::Windows::Foundation::Collections::IObservableVector<Model::Profile> _activeProfiles = winrt::single_threaded_observable_vector<Model::Profile>();
 
         // load errors
-        winrt::Windows::Foundation::Collections::IVector<Model::SettingsLoadWarnings> _warnings;
+        winrt::Windows::Foundation::Collections::IVector<Model::SettingsLoadWarnings> _warnings = winrt::single_threaded_vector<Model::SettingsLoadWarnings>();
         winrt::Windows::Foundation::IReference<Model::SettingsLoadErrors> _loadError;
         winrt::hstring _deserializationErrorMessage;
 

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -743,7 +743,14 @@ CascadiaSettings::CascadiaSettings(const std::string_view& userJSON, const std::
 {
 }
 
-CascadiaSettings::CascadiaSettings(SettingsLoader&& loader)
+CascadiaSettings::CascadiaSettings(SettingsLoader&& loader) :
+    // The CascadiaSettings class declaration initializes these fields by default,
+    // but we're going to set these fields in our constructor later on anyways.
+    _globals{},
+    _baseLayerProfile{},
+    _allProfiles{},
+    _activeProfiles{},
+    _warnings{}
 {
     std::vector<Model::Profile> allProfiles;
     std::vector<Model::Profile> activeProfiles;


### PR DESCRIPTION
`CascadiaSettings` is default constructed when human readable error messages are
returned. Even in such cases we need to ensure that all fields are properly
initialized, as a caller might decide to call a `GlobalSettings` getter.
Thus a crash occurred whenever a user was hot-reloading their settings file with
invalid JSON as other code then tried to compare the `GlobalSettings()`.

## PR Checklist
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed

* Start Windows Terminal and ensure the settings load fine
* Add `"commandline": 123` to any of the generated profiles in settings.json
* The application doesn't crash and shows a warning message