### PR TITLE
Add support for ctrl+click on the dropdown to launch elevated

### DIFF
--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -709,7 +709,6 @@ namespace winrt::TerminalApp::implementation
     //   This might cause a UAC prompt. The elevation is performed on a
     //   background thread, as to not block the UI thread.
     // Arguments:
-    // - elevate: If true, launch the new Terminal elevated using `runas`
     // - newTerminalArgs: A NewTerminalArgs describing the terminal instance
     //   that should be spawned. The Profile should be filled in with the GUID
     //   of the profile we want to launch.
@@ -717,8 +716,7 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     // Important: Don't take the param by reference, since we'll be doing work
     // on another thread.
-    fire_and_forget TerminalPage::_OpenNewWindow(const bool elevate,
-                                                 const NewTerminalArgs newTerminalArgs)
+    fire_and_forget TerminalPage::_OpenNewWindow(const NewTerminalArgs newTerminalArgs)
     {
         // Hop to the BG thread
         co_await winrt::resume_background();
@@ -745,9 +743,8 @@ namespace winrt::TerminalApp::implementation
         SHELLEXECUTEINFOW seInfo{ 0 };
         seInfo.cbSize = sizeof(seInfo);
         seInfo.fMask = SEE_MASK_NOASYNC;
-        // `runas` will cause the shell to launch this child process elevated.
         // `open` will just run the executable normally.
-        seInfo.lpVerb = elevate ? L"runas" : L"open";
+        seInfo.lpVerb = L"open";
         seInfo.lpFile = exePath.c_str();
         seInfo.lpParameters = cmdline.c_str();
         seInfo.nShow = SW_SHOWNORMAL;
@@ -781,7 +778,7 @@ namespace winrt::TerminalApp::implementation
 
         // Manually fill in the evaluated profile.
         newTerminalArgs.Profile(::Microsoft::Console::Utils::GuidToString(profile.Guid()));
-        _OpenNewWindow(false, newTerminalArgs);
+        _OpenNewWindow(newTerminalArgs);
         actionArgs.Handled(true);
     }
 

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -405,6 +405,9 @@
   <data name="NewWindowRun.Text" xml:space="preserve">
     <value>Shift+Click to open a new window</value>
   </data>
+  <data name="ElevatedRun.Text" xml:space="preserve">
+    <value>Ctrl+Click to open as administrator</value>
+  </data>
   <data name="WindowCloseButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Close</value>
   </data>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -731,6 +731,9 @@ namespace winrt::TerminalApp::implementation
             auto newWindowRun = WUX::Documents::Run();
             newWindowRun.Text(RS_(L"NewWindowRun/Text"));
             newWindowRun.FontStyle(FontStyle::Italic);
+            auto elevatedRun = WUX::Documents::Run();
+            elevatedRun.Text(RS_(L"ElevatedRun/Text"));
+            elevatedRun.FontStyle(FontStyle::Italic);
 
             auto textBlock = WUX::Controls::TextBlock{};
             textBlock.Inlines().Append(newTabRun);
@@ -738,6 +741,8 @@ namespace winrt::TerminalApp::implementation
             textBlock.Inlines().Append(newPaneRun);
             textBlock.Inlines().Append(WUX::Documents::LineBreak{});
             textBlock.Inlines().Append(newWindowRun);
+            textBlock.Inlines().Append(WUX::Documents::LineBreak{});
+            textBlock.Inlines().Append(elevatedRun);
 
             auto toolTip = WUX::Controls::ToolTip{};
             toolTip.Content(textBlock);

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -226,9 +226,9 @@ namespace winrt::TerminalApp::implementation
         void _CreateNewTabFromPane(std::shared_ptr<Pane> pane);
         winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection _CreateConnectionFromSettings(Microsoft::Terminal::Settings::Model::Profile profile, Microsoft::Terminal::Settings::Model::TerminalSettings settings);
 
-        winrt::fire_and_forget _OpenNewWindow(const bool elevate, const Microsoft::Terminal::Settings::Model::NewTerminalArgs newTerminalArgs);
+        winrt::fire_and_forget _OpenNewWindow(const Microsoft::Terminal::Settings::Model::NewTerminalArgs newTerminalArgs);
 
-        void _OpenNewTerminal(const Microsoft::Terminal::Settings::Model::NewTerminalArgs newTerminalArgs);
+        void _OpenNewTerminalViaDropdown(const Microsoft::Terminal::Settings::Model::NewTerminalArgs newTerminalArgs);
 
         bool _displayingCloseDialog{ false };
         void _SettingsButtonOnClick(const IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& eventArgs);

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
@@ -99,6 +99,11 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             }
         }
 
+        if (Elevate())
+        {
+            ss << fmt::format(L"elevate: {}, ", Elevate().Value());
+        }
+
         auto s = ss.str();
         if (s.empty())
         {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18356694/150421834-de68140b-a935-47d7-95ca-ab91a6421f1b.png)

Just like the shift+click and the alt click shortcuts, now Ctrl+Click will launch a new window with that profile, elevated.

I also found that the GenerateName wasn't updated for the elevate arg, so added that. I considered adding the following to the defaults, but decided against it. It added 10 more entries to the command palette that were only separated by the `elevate: true` param, so that didn't feel valuable. Those are posted below for posterity.

* [x] closes https://github.com/microsoft/terminal/projects/5#card-50759221
* [x] Tested manually
* [ ] Docs.... maybe need updating?

Considered new keybindings:
```jsonc
        { "command": { "action": "newTab", "index": 0, "elevate": true }, "keys": "ctrl+shift+alt+1" },
        { "command": { "action": "newTab", "index": 1, "elevate": true }, "keys": "ctrl+shift+alt+2" },
        { "command": { "action": "newTab", "index": 2, "elevate": true }, "keys": "ctrl+shift+alt+3" },
        { "command": { "action": "newTab", "index": 3, "elevate": true }, "keys": "ctrl+shift+alt+4" },
        { "command": { "action": "newTab", "index": 4, "elevate": true }, "keys": "ctrl+shift+alt+5" },
        { "command": { "action": "newTab", "index": 5, "elevate": true }, "keys": "ctrl+shift+alt+6" },
        { "command": { "action": "newTab", "index": 6, "elevate": true }, "keys": "ctrl+shift+alt+7" },
        { "command": { "action": "newTab", "index": 7, "elevate": true }, "keys": "ctrl+shift+alt+8" },
        { "command": { "action": "newTab", "index": 8, "elevate": true }, "keys": "ctrl+shift+alt+9" },
```

Includes a semi-related dead code removal for the `elevated` param for `_OpenNewWindow`, which didn't end up being used, and wouldn't work as intended anyways. 