### PR TITLE
Allow exceptions from ITerminalApi and TerminalDispatch

### DIFF
--- a/src/cascadia/TerminalCore/ITerminalApi.hpp
+++ b/src/cascadia/TerminalCore/ITerminalApi.hpp
@@ -19,54 +19,54 @@ namespace Microsoft::Terminal::Core
         ITerminalApi& operator=(const ITerminalApi&) = default;
         ITerminalApi& operator=(ITerminalApi&&) = default;
 
-        virtual bool PrintString(std::wstring_view string) noexcept = 0;
-        virtual bool ExecuteChar(wchar_t wch) noexcept = 0;
+        virtual bool PrintString(std::wstring_view string) = 0;
+        virtual bool ExecuteChar(wchar_t wch) = 0;
 
-        virtual TextAttribute GetTextAttributes() const noexcept = 0;
-        virtual void SetTextAttributes(const TextAttribute& attrs) noexcept = 0;
+        virtual TextAttribute GetTextAttributes() const = 0;
+        virtual void SetTextAttributes(const TextAttribute& attrs) = 0;
 
-        virtual Microsoft::Console::Types::Viewport GetBufferSize() noexcept = 0;
-        virtual bool SetCursorPosition(short x, short y) noexcept = 0;
-        virtual COORD GetCursorPosition() noexcept = 0;
-        virtual bool SetCursorVisibility(const bool visible) noexcept = 0;
-        virtual bool CursorLineFeed(const bool withReturn) noexcept = 0;
-        virtual bool EnableCursorBlinking(const bool enable) noexcept = 0;
+        virtual Microsoft::Console::Types::Viewport GetBufferSize() = 0;
+        virtual bool SetCursorPosition(short x, short y) = 0;
+        virtual COORD GetCursorPosition() = 0;
+        virtual bool SetCursorVisibility(const bool visible) = 0;
+        virtual bool CursorLineFeed(const bool withReturn) = 0;
+        virtual bool EnableCursorBlinking(const bool enable) = 0;
 
-        virtual bool DeleteCharacter(const size_t count) noexcept = 0;
-        virtual bool InsertCharacter(const size_t count) noexcept = 0;
-        virtual bool EraseCharacters(const size_t numChars) noexcept = 0;
-        virtual bool EraseInLine(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) noexcept = 0;
-        virtual bool EraseInDisplay(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) noexcept = 0;
+        virtual bool DeleteCharacter(const size_t count) = 0;
+        virtual bool InsertCharacter(const size_t count) = 0;
+        virtual bool EraseCharacters(const size_t numChars) = 0;
+        virtual bool EraseInLine(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) = 0;
+        virtual bool EraseInDisplay(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) = 0;
 
-        virtual bool WarningBell() noexcept = 0;
-        virtual bool SetWindowTitle(std::wstring_view title) noexcept = 0;
+        virtual bool WarningBell() = 0;
+        virtual bool SetWindowTitle(std::wstring_view title) = 0;
 
-        virtual COLORREF GetColorTableEntry(const size_t tableIndex) const noexcept = 0;
-        virtual bool SetColorTableEntry(const size_t tableIndex, const COLORREF color) noexcept = 0;
-        virtual void SetColorAliasIndex(const ColorAlias alias, const size_t tableIndex) noexcept = 0;
+        virtual COLORREF GetColorTableEntry(const size_t tableIndex) const = 0;
+        virtual bool SetColorTableEntry(const size_t tableIndex, const COLORREF color) = 0;
+        virtual void SetColorAliasIndex(const ColorAlias alias, const size_t tableIndex) = 0;
 
-        virtual bool SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) noexcept = 0;
+        virtual bool SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) = 0;
 
-        virtual bool SetInputMode(const ::Microsoft::Console::VirtualTerminal::TerminalInput::Mode mode, const bool enabled) noexcept = 0;
-        virtual bool SetRenderMode(const ::Microsoft::Console::Render::RenderSettings::Mode mode, const bool enabled) noexcept = 0;
+        virtual bool SetInputMode(const ::Microsoft::Console::VirtualTerminal::TerminalInput::Mode mode, const bool enabled) = 0;
+        virtual bool SetRenderMode(const ::Microsoft::Console::Render::RenderSettings::Mode mode, const bool enabled) = 0;
 
-        virtual bool EnableXtermBracketedPasteMode(const bool enabled) noexcept = 0;
+        virtual bool EnableXtermBracketedPasteMode(const bool enabled) = 0;
         virtual bool IsXtermBracketedPasteModeEnabled() const = 0;
 
         virtual bool IsVtInputEnabled() const = 0;
 
-        virtual bool CopyToClipboard(std::wstring_view content) noexcept = 0;
+        virtual bool CopyToClipboard(std::wstring_view content) = 0;
 
-        virtual bool AddHyperlink(std::wstring_view uri, std::wstring_view params) noexcept = 0;
-        virtual bool EndHyperlink() noexcept = 0;
+        virtual bool AddHyperlink(std::wstring_view uri, std::wstring_view params) = 0;
+        virtual bool EndHyperlink() = 0;
 
-        virtual bool SetTaskbarProgress(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::TaskbarState state, const size_t progress) noexcept = 0;
+        virtual bool SetTaskbarProgress(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::TaskbarState state, const size_t progress) = 0;
 
-        virtual bool SetWorkingDirectory(std::wstring_view uri) noexcept = 0;
-        virtual std::wstring_view GetWorkingDirectory() noexcept = 0;
+        virtual bool SetWorkingDirectory(std::wstring_view uri) = 0;
+        virtual std::wstring_view GetWorkingDirectory() = 0;
 
-        virtual bool PushGraphicsRendition(const ::Microsoft::Console::VirtualTerminal::VTParameters options) noexcept = 0;
-        virtual bool PopGraphicsRendition() noexcept = 0;
+        virtual bool PushGraphicsRendition(const ::Microsoft::Console::VirtualTerminal::VTParameters options) = 0;
+        virtual bool PopGraphicsRendition() = 0;
 
     protected:
         ITerminalApi() = default;

--- a/src/cascadia/TerminalCore/ITerminalApi.hpp
+++ b/src/cascadia/TerminalCore/ITerminalApi.hpp
@@ -19,54 +19,54 @@ namespace Microsoft::Terminal::Core
         ITerminalApi& operator=(const ITerminalApi&) = default;
         ITerminalApi& operator=(ITerminalApi&&) = default;
 
-        virtual bool PrintString(std::wstring_view string) = 0;
-        virtual bool ExecuteChar(wchar_t wch) = 0;
+        virtual void PrintString(std::wstring_view string) = 0;
+        virtual void ExecuteChar(wchar_t wch) = 0;
 
         virtual TextAttribute GetTextAttributes() const = 0;
         virtual void SetTextAttributes(const TextAttribute& attrs) = 0;
 
         virtual Microsoft::Console::Types::Viewport GetBufferSize() = 0;
-        virtual bool SetCursorPosition(short x, short y) = 0;
+        virtual void SetCursorPosition(short x, short y) = 0;
         virtual COORD GetCursorPosition() = 0;
-        virtual bool SetCursorVisibility(const bool visible) = 0;
-        virtual bool CursorLineFeed(const bool withReturn) = 0;
-        virtual bool EnableCursorBlinking(const bool enable) = 0;
+        virtual void SetCursorVisibility(const bool visible) = 0;
+        virtual void CursorLineFeed(const bool withReturn) = 0;
+        virtual void EnableCursorBlinking(const bool enable) = 0;
 
-        virtual bool DeleteCharacter(const size_t count) = 0;
-        virtual bool InsertCharacter(const size_t count) = 0;
-        virtual bool EraseCharacters(const size_t numChars) = 0;
+        virtual void DeleteCharacter(const size_t count) = 0;
+        virtual void InsertCharacter(const size_t count) = 0;
+        virtual void EraseCharacters(const size_t numChars) = 0;
         virtual bool EraseInLine(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) = 0;
         virtual bool EraseInDisplay(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) = 0;
 
-        virtual bool WarningBell() = 0;
-        virtual bool SetWindowTitle(std::wstring_view title) = 0;
+        virtual void WarningBell() = 0;
+        virtual void SetWindowTitle(std::wstring_view title) = 0;
 
         virtual COLORREF GetColorTableEntry(const size_t tableIndex) const = 0;
-        virtual bool SetColorTableEntry(const size_t tableIndex, const COLORREF color) = 0;
+        virtual void SetColorTableEntry(const size_t tableIndex, const COLORREF color) = 0;
         virtual void SetColorAliasIndex(const ColorAlias alias, const size_t tableIndex) = 0;
 
-        virtual bool SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) = 0;
+        virtual void SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) = 0;
 
-        virtual bool SetInputMode(const ::Microsoft::Console::VirtualTerminal::TerminalInput::Mode mode, const bool enabled) = 0;
-        virtual bool SetRenderMode(const ::Microsoft::Console::Render::RenderSettings::Mode mode, const bool enabled) = 0;
+        virtual void SetInputMode(const ::Microsoft::Console::VirtualTerminal::TerminalInput::Mode mode, const bool enabled) = 0;
+        virtual void SetRenderMode(const ::Microsoft::Console::Render::RenderSettings::Mode mode, const bool enabled) = 0;
 
-        virtual bool EnableXtermBracketedPasteMode(const bool enabled) = 0;
+        virtual void EnableXtermBracketedPasteMode(const bool enabled) = 0;
         virtual bool IsXtermBracketedPasteModeEnabled() const = 0;
 
         virtual bool IsVtInputEnabled() const = 0;
 
-        virtual bool CopyToClipboard(std::wstring_view content) = 0;
+        virtual void CopyToClipboard(std::wstring_view content) = 0;
 
-        virtual bool AddHyperlink(std::wstring_view uri, std::wstring_view params) = 0;
-        virtual bool EndHyperlink() = 0;
+        virtual void AddHyperlink(std::wstring_view uri, std::wstring_view params) = 0;
+        virtual void EndHyperlink() = 0;
 
-        virtual bool SetTaskbarProgress(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::TaskbarState state, const size_t progress) = 0;
+        virtual void SetTaskbarProgress(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::TaskbarState state, const size_t progress) = 0;
 
-        virtual bool SetWorkingDirectory(std::wstring_view uri) = 0;
+        virtual void SetWorkingDirectory(std::wstring_view uri) = 0;
         virtual std::wstring_view GetWorkingDirectory() = 0;
 
-        virtual bool PushGraphicsRendition(const ::Microsoft::Console::VirtualTerminal::VTParameters options) = 0;
-        virtual bool PopGraphicsRendition() = 0;
+        virtual void PushGraphicsRendition(const ::Microsoft::Console::VirtualTerminal::VTParameters options) = 0;
+        virtual void PopGraphicsRendition() = 0;
 
     protected:
         ITerminalApi() = default;

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -95,47 +95,47 @@ public:
 
 #pragma region ITerminalApi
     // These methods are defined in TerminalApi.cpp
-    bool PrintString(std::wstring_view stringView) override;
-    bool ExecuteChar(wchar_t wch) override;
+    void PrintString(std::wstring_view stringView) override;
+    void ExecuteChar(wchar_t wch) override;
     TextAttribute GetTextAttributes() const override;
     void SetTextAttributes(const TextAttribute& attrs) override;
     Microsoft::Console::Types::Viewport GetBufferSize() override;
-    bool SetCursorPosition(short x, short y) override;
+    void SetCursorPosition(short x, short y) override;
     COORD GetCursorPosition() override;
