### PR TITLE
Update accessible names for 'add profile' page buttons

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/AddProfile.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AddProfile.cpp
@@ -23,6 +23,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         InitializeComponent();
 
         Automation::AutomationProperties::SetName(AddNewButton(), RS_(L"AddProfile_AddNewTextBlock/Text"));
+        Automation::AutomationProperties::SetName(DuplicateButton(), RS_(L"AddProfile_DuplicateTextBlock/Text"));
     }
 
     void AddProfile::OnNavigatedTo(const NavigationEventArgs& e)

--- a/src/cascadia/TerminalSettingsEditor/AddProfile.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AddProfile.cpp
@@ -7,9 +7,12 @@
 #include "AddProfilePageNavigationState.g.cpp"
 #include "EnumEntry.h"
 
+#include <LibraryResources.h>
+
 using namespace winrt::Windows::Foundation;
 using namespace winrt::Windows::System;
 using namespace winrt::Windows::UI::Core;
+using namespace winrt::Windows::UI::Xaml;
 using namespace winrt::Windows::UI::Xaml::Navigation;
 using namespace winrt::Microsoft::Terminal::Settings::Model;
 
@@ -18,6 +21,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     AddProfile::AddProfile()
     {
         InitializeComponent();
+
+        Automation::AutomationProperties::SetName(AddNewButton(), RS_(L"AddProfile_AddNewTextBlock/Text"));
     }
 
     void AddProfile::OnNavigatedTo(const NavigationEventArgs& e)

--- a/src/cascadia/TerminalSettingsEditor/AddProfile.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AddProfile.xaml
@@ -26,12 +26,14 @@
             <Button x:Name="AddNewButton"
                     Click="AddNewClick"
                     Style="{StaticResource AccentButtonStyle}">
-                <StackPanel Orientation="Horizontal">
-                    <FontIcon FontSize="{StaticResource StandardIconSize}"
-                              Glyph="&#xE710;" />
-                    <TextBlock x:Uid="AddProfile_AddNewTextBlock"
-                               Style="{StaticResource IconButtonTextBlockStyle}" />
-                </StackPanel>
+                <Button.Content>
+                    <StackPanel Orientation="Horizontal">
+                        <FontIcon FontSize="{StaticResource StandardIconSize}"
+                                  Glyph="&#xE710;" />
+                        <TextBlock x:Uid="AddProfile_AddNewTextBlock"
+                                   Style="{StaticResource IconButtonTextBlockStyle}" />
+                    </StackPanel>
+                </Button.Content>
             </Button>
             <StackPanel Margin="{StaticResource StandardControlMargin}">
                 <local:SettingContainer x:Uid="AddProfile_Duplicate">
@@ -69,12 +71,14 @@
                         Click="DuplicateClick"
                         IsEnabled="{x:Bind IsProfileSelected, Mode=OneWay}"
                         Style="{StaticResource AccentButtonStyle}">
-                    <StackPanel Orientation="Horizontal">
-                        <FontIcon FontSize="{StaticResource StandardIconSize}"
-                                  Glyph="&#xE8C8;" />
-                        <TextBlock x:Uid="AddProfile_DuplicateTextBlock"
-                                   Style="{StaticResource IconButtonTextBlockStyle}" />
-                    </StackPanel>
+                    <Button.Content>
+                        <StackPanel Orientation="Horizontal">
+                            <FontIcon FontSize="{StaticResource StandardIconSize}"
+                                      Glyph="&#xE8C8;" />
+                            <TextBlock x:Uid="AddProfile_DuplicateTextBlock"
+                                       Style="{StaticResource IconButtonTextBlockStyle}" />
+                        </StackPanel>
+                    </Button.Content>
                 </Button>
             </StackPanel>
         </StackPanel>

--- a/src/cascadia/TerminalSettingsEditor/AddProfile.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AddProfile.xaml
@@ -27,11 +27,11 @@
                     Click="AddNewClick"
                     Style="{StaticResource AccentButtonStyle}">
                 <StackPanel Orientation="Horizontal">
