### PR TITLE
Update PGO helpers to mitigate Y2K22 bug

### DIFF
--- a/build/packages.config
+++ b/build/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="MUXCustomBuildTasks" version="1.0.48" targetFramework="native" />
   <package id="Microsoft.Taef" version="10.60.210621002" targetFramework="native" />
-  <package id="Microsoft.PGO-Helpers.Cpp" version="0.2.22" targetFramework="native" />
+  <package id="Microsoft.Internal.PGO-Helpers.Cpp" version="0.2.34" targetFramework="native" />
 </packages>

--- a/build/pgo/Terminal.PGO.props
+++ b/build/pgo/Terminal.PGO.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <NuGetPackageDirectory>$(MSBuildThisFileDirectory)..\..\packages</NuGetPackageDirectory>
-    <PkgMicrosoft_PGO_Helpers_Cpp>$(NuGetPackageDirectory)\Microsoft.PGO-Helpers.Cpp.0.2.22</PkgMicrosoft_PGO_Helpers_Cpp>
+    <PkgMicrosoft_PGO_Helpers_Cpp>$(NuGetPackageDirectory)\Microsoft.Internal.PGO-Helpers.Cpp.0.2.34</PkgMicrosoft_PGO_Helpers_Cpp>
   </PropertyGroup>
 
   <!-- Get version information -->
@@ -19,6 +19,12 @@
 
     <!-- Mandatory.  Minor version number of the PGO database which should match the version of the product.  This can be hardcoded or obtained from other sources in build system. -->
     <PGOPackageVersionMinor>$(VersionMinor)</PGOPackageVersionMinor>
+
+    <!-- Mandatory, defaults to 0.  Patch version number of the PGO database which should match the version of the product.  This can be hardcoded or obtained from other sources in build system. -->
+    <PGOPackageVersionPatch>0</PGOPackageVersionPatch>
+    
+    <!-- Optional, defaults to empty.  Prerelease version number of the PGO database which should match the version of the product.  This can be hardcoded or obtained from other sources in build system. -->
+    <PGOPackageVersionPrerelease></PGOPackageVersionPrerelease>
 
     <!-- Mandatory.  Path to nuget.config file for the project.  Path is relative to where the props file will be. -->
     <PGONuGetConfigPath>$(MSBuildThisFileDirectory)..\..\nuget.config</PGONuGetConfigPath>

--- a/src/cascadia/Remoting/packages.config
+++ b/src/cascadia/Remoting/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />
-  <package id="Microsoft.PGO-Helpers.Cpp" version="0.2.22" targetFramework="native" />
+  <package id="Microsoft.Internal.PGO-Helpers.Cpp" version="0.2.34" targetFramework="native" />
 </packages>

--- a/src/cascadia/TerminalApp/packages.config
+++ b/src/cascadia/TerminalApp/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Toolkit.Win32.UI.XamlApplication" version="6.1.3" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.7.0-prerelease.210913003" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />
-  <package id="Microsoft.PGO-Helpers.Cpp" version="0.2.22" targetFramework="native" />
+  <package id="Microsoft.Internal.PGO-Helpers.Cpp" version="0.2.34" targetFramework="native" />
 </packages>

--- a/src/cascadia/TerminalConnection/packages.config
+++ b/src/cascadia/TerminalConnection/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />
   <package id="vcpkg-cpprestsdk" version="2.10.14" targetFramework="native" />
-  <package id="Microsoft.PGO-Helpers.Cpp" version="0.2.22" targetFramework="native" />
+  <package id="Microsoft.Internal.PGO-Helpers.Cpp" version="0.2.34" targetFramework="native" />
 </packages>

--- a/src/cascadia/TerminalControl/packages.config
+++ b/src/cascadia/TerminalControl/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />
-  <package id="Microsoft.PGO-Helpers.Cpp" version="0.2.22" targetFramework="native" />
+  <package id="Microsoft.Internal.PGO-Helpers.Cpp" version="0.2.34" targetFramework="native" />
 </packages>

--- a/src/cascadia/TerminalSettingsEditor/packages.config
+++ b/src/cascadia/TerminalSettingsEditor/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.UI.Xaml" version="2.7.0-prerelease.210913003" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />
-  <package id="Microsoft.PGO-Helpers.Cpp" version="0.2.22" targetFramework="native" />
+  <package id="Microsoft.Internal.PGO-Helpers.Cpp" version="0.2.34" targetFramework="native" />
 </packages>

--- a/src/cascadia/TerminalSettingsModel/packages.config
+++ b/src/cascadia/TerminalSettingsModel/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.VisualStudio.Setup.Configuration.Native" version="2.3.2262" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />
-  <package id="Microsoft.PGO-Helpers.Cpp" version="0.2.22" targetFramework="native" />
+  <package id="Microsoft.Internal.PGO-Helpers.Cpp" version="0.2.34" targetFramework="native" />
 </packages>

--- a/src/cascadia/WindowsTerminal/packages.config
+++ b/src/cascadia/WindowsTerminal/packages.config
@@ -5,5 +5,5 @@
   <package id="Microsoft.UI.Xaml" version="2.7.0-prerelease.210913003" targetFramework="native" />
   <package id="Microsoft.VCRTForwarders.140" version="1.0.4" targetFramework="native" />
   <package id="Microsoft.Internal.Windows.Terminal.ThemeHelpers" version="0.4.210908001" targetFramework="native" />
-  <package id="Microsoft.PGO-Helpers.Cpp" version="0.2.22" targetFramework="native" />
+  <package id="Microsoft.Internal.PGO-Helpers.Cpp" version="0.2.34" targetFramework="native" />
 </packages>

--- a/src/host/exe/packages.config
+++ b/src/host/exe/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.PGO-Helpers.Cpp" version="0.2.22" targetFramework="native" />
+  <package id="Microsoft.Internal.PGO-Helpers.Cpp" version="0.2.34" targetFramework="native" />
 </packages>


### PR DESCRIPTION
The PGO helpers NuGet had the Y2K22 bug. This receives and integrates the updated package in our project to restore NuGet functionality.

## PR Checklist
* [x] Closes #12261
* [x] I work here
* [x] If it builds it sits.

## Validation Steps Performed
* [x] Build new PGO instrument data with this pipeline update: https://dev.azure.com/microsoft/Dart/_build/results?buildId=44304850&view=results
