### PR TITLE
Round our Maximize button to match ControlsV2 styles

### DIFF
--- a/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
+++ b/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
@@ -247,9 +247,10 @@
             Click="_MaximizeClick"
             Style="{StaticResource CaptionButton}">
         <Button.Resources>
+            <!--  These paths are complicated, but taken directly from WinUI's WindowCaptionButton paths.  -->
             <ResourceDictionary>
-                <x:String x:Key="CaptionButtonPath">M 0 0 H 10 V 10 H 0 V 0</x:String>
-                <x:String x:Key="CaptionButtonPathWindowMaximized">M 0 2 h 8 v 8 h -8 v -8 M 2 2 v -2 h 8 v 8 h -2</x:String>
+                <x:String x:Key="CaptionButtonPath">M 1.516 -0.001 L 7.451 0.009 C 8.751 0.019 9 1 8.981 1.477 L 9.002 7.558 M 9.002 7.547 C 8.929 8.669 8 9 7.43 9.015 L 1.464 9.005 C 0.374 8.973 0 8 -0.004 7.484 L -0.004 1.477 C 0 1 0.415 0.009 1.527 -0.001</x:String>
+                <x:String x:Key="CaptionButtonPathWindowMaximized">M 1.516 -0.001 L 7.451 0.009 C 8.751 0.019 9 1 8.981 1.477 L 9.002 7.558 M 11 6 L 11 2 C 11 0 10 -2 8.011 -1.946 L 7.06 -1.969 L 3 -2 M 9.002 7.547 C 8.929 8.669 8 9 7.43 9.015 L 1.464 9.005 C 0.374 8.973 0 8 -0.004 7.484 L -0.004 1.477 C 0 1 0.415 0.009 1.527 -0.001</x:String>
             </ResourceDictionary>
         </Button.Resources>
         <ToolTipService.ToolTip>


### PR DESCRIPTION
Just look at the screenshot. Above is before, below is now.
![image](https://user-images.githubusercontent.com/18356694/157717931-f3e3167e-0234-425a-a8eb-02303f386dc6.png)

These paths were taken straight from WinUI versions of these icons, thanks @pratikone for the alley oop.

* [x] Closes #12433
* [x] Tested manually by _lookin at it_
