### PR TITLE
Fix more SUI and Rejuvenated UI issues

### DIFF
--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -57,8 +57,8 @@
                             <StaticResource x:Key="TabViewBackground"
                                             ResourceKey="ApplicationPageBackgroundThemeBrush" />
 
-                            <SolidColorBrush x:Key="UnfocusedBorderBrush"
-                                             Color="#FF333333" />
+                            <StaticResource x:Key="UnfocusedBorderBrush"
+                                            ResourceKey="ApplicationPageBackgroundThemeBrush" />
                         </ResourceDictionary>
 
                         <ResourceDictionary x:Key="Light">
@@ -66,8 +66,8 @@
                             <StaticResource x:Key="TabViewBackground"
                                             ResourceKey="ApplicationPageBackgroundThemeBrush" />
 
-                            <SolidColorBrush x:Key="UnfocusedBorderBrush"
-                                             Color="#FFCCCCCC" />
+                            <StaticResource x:Key="UnfocusedBorderBrush"
+                                            ResourceKey="ApplicationPageBackgroundThemeBrush" />
                         </ResourceDictionary>
 
                     </ResourceDictionary.ThemeDictionaries>

--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -54,8 +54,8 @@
                     <ResourceDictionary.ThemeDictionaries>
                         <ResourceDictionary x:Key="Dark">
                             <!--  Define resources for Dark mode here  -->
-                            <SolidColorBrush x:Key="TabViewBackground"
-                                             Color="#FF333333" />
+                            <StaticResource x:Key="TabViewBackground"
+                                            ResourceKey="ApplicationPageBackgroundThemeBrush" />
 
                             <SolidColorBrush x:Key="UnfocusedBorderBrush"
                                              Color="#FF333333" />
@@ -63,8 +63,8 @@
 
                         <ResourceDictionary x:Key="Light">
                             <!--  Define resources for Light mode here  -->
-                            <SolidColorBrush x:Key="TabViewBackground"
-                                             Color="#FFCCCCCC" />
+                            <StaticResource x:Key="TabViewBackground"
+                                            ResourceKey="ApplicationPageBackgroundThemeBrush" />
 
                             <SolidColorBrush x:Key="UnfocusedBorderBrush"
                                              Color="#FFCCCCCC" />

--- a/src/cascadia/TerminalSettingsEditor/Actions.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Actions.xaml
@@ -375,29 +375,30 @@
     </Page.Resources>
 
     <ScrollViewer ViewChanging="ViewChanging">
-        <StackPanel MaxWidth="600"
-                    HorizontalAlignment="Left"
-                    Spacing="8"
-                    Style="{StaticResource SettingsStackStyle}">
-            <!--  Add New Button  -->
-            <Button x:Name="AddNewButton"
-                    Click="AddNew_Click">
-                <Button.Content>
-                    <StackPanel Orientation="Horizontal">
-                        <FontIcon FontSize="{StaticResource StandardIconSize}"
-                                  Glyph="&#xE710;" />
-                        <TextBlock x:Uid="Actions_AddNewTextBlock"
-                                   Style="{StaticResource IconButtonTextBlockStyle}" />
-                    </StackPanel>
-                </Button.Content>
-            </Button>
+        <Border MaxWidth="1000">
+            <StackPanel MaxWidth="600"
+                        HorizontalAlignment="Left"
+                        Spacing="8"
+                        Style="{StaticResource SettingsStackStyle}">
+                <!--  Add New Button  -->
+                <Button x:Name="AddNewButton"
+                        Click="AddNew_Click">
+                    <Button.Content>
+                        <StackPanel Orientation="Horizontal">
+                            <FontIcon FontSize="{StaticResource StandardIconSize}"
+                                      Glyph="&#xE710;" />
+                            <TextBlock x:Uid="Actions_AddNewTextBlock"
+                                       Style="{StaticResource IconButtonTextBlockStyle}" />
+                        </StackPanel>
+                    </Button.Content>
+                </Button>
 
