### PR TITLE
Fix a memory leak in onecore interactivity

### DIFF
--- a/src/interactivity/onecore/ConIoSrvComm.cpp
+++ b/src/interactivity/onecore/ConIoSrvComm.cpp
@@ -71,12 +71,11 @@ ConIoSrvComm::~ConIoSrvComm()
 
 [[nodiscard]] NTSTATUS ConIoSrvComm::Connect()
 {
-    BOOL Ret = TRUE;
     NTSTATUS Status = STATUS_SUCCESS;
 
     // Port handle and name.
     HANDLE PortHandle;
-    UNICODE_STRING PortName;
+    static UNICODE_STRING PortName = RTL_CONSTANT_STRING(CIS_ALPC_PORT_NAME);
 
     // Generic Object Manager attributes for the port object and ALPC-specific
     // port attributes.
@@ -97,13 +96,6 @@ ConIoSrvComm::~ConIoSrvComm()
 
     // Structure used to iterate over the handles given to us by the server.
     ALPC_MESSAGE_HANDLE_INFORMATION HandleInfo;
-
-    // Initialize the server port name.
-    Ret = RtlCreateUnicodeString(&PortName, CIS_ALPC_PORT_NAME);
-    if (!Ret)
-    {
-        return STATUS_NO_MEMORY;
-    }
 
     // Initialize the attributes of the port object.
     InitializeObjectAttributes(&ObjectAttributes,


### PR DESCRIPTION
As noted in #6759:

> `RtlCreateUnicodeString` creates a copy of the string on the process heap and the `PortName` variable has local-scope. The string doesn't get freed with `RtlFreeUnicodeString` before the function returns creating a memory leak.
> `CIS_ALPC_PORT_NAME` is a constant string and the `PortName` variable should instead be initialized using the `RTL_CONSTANT_STRING` macro:
>
> ```c++
> static UNICODE_STRING PortName = RTL_CONSTANT_STRING(CIS_ALPC_PORT_NAME);
> ```

I actually built this in the OS repo to make sure it'll still build, because this code doesn't even build outside Windows.

* [x] Closes #6759
* I work here.
