### PR TITLE
Make sure to deserialize arg params _before_ validating

### DIFF
--- a/src/cascadia/TerminalSettingsModel/ActionArgsMagic.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgsMagic.h
@@ -78,11 +78,11 @@ struct InitListPlaceholder
 //    args->ResizeDirection() == ResizeDirection::None
 // is used as the conditional for the validation here.
 #define FROM_JSON_ARGS(type, name, jsonKey, required, ...)                      \
+    JsonUtils::GetValueForKey(json, jsonKey, args->_##name);                    \
     if (required)                                                               \
     {                                                                           \
         return { nullptr, { SettingsLoadWarnings::MissingRequiredParameter } }; \
-    }                                                                           \
-    JsonUtils::GetValueForKey(json, jsonKey, args->_##name);
+    }
 
 // JSON serialization
 #define TO_JSON_ARGS(type, name, jsonKey, required, ...) \


### PR DESCRIPTION
I had these out of order, and apparently forgot to launch the Terminal before pushing that commit. This resulted in getting the following with the default settings:
![image](https://user-images.githubusercontent.com/18356694/145033088-d6483a75-9dfc-4af4-8bf0-0a35b889aeef.png)

So yea obviously, we should deserialize first, then check if the setting is valid.

* [x] regressed in #11859 
* [x] actually tested this time
* [x] Closes #11896
* [x] Closes #11895
