### PR TITLE
Use shallow fetch depth

### DIFF
--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -69,6 +69,7 @@ jobs:
   steps:
   - checkout: self
     clean: true
+    fetchDepth: 1
     submodules: true
     persistCredentials: True
   - task: PkgESSetupBuild@12
@@ -272,6 +273,7 @@ jobs:
     steps:
     - checkout: self
       clean: true
+      fetchDepth: 1
       submodules: true
       persistCredentials: True
     - task: PkgESSetupBuild@12
@@ -349,6 +351,7 @@ jobs:
     steps:
     - checkout: self
       clean: true
+      fetchDepth: 1
       submodules: true
       persistCredentials: True
     - task: PkgESSetupBuild@12
@@ -451,6 +454,7 @@ jobs:
     steps:
     - checkout: self
       clean: true
+      fetchDepth: 1
       submodules: true
     - task: PkgESSetupBuild@12
       displayName: Package ES - Setup Build

--- a/build/pipelines/templates/build-console-audit-job.yml
+++ b/build/pipelines/templates/build-console-audit-job.yml
@@ -19,6 +19,7 @@ jobs:
   - checkout: self
     submodules: true
     clean: true
+    fetchDepth: 1
 
   - task: NuGetToolInstaller@0
     displayName: Ensure NuGet 4.8.1

--- a/build/pipelines/templates/build-console-steps.yml
+++ b/build/pipelines/templates/build-console-steps.yml
@@ -6,6 +6,7 @@ steps:
 - checkout: self
   submodules: true
   clean: true
+  fetchDepth: 1
 
 - task: NuGetToolInstaller@0
   displayName: 'Use NuGet 5.2.0'


### PR DESCRIPTION
Set fetch limit to a depth of 1 for our pipelines as they're just building off of one commit. Saves disk space at least. Might save time.

## PR Checklist
* [x] Closes #10803
* [x] I work here
* [ ] Blends.

See also: https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/pipeline-options-for-git?view=azure-devops&tabs=yaml#shallow-fetch
