### PR TITLE
Make sure titles always sanitized before passing over conpty

### DIFF
--- a/src/host/ConsoleArguments.cpp
+++ b/src/host/ConsoleArguments.cpp
@@ -667,7 +667,7 @@ bool ConsoleArguments::IsWin32InputModeEnabled() const
 #ifdef UNIT_TESTING
 // Method Description:
 // - This is a test helper method. It can be used to trick us into thinking
-//   we're headless (in conpty mode), even without parsing any arguments.
+//   we're in conpty mode, even without parsing any arguments.
 // Arguments:
 // - <none>
 // Return Value:
@@ -675,5 +675,7 @@ bool ConsoleArguments::IsWin32InputModeEnabled() const
 void ConsoleArguments::EnableConptyModeForTests()
 {
     _headless = true;
+    _vtInHandle = GetStdHandle(STD_INPUT_HANDLE);
+    _vtOutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
 }
 #endif

--- a/src/host/getset.cpp
+++ b/src/host/getset.cpp
@@ -1798,26 +1798,7 @@ void DoSrvPrivateRefreshWindow(_In_ const SCREEN_INFORMATION& screenInfo)
 [[nodiscard]] HRESULT DoSrvSetConsoleTitleW(const std::wstring_view title) noexcept
 {
     CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
-
-    // Sanitize the input if we're in pty mode. No control chars - this string
-    //      will get emitted back to the TTY in a VT sequence, and we don't want
-    //      to embed control characters in that string.
-    if (gci.IsInVtIoMode())
-    {
-        std::wstring sanitized{ title };
-        sanitized.erase(std::remove_if(sanitized.begin(), sanitized.end(), [](auto ch) {
-                            return ch < UNICODE_SPACE || (ch > UNICODE_DEL && ch < UNICODE_NBSP);
-                        }),
-                        sanitized.end());
-
-        gci.SetTitle({ sanitized });
-    }
-    else
-    {
-        // SetTitle will trigger the renderer to update the titlebar for us.
-        gci.SetTitle(title);
-    }
-
+    gci.SetTitle(title);
     return S_OK;
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

When title updates are forwarded from the host to the client terminal,
they're passed over conpty in an `OSC 0` sequence. If there are any
control characters embedded in that title text it's essential they be
filtered out, otherwise they are likely to be misinterpreted by the VT
parser on the other side. This PR fixes a case where that sanitization
step was missed for titles initialized at startup.

## PR Checklist
* [x] Closes #12206
* [x] CLA signed.
* [ ] Tests added/passed
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] I've discussed this with core contributors already. Issue number where discussion took place: #12206

## Detailed Description of the Pull Request / Additional comments

Originally the sanitization step was handled in `DoSrvSetConsoleTitleW`,
which catches title changes made via VT escape sequences, or through the
console API, but missed the title initialization at startup. I've now
moved that sanitization code into the `CONSOLE_INFORMATION::SetTitle`
method, which should cover all cases.

This sanitization is only meant to occur when in "pty mode", though,
which we were originally establishing with an `IsInVtIoMode` call.
However, `IsInVtIoMode` does not return the correct result when the
title is set at startup, since the VT I/O thread is not initialized at
that point. So I've instead had to change that to an `InConptyMode`
call, which determines the conpty state from the launch args.

## Validation Steps Performed

I've manually confirmed the test case described in issue #12206 is now
working correctly.

However, the change to using `InConptyMode` caused some of the unit
tests to fail, because there isn't a real conpty connection when
testing. Fortunately there are some `EnableConptyModeForTests` methods
used by the unit tests to fake the appearance of a conpty connection,
and I just needed to add some additional state in one of those methods
to trigger the correct `InConptyMode` response.