### PR TITLE
Tell PublishSymbols task about binaries as well as the PDB files

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -385,12 +385,14 @@ CPINFOEX
 CPLINFO
 cplusplus
 cpp
+CPPARM
 CPPCORECHECK
 cppcorecheckrules
 cppm
 cpprest
 cpprestsdk
 cppwinrt
+CPPx
 CProc
 cpx
 crbegin
@@ -1577,6 +1579,7 @@ nothrow
 NOTICKS
 NOTIMPL
 notin
+notmatch
 NOTNULL
 NOTOPMOST
 NOTRACK
@@ -2479,6 +2482,7 @@ uint
 uintptr
 ulcch
 ulong
+umd
 Unadvise
 unattend
 uncomment
@@ -2649,6 +2653,7 @@ wddmcon
 wddmconrenderer
 WDDMCONSOLECONTEXT
 wdm
+webclient
 webpage
 website
 websocket
@@ -2723,6 +2728,7 @@ Winperf
 WInplace
 winres
 winrt
+winsdk
 wintelnet
 winternl
 winuser

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -262,9 +262,9 @@ jobs:
     continueOnError: True
     inputs:
       SearchPattern: |
-        **/*.pdb
-        **/*.exe
-        **/*.dll
+        $(Build.SourcesDirectory)/bin/**/*.pdb
+        $(Build.SourcesDirectory)/bin/**/*.exe
+        $(Build.SourcesDirectory)/bin/**/*.dll
       IndexSources: false
       SymbolServerType: TeamServices
 
@@ -406,9 +406,9 @@ jobs:
       continueOnError: True
       inputs:
         SearchPattern: |
-          **/*.pdb
-          **/*.exe
-          **/*.dll
+          $(Build.SourcesDirectory)/bin/**/*.pdb
+          $(Build.SourcesDirectory)/bin/**/*.exe
+          $(Build.SourcesDirectory)/bin/**/*.dll
         IndexSources: false
         SymbolServerType: TeamServices
         SymbolsArtifactName: Symbols_WPF_$(BuildConfiguration)

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -261,7 +261,10 @@ jobs:
     displayName: Publish symbols path
     continueOnError: True
     inputs:
-      SearchPattern: '**/*.pdb'
+      SearchPattern: |
+        **/*.pdb
+        **/*.exe
+        **/*.dll
       IndexSources: false
       SymbolServerType: TeamServices
 
@@ -402,7 +405,10 @@ jobs:
       displayName: Publish symbols path
       continueOnError: True
       inputs:
-        SearchPattern: '**/*.pdb'
+        SearchPattern: |
+          **/*.pdb
+          **/*.exe
+          **/*.dll
         IndexSources: false
         SymbolServerType: TeamServices
         SymbolsArtifactName: Symbols_WPF_$(BuildConfiguration)

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -96,6 +96,8 @@ jobs:
       selectOrConfig: config
       nugetConfigPath: NuGet.Config
       arguments: restore OpenConsole.sln -SolutionDirectory $(Build.SourcesDirectory)
+  # Pull the Windows SDK for the developer tools like the debuggers so we can index sources later
+  - template: .\templates\install-winsdk-steps.yml
   - task: UniversalPackages@0
     displayName: Download terminal-internal Universal Package
     inputs:

--- a/build/pipelines/templates/install-winsdk-steps.yml
+++ b/build/pipelines/templates/install-winsdk-steps.yml
@@ -1,0 +1,9 @@
+parameters:
+  sdkVersion: 18362
+steps:
+  - task: powershell@2
+    inputs:
+      targetType: filePath
+      filePath: build\Install-WindowsSdkISO.ps1
+      arguments: ${{ parameters.sdkVersion }}
+    displayName: 'Install Windows SDK (${{ parameters.sdkVersion }})'

--- a/build/pipelines/templates/install-winsdk-steps.yml
+++ b/build/pipelines/templates/install-winsdk-steps.yml
@@ -4,6 +4,6 @@ steps:
   - task: powershell@2
     inputs:
       targetType: filePath
-      filePath: build\Install-WindowsSdkISO.ps1
+      filePath: build\scripts\Install-WindowsSdkISO.ps1
       arguments: ${{ parameters.sdkVersion }}
     displayName: 'Install Windows SDK (${{ parameters.sdkVersion }})'

--- a/build/scripts/Index-Pdbs.ps1
+++ b/build/scripts/Index-Pdbs.ps1
@@ -23,6 +23,7 @@ $mappedFiles = New-Object System.Collections.ArrayList
 
 foreach ($file in (Get-ChildItem -r:$recursive "$SearchDir\*.pdb"))
 {
+    $mappedFiles = New-Object System.Collections.ArrayList
     Write-Verbose "Found $file"
 
     $ErrorActionPreference = "Continue" # Azure Pipelines defaults to "Stop", continue past errors in this script.
@@ -50,7 +51,7 @@ foreach ($file in (Get-ChildItem -r:$recursive "$SearchDir\*.pdb"))
             if ($relative)
             {
                 $mapping = $allFiles[$i] + "*$relative"
-                $mappedFiles.Add($mapping)
+                $ignore = $mappedFiles.Add($mapping)
 
                 Write-Verbose "Mapped path $($i): $mapping"
             }
@@ -78,7 +79,26 @@ $($mappedFiles -join "`r`n")
 SRCSRV: end ------------------------------------------------
 "@ | Set-Content $pdbstrFile
 
+    Write-Host
+    Write-Host
+    Write-Host (Get-Content $pdbstrFile)
+    Write-Host
+    Write-Host
+
+    Write-Host "$pdbstrExe -p:""$file"" -w -s:srcsrv -i:$pdbstrFile"
     & $pdbstrExe -p:"$file" -w -s:srcsrv -i:$pdbstrFile
+    Write-Host
+    Write-Host
+
+    Write-Host "$pdbstrExe -p:""$file"" -r -s:srcsrv"
+    & $pdbstrExe -p:"$file" -r -s:srcsrv
+    Write-Host
+    Write-Host
+
+    Write-Host "$srctoolExe $file"
+    & $srctoolExe "$file"
+    Write-Host
+    Write-Host
 }
 
 # Return with exit 0 to override any weird error code from other tools

--- a/build/scripts/Install-WindowsSdkISO.ps1
+++ b/build/scripts/Install-WindowsSdkISO.ps1
@@ -1,0 +1,346 @@
+[CmdletBinding()]
+param([Parameter(Mandatory=$true, Position=0)]
+      [string]$buildNumber)
+
+# Ensure the error action preference is set to the default for PowerShell3, 'Stop'
+$ErrorActionPreference = 'Stop'
+
+# Constants
+$WindowsSDKOptions = @("OptionId.UWPCpp", "OptionId.DesktopCPPx64", "OptionId.DesktopCPPx86", "OptionId.DesktopCPPARM64", "OptionId.DesktopCPPARM", "OptionId.WindowsDesktopDebuggers")
+$WindowsSDKRegPath = "HKLM:\Software\WOW6432Node\Microsoft\Windows Kits\Installed Roots"
+$WindowsSDKRegRootKey = "KitsRoot10"
+$WindowsSDKVersion = "10.0.$buildNumber.0"
+$WindowsSDKInstalledRegPath = "$WindowsSDKRegPath\$WindowsSDKVersion\Installed Options"
+$StrongNameRegPath = "HKLM:\SOFTWARE\Microsoft\StrongName\Verification"
+$PublicKeyTokens = @("31bf3856ad364e35")
+
+if ($buildNumber -notmatch "^\d{5,}$")
+{
+    Write-Host "ERROR: '$buildNumber' doesn't look like a windows build number"
+    Write-Host
+    Exit 1
+}
+
+function Download-File
+{
+    param ([string] $outDir,
+           [string] $downloadUrl,
+           [string] $downloadName)
+
+    $downloadPath = Join-Path $outDir "$downloadName.download"
+    $downloadDest = Join-Path $outDir $downloadName
+    $downloadDestTemp = Join-Path $outDir "$downloadName.tmp"
+
+    Write-Host -NoNewline "Downloading $downloadName..."
+
+    $retries = 10
+    $downloaded = $false
+    while (-not $downloaded)
+    {
+        try
+        {
+            $webclient = new-object System.Net.WebClient
+            $webclient.DownloadFile($downloadUrl, $downloadPath)
+            $downloaded = $true
+        }
+        catch [System.Net.WebException]
+        {
+            Write-Host
+            Write-Warning "Failed to fetch updated file from $downloadUrl : $($error[0])"
+            if (!(Test-Path $downloadDest))
+            {
+                if ($retries -gt 0)
+                {
+                    Write-Host "$retries retries left, trying download again"
+                    $retries--
+                    start-sleep -Seconds 10
+                }
+                else
+                {
+                    throw "$downloadName was not found at $downloadDest"
+                }
+            }
+            else
+            {
+                Write-Warning "$downloadName may be out of date"
+            }
+        }
+    }
+
+    Unblock-File $downloadPath
+
+    $downloadDestTemp = $downloadPath;
+
+    # Delete and rename to final dest
+    Write-Host "testing $downloadDest"
+    if (Test-Path $downloadDest)
+    {
+        Write-Host "Deleting: $downloadDest"
+        Remove-Item $downloadDest -Force
+    }
+
+    Move-Item -Force $downloadDestTemp $downloadDest
+    Write-Host "Done"
+
+    return $downloadDest
+}
+
+function Get-ISODriveLetter
+{
+    param ([string] $isoPath)
+
+    $diskImage = Get-DiskImage -ImagePath $isoPath
+    if ($diskImage)
+    {
+        $volume = Get-Volume -DiskImage $diskImage
+
+        if ($volume)
+        {
+            $driveLetter = $volume.DriveLetter
+            if ($driveLetter)
+            {
+                $driveLetter += ":"
+                return $driveLetter
+            }
+        }
+    }
+
+    return $null
+}
+
+function Mount-ISO
+{
+    param ([string] $isoPath)
+
+    # Check if image is already mounted
+    $isoDrive = Get-ISODriveLetter $isoPath
+
+    if (!$isoDrive)
+    {
+        Mount-DiskImage -ImagePath $isoPath -StorageType ISO | Out-Null
+    }
+
+    $isoDrive = Get-ISODriveLetter $isoPath
+    Write-Verbose "$isoPath mounted to ${isoDrive}:"
+}
+
+function Dismount-ISO
+{
+    param ([string] $isoPath)
+
+    $isoDrive = (Get-DiskImage -ImagePath $isoPath | Get-Volume).DriveLetter
+
+    if ($isoDrive)
+    {
+        Write-Verbose "$isoPath dismounted"
+        Dismount-DiskImage -ImagePath $isoPath | Out-Null
+    }
+}
+
+function Disable-StrongName
+{
+    param ([string] $publicKeyToken = "*")
+
+    reg ADD "HKLM\SOFTWARE\Microsoft\StrongName\Verification\*,$publicKeyToken" /f | Out-Null
+    if ($env:PROCESSOR_ARCHITECTURE -eq "AMD64")
+    {
+        reg ADD "HKLM\SOFTWARE\Wow6432Node\Microsoft\StrongName\Verification\*,$publicKeyToken" /f | Out-Null
+    }
+}
+
+function Test-Admin
+{
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal $identity
+    $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Test-RegistryPathAndValue
+{
+    param (
+        [parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $path,
+        [parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $value)
+
+    try
+    {
+        if (Test-Path $path)
+        {
+            Get-ItemProperty -Path $path | Select-Object -ExpandProperty $value -ErrorAction Stop | Out-Null
+            return $true
+        }
+    }
+    catch
+    {
+    }
+
+    return $false
+}
+
+function Test-InstallWindowsSDK
+{
+    $retval = $true
+
+    if (Test-RegistryPathAndValue -Path $WindowsSDKRegPath -Value $WindowsSDKRegRootKey)
+    {
+        # A Windows SDK is installed
+        # Is an SDK of our version installed with the options we need?
+        $allRequiredSdkOptionsInstalled = $true
+        foreach($sdkOption in $WindowsSDKOptions)
+        {
+            if (!(Test-RegistryPathAndValue -Path $WindowsSDKInstalledRegPath -Value $sdkOption))
+            {
+                $allRequiredSdkOptionsInstalled = $false
+            }
+        }
+
+        if($allRequiredSdkOptionsInstalled)
+        {
+            # It appears we have what we need. Double check the disk
+            $sdkRoot = Get-ItemProperty -Path $WindowsSDKRegPath | Select-Object -ExpandProperty $WindowsSDKRegRootKey
+            if ($sdkRoot)
+            {
+                if (Test-Path $sdkRoot)
+                {
+                    $refPath = Join-Path $sdkRoot "References\$WindowsSDKVersion"
+                    if (Test-Path $refPath)
+                    {
+                        $umdPath = Join-Path $sdkRoot "UnionMetadata\$WindowsSDKVersion"
+                        if (Test-Path $umdPath)
+                        {
+                            # Pretty sure we have what we need
+                            $retval = $false
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return $retval
+}
+
+function Test-InstallStrongNameHijack
+{
+    foreach($publicKeyToken in $PublicKeyTokens)
+    {
+        $key = "$StrongNameRegPath\*,$publicKeyToken"
+        if (!(Test-Path $key))
+        {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+Write-Host -NoNewline "Checking for installed Windows SDK $WindowsSDKVersion..."
+$InstallWindowsSDK = Test-InstallWindowsSDK
+if ($InstallWindowsSDK)
+{
+    Write-Host "Installation required"
+}
+else
+{
+    Write-Host "INSTALLED"
+}
+
+$StrongNameHijack = Test-InstallStrongNameHijack
+Write-Host -NoNewline "Checking if StrongName bypass required..."
+
+if ($StrongNameHijack)
+{
+    Write-Host "REQUIRED"
+}
+else
+{
+    Write-Host "Done"
+}
+
+if ($StrongNameHijack -or $InstallWindowsSDK)
+{
+    if (!(Test-Admin))
+    {
+        Write-Host
+        throw "ERROR: Elevation required"
+    }
+}
+
+if ($InstallWindowsSDK)
+{
+    # Static(ish) link for Windows SDK
+    # Note: there is a delay from Windows SDK announcements to availability via the static link
+    $uri = "https://software-download.microsoft.com/download/sg/Windows_InsiderPreview_SDK_en-us_$($buildNumber)_1.iso";
+
+    if ($env:TEMP -eq $null)
+    {
+        $env:TEMP = Join-Path $env:SystemDrive 'temp'
+    }
+
+    $winsdkTempDir = Join-Path (Join-Path $env:TEMP ([System.IO.Path]::GetRandomFileName())) "WindowsSDK"
+
+    if (![System.IO.Directory]::Exists($winsdkTempDir))
+    {
+        [void][System.IO.Directory]::CreateDirectory($winsdkTempDir)
+    }
+
+    $file = "winsdk_$buildNumber.iso"
+
+    Write-Verbose "Getting WinSDK from $uri"
+    $downloadFile = Download-File $winsdkTempDir $uri $file
+    Write-Verbose "File is at $downloadFile"
+    $downloadFileItem = Get-Item $downloadFile
+    
+    # Check to make sure the file is at least 10 MB.
+    if ($downloadFileItem.Length -lt 10*1024*1024)
+    {
+        Write-Host
+        Write-Host "ERROR: Downloaded file doesn't look large enough to be an ISO. The requested version may not be on microsoft.com yet."
+        Write-Host
+        Exit 1
+    }
+
+    # TODO Check if zip, exe, iso, etc.
+    try
+    {
+        Write-Host -NoNewline "Mounting ISO $file..."
+        Mount-ISO $downloadFile
+        Write-Host "Done"
+
+        $isoDrive = Get-ISODriveLetter $downloadFile
+
+        if (Test-Path $isoDrive)
+        {
+            Write-Host -NoNewLine "Installing WinSDK..."
+
+            $setupPath = Join-Path "$isoDrive" "WinSDKSetup.exe"
+            Start-Process -Wait $setupPath "/features $WindowsSDKOptions /q"
+            Write-Host "Done"
+        }
+        else
+        {
+            throw "Could not find mounted ISO at ${isoDrive}"
+        }
+    }
+    finally
+    {
+        Write-Host -NoNewline "Dismounting ISO $file..."
+        Dismount-ISO $downloadFile
+        Write-Host "Done"
+    }
+}
+
+if ($StrongNameHijack)
+{
+    Write-Host -NoNewline "Disabling StrongName for Windows SDK..."
+
+    foreach($key in $PublicKeyTokens)
+    {
+        Disable-StrongName $key
+    }
+
+    Write-Host "Done"
+}


### PR DESCRIPTION
We have been advised to give not only the PDB paths, but paths to the EXE and DLL files we produce, to the PublishSymbols build task. We are assured by our engineering systems teams that enlightening the task to all of this information helps it hook things up better somewhere between our build machine and the symbol server such that debugging is more robust, especially around thrown exception stacks. 

## PR Checklist
* [x] Closes #11737 - main fix for feeding EXEs and DLLs into the symbol publisher
* [x] Closes #11860 - bonus fix because I noticed the PDB source linking wasn't working
* [x] I work here.
* [x] If it fits, it sits.

