### PR TITLE
Copy localized strings from ContextMenu into the resource root

### DIFF
--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -152,6 +152,11 @@ jobs:
         $Files | % { Move-Item -Verbose $_.Directory $_.Directory.Parent.Parent -EA:Ignore }
       pwsh: true
   - task: PowerShell@2
+    displayName: Copy the Context Menu Loc Resources to CascadiaPackage
+    inputs:
+      filePath: ./build/scripts/Copy-ContextMenuResourcesToCascadiaPackage.ps1
+      pwsh: true
+  - task: PowerShell@2
     displayName: Generate NOTICE.html from NOTICE.md
     inputs:
       filePath: .\build\scripts\Generate-ThirdPartyNotices.ps1

--- a/build/scripts/Copy-ContextMenuResourcesToCascadiaPackage.ps1
+++ b/build/scripts/Copy-ContextMenuResourcesToCascadiaPackage.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 $LocalizationsFromContextMenu = Get-ChildItem ./src/cascadia/TerminalApp/Resources -Recurse -Filter ContextMenu.resw
 $Languages = [System.Collections.HashTable]::New()
 $LocalizationsFromContextMenu | ForEach-Object {

--- a/build/scripts/Copy-ContextMenuResourcesToCascadiaPackage.ps1
+++ b/build/scripts/Copy-ContextMenuResourcesToCascadiaPackage.ps1
@@ -1,0 +1,31 @@
+$LocalizationsFromContextMenu = Get-ChildItem ./src/cascadia/TerminalApp/Resources -Recurse -Filter ContextMenu.resw
+$Languages = [System.Collections.HashTable]::New()
+$LocalizationsFromContextMenu | ForEach-Object {
+	$Languages[$_.Directory.Name] = $_
+}
+
+ForEach ($pair in $Languages.GetEnumerator()) {
+	$LanguageDir = "./src/cascadia/CascadiaPackage/Resources/$($pair.Key)"
+	$ResPath = "$LanguageDir/Resources.resw"
+	$PreexistingResw = Get-Item $ResPath -EA:Ignore
+	If ($null -eq $PreexistingResw) {
+		Write-Host "Copying $($pair.Value.FullName) to $ResPath"
+		New-Item -type Directory $LanguageDir -EA:Ignore
+		Copy-Item $pair.Value.FullName $ResPath
+	} Else {
+		# Merge Them!
+		Write-Host "Merging $($pair.Value.FullName) into $ResPath"
+		$existingXml = [xml](Get-Content $PreexistingResw.FullName)
+		$newXml = [xml](Get-Content $pair.Value.FullName)
+		$newDataKeys = $newXml.root.data.name
+		$existingXml.root.data | % {
+			If ($_.name -in $newDataKeys) {
+				$null = $existingXml.root.RemoveChild($_)
+			}
+		}
+		$newXml.root.data | % {
+			$null = $existingXml.root.AppendChild($existingXml.ImportNode($_, $true))
+		}
+		$existingXml.Save($PreexistingResw.FullName)
+	}
+}

--- a/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Dev.appxmanifest
@@ -20,7 +20,7 @@
     Version="0.0.1.0" />
 
   <Properties>
-    <DisplayName>ms-resource:TerminalApp/ContextMenu/AppStoreNameDev</DisplayName>
+    <DisplayName>ms-resource:AppStoreNameDev</DisplayName>
     <PublisherDisplayName>A Lone Developer</PublisherDisplayName>
     <Logo>Images\StoreLogo.png</Logo>
   </Properties>
@@ -38,8 +38,8 @@
       Executable="$targetnametoken$.exe"
       EntryPoint="$targetentrypoint$">
       <uap:VisualElements
-        DisplayName="ms-resource:TerminalApp/ContextMenu/AppNameDev"
-        Description="ms-resource:TerminalApp/ContextMenu/AppDescriptionDev"
+        DisplayName="ms-resource:AppNameDev"
+        Description="ms-resource:AppDescriptionDev"
         BackgroundColor="transparent"
         Square150x150Logo="Images\Square150x150Logo.png"
         Square44x44Logo="Images\Square44x44Logo.png">
@@ -47,7 +47,7 @@
           Wide310x150Logo="Images\Wide310x150Logo.png"
           Square71x71Logo="Images\SmallTile.png"
           Square310x310Logo="Images\LargeTile.png"
-          ShortName="ms-resource:TerminalApp/ContextMenu/AppShortNameDev">
+          ShortName="ms-resource:AppShortNameDev">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo"/>
             <uap:ShowOn Tile="wide310x150Logo"/>
@@ -66,7 +66,7 @@
           <uap5:StartupTask
             TaskId="StartTerminalOnLoginTask"
             Enabled="false"
-            DisplayName="ms-resource:TerminalApp/ContextMenu/AppNameDev" />
+            DisplayName="ms-resource:AppNameDev" />
         </uap5:Extension>
         <uap3:Extension Category="windows.appExtensionHost">
               <uap3:AppExtensionHost>

--- a/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Pre.appxmanifest
@@ -21,7 +21,7 @@
     Version="0.5.0.0" />
 
   <Properties>
-    <DisplayName>ms-resource:TerminalApp/ContextMenu/AppStoreNamePre</DisplayName>
+    <DisplayName>ms-resource:AppStoreNamePre</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Images\StoreLogo.png</Logo>
   </Properties>
@@ -127,8 +127,8 @@
       Executable="$targetnametoken$.exe"
       EntryPoint="$targetentrypoint$">
       <uap:VisualElements
-        DisplayName="ms-resource:TerminalApp/ContextMenu/AppNamePre"
-        Description="ms-resource:TerminalApp/ContextMenu/AppDescriptionPre"
+        DisplayName="ms-resource:AppNamePre"
+        Description="ms-resource:AppDescriptionPre"
         BackgroundColor="transparent"
         Square150x150Logo="Images\Square150x150Logo.png"
         Square44x44Logo="Images\Square44x44Logo.png">
@@ -136,7 +136,7 @@
           Wide310x150Logo="Images\Wide310x150Logo.png"
           Square71x71Logo="Images\SmallTile.png"
           Square310x310Logo="Images\LargeTile.png"
-          ShortName="ms-resource:TerminalApp/ContextMenu/AppShortNamePre">
+          ShortName="ms-resource:AppShortNamePre">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo"/>
             <uap:ShowOn Tile="wide310x150Logo"/>
@@ -160,7 +160,7 @@
           <uap5:StartupTask
             TaskId="StartTerminalOnLoginTask"
             Enabled="false"
-            DisplayName="ms-resource:TerminalApp/ContextMenu/AppNamePre" />
+            DisplayName="ms-resource:AppNamePre" />
         </uap5:Extension>
         <uap3:Extension Category="windows.appExtension">
             <uap3:AppExtension Name="com.microsoft.windows.console.host"

--- a/src/cascadia/CascadiaPackage/Package.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package.appxmanifest
@@ -21,7 +21,7 @@
     Version="1.0.0.0" />
 
   <Properties>
-    <DisplayName>ms-resource:TerminalApp/ContextMenu/AppStoreName</DisplayName>
+    <DisplayName>ms-resource:AppStoreName</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Images\StoreLogo.png</Logo>
   </Properties>
@@ -127,8 +127,8 @@
       Executable="$targetnametoken$.exe"
       EntryPoint="$targetentrypoint$">
       <uap:VisualElements
-        DisplayName="ms-resource:TerminalApp/ContextMenu/AppName"
-        Description="ms-resource:TerminalApp/ContextMenu/AppDescription"
+        DisplayName="ms-resource:AppName"
+        Description="ms-resource:AppDescription"
         BackgroundColor="transparent"
         Square150x150Logo="Images\Square150x150Logo.png"
         Square44x44Logo="Images\Square44x44Logo.png">
@@ -136,7 +136,7 @@
           Wide310x150Logo="Images\Wide310x150Logo.png"
           Square71x71Logo="Images\SmallTile.png"
           Square310x310Logo="Images\LargeTile.png"
-          ShortName="ms-resource:TerminalApp/ContextMenu/AppShortName">
+          ShortName="ms-resource:AppShortName">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo"/>
             <uap:ShowOn Tile="wide310x150Logo"/>
@@ -160,7 +160,7 @@
           <uap5:StartupTask
             TaskId="StartTerminalOnLoginTask"
             Enabled="false"
-            DisplayName="ms-resource:TerminalApp/ContextMenu/AppName" />
+            DisplayName="ms-resource:AppName" />
         </uap5:Extension>
         <uap3:Extension Category="windows.appExtension">
             <uap3:AppExtension Name="com.microsoft.windows.console.host"

--- a/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
@@ -117,4 +117,52 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AppName" xml:space="preserve">
+    <value>Terminal</value>
+    <comment>{Locked}</comment>
+  </data>
+  <data name="AppNameDev" xml:space="preserve">
+    <value>Terminal Dev</value>
+    <comment>{Locked}</comment>
+  </data>
+  <data name="AppNamePre" xml:space="preserve">
+    <value>Terminal Preview</value>
+    <comment>{Locked}</comment>
+  </data>
+  <data name="AppStoreName" xml:space="preserve">
+    <value>Windows Terminal</value>
+    <comment>{Locked}</comment>
+  </data>
+  <data name="AppStoreNameDev" xml:space="preserve">
+    <value>Windows Terminal Dev</value>
+    <comment>{Locked}</comment>
+  </data>
+  <data name="AppStoreNamePre" xml:space="preserve">
+    <value>Windows Terminal Preview</value>
+    <comment>{Locked}</comment>
+  </data>
+  <data name="AppShortName" xml:space="preserve">
+    <value>Terminal</value>
+    <comment>{Locked}</comment>
+  </data>
+  <data name="AppShortNameDev" xml:space="preserve">
+    <value>Terminal Dev</value>
+    <comment>{Locked}</comment>
+  </data>
+  <data name="AppShortNamePre" xml:space="preserve">
+    <value>Terminal Preview</value>
+    <comment>{Locked}</comment>
+  </data>
+  <data name="AppDescription" xml:space="preserve">
+    <value>The New Windows Terminal</value>
+    <comment>{Locked}</comment>
+  </data>
+  <data name="AppDescriptionDev" xml:space="preserve">
+    <value>The Windows Terminal, but Unofficial</value>
+    <comment>{Locked}</comment>
+  </data>
+  <data name="AppDescriptionPre" xml:space="preserve">
+    <value>Windows Terminal with a preview of upcoming features</value>
+    <comment>{Locked}</comment>
+  </data>
 </root>


### PR DESCRIPTION
We chose to use the "ContextMenu" resource compartment when we
changed the package name to Terminal in #12264 because it was more
broadly localized than the rest of the application.

It appears as though some platform features have trouble with the
"more qualified" resource paths that #12264 required.

To fix this, we will:

1. Copy all of the ContextMenu localizations into CascadiaPackage's
   resource root
2. Switch all manifest resource paths to use resources from the package
   root.

Regressed in #12264
Closes #12384
Closes #12406 (tracked in microsoft/powertoys#16118)