### PR TITLE
Enable the "Defaults" settings page in Stable

### DIFF
--- a/src/features.xml
+++ b/src/features.xml
@@ -76,8 +76,6 @@
         <description>Whether to show the "defaults" page in the Terminal settings UI</description>
         <id>10430</id>
         <stage>AlwaysEnabled</stage>
-        <!-- This feature will not ship to Stable until it is complete. -->
-        <alwaysDisabledReleaseTokens />
     </feature>
 
     <feature>


### PR DESCRIPTION
This change enables access to the Defaults page in stable builds of
terminal. It is intended that we backport this feature flag edit to
1.11, so that Defaults can roll out with 1.11 when it becomes stable.