### PR TITLE
Fix the grammar in a comment

### DIFF
--- a/src/host/_stream.cpp
+++ b/src/host/_stream.cpp
@@ -1221,7 +1221,7 @@ using Microsoft::Console::VirtualTerminal::StateMachine;
             wstr.resize((dbcsLength + mbPtrLength) / sizeof(wchar_t));
         }
 
-        // Hold the specific version of the waiter locally so we can tinker with it if we must to store additional context.
+        // Hold the specific version of the waiter locally so we can tinker with it if we have to store additional context.
         std::unique_ptr<WriteData> writeDataWaiter{};
 
         // Make the W version of the call


### PR DESCRIPTION
## Summary of the Pull Request
After 'must', the verb is used without 'to'. Correct: "must" or "have to".

## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA

## Validation Steps Performed
Not required, only comment has been changed.