### PR TITLE
Fix OpenConsoleProxy for Debug builds

### DIFF
--- a/src/host/proxy/Host.Proxy.vcxproj
+++ b/src/host/proxy/Host.Proxy.vcxproj
@@ -62,6 +62,7 @@
       <!-- Must be Stdcall on all platforms to resolve _ObjectStublessClient3 -->
       <PreprocessorDefinitions>REGISTER_PROXY_DLL;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <SDLCheck>false</SDLCheck>
       <ForcedIncludeFiles>nodefaultlib_shim.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>

--- a/src/host/proxy/nodefaultlib_shim.h
+++ b/src/host/proxy/nodefaultlib_shim.h
@@ -1,18 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+#pragma once
+
 #include <guiddef.h>
 
-#if !defined(_M_IX86) && !defined(_M_X64)
-
-// ARM64 doesn't define a (__builtin_)memcmp function without CRT,
-// but we need one to compile IID_GENERIC_CHECK_IID.
-// Luckily we only ever use memcmp for IIDs.
-#pragma function(memcmp)
-inline int memcmp(const IID* a, const IID* b, size_t count)
-{
-    (void)(count);
-    return 1 - InlineIsEqualGUID(a, b);
-}
-
-#endif
+#define memcmp(a, b, c) (!InlineIsEqualGUID(a, b))


### PR DESCRIPTION
Basic runtime checks introduce link dependencies which we don't have
without a CRT. Additionally we can't implement memcmp ourselves,
as this would force us to disable /GL on ARM64 in Release builds.

## Validation Steps Performed
* Builds on x86, x64, ARM64 in Debug, Release each ✔️