### PR TITLE
Check that the control exists before we try to focus it

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1597,7 +1597,10 @@ namespace winrt::TerminalApp::implementation
             // the control here instead.
             if (_startupState == StartupState::Initialized)
             {
-                _GetActiveControl().Focus(FocusState::Programmatic);
+                if (const auto control = _GetActiveControl())
+                {
+                    control.Focus(FocusState::Programmatic);
+                }
             }
         }
         CATCH_LOG();


### PR DESCRIPTION
## Summary of the Pull Request
When we are on a settings UI tab, `_GetActiveControl` returns a `nullptr`, make sure not to try and focus it in that case

## PR Checklist
* [x] Closes #11633 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I work here

## Validation Steps Performed
No longer crashes