### PR TITLE
Enable using the alt buffer in the Terminal

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -556,7 +556,7 @@ bool TextBuffer::IncrementCircularBuffer(const bool inVtMode)
 {
     // FirstRow is at any given point in time the array index in the circular buffer that corresponds
     // to the logical position 0 in the window (cursor coordinates and all other coordinates).
-    _renderTarget.TriggerCircling();
+    _renderTarget.TriggerFlush(true);
 
     // Prune hyperlinks to delete obsolete references
     _PruneHyperlinks();

--- a/src/cascadia/TerminalCore/ITerminalApi.hpp
+++ b/src/cascadia/TerminalCore/ITerminalApi.hpp
@@ -67,6 +67,9 @@ namespace Microsoft::Terminal::Core
         virtual void PushGraphicsRendition(const ::Microsoft::Console::VirtualTerminal::VTParameters options) = 0;
         virtual void PopGraphicsRendition() = 0;
 
+        virtual void UseAlternateScreenBuffer() = 0;
+        virtual void UseMainScreenBuffer() = 0;
+
     protected:
         ITerminalApi() = default;
     };

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -136,6 +136,8 @@ public:
     void PushGraphicsRendition(const ::Microsoft::Console::VirtualTerminal::VTParameters options) override;
     void PopGraphicsRendition() override;
 
+    void UseAlternateScreenBuffer() override;
+    void UseMainScreenBuffer() override;
 #pragma endregion
 
 #pragma region ITerminalInput
@@ -319,7 +321,8 @@ private:
 
     // TODO: These members are not shared by an alt-buffer. They should be
     //      encapsulated, such that a Terminal can have both a main and alt buffer.
-    std::unique_ptr<TextBuffer> _buffer;
+    std::unique_ptr<TextBuffer> _mainBuffer;
+    std::unique_ptr<TextBuffer> _altBuffer;
     Microsoft::Console::Types::Viewport _mutableViewport;
     SHORT _scrollbackLines;
 
@@ -372,6 +375,9 @@ private:
     void _NotifyScrollEvent() noexcept;
 
     void _NotifyTerminalCursorPositionChanged() noexcept;
+
+    bool _inAltBuffer() const noexcept;
+    TextBuffer& _activeBuffer() const noexcept;
 
 #pragma region TextSelection
     // These methods are defined in TerminalSelection.cpp

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -18,17 +18,17 @@ void Terminal::PrintString(std::wstring_view stringView)
 
 TextAttribute Terminal::GetTextAttributes() const
 {
-    return _buffer->GetCurrentAttributes();
+    return _activeBuffer().GetCurrentAttributes();
 }
 
 void Terminal::SetTextAttributes(const TextAttribute& attrs)
 {
-    _buffer->SetCurrentAttributes(attrs);
+    _activeBuffer().SetCurrentAttributes(attrs);
 }
 
 Viewport Terminal::GetBufferSize()
 {
-    return _buffer->GetSize();
+    return _activeBuffer().GetSize();
 }
 
 void Terminal::SetCursorPosition(short x, short y)
@@ -39,12 +39,12 @@ void Terminal::SetCursorPosition(short x, short y)
     const short absoluteY = viewOrigin.Y + y;
     COORD newPos{ absoluteX, absoluteY };
     viewport.Clamp(newPos);
