### PR TITLE
Always publish the binlog

### DIFF
--- a/build/pipelines/templates/build-console-steps.yml
+++ b/build/pipelines/templates/build-console-steps.yml
@@ -147,6 +147,7 @@ steps:
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: binlog'
+  condition: always()
   continueOnError: True
   inputs:
     PathtoPublish: $(Build.SourcesDirectory)\msbuild.binlog

--- a/build/pipelines/templates/build-console-steps.yml
+++ b/build/pipelines/templates/build-console-steps.yml
@@ -147,7 +147,6 @@ steps:
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: binlog'
-  condition: failed()
   continueOnError: True
   inputs:
     PathtoPublish: $(Build.SourcesDirectory)\msbuild.binlog


### PR DESCRIPTION
We're investigating an issue where the build succeeded but something still got lost somewhere. If we had the binlogs, maybe we could diff and track it down faster.
