### PR TITLE
Disable the acceptance of C1 control codes by default

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -508,6 +508,7 @@ dealloc
 Debian
 debolden
 debugtype
+DECAC1
 DECALN
 DECANM
 DECAUPSS

--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -508,7 +508,7 @@ dealloc
 Debian
 debolden
 debugtype
-DECAC1
+DECAC
 DECALN
 DECANM
 DECAUPSS

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -61,6 +61,14 @@ Terminal::Terminal() :
 
     _stateMachine = std::make_unique<StateMachine>(std::move(engine));
 
+    // Until we have a true pass-through mode, the decision as to whether C1
+    // controls are interpreted or not is made at the conhost level. If they
+    // are being filtered out, then we will simply never receive them. But if
+    // they are being accepted by conhost, there's a chance they may get passed
+    // through in some situations, so it's important that our state machine is
+    // always prepared to accept them.
+    _stateMachine->SetParserMode(StateMachine::Mode::AcceptC1, true);
+
     auto passAlongInput = [&](std::deque<std::unique_ptr<IInputEvent>>& inEventsToWrite) {
         if (!_pfnWriteInput)
         {

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -61,12 +61,12 @@ Terminal::Terminal() :
 
     _stateMachine = std::make_unique<StateMachine>(std::move(engine));
 
-    // Until we have a true pass-through mode, the decision as to whether C1
-    // controls are interpreted or not is made at the conhost level. If they
-    // are being filtered out, then we will simply never receive them. But if
-    // they are being accepted by conhost, there's a chance they may get passed
-    // through in some situations, so it's important that our state machine is
-    // always prepared to accept them.
+    // Until we have a true pass-through mode (GH#1173), the decision as to
+    // whether C1 controls are interpreted or not is made at the conhost level.
+    // If they are being filtered out, then we will simply never receive them.
+    // But if they are being accepted by conhost, there's a chance they may get
+    // passed through in some situations, so it's important that our state
+    // machine is always prepared to accept them.
     _stateMachine->SetParserMode(StateMachine::Mode::AcceptC1, true);
 
     auto passAlongInput = [&](std::deque<std::unique_ptr<IInputEvent>>& inEventsToWrite) {

--- a/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
@@ -271,7 +271,7 @@ void TerminalCoreUnitTests::TerminalApiTest::AddHyperlink()
     auto& stateMachine = *(term._stateMachine);
 
     // Process the opening osc 8 sequence
-    stateMachine.ProcessString(L"\x1b]8;;test.url\x9c");
+    stateMachine.ProcessString(L"\x1b]8;;test.url\x1b\\");
     VERIFY_IS_TRUE(tbi.GetCurrentAttributes().IsHyperlink());
     VERIFY_ARE_EQUAL(tbi.GetHyperlinkUriFromId(tbi.GetCurrentAttributes().GetHyperlinkId()), L"test.url");
 
@@ -281,7 +281,7 @@ void TerminalCoreUnitTests::TerminalApiTest::AddHyperlink()
     VERIFY_ARE_EQUAL(tbi.GetHyperlinkUriFromId(tbi.GetCurrentAttributes().GetHyperlinkId()), L"test.url");
 
     // Process the closing osc 8 sequences
-    stateMachine.ProcessString(L"\x1b]8;;\x9c");
+    stateMachine.ProcessString(L"\x1b]8;;\x1b\\");
     VERIFY_IS_FALSE(tbi.GetCurrentAttributes().IsHyperlink());
 }
 
@@ -297,7 +297,7 @@ void TerminalCoreUnitTests::TerminalApiTest::AddHyperlinkCustomId()
     auto& stateMachine = *(term._stateMachine);
 
     // Process the opening osc 8 sequence
-    stateMachine.ProcessString(L"\x1b]8;id=myId;test.url\x9c");
+    stateMachine.ProcessString(L"\x1b]8;id=myId;test.url\x1b\\");
     VERIFY_IS_TRUE(tbi.GetCurrentAttributes().IsHyperlink());
     VERIFY_ARE_EQUAL(tbi.GetHyperlinkUriFromId(tbi.GetCurrentAttributes().GetHyperlinkId()), L"test.url");
     VERIFY_ARE_EQUAL(tbi.GetHyperlinkId(L"test.url", L"myId"), tbi.GetCurrentAttributes().GetHyperlinkId());
@@ -309,7 +309,7 @@ void TerminalCoreUnitTests::TerminalApiTest::AddHyperlinkCustomId()
     VERIFY_ARE_EQUAL(tbi.GetHyperlinkId(L"test.url", L"myId"), tbi.GetCurrentAttributes().GetHyperlinkId());
 
     // Process the closing osc 8 sequences
-    stateMachine.ProcessString(L"\x1b]8;;\x9c");
+    stateMachine.ProcessString(L"\x1b]8;;\x1b\\");
     VERIFY_IS_FALSE(tbi.GetCurrentAttributes().IsHyperlink());
 }
 
@@ -325,7 +325,7 @@ void TerminalCoreUnitTests::TerminalApiTest::AddHyperlinkCustomIdDifferentUri()
     auto& stateMachine = *(term._stateMachine);
 
     // Process the opening osc 8 sequence
-    stateMachine.ProcessString(L"\x1b]8;id=myId;test.url\x9c");
+    stateMachine.ProcessString(L"\x1b]8;id=myId;test.url\x1b\\");
     VERIFY_IS_TRUE(tbi.GetCurrentAttributes().IsHyperlink());
     VERIFY_ARE_EQUAL(tbi.GetHyperlinkUriFromId(tbi.GetCurrentAttributes().GetHyperlinkId()), L"test.url");
     VERIFY_ARE_EQUAL(tbi.GetHyperlinkId(L"test.url", L"myId"), tbi.GetCurrentAttributes().GetHyperlinkId());
@@ -333,7 +333,7 @@ void TerminalCoreUnitTests::TerminalApiTest::AddHyperlinkCustomIdDifferentUri()
     const auto oldAttributes{ tbi.GetCurrentAttributes() };
 
     // Send any other text
-    stateMachine.ProcessString(L"\x1b]8;id=myId;other.url\x9c");
+    stateMachine.ProcessString(L"\x1b]8;id=myId;other.url\x1b\\");
     VERIFY_IS_TRUE(tbi.GetCurrentAttributes().IsHyperlink());
     VERIFY_ARE_EQUAL(tbi.GetHyperlinkUriFromId(tbi.GetCurrentAttributes().GetHyperlinkId()), L"other.url");
     VERIFY_ARE_EQUAL(tbi.GetHyperlinkId(L"other.url", L"myId"), tbi.GetCurrentAttributes().GetHyperlinkId());
@@ -356,58 +356,58 @@ void TerminalCoreUnitTests::TerminalApiTest::SetTaskbarProgress()
     VERIFY_ARE_EQUAL(term.GetTaskbarProgress(), gsl::narrow<size_t>(0));
 
     // Set some values for taskbar state and progress through state machine
-    stateMachine.ProcessString(L"\x1b]9;4;1;50\x9c");
+    stateMachine.ProcessString(L"\x1b]9;4;1;50\x1b\\");
     VERIFY_ARE_EQUAL(term.GetTaskbarState(), gsl::narrow<size_t>(1));
     VERIFY_ARE_EQUAL(term.GetTaskbarProgress(), gsl::narrow<size_t>(50));
 
     // Reset to 0
-    stateMachine.ProcessString(L"\x1b]9;4;0;0\x9c");
+    stateMachine.ProcessString(L"\x1b]9;4;0;0\x1b\\");
     VERIFY_ARE_EQUAL(term.GetTaskbarState(), gsl::narrow<size_t>(0));
     VERIFY_ARE_EQUAL(term.GetTaskbarProgress(), gsl::narrow<size_t>(0));
 
     // Set an out of bounds value for state
-    stateMachine.ProcessString(L"\x1b]9;4;5;50\x9c");
+    stateMachine.ProcessString(L"\x1b]9;4;5;50\x1b\\");
     // Nothing should have changed (dispatch should have returned false)
     VERIFY_ARE_EQUAL(term.GetTaskbarState(), gsl::narrow<size_t>(0));
     VERIFY_ARE_EQUAL(term.GetTaskbarProgress(), gsl::narrow<size_t>(0));
 
     // Set an out of bounds value for progress
-    stateMachine.ProcessString(L"\x1b]9;4;1;999\x9c");
+    stateMachine.ProcessString(L"\x1b]9;4;1;999\x1b\\");
     // Progress should have been clamped to 100
     VERIFY_ARE_EQUAL(term.GetTaskbarState(), gsl::narrow<size_t>(1));
     VERIFY_ARE_EQUAL(term.GetTaskbarProgress(), gsl::narrow<size_t>(100));
 
     // Don't specify any params
-    stateMachine.ProcessString(L"\x1b]9;4\x9c");
+    stateMachine.ProcessString(L"\x1b]9;4\x1b\\");
     // State and progress should both be reset to 0
     VERIFY_ARE_EQUAL(term.GetTaskbarState(), gsl::narrow<size_t>(0));
     VERIFY_ARE_EQUAL(term.GetTaskbarProgress(), gsl::narrow<size_t>(0));
 
     // Specify additional params
-    stateMachine.ProcessString(L"\x1b]9;4;1;80;123\x9c");
+    stateMachine.ProcessString(L"\x1b]9;4;1;80;123\x1b\\");
     // Additional params should be ignored, state and progress still set normally
     VERIFY_ARE_EQUAL(term.GetTaskbarState(), gsl::narrow<size_t>(1));
     VERIFY_ARE_EQUAL(term.GetTaskbarProgress(), gsl::narrow<size_t>(80));
 
     // Edge cases + trailing semicolon testing
-    stateMachine.ProcessString(L"\x1b]9;4;2;\x9c");
+    stateMachine.ProcessString(L"\x1b]9;4;2;\x1b\\");
     // String should be processed correctly despite the trailing semicolon,
     // taskbar progress should remain unchanged from previous value
     VERIFY_ARE_EQUAL(term.GetTaskbarState(), gsl::narrow<size_t>(2));
     VERIFY_ARE_EQUAL(term.GetTaskbarProgress(), gsl::narrow<size_t>(80));
 
-    stateMachine.ProcessString(L"\x1b]9;4;3;75\x9c");
+    stateMachine.ProcessString(L"\x1b]9;4;3;75\x1b\\");
     // Given progress value should be ignored because this is the indeterminate state,
     // so the progress value should remain unchanged
     VERIFY_ARE_EQUAL(term.GetTaskbarState(), gsl::narrow<size_t>(3));
     VERIFY_ARE_EQUAL(term.GetTaskbarProgress(), gsl::narrow<size_t>(80));
 
-    stateMachine.ProcessString(L"\x1b]9;4;0;50\x9c");
+    stateMachine.ProcessString(L"\x1b]9;4;0;50\x1b\\");
     // Taskbar progress should be 0 (the given value should be ignored)
     VERIFY_ARE_EQUAL(term.GetTaskbarState(), gsl::narrow<size_t>(0));
     VERIFY_ARE_EQUAL(term.GetTaskbarProgress(), gsl::narrow<size_t>(0));
 
-    stateMachine.ProcessString(L"\x1b]9;4;2;\x9c");
+    stateMachine.ProcessString(L"\x1b]9;4;2;\x1b\\");
     // String should be processed correctly despite the trailing semicolon,
     // taskbar progress should be set to a 'minimum', non-zero value
     VERIFY_ARE_EQUAL(term.GetTaskbarState(), gsl::narrow<size_t>(2));
@@ -427,45 +427,45 @@ void TerminalCoreUnitTests::TerminalApiTest::SetWorkingDirectory()
     VERIFY_IS_TRUE(term.GetWorkingDirectory().empty());
 
     // Invalid sequences should not change CWD
-    stateMachine.ProcessString(L"\x1b]9;9\x9c");
+    stateMachine.ProcessString(L"\x1b]9;9\x1b\\");
     VERIFY_IS_TRUE(term.GetWorkingDirectory().empty());
 
-    stateMachine.ProcessString(L"\x1b]9;9\"\x9c");
+    stateMachine.ProcessString(L"\x1b]9;9\"\x1b\\");
     VERIFY_IS_TRUE(term.GetWorkingDirectory().empty());
 
-    stateMachine.ProcessString(L"\x1b]9;9\"C:\\\"\x9c");
+    stateMachine.ProcessString(L"\x1b]9;9\"C:\\\"\x1b\\");
     VERIFY_IS_TRUE(term.GetWorkingDirectory().empty());
 
     // Valid sequences should change CWD
-    stateMachine.ProcessString(L"\x1b]9;9;\"C:\\\"\x9c");
+    stateMachine.ProcessString(L"\x1b]9;9;\"C:\\\"\x1b\\");
     VERIFY_ARE_EQUAL(term.GetWorkingDirectory(), L"C:\\");
 
-    stateMachine.ProcessString(L"\x1b]9;9;\"C:\\Program Files\"\x9c");
+    stateMachine.ProcessString(L"\x1b]9;9;\"C:\\Program Files\"\x1b\\");
     VERIFY_ARE_EQUAL(term.GetWorkingDirectory(), L"C:\\Program Files");
 
-    stateMachine.ProcessString(L"\x1b]9;9;\"D:\\中文\"\x9c");
+    stateMachine.ProcessString(L"\x1b]9;9;\"D:\\中文\"\x1b\\");
     VERIFY_ARE_EQUAL(term.GetWorkingDirectory(), L"D:\\中文");
 
     // Test OSC 9;9 sequences without quotation marks
-    stateMachine.ProcessString(L"\x1b]9;9;C:\\\x9c");
+    stateMachine.ProcessString(L"\x1b]9;9;C:\\\x1b\\");
     VERIFY_ARE_EQUAL(term.GetWorkingDirectory(), L"C:\\");
 
-    stateMachine.ProcessString(L"\x1b]9;9;C:\\Program Files\x9c");
+    stateMachine.ProcessString(L"\x1b]9;9;C:\\Program Files\x1b\\");
     VERIFY_ARE_EQUAL(term.GetWorkingDirectory(), L"C:\\Program Files");
 
-    stateMachine.ProcessString(L"\x1b]9;9;D:\\中文\x9c");
+    stateMachine.ProcessString(L"\x1b]9;9;D:\\中文\x1b\\");
     VERIFY_ARE_EQUAL(term.GetWorkingDirectory(), L"D:\\中文");
 
     // These OSC 9;9 sequences will result in invalid CWD. We shouldn't crash on these.
-    stateMachine.ProcessString(L"\x1b]9;9;\"\x9c");
+    stateMachine.ProcessString(L"\x1b]9;9;\"\x1b\\");
     VERIFY_ARE_EQUAL(term.GetWorkingDirectory(), L"\"");
 
-    stateMachine.ProcessString(L"\x1b]9;9;\"\"\x9c");
+    stateMachine.ProcessString(L"\x1b]9;9;\"\"\x1b\\");
     VERIFY_ARE_EQUAL(term.GetWorkingDirectory(), L"\"\"");
 
-    stateMachine.ProcessString(L"\x1b]9;9;\"\"\"\x9c");
+    stateMachine.ProcessString(L"\x1b]9;9;\"\"\"\x1b\\");
     VERIFY_ARE_EQUAL(term.GetWorkingDirectory(), L"\"");
 
-    stateMachine.ProcessString(L"\x1b]9;9;\"\"\"\"\x9c");
+    stateMachine.ProcessString(L"\x1b]9;9;\"\"\"\"\x1b\\");
     VERIFY_ARE_EQUAL(term.GetWorkingDirectory(), L"\"\"");
 }

