### PR TITLE
Potentially fix Submit OneFuzz CI Job

### DIFF
--- a/build/pipelines/fuzz.yml
+++ b/build/pipelines/fuzz.yml
@@ -52,7 +52,7 @@ stages:
           sed -i s/INSERT_ASSIGNED_HERE/$(ado_assigned_to)/ build/Fuzz/notifications-ado.json
         displayName: Configure OneFuzz
       - bash: |
-          onefuzz template libfuzzer basic --colocate_all_tasks --vm_count 1 --target_exe $target_exe_path --notification_config build/Fuzz/notifications-ado.json OpenConsole $test_name $(Build.SourceVersion) default
+          onefuzz template libfuzzer basic --colocate_all_tasks --vm_count 1 --target_exe $target_exe_path --notification_config @./build/Fuzz/notifications-ado.json OpenConsole $test_name $(Build.SourceVersion) default
         displayName: Submit OneFuzz Job
         env:
           target_exe_path: $(Build.ArtifactStagingDirectory)/$(artifactName)/Fuzzing/x64/test/OpenConsoleFuzzer.exe


### PR DESCRIPTION
## Summary of the Pull Request
Modifies the OneFuzz CI Job so that it attempts to read the notification config from a file rather than the command line.

## References
Potential oversight in #10431.

## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA

## Detailed Description of the Pull Request / Additional comments
Noticed that the CI job was failing on main, so took a look. According to the [docs](https://github.com/microsoft/onefuzz/blob/7f7d76fa7fd0e351f8ffd8c7aa5c5729e30f9e8f/docs/notifications.md#implementation), files should be referenced using `@./` notation.