-                        <FontIcon FontSize="{StaticResource StandardIconSize}"
-                                  Glyph="&#xE710;" />
-                        <TextBlock x:Uid="AddProfile_AddNewTextBlock"
-                                   Style="{StaticResource IconButtonTextBlockStyle}" />
-                    </StackPanel>
+                    <FontIcon FontSize="{StaticResource StandardIconSize}"
+                              Glyph="&#xE710;" />
+                    <TextBlock x:Uid="AddProfile_AddNewTextBlock"
+                               Style="{StaticResource IconButtonTextBlockStyle}" />
+                </StackPanel>
             </Button>
             <StackPanel Margin="{StaticResource StandardControlMargin}">
                 <local:SettingContainer x:Uid="AddProfile_Duplicate">
@@ -64,21 +64,17 @@
                         </muxc:RadioButtons.ItemTemplate>
                     </muxc:RadioButtons>
                 </local:SettingContainer>
-                <Button x:Uid="AddProfile_DuplicateButton"
+                <Button x:Name="DuplicateButton"
                         Margin="{StaticResource StandardControlMargin}"
-                        AutomationProperties.AutomationId="AddProfile_DuplicateButton"
-                        AutomationProperties.Name="{Binding Tag, RelativeSource={RelativeSource Self}}"
                         Click="DuplicateClick"
                         IsEnabled="{x:Bind IsProfileSelected, Mode=OneWay}"
                         Style="{StaticResource AccentButtonStyle}">
-                    <Button.Content>
-                        <StackPanel Orientation="Horizontal">
-                            <FontIcon FontSize="{StaticResource StandardIconSize}"
-                                      Glyph="&#xE8C8;" />
-                            <TextBlock x:Uid="AddProfile_DuplicateTextBlock"
-                                       Style="{StaticResource IconButtonTextBlockStyle}" />
-                        </StackPanel>
-                    </Button.Content>
+                    <StackPanel Orientation="Horizontal">
+                        <FontIcon FontSize="{StaticResource StandardIconSize}"
+                                  Glyph="&#xE8C8;" />
+                        <TextBlock x:Uid="AddProfile_DuplicateTextBlock"
+                                   Style="{StaticResource IconButtonTextBlockStyle}" />
+                    </StackPanel>
                 </Button>
             </StackPanel>
         </StackPanel>

--- a/src/cascadia/TerminalSettingsEditor/AddProfile.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AddProfile.xaml
@@ -23,19 +23,15 @@
 
     <ScrollViewer ViewChanging="ViewChanging">
         <StackPanel Style="{StaticResource SettingsStackStyle}">
-            <Button x:Uid="AddProfile_AddNewButton"
-                    AutomationProperties.AutomationId="AddProfile_AddNewButton"
-                    AutomationProperties.Name="{Binding Tag, RelativeSource={RelativeSource Self}}"
+            <Button x:Name="AddNewButton"
                     Click="AddNewClick"
                     Style="{StaticResource AccentButtonStyle}">
-                <Button.Content>
-                    <StackPanel Orientation="Horizontal">
+                <StackPanel Orientation="Horizontal">
                         <FontIcon FontSize="{StaticResource StandardIconSize}"
                                   Glyph="&#xE710;" />
                         <TextBlock x:Uid="AddProfile_AddNewTextBlock"
                                    Style="{StaticResource IconButtonTextBlockStyle}" />
                     </StackPanel>
-                </Button.Content>
             </Button>
             <StackPanel Margin="{StaticResource StandardControlMargin}">
                 <local:SettingContainer x:Uid="AddProfile_Duplicate">


### PR DESCRIPTION
## Summary of the Pull Request
When using a screen reader, the buttons on the "add a new profile" page were being read weirdly:
- "New empty profile" button read as "create new button button"
- "duplicate" button read as "duplicate button button"

It's generally standard to read out the text inside the button, so I did just that by reusing the existing localized resources. This also removes the redundant "button" that is said by the screen reader.

I also removed the unused `AutomationId` and unnecessary `Button.Content` tags. 

#11156 can be closed upon validation by the accessibility team.

## Validation Steps Performed
✅ navigate to both buttons using Narrator; make sure it sounds right