### PR TITLE
Ensure the background image path is displayed in the settings UI

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -220,7 +220,7 @@
                         <TextBox IsEnabled="{x:Bind local:Converters.StringsAreNotEqual('desktopWallpaper', Appearance.BackgroundImagePath), Mode=OneWay}"
                                  IsSpellCheckEnabled="False"
                                  Style="{StaticResource TextBoxSettingStyle}"
-                                 Text="{x:Bind local:Converters.StringFallBackToEmptyString('desktopWallpaper', Appearance.BackgroundImagePath), Mode=TwoWay, BindBack=Appearance.SetBackgroundImagePath}" />
+                                 Text="{x:Bind local:Converters.StringOrEmptyIfPlaceholder('desktopWallpaper', Appearance.BackgroundImagePath), Mode=TwoWay, BindBack=Appearance.SetBackgroundImagePath}" />
                         <Button x:Uid="Profile_BackgroundImageBrowse"
                                 Click="BackgroundImage_Click"
                                 IsEnabled="{x:Bind local:Converters.StringsAreNotEqual('desktopWallpaper', Appearance.BackgroundImagePath), Mode=OneWay}"

--- a/src/cascadia/TerminalSettingsEditor/Converters.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Converters.cpp
@@ -1,4 +1,4 @@
-﻿#include "pch.h"
+#include "pch.h"
 #include "Converters.h"
 #if __has_include("Converters.g.cpp")
 #include "Converters.g.cpp"
@@ -99,8 +99,16 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         return value.empty() ? winrt::Windows::UI::Xaml::Visibility::Collapsed : winrt::Windows::UI::Xaml::Visibility::Visible;
     }
-    winrt::hstring Converters::StringFallBackToEmptyString(winrt::hstring expected, winrt::hstring actual)
+
+    // Method Description:
+    // - Returns the value string, unless it matches the placeholder in which case the empty string.
+    // Arguments:
+    // - placeholder - the placeholder string.
+    // - value - the value string.
+    // Return Value:
+    // - The value string, unless it matches the placeholder in which case the empty string.
+    winrt::hstring Converters::StringOrEmptyIfPlaceholder(winrt::hstring placeholder, winrt::hstring value)
     {
-        return expected == actual ? expected : L"";
+        return placeholder == value ? L"" : value;
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Converters.h
+++ b/src/cascadia/TerminalSettingsEditor/Converters.h
@@ -21,7 +21,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         static double PercentageValueToPercentage(double value);
         static bool StringsAreNotEqual(winrt::hstring expected, winrt::hstring actual);
         static winrt::Windows::UI::Xaml::Visibility StringNotEmptyToVisibility(winrt::hstring value);
-        static winrt::hstring StringFallBackToEmptyString(winrt::hstring expected, winrt::hstring actual);
+        static winrt::hstring StringOrEmptyIfPlaceholder(winrt::hstring placeholder, winrt::hstring value);
     };
 }
 

--- a/src/cascadia/TerminalSettingsEditor/Converters.idl
+++ b/src/cascadia/TerminalSettingsEditor/Converters.idl
@@ -20,6 +20,6 @@ namespace Microsoft.Terminal.Settings.Editor
         static Double PercentageValueToPercentage(Double value);
         static Boolean StringsAreNotEqual(String expected, String actual);
         static Windows.UI.Xaml.Visibility StringNotEmptyToVisibility(String value);
-        static String StringFallBackToEmptyString(String expected, String actual);
+        static String StringOrEmptyIfPlaceholder(String placeholder, String value);
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request
Ensures that the background image path is displayed in the settings UI.

## References
One of the items on #11353

## PR Checklist
* [x] Closes #11541
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA

## Validation Steps Performed
Set the background image path and saw that it was displayed in the settings UI.