### PR TITLE
Rename IInheritable::InsertParent to improve clarity of intent

### DIFF
--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -36,7 +36,7 @@ winrt::com_ptr<Profile> Model::implementation::CreateChild(const winrt::com_ptr<
     profile->Name(parent->Name());
     profile->Guid(parent->Guid());
     profile->Hidden(parent->Hidden());
-    profile->InsertParent(parent);
+    profile->AddLeastImportantParent(parent);
     return profile;
 }
 
@@ -336,7 +336,7 @@ Model::Profile CascadiaSettings::DuplicateProfile(const Model::Profile& source)
         // Make sure to add the default appearance of the duplicated profile as a parent to the duplicate's UnfocusedAppearance
         winrt::com_ptr<AppearanceConfig> defaultAppearance;
         defaultAppearance.copy_from(winrt::get_self<AppearanceConfig>(duplicated->DefaultAppearance()));
-        unfocusedAppearance->InsertParent(defaultAppearance);
+        unfocusedAppearance->AddLeastImportantParent(defaultAppearance);
 
         duplicated->UnfocusedAppearance(*unfocusedAppearance);
     }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -284,15 +284,15 @@ void SettingsLoader::MergeFragmentIntoUserSettings(const winrt::hstring& source,
 void SettingsLoader::FinalizeLayering()
 {
     // Layer default globals -> user globals
-    userSettings.globals->InsertParent(inboxSettings.globals);
+    userSettings.globals->AddLeastImportantParent(inboxSettings.globals);
     userSettings.globals->_FinalizeInheritance();
     // Layer default profile defaults -> user profile defaults
-    userSettings.baseLayerProfile->InsertParent(inboxSettings.baseLayerProfile);
+    userSettings.baseLayerProfile->AddLeastImportantParent(inboxSettings.baseLayerProfile);
     userSettings.baseLayerProfile->_FinalizeInheritance();
     // Layer user profile defaults -> user profiles
     for (const auto& profile : userSettings.profiles)
     {
-        profile->InsertParent(0, userSettings.baseLayerProfile);
+        profile->AddMostImportantParent(userSettings.baseLayerProfile);
         profile->_FinalizeInheritance();
     }
 }
@@ -524,7 +524,7 @@ void SettingsLoader::_parseFragment(const winrt::hstring& source, const std::str
         {
             if (const auto it = userSettings.profilesByGuid.find(updates); it != userSettings.profilesByGuid.end())
             {
-                it->second->InsertParent(0, fragmentProfile);
+                it->second->AddMostImportantParent(fragmentProfile);
             }
         }
         else
@@ -598,7 +598,7 @@ void SettingsLoader::_addParentProfile(const winrt::com_ptr<implementation::Prof
     {
         // If inserted is false, we got a matching user profile with identical GUID.
         // --> The generated profile is a parent of the existing user profile.
-        it->second->InsertParent(profile);
+        it->second->AddLeastImportantParent(profile);
     }
     else
     {

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.cpp
@@ -30,7 +30,7 @@ void GlobalAppSettings::_FinalizeInheritance()
 {
     for (const auto& parent : _parents)
     {
-        _actionMap->InsertParent(parent->_actionMap);
+        _actionMap->AddLeastImportantParent(parent->_actionMap);
         _keybindingsWarnings.insert(_keybindingsWarnings.end(), parent->_keybindingsWarnings.begin(), parent->_keybindingsWarnings.end());
         for (const auto& [k, v] : parent->_colorSchemes)
         {
@@ -68,7 +68,7 @@ winrt::com_ptr<GlobalAppSettings> GlobalAppSettings::Copy() const
 
     for (const auto& parent : _parents)
     {
-        globals->InsertParent(parent->Copy());
+        globals->AddLeastImportantParent(parent->Copy());
     }
     return globals;
 }

--- a/src/cascadia/TerminalSettingsModel/IInheritable.h
+++ b/src/cascadia/TerminalSettingsModel/IInheritable.h
@@ -35,7 +35,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             //  to pass ownership over to the com_ptr.
             com_ptr<T> parent;
             winrt::copy_from_abi(parent, const_cast<T*>(static_cast<const T*>(this)));
-            child->InsertParent(parent);
+            child->AddLeastImportantParent(parent);
 
             child->_FinalizeInheritance();
             return child;
@@ -46,15 +46,14 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             _parents.clear();
         }
 
-        void InsertParent(com_ptr<T> parent)
+        void AddLeastImportantParent(com_ptr<T> parent)
         {
             _parents.emplace_back(std::move(parent));
         }
 
-        void InsertParent(size_t index, com_ptr<T> parent)
+        void AddMostImportantParent(com_ptr<T> parent)
         {
-            auto pos{ _parents.begin() + index };
-            _parents.emplace(pos, std::move(parent));
+            _parents.emplace(_parents.begin(), std::move(parent));
         }
 
         const std::vector<com_ptr<T>>& Parents()

--- a/src/cascadia/TerminalSettingsModel/Profile.cpp
+++ b/src/cascadia/TerminalSettingsModel/Profile.cpp
@@ -46,7 +46,7 @@ void Profile::CreateUnfocusedAppearance()
         // taken from this profile's default appearance, so add it as a parent
         com_ptr<AppearanceConfig> parentCom;
         parentCom.copy_from(winrt::get_self<implementation::AppearanceConfig>(_DefaultAppearance));
-        unfocusedAppearance->InsertParent(parentCom);
+        unfocusedAppearance->AddLeastImportantParent(parentCom);
 
         _UnfocusedAppearance = *unfocusedAppearance;
     }
@@ -119,7 +119,7 @@ winrt::com_ptr<Profile> Profile::CopySettings() const
         if (*_UnfocusedAppearance)
         {
             const auto appearance = AppearanceConfig::CopyAppearance(winrt::get_self<AppearanceConfig>(*_UnfocusedAppearance), weakProfile);
-            appearance->InsertParent(defaultAppearance);
+            appearance->AddLeastImportantParent(defaultAppearance);
             unfocused = *appearance;
         }
         profile->_UnfocusedAppearance = unfocused;
@@ -189,7 +189,7 @@ void Profile::LayerJson(const Json::Value& json)
         // taken from this profile's default appearance, so add it as a parent
         com_ptr<AppearanceConfig> parentCom;
         parentCom.copy_from(defaultAppearanceImpl);
-        unfocusedAppearance->InsertParent(parentCom);
+        unfocusedAppearance->AddLeastImportantParent(parentCom);
 
         unfocusedAppearance->LayerJson(json[JsonKey(UnfocusedAppearanceKey)]);
         _UnfocusedAppearance = *unfocusedAppearance;
@@ -218,7 +218,7 @@ void Profile::_FinalizeInheritance()
         {
             if (auto parentDefaultAppearanceImpl = parent->_DefaultAppearance.try_as<AppearanceConfig>())
             {
-                defaultAppearanceImpl->InsertParent(parentDefaultAppearanceImpl);
+                defaultAppearanceImpl->AddLeastImportantParent(parentDefaultAppearanceImpl);
             }
         }
     }
@@ -231,7 +231,7 @@ void Profile::_FinalizeInheritance()
         {
             if (auto parentFontInfoImpl = parent->_FontInfo.try_as<FontConfig>())
             {
-                fontInfoImpl->InsertParent(parentFontInfoImpl);
+                fontInfoImpl->AddLeastImportantParent(parentFontInfoImpl);
             }
         }
     }

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
@@ -247,7 +247,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         ClearParents();
         com_ptr<TerminalSettings> parentImpl;
         parentImpl.copy_from(get_self<TerminalSettings>(parent));
-        InsertParent(parentImpl);
+        AddLeastImportantParent(parentImpl);
     }
 
     Model::TerminalSettings TerminalSettings::GetParent()


### PR DESCRIPTION
This is a followup commit for 168d28b.
By renaming `IInheritable::InsertParent(com_ptr)` and
`InsertParent(size_t, com_ptr)` into `AddLeastImportantParent(com_ptr)`
and `AddMostImportantParent(com_ptr)` respectively, we can improve
the clarity of our code's intent without the need for comments.

## PR Checklist
* [x] I work here
* [x] Tests added/passed