### PR TITLE
Remove unused `Feature_ShowProfileDefaultsInSettings`

### DIFF
--- a/src/cascadia/LocalTests_SettingsModel/TerminalSettingsTests.cpp
+++ b/src/cascadia/LocalTests_SettingsModel/TerminalSettingsTests.cpp
@@ -359,17 +359,9 @@ namespace SettingsModelLocalTests
             const auto profile{ settings->GetProfileForArgs(realArgs.TerminalArgs()) };
             const auto settingsStruct{ TerminalSettings::CreateWithNewTerminalArgs(*settings, realArgs.TerminalArgs(), nullptr) };
             const auto termSettings = settingsStruct.DefaultSettings();
-            if constexpr (Feature_ShowProfileDefaultsInSettings::IsEnabled())
-            {
-                // This action specified a command but no profile; it gets reassigned to the base profile
-                VERIFY_ARE_EQUAL(settings->ProfileDefaults(), profile);
-                VERIFY_ARE_EQUAL(29, termSettings.HistorySize());
-            }
-            else
-            {
-                VERIFY_ARE_EQUAL(guid0, profile.Guid());
-                VERIFY_ARE_EQUAL(1, termSettings.HistorySize());
-            }
+            // This action specified a command but no profile; it gets reassigned to the base profile
+            VERIFY_ARE_EQUAL(settings->ProfileDefaults(), profile);
+            VERIFY_ARE_EQUAL(29, termSettings.HistorySize());
             VERIFY_ARE_EQUAL(L"foo.exe", termSettings.Commandline());
         }
         {

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -470,8 +470,4 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _Navigate(newSelectedItem.try_as<MUX::Controls::NavigationViewItem>().Tag().try_as<Editor::ProfileViewModel>());
     }
 
-    bool MainPage::ShowBaseLayerMenuItem() const noexcept
-    {
-        return Feature_ShowProfileDefaultsInSettings::IsEnabled();
-    }
 }

--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -26,8 +26,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         bool TryPropagateHostingWindow(IInspectable object) noexcept;
         uint64_t GetHostingWindow() const noexcept;
 
-        bool ShowBaseLayerMenuItem() const noexcept;
-
         TYPED_EVENT(OpenJson, Windows::Foundation::IInspectable, Model::SettingsTarget);
 
     private:

--- a/src/cascadia/TerminalSettingsEditor/MainPage.idl
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.idl
@@ -23,7 +23,5 @@ namespace Microsoft.Terminal.Settings.Editor
         // Due to the aforementioned bug, we can't use IInitializeWithWindow _here_ either.
         // Let's just smuggle the HWND in as a UInt64 :|
         void SetHostingWindow(UInt64 window);
-
-        Boolean ShowBaseLayerMenuItem { get; };
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -91,8 +91,7 @@
 
             <muxc:NavigationViewItem x:Name="BaseLayerMenuItem"
                                      x:Uid="Nav_ProfileDefaults"
-                                     Tag="GlobalProfile_Nav"
-                                     Visibility="{x:Bind ShowBaseLayerMenuItem}">
+                                     Tag="GlobalProfile_Nav">
                 <muxc:NavigationViewItem.Icon>
                     <FontIcon Glyph="&#xE81E;" />
                 </muxc:NavigationViewItem.Icon>

--- a/src/cascadia/TerminalSettingsEditor/SettingContainer.cpp
+++ b/src/cascadia/TerminalSettingsEditor/SettingContainer.cpp
@@ -192,25 +192,12 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             originTag = profile.Origin();
         }
 
-        if constexpr (Feature_ShowProfileDefaultsInSettings::IsEnabled())
+        // We will display arrows for all origins, and informative tooltips for Fragments and Generated
+        if (originTag == Model::OriginTag::Fragment || originTag == Model::OriginTag::Generated)
         {
-            // EXPERIMENTAL FEATURE
-            // We will display arrows for all origins, and informative tooltips for Fragments and Generated
-            if (originTag == Model::OriginTag::Fragment || originTag == Model::OriginTag::Generated)
-            {
-                // from a fragment extension or generated profile
-                return hstring{ fmt::format(std::wstring_view{ RS_(L"SettingContainer_OverrideMessageFragmentExtension") }, source) };
-            }
-            return RS_(L"SettingContainer_OverrideMessageBaseLayer");
-        }
-
-        // STABLE FEATURE
-        // We will only display arrows and informative tooltips for Fragments
-        if (originTag == Model::OriginTag::Fragment)
-        {
-            // from a fragment extension
+            // from a fragment extension or generated profile
             return hstring{ fmt::format(std::wstring_view{ RS_(L"SettingContainer_OverrideMessageFragmentExtension") }, source) };
         }
-        return {}; // no tooltip
+        return RS_(L"SettingContainer_OverrideMessageBaseLayer");
     }
 }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -569,24 +569,16 @@ Model::Profile CascadiaSettings::GetProfileForArgs(const Model::NewTerminalArgs&
         }
     }
 
-    if constexpr (Feature_ShowProfileDefaultsInSettings::IsEnabled())
-    {
-        // If the user has access to the "Defaults" profile, and no profile was otherwise specified,
-        // what we do is dependent on whether there was a commandline.
-        // If there was a commandline (case 1), we we'll launch in the "Defaults" profile.
-        // If there wasn't a commandline or there wasn't a NewTerminalArgs (case 2), we'll
-        //   launch in the user's actual default profile.
-        // Case 2 above could be the result of a "nt" or "sp" invocation that doesn't specify anything.
-        // TODO GH#10952: Detect the profile based on the commandline (add matching support)
-        return (!newTerminalArgs || newTerminalArgs.Commandline().empty()) ?
-                   FindProfile(GlobalSettings().DefaultProfile()) :
-                   ProfileDefaults();
-    }
-    else
-    {
-        // For compatibility with the stable version's behavior, return the default by GUID in all other cases.
-        return FindProfile(GlobalSettings().DefaultProfile());
-    }
+    // If the user has access to the "Defaults" profile, and no profile was otherwise specified,
+    // what we do is dependent on whether there was a commandline.
+    // If there was a commandline (case 1), we we'll launch in the "Defaults" profile.
+    // If there wasn't a commandline or there wasn't a NewTerminalArgs (case 2), we'll
+    //   launch in the user's actual default profile.
+    // Case 2 above could be the result of a "nt" or "sp" invocation that doesn't specify anything.
+    // TODO GH#10952: Detect the profile based on the commandline (add matching support)
+    return (!newTerminalArgs || newTerminalArgs.Commandline().empty()) ?
+               FindProfile(GlobalSettings().DefaultProfile()) :
+               ProfileDefaults();
 }
 
 // The method does some crude command line matching for our console hand-off support.

--- a/src/features.xml
+++ b/src/features.xml
@@ -65,13 +65,6 @@
     </feature>
 
     <feature>
-        <name>Feature_ShowProfileDefaultsInSettings</name>
-        <description>Whether to show the "defaults" page in the Terminal settings UI</description>
-        <id>10430</id>
-        <stage>AlwaysEnabled</stage>
-    </feature>
-
-    <feature>
         <name>Feature_PersistedWindowLayout</name>
         <description>Whether to allow the user to enable persisted window layout saving and loading</description>
         <id>766</id>


### PR DESCRIPTION
Title says it all. This is on by default, and we've committed to keeping it around. Having a velocity flag for it is redundant now.

* [x] Closes #11454
* [x] I work here
