### PR TITLE
Manually replace unqualified cmd, powershell paths for the default profiles

### DIFF
--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -403,6 +403,7 @@ winrt::com_ptr<Profile> CascadiaSettings::_createNewProfile(const std::wstring_v
 // - <none>
 void CascadiaSettings::_validateSettings()
 {
+    _validateCorrectDefaultShellPaths();
     _validateAllSchemesExist();
     _validateMediaResources();
     _validateKeybindings();

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -155,6 +155,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         void _validateMediaResources();
         void _validateKeybindings() const;
         void _validateColorSchemesInCommands() const;
+        void _validateCorrectDefaultShellPaths() const;
         bool _hasInvalidColorScheme(const Model::Command& command) const;
 
         // user settings

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -988,7 +988,7 @@ void CascadiaSettings::_validateCorrectDefaultShellPaths() const
             profile.Commandline(L"%SystemRoot%\\System32\\cmd.exe");
         }
         else if (profile.Guid() == DEFAULT_WINDOWS_POWERSHELL_GUID &&
-                 profile.Commandline() == L"cmd.exe")
+                 profile.Commandline() == L"powershell.exe")
         {
             profile.Commandline(L"%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe");
         }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -985,12 +985,12 @@ void CascadiaSettings::_validateCorrectDefaultShellPaths() const
         if (profile.Guid() == DEFAULT_COMMAND_PROMPT_GUID &&
             profile.Commandline() == L"cmd.exe")
         {
-            profile.Commandline(L"%SystemRoot%\\System32\\cmd.exe");
+            profile.ClearCommandline();
         }
         else if (profile.Guid() == DEFAULT_WINDOWS_POWERSHELL_GUID &&
                  profile.Commandline() == L"powershell.exe")
         {
-            profile.Commandline(L"%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe");
+            profile.ClearCommandline();
         }
     }
 }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -977,3 +977,20 @@ void CascadiaSettings::_resolveDefaultProfile() const
     // Use the first profile as the new default.
     GlobalSettings().DefaultProfile(_allProfiles.GetAt(0).Guid());
 }
+
+void CascadiaSettings::_validateCorrectDefaultShellPaths() const
+{
+    for (auto profile : _allProfiles)
+    {
+        if (profile.Guid() == DEFAULT_COMMAND_PROMPT_GUID &&
+            profile.Commandline() == L"cmd.exe")
+        {
+            profile.Commandline(L"%SystemRoot%\\System32\\cmd.exe");
+        }
+        else if (profile.Guid() == DEFAULT_WINDOWS_POWERSHELL_GUID &&
+                 profile.Commandline() == L"cmd.exe")
+        {
+            profile.Commandline(L"%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe");
+        }
+    }
+}


### PR DESCRIPTION
In previous releases, we had the commandlines for the Command Prompt and PowerShell profiles unqualified, as `cmd.exe` and `powershell.exe`. This was bad - theoretically, that would have preferred the cmd that was in the CWD over the one in System32. Or, something could insert itself into the path, and you'd end up with a malicious `cmd.exe` before the real one.

In #11437, we made sure that the `userDefaults` are initiated with the fully qualified paths. However, that didn't fix the issue for folks who already had settings files.

In an effort to better prevent this kind of badness, if we see a profile _with a default profile guid_, AND the unqualified version of the path, then we'll stealth replace it with the fully qualified one.

* Related to #11437
* [x] fixes #12126
* [x] Tests added  