### PR TITLE
Separate terminal version and Windows version in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yml
@@ -10,14 +10,21 @@ body:
 
 - type: input
   attributes:
-    label: Windows Terminal version (or Windows build number)
-    placeholder: "10.0.19042.0, 1.7.3651.0"
+    label: Windows Terminal version
+    placeholder: "1.7.3651.0"
     description: |
-      If you are reporting an issue in Windows Terminal, you can find the version in the about dialog.
-
-      If you are reporting an issue with the Windows Console, please run `ver` or `[Environment]::OSVersion`.
+      You can find the version in the about dialog, or by running `wt -v` at the commandline.
   validations:
-    required: true
+    required: false
+    
+- type: input
+  attributes:
+    label: Windows build number
+    placeholder: "10.0.19042.0"
+    description: |
+      Please run `ver` or `[Environment]::OSVersion`.
+  validations:
+    required: false
 
 - type: textarea
   attributes:


### PR DESCRIPTION
We're getting a LOT of issues that are all "I cant ~read~ set the terminal as the default terminal" that would all be instantaneously diagnosable if we knew OP's terminal version. Weirdly, these posts always include the OS version. So I'm separating these out into two different line items.

I'm not marking them both as required, because for conhost bugs the Terminal version isn't relevant. I'm debating that with myself.

I might instead go for:


```yaml
- type: input
  attributes:
    label: Windows Terminal version
    placeholder: "1.7.3651.0"
    description: |
      You can find the version in the about dialog, or by running `wt -v` at the commandline. If your bug doesn't involve the Windows Terminal (i.e. it's a conhost bug), then you can just put N/A
  validations:
    required: true

- type: input
  attributes:
    label: Windows build number
    placeholder: "10.0.19042.0"
    description: |
      Please run `ver` or `[Environment]::OSVersion`.
  validations:
    required: true
```
