### PR TITLE
AtlasEngine: Fix various ClearType rendering issues

### DIFF
--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -614,6 +614,7 @@ namespace Microsoft::Console::Render
         void _emplaceGlyph(IDWriteFontFace* fontFace, size_t bufferPos1, size_t bufferPos2);
 
         // AtlasEngine.api.cpp
+        void _resolveAntialiasingMode() noexcept;
         void _resolveFontMetrics(const FontInfoDesired& fontInfoDesired, FontInfo& fontInfo, FontMetrics* fontMetrics = nullptr) const;
 
         // AtlasEngine.r.cpp
@@ -754,7 +755,8 @@ namespace Microsoft::Console::Render
             wil::unique_handle swapChainHandle;
             HWND hwnd = nullptr;
             u16 dpi = USER_DEFAULT_SCREEN_DPI; // changes are flagged as ApiInvalidations::Font|Size
-            u16 antialiasingMode = D2D1_TEXT_ANTIALIAS_MODE_CLEARTYPE; // changes are flagged as ApiInvalidations::Font
+            u8 antialiasingMode = D2D1_TEXT_ANTIALIAS_MODE_CLEARTYPE; // changes are flagged as ApiInvalidations::Font
+            u8 realizedAntialiasingMode = D2D1_TEXT_ANTIALIAS_MODE_CLEARTYPE; // caches antialiasingMode, depends on antialiasingMode and backgroundOpaqueMixin, see _resolveAntialiasingMode
 
             ApiInvalidations invalidations = ApiInvalidations::Device;
         } _api;


### PR DESCRIPTION
This commit fixes the following issues when ClearType rendering is enabled:
* Colored glyphs are now drawn using grayscale AA, similar to all current
  browsers. This ensures proper gamma correctness during blending in our
  shader, while generally making no discernable difference for legibility.
* Our ClearType shader only emits fully opaque colors, just like the official
  ClearType implementation. Due to this we need to force grayscale AA if the
  user specifies both ClearType and a background image, as the image would
  otherwise not be visible.

## PR Checklist
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed
* Grayscale AA when drawing emojis ✅
* Grayscale AA when using a background image ✅