### PR TITLE
Fix for missing CopyComplete files in TerminalConnection.vcxproj

### DIFF
--- a/src/cascadia/TerminalConnection/TerminalConnection.vcxproj
+++ b/src/cascadia/TerminalConnection/TerminalConnection.vcxproj
@@ -98,45 +98,37 @@
   </ItemDefinitionGroup>
   <Import Project="$(SolutionDir)build\rules\CollectWildcardResources.targets" />
 
+  <!--
+  BODGY:
+
+  We depend on `cpprest142*.dll`, which comes from our vcpkg dependency. As a
+  part of the vcpkg dependency restore, msbuild will call the `deployBinary()`
+  function in
+  `packages\vcpkg-cpprestsdk.2.10.14\scripts\buildsystems\msbuild\applocal.ps1`.
+  That function does the actual job of copying the file. It copies it outside of
+  MsBuild. MsBuild then, in the `_CopyFilesMarkedCopyLocal` target, determines
+  that it needs to copy `cpprest142*.dll`, because that dll is a member of
+  `@(ReferencesCopiedInThisBuild)`. However, the file's already been copied, so
+  MsBuild never copies it. But that also prevents MsBuild from setting
+  `WroteAtLeastOneFile`, which then means that MsBuild will never create the
+  .copycomplete file for this project.
+
+  Because that file is missing, MsBuild will never thiqnk the project is up to
+  date, and the FastUpToDate check in VS will always force MsBuild to run a pass
+  on this project.
+
+  To mitigate this, we're adding this other target here, which runs after
+  _CopyFilesMarkedCopyLocal, and always creates the CopyUpToDateMarker. This
+  makes the FastUpTodate check succeed.
+  -->
+
   <Target
       Name="_Post_CopyFilesMarkedCopyLocal"
       AfterTargets="_CopyFilesMarkedCopyLocal"
       Condition="'@(ReferenceCopyLocalPaths)' != ''">
 
-<!--     <PropertyGroup>
-      <CreateHardLinksForCopyLocalIfPossible Condition="'$(BuildingInsideVisualStudio)' == 'true' or '$(CreateHardLinksForCopyLocalIfPossible)' == ''">false</CreateHardLinksForCopyLocalIfPossible>
-      <CreateSymbolicLinksForCopyLocalIfPossible Condition="'$(BuildingInsideVisualStudio)' == 'true' or '$(CreateSymbolicLinksForCopyLocalIfPossible)' == ''">false</CreateSymbolicLinksForCopyLocalIfPossible>
-    </PropertyGroup>
-
-    <Copy
-        SourceFiles="@(ReferenceCopyLocalPaths)"
-        DestinationFiles="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename)%(Extension)')"
-        SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
-        OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
-        Retries="$(CopyRetryCount)"
-        RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
-        UseHardlinksIfPossible="$(CreateHardLinksForCopyLocalIfPossible)"
-        UseSymboliclinksIfPossible="$(CreateSymbolicLinksForCopyLocalIfPossible)"
-        Condition="'$(UseCommonOutputDirectory)' != 'true'"
-            >
-
-      <Output TaskParameter="DestinationFiles" ItemName="FileWritesShareable"/>
-      <Output TaskParameter="CopiedFiles" ItemName="ReferencesCopiedInThisBuild"/>
-      <Output TaskParameter="WroteAtLeastOneFile" PropertyName="WroteAtLeastOneFile"/>
-
-    </Copy> -->
-
-    <!-- If this project produces reference assemblies *and* copied (possibly transitive)
-         references on this build, subsequent builds of projects that depend on it must
-         not be considered up to date, so touch this marker file that is considered an
-         input to projects that reference this one. -->
     <Touch Files="@(CopyUpToDateMarker)"
       AlwaysCreate="true" />
-
-    <!-- <ItemGroup>
-      <FileWrites Include="@(CopyUpToDateMarker)" />
-    </ItemGroup> -->
-
   </Target>
 
 

