### PR TITLE
Try to fix crash on close with saving enabled

### DIFF
--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -86,7 +86,7 @@ AppHost::AppHost() noexcept :
     _window->SetAlwaysOnTop(_logic.GetInitialAlwaysOnTop());
     _window->MakeWindow();
 
-    _windowManager.GetWindowLayoutRequested([this](auto&&, const winrt::Microsoft::Terminal::Remoting::GetWindowLayoutArgs& args) {
+    _GetWindowLayoutRequestedToken = _windowManager.GetWindowLayoutRequested([this](auto&&, const winrt::Microsoft::Terminal::Remoting::GetWindowLayoutArgs& args) {
         // The peasants are running on separate threads, so they'll need to
         // swap what context they are in to the ui thread to get the actual layout.
         args.WindowLayoutJsonAsync(_GetWindowLayoutAsync());
@@ -401,23 +401,38 @@ void AppHost::LastTabClosed(const winrt::Windows::Foundation::IInspectable& /*se
         _HideNotificationIconRequested();
     }
 
+    // We don't want to try to save layouts if we are about to close
+    _getWindowLayoutThrottler.reset();
+    _windowManager.GetWindowLayoutRequested(_GetWindowLayoutRequestedToken);
+
     _window->Close();
 }
 
 LaunchPosition AppHost::_GetWindowLaunchPosition()
 {
-    // Get the position of the current window. This includes the
-    // non-client already.
-    const auto window = _window->GetWindowRect();
-
-    const auto dpi = _window->GetCurrentDpi();
-    const auto nonClientArea = _window->GetNonClientFrame(dpi);
-
-    // The nonClientArea adjustment is negative, so subtract that out.
-    // This way we save the user-visible location of the terminal.
     LaunchPosition pos{};
-    pos.X = window.left - nonClientArea.left;
-    pos.Y = window.top;
+    // If we started saving before closing, but didn't resume the event handler
+    // until after _window might be a nullptr.
+    if (!_window)
+    {
+        return pos;
+    }
+
+    try
+    {
+        // Get the position of the current window. This includes the
+        // non-client already.
+        const auto window = _window->GetWindowRect();
+
+        const auto dpi = _window->GetCurrentDpi();
+        const auto nonClientArea = _window->GetNonClientFrame(dpi);
+
+        // The nonClientArea adjustment is negative, so subtract that out.
+        // This way we save the user-visible location of the terminal.
+        pos.X = window.left - nonClientArea.left;
+        pos.Y = window.top;
+    }
+    CATCH_LOG();
 
     return pos;
 }
@@ -723,10 +738,15 @@ winrt::Windows::Foundation::IAsyncOperation<winrt::hstring> AppHost::_GetWindowL
 {
     winrt::apartment_context peasant_thread;
 
+    winrt::hstring layoutJson = L"";
     // Use the main thread since we are accessing controls.
     co_await winrt::resume_foreground(_logic.GetRoot().Dispatcher());
-    const auto pos = _GetWindowLaunchPosition();
-    const auto layoutJson = _logic.GetWindowLayoutJson(pos);
+    try
+    {
+        const auto pos = _GetWindowLaunchPosition();
+        layoutJson = _logic.GetWindowLayoutJson(pos);
+    }
+    CATCH_LOG()
 
     // go back to give the result to the peasant.
     co_await peasant_thread;

--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -114,4 +114,5 @@ private:
     winrt::event_token _NotificationIconPressedToken;
     winrt::event_token _ShowNotificationIconContextMenuToken;
     winrt::event_token _NotificationIconMenuItemSelectedToken;
+    winrt::event_token _GetWindowLayoutRequestedToken;
 };


### PR DESCRIPTION


<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
dont crash if we try to save the window layout while we are closing, and try to avoid saving at all.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] maybe closes #11354 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Revoke the event handler/save throttler so we don't even try to get the window layout when we are closing
- Try to check for nullptrs, but then apply `try {} CATCH_LOG()` liberally

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
The happy path of saving normally is still fine, but I haven't been unlucky enough to trigger the crash myself.
