### PR TITLE
Replace GetDefaultBrushColors with hardcoded default attributes

### DIFF
--- a/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.cpp
@@ -883,7 +883,7 @@ try
         {
             const auto& fontData = _actualFont;
             int const iFontHeightPoints = fontData.GetUnscaledSize().Y; // this renderer uses points already
-            const COLORREF bgColor = _terminal->GetAttributeColors(_terminal->GetDefaultBrushColors()).second;
+            const COLORREF bgColor = _terminal->GetAttributeColors({}).second;
 
             std::string HTMLToPlaceOnClip = TextBuffer::GenHTML(rows, iFontHeightPoints, fontData.GetFaceName(), bgColor);
             _CopyToSystemClipboard(HTMLToPlaceOnClip, L"HTML Format");

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -164,7 +164,6 @@ public:
 
 #pragma region IRenderData
     // These methods are defined in TerminalRenderData.cpp
-    const TextAttribute GetDefaultBrushColors() noexcept override;
     COORD GetCursorPosition() const noexcept override;
     bool IsCursorVisible() const noexcept override;
     bool IsCursorOn() const noexcept override;

--- a/src/cascadia/TerminalCore/terminalrenderdata.cpp
+++ b/src/cascadia/TerminalCore/terminalrenderdata.cpp
@@ -42,11 +42,6 @@ void Terminal::SetFontInfo(const FontInfo& fontInfo)
     _fontInfo = fontInfo;
 }
 
-const TextAttribute Terminal::GetDefaultBrushColors() noexcept
-{
-    return TextAttribute{};
-}
-
 std::pair<COLORREF, COLORREF> Terminal::GetAttributeColors(const TextAttribute& attr) const noexcept
 {
     std::pair<COLORREF, COLORREF> colors;

--- a/src/host/renderData.cpp
+++ b/src/host/renderData.cpp
@@ -102,17 +102,6 @@ void RenderData::UnlockConsole() noexcept
 #pragma endregion
 
 #pragma region IRenderData
-// Routine Description:
-// - Retrieves the brush colors that should be used in absence of any other color data from
-//   cells in the text buffer.
-// Return Value:
-// - TextAttribute containing the foreground and background brush color data.
-const TextAttribute RenderData::GetDefaultBrushColors() noexcept
-{
-    const CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
-    return gci.GetActiveOutputBuffer().GetAttributes();
-}
-
 // Method Description:
 // - Gets the cursor's position in the buffer, relative to the buffer origin.
 // Arguments:

--- a/src/host/renderData.hpp
+++ b/src/host/renderData.hpp
@@ -37,8 +37,6 @@ public:
 #pragma endregion
 
 #pragma region IRenderData
-    const TextAttribute GetDefaultBrushColors() noexcept override;
-
     COORD GetCursorPosition() const noexcept override;
     bool IsCursorVisible() const noexcept override;
     bool IsCursorOn() const noexcept override;

--- a/src/host/ut_host/VtIoTests.cpp
+++ b/src/host/ut_host/VtIoTests.cpp
@@ -290,11 +290,6 @@ public:
     {
     }
 
-    const TextAttribute GetDefaultBrushColors() noexcept override
-    {
-        return TextAttribute{};
-    }
-
     std::pair<COLORREF, COLORREF> GetAttributeColors(const TextAttribute& /*attr*/) const noexcept override
     {
         return std::make_pair(COLORREF{}, COLORREF{});

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -142,7 +142,7 @@ try
     });
 
     // A. Prep Colors
-    RETURN_IF_FAILED(_UpdateDrawingBrushes(pEngine, _pData->GetDefaultBrushColors(), false, true));
+    RETURN_IF_FAILED(_UpdateDrawingBrushes(pEngine, {}, false, true));
 
     // B. Perform Scroll Operations
     RETURN_IF_FAILED(_PerformScrolling(pEngine));

--- a/src/renderer/inc/IRenderData.hpp
+++ b/src/renderer/inc/IRenderData.hpp
@@ -46,8 +46,6 @@ namespace Microsoft::Console::Render
         IRenderData& operator=(const IRenderData&) = default;
         IRenderData& operator=(IRenderData&&) = default;
 
-        virtual const TextAttribute GetDefaultBrushColors() noexcept = 0;
-
         virtual COORD GetCursorPosition() const noexcept = 0;
         virtual bool IsCursorVisible() const noexcept = 0;
         virtual bool IsCursorOn() const noexcept = 0;


### PR DESCRIPTION
The `IRenderData::GetDefaultBrushColors` method was intended to return
the default attributes from which the renderer would calculate the
default background color. It should always have been returning a default
`TextAttribute` object, but the conhost `RenderData` implementation was
mistakenly returning the active attributes instead. This resulted in
margin areas being filled with the wrong color. To correct that, this PR
simply replaces all usage of `GetDefaultBrushColors` with hardcoded
default attributes.

## Validation Steps Performed

I've manually checked the test case described in issue #11976 and
confirmed that the conhost margin areas are now correctly filled with
the default background color.

Closes #11976