-    bool SetCursorVisibility(const bool visible) override;
-    bool EnableCursorBlinking(const bool enable) override;
-    bool CursorLineFeed(const bool withReturn) override;
-    bool DeleteCharacter(const size_t count) override;
-    bool InsertCharacter(const size_t count) override;
-    bool EraseCharacters(const size_t numChars) override;
+    void SetCursorVisibility(const bool visible) override;
+    void EnableCursorBlinking(const bool enable) override;
+    void CursorLineFeed(const bool withReturn) override;
+    void DeleteCharacter(const size_t count) override;
+    void InsertCharacter(const size_t count) override;
+    void EraseCharacters(const size_t numChars) override;
     bool EraseInLine(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) override;
     bool EraseInDisplay(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) override;
-    bool WarningBell() override;
-    bool SetWindowTitle(std::wstring_view title) override;
+    void WarningBell() override;
+    void SetWindowTitle(std::wstring_view title) override;
     COLORREF GetColorTableEntry(const size_t tableIndex) const override;
-    bool SetColorTableEntry(const size_t tableIndex, const COLORREF color) override;
+    void SetColorTableEntry(const size_t tableIndex, const COLORREF color) override;
     void SetColorAliasIndex(const ColorAlias alias, const size_t tableIndex) override;
-    bool SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) override;
+    void SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) override;
 
-    bool SetInputMode(const ::Microsoft::Console::VirtualTerminal::TerminalInput::Mode mode, const bool enabled) override;
-    bool SetRenderMode(const ::Microsoft::Console::Render::RenderSettings::Mode mode, const bool enabled) override;
+    void SetInputMode(const ::Microsoft::Console::VirtualTerminal::TerminalInput::Mode mode, const bool enabled) override;
+    void SetRenderMode(const ::Microsoft::Console::Render::RenderSettings::Mode mode, const bool enabled) override;
 
-    bool EnableXtermBracketedPasteMode(const bool enabled) override;
+    void EnableXtermBracketedPasteMode(const bool enabled) override;
     bool IsXtermBracketedPasteModeEnabled() const override;
 
     bool IsVtInputEnabled() const override;
 
-    bool CopyToClipboard(std::wstring_view content) override;
+    void CopyToClipboard(std::wstring_view content) override;
 
-    bool AddHyperlink(std::wstring_view uri, std::wstring_view params) override;
-    bool EndHyperlink() override;
+    void AddHyperlink(std::wstring_view uri, std::wstring_view params) override;
+    void EndHyperlink() override;
 
-    bool SetTaskbarProgress(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::TaskbarState state, const size_t progress) override;
-    bool SetWorkingDirectory(std::wstring_view uri) override;
+    void SetTaskbarProgress(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::TaskbarState state, const size_t progress) override;
+    void SetWorkingDirectory(std::wstring_view uri) override;
     std::wstring_view GetWorkingDirectory() override;
 
-    bool PushGraphicsRendition(const ::Microsoft::Console::VirtualTerminal::VTParameters options) override;
-    bool PopGraphicsRendition() override;
+    void PushGraphicsRendition(const ::Microsoft::Console::VirtualTerminal::VTParameters options) override;
+    void PopGraphicsRendition() override;
 
 #pragma endregion
 

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -95,47 +95,47 @@ public:
 
 #pragma region ITerminalApi
     // These methods are defined in TerminalApi.cpp
-    bool PrintString(std::wstring_view stringView) noexcept override;
-    bool ExecuteChar(wchar_t wch) noexcept override;
-    TextAttribute GetTextAttributes() const noexcept override;
-    void SetTextAttributes(const TextAttribute& attrs) noexcept override;
-    Microsoft::Console::Types::Viewport GetBufferSize() noexcept override;
-    bool SetCursorPosition(short x, short y) noexcept override;
-    COORD GetCursorPosition() noexcept override;
-    bool SetCursorVisibility(const bool visible) noexcept override;
-    bool EnableCursorBlinking(const bool enable) noexcept override;
-    bool CursorLineFeed(const bool withReturn) noexcept override;
-    bool DeleteCharacter(const size_t count) noexcept override;
-    bool InsertCharacter(const size_t count) noexcept override;
-    bool EraseCharacters(const size_t numChars) noexcept override;
-    bool EraseInLine(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) noexcept override;
-    bool EraseInDisplay(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) noexcept override;
-    bool WarningBell() noexcept override;
-    bool SetWindowTitle(std::wstring_view title) noexcept override;
-    COLORREF GetColorTableEntry(const size_t tableIndex) const noexcept override;
-    bool SetColorTableEntry(const size_t tableIndex, const COLORREF color) noexcept override;
-    void SetColorAliasIndex(const ColorAlias alias, const size_t tableIndex) noexcept override;
-    bool SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) noexcept override;
+    bool PrintString(std::wstring_view stringView) override;
+    bool ExecuteChar(wchar_t wch) override;
+    TextAttribute GetTextAttributes() const override;
+    void SetTextAttributes(const TextAttribute& attrs) override;
+    Microsoft::Console::Types::Viewport GetBufferSize() override;
+    bool SetCursorPosition(short x, short y) override;
+    COORD GetCursorPosition() override;
+    bool SetCursorVisibility(const bool visible) override;
+    bool EnableCursorBlinking(const bool enable) override;
+    bool CursorLineFeed(const bool withReturn) override;
+    bool DeleteCharacter(const size_t count) override;
+    bool InsertCharacter(const size_t count) override;
+    bool EraseCharacters(const size_t numChars) override;
+    bool EraseInLine(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) override;
+    bool EraseInDisplay(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) override;
+    bool WarningBell() override;
+    bool SetWindowTitle(std::wstring_view title) override;
+    COLORREF GetColorTableEntry(const size_t tableIndex) const override;
+    bool SetColorTableEntry(const size_t tableIndex, const COLORREF color) override;
+    void SetColorAliasIndex(const ColorAlias alias, const size_t tableIndex) override;
+    bool SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) override;
 
-    bool SetInputMode(const ::Microsoft::Console::VirtualTerminal::TerminalInput::Mode mode, const bool enabled) noexcept override;
-    bool SetRenderMode(const ::Microsoft::Console::Render::RenderSettings::Mode mode, const bool enabled) noexcept override;
+    bool SetInputMode(const ::Microsoft::Console::VirtualTerminal::TerminalInput::Mode mode, const bool enabled) override;
+    bool SetRenderMode(const ::Microsoft::Console::Render::RenderSettings::Mode mode, const bool enabled) override;
 
-    bool EnableXtermBracketedPasteMode(const bool enabled) noexcept override;
-    bool IsXtermBracketedPasteModeEnabled() const noexcept override;
+    bool EnableXtermBracketedPasteMode(const bool enabled) override;
+    bool IsXtermBracketedPasteModeEnabled() const override;
 
-    bool IsVtInputEnabled() const noexcept override;
+    bool IsVtInputEnabled() const override;
 
-    bool CopyToClipboard(std::wstring_view content) noexcept override;
+    bool CopyToClipboard(std::wstring_view content) override;
 
-    bool AddHyperlink(std::wstring_view uri, std::wstring_view params) noexcept override;
-    bool EndHyperlink() noexcept override;
+    bool AddHyperlink(std::wstring_view uri, std::wstring_view params) override;
+    bool EndHyperlink() override;
 
-    bool SetTaskbarProgress(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::TaskbarState state, const size_t progress) noexcept override;
-    bool SetWorkingDirectory(std::wstring_view uri) noexcept override;
-    std::wstring_view GetWorkingDirectory() noexcept override;
+    bool SetTaskbarProgress(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::TaskbarState state, const size_t progress) override;
+    bool SetWorkingDirectory(std::wstring_view uri) override;
+    std::wstring_view GetWorkingDirectory() override;
 
-    bool PushGraphicsRendition(const ::Microsoft::Console::VirtualTerminal::VTParameters options) noexcept override;
-    bool PopGraphicsRendition() noexcept override;
+    bool PushGraphicsRendition(const ::Microsoft::Console::VirtualTerminal::VTParameters options) override;
+    bool PopGraphicsRendition() override;
 
 #pragma endregion
 

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -19,77 +19,68 @@ TerminalDispatch::TerminalDispatch(ITerminalApi& terminalApi) noexcept :
 {
 }
 
-void TerminalDispatch::Execute(const wchar_t wchControl) noexcept
+void TerminalDispatch::Execute(const wchar_t wchControl)
 {
     _terminalApi.ExecuteChar(wchControl);
 }
 
-void TerminalDispatch::Print(const wchar_t wchPrintable) noexcept
+void TerminalDispatch::Print(const wchar_t wchPrintable)
 {
     _terminalApi.PrintString({ &wchPrintable, 1 });
 }
 
-void TerminalDispatch::PrintString(const std::wstring_view string) noexcept
+void TerminalDispatch::PrintString(const std::wstring_view string)
 {
     _terminalApi.PrintString(string);
 }
 
 bool TerminalDispatch::CursorPosition(const size_t line,
-                                      const size_t column) noexcept
-try
+                                      const size_t column)
 {
     SHORT x{ 0 };
     SHORT y{ 0 };
 
-    RETURN_BOOL_IF_FALSE(SUCCEEDED(SizeTToShort(column, &x)) &&
-                         SUCCEEDED(SizeTToShort(line, &y)));
+    THROW_IF_FAILED(SizeTToShort(column, &x));
+    THROW_IF_FAILED(SizeTToShort(line, &y));
 
-    RETURN_BOOL_IF_FALSE(SUCCEEDED(ShortSub(x, 1, &x)) &&
-                         SUCCEEDED(ShortSub(y, 1, &y)));
+    THROW_IF_FAILED(ShortSub(x, 1, &x));
+    THROW_IF_FAILED(ShortSub(y, 1, &y));
 
     return _terminalApi.SetCursorPosition(x, y);
 }
-CATCH_LOG_RETURN_FALSE()
 
-bool TerminalDispatch::CursorVisibility(const bool isVisible) noexcept
+bool TerminalDispatch::CursorVisibility(const bool isVisible)
 {
     return _terminalApi.SetCursorVisibility(isVisible);
 }
 
-bool TerminalDispatch::EnableCursorBlinking(const bool enable) noexcept
+bool TerminalDispatch::EnableCursorBlinking(const bool enable)
 {
     return _terminalApi.EnableCursorBlinking(enable);
 }
 
-bool TerminalDispatch::CursorForward(const size_t distance) noexcept
-try
+bool TerminalDispatch::CursorForward(const size_t distance)
 {
     const auto cursorPos = _terminalApi.GetCursorPosition();
     const COORD newCursorPos{ cursorPos.X + gsl::narrow<short>(distance), cursorPos.Y };
     return _terminalApi.SetCursorPosition(newCursorPos.X, newCursorPos.Y);
 }
-CATCH_LOG_RETURN_FALSE()
 
-bool TerminalDispatch::CursorBackward(const size_t distance) noexcept
-try
+bool TerminalDispatch::CursorBackward(const size_t distance)
 {
     const auto cursorPos = _terminalApi.GetCursorPosition();
     const COORD newCursorPos{ cursorPos.X - gsl::narrow<short>(distance), cursorPos.Y };
     return _terminalApi.SetCursorPosition(newCursorPos.X, newCursorPos.Y);
 }
-CATCH_LOG_RETURN_FALSE()
 
-bool TerminalDispatch::CursorUp(const size_t distance) noexcept
-try
+bool TerminalDispatch::CursorUp(const size_t distance)
 {
     const auto cursorPos = _terminalApi.GetCursorPosition();
     const COORD newCursorPos{ cursorPos.X, cursorPos.Y + gsl::narrow<short>(distance) };
     return _terminalApi.SetCursorPosition(newCursorPos.X, newCursorPos.Y);
 }
-CATCH_LOG_RETURN_FALSE()
 
-bool TerminalDispatch::LineFeed(const DispatchTypes::LineFeedType lineFeedType) noexcept
-try
+bool TerminalDispatch::LineFeed(const DispatchTypes::LineFeedType lineFeedType)
 {
     switch (lineFeedType)
     {
@@ -104,38 +95,28 @@ try
         return false;
     }
 }
