### PR TITLE
Fix browse buttons getting cut off when the window is too narrow

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -221,20 +221,22 @@
                                     SettingOverrideSource="{x:Bind Appearance.BackgroundImagePathOverrideSource, Mode=OneWay}"
                                     Style="{StaticResource ExpanderSettingContainerStyle}">
                 <StackPanel Orientation="Vertical">
+                    <TextBox x:Uid="Profile_BackgroundImageBox"
+                             IsEnabled="{x:Bind local:Converters.StringsAreNotEqual('desktopWallpaper', Appearance.BackgroundImagePath), Mode=OneWay}"
+                             IsSpellCheckEnabled="False"
+                             Style="{StaticResource TextBoxSettingStyle}"
+                             Text="{x:Bind local:Converters.StringOrEmptyIfPlaceholder('desktopWallpaper', Appearance.BackgroundImagePath), Mode=TwoWay, BindBack=Appearance.SetBackgroundImagePath}" />
                     <StackPanel Orientation="Horizontal">
-                        <TextBox x:Uid="Profile_BackgroundImageBox"
-                                 IsEnabled="{x:Bind local:Converters.StringsAreNotEqual('desktopWallpaper', Appearance.BackgroundImagePath), Mode=OneWay}"
-                                 IsSpellCheckEnabled="False"
-                                 Style="{StaticResource TextBoxSettingStyle}"
-                                 Text="{x:Bind local:Converters.StringOrEmptyIfPlaceholder('desktopWallpaper', Appearance.BackgroundImagePath), Mode=TwoWay, BindBack=Appearance.SetBackgroundImagePath}" />
                         <Button x:Uid="Profile_BackgroundImageBrowse"
+                                Margin="0,10,10,0"
                                 Click="BackgroundImage_Click"
                                 IsEnabled="{x:Bind local:Converters.StringsAreNotEqual('desktopWallpaper', Appearance.BackgroundImagePath), Mode=OneWay}"
                                 Style="{StaticResource BrowseButtonStyle}" />
+                        <CheckBox x:Name="UseDesktopImageCheckBox"
+                                  x:Uid="Profile_UseDesktopImage"
+                                  Margin="0,5,0,0"
+                                  IsChecked="{x:Bind Appearance.UseDesktopBGImage, Mode=TwoWay}" />
                     </StackPanel>
-                    <CheckBox x:Name="UseDesktopImageCheckBox"
-                              x:Uid="Profile_UseDesktopImage"
-                              IsChecked="{x:Bind Appearance.UseDesktopBGImage, Mode=TwoWay}" />
                 </StackPanel>
             </local:SettingContainer>
 

--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -50,7 +50,7 @@
            BasedOn="{StaticResource DefaultTextBoxStyle}"
            TargetType="TextBox">
         <Setter Property="MinWidth" Value="{StaticResource StandardBoxMinWidth}" />
-        <Setter Property="MaxWidth" Value="500" />
+        <Setter Property="MaxWidth" Value="400" />
         <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="TextWrapping" Value="Wrap" />
     </Style>

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
@@ -64,9 +64,9 @@
                                  Style="{StaticResource TextBoxSettingStyle}"
                                  Text="{x:Bind Profile.Commandline, Mode=TwoWay}" />
                         <Button x:Uid="Profile_CommandlineBrowse"
+                                Margin="0,10,0,0"
                                 Click="Commandline_Click"
-                                Style="{StaticResource BrowseButtonStyle}"
-                                Margin="0,10,0,0"/>
+                                Style="{StaticResource BrowseButtonStyle}" />
                     </StackPanel>
                 </local:SettingContainer>
 
@@ -79,21 +79,23 @@
                                         SettingOverrideSource="{x:Bind Profile.StartingDirectoryOverrideSource, Mode=OneWay}"
                                         Style="{StaticResource ExpanderSettingContainerStyle}">
                     <StackPanel Orientation="Vertical">
+                        <TextBox x:Uid="Profile_StartingDirectoryBox"
+                                 IsEnabled="{x:Bind Profile.UseCustomStartingDirectory, Mode=OneWay}"
+                                 IsSpellCheckEnabled="False"
+                                 Style="{StaticResource TextBoxSettingStyle}"
+                                 Text="{x:Bind Profile.StartingDirectory, Mode=TwoWay}" />
                         <StackPanel Orientation="Horizontal">
