### PR TITLE
Make sure all the commandlines are fully qualified

### DIFF
--- a/src/cascadia/TerminalSettingsModel/Profile.h
+++ b/src/cascadia/TerminalSettingsModel/Profile.h
@@ -125,7 +125,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         INHERITABLE_SETTING(Model::Profile, hstring, Padding, DEFAULT_PADDING);
 
-        INHERITABLE_SETTING(Model::Profile, hstring, Commandline, L"cmd.exe");
+        INHERITABLE_SETTING(Model::Profile, hstring, Commandline, L"%SystemRoot%\\System32\\cmd.exe");
         INHERITABLE_SETTING(Model::Profile, hstring, StartingDirectory);
 
         INHERITABLE_SETTING(Model::Profile, Microsoft::Terminal::Control::TextAntialiasingMode, AntialiasingMode, Microsoft::Terminal::Control::TextAntialiasingMode::Grayscale);

--- a/src/cascadia/TerminalSettingsModel/WslDistroGenerator.cpp
+++ b/src/cascadia/TerminalSettingsModel/WslDistroGenerator.cpp
@@ -37,7 +37,12 @@ std::wstring_view WslDistroGenerator::GetNamespace() const noexcept
 static winrt::com_ptr<implementation::Profile> makeProfile(const std::wstring& distName)
 {
     const auto WSLDistro{ CreateDynamicProfile(distName) };
-    WSLDistro->Commandline(winrt::hstring{ L"wsl.exe -d " + distName });
+    // GH#11096 - make sure the WSL path starts explicitly with
+    // C:\Windows\System32. Don't want someone path hijacking wsl.exe.
+    wil::unique_cotaskmem_string systemPath;
+    THROW_IF_FAILED(wil::GetSystemDirectoryW(systemPath));
+    std::wstring command(systemPath.get());
+    WSLDistro->Commandline(winrt::hstring{ command + L"\\wsl.exe -d " + distName });
     WSLDistro->DefaultAppearance().ColorSchemeName(L"Campbell");
     WSLDistro->StartingDirectory(winrt::hstring{ DEFAULT_STARTING_DIRECTORY });
     WSLDistro->Icon(L"ms-appx:///ProfileIcons/{9acb9455-ca41-5af7-950f-6bca1bc9722f}.png");

--- a/src/cascadia/TerminalSettingsModel/userDefaults.json
+++ b/src/cascadia/TerminalSettingsModel/userDefaults.json
@@ -10,13 +10,13 @@
             {
                 "guid": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
                 "name": "Windows PowerShell",
-                "commandline": "powershell.exe",
+                "commandline": "%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
                 "hidden": false
             },
             {
                 // "name" is filled in by CascadiaSettings as a localized string.
                 "guid": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
-                "commandline": "cmd.exe",
+                "commandline": "%SystemRoot%\\System32\\cmd.exe",
                 "hidden": false
             }
         ]


### PR DESCRIPTION
This was originally in #11308. Thought we should check it in for 1.12 even
though that won't merge this release. Should slightly mitigate the number of
users that see this warning.

* [x] I work here
