### PR TITLE
Expose Defterm info to ComboBoxItem properly

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -110,15 +110,18 @@
                                     <TextBlock Grid.Row="0"
                                                Grid.Column="1"
                                                Grid.ColumnSpan="2"
+                                               AutomationProperties.AccessibilityView="Raw"
                                                Text="{x:Bind Name}" />
 
                                     <TextBlock Grid.Row="1"
                                                Grid.Column="1"
+                                               AutomationProperties.AccessibilityView="Raw"
                                                Style="{ThemeResource SecondaryTextBlockStyle}"
                                                Text="{x:Bind Author}" />
 
                                     <TextBlock Grid.Row="1"
                                                Grid.Column="2"
+                                               AutomationProperties.AccessibilityView="Raw"
                                                Style="{ThemeResource SecondaryTextBlockStyle}"
                                                Text="{x:Bind Version}" />
 

--- a/src/cascadia/TerminalSettingsModel/DefaultTerminal.h
+++ b/src/cascadia/TerminalSettingsModel/DefaultTerminal.h
@@ -28,6 +28,11 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     {
         explicit DefaultTerminal(DelegationConfig::DelegationPackage&& pkg);
 
+        hstring ToString()
+        {
+            return hstring{ fmt::format(L"{}, {}, {}", Name(), Author(), Version()) };
+        }
+
         hstring Name() const;
         hstring Author() const;
         hstring Version() const;

--- a/src/cascadia/TerminalSettingsModel/DefaultTerminal.idl
+++ b/src/cascadia/TerminalSettingsModel/DefaultTerminal.idl
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Terminal.Settings.Model
 {
-    runtimeclass DefaultTerminal
+    runtimeclass DefaultTerminal : Windows.Foundation.IStringable
     {
         String Name { get; };
         String Author { get; };


### PR DESCRIPTION
## Summary of the Pull Request
Makes `Model::DefaultTerminal` an `IStringable`, which presents it as a string, when possible. This enables text search for defterm's setting. This also enables screen readers to identify the combo box items by their text content (app name, author, and version) as opposed to being treated as an item containing more text. As a part of that, I cleaned up the UIA tree to treat the item's name as "\<name\>, \<author\>, \<version\>". This is consistent with how the Settings App presents installed apps in Apps > Installed apps.

#11251 will be resolved upon verification by the accessibility team.

## Validation Steps Performed
Verified using Narrator and Accessibility Insights.