### PR TITLE
Source index the public symbols too

### DIFF
--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -363,7 +363,6 @@ jobs:
     # Publish the app symbols to the public MSDL symbol server
     # accessible via https://msdl.microsoft.com/download/symbols
     - task: PublishSymbols@2
-      condition: false
       displayName: 'Publish app symbols to MSDL'
       inputs:
         symbolsFolder: '$(Build.SourcesDirectory)/appxsym-temp'

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -358,7 +358,7 @@ jobs:
       displayName: Source Index PDBs (the public ones)
       inputs:
         filePath: build\scripts\Index-Pdbs.ps1
-        arguments: -SearchDir '$(Build.SourcesDirectory)/appxsym-tmp' -SourceRoot '$(Build.SourcesDirectory)' -recursive -Verbose -CommitId $(Build.SourceVersion)
+        arguments: -SearchDir '$(Build.SourcesDirectory)/appxsym-temp' -SourceRoot '$(Build.SourcesDirectory)' -recursive -Verbose -CommitId $(Build.SourceVersion)
 
     # Publish the app symbols to the public MSDL symbol server
     # accessible via https://msdl.microsoft.com/download/symbols

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -352,6 +352,12 @@ jobs:
         }
       displayName: Extract symbols for public consumption
 
+    - task: PowerShell@2
+      displayName: Source Index PDBs (the public ones)
+      inputs:
+        filePath: build\scripts\Index-Pdbs.ps1
+        arguments: -SearchDir '$(Build.SourcesDirectory)/appxsym-tmp' -SourceRoot '$(Build.SourcesDirectory)' -recursive -Verbose -CommitId $(Build.SourceVersion)
+
     # Publish the app symbols to the public MSDL symbol server
     # accessible via https://msdl.microsoft.com/download/symbols
     - task: PublishSymbols@2

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -361,6 +361,7 @@ jobs:
     # Publish the app symbols to the public MSDL symbol server
     # accessible via https://msdl.microsoft.com/download/symbols
     - task: PublishSymbols@2
+      condition: false
       displayName: 'Publish app symbols to MSDL'
       inputs:
         symbolsFolder: '$(Build.SourcesDirectory)/appxsym-temp'

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -352,6 +352,8 @@ jobs:
         }
       displayName: Extract symbols for public consumption
 
+    # Pull the Windows SDK for the developer tools like the debuggers so we can index sources later
+    - template: .\templates\install-winsdk-steps.yml
     - task: PowerShell@2
       displayName: Source Index PDBs (the public ones)
       inputs:


### PR DESCRIPTION
Now that we've figured out how to publish the public symbols to the official Microsoft download server... we may as well embed the source code linking information inside of them given that it's right here on GitHub. This attempts to run our existing source linking scripts against the public copy of the symbols. 

## PR Checklist
* [x] Closes #12443
* [x] I work here
* [x] Tested manually

## Validation Steps Performed
* [x] Build with it: https://dev.azure.com/microsoft/Dart/_build/results?buildId=44930661&view=logs&j=8f802011-b567-5b81-5fa6-bce316c020ce
* [x] Point the debugger at them and see if it can find the sources
* [x] Maybe also look at them in a hex editor or whatnot and validate I can see the source paths pointing at GitHub