-            <!--  Keybindings  -->
-            <ListView x:Name="KeyBindingsListView"
-                      ItemTemplate="{StaticResource KeyBindingTemplate}"
-                      ItemsSource="{x:Bind KeyBindingList, Mode=OneWay}"
-                      SelectionMode="None" />
-        </StackPanel>
-
+                <!--  Keybindings  -->
+                <ListView x:Name="KeyBindingsListView"
+                          ItemTemplate="{StaticResource KeyBindingTemplate}"
+                          ItemsSource="{x:Bind KeyBindingList, Mode=OneWay}"
+                          SelectionMode="None" />
+            </StackPanel>
+        </Border>
     </ScrollViewer>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/Actions.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Actions.xaml
@@ -375,7 +375,7 @@
     </Page.Resources>
 
     <ScrollViewer ViewChanging="ViewChanging">
-        <Border MaxWidth="1000">
+        <Border MaxWidth="{StaticResource StandardControlMaxWidth}">
             <StackPanel MaxWidth="600"
                         HorizontalAlignment="Left"
                         Spacing="8"

--- a/src/cascadia/TerminalSettingsEditor/AddProfile.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AddProfile.xaml
@@ -23,7 +23,7 @@
 
     <ScrollViewer ViewChanging="ViewChanging">
         <StackPanel Style="{StaticResource SettingsStackStyle}">
-            <Border MaxWidth="1000">
+            <Border MaxWidth="{StaticResource StandardControlMaxWidth}">
                 <Button x:Uid="AddProfile_AddNewButton"
                         AutomationProperties.AutomationId="AddProfile_AddNewButton"
                         AutomationProperties.Name="{Binding Tag, RelativeSource={RelativeSource Self}}"
@@ -45,7 +45,8 @@
                               AutomationProperties.AccessibilityView="Content"
                               ItemsSource="{x:Bind State.Settings.AllProfiles, Mode=OneWay}"
                               SelectedIndex="0"
-                              SelectionChanged="ProfilesSelectionChanged">
+                              SelectionChanged="ProfilesSelectionChanged"
+                              Style="{StaticResource ComboBoxSettingStyle}">
                         <ComboBox.ItemTemplate>
                             <DataTemplate x:DataType="model:Profile">
                                 <Grid HorizontalAlignment="Stretch"
@@ -71,7 +72,7 @@
                         </ComboBox.ItemTemplate>
                     </ComboBox>
                 </local:SettingContainer>
-                <Border MaxWidth="1000">
+                <Border MaxWidth="{StaticResource StandardControlMaxWidth}">
                     <Button x:Uid="AddProfile_DuplicateButton"
                             Margin="{StaticResource StandardControlMargin}"
                             AutomationProperties.AutomationId="AddProfile_DuplicateButton"

--- a/src/cascadia/TerminalSettingsEditor/AddProfile.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AddProfile.xaml
@@ -37,7 +37,7 @@
                     </Button.Content>
                 </Button>
             </Border>
-                <StackPanel Margin="{StaticResource StandardControlMargin}">
+            <StackPanel Margin="{StaticResource StandardControlMargin}">
                 <local:SettingContainer x:Uid="AddProfile_Duplicate">
                     <ComboBox x:Name="Profiles"
                               AutomationProperties.AccessibilityView="Content"

--- a/src/cascadia/TerminalSettingsEditor/AddProfile.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AddProfile.xaml
@@ -23,27 +23,30 @@
 
     <ScrollViewer ViewChanging="ViewChanging">
         <StackPanel Style="{StaticResource SettingsStackStyle}">
