### PR TITLE
Fixed VsDevCmd command line quoting

### DIFF
--- a/src/cascadia/TerminalSettingsModel/VsDevCmdGenerator.cpp
+++ b/src/cascadia/TerminalSettingsModel/VsDevCmdGenerator.cpp
@@ -40,7 +40,7 @@ std::wstring VsDevCmdGenerator::GetProfileCommandLine(const VsSetupConfiguration
 {
     std::wstring commandLine;
     commandLine.reserve(256);
-    commandLine.append(LR"("cmd.exe /k ")");
+    commandLine.append(LR"(cmd.exe /k ")");
     commandLine.append(GetDevCmdScriptPath(instance));
 #if defined(_M_ARM64)
     commandLine.append(LR"(" -arch=arm64 -host_arch=x64)");


### PR DESCRIPTION
An extra `"` sneaked in when I changed the code
from string literals to raw string literals.

## PR Checklist
* [x] Closes #11552
* [x] I work here

## Validation Steps Performed
* `Developer PowerShell for VS 2022 [Preview]` profile exists ✔️
  * Launches developer PowerShell ✔️
  * `$env:VSCMD_ARG_TGT_ARCH` is `x64` ✔️
* `Developer Command Prompt for VS 2022 [Preview]` profile exists ✔️
  * Launches regular developer shell ✔️
  * `%VSCMD_ARG_TGT_ARCH%` is `x64` ✔️