### PR TITLE
Fix typo in #653 - Quake Mode.md

### DIFF
--- a/doc/specs/#653 - Quake Mode/#653 - Quake Mode.md
+++ b/doc/specs/#653 - Quake Mode/#653 - Quake Mode.md
@@ -714,7 +714,7 @@ Docs regarding hiding a window from the taskbar:
 ### Footnotes
 
 <a name="footnote-1"><a>[1]: Quitting the terminal is different than closing the
-windows one-by-one. Quiting implies an atomic action, for closing all the
+windows one-by-one. Quitting implies an atomic action, for closing all the
 windows. Once [#766] lands, this will give us a chance to persist the state of
 _all_ open windows. This will allow us to re-open with all the user's windows,
 not just the one that happened to be closed last.


### PR DESCRIPTION

Fixed typo.
```
Quiting -> Quitting
```

* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA