### PR TITLE
[Prototype] Use UIA notifications for text output

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -388,6 +388,7 @@ OutputCellIterator TextBuffer::WriteLine(const OutputCellIterator givenIt,
     const auto written = newIt.GetCellDistance(givenIt);
     const Viewport paint = Viewport::FromDimensions(target, { gsl::narrow<SHORT>(written), 1 });
     _NotifyPaint(paint);
+    _renderTarget.TriggerNewTextNotification(givenIt->Chars());
 
     return newIt;
 }

--- a/src/cascadia/TerminalControl/InteractivityAutomationPeer.cpp
+++ b/src/cascadia/TerminalControl/InteractivityAutomationPeer.cpp
@@ -93,6 +93,11 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         _CursorChangedHandlers(*this, nullptr);
     }
 
+    void InteractivityAutomationPeer::NotifyNewOutput(const std::wstring_view newOutput)
+    {
+        _NewOutputHandlers(*this, hstring{ newOutput });
+    }
+
 #pragma region ITextProvider
     com_array<XamlAutomation::ITextRangeProvider> InteractivityAutomationPeer::GetSelection()
     {

--- a/src/cascadia/TerminalControl/InteractivityAutomationPeer.h
+++ b/src/cascadia/TerminalControl/InteractivityAutomationPeer.h
@@ -49,6 +49,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void SignalSelectionChanged() override;
         void SignalTextChanged() override;
         void SignalCursorChanged() override;
+        void NotifyNewOutput(const std::wstring_view newOutput) override;
 #pragma endregion
 
 #pragma region ITextProvider Pattern
@@ -73,6 +74,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         TYPED_EVENT(SelectionChanged, IInspectable, IInspectable);
         TYPED_EVENT(TextChanged, IInspectable, IInspectable);
         TYPED_EVENT(CursorChanged, IInspectable, IInspectable);
+        TYPED_EVENT(NewOutput, IInspectable, hstring);
 
     private:
         Windows::UI::Xaml::Automation::Provider::ITextRangeProvider _CreateXamlUiaTextRange(::ITextRangeProvider* returnVal) const;

--- a/src/cascadia/TerminalControl/InteractivityAutomationPeer.idl
+++ b/src/cascadia/TerminalControl/InteractivityAutomationPeer.idl
@@ -14,5 +14,6 @@ namespace Microsoft.Terminal.Control
         event Windows.Foundation.TypedEventHandler<Object, Object> SelectionChanged;
         event Windows.Foundation.TypedEventHandler<Object, Object> TextChanged;
         event Windows.Foundation.TypedEventHandler<Object, Object> CursorChanged;
+        event Windows.Foundation.TypedEventHandler<Object, String> NewOutput;
     }
 }

--- a/src/cascadia/TerminalControl/TermControlAutomationPeer.h
+++ b/src/cascadia/TerminalControl/TermControlAutomationPeer.h
@@ -64,6 +64,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void SignalSelectionChanged() override;
         void SignalTextChanged() override;
         void SignalCursorChanged() override;
+        void NotifyNewOutput(const std::wstring_view newOutput) override;
 #pragma endregion
 
 #pragma region ITextProvider Pattern

--- a/src/host/ScreenBufferRenderTarget.cpp
+++ b/src/host/ScreenBufferRenderTarget.cpp
@@ -110,3 +110,13 @@ void ScreenBufferRenderTarget::TriggerTitleChange()
         pRenderer->TriggerTitleChange();
     }
 }
+
+void ScreenBufferRenderTarget::TriggerNewTextNotification(const std::wstring_view newText)
+{
+    auto* pRenderer = ServiceLocator::LocateGlobals().pRender;
+    const auto* pActive = &ServiceLocator::LocateGlobals().getConsoleInformation().GetActiveOutputBuffer().GetActiveBuffer();
+    if (pRenderer != nullptr && pActive == &_owner)
+    {
+        pRenderer->TriggerNewTextNotification(newText);
+    }
+}

--- a/src/host/ScreenBufferRenderTarget.hpp
+++ b/src/host/ScreenBufferRenderTarget.hpp
@@ -39,6 +39,7 @@ public:
     void TriggerScroll(const COORD* const pcoordDelta) override;
     void TriggerCircling() override;
     void TriggerTitleChange() override;
+    void TriggerNewTextNotification(const std::wstring_view newText) override;
 
 private:
     SCREEN_INFORMATION& _owner;

