### PR TITLE
Rename the "Bold" SGR attribute as "Intense"

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -2508,6 +2508,7 @@ UNICRT
 uninit
 uninitialize
 uninstall
+unintense
 Uniscribe
 unittest
 unittesting

--- a/src/buffer/out/TextAttribute.cpp
+++ b/src/buffer/out/TextAttribute.cpp
@@ -91,7 +91,7 @@ TextAttribute TextAttribute::StripErroneousVT16VersionsOfLegacyDefaults(const Te
     const auto bg{ attribute.GetBackground() };
     auto copy{ attribute };
     if (fg.IsIndex16() &&
-        attribute.IsBold() == WI_IsFlagSet(s_ansiDefaultForeground, FOREGROUND_INTENSITY) &&
+        attribute.IsIntense() == WI_IsFlagSet(s_ansiDefaultForeground, FOREGROUND_INTENSITY) &&
         fg.GetIndex() == (s_ansiDefaultForeground & ~FOREGROUND_INTENSITY))
     {
         // We don't want to turn 1;37m into 39m (or even 1;39m), as this was meant to mimic a legacy color.
@@ -115,7 +115,7 @@ WORD TextAttribute::GetLegacyAttributes() const noexcept
     const BYTE fgIndex = _foreground.GetLegacyIndex(s_legacyDefaultForeground);
     const BYTE bgIndex = _background.GetLegacyIndex(s_legacyDefaultBackground);
     const WORD metaAttrs = _wAttrLegacy & META_ATTRS;
-    const bool brighten = IsBold() && _foreground.CanBeBrightened();
+    const bool brighten = IsIntense() && _foreground.CanBeBrightened();
     return fgIndex | (bgIndex << 4) | metaAttrs | (brighten ? FOREGROUND_INTENSITY : 0);
 }
 
@@ -255,9 +255,9 @@ void TextAttribute::SetRightVerticalDisplayed(const bool isDisplayed) noexcept
     WI_UpdateFlag(_wAttrLegacy, COMMON_LVB_GRID_RVERTICAL, isDisplayed);
 }
 
-bool TextAttribute::IsBold() const noexcept
+bool TextAttribute::IsIntense() const noexcept
 {
-    return WI_IsFlagSet(_extendedAttrs, ExtendedAttributes::Bold);
+    return WI_IsFlagSet(_extendedAttrs, ExtendedAttributes::Intense);
 }
 
 bool TextAttribute::IsFaint() const noexcept
@@ -305,9 +305,9 @@ bool TextAttribute::IsReverseVideo() const noexcept
     return WI_IsFlagSet(_wAttrLegacy, COMMON_LVB_REVERSE_VIDEO);
 }
 
-void TextAttribute::SetBold(bool isBold) noexcept
+void TextAttribute::SetIntense(bool isIntense) noexcept
 {
-    WI_UpdateFlag(_extendedAttrs, ExtendedAttributes::Bold, isBold);
+    WI_UpdateFlag(_extendedAttrs, ExtendedAttributes::Intense, isIntense);
 }
 
 void TextAttribute::SetFaint(bool isFaint) noexcept

--- a/src/buffer/out/TextAttribute.hpp
+++ b/src/buffer/out/TextAttribute.hpp
@@ -84,7 +84,7 @@ public:
     friend constexpr bool operator!=(const WORD& legacyAttr, const TextAttribute& attr) noexcept;
 
     bool IsLegacy() const noexcept;
-    bool IsBold() const noexcept;
+    bool IsIntense() const noexcept;
     bool IsFaint() const noexcept;
     bool IsItalic() const noexcept;
     bool IsBlinking() const noexcept;
@@ -95,7 +95,7 @@ public:
     bool IsOverlined() const noexcept;
     bool IsReverseVideo() const noexcept;
 
-    void SetBold(bool isBold) noexcept;
+    void SetIntense(bool isIntense) noexcept;
     void SetFaint(bool isFaint) noexcept;
     void SetItalic(bool isItalic) noexcept;
     void SetBlinking(bool isBlinking) noexcept;
@@ -214,10 +214,10 @@ namespace WEX
             static WEX::Common::NoThrowString ToString(const TextAttribute& attr)
             {
                 return WEX::Common::NoThrowString().Format(
-                    L"{FG:%s,BG:%s,bold:%d,wLegacy:(0x%04x),ext:(0x%02x)}",
+                    L"{FG:%s,BG:%s,intense:%d,wLegacy:(0x%04x),ext:(0x%02x)}",
                     VerifyOutputTraits<TextColor>::ToString(attr._foreground).GetBuffer(),
                     VerifyOutputTraits<TextColor>::ToString(attr._background).GetBuffer(),
-                    attr.IsBold(),
+                    attr.IsIntense(),
                     attr._wAttrLegacy,
                     static_cast<DWORD>(attr._extendedAttrs));
             }

--- a/src/buffer/out/TextColor.cpp
+++ b/src/buffer/out/TextColor.cpp
@@ -133,8 +133,8 @@ void TextColor::SetDefault() noexcept
 //     - If brighten is true, and we've got a 16 color index in the "dark"
 //       portion of the color table (indices [0,7]), then we'll look up the
 //       bright version of this color (from indices [8,15]). This should be
-//       true for TextAttributes that are "Bold" and we're treating bold as
-//       bright (which is the default behavior of most terminals.)
+//       true for TextAttributes that are "intense" and we're treating intense
+//       as bright (which is the default behavior of most terminals.)
 //   * If we're a default color, we'll return the default color provided.
 // Arguments:
 // - colorTable: The table of colors we should use to look up the value of

--- a/src/buffer/out/ut_textbuffer/TextAttributeTests.cpp
+++ b/src/buffer/out/ut_textbuffer/TextAttributeTests.cpp
@@ -24,7 +24,7 @@ class TextAttributeTests
     TEST_METHOD(TestTextAttributeColorGetters);
     TEST_METHOD(TestReverseDefaultColors);
     TEST_METHOD(TestRoundtripDefaultColors);
-    TEST_METHOD(TestBoldAsBright);
+    TEST_METHOD(TestIntenseAsBright);
 
     RenderSettings _renderSettings;
     const COLORREF _defaultFg = RGB(1, 2, 3);
@@ -257,7 +257,7 @@ void TextAttributeTests::TestRoundtripDefaultColors()
     TextAttribute::SetLegacyDefaultAttributes(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE);
 }
 