--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -280,6 +280,20 @@ bool ConhostInternalGetSet::SetParserMode(const StateMachine::Mode mode, const b
 }
 
 // Routine Description:
+// - Retrieves the various StateMachine parser modes.
+//   GetParserMode is an internal-only "API" call that the vt commands can execute,
+//     but it is not represented as a function call on out public API surface.
+// Arguments:
+// - mode - the parser mode to query.
+// Return Value:
+// - true if the mode is enabled. false if disabled.
+bool ConhostInternalGetSet::GetParserMode(const Microsoft::Console::VirtualTerminal::StateMachine::Mode mode) const
+{
+    auto& stateMachine = _io.GetActiveOutputBuffer().GetStateMachine();
+    return stateMachine.GetParserMode(mode);
+}
+
+// Routine Description:
 // - Connects the PrivateSetScreenMode call directly into our Driver Message servicing call inside Conhost.exe
 //   PrivateSetScreenMode is an internal-only "API" call that the vt commands can execute,
 //     but it is not represented as a function call on our public API surface.

--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -264,19 +264,18 @@ bool ConhostInternalGetSet::SetInputMode(const TerminalInput::Mode mode, const b
 }
 
 // Routine Description:
-// - Sets the terminal emulation mode to either ANSI-compatible or VT52.
-//   PrivateSetAnsiMode is an internal-only "API" call that the vt commands can execute,
+// - Sets the various StateMachine parser modes.
+//   SetParserMode is an internal-only "API" call that the vt commands can execute,
 //     but it is not represented as a function call on out public API surface.
 // Arguments:
-// - ansiMode - set to true to enable the ANSI mode, false for VT52 mode.
+// - mode - the parser mode to change.
+// - enabled - set to true to enable the mode, false to disable it.
 // Return Value:
 // - true if successful. false otherwise.
-bool ConhostInternalGetSet::PrivateSetAnsiMode(const bool ansiMode)
+bool ConhostInternalGetSet::SetParserMode(const StateMachine::Mode mode, const bool enabled)
 {
     auto& stateMachine = _io.GetActiveOutputBuffer().GetStateMachine();
-    stateMachine.SetParserMode(StateMachine::Mode::Ansi, ansiMode);
-    auto& terminalInput = _io.GetActiveInputBuffer()->GetTerminalInput();
-    terminalInput.SetInputMode(TerminalInput::Mode::Ansi, ansiMode);
+    stateMachine.SetParserMode(mode, enabled);
     return true;
 }
 

--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -15,6 +15,7 @@
 
 using namespace Microsoft::Console;
 using Microsoft::Console::Interactivity::ServiceLocator;
+using Microsoft::Console::VirtualTerminal::StateMachine;
 using Microsoft::Console::VirtualTerminal::TerminalInput;
 
 WriteBuffer::WriteBuffer(_In_ Microsoft::Console::IIoProvider& io) :
