### PR TITLE
AtlasEngine: Fix support for combining diacritics

### DIFF
--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -724,6 +724,8 @@ namespace Microsoft::Console::Render
             Buffer<DWRITE_SHAPING_TEXT_PROPERTIES> textProps;
             Buffer<u16> glyphIndices;
             Buffer<DWRITE_SHAPING_GLYPH_PROPERTIES> glyphProps;
+            Buffer<f32> glyphAdvances;
+            Buffer<DWRITE_GLYPH_OFFSET> glyphOffsets;
             std::vector<DWRITE_FONT_FEATURE> fontFeatures; // changes are flagged as ApiInvalidations::Font|Size
             std::vector<DWRITE_FONT_AXIS_VALUE> fontAxisValues; // changes are flagged as ApiInvalidations::Font|Size
             FontMetrics fontMetrics; // changes are flagged as ApiInvalidations::Font|Size


### PR DESCRIPTION
`IDWriteTextAnalyzer::GetGlyphs` is not enough to get a
`DWRITE_SHAPING_TEXT_PROPERTIES::canBreakShapingAfter`
value that works for combining diacritical marks.
This requires an additional call to `GetGlyphPlacements`.
This commit increases CPU usage for complex text by ~10%.

## PR Checklist
* [x] Closes #11925
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed
* ``echo "[e`u{0301}`u{0301}]"`` prints an "e" with 2 accents ✅