--- a/src/cascadia/TerminalConnection/TerminalConnection.vcxproj
+++ b/src/cascadia/TerminalConnection/TerminalConnection.vcxproj
@@ -97,4 +97,47 @@
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(SolutionDir)build\rules\CollectWildcardResources.targets" />
+
+  <Target
+      Name="_Post_CopyFilesMarkedCopyLocal"
+      AfterTargets="_CopyFilesMarkedCopyLocal"
+      Condition="'@(ReferenceCopyLocalPaths)' != ''">
+
+<!--     <PropertyGroup>
+      <CreateHardLinksForCopyLocalIfPossible Condition="'$(BuildingInsideVisualStudio)' == 'true' or '$(CreateHardLinksForCopyLocalIfPossible)' == ''">false</CreateHardLinksForCopyLocalIfPossible>
+      <CreateSymbolicLinksForCopyLocalIfPossible Condition="'$(BuildingInsideVisualStudio)' == 'true' or '$(CreateSymbolicLinksForCopyLocalIfPossible)' == ''">false</CreateSymbolicLinksForCopyLocalIfPossible>
+    </PropertyGroup>
+
+    <Copy
+        SourceFiles="@(ReferenceCopyLocalPaths)"
+        DestinationFiles="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename)%(Extension)')"
+        SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
+        OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+        Retries="$(CopyRetryCount)"
+        RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+        UseHardlinksIfPossible="$(CreateHardLinksForCopyLocalIfPossible)"
+        UseSymboliclinksIfPossible="$(CreateSymbolicLinksForCopyLocalIfPossible)"
+        Condition="'$(UseCommonOutputDirectory)' != 'true'"
+            >
+
+      <Output TaskParameter="DestinationFiles" ItemName="FileWritesShareable"/>
+      <Output TaskParameter="CopiedFiles" ItemName="ReferencesCopiedInThisBuild"/>
+      <Output TaskParameter="WroteAtLeastOneFile" PropertyName="WroteAtLeastOneFile"/>
+
+    </Copy> -->
+
+    <!-- If this project produces reference assemblies *and* copied (possibly transitive)
+         references on this build, subsequent builds of projects that depend on it must
+         not be considered up to date, so touch this marker file that is considered an
+         input to projects that reference this one. -->
+    <Touch Files="@(CopyUpToDateMarker)"
+      AlwaysCreate="true" />
+
+    <!-- <ItemGroup>
+      <FileWrites Include="@(CopyUpToDateMarker)" />
+    </ItemGroup> -->
+
+  </Target>
+
+
 </Project>

--- a/src/cascadia/TerminalConnection/TerminalConnection.vcxproj
+++ b/src/cascadia/TerminalConnection/TerminalConnection.vcxproj
@@ -104,22 +104,22 @@
   We depend on `cpprest142*.dll`, which comes from our vcpkg dependency. As a
   part of the vcpkg dependency restore, msbuild will call the `deployBinary()`
   function in
-  `packages\vcpkg-cpprestsdk.2.10.14\scripts\buildsystems\msbuild\applocal.ps1`.
+  `packages\vcpkg-cpprestsdk.2.10.14\scripts\BuildSystems\msbuild\AppLocal.ps1`.
   That function does the actual job of copying the file. It copies it outside of
   MsBuild. MsBuild then, in the `_CopyFilesMarkedCopyLocal` target, determines
   that it needs to copy `cpprest142*.dll`, because that dll is a member of
   `@(ReferencesCopiedInThisBuild)`. However, the file's already been copied, so
   MsBuild never copies it. But that also prevents MsBuild from setting
   `WroteAtLeastOneFile`, which then means that MsBuild will never create the
-  .copycomplete file for this project.
+  .CopyComplete file for this project.
 
-  Because that file is missing, MsBuild will never thiqnk the project is up to
+  Because that file is missing, MsBuild will never think the project is up to
   date, and the FastUpToDate check in VS will always force MsBuild to run a pass
   on this project.
 
   To mitigate this, we're adding this other target here, which runs after
   _CopyFilesMarkedCopyLocal, and always creates the CopyUpToDateMarker. This
-  makes the FastUpTodate check succeed.
+  makes the FastUpToDate check succeed.
   -->
 
   <Target


### PR DESCRIPTION
I'm working on making the FastUpToDate check in Vs work for the Terminal project. This is one of a few PRs in this area.

FastUpToDate lets vs check quickly determine that it doesn't need to do anything for a given project. 

However, a few of our projects don't produce all the right artifacts, or check too many things, and this eventually causes the `wapproj` to rebuild, EVERY TIME YOU F5 in VS. 