@@ -273,7 +274,7 @@ bool ConhostInternalGetSet::SetInputMode(const TerminalInput::Mode mode, const b
 bool ConhostInternalGetSet::PrivateSetAnsiMode(const bool ansiMode)
 {
     auto& stateMachine = _io.GetActiveOutputBuffer().GetStateMachine();
-    stateMachine.SetAnsiMode(ansiMode);
+    stateMachine.SetParserMode(StateMachine::Mode::Ansi, ansiMode);
     auto& terminalInput = _io.GetActiveInputBuffer()->GetTerminalInput();
     terminalInput.SetInputMode(TerminalInput::Mode::Ansi, ansiMode);
     return true;

--- a/src/host/outputStream.hpp
+++ b/src/host/outputStream.hpp
@@ -73,8 +73,8 @@ public:
                               const SMALL_RECT& window) override;
 
     bool SetInputMode(const Microsoft::Console::VirtualTerminal::TerminalInput::Mode mode, const bool enabled) override;
+    bool SetParserMode(const Microsoft::Console::VirtualTerminal::StateMachine::Mode mode, const bool enabled) override;
 
-    bool PrivateSetAnsiMode(const bool ansiMode) override;
     bool PrivateSetScreenMode(const bool reverseMode) override;
     bool PrivateSetAutoWrapMode(const bool wrapAtEOL) override;
 

--- a/src/host/outputStream.hpp
+++ b/src/host/outputStream.hpp
@@ -74,6 +74,7 @@ public:
 
     bool SetInputMode(const Microsoft::Console::VirtualTerminal::TerminalInput::Mode mode, const bool enabled) override;
     bool SetParserMode(const Microsoft::Console::VirtualTerminal::StateMachine::Mode mode, const bool enabled) override;
+    bool GetParserMode(const Microsoft::Console::VirtualTerminal::StateMachine::Mode mode) const override;
 
     bool PrivateSetScreenMode(const bool reverseMode) override;
     bool PrivateSetAutoWrapMode(const bool wrapAtEOL) override;

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -5978,7 +5978,7 @@ void ScreenBufferTests::TestAddHyperlink()
     auto& stateMachine = si.GetStateMachine();
 
     // Process the opening osc 8 sequence with no custom id
-    stateMachine.ProcessString(L"\x1b]8;;test.url\x9c");
+    stateMachine.ProcessString(L"\x1b]8;;test.url\x1b\\");
     VERIFY_IS_TRUE(tbi.GetCurrentAttributes().IsHyperlink());
     VERIFY_ARE_EQUAL(tbi.GetHyperlinkUriFromId(tbi.GetCurrentAttributes().GetHyperlinkId()), L"test.url");
 
@@ -5988,7 +5988,7 @@ void ScreenBufferTests::TestAddHyperlink()
     VERIFY_ARE_EQUAL(tbi.GetHyperlinkUriFromId(tbi.GetCurrentAttributes().GetHyperlinkId()), L"test.url");
 
     // Process the closing osc 8 sequences
-    stateMachine.ProcessString(L"\x1b]8;;\x9c");
+    stateMachine.ProcessString(L"\x1b]8;;\x1b\\");
     VERIFY_IS_FALSE(tbi.GetCurrentAttributes().IsHyperlink());
 }
 
@@ -6001,7 +6001,7 @@ void ScreenBufferTests::TestAddHyperlinkCustomId()
     auto& stateMachine = si.GetStateMachine();
 
     // Process the opening osc 8 sequence with a custom id
-    stateMachine.ProcessString(L"\x1b]8;id=myId;test.url\x9c");
+    stateMachine.ProcessString(L"\x1b]8;id=myId;test.url\x1b\\");
     VERIFY_IS_TRUE(tbi.GetCurrentAttributes().IsHyperlink());
     VERIFY_ARE_EQUAL(tbi.GetHyperlinkUriFromId(tbi.GetCurrentAttributes().GetHyperlinkId()), L"test.url");
     VERIFY_ARE_EQUAL(tbi.GetHyperlinkId(L"test.url", L"myId"), tbi.GetCurrentAttributes().GetHyperlinkId());
@@ -6013,7 +6013,7 @@ void ScreenBufferTests::TestAddHyperlinkCustomId()
     VERIFY_ARE_EQUAL(tbi.GetHyperlinkId(L"test.url", L"myId"), tbi.GetCurrentAttributes().GetHyperlinkId());
 
     // Process the closing osc 8 sequences
-    stateMachine.ProcessString(L"\x1b]8;;\x9c");
+    stateMachine.ProcessString(L"\x1b]8;;\x1b\\");
     VERIFY_IS_FALSE(tbi.GetCurrentAttributes().IsHyperlink());
 }
 
@@ -6026,7 +6026,7 @@ void ScreenBufferTests::TestAddHyperlinkCustomIdDifferentUri()
     auto& stateMachine = si.GetStateMachine();
 
     // Process the opening osc 8 sequence with a custom id
