### PR TITLE
Wrap these commands with quotes

### DIFF
--- a/build/rules/GenerateFeatureFlags.proj
+++ b/build/rules/GenerateFeatureFlags.proj
@@ -63,8 +63,14 @@
     Outputs="$(OpenConsoleCommonOutDir)\inc\TilFeatureStaging.h"
     DependsOnTargets="_GenerateBranchAndBrandingCache">
     <MakeDir Directories="$(OpenConsoleCommonOutDir)\inc" />
+    <!-- This commandline is escaped like:
+
+    powershell -Command "&'$(SolutionDir)\tools\Generate-FeatureStagingHeader.ps1' -Path '%(FeatureFlagFile.FullPath)'' -Branding $(_WTBrandingName)"
+
+    which was the only way I could find to get it to obey spaces in the SolutionDir
+    -->
     <Exec
-      Command="powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy ByPass -Command &quot;$(SolutionDir)\tools\Generate-FeatureStagingHeader.ps1&quot; -Path &quot;%(FeatureFlagFile.FullPath)&quot; -Branding $(_WTBrandingName)"
+      Command="powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy ByPass -Command &quot;&amp;&apos;$(SolutionDir)\tools\Generate-FeatureStagingHeader.ps1&apos; -Path &apos;%(FeatureFlagFile.FullPath)&apos; -Branding $(_WTBrandingName)&quot;"
       ConsoleToMsBuild="true"
       StandardOutputImportance="low">
       <Output TaskParameter="ConsoleOutput" ItemName="_FeatureFlagFileLines" />

--- a/src/host/ft_uia/Host.Tests.UIA.csproj
+++ b/src/host/ft_uia/Host.Tests.UIA.csproj
@@ -143,7 +143,7 @@
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy $(SolutionDir)\dep\WinAppDriver\* $(OutDir)\</PostBuildEvent>
+    <PostBuildEvent>copy &quot;$(SolutionDir)\dep\WinAppDriver\*&quot; &quot;$(OutDir)\&quot;</PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\..\..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets" Condition="Exists('..\..\..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/propsheet/propsheet.vcxproj
+++ b/src/propsheet/propsheet.vcxproj
@@ -78,8 +78,10 @@
       <AdditionalIncludeDirectories>$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
   </ItemDefinitionGroup>
+  <!-- If you don't include a '.' at the end of the $(IntermediateOutputPath),
+  mc.exe will get confused by the trailign slash. -->
   <Target Name="MessageCompile" Inputs="@(MessageCompile)" Outputs="$(IntermediateOutputPath)\%(MessageCompile.Filename).h" BeforeTargets="ClCompile">
-    <Exec Command="mc.exe /h &quot;$(IntermediateOutputPath)&quot; /r &quot;$(IntermediateOutputPath)&quot; @(MessageCompile)" />
+    <Exec Command="mc.exe /h &quot;$(IntermediateOutputPath).&quot; /r &quot;$(IntermediateOutputPath).&quot; @(MessageCompile)" />
   </Target>
   <!-- Careful reordering these. Some default props (contained in these files) are order sensitive. -->
   <Import Project="..\common.build.post.props" />

--- a/src/propsheet/propsheet.vcxproj
+++ b/src/propsheet/propsheet.vcxproj
@@ -79,7 +79,7 @@
     </ResourceCompile>
   </ItemDefinitionGroup>
   <!-- If you don't include a '.' at the end of the $(IntermediateOutputPath),
-  mc.exe will get confused by the trailign slash. -->
+  mc.exe will get confused by the trailing slash. -->
   <Target Name="MessageCompile" Inputs="@(MessageCompile)" Outputs="$(IntermediateOutputPath)\%(MessageCompile.Filename).h" BeforeTargets="ClCompile">
     <Exec Command="mc.exe /h &quot;$(IntermediateOutputPath).&quot; /r &quot;$(IntermediateOutputPath).&quot; @(MessageCompile)" />
   </Target>

--- a/src/propsheet/propsheet.vcxproj
+++ b/src/propsheet/propsheet.vcxproj
@@ -79,7 +79,7 @@
     </ResourceCompile>
   </ItemDefinitionGroup>
   <Target Name="MessageCompile" Inputs="@(MessageCompile)" Outputs="$(IntermediateOutputPath)\%(MessageCompile.Filename).h" BeforeTargets="ClCompile">
-    <Exec Command="mc.exe /h $(IntermediateOutputPath) /r $(IntermediateOutputPath) @(MessageCompile)" />
+    <Exec Command="mc.exe /h &quot;$(IntermediateOutputPath)&quot; /r &quot;$(IntermediateOutputPath)&quot; @(MessageCompile)" />
   </Target>
   <!-- Careful reordering these. Some default props (contained in these files) are order sensitive. -->
   <Import Project="..\common.build.post.props" />


### PR DESCRIPTION
I'm pretty exactly following the diff from #917. These paths weren't wrapped in `&quot;`s, so building the solution in a directory with a space in it would explode.

Closes #917.

Turns out, the diff provided by that user wasn't exactly right. I've tested building in a directory with spaces now, and this seems to work. 

Also caught a bug in the Generate Feature Flags script. 
