### PR TITLE
Fix Windows 10 support for nearby font loading

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
@@ -7,55 +7,8 @@
 #include "EnumEntry.h"
 
 #include <LibraryResources.h>
-#include "..\WinRTUtils\inc\Utils.h"
-
-// This function is a copy of DxFontInfo::_NearbyCollection() with
-// * the call to DxFontInfo::s_GetNearbyFonts() inlined
-// * checkForUpdates for GetSystemFontCollection() set to true
-static wil::com_ptr<IDWriteFontCollection1> NearbyCollection(IDWriteFactory* dwriteFactory)
-{
-    // The convenience interfaces for loading fonts from files
-    // are only available on Windows 10+.
-    wil::com_ptr<IDWriteFactory6> factory6;
-    // wil's query() facilities don't work inside WinRT land at the moment.
-    // They produce a compilation error due to IUnknown and winrt::Windows::Foundation::IUnknown being ambiguous.
-    if (!SUCCEEDED(dwriteFactory->QueryInterface(__uuidof(IDWriteFactory6), factory6.put_void())))
-    {
-        return nullptr;
-    }
-
-    wil::com_ptr<IDWriteFontCollection1> systemFontCollection;
-    THROW_IF_FAILED(factory6->GetSystemFontCollection(false, systemFontCollection.addressof(), true));
-
-    wil::com_ptr<IDWriteFontSet> systemFontSet;
-    THROW_IF_FAILED(systemFontCollection->GetFontSet(systemFontSet.addressof()));
-
-    wil::com_ptr<IDWriteFontSetBuilder2> fontSetBuilder2;
-    THROW_IF_FAILED(factory6->CreateFontSetBuilder(fontSetBuilder2.addressof()));
-
-    THROW_IF_FAILED(fontSetBuilder2->AddFontSet(systemFontSet.get()));
-
-    {
-        const std::filesystem::path module{ wil::GetModuleFileNameW<std::wstring>(nullptr) };
-        const auto folder{ module.parent_path() };
-
-        for (const auto& p : std::filesystem::directory_iterator(folder))
-        {
-            if (til::ends_with(p.path().native(), L".ttf"))
-            {
-                fontSetBuilder2->AddFontFile(p.path().c_str());
-            }
-        }
-    }
-
-    wil::com_ptr<IDWriteFontSet> fontSet;
-    THROW_IF_FAILED(fontSetBuilder2->CreateFontSet(fontSet.addressof()));
-
-    wil::com_ptr<IDWriteFontCollection1> fontCollection;
-    THROW_IF_FAILED(factory6->CreateFontCollectionFromFontSet(fontSet.get(), &fontCollection));
-
-    return fontCollection;
-}
+#include "../WinRTUtils/inc/Utils.h"
+#include "../../renderer/base/FontCache.h"
 
 using namespace winrt::Windows::UI::Text;
 using namespace winrt::Windows::UI::Xaml;
@@ -166,15 +119,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         std::vector<Editor::Font> fontList;
         std::vector<Editor::Font> monospaceFontList;
 
-        // get a DWriteFactory
-        com_ptr<IDWriteFactory> factory;
-        THROW_IF_FAILED(DWriteCreateFactory(
-            DWRITE_FACTORY_TYPE_SHARED,
-            __uuidof(IDWriteFactory),
-            reinterpret_cast<::IUnknown**>(factory.put())));
-
         // get the font collection; subscribe to updates
