### PR TITLE
Disable duplicate button without selected profile

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/AddProfile.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AddProfile.cpp
@@ -41,7 +41,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     }
 
     void AddProfile::ProfilesSelectionChanged(const IInspectable& /*sender*/,
-                                    const Windows::UI::Xaml::RoutedEventArgs& /*eventArgs*/)
+                                              const Windows::UI::Xaml::RoutedEventArgs& /*eventArgs*/)
     {
         if (!IsProfileSelected())
         {

--- a/src/cascadia/TerminalSettingsEditor/AddProfile.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AddProfile.cpp
@@ -39,4 +39,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             _State.RequestDuplicate(selected.try_as<Model::Profile>().Guid());
         }
     }
+
+    void AddProfile::ProfilesSelectionChanged(const IInspectable& /*sender*/,
+                                    const Windows::UI::Xaml::RoutedEventArgs& /*eventArgs*/)
+    {
+        if (!IsProfileSelected())
+        {
+            IsProfileSelected(true);
+        }
+    }
 }

--- a/src/cascadia/TerminalSettingsEditor/AddProfile.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AddProfile.cpp
@@ -43,7 +43,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     void AddProfile::ProfilesSelectionChanged(const IInspectable& /*sender*/,
                                               const Windows::UI::Xaml::RoutedEventArgs& /*eventArgs*/)
     {
-        if (!IsProfileSelected())
+        if (!_IsProfileSelected)
         {
             IsProfileSelected(true);
         }

--- a/src/cascadia/TerminalSettingsEditor/AddProfile.h
+++ b/src/cascadia/TerminalSettingsEditor/AddProfile.h
@@ -52,8 +52,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         void AddNewClick(const IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& eventArgs);
         void DuplicateClick(const IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& eventArgs);
+        void ProfilesSelectionChanged(const IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& eventArgs);
 
         WINRT_PROPERTY(Editor::AddProfilePageNavigationState, State, nullptr);
+        WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
+        WINRT_OBSERVABLE_PROPERTY(bool, IsProfileSelected, _PropertyChangedHandlers, nullptr);
     };
 }
 

--- a/src/cascadia/TerminalSettingsEditor/AddProfile.idl
+++ b/src/cascadia/TerminalSettingsEditor/AddProfile.idl
@@ -13,9 +13,10 @@ namespace Microsoft.Terminal.Settings.Editor
         event AddNewArgs AddNew;
     };
 
-    [default_interface] runtimeclass AddProfile : Windows.UI.Xaml.Controls.Page
+    [default_interface] runtimeclass AddProfile : Windows.UI.Xaml.Controls.Page, Windows.UI.Xaml.Data.INotifyPropertyChanged
     {
         AddProfile();
         AddProfilePageNavigationState State { get; };
+        Boolean IsProfileSelected { get; };
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/AddProfile.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AddProfile.xaml
@@ -41,8 +41,8 @@
                 <local:SettingContainer x:Uid="AddProfile_Duplicate">
                     <muxc:RadioButtons x:Name="Profiles"
                                        AutomationProperties.AccessibilityView="Content"
-                                       SelectionChanged="ProfilesSelectionChanged"
-                                       ItemsSource="{x:Bind State.Settings.AllProfiles, Mode=OneWay}">
+                                       ItemsSource="{x:Bind State.Settings.AllProfiles, Mode=OneWay}"
+                                       SelectionChanged="ProfilesSelectionChanged">
                         <muxc:RadioButtons.ItemTemplate>
                             <DataTemplate x:DataType="model:Profile">
                                 <Grid HorizontalAlignment="Stretch"

--- a/src/cascadia/TerminalSettingsEditor/AddProfile.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AddProfile.xaml
@@ -41,6 +41,7 @@
                 <local:SettingContainer x:Uid="AddProfile_Duplicate">
                     <muxc:RadioButtons x:Name="Profiles"
                                        AutomationProperties.AccessibilityView="Content"
+                                       SelectionChanged="ProfilesSelectionChanged"
                                        ItemsSource="{x:Bind State.Settings.AllProfiles, Mode=OneWay}">
                         <muxc:RadioButtons.ItemTemplate>
                             <DataTemplate x:DataType="model:Profile">
@@ -72,6 +73,7 @@
                         AutomationProperties.AutomationId="AddProfile_DuplicateButton"
                         AutomationProperties.Name="{Binding Tag, RelativeSource={RelativeSource Self}}"
                         Click="DuplicateClick"
+                        IsEnabled="{x:Bind IsProfileSelected, Mode=OneWay}"
                         Style="{StaticResource AccentButtonStyle}">
                     <Button.Content>
                         <StackPanel Orientation="Horizontal">


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

- Settings > Add a new profile
- Disable "Duplicate" button until a profile is selected

![Duplicate](https://user-images.githubusercontent.com/25966642/148303450-a084cd5f-7f1c-4de3-86bd-602b9336649e.gif)

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Should take care of #12056, once we can get a build to the a11y team (MAINTAINER EDIT: we unfortunately can't just say "closes #foo" for issues like this one, we need another team to validate the following build.)
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
