### PR TITLE
AtlasEngine: Fix inverted cursor alpha

### DIFF
--- a/src/renderer/atlas/shader_ps.hlsl
+++ b/src/renderer/atlas/shader_ps.hlsl
@@ -142,10 +142,13 @@ float4 main(float4 pos: SV_Position): SV_Target
     }
 
     // Layer 3 (optional):
-    // Uncolored cursors invert the cells color.
-    if ((cell.flags & CellFlags_Cursor) && cursorColor == INVALID_COLOR)
+    // Uncolored cursors are used as a mask that inverts the cells color.
+    [branch] if (cell.flags & CellFlags_Cursor)
     {
-        color.rgb = abs(glyphs[cellPos].rgb - color.rgb);
+        [flatten] if (cursorColor == INVALID_COLOR && glyphs[cellPos].a != 0)
+        {
+            color = float4(1 - color.rgb, 1);
+        }
     }
 
     // Layer 4:


### PR DESCRIPTION
The previous implementation only inverted the RGB values of the cell,
but failed to account for situations where the `color` is transparent,
which is the case when `backgroundOpaqueMixin` is 0 (for instance if
acrylic backgrounds are enabled). In these situations the alpha
component remained 0 which caused the cursor to be invisible.

For some inexplicable reason this issue is only visible on a HDR display,
even though it should also effect regular ones. God knows why.

With this commit the cursor texture is treated as a mask that inverts the color.
We use branching here, because I couldn't come up with a more clever solution.

## PR Checklist
* [x] Closes #12507
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed
* Cursor is visible on a HDR display with acrylic background ✅
* TBD performance benchmark for `[branch]` ❌