-CATCH_LOG_RETURN_FALSE()
 
-bool TerminalDispatch::EraseCharacters(const size_t numChars) noexcept
-try
+bool TerminalDispatch::EraseCharacters(const size_t numChars)
 {
     return _terminalApi.EraseCharacters(numChars);
 }
-CATCH_LOG_RETURN_FALSE()
 
-bool TerminalDispatch::WarningBell() noexcept
-try
+bool TerminalDispatch::WarningBell()
 {
     return _terminalApi.WarningBell();
 }
-CATCH_LOG_RETURN_FALSE()
 
-bool TerminalDispatch::CarriageReturn() noexcept
-try
+bool TerminalDispatch::CarriageReturn()
 {
     const auto cursorPos = _terminalApi.GetCursorPosition();
     return _terminalApi.SetCursorPosition(0, cursorPos.Y);
 }
-CATCH_LOG_RETURN_FALSE()
 
-bool TerminalDispatch::SetWindowTitle(std::wstring_view title) noexcept
-try
+bool TerminalDispatch::SetWindowTitle(std::wstring_view title)
 {
     return _terminalApi.SetWindowTitle(title);
 }
-CATCH_LOG_RETURN_FALSE()
-
-bool TerminalDispatch::HorizontalTabSet() noexcept
+bool TerminalDispatch::HorizontalTabSet()
 {
     const auto width = _terminalApi.GetBufferSize().Dimensions().X;
     const auto column = _terminalApi.GetCursorPosition().X;
@@ -145,7 +126,7 @@ bool TerminalDispatch::HorizontalTabSet() noexcept
     return true;
 }
 
-bool TerminalDispatch::ForwardTab(const size_t numTabs) noexcept
+bool TerminalDispatch::ForwardTab(const size_t numTabs)
 {
     const auto width = _terminalApi.GetBufferSize().Dimensions().X;
     const auto cursorPosition = _terminalApi.GetCursorPosition();
@@ -165,7 +146,7 @@ bool TerminalDispatch::ForwardTab(const size_t numTabs) noexcept
     return _terminalApi.SetCursorPosition(column, row);
 }
 
-bool TerminalDispatch::BackwardsTab(const size_t numTabs) noexcept
+bool TerminalDispatch::BackwardsTab(const size_t numTabs)
 {
     const auto width = _terminalApi.GetBufferSize().Dimensions().X;
     const auto cursorPosition = _terminalApi.GetCursorPosition();
@@ -185,7 +166,7 @@ bool TerminalDispatch::BackwardsTab(const size_t numTabs) noexcept
     return _terminalApi.SetCursorPosition(column, row);
 }
 
-bool TerminalDispatch::TabClear(const DispatchTypes::TabClearType clearType) noexcept
+bool TerminalDispatch::TabClear(const DispatchTypes::TabClearType clearType)
 {
     bool success = false;
     switch (clearType)
@@ -211,33 +192,25 @@ bool TerminalDispatch::TabClear(const DispatchTypes::TabClearType clearType) noe
 // Return Value:
 // True if handled successfully. False otherwise.
 bool TerminalDispatch::SetColorTableEntry(const size_t tableIndex,
-                                          const DWORD color) noexcept
-try
+                                          const DWORD color)
 {
     return _terminalApi.SetColorTableEntry(tableIndex, color);
 }
-CATCH_LOG_RETURN_FALSE()
 
-bool TerminalDispatch::SetCursorStyle(const DispatchTypes::CursorStyle cursorStyle) noexcept
-try
+bool TerminalDispatch::SetCursorStyle(const DispatchTypes::CursorStyle cursorStyle)
 {
     return _terminalApi.SetCursorStyle(cursorStyle);
 }
-CATCH_LOG_RETURN_FALSE()
 
-bool TerminalDispatch::SetCursorColor(const DWORD color) noexcept
-try
+bool TerminalDispatch::SetCursorColor(const DWORD color)
 {
     return _terminalApi.SetColorTableEntry(TextColor::CURSOR_COLOR, color);
 }
-CATCH_LOG_RETURN_FALSE()
 
-bool TerminalDispatch::SetClipboard(std::wstring_view content) noexcept
-try
+bool TerminalDispatch::SetClipboard(std::wstring_view content)
 {
     return _terminalApi.CopyToClipboard(content);
 }
-CATCH_LOG_RETURN_FALSE()
 
 // Method Description:
 // - Sets the default foreground color to a new value
@@ -245,13 +218,11 @@ CATCH_LOG_RETURN_FALSE()
 // - color: The new RGB color value to use, in 0x00BBGGRR form
 // Return Value:
 // True if handled successfully. False otherwise.
-bool TerminalDispatch::SetDefaultForeground(const DWORD color) noexcept
-try
+bool TerminalDispatch::SetDefaultForeground(const DWORD color)
 {
     _terminalApi.SetColorAliasIndex(ColorAlias::DefaultForeground, TextColor::DEFAULT_FOREGROUND);
     return _terminalApi.SetColorTableEntry(TextColor::DEFAULT_FOREGROUND, color);
 }
-CATCH_LOG_RETURN_FALSE()
 
 // Method Description:
 // - Sets the default background color to a new value
@@ -259,13 +230,11 @@ CATCH_LOG_RETURN_FALSE()
 // - color: The new RGB color value to use, in 0x00BBGGRR form
 // Return Value:
 // True if handled successfully. False otherwise.
-bool TerminalDispatch::SetDefaultBackground(const DWORD color) noexcept
-try
+bool TerminalDispatch::SetDefaultBackground(const DWORD color)
 {
     _terminalApi.SetColorAliasIndex(ColorAlias::DefaultBackground, TextColor::DEFAULT_BACKGROUND);
     return _terminalApi.SetColorTableEntry(TextColor::DEFAULT_BACKGROUND, color);
 }
-CATCH_LOG_RETURN_FALSE()
 
 // Method Description:
 // - Erases characters in the buffer depending on the erase type
@@ -273,12 +242,10 @@ CATCH_LOG_RETURN_FALSE()
 // - eraseType: the erase type (from beginning, to end, or all)
 // Return Value:
 // True if handled successfully. False otherwise.
-bool TerminalDispatch::EraseInLine(const DispatchTypes::EraseType eraseType) noexcept
-try
+bool TerminalDispatch::EraseInLine(const DispatchTypes::EraseType eraseType)
 {
     return _terminalApi.EraseInLine(eraseType);
 }
-CATCH_LOG_RETURN_FALSE()
 
 // Method Description:
 // - Deletes count number of characters starting from where the cursor is currently
@@ -286,12 +253,10 @@ CATCH_LOG_RETURN_FALSE()
 // - count, the number of characters to delete
 // Return Value:
 // True if handled successfully. False otherwise.
-bool TerminalDispatch::DeleteCharacter(const size_t count) noexcept
-try
+bool TerminalDispatch::DeleteCharacter(const size_t count)
 {
     return _terminalApi.DeleteCharacter(count);
 }
-CATCH_LOG_RETURN_FALSE()
 
 // Method Description:
 // - Adds count number of spaces starting from where the cursor is currently
@@ -299,12 +264,10 @@ CATCH_LOG_RETURN_FALSE()
 // - count, the number of spaces to add
 // Return Value:
 // True if handled successfully, false otherwise
-bool TerminalDispatch::InsertCharacter(const size_t count) noexcept
-try
+bool TerminalDispatch::InsertCharacter(const size_t count)
 {
     return _terminalApi.InsertCharacter(count);
 }
-CATCH_LOG_RETURN_FALSE()
 
 // Method Description:
 // - Moves the viewport and erases text from the buffer depending on the eraseType
@@ -312,19 +275,17 @@ CATCH_LOG_RETURN_FALSE()
 // - eraseType: the desired erase type
 // Return Value:
 // True if handled successfully. False otherwise
-bool TerminalDispatch::EraseInDisplay(const DispatchTypes::EraseType eraseType) noexcept
-try
+bool TerminalDispatch::EraseInDisplay(const DispatchTypes::EraseType eraseType)
 {
     return _terminalApi.EraseInDisplay(eraseType);
 }
-CATCH_LOG_RETURN_FALSE()
 
 // - DECKPAM, DECKPNM - Sets the keypad input mode to either Application mode or Numeric mode (true, false respectively)
 // Arguments:
 // - applicationMode - set to true to enable Application Mode Input, false for Numeric Mode Input.
 // Return Value:
 // - True if handled successfully. False otherwise.
