### PR TITLE
Replaced the sizeof parameter of the if statement with ARRAYSIZE

### DIFF
--- a/src/interactivity/win32/SystemConfigurationProvider.cpp
+++ b/src/interactivity/win32/SystemConfigurationProvider.cpp
@@ -174,9 +174,9 @@ void SystemConfigurationProvider::GetSettingsFromLink(
             const DWORD dwLinkLen = SearchPathW(pwszCurrDir, pwszAppName, nullptr, ARRAYSIZE(wszIconLocation), wszIconLocation, nullptr);
 
             // If we cannot find the application in the path, then try to fall back and see if the window title is a valid path and use that.
-            if (dwLinkLen <= 0 || dwLinkLen > sizeof(wszIconLocation))
+            if (dwLinkLen <= 0 || dwLinkLen > ARRAYSIZE(wszIconLocation))
             {
-                if (PathFileExistsW(pwszTitle) && (wcslen(pwszTitle) < sizeof(wszIconLocation)))
+                if (PathFileExistsW(pwszTitle) && (wcslen(pwszTitle) < ARRAYSIZE(wszIconLocation)))
                 {
                     StringCchCopyW(wszIconLocation, ARRAYSIZE(wszIconLocation), pwszTitle);
                 }


### PR DESCRIPTION
The pull request fixes the issue where "sizeof" parameter was use instead of "ARRAYSIZE".

## PR Checklist
* [x] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments

This was a pretty straight forward issue, i just replace sizeof which gives the byte size with ARRAYSIZE which give the number of elements in the array.