### PR TITLE
Updates all our icons to use Segoe Fluent

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.xaml
+++ b/src/cascadia/TerminalApp/CommandPalette.xaml
@@ -145,7 +145,7 @@
                     <!--  xE70E is ChevronUp. Rotated 90 degrees, it's _ChevronRight_  -->
                     <FontIcon Grid.Column="2"
                               HorizontalAlignment="Right"
-                              FontFamily="Segoe MDL2 Assets"
+                              FontFamily="{ThemeResource SymbolThemeFontFamily}"
                               Glyph="&#xE70E;">
 
                         <FontIcon.RenderTransform>
@@ -199,20 +199,20 @@
                                 Orientation="Horizontal">
 
                         <FontIcon Margin="0,0,8,0"
-                                  FontFamily="Segoe MDL2 Assets"
+                                  FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                   FontSize="12"
                                   Glyph="&#xEA8F;"
                                   Visibility="{x:Bind Item.(local:TabPaletteItem.TabStatus).BellIndicator, Mode=OneWay}" />
 
                         <FontIcon Margin="0,0,8,0"
-                                  FontFamily="Segoe MDL2 Assets"
+                                  FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                   FontSize="12"
                                   Glyph="&#xE8A3;"
                                   Visibility="{x:Bind Item.(local:TabPaletteItem.TabStatus).IsPaneZoomed, Mode=OneWay}" />
 
                         <FontIcon x:Name="HeaderLockIcon"
                                   Margin="0,0,8,0"
-                                  FontFamily="Segoe MDL2 Assets"
+                                  FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                   FontSize="12"
                                   Glyph="&#xE72E;"
                                   Visibility="{x:Bind Item.(local:TabPaletteItem.TabStatus).IsReadOnlyActive, Mode=OneWay}" />
@@ -445,7 +445,7 @@
                         Background="Transparent"
                         Click="_moveBackButtonClicked"
                         ClickMode="Press">
-                    <FontIcon FontFamily="Segoe MDL2 Assets"
+                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
                               FontSize="12"
                               Glyph="&#xE76b;" />
                 </Button>