-    stateMachine.ProcessString(L"\x1b]8;id=myId;test.url\x9c");
+    stateMachine.ProcessString(L"\x1b]8;id=myId;test.url\x1b\\");
     VERIFY_IS_TRUE(tbi.GetCurrentAttributes().IsHyperlink());
     VERIFY_ARE_EQUAL(tbi.GetHyperlinkUriFromId(tbi.GetCurrentAttributes().GetHyperlinkId()), L"test.url");
     VERIFY_ARE_EQUAL(tbi.GetHyperlinkId(L"test.url", L"myId"), tbi.GetCurrentAttributes().GetHyperlinkId());
@@ -6034,7 +6034,7 @@ void ScreenBufferTests::TestAddHyperlinkCustomIdDifferentUri()
     const auto oldAttributes{ tbi.GetCurrentAttributes() };
 
     // Send any other text
-    stateMachine.ProcessString(L"\x1b]8;id=myId;other.url\x9c");
+    stateMachine.ProcessString(L"\x1b]8;id=myId;other.url\x1b\\");
     VERIFY_IS_TRUE(tbi.GetCurrentAttributes().IsHyperlink());
     VERIFY_ARE_EQUAL(tbi.GetHyperlinkUriFromId(tbi.GetCurrentAttributes().GetHyperlinkId()), L"other.url");
     VERIFY_ARE_EQUAL(tbi.GetHyperlinkId(L"other.url", L"myId"), tbi.GetCurrentAttributes().GetHyperlinkId());

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -113,6 +113,7 @@ public:
     virtual bool LockingShift(const size_t gsetNumber) = 0; // LS0, LS1, LS2, LS3
     virtual bool LockingShiftRight(const size_t gsetNumber) = 0; // LS1R, LS2R, LS3R
     virtual bool SingleShift(const size_t gsetNumber) = 0; // SS2, SS3
+    virtual bool AcceptC1Controls(const bool enabled) = 0; // DECAC1
 
     virtual bool SoftReset() = 0; // DECSTR
     virtual bool HardReset() = 0; // RIS

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1243,7 +1243,12 @@ bool AdaptDispatch::SetAnsiMode(const bool ansiMode)
     // need to be reset to defaults, even if the mode doesn't actually change.
     _termOutput = {};
 
-    return _pConApi->PrivateSetAnsiMode(ansiMode);
+    _pConApi->SetParserMode(StateMachine::Mode::Ansi, ansiMode);
+    _pConApi->SetInputMode(TerminalInput::Mode::Ansi, ansiMode);
+
+    // We don't check the SetInputMode return value, because we'll never want
+    // to forward a DECANM mode change over conpty.
+    return true;
 }
 
 // Routine Description:

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1692,9 +1692,10 @@ void AdaptDispatch::_InitTabStopsForWidth(const size_t width)
 
 //Routine Description:
 // DOCS - Selects the coding system through which character sets are activated.
-//     When ISO2022 is selected, the code page is set to ISO-8859-1, and both
-//     GL and GR areas of the code table can be remapped. When UTF8 is selected,
-//     the code page is set to UTF-8, and only the GL area can be remapped.
+//     When ISO2022 is selected, the code page is set to ISO-8859-1, C1 control
+//     codes are accepted, and both GL and GR areas of the code table can be
+//     remapped. When UTF8 is selected, the code page is set to UTF-8, the C1
+//     control codes are disabled, and only the GL area can be remapped.
 //Arguments:
 // - codingSystem - The coding system that will be selected.
 // Return value:
@@ -1717,6 +1718,7 @@ bool AdaptDispatch::DesignateCodingSystem(const VTID codingSystem)
         success = _pConApi->SetConsoleOutputCP(28591);
         if (success)
         {
+            _pConApi->SetParserMode(StateMachine::Mode::AcceptC1, true);
             _termOutput.EnableGrTranslation(true);
         }
         break;
@@ -1724,6 +1726,7 @@ bool AdaptDispatch::DesignateCodingSystem(const VTID codingSystem)
         success = _pConApi->SetConsoleOutputCP(CP_UTF8);
         if (success)
         {
+            _pConApi->SetParserMode(StateMachine::Mode::AcceptC1, false);
             _termOutput.EnableGrTranslation(false);
         }
         break;

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -344,6 +344,7 @@ bool AdaptDispatch::CursorSaveState()
         savedCursorState.IsOriginModeRelative = _isOriginModeRelative;
         savedCursorState.Attributes = attributes;
         savedCursorState.TermOutput = _termOutput;
+        savedCursorState.C1ControlsAccepted = _pConApi->GetParserMode(StateMachine::Mode::AcceptC1);
         _pConApi->GetConsoleOutputCP(savedCursorState.CodePage);
     }
 
@@ -385,6 +386,9 @@ bool AdaptDispatch::CursorRestoreState()
 
     // Restore designated character set.
     _termOutput = savedCursorState.TermOutput;
+
+    // Restore the parsing state of C1 control codes.
+    _pConApi->SetParserMode(StateMachine::Mode::AcceptC1, savedCursorState.C1ControlsAccepted);
 
     // Restore the code page if it was previously saved.
     if (savedCursorState.CodePage != 0)
@@ -1848,6 +1852,8 @@ bool AdaptDispatch::SoftReset()
         // Restore initial code page if previously changed by a DOCS sequence.
         success = _pConApi->SetConsoleOutputCP(_initialCodePage.value()) && success;
     }
+    // Disable parsing of C1 control codes.
+    success = _pConApi->SetParserMode(StateMachine::Mode::AcceptC1, false) && success;
 
     success = SetGraphicsRendition({}) && success; // Normal rendition.
 

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -101,6 +101,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool LockingShift(const size_t gsetNumber) override; // LS0, LS1, LS2, LS3
         bool LockingShiftRight(const size_t gsetNumber) override; // LS1R, LS2R, LS3R
         bool SingleShift(const size_t gsetNumber) override; // SS2, SS3
