### PR TITLE
Remove last remaining winrt::hstring allocation during text output

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -195,6 +195,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         FontInfoDesired _desiredFont;
         FontInfo _actualFont;
+        winrt::hstring _actualFontFaceName;
 
         // storage location for the leading surrogate of a utf-16 surrogate pair
         std::optional<wchar_t> _leadingSurrogate{ std::nullopt };


### PR DESCRIPTION
ControlCore::FontFaceName() is called 10/s by TSFInputControl.
The getter was modified to cache the STL string in a hstring allowing
us to return a value without temporary allocations during runtime.

## PR Checklist
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed
* Font face and size changes properly update TSFInputControl ✔️