### PR TITLE
Don't open a hole in the terminal window when pasting

### DIFF
--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -21,7 +21,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <!--  Include the MUX Controls resources  -->
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls"
-                                       ControlsResourcesVersion="Version1" />
+                                       ControlsResourcesVersion="Version2" />
                 <ResourceDictionary>
 
                     <!--

--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -21,7 +21,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <!--  Include the MUX Controls resources  -->
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls"
-                                       ControlsResourcesVersion="Version2" />
+                                       ControlsResourcesVersion="Version1" />
                 <ResourceDictionary>
 
                     <!--

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1991,6 +1991,11 @@ namespace winrt::TerminalApp::implementation
                     const auto focusedTab = _GetFocusedTabImpl();
                     // Do not warn about multi line pasting if the current tab has bracketed paste enabled.
                     warnMultiLine = warnMultiLine && !focusedTab->GetActiveTerminalControl().BracketedPasteEnabled();
+                    if (!warnLargeText && !warnMultiLine)
+                    {
+                        eventArgs.HandleClipboardData(text);
+                        co_return;
+                    }
                 }
 
                 // We have to initialize the dialog here to be able to change the text of the text block within it

--- a/src/cascadia/TerminalControl/ControlInteractivity.cpp
+++ b/src/cascadia/TerminalControl/ControlInteractivity.cpp
@@ -174,7 +174,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // clipboardDataHandler. This is called when the clipboard data is
         // loaded.
         auto clipboardDataHandler = std::bind(&ControlInteractivity::_sendPastedTextToConnection, this, std::placeholders::_1);
-        auto pasteArgs = winrt::make_self<PasteFromClipboardEventArgs>(clipboardDataHandler);
+        auto pasteArgs = winrt::make_self<PasteFromClipboardEventArgs>(clipboardDataHandler, _core->BracketedPasteEnabled());
 
         // send paste event up to TermApp
         _PasteFromClipboardHandlers(*this, *pasteArgs);

--- a/src/cascadia/TerminalControl/EventArgs.h
+++ b/src/cascadia/TerminalControl/EventArgs.h
@@ -53,13 +53,16 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     struct PasteFromClipboardEventArgs : public PasteFromClipboardEventArgsT<PasteFromClipboardEventArgs>
     {
     public:
-        PasteFromClipboardEventArgs(std::function<void(std::wstring_view)> clipboardDataHandler) :
-            m_clipboardDataHandler(clipboardDataHandler) {}
+        PasteFromClipboardEventArgs(std::function<void(std::wstring_view)> clipboardDataHandler, bool bracketedPasteEnabled) :
+            m_clipboardDataHandler(clipboardDataHandler),
+            _BracketedPasteEnabled{ bracketedPasteEnabled } {}
 
         void HandleClipboardData(hstring value)
         {
             m_clipboardDataHandler(value);
         };
+
+        WINRT_PROPERTY(bool, BracketedPasteEnabled, false);
 
     private:
         std::function<void(std::wstring_view)> m_clipboardDataHandler;

--- a/src/cascadia/TerminalControl/EventArgs.idl
+++ b/src/cascadia/TerminalControl/EventArgs.idl
@@ -30,6 +30,7 @@ namespace Microsoft.Terminal.Control
     runtimeclass PasteFromClipboardEventArgs
     {
         void HandleClipboardData(String data);
+        Boolean BracketedPasteEnabled { get; };
     }
 
     runtimeclass OpenHyperlinkEventArgs


### PR DESCRIPTION
Turns out, this bug only repros in Controls version 2. I'm not sure why, but it didn't repro only on main. So this fix does nothing until #11720 merges.

This PR prevents us from setting properties on the paste warning dialog unless we actually need to paste. 5f9c551b7edced4ed72a4b9694998143f96589a3 proves that settings these properties is what would cause the bug in the first place. 

I went a step further and cleaned this up a bit. This was always a little weird, having to get the `BracketedPasteEnabled` for the active control on the UI thread before we actually display the warning. In the post-#5000 future where going back to the control like this would be a x-proc hop, I figured I should just skip that entirely and plumb the `BracketedPaste` state out in the initial request. 

* [x] Closes #12202
* [x] I work here
* [x] No tests, but there's not a great place for a test like this
* [x] Doesn't affect docs

See also: #12241 which would introduce #12202 on its own.