-void TextAttributeTests::TestBoldAsBright()
+void TextAttributeTests::TestIntenseAsBright()
 {
     const auto& colorTable = _renderSettings.GetColorTable();
     const COLORREF darkBlack = til::at(colorTable, 0);
@@ -267,8 +267,8 @@ void TextAttributeTests::TestBoldAsBright()
     TextAttribute attr{};
 
     // verify that calculated foreground/background are the same as the direct
-    //      values when not bold
-    VERIFY_IS_FALSE(attr.IsBold());
+    //      values when not intense
+    VERIFY_IS_FALSE(attr.IsIntense());
 
     VERIFY_ARE_EQUAL(_defaultFg, attr.GetForeground().GetColor(colorTable, _defaultFgIndex));
     VERIFY_ARE_EQUAL(_defaultBg, attr.GetBackground().GetColor(colorTable, _defaultBgIndex));
@@ -277,46 +277,46 @@ void TextAttributeTests::TestBoldAsBright()
     _renderSettings.SetRenderMode(RenderSettings::Mode::IntenseIsBright, false);
     VERIFY_ARE_EQUAL(std::make_pair(_defaultFg, _defaultBg), _renderSettings.GetAttributeColors(attr));
 
-    // with bold set, calculated foreground/background values shouldn't change for the default colors.
-    attr.SetBold(true);
-    VERIFY_IS_TRUE(attr.IsBold());
+    // with intense set, calculated foreground/background values shouldn't change for the default colors.
+    attr.SetIntense(true);
+    VERIFY_IS_TRUE(attr.IsIntense());
     _renderSettings.SetRenderMode(RenderSettings::Mode::IntenseIsBright, true);
     VERIFY_ARE_EQUAL(std::make_pair(_defaultFg, _defaultBg), _renderSettings.GetAttributeColors(attr));
     _renderSettings.SetRenderMode(RenderSettings::Mode::IntenseIsBright, false);
     VERIFY_ARE_EQUAL(std::make_pair(_defaultFg, _defaultBg), _renderSettings.GetAttributeColors(attr));
 
     attr.SetIndexedForeground(TextColor::DARK_BLACK);
-    VERIFY_IS_TRUE(attr.IsBold());
+    VERIFY_IS_TRUE(attr.IsIntense());
 
-    Log::Comment(L"Foreground should be bright black when bold is bright is enabled");
+    Log::Comment(L"Foreground should be bright black when intense is bright is enabled");
     _renderSettings.SetRenderMode(RenderSettings::Mode::IntenseIsBright, true);
     VERIFY_ARE_EQUAL(std::make_pair(brightBlack, _defaultBg), _renderSettings.GetAttributeColors(attr));
 
-    Log::Comment(L"Foreground should be dark black when bold is bright is disabled");
+    Log::Comment(L"Foreground should be dark black when intense is bright is disabled");
     _renderSettings.SetRenderMode(RenderSettings::Mode::IntenseIsBright, false);
     VERIFY_ARE_EQUAL(std::make_pair(darkBlack, _defaultBg), _renderSettings.GetAttributeColors(attr));
 
     attr.SetIndexedBackground(TextColor::DARK_GREEN);
-    VERIFY_IS_TRUE(attr.IsBold());
+    VERIFY_IS_TRUE(attr.IsIntense());
 
-    Log::Comment(L"background should be unaffected by 'bold is bright'");
+    Log::Comment(L"background should be unaffected by 'intense is bright'");
     _renderSettings.SetRenderMode(RenderSettings::Mode::IntenseIsBright, true);
     VERIFY_ARE_EQUAL(std::make_pair(brightBlack, darkGreen), _renderSettings.GetAttributeColors(attr));
     _renderSettings.SetRenderMode(RenderSettings::Mode::IntenseIsBright, false);
     VERIFY_ARE_EQUAL(std::make_pair(darkBlack, darkGreen), _renderSettings.GetAttributeColors(attr));
 
-    attr.SetBold(false);
-    VERIFY_IS_FALSE(attr.IsBold());
-    Log::Comment(L"when not bold, 'bold is bright' changes nothing");
+    attr.SetIntense(false);
+    VERIFY_IS_FALSE(attr.IsIntense());
+    Log::Comment(L"when not intense, 'intense is bright' changes nothing");
     _renderSettings.SetRenderMode(RenderSettings::Mode::IntenseIsBright, true);
     VERIFY_ARE_EQUAL(std::make_pair(darkBlack, darkGreen), _renderSettings.GetAttributeColors(attr));
     _renderSettings.SetRenderMode(RenderSettings::Mode::IntenseIsBright, false);
     VERIFY_ARE_EQUAL(std::make_pair(darkBlack, darkGreen), _renderSettings.GetAttributeColors(attr));
 
-    Log::Comment(L"When set to a bright color, and bold, 'bold is bright' changes nothing");
-    attr.SetBold(true);
+    Log::Comment(L"When set to a bright color, and intense, 'intense is bright' changes nothing");
+    attr.SetIntense(true);
     attr.SetIndexedForeground(TextColor::BRIGHT_BLACK);
-    VERIFY_IS_TRUE(attr.IsBold());
+    VERIFY_IS_TRUE(attr.IsIntense());
     _renderSettings.SetRenderMode(RenderSettings::Mode::IntenseIsBright, true);
     VERIFY_ARE_EQUAL(std::make_pair(brightBlack, darkGreen), _renderSettings.GetAttributeColors(attr));
     _renderSettings.SetRenderMode(RenderSettings::Mode::IntenseIsBright, false);

--- a/src/cascadia/TerminalCore/TerminalDispatchGraphics.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatchGraphics.cpp
@@ -88,14 +88,14 @@ bool TerminalDispatch::SetGraphicsRendition(const VTParameters options) noexcept
         case BackgroundDefault:
             attr.SetDefaultBackground();
             break;
-        case BoldBright:
-            attr.SetBold(true);
+        case Intense:
+            attr.SetIntense(true);
             break;
         case RGBColorOrFaint:
             attr.SetFaint(true);
             break;
-        case NotBoldOrFaint:
-            attr.SetBold(false);
+        case NotIntenseOrFaint:
+            attr.SetIntense(false);
             attr.SetFaint(false);
             break;
         case Italics:

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -5076,7 +5076,7 @@ void ScreenBufferTests::TestExtendedTextAttributes()
 
     // Run this test for each and every possible combination of states.
     BEGIN_TEST_METHOD_PROPERTIES()
-        TEST_METHOD_PROPERTY(L"Data:bold", L"{false, true}")
+        TEST_METHOD_PROPERTY(L"Data:intense", L"{false, true}")
         TEST_METHOD_PROPERTY(L"Data:faint", L"{false, true}")
         TEST_METHOD_PROPERTY(L"Data:italics", L"{false, true}")
         TEST_METHOD_PROPERTY(L"Data:underlined", L"{false, true}")
@@ -5086,8 +5086,8 @@ void ScreenBufferTests::TestExtendedTextAttributes()
         TEST_METHOD_PROPERTY(L"Data:crossedOut", L"{false, true}")
     END_TEST_METHOD_PROPERTIES()
 
-    bool bold, faint, italics, underlined, doublyUnderlined, blink, invisible, crossedOut;
-    VERIFY_SUCCEEDED(TestData::TryGetValue(L"bold", bold));
+    bool intense, faint, italics, underlined, doublyUnderlined, blink, invisible, crossedOut;
+    VERIFY_SUCCEEDED(TestData::TryGetValue(L"intense", intense));
     VERIFY_SUCCEEDED(TestData::TryGetValue(L"faint", faint));
     VERIFY_SUCCEEDED(TestData::TryGetValue(L"italics", italics));
     VERIFY_SUCCEEDED(TestData::TryGetValue(L"underlined", underlined));
@@ -5107,9 +5107,9 @@ void ScreenBufferTests::TestExtendedTextAttributes()
     std::wstring vtSeq = L"";
 
     // Collect up a VT sequence to set the state given the method properties
-    if (bold)
+    if (intense)
     {
-        WI_SetFlag(expectedAttrs, ExtendedAttributes::Bold);
+        WI_SetFlag(expectedAttrs, ExtendedAttributes::Intense);
         vtSeq += L"\x1b[1m";
     }
     if (faint)
@@ -5184,10 +5184,10 @@ void ScreenBufferTests::TestExtendedTextAttributes()
 
     // One-by-one, turn off each of these states with VT, then check that the
     // state matched.
-    if (bold || faint)
+    if (intense || faint)
     {
-        // The bold and faint attributes share the same reset sequence.
-        WI_ClearAllFlags(expectedAttrs, ExtendedAttributes::Bold | ExtendedAttributes::Faint);
+        // The intense and faint attributes share the same reset sequence.
+        WI_ClearAllFlags(expectedAttrs, ExtendedAttributes::Intense | ExtendedAttributes::Faint);
         vtSeq = L"\x1b[22m";
         validate(expectedAttrs, vtSeq);
     }
@@ -5238,7 +5238,7 @@ void ScreenBufferTests::TestExtendedTextAttributesWithColors()
 
     // Run this test for each and every possible combination of states.
     BEGIN_TEST_METHOD_PROPERTIES()
-        TEST_METHOD_PROPERTY(L"Data:bold", L"{false, true}")
+        TEST_METHOD_PROPERTY(L"Data:intense", L"{false, true}")
         TEST_METHOD_PROPERTY(L"Data:faint", L"{false, true}")
         TEST_METHOD_PROPERTY(L"Data:italics", L"{false, true}")
         TEST_METHOD_PROPERTY(L"Data:underlined", L"{false, true}")
@@ -5257,8 +5257,8 @@ void ScreenBufferTests::TestExtendedTextAttributesWithColors()
     const int Use256Color = 2;
     const int UseRGBColor = 3;
 
-    bool bold, faint, italics, underlined, doublyUnderlined, blink, invisible, crossedOut;
-    VERIFY_SUCCEEDED(TestData::TryGetValue(L"bold", bold));
+    bool intense, faint, italics, underlined, doublyUnderlined, blink, invisible, crossedOut;
+    VERIFY_SUCCEEDED(TestData::TryGetValue(L"intense", intense));
     VERIFY_SUCCEEDED(TestData::TryGetValue(L"faint", faint));
     VERIFY_SUCCEEDED(TestData::TryGetValue(L"italics", italics));
     VERIFY_SUCCEEDED(TestData::TryGetValue(L"underlined", underlined));
@@ -5282,9 +5282,9 @@ void ScreenBufferTests::TestExtendedTextAttributesWithColors()
     std::wstring vtSeq = L"";
 
     // Collect up a VT sequence to set the state given the method properties
-    if (bold)
+    if (intense)
     {
-        expectedAttr.SetBold(true);
+        expectedAttr.SetIntense(true);
         vtSeq += L"\x1b[1m";
     }
     if (faint)
@@ -5403,10 +5403,10 @@ void ScreenBufferTests::TestExtendedTextAttributesWithColors()
 
     // One-by-one, turn off each of these states with VT, then check that the
     // state matched.
-    if (bold || faint)
+    if (intense || faint)
     {
-        // The bold and faint attributes share the same reset sequence.
-        expectedAttr.SetBold(false);
+        // The intense and faint attributes share the same reset sequence.
+        expectedAttr.SetIntense(false);
         expectedAttr.SetFaint(false);
         vtSeq = L"\x1b[22m";
         validate(expectedAttr, vtSeq);
@@ -6222,7 +6222,7 @@ void ScreenBufferTests::TestWriteConsoleVTQuirkMode()
         TextAttribute vtBrightWhiteOnBlackAttribute{};
         vtBrightWhiteOnBlackAttribute.SetForeground(TextColor{ TextColor::DARK_WHITE, false });
         vtBrightWhiteOnBlackAttribute.SetBackground(TextColor{ TextColor::DARK_BLACK, false });
-        vtBrightWhiteOnBlackAttribute.SetBold(true);
+        vtBrightWhiteOnBlackAttribute.SetIntense(true);
 
         TextAttribute vtBrightWhiteOnDefaultAttribute{ vtBrightWhiteOnBlackAttribute }; // copy the above attribute
         vtBrightWhiteOnDefaultAttribute.SetDefaultBackground();
@@ -6248,7 +6248,7 @@ void ScreenBufferTests::TestWriteConsoleVTQuirkMode()
         vtWhiteOnBlack256Attribute.SetForeground(TextColor{ TextColor::DARK_WHITE, true });
         vtWhiteOnBlack256Attribute.SetBackground(TextColor{ TextColor::DARK_BLACK, true });
 
-        // reset (disable bold from the last test) before setting both colors
+        // reset (disable intense from the last test) before setting both colors
         seq = L"\x1b[m\x1b[38;5;7;48;5;0m"; // the quirk should *not* suppress this (!)
         seqCb = 2 * seq.size();
         VERIFY_SUCCEEDED(DoWriteConsole(&seq[0], &seqCb, mainBuffer, useQuirk, waiter));

--- a/src/host/ut_host/TextBufferTests.cpp
+++ b/src/host/ut_host/TextBufferTests.cpp
@@ -114,9 +114,9 @@ class TextBufferTests
 
     TEST_METHOD(TestRgbEraseLine);
 
-    TEST_METHOD(TestUnBold);
-    TEST_METHOD(TestUnBoldRgb);
-    TEST_METHOD(TestComplexUnBold);
+    TEST_METHOD(TestUnintense);
+    TEST_METHOD(TestUnintenseRgb);
+    TEST_METHOD(TestComplexUnintense);
 
     TEST_METHOD(CopyAttrs);
 
@@ -126,8 +126,8 @@ class TextBufferTests
 
     TEST_METHOD(CopyLastAttr);
 
-    TEST_METHOD(TestRgbThenBold);
-    TEST_METHOD(TestResetClearsBoldness);
+    TEST_METHOD(TestRgbThenIntense);
+    TEST_METHOD(TestResetClearsIntensity);
 
     TEST_METHOD(TestBackspaceRightSideVt);
 
@@ -874,7 +874,7 @@ void TextBufferTests::TestRgbEraseLine()
     }
 }
 
