### PR TITLE
Use more `cppwinrt_utils`

### DIFF
--- a/src/cascadia/LocalTests_SettingsModel/pch.h
+++ b/src/cascadia/LocalTests_SettingsModel/pch.h
@@ -66,3 +66,5 @@ Author(s):
 #include "../../inc/conattrs.hpp"
 #include "../../types/inc/utils.hpp"
 #include "../../inc/DefaultSettings.h"
+
+#include <cppwinrt_utils.h>

--- a/src/cascadia/LocalTests_TerminalApp/pch.h
+++ b/src/cascadia/LocalTests_TerminalApp/pch.h
@@ -73,3 +73,5 @@ Author(s):
 #include "../../inc/conattrs.hpp"
 #include "../../types/inc/utils.hpp"
 #include "../../inc/DefaultSettings.h"
+
+#include <cppwinrt_utils.h>

--- a/src/cascadia/Remoting/CommandlineArgs.h
+++ b/src/cascadia/Remoting/CommandlineArgs.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "CommandlineArgs.g.h"
-#include "../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Remoting::implementation
 {

--- a/src/cascadia/Remoting/CommandlineArgs.h
+++ b/src/cascadia/Remoting/CommandlineArgs.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "CommandlineArgs.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Remoting::implementation
 {

--- a/src/cascadia/Remoting/FindTargetWindowArgs.h
+++ b/src/cascadia/Remoting/FindTargetWindowArgs.h
@@ -19,7 +19,6 @@ Abstract:
 #pragma once
 
 #include "FindTargetWindowArgs.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Remoting::implementation
 {

--- a/src/cascadia/Remoting/FindTargetWindowArgs.h
+++ b/src/cascadia/Remoting/FindTargetWindowArgs.h
@@ -19,7 +19,7 @@ Abstract:
 #pragma once
 
 #include "FindTargetWindowArgs.g.h"
-#include "../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Remoting::implementation
 {

--- a/src/cascadia/Remoting/GetWindowLayoutArgs.h
+++ b/src/cascadia/Remoting/GetWindowLayoutArgs.h
@@ -15,7 +15,6 @@ Abstract:
 #pragma once
 
 #include "GetWindowLayoutArgs.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Remoting::implementation
 {

--- a/src/cascadia/Remoting/GetWindowLayoutArgs.h
+++ b/src/cascadia/Remoting/GetWindowLayoutArgs.h
@@ -15,7 +15,7 @@ Abstract:
 #pragma once
 
 #include "GetWindowLayoutArgs.g.h"
-#include "../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Remoting::implementation
 {

--- a/src/cascadia/Remoting/Monarch.h
+++ b/src/cascadia/Remoting/Monarch.h
@@ -5,7 +5,6 @@
 
 #include "Monarch.g.h"
 #include "Peasant.h"
-#include <cppwinrt_utils.h>
 #include "WindowActivatedArgs.h"
 #include <atomic>
 

--- a/src/cascadia/Remoting/Monarch.h
+++ b/src/cascadia/Remoting/Monarch.h
@@ -5,7 +5,7 @@
 
 #include "Monarch.g.h"
 #include "Peasant.h"
-#include "../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include "WindowActivatedArgs.h"
 #include <atomic>
 

--- a/src/cascadia/Remoting/Peasant.h
+++ b/src/cascadia/Remoting/Peasant.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "Peasant.g.h"
-#include <cppwinrt_utils.h>
 #include "RenameRequestArgs.h"
 
 namespace RemotingUnitTests

--- a/src/cascadia/Remoting/Peasant.h
+++ b/src/cascadia/Remoting/Peasant.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "Peasant.g.h"
-#include "../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include "RenameRequestArgs.h"
 
 namespace RemotingUnitTests

--- a/src/cascadia/Remoting/ProposeCommandlineResult.h
+++ b/src/cascadia/Remoting/ProposeCommandlineResult.h
@@ -19,7 +19,7 @@ Abstract:
 #pragma once
 
 #include "ProposeCommandlineResult.g.h"
-#include "../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Remoting::implementation
 {

--- a/src/cascadia/Remoting/ProposeCommandlineResult.h
+++ b/src/cascadia/Remoting/ProposeCommandlineResult.h
@@ -19,7 +19,6 @@ Abstract:
 #pragma once
 
 #include "ProposeCommandlineResult.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Remoting::implementation
 {

--- a/src/cascadia/Remoting/QuitAllRequestedArgs.h
+++ b/src/cascadia/Remoting/QuitAllRequestedArgs.h
@@ -14,7 +14,6 @@ Abstract:
 #pragma once
 
 #include "QuitAllRequestedArgs.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Remoting::implementation
 {

--- a/src/cascadia/Remoting/QuitAllRequestedArgs.h
+++ b/src/cascadia/Remoting/QuitAllRequestedArgs.h
@@ -14,7 +14,7 @@ Abstract:
 #pragma once
 
 #include "QuitAllRequestedArgs.g.h"
-#include "../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Remoting::implementation
 {

--- a/src/cascadia/Remoting/RenameRequestArgs.h
+++ b/src/cascadia/Remoting/RenameRequestArgs.h
@@ -9,7 +9,7 @@ Class Name:
 #pragma once
 
 #include "RenameRequestArgs.g.h"
-#include "../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Remoting::implementation
 {

--- a/src/cascadia/Remoting/RenameRequestArgs.h
+++ b/src/cascadia/Remoting/RenameRequestArgs.h
@@ -9,7 +9,6 @@ Class Name:
 #pragma once
 
 #include "RenameRequestArgs.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Remoting::implementation
 {

--- a/src/cascadia/Remoting/SummonWindowBehavior.h
+++ b/src/cascadia/Remoting/SummonWindowBehavior.h
@@ -13,7 +13,6 @@ Abstract:
 #pragma once
 
 #include "SummonWindowBehavior.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Remoting::implementation
 {

--- a/src/cascadia/Remoting/SummonWindowBehavior.h
+++ b/src/cascadia/Remoting/SummonWindowBehavior.h
@@ -13,7 +13,7 @@ Abstract:
 #pragma once
 
 #include "SummonWindowBehavior.g.h"
-#include "../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Remoting::implementation
 {

--- a/src/cascadia/Remoting/SummonWindowSelectionArgs.h
+++ b/src/cascadia/Remoting/SummonWindowSelectionArgs.h
@@ -18,7 +18,7 @@ Abstract:
 #pragma once
 
 #include "SummonWindowSelectionArgs.g.h"
-#include "../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Remoting::implementation
 {

--- a/src/cascadia/Remoting/SummonWindowSelectionArgs.h
+++ b/src/cascadia/Remoting/SummonWindowSelectionArgs.h
@@ -18,7 +18,6 @@ Abstract:
 #pragma once
 
 #include "SummonWindowSelectionArgs.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Remoting::implementation
 {

--- a/src/cascadia/Remoting/WindowActivatedArgs.h
+++ b/src/cascadia/Remoting/WindowActivatedArgs.h
@@ -14,7 +14,6 @@ Abstract:
 #pragma once
 
 #include "WindowActivatedArgs.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Remoting::implementation
 {

--- a/src/cascadia/Remoting/WindowActivatedArgs.h
+++ b/src/cascadia/Remoting/WindowActivatedArgs.h
@@ -14,7 +14,7 @@ Abstract:
 #pragma once
 
 #include "WindowActivatedArgs.g.h"
-#include "../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Remoting::implementation
 {

--- a/src/cascadia/Remoting/WindowManager.h
+++ b/src/cascadia/Remoting/WindowManager.h
@@ -24,7 +24,7 @@ Abstract:
 #include "WindowManager.g.h"
 #include "Peasant.h"
 #include "Monarch.h"
-#include "../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Remoting::implementation
 {

--- a/src/cascadia/Remoting/WindowManager.h
+++ b/src/cascadia/Remoting/WindowManager.h
@@ -24,7 +24,6 @@ Abstract:
 #include "WindowManager.g.h"
 #include "Peasant.h"
 #include "Monarch.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Remoting::implementation
 {

--- a/src/cascadia/Remoting/pch.h
+++ b/src/cascadia/Remoting/pch.h
@@ -50,3 +50,5 @@ TRACELOGGING_DECLARE_PROVIDER(g_hRemotingProvider);
 
 // Manually include til after we include Windows.Foundation to give it winrt superpowers
 #include "til.h"
+
+#include <cppwinrt_utils.h>

--- a/src/cascadia/ShellExtension/OpenTerminalHere.h
+++ b/src/cascadia/ShellExtension/OpenTerminalHere.h
@@ -23,7 +23,7 @@ Author(s):
 #pragma once
 
 #include <conattrs.hpp>
-#include "../../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 using namespace Microsoft::WRL;
 

--- a/src/cascadia/ShellExtension/OpenTerminalHere.h
+++ b/src/cascadia/ShellExtension/OpenTerminalHere.h
@@ -23,7 +23,6 @@ Author(s):
 #pragma once
 
 #include <conattrs.hpp>
-#include <cppwinrt_utils.h>
 
 using namespace Microsoft::WRL;
 

--- a/src/cascadia/TerminalApp/ActionPaletteItem.h
+++ b/src/cascadia/TerminalApp/ActionPaletteItem.h
@@ -5,7 +5,7 @@
 
 #include "PaletteItem.h"
 #include "ActionPaletteItem.g.h"
-#include "inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::TerminalApp::implementation
 {

--- a/src/cascadia/TerminalApp/ActionPaletteItem.h
+++ b/src/cascadia/TerminalApp/ActionPaletteItem.h
@@ -5,7 +5,6 @@
 
 #include "PaletteItem.h"
 #include "ActionPaletteItem.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::TerminalApp::implementation
 {

--- a/src/cascadia/TerminalApp/AppKeyBindings.h
+++ b/src/cascadia/TerminalApp/AppKeyBindings.h
@@ -5,7 +5,7 @@
 
 #include "AppKeyBindings.g.h"
 #include "ShortcutActionDispatch.h"
-#include "../inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 // fwdecl unittest classes
 namespace TerminalAppLocalTests

--- a/src/cascadia/TerminalApp/AppKeyBindings.h
+++ b/src/cascadia/TerminalApp/AppKeyBindings.h
@@ -5,7 +5,6 @@
 
 #include "AppKeyBindings.g.h"
 #include "ShortcutActionDispatch.h"
-#include <cppwinrt_utils.h>
 
 // fwdecl unittest classes
 namespace TerminalAppLocalTests

--- a/src/cascadia/TerminalApp/AppLogic.h
+++ b/src/cascadia/TerminalApp/AppLogic.h
@@ -212,7 +212,5 @@ namespace winrt::TerminalApp::implementation
 
 namespace winrt::TerminalApp::factory_implementation
 {
-    struct AppLogic : AppLogicT<AppLogic, implementation::AppLogic>
-    {
-    };
+    BASIC_FACTORY(AppLogic);
 }

--- a/src/cascadia/TerminalApp/ColorPickupFlyout.h
+++ b/src/cascadia/TerminalApp/ColorPickupFlyout.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "ColorPickupFlyout.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::TerminalApp::implementation
 {

--- a/src/cascadia/TerminalApp/ColorPickupFlyout.h
+++ b/src/cascadia/TerminalApp/ColorPickupFlyout.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "ColorPickupFlyout.g.h"
-#include "../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::TerminalApp::implementation
 {

--- a/src/cascadia/TerminalApp/ColorPickupFlyout.h
+++ b/src/cascadia/TerminalApp/ColorPickupFlyout.h
@@ -21,7 +21,5 @@ namespace winrt::TerminalApp::implementation
 
 namespace winrt::TerminalApp::factory_implementation
 {
-    struct ColorPickupFlyout : ColorPickupFlyoutT<ColorPickupFlyout, implementation::ColorPickupFlyout>
-    {
-    };
+    BASIC_FACTORY(ColorPickupFlyout);
 }

--- a/src/cascadia/TerminalApp/CommandLinePaletteItem.h
+++ b/src/cascadia/TerminalApp/CommandLinePaletteItem.h
@@ -5,7 +5,6 @@
 
 #include "PaletteItem.h"
 #include "CommandLinePaletteItem.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::TerminalApp::implementation
 {

--- a/src/cascadia/TerminalApp/CommandLinePaletteItem.h
+++ b/src/cascadia/TerminalApp/CommandLinePaletteItem.h
@@ -5,7 +5,7 @@
 
 #include "PaletteItem.h"
 #include "CommandLinePaletteItem.g.h"
-#include "inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::TerminalApp::implementation
 {

--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -6,7 +6,7 @@
 #include "FilteredCommand.h"
 #include "CommandPalette.g.h"
 #include "AppCommandlineArgs.h"
-#include "../../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 // fwdecl unittest classes
 namespace TerminalAppLocalTests

--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -6,7 +6,6 @@
 #include "FilteredCommand.h"
 #include "CommandPalette.g.h"
 #include "AppCommandlineArgs.h"
-#include <cppwinrt_utils.h>
 
 // fwdecl unittest classes
 namespace TerminalAppLocalTests

--- a/src/cascadia/TerminalApp/DebugTapConnection.h
+++ b/src/cascadia/TerminalApp/DebugTapConnection.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <winrt/Microsoft.Terminal.TerminalConnection.h>
-#include <cppwinrt_utils.h>
 #include <til/latch.h>
 
 namespace winrt::Microsoft::TerminalApp::implementation

--- a/src/cascadia/TerminalApp/DebugTapConnection.h
+++ b/src/cascadia/TerminalApp/DebugTapConnection.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <winrt/Microsoft.Terminal.TerminalConnection.h>
-#include "../../inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include <til/latch.h>
 
 namespace winrt::Microsoft::TerminalApp::implementation

--- a/src/cascadia/TerminalApp/EmptyStringVisibilityConverter.h
+++ b/src/cascadia/TerminalApp/EmptyStringVisibilityConverter.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "EmptyStringVisibilityConverter.g.h"
-#include "../inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::TerminalApp::implementation
 {

--- a/src/cascadia/TerminalApp/EmptyStringVisibilityConverter.h
+++ b/src/cascadia/TerminalApp/EmptyStringVisibilityConverter.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "EmptyStringVisibilityConverter.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::TerminalApp::implementation
 {

--- a/src/cascadia/TerminalApp/FilteredCommand.h
+++ b/src/cascadia/TerminalApp/FilteredCommand.h
@@ -5,7 +5,6 @@
 
 #include "HighlightedTextControl.h"
 #include "FilteredCommand.g.h"
-#include <cppwinrt_utils.h>
 
 // fwdecl unittest classes
 namespace TerminalAppLocalTests

--- a/src/cascadia/TerminalApp/FilteredCommand.h
+++ b/src/cascadia/TerminalApp/FilteredCommand.h
@@ -5,7 +5,7 @@
 
 #include "HighlightedTextControl.h"
 #include "FilteredCommand.g.h"
-#include "../../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 // fwdecl unittest classes
 namespace TerminalAppLocalTests

--- a/src/cascadia/TerminalApp/HighlightedText.h
+++ b/src/cascadia/TerminalApp/HighlightedText.h
@@ -7,7 +7,7 @@
 
 #include "HighlightedTextSegment.g.h"
 #include "HighlightedText.g.h"
-#include "../../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::TerminalApp::implementation
 {

--- a/src/cascadia/TerminalApp/HighlightedText.h
+++ b/src/cascadia/TerminalApp/HighlightedText.h
@@ -7,7 +7,6 @@
 
 #include "HighlightedTextSegment.g.h"
 #include "HighlightedText.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::TerminalApp::implementation
 {

--- a/src/cascadia/TerminalApp/HighlightedTextControl.h
+++ b/src/cascadia/TerminalApp/HighlightedTextControl.h
@@ -6,7 +6,7 @@
 #include "winrt/Microsoft.UI.Xaml.Controls.h"
 
 #include "HighlightedTextControl.g.h"
-#include "../../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::TerminalApp::implementation
 {

--- a/src/cascadia/TerminalApp/HighlightedTextControl.h
+++ b/src/cascadia/TerminalApp/HighlightedTextControl.h
@@ -6,7 +6,6 @@
 #include "winrt/Microsoft.UI.Xaml.Controls.h"
 
 #include "HighlightedTextControl.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::TerminalApp::implementation
 {

--- a/src/cascadia/TerminalApp/MinMaxCloseControl.h
+++ b/src/cascadia/TerminalApp/MinMaxCloseControl.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "MinMaxCloseControl.g.h"
-#include <cppwinrt_utils.h>
 #include <ThrottledFunc.h>
 
 namespace winrt::TerminalApp::implementation

--- a/src/cascadia/TerminalApp/MinMaxCloseControl.h
+++ b/src/cascadia/TerminalApp/MinMaxCloseControl.h
@@ -40,7 +40,5 @@ namespace winrt::TerminalApp::implementation
 
 namespace winrt::TerminalApp::factory_implementation
 {
-    struct MinMaxCloseControl : MinMaxCloseControlT<MinMaxCloseControl, implementation::MinMaxCloseControl>
-    {
-    };
+    BASIC_FACTORY(MinMaxCloseControl);
 }

--- a/src/cascadia/TerminalApp/MinMaxCloseControl.h
+++ b/src/cascadia/TerminalApp/MinMaxCloseControl.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "MinMaxCloseControl.g.h"
-#include "../../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include <ThrottledFunc.h>
 
 namespace winrt::TerminalApp::implementation

--- a/src/cascadia/TerminalApp/PaletteItem.h
+++ b/src/cascadia/TerminalApp/PaletteItem.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 #pragma once
-#include "inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include "PaletteItem.g.h"
 
 namespace winrt::TerminalApp::implementation

--- a/src/cascadia/TerminalApp/PaletteItem.h
+++ b/src/cascadia/TerminalApp/PaletteItem.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 #pragma once
-#include <cppwinrt_utils.h>
 #include "PaletteItem.g.h"
 
 namespace winrt::TerminalApp::implementation

--- a/src/cascadia/TerminalApp/PaletteItemTemplateSelector.h
+++ b/src/cascadia/TerminalApp/PaletteItemTemplateSelector.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "PaletteItemTemplateSelector.g.h"
-#include "inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::TerminalApp::implementation
 {

--- a/src/cascadia/TerminalApp/PaletteItemTemplateSelector.h
+++ b/src/cascadia/TerminalApp/PaletteItemTemplateSelector.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "PaletteItemTemplateSelector.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::TerminalApp::implementation
 {

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -1542,7 +1542,7 @@ std::shared_ptr<Pane> Pane::DetachPane(std::shared_ptr<Pane> pane)
 
         // Trigger the detached event on each child
         detached->WalkTree([](auto pane) {
-            pane->_PaneDetachedHandlers(pane);
+            pane->_DetachedHandlers(pane);
             return false;
         });
 
@@ -3269,8 +3269,3 @@ void Pane::CollectTaskbarStates(std::vector<winrt::TerminalApp::TaskbarState>& s
         _secondChild->CollectTaskbarStates(states);
     }
 }
-
-DEFINE_EVENT(Pane, GotFocus, _GotFocusHandlers, Pane::gotFocusArgs);
-DEFINE_EVENT(Pane, LostFocus, _LostFocusHandlers, winrt::delegate<std::shared_ptr<Pane>>);
-DEFINE_EVENT(Pane, PaneRaiseBell, _PaneRaiseBellHandlers, winrt::Windows::Foundation::EventHandler<bool>);
-DEFINE_EVENT(Pane, Detached, _PaneDetachedHandlers, winrt::delegate<std::shared_ptr<Pane>>);

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include <cppwinrt_utils.h>
 #include "TaskbarState.h"
 
 // fwdecl unittest classes

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -185,10 +185,10 @@ public:
 
     using gotFocusArgs = winrt::delegate<std::shared_ptr<Pane>, winrt::Windows::UI::Xaml::FocusState>;
 
-    DECLARE_EVENT(GotFocus, _GotFocusHandlers, gotFocusArgs);
-    DECLARE_EVENT(LostFocus, _LostFocusHandlers, winrt::delegate<std::shared_ptr<Pane>>);
-    DECLARE_EVENT(PaneRaiseBell, _PaneRaiseBellHandlers, winrt::Windows::Foundation::EventHandler<bool>);
-    DECLARE_EVENT(Detached, _PaneDetachedHandlers, winrt::delegate<std::shared_ptr<Pane>>);
+    WINRT_CALLBACK(GotFocus, gotFocusArgs);
+    WINRT_CALLBACK(LostFocus, winrt::delegate<std::shared_ptr<Pane>>);
+    WINRT_CALLBACK(PaneRaiseBell, winrt::Windows::Foundation::EventHandler<bool>);
+    WINRT_CALLBACK(Detached, winrt::delegate<std::shared_ptr<Pane>>);
 
 private:
     struct PanePoint;

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include "../../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include "TaskbarState.h"
 
 // fwdecl unittest classes

--- a/src/cascadia/TerminalApp/SettingsTab.h
+++ b/src/cascadia/TerminalApp/SettingsTab.h
@@ -18,7 +18,7 @@ Author(s):
 #pragma once
 #include "TabBase.h"
 #include "SettingsTab.g.h"
-#include "../../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::TerminalApp::implementation
 {

--- a/src/cascadia/TerminalApp/SettingsTab.h
+++ b/src/cascadia/TerminalApp/SettingsTab.h
@@ -18,7 +18,6 @@ Author(s):
 #pragma once
 #include "TabBase.h"
 #include "SettingsTab.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::TerminalApp::implementation
 {

--- a/src/cascadia/TerminalApp/ShortcutActionDispatch.h
+++ b/src/cascadia/TerminalApp/ShortcutActionDispatch.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "ShortcutActionDispatch.g.h"
-#include "../inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include "../TerminalSettingsModel/AllShortcutActions.h"
 
 // fwdecl unittest classes

--- a/src/cascadia/TerminalApp/ShortcutActionDispatch.h
+++ b/src/cascadia/TerminalApp/ShortcutActionDispatch.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "ShortcutActionDispatch.g.h"
-#include <cppwinrt_utils.h>
 #include "../TerminalSettingsModel/AllShortcutActions.h"
 
 // fwdecl unittest classes

--- a/src/cascadia/TerminalApp/TabBase.h
+++ b/src/cascadia/TerminalApp/TabBase.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 #pragma once
-#include "inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include "TabBase.g.h"
 
 // fwdecl unittest classes

--- a/src/cascadia/TerminalApp/TabBase.h
+++ b/src/cascadia/TerminalApp/TabBase.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 #pragma once
-#include <cppwinrt_utils.h>
 #include "TabBase.g.h"
 
 // fwdecl unittest classes

--- a/src/cascadia/TerminalApp/TabHeaderControl.h
+++ b/src/cascadia/TerminalApp/TabHeaderControl.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "winrt/Microsoft.UI.Xaml.Controls.h"
-#include <cppwinrt_utils.h>
 
 #include "TabHeaderControl.g.h"
 

--- a/src/cascadia/TerminalApp/TabHeaderControl.h
+++ b/src/cascadia/TerminalApp/TabHeaderControl.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "winrt/Microsoft.UI.Xaml.Controls.h"
-#include "inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 #include "TabHeaderControl.g.h"
 

--- a/src/cascadia/TerminalApp/TabPaletteItem.h
+++ b/src/cascadia/TerminalApp/TabPaletteItem.h
@@ -5,7 +5,7 @@
 
 #include "PaletteItem.h"
 #include "TabPaletteItem.g.h"
-#include "inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::TerminalApp::implementation
 {

--- a/src/cascadia/TerminalApp/TabPaletteItem.h
+++ b/src/cascadia/TerminalApp/TabPaletteItem.h
@@ -5,7 +5,6 @@
 
 #include "PaletteItem.h"
 #include "TabPaletteItem.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::TerminalApp::implementation
 {

--- a/src/cascadia/TerminalApp/TabRowControl.h
+++ b/src/cascadia/TerminalApp/TabRowControl.h
@@ -25,7 +25,5 @@ namespace winrt::TerminalApp::implementation
 
 namespace winrt::TerminalApp::factory_implementation
 {
-    struct TabRowControl : TabRowControlT<TabRowControl, implementation::TabRowControl>
-    {
-    };
+    BASIC_FACTORY(TabRowControl);
 }

--- a/src/cascadia/TerminalApp/TabRowControl.h
+++ b/src/cascadia/TerminalApp/TabRowControl.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "winrt/Microsoft.UI.Xaml.Controls.h"
-#include "../../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 #include "TabRowControl.g.h"
 

--- a/src/cascadia/TerminalApp/TabRowControl.h
+++ b/src/cascadia/TerminalApp/TabRowControl.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "winrt/Microsoft.UI.Xaml.Controls.h"
-#include <cppwinrt_utils.h>
 
 #include "TabRowControl.g.h"
 

--- a/src/cascadia/TerminalApp/TaskbarState.h
+++ b/src/cascadia/TerminalApp/TaskbarState.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 #pragma once
-#include "inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include "TaskbarState.g.h"
 
 // fwdecl unittest classes

--- a/src/cascadia/TerminalApp/TaskbarState.h
+++ b/src/cascadia/TerminalApp/TaskbarState.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 #pragma once
-#include <cppwinrt_utils.h>
 #include "TaskbarState.g.h"
 
 // fwdecl unittest classes

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -583,7 +583,7 @@ namespace winrt::TerminalApp::implementation
         _rootPane->Closed(_rootClosedToken);
         auto p = _rootPane;
         p->WalkTree([](auto pane) {
-            pane->_PaneDetachedHandlers(pane);
+            pane->_DetachedHandlers(pane);
             return false;
         });
 
@@ -1481,7 +1481,7 @@ namespace winrt::TerminalApp::implementation
 
         _RefreshVisualState();
 
-        _colorSelected(color);
+        _ColorSelectedHandlers(color);
     }
 
     // Method Description:
@@ -1535,7 +1535,7 @@ namespace winrt::TerminalApp::implementation
         TabViewItem().Background(WUX::Media::SolidColorBrush{ Windows::UI::Colors::Transparent() });
 
         _RefreshVisualState();
-        _colorCleared();
+        _ColorClearedHandlers();
     }
 
     // Method Description:
@@ -1743,12 +1743,4 @@ namespace winrt::TerminalApp::implementation
 
         return Title();
     }
-
-    DEFINE_EVENT(TerminalTab, ActivePaneChanged, _ActivePaneChangedHandlers, winrt::delegate<>);
-    DEFINE_EVENT(TerminalTab, ColorSelected, _colorSelected, winrt::delegate<winrt::Windows::UI::Color>);
-    DEFINE_EVENT(TerminalTab, ColorCleared, _colorCleared, winrt::delegate<>);
-    DEFINE_EVENT(TerminalTab, TabRaiseVisualBell, _TabRaiseVisualBellHandlers, winrt::delegate<>);
-    DEFINE_EVENT(TerminalTab, DuplicateRequested, _DuplicateRequestedHandlers, winrt::delegate<>);
-    DEFINE_EVENT(TerminalTab, SplitTabRequested, _SplitTabRequestedHandlers, winrt::delegate<>);
-    DEFINE_EVENT(TerminalTab, ExportTabRequested, _ExportTabRequestedHandlers, winrt::delegate<>);
 }

--- a/src/cascadia/TerminalApp/TerminalTab.h
+++ b/src/cascadia/TerminalApp/TerminalTab.h
@@ -98,13 +98,13 @@ namespace winrt::TerminalApp::implementation
             return _tabStatus;
         }
 
-        DECLARE_EVENT(ActivePaneChanged, _ActivePaneChangedHandlers, winrt::delegate<>);
-        DECLARE_EVENT(ColorSelected, _colorSelected, winrt::delegate<winrt::Windows::UI::Color>);
-        DECLARE_EVENT(ColorCleared, _colorCleared, winrt::delegate<>);
-        DECLARE_EVENT(TabRaiseVisualBell, _TabRaiseVisualBellHandlers, winrt::delegate<>);
-        DECLARE_EVENT(DuplicateRequested, _DuplicateRequestedHandlers, winrt::delegate<>);
-        DECLARE_EVENT(SplitTabRequested, _SplitTabRequestedHandlers, winrt::delegate<>);
-        DECLARE_EVENT(ExportTabRequested, _ExportTabRequestedHandlers, winrt::delegate<>);
+        WINRT_CALLBACK(ActivePaneChanged, winrt::delegate<>);
+        WINRT_CALLBACK(ColorSelected, winrt::delegate<winrt::Windows::UI::Color>);
+        WINRT_CALLBACK(ColorCleared, winrt::delegate<>);
+        WINRT_CALLBACK(TabRaiseVisualBell, winrt::delegate<>);
+        WINRT_CALLBACK(DuplicateRequested, winrt::delegate<>);
+        WINRT_CALLBACK(SplitTabRequested, winrt::delegate<>);
+        WINRT_CALLBACK(ExportTabRequested, winrt::delegate<>);
         TYPED_EVENT(TaskbarProgressChanged, IInspectable, IInspectable);
 
     private:

--- a/src/cascadia/TerminalApp/TerminalTabStatus.h
+++ b/src/cascadia/TerminalApp/TerminalTabStatus.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <cppwinrt_utils.h>
 #include "TerminalTabStatus.g.h"
 
 namespace winrt::TerminalApp::implementation

--- a/src/cascadia/TerminalApp/TerminalTabStatus.h
+++ b/src/cascadia/TerminalApp/TerminalTabStatus.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include "TerminalTabStatus.g.h"
 
 namespace winrt::TerminalApp::implementation

--- a/src/cascadia/TerminalApp/TitlebarControl.h
+++ b/src/cascadia/TerminalApp/TitlebarControl.h
@@ -36,7 +36,5 @@ namespace winrt::TerminalApp::implementation
 
 namespace winrt::TerminalApp::factory_implementation
 {
-    struct TitlebarControl : TitlebarControlT<TitlebarControl, implementation::TitlebarControl>
-    {
-    };
+    BASIC_FACTORY(TitlebarControl);
 }

--- a/src/cascadia/TerminalApp/pch.h
+++ b/src/cascadia/TerminalApp/pch.h
@@ -77,3 +77,5 @@ TRACELOGGING_DECLARE_PROVIDER(g_hTerminalAppProvider);
 
 // Manually include til after we include Windows.Foundation to give it winrt superpowers
 #include "til.h"
+
+#include <cppwinrt_utils.h>

--- a/src/cascadia/TerminalAzBridge/pch.h
+++ b/src/cascadia/TerminalAzBridge/pch.h
@@ -38,3 +38,5 @@ Abstract:
 
 #include <wil/resource.h>
 #include <wil/win32_helpers.h>
+
+#include <cppwinrt_utils.h>

--- a/src/cascadia/TerminalConnection/AzureConnection.h
+++ b/src/cascadia/TerminalConnection/AzureConnection.h
@@ -11,7 +11,7 @@
 #include <mutex>
 #include <condition_variable>
 
-#include "../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include "ConnectionStateHolder.h"
 #include "AzureClient.h"
 

--- a/src/cascadia/TerminalConnection/AzureConnection.h
+++ b/src/cascadia/TerminalConnection/AzureConnection.h
@@ -104,7 +104,5 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 
 namespace winrt::Microsoft::Terminal::TerminalConnection::factory_implementation
 {
-    struct AzureConnection : AzureConnectionT<AzureConnection, implementation::AzureConnection>
-    {
-    };
+    BASIC_FACTORY(AzureConnection);
 }

--- a/src/cascadia/TerminalConnection/AzureConnection.h
+++ b/src/cascadia/TerminalConnection/AzureConnection.h
@@ -11,7 +11,6 @@
 #include <mutex>
 #include <condition_variable>
 
-#include <cppwinrt_utils.h>
 #include "ConnectionStateHolder.h"
 #include "AzureClient.h"
 

--- a/src/cascadia/TerminalConnection/ConnectionInformation.h
+++ b/src/cascadia/TerminalConnection/ConnectionInformation.h
@@ -16,7 +16,7 @@ Abstract:
 --*/
 
 #pragma once
-#include "../inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include "ConnectionInformation.g.h"
 
 namespace winrt::Microsoft::Terminal::TerminalConnection::implementation

--- a/src/cascadia/TerminalConnection/ConnectionInformation.h
+++ b/src/cascadia/TerminalConnection/ConnectionInformation.h
@@ -16,7 +16,6 @@ Abstract:
 --*/
 
 #pragma once
-#include <cppwinrt_utils.h>
 #include "ConnectionInformation.g.h"
 
 namespace winrt::Microsoft::Terminal::TerminalConnection::implementation

--- a/src/cascadia/TerminalConnection/ConnectionStateHolder.h
+++ b/src/cascadia/TerminalConnection/ConnectionStateHolder.h
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#include <cppwinrt_utils.h>
-
 namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 {
     template<typename T>

--- a/src/cascadia/TerminalConnection/ConnectionStateHolder.h
+++ b/src/cascadia/TerminalConnection/ConnectionStateHolder.h
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#include "../inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 {

--- a/src/cascadia/TerminalConnection/ConptyConnection.h
+++ b/src/cascadia/TerminalConnection/ConptyConnection.h
@@ -5,7 +5,7 @@
 
 #include "ConptyConnection.g.h"
 #include "ConnectionStateHolder.h"
-#include "../inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 #include <conpty-static.h>
 

--- a/src/cascadia/TerminalConnection/ConptyConnection.h
+++ b/src/cascadia/TerminalConnection/ConptyConnection.h
@@ -5,7 +5,6 @@
 
 #include "ConptyConnection.g.h"
 #include "ConnectionStateHolder.h"
-#include <cppwinrt_utils.h>
 
 #include <conpty-static.h>
 

--- a/src/cascadia/TerminalConnection/ConptyConnection.h
+++ b/src/cascadia/TerminalConnection/ConptyConnection.h
@@ -93,7 +93,5 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 
 namespace winrt::Microsoft::Terminal::TerminalConnection::factory_implementation
 {
-    struct ConptyConnection : ConptyConnectionT<ConptyConnection, implementation::ConptyConnection>
-    {
-    };
+    BASIC_FACTORY(ConptyConnection);
 }

--- a/src/cascadia/TerminalConnection/EchoConnection.h
+++ b/src/cascadia/TerminalConnection/EchoConnection.h
@@ -5,8 +5,6 @@
 
 #include "EchoConnection.g.h"
 
-#include <cppwinrt_utils.h>
-
 namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 {
     struct EchoConnection : EchoConnectionT<EchoConnection>

--- a/src/cascadia/TerminalConnection/EchoConnection.h
+++ b/src/cascadia/TerminalConnection/EchoConnection.h
@@ -5,7 +5,7 @@
 
 #include "EchoConnection.g.h"
 
-#include "../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 {

--- a/src/cascadia/TerminalConnection/EchoConnection.h
+++ b/src/cascadia/TerminalConnection/EchoConnection.h
@@ -29,7 +29,5 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 
 namespace winrt::Microsoft::Terminal::TerminalConnection::factory_implementation
 {
-    struct EchoConnection : EchoConnectionT<EchoConnection, implementation::EchoConnection>
-    {
-    };
+    BASIC_FACTORY(EchoConnection);
 }

--- a/src/cascadia/TerminalConnection/pch.h
+++ b/src/cascadia/TerminalConnection/pch.h
@@ -31,3 +31,5 @@ TRACELOGGING_DECLARE_PROVIDER(g_hTerminalConnectionProvider);
 #include <telemetry/ProjectTelemetry.h>
 
 #include "til.h"
+
+#include <cppwinrt_utils.h>

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -19,7 +19,6 @@
 #include "../../renderer/base/Renderer.hpp"
 #include "../../cascadia/TerminalCore/Terminal.hpp"
 #include "../buffer/out/search.h"
-#include <cppwinrt_utils.h>
 
 namespace ControlUnitTests
 {

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -19,7 +19,7 @@
 #include "../../renderer/base/Renderer.hpp"
 #include "../../cascadia/TerminalCore/Terminal.hpp"
 #include "../buffer/out/search.h"
-#include "cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace ControlUnitTests
 {

--- a/src/cascadia/TerminalControl/ControlInteractivity.h
+++ b/src/cascadia/TerminalControl/ControlInteractivity.h
@@ -19,7 +19,6 @@
 #include "ControlInteractivity.g.h"
 #include "EventArgs.h"
 #include "../buffer/out/search.h"
-#include <cppwinrt_utils.h>
 
 #include "ControlCore.h"
 #include "../../renderer/uia/UiaRenderer.hpp"

--- a/src/cascadia/TerminalControl/ControlInteractivity.h
+++ b/src/cascadia/TerminalControl/ControlInteractivity.h
@@ -19,7 +19,7 @@
 #include "ControlInteractivity.g.h"
 #include "EventArgs.h"
 #include "../buffer/out/search.h"
-#include "cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 #include "ControlCore.h"
 #include "../../renderer/uia/UiaRenderer.hpp"

--- a/src/cascadia/TerminalControl/EventArgs.h
+++ b/src/cascadia/TerminalControl/EventArgs.h
@@ -11,7 +11,7 @@
 #include "ScrollPositionChangedArgs.g.h"
 #include "RendererWarningArgs.g.h"
 #include "TransparencyChangedEventArgs.g.h"
-#include "cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Control::implementation
 {

--- a/src/cascadia/TerminalControl/EventArgs.h
+++ b/src/cascadia/TerminalControl/EventArgs.h
@@ -11,7 +11,6 @@
 #include "ScrollPositionChangedArgs.g.h"
 #include "RendererWarningArgs.g.h"
 #include "TransparencyChangedEventArgs.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Control::implementation
 {

--- a/src/cascadia/TerminalControl/KeyChord.h
+++ b/src/cascadia/TerminalControl/KeyChord.h
@@ -32,7 +32,5 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
 namespace winrt::Microsoft::Terminal::Control::factory_implementation
 {
-    struct KeyChord : KeyChordT<KeyChord, implementation::KeyChord>
-    {
-    };
+    BASIC_FACTORY(KeyChord);
 }

--- a/src/cascadia/TerminalControl/SearchBoxControl.h
+++ b/src/cascadia/TerminalControl/SearchBoxControl.h
@@ -16,7 +16,6 @@ Author(s):
 #pragma once
 #include "winrt/Windows.UI.Xaml.h"
 #include "winrt/Windows.UI.Xaml.Controls.h"
-#include <cppwinrt_utils.h>
 
 #include "SearchBoxControl.g.h"
 

--- a/src/cascadia/TerminalControl/SearchBoxControl.h
+++ b/src/cascadia/TerminalControl/SearchBoxControl.h
@@ -51,7 +51,5 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
 namespace winrt::Microsoft::Terminal::Control::factory_implementation
 {
-    struct SearchBoxControl : SearchBoxControlT<SearchBoxControl, implementation::SearchBoxControl>
-    {
-    };
+    BASIC_FACTORY(SearchBoxControl);
 }

--- a/src/cascadia/TerminalControl/SearchBoxControl.h
+++ b/src/cascadia/TerminalControl/SearchBoxControl.h
@@ -16,7 +16,7 @@ Author(s):
 #pragma once
 #include "winrt/Windows.UI.Xaml.h"
 #include "winrt/Windows.UI.Xaml.Controls.h"
-#include "../../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 #include "SearchBoxControl.g.h"
 

--- a/src/cascadia/TerminalControl/TSFInputControl.cpp
+++ b/src/cascadia/TerminalControl/TSFInputControl.cpp
@@ -441,7 +441,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
         const auto text = _inputBuffer.substr(_activeTextStart);
 
-        _compositionCompletedHandlers(text);
+        _CompositionCompletedHandlers(text);
 
         _activeTextStart = _inputBuffer.length();
 
@@ -470,6 +470,4 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TSFInputControl::_formatUpdatingHandler(CoreTextEditContext sender, CoreTextFormatUpdatingEventArgs const& /*args*/)
     {
     }
-
-    DEFINE_EVENT(TSFInputControl, CompositionCompleted, _compositionCompletedHandlers, Control::CompositionCompletedEventArgs);
 }

--- a/src/cascadia/TerminalControl/TSFInputControl.h
+++ b/src/cascadia/TerminalControl/TSFInputControl.h
@@ -89,7 +89,5 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 }
 namespace winrt::Microsoft::Terminal::Control::factory_implementation
 {
-    struct TSFInputControl : TSFInputControlT<TSFInputControl, implementation::TSFInputControl>
-    {
-    };
+    BASIC_FACTORY(TSFInputControl);
 }

--- a/src/cascadia/TerminalControl/TSFInputControl.h
+++ b/src/cascadia/TerminalControl/TSFInputControl.h
@@ -46,7 +46,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // -------------------------------- WinRT Events ---------------------------------
         TYPED_EVENT(CurrentCursorPosition, Control::TSFInputControl, Control::CursorPositionEventArgs);
         TYPED_EVENT(CurrentFontInfo, Control::TSFInputControl, Control::FontInfoEventArgs);
-        DECLARE_EVENT(CompositionCompleted, _compositionCompletedHandlers, Control::CompositionCompletedEventArgs);
+        WINRT_CALLBACK(CompositionCompleted, Control::CompositionCompletedEventArgs);
 
     private:
         void _layoutRequestedHandler(winrt::Windows::UI::Text::Core::CoreTextEditContext sender, winrt::Windows::UI::Text::Core::CoreTextLayoutRequestedEventArgs const& args);

--- a/src/cascadia/TerminalControl/TSFInputControl.h
+++ b/src/cascadia/TerminalControl/TSFInputControl.h
@@ -5,7 +5,7 @@
 #include "TSFInputControl.g.h"
 #include "CursorPositionEventArgs.g.h"
 #include "FontInfoEventArgs.g.h"
-#include "cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Control::implementation
 {

--- a/src/cascadia/TerminalControl/TSFInputControl.h
+++ b/src/cascadia/TerminalControl/TSFInputControl.h
@@ -5,7 +5,6 @@
 #include "TSFInputControl.g.h"
 #include "CursorPositionEventArgs.g.h"
 #include "FontInfoEventArgs.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Control::implementation
 {

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -11,7 +11,7 @@
 #include "../../renderer/uia/UiaRenderer.hpp"
 #include "../../cascadia/TerminalCore/Terminal.hpp"
 #include "../buffer/out/search.h"
-#include "cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include "SearchBoxControl.h"
 
 #include "ControlInteractivity.h"

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -11,7 +11,6 @@
 #include "../../renderer/uia/UiaRenderer.hpp"
 #include "../../cascadia/TerminalCore/Terminal.hpp"
 #include "../buffer/out/search.h"
-#include <cppwinrt_utils.h>
 #include "SearchBoxControl.h"
 
 #include "ControlInteractivity.h"

--- a/src/cascadia/TerminalControl/XamlLights.h
+++ b/src/cascadia/TerminalControl/XamlLights.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <cppwinrt_utils.h>
 #include "VisualBellLight.g.h"
 
 namespace winrt::Microsoft::Terminal::Control::implementation

--- a/src/cascadia/TerminalControl/XamlLights.h
+++ b/src/cascadia/TerminalControl/XamlLights.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include "VisualBellLight.g.h"
 
 namespace winrt::Microsoft::Terminal::Control::implementation

--- a/src/cascadia/TerminalControl/pch.h
+++ b/src/cascadia/TerminalControl/pch.h
@@ -62,3 +62,5 @@ TRACELOGGING_DECLARE_PROVIDER(g_hTerminalControlProvider);
 #include "til.h"
 
 #include "ThrottledFunc.h"
+
+#include <cppwinrt_utils.h>

--- a/src/cascadia/TerminalSettingsEditor/Converters.h
+++ b/src/cascadia/TerminalSettingsEditor/Converters.h
@@ -27,7 +27,5 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::factory_implementation
 {
-    struct Converters : ConvertersT<Converters, implementation::Converters>
-    {
-    };
+    BASIC_FACTORY(Converters);
 }

--- a/src/cascadia/TerminalSettingsEditor/PreviewConnection.h
+++ b/src/cascadia/TerminalSettingsEditor/PreviewConnection.h
@@ -13,7 +13,7 @@
 #pragma once
 
 #include <winrt/Microsoft.Terminal.TerminalConnection.h>
-#include "../../inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {

--- a/src/cascadia/TerminalSettingsEditor/PreviewConnection.h
+++ b/src/cascadia/TerminalSettingsEditor/PreviewConnection.h
@@ -13,7 +13,6 @@
 #pragma once
 
 #include <winrt/Microsoft.Terminal.TerminalConnection.h>
-#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {

--- a/src/cascadia/TerminalSettingsEditor/Utils.h
+++ b/src/cascadia/TerminalSettingsEditor/Utils.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "../inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 // This macro must be used alongside GETSET_BINDABLE_ENUM_SETTING.
 // Use this in your class's constructor after Initialize_Component().

--- a/src/cascadia/TerminalSettingsEditor/Utils.h
+++ b/src/cascadia/TerminalSettingsEditor/Utils.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <cppwinrt_utils.h>
-
 // This macro must be used alongside GETSET_BINDABLE_ENUM_SETTING.
 // Use this in your class's constructor after Initialize_Component().
 // It sorts and initializes the observable list of enum entries with the enum name

--- a/src/cascadia/TerminalSettingsEditor/ViewModelHelpers.h
+++ b/src/cascadia/TerminalSettingsEditor/ViewModelHelpers.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <cppwinrt_utils.h>
-
 template<typename T>
 struct ViewModelHelper
 {

--- a/src/cascadia/TerminalSettingsEditor/ViewModelHelpers.h
+++ b/src/cascadia/TerminalSettingsEditor/ViewModelHelpers.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "../inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 template<typename T>
 struct ViewModelHelper

--- a/src/cascadia/TerminalSettingsEditor/pch.h
+++ b/src/cascadia/TerminalSettingsEditor/pch.h
@@ -55,3 +55,5 @@
 
 // Manually include til after we include Windows.Foundation to give it winrt superpowers
 #include "til.h"
+
+#include <cppwinrt_utils.h>

--- a/src/cascadia/TerminalSettingsModel/ActionAndArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionAndArgs.h
@@ -6,7 +6,7 @@
 #include "ActionAndArgs.g.h"
 #include "ActionArgs.h"
 #include "TerminalWarnings.h"
-#include "../inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 {

--- a/src/cascadia/TerminalSettingsModel/ActionAndArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionAndArgs.h
@@ -6,7 +6,6 @@
 #include "ActionAndArgs.g.h"
 #include "ActionArgs.h"
 #include "TerminalWarnings.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 {

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -39,7 +39,6 @@
 #include "ClearBufferArgs.g.h"
 #include "MultipleActionsArgs.g.h"
 
-#include <cppwinrt_utils.h>
 #include "JsonUtils.h"
 #include "HashUtils.h"
 #include "TerminalWarnings.h"

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -39,7 +39,7 @@
 #include "ClearBufferArgs.g.h"
 #include "MultipleActionsArgs.g.h"
 
-#include "../../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include "JsonUtils.h"
 #include "HashUtils.h"
 #include "TerminalWarnings.h"

--- a/src/cascadia/TerminalSettingsModel/ActionMap.h
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.h
@@ -18,7 +18,6 @@ Author(s):
 #include "ActionMap.g.h"
 #include "IInheritable.h"
 #include "Command.h"
-#include <cppwinrt_utils.h>
 
 // fwdecl unittest classes
 namespace SettingsModelLocalTests

--- a/src/cascadia/TerminalSettingsModel/ActionMap.h
+++ b/src/cascadia/TerminalSettingsModel/ActionMap.h
@@ -18,7 +18,7 @@ Author(s):
 #include "ActionMap.g.h"
 #include "IInheritable.h"
 #include "Command.h"
-#include "../inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 // fwdecl unittest classes
 namespace SettingsModelLocalTests

--- a/src/cascadia/TerminalSettingsModel/ColorScheme.h
+++ b/src/cascadia/TerminalSettingsModel/ColorScheme.h
@@ -17,7 +17,7 @@ Author(s):
 #pragma once
 
 #include "../../inc/conattrs.hpp"
-#include "inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include "DefaultSettings.h"
 
 #include "ColorScheme.g.h"

--- a/src/cascadia/TerminalSettingsModel/ColorScheme.h
+++ b/src/cascadia/TerminalSettingsModel/ColorScheme.h
@@ -17,7 +17,6 @@ Author(s):
 #pragma once
 
 #include "../../inc/conattrs.hpp"
-#include <cppwinrt_utils.h>
 #include "DefaultSettings.h"
 
 #include "ColorScheme.g.h"

--- a/src/cascadia/TerminalSettingsModel/Command.h
+++ b/src/cascadia/TerminalSettingsModel/Command.h
@@ -22,7 +22,7 @@ Author(s):
 #include "TerminalWarnings.h"
 #include "Profile.h"
 #include "ActionAndArgs.h"
-#include "../inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include "SettingsTypes.h"
 
 // fwdecl unittest classes

--- a/src/cascadia/TerminalSettingsModel/Command.h
+++ b/src/cascadia/TerminalSettingsModel/Command.h
@@ -22,7 +22,6 @@ Author(s):
 #include "TerminalWarnings.h"
 #include "Profile.h"
 #include "ActionAndArgs.h"
-#include <cppwinrt_utils.h>
 #include "SettingsTypes.h"
 
 // fwdecl unittest classes

--- a/src/cascadia/TerminalSettingsModel/FontConfig.h
+++ b/src/cascadia/TerminalSettingsModel/FontConfig.h
@@ -20,7 +20,7 @@ Author(s):
 #include "FontConfig.g.h"
 #include "JsonUtils.h"
 #include "MTSMSettings.h"
-#include "../inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include "IInheritable.h"
 #include <DefaultSettings.h>
 

--- a/src/cascadia/TerminalSettingsModel/FontConfig.h
+++ b/src/cascadia/TerminalSettingsModel/FontConfig.h
@@ -20,7 +20,6 @@ Author(s):
 #include "FontConfig.g.h"
 #include "JsonUtils.h"
 #include "MTSMSettings.h"
-#include <cppwinrt_utils.h>
 #include "IInheritable.h"
 #include <DefaultSettings.h>
 

--- a/src/cascadia/TerminalSettingsModel/IconPathConverter.h
+++ b/src/cascadia/TerminalSettingsModel/IconPathConverter.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "IconPathConverter.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 {

--- a/src/cascadia/TerminalSettingsModel/IconPathConverter.h
+++ b/src/cascadia/TerminalSettingsModel/IconPathConverter.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "IconPathConverter.g.h"
-#include "../inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 {

--- a/src/cascadia/TerminalSettingsModel/KeyChordSerialization.h
+++ b/src/cascadia/TerminalSettingsModel/KeyChordSerialization.h
@@ -5,7 +5,7 @@
 
 #include "KeyChordSerialization.g.h"
 #include "JsonUtils.h"
-#include "../inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 {

--- a/src/cascadia/TerminalSettingsModel/KeyChordSerialization.h
+++ b/src/cascadia/TerminalSettingsModel/KeyChordSerialization.h
@@ -5,7 +5,6 @@
 
 #include "KeyChordSerialization.g.h"
 #include "JsonUtils.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 {

--- a/src/cascadia/TerminalSettingsModel/Profile.h
+++ b/src/cascadia/TerminalSettingsModel/Profile.h
@@ -48,7 +48,7 @@ Author(s):
 #include "IInheritable.h"
 #include "MTSMSettings.h"
 
-#include "../inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include "JsonUtils.h"
 #include <DefaultSettings.h>
 #include "AppearanceConfig.h"

--- a/src/cascadia/TerminalSettingsModel/Profile.h
+++ b/src/cascadia/TerminalSettingsModel/Profile.h
@@ -48,7 +48,6 @@ Author(s):
 #include "IInheritable.h"
 #include "MTSMSettings.h"
 
-#include <cppwinrt_utils.h>
 #include "JsonUtils.h"
 #include <DefaultSettings.h>
 #include "AppearanceConfig.h"

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -17,7 +17,6 @@ Author(s):
 #include "TerminalSettings.g.h"
 #include "TerminalSettingsCreateResult.g.h"
 #include "IInheritable.h"
-#include <cppwinrt_utils.h>
 #include <DefaultSettings.h>
 #include <conattrs.hpp>
 

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -17,7 +17,7 @@ Author(s):
 #include "TerminalSettings.g.h"
 #include "TerminalSettingsCreateResult.g.h"
 #include "IInheritable.h"
-#include "../inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include <DefaultSettings.h>
 #include <conattrs.hpp>
 

--- a/src/cascadia/TerminalSettingsModel/pch.h
+++ b/src/cascadia/TerminalSettingsModel/pch.h
@@ -56,3 +56,5 @@ TRACELOGGING_DECLARE_PROVIDER(g_hSettingsModelProvider);
 
 #include <til/mutex.h>
 #include <til/throttled_func.h>
+
+#include <cppwinrt_utils.h>

--- a/src/cascadia/UnitTests_Control/MockConnection.h
+++ b/src/cascadia/UnitTests_Control/MockConnection.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include <cppwinrt_utils.h>
-
 namespace ControlUnitTests
 {
     class MockConnection : public winrt::implements<MockConnection, winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection>

--- a/src/cascadia/UnitTests_Control/MockConnection.h
+++ b/src/cascadia/UnitTests_Control/MockConnection.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace ControlUnitTests
 {

--- a/src/cascadia/UnitTests_Control/MockControlSettings.h
+++ b/src/cascadia/UnitTests_Control/MockControlSettings.h
@@ -4,7 +4,7 @@ Licensed under the MIT license.
 --*/
 #pragma once
 
-#include "../inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 #include <DefaultSettings.h>
 #include <conattrs.hpp>
 

--- a/src/cascadia/UnitTests_Control/MockControlSettings.h
+++ b/src/cascadia/UnitTests_Control/MockControlSettings.h
@@ -4,7 +4,6 @@ Licensed under the MIT license.
 --*/
 #pragma once
 
-#include <cppwinrt_utils.h>
 #include <DefaultSettings.h>
 #include <conattrs.hpp>
 

--- a/src/cascadia/UnitTests_Control/pch.h
+++ b/src/cascadia/UnitTests_Control/pch.h
@@ -54,3 +54,5 @@ Licensed under the MIT license.
 #include "../../inc/conattrs.hpp"
 #include "../../types/inc/utils.hpp"
 #include "../../inc/DefaultSettings.h"
+
+#include <cppwinrt_utils.h>

--- a/src/cascadia/UnitTests_Remoting/pch.h
+++ b/src/cascadia/UnitTests_Remoting/pch.h
@@ -48,3 +48,5 @@ Licensed under the MIT license.
 #include "../../inc/conattrs.hpp"
 #include "../../types/inc/utils.hpp"
 #include "../../inc/DefaultSettings.h"
+
+#include <cppwinrt_utils.h>

--- a/src/cascadia/UnitTests_TerminalCore/MockTermSettings.h
+++ b/src/cascadia/UnitTests_TerminalCore/MockTermSettings.h
@@ -6,7 +6,7 @@
 #include "DefaultSettings.h"
 
 #include <winrt/Microsoft.Terminal.Core.h>
-#include "../inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 using namespace winrt::Microsoft::Terminal::Core;
 

--- a/src/cascadia/UnitTests_TerminalCore/MockTermSettings.h
+++ b/src/cascadia/UnitTests_TerminalCore/MockTermSettings.h
@@ -6,7 +6,6 @@
 #include "DefaultSettings.h"
 
 #include <winrt/Microsoft.Terminal.Core.h>
-#include <cppwinrt_utils.h>
 
 using namespace winrt::Microsoft::Terminal::Core;
 

--- a/src/cascadia/UnitTests_TerminalCore/pch.h
+++ b/src/cascadia/UnitTests_TerminalCore/pch.h
@@ -57,3 +57,5 @@ typedef NTSTATUS* PNTSTATUS;
 /*lint -restore */ // Resume checking for different typedefs.
 #define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
 // </Conhost Includes>
+
+#include <cppwinrt_utils.h>

--- a/src/cascadia/WinRTUtils/pch.h
+++ b/src/cascadia/WinRTUtils/pch.h
@@ -34,3 +34,5 @@
 
 #include <shlobj.h>
 #include <shobjidl_core.h>
+
+#include <cppwinrt_utils.h>

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -492,7 +492,7 @@ long IslandWindow::_calculateTotalSize(const bool isWidth, const long clientSize
         // If the user wants to close the app by clicking 'X' button,
         // we hand off the close experience to the app layer. If all the tabs
         // are closed, the window will be closed as well.
-        _windowCloseButtonClickedHandler();
+        _WindowCloseButtonClickedHandlers();
         return 0;
     }
     case WM_MOUSEWHEEL:
@@ -1778,6 +1778,3 @@ void IslandWindow::RemoveFromSystemMenu(const winrt::hstring& itemLabel)
     }
     _systemMenuItems.erase(it->first);
 }
-
-DEFINE_EVENT(IslandWindow, DragRegionClicked, _DragRegionClickedHandlers, winrt::delegate<>);
-DEFINE_EVENT(IslandWindow, WindowCloseButtonClicked, _windowCloseButtonClickedHandler, winrt::delegate<>);

--- a/src/cascadia/WindowsTerminal/IslandWindow.h
+++ b/src/cascadia/WindowsTerminal/IslandWindow.h
@@ -4,7 +4,6 @@
 #include "pch.h"
 #include "BaseWindow.h"
 #include <winrt/TerminalApp.h>
-#include <cppwinrt_utils.h>
 
 void SetWindowLongWHelper(const HWND hWnd, const int nIndex, const LONG dwNewLong) noexcept;
 

--- a/src/cascadia/WindowsTerminal/IslandWindow.h
+++ b/src/cascadia/WindowsTerminal/IslandWindow.h
@@ -63,8 +63,8 @@ public:
     void AddToSystemMenu(const winrt::hstring& itemLabel, winrt::delegate<void()> callback);
     void RemoveFromSystemMenu(const winrt::hstring& itemLabel);
 
-    DECLARE_EVENT(DragRegionClicked, _DragRegionClickedHandlers, winrt::delegate<>);
-    DECLARE_EVENT(WindowCloseButtonClicked, _windowCloseButtonClickedHandler, winrt::delegate<>);
+    WINRT_CALLBACK(DragRegionClicked, winrt::delegate<>);
+    WINRT_CALLBACK(WindowCloseButtonClicked, winrt::delegate<>);
     WINRT_CALLBACK(MouseScrolled, winrt::delegate<void(til::point, int32_t)>);
     WINRT_CALLBACK(WindowActivated, winrt::delegate<void()>);
     WINRT_CALLBACK(HotkeyPressed, winrt::delegate<void(long)>);

--- a/src/cascadia/WindowsTerminal/IslandWindow.h
+++ b/src/cascadia/WindowsTerminal/IslandWindow.h
@@ -4,7 +4,7 @@
 #include "pch.h"
 #include "BaseWindow.h"
 #include <winrt/TerminalApp.h>
-#include "../../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 void SetWindowLongWHelper(const HWND hWnd, const int nIndex, const LONG dwNewLong) noexcept;
 

--- a/src/cascadia/WindowsTerminal/NotificationIcon.h
+++ b/src/cascadia/WindowsTerminal/NotificationIcon.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 #include "pch.h"
-#include "../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 // This enumerates all the possible actions
 // that our notification icon context menu could do.

--- a/src/cascadia/WindowsTerminal/NotificationIcon.h
+++ b/src/cascadia/WindowsTerminal/NotificationIcon.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 #include "pch.h"
-#include <cppwinrt_utils.h>
 
 // This enumerates all the possible actions
 // that our notification icon context menu could do.

--- a/src/cascadia/WindowsTerminal/pch.h
+++ b/src/cascadia/WindowsTerminal/pch.h
@@ -89,3 +89,5 @@ TRACELOGGING_DECLARE_PROVIDER(g_hWindowsTerminalProvider);
 #include <processenv.h>
 #include <WinUser.h>
 #include "til.h"
+
+#include <cppwinrt_utils.h>

--- a/src/cascadia/ut_app/TerminalApp.UnitTests.vcxproj
+++ b/src/cascadia/ut_app/TerminalApp.UnitTests.vcxproj
@@ -58,7 +58,7 @@
   <!-- ====================== Compiler & Linker Flags ===================== -->
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>..;$(OpenConsoleDir)\dep\jsoncpp\json;$(OpenConsoleDir)src\inc;$(OpenConsoleDir)src\inc\test;$(WinRT_IncludePath)\..\cppwinrt\winrt;"$(OpenConsoleDir)\src\cascadia\TerminalApp\Generated Files";"$(OpenConsoleDir)\src\cascadia\TerminalSettingsModel\Generated Files";%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..;$(OpenConsoleDir)src\cascadia\inc;$(OpenConsoleDir)\dep\jsoncpp\json;$(OpenConsoleDir)src\inc;$(OpenConsoleDir)src\inc\test;$(WinRT_IncludePath)\..\cppwinrt\winrt;"$(OpenConsoleDir)\src\cascadia\TerminalApp\Generated Files";"$(OpenConsoleDir)\src\cascadia\TerminalSettingsModel\Generated Files";%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>precomp.h</PrecompiledHeaderFile>
 
       <!-- Manually disable unreachable code warning, because jconcpp has a ton of that. -->

--- a/src/cppwinrt.build.pre.props
+++ b/src/cppwinrt.build.pre.props
@@ -78,8 +78,6 @@
       <DisableSpecificWarnings>5104;28204;%(DisableSpecificWarnings)</DisableSpecificWarnings>
 
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-
-      <AdditionalIncludeDirectories>$(OpenConsoleDir)src\cascadia\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem Condition="'%(SubSystem)'==''">Console</SubSystem>
@@ -89,7 +87,7 @@
 
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(OpenConsoleDir)\src\cascadia\WinRTUtils\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(OpenConsoleDir)\src\cascadia\WinRTUtils\inc;$(OpenConsoleDir)src\cascadia\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>WindowsApp.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/cppwinrt.build.pre.props
+++ b/src/cppwinrt.build.pre.props
@@ -78,6 +78,8 @@
       <DisableSpecificWarnings>5104;28204;%(DisableSpecificWarnings)</DisableSpecificWarnings>
 
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+
+      <AdditionalIncludeDirectories>$(OpenConsoleDir)src\cascadia\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem Condition="'%(SubSystem)'==''">Console</SubSystem>

--- a/src/tools/MonarchPeasantSample/SampleMonarch.h
+++ b/src/tools/MonarchPeasantSample/SampleMonarch.h
@@ -2,7 +2,6 @@
 
 #include "Monarch.g.h"
 #include "SamplePeasant.h"
-#include <cppwinrt_utils.h>
 
 // {50dba6cd-2222-4b12-8363-5e06f5d0082c}
 constexpr GUID Monarch_clsid{

--- a/src/tools/MonarchPeasantSample/SampleMonarch.h
+++ b/src/tools/MonarchPeasantSample/SampleMonarch.h
@@ -51,7 +51,5 @@ namespace winrt::MonarchPeasantSample::implementation
 
 namespace winrt::MonarchPeasantSample::factory_implementation
 {
-    struct Monarch : MonarchT<Monarch, implementation::Monarch>
-    {
-    };
+    BASIC_FACTORY(Monarch);
 }

--- a/src/tools/MonarchPeasantSample/SampleMonarch.h
+++ b/src/tools/MonarchPeasantSample/SampleMonarch.h
@@ -2,7 +2,7 @@
 
 #include "Monarch.g.h"
 #include "SamplePeasant.h"
-#include "../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 // {50dba6cd-2222-4b12-8363-5e06f5d0082c}
 constexpr GUID Monarch_clsid{

--- a/src/tools/MonarchPeasantSample/SamplePeasant.h
+++ b/src/tools/MonarchPeasantSample/SamplePeasant.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "Peasant.g.h"
-#include "../cascadia/inc/cppwinrt_utils.h"
+#include <cppwinrt_utils.h>
 
 namespace winrt::MonarchPeasantSample::implementation
 {

--- a/src/tools/MonarchPeasantSample/SamplePeasant.h
+++ b/src/tools/MonarchPeasantSample/SamplePeasant.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Peasant.g.h"
-#include <cppwinrt_utils.h>
 
 namespace winrt::MonarchPeasantSample::implementation
 {

--- a/src/tools/MonarchPeasantSample/SamplePeasant.h
+++ b/src/tools/MonarchPeasantSample/SamplePeasant.h
@@ -26,7 +26,5 @@ namespace winrt::MonarchPeasantSample::implementation
 
 namespace winrt::MonarchPeasantSample::factory_implementation
 {
-    struct Peasant : PeasantT<Peasant, implementation::Peasant>
-    {
-    };
+    BASIC_FACTORY(Peasant);
 }

--- a/src/tools/MonarchPeasantSample/pch.h
+++ b/src/tools/MonarchPeasantSample/pch.h
@@ -24,3 +24,5 @@
 #include "til.h"
 
 #include <conio.h>
+
+#include <cppwinrt_utils.h>


### PR DESCRIPTION
* Adds the `cppwinrt_utils.h` to the include path for all winrt projects.
* Adds the file to the pch.h's for every project, so you don't need to include it in every header.
* Replaces some usages of `DECLARE_EVENT`/`DEFINE_EVENT` with `WINRT_CALLBACK`, which will do it in a oneliner
* Adds more `BASIC_FACTORY` usage.
* [x] Closes #2456

It's 92 files with one-line changes, don't be scared.