--- a/src/cascadia/TerminalApp/SettingsTab.cpp
+++ b/src/cascadia/TerminalApp/SettingsTab.cpp
@@ -98,7 +98,6 @@ namespace winrt::TerminalApp::implementation
 
         if (auto tab{ weakThis.get() })
         {
-            auto fontFamily = winrt::WUX::Media::FontFamily(L"Segoe MDL2 Assets");
             auto glyph = L"\xE713"; // This is the Setting icon (looks like a gear)
 
             // The TabViewItem Icon needs MUX while the IconSourceElement in the CommandPalette needs WUX...

--- a/src/cascadia/TerminalApp/TabBase.cpp
+++ b/src/cascadia/TerminalApp/TabBase.cpp
@@ -90,7 +90,7 @@ namespace winrt::TerminalApp::implementation
         // Close
         Controls::MenuFlyoutItem closeTabMenuItem;
         Controls::FontIcon closeSymbol;
-        closeSymbol.FontFamily(Media::FontFamily{ L"Segoe MDL2 Assets" });
+        closeSymbol.FontFamily(Media::FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" });
         closeSymbol.Glyph(L"\xE711");
 
         closeTabMenuItem.Click([weakThis](auto&&, auto&&) {

--- a/src/cascadia/TerminalApp/TabHeaderControl.xaml
+++ b/src/cascadia/TerminalApp/TabHeaderControl.xaml
@@ -48,19 +48,19 @@
         -->
         <FontIcon x:Name="HeaderBellIndicator"
                   Margin="0,0,8,0"
-                  FontFamily="Segoe MDL2 Assets"
+                  FontFamily="{ThemeResource SymbolThemeFontFamily}"
                   FontSize="12"
                   Glyph="&#xEA8F;"
                   Visibility="{x:Bind TabStatus.BellIndicator, Mode=OneWay}" />
         <FontIcon x:Name="HeaderZoomIcon"
                   Margin="0,0,8,0"
-                  FontFamily="Segoe MDL2 Assets"
+                  FontFamily="{ThemeResource SymbolThemeFontFamily}"
                   FontSize="12"
                   Glyph="&#xE8A3;"
                   Visibility="{x:Bind TabStatus.IsPaneZoomed, Mode=OneWay}" />
         <FontIcon x:Name="HeaderLockIcon"
                   Margin="0,0,8,0"
-                  FontFamily="Segoe MDL2 Assets"
+                  FontFamily="{ThemeResource SymbolThemeFontFamily}"
                   FontSize="12"
                   Glyph="&#xE72E;"
                   Visibility="{x:Bind TabStatus.IsReadOnlyActive, Mode=OneWay}" />

--- a/src/cascadia/TerminalApp/TabRowControl.xaml
+++ b/src/cascadia/TerminalApp/TabRowControl.xaml
@@ -24,7 +24,7 @@
             <!--  EA18 is the "Shield" glyph  -->
             <FontIcon x:Uid="ElevationShield"
                       Margin="9,4,0,4"
-                      FontFamily="Segoe MDL2 Assets"
+                      FontFamily="{ThemeResource SymbolThemeFontFamily}"
                       FontSize="16"
                       Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
                       Glyph="&#xEA18;"
@@ -44,7 +44,7 @@
                              CornerRadius="{Binding Source={ThemeResource OverlayCornerRadius}, Converter={StaticResource TopCornerRadiusFilterConverter}}"
                              DragOver="OnNewTabButtonDragOver"
                              Drop="OnNewTabButtonDrop"
-                             FontFamily="Segoe MDL2 Assets"
+                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
                              FontSize="12"
                              FontWeight="SemiLight"
                              UseLayoutRounding="true">

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -914,7 +914,7 @@ namespace winrt::TerminalApp::implementation
 
                 WUX::Controls::FontIcon commandPaletteIcon{};
                 commandPaletteIcon.Glyph(L"\xE945");
-                commandPaletteIcon.FontFamily(Media::FontFamily{ L"Segoe MDL2 Assets" });
+                commandPaletteIcon.FontFamily(Media::FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" });
                 commandPaletteFlyout.Icon(commandPaletteIcon);
 
                 commandPaletteFlyout.Click({ this, &TerminalPage::_CommandPaletteButtonOnClick });

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -1178,7 +1178,7 @@ namespace winrt::TerminalApp::implementation
         // "Color..."
         Controls::MenuFlyoutItem chooseColorMenuItem;
         Controls::FontIcon colorPickSymbol;
-        colorPickSymbol.FontFamily(Media::FontFamily{ L"Segoe MDL2 Assets" });
+        colorPickSymbol.FontFamily(Media::FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" });
         colorPickSymbol.Glyph(L"\xE790");
 
         chooseColorMenuItem.Click([weakThis](auto&&, auto&&) {
@@ -1209,7 +1209,7 @@ namespace winrt::TerminalApp::implementation
         {
             // "Rename Tab"
             Controls::FontIcon renameTabSymbol;
-            renameTabSymbol.FontFamily(Media::FontFamily{ L"Segoe MDL2 Assets" });
+            renameTabSymbol.FontFamily(Media::FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" });
             renameTabSymbol.Glyph(L"\xE8AC"); // Rename
 
             renameTabMenuItem.Click([weakThis](auto&&, auto&&) {
@@ -1226,7 +1226,7 @@ namespace winrt::TerminalApp::implementation
         {
             // "Duplicate Tab"
             Controls::FontIcon duplicateTabSymbol;
-            duplicateTabSymbol.FontFamily(Media::FontFamily{ L"Segoe MDL2 Assets" });
+            duplicateTabSymbol.FontFamily(Media::FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" });
             duplicateTabSymbol.Glyph(L"\xF5ED");
 
             duplicateTabMenuItem.Click([weakThis](auto&&, auto&&) {
@@ -1243,7 +1243,7 @@ namespace winrt::TerminalApp::implementation
         {
             // "Split Tab"
             Controls::FontIcon splitTabSymbol;
-            splitTabSymbol.FontFamily(Media::FontFamily{ L"Segoe MDL2 Assets" });
+            splitTabSymbol.FontFamily(Media::FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" });
             splitTabSymbol.Glyph(L"\xF246"); // ViewDashboard
 
             splitTabMenuItem.Click([weakThis](auto&&, auto&&) {
@@ -1260,7 +1260,7 @@ namespace winrt::TerminalApp::implementation
         {
             // "Split Tab"
             Controls::FontIcon exportTabSymbol;
-            exportTabSymbol.FontFamily(Media::FontFamily{ L"Segoe MDL2 Assets" });
+            exportTabSymbol.FontFamily(Media::FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" });
             exportTabSymbol.Glyph(L"\xE74E"); // Save
 
             exportTabMenuItem.Click([weakThis](auto&&, auto&&) {

--- a/src/cascadia/TerminalControl/SearchBoxControl.xaml
+++ b/src/cascadia/TerminalControl/SearchBoxControl.xaml
@@ -255,7 +255,7 @@
                       Click="GoBackwardClicked"
                       IsChecked="True"
                       Style="{StaticResource ToggleButtonStyle}">
-            <FontIcon FontFamily="Segoe MDL2 Assets"
+            <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
                       Glyph="&#xE74A;"
                       Style="{ThemeResource FontIconStyle}" />
         </ToggleButton>
@@ -263,7 +263,7 @@
                       x:Uid="SearchBox_SearchForwards"
                       Click="GoForwardClicked"
                       Style="{StaticResource ToggleButtonStyle}">
-            <FontIcon FontFamily="Segoe MDL2 Assets"
+            <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
                       Glyph="&#xE74B;"
                       Style="{ThemeResource FontIconStyle}" />
         </ToggleButton>
@@ -278,7 +278,7 @@
                 x:Uid="SearchBox_Close"
                 Click="CloseClick"
                 Style="{ThemeResource ButtonStyle}">
-            <FontIcon FontFamily="Segoe MDL2 Assets"
+            <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}"
                       FontSize="12"
                       Glyph="&#xE711;" />
         </Button>

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Base.xaml
@@ -108,7 +108,7 @@
                                         Style="{StaticResource ExpanderSettingContainerStyle}">
                     <StackPanel>
                         <TextBox x:Uid="Profile_IconBox"
-                                 FontFamily="Segoe UI, Segoe MDL2 Assets"
+                                 FontFamily="Segoe UI, Segoe Fluent Icons, Segoe MDL2 Assets"
                                  IsSpellCheckEnabled="False"
                                  Style="{StaticResource TextBoxSettingStyle}"
                                  Text="{x:Bind Profile.Icon, Mode=TwoWay}" />

--- a/src/cascadia/TerminalSettingsEditor/SettingContainerStyle.xaml
+++ b/src/cascadia/TerminalSettingsEditor/SettingContainerStyle.xaml
@@ -171,7 +171,7 @@
                                            Margin="0,0,-16,0"
                                            HorizontalAlignment="Right"
                                            VerticalAlignment="Center"
-                                           FontFamily="Segoe UI, Segoe MDL2 Assets"
+                                           FontFamily="Segoe UI, Segoe Fluent Icons, Segoe MDL2 Assets"
                                            Style="{StaticResource SettingsPageItemDescriptionStyle}"
                                            Text="{TemplateBinding CurrentValue}" />
                             </Grid>

--- a/src/cascadia/TerminalSettingsModel/IconPathConverter.cpp
+++ b/src/cascadia/TerminalSettingsModel/IconPathConverter.cpp
@@ -124,7 +124,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                     const bool isMDL2Icon = ch >= L'\uE700' && ch <= L'\uF8FF';
                     if (isMDL2Icon)
                     {
-                        icon.FontFamily(winrt::Windows::UI::Xaml::Media::FontFamily{ L"Segoe MDL2 Assets" });
+                        icon.FontFamily(winrt::Windows::UI::Xaml::Media::FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" });
                     }
                     else
                     {


### PR DESCRIPTION
* use `FontFamily="{ThemeResource SymbolThemeFontFamily}"` where possible, in XAML
* use `FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" }` in codebehind

Basically just a simple string replace.

* [x] This was a bullet point in #11353
* [x] Confirmed manually on my win10 PC
* see also #12438

Actually, this is the last bullet in #11353, so I'm gonna say closes #11353. 

Screenshots below.
