### PR TITLE
Don't ever allow `~` as a startingDirectory

### DIFF
--- a/src/types/ut_types/UtilsTests.cpp
+++ b/src/types/ut_types/UtilsTests.cpp
@@ -479,5 +479,29 @@ void UtilsTests::TestMangleWSLPaths()
         VERIFY_ARE_EQUAL(LR"("wsl" --cd "\\wsl.localhost\Ubuntu\home\user" -d Ubuntu)", commandline);
         VERIFY_ARE_EQUAL(L"", path);
     }
+
+    /// Tests for GH #12353
+
+    const auto expectedUserProfilePath = wil::ExpandEnvironmentStringsW<std::wstring>(L"%USERPROFILE%");
+    {
+        auto [commandline, path] = MangleStartingDirectoryForWSL(LR"(wsl -d Ubuntu)", L"~");
+        VERIFY_ARE_EQUAL(LR"("wsl" --cd "~" -d Ubuntu)", commandline);
+        VERIFY_ARE_EQUAL(L"", path);
+    }
+    {
+        auto [commandline, path] = MangleStartingDirectoryForWSL(LR"(wsl ~ -d Ubuntu)", L"~");
+        VERIFY_ARE_EQUAL(LR"(wsl ~ -d Ubuntu)", commandline);
+        VERIFY_ARE_EQUAL(expectedUserProfilePath, path);
+    }
+    {
+        auto [commandline, path] = MangleStartingDirectoryForWSL(LR"(ubuntu ~ -d Ubuntu)", L"~");
+        VERIFY_ARE_EQUAL(LR"(ubuntu ~ -d Ubuntu)", commandline);
+        VERIFY_ARE_EQUAL(expectedUserProfilePath, path);
+    }
+    {
+        auto [commandline, path] = MangleStartingDirectoryForWSL(LR"(powershell.exe)", L"~");
+        VERIFY_ARE_EQUAL(LR"(powershell.exe)", commandline);
+        VERIFY_ARE_EQUAL(expectedUserProfilePath, path);
+    }
 }
 #endif

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -600,7 +600,6 @@ bool Utils::IsElevated()
 std::tuple<std::wstring, std::wstring> Utils::MangleStartingDirectoryForWSL(std::wstring_view commandLine,
                                                                             std::wstring_view startingDirectory)
 {
-    bool executableWasWSL{ false };
     do
     {
         if (startingDirectory.size() > 0 && commandLine.size() >= 3)
@@ -612,7 +611,6 @@ std::tuple<std::wstring, std::wstring> Utils::MangleStartingDirectoryForWSL(std:
             const auto executableFilename{ executablePath.filename().wstring() };
             if (executableFilename == L"wsl" || executableFilename == L"wsl.exe")
             {
-                executableWasWSL = true;
                 // We've got a WSL -- let's just make sure it's the right one.
                 if (executablePath.has_parent_path())
                 {

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -678,7 +678,7 @@ std::tuple<std::wstring, std::wstring> Utils::MangleStartingDirectoryForWSL(std:
     // %userprofile%, so it's at least something reasonable.
     return {
         std::wstring{ commandLine },
-        std::wstring{ startingDirectory == L"~" ? wil::ExpandEnvironmentStringsW<std::wstring>(L"%USERPROFILE%") :
-                                                  startingDirectory }
+        startingDirectory == L"~" ? wil::ExpandEnvironmentStringsW<std::wstring>(L"%USERPROFILE%") :
+                                    std::wstring{ startingDirectory }
     };
 }


### PR DESCRIPTION
Basically, some WSL distros ship fragments that replace the `commandline` with the executable for their distro (`ubuntu.exe`, etc.). We didn't expect that when we changed the `startingDirectory` for them all to `~`. 

Unfortunately, `~` is really never a valid path for a process on windows, so those distros would now fail with

```
[error 2147942667 (0x8007010b) when launching `ubuntu1804.exe']
Could not access starting directory "~"
```

If we find that we were unable to mangle `~` into the user's WSL `commandline`, then we will re-evaluate that `startingDirectory` as `%USERPROFILE%`, which is at least something sensible, if albeit not what they wanted. 

* regressed in #12315
* [x] Closes #12353
* [x] Tested with a (`ubuntu1804.exe`, `~`) profile - launched successfully, where 1.13 in market fails.
* [x] added tests