-            <Button x:Uid="AddProfile_AddNewButton"
-                    AutomationProperties.AutomationId="AddProfile_AddNewButton"
-                    AutomationProperties.Name="{Binding Tag, RelativeSource={RelativeSource Self}}"
-                    Click="AddNewClick"
-                    Style="{StaticResource AccentButtonStyle}">
-                <Button.Content>
-                    <StackPanel Orientation="Horizontal">
-                        <FontIcon FontSize="{StaticResource StandardIconSize}"
-                                  Glyph="&#xE710;" />
-                        <TextBlock x:Uid="AddProfile_AddNewTextBlock"
-                                   Style="{StaticResource IconButtonTextBlockStyle}" />
-                    </StackPanel>
-                </Button.Content>
-            </Button>
+            <Border MaxWidth="1000">
+                <Button x:Uid="AddProfile_AddNewButton"
+                        AutomationProperties.AutomationId="AddProfile_AddNewButton"
+                        AutomationProperties.Name="{Binding Tag, RelativeSource={RelativeSource Self}}"
+                        Click="AddNewClick"
+                        Style="{StaticResource AccentButtonStyle}">
+                    <Button.Content>
+                        <StackPanel Orientation="Horizontal">
+                            <FontIcon FontSize="{StaticResource StandardIconSize}"
+                                      Glyph="&#xE710;" />
+                            <TextBlock x:Uid="AddProfile_AddNewTextBlock"
+                                       Style="{StaticResource IconButtonTextBlockStyle}" />
+                        </StackPanel>
+                    </Button.Content>
+                </Button>
+            </Border>
             <StackPanel Margin="{StaticResource StandardControlMargin}">
                 <local:SettingContainer x:Uid="AddProfile_Duplicate">
-                    <muxc:RadioButtons x:Name="Profiles"
-                                       AutomationProperties.AccessibilityView="Content"
-                                       ItemsSource="{x:Bind State.Settings.AllProfiles, Mode=OneWay}"
-                                       SelectionChanged="ProfilesSelectionChanged">
-                        <muxc:RadioButtons.ItemTemplate>
+                    <ComboBox x:Name="Profiles"
+                              AutomationProperties.AccessibilityView="Content"
+                              ItemsSource="{x:Bind State.Settings.AllProfiles, Mode=OneWay}"
+                              SelectedIndex="0"
+                              SelectionChanged="ProfilesSelectionChanged">
+                        <ComboBox.ItemTemplate>
                             <DataTemplate x:DataType="model:Profile">
                                 <Grid HorizontalAlignment="Stretch"
                                       ColumnSpacing="8">
@@ -65,25 +68,27 @@
 
                                 </Grid>
                             </DataTemplate>
-                        </muxc:RadioButtons.ItemTemplate>
-                    </muxc:RadioButtons>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
                 </local:SettingContainer>
-                <Button x:Uid="AddProfile_DuplicateButton"
-                        Margin="{StaticResource StandardControlMargin}"
-                        AutomationProperties.AutomationId="AddProfile_DuplicateButton"
-                        AutomationProperties.Name="{Binding Tag, RelativeSource={RelativeSource Self}}"
-                        Click="DuplicateClick"
-                        IsEnabled="{x:Bind IsProfileSelected, Mode=OneWay}"
-                        Style="{StaticResource AccentButtonStyle}">
-                    <Button.Content>
-                        <StackPanel Orientation="Horizontal">
-                            <FontIcon FontSize="{StaticResource StandardIconSize}"
-                                      Glyph="&#xE8C8;" />
-                            <TextBlock x:Uid="AddProfile_DuplicateTextBlock"
-                                       Style="{StaticResource IconButtonTextBlockStyle}" />
-                        </StackPanel>
-                    </Button.Content>
-                </Button>
+                <Border MaxWidth="1000">
+                    <Button x:Uid="AddProfile_DuplicateButton"
+                            Margin="{StaticResource StandardControlMargin}"
+                            AutomationProperties.AutomationId="AddProfile_DuplicateButton"
+                            AutomationProperties.Name="{Binding Tag, RelativeSource={RelativeSource Self}}"
+                            Click="DuplicateClick"
+                            IsEnabled="{x:Bind IsProfileSelected, Mode=OneWay}"
+                            Style="{StaticResource AccentButtonStyle}">
+                        <Button.Content>
+                            <StackPanel Orientation="Horizontal">
+                                <FontIcon FontSize="{StaticResource StandardIconSize}"
+                                          Glyph="&#xE8C8;" />
+                                <TextBlock x:Uid="AddProfile_DuplicateTextBlock"
+                                           Style="{StaticResource IconButtonTextBlockStyle}" />
+                            </StackPanel>
+                        </Button.Content>
+                    </Button>
+                </Border>
             </StackPanel>
         </StackPanel>
     </ScrollViewer>

