### PR TITLE
Replace scan codes with key names in command picker

### DIFF
--- a/src/cascadia/TerminalApp/ActionPaletteItem.cpp
+++ b/src/cascadia/TerminalApp/ActionPaletteItem.cpp
@@ -7,6 +7,9 @@
 
 #include "ActionPaletteItem.g.cpp"
 
+#include <regex>
+#include <vector>
+
 using namespace winrt;
 using namespace winrt::TerminalApp;
 using namespace winrt::Windows::UI::Core;
@@ -18,11 +21,67 @@ using namespace winrt::Microsoft::Terminal::Settings::Model;
 
 namespace winrt::TerminalApp::implementation
 {
+    static std::wstring scan_code_to_name(const std::wstring& str)
+    {
+        std::size_t idx = 0;
+        auto scan_code = std::stoul(str, &idx);
+
+        if (idx != str.length())
+            throw std::runtime_error{ "cannot convert scan_code from str" };
+
+        std::vector<wchar_t> buffer;
+        buffer.resize(64);
+        if (!GetKeyNameTextW(scan_code << 16, buffer.data(), static_cast<int>(buffer.size())))
+        {
+            throw std::runtime_error{ "cannot resolve scan_code to name" };
+        }
+
+        return { buffer.data() };
+    }
+
+    static winrt::hstring replace_scan_codes(const std::wstring_view& input)
+    {
+        static std::wregex regex{ L"sc\\(([0-9]+)\\)" };
+
+        std::wstring key_chord_text{ input.begin(), input.end() };
+        
+        std::wstring result;
+
+        std::wsregex_token_iterator end;
+        std::wsregex_token_iterator iter{ key_chord_text.begin(), key_chord_text.end(), regex, 1 };
+        std::wstring::const_iterator last = key_chord_text.begin();
+        for (; iter != end; ++iter)
+        {
+            if (iter->matched)
+            {
+                constexpr auto length_of_scan_code_prefix = 3;
+                result.append(last, iter->first - length_of_scan_code_prefix);
+
+                try
+                {
+                    result.append(scan_code_to_name(iter->str()));
+                }
+                catch (const std::runtime_error&)
+                {
+                    // LOG?
+                    result.append(L"sc(" + iter->str() + L")");
+                }
+
+                constexpr auto length_of_scan_code_suffix = 1;
+                last = iter->second + length_of_scan_code_suffix;
+            }
+        }
+
+        result.append(last, key_chord_text.cend());
+
+        return winrt::hstring{ result.c_str() };
+    }
+
     ActionPaletteItem::ActionPaletteItem(Microsoft::Terminal::Settings::Model::Command const& command) :
         _Command(command)
     {
         Name(command.Name());
-        KeyChordText(command.KeyChordText());
+        KeyChordText(replace_scan_codes(command.KeyChordText()));
         Icon(command.IconPath());
 
         _commandChangedRevoker = command.PropertyChanged(winrt::auto_revoke, [weakThis{ get_weak() }](auto& sender, auto& e) {
@@ -38,7 +97,7 @@ namespace winrt::TerminalApp::implementation
                 }
                 else if (changedProperty == L"KeyChordText")
                 {
-                    item->KeyChordText(senderCommand.KeyChordText());
+                    item->KeyChordText(replace_scan_codes(senderCommand.KeyChordText()));
                 }
                 else if (changedProperty == L"IconPath")
                 {

--- a/src/cascadia/TerminalApp/ActionPaletteItem.cpp
+++ b/src/cascadia/TerminalApp/ActionPaletteItem.cpp
@@ -44,7 +44,7 @@ namespace winrt::TerminalApp::implementation
         static std::wregex regex{ L"sc\\(([0-9]+)\\)" };
 
         std::wstring key_chord_text{ input.begin(), input.end() };
-        
+
         std::wstring result;
 
         std::wsregex_token_iterator end;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Replace the key chord text containing scan codes, e.g. `win+sc(41)` with the appropriate key <code>win+`</code>

![image](https://user-images.githubusercontent.com/795800/154843604-35e0601c-46bf-4c17-8bcc-26452b628b77.png)


<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #12123
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
