### PR TITLE
Disable the VS profile generators in Preview, Stable

### DIFF
--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -137,7 +137,10 @@ void SettingsLoader::GenerateProfiles()
     _executeGenerator(PowershellCoreProfileGenerator{});
     _executeGenerator(WslDistroGenerator{});
     _executeGenerator(AzureCloudShellGenerator{});
-    _executeGenerator(VisualStudioGenerator{});
+    if constexpr (Feature_VisualStudioGenerator::IsEnabled())
+    {
+        _executeGenerator(VisualStudioGenerator{});
+    }
 }
 
 // A new settings.json gets a special treatment:

--- a/src/features.xml
+++ b/src/features.xml
@@ -85,4 +85,14 @@
         <!-- This feature will not ship to Stable until it is complete. -->
         <alwaysDisabledReleaseTokens />
     </feature>
+
+    <feature>
+        <name>Feature_VisualStudioGenerator</name>
+        <description>Controls whether Terminal will generate Visual Studio DevPS/DevCMD profiles</description>
+        <stage>AlwaysDisabled</stage>
+        <alwaysEnabledBrandingTokens>
+            <!-- This one is only enabled in Dev (not Preview or Release) right now. -->
+            <brandingToken>Dev</brandingToken>
+        </alwaysEnabledBrandingTokens>
+    </feature>
 </featureStaging>


### PR DESCRIPTION
We may need to ship Preview without the VS profile generators.
The easiest way to do that is by using Velocity! Woo!