--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -41,7 +41,7 @@
         <StackPanel Style="{StaticResource PivotStackStyle}">
             <!--  Grouping: Text  -->
             <TextBlock x:Uid="Profile_TextHeader"
-                       Style="{StaticResource SubtitleTextBlockStyle}" />
+                       Style="{StaticResource TextBlockSubHeaderStyle}" />
 
             <!--  Color Scheme  -->
             <local:SettingContainer x:Uid="Profile_ColorScheme"
@@ -170,7 +170,7 @@
         <!--  Grouping: Cursor  -->
         <StackPanel Style="{StaticResource PivotStackStyle}">
             <TextBlock x:Uid="Profile_CursorHeader"
-                       Style="{StaticResource SubtitleTextBlockStyle}" />
+                       Style="{StaticResource TextBlockSubHeaderStyle}" />
 
             <!--  Cursor Shape  -->
             <local:SettingContainer x:Uid="Profile_CursorShape"
@@ -210,7 +210,7 @@
         <!--  Grouping: Background  -->
         <StackPanel Style="{StaticResource PivotStackStyle}">
             <TextBlock x:Uid="Profile_BackgroundHeader"
-                       Style="{StaticResource SubtitleTextBlockStyle}" />
+                       Style="{StaticResource TextBlockSubHeaderStyle}" />
 
             <!--  Background Image  -->
             <local:SettingContainer x:Name="BackgroundImageContainer"
@@ -464,7 +464,7 @@
         <!--  Grouping: Text Formatting  -->
         <StackPanel Style="{StaticResource PivotStackStyle}">
             <TextBlock x:Uid="Appearance_TextFormattingHeader"
-                       Style="{StaticResource SubtitleTextBlockStyle}" />
+                       Style="{StaticResource TextBlockSubHeaderStyle}" />
 
             <!--  Intense is bold, bright  -->
             <local:SettingContainer x:Uid="Appearance_IntenseTextStyle"

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -94,7 +94,7 @@
     </Page.Resources>
 
     <ScrollViewer ViewChanging="ViewChanging">
-        <StackPanel MaxWidth="1000"
+        <StackPanel MaxWidth="{StaticResource StandardControlMaxWidth}"
                     Margin="{StaticResource StandardIndentMargin}"
                     Spacing="24">
 

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -94,7 +94,8 @@
     </Page.Resources>
 
     <ScrollViewer ViewChanging="ViewChanging">
-        <StackPanel Margin="{StaticResource StandardIndentMargin}"
+        <StackPanel MaxWidth="1000"
+                    Margin="{StaticResource StandardIndentMargin}"
                     Spacing="24">
 
             <!--  Select Color and Add New Button  -->

--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -58,7 +58,7 @@
     <Style x:Key="TextBlockSubHeaderStyle"
            BasedOn="{StaticResource SubtitleTextBlockStyle}"
            TargetType="TextBlock">
-        <Setter Property="MaxWidth" Value="1000" />
+        <Setter Property="MaxWidth" Value="{StaticResource StandardControlMaxWidth}" />
     </Style>
 
     <!--  Used for disclaimers  -->

--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -53,6 +53,12 @@
         <Setter Property="TextWrapping" Value="Wrap" />
     </Style>
 
+    <Style x:Key="TextBlockSubHeaderStyle"
+           BasedOn="{StaticResource SubtitleTextBlockStyle}"
+           TargetType="TextBlock">
+        <Setter Property="MaxWidth" Value="1000" />
+    </Style>
+
     <!--  Used for disclaimers  -->
     <Style x:Key="DisclaimerStyle"
            TargetType="TextBlock">
