### PR TITLE
Fix missing window border when use "win+arrow down" in fullscreen mode in Conhost

### DIFF
--- a/src/interactivity/win32/windowproc.cpp
+++ b/src/interactivity/win32/windowproc.cpp
@@ -574,6 +574,10 @@ using namespace Microsoft::Console::Types;
         {
             Menu::s_ShowPropertiesDialog(hWnd, TRUE);
         }
+        else if (wParam == SC_RESTORE && _fIsInFullscreen)
+        {
+            SetIsFullscreen(false);
+        }
         else
         {
             goto CallDefWin;


### PR DESCRIPTION
Window exits out of fullscreen if it receives SC_RESTORE

Closes #10607
