### PR TITLE
Fix compilation under VS 2022.1

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -2391,6 +2391,7 @@ TIcon
 tif
 tilunittests
 Timeline
+timelines
 titlebar
 TITLEISLINKNAME
 TJson

--- a/src/inc/til/coalesce.h
+++ b/src/inc/til/coalesce.h
@@ -18,7 +18,9 @@ namespace til
     template<typename T>
     T coalesce_value(const std::optional<T>& base)
     {
-        static_assert(false, "coalesce_value must be passed a base non-optional value to be used if all optionals are empty");
+        // There's no particular reason to use `sizeof(base) == 0`
+        // apart from making this static_assert lazily evaluated.
+        static_assert(sizeof(base) == 0, "coalesce_value must be passed a base non-optional value to be used if all optionals are empty");
         return T{};
     }
 

--- a/src/inc/til/coalesce.h
+++ b/src/inc/til/coalesce.h
@@ -18,8 +18,9 @@ namespace til
     template<typename T>
     T coalesce_value(const std::optional<T>& base)
     {
-        // There's no particular reason to use `sizeof(base) == 0`
-        // apart from making this static_assert lazily evaluated.
+        // There's no particular reason to use `sizeof(base) == 0` specifically.
+        // We just need this assertion to be dependent on the type T here,
+        // in order to delay the assertion until template instantiation.
         static_assert(sizeof(base) == 0, "coalesce_value must be passed a base non-optional value to be used if all optionals are empty");
         return T{};
     }


### PR DESCRIPTION
This commit fixes the compilation under VS 2022.1 and clang, by evaluating a
`static_assert(false)` safety check only when the template is instantiated.
This is achieved by making the assertion depend on the template parameter.

## Validation Steps Performed
* Host.EXE compiles under VS 17.1.0 Preview 3.0 (32110.40.d17.1) ✅