### PR TITLE
Manually set the colors of the TabViewBackground

### DIFF
--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -54,20 +54,36 @@
                     <ResourceDictionary.ThemeDictionaries>
                         <ResourceDictionary x:Key="Dark">
                             <!--  Define resources for Dark mode here  -->
-                            <StaticResource x:Key="TabViewBackground"
-                                            ResourceKey="ApplicationPageBackgroundThemeBrush" />
+                            <!-- <SolidColorBrush x:Key="TabViewBackground"
+                                            Color="{ThemeResource SolidBackgroundFillColorBase}" />-->
+                            <!-- <SolidColorBrush x:Key="TabViewBackground"
+                                            Color="{StaticResource SolidBackgroundFillColorBase}" />-->
+                            <SolidColorBrush x:Key="TabViewBackground"
+                                             Color="#202020" />
 
-                            <StaticResource x:Key="UnfocusedBorderBrush"
-                                            ResourceKey="ApplicationPageBackgroundThemeBrush" />
+
+
+                            <SolidColorBrush x:Key="UnfocusedBorderBrush"
+                                             Color="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
+
+
                         </ResourceDictionary>
 
                         <ResourceDictionary x:Key="Light">
                             <!--  Define resources for Light mode here  -->
-                            <StaticResource x:Key="TabViewBackground"
-                                            ResourceKey="ApplicationPageBackgroundThemeBrush" />
+                            <!-- <SolidColorBrush x:Key="TabViewBackground"
+                                            Color="{ThemeResource SolidBackgroundFillColorBase}" />-->
+                            <!-- <SolidColorBrush x:Key="TabViewBackground"
+                                            Color="{StaticResource SolidBackgroundFillColorBase}" />-->
+                            <SolidColorBrush x:Key="TabViewBackground"
+                                             Color="#F3F3F3" />
 
-                            <StaticResource x:Key="UnfocusedBorderBrush"
-                                            ResourceKey="ApplicationPageBackgroundThemeBrush" />
+
+
+                            <SolidColorBrush x:Key="UnfocusedBorderBrush"
+                                             Color="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
+
+
                         </ResourceDictionary>
 
                     </ResourceDictionary.ThemeDictionaries>

--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -63,25 +63,23 @@
 
 
 
-                            <SolidColorBrush x:Key="UnfocusedBorderBrush"
-                                             Color="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
+                            <StaticResource x:Key="UnfocusedBorderBrush"
+                                            ResourceKey="ApplicationPageBackgroundThemeBrush" />
 
 
                         </ResourceDictionary>
 
                         <ResourceDictionary x:Key="Light">
                             <!--  Define resources for Light mode here  -->
-                            <!-- <SolidColorBrush x:Key="TabViewBackground"
-                                            Color="{ThemeResource SolidBackgroundFillColorBase}" />-->
-                            <!-- <SolidColorBrush x:Key="TabViewBackground"
-                                            Color="{StaticResource SolidBackgroundFillColorBase}" />-->
+
+                            <!--  This is the color of ApplicationPageBackgroundThemeBrush, which is evaluated as SolidBackgroundFillColorBase. If we try to use those resources directly though, we don't get the properly themed versions. Presumably because the App itself can't have it's RequestedTheme changed at runtime.  -->
                             <SolidColorBrush x:Key="TabViewBackground"
                                              Color="#F3F3F3" />
 
 
 
-                            <SolidColorBrush x:Key="UnfocusedBorderBrush"
-                                             Color="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
+                            <StaticResource x:Key="UnfocusedBorderBrush"
+                                            ResourceKey="ApplicationPageBackgroundThemeBrush" />
 
 
                         </ResourceDictionary>

--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -54,14 +54,20 @@
                     <ResourceDictionary.ThemeDictionaries>
                         <ResourceDictionary x:Key="Dark">
                             <!--  Define resources for Dark mode here  -->
-                            <!-- <SolidColorBrush x:Key="TabViewBackground"
-                                            Color="{ThemeResource SolidBackgroundFillColorBase}" />-->
-                            <!-- <SolidColorBrush x:Key="TabViewBackground"
-                                            Color="{StaticResource SolidBackgroundFillColorBase}" />-->
+
+                            <!--
+                                This is the color of
+                                ApplicationPageBackgroundThemeBrush, which is
+                                evaluated as SolidBackgroundFillColorBase. If we try
+                                to use those resources directly though, we don't get
+                                the properly themed versions. Presumably because the
+                                App itself can't have it's RequestedTheme changed at
+                                runtime.
+                                
+                                See GH #12356 for more history on the subject.
+                            -->
                             <SolidColorBrush x:Key="TabViewBackground"
                                              Color="#202020" />
-
-
 
                             <StaticResource x:Key="UnfocusedBorderBrush"
                                             ResourceKey="ApplicationPageBackgroundThemeBrush" />
@@ -71,17 +77,11 @@
 
                         <ResourceDictionary x:Key="Light">
                             <!--  Define resources for Light mode here  -->
-
-                            <!--  This is the color of ApplicationPageBackgroundThemeBrush, which is evaluated as SolidBackgroundFillColorBase. If we try to use those resources directly though, we don't get the properly themed versions. Presumably because the App itself can't have it's RequestedTheme changed at runtime.  -->
                             <SolidColorBrush x:Key="TabViewBackground"
                                              Color="#F3F3F3" />
 
-
-
                             <StaticResource x:Key="UnfocusedBorderBrush"
                                             ResourceKey="ApplicationPageBackgroundThemeBrush" />
-
-
                         </ResourceDictionary>
 
                     </ResourceDictionary.ThemeDictionaries>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -156,7 +156,6 @@ namespace winrt::TerminalApp::implementation
         if (_settings.GlobalSettings().UseAcrylicInTabRow())
         {
             const auto res = Application::Current().Resources();
-
             const auto lightKey = winrt::box_value(L"Light");
             const auto darkKey = winrt::box_value(L"Dark");
             const auto tabViewBackgroundKey = winrt::box_value(L"TabViewBackground");


### PR DESCRIPTION
This has been a saga.

Basically, any resources in `App.xaml` aren't going to be able to reference other theme-aware resources. We can't change the theme of the app at runtime, only elements within the app. So we can't use `ApplicationPageBackgroundThemeBrush` in app.xaml, because it will ALWAYS be evaluated as the OS theme version of that brush.

* regressed in #12326
* See also #10864
* #3917 CANNOT be fixed in the same way. We're lucky here that the TabView uses a `{ThemeResource TabViewBackground}` in markup to set the bg. We're not similarly lucky with the Pane one. 
* [x] closes #12356
* [x] Tested manually. You can confirm, my eyes are bleeding from the OS-wide light mode
