### PR TITLE
Improve conhost CPU usage during text selection

### DIFF
--- a/src/host/selection.cpp
+++ b/src/host/selection.cpp
@@ -255,6 +255,14 @@ void Selection::ExtendSelection(_In_ COORD coordBufferPos)
         srNewSelection.Top = _coordSelectionAnchor.Y;
     }
 
+    // This function is called on WM_MOUSEMOVE.
+    // Prevent triggering an invalidation just because the mouse moved
+    // in the same cell without changing the actual (visible) selection.
+    if (_srSelectionRect == srNewSelection)
+    {
+        return;
+    }
+
     // call special update method to modify the displayed selection in-place
     // NOTE: Using HideSelection, editing the rectangle, then ShowSelection will cause flicker.
     //_PaintUpdateSelection(&srNewSelection);


### PR DESCRIPTION
During text selection we redraw the window every time the cursor moves by a pixel.
This commit changes it so that it only updates once the selection actually changes.

This is an offshoot from #11623.

## Validation Steps Performed
* Text selection continues to work in DxEngine and AtlasEngine ✔️
* Reduction in redraws ✔️