### PR TITLE
Fix focus box around color schemes combo box

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -99,7 +99,8 @@
                     Spacing="24">
 
             <!--  Select Color and Add New Button  -->
-            <StackPanel Orientation="Horizontal">
+            <StackPanel Orientation="Horizontal"
+                        Margin="0,5,0,0">
 
                 <StackPanel Orientation="Horizontal"
                             Visibility="{x:Bind local:Converters.InvertedBooleanToVisibility(IsRenaming), Mode=OneWay}">

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -99,8 +99,8 @@
                     Spacing="24">
 
             <!--  Select Color and Add New Button  -->
-            <StackPanel Orientation="Horizontal"
-                        Margin="0,5,0,0">
+            <StackPanel Margin="0,5,0,0"
+                        Orientation="Horizontal">
 
                 <StackPanel Orientation="Horizontal"
                             Visibility="{x:Bind local:Converters.InvertedBooleanToVisibility(IsRenaming), Mode=OneWay}">


### PR DESCRIPTION
## Summary of the Pull Request
The focus box around the color schemes combo box was getting cut off, this change adds a small margin to the stackpanel to allow space for the focus box

## PR Checklist
* [x] Closes #12328 

## Validation Steps Performed
<img width="494" alt="combobox" src="https://user-images.githubusercontent.com/26824113/153078162-8b095b13-d95f-4488-bd0c-e97edbd45b28.png">
