### PR TITLE
Use ControlProperties macros everywhere

### DIFF
--- a/scratch/ScratchIslandApp/SampleApp/MyPage.cpp
+++ b/scratch/ScratchIslandApp/SampleApp/MyPage.cpp
@@ -41,7 +41,7 @@ namespace winrt::SampleApp::implementation
         TerminalConnection::ConnectionInformation connectInfo{ myClass, connectionSettings };
 
         TerminalConnection::ITerminalConnection conn{ TerminalConnection::ConnectionInformation::CreateConnection(connectInfo) };
-        Control::TermControl control{ *settings, conn };
+        Control::TermControl control{ *settings, *settings, conn };
 
         InProcContent().Children().Append(control);
     }

--- a/scratch/ScratchIslandApp/SampleApp/MySettings.h
+++ b/scratch/ScratchIslandApp/SampleApp/MySettings.h
@@ -5,83 +5,28 @@ Licensed under the MIT license.
 #pragma once
 #include "../../inc/cppwinrt_utils.h"
 #include "../types/inc/colorTable.hpp"
+#include "../../inc/ControlProperties.h"
 
 #include <DefaultSettings.h>
 #include <conattrs.hpp>
 #include "MySettings.g.h"
 
+using IFontFeatureMap = winrt::Windows::Foundation::Collections::IMap<winrt::hstring, uint32_t>;
+using IFontAxesMap = winrt::Windows::Foundation::Collections::IMap<winrt::hstring, float>;
+
 namespace winrt::SampleApp::implementation
 {
     struct MySettings : MySettingsT<MySettings>
     {
-        // --------------------------- Core Settings ---------------------------
-        //  All of these settings are defined in ICoreSettings.
-
-        WINRT_PROPERTY(til::color, DefaultForeground, DEFAULT_FOREGROUND);
-        WINRT_PROPERTY(til::color, DefaultBackground, DEFAULT_BACKGROUND);
-        WINRT_PROPERTY(til::color, SelectionBackground, DEFAULT_FOREGROUND);
-        WINRT_PROPERTY(int32_t, HistorySize, DEFAULT_HISTORY_SIZE);
-        WINRT_PROPERTY(int32_t, InitialRows, 30);
-        WINRT_PROPERTY(int32_t, InitialCols, 80);
-
-        WINRT_PROPERTY(bool, SnapOnInput, true);
-        WINRT_PROPERTY(bool, AltGrAliasing, true);
-        WINRT_PROPERTY(til::color, CursorColor, DEFAULT_CURSOR_COLOR);
-        WINRT_PROPERTY(winrt::Microsoft::Terminal::Core::CursorStyle, CursorShape, winrt::Microsoft::Terminal::Core::CursorStyle::Vintage);
-        WINRT_PROPERTY(uint32_t, CursorHeight, DEFAULT_CURSOR_HEIGHT);
-        WINRT_PROPERTY(winrt::hstring, WordDelimiters, DEFAULT_WORD_DELIMITERS);
-        WINRT_PROPERTY(bool, CopyOnSelect, false);
-        WINRT_PROPERTY(bool, InputServiceWarning, true);
-        WINRT_PROPERTY(bool, FocusFollowMouse, false);
-
-        WINRT_PROPERTY(winrt::Windows::Foundation::IReference<winrt::Microsoft::Terminal::Core::Color>, TabColor, nullptr);
-
-        WINRT_PROPERTY(winrt::Windows::Foundation::IReference<winrt::Microsoft::Terminal::Core::Color>, StartingTabColor, nullptr);
-
-        winrt::Microsoft::Terminal::Core::ICoreAppearance UnfocusedAppearance() { return {}; };
-
-        WINRT_PROPERTY(bool, TrimBlockSelection, false);
-        // ------------------------ End of Core Settings -----------------------
-
-        WINRT_PROPERTY(winrt::hstring, ProfileName);
-        WINRT_PROPERTY(bool, UseAcrylic, false);
-        WINRT_PROPERTY(double, Opacity, .5);
-        WINRT_PROPERTY(winrt::hstring, Padding, DEFAULT_PADDING);
-        WINRT_PROPERTY(winrt::hstring, FontFace, L"Consolas");
-        WINRT_PROPERTY(int32_t, FontSize, DEFAULT_FONT_SIZE);
-
-        WINRT_PROPERTY(winrt::Windows::UI::Text::FontWeight, FontWeight);
-
-        WINRT_PROPERTY(winrt::hstring, BackgroundImage);
-        WINRT_PROPERTY(double, BackgroundImageOpacity, 1.0);
-
-        WINRT_PROPERTY(winrt::Windows::UI::Xaml::Media::Stretch, BackgroundImageStretchMode, winrt::Windows::UI::Xaml::Media::Stretch::UniformToFill);
-        WINRT_PROPERTY(winrt::Windows::UI::Xaml::HorizontalAlignment, BackgroundImageHorizontalAlignment, winrt::Windows::UI::Xaml::HorizontalAlignment::Center);
-        WINRT_PROPERTY(winrt::Windows::UI::Xaml::VerticalAlignment, BackgroundImageVerticalAlignment, winrt::Windows::UI::Xaml::VerticalAlignment::Center);
-
-        WINRT_PROPERTY(winrt::Microsoft::Terminal::Control::IKeyBindings, KeyBindings, nullptr);
-
-        WINRT_PROPERTY(winrt::hstring, Commandline);
-        WINRT_PROPERTY(winrt::hstring, StartingDirectory);
-        WINRT_PROPERTY(winrt::hstring, StartingTitle);
-        WINRT_PROPERTY(bool, SuppressApplicationTitle);
-        WINRT_PROPERTY(winrt::hstring, EnvironmentVariables);
-
-        WINRT_PROPERTY(winrt::Microsoft::Terminal::Control::ScrollbarState, ScrollState, winrt::Microsoft::Terminal::Control::ScrollbarState::Visible);
-
-        WINRT_PROPERTY(winrt::Microsoft::Terminal::Control::TextAntialiasingMode, AntialiasingMode, winrt::Microsoft::Terminal::Control::TextAntialiasingMode::Grayscale);
-
-        WINRT_PROPERTY(bool, RetroTerminalEffect, false);
-        WINRT_PROPERTY(bool, ForceFullRepaintRendering, false);
-        WINRT_PROPERTY(bool, SoftwareRendering, false);
-        WINRT_PROPERTY(bool, ForceVTInput, false);
-
-        WINRT_PROPERTY(winrt::hstring, PixelShaderPath);
-
-        WINRT_PROPERTY(bool, DetectURLs, true);
-
-    private:
+        // Color Table is special because it's an array
         std::array<winrt::Microsoft::Terminal::Core::Color, COLOR_TABLE_SIZE> _ColorTable;
+
+#define SETTINGS_GEN(type, name, ...) WINRT_PROPERTY(type, name, __VA_ARGS__);
+        CORE_SETTINGS(SETTINGS_GEN)
+        CORE_APPEARANCE_SETTINGS(SETTINGS_GEN)
+        CONTROL_SETTINGS(SETTINGS_GEN)
+        CONTROL_APPEARANCE_SETTINGS(SETTINGS_GEN)
+#undef SETTINGS_GEN
 
     public:
         winrt::Microsoft::Terminal::Core::Color GetColorTableEntry(int32_t index) noexcept { return _ColorTable.at(index); }

--- a/src/cascadia/UnitTests_Control/MockControlSettings.h
+++ b/src/cascadia/UnitTests_Control/MockControlSettings.h
@@ -6,6 +6,7 @@ Licensed under the MIT license.
 
 #include <DefaultSettings.h>
 #include <conattrs.hpp>
+#include "../../inc/ControlProperties.h"
 
 using IFontFeatureMap = winrt::Windows::Foundation::Collections::IMap<winrt::hstring, uint32_t>;
 using IFontAxesMap = winrt::Windows::Foundation::Collections::IMap<winrt::hstring, float>;
@@ -14,87 +15,27 @@ namespace ControlUnitTests
 {
     class MockControlSettings : public winrt::implements<MockControlSettings, winrt::Microsoft::Terminal::Core::ICoreSettings, winrt::Microsoft::Terminal::Control::IControlSettings, winrt::Microsoft::Terminal::Core::ICoreAppearance, winrt::Microsoft::Terminal::Control::IControlAppearance>
     {
+        // Color Table is special because it's an array
+        std::array<winrt::Microsoft::Terminal::Core::Color, COLOR_TABLE_SIZE> _ColorTable;
+
+#define SETTINGS_GEN(type, name, ...) WINRT_PROPERTY(type, name, __VA_ARGS__);
+        CORE_SETTINGS(SETTINGS_GEN)
+        CORE_APPEARANCE_SETTINGS(SETTINGS_GEN)
+        CONTROL_SETTINGS(SETTINGS_GEN)
+        CONTROL_APPEARANCE_SETTINGS(SETTINGS_GEN)
+#undef SETTINGS_GEN
+
     public:
         MockControlSettings() = default;
 
-        // --------------------------- Core Settings ---------------------------
-        //  All of these settings are defined in ICoreSettings.
-
-        WINRT_PROPERTY(til::color, DefaultForeground, DEFAULT_FOREGROUND);
-        WINRT_PROPERTY(til::color, DefaultBackground, DEFAULT_BACKGROUND);
-        WINRT_PROPERTY(til::color, SelectionBackground, DEFAULT_FOREGROUND);
-        WINRT_PROPERTY(int32_t, HistorySize, DEFAULT_HISTORY_SIZE);
-        WINRT_PROPERTY(int32_t, InitialRows, 30);
-        WINRT_PROPERTY(int32_t, InitialCols, 80);
-
-        WINRT_PROPERTY(bool, SnapOnInput, true);
-        WINRT_PROPERTY(bool, AltGrAliasing, true);
-        WINRT_PROPERTY(til::color, CursorColor, DEFAULT_CURSOR_COLOR);
-        WINRT_PROPERTY(winrt::Microsoft::Terminal::Core::CursorStyle, CursorShape, winrt::Microsoft::Terminal::Core::CursorStyle::Vintage);
-        WINRT_PROPERTY(uint32_t, CursorHeight, DEFAULT_CURSOR_HEIGHT);
-        WINRT_PROPERTY(winrt::hstring, WordDelimiters, DEFAULT_WORD_DELIMITERS);
-        WINRT_PROPERTY(bool, CopyOnSelect, false);
-        WINRT_PROPERTY(bool, FocusFollowMouse, false);
-
-        WINRT_PROPERTY(winrt::Windows::Foundation::IReference<winrt::Microsoft::Terminal::Core::Color>, TabColor, nullptr);
-
-        WINRT_PROPERTY(winrt::Windows::Foundation::IReference<winrt::Microsoft::Terminal::Core::Color>, StartingTabColor, nullptr);
-
-        winrt::Microsoft::Terminal::Core::ICoreAppearance UnfocusedAppearance() { return {}; };
-
-        WINRT_PROPERTY(bool, TrimBlockSelection, false);
-        WINRT_PROPERTY(bool, DetectURLs, true);
-        WINRT_PROPERTY(bool, IntenseIsBright, true);
-        WINRT_PROPERTY(bool, AdjustIndistinguishableColors, true);
-        // ------------------------ End of Core Settings -----------------------
-
-        WINRT_PROPERTY(winrt::hstring, ProfileName);
-        WINRT_PROPERTY(winrt::hstring, ProfileSource);
-        WINRT_PROPERTY(bool, UseAcrylic, false);
-        WINRT_PROPERTY(double, Opacity, .5);
-        WINRT_PROPERTY(winrt::hstring, Padding, DEFAULT_PADDING);
-        WINRT_PROPERTY(winrt::hstring, FontFace, L"Consolas");
-        WINRT_PROPERTY(int32_t, FontSize, DEFAULT_FONT_SIZE);
-
-        WINRT_PROPERTY(winrt::Windows::UI::Text::FontWeight, FontWeight);
-
-        WINRT_PROPERTY(winrt::hstring, BackgroundImage);
-        WINRT_PROPERTY(double, BackgroundImageOpacity, 1.0);
-
-        WINRT_PROPERTY(winrt::Windows::UI::Xaml::Media::Stretch, BackgroundImageStretchMode, winrt::Windows::UI::Xaml::Media::Stretch::UniformToFill);
-        WINRT_PROPERTY(winrt::Windows::UI::Xaml::HorizontalAlignment, BackgroundImageHorizontalAlignment, winrt::Windows::UI::Xaml::HorizontalAlignment::Center);
-        WINRT_PROPERTY(winrt::Windows::UI::Xaml::VerticalAlignment, BackgroundImageVerticalAlignment, winrt::Windows::UI::Xaml::VerticalAlignment::Center);
-
-        WINRT_PROPERTY(winrt::Microsoft::Terminal::Control::IKeyBindings, KeyBindings, nullptr);
-
-        WINRT_PROPERTY(winrt::hstring, Commandline);
-        WINRT_PROPERTY(winrt::hstring, StartingDirectory);
-        WINRT_PROPERTY(winrt::hstring, StartingTitle);
-        WINRT_PROPERTY(bool, SuppressApplicationTitle);
-        WINRT_PROPERTY(winrt::hstring, EnvironmentVariables);
-
-        WINRT_PROPERTY(winrt::Microsoft::Terminal::Control::ScrollbarState, ScrollState, winrt::Microsoft::Terminal::Control::ScrollbarState::Visible);
-        WINRT_PROPERTY(bool, UseAtlasEngine, false);
-
-        WINRT_PROPERTY(winrt::Microsoft::Terminal::Control::TextAntialiasingMode, AntialiasingMode, winrt::Microsoft::Terminal::Control::TextAntialiasingMode::Grayscale);
-
-        WINRT_PROPERTY(bool, RetroTerminalEffect, false);
-        WINRT_PROPERTY(bool, ForceFullRepaintRendering, false);
-        WINRT_PROPERTY(bool, SoftwareRendering, false);
-        WINRT_PROPERTY(bool, ForceVTInput, false);
-
-        WINRT_PROPERTY(winrt::hstring, PixelShaderPath);
-
-        WINRT_PROPERTY(IFontFeatureMap, FontFeatures);
-        WINRT_PROPERTY(IFontAxesMap, FontAxes);
-        WINRT_PROPERTY(bool, IntenseIsBold, true);
-
-    private:
-        std::array<winrt::Microsoft::Terminal::Core::Color, COLOR_TABLE_SIZE> _ColorTable;
-
-    public:
-        winrt::Microsoft::Terminal::Core::Color GetColorTableEntry(int32_t index) noexcept { return _ColorTable.at(index); }
-        std::array<winrt::Microsoft::Terminal::Core::Color, 16> ColorTable() { return _ColorTable; }
-        void ColorTable(std::array<winrt::Microsoft::Terminal::Core::Color, 16> /*colors*/) {}
+        winrt::Microsoft::Terminal::Core::Color GetColorTableEntry(int32_t index) noexcept
+        {
+            return _ColorTable.at(index);
+        }
+        void SetColorTableEntry(int32_t index,
+                                winrt::Microsoft::Terminal::Core::Color color) noexcept
+        {
+            _ColorTable.at(index) = color;
+        }
     };
 }

--- a/src/cascadia/UnitTests_TerminalCore/MockTermSettings.h
+++ b/src/cascadia/UnitTests_TerminalCore/MockTermSettings.h
@@ -4,6 +4,7 @@
 #include <WexTestClass.h>
 
 #include "DefaultSettings.h"
+#include "../../inc/ControlProperties.h"
 
 #include <winrt/Microsoft.Terminal.Core.h>
 
@@ -13,75 +14,30 @@ namespace TerminalCoreUnitTests
 {
     class MockTermSettings : public winrt::implements<MockTermSettings, ICoreSettings, ICoreAppearance>
     {
+        // Color Table is special because it's an array
+        std::array<winrt::Microsoft::Terminal::Core::Color, COLOR_TABLE_SIZE> _ColorTable;
+
+#define SETTINGS_GEN(type, name, ...) WINRT_PROPERTY(type, name, __VA_ARGS__);
+        CORE_SETTINGS(SETTINGS_GEN)
+        CORE_APPEARANCE_SETTINGS(SETTINGS_GEN)
+#undef SETTINGS_GEN
+
     public:
         MockTermSettings(int32_t historySize, int32_t initialRows, int32_t initialCols) :
-            _historySize(historySize),
-            _initialRows(initialRows),
-            _initialCols(initialCols)
+            _HistorySize(historySize),
+            _InitialRows(initialRows),
+            _InitialCols(initialCols)
         {
         }
 
-        // property getters - all implemented
-        int32_t HistorySize() { return _historySize; }
-        int32_t InitialRows() { return _initialRows; }
-        int32_t InitialCols() { return _initialCols; }
-        til::color DefaultForeground() { return COLOR_WHITE; }
-        til::color DefaultBackground() { return COLOR_BLACK; }
-        bool SnapOnInput() { return false; }
-        bool AltGrAliasing() { return true; }
-        til::color CursorColor() { return COLOR_WHITE; }
-        CursorStyle CursorShape() const noexcept { return CursorStyle::Vintage; }
-        uint32_t CursorHeight() { return 42UL; }
-        winrt::hstring WordDelimiters() { return winrt::hstring(DEFAULT_WORD_DELIMITERS); }
-        bool CopyOnSelect() { return _copyOnSelect; }
-        bool FocusFollowMouse() { return _focusFollowMouse; }
-        winrt::hstring StartingTitle() { return _startingTitle; }
-        bool SuppressApplicationTitle() { return _suppressApplicationTitle; }
-        til::color SelectionBackground() { return COLOR_WHITE; }
-        bool ForceVTInput() { return false; }
-        ICoreAppearance UnfocusedAppearance() { return {}; };
-        winrt::Windows::Foundation::IReference<winrt::Microsoft::Terminal::Core::Color> TabColor() { return nullptr; }
-        winrt::Windows::Foundation::IReference<winrt::Microsoft::Terminal::Core::Color> StartingTabColor() { return nullptr; }
-        bool TrimBlockSelection() { return false; }
-        bool DetectURLs() { return true; }
-
-        // other implemented methods
-        til::color GetColorTableEntry(int32_t) const { return 123; }
-
-        // property setters - all unimplemented
-        void HistorySize(int32_t) {}
-        void InitialRows(int32_t) {}
-        void InitialCols(int32_t) {}
-        void DefaultForeground(til::color) {}
-        void DefaultBackground(til::color) {}
-        void SnapOnInput(bool) {}
-        void AltGrAliasing(bool) {}
-        void CursorColor(til::color) {}
-        void CursorShape(CursorStyle const&) noexcept {}
-        void CursorHeight(uint32_t) {}
-        void WordDelimiters(winrt::hstring) {}
-        void CopyOnSelect(bool copyOnSelect) { _copyOnSelect = copyOnSelect; }
-        void FocusFollowMouse(bool focusFollowMouse) { _focusFollowMouse = focusFollowMouse; }
-        void StartingTitle(winrt::hstring const& value) { _startingTitle = value; }
-        void SuppressApplicationTitle(bool suppressApplicationTitle) { _suppressApplicationTitle = suppressApplicationTitle; }
-        void SelectionBackground(til::color) {}
-        void ForceVTInput(bool) {}
-        void UnfocusedAppearance(ICoreAppearance) {}
-        void TabColor(const IInspectable&) {}
-        void StartingTabColor(const IInspectable&) {}
-        void TrimBlockSelection(bool) {}
-        void DetectURLs(bool) {}
-
-        WINRT_PROPERTY(bool, IntenseIsBright, true);
-        WINRT_PROPERTY(bool, AdjustIndistinguishableColors, true);
-
-    private:
-        int32_t _historySize;
-        int32_t _initialRows;
-        int32_t _initialCols;
-        bool _copyOnSelect{ false };
-        bool _focusFollowMouse{ false };
-        bool _suppressApplicationTitle{ false };
-        winrt::hstring _startingTitle;
+        winrt::Microsoft::Terminal::Core::Color GetColorTableEntry(int32_t index) noexcept
+        {
+            return _ColorTable.at(index);
+        }
+        void SetColorTableEntry(int32_t index,
+                                winrt::Microsoft::Terminal::Core::Color color) noexcept
+        {
+            _ColorTable.at(index) = color;
+        }
     };
 }

--- a/src/cascadia/inc/ControlProperties.h
+++ b/src/cascadia/inc/ControlProperties.h
@@ -42,6 +42,9 @@
     X(winrt::Windows::Foundation::IReference<winrt::Microsoft::Terminal::Core::Color>, TabColor, nullptr)         \
     X(winrt::Windows::Foundation::IReference<winrt::Microsoft::Terminal::Core::Color>, StartingTabColor, nullptr) \
     X(bool, TrimBlockSelection, false)                                                                            \
+    X(bool, SuppressApplicationTitle)                                                                             \
+    X(bool, ForceVTInput, false)                                                                                  \
+    X(winrt::hstring, StartingTitle)                                                                              \
     X(bool, DetectURLs, true)
 
 // --------------------------- Control Settings ---------------------------
@@ -59,12 +62,9 @@
     X(winrt::Microsoft::Terminal::Control::IKeyBindings, KeyBindings, nullptr)                                                                           \
     X(winrt::hstring, Commandline)                                                                                                                       \
     X(winrt::hstring, StartingDirectory)                                                                                                                 \
-    X(winrt::hstring, StartingTitle)                                                                                                                     \
-    X(bool, SuppressApplicationTitle)                                                                                                                    \
     X(winrt::hstring, EnvironmentVariables)                                                                                                              \
     X(winrt::Microsoft::Terminal::Control::ScrollbarState, ScrollState, winrt::Microsoft::Terminal::Control::ScrollbarState::Visible)                    \
     X(winrt::Microsoft::Terminal::Control::TextAntialiasingMode, AntialiasingMode, winrt::Microsoft::Terminal::Control::TextAntialiasingMode::Grayscale) \
     X(bool, ForceFullRepaintRendering, false)                                                                                                            \
     X(bool, SoftwareRendering, false)                                                                                                                    \
-    X(bool, ForceVTInput, false)                                                                                                                         \
     X(bool, UseAtlasEngine, false)


### PR DESCRIPTION
When I added these macros in #11619, the real purpose was to make sure we don't forget to add new settings to these test mocks as well. However, I totally forgot to convert those. I guess that happens with a 1300 line diff ¯\\\_(ツ)_/¯

* [x] Is a codehealth thing
* [x] I work here
* [x] tests still pass