### PR TITLE
Fix a potential crash when setting up the jumplist

### DIFF
--- a/src/cascadia/TerminalApp/Jumplist.cpp
+++ b/src/cascadia/TerminalApp/Jumplist.cpp
@@ -62,6 +62,19 @@ static std::wstring _normalizeIconPath(std::wstring_view path)
 // - <none>
 winrt::fire_and_forget Jumplist::UpdateJumplist(const CascadiaSettings& settings) noexcept
 {
+    if (!settings)
+    {
+        // By all accounts, this shouldn't be null. Seemingly however (GH
+        // #12360), it sometimes is. So just check this case here and log a
+        // message.
+        TraceLoggingWrite(g_hTerminalAppProvider,
+                          "Jumplist_UpdateJumplist_NullSettings",
+                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+
+        co_return;
+    }
+
     // make sure to capture the settings _before_ the co_await
     const auto strongSettings = settings;
 


### PR DESCRIPTION
I have no idea how this is even possible to hit. If this is able to be null, then we failed to load the settings in such a catastrophic way that nothing should work. However, OP's Terminal seemed to have already loaded the settings. By all accounts, doesn't make sense.

Regardless, the code here would crash if this ever is null, so we may as well catch it.

* [x] Closes #12360
* [ ] No way to verify this since it isn't even reproable on OPs machine, but it does have a lot of hits for that failure bucket (!!!)