-    _buffer->GetCursor().SetPosition(newPos);
+    _activeBuffer().GetCursor().SetPosition(newPos);
 }
 
 COORD Terminal::GetCursorPosition()
 {
-    const auto absoluteCursorPos = _buffer->GetCursor().GetPosition();
+    const auto absoluteCursorPos = _activeBuffer().GetCursor().GetPosition();
     const auto viewport = _GetMutableViewport();
     const auto viewOrigin = viewport.Origin();
     const short relativeX = absoluteCursorPos.X - viewOrigin.X;
@@ -63,11 +63,11 @@ COORD Terminal::GetCursorPosition()
 // - <none>
 void Terminal::CursorLineFeed(const bool withReturn)
 {
-    auto cursorPos = _buffer->GetCursor().GetPosition();
+    auto cursorPos = _activeBuffer().GetCursor().GetPosition();
 
     // since we explicitly just moved down a row, clear the wrap status on the
     // row we just came from
-    _buffer->GetRowByOffset(cursorPos.Y).SetWrapForced(false);
+    _activeBuffer().GetRowByOffset(cursorPos.Y).SetWrapForced(false);
 
     cursorPos.Y++;
     if (withReturn)
@@ -91,10 +91,12 @@ void Terminal::DeleteCharacter(const size_t count)
 {
     SHORT dist;
     THROW_IF_FAILED(SizeTToShort(count, &dist));
-    const auto cursorPos = _buffer->GetCursor().GetPosition();
+    const auto cursorPos = _activeBuffer().GetCursor().GetPosition();
     const auto copyToPos = cursorPos;
     const COORD copyFromPos{ cursorPos.X + dist, cursorPos.Y };
-    const auto sourceWidth = _mutableViewport.RightExclusive() - copyFromPos.X;
+    const auto viewport = _GetMutableViewport();
+
+    const auto sourceWidth = viewport.RightExclusive() - copyFromPos.X;
     SHORT width;
     THROW_IF_FAILED(UIntToShort(sourceWidth, &width));
 
@@ -111,8 +113,8 @@ void Terminal::DeleteCharacter(const size_t count)
     // Iterate over the source cell data and copy it over to the target
     do
     {
-        const auto data = OutputCell(*(_buffer->GetCellDataAt(sourcePos)));
-        _buffer->Write(OutputCellIterator({ &data, 1 }), targetPos);
+        const auto data = OutputCell(*(_activeBuffer().GetCellDataAt(sourcePos)));
+        _activeBuffer().Write(OutputCellIterator({ &data, 1 }), targetPos);
     } while (source.WalkInBounds(sourcePos, walkDirection) && target.WalkInBounds(targetPos, walkDirection));
 }
 
@@ -133,10 +135,11 @@ void Terminal::InsertCharacter(const size_t count)
     // TODO: Github issue #2163
     SHORT dist;
     THROW_IF_FAILED(SizeTToShort(count, &dist));
-    const auto cursorPos = _buffer->GetCursor().GetPosition();
+    const auto cursorPos = _activeBuffer().GetCursor().GetPosition();
     const auto copyFromPos = cursorPos;
     const COORD copyToPos{ cursorPos.X + dist, cursorPos.Y };
-    const auto sourceWidth = _mutableViewport.RightExclusive() - copyFromPos.X;
+    const auto viewport = _GetMutableViewport();
+    const auto sourceWidth = viewport.RightExclusive() - copyFromPos.X;
     SHORT width;
     THROW_IF_FAILED(UIntToShort(sourceWidth, &width));
 
@@ -154,21 +157,21 @@ void Terminal::InsertCharacter(const size_t count)
     // Iterate over the source cell data and copy it over to the target
     do
     {
-        const auto data = OutputCell(*(_buffer->GetCellDataAt(sourcePos)));
-        _buffer->Write(OutputCellIterator({ &data, 1 }), targetPos);
+        const auto data = OutputCell(*(_activeBuffer().GetCellDataAt(sourcePos)));
+        _activeBuffer().Write(OutputCellIterator({ &data, 1 }), targetPos);
     } while (source.WalkInBounds(sourcePos, walkDirection) && target.WalkInBounds(targetPos, walkDirection));
-    const auto eraseIter = OutputCellIterator(UNICODE_SPACE, _buffer->GetCurrentAttributes(), dist);
-    _buffer->Write(eraseIter, cursorPos);
+    const auto eraseIter = OutputCellIterator(UNICODE_SPACE, _activeBuffer().GetCurrentAttributes(), dist);
+    _activeBuffer().Write(eraseIter, cursorPos);
 }
 
 void Terminal::EraseCharacters(const size_t numChars)
 {
-    const auto absoluteCursorPos = _buffer->GetCursor().GetPosition();
+    const auto absoluteCursorPos = _activeBuffer().GetCursor().GetPosition();
     const auto viewport = _GetMutableViewport();
     const short distanceToRight = viewport.RightExclusive() - absoluteCursorPos.X;
     const short fillLimit = std::min(static_cast<short>(numChars), distanceToRight);
-    const auto eraseIter = OutputCellIterator(UNICODE_SPACE, _buffer->GetCurrentAttributes(), fillLimit);
-    _buffer->Write(eraseIter, absoluteCursorPos);
+    const auto eraseIter = OutputCellIterator(UNICODE_SPACE, _activeBuffer().GetCurrentAttributes(), fillLimit);
+    _activeBuffer().Write(eraseIter, absoluteCursorPos);
 }
 
 // Method description:
@@ -183,7 +186,7 @@ void Terminal::EraseCharacters(const size_t numChars)
 // - true if succeeded, false otherwise
 bool Terminal::EraseInLine(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::EraseType eraseType)
 {
-    const auto cursorPos = _buffer->GetCursor().GetPosition();
+    const auto cursorPos = _activeBuffer().GetCursor().GetPosition();
     const auto viewport = _GetMutableViewport();
     COORD startPos = { 0 };
     startPos.Y = cursorPos.Y;
@@ -208,10 +211,10 @@ bool Terminal::EraseInLine(const ::Microsoft::Console::VirtualTerminal::Dispatch
         return false;
     }
 
-    const auto eraseIter = OutputCellIterator(UNICODE_SPACE, _buffer->GetCurrentAttributes(), nlength);
+    const auto eraseIter = OutputCellIterator(UNICODE_SPACE, _activeBuffer().GetCurrentAttributes(), nlength);
 
     // Explicitly turn off end-of-line wrap-flag-setting when erasing cells.
-    _buffer->Write(eraseIter, startPos, false);
+    _activeBuffer().Write(eraseIter, startPos, false);
     return true;
 }
 
@@ -226,22 +229,33 @@ bool Terminal::EraseInLine(const ::Microsoft::Console::VirtualTerminal::Dispatch
 bool Terminal::EraseInDisplay(const DispatchTypes::EraseType eraseType)
 {
     // Store the relative cursor position so we can restore it later after we move the viewport
-    const auto cursorPos = _buffer->GetCursor().GetPosition();
+    const auto cursorPos = _activeBuffer().GetCursor().GetPosition();
 #pragma warning(suppress : 26496) // This is written by ConvertToOrigin, cpp core checks is wrong saying it should be const.
     auto relativeCursor = cursorPos;
-    _mutableViewport.ConvertToOrigin(&relativeCursor);
+    const auto viewport = _GetMutableViewport();
+
+    viewport.ConvertToOrigin(&relativeCursor);
 
     // Initialize the new location of the viewport
     // the top and bottom parameters are determined by the eraseType
     SMALL_RECT newWin;
-    newWin.Left = _mutableViewport.Left();
-    newWin.Right = _mutableViewport.RightExclusive();
+    newWin.Left = viewport.Left();
+    newWin.Right = viewport.RightExclusive();
 
     if (eraseType == DispatchTypes::EraseType::All)
     {
+        // If we're in the alt buffer, take a shortcut. Just increment the buffer enough to cycle the whole thing out and start fresh. This
+        if (_inAltBuffer())
+        {
+            for (auto i = 0; i < viewport.Height(); i++)
+            {
+                _activeBuffer().IncrementCircularBuffer();
+            }
+            return true;
+        }
         // In this case, we simply move the viewport down, effectively pushing whatever text was on the screen into the scrollback
         // and thus 'erasing' the text visible to the user
-        const auto coordLastChar = _buffer->GetLastNonSpaceCharacter(_mutableViewport);
+        const auto coordLastChar = _activeBuffer().GetLastNonSpaceCharacter(viewport);
         if (coordLastChar.X == 0 && coordLastChar.Y == 0)
         {
             // Nothing to clear, just return
@@ -251,38 +265,38 @@ bool Terminal::EraseInDisplay(const DispatchTypes::EraseType eraseType)
         short sNewTop = coordLastChar.Y + 1;
 
         // Increment the circular buffer only if the new location of the viewport would be 'below' the buffer
-        const short delta = (sNewTop + _mutableViewport.Height()) - (_buffer->GetSize().Height());
+        const short delta = (sNewTop + viewport.Height()) - (_activeBuffer().GetSize().Height());
         for (auto i = 0; i < delta; i++)
         {
-            _buffer->IncrementCircularBuffer();
+            _activeBuffer().IncrementCircularBuffer();
             sNewTop--;
         }
 
         newWin.Top = sNewTop;
-        newWin.Bottom = sNewTop + _mutableViewport.Height();
+        newWin.Bottom = sNewTop + viewport.Height();
     }
     else if (eraseType == DispatchTypes::EraseType::Scrollback)
     {
         // We only want to erase the scrollback, and leave everything else on the screen as it is
         // so we grab the text in the viewport and rotate it up to the top of the buffer
         COORD scrollFromPos{ 0, 0 };
-        _mutableViewport.ConvertFromOrigin(&scrollFromPos);
-        _buffer->ScrollRows(scrollFromPos.Y, _mutableViewport.Height(), -scrollFromPos.Y);
+        viewport.ConvertFromOrigin(&scrollFromPos);
+        _activeBuffer().ScrollRows(scrollFromPos.Y, viewport.Height(), -scrollFromPos.Y);
 
         // Since we only did a rotation, the text that was in the scrollback is now _below_ where we are going to move the viewport
         // and we have to make sure we erase that text
-        const auto eraseStart = _mutableViewport.Height();
-        const auto eraseEnd = _buffer->GetLastNonSpaceCharacter(_mutableViewport).Y;
+        const auto eraseStart = viewport.Height();
+        const auto eraseEnd = _activeBuffer().GetLastNonSpaceCharacter(viewport).Y;
         for (SHORT i = eraseStart; i <= eraseEnd; i++)
         {
-            _buffer->GetRowByOffset(i).Reset(_buffer->GetCurrentAttributes());
+            _activeBuffer().GetRowByOffset(i).Reset(_activeBuffer().GetCurrentAttributes());
         }
 
         // Reset the scroll offset now because there's nothing for the user to 'scroll' to
         _scrollOffset = 0;
 
         newWin.Top = 0;
-        newWin.Bottom = _mutableViewport.Height();
+        newWin.Bottom = viewport.Height();
     }
     else
     {
@@ -340,7 +354,7 @@ void Terminal::SetColorTableEntry(const size_t tableIndex, const COLORREF color)
     }
 
     // Repaint everything - the colors might have changed
-    _buffer->GetRenderTarget().TriggerRedrawAll();
+    _activeBuffer().GetRenderTarget().TriggerRedrawAll();
 }
 
 // Method Description:
@@ -402,8 +416,8 @@ void Terminal::SetCursorStyle(const DispatchTypes::CursorStyle cursorStyle)
         return;
     }
 
-    _buffer->GetCursor().SetType(finalCursorType);
-    _buffer->GetCursor().SetBlinkingAllowed(shouldBlink);
+    _activeBuffer().GetCursor().SetType(finalCursorType);
+    _activeBuffer().GetCursor().SetBlinkingAllowed(shouldBlink);
 }
 
 void Terminal::SetInputMode(const TerminalInput::Mode mode, const bool enabled)
@@ -416,7 +430,7 @@ void Terminal::SetRenderMode(const RenderSettings::Mode mode, const bool enabled
     _renderSettings.SetRenderMode(mode, enabled);
 
     // Repaint everything - the colors will have changed
-    _buffer->GetRenderTarget().TriggerRedrawAll();
+    _activeBuffer().GetRenderTarget().TriggerRedrawAll();
 }
 
 void Terminal::EnableXtermBracketedPasteMode(const bool enabled)
@@ -437,12 +451,12 @@ bool Terminal::IsVtInputEnabled() const
 
 void Terminal::SetCursorVisibility(const bool visible)
 {
-    _buffer->GetCursor().SetIsVisible(visible);
+    _activeBuffer().GetCursor().SetIsVisible(visible);
 }
 
 void Terminal::EnableCursorBlinking(const bool enable)
 {
-    _buffer->GetCursor().SetBlinkingAllowed(enable);
+    _activeBuffer().GetCursor().SetBlinkingAllowed(enable);
 
     // GH#2642 - From what we've gathered from other terminals, when blinking is
     // disabled, the cursor should remain On always, and have the visibility
@@ -450,7 +464,7 @@ void Terminal::EnableCursorBlinking(const bool enable)
     // to disable blinking, the cursor stays stuck On. At this point, only the
     // cursor visibility property controls whether the user can see it or not.
     // (Yes, the cursor can be On and NOT Visible)
-    _buffer->GetCursor().SetIsOn(true);
+    _activeBuffer().GetCursor().SetIsOn(true);
 }
 
 void Terminal::CopyToClipboard(std::wstring_view content)
@@ -467,11 +481,11 @@ void Terminal::CopyToClipboard(std::wstring_view content)
 // - <none>
 void Terminal::AddHyperlink(std::wstring_view uri, std::wstring_view params)
 {
-    auto attr = _buffer->GetCurrentAttributes();
-    const auto id = _buffer->GetHyperlinkId(uri, params);
+    auto attr = _activeBuffer().GetCurrentAttributes();
+    const auto id = _activeBuffer().GetHyperlinkId(uri, params);
     attr.SetHyperlinkId(id);
-    _buffer->SetCurrentAttributes(attr);
-    _buffer->AddHyperlinkToMap(uri, id);
+    _activeBuffer().SetCurrentAttributes(attr);
+    _activeBuffer().AddHyperlinkToMap(uri, id);
 }
 
 // Method Description:
@@ -480,9 +494,9 @@ void Terminal::AddHyperlink(std::wstring_view uri, std::wstring_view params)
 // - <none>
 void Terminal::EndHyperlink()
 {
-    auto attr = _buffer->GetCurrentAttributes();
+    auto attr = _activeBuffer().GetCurrentAttributes();
     attr.SetHyperlinkId(0);
-    _buffer->SetCurrentAttributes(attr);
+    _activeBuffer().SetCurrentAttributes(attr);
 }
 
 // Method Description:
@@ -555,7 +569,7 @@ std::wstring_view Terminal::GetWorkingDirectory()
 // - <none>
 void Terminal::PushGraphicsRendition(const VTParameters options)
 {
-    _sgrStack.Push(_buffer->GetCurrentAttributes(), options);
+    _sgrStack.Push(_activeBuffer().GetCurrentAttributes(), options);
 }
 
 // Method Description:
@@ -567,6 +581,86 @@ void Terminal::PushGraphicsRendition(const VTParameters options)
 // - <none>
 void Terminal::PopGraphicsRendition()
 {
-    const TextAttribute current = _buffer->GetCurrentAttributes();
-    _buffer->SetCurrentAttributes(_sgrStack.Pop(current));
+    const TextAttribute current = _activeBuffer().GetCurrentAttributes();
+    _activeBuffer().SetCurrentAttributes(_sgrStack.Pop(current));
+}
+
+void Terminal::UseAlternateScreenBuffer()
+{
+    if (_inAltBuffer())
+    {
+        return;
+    }
+    _activeBuffer().GetCursor().StartDeferDrawing();
+    // we're capturing _buffer by reference here because when we exit, we want to EndDefer on the current active buffer.
+    // TODO! this ^ statement is not accurate.
+    auto endDefer = wil::scope_exit([&]() noexcept { _activeBuffer().GetCursor().EndDeferDrawing(); });
+
+    // auto lock = LockForWriting();
+
+    const COORD bufferSize{ _mutableViewport.Dimensions() };
+    const auto cursorSize = _mainBuffer->GetCursor().GetSize();
+
+    _altBuffer = std::make_unique<TextBuffer>(bufferSize, TextAttribute{}, cursorSize, _mainBuffer->GetRenderTarget());
+    {
+        // Update the alt buffer's cursor style, visibility, and position to match our own.
+        auto& myCursor = _mainBuffer->GetCursor();
+        auto& altCursor = _altBuffer->GetCursor();
+        altCursor.SetStyle(myCursor.GetSize(), myCursor.GetType());
+        altCursor.SetIsVisible(myCursor.IsVisible());
+        altCursor.SetBlinkingAllowed(myCursor.IsBlinkingAllowed());
+
+        // The new position should match the viewport-relative position of the main buffer.
+        auto altCursorPos = myCursor.GetPosition();
+        altCursorPos.Y -= _mutableViewport.Top();
+        altCursor.SetPosition(altCursorPos);
+    }
+
+    // _mutableViewport = Viewport::FromDimensions({ 0, 0 }, _mutableViewport.Dimensions());
+    // _scrollbackLines = 0;
+
+    UpdatePatternsUnderLock();
+    _NotifyScrollEvent();
+    try
+    {
+        _activeBuffer().GetRenderTarget().TriggerRedrawAll();
+    }
+    CATCH_LOG();
+}
+void Terminal::UseMainScreenBuffer()
+{
+    if (!_inAltBuffer())
+    {
+        return;
+    }
+    _activeBuffer().GetCursor().StartDeferDrawing();
+    // we're capturing _buffer by reference here because when we exit, we want to EndDefer on the current active buffer.
+    // TODO! this ^ statement is not accurate.
+    auto endDefer = wil::scope_exit([&]() noexcept { _activeBuffer().GetCursor().EndDeferDrawing(); });
+
+    // auto lock = LockForWriting();
+
+    {
+        // Update the alt buffer's cursor style, visibility, and position to match our own.
+        auto& myCursor = _altBuffer->GetCursor();
+        auto& altCursor = _mainBuffer->GetCursor();
+        altCursor.SetStyle(myCursor.GetSize(), myCursor.GetType());
+        altCursor.SetIsVisible(myCursor.IsVisible());
+        altCursor.SetBlinkingAllowed(myCursor.IsBlinkingAllowed());
+
+        // The new position should match the viewport-relative position of the main buffer.
+        auto altCursorPos = myCursor.GetPosition();
+        altCursorPos.Y += _mutableViewport.Top();
+        altCursor.SetPosition(altCursorPos);
+    }
+
+    _altBuffer = nullptr;
+
+    UpdatePatternsUnderLock();
+    _NotifyScrollEvent();
+    try
+    {
+        _activeBuffer().GetRenderTarget().TriggerRedrawAll();
+    }
+    CATCH_LOG();
 }

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -735,7 +735,7 @@ bool TerminalDispatch::HardReset()
 // - True.
 bool TerminalDispatch::UseAlternateScreenBuffer()
 {
-    // TODO!
+    // TODO GH#3849: When deduplicating this, the AdaptDispatch version of this calls:
     // CursorSaveState();
     _terminalApi.UseAlternateScreenBuffer();
     _usingAltBuffer = true;
@@ -753,7 +753,7 @@ bool TerminalDispatch::UseMainScreenBuffer()
 {
     _terminalApi.UseMainScreenBuffer();
     _usingAltBuffer = false;
-    // TODO!
+    // TODO GH#3849: When deduplicating this, the AdaptDispatch version of this calls:
     // CursorRestoreState();
     return true;
 }

--- a/src/cascadia/TerminalCore/TerminalDispatch.cpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.cpp
@@ -594,6 +594,9 @@ bool TerminalDispatch::_ModeParamsHelper(const DispatchTypes::ModeParams param, 
     case DispatchTypes::ModeParams::W32IM_Win32InputMode:
         success = EnableWin32InputMode(enable);
         break;
+    case DispatchTypes::ModeParams::ASB_AlternateScreenBuffer:
+        success = enable ? UseAlternateScreenBuffer() : UseMainScreenBuffer();
+        break;
     default:
         // If no functions to call, overall dispatch was a failure.
         success = false;
@@ -720,5 +723,37 @@ bool TerminalDispatch::HardReset()
     // Delete all current tab stops and reapply
     _ResetTabStops();
 
+    return true;
+}
+
+// - ASBSET - Creates and swaps to the alternate screen buffer. In virtual terminals, there exists both a "main"
+//     screen buffer and an alternate. ASBSET creates a new alternate, and switches to it. If there is an already
+//     existing alternate, it is discarded.
+// Arguments:
+// - None
+// Return Value:
+// - True.
+bool TerminalDispatch::UseAlternateScreenBuffer()
+{
+    // TODO!
+    // CursorSaveState();
+    _terminalApi.UseAlternateScreenBuffer();
+    _usingAltBuffer = true;
+    return true;
+}
+
+// Routine Description:
+// - ASBRST - From the alternate buffer, returns to the main screen buffer.
+//     From the main screen buffer, does nothing. The alternate is discarded.
+// Arguments:
+// - None
+// Return Value:
+// - True.
+bool TerminalDispatch::UseMainScreenBuffer()
+{
+    _terminalApi.UseMainScreenBuffer();
+    _usingAltBuffer = false;
+    // TODO!
+    // CursorRestoreState();
     return true;
 }

--- a/src/cascadia/TerminalCore/TerminalDispatch.hpp
+++ b/src/cascadia/TerminalCore/TerminalDispatch.hpp
@@ -39,6 +39,9 @@ public:
     bool CarriageReturn() override;
     bool SetWindowTitle(std::wstring_view title) override;
 
+    bool UseAlternateScreenBuffer() override; // ASBSET
+    bool UseMainScreenBuffer() override; // ASBRST
+
     bool HorizontalTabSet() override; // HTS
     bool ForwardTab(const size_t numTabs) override; // CHT, HT
     bool BackwardsTab(const size_t numTabs) override; // CBT
@@ -85,6 +88,7 @@ private:
 
     std::vector<bool> _tabStopColumns;
     bool _initDefaultTabStops = true;
+    bool _usingAltBuffer = false;
 
     size_t _SetRgbColorsHelper(const ::Microsoft::Console::VirtualTerminal::VTParameters options,
                                TextAttribute& attr,

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -54,7 +54,7 @@ std::vector<SMALL_RECT> Terminal::_GetSelectionRects() const noexcept
 
     try
     {
-        return _buffer->GetTextRects(_selection->start, _selection->end, _blockSelection, false);
+        return _activeBuffer().GetTextRects(_selection->start, _selection->end, _blockSelection, false);
     }
     CATCH_LOG();
     return result;
@@ -182,7 +182,7 @@ void Terminal::SetSelectionEnd(const COORD viewportPos, std::optional<SelectionE
 // - the new start/end for a selection
 std::pair<COORD, COORD> Terminal::_PivotSelection(const COORD targetPos, bool& targetStart) const
 {
-    if (targetStart = _buffer->GetSize().CompareInBounds(targetPos, _selection->pivot) <= 0)
+    if (targetStart = _activeBuffer().GetSize().CompareInBounds(targetPos, _selection->pivot) <= 0)
     {
         // target is before pivot
         // treat target as start
@@ -207,7 +207,7 @@ std::pair<COORD, COORD> Terminal::_ExpandSelectionAnchors(std::pair<COORD, COORD
     COORD start = anchors.first;
     COORD end = anchors.second;
 
-    const auto bufferSize = _buffer->GetSize();
+    const auto bufferSize = _activeBuffer().GetSize();
     switch (_multiClickSelectionMode)
     {
     case SelectionExpansion::Line:
@@ -215,8 +215,8 @@ std::pair<COORD, COORD> Terminal::_ExpandSelectionAnchors(std::pair<COORD, COORD
         end = { bufferSize.RightInclusive(), end.Y };
         break;
     case SelectionExpansion::Word:
-        start = _buffer->GetWordStart(start, _wordDelimiters);
-        end = _buffer->GetWordEnd(end, _wordDelimiters);
+        start = _activeBuffer().GetWordStart(start, _wordDelimiters);
+        end = _activeBuffer().GetWordEnd(end, _wordDelimiters);
         break;
     case SelectionExpansion::Char:
     default:
@@ -325,7 +325,7 @@ void Terminal::UpdateSelection(SelectionDirection direction, SelectionExpansion 
             _scrollOffset -= amtBelowView;
         }
         _NotifyScrollEvent();
-        _buffer->GetRenderTarget().TriggerScroll();
+        _activeBuffer().GetRenderTarget().TriggerScroll();
     }
 }
 
@@ -334,22 +334,22 @@ void Terminal::_MoveByChar(SelectionDirection direction, COORD& pos)
     switch (direction)
     {
     case SelectionDirection::Left:
-        _buffer->GetSize().DecrementInBounds(pos);
-        pos = _buffer->GetGlyphStart(til::point{ pos }).to_win32_coord();
+        _activeBuffer().GetSize().DecrementInBounds(pos);
+        pos = _activeBuffer().GetGlyphStart(til::point{ pos }).to_win32_coord();
         break;
     case SelectionDirection::Right:
-        _buffer->GetSize().IncrementInBounds(pos);
-        pos = _buffer->GetGlyphEnd(til::point{ pos }).to_win32_coord();
+        _activeBuffer().GetSize().IncrementInBounds(pos);
+        pos = _activeBuffer().GetGlyphEnd(til::point{ pos }).to_win32_coord();
         break;
     case SelectionDirection::Up:
     {
-        const auto bufferSize{ _buffer->GetSize() };
+        const auto bufferSize{ _activeBuffer().GetSize() };
         pos = { pos.X, std::clamp(base::ClampSub<short, short>(pos.Y, 1).RawValue(), bufferSize.Top(), bufferSize.BottomInclusive()) };
         break;
     }
     case SelectionDirection::Down:
     {
-        const auto bufferSize{ _buffer->GetSize() };
+        const auto bufferSize{ _activeBuffer().GetSize() };
         pos = { pos.X, std::clamp(base::ClampAdd<short, short>(pos.Y, 1).RawValue(), bufferSize.Top(), bufferSize.BottomInclusive()) };
         break;
     }
@@ -361,19 +361,19 @@ void Terminal::_MoveByWord(SelectionDirection direction, COORD& pos)
     switch (direction)
     {
     case SelectionDirection::Left:
-        const auto wordStartPos{ _buffer->GetWordStart(pos, _wordDelimiters) };
-        if (_buffer->GetSize().CompareInBounds(_selection->pivot, pos) < 0)
+        const auto wordStartPos{ _activeBuffer().GetWordStart(pos, _wordDelimiters) };
+        if (_activeBuffer().GetSize().CompareInBounds(_selection->pivot, pos) < 0)
         {
             // If we're moving towards the pivot, move one more cell
             pos = wordStartPos;
-            _buffer->GetSize().DecrementInBounds(pos);
+            _activeBuffer().GetSize().DecrementInBounds(pos);
         }
         else if (wordStartPos == pos)
         {
             // already at the beginning of the current word,
             // move to the beginning of the previous word
-            _buffer->GetSize().DecrementInBounds(pos);
-            pos = _buffer->GetWordStart(pos, _wordDelimiters);
+            _activeBuffer().GetSize().DecrementInBounds(pos);
+            pos = _activeBuffer().GetWordStart(pos, _wordDelimiters);
         }
         else
         {
@@ -382,19 +382,19 @@ void Terminal::_MoveByWord(SelectionDirection direction, COORD& pos)
         }
         break;
     case SelectionDirection::Right:
-        const auto wordEndPos{ _buffer->GetWordEnd(pos, _wordDelimiters) };
-        if (_buffer->GetSize().CompareInBounds(pos, _selection->pivot) < 0)
+        const auto wordEndPos{ _activeBuffer().GetWordEnd(pos, _wordDelimiters) };
+        if (_activeBuffer().GetSize().CompareInBounds(pos, _selection->pivot) < 0)
         {
             // If we're moving towards the pivot, move one more cell
-            pos = _buffer->GetWordEnd(pos, _wordDelimiters);
-            _buffer->GetSize().IncrementInBounds(pos);
+            pos = _activeBuffer().GetWordEnd(pos, _wordDelimiters);
+            _activeBuffer().GetSize().IncrementInBounds(pos);
         }
         else if (wordEndPos == pos)
         {
             // already at the end of the current word,
             // move to the end of the next word
-            _buffer->GetSize().IncrementInBounds(pos);
-            pos = _buffer->GetWordEnd(pos, _wordDelimiters);
+            _activeBuffer().GetSize().IncrementInBounds(pos);
+            pos = _activeBuffer().GetWordEnd(pos, _wordDelimiters);
         }
         else
         {
@@ -404,18 +404,18 @@ void Terminal::_MoveByWord(SelectionDirection direction, COORD& pos)
         break;
     case SelectionDirection::Up:
         _MoveByChar(direction, pos);
-        pos = _buffer->GetWordStart(pos, _wordDelimiters);
+        pos = _activeBuffer().GetWordStart(pos, _wordDelimiters);
         break;
     case SelectionDirection::Down:
         _MoveByChar(direction, pos);
-        pos = _buffer->GetWordEnd(pos, _wordDelimiters);
+        pos = _activeBuffer().GetWordEnd(pos, _wordDelimiters);
         break;
     }
 }
 
 void Terminal::_MoveByViewport(SelectionDirection direction, COORD& pos)
 {
-    const auto bufferSize{ _buffer->GetSize() };
+    const auto bufferSize{ _activeBuffer().GetSize() };
     switch (direction)
     {
     case SelectionDirection::Left:
@@ -444,7 +444,7 @@ void Terminal::_MoveByViewport(SelectionDirection direction, COORD& pos)
 
 void Terminal::_MoveByBuffer(SelectionDirection direction, COORD& pos)
 {
-    const auto bufferSize{ _buffer->GetSize() };
+    const auto bufferSize{ _activeBuffer().GetSize() };
     switch (direction)
     {
     case SelectionDirection::Left:
@@ -489,7 +489,7 @@ const TextBuffer::TextAndColor Terminal::RetrieveSelectedTextFromBuffer(bool sin
     const auto includeCRLF = !singleLine || _blockSelection;
     const auto trimTrailingWhitespace = !singleLine && (!_blockSelection || _trimBlockSelection);
     const auto formatWrappedRows = _blockSelection;
-    return _buffer->GetText(includeCRLF, trimTrailingWhitespace, selectionRects, GetAttributeColors, formatWrappedRows);
+    return _activeBuffer().GetText(includeCRLF, trimTrailingWhitespace, selectionRects, GetAttributeColors, formatWrappedRows);
 }
 
 // Method Description:
@@ -502,7 +502,7 @@ COORD Terminal::_ConvertToBufferCell(const COORD viewportPos) const
 {
     const auto yPos = base::ClampedNumeric<short>(_VisibleStartIndex()) + viewportPos.Y;
     COORD bufferPos = { viewportPos.X, yPos };
-    _buffer->GetSize().Clamp(bufferPos);
+    _activeBuffer().GetSize().Clamp(bufferPos);
     return bufferPos;
 }
 

--- a/src/cascadia/TerminalCore/terminalrenderdata.cpp
+++ b/src/cascadia/TerminalCore/terminalrenderdata.cpp
@@ -25,7 +25,7 @@ COORD Terminal::GetTextBufferEndPosition() const noexcept
 
 const TextBuffer& Terminal::GetTextBuffer() noexcept
 {
-    return *_buffer;
+    return _activeBuffer();
 }
 
 const FontInfo& Terminal::GetFontInfo() noexcept
@@ -40,19 +40,19 @@ void Terminal::SetFontInfo(const FontInfo& fontInfo)
 
 COORD Terminal::GetCursorPosition() const noexcept
 {
-    const auto& cursor = _buffer->GetCursor();
+    const auto& cursor = _activeBuffer().GetCursor();
     return cursor.GetPosition();
 }
 
 bool Terminal::IsCursorVisible() const noexcept
 {
-    const auto& cursor = _buffer->GetCursor();
+    const auto& cursor = _activeBuffer().GetCursor();
     return cursor.IsVisible() && !cursor.IsPopupShown();
 }
 
 bool Terminal::IsCursorOn() const noexcept
 {
-    const auto& cursor = _buffer->GetCursor();
+    const auto& cursor = _activeBuffer().GetCursor();
     return cursor.IsOn();
 }
 
@@ -63,18 +63,18 @@ ULONG Terminal::GetCursorPixelWidth() const noexcept
 
 ULONG Terminal::GetCursorHeight() const noexcept
 {
-    return _buffer->GetCursor().GetSize();
+    return _activeBuffer().GetCursor().GetSize();
 }
 
 CursorType Terminal::GetCursorStyle() const noexcept
 {
-    return _buffer->GetCursor().GetType();
+    return _activeBuffer().GetCursor().GetType();
 }
 
 bool Terminal::IsCursorDoubleWidth() const
 {
-    const auto position = _buffer->GetCursor().GetPosition();
-    TextBufferTextIterator it(TextBufferCellIterator(*_buffer, position));
+    const auto position = _activeBuffer().GetCursor().GetPosition();
+    TextBufferTextIterator it(TextBufferCellIterator(_activeBuffer(), position));
     return IsGlyphFullWidth(*it);
 }
 
@@ -90,12 +90,12 @@ const bool Terminal::IsGridLineDrawingAllowed() noexcept
 
 const std::wstring Microsoft::Terminal::Core::Terminal::GetHyperlinkUri(uint16_t id) const noexcept
 {
-    return _buffer->GetHyperlinkUriFromId(id);
+    return _activeBuffer().GetHyperlinkUriFromId(id);
 }
 
 const std::wstring Microsoft::Terminal::Core::Terminal::GetHyperlinkCustomId(uint16_t id) const noexcept
 {
-    return _buffer->GetCustomIdFromId(id);
+    return _activeBuffer().GetCustomIdFromId(id);
 }
 
 // Method Description:
@@ -174,7 +174,7 @@ void Terminal::SelectNewRegion(const COORD coordStart, const COORD coordEnd)
 
     if (notifyScrollChange)
     {
-        _buffer->GetRenderTarget().TriggerScroll();
+        _activeBuffer().GetRenderTarget().TriggerScroll();
         _NotifyScrollEvent();
     }
 
@@ -227,5 +227,5 @@ const bool Terminal::IsUiaDataInitialized() const noexcept
     // when a screen reader requests it. However, the terminal might not be fully
     // initialized yet. So we use this to check if any crucial components of
     // UiaData are not yet initialized.
-    return !!_buffer;
+    return !!_mainBuffer;
 }

--- a/src/cascadia/UnitTests_TerminalCore/ScrollTest.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ScrollTest.cpp
@@ -51,7 +51,7 @@ namespace
         {
             _triggerScrollDelta = { *delta };
         };
-        virtual void TriggerCircling(){};
+        virtual void TriggerFlush(const bool circling){};
         void TriggerTitleChange(){};
 
     private:

--- a/src/host/ScreenBufferRenderTarget.cpp
+++ b/src/host/ScreenBufferRenderTarget.cpp
@@ -91,13 +91,13 @@ void ScreenBufferRenderTarget::TriggerScroll(const COORD* const pcoordDelta)
     }
 }
 
-void ScreenBufferRenderTarget::TriggerCircling()
+void ScreenBufferRenderTarget::TriggerFlush(const bool circling)
 {
     auto* pRenderer = ServiceLocator::LocateGlobals().pRender;
     const auto* pActive = &ServiceLocator::LocateGlobals().getConsoleInformation().GetActiveOutputBuffer().GetActiveBuffer();
     if (pRenderer != nullptr && pActive == &_owner)
     {
-        pRenderer->TriggerCircling();
+        pRenderer->TriggerFlush(circling);
     }
 }
 

--- a/src/host/ScreenBufferRenderTarget.hpp
+++ b/src/host/ScreenBufferRenderTarget.hpp
@@ -37,7 +37,7 @@ public:
     void TriggerSelection() override;
     void TriggerScroll() override;
     void TriggerScroll(const COORD* const pcoordDelta) override;
-    void TriggerCircling() override;
+    void TriggerFlush(const bool circling) override;
     void TriggerTitleChange() override;
 
 private:

--- a/src/host/VtIo.cpp
+++ b/src/host/VtIo.cpp
@@ -338,6 +338,16 @@ bool VtIo::IsUsingVt() const
     return hr;
 }
 
+[[nodiscard]] HRESULT VtIo::SwitchScreenBuffer(const bool useAltBuffer)
+{
+    HRESULT hr = S_OK;
+    if (_pVtRenderEngine)
+    {
+        hr = _pVtRenderEngine->SwitchScreenBuffer(useAltBuffer);
+    }
+    return hr;
+}
+
 void VtIo::CloseInput()
 {
     // This will release the lock when it goes out of scope

--- a/src/host/VtIo.hpp
+++ b/src/host/VtIo.hpp
@@ -36,6 +36,8 @@ namespace Microsoft::Console::VirtualTerminal
         [[nodiscard]] HRESULT SuppressResizeRepaint();
         [[nodiscard]] HRESULT SetCursorPosition(const COORD coordCursor);
 
+        [[nodiscard]] HRESULT SwitchScreenBuffer(const bool useAltBuffer);
+
         void CloseInput();
         void CloseOutput();
 

--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -1941,6 +1941,9 @@ const SCREEN_INFORMATION& SCREEN_INFORMATION::GetMainBuffer() const
             s_RemoveScreenBuffer(psiOldAltBuffer); // this will also delete the old alt buffer
         }
 
+        // GH#381: When we switch into the alt buffer:
+        //  * flush the current frame, to clear out anything that we prepared for this buffer.
+        //  * Emit a ?1049h/l to the remote side, to let them know that we've switched buffers.
         if (gci.IsInVtIoMode() && ServiceLocator::LocateGlobals().pRender)
         {
             ServiceLocator::LocateGlobals().pRender->TriggerFlush(false);
@@ -1978,6 +1981,9 @@ void SCREEN_INFORMATION::UseMainScreenBuffer()
             psiMain->_fAltWindowChanged = false;
         }
 
+        // GH#381: When we switch into the alt buffer:
+        //  * flush the current frame, to clear out anything that we prepared for this buffer.
+        //  * Emit a ?1049h/l to the remote side, to let them know that we've switched buffers.
         if (gci.IsInVtIoMode() && ServiceLocator::LocateGlobals().pRender)
         {
             ServiceLocator::LocateGlobals().pRender->TriggerFlush(false);

--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -1941,6 +1941,12 @@ const SCREEN_INFORMATION& SCREEN_INFORMATION::GetMainBuffer() const
             s_RemoveScreenBuffer(psiOldAltBuffer); // this will also delete the old alt buffer
         }
 
+        if (gci.IsInVtIoMode() && ServiceLocator::LocateGlobals().pRender)
+        {
+            ServiceLocator::LocateGlobals().pRender->TriggerFlush(false);
+            LOG_IF_FAILED(gci.GetVtIo()->SwitchScreenBuffer(true));
+        }
+
         ::SetActiveScreenBuffer(*psiNewAltBuffer);
 
         // Kind of a hack until we have proper signal channels: If the client app wants window size events, send one for
@@ -1971,6 +1977,13 @@ void SCREEN_INFORMATION::UseMainScreenBuffer()
             psiMain->ProcessResizeWindow(&(psiMain->_rcAltSavedClientNew), &(psiMain->_rcAltSavedClientOld));
             psiMain->_fAltWindowChanged = false;
         }
+
+        if (gci.IsInVtIoMode() && ServiceLocator::LocateGlobals().pRender)
+        {
+            ServiceLocator::LocateGlobals().pRender->TriggerFlush(false);
+            LOG_IF_FAILED(gci.GetVtIo()->SwitchScreenBuffer(false));
+        }
+
         ::SetActiveScreenBuffer(*psiMain);
         psiMain->UpdateScrollBars(); // The alt had disabled scrollbars, re-enable them
 

--- a/src/interactivity/onecore/BgfxEngine.cpp
+++ b/src/interactivity/onecore/BgfxEngine.cpp
@@ -63,12 +63,6 @@ BgfxEngine::BgfxEngine(PVOID SharedViewBase, LONG DisplayHeight, LONG DisplayWid
     return S_OK;
 }
 
-[[nodiscard]] HRESULT BgfxEngine::InvalidateCircling(_Out_ bool* const pForcePaint) noexcept
-{
-    *pForcePaint = false;
-    return S_FALSE;
-}
-
 [[nodiscard]] HRESULT BgfxEngine::PrepareForTeardown(_Out_ bool* const pForcePaint) noexcept
 {
     *pForcePaint = false;

--- a/src/interactivity/onecore/BgfxEngine.hpp
+++ b/src/interactivity/onecore/BgfxEngine.hpp
@@ -39,7 +39,6 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT InvalidateSelection(const std::vector<SMALL_RECT>& rectangles) noexcept override;
         [[nodiscard]] HRESULT InvalidateScroll(const COORD* const pcoordDelta) noexcept override;
         [[nodiscard]] HRESULT InvalidateAll() noexcept override;
-        [[nodiscard]] HRESULT InvalidateCircling(_Out_ bool* const pForcePaint) noexcept override;
         [[nodiscard]] HRESULT PrepareForTeardown(_Out_ bool* const pForcePaint) noexcept override;
 
         [[nodiscard]] HRESULT StartPaint() noexcept override;

--- a/src/renderer/atlas/AtlasEngine.api.cpp
+++ b/src/renderer/atlas/AtlasEngine.api.cpp
@@ -128,7 +128,7 @@ constexpr HRESULT vec2_narrow(U x, U y, AtlasEngine::vec2<T>& out) noexcept
     return S_OK;
 }
 
-[[nodiscard]] HRESULT AtlasEngine::InvalidateCircling(_Out_ bool* const pForcePaint) noexcept
+[[nodiscard]] HRESULT AtlasEngine::InvalidateFlush(_In_ const bool /*circled*/, _Out_ bool* const pForcePaint) noexcept
 {
     RETURN_HR_IF_NULL(E_INVALIDARG, pForcePaint);
     *pForcePaint = false;

--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -33,7 +33,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT InvalidateSelection(const std::vector<SMALL_RECT>& rectangles) noexcept override;
         [[nodiscard]] HRESULT InvalidateScroll(const COORD* pcoordDelta) noexcept override;
         [[nodiscard]] HRESULT InvalidateAll() noexcept override;
-        [[nodiscard]] HRESULT InvalidateCircling(_Out_ bool* pForcePaint) noexcept override;
+        [[nodiscard]] HRESULT InvalidateFlush(_In_ const bool circled, _Out_ bool* const pForcePaint) noexcept override;
         [[nodiscard]] HRESULT InvalidateTitle(std::wstring_view proposedTitle) noexcept override;
         [[nodiscard]] HRESULT PrepareRenderInfo(const RenderFrameInfo& info) noexcept override;
         [[nodiscard]] HRESULT ResetLineTransform() noexcept override;

--- a/src/renderer/base/RenderEngineBase.cpp
+++ b/src/renderer/base/RenderEngineBase.cpp
@@ -77,3 +77,19 @@ void RenderEngineBase::WaitUntilCanRender() noexcept
     // Throttle the render loop a bit by default (~60 FPS), improving throughput.
     Sleep(8);
 }
+
+// Routine Description:
+// - Notifies us that we're about to circle the buffer, giving us a chance to
+//   force a repaint before the buffer contents are lost.
+// - The default implementation of flush, is to do nothing for most renderers.
+// Arguments:
+// - circled - ignored
+// - pForcePaint - Always filled with false
+// Return Value:
+// - S_FALSE because we don't use this.
+[[nodiscard]] HRESULT RenderEngineBase::InvalidateFlush(_In_ const bool /*circled*/, _Out_ bool* const pForcePaint) noexcept
+{
+    RETURN_HR_IF_NULL(E_INVALIDARG, pForcePaint);
+    *pForcePaint = false;
+    return S_FALSE;
+}

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -457,14 +457,14 @@ void Renderer::TriggerScroll(const COORD* const pcoordDelta)
 // - <none>
 // Return Value:
 // - <none>
-void Renderer::TriggerCircling()
+void Renderer::TriggerFlush(const bool circling)
 {
     const auto rects = _GetSelectionRects();
 
     FOREACH_ENGINE(pEngine)
     {
         bool fEngineRequestsRepaint = false;
-        HRESULT hr = pEngine->InvalidateCircling(&fEngineRequestsRepaint);
+        HRESULT hr = pEngine->InvalidateFlush(circling, &fEngineRequestsRepaint);
         LOG_IF_FAILED(hr);
 
         LOG_IF_FAILED(pEngine->InvalidateSelection(rects));

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -51,7 +51,7 @@ namespace Microsoft::Console::Render
         void TriggerScroll() override;
         void TriggerScroll(const COORD* const pcoordDelta) override;
 
-        void TriggerCircling() override;
+        void TriggerFlush(const bool circling) override;
         void TriggerTitleChange() override;
 
         void TriggerFontChange(const int iDpi,

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -1186,20 +1186,6 @@ try
 CATCH_RETURN();
 
 // Routine Description:
-// - This currently has no effect in this renderer.
-// Arguments:
-// - pForcePaint - Always filled with false
-// Return Value:
-// - S_FALSE because we don't use this.
-[[nodiscard]] HRESULT DxEngine::InvalidateCircling(_Out_ bool* const pForcePaint) noexcept
-{
-    RETURN_HR_IF_NULL(E_INVALIDARG, pForcePaint);
-
-    *pForcePaint = false;
-    return S_FALSE;
-}
-
-// Routine Description:
 // - Gets the area in pixels of the surface we are targeting
 // Arguments:
 // - <none>

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -79,7 +79,6 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT InvalidateSelection(const std::vector<SMALL_RECT>& rectangles) noexcept override;
         [[nodiscard]] HRESULT InvalidateScroll(const COORD* const pcoordDelta) noexcept override;
         [[nodiscard]] HRESULT InvalidateAll() noexcept override;
-        [[nodiscard]] HRESULT InvalidateCircling(_Out_ bool* const pForcePaint) noexcept override;
         [[nodiscard]] HRESULT PrepareForTeardown(_Out_ bool* const pForcePaint) noexcept override;
 
         [[nodiscard]] HRESULT StartPaint() noexcept override;

--- a/src/renderer/gdi/gdirenderer.hpp
+++ b/src/renderer/gdi/gdirenderer.hpp
@@ -33,7 +33,6 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT Invalidate(const SMALL_RECT* const psrRegion) noexcept override;
         [[nodiscard]] HRESULT InvalidateCursor(const SMALL_RECT* const psrRegion) noexcept override;
         [[nodiscard]] HRESULT InvalidateAll() noexcept override;
-        [[nodiscard]] HRESULT InvalidateCircling(_Out_ bool* const pForcePaint) noexcept override;
         [[nodiscard]] HRESULT PrepareForTeardown(_Out_ bool* const pForcePaint) noexcept override;
 
         [[nodiscard]] HRESULT StartPaint() noexcept override;

--- a/src/renderer/gdi/invalidate.cpp
+++ b/src/renderer/gdi/invalidate.cpp
@@ -110,21 +110,6 @@ HRESULT GdiEngine::InvalidateAll() noexcept
 }
 
 // Method Description:
-// - Notifies us that we're about to circle the buffer, giving us a chance to
-//      force a repaint before the buffer contents are lost. The GDI renderer
-//      doesn't care if we lose text - we're only painting visible text anyways,
-//      so we return false.
-// Arguments:
-// - Receives a bool indicating if we should force the repaint.
-// Return Value:
-// - S_FALSE - we succeeded, but the result was false.
-HRESULT GdiEngine::InvalidateCircling(_Out_ bool* const pForcePaint) noexcept
-{
-    *pForcePaint = false;
-    return S_FALSE;
-}
-
-// Method Description:
 // - Notifies us that we're about to be torn down. This gives us a last chance
 //      to force a repaint before the buffer contents are lost. The GDI renderer
 //      doesn't care if we lose text - we're only painting visible text anyways,

--- a/src/renderer/inc/DummyRenderTarget.hpp
+++ b/src/renderer/inc/DummyRenderTarget.hpp
@@ -29,6 +29,6 @@ public:
     void TriggerSelection() override {}
     void TriggerScroll() override {}
     void TriggerScroll(const COORD* const /*pcoordDelta*/) override {}
-    void TriggerCircling() override {}
+    void TriggerFlush(const bool circling) override {}
     void TriggerTitleChange() override {}
 };

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -67,7 +67,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] virtual HRESULT InvalidateSelection(const std::vector<SMALL_RECT>& rectangles) noexcept = 0;
         [[nodiscard]] virtual HRESULT InvalidateScroll(const COORD* pcoordDelta) noexcept = 0;
         [[nodiscard]] virtual HRESULT InvalidateAll() noexcept = 0;
-        [[nodiscard]] virtual HRESULT InvalidateCircling(_Out_ bool* pForcePaint) noexcept = 0;
+        [[nodiscard]] virtual HRESULT InvalidateFlush(_In_ const bool circled, _Out_ bool* const pForcePaint) noexcept = 0;
         [[nodiscard]] virtual HRESULT InvalidateTitle(std::wstring_view proposedTitle) noexcept = 0;
         [[nodiscard]] virtual HRESULT PrepareRenderInfo(const RenderFrameInfo& info) noexcept = 0;
         [[nodiscard]] virtual HRESULT ResetLineTransform() noexcept = 0;

--- a/src/renderer/inc/IRenderTarget.hpp
+++ b/src/renderer/inc/IRenderTarget.hpp
@@ -43,7 +43,7 @@ namespace Microsoft::Console::Render
         virtual void TriggerSelection() = 0;
         virtual void TriggerScroll() = 0;
         virtual void TriggerScroll(const COORD* const pcoordDelta) = 0;
-        virtual void TriggerCircling() = 0;
+        virtual void TriggerFlush(const bool circling) = 0;
         virtual void TriggerTitleChange() = 0;
     };
 

--- a/src/renderer/inc/RenderEngineBase.hpp
+++ b/src/renderer/inc/RenderEngineBase.hpp
@@ -51,6 +51,8 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] virtual bool RequiresContinuousRedraw() noexcept override;
 
+        [[nodiscard]] HRESULT InvalidateFlush(_In_ const bool circled, _Out_ bool* const pForcePaint) noexcept override;
+
         void WaitUntilCanRender() noexcept override;
 
     protected:

--- a/src/renderer/uia/UiaRenderer.cpp
+++ b/src/renderer/uia/UiaRenderer.cpp
@@ -169,20 +169,6 @@ CATCH_RETURN();
 }
 
 // Routine Description:
-// - This currently has no effect in this renderer.
-// Arguments:
-// - pForcePaint - Always filled with false
-// Return Value:
-// - S_FALSE because we don't use this.
-[[nodiscard]] HRESULT UiaEngine::InvalidateCircling(_Out_ bool* const pForcePaint) noexcept
-{
-    RETURN_HR_IF_NULL(E_INVALIDARG, pForcePaint);
-
-    *pForcePaint = false;
-    return S_FALSE;
-}
-
-// Routine Description:
 // - This is unused by this renderer.
 // Arguments:
 // - pForcePaint - always filled with false.

--- a/src/renderer/uia/UiaRenderer.hpp
+++ b/src/renderer/uia/UiaRenderer.hpp
@@ -46,7 +46,6 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT InvalidateSelection(const std::vector<SMALL_RECT>& rectangles) noexcept override;
         [[nodiscard]] HRESULT InvalidateScroll(const COORD* const pcoordDelta) noexcept override;
         [[nodiscard]] HRESULT InvalidateAll() noexcept override;
-        [[nodiscard]] HRESULT InvalidateCircling(_Out_ bool* const pForcePaint) noexcept override;
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
         [[nodiscard]] HRESULT PaintBufferLine(gsl::span<const Cluster> const clusters, const COORD coord, const bool fTrimLeft, const bool lineWrapped) noexcept override;
         [[nodiscard]] HRESULT PaintBufferGridLines(const GridLineSet lines, const COLORREF color, const size_t cchLine, const COORD coordTarget) noexcept override;

--- a/src/renderer/vt/VtSequences.cpp
+++ b/src/renderer/vt/VtSequences.cpp
@@ -435,6 +435,20 @@ using namespace Microsoft::Console::Render;
 }
 
 // Method Description:
+// - Send a sequence to the connected terminal to request win32-input-mode from
+//   them. This will enable the connected terminal to send us full INPUT_RECORDs
+//   as input. If the terminal doesn't understand this sequence, it'll just
+//   ignore it.
+// Arguments:
+// - <none>
+// Return Value:
+// - S_OK if we succeeded, else an appropriate HRESULT for failing to allocate or write.
+[[nodiscard]] HRESULT VtEngine::_SwitchScreenBuffer(const bool useAltBuffer) noexcept
+{
+    return _Write(useAltBuffer ? "\x1b[?1049h" : "\x1b[?1049l");
+}
+
+// Method Description:
 // - Formats and writes a sequence to add a hyperlink to the terminal buffer
 // Arguments:
 // - The hyperlink URI

--- a/src/renderer/vt/invalidate.cpp
+++ b/src/renderer/vt/invalidate.cpp
@@ -105,7 +105,7 @@ CATCH_RETURN();
 // - Receives a bool indicating if we should force the repaint.
 // Return Value:
 // - S_OK
-[[nodiscard]] HRESULT VtEngine::InvalidateCircling(_Out_ bool* const pForcePaint) noexcept
+[[nodiscard]] HRESULT VtEngine::InvalidateFlush(_In_ const bool circled, _Out_ bool* const pForcePaint) noexcept
 {
     // If we're in the middle of a resize request, don't try to immediately start a frame.
     if (_inResizeRequest)
@@ -118,7 +118,7 @@ CATCH_RETURN();
 
         // Keep track of the fact that we circled, we'll need to do some work on
         //      end paint to specifically handle this.
-        _circled = true;
+        _circled = circled;
     }
 
     _trace.TraceTriggerCircling(*pForcePaint);

--- a/src/renderer/vt/state.cpp
+++ b/src/renderer/vt/state.cpp
@@ -455,3 +455,10 @@ HRESULT VtEngine::RequestWin32Input() noexcept
     RETURN_IF_FAILED(_Flush());
     return S_OK;
 }
+
+HRESULT VtEngine::SwitchScreenBuffer(const bool useAltBuffer) noexcept
+{
+    RETURN_IF_FAILED(_SwitchScreenBuffer(useAltBuffer));
+    RETURN_IF_FAILED(_Flush());
+    return S_OK;
+}

--- a/src/renderer/vt/vtrenderer.hpp
+++ b/src/renderer/vt/vtrenderer.hpp
@@ -56,7 +56,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT InvalidateSystem(const RECT* prcDirtyClient) noexcept override;
         [[nodiscard]] HRESULT InvalidateSelection(const std::vector<SMALL_RECT>& rectangles) noexcept override;
         [[nodiscard]] HRESULT InvalidateAll() noexcept override;
-        [[nodiscard]] HRESULT InvalidateCircling(_Out_ bool* pForcePaint) noexcept override;
+        [[nodiscard]] HRESULT InvalidateFlush(_In_ const bool circled, _Out_ bool* const pForcePaint) noexcept override;
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
         [[nodiscard]] HRESULT PaintBufferLine(gsl::span<const Cluster> clusters, COORD coord, bool fTrimLeft, bool lineWrapped) noexcept override;
         [[nodiscard]] HRESULT PaintBufferGridLines(GridLineSet lines, COLORREF color, size_t cchLine, COORD coordTarget) noexcept override;
@@ -82,6 +82,7 @@ namespace Microsoft::Console::Render
         void SetResizeQuirk(const bool resizeQuirk);
         [[nodiscard]] virtual HRESULT ManuallyClearScrollback() noexcept;
         [[nodiscard]] HRESULT RequestWin32Input() noexcept;
+        [[nodiscard]] HRESULT SwitchScreenBuffer(const bool useAltBuffer) noexcept;
 
     protected:
         wil::unique_hfile _hFile;
@@ -188,6 +189,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT _RequestCursor() noexcept;
 
         [[nodiscard]] HRESULT _RequestWin32Input() noexcept;
+        [[nodiscard]] HRESULT _SwitchScreenBuffer(const bool useAltBuffer) noexcept;
 
         [[nodiscard]] virtual HRESULT _MoveCursor(const COORD coord) noexcept = 0;
         [[nodiscard]] HRESULT _RgbUpdateDrawingBrushes(const TextAttribute& textAttributes) noexcept;

--- a/src/renderer/wddmcon/WddmConRenderer.cpp
+++ b/src/renderer/wddmcon/WddmConRenderer.cpp
@@ -191,12 +191,6 @@ bool WddmConEngine::IsInitialized()
     return S_OK;
 }
 
-[[nodiscard]] HRESULT WddmConEngine::InvalidateCircling(_Out_ bool* const pForcePaint) noexcept
-{
-    *pForcePaint = false;
-    return S_FALSE;
-}
-
 [[nodiscard]] HRESULT WddmConEngine::PrepareForTeardown(_Out_ bool* const pForcePaint) noexcept
 {
     *pForcePaint = false;

--- a/src/renderer/wddmcon/WddmConRenderer.hpp
+++ b/src/renderer/wddmcon/WddmConRenderer.hpp
@@ -31,7 +31,6 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT InvalidateSelection(const std::vector<SMALL_RECT>& rectangles) noexcept override;
         [[nodiscard]] HRESULT InvalidateScroll(const COORD* const pcoordDelta) noexcept override;
         [[nodiscard]] HRESULT InvalidateAll() noexcept override;
-        [[nodiscard]] HRESULT InvalidateCircling(_Out_ bool* const pForcePaint) noexcept override;
         [[nodiscard]] HRESULT PrepareForTeardown(_Out_ bool* const pForcePaint) noexcept override;
 
         [[nodiscard]] HRESULT StartPaint() noexcept override;


### PR DESCRIPTION
This PR allows the Terminal to actually use the alt buffer appropriately. Currently, we just render the alt buffer state into the main buffer and that is wild. It means things like `vim` will let the user scroll up to see the previous history (which it shouldn't).

Very first thing this PR does: updates the `{Trigger|Invalidate}Circling` methods to instead be `{Trigger|Invalidate}Flush(bool circling)`. We need this so that when an app requests the alt buffer in conpty, we can immediately flush the frame before asking the Terminal side to switch to the other buffer. The `Circling` methods was a great place to do this, but we don't actually want to set the circled flag in VtRenderer when that happens just for a flush. 

The Terminal's implementation is a little different than conhost's. Conhost's implementation grew organically, so I had it straight up create an entire new screen buffer for the alt buffer. The Terminal doesn't need all that! All we need to do is have a separate `TextBuffer` for the alt buffer contents. This makes other parts easier as well - we don't really need to do anything with the `_mutableViewport` in the alt buffer, because it's always in the same place. So, we can just leave it alone and when we come back to the main buffer, there it is. Helper methods have been updated to account for this. 

* [x] Closes #381
* [x] Closes #3492
* [x] I work here
* [ ] Tests would be nice
* #3686, #3082, #3321, #3493 are all good follow-ups here.