### PR TITLE
[Command Palette] Announce if suggestions were found to screen readers

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -822,16 +822,13 @@ namespace winrt::TerminalApp::implementation
         {
             const auto currentNeedleHasResults{ _filteredActions.Size() > 0 };
             _noMatchesText().Visibility(currentNeedleHasResults ? Visibility::Collapsed : Visibility::Visible);
-            if (!currentNeedleHasResults)
+            if (auto automationPeer{ Automation::Peers::FrameworkElementAutomationPeer::FromElement(_searchBox()) })
             {
-                if (auto automationPeer{ Automation::Peers::FrameworkElementAutomationPeer::FromElement(_searchBox()) })
-                {
-                    automationPeer.RaiseNotificationEvent(
-                        Automation::Peers::AutomationNotificationKind::ActionCompleted,
-                        Automation::Peers::AutomationNotificationProcessing::ImportantMostRecent,
-                        NoMatchesText(), // NoMatchesText contains the right text for the current mode
-                        L"CommandPaletteResultAnnouncement" /* unique name for this notification */);
-                }
+                automationPeer.RaiseNotificationEvent(
+                    Automation::Peers::AutomationNotificationKind::ActionCompleted,
+                    Automation::Peers::AutomationNotificationProcessing::ImportantMostRecent,
+                    currentNeedleHasResults ? RS_(L"CommandPalette_MatchesAvailable") : NoMatchesText(), // what to announce if results were found
+                    L"CommandPaletteResultAnnouncement" /* unique name for this group of notifications */);
             }
         }
         else

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -725,4 +725,7 @@
     <value>Open Settings</value>
     <comment>This is a call-to-action hyperlink; it will open the settings.</comment>
   </data>
+  <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
+    <value>Suggestions available</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request
Expands on #9582. If the command palette finds results, the screen reader says "Suggestions available".

Makes the scenario mentioned in #7907 work.

This is sufficient for various reasons:
1. According to the bug report, saying that suggestions are available is sufficient
> Screen reader should provide the results info on searching commands like 10 results found or suggestions available when there are any search results (Source: #7907)

2. This is common practice. Settings app and XAML Controls Gallery do this for their search box.

Also, the user should be able to know how many results were found by tabbing/selecting a result item. When this is done, the screen reader will use `SizeOfSet` and `PositionInSet` to announce how many results were found and which one we're currently on.

## Validation Steps Performed
Verified this behavior using Narrator.
Verified it matches the behavior of the Settings app and the XAML Controls Gallery.