-bool TerminalDispatch::SetKeypadMode(const bool applicationMode) noexcept
+bool TerminalDispatch::SetKeypadMode(const bool applicationMode)
 {
     _terminalApi.SetInputMode(TerminalInput::Mode::Keypad, applicationMode);
     return true;
@@ -335,7 +296,7 @@ bool TerminalDispatch::SetKeypadMode(const bool applicationMode) noexcept
 // - applicationMode - set to true to enable Application Mode Input, false for Normal Mode Input.
 // Return Value:
 // - True if handled successfully. False otherwise.
-bool TerminalDispatch::SetCursorKeysMode(const bool applicationMode) noexcept
+bool TerminalDispatch::SetCursorKeysMode(const bool applicationMode)
 {
     _terminalApi.SetInputMode(TerminalInput::Mode::CursorKey, applicationMode);
     return true;
@@ -348,7 +309,7 @@ bool TerminalDispatch::SetCursorKeysMode(const bool applicationMode) noexcept
 // - reverseMode - set to true to enable reverse screen mode, false for normal mode.
 // Return Value:
 // - True if handled successfully. False otherwise.
-bool TerminalDispatch::SetScreenMode(const bool reverseMode) noexcept
+bool TerminalDispatch::SetScreenMode(const bool reverseMode)
 {
     return _terminalApi.SetRenderMode(RenderSettings::Mode::ScreenReversed, reverseMode);
 }
@@ -360,7 +321,7 @@ bool TerminalDispatch::SetScreenMode(const bool reverseMode) noexcept
 // - win32InputMode - set to true to enable win32-input-mode, false to disable.
 // Return Value:
 // - True if handled successfully. False otherwise.
-bool TerminalDispatch::EnableWin32InputMode(const bool win32Mode) noexcept
+bool TerminalDispatch::EnableWin32InputMode(const bool win32Mode)
 {
     _terminalApi.SetInputMode(TerminalInput::Mode::Win32, win32Mode);
     return true;
@@ -372,7 +333,7 @@ bool TerminalDispatch::EnableWin32InputMode(const bool win32Mode) noexcept
 // - enabled - true to enable, false to disable.
 // Return value:
 // True if handled successfully. False otherwise.
-bool TerminalDispatch::EnableVT200MouseMode(const bool enabled) noexcept
+bool TerminalDispatch::EnableVT200MouseMode(const bool enabled)
 {
     _terminalApi.SetInputMode(TerminalInput::Mode::DefaultMouseTracking, enabled);
     return true;
@@ -385,7 +346,7 @@ bool TerminalDispatch::EnableVT200MouseMode(const bool enabled) noexcept
 // - enabled - true to enable, false to disable.
 // Return value:
 // True if handled successfully. False otherwise.
-bool TerminalDispatch::EnableUTF8ExtendedMouseMode(const bool enabled) noexcept
+bool TerminalDispatch::EnableUTF8ExtendedMouseMode(const bool enabled)
 {
     _terminalApi.SetInputMode(TerminalInput::Mode::Utf8MouseEncoding, enabled);
     return true;
@@ -398,7 +359,7 @@ bool TerminalDispatch::EnableUTF8ExtendedMouseMode(const bool enabled) noexcept
 // - enabled - true to enable, false to disable.
 // Return value:
 // True if handled successfully. False otherwise.
-bool TerminalDispatch::EnableSGRExtendedMouseMode(const bool enabled) noexcept
+bool TerminalDispatch::EnableSGRExtendedMouseMode(const bool enabled)
 {
     _terminalApi.SetInputMode(TerminalInput::Mode::SgrMouseEncoding, enabled);
     return true;
@@ -410,7 +371,7 @@ bool TerminalDispatch::EnableSGRExtendedMouseMode(const bool enabled) noexcept
 // - enabled - true to enable, false to disable.
 // Return value:
 // True if handled successfully. False otherwise.
-bool TerminalDispatch::EnableButtonEventMouseMode(const bool enabled) noexcept
+bool TerminalDispatch::EnableButtonEventMouseMode(const bool enabled)
 {
     _terminalApi.SetInputMode(TerminalInput::Mode::ButtonEventMouseTracking, enabled);
     return true;
@@ -423,7 +384,7 @@ bool TerminalDispatch::EnableButtonEventMouseMode(const bool enabled) noexcept
 // - enabled - true to enable, false to disable.
 // Return value:
 // True if handled successfully. False otherwise.
-bool TerminalDispatch::EnableAnyEventMouseMode(const bool enabled) noexcept
+bool TerminalDispatch::EnableAnyEventMouseMode(const bool enabled)
 {
     _terminalApi.SetInputMode(TerminalInput::Mode::AnyEventMouseTracking, enabled);
     return true;
@@ -436,7 +397,7 @@ bool TerminalDispatch::EnableAnyEventMouseMode(const bool enabled) noexcept
 // - enabled - true to enable, false to disable.
 // Return value:
 // True if handled successfully. False otherwise.
-bool TerminalDispatch::EnableAlternateScroll(const bool enabled) noexcept
+bool TerminalDispatch::EnableAlternateScroll(const bool enabled)
 {
     _terminalApi.SetInputMode(TerminalInput::Mode::AlternateScroll, enabled);
     return true;
@@ -449,18 +410,18 @@ bool TerminalDispatch::EnableAlternateScroll(const bool enabled) noexcept
 // - enabled - true to enable, false to disable.
 // Return value:
 // True if handled successfully. False otherwise.
-bool TerminalDispatch::EnableXtermBracketedPasteMode(const bool enabled) noexcept
+bool TerminalDispatch::EnableXtermBracketedPasteMode(const bool enabled)
 {
     _terminalApi.EnableXtermBracketedPasteMode(enabled);
     return true;
 }
 
-bool TerminalDispatch::SetMode(const DispatchTypes::ModeParams param) noexcept
+bool TerminalDispatch::SetMode(const DispatchTypes::ModeParams param)
 {
     return _ModeParamsHelper(param, true);
 }
 
-bool TerminalDispatch::ResetMode(const DispatchTypes::ModeParams param) noexcept
+bool TerminalDispatch::ResetMode(const DispatchTypes::ModeParams param)
 {
     return _ModeParamsHelper(param, false);
 }
@@ -472,7 +433,7 @@ bool TerminalDispatch::ResetMode(const DispatchTypes::ModeParams param) noexcept
 // - params - the optional custom ID
 // Return Value:
 // - true
-bool TerminalDispatch::AddHyperlink(const std::wstring_view uri, const std::wstring_view params) noexcept
+bool TerminalDispatch::AddHyperlink(const std::wstring_view uri, const std::wstring_view params)
 {
     return _terminalApi.AddHyperlink(uri, params);
 }
@@ -481,7 +442,7 @@ bool TerminalDispatch::AddHyperlink(const std::wstring_view uri, const std::wstr
 // - End a hyperlink
 // Return Value:
 // - true
-bool TerminalDispatch::EndHyperlink() noexcept
+bool TerminalDispatch::EndHyperlink()
 {
     return _terminalApi.EndHyperlink();
 }
@@ -493,7 +454,7 @@ bool TerminalDispatch::EndHyperlink() noexcept
 // - string: contains the parameters that define which action we do
 // Return Value:
 // - true
-bool TerminalDispatch::DoConEmuAction(const std::wstring_view string) noexcept
+bool TerminalDispatch::DoConEmuAction(const std::wstring_view string)
 {
     unsigned int state = 0;
     unsigned int progress = 0;
@@ -571,7 +532,7 @@ bool TerminalDispatch::DoConEmuAction(const std::wstring_view string) noexcept
 // - enable - True for set, false for unset.
 // Return Value:
 // - True if handled successfully. False otherwise.
-bool TerminalDispatch::_ModeParamsHelper(const DispatchTypes::ModeParams param, const bool enable) noexcept
+bool TerminalDispatch::_ModeParamsHelper(const DispatchTypes::ModeParams param, const bool enable)
 {
     bool success = false;
     switch (param)
@@ -621,7 +582,7 @@ bool TerminalDispatch::_ModeParamsHelper(const DispatchTypes::ModeParams param, 
     return success;
 }
 
-bool TerminalDispatch::_ClearSingleTabStop() noexcept
+bool TerminalDispatch::_ClearSingleTabStop()
 {
     const auto width = _terminalApi.GetBufferSize().Dimensions().X;
     const auto column = _terminalApi.GetCursorPosition().X;
@@ -631,14 +592,14 @@ bool TerminalDispatch::_ClearSingleTabStop() noexcept
     return true;
 }
 
-bool TerminalDispatch::_ClearAllTabStops() noexcept
+bool TerminalDispatch::_ClearAllTabStops()
 {
     _tabStopColumns.clear();
     _initDefaultTabStops = false;
     return true;
 }
 
-void TerminalDispatch::_ResetTabStops() noexcept
+void TerminalDispatch::_ResetTabStops()
 {
     _tabStopColumns.clear();
     _initDefaultTabStops = true;
@@ -663,7 +624,7 @@ void TerminalDispatch::_InitTabStopsForWidth(const size_t width)
     }
 }
 
-bool TerminalDispatch::SoftReset() noexcept
+bool TerminalDispatch::SoftReset()
 {
     // TODO:GH#1883 much of this method is not yet implemented in the Terminal,
     // because the Terminal _doesn't need to_ yet. The terminal is only ever
@@ -702,7 +663,7 @@ bool TerminalDispatch::SoftReset() noexcept
     return success;
 }
 
-bool TerminalDispatch::HardReset() noexcept
+bool TerminalDispatch::HardReset()
 {
     // TODO:GH#1883 much of this method is not yet implemented in the Terminal,
     // because the Terminal _doesn't need to_ yet. The terminal is only ever

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -46,38 +46,44 @@ bool TerminalDispatch::CursorPosition(const size_t line,
     THROW_IF_FAILED(ShortSub(x, 1, &x));
     THROW_IF_FAILED(ShortSub(y, 1, &y));
 
-    return _terminalApi.SetCursorPosition(x, y);
+    _terminalApi.SetCursorPosition(x, y);
+    return true;
 }
 
 bool TerminalDispatch::CursorVisibility(const bool isVisible)
 {
-    return _terminalApi.SetCursorVisibility(isVisible);
+    _terminalApi.SetCursorVisibility(isVisible);
+    return true;
 }
 
 bool TerminalDispatch::EnableCursorBlinking(const bool enable)
 {
-    return _terminalApi.EnableCursorBlinking(enable);
+    _terminalApi.EnableCursorBlinking(enable);
+    return true;
 }
 
 bool TerminalDispatch::CursorForward(const size_t distance)
 {
     const auto cursorPos = _terminalApi.GetCursorPosition();
     const COORD newCursorPos{ cursorPos.X + gsl::narrow<short>(distance), cursorPos.Y };
-    return _terminalApi.SetCursorPosition(newCursorPos.X, newCursorPos.Y);
+    _terminalApi.SetCursorPosition(newCursorPos.X, newCursorPos.Y);
+    return true;
 }
 
 bool TerminalDispatch::CursorBackward(const size_t distance)
 {
     const auto cursorPos = _terminalApi.GetCursorPosition();
     const COORD newCursorPos{ cursorPos.X - gsl::narrow<short>(distance), cursorPos.Y };
-    return _terminalApi.SetCursorPosition(newCursorPos.X, newCursorPos.Y);
+    _terminalApi.SetCursorPosition(newCursorPos.X, newCursorPos.Y);
+    return true;
 }
 
 bool TerminalDispatch::CursorUp(const size_t distance)
 {
     const auto cursorPos = _terminalApi.GetCursorPosition();
     const COORD newCursorPos{ cursorPos.X, cursorPos.Y + gsl::narrow<short>(distance) };
-    return _terminalApi.SetCursorPosition(newCursorPos.X, newCursorPos.Y);
+    _terminalApi.SetCursorPosition(newCursorPos.X, newCursorPos.Y);
+    return true;
 }
 
 bool TerminalDispatch::LineFeed(const DispatchTypes::LineFeedType lineFeedType)
@@ -88,9 +94,11 @@ bool TerminalDispatch::LineFeed(const DispatchTypes::LineFeedType lineFeedType)
         // There is currently no need for mode-specific line feeds in the Terminal,
         // so for now we just treat them as a line feed without carriage return.
     case DispatchTypes::LineFeedType::WithoutReturn:
-        return _terminalApi.CursorLineFeed(false);
+        _terminalApi.CursorLineFeed(false);
+        return true;
     case DispatchTypes::LineFeedType::WithReturn:
-        return _terminalApi.CursorLineFeed(true);
+        _terminalApi.CursorLineFeed(true);
+        return true;
     default:
         return false;
     }
@@ -98,24 +106,29 @@ bool TerminalDispatch::LineFeed(const DispatchTypes::LineFeedType lineFeedType)
 
 bool TerminalDispatch::EraseCharacters(const size_t numChars)
 {
-    return _terminalApi.EraseCharacters(numChars);
+    _terminalApi.EraseCharacters(numChars);
+    return true;
 }
 
 bool TerminalDispatch::WarningBell()
 {
-    return _terminalApi.WarningBell();
+    _terminalApi.WarningBell();
+    return true;
 }
 
 bool TerminalDispatch::CarriageReturn()
 {
     const auto cursorPos = _terminalApi.GetCursorPosition();
-    return _terminalApi.SetCursorPosition(0, cursorPos.Y);
+    _terminalApi.SetCursorPosition(0, cursorPos.Y);
+    return true;
 }
 
 bool TerminalDispatch::SetWindowTitle(std::wstring_view title)
 {
-    return _terminalApi.SetWindowTitle(title);
+    _terminalApi.SetWindowTitle(title);
+    return true;
 }
+
 bool TerminalDispatch::HorizontalTabSet()
 {
     const auto width = _terminalApi.GetBufferSize().Dimensions().X;
@@ -143,7 +156,8 @@ bool TerminalDispatch::ForwardTab(const size_t numTabs)
         }
     }
 
-    return _terminalApi.SetCursorPosition(column, row);
+    _terminalApi.SetCursorPosition(column, row);
+    return true;
 }
 
 bool TerminalDispatch::BackwardsTab(const size_t numTabs)
@@ -163,25 +177,23 @@ bool TerminalDispatch::BackwardsTab(const size_t numTabs)
         }
     }
 
-    return _terminalApi.SetCursorPosition(column, row);
+    _terminalApi.SetCursorPosition(column, row);
+    return true;
 }
 
 bool TerminalDispatch::TabClear(const DispatchTypes::TabClearType clearType)
 {
-    bool success = false;
     switch (clearType)
     {
     case DispatchTypes::TabClearType::ClearCurrentColumn:
-        success = _ClearSingleTabStop();
-        break;
+        _ClearSingleTabStop();
+        return true;
     case DispatchTypes::TabClearType::ClearAllColumns:
-        success = _ClearAllTabStops();
-        break;
+        _ClearAllTabStops();
+        return true;
     default:
-        success = false;
-        break;
+        return false;
     }
-    return success;
 }
 
 // Method Description:
@@ -190,26 +202,30 @@ bool TerminalDispatch::TabClear(const DispatchTypes::TabClearType clearType)
 // - tableIndex: The VT color table index
 // - color: The new RGB color value to use.
 // Return Value:
-// True if handled successfully. False otherwise.
+// - True.
 bool TerminalDispatch::SetColorTableEntry(const size_t tableIndex,
                                           const DWORD color)
 {
-    return _terminalApi.SetColorTableEntry(tableIndex, color);
+    _terminalApi.SetColorTableEntry(tableIndex, color);
+    return true;
 }
 
 bool TerminalDispatch::SetCursorStyle(const DispatchTypes::CursorStyle cursorStyle)
 {
-    return _terminalApi.SetCursorStyle(cursorStyle);
+    _terminalApi.SetCursorStyle(cursorStyle);
+    return true;
 }
 
 bool TerminalDispatch::SetCursorColor(const DWORD color)
 {
-    return _terminalApi.SetColorTableEntry(TextColor::CURSOR_COLOR, color);
+    _terminalApi.SetColorTableEntry(TextColor::CURSOR_COLOR, color);
+    return true;
 }
 
 bool TerminalDispatch::SetClipboard(std::wstring_view content)
 {
-    return _terminalApi.CopyToClipboard(content);
+    _terminalApi.CopyToClipboard(content);
+    return true;
 }
 
 // Method Description:
@@ -217,11 +233,12 @@ bool TerminalDispatch::SetClipboard(std::wstring_view content)
 // Arguments:
 // - color: The new RGB color value to use, in 0x00BBGGRR form
 // Return Value:
-// True if handled successfully. False otherwise.
+// - True.
 bool TerminalDispatch::SetDefaultForeground(const DWORD color)
 {
     _terminalApi.SetColorAliasIndex(ColorAlias::DefaultForeground, TextColor::DEFAULT_FOREGROUND);
-    return _terminalApi.SetColorTableEntry(TextColor::DEFAULT_FOREGROUND, color);
+    _terminalApi.SetColorTableEntry(TextColor::DEFAULT_FOREGROUND, color);
+    return true;
 }
 
 // Method Description:
@@ -229,11 +246,12 @@ bool TerminalDispatch::SetDefaultForeground(const DWORD color)
 // Arguments:
 // - color: The new RGB color value to use, in 0x00BBGGRR form
 // Return Value:
-// True if handled successfully. False otherwise.
+// - True.
 bool TerminalDispatch::SetDefaultBackground(const DWORD color)
 {
     _terminalApi.SetColorAliasIndex(ColorAlias::DefaultBackground, TextColor::DEFAULT_BACKGROUND);
-    return _terminalApi.SetColorTableEntry(TextColor::DEFAULT_BACKGROUND, color);
+    _terminalApi.SetColorTableEntry(TextColor::DEFAULT_BACKGROUND, color);
+    return true;
 }
 
 // Method Description:
@@ -252,10 +270,11 @@ bool TerminalDispatch::EraseInLine(const DispatchTypes::EraseType eraseType)
 // Arguments:
 // - count, the number of characters to delete
 // Return Value:
-// True if handled successfully. False otherwise.
+// - True.
 bool TerminalDispatch::DeleteCharacter(const size_t count)
 {
-    return _terminalApi.DeleteCharacter(count);
+    _terminalApi.DeleteCharacter(count);
+    return true;
 }
 
 // Method Description:
@@ -263,10 +282,11 @@ bool TerminalDispatch::DeleteCharacter(const size_t count)
 // Arguments:
 // - count, the number of spaces to add
 // Return Value:
-// True if handled successfully, false otherwise
+// - True.
 bool TerminalDispatch::InsertCharacter(const size_t count)
 {
-    return _terminalApi.InsertCharacter(count);
+    _terminalApi.InsertCharacter(count);
+    return true;
 }
 
 // Method Description:
@@ -284,7 +304,7 @@ bool TerminalDispatch::EraseInDisplay(const DispatchTypes::EraseType eraseType)
 // Arguments:
 // - applicationMode - set to true to enable Application Mode Input, false for Numeric Mode Input.
 // Return Value:
-// - True if handled successfully. False otherwise.
+// - True.
 bool TerminalDispatch::SetKeypadMode(const bool applicationMode)
 {
     _terminalApi.SetInputMode(TerminalInput::Mode::Keypad, applicationMode);
@@ -295,7 +315,7 @@ bool TerminalDispatch::SetKeypadMode(const bool applicationMode)
 // Arguments:
 // - applicationMode - set to true to enable Application Mode Input, false for Normal Mode Input.
 // Return Value:
-// - True if handled successfully. False otherwise.
+// - True.
 bool TerminalDispatch::SetCursorKeysMode(const bool applicationMode)
 {
     _terminalApi.SetInputMode(TerminalInput::Mode::CursorKey, applicationMode);
@@ -308,10 +328,11 @@ bool TerminalDispatch::SetCursorKeysMode(const bool applicationMode)
 // Arguments:
 // - reverseMode - set to true to enable reverse screen mode, false for normal mode.
 // Return Value:
-// - True if handled successfully. False otherwise.
+// - True.
 bool TerminalDispatch::SetScreenMode(const bool reverseMode)
 {
-    return _terminalApi.SetRenderMode(RenderSettings::Mode::ScreenReversed, reverseMode);
+    _terminalApi.SetRenderMode(RenderSettings::Mode::ScreenReversed, reverseMode);
+    return true;
 }
 
 // Method Description:
@@ -320,7 +341,7 @@ bool TerminalDispatch::SetScreenMode(const bool reverseMode)
 // Arguments:
 // - win32InputMode - set to true to enable win32-input-mode, false to disable.
 // Return Value:
-// - True if handled successfully. False otherwise.
+// - True.
 bool TerminalDispatch::EnableWin32InputMode(const bool win32Mode)
 {
     _terminalApi.SetInputMode(TerminalInput::Mode::Win32, win32Mode);
@@ -332,7 +353,7 @@ bool TerminalDispatch::EnableWin32InputMode(const bool win32Mode)
 //Arguments:
 // - enabled - true to enable, false to disable.
 // Return value:
-// True if handled successfully. False otherwise.
+// - True.
 bool TerminalDispatch::EnableVT200MouseMode(const bool enabled)
 {
     _terminalApi.SetInputMode(TerminalInput::Mode::DefaultMouseTracking, enabled);
@@ -345,7 +366,7 @@ bool TerminalDispatch::EnableVT200MouseMode(const bool enabled)
 //Arguments:
 // - enabled - true to enable, false to disable.
 // Return value:
-// True if handled successfully. False otherwise.
+// - True.
 bool TerminalDispatch::EnableUTF8ExtendedMouseMode(const bool enabled)
 {
     _terminalApi.SetInputMode(TerminalInput::Mode::Utf8MouseEncoding, enabled);
@@ -358,7 +379,7 @@ bool TerminalDispatch::EnableUTF8ExtendedMouseMode(const bool enabled)
 //Arguments:
 // - enabled - true to enable, false to disable.
 // Return value:
-// True if handled successfully. False otherwise.
+// - True.
 bool TerminalDispatch::EnableSGRExtendedMouseMode(const bool enabled)
 {
     _terminalApi.SetInputMode(TerminalInput::Mode::SgrMouseEncoding, enabled);
@@ -370,7 +391,7 @@ bool TerminalDispatch::EnableSGRExtendedMouseMode(const bool enabled)
 //Arguments:
 // - enabled - true to enable, false to disable.
 // Return value:
-// True if handled successfully. False otherwise.
+// - True.
 bool TerminalDispatch::EnableButtonEventMouseMode(const bool enabled)
 {
     _terminalApi.SetInputMode(TerminalInput::Mode::ButtonEventMouseTracking, enabled);
@@ -383,7 +404,7 @@ bool TerminalDispatch::EnableButtonEventMouseMode(const bool enabled)
 //Arguments:
 // - enabled - true to enable, false to disable.
 // Return value:
-// True if handled successfully. False otherwise.
+// - True.
 bool TerminalDispatch::EnableAnyEventMouseMode(const bool enabled)
 {
     _terminalApi.SetInputMode(TerminalInput::Mode::AnyEventMouseTracking, enabled);
@@ -396,7 +417,7 @@ bool TerminalDispatch::EnableAnyEventMouseMode(const bool enabled)
 //Arguments:
 // - enabled - true to enable, false to disable.
 // Return value:
-// True if handled successfully. False otherwise.
+// - True.
 bool TerminalDispatch::EnableAlternateScroll(const bool enabled)
 {
     _terminalApi.SetInputMode(TerminalInput::Mode::AlternateScroll, enabled);
@@ -409,7 +430,7 @@ bool TerminalDispatch::EnableAlternateScroll(const bool enabled)
 //Arguments:
 // - enabled - true to enable, false to disable.
 // Return value:
-// True if handled successfully. False otherwise.
+// - True.
 bool TerminalDispatch::EnableXtermBracketedPasteMode(const bool enabled)
 {
     _terminalApi.EnableXtermBracketedPasteMode(enabled);
@@ -435,7 +456,8 @@ bool TerminalDispatch::ResetMode(const DispatchTypes::ModeParams param)
 // - true
 bool TerminalDispatch::AddHyperlink(const std::wstring_view uri, const std::wstring_view params)
 {
-    return _terminalApi.AddHyperlink(uri, params);
+    _terminalApi.AddHyperlink(uri, params);
+    return true;
 }
 
 // Method Description:
@@ -444,7 +466,8 @@ bool TerminalDispatch::AddHyperlink(const std::wstring_view uri, const std::wstr
 // - true
 bool TerminalDispatch::EndHyperlink()
 {
-    return _terminalApi.EndHyperlink();
+    _terminalApi.EndHyperlink();
+    return true;
 }
 
 // Method Description:
@@ -499,7 +522,8 @@ bool TerminalDispatch::DoConEmuAction(const std::wstring_view string)
             // progress is greater than the maximum allowed value, clamp it to the max
             progress = TaskbarMaxProgress;
         }
-        return _terminalApi.SetTaskbarProgress(static_cast<DispatchTypes::TaskbarState>(state), progress);
+        _terminalApi.SetTaskbarProgress(static_cast<DispatchTypes::TaskbarState>(state), progress);
+        return true;
     }
     // 9 is SetWorkingDirectory, which informs the terminal about the current working directory.
     else if (subParam == 9)
@@ -511,14 +535,15 @@ bool TerminalDispatch::DoConEmuAction(const std::wstring_view string)
             // An example: 9;"D:/"
             if (path.at(0) == L'"' && path.at(path.size() - 1) == L'"' && path.size() >= 3)
             {
-                return _terminalApi.SetWorkingDirectory(path.substr(1, path.size() - 2));
+                _terminalApi.SetWorkingDirectory(path.substr(1, path.size() - 2));
             }
             else
             {
                 // If we fail to find the surrounding quotation marks, we'll give the path a try anyway.
                 // ConEmu also does this.
-                return _terminalApi.SetWorkingDirectory(path);
+                _terminalApi.SetWorkingDirectory(path);
             }
+            return true;
         }
     }
 
@@ -582,21 +607,19 @@ bool TerminalDispatch::_ModeParamsHelper(const DispatchTypes::ModeParams param, 
     return success;
 }
 
-bool TerminalDispatch::_ClearSingleTabStop()
+void TerminalDispatch::_ClearSingleTabStop()
 {
     const auto width = _terminalApi.GetBufferSize().Dimensions().X;
     const auto column = _terminalApi.GetCursorPosition().X;
 
     _InitTabStopsForWidth(width);
     _tabStopColumns.at(column) = false;
-    return true;
 }
 
-bool TerminalDispatch::_ClearAllTabStops()
+void TerminalDispatch::_ClearAllTabStops()
 {
     _tabStopColumns.clear();
     _initDefaultTabStops = false;
-    return true;
 }
 
 void TerminalDispatch::_ResetTabStops()
@@ -636,23 +659,23 @@ bool TerminalDispatch::SoftReset()
     // This code is left here (from its original form in conhost) as a reminder
     // of what needs to be done.
 
-    bool success = CursorVisibility(true); // Cursor enabled.
-    // success = SetOriginMode(false) && success; // Absolute cursor addressing.
-    // success = SetAutoWrapMode(true) && success; // Wrap at end of line.
-    success = SetCursorKeysMode(false) && success; // Normal characters.
-    success = SetKeypadMode(false) && success; // Numeric characters.
+    CursorVisibility(true); // Cursor enabled.
+    // SetOriginMode(false); // Absolute cursor addressing.
+    // SetAutoWrapMode(true); // Wrap at end of line.
+    SetCursorKeysMode(false); // Normal characters.
+    SetKeypadMode(false); // Numeric characters.
 
     // // Top margin = 1; bottom margin = page length.
-    // success = _DoSetTopBottomScrollingMargins(0, 0) && success;
+    // _DoSetTopBottomScrollingMargins(0, 0);
 
     // _termOutput = {}; // Reset all character set designations.
     // if (_initialCodePage.has_value())
     // {
     //     // Restore initial code page if previously changed by a DOCS sequence.
-    //     success = _pConApi->SetConsoleOutputCP(_initialCodePage.value()) && success;
+    //     _pConApi->SetConsoleOutputCP(_initialCodePage.value());
     // }
 
-    success = SetGraphicsRendition({}) && success; // Normal rendition.
+    SetGraphicsRendition({}); // Normal rendition.
 
     // // Reset the saved cursor state.
     // // Note that XTerm only resets the main buffer state, but that
@@ -660,7 +683,7 @@ bool TerminalDispatch::SoftReset()
     // _savedCursorState.at(0) = {}; // Main buffer
     // _savedCursorState.at(1) = {}; // Alt buffer
 
-    return success;
+    return true;
 }
 
 bool TerminalDispatch::HardReset()
@@ -674,35 +697,33 @@ bool TerminalDispatch::HardReset()
     // This code is left here (from its original form in conhost) as a reminder
     // of what needs to be done.
 
-    bool success = true;
-
     // // If in the alt buffer, switch back to main before doing anything else.
     // if (_usingAltBuffer)
     // {
-    //     success = _pConApi->PrivateUseMainScreenBuffer();
-    //     _usingAltBuffer = !success;
+    //     _pConApi->PrivateUseMainScreenBuffer();
+    //     _usingAltBuffer = false;
     // }
 
     // Sets the SGR state to normal - this must be done before EraseInDisplay
     //      to ensure that it clears with the default background color.
-    success = SoftReset() && success;
+    SoftReset();
 
     // Clears the screen - Needs to be done in two operations.
-    success = EraseInDisplay(DispatchTypes::EraseType::All) && success;
-    success = EraseInDisplay(DispatchTypes::EraseType::Scrollback) && success;
+    EraseInDisplay(DispatchTypes::EraseType::All);
+    EraseInDisplay(DispatchTypes::EraseType::Scrollback);
 
     // Set the DECSCNM screen mode back to normal.
-    success = SetScreenMode(false) && success;
+    SetScreenMode(false);
 
     // Cursor to 1,1 - the Soft Reset guarantees this is absolute
-    success = CursorPosition(1, 1) && success;
+    CursorPosition(1, 1);
 
     // Reset the mouse mode
-    success = EnableSGRExtendedMouseMode(false) && success;
-    success = EnableAnyEventMouseMode(false) && success;
+    EnableSGRExtendedMouseMode(false);
+    EnableAnyEventMouseMode(false);
 
     // Delete all current tab stops and reapply
     _ResetTabStops();
 
-    return success;
+    return true;
 }

--- a/src/cascadia/TerminalCore/TerminalDispatch.hpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.hpp
@@ -93,8 +93,8 @@ private:
 
     bool _ModeParamsHelper(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ModeParams param, const bool enable);
 
-    bool _ClearSingleTabStop();
-    bool _ClearAllTabStops();
+    void _ClearSingleTabStop();
+    void _ClearAllTabStops();
     void _ResetTabStops();
     void _InitTabStopsForWidth(const size_t width);
 };

--- a/src/cascadia/TerminalCore/TerminalDispatch.hpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.hpp
@@ -12,74 +12,74 @@ class TerminalDispatch : public Microsoft::Console::VirtualTerminal::TermDispatc
 public:
     TerminalDispatch(::Microsoft::Terminal::Core::ITerminalApi& terminalApi) noexcept;
 
-    void Execute(const wchar_t wchControl) noexcept override;
-    void Print(const wchar_t wchPrintable) noexcept override;
-    void PrintString(const std::wstring_view string) noexcept override;
+    void Execute(const wchar_t wchControl) override;
+    void Print(const wchar_t wchPrintable) override;
+    void PrintString(const std::wstring_view string) override;
 
-    bool SetGraphicsRendition(const ::Microsoft::Console::VirtualTerminal::VTParameters options) noexcept override;
+    bool SetGraphicsRendition(const ::Microsoft::Console::VirtualTerminal::VTParameters options) override;
 
-    bool PushGraphicsRendition(const ::Microsoft::Console::VirtualTerminal::VTParameters options) noexcept override;
-    bool PopGraphicsRendition() noexcept override;
+    bool PushGraphicsRendition(const ::Microsoft::Console::VirtualTerminal::VTParameters options) override;
+    bool PopGraphicsRendition() override;
 
     bool CursorPosition(const size_t line,
-                        const size_t column) noexcept override; // CUP
+                        const size_t column) override; // CUP
 
-    bool EnableWin32InputMode(const bool win32InputMode) noexcept override; // win32-input-mode
+    bool EnableWin32InputMode(const bool win32InputMode) override; // win32-input-mode
 
-    bool CursorVisibility(const bool isVisible) noexcept override; // DECTCEM
-    bool EnableCursorBlinking(const bool enable) noexcept override; // ATT610
+    bool CursorVisibility(const bool isVisible) override; // DECTCEM
+    bool EnableCursorBlinking(const bool enable) override; // ATT610
 
-    bool CursorForward(const size_t distance) noexcept override;
-    bool CursorBackward(const size_t distance) noexcept override;
-    bool CursorUp(const size_t distance) noexcept override;
+    bool CursorForward(const size_t distance) override;
+    bool CursorBackward(const size_t distance) override;
+    bool CursorUp(const size_t distance) override;
 
-    bool LineFeed(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::LineFeedType lineFeedType) noexcept override;
+    bool LineFeed(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::LineFeedType lineFeedType) override;
 
-    bool EraseCharacters(const size_t numChars) noexcept override;
-    bool WarningBell() noexcept override;
-    bool CarriageReturn() noexcept override;
-    bool SetWindowTitle(std::wstring_view title) noexcept override;
+    bool EraseCharacters(const size_t numChars) override;
+    bool WarningBell() override;
+    bool CarriageReturn() override;
+    bool SetWindowTitle(std::wstring_view title) override;
 
-    bool HorizontalTabSet() noexcept override; // HTS
-    bool ForwardTab(const size_t numTabs) noexcept override; // CHT, HT
-    bool BackwardsTab(const size_t numTabs) noexcept override; // CBT
-    bool TabClear(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::TabClearType clearType) noexcept override; // TBC
+    bool HorizontalTabSet() override; // HTS
+    bool ForwardTab(const size_t numTabs) override; // CHT, HT
+    bool BackwardsTab(const size_t numTabs) override; // CBT
+    bool TabClear(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::TabClearType clearType) override; // TBC
 
-    bool SetColorTableEntry(const size_t tableIndex, const DWORD color) noexcept override;
-    bool SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) noexcept override;
-    bool SetCursorColor(const DWORD color) noexcept override;
+    bool SetColorTableEntry(const size_t tableIndex, const DWORD color) override;
+    bool SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle) override;
+    bool SetCursorColor(const DWORD color) override;
 
-    bool SetClipboard(std::wstring_view content) noexcept override;
+    bool SetClipboard(std::wstring_view content) override;
 
-    bool SetDefaultForeground(const DWORD color) noexcept override;
-    bool SetDefaultBackground(const DWORD color) noexcept override;
-    bool EraseInLine(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) noexcept override; // ED
-    bool DeleteCharacter(const size_t count) noexcept override;
-    bool InsertCharacter(const size_t count) noexcept override;
-    bool EraseInDisplay(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) noexcept override;
+    bool SetDefaultForeground(const DWORD color) override;
+    bool SetDefaultBackground(const DWORD color) override;
+    bool EraseInLine(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) override; // ED
+    bool DeleteCharacter(const size_t count) override;
+    bool InsertCharacter(const size_t count) override;
+    bool EraseInDisplay(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType) override;
 
-    bool SetCursorKeysMode(const bool applicationMode) noexcept override; // DECCKM
-    bool SetKeypadMode(const bool applicationMode) noexcept override; // DECKPAM, DECKPNM
-    bool SetScreenMode(const bool reverseMode) noexcept override; // DECSCNM
+    bool SetCursorKeysMode(const bool applicationMode) override; // DECCKM
+    bool SetKeypadMode(const bool applicationMode) override; // DECKPAM, DECKPNM
+    bool SetScreenMode(const bool reverseMode) override; // DECSCNM
 
-    bool SoftReset() noexcept override; // DECSTR
-    bool HardReset() noexcept override; // RIS
+    bool SoftReset() override; // DECSTR
+    bool HardReset() override; // RIS
 
-    bool EnableVT200MouseMode(const bool enabled) noexcept override; // ?1000
-    bool EnableUTF8ExtendedMouseMode(const bool enabled) noexcept override; // ?1005
-    bool EnableSGRExtendedMouseMode(const bool enabled) noexcept override; // ?1006
-    bool EnableButtonEventMouseMode(const bool enabled) noexcept override; // ?1002
-    bool EnableAnyEventMouseMode(const bool enabled) noexcept override; // ?1003
-    bool EnableAlternateScroll(const bool enabled) noexcept override; // ?1007
-    bool EnableXtermBracketedPasteMode(const bool enabled) noexcept override; // ?2004
+    bool EnableVT200MouseMode(const bool enabled) override; // ?1000
+    bool EnableUTF8ExtendedMouseMode(const bool enabled) override; // ?1005
+    bool EnableSGRExtendedMouseMode(const bool enabled) override; // ?1006
+    bool EnableButtonEventMouseMode(const bool enabled) override; // ?1002
+    bool EnableAnyEventMouseMode(const bool enabled) override; // ?1003
+    bool EnableAlternateScroll(const bool enabled) override; // ?1007
+    bool EnableXtermBracketedPasteMode(const bool enabled) override; // ?2004
 
-    bool SetMode(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ModeParams /*param*/) noexcept override; // DECSET
-    bool ResetMode(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ModeParams /*param*/) noexcept override; // DECRST
+    bool SetMode(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ModeParams /*param*/) override; // DECSET
+    bool ResetMode(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ModeParams /*param*/) override; // DECRST
 
-    bool AddHyperlink(const std::wstring_view uri, const std::wstring_view params) noexcept override;
-    bool EndHyperlink() noexcept override;
+    bool AddHyperlink(const std::wstring_view uri, const std::wstring_view params) override;
+    bool EndHyperlink() override;
 
-    bool DoConEmuAction(const std::wstring_view string) noexcept override;
+    bool DoConEmuAction(const std::wstring_view string) override;
 
 private:
     ::Microsoft::Terminal::Core::ITerminalApi& _terminalApi;
@@ -89,12 +89,12 @@ private:
 
     size_t _SetRgbColorsHelper(const ::Microsoft::Console::VirtualTerminal::VTParameters options,
                                TextAttribute& attr,
-                               const bool isForeground) noexcept;
+                               const bool isForeground);
 
-    bool _ModeParamsHelper(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ModeParams param, const bool enable) noexcept;
+    bool _ModeParamsHelper(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ModeParams param, const bool enable);
 
-    bool _ClearSingleTabStop() noexcept;
-    bool _ClearAllTabStops() noexcept;
-    void _ResetTabStops() noexcept;
+    bool _ClearSingleTabStop();
+    bool _ClearAllTabStops();
+    void _ResetTabStops();
     void _InitTabStopsForWidth(const size_t width);
 };

--- a/src/cascadia/TerminalCore/TerminalDispatchGraphics.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatchGraphics.cpp
@@ -256,10 +256,12 @@ bool TerminalDispatch::SetGraphicsRendition(const VTParameters options)
 
 bool TerminalDispatch::PushGraphicsRendition(const VTParameters options)
 {
-    return _terminalApi.PushGraphicsRendition(options);
+    _terminalApi.PushGraphicsRendition(options);
+    return true;
 }
 
 bool TerminalDispatch::PopGraphicsRendition()
 {
-    return _terminalApi.PopGraphicsRendition();
+    _terminalApi.PopGraphicsRendition();
+    return true;
 }

--- a/src/cascadia/TerminalCore/TerminalDispatchGraphics.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatchGraphics.cpp
@@ -20,7 +20,7 @@ using namespace Microsoft::Console::VirtualTerminal::DispatchTypes;
 // - The number of options consumed, not including the initial 38/48.
 size_t TerminalDispatch::_SetRgbColorsHelper(const VTParameters options,
                                              TextAttribute& attr,
-                                             const bool isForeground) noexcept
+                                             const bool isForeground)
 {
     size_t optionsConsumed = 1;
     const DispatchTypes::GraphicsOptions typeOpt = options.at(0);
@@ -67,7 +67,7 @@ size_t TerminalDispatch::_SetRgbColorsHelper(const VTParameters options,
 //   one at a time by setting or removing flags in the font style properties.
 // Return Value:
 // - True if handled successfully. False otherwise.
-bool TerminalDispatch::SetGraphicsRendition(const VTParameters options) noexcept
+bool TerminalDispatch::SetGraphicsRendition(const VTParameters options)
 {
     TextAttribute attr = _terminalApi.GetTextAttributes();
 
@@ -254,12 +254,12 @@ bool TerminalDispatch::SetGraphicsRendition(const VTParameters options) noexcept
     return true;
 }
 
-bool TerminalDispatch::PushGraphicsRendition(const VTParameters options) noexcept
+bool TerminalDispatch::PushGraphicsRendition(const VTParameters options)
 {
     return _terminalApi.PushGraphicsRendition(options);
 }
 
-bool TerminalDispatch::PopGraphicsRendition() noexcept
+bool TerminalDispatch::PopGraphicsRendition()
 {
     return _terminalApi.PopGraphicsRendition();
 }

--- a/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/TerminalApiTest.cpp
@@ -55,11 +55,11 @@ void TerminalApiTest::SetColorTableEntry()
     auto settings = winrt::make<MockTermSettings>(100, 100, 100);
     term.UpdateSettings(settings);
 
-    VERIFY_IS_TRUE(term.SetColorTableEntry(0, 100));
-    VERIFY_IS_TRUE(term.SetColorTableEntry(128, 100));
-    VERIFY_IS_TRUE(term.SetColorTableEntry(255, 100));
+    VERIFY_NO_THROW(term.SetColorTableEntry(0, 100));
+    VERIFY_NO_THROW(term.SetColorTableEntry(128, 100));
+    VERIFY_NO_THROW(term.SetColorTableEntry(255, 100));
 
-    VERIFY_IS_FALSE(term.SetColorTableEntry(512, 100));
+    VERIFY_THROWS(term.SetColorTableEntry(512, 100), std::exception);
 }
 
 // Terminal::_WriteBuffer used to enter infinite loops under certain conditions.

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -17,6 +17,8 @@ namespace Microsoft::Console::VirtualTerminal
     class TermDispatch;
 };
 
+#pragma warning(disable : 26440) // Making these methods noexcept would require the same of all derived classes
+
 class Microsoft::Console::VirtualTerminal::TermDispatch : public Microsoft::Console::VirtualTerminal::ITermDispatch
 {
 public:
@@ -24,106 +26,106 @@ public:
     void Print(const wchar_t wchPrintable) override = 0;
     void PrintString(const std::wstring_view string) override = 0;
 
-    bool CursorUp(const size_t /*distance*/) noexcept override { return false; } // CUU
-    bool CursorDown(const size_t /*distance*/) noexcept override { return false; } // CUD
-    bool CursorForward(const size_t /*distance*/) noexcept override { return false; } // CUF
-    bool CursorBackward(const size_t /*distance*/) noexcept override { return false; } // CUB, BS
-    bool CursorNextLine(const size_t /*distance*/) noexcept override { return false; } // CNL
-    bool CursorPrevLine(const size_t /*distance*/) noexcept override { return false; } // CPL
-    bool CursorHorizontalPositionAbsolute(const size_t /*column*/) noexcept override { return false; } // HPA, CHA
-    bool VerticalLinePositionAbsolute(const size_t /*line*/) noexcept override { return false; } // VPA
-    bool HorizontalPositionRelative(const size_t /*distance*/) noexcept override { return false; } // HPR
-    bool VerticalPositionRelative(const size_t /*distance*/) noexcept override { return false; } // VPR
-    bool CursorPosition(const size_t /*line*/, const size_t /*column*/) noexcept override { return false; } // CUP, HVP
-    bool CursorSaveState() noexcept override { return false; } // DECSC
-    bool CursorRestoreState() noexcept override { return false; } // DECRC
-    bool CursorVisibility(const bool /*isVisible*/) noexcept override { return false; } // DECTCEM
-    bool InsertCharacter(const size_t /*count*/) noexcept override { return false; } // ICH
-    bool DeleteCharacter(const size_t /*count*/) noexcept override { return false; } // DCH
-    bool ScrollUp(const size_t /*distance*/) noexcept override { return false; } // SU
-    bool ScrollDown(const size_t /*distance*/) noexcept override { return false; } // SD
-    bool InsertLine(const size_t /*distance*/) noexcept override { return false; } // IL
-    bool DeleteLine(const size_t /*distance*/) noexcept override { return false; } // DL
-    bool SetColumns(const size_t /*columns*/) noexcept override { return false; } // DECCOLM
-    bool SetCursorKeysMode(const bool /*applicationMode*/) noexcept override { return false; } // DECCKM
-    bool SetKeypadMode(const bool /*applicationMode*/) noexcept override { return false; } // DECKPAM, DECKPNM
-    bool EnableWin32InputMode(const bool /*win32InputMode*/) noexcept override { return false; } // win32-input-mode
-    bool EnableCursorBlinking(const bool /*enable*/) noexcept override { return false; } // ATT610
-    bool SetAnsiMode(const bool /*ansiMode*/) noexcept override { return false; } // DECANM
-    bool SetScreenMode(const bool /*reverseMode*/) noexcept override { return false; } // DECSCNM
-    bool SetOriginMode(const bool /*relativeMode*/) noexcept override { return false; }; // DECOM
-    bool SetAutoWrapMode(const bool /*wrapAtEOL*/) noexcept override { return false; }; // DECAWM
-    bool SetTopBottomScrollingMargins(const size_t /*topMargin*/, const size_t /*bottomMargin*/) noexcept override { return false; } // DECSTBM
-    bool WarningBell() noexcept override { return false; } // BEL
-    bool CarriageReturn() noexcept override { return false; } // CR
-    bool LineFeed(const DispatchTypes::LineFeedType /*lineFeedType*/) noexcept override { return false; } // IND, NEL, LF, FF, VT
-    bool ReverseLineFeed() noexcept override { return false; } // RI
-    bool SetWindowTitle(std::wstring_view /*title*/) noexcept override { return false; } // OscWindowTitle
-    bool UseAlternateScreenBuffer() noexcept override { return false; } // ASBSET
-    bool UseMainScreenBuffer() noexcept override { return false; } // ASBRST
-    bool HorizontalTabSet() noexcept override { return false; } // HTS
-    bool ForwardTab(const size_t /*numTabs*/) noexcept override { return false; } // CHT, HT
-    bool BackwardsTab(const size_t /*numTabs*/) noexcept override { return false; } // CBT
-    bool TabClear(const DispatchTypes::TabClearType /*clearType*/) noexcept override { return false; } // TBC
-    bool EnableDECCOLMSupport(const bool /*enabled*/) noexcept override { return false; } // ?40
-    bool EnableVT200MouseMode(const bool /*enabled*/) noexcept override { return false; } // ?1000
-    bool EnableUTF8ExtendedMouseMode(const bool /*enabled*/) noexcept override { return false; } // ?1005
-    bool EnableSGRExtendedMouseMode(const bool /*enabled*/) noexcept override { return false; } // ?1006
-    bool EnableButtonEventMouseMode(const bool /*enabled*/) noexcept override { return false; } // ?1002
-    bool EnableAnyEventMouseMode(const bool /*enabled*/) noexcept override { return false; } // ?1003
-    bool EnableAlternateScroll(const bool /*enabled*/) noexcept override { return false; } // ?1007
-    bool EnableXtermBracketedPasteMode(const bool /*enabled*/) noexcept override { return false; } // ?2004
-    bool SetColorTableEntry(const size_t /*tableIndex*/, const DWORD /*color*/) noexcept override { return false; } // OSCColorTable
-    bool SetDefaultForeground(const DWORD /*color*/) noexcept override { return false; } // OSCDefaultForeground
-    bool SetDefaultBackground(const DWORD /*color*/) noexcept override { return false; } // OSCDefaultBackground
+    bool CursorUp(const size_t /*distance*/) override { return false; } // CUU
+    bool CursorDown(const size_t /*distance*/) override { return false; } // CUD
+    bool CursorForward(const size_t /*distance*/) override { return false; } // CUF
+    bool CursorBackward(const size_t /*distance*/) override { return false; } // CUB, BS
+    bool CursorNextLine(const size_t /*distance*/) override { return false; } // CNL
+    bool CursorPrevLine(const size_t /*distance*/) override { return false; } // CPL
+    bool CursorHorizontalPositionAbsolute(const size_t /*column*/) override { return false; } // HPA, CHA
+    bool VerticalLinePositionAbsolute(const size_t /*line*/) override { return false; } // VPA
+    bool HorizontalPositionRelative(const size_t /*distance*/) override { return false; } // HPR
+    bool VerticalPositionRelative(const size_t /*distance*/) override { return false; } // VPR
+    bool CursorPosition(const size_t /*line*/, const size_t /*column*/) override { return false; } // CUP, HVP
+    bool CursorSaveState() override { return false; } // DECSC
+    bool CursorRestoreState() override { return false; } // DECRC
+    bool CursorVisibility(const bool /*isVisible*/) override { return false; } // DECTCEM
+    bool InsertCharacter(const size_t /*count*/) override { return false; } // ICH
+    bool DeleteCharacter(const size_t /*count*/) override { return false; } // DCH
+    bool ScrollUp(const size_t /*distance*/) override { return false; } // SU
+    bool ScrollDown(const size_t /*distance*/) override { return false; } // SD
+    bool InsertLine(const size_t /*distance*/) override { return false; } // IL
+    bool DeleteLine(const size_t /*distance*/) override { return false; } // DL
+    bool SetColumns(const size_t /*columns*/) override { return false; } // DECCOLM
+    bool SetCursorKeysMode(const bool /*applicationMode*/) override { return false; } // DECCKM
+    bool SetKeypadMode(const bool /*applicationMode*/) override { return false; } // DECKPAM, DECKPNM
+    bool EnableWin32InputMode(const bool /*win32InputMode*/) override { return false; } // win32-input-mode
+    bool EnableCursorBlinking(const bool /*enable*/) override { return false; } // ATT610
+    bool SetAnsiMode(const bool /*ansiMode*/) override { return false; } // DECANM
+    bool SetScreenMode(const bool /*reverseMode*/) override { return false; } // DECSCNM
+    bool SetOriginMode(const bool /*relativeMode*/) override { return false; }; // DECOM
+    bool SetAutoWrapMode(const bool /*wrapAtEOL*/) override { return false; }; // DECAWM
+    bool SetTopBottomScrollingMargins(const size_t /*topMargin*/, const size_t /*bottomMargin*/) override { return false; } // DECSTBM
+    bool WarningBell() override { return false; } // BEL
+    bool CarriageReturn() override { return false; } // CR
+    bool LineFeed(const DispatchTypes::LineFeedType /*lineFeedType*/) override { return false; } // IND, NEL, LF, FF, VT
+    bool ReverseLineFeed() override { return false; } // RI
+    bool SetWindowTitle(std::wstring_view /*title*/) override { return false; } // OscWindowTitle
+    bool UseAlternateScreenBuffer() override { return false; } // ASBSET
+    bool UseMainScreenBuffer() override { return false; } // ASBRST
+    bool HorizontalTabSet() override { return false; } // HTS
+    bool ForwardTab(const size_t /*numTabs*/) override { return false; } // CHT, HT
+    bool BackwardsTab(const size_t /*numTabs*/) override { return false; } // CBT
+    bool TabClear(const DispatchTypes::TabClearType /*clearType*/) override { return false; } // TBC
+    bool EnableDECCOLMSupport(const bool /*enabled*/) override { return false; } // ?40
+    bool EnableVT200MouseMode(const bool /*enabled*/) override { return false; } // ?1000
+    bool EnableUTF8ExtendedMouseMode(const bool /*enabled*/) override { return false; } // ?1005
+    bool EnableSGRExtendedMouseMode(const bool /*enabled*/) override { return false; } // ?1006
+    bool EnableButtonEventMouseMode(const bool /*enabled*/) override { return false; } // ?1002
+    bool EnableAnyEventMouseMode(const bool /*enabled*/) override { return false; } // ?1003
+    bool EnableAlternateScroll(const bool /*enabled*/) override { return false; } // ?1007
+    bool EnableXtermBracketedPasteMode(const bool /*enabled*/) override { return false; } // ?2004
+    bool SetColorTableEntry(const size_t /*tableIndex*/, const DWORD /*color*/) override { return false; } // OSCColorTable
+    bool SetDefaultForeground(const DWORD /*color*/) override { return false; } // OSCDefaultForeground
+    bool SetDefaultBackground(const DWORD /*color*/) override { return false; } // OSCDefaultBackground
 
-    bool EraseInDisplay(const DispatchTypes::EraseType /* eraseType*/) noexcept override { return false; } // ED
-    bool EraseInLine(const DispatchTypes::EraseType /* eraseType*/) noexcept override { return false; } // EL
-    bool EraseCharacters(const size_t /*numChars*/) noexcept override { return false; } // ECH
+    bool EraseInDisplay(const DispatchTypes::EraseType /* eraseType*/) override { return false; } // ED
+    bool EraseInLine(const DispatchTypes::EraseType /* eraseType*/) override { return false; } // EL
+    bool EraseCharacters(const size_t /*numChars*/) override { return false; } // ECH
 
-    bool SetGraphicsRendition(const VTParameters /*options*/) noexcept override { return false; } // SGR
-    bool SetLineRendition(const LineRendition /*rendition*/) noexcept override { return false; } // DECSWL, DECDWL, DECDHL
+    bool SetGraphicsRendition(const VTParameters /*options*/) override { return false; } // SGR
+    bool SetLineRendition(const LineRendition /*rendition*/) override { return false; } // DECSWL, DECDWL, DECDHL
 
-    bool PushGraphicsRendition(const VTParameters /*options*/) noexcept override { return false; } // XTPUSHSGR
-    bool PopGraphicsRendition() noexcept override { return false; } // XTPOPSGR
+    bool PushGraphicsRendition(const VTParameters /*options*/) override { return false; } // XTPUSHSGR
+    bool PopGraphicsRendition() override { return false; } // XTPOPSGR
 
-    bool SetMode(const DispatchTypes::ModeParams /*param*/) noexcept override { return false; } // DECSET
+    bool SetMode(const DispatchTypes::ModeParams /*param*/) override { return false; } // DECSET
 
-    bool ResetMode(const DispatchTypes::ModeParams /*param*/) noexcept override { return false; } // DECRST
+    bool ResetMode(const DispatchTypes::ModeParams /*param*/) override { return false; } // DECRST
 
-    bool DeviceStatusReport(const DispatchTypes::AnsiStatusType /*statusType*/) noexcept override { return false; } // DSR, DSR-OS, DSR-CPR
-    bool DeviceAttributes() noexcept override { return false; } // DA1
-    bool SecondaryDeviceAttributes() noexcept override { return false; } // DA2
-    bool TertiaryDeviceAttributes() noexcept override { return false; } // DA3
-    bool Vt52DeviceAttributes() noexcept override { return false; } // VT52 Identify
-    bool RequestTerminalParameters(const DispatchTypes::ReportingPermission /*permission*/) noexcept override { return false; } // DECREQTPARM
+    bool DeviceStatusReport(const DispatchTypes::AnsiStatusType /*statusType*/) override { return false; } // DSR, DSR-OS, DSR-CPR
+    bool DeviceAttributes() override { return false; } // DA1
+    bool SecondaryDeviceAttributes() override { return false; } // DA2
+    bool TertiaryDeviceAttributes() override { return false; } // DA3
+    bool Vt52DeviceAttributes() override { return false; } // VT52 Identify
+    bool RequestTerminalParameters(const DispatchTypes::ReportingPermission /*permission*/) override { return false; } // DECREQTPARM
 
-    bool DesignateCodingSystem(const VTID /*codingSystem*/) noexcept override { return false; } // DOCS
-    bool Designate94Charset(const size_t /*gsetNumber*/, const VTID /*charset*/) noexcept override { return false; } // SCS
-    bool Designate96Charset(const size_t /*gsetNumber*/, const VTID /*charset*/) noexcept override { return false; } // SCS
-    bool LockingShift(const size_t /*gsetNumber*/) noexcept override { return false; } // LS0, LS1, LS2, LS3
-    bool LockingShiftRight(const size_t /*gsetNumber*/) noexcept override { return false; } // LS1R, LS2R, LS3R
-    bool SingleShift(const size_t /*gsetNumber*/) noexcept override { return false; } // SS2, SS3
-    bool AcceptC1Controls(const bool /*enabled*/) noexcept override { return false; } // DECAC1
+    bool DesignateCodingSystem(const VTID /*codingSystem*/) override { return false; } // DOCS
+    bool Designate94Charset(const size_t /*gsetNumber*/, const VTID /*charset*/) override { return false; } // SCS
+    bool Designate96Charset(const size_t /*gsetNumber*/, const VTID /*charset*/) override { return false; } // SCS
+    bool LockingShift(const size_t /*gsetNumber*/) override { return false; } // LS0, LS1, LS2, LS3
+    bool LockingShiftRight(const size_t /*gsetNumber*/) override { return false; } // LS1R, LS2R, LS3R
+    bool SingleShift(const size_t /*gsetNumber*/) override { return false; } // SS2, SS3
+    bool AcceptC1Controls(const bool /*enabled*/) override { return false; } // DECAC1
 
-    bool SoftReset() noexcept override { return false; } // DECSTR
-    bool HardReset() noexcept override { return false; } // RIS
-    bool ScreenAlignmentPattern() noexcept override { return false; } // DECALN
+    bool SoftReset() override { return false; } // DECSTR
+    bool HardReset() override { return false; } // RIS
+    bool ScreenAlignmentPattern() override { return false; } // DECALN
 
-    bool SetCursorStyle(const DispatchTypes::CursorStyle /*cursorStyle*/) noexcept override { return false; } // DECSCUSR
-    bool SetCursorColor(const COLORREF /*color*/) noexcept override { return false; } // OSCSetCursorColor, OSCResetCursorColor
+    bool SetCursorStyle(const DispatchTypes::CursorStyle /*cursorStyle*/) override { return false; } // DECSCUSR
+    bool SetCursorColor(const COLORREF /*color*/) override { return false; } // OSCSetCursorColor, OSCResetCursorColor
 
-    bool SetClipboard(std::wstring_view /*content*/) noexcept override { return false; } // OscSetClipboard
+    bool SetClipboard(std::wstring_view /*content*/) override { return false; } // OscSetClipboard
 
     // DTTERM_WindowManipulation
     bool WindowManipulation(const DispatchTypes::WindowManipulationType /*function*/,
                             const VTParameter /*parameter1*/,
-                            const VTParameter /*parameter2*/) noexcept override { return false; }
+                            const VTParameter /*parameter2*/) override { return false; }
 
-    bool AddHyperlink(const std::wstring_view /*uri*/, const std::wstring_view /*params*/) noexcept override { return false; }
-    bool EndHyperlink() noexcept override { return false; }
+    bool AddHyperlink(const std::wstring_view /*uri*/, const std::wstring_view /*params*/) override { return false; }
+    bool EndHyperlink() override { return false; }
 
-    bool DoConEmuAction(const std::wstring_view /*string*/) noexcept override { return false; }
+    bool DoConEmuAction(const std::wstring_view /*string*/) override { return false; }
 
     StringHandler DownloadDRCS(const size_t /*fontNumber*/,
                                const VTParameter /*startChar*/,
@@ -132,7 +134,9 @@ public:
                                const DispatchTypes::DrcsFontSet /*fontSet*/,
                                const DispatchTypes::DrcsFontUsage /*fontUsage*/,
                                const VTParameter /*cellHeight*/,
-                               const DispatchTypes::DrcsCharsetSize /*charsetSize*/) noexcept override { return nullptr; }
+                               const DispatchTypes::DrcsCharsetSize /*charsetSize*/) override { return nullptr; }
 
-    StringHandler RequestSetting() noexcept override { return nullptr; }; // DECRQSS
+    StringHandler RequestSetting() override { return nullptr; }; // DECRQSS
 };
+
+#pragma warning(default : 26440) // Restore "can be declared noexcept" warning


### PR DESCRIPTION
This PR updates the `ITerminalApi` and `TerminalDispatch` classes to
allow exceptions to be thrown in case of errors instead of using boolean
return values.

## References

This brings the Terminal code into alignment with the `AdaptDispatch`
and `ConGetSet` changes made in PR #12247.

And while this isn't exactly a fix for #12378, it does at least stop the
app from crashing now.

## PR Checklist
* [x] CLA signed.
* [ ] Tests added/passed
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] I've discussed this with core contributors already. Issue number
where discussion took place: #12378

## Detailed Description of the Pull Request / Additional comments

All the `TerminalDispatch` methods have had their `noexcept` specifiers
dropped, and any `try`/`catch` wrapping removed, so exceptions will now
fall through to the `StateMachine` class where they should be safely
caught and logged.

The same goes for the `ITerminalApi` interface and its implementation in
the `Terminal` class. And many of the methods in this interface have
also had their `bool` return values changed to `void`, since there is
usually not a need for error return values now.

## Validation Steps Performed

I've manually tested the `OSC 9;9` sequence described in #12378 and
confirmed that it no longer crashes.