### PR TITLE
Ensure PowerShell Core profile commandline is quoted

### DIFF
--- a/src/cascadia/TerminalSettingsModel/PowershellCoreProfileGenerator.cpp
+++ b/src/cascadia/TerminalSettingsModel/PowershellCoreProfileGenerator.cpp
@@ -309,7 +309,15 @@ void PowershellCoreProfileGenerator::GenerateProfiles(std::vector<winrt::com_ptr
     {
         const auto name = psI.Name();
         auto profile{ CreateDynamicProfile(name) };
-        profile->Commandline(winrt::hstring{ psI.executablePath.native() });
+
+        const auto& unquotedCommandline = psI.executablePath.native();
+        std::wstring quotedCommandline;
+        quotedCommandline.reserve(unquotedCommandline.size() + 2);
+        quotedCommandline.push_back(L'"');
+        quotedCommandline.append(unquotedCommandline);
+        quotedCommandline.push_back(L'"');
+        profile->Commandline(winrt::hstring{ quotedCommandline });
+
         profile->StartingDirectory(winrt::hstring{ DEFAULT_STARTING_DIRECTORY });
         profile->DefaultAppearance().ColorSchemeName(L"Campbell");
         profile->Icon(winrt::hstring{ WI_IsFlagSet(psI.flags, PowerShellFlags::Preview) ? POWERSHELL_PREVIEW_ICON : POWERSHELL_ICON });


### PR DESCRIPTION
Ensures the PowerShell Core profile's commandline is quoted. This allows
the profile to work correctly if there are files in place on the machine
(e.g. one called `C:\Program`) that prevent `CreateProcess()` from
invoking the un-quoted commandline.

## Validation Steps Performed
Created a file called `C:\Program` and opened the PowerShell profile in
terminal.

Closes #11717