### PR TITLE
Automate packaged submission into Windows

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -318,6 +318,7 @@ concat
 concfg
 conclnt
 conddkrefs
+condev
 condrv
 conechokey
 conemu
@@ -1152,6 +1153,7 @@ ioctl
 iomanip
 iostream
 iot
+ipa
 ipch
 ipconfig
 IPersist
@@ -1475,6 +1477,7 @@ MSGSELECTMODE
 msiexec
 MSIL
 msix
+mspartners
 msrc
 msvcrt
 MSVCRTD

--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -237,6 +237,7 @@ charlespetzold
 charset
 CHARSETINFO
 chcp
+Checkin
 checkbox
 checkboxes
 chh
@@ -673,6 +674,7 @@ dwriteglyphrundescriptionclustermap
 dxgi
 dxgidwm
 dxinterop
+dxp
 dxsm
 dxttbmp
 Dyreen
@@ -2671,6 +2673,7 @@ wddmcon
 wddmconrenderer
 WDDMCONSOLECONTEXT
 wdm
+wdx
 webclient
 webpage
 website
@@ -2705,6 +2708,7 @@ wincontypes
 WINCORE
 windbg
 WINDEF
+windev
 WINDIR
 windll
 WINDOWALPHA

--- a/build/config/GitCheckin.json
+++ b/build/config/GitCheckin.json
@@ -1,0 +1,24 @@
+{
+    "Branch": [
+      {
+        "collection": "microsoft",
+        "project": "OS",
+        "repo": "os.2020",
+        "name": "official/rs_wdx_dxp_windev",
+        "workitem": "38106206",
+        "CheckinFiles": [
+          {
+            "source": "WindowsTerminal.app.man",
+            "path": "/redist/mspartners/ipa/WindowsTerminal",
+            "type": "File"
+          }
+        ]
+      }
+    ],
+    "Email": [
+      {
+        "sendTo": "condev",
+        "sendOnErrorOnly": "False"
+      }
+    ]
+  }

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -529,7 +529,18 @@ jobs:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       inputs:
         sourceDirectory: $(System.ArtifactsDirectory)\appxbundle-signed\WindowsTerminal.app
-        description: Windows Terminal pre-install application
+        description: VPack for the Windows Terminal Application
         pushPkgName: WindowsTerminal.app
-        owner: condev
+        owner: conhost
+    - task: PublishPipelineArtifact@1
+      displayName: 'Copy VPack Manifest to Drop'
+      inputs:
+        targetPath: $(XES_VPACKMANIFESTDIRECTORY)
+        artifactName: VPackManifest
+    - task: PkgESFCIBGit@12
+      displayName: 'Submit VPack Manifest to Windows'
+      inputs:
+        configPath: '$(Build.SourcesDirectory)\build\config\GitCheckin.json'
+        artifactsDirectory: $(XES_VPACKMANIFESTDIRECTORY)
+        prTimeOut: 5
 ...


### PR DESCRIPTION
We're now building a fully provenance, compliance, and security validated package (vpack) through our Release pipeline. This attaches the last phase which automates the submission into the Windows product. It will also automatically trace back the source, commit SHA, and build to the submission here from the Windows side.

## PR Checklist
* [x] Automates a manual activity I performed a few times recently
* [x] I work here
* [x] Ran a test of it against `release-1.12` and it worked

## Validation Steps Performed
* https://microsoft.visualstudio.com/Dart/_build/results?buildId=44914810&view=logs&j=dcd45bf9-728b-574c-bbda-47373b5c16e2&t=5f2db042-0803-5778-3c08-6bbbc7057964
