### PR TITLE
Preserve cursor visibility on resize in conhost

### DIFF
--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -1020,6 +1020,8 @@ void SCREEN_INFORMATION::ProcessResizeWindow(const RECT* const prcClientNew,
         // TODO: Deleting and redrawing the command line during resizing can cause flickering. See: http://osgvsowi/658439
         // 1. Delete input string if necessary (see menu.c)
         commandLine.Hide(FALSE);
+
+        const auto savedCursorVisibility = _textBuffer->GetCursor().IsVisible();
         _textBuffer->GetCursor().SetIsVisible(false);
 
         // 2. Call the resize screen buffer method (expensive) to redimension the backing buffer (and reflow)
@@ -1028,7 +1030,7 @@ void SCREEN_INFORMATION::ProcessResizeWindow(const RECT* const prcClientNew,
         // MSFT:19976291 Don't re-show the commandline here. We need to wait for
         //      the viewport to also get resized before we can re-show the commandline.
         //      ProcessResizeWindow will call commandline.Show() for us.
-        _textBuffer->GetCursor().SetIsVisible(true);
+        _textBuffer->GetCursor().SetIsVisible(savedCursorVisibility);
 
         // Return S_OK, to indicate we succeeded and actually did something.
         hr = S_OK;


### PR DESCRIPTION
## Summary of the Pull Request

When a conhost window is resized, the cursor is temporarily hidden, and the visibility is restored when the resize is finished. However, it wasn't taking into account that the cursor may already have been hidden to start with, in which case it would mistakenly force the cursor to be visible. This PR now saves the initial state of the visibility, so it can be correctly restored.

## PR Checklist
* [x] Closes #12024
* [x] CLA signed.
* [ ] Tests added/passed
* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

I've manually verified that this fixes the issue, and the cursor is no longer forced to be visible when the window is resized.