-        const auto fontCollection = NearbyCollection(factory.get());
+        const auto fontCollection = ::Microsoft::Console::Render::FontCache::GetFresh();
 
         for (UINT32 i = 0; i < fontCollection->GetFontFamilyCount(); ++i)
         {

--- a/src/features.xml
+++ b/src/features.xml
@@ -68,6 +68,15 @@
     </feature>
 
     <feature>
+        <name>Feature_NearbyFontLoading</name>
+        <description>Controls whether fonts in the same directory as the binary are used during rendering. Disabled for conhost so that it doesn't iterate the entire system32 directory.</description>
+        <stage>AlwaysEnabled</stage>
+        <alwaysDisabledBrandingTokens>
+            <brandingToken>WindowsInbox</brandingToken>
+        </alwaysDisabledBrandingTokens>
+    </feature>
+
+    <feature>
         <name>Feature_AdjustIndistinguishableText</name>
         <description>If enabled, the foreground color will, when necessary, be automatically adjusted to make it more visible.</description>
         <stage>AlwaysDisabled</stage>

--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -7,6 +7,7 @@
 #include <shader_ps.h>
 #include <shader_vs.h>
 
+#include "../base/FontCache.h"
 #include "../../interactivity/win32/CustomWindowMessages.h"
 
 // #### NOTE ####
@@ -1023,7 +1024,7 @@ void AtlasEngine::_recreateFontDependentResources()
                 const auto fontStyle = italic ? DWRITE_FONT_STYLE_ITALIC : DWRITE_FONT_STYLE_NORMAL;
                 auto& textFormat = _r.textFormats[italic][bold];
 
-                THROW_IF_FAILED(_sr.dwriteFactory->CreateTextFormat(_api.fontMetrics.fontName.get(), nullptr, fontWeight, fontStyle, DWRITE_FONT_STRETCH_NORMAL, _api.fontMetrics.fontSizeInDIP, L"", textFormat.put()));
+                THROW_IF_FAILED(_sr.dwriteFactory->CreateTextFormat(_api.fontMetrics.fontName.get(), _api.fontMetrics.fontCollection.get(), fontWeight, fontStyle, DWRITE_FONT_STRETCH_NORMAL, _api.fontMetrics.fontSizeInDIP, L"", textFormat.put()));
                 textFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
                 textFormat->SetWordWrapping(DWRITE_WORD_WRAPPING_NO_WRAP);
 

--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -376,6 +376,7 @@ namespace Microsoft::Console::Render
 
         struct FontMetrics
         {
+            wil::com_ptr<IDWriteFontCollection> fontCollection;
             wil::unique_process_heap_string fontName;
             float baselineInDIP = 0.0f;
             float fontSizeInDIP = 0.0f;
@@ -615,7 +616,8 @@ namespace Microsoft::Console::Render
 
         // AtlasEngine.api.cpp
         void _resolveAntialiasingMode() noexcept;
-        void _resolveFontMetrics(const FontInfoDesired& fontInfoDesired, FontInfo& fontInfo, FontMetrics* fontMetrics = nullptr) const;
+        void _updateFont(const wchar_t* faceName, const FontInfoDesired& fontInfoDesired, FontInfo& fontInfo, const std::unordered_map<std::wstring_view, uint32_t>& features, const std::unordered_map<std::wstring_view, float>& axes);
+        void _resolveFontMetrics(const wchar_t* faceName, const FontInfoDesired& fontInfoDesired, FontInfo& fontInfo, FontMetrics* fontMetrics = nullptr) const;
 
         // AtlasEngine.r.cpp
         void _setShaderResources() const;

--- a/src/renderer/base/FontCache.h
+++ b/src/renderer/base/FontCache.h
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+namespace Microsoft::Console::Render::FontCache
+{
+    namespace details
+    {
+        inline const std::vector<wil::com_ptr<IDWriteFontFile>>& getNearbyFontFiles(IDWriteFactory5* factory5)
+        {
+            static const auto fontFiles = [=]() {
+                std::vector<wil::com_ptr<IDWriteFontFile>> files;
+
+                const std::filesystem::path module{ wil::GetModuleFileNameW<std::wstring>(nullptr) };
+                const auto folder{ module.parent_path() };
+
+                for (const auto& p : std::filesystem::directory_iterator(folder))
+                {
+                    if (til::ends_with(p.path().native(), L".ttf"))
+                    {
+                        wil::com_ptr<IDWriteFontFile> fontFile;
+                        if (SUCCEEDED_LOG(factory5->CreateFontFileReference(p.path().c_str(), nullptr, fontFile.addressof())))
+                        {
+                            files.emplace_back(std::move(fontFile));
+                        }
+                    }
+                }
+
+                files.shrink_to_fit();
+                return files;
+            }();
+            return fontFiles;
+        }
+
+        inline wil::com_ptr<IDWriteFontCollection> getFontCollection(bool forceUpdate)
+        {
+            wil::com_ptr<IDWriteFactory> factory;
+            THROW_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(factory), reinterpret_cast<::IUnknown**>(factory.addressof())));
+
+            wil::com_ptr<IDWriteFontCollection> systemFontCollection;
+            THROW_IF_FAILED(factory->GetSystemFontCollection(systemFontCollection.addressof(), forceUpdate));
+
+            if constexpr (Feature_NearbyFontLoading::IsEnabled())
+            {
+                // IDWriteFactory5 is supported since Windows 10, build 15021.
+                const auto factory5 = factory.try_query<IDWriteFactory5>();
+                if (!factory5)
+                {
+                    return systemFontCollection;
+                }
+
+                const auto& nearbyFontFiles = getNearbyFontFiles(factory5.get());
+                if (nearbyFontFiles.empty())
+                {
+                    return systemFontCollection;
+                }
+
+                wil::com_ptr<IDWriteFontSet> systemFontSet;
+                // IDWriteFontCollection1 is supported since Windows 7.
+                THROW_IF_FAILED(systemFontCollection.query<IDWriteFontCollection1>()->GetFontSet(systemFontSet.addressof()));
+
+                wil::com_ptr<IDWriteFontSetBuilder1> fontSetBuilder;
+                THROW_IF_FAILED(factory5->CreateFontSetBuilder(fontSetBuilder.addressof()));
+                THROW_IF_FAILED(fontSetBuilder->AddFontSet(systemFontSet.get()));
+
+                for (const auto& file : nearbyFontFiles)
+                {
+                    LOG_IF_FAILED(fontSetBuilder->AddFontFile(file.get()));
+                }
+
+                wil::com_ptr<IDWriteFontSet> fontSet;
+                THROW_IF_FAILED(fontSetBuilder->CreateFontSet(fontSet.addressof()));
+
+                wil::com_ptr<IDWriteFontCollection1> fontCollection;
+                THROW_IF_FAILED(factory5->CreateFontCollectionFromFontSet(fontSet.get(), fontCollection.addressof()));
+
+                return std::move(fontCollection);
+            }
+            else
+            {
+                return systemFontCollection;
+            }
+        }
+    }
+
+    inline wil::com_ptr<IDWriteFontCollection> GetCached()
+    {
+        return details::getFontCollection(false);
+    }
+
+    inline wil::com_ptr<IDWriteFontCollection> GetFresh()
+    {
+        return details::getFontCollection(true);
+    }
+}

