### PR TITLE
Fix quoted boolean defaults in schema

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -459,7 +459,7 @@
         },
         "suppressApplicationTitle": {
           "type": "boolean",
-          "default": "false",
+          "default": false,
           "description": "When set to true, tabTitle overrides the default title of the tab and any title change messages from the application will be suppressed. When set to false, tabTitle behaves as normal"
         },
         "colorScheme": {
@@ -1575,22 +1575,22 @@
           "deprecated": true
         },
         "minimizeToNotificationArea": {
-          "default": "false",
+          "default": false,
           "description": "When set to true, minimizing a Terminal window will no longer appear in the taskbar. Instead, a Terminal icon will appear in the notification area through which the user can access their windows.",
           "type": "boolean"
         },
         "alwaysShowNotificationIcon": {
-          "default": "false",
+          "default": false,
           "description": "When set to true, the Terminal's notification icon will always be shown in the notification area.",
           "type": "boolean"
         },
         "showAdminShield": {
-          "default": "true",
+          "default": true,
           "description": "When set to true, the Terminal's tab row will display a shield icon when the Terminal is running with administrator privileges",
           "type": "boolean"
         },
         "useAcrylicInTabRow": {
-          "default": "false",
+          "default": false,
           "description": "When set to true, the tab row will have an acrylic background with 50% opacity.",
           "type": "boolean"
         },


### PR DESCRIPTION
## Summary of the Pull Request

The `settings.json` schema had `"default"`s for some boolean settings set as quoted strings (`"true"` / `"false"`), so I removed the quotes.

## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed
* [ ] Tests added/passed
* [ ] Documentation updated
* [x] Schema updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan

## Detailed Description of the Pull Request / Additional comments

VSCode autocompletes the default value when you select the setting in intellisense, so it autocompleted a string which caused a schema error. Booleans should be JSON booleans, not quoted.

## Validation Steps Performed
