### PR TITLE
Fix Opacity in Windows 10, again

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.idl
+++ b/src/cascadia/TerminalControl/ControlCore.idl
@@ -54,6 +54,7 @@ namespace Microsoft.Terminal.Control
         String FontFaceName { get; };
         UInt16 FontWeight { get; };
         Double Opacity { get; };
+        Boolean UseAcrylic { get; };
 
         Boolean TrySendKeyEvent(Int16 vkey,
                              Int16 scanCode,

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -452,7 +452,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         auto settings{ _core.Settings() };
         auto bgColor = til::color{ _core.FocusedAppearance().DefaultBackground() };
         // GH#11743: Make sure to use the Core's current UseAcrylic value, not
-        // the one from the settings.
+        // the one from the settings. The Core's runtime UseAcrylic may have
+        // changed from what was in the original settings.
         if (_core.UseAcrylic())
         {
             // See if we've already got an acrylic background brush

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -451,7 +451,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
         auto settings{ _core.Settings() };
         auto bgColor = til::color{ _core.FocusedAppearance().DefaultBackground() };
-        if (settings.UseAcrylic())
+        // GH#11743: Make sure to use the Core's current UseAcrylic value, not
+        // the one from the settings.
+        if (_core.UseAcrylic())
         {
             // See if we've already got an acrylic background brush
             // to avoid the flicker when setting up a new one
@@ -536,12 +538,30 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_changeBackgroundOpacity()
     {
         const auto opacity{ _core.Opacity() };
+        const auto useAcrylic{ _core.UseAcrylic() };
+
+        // GH#11743, #11619: If we're changing whether or not acrylic is used,
+        // then just entirely reinitialize the brush. The primary way that this
+        // happens is on Windows 10, where we need to enable acrylic when the
+        // user asks for <100% opacity. Even when we remove this Windows 10
+        // fallback, we may still need this for something like changing if
+        // acrylic is enabled at runtime (GH#2531)
         if (auto acrylic = RootGrid().Background().try_as<Media::AcrylicBrush>())
         {
+            if (!useAcrylic)
+            {
+                _InitializeBackgroundBrush();
+                return;
+            }
             acrylic.TintOpacity(opacity);
         }
         else if (auto solidColor = RootGrid().Background().try_as<Media::SolidColorBrush>())
         {
+            if (useAcrylic)
+            {
+                _InitializeBackgroundBrush();
+                return;
+            }
             solidColor.Opacity(opacity);
         }
     }


### PR DESCRIPTION
More fallout from the settings refactor. Probably because testing on a Windows
10 device is hard, because you actually need a physical machine to get acrylic
to behave correctly.

Basically, the code is simpler now, but we missed the windows 10 only edge case
where acrylic can get turned on, but we forget to enable the acrylic brush, so
it just stays off.

Refer to #11619 where this regressed, and #11643, #12229, because this is just a
hard problem apparently

* [x] Closes #11743. Technically OP is complaining about behavior that's
  by-design, but it made me realize this regressed in 1.12.
* [ ] No tests on this part of the `TermControl` unfortunately.
* [x] Hauled out my old Win10 laptop to verify that opacity works right:
  - [x] A fresh profile isn't created with any opacity
  - [x] Mouse wheeling turns on acrylic
  - [x] Using `opacity` only in the settings still stealthily enables acrylic
