### PR TITLE
Center-align the shield with the other tab row icons

### DIFF
--- a/src/cascadia/TerminalApp/TabRowControl.xaml
+++ b/src/cascadia/TerminalApp/TabRowControl.xaml
@@ -23,7 +23,7 @@
         <mux:TabView.TabStripHeader>
             <!--  EA18 is the "Shield" glyph  -->
             <FontIcon x:Uid="ElevationShield"
-                      Margin="9,4,0,0"
+                      Margin="9,4,0,4"
                       FontFamily="Segoe MDL2 Assets"
                       FontSize="16"
                       Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"


### PR DESCRIPTION
I started from here:
https://github.com/microsoft/microsoft-ui-xaml/blob/9052972906c8a0a1b6cb5d5c61b27d6d27cd7f11/dev/CommonStyles/Button_themeresources_v1.xaml#L121

but adding a padding of 3 was still off by one pixel, so it's 4 now.

_enhance.png_
![image](https://user-images.githubusercontent.com/18356694/136219225-3fcffd48-79b4-4efc-a4c3-4b59f9878962.png)

* [x] closes #11421