### PR TITLE
Commit updated TerminalApp.Unit.Tests.manifest file

### DIFF
--- a/src/cascadia/ut_app/TerminalApp.Unit.Tests.manifest
+++ b/src/cascadia/ut_app/TerminalApp.Unit.Tests.manifest
@@ -14,6 +14,11 @@
         <!-- This will cause unpackaged activation failures in XAML Islands. -->
         <!-- (We use unpackaged activation in test scenarios.) See GH#10265. -->
         <maxversiontested Id="10.0.18362.0"/>
+
+        <!-- You apparently are expected to include all the maxversiontested
+        entries separately. They are treated like an array. This one turns on Segoe
+        UI Variable, GH #12452 -->
+        <maxversiontested Id="10.0.22000.0"/>
         <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
     </application>
   </compatibility>


### PR DESCRIPTION
## Summary of the Pull Request

In PR #12462, a new `maxversiontested` entry was added to the
_WindowsTerminal.manifest_ file which now gets propagated to the
_TerminalApp.Unit.Tests.manifest_ file whenever a full build is
executed. This PR is just committing the updated test manifest.
 
## PR Checklist
* [x] Closes #12543
* [x] CLA signed.
* [ ] Tests added/passed
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] I've discussed this with core contributors already. Issue number
where discussion took place: #12543
