### PR TITLE
Add a pipeline that validates builds that touch features.xml

### DIFF
--- a/build/pipelines/feature-flag-ci.yml
+++ b/build/pipelines/feature-flag-ci.yml
@@ -1,0 +1,34 @@
+trigger: none
+
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - src/features.xml
+
+variables:
+  - name: runCodesignValidationInjectionBG
+    value: false
+
+parameters:
+  - name: buildBrandings
+    type: object
+    default:
+      - Release
+      - Preview
+      # Dev is built automatically
+      # WindowsInbox does not typically build with VS.
+
+stages:
+  - ${{ each branding in parameters.buildBrandings }}
+    - stage: Build_x64_${{ branding }}
+      displayName: Build x64 ${{ branding }}
+      dependsOn: []
+      condition: succeeded()
+      jobs:
+        - template: ./templates/build-console-ci.yml
+          parameters:
+            platform: x64
+            branding: ${{ branding }}

--- a/build/pipelines/feature-flag-ci.yml
+++ b/build/pipelines/feature-flag-ci.yml
@@ -21,14 +21,10 @@ parameters:
       # Dev is built automatically
       # WindowsInbox does not typically build with VS.
 
-stages:
+jobs:
   - ${{ each branding in parameters.buildBrandings }}
-    - stage: Build_x64_${{ branding }}
+    - template: ./templates/build-console-ci.yml
       displayName: Build x64 ${{ branding }}
-      dependsOn: []
-      condition: succeeded()
-      jobs:
-        - template: ./templates/build-console-ci.yml
-          parameters:
-            platform: x64
-            branding: ${{ branding }}
+      parameters:
+        platform: x64
+        branding: ${{ branding }}

--- a/build/pipelines/feature-flag-ci.yml
+++ b/build/pipelines/feature-flag-ci.yml
@@ -24,7 +24,6 @@ parameters:
 jobs:
   - ${{ each branding in parameters.buildBrandings }}:
     - template: ./templates/build-console-ci.yml
-      displayName: Build x64 ${{ branding }}
       parameters:
         platform: x64
         branding: ${{ branding }}

--- a/build/pipelines/feature-flag-ci.yml
+++ b/build/pipelines/feature-flag-ci.yml
@@ -22,7 +22,7 @@ parameters:
       # WindowsInbox does not typically build with VS.
 
 jobs:
-  - ${{ each branding in parameters.buildBrandings }}
+  - ${{ each branding in parameters.buildBrandings }}:
     - template: ./templates/build-console-ci.yml
       displayName: Build x64 ${{ branding }}
       parameters:

--- a/build/pipelines/templates/build-console-ci.yml
+++ b/build/pipelines/templates/build-console-ci.yml
@@ -1,5 +1,6 @@
 parameters:
   configuration: 'Release'
+  branding: 'Dev'
   platform: ''
   additionalBuildArguments: ''
 
@@ -9,6 +10,7 @@ jobs:
   variables:
     BuildConfiguration: ${{ parameters.configuration }}
     BuildPlatform: ${{ parameters.platform }}
+    WindowsTerminalBranding: ${{ parameters.branding }}
   pool: 
     ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: WinDevPoolOSS-L

--- a/build/pipelines/templates/build-console-ci.yml
+++ b/build/pipelines/templates/build-console-ci.yml
@@ -5,8 +5,8 @@ parameters:
   additionalBuildArguments: ''
 
 jobs:
-- job: Build${{ parameters.platform }}${{ parameters.configuration }}
-  displayName: Build ${{ parameters.platform }} ${{ parameters.configuration }}
+- job: Build${{ parameters.platform }}${{ parameters.configuration }}${{ parameters.branding }}
+  displayName: Build ${{ parameters.platform }} ${{ parameters.configuration }} ${{ parameters.branding }}
   variables:
     BuildConfiguration: ${{ parameters.configuration }}
     BuildPlatform: ${{ parameters.platform }}

--- a/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
+++ b/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
@@ -11,7 +11,7 @@
      -->
     <AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>
     <AppxOSMaxVersionTestedReplaceManifestVersion>false</AppxOSMaxVersionTestedReplaceManifestVersion>
-    <OCExecutionAliasName Condition="'$(WindowsTerminalBranding)'==''">wtd</OCExecutionAliasName>
+    <OCExecutionAliasName Condition="'$(WindowsTerminalBranding)'=='' or '$(WindowsTerminalBranding)'=='Dev'">wtd</OCExecutionAliasName>
     <OCExecutionAliasName Condition="'$(OCExecutionAliasName)'==''">wt</OCExecutionAliasName>
   </PropertyGroup>
   <PropertyGroup>
@@ -38,7 +38,7 @@
     <AppxManifest Include="Package-Pre.appxmanifest" Condition="'$(WindowsTerminalBranding)'=='Preview'">
       <SubType>Designer</SubType>
     </AppxManifest>
-    <AppxManifest Include="Package-Dev.appxmanifest" Condition="'$(WindowsTerminalBranding)'==''">
+    <AppxManifest Include="Package-Dev.appxmanifest" Condition="'$(WindowsTerminalBranding)'=='' or '$(WindowsTerminalBranding)'=='Dev'">
       <SubType>Designer</SubType>
     </AppxManifest>
   </ItemGroup>
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <!-- This is picked up by CascadiaResources.build.items. -->
-  <PropertyGroup Condition="'$(WindowsTerminalBranding)'==''">
+  <PropertyGroup Condition="'$(WindowsTerminalBranding)'=='' or '$(WindowsTerminalBranding)'=='Dev'">
     <WindowsTerminalAssetSuffix>-Dev</WindowsTerminalAssetSuffix>
   </PropertyGroup>
   <PropertyGroup Condition="'$(WindowsTerminalBranding)'=='Preview'">

--- a/src/features.xml
+++ b/src/features.xml
@@ -76,3 +76,4 @@
         </alwaysEnabledBrandingTokens>
     </feature>
 </featureStaging>
+<!-- revert this commit, you are testing features.xml changes triggering a build... -->

--- a/src/features.xml
+++ b/src/features.xml
@@ -76,4 +76,3 @@
         </alwaysEnabledBrandingTokens>
     </feature>
 </featureStaging>
-<!-- revert this commit, you are testing features.xml changes triggering a build... -->

--- a/src/host/proxy/Host.Proxy.vcxproj
+++ b/src/host/proxy/Host.Proxy.vcxproj
@@ -60,7 +60,7 @@
       <PreprocessorDefinitions>PROXY_CLSID_IS={0x1833E661,0xCC81,0x4DD0,{0x87,0xC6,0xC2,0xF7,0x4B,0xD3,0x9E,0xFA}};%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(WindowsTerminalBranding)'==''">
+  <ItemDefinitionGroup Condition="'$(WindowsTerminalBranding)'=='' or '$(WindowsTerminalBranding)'=='Dev'">
     <ClCompile>
       <PreprocessorDefinitions>PROXY_CLSID_IS={0xDEC4804D,0x56D1,0x4F73,{0x9F,0xBE,0x68,0x28,0xE7,0xC8,0x5C,0x56}};%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>


### PR DESCRIPTION
This is intended to be a PR triggered build that only runs when
features.xml has been touched, to validate that the disabled features do
not cause compilation errors.