### PR TITLE
doc: Fix typo in #885 - Terminal Settings Model.md

### DIFF
--- a/doc/specs/#885 - Terminal Settings Model/#885 - Terminal Settings Model.md
+++ b/doc/specs/#885 - Terminal Settings Model/#885 - Terminal Settings Model.md
@@ -268,7 +268,7 @@ Today, if the deserialization of `CascadiaSettings` encounters any errors, an ex
 To get around this issue, when `CascadiaSettings` encounters a serialization error, it must internally record
  any pertinent information for that error, and return the simple `CascadiaSettings` as if nothing happened.
  The consumer must then call `CascadiaSettings::GetErrors()` and `CascadiaSettings::GetWarnings()` to properly
- understand whether an error ocurred and how to present that to the user.
+ understand whether an error occurred and how to present that to the user.
 
 
 #### TerminalApp: Loading and Reloading Changes


### PR DESCRIPTION

Fixed typo.
```
ocurred -> occurred
```

* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA