### PR TITLE
Fix gridline drawings for DxEngine

### DIFF
--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1705,7 +1705,7 @@ try
     const auto existingColor = _d2dBrushForeground->GetColor();
     const auto restoreBrushOnExit = wil::scope_exit([&]() noexcept { _d2dBrushForeground->SetColor(existingColor); });
 
-    _d2dBrushForeground->SetColor(_ColorFFromColorRef(color));
+    _d2dBrushForeground->SetColor(_ColorFFromColorRef(color | 0xff000000));
 
     const D2D1_SIZE_F font = _fontRenderData->GlyphCell().to_d2d_size();
     const D2D_POINT_2F target = { coordTarget.X * font.width, coordTarget.Y * font.height };


### PR DESCRIPTION
With the introduction of a common `RenderSettings` class in 62c95b5, `PaintBufferGridLines` was now uniformly called with a proper alpha-less `COLORREF` argument. This commit crudely fixes the issue by forcing the color to be fully opaque in the `DxEngine` class.

## PR Checklist
* [x] Closes #12223
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed

* Launch pwsh.exe
* Hyperlinks get underlines on hover ✅