### PR TITLE
Fix RTF generation for Unicode characters

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -2142,13 +2142,13 @@ void TextBuffer::_AppendRTFText(std::ostringstream& contentBuilder, const std::w
         {
             switch (codeUnit)
             {
-            case '\\':
-            case '{':
-            case '}':
-                contentBuilder << "\\" << static_cast<char>(codeUnit);
+            case L'\\':
+            case L'{':
+            case L'}':
+                contentBuilder << "\\" << gsl::narrow<char>(codeUnit);
                 break;
             default:
-                contentBuilder << static_cast<char>(codeUnit);
+                contentBuilder << gsl::narrow<char>(codeUnit);
             }
         }
         else if (codeUnit <= 32767)

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -2157,7 +2157,8 @@ void TextBuffer::_AppendRTFText(std::ostringstream& contentBuilder, const std::w
         }
         else
         {
-            contentBuilder << "\\u" << std::to_string(codeUnit - 65536) << "?";
+            // Windows uses unsigned wchar_t - RTF uses signed ones.
+            contentBuilder << "\\u" << std::to_string(til::bit_cast<int16_t>(codeUnit)) << "?";
         }
     }
 }

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -2151,10 +2151,6 @@ void TextBuffer::_AppendRTFText(std::ostringstream& contentBuilder, const std::w
                 contentBuilder << gsl::narrow<char>(codeUnit);
             }
         }
-        else if (codeUnit <= 32767)
-        {
-            contentBuilder << "\\u" << std::to_string(codeUnit) << "?";
-        }
         else
         {
             // Windows uses unsigned wchar_t - RTF uses signed ones.

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -247,6 +247,8 @@ private:
 
     void _PruneHyperlinks();
 
+    static void _AppendRTFText(std::ostringstream& contentBuilder, const std::wstring_view& text);
+
     std::unordered_map<size_t, std::wstring> _idsAndPatterns;
     size_t _currentPatternId;
 


### PR DESCRIPTION
## Summary of the Pull Request
Fixes RTF generation for text with Unicode characters.

## PR Checklist
* [x] Closes #12379
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed
Added some unit tests.

Ran the following in PowerShell and copied the emitted text into WordPad.
```pwsh
echo "This is some Ascii \ {}`nLow code units: á é í ó ú `u{2b81} `u{2b82}`nHigh code units: `u{a7b5} `u{a7b7}`nSurrogates: `u{1f366} `u{1f47e} `u{1f440}"
```