--- a/src/renderer/atlas/AtlasEngine.api.cpp
+++ b/src/renderer/atlas/AtlasEngine.api.cpp
@@ -141,6 +141,11 @@ constexpr HRESULT vec2_narrow(U x, U y, AtlasEngine::vec2<T>& out) noexcept
     return S_OK;
 }
 
+[[nodiscard]] HRESULT AtlasEngine::NotifyNewText(const std::wstring_view newText) noexcept
+{
+    return S_OK;
+}
+
 [[nodiscard]] HRESULT AtlasEngine::UpdateFont(const FontInfoDesired& fontInfoDesired, _Out_ FontInfo& fontInfo) noexcept
 {
     return UpdateFont(fontInfoDesired, fontInfo, {}, {});

--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -35,6 +35,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT InvalidateAll() noexcept override;
         [[nodiscard]] HRESULT InvalidateCircling(_Out_ bool* pForcePaint) noexcept override;
         [[nodiscard]] HRESULT InvalidateTitle(std::wstring_view proposedTitle) noexcept override;
+        [[nodiscard]] HRESULT NotifyNewText(const std::wstring_view newText) noexcept override;
         [[nodiscard]] HRESULT PrepareRenderInfo(const RenderFrameInfo& info) noexcept override;
         [[nodiscard]] HRESULT ResetLineTransform() noexcept override;
         [[nodiscard]] HRESULT PrepareLineTransform(LineRendition lineRendition, size_t targetRow, size_t viewportLeft) noexcept override;

--- a/src/renderer/base/RenderEngineBase.cpp
+++ b/src/renderer/base/RenderEngineBase.cpp
@@ -36,6 +36,11 @@ HRESULT RenderEngineBase::UpdateTitle(const std::wstring_view newTitle) noexcept
     return hr;
 }
 
+HRESULT RenderEngineBase::NotifyNewText(const std::wstring_view /*newText*/) noexcept
+{
+    return S_FALSE;
+}
+
 HRESULT RenderEngineBase::UpdateSoftFont(const gsl::span<const uint16_t> /*bitPattern*/,
                                          const SIZE /*cellSize*/,
                                          const size_t /*centeringHint*/) noexcept

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -493,6 +493,14 @@ void Renderer::TriggerTitleChange()
     NotifyPaintFrame();
 }
 
+void Renderer::TriggerNewTextNotification(const std::wstring_view newText)
+{
+    FOREACH_ENGINE(pEngine)
+    {
+        LOG_IF_FAILED(pEngine->NotifyNewText(newText));
+    }
+}
+
 // Routine Description:
 // - Update the title for a particular engine.
 // Arguments:

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -54,6 +54,8 @@ namespace Microsoft::Console::Render
         void TriggerCircling() override;
         void TriggerTitleChange() override;
 
+        void TriggerNewTextNotification(const std::wstring_view newText) override;
+
         void TriggerFontChange(const int iDpi,
                                const FontInfoDesired& FontInfoDesired,
                                _Out_ FontInfo& FontInfo);

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -69,6 +69,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] virtual HRESULT InvalidateAll() noexcept = 0;
         [[nodiscard]] virtual HRESULT InvalidateCircling(_Out_ bool* pForcePaint) noexcept = 0;
         [[nodiscard]] virtual HRESULT InvalidateTitle(std::wstring_view proposedTitle) noexcept = 0;
+        [[nodiscard]] virtual HRESULT NotifyNewText(const std::wstring_view newText) noexcept = 0;
         [[nodiscard]] virtual HRESULT PrepareRenderInfo(const RenderFrameInfo& info) noexcept = 0;
         [[nodiscard]] virtual HRESULT ResetLineTransform() noexcept = 0;
         [[nodiscard]] virtual HRESULT PrepareLineTransform(LineRendition lineRendition, size_t targetRow, size_t viewportLeft) noexcept = 0;

--- a/src/renderer/inc/IRenderTarget.hpp
+++ b/src/renderer/inc/IRenderTarget.hpp
@@ -45,6 +45,8 @@ namespace Microsoft::Console::Render
         virtual void TriggerScroll(const COORD* const pcoordDelta) = 0;
         virtual void TriggerCircling() = 0;
         virtual void TriggerTitleChange() = 0;
+
+        virtual void TriggerNewTextNotification(const std::wstring_view newText) = 0;
     };
 
     inline Microsoft::Console::Render::IRenderTarget::~IRenderTarget() {}

--- a/src/renderer/inc/RenderEngineBase.hpp
+++ b/src/renderer/inc/RenderEngineBase.hpp
@@ -38,6 +38,8 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT UpdateTitle(const std::wstring_view newTitle) noexcept override;
 
