### PR TITLE
AtlasEngine: Redraw immediately on opacity changes

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -478,6 +478,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         if (_renderEngine)
         {
             _renderEngine->EnableTransparentBackground(_isBackgroundTransparent());
+            _renderer->NotifyPaintFrame();
         }
 
         auto eventArgs = winrt::make_self<TransparencyChangedEventArgs>(newOpacity);

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -138,7 +138,7 @@ try
         // at the next opportunity.
         if (pEngine->RequiresContinuousRedraw())
         {
-            _NotifyPaintFrame();
+            NotifyPaintFrame();
         }
     });
 
@@ -183,7 +183,7 @@ try
 }
 CATCH_RETURN()
 
-void Renderer::_NotifyPaintFrame()
+void Renderer::NotifyPaintFrame() noexcept
 {
     // If we're running in the unittests, we might not have a render thread.
     if (_pThread)
@@ -206,7 +206,7 @@ void Renderer::TriggerSystemRedraw(const RECT* const prcDirtyClient)
         LOG_IF_FAILED(pEngine->InvalidateSystem(prcDirtyClient));
     }
 
-    _NotifyPaintFrame();
+    NotifyPaintFrame();
 }
 
 // Routine Description:
@@ -240,7 +240,7 @@ void Renderer::TriggerRedraw(const Viewport& region)
             LOG_IF_FAILED(pEngine->Invalidate(&srUpdateRegion));
         }
 
-        _NotifyPaintFrame();
+        NotifyPaintFrame();
     }
 }
 
@@ -292,7 +292,7 @@ void Renderer::TriggerRedrawCursor(const COORD* const pcoord)
                 LOG_IF_FAILED(pEngine->InvalidateCursor(&updateRect));
             }
 
-            _NotifyPaintFrame();
+            NotifyPaintFrame();
         }
     }
 }
@@ -311,7 +311,7 @@ void Renderer::TriggerRedrawAll()
         LOG_IF_FAILED(pEngine->InvalidateAll());
     }
 
-    _NotifyPaintFrame();
+    NotifyPaintFrame();
 }
 
 // Method Description:
@@ -377,7 +377,7 @@ void Renderer::TriggerSelection()
 
         _previousSelection = std::move(rects);
 
-        _NotifyPaintFrame();
+        NotifyPaintFrame();
     }
     CATCH_LOG();
 }
@@ -425,7 +425,7 @@ void Renderer::TriggerScroll()
 {
     if (_CheckViewportAndScroll())
     {
-        _NotifyPaintFrame();
+        NotifyPaintFrame();
     }
 }
 
@@ -447,7 +447,7 @@ void Renderer::TriggerScroll(const COORD* const pcoordDelta)
 
     _ScrollPreviousSelection(til::point{ *pcoordDelta });
 
-    _NotifyPaintFrame();
+    NotifyPaintFrame();
 }
 
 // Routine Description:
@@ -490,7 +490,7 @@ void Renderer::TriggerTitleChange()
     {
         LOG_IF_FAILED(pEngine->InvalidateTitle(newTitle));
     }
-    _NotifyPaintFrame();
+    NotifyPaintFrame();
 }
 
 // Routine Description:
@@ -521,7 +521,7 @@ void Renderer::TriggerFontChange(const int iDpi, const FontInfoDesired& FontInfo
         LOG_IF_FAILED(pEngine->UpdateFont(FontInfoDesired, FontInfo));
     }
 
-    _NotifyPaintFrame();
+    NotifyPaintFrame();
 }
 
 // Routine Description:

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -39,6 +39,7 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT PaintFrame();
 
+        void NotifyPaintFrame() noexcept;
         void TriggerSystemRedraw(const RECT* const prcDirtyClient);
         void TriggerRedraw(const Microsoft::Console::Types::Viewport& region) override;
         void TriggerRedraw(const COORD* const pcoord) override;
@@ -82,7 +83,6 @@ namespace Microsoft::Console::Render
         static IRenderEngine::GridLineSet s_GetGridlines(const TextAttribute& textAttribute) noexcept;
         static bool s_IsSoftFontChar(const std::wstring_view& v, const size_t firstSoftFontChar, const size_t lastSoftFontChar);
 
-        void _NotifyPaintFrame();
         [[nodiscard]] HRESULT _PaintFrameForEngine(_In_ IRenderEngine* const pEngine) noexcept;
         bool _CheckViewportAndScroll();
         [[nodiscard]] HRESULT _PaintBackground(_In_ IRenderEngine* const pEngine);

--- a/src/renderer/base/thread.cpp
+++ b/src/renderer/base/thread.cpp
@@ -219,7 +219,7 @@ DWORD WINAPI RenderThread::_ThreadProc()
     return S_OK;
 }
 
-void RenderThread::NotifyPaint()
+void RenderThread::NotifyPaint() noexcept
 {
     if (_fWaiting.load(std::memory_order_acquire))
     {
@@ -231,17 +231,17 @@ void RenderThread::NotifyPaint()
     }
 }
 
-void RenderThread::EnablePainting()
+void RenderThread::EnablePainting() noexcept
 {
     SetEvent(_hPaintEnabledEvent);
 }
 
-void RenderThread::DisablePainting()
+void RenderThread::DisablePainting() noexcept
 {
     ResetEvent(_hPaintEnabledEvent);
 }
 
-void RenderThread::WaitForPaintCompletionAndDisable(const DWORD dwTimeoutMs)
+void RenderThread::WaitForPaintCompletionAndDisable(const DWORD dwTimeoutMs) noexcept
 {
     // When rendering takes place via DirectX, and a console application
     // currently owns the screen, and a new console application is launched (or

--- a/src/renderer/base/thread.hpp
+++ b/src/renderer/base/thread.hpp
@@ -26,11 +26,10 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT Initialize(Renderer* const pRendererParent) noexcept;
 
-        void NotifyPaint();
-
-        void EnablePainting();
-        void DisablePainting();
-        void WaitForPaintCompletionAndDisable(const DWORD dwTimeoutMs);
+        void NotifyPaint() noexcept;
+        void EnablePainting() noexcept;
+        void DisablePainting() noexcept;
+        void WaitForPaintCompletionAndDisable(const DWORD dwTimeoutMs) noexcept;
 
     private:
         static DWORD WINAPI s_ThreadProc(_In_ LPVOID lpParameter);


### PR DESCRIPTION
Since `AtlasEngine` prefers drawing without alpha for performance reasons,
calls to `EnableTransparentBackground` require a draw cycle.
This PR makes `Renderer::_NotifyPaintFrame` public and calls it.

Related to #9999.

## PR Checklist
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed

* Open Windows Terminal command palette
* Choose "Set background opacity..."
* Cycling through the items without selecting one
  changes background opacity immediately ✅