### PR TITLE
Protect the command palette against being paged with no items

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -164,11 +164,16 @@ namespace winrt::TerminalApp::implementation
     // - the approximate number of items visible in the list (in other words the size of the page)
     uint32_t CommandPalette::_getNumVisibleItems()
     {
-        const auto container = _filteredActionsView().ContainerFromIndex(0);
-        const auto item = container.try_as<winrt::Windows::UI::Xaml::Controls::ListViewItem>();
-        const auto itemHeight = ::base::saturated_cast<int>(item.ActualHeight());
-        const auto listHeight = ::base::saturated_cast<int>(_filteredActionsView().ActualHeight());
-        return listHeight / itemHeight;
+        if (const auto container = _filteredActionsView().ContainerFromIndex(0))
+        {
+            if (const auto item = container.try_as<winrt::Windows::UI::Xaml::Controls::ListViewItem>())
+            {
+                const auto itemHeight = ::base::saturated_cast<int>(item.ActualHeight());
+                const auto listHeight = ::base::saturated_cast<int>(_filteredActionsView().ActualHeight());
+                return listHeight / itemHeight;
+            }
+        }
+        return 0;
     }
 
     // Method Description:


### PR DESCRIPTION
Fixes two crashes amounting to 14% of our crash burden in Simulated
Selfhost. I can't reproduce this organically, but I was able to do so by
forcing the command palette to be empty.