### PR TITLE
DON'T default-construct the `MediaPlayer`

### DIFF
--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -1044,7 +1044,12 @@ winrt::fire_and_forget Pane::_playBellSound(winrt::Windows::Foundation::Uri uri)
 
         if (!_bellPlayer)
         {
-            _bellPlayer = winrt::Windows::Media::Playback::MediaPlayer();
+            // The MediaPlayer might not exist on Windows N SKU.
+            try
+            {
+                _bellPlayer = winrt::Windows::Media::Playback::MediaPlayer();
+            }
+            CATCH_LOG();
         }
         if (_bellPlayer)
         {

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -241,7 +241,7 @@ private:
 
     bool _zoomed{ false };
 
-    winrt::Windows::Media::Playback::MediaPlayer _bellPlayer;
+    winrt::Windows::Media::Playback::MediaPlayer _bellPlayer{ nullptr };
     winrt::Windows::Media::Playback::MediaPlayer::MediaEnded_revoker _mediaEndedRevoker;
 
     bool _IsLeaf() const noexcept;


### PR DESCRIPTION
I believe this fixes #12383, but I can't seem to find a way to set up a N SKU VM to confirm this.

* [ ] TODO: wait till the morning to finish copying the N vhd I found off the build shares, to confirm this doesn't crash on launch.
