### PR TITLE
Make sure the infobar is inserted before the tab content, not on top of

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -16,65 +16,59 @@
           Background="Transparent">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
         <local:TabRowControl x:Name="TabRow"
                              Grid.Row="0" />
 
-        <Grid Grid.Row="1"
+        <StackPanel Grid.Row="1">
+            <mux:InfoBar x:Name="KeyboardServiceWarningInfoBar"
+                         x:Load="False"
+                         IsClosable="True"
+                         IsIconVisible="True"
+                         IsOpen="False"
+                         Message="{x:Bind KeyboardServiceDisabledText, Mode=OneWay}"
+                         Severity="Warning">
+                <mux:InfoBar.ActionButton>
+                    <Button x:Uid="InfoBarDismissButton"
+                            Click="_KeyboardServiceWarningInfoDismissHandler" />
+                </mux:InfoBar.ActionButton>
+            </mux:InfoBar>
+
+            <mux:InfoBar x:Name="CloseOnExitInfoBar"
+                         x:Uid="CloseOnExitInfoBar"
+                         x:Load="False"
+                         IsClosable="True"
+                         IsIconVisible="True"
+                         IsOpen="False"
+                         Severity="Informational">
+                <mux:InfoBar.ActionButton>
+                    <Button x:Uid="InfoBarDismissButton"
+                            Click="_CloseOnExitInfoDismissHandler" />
+                </mux:InfoBar.ActionButton>
+            </mux:InfoBar>
+
+            <mux:InfoBar x:Name="SetAsDefaultInfoBar"
+                         x:Uid="SetAsDefaultInfoBar"
+                         x:Load="False"
+                         CloseButtonClick="_SetAsDefaultDismissHandler"
+                         IsClosable="True"
+                         IsIconVisible="True"
+                         IsOpen="False"
+                         Severity="Informational">
+                <mux:InfoBar.ActionButton>
+                    <HyperlinkButton x:Uid="SetAsDefaultTip_OpenSettingsLink"
+                                     Click="_SetAsDefaultOpenSettingsHandler" />
+                </mux:InfoBar.ActionButton>
+            </mux:InfoBar>
+        </StackPanel>
+
+        <Grid x:Name="TabContent"
+              Grid.Row="2"
               HorizontalAlignment="Stretch"
-              VerticalAlignment="Stretch">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" />
-            </Grid.RowDefinitions>
-            <StackPanel Grid.Row="0">
-                <mux:InfoBar x:Name="KeyboardServiceWarningInfoBar"
-                             x:Load="False"
-                             IsClosable="True"
-                             IsIconVisible="True"
-                             IsOpen="False"
-                             Message="{x:Bind KeyboardServiceDisabledText, Mode=OneWay}"
-                             Severity="Warning">
-                    <mux:InfoBar.ActionButton>
-                        <Button x:Uid="InfoBarDismissButton"
-                                Click="_KeyboardServiceWarningInfoDismissHandler" />
-                    </mux:InfoBar.ActionButton>
-                </mux:InfoBar>
-
-                <mux:InfoBar x:Name="CloseOnExitInfoBar"
-                             x:Uid="CloseOnExitInfoBar"
-                             x:Load="False"
-                             IsClosable="True"
-                             IsIconVisible="True"
-                             IsOpen="False"
-                             Severity="Informational">
-                    <mux:InfoBar.ActionButton>
-                        <Button x:Uid="InfoBarDismissButton"
-                                Click="_CloseOnExitInfoDismissHandler" />
-                    </mux:InfoBar.ActionButton>
-                </mux:InfoBar>
-
-                <mux:InfoBar x:Name="SetAsDefaultInfoBar"
-                             x:Uid="SetAsDefaultInfoBar"
-                             x:Load="False"
-                             CloseButtonClick="_SetAsDefaultDismissHandler"
-                             IsClosable="True"
-                             IsIconVisible="True"
-                             IsOpen="False"
-                             Severity="Informational">
-                    <mux:InfoBar.ActionButton>
-                        <HyperlinkButton x:Uid="SetAsDefaultTip_OpenSettingsLink"
-                                         Click="_SetAsDefaultOpenSettingsHandler" />
-                    </mux:InfoBar.ActionButton>
-                </mux:InfoBar>
-            </StackPanel>
-            <Grid x:Name="TabContent"
-                  Grid.Row="1"
-                  HorizontalAlignment="Stretch"
-                  VerticalAlignment="Stretch" />
-        </Grid>
+              VerticalAlignment="Stretch" />
 
         <ContentDialog x:Name="AboutDialog"
                        x:Uid="AboutDialog"


### PR DESCRIPTION
Fixes #11606

This is weird, but the infobars would appear totally on top of the
TerminalPage when `showTabsInTitlebar:false`. This would result in the infobar
obscuring the tabs.

Now, the infobars are strictly inserted after the tabs, before the content. So
when they appear, they will reduce the amount of space usable for the control.
That is a little annoying, but preferable to the tabs totally not existing.

Relevant conversation notes from #10798:

> > If the info bar is not local to the tab, then its location between the tab
> > bar (when the title bar is hidden) and the terminal panes feels
> > misleading. Should it instead be above the tab bar or below the terminal
> > panes?
>
> You're... not wrong here. It's maybe not the best place for it, but _on top_
> of the tabs would look insane, and probably wouldn't even work easily, given
> the way we reparent the tab row into the titlebar.
>
> In the pane itself would make more sense, but that runs abreast of all sorts
> of things like #9024, #4998, which might make more sense.

I'm just gonna go with this now, because it's _better_ than before, while we
work out what's _best_.

![gh-11606-fix](https://user-images.githubusercontent.com/18356694/138729178-b96b7003-0dd2-4521-8fff-0fd2a5989f22.gif)


