### PR TITLE
Prevent potential null pointer crash in export buffer action

### DIFF
--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -923,7 +923,10 @@ namespace winrt::TerminalApp::implementation
 
             // If we didn't have args, or the args weren't ExportBufferArgs (somehow)
             _ExportTab(*activeTab, L"");
-            args.Handled(true);
+            if (args)
+            {
+                args.Handled(true);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary of the Pull Request
Prevents a potential null pointer crash in the export buffer action.

## PR Checklist
* [x] Closes #12170
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed
Manually tested.