+        bool AcceptC1Controls(const bool enabled) override; // DECAC1
         bool SoftReset() override; // DECSTR
         bool HardReset() override; // RIS
         bool ScreenAlignmentPattern() override; // DECALN

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -155,6 +155,7 @@ namespace Microsoft::Console::VirtualTerminal
             bool IsOriginModeRelative = false;
             TextAttribute Attributes = {};
             TerminalOutput TermOutput = {};
+            bool C1ControlsAccepted = false;
             unsigned int CodePage = 0;
         };
         struct Offset

--- a/src/terminal/adapter/conGetSet.hpp
+++ b/src/terminal/adapter/conGetSet.hpp
@@ -16,6 +16,7 @@ Author(s):
 #pragma once
 
 #include "../input/terminalInput.hpp"
+#include "../parser/stateMachine.hpp"
 #include "../../types/inc/IInputEvent.hpp"
 #include "../../buffer/out/LineRendition.hpp"
 #include "../../buffer/out/TextAttribute.hpp"
@@ -49,8 +50,8 @@ namespace Microsoft::Console::VirtualTerminal
                                           const SMALL_RECT& window) = 0;
 
         virtual bool SetInputMode(const TerminalInput::Mode mode, const bool enabled) = 0;
+        virtual bool SetParserMode(const StateMachine::Mode mode, const bool enabled) = 0;
 
-        virtual bool PrivateSetAnsiMode(const bool ansiMode) = 0;
         virtual bool PrivateSetScreenMode(const bool reverseMode) = 0;
         virtual bool PrivateSetAutoWrapMode(const bool wrapAtEOL) = 0;
 

--- a/src/terminal/adapter/conGetSet.hpp
+++ b/src/terminal/adapter/conGetSet.hpp
@@ -51,6 +51,7 @@ namespace Microsoft::Console::VirtualTerminal
 
         virtual bool SetInputMode(const TerminalInput::Mode mode, const bool enabled) = 0;
         virtual bool SetParserMode(const StateMachine::Mode mode, const bool enabled) = 0;
+        virtual bool GetParserMode(const StateMachine::Mode mode) const = 0;
 
         virtual bool PrivateSetScreenMode(const bool reverseMode) = 0;
         virtual bool PrivateSetAutoWrapMode(const bool wrapAtEOL) = 0;

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -104,6 +104,7 @@ public:
     bool LockingShift(const size_t /*gsetNumber*/) noexcept override { return false; } // LS0, LS1, LS2, LS3
     bool LockingShiftRight(const size_t /*gsetNumber*/) noexcept override { return false; } // LS1R, LS2R, LS3R
     bool SingleShift(const size_t /*gsetNumber*/) noexcept override { return false; } // SS2, SS3
+    bool AcceptC1Controls(const bool /*enabled*/) noexcept override { return false; } // DECAC1
 
     bool SoftReset() noexcept override { return false; } // DECSTR
     bool HardReset() noexcept override { return false; } // RIS

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -125,16 +125,17 @@ public:
         return _setInputModeResult;
     }
 
-    bool PrivateSetAnsiMode(const bool ansiMode) override
+    bool SetParserMode(const StateMachine::Mode mode, const bool enabled) override
     {
-        Log::Comment(L"PrivateSetAnsiMode MOCK called...");
+        Log::Comment(L"SetParserMode MOCK called...");
 
-        if (_privateSetAnsiModeResult)
+        if (_setParserModeResult)
         {
-            VERIFY_ARE_EQUAL(_expectedAnsiMode, ansiMode);
+            VERIFY_ARE_EQUAL(_expectedParserMode, mode);
+            VERIFY_ARE_EQUAL(_expectedParserModeEnabled, enabled);
         }
 
-        return _privateSetAnsiModeResult;
+        return _setParserModeResult;
     }
 
     bool PrivateSetScreenMode(const bool /*reverseMode*/) override
@@ -712,8 +713,9 @@ public:
     bool _setInputModeResult = false;
     TerminalInput::Mode _expectedInputMode;
     bool _expectedInputModeEnabled = false;
-    bool _privateSetAnsiModeResult = false;
-    bool _expectedAnsiMode = false;
+    bool _setParserModeResult = false;
+    StateMachine::Mode _expectedParserMode;
+    bool _expectedParserModeEnabled = false;
     bool _privateAllowCursorBlinkingResult = false;
     bool _enable = false; // for cursor blinking
     bool _privateSetScrollingRegionResult = false;
@@ -2057,15 +2059,17 @@ public:
         // success cases
         // set ansi mode = true
         Log::Comment(L"Test 1: ansi mode = true");
-        _testGetSet->_privateSetAnsiModeResult = true;
-        _testGetSet->_expectedAnsiMode = true;
+        _testGetSet->_setParserModeResult = true;
+        _testGetSet->_expectedParserMode = StateMachine::Mode::Ansi;
+        _testGetSet->_expectedParserModeEnabled = true;
 
         VERIFY_IS_TRUE(_pDispatch.get()->SetAnsiMode(true));
 
         // set ansi mode = false
         Log::Comment(L"Test 2: ansi mode = false.");
-        _testGetSet->_privateSetAnsiModeResult = true;
-        _testGetSet->_expectedAnsiMode = false;
+        _testGetSet->_setParserModeResult = true;
+        _testGetSet->_expectedParserMode = StateMachine::Mode::Ansi;
+        _testGetSet->_expectedParserModeEnabled = false;
 
         VERIFY_IS_TRUE(_pDispatch.get()->SetAnsiMode(false));
     }

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -138,6 +138,13 @@ public:
         return _setParserModeResult;
     }
 
