### PR TITLE
Fix fail-fast due to unlocked FreeProcessData call

### DIFF
--- a/src/server/IoDispatchers.cpp
+++ b/src/server/IoDispatchers.cpp
@@ -288,8 +288,6 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleHandleConnectionRequest(_In_ PCONSOLE_API
     LockConsole();
 
     const auto cleanup = wil::scope_exit([&]() noexcept {
-        UnlockConsole();
-
         if (!NT_SUCCESS(Status))
         {
             pReceiveMsg->SetReplyStatus(Status);
@@ -299,6 +297,9 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleHandleConnectionRequest(_In_ PCONSOLE_API
                 gci.ProcessHandleList.FreeProcessData(ProcessData);
             }
         }
+
+        // FreeProcessData() above requires the console to be locked.
+        UnlockConsole();
     });
 
     DWORD const dwProcessId = (DWORD)pReceiveMsg->Descriptor.Process;


### PR DESCRIPTION
2b202ce6 introduced a bug, where FreeProcessData was called without the console
lock being held. The previous code can be found in 40e3dea, on line 441-454.

## PR Checklist
* [x] Closes MSFT:21372705
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed
None, as this fix is purely theoretic, but it matches the stack trace
and 40e3dea clearly wasn't correctly ported to strict C++ either.