### PR TITLE
Add PGOBuildMode to PGD merge step

### DIFF
--- a/build/pipelines/templates/pgo-merge-pgd-job.yml
+++ b/build/pipelines/templates/pgo-merge-pgd-job.yml
@@ -55,7 +55,7 @@ jobs:
       solution: $(Build.SourcesDirectory)\OpenConsole.sln
       platform: $(buildPlatform)
       configuration: $(buildConfiguration)
-      msbuildArguments: '/t:MergePGOCounts /p:PGDPath=$(pgoArtifactsPath)\$(buildPlatform) /p:PGCRootPath=$(pgoArtifactsPath)\$(buildPlatform)'
+      msbuildArguments: '/t:MergePGOCounts /p:PGOBuildMode=Optimize /p:PGDPath=$(pgoArtifactsPath)\$(buildPlatform) /p:PGCRootPath=$(pgoArtifactsPath)\$(buildPlatform)'
 
   - task: CopyFiles@2
     displayName: 'Copy merged pgd to artifact staging'

--- a/build/pipelines/templates/pgo-merge-pgd-job.yml
+++ b/build/pipelines/templates/pgo-merge-pgd-job.yml
@@ -55,7 +55,7 @@ jobs:
       solution: $(Build.SourcesDirectory)\OpenConsole.sln
       platform: $(buildPlatform)
       configuration: $(buildConfiguration)
-      msbuildArguments: '/t:MergePGOCounts /p:PGOBuildMode=Optimize /p:PGDPath=$(pgoArtifactsPath)\$(buildPlatform) /p:PGCRootPath=$(pgoArtifactsPath)\$(buildPlatform)'
+      msbuildArguments: '/t:MergePGOCounts /p:PGOBuildMode=Instrument /p:PGDPath=$(pgoArtifactsPath)\$(buildPlatform) /p:PGCRootPath=$(pgoArtifactsPath)\$(buildPlatform)'
 
   - task: CopyFiles@2
     displayName: 'Copy merged pgd to artifact staging'


### PR DESCRIPTION
I added a condition to exclude some of the NuGet PGO stuff when there was no build mode, but appear to not have propagated any of it in the PGD merge job. This sets it to Optimize here so it'll go through.

## PR Checklist
* [x] Closes #12300
* [x] I work here.
* [x] It blends.

## Validation Steps Performed
* [x] Ran the PGO Instrument Phase
* [x] Ran the PGO Optimize Phase