-void TextBufferTests::TestUnBold()
+void TextBufferTests::TestUnintense()
 {
     CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     SCREEN_INFORMATION& si = gci.GetActiveOutputBuffer().GetActiveBuffer();
@@ -925,7 +925,7 @@ void TextBufferTests::TestUnBold()
     stateMachine.ProcessString(reset);
 }
 
-void TextBufferTests::TestUnBoldRgb()
+void TextBufferTests::TestUnintenseRgb()
 {
     CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     SCREEN_INFORMATION& si = gci.GetActiveOutputBuffer().GetActiveBuffer();
@@ -980,7 +980,7 @@ void TextBufferTests::TestUnBoldRgb()
     stateMachine.ProcessString(reset);
 }
 
-void TextBufferTests::TestComplexUnBold()
+void TextBufferTests::TestComplexUnintense()
 {
     CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     SCREEN_INFORMATION& si = gci.GetActiveOutputBuffer().GetActiveBuffer();
@@ -1047,22 +1047,22 @@ void TextBufferTests::TestComplexUnBold()
     VERIFY_ARE_EQUAL(attrF.IsLegacy(), false);
 
     VERIFY_ARE_EQUAL(renderSettings.GetAttributeColors(attrA), std::make_pair(bright_green, RGB(1, 2, 3)));
-    VERIFY_IS_TRUE(attrA.IsBold());
+    VERIFY_IS_TRUE(attrA.IsIntense());
 
     VERIFY_ARE_EQUAL(renderSettings.GetAttributeColors(attrB), std::make_pair(dark_green, RGB(1, 2, 3)));
-    VERIFY_IS_FALSE(attrB.IsBold());
+    VERIFY_IS_FALSE(attrB.IsIntense());
 
     VERIFY_ARE_EQUAL(renderSettings.GetAttributeColors(attrC), std::make_pair(RGB(32, 32, 32), RGB(1, 2, 3)));
-    VERIFY_IS_FALSE(attrC.IsBold());
+    VERIFY_IS_FALSE(attrC.IsIntense());
 
     VERIFY_ARE_EQUAL(renderSettings.GetAttributeColors(attrD), renderSettings.GetAttributeColors(attrC));
-    VERIFY_IS_TRUE(attrD.IsBold());
+    VERIFY_IS_TRUE(attrD.IsIntense());
 
     VERIFY_ARE_EQUAL(renderSettings.GetAttributeColors(attrE), std::make_pair(RGB(64, 64, 64), RGB(1, 2, 3)));
-    VERIFY_IS_TRUE(attrE.IsBold());
+    VERIFY_IS_TRUE(attrE.IsIntense());
 
     VERIFY_ARE_EQUAL(renderSettings.GetAttributeColors(attrF), std::make_pair(RGB(64, 64, 64), RGB(1, 2, 3)));
-    VERIFY_IS_FALSE(attrF.IsBold());
+    VERIFY_IS_FALSE(attrF.IsIntense());
 
     std::wstring reset = L"\x1b[0m";
     stateMachine.ProcessString(reset);
@@ -1358,7 +1358,7 @@ void TextBufferTests::CopyLastAttr()
     stateMachine.ProcessString(reset);
 }
 
-void TextBufferTests::TestRgbThenBold()
+void TextBufferTests::TestRgbThenIntense()
 {
     CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     SCREEN_INFORMATION& si = gci.GetActiveOutputBuffer().GetActiveBuffer();
@@ -1369,7 +1369,7 @@ void TextBufferTests::TestRgbThenBold()
 
     // See MSFT:16398982
     Log::Comment(NoThrowString().Format(
-        L"Test that a bold following a RGB color doesn't remove the RGB color"));
+        L"Test that an intense attribute following a RGB color doesn't remove the RGB color"));
     Log::Comment(L"\"\\x1b[38;2;40;40;40m\\x1b[48;2;168;153;132mX\\x1b[1mX\\x1b[m\"");
     const auto foreground = RGB(40, 40, 40);
     const auto background = RGB(168, 153, 132);
@@ -1388,7 +1388,7 @@ void TextBufferTests::TestRgbThenBold()
         x,
         y));
     Log::Comment(NoThrowString().Format(
-        L"attrA should be RGB, and attrB should be the same as attrA, NOT bolded"));
+        L"attrA should be RGB, and attrB should be the same as attrA, NOT intense"));
 
     LOG_ATTR(attrA);
     LOG_ATTR(attrB);
@@ -1403,7 +1403,7 @@ void TextBufferTests::TestRgbThenBold()
     stateMachine.ProcessString(reset);
 }
 
-void TextBufferTests::TestResetClearsBoldness()
+void TextBufferTests::TestResetClearsIntensity()
 {
     CONSOLE_INFORMATION& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     SCREEN_INFORMATION& si = gci.GetActiveOutputBuffer().GetActiveBuffer();
@@ -1413,7 +1413,7 @@ void TextBufferTests::TestResetClearsBoldness()
     const auto& renderSettings = gci.GetRenderSettings();
 
     Log::Comment(NoThrowString().Format(
-        L"Test that resetting bold attributes clears the boldness."));
+        L"Test that resetting intense attributes clears the intensity."));
     const auto x0 = cursor.GetPosition().X;
 
     // Test assumes that the background/foreground were default attribute when it starts up,
@@ -1443,7 +1443,7 @@ void TextBufferTests::TestResetClearsBoldness()
         x,
         y));
     Log::Comment(NoThrowString().Format(
-        L"attrA should be RGB, and attrB should be the same as attrA, NOT bolded"));
+        L"attrA should be RGB, and attrB should be the same as attrA, NOT intense"));
 
     LOG_ATTR(attrA);
     LOG_ATTR(attrB);
@@ -1455,10 +1455,10 @@ void TextBufferTests::TestResetClearsBoldness()
     VERIFY_ARE_EQUAL(renderSettings.GetAttributeColors(attrC).first, defaultFg);
     VERIFY_ARE_EQUAL(renderSettings.GetAttributeColors(attrD).first, dark_green);
 
-    VERIFY_IS_FALSE(attrA.IsBold());
-    VERIFY_IS_TRUE(attrB.IsBold());
-    VERIFY_IS_FALSE(attrC.IsBold());
-    VERIFY_IS_FALSE(attrD.IsBold());
+    VERIFY_IS_FALSE(attrA.IsIntense());
+    VERIFY_IS_TRUE(attrB.IsIntense());
+    VERIFY_IS_FALSE(attrC.IsIntense());
+    VERIFY_IS_FALSE(attrD.IsIntense());
 
     const auto reset = L"\x1b[0m";
     stateMachine.ProcessString(reset);

