### PR TITLE
Pin the `NETCore.App.Host` version to appease nuget

### DIFF
--- a/src/cascadia/WpfTerminalTestNetCore/WpfTerminalTestNetCore.csproj
+++ b/src/cascadia/WpfTerminalTestNetCore/WpfTerminalTestNetCore.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RuntimeFrameworkVersion>3.1.18</RuntimeFrameworkVersion>
     <UseWPF>true</UseWPF>
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>


### PR DESCRIPTION
This gets rid of warnings like

```
NU1102: Unable to find package Microsoft.NETCore.App.Host.win-x64 with version (= 3.1.21)
- Found 1 version(s) in TerminalDependencies [ Nearest version: 3.1.18 ]
```

Technically, there's a `NETCore.App.Host.3.1.21` that's out now. We _could_
migrate to that, but then we'd have to make sure to manually re-upload that
nuget package to our nuget feed, and then we'd still get this warning the
next time that package is updated.

Theoretically, there's a 6.x version too, but considering this is a debugging
tool, we don't care all that much.

* [x] I work here
* [x] Discussed this with Dustin
* [x] Gets rid of a SUPER TRIVIAL warning.
