### PR TITLE
Use the macros for duplicating as well

### DIFF
--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -280,50 +280,43 @@ Model::Profile CascadiaSettings::DuplicateProfile(const Model::Profile& source)
     // If the source is hidden and the Settings UI creates a
     // copy of it we don't want the copy to be hidden as well.
     // --> Don't do DUPLICATE_SETTING_MACRO(Hidden);
-    DUPLICATE_SETTING_MACRO(Icon);
-    DUPLICATE_SETTING_MACRO(CloseOnExit);
-    DUPLICATE_SETTING_MACRO(TabTitle);
+
+#define DUPLICATE_PROFILE_SETTINGS(type, name, jsonKey, ...) \
+    DUPLICATE_SETTING_MACRO(name);
+
+    MTSM_PROFILE_SETTINGS(DUPLICATE_PROFILE_SETTINGS)
+#undef DUPLICATE_PROFILE_SETTINGS
+
+    // These two aren't in MTSM_PROFILE_SETTINGS because they're special
     DUPLICATE_SETTING_MACRO(TabColor);
-    DUPLICATE_SETTING_MACRO(SuppressApplicationTitle);
-    DUPLICATE_SETTING_MACRO(UseAcrylic);
-    DUPLICATE_SETTING_MACRO(ScrollState);
     DUPLICATE_SETTING_MACRO(Padding);
-    DUPLICATE_SETTING_MACRO(Commandline);
-    DUPLICATE_SETTING_MACRO(StartingDirectory);
-    DUPLICATE_SETTING_MACRO(AntialiasingMode);
-    DUPLICATE_SETTING_MACRO(HistorySize);
-    DUPLICATE_SETTING_MACRO(SnapOnInput);
-    DUPLICATE_SETTING_MACRO(AltGrAliasing);
-    DUPLICATE_SETTING_MACRO(BellStyle);
 
     {
         const auto font = source.FontInfo();
         const auto target = duplicated->FontInfo();
-        DUPLICATE_SETTING_MACRO_SUB(font, target, FontFace);
-        DUPLICATE_SETTING_MACRO_SUB(font, target, FontSize);
-        DUPLICATE_SETTING_MACRO_SUB(font, target, FontWeight);
-        DUPLICATE_SETTING_MACRO_SUB(font, target, FontFeatures);
-        DUPLICATE_SETTING_MACRO_SUB(font, target, FontAxes);
+
+#define DUPLICATE_FONT_SETTINGS(type, name, jsonKey, ...) \
+    DUPLICATE_SETTING_MACRO_SUB(font, target, name);
+
+        MTSM_FONT_SETTINGS(DUPLICATE_FONT_SETTINGS)
+#undef DUPLICATE_FONT_SETTINGS
     }
 
     {
         const auto appearance = source.DefaultAppearance();
         const auto target = duplicated->DefaultAppearance();
-        DUPLICATE_SETTING_MACRO_SUB(appearance, target, ColorSchemeName);
+
+#define DUPLICATE_APPEARANCE_SETTINGS(type, name, jsonKey, ...) \
+    DUPLICATE_SETTING_MACRO_SUB(appearance, target, name);
+
+        MTSM_APPEARANCE_SETTINGS(DUPLICATE_APPEARANCE_SETTINGS)
+#undef DUPLICATE_APPEARANCE_SETTINGS
+
+        // These aren't in MTSM_APPEARANCE_SETTINGS because they're special
         DUPLICATE_SETTING_MACRO_SUB(appearance, target, Foreground);
         DUPLICATE_SETTING_MACRO_SUB(appearance, target, Background);
         DUPLICATE_SETTING_MACRO_SUB(appearance, target, SelectionBackground);
         DUPLICATE_SETTING_MACRO_SUB(appearance, target, CursorColor);
-        DUPLICATE_SETTING_MACRO_SUB(appearance, target, PixelShaderPath);
-        DUPLICATE_SETTING_MACRO_SUB(appearance, target, IntenseTextStyle);
-        DUPLICATE_SETTING_MACRO_SUB(appearance, target, BackgroundImagePath);
-        DUPLICATE_SETTING_MACRO_SUB(appearance, target, BackgroundImageOpacity);
-        DUPLICATE_SETTING_MACRO_SUB(appearance, target, BackgroundImageStretchMode);
-        DUPLICATE_SETTING_MACRO_SUB(appearance, target, BackgroundImageAlignment);
-        DUPLICATE_SETTING_MACRO_SUB(appearance, target, RetroTerminalEffect);
-        DUPLICATE_SETTING_MACRO_SUB(appearance, target, CursorShape);
-        DUPLICATE_SETTING_MACRO_SUB(appearance, target, CursorHeight);
-        DUPLICATE_SETTING_MACRO_SUB(appearance, target, AdjustIndistinguishableColors);
         DUPLICATE_SETTING_MACRO_SUB(appearance, target, Opacity);
     }
 

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -78,6 +78,15 @@ Author(s):
     X(Windows::Foundation::Collections::IVector<winrt::hstring>, BellSound, "bellSound", nullptr)                                                              \
     X(bool, Elevate, "elevate", false)
 
+// Intentionally omitted Profile settings:
+// * Name
+// * Updates
+// * Guid
+// * Hidden
+// * Source
+// * Padding: needs special FromJson parsing
+// * TabColor: is an optional setting, so needs to be set with INHERITABLE_NULLABLE_SETTING
+
 #define MTSM_FONT_SETTINGS(X)                                                          \
     X(hstring, FontFace, "face", DEFAULT_FONT_FACE)                                    \
     X(int32_t, FontSize, "size", DEFAULT_FONT_SIZE)                                    \
@@ -97,3 +106,7 @@ Author(s):
     X(hstring, BackgroundImagePath, "backgroundImage")                                                                                                             \
     X(Model::IntenseStyle, IntenseTextStyle, "intenseTextStyle", Model::IntenseStyle::Bright)                                                                      \
     X(bool, AdjustIndistinguishableColors, "adjustIndistinguishableColors", true)
+
+// Intentionally omitted Appearance settings:
+// * ForegroundKey, BackgroundKey, SelectionBackgroundKey, CursorColorKey: all optional colorsq
+// * Opacity: needs special parsing

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -108,5 +108,5 @@ Author(s):
     X(bool, AdjustIndistinguishableColors, "adjustIndistinguishableColors", true)
 
 // Intentionally omitted Appearance settings:
-// * ForegroundKey, BackgroundKey, SelectionBackgroundKey, CursorColorKey: all optional colorsq
+// * ForegroundKey, BackgroundKey, SelectionBackgroundKey, CursorColorKey: all optional colors
 // * Opacity: needs special parsing


### PR DESCRIPTION
Introduced in #11416

We weren't using these macros for duplicating as well, so I forgot to duplicate a couple settings. This PR switches duplicating over to using the macros as well, which shou;d reduce future bugs. 

Also adds notes to which properties are intentionally omitted from these macros.

* [x] closes #12265
* [x] Verified manually that #12120 still works as expected