### PR TITLE
Update the cmdpal narrator message to include the number of results.

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -832,7 +832,7 @@ namespace winrt::TerminalApp::implementation
                     currentNeedleHasResults ?
                         (hasMultipleMatches ?
                              winrt::hstring{ fmt::format(std::wstring_view{ RS_(L"CommandPalette_ManyMatchesAvailable") }, _filteredActions.Size()) } :
-                             RS_(L"CommandPalette_OneMatcheAvailable")) :
+                             RS_(L"CommandPalette_OneMatchAvailable")) :
                         NoMatchesText(), // what to announce if results were found
                     L"CommandPaletteResultAnnouncement" /* unique name for this group of notifications */);
             }

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -824,10 +824,17 @@ namespace winrt::TerminalApp::implementation
             _noMatchesText().Visibility(currentNeedleHasResults ? Visibility::Collapsed : Visibility::Visible);
             if (auto automationPeer{ Automation::Peers::FrameworkElementAutomationPeer::FromElement(_searchBox()) })
             {
+                const bool hasMultipleMatches{ _filteredActions.Size() > 1 };
+                const auto message{ currentNeedleHasResults ?
+                                        (hasMultipleMatches ?
+                                             winrt::hstring{ fmt::format(std::wstring_view{ RS_(L"CommandPalette_ManyMatchesAvailable") }, _filteredActions.Size()) } :
+                                             RS_(L"CommandPalette_OneMatcheAvailable")) :
+                                        NoMatchesText() };
+
                 automationPeer.RaiseNotificationEvent(
                     Automation::Peers::AutomationNotificationKind::ActionCompleted,
                     Automation::Peers::AutomationNotificationProcessing::ImportantMostRecent,
-                    currentNeedleHasResults ? RS_(L"CommandPalette_MatchesAvailable") : NoMatchesText(), // what to announce if results were found
+                    message, // what to announce if results were found
                     L"CommandPaletteResultAnnouncement" /* unique name for this group of notifications */);
             }
         }

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -824,15 +824,11 @@ namespace winrt::TerminalApp::implementation
             _noMatchesText().Visibility(currentNeedleHasResults ? Visibility::Collapsed : Visibility::Visible);
             if (auto automationPeer{ Automation::Peers::FrameworkElementAutomationPeer::FromElement(_searchBox()) })
             {
-                const bool hasMultipleMatches{ _filteredActions.Size() > 1 };
-
                 automationPeer.RaiseNotificationEvent(
                     Automation::Peers::AutomationNotificationKind::ActionCompleted,
                     Automation::Peers::AutomationNotificationProcessing::ImportantMostRecent,
                     currentNeedleHasResults ?
-                        (hasMultipleMatches ?
-                             winrt::hstring{ fmt::format(std::wstring_view{ RS_(L"CommandPalette_ManyMatchesAvailable") }, _filteredActions.Size()) } :
-                             RS_(L"CommandPalette_OneMatchAvailable")) :
+                        winrt::hstring{ fmt::format(std::wstring_view{ RS_(L"CommandPalette_MatchesAvailable") }, _filteredActions.Size()) } :
                         NoMatchesText(), // what to announce if results were found
                     L"CommandPaletteResultAnnouncement" /* unique name for this group of notifications */);
             }

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -825,16 +825,15 @@ namespace winrt::TerminalApp::implementation
             if (auto automationPeer{ Automation::Peers::FrameworkElementAutomationPeer::FromElement(_searchBox()) })
             {
                 const bool hasMultipleMatches{ _filteredActions.Size() > 1 };
-                const auto message{ currentNeedleHasResults ?
-                                        (hasMultipleMatches ?
-                                             winrt::hstring{ fmt::format(std::wstring_view{ RS_(L"CommandPalette_ManyMatchesAvailable") }, _filteredActions.Size()) } :
-                                             RS_(L"CommandPalette_OneMatcheAvailable")) :
-                                        NoMatchesText() };
 
                 automationPeer.RaiseNotificationEvent(
                     Automation::Peers::AutomationNotificationKind::ActionCompleted,
                     Automation::Peers::AutomationNotificationProcessing::ImportantMostRecent,
-                    message, // what to announce if results were found
+                    currentNeedleHasResults ?
+                        (hasMultipleMatches ?
+                             winrt::hstring{ fmt::format(std::wstring_view{ RS_(L"CommandPalette_ManyMatchesAvailable") }, _filteredActions.Size()) } :
+                             RS_(L"CommandPalette_OneMatcheAvailable")) :
+                        NoMatchesText(), // what to announce if results were found
                     L"CommandPaletteResultAnnouncement" /* unique name for this group of notifications */);
             }
         }

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -731,4 +731,11 @@
   <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
     <value>Suggestions available</value>
   </data>
+  <data name="CommandPalette_OneMatcheAvailable" xml:space="preserve">
+    <value>One suggestion available</value>
+  </data>
+  <data name="CommandPalette_ManyMatchesAvailable" xml:space="preserve">
+    <value>{0} suggestions available</value>
+    <comment>{0}</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -728,14 +728,11 @@
     <value>Open Settings</value>
     <comment>This is a call-to-action hyperlink; it will open the settings.</comment>
   </data>
-  <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
-    <value>Suggestions available</value>
-  </data>
   <data name="CommandPalette_OneMatcheAvailable" xml:space="preserve">
     <value>One suggestion available</value>
   </data>
   <data name="CommandPalette_ManyMatchesAvailable" xml:space="preserve">
     <value>{0} suggestions available</value>
-    <comment>{0}</comment>
+    <comment>{0} will be replaced with a number bigger than 1</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -728,11 +728,8 @@
     <value>Open Settings</value>
     <comment>This is a call-to-action hyperlink; it will open the settings.</comment>
   </data>
-  <data name="CommandPalette_OneMatchAvailable" xml:space="preserve">
-    <value>One suggestion available</value>
-  </data>
-  <data name="CommandPalette_ManyMatchesAvailable" xml:space="preserve">
-    <value>{0} suggestions available</value>
-    <comment>{0} will be replaced with a number bigger than 1</comment>
+  <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
+    <value>Suggestions found: {0}</value>
+    <comment>{0} will be replaced with a number.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -728,7 +728,7 @@
     <value>Open Settings</value>
     <comment>This is a call-to-action hyperlink; it will open the settings.</comment>
   </data>
-  <data name="CommandPalette_OneMatcheAvailable" xml:space="preserve">
+  <data name="CommandPalette_OneMatchAvailable" xml:space="preserve">
     <value>One suggestion available</value>
   </data>
   <data name="CommandPalette_ManyMatchesAvailable" xml:space="preserve">


### PR DESCRIPTION
Updates this narrator announcement message to include the number of results it found. There are two versions:
* one for a singular result
* one for multiple results.

which should help with loc.

We're trying to get this in with the loc hotfix, so 👀 please 

* [x] will take care of the last bit of #7907

verified with narrator locally. 