### PR TITLE
ci: move helix queueing to a separate stage as well

### DIFF
--- a/build/pipelines/ci.yml
+++ b/build/pipelines/ci.yml
@@ -38,6 +38,7 @@ stages:
       - template: ./templates/build-console-audit-job.yml
         parameters:
           platform: x64
+
   - stage: Build_x64
     displayName: Build x64
     dependsOn: []
@@ -61,6 +62,7 @@ stages:
       - template: ./templates/build-console-ci.yml
         parameters:
           platform: ARM64
+
   - stage: Test_x64
     displayName: Test x64
     dependsOn: [Build_x64]
@@ -76,6 +78,16 @@ stages:
       - template: ./templates/test-console-ci.yml
         parameters:
           platform: x86
+
+  - stage: Helix_x64
+    displayName: Helix x64
+    dependsOn: [Build_x64]
+    condition: and(succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
+    jobs:
+      - template: ./templates/console-helix-ci-job.yml
+        parameters:
+          platform: x64
+
   - stage: Scripts
     displayName: Code Health Scripts
     dependsOn: []

--- a/build/pipelines/ci.yml
+++ b/build/pipelines/ci.yml
@@ -84,7 +84,7 @@ stages:
     dependsOn: [Build_x64]
     condition: and(succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
     jobs:
-      - template: ./templates/console-helix-ci-job.yml
+      - template: ./templates/console-ci-helix-job.yml
         parameters:
           platform: x64
 

--- a/build/pipelines/templates/build-console-ci.yml
+++ b/build/pipelines/templates/build-console-ci.yml
@@ -2,8 +2,6 @@ parameters:
   configuration: 'Release'
   platform: ''
   additionalBuildArguments: ''
-  minimumExpectedTestsExecutedCount: 10  # Sanity check for minimum expected tests to be reported
-  rerunPassesRequiredToAvoidFailure: 5
 
 jobs:
 - job: Build${{ parameters.platform }}${{ parameters.configuration }}
@@ -28,21 +26,3 @@ jobs:
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
     condition: and(succeededOrFailed(), not(eq(variables['Build.Reason'], 'PullRequest')))
-
-- template: helix-runtests-job.yml
-  parameters:
-    name: 'RunTestsInHelix'
-    dependsOn: Build${{ parameters.platform }}${{ parameters.configuration }}
-    condition: and(succeeded(), and(eq('${{ parameters.platform }}', 'x64'), not(eq(variables['Build.Reason'], 'PullRequest')))) 
-    testSuite: 'DevTestSuite'
-    platform: ${{ parameters.platform }}
-    configuration: ${{ parameters.configuration }}
-    rerunPassesRequiredToAvoidFailure: ${{ parameters.rerunPassesRequiredToAvoidFailure }}
-    
-- template: helix-processtestresults-job.yml
-  parameters:
-    dependsOn:
-    - RunTestsInHelix
-    condition: and(succeededOrFailed(), and(eq('${{ parameters.platform }}', 'x64'), not(eq(variables['Build.Reason'], 'PullRequest')))) 
-    rerunPassesRequiredToAvoidFailure: ${{ parameters.rerunPassesRequiredToAvoidFailure }}
-    minimumExpectedTestsExecutedCount: ${{ parameters.minimumExpectedTestsExecutedCount }}

--- a/build/pipelines/templates/console-ci-helix-job.yml
+++ b/build/pipelines/templates/console-ci-helix-job.yml
@@ -1,0 +1,25 @@
+parameters:
+  configuration: 'Release'
+  platform: ''
+  minimumExpectedTestsExecutedCount: 10  # Sanity check for minimum expected tests to be reported
+  rerunPassesRequiredToAvoidFailure: 5
+
+jobs:
+- template: helix-runtests-job.yml
+  parameters:
+    name: 'RunTestsInHelix'
+    # We're not setting dependsOn as we want to rely on the "stage" dependency above us
+    testSuite: 'DevTestSuite'
+    platform: ${{ parameters.platform }}
+    configuration: ${{ parameters.configuration }}
+    rerunPassesRequiredToAvoidFailure: ${{ parameters.rerunPassesRequiredToAvoidFailure }}
+    
+- template: helix-processtestresults-job.yml
+  parameters:
+    dependsOn:
+    - RunTestsInHelix
+    # the default condition is succeededOrFailed(), and the "stage" condition ensures we only run as needed
+    platform: ${{ parameters.platform }}
+    configuration: ${{ parameters.configuration }}
+    rerunPassesRequiredToAvoidFailure: ${{ parameters.rerunPassesRequiredToAvoidFailure }}
+    minimumExpectedTestsExecutedCount: ${{ parameters.minimumExpectedTestsExecutedCount }}

--- a/build/pipelines/templates/helix-processtestresults-job.yml
+++ b/build/pipelines/templates/helix-processtestresults-job.yml
@@ -8,6 +8,7 @@ parameters:
 
 jobs:
 - job: ProcessTestResults
+  displayName: Process Helix Results ${{ parameters.configuration }} ${{ parameters.platform }}
   condition: ${{ parameters.condition }}
   dependsOn: ${{ parameters.dependsOn }}
   pool:

--- a/build/pipelines/templates/helix-processtestresults-job.yml
+++ b/build/pipelines/templates/helix-processtestresults-job.yml
@@ -8,7 +8,7 @@ parameters:
 
 jobs:
 - job: ProcessTestResults
-  displayName: Process Helix Results ${{ parameters.configuration }} ${{ parameters.platform }}
+  displayName: Process Helix Results ${{ parameters.platform }} ${{ parameters.configuration }}
   condition: ${{ parameters.condition }}
   dependsOn: ${{ parameters.dependsOn }}
   pool:

--- a/build/pipelines/templates/helix-runtests-job.yml
+++ b/build/pipelines/templates/helix-runtests-job.yml
@@ -19,6 +19,7 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
+  displayName: Submit Helix ${{ parameters.configuration }} ${{ parameters.platform }}
   dependsOn: ${{ parameters.dependsOn }}
   condition: ${{ parameters.condition }}
   pool:

--- a/build/pipelines/templates/helix-runtests-job.yml
+++ b/build/pipelines/templates/helix-runtests-job.yml
@@ -19,7 +19,7 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
-  displayName: Submit Helix ${{ parameters.configuration }} ${{ parameters.platform }}
+  displayName: Submit Helix ${{ parameters.platform }} ${{ parameters.configuration }}
   dependsOn: ${{ parameters.dependsOn }}
   condition: ${{ parameters.condition }}
   pool:

--- a/build/pipelines/templates/test-console-ci.yml
+++ b/build/pipelines/templates/test-console-ci.yml
@@ -2,8 +2,6 @@ parameters:
   configuration: 'Release'
   platform: ''
   additionalBuildArguments: ''
-  minimumExpectedTestsExecutedCount: 10  # Sanity check for minimum expected tests to be reported
-  rerunPassesRequiredToAvoidFailure: 5
   artifactName: 'drop'
   testLogPath: '$(Build.BinariesDirectory)\$(BuildPlatform)\$(BuildConfiguration)\testsOnBuildMachine.wtl'
 


### PR DESCRIPTION
This pull request moves the Helix queuing to a separate stage outside of the build stage.