+        [[nodiscard]] HRESULT NotifyNewText(const std::wstring_view newText) noexcept override;
+
         [[nodiscard]] HRESULT UpdateSoftFont(const gsl::span<const uint16_t> bitPattern,
                                              const SIZE cellSize,
                                              const size_t centeringHint) noexcept override;

--- a/src/renderer/uia/UiaRenderer.cpp
+++ b/src/renderer/uia/UiaRenderer.cpp
@@ -182,6 +182,15 @@ CATCH_RETURN();
     return S_FALSE;
 }
 
+[[nodiscard]] HRESULT UiaEngine::NotifyNewText(const std::wstring_view newText) noexcept
+{
+    if (!newText.empty())
+    {
+        _newOutput += newText;
+    }
+    return S_OK;
+}
+
 // Routine Description:
 // - This is unused by this renderer.
 // Arguments:
@@ -252,11 +261,20 @@ CATCH_RETURN();
         }
         CATCH_LOG();
     }
+    if (!_newOutput.empty())
+    {
+        try
+        {
+            _dispatcher->NotifyNewOutput(_newOutput);
+        }
+        CATCH_LOG();
+    }
 
     _selectionChanged = false;
     _textBufferChanged = false;
     _cursorChanged = false;
     _isPainting = false;
+    _newOutput.clear();
 
     return S_OK;
 }

--- a/src/renderer/uia/UiaRenderer.hpp
+++ b/src/renderer/uia/UiaRenderer.hpp
@@ -47,6 +47,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT InvalidateScroll(const COORD* const pcoordDelta) noexcept override;
         [[nodiscard]] HRESULT InvalidateAll() noexcept override;
         [[nodiscard]] HRESULT InvalidateCircling(_Out_ bool* const pForcePaint) noexcept override;
+        [[nodiscard]] HRESULT NotifyNewText(const std::wstring_view newText) noexcept override;
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
         [[nodiscard]] HRESULT PaintBufferLine(gsl::span<const Cluster> const clusters, const COORD coord, const bool fTrimLeft, const bool lineWrapped) noexcept override;
         [[nodiscard]] HRESULT PaintBufferGridLines(const GridLineSet lines, const COLORREF color, const size_t cchLine, const COORD coordTarget) noexcept override;
@@ -70,6 +71,7 @@ namespace Microsoft::Console::Render
         bool _selectionChanged;
         bool _textBufferChanged;
         bool _cursorChanged;
+        std::wstring _newOutput;
 
         Microsoft::Console::Types::IUiaEventDispatcher* _dispatcher;
 

--- a/src/types/IUiaEventDispatcher.h
+++ b/src/types/IUiaEventDispatcher.h
@@ -23,5 +23,6 @@ namespace Microsoft::Console::Types
         virtual void SignalSelectionChanged() = 0;
         virtual void SignalTextChanged() = 0;
         virtual void SignalCursorChanged() = 0;
+        virtual void NotifyNewOutput(const std::wstring_view newOutput) = 0;
     };
 }


### PR DESCRIPTION
## Summary of the Pull Request
This change makes Windows Terminal raise a `RaiseNotificationEvent()` ([docs](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.automation.peers.automationpeer.raisenotificationevent?view=winrt-22000)) for new text output to the buffer.

This is intended to help Narrator identify what new output appears and reduce the workload of diffing the buffer when a `TextChanged` event occurs.

## Detailed Description of the Pull Request / Additional comments
The flow of the event occurs as follows:
- `TextBuffer::WriteLine()`
   - New text is output to the text buffer. Notify the renderer that we have new text (and what that text is).
- `Renderer::TriggerNewTextNotification()`
   - Cycle through all the rendering engines and tell them to notify handle the new text output.
   - None of the rendering engines _except_ `UiaEngine` has it implemented, so really we're just notifying UIA.
- `UiaEngine::NotifyNewText()`
   - Concatenate any new output into a string.
   - When we're done painting, tell the notification system to actually notify of new events occurring and clear any stored output text. That way, we're ready for the next renderer frame.
- `InteractivityAutomationPeer::NotifyNewOutput()` --> `TermControlAutomationPeer::NotifyNewOutput`
   - NOTE: these are split because of the in-proc and out-of-proc separation of the buffer.
   - Actually `RaiseNotificationEvent()` for the new text output.

## Test cases
- [ ] Base case: "echo hello"
- [ ] Partial line change
- [ ] Passwords (needs Automation Client side work)
- [ ] Scrolling (should be unaffected)
- [ ] Large output