### PR TITLE
Fix the add/delete unfocused appearance buttons

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
@@ -141,23 +141,31 @@
                         <TextBlock x:Uid="Profile_UnfocusedAppearanceTextBlock"
                                    Style="{StaticResource TitleTextBlockStyle}" />
                         <Button x:Uid="Profile_CreateUnfocusedAppearanceButton"
-                                Margin="32,0,0,0"
+                                Margin="10,0,0,0"
                                 Click="CreateUnfocusedAppearance_Click"
                                 Style="{StaticResource BaseButtonStyle}"
                                 Visibility="{x:Bind local:Converters.InvertedBooleanToVisibility(Profile.HasUnfocusedAppearance), Mode=OneWay}">
                             <Button.Content>
-                                <FontIcon FontSize="{StaticResource StandardIconSize}"
-                                          Glyph="&#xE710;" />
+                                <StackPanel Orientation="Horizontal">
+                                    <FontIcon FontSize="{StaticResource StandardIconSize}"
+                                              Glyph="&#xE710;" />
+                                    <TextBlock x:Uid="Profile_AddAppearanceButton"
+                                               Margin="10,0,0,0" />
+                                </StackPanel>
                             </Button.Content>
                         </Button>
                         <Button x:Uid="Profile_DeleteUnfocusedAppearanceButton"
-                                Margin="32,0,0,0"
+                                Margin="10,0,0,0"
                                 Click="DeleteUnfocusedAppearance_Click"
                                 Style="{StaticResource BaseButtonStyle}"
                                 Visibility="{x:Bind Profile.HasUnfocusedAppearance, Mode=OneWay}">
                             <Button.Content>
-                                <FontIcon FontSize="{StaticResource StandardIconSize}"
-                                          Glyph="&#xE74D;" />
+                                <StackPanel Orientation="Horizontal">
+                                    <FontIcon FontSize="{StaticResource StandardIconSize}"
+                                              Glyph="&#xE74D;" />
+                                    <TextBlock x:Uid="Profile_DeleteAppearanceButton"
+                                               Margin="10,0,0,0" />
+                                </StackPanel>
                             </Button.Content>
                             <Button.Resources>
                                 <ResourceDictionary>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -936,8 +936,16 @@
     <comment>A description for what the "tab title" setting does. Presented near "Profile_TabTitle".</comment>
   </data>
   <data name="Profile_UnfocusedAppearanceTextBlock.Text" xml:space="preserve">
-    <value>Unfocused Appearance</value>
+    <value>Unfocused appearance</value>
     <comment>The header for the section where the unfocused appearance settings can be changed.</comment>
+  </data>
+  <data name="Profile_AddAppearanceButton.Text" xml:space="preserve">
+    <value>Add unfocused appearance</value>
+    <comment>Button label that adds an unfocused appearance for this profile.</comment>
+  </data>
+  <data name="Profile_DeleteAppearanceButton.Text" xml:space="preserve">
+    <value>Delete unfocused appearance</value>
+    <comment>Button label that deletes the unfocused appearance for this profile.</comment>
   </data>
   <data name="Profile_UseAcrylic.Header" xml:space="preserve">
     <value>Enable acrylic</value>


### PR DESCRIPTION
## Summary of the Pull Request
The add/delete unfocused appearance buttons now have text on them and are closed to the `Unfocused appearance` header

## References
#11353 

## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I work here

## Validation Steps Performed
<img width="551" alt="delete" src="https://user-images.githubusercontent.com/26824113/153312630-90a0fc40-798a-4d54-9234-01d4ca8e861c.png">
<img width="552" alt="add" src="https://user-images.githubusercontent.com/26824113/153312638-d8a69f59-fae9-49eb-bf69-d751e6c39109.png">