@@ -71,7 +77,7 @@
     <!--  Number Box  -->
     <Style x:Key="NumberBoxSettingStyle"
            TargetType="muxc:NumberBox">
-        <Setter Property="SpinButtonPlacementMode" Value="Compact" />
+        <Setter Property="SpinButtonPlacementMode" Value="Inline" />
         <Setter Property="HorizontalAlignment" Value="Left" />
     </Style>
 

--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -15,6 +15,7 @@
     <Thickness x:Key="StandardIndentMargin">13,0,0,0</Thickness>
     <Thickness x:Key="StandardControlMargin">0,24,0,0</Thickness>
     <x:Double x:Key="StandardBoxMinWidth">250</x:Double>
+    <x:Double x:Key="StandardControlMaxWidth">1000</x:Double>
 
     <!--
         This is for styling the entire items control used on the

--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -48,7 +48,8 @@
     <Style x:Key="TextBoxSettingStyle"
            BasedOn="{StaticResource DefaultTextBoxStyle}"
            TargetType="TextBox">
-        <Setter Property="Width" Value="{StaticResource StandardBoxMinWidth}" />
+        <Setter Property="MinWidth" Value="{StaticResource StandardBoxMinWidth}" />
+        <Setter Property="MaxWidth" Value="500" />
         <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="TextWrapping" Value="Wrap" />
     </Style>

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -42,9 +42,14 @@
                          ItemInvoked="SettingsNav_ItemInvoked"
                          Loaded="SettingsNav_Loaded"
                          TabFocusNavigation="Cycle">
+        <muxc:NavigationView.Resources>
+            <ResourceDictionary>
+                <Thickness x:Key="NavigationViewHeaderMargin">15,0,0,0</Thickness>
+            </ResourceDictionary>
+        </muxc:NavigationView.Resources>
         <muxc:NavigationView.Header>
             <muxc:BreadcrumbBar x:Name="NavigationBreadcrumbBar"
-                                Margin="-40,-40,0,16"
+                                MaxWidth="1000"
                                 ItemClicked="BreadcrumbBar_ItemClicked"
                                 ItemsSource="{x:Bind Breadcrumbs}">
                 <muxc:BreadcrumbBar.ItemTemplate>
@@ -131,7 +136,7 @@
             </muxc:NavigationViewItem>
         </muxc:NavigationView.FooterMenuItems>
 
-        <Grid Margin="0,-30,0,0">
+        <Grid Margin="0,0,0,0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -49,7 +49,7 @@
         </muxc:NavigationView.Resources>
         <muxc:NavigationView.Header>
             <muxc:BreadcrumbBar x:Name="NavigationBreadcrumbBar"
-                                MaxWidth="1000"
+                                MaxWidth="{StaticResource StandardControlMaxWidth}"
                                 ItemClicked="BreadcrumbBar_ItemClicked"
                                 ItemsSource="{x:Bind Breadcrumbs}">
                 <muxc:BreadcrumbBar.ItemTemplate>

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
@@ -45,13 +45,15 @@
                       ViewChanging="ViewChanging">
             <StackPanel Style="{StaticResource SettingsStackStyle}">
                 <!--  Control Preview  -->
-                <Border x:Name="ControlPreview"
-                        Width="350"
-                        Height="160"
-                        Margin="0,0,0,12"
-                        HorizontalAlignment="Left"
-                        BorderBrush="{ThemeResource SystemControlForegroundBaseMediumLowBrush}"
-                        BorderThickness="1" />
+                <Border MaxWidth="1000">
+                    <Border x:Name="ControlPreview"
+                            Width="350"
+                            Height="160"
+                            Margin="0,0,0,12"
+                            HorizontalAlignment="Left"
+                            BorderBrush="{ThemeResource SystemControlForegroundBaseMediumLowBrush}"
+                            BorderThickness="1" />
+                </Border>
 
                 <local:Appearances Appearance="{x:Bind Profile.DefaultAppearance, Mode=OneWay}"
                                    SourceProfile="{x:Bind Profile, Mode=OneWay}" />
