### PR TITLE
Change where the NotificationIcon looks up our resources

### DIFF
--- a/src/cascadia/WindowsTerminal/NotificationIcon.cpp
+++ b/src/cascadia/WindowsTerminal/NotificationIcon.cpp
@@ -82,8 +82,8 @@ void NotificationIcon::CreateNotificationIcon()
 
     nid.uCallbackMessage = CM_NOTIFY_FROM_NOTIFICATION_AREA;
 
-    // AppName happens to be in CascadiaPackage's Resources.
-    ScopedResourceLoader loader{ L"Resources" };
+    // AppName happens to be in the ContextMenu's Resources, see GH#12264
+    ScopedResourceLoader loader{ L"TerminalApp/ContextMenu" };
     const auto appNameLoc = loader.GetLocalizedString(L"AppName");
 
     nid.hIcon = static_cast<HICON>(GetActiveAppIconHandle(true));


### PR DESCRIPTION
I didn't have the tray icon enabled before I suppose, so this never got hit? Anyhow, we need to change where we look for the AppName. Otherwise we crash on launch 😨

* [x] fixes `main`
* [x] I work here
* regressed in #12264
* [x] Tested by: actually running the Terminal with this, it launched