### PR TITLE
Add notes on building package from commandline

### DIFF
--- a/.github/actions/spelling/allow/allow.txt
+++ b/.github/actions/spelling/allow/allow.txt
@@ -75,6 +75,7 @@ UIs
 und
 unregister
 versioned
+vsdevcmd
 We'd
 wildcards
 yeru

--- a/doc/building.md
+++ b/doc/building.md
@@ -87,3 +87,46 @@ If you want to use .nupkg files instead of the downloaded Nuget package, you can
 2. Create the folder /dep/packages
 3. Put your .nupkg files in /dep/packages
 4. If you are using different versions than those already being used, you need to update the references as well. How to do that is explained under "Updating Nuget package references".
+
+
+## Building the Terminal package from the commandline
+
+The Terminal is bundled as an `.msix`, which is produced by the `CascadiaPackage.wapproj` project. To build that project from the commandline, you can run the following (from a window you've already run `tools\razzle.cmd` in):
+
+```cmd
+"%msbuild%" "%OPENCON%\OpenConsole.sln" /p:Configuration=%_LAST_BUILD_CONF% /p:Platform=%ARCH% /p:AppxSymbolPackageEnabled=false /t:Terminal\CascadiaPackage /m
+```
+
+This takes quite some time, and only generates an `msix`. It does not install the msix. To deploy the package:
+
+```powershell
+# If you haven't already:
+Import-Module tools\OpenConsole.psm1;
+Set-MsBuildDevEnvironment;
+
+# The Set-MsBuildDevEnvironment call is needed for finding the path to
+# makeappx. It also takes a little longer to run. If you're sticking in powershell, best to do that.
+
+Set-Location -Path src\cascadia\CascadiaPackage\AppPackages\CascadiaPackage_0.0.1.0_x64_Debug_Test;
+if ((Get-AppxPackage -Name 'WindowsTerminalDev*') -ne $null) {
+Remove-AppxPackage 'WindowsTerminalDev_0.0.1.0_x64__8wekyb3d8bbwe'
+};
+New-Item ..\loose -Type Directory -Force;
+makeappx unpack /v /o /p .\CascadiaPackage_0.0.1.0_x64_Debug.msix /d ..\Loose\;
+Add-AppxPackage -Path ..\loose\AppxManifest.xml -Register -ForceUpdateFromAnyVersion -ForceApplicationShutdown
+```
+
+Or the cmd.exe version:
+```cmd
+@rem razzle.cmd doesn't set:
+@rem set WindowsSdkDir=C:\Program Files (x86)\Windows Kits\10\
+@rem vsdevcmd.bat does a lot of logic to find that.
+@rem
+@rem I'm gonna hardcode it below:
+
+powershell -Command Set-Location -Path %OPENCON%\src\cascadia\CascadiaPackage\AppPackages\CascadiaPackage_0.0.1.0_x64_Debug_Test;if ((Get-AppxPackage -Name 'WindowsTerminalDev*') -ne $null) { Remove-AppxPackage 'WindowsTerminalDev_0.0.1.0_x64__8wekyb3d8bbwe'};New-Item ..\loose -Type Directory -Force;C:\'Program Files (x86)'\'Windows Kits'\10\bin\10.0.19041.0\x64\makeappx unpack /v /o /p .\CascadiaPackage_0.0.1.0_x64_Debug.msix /d ..\Loose\;Add-AppxPackage -Path ..\loose\AppxManifest.xml -Register -ForceUpdateFromAnyVersion -ForceApplicationShutdown
+```
+
+(yes, the cmd version is just calling powershell to do the powershell version. Too lazy to convert the rest by hand, I'm already copying from `.vscode\tasks.json`)
+
+Building the package from VS generates the loose layout to begin with, and then registers the loose manifest, skipping the msix stop. It's a lot faster than the commandline inner loop here, unfortunately.

--- a/doc/building.md
+++ b/doc/building.md
@@ -122,7 +122,7 @@ Or the cmd.exe version:
 @rem set WindowsSdkDir=C:\Program Files (x86)\Windows Kits\10\
 @rem vsdevcmd.bat does a lot of logic to find that.
 @rem
-@rem I'm gonna hardcode it below:
+@rem I'm gonna hard code it below:
 
 powershell -Command Set-Location -Path %OPENCON%\src\cascadia\CascadiaPackage\AppPackages\CascadiaPackage_0.0.1.0_x64_Debug_Test;if ((Get-AppxPackage -Name 'WindowsTerminalDev*') -ne $null) { Remove-AppxPackage 'WindowsTerminalDev_0.0.1.0_x64__8wekyb3d8bbwe'};New-Item ..\loose -Type Directory -Force;C:\'Program Files (x86)'\'Windows Kits'\10\bin\10.0.19041.0\x64\makeappx unpack /v /o /p .\CascadiaPackage_0.0.1.0_x64_Debug.msix /d ..\Loose\;Add-AppxPackage -Path ..\loose\AppxManifest.xml -Register -ForceUpdateFromAnyVersion -ForceApplicationShutdown
 ```


### PR DESCRIPTION
Unfortunately, does not come up with a good inner loop for buidling the package from the commandline. The inner loop for the resources just sucks.

* [x] closes #926