--- a/src/host/ut_host/VtRendererTests.cpp
+++ b/src/host/ut_host/VtRendererTests.cpp
@@ -831,9 +831,9 @@ void VtRendererTest::Xterm256TestAttributesAcrossReset()
 
     switch (renditionAttribute)
     {
-    case GraphicsOptions::BoldBright:
-        Log::Comment(L"----Set Bold Attribute----");
-        textAttributes.SetBold(true);
+    case GraphicsOptions::Intense:
+        Log::Comment(L"----Set Intense Attribute----");
+        textAttributes.SetIntense(true);
         break;
     case GraphicsOptions::RGBColorOrFaint:
         Log::Comment(L"----Set Faint Attribute----");
@@ -1364,9 +1364,9 @@ void VtRendererTest::XtermTestAttributesAcrossReset()
 
     switch (renditionAttribute)
     {
-    case GraphicsOptions::BoldBright:
-        Log::Comment(L"----Set Bold Attribute----");
-        textAttributes.SetBold(true);
+    case GraphicsOptions::Intense:
+        Log::Comment(L"----Set Intense Attribute----");
+        textAttributes.SetIntense(true);
         break;
     case GraphicsOptions::Underline:
         Log::Comment(L"----Set Underline Attribute----");

--- a/src/inc/conattrs.hpp
+++ b/src/inc/conattrs.hpp
@@ -11,7 +11,7 @@ Licensed under the MIT license.
 enum class ExtendedAttributes : BYTE
 {
     Normal = 0x00,
-    Bold = 0x01,
+    Intense = 0x01,
     Italics = 0x02,
     Blinking = 0x04,
     Invisible = 0x08,

--- a/src/interactivity/win32/ut_interactivity_win32/UiaTextRangeTests.cpp
+++ b/src/interactivity/win32/ut_interactivity_win32/UiaTextRangeTests.cpp
@@ -1608,13 +1608,13 @@ class UiaTextRangeTests
         }
         {
             Log::Comment(L"Test Font Weight");
-            attr.SetBold(true);
+            attr.SetIntense(true);
             updateBuffer(attr);
             VARIANT result;
             VERIFY_SUCCEEDED(utr->GetAttributeValue(UIA_FontWeightAttributeId, &result));
             VERIFY_ARE_EQUAL(FW_BOLD, result.lVal);
 
-            attr.SetBold(false);
+            attr.SetIntense(false);
             updateBuffer(attr);
             VERIFY_SUCCEEDED(utr->GetAttributeValue(UIA_FontWeightAttributeId, &result));
             VERIFY_ARE_EQUAL(FW_NORMAL, result.lVal);

--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -600,7 +600,7 @@ try
         }
 
         const u32x2 newColors{ gsl::narrow_cast<u32>(fg | 0xff000000), gsl::narrow_cast<u32>(bg | _api.backgroundOpaqueMixin) };
-        const AtlasKeyAttributes attributes{ 0, textAttributes.IsBold(), textAttributes.IsItalic(), 0 };
+        const AtlasKeyAttributes attributes{ 0, textAttributes.IsIntense(), textAttributes.IsItalic(), 0 };
 
         if (_api.attributes != attributes)
         {

--- a/src/renderer/base/RenderSettings.cpp
+++ b/src/renderer/base/RenderSettings.cpp
@@ -180,7 +180,7 @@ std::pair<COLORREF, COLORREF> RenderSettings::GetAttributeColors(const TextAttri
     const auto defaultFgIndex = GetColorAliasIndex(ColorAlias::DefaultForeground);
     const auto defaultBgIndex = GetColorAliasIndex(ColorAlias::DefaultBackground);
 
-    const auto brightenFg = attr.IsBold() && GetRenderMode(Mode::IntenseIsBright);
+    const auto brightenFg = attr.IsIntense() && GetRenderMode(Mode::IntenseIsBright);
     const auto dimFg = attr.IsFaint() || (_blinkShouldBeFaint && attr.IsBlinking());
     const auto swapFgAndBg = attr.IsReverseVideo() ^ GetRenderMode(Mode::ScreenReversed);
 
@@ -197,7 +197,7 @@ std::pair<COLORREF, COLORREF> RenderSettings::GetAttributeColors(const TextAttri
 
         if (fgTextColor.IsIndex16() && (fgIndex < 8) && brightenFg)
         {
-            // There is a special case for bold here - we need to get the bright version of the foreground color
+            // There is a special case for intense here - we need to get the bright version of the foreground color
             fgIndex += 8;
         }
 

--- a/src/renderer/dx/DxFontRenderData.cpp
+++ b/src/renderer/dx/DxFontRenderData.cpp
@@ -467,7 +467,7 @@ bool DxFontRenderData::DidUserSetAxes() const noexcept
 // Routine Description:
 // - Function called to inform us whether to use the user set weight
 //   in the font axes
-// - Called by CustomTextLayout, when the text attribute is bold we should
+// - Called by CustomTextLayout, when the text attribute is intense we should
 //   ignore the user set weight, otherwise setting the bold font axis
 //   breaks the bold font attribute
 // Arguments:
@@ -547,7 +547,7 @@ void DxFontRenderData::_SetAxes(const std::unordered_map<std::wstring_view, floa
     {
         // Store the weight aside: we will be creating a span of all the axes in the vector except the weight,
         // and then we will add the weight to the vector
-        // We are doing this so that when the text attribute is bold, we can apply all the axes except the weight
+        // We are doing this so that when the text attribute is intense, we can apply all the axes except the weight
         std::optional<DWRITE_FONT_AXIS_VALUE> weightAxis;
 
         // Since we are calling an 'emplace_back' after creating the span,

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1962,7 +1962,7 @@ CATCH_RETURN()
     if (_drawingContext)
     {
         _drawingContext->forceGrayscaleAA = _ShouldForceGrayscaleAA();
-        _drawingContext->useBoldFont = textAttributes.IsBold() && renderSettings.GetRenderMode(RenderSettings::Mode::IntenseIsBold);
+        _drawingContext->useBoldFont = textAttributes.IsIntense() && renderSettings.GetRenderMode(RenderSettings::Mode::IntenseIsBold);
         _drawingContext->useItalicFont = textAttributes.IsItalic();
     }
 

--- a/src/renderer/vt/VtSequences.cpp
+++ b/src/renderer/vt/VtSequences.cpp
@@ -216,12 +216,12 @@ using namespace Microsoft::Console::Render;
     // Foreground sequences are in [30,37] U [90,97]
     // Background sequences are in [40,47] U [100,107]
     // The "dark" sequences are in the first 7 values, the bright sequences in the second set.
-    // Note that text brightness and boldness are different in VT. Boldness is
-    //      handled by _SetGraphicsBoldness. Here, we can emit either bright or
+    // Note that text brightness and intensity are different in VT. Intensity is
+    //      handled by _SetIntense. Here, we can emit either bright or
     //      dark colors. For conhost as a terminal, it can't draw bold
-    //      characters, so it displays "bold" as bright, and in fact most
-    //      terminals display the bright color when displaying bolded text.
-    // By specifying the boldness and brightness separately, we'll make sure the
+    //      characters, so it displays "intense" as bright, and in fact most
+    //      terminals display the bright color when displaying intense text.
+    // By specifying the intensity and brightness separately, we'll make sure the
     //      terminal has an accurate representation of our buffer.
     const auto prefix = WI_IsFlagSet(index, FOREGROUND_INTENSITY) ? (fIsForeground ? 90 : 100) : (fIsForeground ? 30 : 40);
     return _WriteFormatted(FMT_COMPILE("\x1b[{}m"), prefix + (index & 7));
@@ -260,7 +260,7 @@ using namespace Microsoft::Console::Render;
 
 // Method Description:
 // - Formats and writes a sequence to change the current text attributes to the
-//      default foreground or background. Does not affect the boldness of text.
+//      default foreground or background. Does not affect the intensity of text.
 // Arguments:
 // - fIsForeground: true if we should emit the foreground sequence, false for background
 // Return Value:
@@ -311,14 +311,14 @@ using namespace Microsoft::Console::Render;
 }
 
 // Method Description:
-// - Formats and writes a sequence to change the boldness of the following text.
+// - Formats and writes a sequence to change the intensity of the following text.
 // Arguments:
-// - isBold: If true, we'll embolden the text. Otherwise we'll debolden the text.
+// - isIntense: If true, we'll make the text intense. Otherwise we'll remove the intensity.
 // Return Value:
 // - S_OK if we succeeded, else an appropriate HRESULT for failing to allocate or write.
-[[nodiscard]] HRESULT VtEngine::_SetBold(const bool isBold) noexcept
+[[nodiscard]] HRESULT VtEngine::_SetIntense(const bool isIntense) noexcept
 {
-    return _Write(isBold ? "\x1b[1m" : "\x1b[22m");
+    return _Write(isIntense ? "\x1b[1m" : "\x1b[22m");
 }
 
 // Method Description:

--- a/src/renderer/vt/Xterm256Engine.cpp
+++ b/src/renderer/vt/Xterm256Engine.cpp
@@ -43,28 +43,28 @@ Xterm256Engine::Xterm256Engine(_In_ wil::unique_hfile hPipe,
 // Routine Description:
 // - Write a VT sequence to update the character rendition attributes.
 // Arguments:
-// - textAttributes - text attributes (bold, italic, underline, etc.) to use.
+// - textAttributes - text attributes (intense, italic, underline, etc.) to use.
 // Return Value:
 // - S_OK if we succeeded, else an appropriate HRESULT for failing to allocate or write.
 [[nodiscard]] HRESULT Xterm256Engine::_UpdateExtendedAttrs(const TextAttribute& textAttributes) noexcept
 {
-    // Turning off Bold and Faint must be handled at the same time,
+    // Turning off Intense and Faint must be handled at the same time,
     // since there is only one sequence that resets both of them.
-    const auto boldTurnedOff = !textAttributes.IsBold() && _lastTextAttributes.IsBold();
+    const auto intenseTurnedOff = !textAttributes.IsIntense() && _lastTextAttributes.IsIntense();
     const auto faintTurnedOff = !textAttributes.IsFaint() && _lastTextAttributes.IsFaint();
-    if (boldTurnedOff || faintTurnedOff)
+    if (intenseTurnedOff || faintTurnedOff)
     {
-        RETURN_IF_FAILED(_SetBold(false));
-        _lastTextAttributes.SetBold(false);
+        RETURN_IF_FAILED(_SetIntense(false));
+        _lastTextAttributes.SetIntense(false);
         _lastTextAttributes.SetFaint(false);
     }
 
     // Once we've handled the cases where they need to be turned off,
     // we can then check if either should be turned back on again.
-    if (textAttributes.IsBold() && !_lastTextAttributes.IsBold())
+    if (textAttributes.IsIntense() && !_lastTextAttributes.IsIntense())
     {
-        RETURN_IF_FAILED(_SetBold(true));
-        _lastTextAttributes.SetBold(true);
+        RETURN_IF_FAILED(_SetIntense(true));
+        _lastTextAttributes.SetIntense(true);
     }
     if (textAttributes.IsFaint() && !_lastTextAttributes.IsFaint())
     {

--- a/src/renderer/vt/paint.cpp
+++ b/src/renderer/vt/paint.cpp
@@ -292,16 +292,16 @@ using namespace Microsoft::Console::Types;
     auto fgIndex = TextColor::TransposeLegacyIndex(fg.GetLegacyIndex(0));
     auto bgIndex = TextColor::TransposeLegacyIndex(bg.GetLegacyIndex(0));
 
-    // If the bold attribute is set, and the foreground can be brightened, then do so.
-    const bool brighten = textAttributes.IsBold() && fg.CanBeBrightened();
+    // If the intense attribute is set, and the foreground can be brightened, then do so.
+    const bool brighten = textAttributes.IsIntense() && fg.CanBeBrightened();
     fgIndex |= (brighten ? FOREGROUND_INTENSITY : 0);
 
-    // To actually render bright colors, though, we need to use SGR bold.
-    const auto needBold = fgIndex > 7;
-    if (needBold != _lastTextAttributes.IsBold())
+    // To actually render bright colors, though, we need to use SGR intense.
+    const auto needIntense = fgIndex > 7;
+    if (needIntense != _lastTextAttributes.IsIntense())
     {
-        RETURN_IF_FAILED(_SetBold(needBold));
-        _lastTextAttributes.SetBold(needBold);
+        RETURN_IF_FAILED(_SetIntense(needIntense));
+        _lastTextAttributes.SetIntense(needIntense);
     }
 
     // After which we drop the high bits, since only colors 0 to 7 are supported.

--- a/src/renderer/vt/vtrenderer.hpp
+++ b/src/renderer/vt/vtrenderer.hpp
@@ -171,7 +171,7 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT _ResizeWindow(const short sWidth, const short sHeight) noexcept;
 
-        [[nodiscard]] HRESULT _SetBold(const bool isBold) noexcept;
+        [[nodiscard]] HRESULT _SetIntense(const bool isIntense) noexcept;
         [[nodiscard]] HRESULT _SetFaint(const bool isFaint) noexcept;
         [[nodiscard]] HRESULT _SetUnderlined(const bool isUnderlined) noexcept;
         [[nodiscard]] HRESULT _SetDoublyUnderlined(const bool isUnderlined) noexcept;

--- a/src/terminal/adapter/DispatchTypes.hpp
+++ b/src/terminal/adapter/DispatchTypes.hpp
@@ -261,19 +261,19 @@ namespace Microsoft::Console::VirtualTerminal::DispatchTypes
     enum GraphicsOptions : size_t
     {
         Off = 0,
-        BoldBright = 1,
+        Intense = 1,
         // The 2 and 5 entries here are for BOTH the extended graphics options,
         // as well as the Faint/Blink options.
         RGBColorOrFaint = 2, // 2 is also Faint, decreased intensity (ISO 6429).
         Italics = 3,
         Underline = 4,
-        BlinkOrXterm256Index = 5, // 5 is also Blink (appears as Bold).
+        BlinkOrXterm256Index = 5, // 5 is also Blink.
         RapidBlink = 6,
         Negative = 7,
         Invisible = 8,
         CrossedOut = 9,
         DoublyUnderlined = 21,
-        NotBoldOrFaint = 22,
+        NotIntenseOrFaint = 22,
         NotItalics = 23,
         NoUnderline = 24,
         Steady = 25, // _not_ blink
@@ -325,7 +325,7 @@ namespace Microsoft::Console::VirtualTerminal::DispatchTypes
     // are used here to indicate that the foreground/background colors should be saved).
     // From xterm's ctlseqs doc for XTPUSHSGR:
     //
-    //      Ps = 1    =>  Bold.
+    //      Ps = 1    =>  Intense.
     //      Ps = 2    =>  Faint.
     //      Ps = 3    =>  Italicized.
     //      Ps = 4    =>  Underlined.
@@ -340,7 +340,7 @@ namespace Microsoft::Console::VirtualTerminal::DispatchTypes
     enum class SgrSaveRestoreStackOptions : size_t
     {
         All = 0,
-        Boldness = 1,
+        Intense = 1,
         Faintness = 2,
         Italics = 3,
         Underline = 4,

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -2515,7 +2515,7 @@ void AdaptDispatch::_ReportSGRSetting() const
                 response.append(parameter);
             }
         };
-        addAttribute(L";1"sv, attr.IsBold());
+        addAttribute(L";1"sv, attr.IsIntense());
         addAttribute(L";2"sv, attr.IsFaint());
         addAttribute(L";3"sv, attr.IsItalic());
         addAttribute(L";4"sv, attr.IsUnderlined());

--- a/src/terminal/adapter/adaptDispatchGraphics.cpp
+++ b/src/terminal/adapter/adaptDispatchGraphics.cpp
@@ -97,14 +97,14 @@ bool AdaptDispatch::SetGraphicsRendition(const VTParameters options)
             case BackgroundDefault:
                 attr.SetDefaultBackground();
                 break;
-            case BoldBright:
-                attr.SetBold(true);
+            case Intense:
+                attr.SetIntense(true);
                 break;
             case RGBColorOrFaint:
                 attr.SetFaint(true);
                 break;
-            case NotBoldOrFaint:
-                attr.SetBold(false);
+            case NotIntenseOrFaint:
+                attr.SetIntense(false);
                 attr.SetFaint(false);
                 break;
             case Italics:

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -1200,11 +1200,11 @@ public:
             _testGetSet->_attribute = TextAttribute{ (WORD)~_testGetSet->s_defaultFill };
             _testGetSet->_expectedAttribute = TextAttribute{};
             break;
-        case DispatchTypes::GraphicsOptions::BoldBright:
-            Log::Comment(L"Testing graphics 'Bold/Bright'");
+        case DispatchTypes::GraphicsOptions::Intense:
+            Log::Comment(L"Testing graphics 'Intense'");
             _testGetSet->_attribute = TextAttribute{ 0 };
             _testGetSet->_expectedAttribute = TextAttribute{ 0 };
-            _testGetSet->_expectedAttribute.SetBold(true);
+            _testGetSet->_expectedAttribute.SetIntense(true);
             break;
         case DispatchTypes::GraphicsOptions::RGBColorOrFaint:
             Log::Comment(L"Testing graphics 'Faint'");
@@ -1246,10 +1246,10 @@ public:
             _testGetSet->_expectedAttribute = TextAttribute{ 0 };
             _testGetSet->_expectedAttribute.SetCrossedOut(true);
             break;
-        case DispatchTypes::GraphicsOptions::NotBoldOrFaint:
-            Log::Comment(L"Testing graphics 'No Bold or Faint'");
+        case DispatchTypes::GraphicsOptions::NotIntenseOrFaint:
+            Log::Comment(L"Testing graphics 'No Intense or Faint'");
             _testGetSet->_attribute = TextAttribute{ 0 };
-            _testGetSet->_attribute.SetBold(true);
+            _testGetSet->_attribute.SetIntense(true);
             _testGetSet->_attribute.SetFaint(true);
             _testGetSet->_expectedAttribute = TextAttribute{ 0 };
             break;
@@ -1577,10 +1577,10 @@ public:
         VERIFY_IS_TRUE(_pDispatch->SetGraphicsRendition({ rgOptions, cOptions }));
 
         cOptions = 1;
-        rgOptions[0] = DispatchTypes::GraphicsOptions::BoldBright;
+        rgOptions[0] = DispatchTypes::GraphicsOptions::Intense;
         _testGetSet->_expectedAttribute = {};
         _testGetSet->_expectedAttribute.SetIndexedForeground(TextColor::DARK_GREEN);
-        _testGetSet->_expectedAttribute.SetBold(true);
+        _testGetSet->_expectedAttribute.SetIntense(true);
         _testGetSet->_expectedAttribute.SetDefaultBackground();
         VERIFY_IS_TRUE(_pDispatch->SetGraphicsRendition({ rgOptions, cOptions }));
 
@@ -1588,12 +1588,12 @@ public:
         _testGetSet->_expectedAttribute = {};
         _testGetSet->_expectedAttribute.SetIndexedForeground(TextColor::DARK_GREEN);
         _testGetSet->_expectedAttribute.SetIndexedBackground(TextColor::DARK_BLUE);
-        _testGetSet->_expectedAttribute.SetBold(true);
+        _testGetSet->_expectedAttribute.SetIntense(true);
         VERIFY_IS_TRUE(_pDispatch->SetGraphicsRendition({ rgOptions, cOptions }));
 
-        // Push, specifying that we only want to save the background, the boldness, and double-underline-ness:
+        // Push, specifying that we only want to save the background, the intensity, and double-underline-ness:
         cOptions = 3;
-        rgStackOptions[0] = (size_t)DispatchTypes::SgrSaveRestoreStackOptions::Boldness;
+        rgStackOptions[0] = (size_t)DispatchTypes::SgrSaveRestoreStackOptions::Intense;
         rgStackOptions[1] = (size_t)DispatchTypes::SgrSaveRestoreStackOptions::SaveBackgroundColor;
         rgStackOptions[2] = (size_t)DispatchTypes::SgrSaveRestoreStackOptions::DoublyUnderlined;
         VERIFY_IS_TRUE(_pDispatch->PushGraphicsRendition({ rgStackOptions, cOptions }));
@@ -1605,7 +1605,7 @@ public:
         _testGetSet->_expectedAttribute = {};
         _testGetSet->_expectedAttribute.SetIndexedForeground(TextColor::DARK_GREEN);
         _testGetSet->_expectedAttribute.SetIndexedBackground(TextColor::DARK_GREEN);
-        _testGetSet->_expectedAttribute.SetBold(true);
+        _testGetSet->_expectedAttribute.SetIntense(true);
         _testGetSet->_expectedAttribute.SetDoublyUnderlined(true);
         VERIFY_IS_TRUE(_pDispatch->SetGraphicsRendition({ rgOptions, cOptions }));
 
@@ -1614,11 +1614,11 @@ public:
         _testGetSet->_expectedAttribute = {};
         _testGetSet->_expectedAttribute.SetIndexedForeground(TextColor::DARK_RED);
         _testGetSet->_expectedAttribute.SetIndexedBackground(TextColor::DARK_GREEN);
-        _testGetSet->_expectedAttribute.SetBold(true);
+        _testGetSet->_expectedAttribute.SetIntense(true);
         _testGetSet->_expectedAttribute.SetDoublyUnderlined(true);
         VERIFY_IS_TRUE(_pDispatch->SetGraphicsRendition({ rgOptions, cOptions }));
 
-        rgOptions[0] = DispatchTypes::GraphicsOptions::NotBoldOrFaint;
+        rgOptions[0] = DispatchTypes::GraphicsOptions::NotIntenseOrFaint;
         _testGetSet->_expectedAttribute = {};
         _testGetSet->_expectedAttribute.SetIndexedForeground(TextColor::DARK_RED);
         _testGetSet->_expectedAttribute.SetIndexedBackground(TextColor::DARK_GREEN);
@@ -1630,7 +1630,7 @@ public:
         _testGetSet->_expectedAttribute = {};
         _testGetSet->_expectedAttribute.SetIndexedForeground(TextColor::DARK_RED);
         _testGetSet->_expectedAttribute.SetIndexedBackground(TextColor::DARK_BLUE);
-        _testGetSet->_expectedAttribute.SetBold(true);
+        _testGetSet->_expectedAttribute.SetIntense(true);
         VERIFY_IS_TRUE(_pDispatch->PopGraphicsRendition());
     }
 
@@ -1655,17 +1655,17 @@ public:
         VERIFY_IS_TRUE(_pDispatch.get()->SetGraphicsRendition({ rgOptions, cOptions }));
 
         Log::Comment(L"Enabling brightness");
-        rgOptions[0] = DispatchTypes::GraphicsOptions::BoldBright;
-        _testGetSet->_expectedAttribute.SetBold(true);
+        rgOptions[0] = DispatchTypes::GraphicsOptions::Intense;
+        _testGetSet->_expectedAttribute.SetIntense(true);
         VERIFY_IS_TRUE(_pDispatch.get()->SetGraphicsRendition({ rgOptions, cOptions }));
-        VERIFY_IS_TRUE(_testGetSet->_attribute.IsBold());
+        VERIFY_IS_TRUE(_testGetSet->_attribute.IsIntense());
 
         Log::Comment(L"Testing graphics 'Foreground Color Green, with brightness'");
         rgOptions[0] = DispatchTypes::GraphicsOptions::ForegroundGreen;
         _testGetSet->_expectedAttribute.SetIndexedForeground(TextColor::DARK_GREEN);
         VERIFY_IS_TRUE(_pDispatch.get()->SetGraphicsRendition({ rgOptions, cOptions }));
         VERIFY_IS_TRUE(WI_IsFlagSet(_testGetSet->_attribute.GetLegacyAttributes(), FOREGROUND_GREEN));
-        VERIFY_IS_TRUE(_testGetSet->_attribute.IsBold());
+        VERIFY_IS_TRUE(_testGetSet->_attribute.IsIntense());
 
         Log::Comment(L"Test 2: Disable brightness, use a bright color, next normal call remains not bright");
         Log::Comment(L"Resetting graphics options");
@@ -1673,56 +1673,56 @@ public:
         _testGetSet->_expectedAttribute = {};
         VERIFY_IS_TRUE(_pDispatch.get()->SetGraphicsRendition({ rgOptions, cOptions }));
         VERIFY_IS_TRUE(WI_IsFlagClear(_testGetSet->_attribute.GetLegacyAttributes(), FOREGROUND_INTENSITY));
-        VERIFY_IS_FALSE(_testGetSet->_attribute.IsBold());
+        VERIFY_IS_FALSE(_testGetSet->_attribute.IsIntense());
 
         Log::Comment(L"Testing graphics 'Foreground Color Bright Blue'");
         rgOptions[0] = DispatchTypes::GraphicsOptions::BrightForegroundBlue;
         _testGetSet->_expectedAttribute.SetIndexedForeground(TextColor::BRIGHT_BLUE);
         VERIFY_IS_TRUE(_pDispatch.get()->SetGraphicsRendition({ rgOptions, cOptions }));
-        VERIFY_IS_FALSE(_testGetSet->_attribute.IsBold());
+        VERIFY_IS_FALSE(_testGetSet->_attribute.IsIntense());
 
         Log::Comment(L"Testing graphics 'Foreground Color Blue', brightness of 9x series doesn't persist");
         rgOptions[0] = DispatchTypes::GraphicsOptions::ForegroundBlue;
         _testGetSet->_expectedAttribute.SetIndexedForeground(TextColor::DARK_BLUE);
         VERIFY_IS_TRUE(_pDispatch.get()->SetGraphicsRendition({ rgOptions, cOptions }));
-        VERIFY_IS_FALSE(_testGetSet->_attribute.IsBold());
+        VERIFY_IS_FALSE(_testGetSet->_attribute.IsIntense());
 
         Log::Comment(L"Test 3: Enable brightness, use a bright color, brightness persists to next normal call");
         Log::Comment(L"Resetting graphics options");
         rgOptions[0] = DispatchTypes::GraphicsOptions::Off;
         _testGetSet->_expectedAttribute = {};
         VERIFY_IS_TRUE(_pDispatch.get()->SetGraphicsRendition({ rgOptions, cOptions }));
-        VERIFY_IS_FALSE(_testGetSet->_attribute.IsBold());
+        VERIFY_IS_FALSE(_testGetSet->_attribute.IsIntense());
 
         Log::Comment(L"Testing graphics 'Foreground Color Blue'");
         rgOptions[0] = DispatchTypes::GraphicsOptions::ForegroundBlue;
         _testGetSet->_expectedAttribute.SetIndexedForeground(TextColor::DARK_BLUE);
         VERIFY_IS_TRUE(_pDispatch.get()->SetGraphicsRendition({ rgOptions, cOptions }));
-        VERIFY_IS_FALSE(_testGetSet->_attribute.IsBold());
+        VERIFY_IS_FALSE(_testGetSet->_attribute.IsIntense());
 
         Log::Comment(L"Enabling brightness");
-        rgOptions[0] = DispatchTypes::GraphicsOptions::BoldBright;
-        _testGetSet->_expectedAttribute.SetBold(true);
+        rgOptions[0] = DispatchTypes::GraphicsOptions::Intense;
+        _testGetSet->_expectedAttribute.SetIntense(true);
         VERIFY_IS_TRUE(_pDispatch.get()->SetGraphicsRendition({ rgOptions, cOptions }));
-        VERIFY_IS_TRUE(_testGetSet->_attribute.IsBold());
+        VERIFY_IS_TRUE(_testGetSet->_attribute.IsIntense());
 
         Log::Comment(L"Testing graphics 'Foreground Color Bright Blue'");
         rgOptions[0] = DispatchTypes::GraphicsOptions::BrightForegroundBlue;
         _testGetSet->_expectedAttribute.SetIndexedForeground(TextColor::BRIGHT_BLUE);
         VERIFY_IS_TRUE(_pDispatch.get()->SetGraphicsRendition({ rgOptions, cOptions }));
-        VERIFY_IS_TRUE(_testGetSet->_attribute.IsBold());
+        VERIFY_IS_TRUE(_testGetSet->_attribute.IsIntense());
 
         Log::Comment(L"Testing graphics 'Foreground Color Blue, with brightness', brightness of 9x series doesn't affect brightness");
         rgOptions[0] = DispatchTypes::GraphicsOptions::ForegroundBlue;
         _testGetSet->_expectedAttribute.SetIndexedForeground(TextColor::DARK_BLUE);
         VERIFY_IS_TRUE(_pDispatch.get()->SetGraphicsRendition({ rgOptions, cOptions }));
-        VERIFY_IS_TRUE(_testGetSet->_attribute.IsBold());
+        VERIFY_IS_TRUE(_testGetSet->_attribute.IsIntense());
 
         Log::Comment(L"Testing graphics 'Foreground Color Green, with brightness'");
         rgOptions[0] = DispatchTypes::GraphicsOptions::ForegroundGreen;
         _testGetSet->_expectedAttribute.SetIndexedForeground(TextColor::DARK_GREEN);
         VERIFY_IS_TRUE(_pDispatch.get()->SetGraphicsRendition({ rgOptions, cOptions }));
-        VERIFY_IS_TRUE(_testGetSet->_attribute.IsBold());
+        VERIFY_IS_TRUE(_testGetSet->_attribute.IsIntense());
     }
 
     TEST_METHOD(DeviceStatusReportTests)
@@ -1913,10 +1913,10 @@ public:
         requestSetting(L"m");
         _testGetSet->ValidateInputEvent(L"\033P1$r0m\033\\");
 
-        Log::Comment(L"Requesting SGR attributes (bold, underlined, reversed).");
+        Log::Comment(L"Requesting SGR attributes (intense, underlined, reversed).");
         _testGetSet->PrepData();
         _testGetSet->_attribute = {};
-        _testGetSet->_attribute.SetBold(true);
+        _testGetSet->_attribute.SetIntense(true);
         _testGetSet->_attribute.SetUnderlined(true);
         _testGetSet->_attribute.SetReverseVideo(true);
         requestSetting(L"m");

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -2222,7 +2222,7 @@ class StateMachineExternalTest final
         mach.ProcessCharacter(L'm');
         VERIFY_IS_TRUE(pDispatch->_setGraphics);
 
-        rgExpected[0] = DispatchTypes::GraphicsOptions::BoldBright;
+        rgExpected[0] = DispatchTypes::GraphicsOptions::Intense;
         rgExpected[1] = DispatchTypes::GraphicsOptions::Underline;
         rgExpected[2] = DispatchTypes::GraphicsOptions::Negative;
         rgExpected[3] = DispatchTypes::GraphicsOptions::ForegroundBlack;
@@ -2272,23 +2272,23 @@ class StateMachineExternalTest final
         mach.ProcessCharacter(L'm');
         VERIFY_IS_TRUE(pDispatch->_setGraphics);
 
-        rgExpected[0] = DispatchTypes::GraphicsOptions::BoldBright;
+        rgExpected[0] = DispatchTypes::GraphicsOptions::Intense;
         rgExpected[1] = DispatchTypes::GraphicsOptions::Underline;
-        rgExpected[2] = DispatchTypes::GraphicsOptions::BoldBright;
+        rgExpected[2] = DispatchTypes::GraphicsOptions::Intense;
         rgExpected[3] = DispatchTypes::GraphicsOptions::Underline;
-        rgExpected[4] = DispatchTypes::GraphicsOptions::BoldBright;
+        rgExpected[4] = DispatchTypes::GraphicsOptions::Intense;
         rgExpected[5] = DispatchTypes::GraphicsOptions::Underline;
-        rgExpected[6] = DispatchTypes::GraphicsOptions::BoldBright;
+        rgExpected[6] = DispatchTypes::GraphicsOptions::Intense;
         rgExpected[7] = DispatchTypes::GraphicsOptions::Underline;
-        rgExpected[8] = DispatchTypes::GraphicsOptions::BoldBright;
+        rgExpected[8] = DispatchTypes::GraphicsOptions::Intense;
         rgExpected[9] = DispatchTypes::GraphicsOptions::Underline;
-        rgExpected[10] = DispatchTypes::GraphicsOptions::BoldBright;
+        rgExpected[10] = DispatchTypes::GraphicsOptions::Intense;
         rgExpected[11] = DispatchTypes::GraphicsOptions::Underline;
-        rgExpected[12] = DispatchTypes::GraphicsOptions::BoldBright;
+        rgExpected[12] = DispatchTypes::GraphicsOptions::Intense;
         rgExpected[13] = DispatchTypes::GraphicsOptions::Underline;
-        rgExpected[14] = DispatchTypes::GraphicsOptions::BoldBright;
+        rgExpected[14] = DispatchTypes::GraphicsOptions::Intense;
         rgExpected[15] = DispatchTypes::GraphicsOptions::Underline;
-        rgExpected[16] = DispatchTypes::GraphicsOptions::BoldBright;
+        rgExpected[16] = DispatchTypes::GraphicsOptions::Intense;
         VerifyDispatchTypes({ rgExpected, 17 }, *pDispatch);
 
         pDispatch->ClearState();
@@ -2299,7 +2299,7 @@ class StateMachineExternalTest final
         mach.ProcessString(sequence);
         VERIFY_IS_TRUE(pDispatch->_setGraphics);
 
-        rgExpected[0] = DispatchTypes::GraphicsOptions::BoldBright;
+        rgExpected[0] = DispatchTypes::GraphicsOptions::Intense;
         rgExpected[1] = DispatchTypes::GraphicsOptions::Off;
         VerifyDispatchTypes({ rgExpected, 2 }, *pDispatch);
 
@@ -2311,9 +2311,9 @@ class StateMachineExternalTest final
         mach.ProcessString(sequence);
         VERIFY_IS_TRUE(pDispatch->_setGraphics);
 
-        rgExpected[0] = DispatchTypes::GraphicsOptions::BoldBright;
+        rgExpected[0] = DispatchTypes::GraphicsOptions::Intense;
         rgExpected[1] = DispatchTypes::GraphicsOptions::Off;
-        rgExpected[2] = DispatchTypes::GraphicsOptions::BoldBright;
+        rgExpected[2] = DispatchTypes::GraphicsOptions::Intense;
         VerifyDispatchTypes({ rgExpected, 3 }, *pDispatch);
 
         pDispatch->ClearState();
@@ -2326,7 +2326,7 @@ class StateMachineExternalTest final
 
         rgExpected[0] = DispatchTypes::GraphicsOptions::Off;
         rgExpected[1] = DispatchTypes::GraphicsOptions::ForegroundRed;
-        rgExpected[2] = DispatchTypes::GraphicsOptions::BoldBright;
+        rgExpected[2] = DispatchTypes::GraphicsOptions::Intense;
         VerifyDispatchTypes({ rgExpected, 3 }, *pDispatch);
 
         pDispatch->ClearState();
@@ -2543,7 +2543,7 @@ class StateMachineExternalTest final
         VERIFY_IS_TRUE(pDispatch->_setGraphics);
         VERIFY_IS_TRUE(pDispatch->_eraseDisplay);
 
-        rgExpected[0] = DispatchTypes::GraphicsOptions::BoldBright;
+        rgExpected[0] = DispatchTypes::GraphicsOptions::Intense;
         rgExpected[1] = DispatchTypes::GraphicsOptions::Underline;
         rgExpected[2] = DispatchTypes::GraphicsOptions::Negative;
         rgExpected[3] = DispatchTypes::GraphicsOptions::ForegroundBlack;
@@ -2560,7 +2560,7 @@ class StateMachineExternalTest final
 
         mach.ProcessString(L"\x1b[1;30mHello World\x1b[2J");
 
-        rgExpected[0] = DispatchTypes::GraphicsOptions::BoldBright;
+        rgExpected[0] = DispatchTypes::GraphicsOptions::Intense;
         rgExpected[1] = DispatchTypes::GraphicsOptions::ForegroundBlack;
         expectedDispatchTypes = DispatchTypes::EraseType::All;
 
@@ -2580,7 +2580,7 @@ class StateMachineExternalTest final
 
         mach.ProcessString(L"30mHello World\x1b[2J");
 
-        rgExpected[0] = DispatchTypes::GraphicsOptions::BoldBright;
+        rgExpected[0] = DispatchTypes::GraphicsOptions::Intense;
         rgExpected[1] = DispatchTypes::GraphicsOptions::ForegroundBlack;
         expectedDispatchTypes = DispatchTypes::EraseType::All;
 
@@ -2595,7 +2595,7 @@ class StateMachineExternalTest final
         ///////////////////////////////////////////////////////////////////////
         Log::Comment(L"Test 5: A sequence with mixed ProcessCharacter and ProcessString calls");
 
-        rgExpected[0] = DispatchTypes::GraphicsOptions::BoldBright;
+        rgExpected[0] = DispatchTypes::GraphicsOptions::Intense;
         rgExpected[1] = DispatchTypes::GraphicsOptions::ForegroundBlack;
 
         mach.ProcessString(L"\x1b[1;");

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -361,18 +361,18 @@ std::optional<bool> UiaTextRangeBase::_verifyAttr(TEXTATTRIBUTEID attributeId, V
 
         // The font weight can be any value from 0 to 900.
         // The text buffer doesn't store the actual value,
-        // we just store "IsBold" and "IsFaint".
+        // we just store "IsIntense" and "IsFaint".
         const auto queryFontWeight{ val.lVal };
 
         if (queryFontWeight > FW_NORMAL)
         {
             // we're looking for a bold font weight
-            return attr.IsBold();
+            return attr.IsIntense();
         }
         else
         {
             // we're looking for "normal" font weight
-            return !attr.IsBold();
+            return !attr.IsIntense();
         }
     }
     case UIA_ForegroundColorAttributeId:
@@ -687,10 +687,10 @@ bool UiaTextRangeBase::_initializeAttrQuery(TEXTATTRIBUTEID attributeId, VARIANT
     {
         // The font weight can be any value from 0 to 900.
         // The text buffer doesn't store the actual value,
-        // we just store "IsBold" and "IsFaint".
+        // we just store "IsIntense" and "IsFaint".
         // Source: https://docs.microsoft.com/en-us/windows/win32/winauto/uiauto-textattribute-ids
         pRetVal->vt = VT_I4;
-        pRetVal->lVal = attr.IsBold() ? FW_BOLD : FW_NORMAL;
+        pRetVal->lVal = attr.IsIntense() ? FW_BOLD : FW_NORMAL;
         return true;
     }
     case UIA_ForegroundColorAttributeId:

--- a/src/types/sgrStack.cpp
+++ b/src/types/sgrStack.cpp
@@ -104,7 +104,7 @@ namespace Microsoft::Console::VirtualTerminal
         //            optional parameters correspond to the SGR encoding for video
         //            attributes, except for colors (which do not have a unique SGR
         //            code):
-        //              Ps = 1  -> Bold.
+        //              Ps = 1  -> Intense.
         //              Ps = 2  -> Faint.
         //              Ps = 3  -> Italicized.
         //              Ps = 4  -> Underlined.
@@ -118,10 +118,10 @@ namespace Microsoft::Console::VirtualTerminal
         //
         //  (some closing braces for people with editors that get thrown off without them: }})
 
-        // Boldness = 1,
-        if (validParts.test(SgrSaveRestoreStackOptions::Boldness))
+        // Intense = 1,
+        if (validParts.test(SgrSaveRestoreStackOptions::Intense))
         {
-            result.SetBold(savedAttribute.IsBold());
+            result.SetIntense(savedAttribute.IsIntense());
         }
 
         // Faintness = 2,


### PR DESCRIPTION
When we gave users the ability to configure how the `SGR 1` attribute
should be rendered, we described those options as "intense is bright"
and "intense is bold". Internally, though, we still referred to the `SGR 1`
attribute as bold. This PR renames all occurrences of "Bold" (when
referring to the `SGR 1` attribute) as "Intense", so the terminology is
more consistent now.

PR #10969 is where we decided on the wording to describe the `SGR 1`
attribute.

Specific changes include:
* `TextAttribute::IsBold` method renamed to `IsIntense`
* `TextAttribute::SetBold` method renamed to `SetIntense`
* `VtEngine::_SetBold` method renamed to `_SetIntense`
* `ExtendedAttributes::Bold` enum renamed to `Intense`
* `GraphicsOptions::BoldBright` enum renamed to `Intense`
* `GraphicsOptions::NotBoldOrFaint` enum renamed to `NotIntenseOrFaint`
* `SgrSaveRestoreStackOptions::Boldness` enum renamed to `Intense`

## Validation Steps Performed

I've checked that the code still compiles and the unit tests still run
successfully.

Closes #12252
