### PR TITLE
Remove double-space in defaults.json

### DIFF
--- a/src/cascadia/TerminalSettingsModel/defaults-universal.json
+++ b/src/cascadia/TerminalSettingsModel/defaults-universal.json
@@ -22,7 +22,7 @@
 
     // Miscellaneous
     "confirmCloseAllTabs": true,
-    "startOnUserLogin":  false,
+    "startOnUserLogin": false,
     "theme": "system",
     "snapToGridOnResize": true,
 

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -24,7 +24,7 @@
 
     // Miscellaneous
     "confirmCloseAllTabs": true,
-    "startOnUserLogin":  false,
+    "startOnUserLogin": false,
     "theme": "system",
     "snapToGridOnResize": true,
     "disableAnimations": false,


### PR DESCRIPTION
## Summary of the Pull Request

There was a double-space after a colon in `defaults.json` and `defaults-universal.json`.

## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed
* [ ] Tests added/passed
* [ ] Documentation updated
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan

## Detailed Description of the Pull Request / Additional comments

It says at the top of these files that they are autogenerated, which made me wonder how they had a double-space.
Then I found [this](https://github.com/microsoft/terminal/blob/fb597ed304ec6eef245405c9652e9b8a029b821f/doc/specs/%23754%20-%20Cascading%20Default%20Settings.md#default-settings) which says it is a lie and they're not autogenerated. Wat.

## Validation Steps Performed