--- a/src/renderer/base/lib/base.vcxproj
+++ b/src/renderer/base/lib/base.vcxproj
@@ -34,6 +34,7 @@
     <ClInclude Include="..\..\inc\IRenderTarget.hpp" />
     <ClInclude Include="..\..\inc\RenderEngineBase.hpp" />
     <ClInclude Include="..\..\inc\RenderSettings.hpp" />
+    <ClInclude Include="..\FontCache.h" />
     <ClInclude Include="..\precomp.h" />
     <ClInclude Include="..\renderer.hpp" />
     <ClInclude Include="..\thread.hpp" />

--- a/src/renderer/base/lib/base.vcxproj.filters
+++ b/src/renderer/base/lib/base.vcxproj.filters
@@ -89,6 +89,9 @@
     <ClInclude Include="..\..\inc\RenderSettings.hpp">
       <Filter>Header Files\inc</Filter>
     </ClInclude>
+    <ClInclude Include="..\FontCache.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="$(SolutionDir)tools\ConsoleTypes.natvis" />

--- a/src/renderer/dx/DxFontInfo.h
+++ b/src/renderer/dx/DxFontInfo.h
@@ -41,29 +41,18 @@ namespace Microsoft::Console::Render
 
         bool GetFallback() const noexcept;
 
-        IDWriteFontCollection* GetNearbyCollection() const noexcept;
-
         void SetFromEngine(const std::wstring_view familyName,
                            const DWRITE_FONT_WEIGHT weight,
                            const DWRITE_FONT_STYLE style,
                            const DWRITE_FONT_STRETCH stretch);
 
