### PR TITLE
Fix a crash setting the hotkey during teardown

### DIFF
--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -967,6 +967,15 @@ winrt::fire_and_forget AppHost::_setupGlobalHotkeys()
     // The hotkey MUST be registered on the main thread. It will fail otherwise!
     co_await winrt::resume_foreground(_logic.GetRoot().Dispatcher());
 
+    if (!_window)
+    {
+        // MSFT:36797001 There's a surprising number of hits of this callback
+        // getting triggered during teardown. As a best practice, we really
+        // should make sure _window exists before accessing it on any coroutine.
+        // We might be getting called back after the app already began getting
+        // cleaned up.
+        co_return;
+    }
     // Unregister all previously registered hotkeys.
     //
     // RegisterHotKey(), will not unregister hotkeys automatically.

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -751,7 +751,7 @@ void AppHost::_AlwaysOnTopChanged(const winrt::Windows::Foundation::IInspectable
 {
     // MSFT:34662459
     //
-    // Although we're manully revoking the event handler now in the dtor before
+    // Although we're manually revoking the event handler now in the dtor before
     // we null out the window, let's be extra careful and check JUST IN CASE.
     if (_window == nullptr)
     {
@@ -922,7 +922,7 @@ void AppHost::_BecomeMonarch(const winrt::Windows::Foundation::IInspectable& /*s
 {
     // MSFT:35726322
     //
-    // Although we're manully revoking the event handler now in the dtor before
+    // Although we're manually revoking the event handler now in the dtor before
     // we null out the window, let's be extra careful and check JUST IN CASE.
     if (_window == nullptr)
     {

--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -127,31 +127,38 @@ private:
     winrt::event_token _WindowCreatedToken;
     winrt::event_token _WindowClosedToken;
 
-    // Event handlers to revoke in ~AppHost, before calling App.Close
-    winrt::Microsoft::Terminal::Remoting::WindowManager::BecameMonarch_revoker _BecameMonarchRevoker;
-    winrt::Microsoft::Terminal::Remoting::Peasant::ExecuteCommandlineRequested_revoker _peasantExecuteCommandlineRequestedRevoker;
-    winrt::Microsoft::Terminal::Remoting::Peasant::SummonRequested_revoker _peasantSummonRequestedRevoker;
-    winrt::Microsoft::Terminal::Remoting::Peasant::DisplayWindowIdRequested_revoker _peasantDisplayWindowIdRequestedRevoker;
-    winrt::Microsoft::Terminal::Remoting::Peasant::QuitRequested_revoker _peasantQuitRequestedRevoker;
-    winrt::TerminalApp::AppLogic::CloseRequested_revoker _CloseRequestedRevoker;
-    winrt::TerminalApp::AppLogic::RequestedThemeChanged_revoker _RequestedThemeChangedRevoker;
-    winrt::TerminalApp::AppLogic::FullscreenChanged_revoker _FullscreenChangedRevoker;
-    winrt::TerminalApp::AppLogic::FocusModeChanged_revoker _FocusModeChangedRevoker;
-    winrt::TerminalApp::AppLogic::AlwaysOnTopChanged_revoker _AlwaysOnTopChangedRevoker;
-    winrt::TerminalApp::AppLogic::RaiseVisualBell_revoker _RaiseVisualBellRevoker;
-    winrt::TerminalApp::AppLogic::SystemMenuChangeRequested_revoker _SystemMenuChangeRequestedRevoker;
-    winrt::TerminalApp::AppLogic::ChangeMaximizeRequested_revoker _ChangeMaximizeRequestedRevoker;
-    winrt::TerminalApp::AppLogic::TitleChanged_revoker _TitleChangedRevoker;
-    winrt::TerminalApp::AppLogic::LastTabClosed_revoker _LastTabClosedRevoker;
-    winrt::TerminalApp::AppLogic::SetTaskbarProgress_revoker _SetTaskbarProgressRevoker;
-    winrt::TerminalApp::AppLogic::IdentifyWindowsRequested_revoker _IdentifyWindowsRequestedRevoker;
-    winrt::TerminalApp::AppLogic::RenameWindowRequested_revoker _RenameWindowRequestedRevoker;
-    winrt::TerminalApp::AppLogic::SettingsChanged_revoker _SettingsChangedRevoker;
-    winrt::TerminalApp::AppLogic::IsQuakeWindowChanged_revoker _IsQuakeWindowChangedRevoker;
-    winrt::TerminalApp::AppLogic::SummonWindowRequested_revoker _SummonWindowRequestedRevoker;
-    winrt::TerminalApp::AppLogic::OpenSystemMenu_revoker _OpenSystemMenuRevoker;
-    winrt::TerminalApp::AppLogic::QuitRequested_revoker _QuitRequestedRevoker;
-    winrt::Microsoft::Terminal::Remoting::WindowManager::ShowNotificationIconRequested_revoker _ShowNotificationIconRequestedRevoker;
-    winrt::Microsoft::Terminal::Remoting::WindowManager::HideNotificationIconRequested_revoker _HideNotificationIconRequestedRevoker;
-    winrt::Microsoft::Terminal::Remoting::WindowManager::QuitAllRequested_revoker _QuitAllRequestedRevoker;
+    // Helper struct. By putting these all into one struct, we can revoke them
+    // all at once, by assigning _revokers to a fresh Revokers instance. That'll
+    // cause us to dtor the old one, which will immediately call revoke on all
+    // the members as a part of their own dtors.
+    struct Revokers
+    {
+        // Event handlers to revoke in ~AppHost, before calling App.Close
+        winrt::Microsoft::Terminal::Remoting::WindowManager::BecameMonarch_revoker BecameMonarch;
+        winrt::Microsoft::Terminal::Remoting::Peasant::ExecuteCommandlineRequested_revoker peasantExecuteCommandlineRequested;
+        winrt::Microsoft::Terminal::Remoting::Peasant::SummonRequested_revoker peasantSummonRequested;
+        winrt::Microsoft::Terminal::Remoting::Peasant::DisplayWindowIdRequested_revoker peasantDisplayWindowIdRequested;
+        winrt::Microsoft::Terminal::Remoting::Peasant::QuitRequested_revoker peasantQuitRequested;
+        winrt::TerminalApp::AppLogic::CloseRequested_revoker CloseRequested;
+        winrt::TerminalApp::AppLogic::RequestedThemeChanged_revoker RequestedThemeChanged;
+        winrt::TerminalApp::AppLogic::FullscreenChanged_revoker FullscreenChanged;
+        winrt::TerminalApp::AppLogic::FocusModeChanged_revoker FocusModeChanged;
+        winrt::TerminalApp::AppLogic::AlwaysOnTopChanged_revoker AlwaysOnTopChanged;
+        winrt::TerminalApp::AppLogic::RaiseVisualBell_revoker RaiseVisualBell;
+        winrt::TerminalApp::AppLogic::SystemMenuChangeRequested_revoker SystemMenuChangeRequested;
+        winrt::TerminalApp::AppLogic::ChangeMaximizeRequested_revoker ChangeMaximizeRequested;
+        winrt::TerminalApp::AppLogic::TitleChanged_revoker TitleChanged;
+        winrt::TerminalApp::AppLogic::LastTabClosed_revoker LastTabClosed;
+        winrt::TerminalApp::AppLogic::SetTaskbarProgress_revoker SetTaskbarProgress;
+        winrt::TerminalApp::AppLogic::IdentifyWindowsRequested_revoker IdentifyWindowsRequested;
+        winrt::TerminalApp::AppLogic::RenameWindowRequested_revoker RenameWindowRequested;
+        winrt::TerminalApp::AppLogic::SettingsChanged_revoker SettingsChanged;
+        winrt::TerminalApp::AppLogic::IsQuakeWindowChanged_revoker IsQuakeWindowChanged;
+        winrt::TerminalApp::AppLogic::SummonWindowRequested_revoker SummonWindowRequested;
+        winrt::TerminalApp::AppLogic::OpenSystemMenu_revoker OpenSystemMenu;
+        winrt::TerminalApp::AppLogic::QuitRequested_revoker QuitRequested;
+        winrt::Microsoft::Terminal::Remoting::WindowManager::ShowNotificationIconRequested_revoker ShowNotificationIconRequested;
+        winrt::Microsoft::Terminal::Remoting::WindowManager::HideNotificationIconRequested_revoker HideNotificationIconRequested;
+        winrt::Microsoft::Terminal::Remoting::WindowManager::QuitAllRequested_revoker QuitAllRequested;
+    } _revokers{};
 };

--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -106,14 +106,18 @@ private:
 
     void _RequestQuitAll(const winrt::Windows::Foundation::IInspectable& sender,
                          const winrt::Windows::Foundation::IInspectable& args);
+    void _CloseRequested(const winrt::Windows::Foundation::IInspectable& sender,
+                         const winrt::Windows::Foundation::IInspectable& args);
 
     void _QuitAllRequested(const winrt::Windows::Foundation::IInspectable& sender,
                            const winrt::Microsoft::Terminal::Remoting::QuitAllRequestedArgs& args);
 
     void _CreateNotificationIcon();
     void _DestroyNotificationIcon();
-    void _ShowNotificationIconRequested();
-    void _HideNotificationIconRequested();
+    void _ShowNotificationIconRequested(const winrt::Windows::Foundation::IInspectable& sender,
+                                        const winrt::Windows::Foundation::IInspectable& args);
+    void _HideNotificationIconRequested(const winrt::Windows::Foundation::IInspectable& sender,
+                                        const winrt::Windows::Foundation::IInspectable& args);
     std::unique_ptr<NotificationIcon> _notificationIcon;
     winrt::event_token _ReAddNotificationIconToken;
     winrt::event_token _NotificationIconPressedToken;
@@ -122,4 +126,37 @@ private:
     winrt::event_token _GetWindowLayoutRequestedToken;
     winrt::event_token _WindowCreatedToken;
     winrt::event_token _WindowClosedToken;
+
+    // winrt::event_revoker _MouseScrolledRevoker;
+    // winrt::event_revoker _WindowActivatedRevoker;
+    // winrt::event_revoker _WindowMovedRevoker;
+    // winrt::event_revoker _HotkeyPressedRevoker;
+    // winrt::event_revoker _SetAlwaysOnTopRevoker;
+    // winrt::event_revoker _ShouldExitFullscreenRevoker;
+    winrt::Microsoft::Terminal::Remoting::WindowManager::BecameMonarch_revoker _BecameMonarchRevoker;
+    winrt::Microsoft::Terminal::Remoting::Peasant::ExecuteCommandlineRequested_revoker _peasantExecuteCommandlineRequestedRevoker;
+    winrt::Microsoft::Terminal::Remoting::Peasant::SummonRequested_revoker _peasantSummonRequestedRevoker;
+    winrt::Microsoft::Terminal::Remoting::Peasant::DisplayWindowIdRequested_revoker _peasantDisplayWindowIdRequestedRevoker;
+    winrt::Microsoft::Terminal::Remoting::Peasant::QuitRequested_revoker _peasantQuitRequestedRevoker;
+    winrt::TerminalApp::AppLogic::CloseRequested_revoker _CloseRequestedRevoker;
+    winrt::TerminalApp::AppLogic::RequestedThemeChanged_revoker _RequestedThemeChangedRevoker;
+    winrt::TerminalApp::AppLogic::FullscreenChanged_revoker _FullscreenChangedRevoker;
+    winrt::TerminalApp::AppLogic::FocusModeChanged_revoker _FocusModeChangedRevoker;
+    winrt::TerminalApp::AppLogic::AlwaysOnTopChanged_revoker _AlwaysOnTopChangedRevoker;
+    winrt::TerminalApp::AppLogic::RaiseVisualBell_revoker _RaiseVisualBellRevoker;
+    winrt::TerminalApp::AppLogic::SystemMenuChangeRequested_revoker _SystemMenuChangeRequestedRevoker;
+    winrt::TerminalApp::AppLogic::ChangeMaximizeRequested_revoker _ChangeMaximizeRequestedRevoker;
+    winrt::TerminalApp::AppLogic::TitleChanged_revoker _TitleChangedRevoker;
+    winrt::TerminalApp::AppLogic::LastTabClosed_revoker _LastTabClosedRevoker;
+    winrt::TerminalApp::AppLogic::SetTaskbarProgress_revoker _SetTaskbarProgressRevoker;
+    winrt::TerminalApp::AppLogic::IdentifyWindowsRequested_revoker _IdentifyWindowsRequestedRevoker;
+    winrt::TerminalApp::AppLogic::RenameWindowRequested_revoker _RenameWindowRequestedRevoker;
+    winrt::TerminalApp::AppLogic::SettingsChanged_revoker _SettingsChangedRevoker;
+    winrt::TerminalApp::AppLogic::IsQuakeWindowChanged_revoker _IsQuakeWindowChangedRevoker;
+    winrt::TerminalApp::AppLogic::SummonWindowRequested_revoker _SummonWindowRequestedRevoker;
+    winrt::TerminalApp::AppLogic::OpenSystemMenu_revoker _OpenSystemMenuRevoker;
+    winrt::TerminalApp::AppLogic::QuitRequested_revoker _QuitRequestedRevoker;
+    winrt::Microsoft::Terminal::Remoting::WindowManager::ShowNotificationIconRequested_revoker _ShowNotificationIconRequestedRevoker;
+    winrt::Microsoft::Terminal::Remoting::WindowManager::HideNotificationIconRequested_revoker _HideNotificationIconRequestedRevoker;
+    winrt::Microsoft::Terminal::Remoting::WindowManager::QuitAllRequested_revoker _QuitAllRequestedRevoker;
 };

--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -127,12 +127,7 @@ private:
     winrt::event_token _WindowCreatedToken;
     winrt::event_token _WindowClosedToken;
 
-    // winrt::event_revoker _MouseScrolledRevoker;
-    // winrt::event_revoker _WindowActivatedRevoker;
-    // winrt::event_revoker _WindowMovedRevoker;
-    // winrt::event_revoker _HotkeyPressedRevoker;
-    // winrt::event_revoker _SetAlwaysOnTopRevoker;
-    // winrt::event_revoker _ShouldExitFullscreenRevoker;
+    // Event handlers to revoke in ~AppHost, before calling App.Close
     winrt::Microsoft::Terminal::Remoting::WindowManager::BecameMonarch_revoker _BecameMonarchRevoker;
     winrt::Microsoft::Terminal::Remoting::Peasant::ExecuteCommandlineRequested_revoker _peasantExecuteCommandlineRequestedRevoker;
     winrt::Microsoft::Terminal::Remoting::Peasant::SummonRequested_revoker _peasantSummonRequestedRevoker;


### PR DESCRIPTION
From MSFT:36797001. Okay so this is only .22% of our crashes, but every little bit helps, right?


Turns out this is also hitting in:
* MSFT:35726322
* MSFT:34662459

and together they're a fairly hot bug. 

There's a large class of bugs where we might get a callback to one of our event handlers when we call `app.Close()` in the `AppHost` dtor. This PR adds manual revokers to these events, and makes sure to revoke them BEFORE nulling out the `_window`. That will prevent callbacks during the rest of the dtor, when the `_window` is null. 