@@ -59,7 +61,7 @@
                 <!--  Grouping: Transparency  -->
                 <StackPanel Style="{StaticResource PivotStackStyle}">
                     <TextBlock x:Uid="Profile_TransparencyHeader"
-                               Style="{StaticResource SubtitleTextBlockStyle}" />
+                               Style="{StaticResource TextBlockSubHeaderStyle}" />
 
                     <!--  Opacity  -->
                     <local:SettingContainer x:Name="OpacityContainer"
@@ -99,7 +101,7 @@
                 <!--  Grouping: Window  -->
                 <StackPanel Style="{StaticResource PivotStackStyle}">
                     <TextBlock x:Uid="Profile_WindowHeader"
-                               Style="{StaticResource SubtitleTextBlockStyle}" />
+                               Style="{StaticResource TextBlockSubHeaderStyle}" />
 
                     <!--  Padding  -->
                     <local:SettingContainer x:Uid="Profile_Padding"
@@ -133,7 +135,7 @@
                                            SelectedItem="{x:Bind Profile.CurrentScrollState, Mode=TwoWay}" />
                     </local:SettingContainer>
                 </StackPanel>
-                <StackPanel>
+                <StackPanel MaxWidth="1000">
                     <StackPanel Orientation="Horizontal"
                                 Visibility="{x:Bind Profile.EditableUnfocusedAppearance, Mode=OneWay}">
                         <TextBlock x:Uid="Profile_UnfocusedAppearanceTextBlock"

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
@@ -45,7 +45,7 @@
                       ViewChanging="ViewChanging">
             <StackPanel Style="{StaticResource SettingsStackStyle}">
                 <!--  Control Preview  -->
-                <Border MaxWidth="1000">
+                <Border MaxWidth="{StaticResource StandardControlMaxWidth}">
                     <Border x:Name="ControlPreview"
                             Width="350"
                             Height="160"
@@ -135,7 +135,7 @@
                                            SelectedItem="{x:Bind Profile.CurrentScrollState, Mode=TwoWay}" />
                     </local:SettingContainer>
                 </StackPanel>
-                <StackPanel MaxWidth="1000">
+                <StackPanel MaxWidth="{StaticResource StandardControlMaxWidth}">
                     <StackPanel Orientation="Horizontal"
                                 Visibility="{x:Bind Profile.EditableUnfocusedAppearance, Mode=OneWay}">
                         <TextBlock x:Uid="Profile_UnfocusedAppearanceTextBlock"

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
@@ -160,7 +160,7 @@
                     </ContentPresenter>
                 </ToggleButton>
                 <!--  Delete Button  -->
-                <Border MaxWidth="1000">
+                <Border MaxWidth="{StaticResource StandardControlMaxWidth}">
                     <Button x:Name="DeleteButton"
                             Margin="{StaticResource StandardControlMargin}"
                             Style="{StaticResource DeleteButtonStyle}"

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
@@ -144,7 +144,7 @@
 
                 <TextBlock x:Uid="Profile_AdditionalSettingsHeader"
                            Margin="0,48,0,0"
-                           Style="{StaticResource SubtitleTextBlockStyle}" />
+                           Style="{StaticResource TextBlockSubHeaderStyle}" />
 
                 <ToggleButton Click="Appearance_Click"
                               Style="{StaticResource ToggleButtonStyle}">
@@ -160,77 +160,79 @@
                     </ContentPresenter>
                 </ToggleButton>
                 <!--  Delete Button  -->