-        [[nodiscard]] ::Microsoft::WRL::ComPtr<IDWriteFontFace1> ResolveFontFaceWithFallback(gsl::not_null<IDWriteFactory1*> dwriteFactory,
-                                                                                             std::wstring& localeName);
+        [[nodiscard]] ::Microsoft::WRL::ComPtr<IDWriteFontFace1> ResolveFontFaceWithFallback(IDWriteFontCollection* fontCollection, std::wstring& localeName);
 
     private:
-        [[nodiscard]] ::Microsoft::WRL::ComPtr<IDWriteFontFace1> _FindFontFace(gsl::not_null<IDWriteFactory1*> dwriteFactory,
-                                                                               std::wstring& localeName,
-                                                                               const bool withNearbyLookup);
+        [[nodiscard]] ::Microsoft::WRL::ComPtr<IDWriteFontFace1> _FindFontFace(IDWriteFontCollection* fontCollection, std::wstring& localeName);
 
         [[nodiscard]] std::wstring _GetFontFamilyName(gsl::not_null<IDWriteFontFamily*> const fontFamily,
                                                       std::wstring& localeName);
-
-        [[nodiscard]] IDWriteFontCollection* _NearbyCollection(gsl::not_null<IDWriteFactory1*> dwriteFactory);
-
-        [[nodiscard]] static std::vector<std::filesystem::path> s_GetNearbyFonts();
-
-        ::Microsoft::WRL::ComPtr<IDWriteFontCollection> _nearbyCollection;
 
         // The font name we should be looking for
         std::wstring _familyName;

--- a/src/renderer/dx/DxFontRenderData.h
+++ b/src/renderer/dx/DxFontRenderData.h
@@ -39,7 +39,7 @@ namespace Microsoft::Console::Render
             float strikethroughWidth;
         };
 
-        DxFontRenderData(::Microsoft::WRL::ComPtr<IDWriteFactory1> dwriteFactory) noexcept;
+        DxFontRenderData(::Microsoft::WRL::ComPtr<IDWriteFactory1> dwriteFactory);
 
         // DirectWrite text analyzer from the factory
         [[nodiscard]] Microsoft::WRL::ComPtr<IDWriteTextAnalyzer1> Analyzer();
@@ -132,6 +132,7 @@ namespace Microsoft::Console::Render
         ::Microsoft::WRL::ComPtr<IDWriteFactory1> _dwriteFactory;
         ::Microsoft::WRL::ComPtr<IDWriteTextAnalyzer1> _dwriteTextAnalyzer;
 
+        wil::com_ptr<IDWriteFontCollection> _nearbyCollection;
         std::wstring _userLocaleName;
         DxFontInfo _defaultFontInfo;
         til::size _glyphCell;

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -2083,10 +2083,12 @@ float DxEngine::GetScaling() const noexcept
 [[nodiscard]] HRESULT DxEngine::GetProposedFont(const FontInfoDesired& pfiFontInfoDesired,
                                                 FontInfo& pfiFontInfo,
                                                 int const iDpi) noexcept
+try
 {
     DxFontRenderData fontRenderData(_dwriteFactory);
     return fontRenderData.UpdateFont(pfiFontInfoDesired, pfiFontInfo, iDpi);
 }
+CATCH_RETURN();
 
 // Routine Description:
 // - Gets the area that we currently believe is dirty within the character cell grid


### PR DESCRIPTION
By replacing `IDWriteFontSetBuilder2::AddFontFile` with
`IDWriteFactory5::CreateFontFileReference` and
`IDWriteFontSetBuilder1::AddFontFile` we add nearby
font loading support for Windows 10, build 15021.

This commit also fixes font fallback for AtlasEngine,
which was crashing during testing.

Finally it fixes a bug in DxEngine, where we only created a "nearby" font
collection if we couldn't find the font in the system collection. This doesn't
fix the bug, if the font is locked or broken in the system collection.

This is related to #11648.

## PR Checklist
* [x] Closes #12420
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed
* Build a Debug version of Windows Terminal
* Put Jetbrains Mono into the writeable AppX directory
* Jetbrains Mono is present in the settings UI ✅
* DxEngine works with Jetbrains Mono ✅
* AtlasEngine works with Jetbrains Mono ✅