### PR TITLE
AtlasEngine: Reduce shader power draw with explicit branching

### DIFF
--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -788,8 +788,6 @@ void AtlasEngine::_createSwapChain()
 
         if (_api.hwnd)
         {
-            desc.AlphaMode = DXGI_ALPHA_MODE_IGNORE;
-
             if (FAILED(dxgiFactory->CreateSwapChainForHwnd(_r.device.get(), _api.hwnd, &desc, nullptr, nullptr, _r.swapChain.put())))
             {
                 // Platform Update for Windows 7:

--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -563,7 +563,7 @@ namespace Microsoft::Console::Render
             alignas(sizeof(u32)) u32 backgroundColor = 0;
             alignas(sizeof(u32)) u32 cursorColor = 0;
             alignas(sizeof(u32)) u32 selectionColor = 0;
-            alignas(sizeof(u32)) u32 useClearType = 0;
+            alignas(sizeof(u32)) bool useClearType = 0;
 #pragma warning(suppress : 4324) // 'ConstBuffer': structure was padded due to alignment specifier
         };
 

--- a/src/renderer/atlas/dwrite.hlsl
+++ b/src/renderer/atlas/dwrite.hlsl
@@ -79,7 +79,7 @@ float4 DWrite_GrayscaleBlend(float4 gammaRatios, float grayscaleEnhancedContrast
     float3 foregroundStraight = DWrite_UnpremultiplyColor(foregroundColor);
     float contrastBoost = isThinFont ? 0.5f : 0.0f;
     float blendEnhancedContrast = contrastBoost + DWrite_ApplyLightOnDarkContrastAdjustment(grayscaleEnhancedContrast, foregroundStraight);
-    float intensity = DWrite_CalcColorIntensity(foregroundColor.rgb);
+    float intensity = DWrite_CalcColorIntensity(foregroundStraight);
     float contrasted = DWrite_EnhanceContrast(glyphAlpha, blendEnhancedContrast);
     return foregroundColor * DWrite_ApplyAlphaCorrection(contrasted, intensity, gammaRatios);
 }
@@ -120,7 +120,7 @@ float4 DWrite_GrayscaleBlend(float4 gammaRatios, float grayscaleEnhancedContrast
 //   overscale (meaning: the glyph is rasterized with 6x the required resolution in the X axis) and thus
 //   only 7 different RGB combinations can exist in this texture (black/white and 5 states in between).
 //   If you wanted to you could just store these in a A8 texture and restore the RGB values in this shader.
-float4 DWrite_CleartypeBlend(float4 gammaRatios, float enhancedContrast, bool isThinFont, float4 backgroundColor, float4 foregroundColor, float4 glyphColor)
+float4 DWrite_ClearTypeBlend(float4 gammaRatios, float enhancedContrast, bool isThinFont, float4 backgroundColor, float4 foregroundColor, float4 glyphColor)
 {
     float3 foregroundStraight = DWrite_UnpremultiplyColor(foregroundColor);
     float contrastBoost = isThinFont ? 0.5f : 0.0f;


### PR DESCRIPTION
Many articles I read while writing this engine claimed that GPUs can't
do branches like CPUs can. One common approach to branching in GPUs is
apparently to "mask" out results, a technique called branch predication.
The GPU will simply execute all instructions in your shader linearly,
but if a branch isn't taken, it'll ignore the computation results.
This is unfortunate for our shader, since most branches we have are
only very seldomly taken. The cursor for instance is only drawn
on a single cell and underlines are seldomly used.

But apparently modern GPUs (2010s and later?) are actually entirely
capable of branching, _if_ all lanes ("pixels") processed by a
wave (""GPU core"") take the same branch.

On both my Nvidia GPU (RTX 3080) and Intel iGPU (Intel HD Graphics 530)
this change has a positive impact on power draw. Most noticeably on the
latter this reduces power draw from 900mW down to 600mW at 60 FPS.

## PR Checklist
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed
It seems to work fine on Intel and Nvidia GPUs.
Unfortunately I don't have a AMD GPU to test this on, but I suspect it can't be worse.