### PR TITLE
Fix opacity restore for command palette previews

### DIFF
--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -970,7 +970,7 @@ namespace winrt::TerminalApp::implementation
             if (const auto& realArgs = args.ActionArgs().try_as<AdjustOpacityArgs>())
             {
                 const auto res = _ApplyToActiveControls([&](auto& control) {
-                    control.AdjustOpacity(realArgs.Opacity(), realArgs.Relative());
+                    control.AdjustOpacity(realArgs.Opacity() / 100.0, realArgs.Relative());
                 });
                 args.Handled(res);
             }

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1718,9 +1718,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         return _settings->HasUnfocusedAppearance();
     }
 
-    void ControlCore::AdjustOpacity(const int32_t& opacity, const bool& relative)
+    void ControlCore::AdjustOpacity(const double opacityAdjust, const bool relative)
     {
-        const double opacityAdjust = static_cast<double>(opacity) / 100.0;
         if (relative)
         {
             AdjustOpacity(opacityAdjust);

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -166,7 +166,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         static bool IsVintageOpacityAvailable() noexcept;
 
-        void AdjustOpacity(const int32_t& opacity, const bool& relative);
+        void AdjustOpacity(const double opacity, const bool relative);
 
         RUNTIME_SETTING(double, Opacity, _settings->Opacity());
         RUNTIME_SETTING(bool, UseAcrylic, _settings->UseAcrylic());

--- a/src/cascadia/TerminalControl/ControlCore.idl
+++ b/src/cascadia/TerminalControl/ControlCore.idl
@@ -98,7 +98,7 @@ namespace Microsoft.Terminal.Control
 
         String ReadEntireBuffer();
 
-        void AdjustOpacity(Int32 Opacity, Boolean relative);
+        void AdjustOpacity(Double Opacity, Boolean relative);
 
         event FontSizeChangedEventArgs FontSizeChanged;
 

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2713,7 +2713,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         _core.ColorScheme(scheme);
     }
 
-    void TermControl::AdjustOpacity(const int32_t& opacity, const bool& relative)
+    void TermControl::AdjustOpacity(const double opacity, const bool relative)
     {
         _core.AdjustOpacity(opacity, relative);
     }

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -110,7 +110,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         winrt::Microsoft::Terminal::Core::Scheme ColorScheme() const noexcept;
         void ColorScheme(const winrt::Microsoft::Terminal::Core::Scheme& scheme) const noexcept;
 
-        void AdjustOpacity(const int32_t& opacity, const bool& relative);
+        void AdjustOpacity(const double opacity, const bool relative);
 
         // -------------------------------- WinRT Events ---------------------------------
         // clang-format off

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -73,7 +73,7 @@ namespace Microsoft.Terminal.Control
 
         String ReadEntireBuffer();
 
-        void AdjustOpacity(Int32 Opacity, Boolean relative);
+        void AdjustOpacity(Double Opacity, Boolean relative);
 
         // You'd think this should just be "Opacity", but UIElement already
         // defines an "Opacity", which we're actually not setting at all. We're


### PR DESCRIPTION
This commit correctly restores the previous opacity when the command palette
preview is cancelled. It includes an additional change in order to make the
`AdjustOpacity` setter consistent and symmetric with the `Opacity` getter.

## PR Checklist
* [x] Closes #12228
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed

* Open Windows Terminal command palette
* Choose "Set background opacity..."
* Cycle through the items without selecting one
* Press Escape
* Previous opacity is restored ✅