### PR TITLE
Update RGB values when selecting a conhost color property

### DIFF
--- a/src/propsheet/ColorsPage.cpp
+++ b/src/propsheet/ColorsPage.cpp
@@ -186,6 +186,11 @@ INT_PTR WINAPI ColorDlgProc(HWND hDlg, UINT wMsg, WPARAM wParam, LPARAM lParam)
                 InvalidateRect(hWndOld, nullptr, TRUE);
             }
 
+            // update color value fields to reflect the new color
+            UpdateItem(hDlg, IDD_COLOR_RED, GetRValue(AttrToRGB(ColorArray[iColor])));
+            UpdateItem(hDlg, IDD_COLOR_GREEN, GetGValue(AttrToRGB(ColorArray[iColor])));
+            UpdateItem(hDlg, IDD_COLOR_BLUE, GetBValue(AttrToRGB(ColorArray[iColor])));
+
             return TRUE;
 
         case IDD_COLOR_RED:


### PR DESCRIPTION
When editing colors in the conhost properties dialog, and you select an
item to update (e.g. Screen Text, or Screen Background), the associated
color swatch for that item would be highlighted, but the RGB color
values weren't updated to reflect that selection. This PR fixes it so
the RGB values are now correctly refreshed.

I just copied the three lines used up update the color value fields from
the code that handles changes to the color swatch selection. I didn't
think it was worth pulling those three lines out into a separate
function.

## Validation Steps Performed
I've manually verified that the RGB values are now refreshed correctly
when selecting a color item to update.

Closes #1220