### PR TITLE
Add `experimental.useAtlasEngine` to schema

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2059,6 +2059,11 @@
           "description": "Use to set a path to a pixel shader to use with the Terminal. Overrides `experimental.retroTerminalEffect`. This is an experimental feature, and its continued existence is not guaranteed.",
           "type": "string"
         },
+        "experimental.useAtlasEngine": {
+          "description": "Enable using the experimental new renderering engine for this profile. This is an experimental feature, and its continued existence is not guaranteed.",
+          "type": "boolean",
+          "default": false
+        },
         "fontFace": {
           "default": "Cascadia Mono",
           "description": "[deprecated] Define 'face' within the 'font' object instead.",

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2060,7 +2060,7 @@
           "type": "string"
         },
         "experimental.useAtlasEngine": {
-          "description": "Enable using the experimental new renderering engine for this profile. This is an experimental feature, and its continued existence is not guaranteed.",
+          "description": "Enable using the experimental new rendering engine for this profile. This is an experimental feature, and its continued existence is not guaranteed.",
           "type": "boolean",
           "default": false
         },


### PR DESCRIPTION
does what it says on the can.

* [x] closes #12302