-                <Button x:Name="DeleteButton"
-                        Margin="{StaticResource StandardControlMargin}"
-                        Style="{StaticResource DeleteButtonStyle}"
-                        Visibility="{x:Bind Profile.CanDeleteProfile}">
-                    <Button.Resources>
-                        <ResourceDictionary>
-                            <ResourceDictionary.ThemeDictionaries>
-                                <ResourceDictionary x:Key="Light">
-                                    <SolidColorBrush x:Key="ButtonBackground"
-                                                     Color="Firebrick" />
-                                    <SolidColorBrush x:Key="ButtonBackgroundPointerOver"
-                                                     Color="#C23232" />
-                                    <SolidColorBrush x:Key="ButtonBackgroundPressed"
-                                                     Color="#A21212" />
-                                    <SolidColorBrush x:Key="ButtonForeground"
-                                                     Color="White" />
-                                    <SolidColorBrush x:Key="ButtonForegroundPointerOver"
-                                                     Color="White" />
-                                    <SolidColorBrush x:Key="ButtonForegroundPressed"
-                                                     Color="White" />
-                                </ResourceDictionary>
-                                <ResourceDictionary x:Key="Dark">
-                                    <SolidColorBrush x:Key="ButtonBackground"
-                                                     Color="Firebrick" />
-                                    <SolidColorBrush x:Key="ButtonBackgroundPointerOver"
-                                                     Color="#C23232" />
-                                    <SolidColorBrush x:Key="ButtonBackgroundPressed"
-                                                     Color="#A21212" />
-                                    <SolidColorBrush x:Key="ButtonForeground"
-                                                     Color="White" />
-                                    <SolidColorBrush x:Key="ButtonForegroundPointerOver"
-                                                     Color="White" />
-                                    <SolidColorBrush x:Key="ButtonForegroundPressed"
-                                                     Color="White" />
-                                </ResourceDictionary>
-                                <ResourceDictionary x:Key="HighContrast">
-                                    <SolidColorBrush x:Key="ButtonBackground"
-                                                     Color="{ThemeResource SystemColorButtonFaceColor}" />
-                                    <SolidColorBrush x:Key="ButtonBackgroundPointerOver"
-                                                     Color="{ThemeResource SystemColorHighlightColor}" />
-                                    <SolidColorBrush x:Key="ButtonBackgroundPressed"
-                                                     Color="{ThemeResource SystemColorHighlightColor}" />
-                                    <SolidColorBrush x:Key="ButtonForeground"
-                                                     Color="{ThemeResource SystemColorButtonTextColor}" />
-                                    <SolidColorBrush x:Key="ButtonForegroundPointerOver"
-                                                     Color="{ThemeResource SystemColorHighlightTextColor}" />
-                                    <SolidColorBrush x:Key="ButtonForegroundPressed"
-                                                     Color="{ThemeResource SystemColorHighlightTextColor}" />
-                                </ResourceDictionary>
-                            </ResourceDictionary.ThemeDictionaries>
-                        </ResourceDictionary>
-                    </Button.Resources>
-                    <Button.Content>
-                        <StackPanel Orientation="Horizontal">
-                            <FontIcon FontSize="{StaticResource StandardIconSize}"
-                                      Glyph="&#xE74D;" />
-                            <TextBlock x:Uid="Profile_DeleteButton"
-                                       Margin="10,0,0,0" />
-                        </StackPanel>
-                    </Button.Content>
-                    <Button.Flyout>
-                        <Flyout>
-                            <StackPanel>
-                                <TextBlock x:Uid="Profile_DeleteConfirmationMessage"
-                                           Style="{StaticResource CustomFlyoutTextStyle}" />
-                                <Button x:Uid="Profile_DeleteConfirmationButton"
-                                        Click="DeleteConfirmation_Click" />
+                <Border MaxWidth="1000">
+                    <Button x:Name="DeleteButton"
+                            Margin="{StaticResource StandardControlMargin}"
+                            Style="{StaticResource DeleteButtonStyle}"
+                            Visibility="{x:Bind Profile.CanDeleteProfile}">
+                        <Button.Resources>
+                            <ResourceDictionary>
+                                <ResourceDictionary.ThemeDictionaries>
+                                    <ResourceDictionary x:Key="Light">
+                                        <SolidColorBrush x:Key="ButtonBackground"
+                                                         Color="Firebrick" />
+                                        <SolidColorBrush x:Key="ButtonBackgroundPointerOver"
+                                                         Color="#C23232" />
+                                        <SolidColorBrush x:Key="ButtonBackgroundPressed"
+                                                         Color="#A21212" />
+                                        <SolidColorBrush x:Key="ButtonForeground"
+                                                         Color="White" />
+                                        <SolidColorBrush x:Key="ButtonForegroundPointerOver"
+                                                         Color="White" />
+                                        <SolidColorBrush x:Key="ButtonForegroundPressed"
+                                                         Color="White" />
+                                    </ResourceDictionary>
+                                    <ResourceDictionary x:Key="Dark">
+                                        <SolidColorBrush x:Key="ButtonBackground"
+                                                         Color="Firebrick" />
+                                        <SolidColorBrush x:Key="ButtonBackgroundPointerOver"
+                                                         Color="#C23232" />
+                                        <SolidColorBrush x:Key="ButtonBackgroundPressed"
+                                                         Color="#A21212" />
+                                        <SolidColorBrush x:Key="ButtonForeground"
+                                                         Color="White" />
+                                        <SolidColorBrush x:Key="ButtonForegroundPointerOver"
+                                                         Color="White" />
+                                        <SolidColorBrush x:Key="ButtonForegroundPressed"
+                                                         Color="White" />
+                                    </ResourceDictionary>
+                                    <ResourceDictionary x:Key="HighContrast">
+                                        <SolidColorBrush x:Key="ButtonBackground"
+                                                         Color="{ThemeResource SystemColorButtonFaceColor}" />
+                                        <SolidColorBrush x:Key="ButtonBackgroundPointerOver"
+                                                         Color="{ThemeResource SystemColorHighlightColor}" />
+                                        <SolidColorBrush x:Key="ButtonBackgroundPressed"
+                                                         Color="{ThemeResource SystemColorHighlightColor}" />
+                                        <SolidColorBrush x:Key="ButtonForeground"
+                                                         Color="{ThemeResource SystemColorButtonTextColor}" />
+                                        <SolidColorBrush x:Key="ButtonForegroundPointerOver"
+                                                         Color="{ThemeResource SystemColorHighlightTextColor}" />
+                                        <SolidColorBrush x:Key="ButtonForegroundPressed"
+                                                         Color="{ThemeResource SystemColorHighlightTextColor}" />
+                                    </ResourceDictionary>
+                                </ResourceDictionary.ThemeDictionaries>
+                            </ResourceDictionary>
+                        </Button.Resources>
+                        <Button.Content>
+                            <StackPanel Orientation="Horizontal">
+                                <FontIcon FontSize="{StaticResource StandardIconSize}"
+                                          Glyph="&#xE74D;" />
+                                <TextBlock x:Uid="Profile_DeleteButton"
+                                           Margin="10,0,0,0" />
                             </StackPanel>