This first PR deals with the `.copycomplete` file in `obj\x64\debug\terminalconnection\`. Below are my verbatim notes, which led to the solution in this PR. 








### Problem 1 ✅
* There were missing `.copycomplete` files across the repo. 
  ```
  obj\x64\debug\microsoft.terminal.settings.model.lib\microsoft.terminal.settings.modellib.vcxproj.copycomplete
  obj\x64\debug\microsoft.terminal.settings.model\microsoft.terminal.settings.model.vcxproj.copycomplete
  obj\x64\debug\terminalapplib\terminalapplib.vcxproj.copycomplete
  obj\x64\debug\terminalapp\terminalapp.vcxproj.copycomplete
  obj\x64\debug\terminalconnection\terminalconnection.vcxproj.copycomplete
  ```
  - just making empty files there seemed good enough. 
  - Might be because the CopyLocal target was already there, but the task didn't ever run to create that file? Weird.
* UPDATE: checking out main, and building again - the `.copycomplete`s are gone. So that's something that can be improved.
* The only place I could find a reference was in `"obj\x64\Debug\TerminalConnection\TerminalConnection.vcxproj.FileListAbsolute.txt"`, which will get updated if you remove the line from that file (but no one seemingly writes it or mentiones it in the log)
* Deleting `bin\x64\Debug\TerminalConnection\cpprest142_2_10d.dll` then building the project did copy the file, but it didn't touch the copycomplete. Weird.
* Why does
  - `TerminalConnection` think it needs this
  - `Microsoft.Terminal.Settings.Model.Lib` have one
  - `Microsoft.Terminal.Control*` **NOT** have one


* This file is a [`@(CopyUpToDateMarker)`](https://github.com/dotnet/msbuild/blob/main/src/Tasks/Microsoft.Common.CurrentVersion.targets#L392)
* The target [`_CopyFilesMarkedCopyLocal`](https://github.com/dotnet/msbuild/blob/main/src/Tasks/Microsoft.Common.CurrentVersion.targets#L4795) touches `@(CopyUpToDateMarker)`, when:
  - `"'@(ReferencesCopiedInThisBuild)' != ''` and
  - `'$(WroteAtLeastOneFile)' == 'true'"`

* In out build output:
```
6>Target _CopyFilesMarkedCopyLocal:
6>  Using "Copy" task from assembly "Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a".
6>  Task "Copy"
6>    Did not copy from file "C:\Users\migrie\dev\public\terminal\bin\x64\Debug\TerminalConnection\cpprest142_2_10d.dll" to file "C:\Users\migrie\dev\public\terminal\bin\x64\Debug\TerminalConnection\cpprest142_2_10d.dll" because the "SkipUnchangedFiles" parameter was set to "true" in the project and the files' sizes and timestamps match.
6>  Done executing task "Copy".
6>  Task "Touch" skipped, due to false condition; ('@(ReferencesCopiedInThisBuild)' != '' and '$(WroteAtLeastOneFile)' == 'true') was evaluated as ('C:\Users\migrie\dev\public\terminal\bin\x64\Debug\TerminalConnection\cpprest142_2_10d.dll' != '' and 'False' == 'true').
```
  - So `WroteAtLeastOneFile` should be true, when it's currently false. That _looks_ like it's set to true when the file does get copied, wheich did't happen because the copy was skipped.
  - WAIT LOOK AT THAT MESSAGE. "Did not copy from file "
    `"C:\Users\migrie\dev\public\terminal\bin\x64\Debug\TerminalConnection\cpprest142_2_10d.dll"`  to file
    `"C:\Users\migrie\dev\public\terminal\bin\x64\Debug\TerminalConnection\cpprest142_2_10d.dll"`
    THESE ARE THE SAME FILE.
    `@(ReferenceCopyLocalPaths)` is filled with the file already?!
- The Target `AppLocalFromInstalled` is the only other thing that references `cpprest142_2_10d.dll`.
- Even if you delete the `cpprest142_2_10d.dll`, then `_CopyFilesMarkedCopyLocal` still evaluates the Touch condition as false, and doesn't touch it.
- the `deployBinary()` function in `packages\vcpkg-cpprestsdk.2.10.14\scripts\buildsystems\msbuild\applocal.ps1` does the actual job of copying the file. It copies it outside of MsBuild, which prevents MsBuild from copying it, and now MsBuild thinks it shouldn't write the `.copycomplete` file itself.