+    bool GetParserMode(const StateMachine::Mode /*mode*/) const override
+    {
+        Log::Comment(L"GetParserMode MOCK called...");
+
+        return false;
+    }
+
     bool PrivateSetScreenMode(const bool /*reverseMode*/) override
     {
         Log::Comment(L"PrivateSetScreenMode MOCK called...");

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -265,6 +265,10 @@ bool OutputStateMachineEngine::ActionEscDispatch(const VTID id)
         success = _dispatch->LockingShiftRight(3);
         TermTelemetry::Instance().Log(TermTelemetry::Codes::LS3R);
         break;
+    case EscActionCodes::DECAC1_AcceptC1Controls:
+        success = _dispatch->AcceptC1Controls(true);
+        TermTelemetry::Instance().Log(TermTelemetry::Codes::DECAC1);
+        break;
     case EscActionCodes::DECDHL_DoubleHeightLineTop:
         _dispatch->SetLineRendition(LineRendition::DoubleHeightTop);
         TermTelemetry::Instance().Log(TermTelemetry::Codes::DECDHL);

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -88,6 +88,7 @@ namespace Microsoft::Console::VirtualTerminal
             LS1R_LockingShift = VTID("~"),
             LS2R_LockingShift = VTID("}"),
             LS3R_LockingShift = VTID("|"),
+            DECAC1_AcceptC1Controls = VTID(" 6"),
             DECDHL_DoubleHeightLineTop = VTID("#3"),
             DECDHL_DoubleHeightLineBottom = VTID("#4"),
             DECSWL_SingleWidthLine = VTID("#5"),

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -88,7 +88,7 @@ namespace Microsoft::Console::VirtualTerminal
             LS1R_LockingShift = VTID("~"),
             LS2R_LockingShift = VTID("}"),
             LS3R_LockingShift = VTID("|"),
-            DECAC1_AcceptC1Controls = VTID(" 6"),
+            DECAC1_AcceptC1Controls = VTID(" 7"),
             DECDHL_DoubleHeightLineTop = VTID("#3"),
             DECDHL_DoubleHeightLineBottom = VTID("#4"),
             DECSWL_SingleWidthLine = VTID("#5"),

--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -14,7 +14,6 @@ StateMachine::StateMachine(std::unique_ptr<IStateMachineEngine> engine) :
     _engine(std::move(engine)),
     _state(VTStates::Ground),
     _trace(Microsoft::Console::VirtualTerminal::ParserTracing()),
-    _isInAnsiMode(true),
     _parameters{},
     _parameterLimitReached(false),
     _oscString{},
@@ -24,9 +23,9 @@ StateMachine::StateMachine(std::unique_ptr<IStateMachineEngine> engine) :
     _ActionClear();
 }
 
-void StateMachine::SetAnsiMode(bool ansiMode) noexcept
+void StateMachine::SetParserMode(const Mode mode, const bool enabled)
 {
-    _isInAnsiMode = ansiMode;
+    _parserMode.set(mode, enabled);
 }
 
 const IStateMachineEngine& StateMachine::Engine() const noexcept
@@ -1064,7 +1063,7 @@ void StateMachine::_EventEscape(const wchar_t wch)
             _EnterEscapeIntermediate();
         }
     }
-    else if (_isInAnsiMode)
+    else if (_parserMode.test(Mode::Ansi))
     {
         if (_isCsiIndicator(wch))
         {
@@ -1129,7 +1128,7 @@ void StateMachine::_EventEscapeIntermediate(const wchar_t wch)
     {
         _ActionIgnore();
     }
-    else if (_isInAnsiMode)
+    else if (_parserMode.test(Mode::Ansi))
     {
         _ActionEscDispatch(wch);
         _EnterGround();
@@ -1729,8 +1728,16 @@ void StateMachine::ProcessCharacter(const wchar_t wch)
     // Preprocess C1 control characters and treat them as ESC + their 7-bit equivalent.
     else if (_isC1ControlCharacter(wch))
     {
-        ProcessCharacter(AsciiChars::ESC);
-        ProcessCharacter(_c1To7Bit(wch));
+        // But note that we only do this if C1 control code parsing has been
+        // explicitly requested, since there are some code pages with "unmapped"
+        // code points that get translated as C1 controls when that is not their
+        // intended use. In order to avoid them triggering unintentional escape
+        // sequences, we ignore these characters by default.
+        if (_parserMode.test(Mode::AcceptC1))
+        {
+            ProcessCharacter(AsciiChars::ESC);
+            ProcessCharacter(_c1To7Bit(wch));
+        }
     }
     // Don't go to escape from the OSC string state - ESC can be used to terminate OSC strings.
     else if (_isEscape(wch) && _state != VTStates::OscString)

--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -28,6 +28,11 @@ void StateMachine::SetParserMode(const Mode mode, const bool enabled)
     _parserMode.set(mode, enabled);
 }
 
+bool StateMachine::GetParserMode(const Mode mode) const
+{
+    return _parserMode.test(mode);
+}
+
 const IStateMachineEngine& StateMachine::Engine() const noexcept
 {
     return *_engine;

--- a/src/terminal/parser/stateMachine.hpp
+++ b/src/terminal/parser/stateMachine.hpp
@@ -49,6 +49,7 @@ namespace Microsoft::Console::VirtualTerminal
         };
 
         void SetParserMode(const Mode mode, const bool enabled);
+        bool GetParserMode(const Mode mode) const;
 
         void ProcessCharacter(const wchar_t wch);
         void ProcessString(const std::wstring_view string);

--- a/src/terminal/parser/stateMachine.hpp
+++ b/src/terminal/parser/stateMachine.hpp
@@ -42,7 +42,13 @@ namespace Microsoft::Console::VirtualTerminal
     public:
         StateMachine(std::unique_ptr<IStateMachineEngine> engine);
 
-        void SetAnsiMode(bool ansiMode) noexcept;
+        enum class Mode : size_t
+        {
+            AcceptC1,
+            Ansi,
+        };
+
+        void SetParserMode(const Mode mode, const bool enabled);
 
         void ProcessCharacter(const wchar_t wch);
         void ProcessString(const std::wstring_view string);
@@ -144,7 +150,7 @@ namespace Microsoft::Console::VirtualTerminal
 
         VTStates _state;
 
-        bool _isInAnsiMode;
+        til::enumset<Mode> _parserMode{ Mode::Ansi };
 
         std::wstring_view _currentString;
         size_t _runOffset;

--- a/src/terminal/parser/telemetry.cpp
+++ b/src/terminal/parser/telemetry.cpp
@@ -273,6 +273,7 @@ void TermTelemetry::WriteFinalTraceLog() const
                                       TraceLoggingUInt32(_uiTimesUsed[OSCBG], "OscBackgroundColor"),
                                       TraceLoggingUInt32(_uiTimesUsed[OSCSCB], "OscSetClipboard"),
                                       TraceLoggingUInt32(_uiTimesUsed[REP], "REP"),
+                                      TraceLoggingUInt32(_uiTimesUsed[DECAC1], "DECAC1"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECSWL], "DECSWL"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECDWL], "DECDWL"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECDHL], "DECDHL"),

