### PR TITLE
Fix invoking the rightmost breadcrumb bringing you back to Profiles_Base

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -476,15 +476,18 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void MainPage::BreadcrumbBar_ItemClicked(Microsoft::UI::Xaml::Controls::BreadcrumbBar const& /*sender*/, Microsoft::UI::Xaml::Controls::BreadcrumbBarItemClickedEventArgs const& args)
     {
-        const auto tag = args.Item().as<Breadcrumb>()->Tag();
-        const auto subPage = args.Item().as<Breadcrumb>()->SubPage();
-        if (const auto profileViewModel = tag.try_as<ProfileViewModel>())
+        if (gsl::narrow_cast<uint32_t>(args.Index()) < (_breadcrumbs.Size() - 1))
         {
-            _Navigate(*profileViewModel, subPage);
-        }
-        else
-        {
-            _Navigate(tag.as<hstring>(), subPage);
+            const auto tag = args.Item().as<Breadcrumb>()->Tag();
+            const auto subPage = args.Item().as<Breadcrumb>()->SubPage();
+            if (const auto profileViewModel = tag.try_as<ProfileViewModel>())
+            {
+                _Navigate(*profileViewModel, subPage);
+            }
+            else
+            {
+                _Navigate(tag.as<hstring>(), subPage);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary of the Pull Request
We no longer do anything when the rightmost breadcrumb is invoked

## PR Checklist
* [x] Closes #12325 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I work here

## Validation Steps Performed
Tested manually, cannot repro #12325 anymore