### PR TITLE
Remove the Tray Icon from velocity

### DIFF
--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -542,10 +542,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
 
     void WindowManager::SummonAllWindows()
     {
-        if constexpr (Feature_NotificationIcon::IsEnabled())
-        {
-            _monarch.SummonAllWindows();
-        }
+        _monarch.SummonAllWindows();
     }
 
     Windows::Foundation::Collections::IVectorView<winrt::Microsoft::Terminal::Remoting::PeasantInfo> WindowManager::GetPeasantInfos()

--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -1587,38 +1587,24 @@ namespace winrt::TerminalApp::implementation
 
     bool AppLogic::GetMinimizeToNotificationArea()
     {
-        if constexpr (Feature_NotificationIcon::IsEnabled())
+        if (!_loadedInitialSettings)
         {
-            if (!_loadedInitialSettings)
-            {
-                // Load settings if we haven't already
-                LoadSettings();
-            }
+            // Load settings if we haven't already
+            LoadSettings();
+        }
 
-            return _settings.GlobalSettings().MinimizeToNotificationArea();
-        }
-        else
-        {
-            return false;
-        }
+        return _settings.GlobalSettings().MinimizeToNotificationArea();
     }
 
     bool AppLogic::GetAlwaysShowNotificationIcon()
     {
-        if constexpr (Feature_NotificationIcon::IsEnabled())
+        if (!_loadedInitialSettings)
         {
-            if (!_loadedInitialSettings)
-            {
-                // Load settings if we haven't already
-                LoadSettings();
-            }
+            // Load settings if we haven't already
+            LoadSettings();
+        }
 
-            return _settings.GlobalSettings().AlwaysShowNotificationIcon();
-        }
-        else
-        {
-            return false;
-        }
+        return _settings.GlobalSettings().AlwaysShowNotificationIcon();
     }
 
     bool AppLogic::GetShowTitleInTitlebar()

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.cpp
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.cpp
@@ -199,8 +199,4 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
     }
 
-    bool GlobalAppearance::FeatureNotificationIconEnabled() const noexcept
-    {
-        return Feature_NotificationIcon::IsEnabled();
-    }
 }

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.h
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.h
@@ -25,8 +25,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         void OnNavigatedTo(const winrt::Windows::UI::Xaml::Navigation::NavigationEventArgs& e);
 
-        bool FeatureNotificationIconEnabled() const noexcept;
-
         WINRT_PROPERTY(Editor::GlobalAppearancePageNavigationState, State, nullptr);
         GETSET_BINDABLE_ENUM_SETTING(Theme, winrt::Windows::UI::Xaml::ElementTheme, State().Globals(), Theme);
         GETSET_BINDABLE_ENUM_SETTING(TabWidthMode, winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode, State().Globals(), TabWidthMode);

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.idl
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.idl
@@ -25,7 +25,5 @@ namespace Microsoft.Terminal.Settings.Editor
 
         IInspectable CurrentTabWidthMode;
         Windows.Foundation.Collections.IObservableVector<Microsoft.Terminal.Settings.Editor.EnumEntry> TabWidthModeList { get; };
-
-        Boolean FeatureNotificationIconEnabled { get; };
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
@@ -88,14 +88,12 @@
             </local:SettingContainer>
 
             <!--  Always Show Notification Icon  -->
-            <local:SettingContainer x:Uid="Globals_AlwaysShowNotificationIcon"
-                                    Visibility="{x:Bind FeatureNotificationIconEnabled}">
+            <local:SettingContainer x:Uid="Globals_AlwaysShowNotificationIcon">
                 <ToggleSwitch IsOn="{x:Bind State.Globals.AlwaysShowNotificationIcon, Mode=TwoWay}" />
             </local:SettingContainer>
 
             <!--  Minimize To Notification Area  -->
-            <local:SettingContainer x:Uid="Globals_MinimizeToNotificationArea"
-                                    Visibility="{x:Bind FeatureNotificationIconEnabled}">
+            <local:SettingContainer x:Uid="Globals_MinimizeToNotificationArea">
                 <ToggleSwitch IsOn="{x:Bind State.Globals.MinimizeToNotificationArea, Mode=TwoWay}" />
             </local:SettingContainer>
         </StackPanel>

--- a/src/features.xml
+++ b/src/features.xml
@@ -58,13 +58,6 @@
     </feature>
 
     <feature>
-        <name>Feature_NotificationIcon</name>
-        <description>Controls whether the Notification Icon and related settings (aka. MinimizeToNotificationArea and AlwaysShowNotificationIcon) are enabled</description>
-        <stage>AlwaysEnabled</stage>
-        <alwaysDisabledReleaseTokens/>
-    </feature>
-
-    <feature>
         <name>Feature_PersistedWindowLayout</name>
         <description>Whether to allow the user to enable persisted window layout saving and loading</description>
         <id>766</id>


### PR DESCRIPTION
This will turn the feature on always from this point on. That means 1.13 Stble
would be the first Stable release to have this feature (unless we cherry-pick
this to 1.12 stable, which we may)

* [x] Closes #12220
* [x] I work here