--- a/src/terminal/parser/telemetry.hpp
+++ b/src/terminal/parser/telemetry.hpp
@@ -99,6 +99,7 @@ namespace Microsoft::Console::VirtualTerminal
             REP,
             OSCFG,
             OSCBG,
+            DECAC1,
             DECSWL,
             DECDWL,
             DECDHL,

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -1828,7 +1828,7 @@ class StateMachineExternalTest final
 
         pDispatch->ClearState();
         pDispatch->_isInAnsiMode = false;
-        mach.SetAnsiMode(false);
+        mach.SetParserMode(StateMachine::Mode::Ansi, false);
 
         mach.ProcessString(L"\x1b<");
         VERIFY_IS_TRUE(pDispatch->_isInAnsiMode);
@@ -2737,7 +2737,7 @@ class StateMachineExternalTest final
         StateMachine mach(std::move(engine));
 
         // ANSI mode must be reset for VT52 sequences to be recognized.
-        mach.SetAnsiMode(false);
+        mach.SetParserMode(StateMachine::Mode::Ansi, false);
 
         Log::Comment(L"Cursor Up");
         mach.ProcessCharacter(AsciiChars::ESC);
@@ -2823,7 +2823,7 @@ class StateMachineExternalTest final
         StateMachine mach(std::move(engine));
 
         Log::Comment(L"Identify Device in VT52 mode.");
-        mach.SetAnsiMode(false);
+        mach.SetParserMode(StateMachine::Mode::Ansi, false);
         mach.ProcessCharacter(AsciiChars::ESC);
         mach.ProcessCharacter(L'Z');
         VERIFY_IS_TRUE(pDispatch->_vt52DeviceAttributes);
@@ -2832,7 +2832,7 @@ class StateMachineExternalTest final
         pDispatch->ClearState();
 
         Log::Comment(L"Identify Device in ANSI mode.");
-        mach.SetAnsiMode(true);
+        mach.SetParserMode(StateMachine::Mode::Ansi, true);
         mach.ProcessCharacter(AsciiChars::ESC);
         mach.ProcessCharacter(L'Z');
         VERIFY_IS_TRUE(pDispatch->_deviceAttributes);


### PR DESCRIPTION
There are some code pages with "unmapped" code points in the C1 range,
which results in them being translated into Unicode C1 control codes,
even though that is not their intended use. To avoid having these
characters triggering unintentional escape sequences, this PR now
disables C1 controls by default.

Switching to ISO-2022 encoding will re-enable them, though, since that
is the most likely scenario in which they would be required. They can
also be explicitly enabled, even in UTF-8 mode, with the `DECAC1` escape
sequence.

What I've done is add a new mode to the `StateMachine` class that
controls whether C1 code points are interpreted as control characters or
not. When disabled, these code points are simply dropped from the
output, similar to the way a `NUL` is interpreted.

This isn't exactly the way they were handled in the v1 console (which I
think replaces them with the font _notdef_ glyph), but it matches the
XTerm behavior, which seems more appropriate considering this is in VT
mode. And it's worth noting that Windows Explorer seems to work the same
way.

As mentioned above, the mode can be enabled by designating the ISO-2022
coding system with a `DOCS` sequence, and it will be disabled again when
UTF-8 is designated. You can also enable it explicitly with a `DECAC1`
sequence (originally this was actually a DEC printer sequence, but it
doesn't seem unreasonable to use it in a terminal).

I've also extended the operations that save and restore "cursor state"
(e.g. `DECSC` and `DECRC`) to include the state of the C1 parser mode,
since it's closely tied to the code page and character sets which are
also saved there. Similarly, when a `DECSTR` sequence resets the code
page and character sets, I've now made it reset the C1 mode as well.

I should note that the new `StateMachine` mode is controlled via a
generic `SetParserMode` method (with a matching API in the `ConGetSet`
interface) to allow for easier addition of other modes in the future.
And I've reimplemented the existing ANSI/VT52 mode in terms of these
generic methods instead of it having to have its own separate APIs.

## Validation Steps Performed

Some of the unit tests for OSC sequences were using a C1 `0x9C` for the
string terminator, which doesn't work by default anymore. Since that's
not a good practice anyway, I thought it best to change those to a
standard 7-bit terminator. However, in tests that were explicitly
validating the C1 controls, I've just enabled the C1 parser mode at the
start of the tests in order to get them working again.

There were also some ANSI mode adapter tests that had to be updated to
account for the fact that it has now been reimplemented in terms of the
`SetParserMode` API.

I've added a new state machine test to validate the changes in behavior
when the C1 parser mode is enabled or disabled. And I've added an
adapter test to verify that the `DesignateCodingSystems` and
`AcceptC1Controls` methods toggle the C1 parser mode as expected.

I've manually verified the test cases in #10069 and #10310 to confirm
that they're no longer triggering control sequences by default.
Although, as I explained above, the C1 code points are completely
dropped from the output rather than displayed as _notdef_ glyphs. I
think this is a reasonable compromise though.

Closes #10069
Closes #10310 