### PR TITLE
Combined revert of Environment Block Changes

### DIFF
--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -5,7 +5,6 @@
 
 #include "ConptyConnection.h"
 
-#include <UserEnv.h>
 #include <winternl.h>
 
 #include "ConptyConnection.g.cpp"
@@ -99,11 +98,8 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             environment.clear();
         });
 
-        {
-            const auto newEnvironmentBlock{ Utils::CreateEnvironmentBlock() };
-            // Populate the environment map with the current environment.
-            RETURN_IF_FAILED(Utils::UpdateEnvironmentMapW(environment, newEnvironmentBlock.get()));
-        }
+        // Populate the environment map with the current environment.
+        RETURN_IF_FAILED(Utils::UpdateEnvironmentMapW(environment));
 
         {
             // Convert connection Guid to string and ignore the enclosing '{}'.

--- a/src/types/Environment.cpp
+++ b/src/types/Environment.cpp
@@ -3,7 +3,6 @@
 
 #include "precomp.h"
 #include "inc/Environment.hpp"
-#include "wil/token_helpers.h"
 
 using namespace ::Microsoft::Console::Utils;
 
@@ -11,42 +10,29 @@ using namespace ::Microsoft::Console::Utils;
 #pragma warning(disable : 26481 26429)
 
 // Function Description:
-// - Wraps win32's CreateEnvironmentBlock to return a smart pointer.
-EnvironmentBlockPtr Microsoft::Console::Utils::CreateEnvironmentBlock()
-{
-    void* newEnvironmentBlock{ nullptr };
-    auto processToken{ wil::open_current_access_token(TOKEN_QUERY | TOKEN_DUPLICATE) };
-    if (!::CreateEnvironmentBlock(&newEnvironmentBlock, processToken.get(), FALSE))
-    {
-        return nullptr;
-    }
-    return EnvironmentBlockPtr{ newEnvironmentBlock };
-}
-
-// Function Description:
 // - Updates an EnvironmentVariableMapW with the current process's unicode
 //   environment variables ignoring ones already set in the provided map.
 // Arguments:
 // - map: The map to populate with the current processes's environment variables.
-// - environmentBlock: Optional environment block to use when filling map. If omitted,
-//   defaults to the current environment.
 // Return Value:
 // - S_OK if we succeeded, or an appropriate HRESULT for failing
-HRESULT Microsoft::Console::Utils::UpdateEnvironmentMapW(EnvironmentVariableMapW& map, void* environmentBlock) noexcept
+HRESULT Microsoft::Console::Utils::UpdateEnvironmentMapW(EnvironmentVariableMapW& map) noexcept
 try
 {
-    wchar_t const* activeEnvironmentBlock{ static_cast<wchar_t const*>(environmentBlock) };
+    LPWCH currentEnvVars{};
+    auto freeCurrentEnv = wil::scope_exit([&] {
+        if (currentEnvVars)
+        {
+            FreeEnvironmentStringsW(currentEnvVars);
+            currentEnvVars = nullptr;
+        }
+    });
 
-    wil::unique_environstrings_ptr currentEnvVars;
-    if (!activeEnvironmentBlock)
-    {
-        currentEnvVars.reset(::GetEnvironmentStringsW());
-        RETURN_HR_IF_NULL(E_OUTOFMEMORY, currentEnvVars);
-        activeEnvironmentBlock = currentEnvVars.get();
-    }
+    currentEnvVars = ::GetEnvironmentStringsW();
+    RETURN_HR_IF_NULL(E_OUTOFMEMORY, currentEnvVars);
 
     // Each entry is NULL-terminated; block is guaranteed to be double-NULL terminated at a minimum.
-    for (wchar_t const* lastCh{ activeEnvironmentBlock }; *lastCh != '\0'; ++lastCh)
+    for (wchar_t const* lastCh{ currentEnvVars }; *lastCh != '\0'; ++lastCh)
     {
         // Copy current entry into temporary map.
         const size_t cchEntry{ ::wcslen(lastCh) };

--- a/src/types/inc/Environment.hpp
+++ b/src/types/inc/Environment.hpp
@@ -21,12 +21,9 @@ namespace Microsoft::Console::Utils
         }
     };
 
-    using EnvironmentBlockPtr = wil::unique_any<void*, decltype(::DestroyEnvironmentBlock), ::DestroyEnvironmentBlock>;
-    [[nodiscard]] EnvironmentBlockPtr CreateEnvironmentBlock();
-
     using EnvironmentVariableMapW = std::map<std::wstring, std::wstring, WStringCaseInsensitiveCompare>;
 
-    [[nodiscard]] HRESULT UpdateEnvironmentMapW(EnvironmentVariableMapW& map, void* environmentBlock = nullptr) noexcept;
+    [[nodiscard]] HRESULT UpdateEnvironmentMapW(EnvironmentVariableMapW& map) noexcept;
 
     [[nodiscard]] HRESULT EnvironmentMapToEnvironmentStringsW(EnvironmentVariableMapW& map,
                                                               std::vector<wchar_t>& newEnvVars) noexcept;

--- a/src/types/precomp.h
+++ b/src/types/precomp.h
@@ -29,7 +29,6 @@ Abstract:
 
 // Windows Header Files:
 #include <windows.h>
-#include <userenv.h>
 #include <combaseapi.h>
 #include <UIAutomation.h>
 #include <objbase.h>


### PR DESCRIPTION
Revert "Fix environment block creation (#7401)"

This reverts commit 7886f16714a734fe1a122b9f22986d283d0f0a41.

(cherry picked from commit e46ba65665610f2544414618b8a0de00c03e7903)

Revert "Always create a new environment block before we spawn a process (#7243)"

This reverts commit 849243af995a05bcce046df010894b60d20ea145.

(cherry picked from commit 4204d2535c82ebeef4f27c306b39ffbcca51a881)
(cherry picked from commit f8e8572c2314004da9c355ef4bfec33a56d54646)
(cherry picked from commit cb4c4f7b739708a4908067918f3e3f31bce1cfbf)
(cherry picked from commit afb0cac3e323f80d4df4804be2155bf317d8c33d)
(cherry picked from commit b25dc74a1d0ef47cf3d2fe599b9f788e89ccbc2f)
(cherry picked from commit 5f7c66bc0cc5d3f217a723ee7f92904fec6be91d)

Fixes #7418