### PR TITLE
Apparently it's called the Windows 11 SDK now

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -17,7 +17,7 @@
     "Microsoft.Net.Component.4.5.TargetingPack",
     "Microsoft.VisualStudio.Component.DiagnosticTools",
     "Microsoft.VisualStudio.Component.Debugger.JustInTime",
-    "Microsoft.VisualStudio.Component.Windows10SDK.22000",
+    "Microsoft.VisualStudio.Component.Windows11SDK.22000",
     "Microsoft.VisualStudio.ComponentGroup.UWP.Support",
     "Microsoft.VisualStudio.Component.VC.CoreIde",
     "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core",


### PR DESCRIPTION
Apparently it's called the Windows 11 SDK now