-                            <TextBox x:Uid="Profile_StartingDirectoryBox"
-                                     IsEnabled="{x:Bind Profile.UseCustomStartingDirectory, Mode=OneWay}"
-                                     IsSpellCheckEnabled="False"
-                                     Style="{StaticResource TextBoxSettingStyle}"
-                                     Text="{x:Bind Profile.StartingDirectory, Mode=TwoWay}" />
                             <Button x:Name="StartingDirectoryBrowse"
                                     x:Uid="Profile_StartingDirectoryBrowse"
+                                    Margin="0,10,10,0"
                                     Click="StartingDirectory_Click"
                                     IsEnabled="{x:Bind Profile.UseCustomStartingDirectory, Mode=OneWay}"
                                     Style="{StaticResource BrowseButtonStyle}" />
+                            <CheckBox x:Name="StartingDirectoryUseParentCheckbox"
+                                      x:Uid="Profile_StartingDirectoryUseParentCheckbox"
+                                      Margin="0,5,0,0"
+                                      IsChecked="{x:Bind Profile.UseParentProcessDirectory, Mode=TwoWay}" />
                         </StackPanel>
-                        <CheckBox x:Name="StartingDirectoryUseParentCheckbox"
-                                  x:Uid="Profile_StartingDirectoryUseParentCheckbox"
-                                  IsChecked="{x:Bind Profile.UseParentProcessDirectory, Mode=TwoWay}" />
                     </StackPanel>
                 </local:SettingContainer>
 
@@ -104,13 +106,14 @@
                                         HasSettingValue="{x:Bind Profile.HasIcon, Mode=OneWay}"
                                         SettingOverrideSource="{x:Bind Profile.IconOverrideSource, Mode=OneWay}"
                                         Style="{StaticResource ExpanderSettingContainerStyle}">
-                    <StackPanel Orientation="Horizontal">
+                    <StackPanel>
                         <TextBox x:Uid="Profile_IconBox"
                                  FontFamily="Segoe UI, Segoe MDL2 Assets"
                                  IsSpellCheckEnabled="False"
                                  Style="{StaticResource TextBoxSettingStyle}"
                                  Text="{x:Bind Profile.Icon, Mode=TwoWay}" />
                         <Button x:Uid="Profile_IconBrowse"
+                                Margin="0,10,0,0"
                                 Click="Icon_Click"
                                 Style="{StaticResource BrowseButtonStyle}" />
                     </StackPanel>

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
@@ -58,14 +58,15 @@
                                         SettingOverrideSource="{x:Bind Profile.CommandlineOverrideSource, Mode=OneWay}"
                                         Style="{StaticResource ExpanderSettingContainerStyle}"
                                         Visibility="{x:Bind local:Converters.InvertedBooleanToVisibility(Profile.IsBaseLayer), Mode=OneWay}">
-                    <StackPanel Orientation="Horizontal">
+                    <StackPanel>
                         <TextBox x:Uid="Profile_CommandlineBox"
                                  IsSpellCheckEnabled="False"
                                  Style="{StaticResource TextBoxSettingStyle}"
                                  Text="{x:Bind Profile.Commandline, Mode=TwoWay}" />
                         <Button x:Uid="Profile_CommandlineBrowse"
                                 Click="Commandline_Click"
-                                Style="{StaticResource BrowseButtonStyle}" />
+                                Style="{StaticResource BrowseButtonStyle}"
+                                Margin="0,10,0,0"/>
                     </StackPanel>
                 </local:SettingContainer>
 


### PR DESCRIPTION
## Summary of the Pull Request
With the recent change to allow text boxes to be bigger, the `Browse` button that some of them have was getting cut off when the window was too narrow. This change puts the `Browse` button below the text box instead of next to it to prevent this issue.

## PR Checklist
* [x] Closes #12335 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I work here

## Validation Steps Performed
<img width="348" alt="commandlinenarrow" src="https://user-images.githubusercontent.com/26824113/153058035-ecbea7f7-849c-4cae-8b0c-0c9372b6ece5.png">
<img width="903" alt="commandlinewide" src="https://user-images.githubusercontent.com/26824113/153058056-7224140d-0708-4629-8b07-345107eb6f98.png">
<img width="552" alt="startingDir" src="https://user-images.githubusercontent.com/26824113/153058076-35281475-2d5d-40ab-be8c-5db14e493212.png">
