### PR TITLE
Enable SBOM generation for Windows Terminal

### DIFF
--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -235,7 +235,7 @@ jobs:
         OverWrite: true
         flattenFolders: true
     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-      displayName: 'Manifest Generation Task'
+      displayName: 'Generate SBOM manifest'
       inputs:
        BuildDropPath: '$(System.ArtifactsDirectory)/appx'
     - task: PublishBuildArtifacts@1

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -237,7 +237,7 @@ jobs:
     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: 'Manifest Generation Task'
       inputs:
-       BuildDropPath: '$(System.ArtifactsDirectory)/buildOutput'
+       BuildDropPath: '$(System.ArtifactsDirectory)/appx'
     - task: PublishBuildArtifacts@1
       displayName: Publish Artifact (appx)
       inputs:

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -234,6 +234,10 @@ jobs:
         TargetFolder: $(Build.ArtifactStagingDirectory)/appx
         OverWrite: true
         flattenFolders: true
+    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+      displayName: 'Manifest Generation Task'
+      inputs:
+       BuildDropPath: '$(System.ArtifactsDirectory)/buildOutput'
     - task: PublishBuildArtifacts@1
       displayName: Publish Artifact (appx)
       inputs:


### PR DESCRIPTION
Microsoft will be providing a Software Bill of Materials for our products. This onboards the Windows Terminal product to the common engineering system task that can scavenge for this information within our build project (already recorded for internal compliance reasons) and present it in a machine-readable interchange format.

See also: https://devblogs.microsoft.com/engineering-at-microsoft/generating-software-bills-of-materials-sboms-with-spdx-at-microsoft/

This does not yet include packaging and distributing the SBOM with our final packages. We are waiting for that tooling to come online for MSIX. Guidance is "Coming Soon™️."

## References
- https://github.com/microsoft/dropvalidator/issues/216 - `cgmanifest.json` are not being pulled in yet, but I've been told internally this will fix it. I will double-check when I hear back on this issue.

## PR Checklist
* [x] Closes #11810 
* [x] I work here
* [x] I ran it and I see the manifest generated.

