### PR TITLE
Remove "Window Persistence" feature flag

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -297,8 +297,7 @@ namespace winrt::TerminalApp::implementation
     // - true if the ApplicationState should be used.
     bool TerminalPage::ShouldUsePersistedLayout(CascadiaSettings& settings) const
     {
-        return Feature_PersistedWindowLayout::IsEnabled() &&
-               settings.GlobalSettings().FirstWindowPreference() == FirstWindowPreference::PersistedWindowLayout;
+        return settings.GlobalSettings().FirstWindowPreference() == FirstWindowPreference::PersistedWindowLayout;
     }
 
     // Method Description:

--- a/src/cascadia/TerminalSettingsEditor/Launch.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Launch.cpp
@@ -73,9 +73,4 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         return winrt::single_threaded_observable_vector(std::move(profiles));
     }
-
-    bool Launch::ShowFirstWindowPreference() const noexcept
-    {
-        return Feature_PersistedWindowLayout::IsEnabled();
-    }
 }

--- a/src/cascadia/TerminalSettingsEditor/Launch.h
+++ b/src/cascadia/TerminalSettingsEditor/Launch.h
@@ -29,8 +29,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         void CurrentDefaultProfile(const IInspectable& value);
         winrt::Windows::Foundation::Collections::IObservableVector<IInspectable> DefaultProfiles() const;
 
-        bool ShowFirstWindowPreference() const noexcept;
-
         WINRT_PROPERTY(Editor::LaunchPageNavigationState, State, nullptr);
 
         GETSET_BINDABLE_ENUM_SETTING(FirstWindowPreference, Model::FirstWindowPreference, State().Settings().GlobalSettings().FirstWindowPreference);

--- a/src/cascadia/TerminalSettingsEditor/Launch.idl
+++ b/src/cascadia/TerminalSettingsEditor/Launch.idl
@@ -20,9 +20,6 @@ namespace Microsoft.Terminal.Settings.Editor
         //   https://github.com/microsoft/microsoft-ui-xaml/issues/5395
         IObservableVector<IInspectable> DefaultProfiles { get; };
 
-
-        Boolean ShowFirstWindowPreference { get; };
-
         IInspectable CurrentFirstWindowPreference;
         IObservableVector<Microsoft.Terminal.Settings.Editor.EnumEntry> FirstWindowPreferenceList { get; };
 

--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -138,8 +138,7 @@
 
                 <!--  First Window Behavior  -->
                 <local:SettingContainer x:Uid="Globals_FirstWindowPreference"
-                                        Style="{StaticResource ExpanderSettingContainerStyle}"
-                                        Visibility="{x:Bind ShowFirstWindowPreference}">
+                                        Style="{StaticResource ExpanderSettingContainerStyle}">
                     <muxc:RadioButtons AutomationProperties.AccessibilityView="Content"
                                        ItemTemplate="{StaticResource EnumRadioButtonTemplate}"
                                        ItemsSource="{x:Bind FirstWindowPreferenceList}"

--- a/src/features.xml
+++ b/src/features.xml
@@ -58,13 +58,6 @@
     </feature>
 
     <feature>
-        <name>Feature_PersistedWindowLayout</name>
-        <description>Whether to allow the user to enable persisted window layout saving and loading</description>
-        <id>766</id>
-        <stage>AlwaysEnabled</stage>
-    </feature>
-
-    <feature>
         <name>Feature_AtlasEngine</name>
         <description>If enabled, AtlasEngine and the experimental.useAtlasEngine setting are compiled into the project</description>
         <stage>AlwaysEnabled</stage>

--- a/src/features.xml
+++ b/src/features.xml
@@ -62,8 +62,6 @@
         <description>Whether to allow the user to enable persisted window layout saving and loading</description>
         <id>766</id>
         <stage>AlwaysEnabled</stage>
-        <!-- This feature will not ship to Stable until it is complete. -->
-        <alwaysDisabledReleaseTokens />
     </feature>
 
     <feature>


### PR DESCRIPTION
Removes the `Feature_PersistedWindowLayout` feature flag so that it's always enabled.

Closes #12422 