### PR TITLE
Fix defterm + elevate by default

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3096,7 +3096,7 @@ namespace winrt::TerminalApp::implementation
             NewTerminalArgs newTerminalArgs;
             newTerminalArgs.Commandline(connection.Commandline());
             // GH #12370: We absolutely cannot allow a defterm connection to
-            // auto-elevate. Defterm doesn't work for elevated senarios in the
+            // auto-elevate. Defterm doesn't work for elevated scenarios in the
             // first place. If we try accepting the connection, the spawning an
             // elevated version of the Terminal with that profile... that's a
             // recipe for disaster. We won't ever open up a tab in this window.

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3095,9 +3095,12 @@ namespace winrt::TerminalApp::implementation
         {
             NewTerminalArgs newTerminalArgs;
             newTerminalArgs.Commandline(connection.Commandline());
-            const auto profile{ _settings.GetProfileForArgs(newTerminalArgs) };
-            const auto settings{ TerminalSettings::CreateWithProfile(_settings, profile, *_bindings) };
-
+            // GH #12370: We absolutely cannot allow a defterm connection to
+            // auto-elevate. Defterm doesn't work for elevated senarios in the
+            // first place. If we try accepting the connection, the spawning an
+            // elevated version of the Terminal with that profile... that's a
+            // recipe for disaster. We won't ever open up a tab in this window.
+            newTerminalArgs.Elevate(false);
             _CreateNewTabFromPane(_MakePane(newTerminalArgs, false, connection));
 
             // Request a summon of this window to the foreground

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -130,7 +130,7 @@ namespace Microsoft.Terminal.Settings.Model
         String ColorScheme;
         // This needs to be an optional so that the default value (null) does
         // not modify whatever the profile's value is (either true or false)
-        Windows.Foundation.IReference<Boolean> Elevate { get; };
+        Windows.Foundation.IReference<Boolean> Elevate;
 
         Boolean Equals(NewTerminalArgs other);
         String GenerateName();


### PR DESCRIPTION
We absolutely cannot allow a defterm connection to
auto-elevate. Defterm doesn't work for elevated senarios in the
first place. If we try accepting the connection, the spawning an
elevated version of the Terminal with that profile... that's a
recipe for disaster. We won't ever open up a tab in this window.

* [x] Closes #12370
* [x] Tested manually, since there's not a great way to add defterm tests
