### PR TITLE
Fix SizeOfSet and PositionInSet for 'Open JSON File' nav item

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -99,7 +99,7 @@
 
         </muxc:NavigationView.MenuItems>
 
-        <muxc:NavigationView.PaneFooter>
+        <muxc:NavigationView.FooterMenuItems>
             <!--  The OpenJson item needs both Tapped and KeyDown handler  -->
             <muxc:NavigationViewItem x:Name="OpenJsonNavItem"
                                      x:Uid="Nav_OpenJSON"
@@ -109,7 +109,7 @@
                     <FontIcon Glyph="&#xE713;" />
                 </muxc:NavigationViewItem.Icon>
             </muxc:NavigationViewItem>
-        </muxc:NavigationView.PaneFooter>
+        </muxc:NavigationView.FooterMenuItems>
 
         <Grid>
             <Grid.RowDefinitions>


### PR DESCRIPTION
## Summary of the Pull Request
According to https://github.com/microsoft/microsoft-ui-xaml/issues/1971, `PaneFooter` does not set the `SizeOfSet` or `PositionInSet` properties. However, `FooterMenuItems` does and works for our scenario. So we just replaced `PaneFooter` with `FooterMenuItems`.

Will handle #11154 upon verification from the accessibility team.

## Validation Steps Performed
✅ Verified using Accessibility Insights
✅ "Open Json File" button can still be invoked and keyboard navigated to as expected