### PR TITLE
AtlasEngine: Make shader hot-reloads possible in Windows Terminal

### DIFF
--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -649,6 +649,7 @@ namespace Microsoft::Console::Render
             bool isWindows10OrGreater = true;
 
 #ifndef NDEBUG
+            std::filesystem::path sourceDirectory;
             wil::unique_folder_change_reader_nothrow sourceCodeWatcher;
             std::atomic<int64_t> sourceCodeInvalidationTime{ INT64_MAX };
 #endif

--- a/src/renderer/atlas/pch.h
+++ b/src/renderer/atlas/pch.h
@@ -7,7 +7,7 @@
 #define WIN32_LEAN_AND_MEAN
 
 #include <array>
-#include <iomanip>
+#include <filesystem>
 #include <optional>
 #include <sstream>
 #include <string_view>


### PR DESCRIPTION
This minor change makes it possible to hot-reload the AtlasEngine shaders under
Windows Terminal. Launching an UWP application from Visual Studio doesn't
necessarily result in a working directory inside the project folder,
which makes relative file paths impractical. While the `__FILE__` macro is
compiler dependent it works under our build setup with MSVC at least.

## Validation Steps Performed

* Shader hot-reloading works under Windows Terminal ✅