### PR TITLE
Fix AltGr+Space not working

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -909,7 +909,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             return;
         }
 
-        if (vkey == VK_SPACE && modifiers.IsAltPressed())
+        if (vkey == VK_SPACE && modifiers.IsAltPressed() && !modifiers.IsAltGrPressed())
         {
             if (const auto bindings = _settings.KeyBindings())
             {


### PR DESCRIPTION
This fixes a regression introduced in #10988 for the 1.11 release branch.
For later branches this issue was fixed in #11086.

## PR Checklist
* [x] Closes #11649
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed
* AltGr+Space produces "_" with the bépo keyboard layout