### PR TITLE
Fix unbalanced unlock in PtySignalInputThread::_Shutdown

### DIFF
--- a/src/host/PtySignalInputThread.cpp
+++ b/src/host/PtySignalInputThread.cpp
@@ -225,6 +225,15 @@ void PtySignalInputThread::_Shutdown()
     // Trigger process shutdown.
     CloseConsoleProcessState();
 
+    // If we haven't terminated by now, that's because there's a client that's still attached.
+    // Force the handling of the control events by the attached clients.
+    // As of MSFT:19419231, CloseConsoleProcessState will make sure this
+    //      happens if this method is called outside of lock, but if we're
+    //      currently locked, we want to make sure ctrl events are handled
+    //      _before_ we RundownAndExit.
+    LockConsole();
+    ProcessCtrlEvents();
+
     // Make sure we terminate.
     ServiceLocator::RundownAndExit(ERROR_BROKEN_PIPE);
 }

--- a/src/host/PtySignalInputThread.cpp
+++ b/src/host/PtySignalInputThread.cpp
@@ -170,7 +170,6 @@ bool PtySignalInputThread::_GetData(_Out_writes_bytes_(cbBuffer) void* const pBu
         if (lastError == ERROR_BROKEN_PIPE)
         {
             _Shutdown();
-            return false;
         }
         else
         {
@@ -180,7 +179,6 @@ bool PtySignalInputThread::_GetData(_Out_writes_bytes_(cbBuffer) void* const pBu
     else if (dwRead != cbBuffer)
     {
         _Shutdown();
-        return false;
     }
 
     return true;

--- a/src/host/PtySignalInputThread.cpp
+++ b/src/host/PtySignalInputThread.cpp
@@ -227,14 +227,6 @@ void PtySignalInputThread::_Shutdown()
     // Trigger process shutdown.
     CloseConsoleProcessState();
 
-    // If we haven't terminated by now, that's because there's a client that's still attached.
-    // Force the handling of the control events by the attached clients.
-    // As of MSFT:19419231, CloseConsoleProcessState will make sure this
-    //      happens if this method is called outside of lock, but if we're
-    //      currently locked, we want to make sure ctrl events are handled
-    //      _before_ we RundownAndExit.
-    ProcessCtrlEvents();
-
     // Make sure we terminate.
     ServiceLocator::RundownAndExit(ERROR_BROKEN_PIPE);
 }

--- a/src/host/VtIo.cpp
+++ b/src/host/VtIo.cpp
@@ -10,6 +10,7 @@
 
 #include "../renderer/base/renderer.hpp"
 #include "../types/inc/utils.hpp"
+#include "handle.h" // LockConsole
 #include "input.h" // ProcessCtrlEvents
 #include "output.h" // CloseConsoleProcessState
 

--- a/src/host/VtIo.cpp
+++ b/src/host/VtIo.cpp
@@ -377,14 +377,6 @@ void VtIo::_ShutdownIfNeeded()
         // if we don't, this will cause us to rundown and exit.
         CloseConsoleProcessState();
 
-        // If we haven't terminated by now, that's because there's a client that's still attached.
-        // Force the handling of the control events by the attached clients.
-        // As of MSFT:19419231, CloseConsoleProcessState will make sure this
-        //      happens if this method is called outside of lock, but if we're
-        //      currently locked, we want to make sure ctrl events are handled
-        //      _before_ we RundownAndExit.
-        ProcessCtrlEvents();
-
         // Make sure we terminate.
         ServiceLocator::RundownAndExit(ERROR_BROKEN_PIPE);
     }

--- a/src/host/VtIo.cpp
+++ b/src/host/VtIo.cpp
@@ -377,6 +377,15 @@ void VtIo::_ShutdownIfNeeded()
         // if we don't, this will cause us to rundown and exit.
         CloseConsoleProcessState();
 
+        // If we haven't terminated by now, that's because there's a client that's still attached.
+        // Force the handling of the control events by the attached clients.
+        // As of MSFT:19419231, CloseConsoleProcessState will make sure this
+        //      happens if this method is called outside of lock, but if we're
+        //      currently locked, we want to make sure ctrl events are handled
+        //      _before_ we RundownAndExit.
+        LockConsole();
+        ProcessCtrlEvents();
+
         // Make sure we terminate.
         ServiceLocator::RundownAndExit(ERROR_BROKEN_PIPE);
     }

