### PR TITLE
appx: Use a different resource for the Properties DisplayName

### DIFF
--- a/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
@@ -20,7 +20,7 @@
     Version="0.0.1.0" />
 
   <Properties>
-    <DisplayName>ms-resource:TerminalApp/ContextMenu/AppNameDev</DisplayName>
+    <DisplayName>ms-resource:TerminalApp/ContextMenu/AppStoreNameDev</DisplayName>
     <PublisherDisplayName>A Lone Developer</PublisherDisplayName>
     <Logo>Images\StoreLogo.png</Logo>
   </Properties>

--- a/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
@@ -21,7 +21,7 @@
     Version="0.5.0.0" />
 
   <Properties>
-    <DisplayName>ms-resource:TerminalApp/ContextMenu/AppNamePre</DisplayName>
+    <DisplayName>ms-resource:TerminalApp/ContextMenu/AppStoreNamePre</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Images\StoreLogo.png</Logo>
   </Properties>

--- a/src/cascadia/CascadiaPackage/Package.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package.appxmanifest
@@ -21,7 +21,7 @@
     Version="1.0.0.0" />
 
   <Properties>
-    <DisplayName>ms-resource:TerminalApp/ContextMenu/AppName</DisplayName>
+    <DisplayName>ms-resource:TerminalApp/ContextMenu/AppStoreName</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Images\StoreLogo.png</Logo>
   </Properties>

--- a/src/cascadia/TerminalApp/Resources/en-US/ContextMenu.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/ContextMenu.resw
@@ -127,6 +127,16 @@
   <data name="AppNamePre" xml:space="preserve">
     <value>Terminal Preview</value>
   </data>
+  <data name="AppStoreName" xml:space="preserve">
+    <value>Windows Terminal</value>
+  </data>
+  <data name="AppStoreNameDev" xml:space="preserve">
+    <value>Windows Terminal Dev</value>
+    <comment>{Locked} The dev build will never be seen in multiple languages</comment>
+  </data>
+  <data name="AppStoreNamePre" xml:space="preserve">
+    <value>Windows Terminal Preview</value>
+  </data>
   <data name="AppShortName" xml:space="preserve">
     <value>Terminal</value>
   </data>


### PR DESCRIPTION
We have to do this so that the store sees us as one thing ("Windows
Terminal") and the Start menu sees us as another ("Terminal").

The store will reject our package if the value we use for "DisplayName"
here doesn't match the store's "reserved names".

This value is *not used* by the start menu.