### PR TITLE
Add a `--elevate` flag

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/CommandlineTest.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/CommandlineTest.cpp
@@ -688,6 +688,54 @@ namespace TerminalAppLocalTests
             VERIFY_IS_FALSE(myArgs.TerminalArgs().ColorScheme().empty());
             VERIFY_ARE_EQUAL(expectedScheme, myArgs.TerminalArgs().ColorScheme());
         }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", subcommand, L"--elevate" };
+
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_ARE_EQUAL(1u, appArgs._startupActions.size());
+
+            auto actionAndArgs = appArgs._startupActions.at(0);
+            VERIFY_ARE_EQUAL(ShortcutAction::NewTab, actionAndArgs.Action());
+            VERIFY_IS_NOT_NULL(actionAndArgs.Args());
+            auto myArgs = actionAndArgs.Args().try_as<NewTabArgs>();
+            VERIFY_IS_NOT_NULL(myArgs);
+            VERIFY_IS_NOT_NULL(myArgs.TerminalArgs());
+            VERIFY_IS_TRUE(myArgs.TerminalArgs().Commandline().empty());
+            VERIFY_IS_TRUE(myArgs.TerminalArgs().StartingDirectory().empty());
+            VERIFY_IS_TRUE(myArgs.TerminalArgs().TabTitle().empty());
+            VERIFY_IS_NULL(myArgs.TerminalArgs().TabColor());
+            VERIFY_IS_NULL(myArgs.TerminalArgs().ProfileIndex());
+            VERIFY_IS_TRUE(myArgs.TerminalArgs().Profile().empty());
+            VERIFY_IS_TRUE(myArgs.TerminalArgs().ColorScheme().empty());
+            VERIFY_IS_NOT_NULL(myArgs.TerminalArgs().Elevate());
+            VERIFY_IS_TRUE(myArgs.TerminalArgs().Elevate().Value());
+        }
+        {
+            AppCommandlineArgs appArgs{};
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", subcommand, L"--no-elevate" };
+
+            _buildCommandlinesHelper(appArgs, 1u, rawCommands);
+
+            VERIFY_ARE_EQUAL(1u, appArgs._startupActions.size());
+
+            auto actionAndArgs = appArgs._startupActions.at(0);
+            VERIFY_ARE_EQUAL(ShortcutAction::NewTab, actionAndArgs.Action());
+            VERIFY_IS_NOT_NULL(actionAndArgs.Args());
+            auto myArgs = actionAndArgs.Args().try_as<NewTabArgs>();
+            VERIFY_IS_NOT_NULL(myArgs);
+            VERIFY_IS_NOT_NULL(myArgs.TerminalArgs());
+            VERIFY_IS_TRUE(myArgs.TerminalArgs().Commandline().empty());
+            VERIFY_IS_TRUE(myArgs.TerminalArgs().StartingDirectory().empty());
+            VERIFY_IS_TRUE(myArgs.TerminalArgs().TabTitle().empty());
+            VERIFY_IS_NULL(myArgs.TerminalArgs().TabColor());
+            VERIFY_IS_NULL(myArgs.TerminalArgs().ProfileIndex());
+            VERIFY_IS_TRUE(myArgs.TerminalArgs().Profile().empty());
+            VERIFY_IS_TRUE(myArgs.TerminalArgs().ColorScheme().empty());
+            VERIFY_IS_NOT_NULL(myArgs.TerminalArgs().Elevate());
+            VERIFY_IS_FALSE(myArgs.TerminalArgs().Elevate().Value());
+        }
     }
 
     void CommandlineTest::ParseSplitPaneIntoArgs()

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -558,6 +558,11 @@ void AppCommandlineArgs::_addNewTerminalArgs(AppCommandlineArgs::NewTerminalSubc
     subcommand.colorSchemeOption = subcommand.subcommand->add_option("--colorScheme",
                                                                      _startingColorScheme,
                                                                      RS_A(L"CmdColorSchemeArgDesc"));
+
+    subcommand.elevateOption = subcommand.subcommand->add_flag("--elevate{true},--no-elevate{false}",
+                                                               _elevate,
+                                                               RS_A(L"CmdElevateArgDesc"));
+
     // Using positionals_at_end allows us to support "wt new-tab -d wsl -d Ubuntu"
     // without CLI11 thinking that we've specified -d twice.
     // There's an alternate construction where we make all subcommands "prefix commands",
@@ -640,6 +645,11 @@ NewTerminalArgs AppCommandlineArgs::_getNewTerminalArgs(AppCommandlineArgs::NewT
         args.SuppressApplicationTitle(_suppressApplicationTitle);
     }
 
+    if (*subcommand.elevateOption)
+    {
+        args.Elevate(_elevate);
+    }
+
     if (*subcommand.colorSchemeOption)
     {
         args.ColorScheme(winrt::to_hstring(_startingColorScheme));
@@ -689,6 +699,7 @@ void AppCommandlineArgs::_resetStateToDefault()
     _startingTabColor.clear();
     _commandline.clear();
     _suppressApplicationTitle = false;
+    _elevate = false;
 
     _splitVertical = false;
     _splitHorizontal = false;

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.h
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.h
@@ -65,6 +65,7 @@ private:
         CLI::Option* tabColorOption;
         CLI::Option* suppressApplicationTitleOption;
         CLI::Option* colorSchemeOption;
+        CLI::Option* elevateOption;
     };
 
     struct NewPaneSubcommand : public NewTerminalSubcommand
@@ -97,6 +98,7 @@ private:
     std::string _startingTabColor;
     std::string _startingColorScheme;
     bool _suppressApplicationTitle{ false };
+    bool _elevate{ false };
 
     winrt::Microsoft::Terminal::Settings::Model::FocusDirection _moveFocusDirection{ winrt::Microsoft::Terminal::Settings::Model::FocusDirection::None };
     winrt::Microsoft::Terminal::Settings::Model::FocusDirection _swapPaneDirection{ winrt::Microsoft::Terminal::Settings::Model::FocusDirection::None };

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -356,6 +356,10 @@
     <value>Open the tab with the specified color scheme, instead of the profile's set "colorScheme"</value>
     <comment>{Locked="\"colorScheme\""}</comment>
   </data>
+  <data name="CmdElevateArgDesc" xml:space="preserve">
+    <value>Override for the profile's "elevate" setting.</value>
+    <comment>{Locked="\"elevate\""}</comment>
+  </data>
   <data name="CmdVersionDesc" xml:space="preserve">
     <value>Display the application version</value>
   </data>

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -130,7 +130,7 @@ namespace Microsoft.Terminal.Settings.Model
         String ColorScheme;
         // This needs to be an optional so that the default value (null) does
         // not modify whatever the profile's value is (either true or false)
-        Windows.Foundation.IReference<Boolean> Elevate { get; };
+        Windows.Foundation.IReference<Boolean> Elevate;
 
         Boolean Equals(NewTerminalArgs other);
         String GenerateName();


### PR DESCRIPTION
_targets #12137_

To match the arg in #12137.

`--elevate` will manually elevate the profile.

`--no-elevate` will override a `elevate: true` in the profile with false.

So now you can `wt --elevate cmd` and it'll do what you think

* [x] I work here
* [x] Tests added
* [ ] need to update docs