-                        </Flyout>
-                    </Button.Flyout>
-                </Button>
+                        </Button.Content>
+                        <Button.Flyout>
+                            <Flyout>
+                                <StackPanel>
+                                    <TextBlock x:Uid="Profile_DeleteConfirmationMessage"
+                                               Style="{StaticResource CustomFlyoutTextStyle}" />
+                                    <Button x:Uid="Profile_DeleteConfirmationButton"
+                                            Click="DeleteConfirmation_Click" />
+                                </StackPanel>
+                            </Flyout>
+                        </Button.Flyout>
+                    </Button>
+                </Border>
             </StackPanel>
         </ScrollViewer>
     </Grid>


### PR DESCRIPTION
- The add new profile page now uses a dropdown rather than radio buttons
- Subheaders, breadcrumb bar, buttons etc are now all centralized when the window is maximized (so they all align with the expanders now)
- We no longer override the titlebar colors and instead use the xaml defaults (these still aren't great but at least we will get the fix automatically when it happens upstream)
- Breadcrumb bar no longer has a negative margin, so there's no weird overlap that happens when the window becomes small
- The number boxes for launch size and font size now use the `Inline` placement mode rather than compact, allowing modification to the number with fewer clicks
- Textboxes now have a greater max width so they can occupy more space in the expander if needed