--- a/src/host/output.cpp
+++ b/src/host/output.cpp
@@ -512,9 +512,13 @@ void CloseConsoleProcessState()
 
     HandleCtrlEvent(CTRL_CLOSE_EVENT);
 
-    // MSFT:19419231
-    // Ensure ctrl events are processed before exiting,
-    // no matter whether the console is locked or not.
+    // Jiggle the handle: (see MSFT:19419231)
+    // When we call this function, we'll only actually close the console once
+    //      we're totally unlocked. If our caller has the console locked, great,
+    //      we'll dispatch the ctrl event once they unlock. However, if they're
+    //      not running under lock (eg PtySignalInputThread::_GetData), then the
+    //      ctrl event will never actually get dispatched.
+    // So, lock and unlock here, to make sure the ctrl event gets handled.
     LockConsole();
-    ProcessCtrlEvents();
+    UnlockConsole();
 }

--- a/src/host/output.cpp
+++ b/src/host/output.cpp
@@ -512,13 +512,9 @@ void CloseConsoleProcessState()
 
     HandleCtrlEvent(CTRL_CLOSE_EVENT);
 
-    // Jiggle the handle: (see MSFT:19419231)
-    // When we call this function, we'll only actually close the console once
-    //      we're totally unlocked. If our caller has the console locked, great,
-    //      we'll dispatch the ctrl event once they unlock. However, if they're
-    //      not running under lock (eg PtySignalInputThread::_GetData), then the
-    //      ctrl event will never actually get dispatched.
-    // So, lock and unlock here, to make sure the ctrl event gets handled.
+    // MSFT:19419231
+    // Ensure ctrl events are processed before exiting,
+    // no matter whether the console is locked or not.
     LockConsole();
-    auto Unlock = wil::scope_exit([&] { UnlockConsole(); });
+    ProcessCtrlEvents();
 }

--- a/src/interactivity/base/HostSignalInputThread.cpp
+++ b/src/interactivity/base/HostSignalInputThread.cpp
@@ -163,7 +163,6 @@ bool HostSignalInputThread::_GetData(gsl::span<gsl::byte> buffer)
         if (lastError == ERROR_BROKEN_PIPE)
         {
             _Shutdown();
-            return false;
         }
 
         THROW_WIN32(lastError);
@@ -172,7 +171,6 @@ bool HostSignalInputThread::_GetData(gsl::span<gsl::byte> buffer)
     if (bytesRead != buffer.size())
     {
         _Shutdown();
-        return false;
     }
 
     return true;

--- a/src/interactivity/base/ServiceLocator.cpp
+++ b/src/interactivity/base/ServiceLocator.cpp
@@ -34,7 +34,7 @@ wil::unique_hwnd ServiceLocator::s_pseudoWindow = nullptr;
 
 #pragma region Public Methods
 
-void ServiceLocator::RundownAndExit(const HRESULT hr)
+[[noreturn]] void ServiceLocator::RundownAndExit(const HRESULT hr)
 {
     // MSFT:15506250
     // In VT I/O Mode, a client application might die before we've rendered
@@ -67,7 +67,7 @@ void ServiceLocator::RundownAndExit(const HRESULT hr)
         s_inputServices.reset(nullptr);
     }
 
-    TerminateProcess(GetCurrentProcess(), hr);
+    ExitProcess(hr);
 }
 
 #pragma region Creation Methods

--- a/src/interactivity/inc/ServiceLocator.hpp
+++ b/src/interactivity/inc/ServiceLocator.hpp
@@ -30,7 +30,7 @@ namespace Microsoft::Console::Interactivity
     class ServiceLocator final
     {
     public:
-        static void RundownAndExit(const HRESULT hr);
+        [[noreturn]] static void RundownAndExit(const HRESULT hr);
 
         // N.B.: Location methods without corresponding creation methods
         //       automatically create the singleton object on demand.


### PR DESCRIPTION
The only way to notice that LeaveCriticalSection() was called more
often than EnterCriticalSection() is by calling EnterCriticalSection()
again in the future, which will then deadlock.
Since this bug occurs on exit it wasn't noticeable with the old console lock.
With the new, stricter ticket lock this bug causes a fail-fast exit.

## PR Checklist
* [x] Closes #12168
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed
* Launch and then exit Windows Terminal
* OpenConsole cleanly exits ✅