### PR TITLE
Fix a pair of crashes, likely related to defterm

### DIFF
--- a/.github/actions/spelling/allow/apis.txt
+++ b/.github/actions/spelling/allow/apis.txt
@@ -72,6 +72,7 @@ IFACEMETHOD
 IFile
 IInheritable
 IMap
+IMonarch
 IObject
 iosfwd
 IPackage

--- a/src/cascadia/Remoting/Monarch.cpp
+++ b/src/cascadia/Remoting/Monarch.cpp
@@ -353,6 +353,14 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
     // - <none>
     void Monarch::HandleActivatePeasant(const Remoting::WindowActivatedArgs& args)
     {
+        if (args == nullptr)
+        {
+            // MSFT:35731327, GH #12624. There's a chance that the way the
+            // window gets set up for defterm, the ActivatedArgs haven't been
+            // created for this window yet. Check here and just ignore them if
+            // they're null. They'll come back with real args soon
+            return;
+        }
         // Start by making a local copy of these args. It's easier for us if our
         // tracking of these args is all in-proc. That way, the only thing that
         // could fail due to the peasant dying is _this first copy_.
@@ -418,6 +426,9 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
     // - <none>
     void Monarch::_doHandleActivatePeasant(const winrt::com_ptr<implementation::WindowActivatedArgs>& localArgs)
     {
+        // We're sure that localArgs isn't null here, we checked before in our
+        // one caller (in Monarch::HandleActivatePeasant)
+
         const auto newLastActiveTime = localArgs->ActivatedTime().time_since_epoch().count();
 
         // * Check all the current lists to look for this peasant.

--- a/src/cascadia/Remoting/Monarch.idl
+++ b/src/cascadia/Remoting/Monarch.idl
@@ -44,8 +44,8 @@ namespace Microsoft.Terminal.Remoting
         String TabTitle;
     };
 
-    [default_interface] runtimeclass Monarch {
-        Monarch();
+    interface IMonarch
+    {
 
         UInt64 GetPID();
         UInt64 AddPeasant(IPeasant peasant);
@@ -66,5 +66,10 @@ namespace Microsoft.Terminal.Remoting
         event Windows.Foundation.TypedEventHandler<Object, Object> WindowCreated;
         event Windows.Foundation.TypedEventHandler<Object, Object> WindowClosed;
         event Windows.Foundation.TypedEventHandler<Object, QuitAllRequestedArgs> QuitAllRequested;
+    };
+
+    [default_interface] runtimeclass Monarch : IMonarch
+    {
+        Monarch();
     };
 }

--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -77,6 +77,140 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         }
     }
 
+    void WindowManager::_proposeToMonarch(const Remoting::CommandlineArgs& args,
+                                          std::optional<uint64_t>& givenID,
+                                          winrt::hstring& givenName)
+    {
+        // these two errors are Win32 errors, convert them to HRESULTS so we can actually compare below.
+        static constexpr HRESULT RPC_SERVER_UNAVAILABLE_HR = HRESULT_FROM_WIN32(RPC_S_SERVER_UNAVAILABLE);
+        static constexpr HRESULT RPC_CALL_FAILED_HR = HRESULT_FROM_WIN32(RPC_S_CALL_FAILED);
+
+        // The monarch may respond back "you should be a new
+        // window, with ID,name of (id, name)". Really the responses are:
+        // * You should not create a new window
+        // * Create a new window (but without a given ID or name). The
+        //   Monarch will assign your ID/name later
+        // * Create a new window, and you'll have this ID or name
+        //   - This is the case where the user provides `wt -w 1`, and
+        //     there's no existing window 1
+
+        // You can emulate the monarh dying by: starting a terminal, sticking a
+        // breakpoint in
+        // TerminalApp!winrt::TerminalApp::implementation::AppLogic::_doFindTargetWindow,
+        // starting a defterm, and when that BP gets hit, kill the original
+        // monarch, and see what happens here.
+
+        bool proposedCommandline = false;
+        Remoting::ProposeCommandlineResult result{ nullptr };
+        while (!proposedCommandline)
+        {
+            try
+            {
+                result = _monarch.ProposeCommandline(args);
+                proposedCommandline = true;
+            }
+            catch (const winrt::hresult_error& e)
+            {
+                // We did not successfully ask the king what to do. They
+                // hopefully just died here. That's okay, let's just go ask the
+                // next in the line of succession. At the very worst, we'll find
+                // _us_, (likely last in the line).
+                //
+                // If the king returned some _other_ error here, than lets
+                // bubble that up because that's a real issue.
+                //
+                // I'm checking both these here. I had previously got
+                // RPC_S_CALL_FAILED about here, but I'm not sure that's
+                // actually possible. TODO!
+                if (e.code() == RPC_SERVER_UNAVAILABLE_HR || e.code() == RPC_CALL_FAILED_HR)
+                {
+                    TraceLoggingWrite(g_hRemotingProvider,
+                                      "WindowManager_proposeToMonarch_kingDied",
+                                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+
+                    // We failed to ask the monarch. It must have died. Try and
+                    // find the real monarch. Don't perform an election, that
+                    // assumes we have a peasant, which we don't yet.
+                    _createMonarchAndCallbacks();
+                    // _createMonarchAndCallbacks will initialize _isKing
+                    if (_isKing)
+                    {
+                        // We became the king. We don't need to ProposeCommandline to ourself, we're just
+                        // going to do it.
+                        //
+                        // Return early, because there's nothing else for us to do here.
+                        TraceLoggingWrite(g_hRemotingProvider,
+                                          "WindowManager_proposeToMonarch_becameKing",
+                                          TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                        return;
+                    }
+
+                    // Here, we created the new monarch, it wasn't us, so we're
+                    // gonna go through the while loop again and ask the new
+                    // king.
+                    TraceLoggingWrite(g_hRemotingProvider,
+                                      "WindowManager_proposeToMonarch_tryAgain",
+                                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                }
+                else
+                {
+                    TraceLoggingWrite(g_hRemotingProvider,
+                                      "WindowManager_proposeToMonarch_unexpectedResultFromKing",
+                                      TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                    LOG_CAUGHT_EXCEPTION();
+                    throw;
+                }
+            }
+            catch (...)
+            {
+                // If the monarch (maybe us) failed for _any other reason_ than
+                // them dying. This IS quite unexpected. We don't catch
+                TraceLoggingWrite(g_hRemotingProvider,
+                                  "WindowManager_proposeToMonarch_unexpectedExceptionFromKing",
+                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+
+                LOG_CAUGHT_EXCEPTION();
+                throw;
+            }
+        }
+
+        // Here, the monarch (not us) has replied to the message. Get the
+        // valuables out of the response:
+        _shouldCreateWindow = result.ShouldCreateWindow();
+        if (result.Id())
+        {
+            givenID = result.Id().Value();
+        }
+        givenName = result.WindowName();
+
+        // TraceLogging doesn't have a good solution for logging an
+        // optional. So we have to repeat the calls here:
+        if (givenID)
+        {
+            TraceLoggingWrite(g_hRemotingProvider,
+                              "WindowManager_ProposeCommandline",
+                              TraceLoggingBoolean(_shouldCreateWindow, "CreateWindow", "true iff we should create a new window"),
+                              TraceLoggingUInt64(givenID.value(), "Id", "The ID we should assign our peasant"),
+                              TraceLoggingWideString(givenName.c_str(), "Name", "The name we should assign this window"),
+                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+        }
+        else
+        {
+            TraceLoggingWrite(g_hRemotingProvider,
+                              "WindowManager_ProposeCommandline",
+                              TraceLoggingBoolean(_shouldCreateWindow, "CreateWindow", "true iff we should create a new window"),
+                              TraceLoggingPointer(nullptr, "Id", "No ID provided"),
+                              TraceLoggingWideString(givenName.c_str(), "Name", "The name we should assign this window"),
+                              TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+        }
+    }
     void WindowManager::ProposeCommandline(const Remoting::CommandlineArgs& args)
     {
         // If we're the king, we _definitely_ want to process the arguments, we were
@@ -88,55 +222,11 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         winrt::hstring givenName{};
         if (!_isKing)
         {
-            // The monarch may respond back "you should be a new
-            // window, with ID,name of (id, name)". Really the responses are:
-            // * You should not create a new window
-            // * Create a new window (but without a given ID or name). The
-            //   Monarch will assign your ID/name later
-            // * Create a new window, and you'll have this ID or name
-            //   - This is the case where the user provides `wt -w 1`, and
-            //     there's no existing window 1
-
-            // TODO! If the monarch dies or otherwise fails, what do we do here?
-            //
-            // I suppose we could emulate this by sticking a breakpoint in
-            // TerminalApp!winrt::TerminalApp::implementation::AppLogic::_doFindTargetWindow,
-            // starting a terminal, starting a defterm, and when that BP gets
-            // hit, kill the original one and see what happens here.
-            const auto result = _monarch.ProposeCommandline(args);
-            // Damn, killing the monarch exactly here still gets us -2147023170,
-            // RPC_S_CALL_FAILED, which is exactly what you'd expect
-
-            _shouldCreateWindow = result.ShouldCreateWindow();
-            if (result.Id())
-            {
-                givenID = result.Id().Value();
-            }
-            givenName = result.WindowName();
-            // TraceLogging doesn't have a good solution for logging an
-            // optional. So we have to repeat the calls here:
-            if (givenID)
-            {
-                TraceLoggingWrite(g_hRemotingProvider,
-                                  "WindowManager_ProposeCommandline",
-                                  TraceLoggingBoolean(_shouldCreateWindow, "CreateWindow", "true iff we should create a new window"),
-                                  TraceLoggingUInt64(givenID.value(), "Id", "The ID we should assign our peasant"),
-                                  TraceLoggingWideString(givenName.c_str(), "Name", "The name we should assign this window"),
-                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE));
-            }
-            else
-            {
-                TraceLoggingWrite(g_hRemotingProvider,
-                                  "WindowManager_ProposeCommandline",
-                                  TraceLoggingBoolean(_shouldCreateWindow, "CreateWindow", "true iff we should create a new window"),
-                                  TraceLoggingPointer(nullptr, "Id", "No ID provided"),
-                                  TraceLoggingWideString(givenName.c_str(), "Name", "The name we should assign this window"),
-                                  TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE));
-            }
+            _proposeToMonarch(args, givenID, givenName);
         }
-        else
+
+        // During _proposeToMonarch, it's possible that we found that the king was dead, and we're the new king. Cool! Do this now.
+        if (_isKing)
         {
             // We're the monarch, we don't need to propose anything. We're just
             // going to do it.

--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -173,7 +173,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
             catch (...)
             {
                 // If the monarch (maybe us) failed for _any other reason_ than
-                // them dying. This IS quite unexpected. We don't catch
+                // them dying. This IS quite unexpected. Let this bubble out. 
                 TraceLoggingWrite(g_hRemotingProvider,
                                   "WindowManager_proposeToMonarch_unexpectedExceptionFromKing",
                                   TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),

--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -94,7 +94,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         //   - This is the case where the user provides `wt -w 1`, and
         //     there's no existing window 1
 
-        // You can emulate the monarh dying by: starting a terminal, sticking a
+        // You can emulate the monarch dying by: starting a terminal, sticking a
         // breakpoint in
         // TerminalApp!winrt::TerminalApp::implementation::AppLogic::_doFindTargetWindow,
         // starting a defterm, and when that BP gets hit, kill the original
@@ -119,9 +119,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                 // If the king returned some _other_ error here, than lets
                 // bubble that up because that's a real issue.
                 //
-                // I'm checking both these here. I had previously got
-                // RPC_S_CALL_FAILED about here, but I'm not sure that's
-                // actually possible. TODO!
+                // I'm checking both these here. I had previously got a
+                // RPC_S_CALL_FAILED about here once.
                 if (e.code() == RPC_SERVER_UNAVAILABLE_HR || e.code() == RPC_CALL_FAILED_HR)
                 {
                     TraceLoggingWrite(g_hRemotingProvider,

--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -173,7 +173,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
             catch (...)
             {
                 // If the monarch (maybe us) failed for _any other reason_ than
-                // them dying. This IS quite unexpected. Let this bubble out. 
+                // them dying. This IS quite unexpected. Let this bubble out.
                 TraceLoggingWrite(g_hRemotingProvider,
                                   "WindowManager_proposeToMonarch_unexpectedExceptionFromKing",
                                   TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),

--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -144,6 +144,12 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                                           "WindowManager_proposeToMonarch_becameKing",
                                           TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                                           TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+
+                        // In WindowManager::ProposeCommandline, had we been the
+                        // king originally, we would have started by setting
+                        // this to true. We became the monarch here, so set it
+                        // here as well.
+                        _shouldCreateWindow = true;
                         return;
                     }
 

--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -97,7 +97,16 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
             //   - This is the case where the user provides `wt -w 1`, and
             //     there's no existing window 1
 
+            // TODO! If the monarch dies or otherwise fails, what do we do here?
+            //
+            // I suppose we could emulate this by sticking a breakpoint in
+            // TerminalApp!winrt::TerminalApp::implementation::AppLogic::_doFindTargetWindow,
+            // starting a terminal, starting a defterm, and when that BP gets
+            // hit, kill the original one and see what happens here.
             const auto result = _monarch.ProposeCommandline(args);
+            // Damn, killing the monarch exactly here still gets us -2147023170,
+            // RPC_S_CALL_FAILED, which is exactly what you'd expect
+
             _shouldCreateWindow = result.ShouldCreateWindow();
             if (result.Id())
             {
@@ -195,6 +204,10 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                 _createPeasantThread();
             }
 
+            // This right here will just tell us to stash the args away for the
+            // future. The AppHost hasnt yet set up the callbacks, and the rest
+            // of the app hasn't started at all. We'll note them and come back
+            // later.
             _peasant.ExecuteCommandline(args);
         }
         // Otherwise, we'll do _nothing_.

--- a/src/cascadia/Remoting/WindowManager.h
+++ b/src/cascadia/Remoting/WindowManager.h
@@ -82,6 +82,10 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         void _waitOnMonarchThread();
         void _raiseFindTargetWindowRequested(const winrt::Windows::Foundation::IInspectable& sender,
                                              const winrt::Microsoft::Terminal::Remoting::FindTargetWindowArgs& args);
+
+        void _proposeToMonarch(const Remoting::CommandlineArgs& args,
+                               std::optional<uint64_t>& givenID,
+                               winrt::hstring& givenName);
     };
 }
 

--- a/src/cascadia/UnitTests_Remoting/RemotingTests.cpp
+++ b/src/cascadia/UnitTests_Remoting/RemotingTests.cpp
@@ -46,6 +46,11 @@ namespace RemotingUnitTests
         std::function<HRESULT(HWND, BOOL*)> pfnIsWindowOnCurrentVirtualDesktop;
     };
 
+#define DIE                                                                \
+    {                                                                      \
+        throw winrt::hresult_error(winrt::hresult{ (int32_t)0x800706ba }); \
+    };
+
     // This is a silly helper struct.
     // It will always throw an hresult_error of "RPC server is unavailable" on any of its methods.
     // The monarch uses this particular error code to check for a dead peasant vs another exception.
@@ -57,28 +62,29 @@ namespace RemotingUnitTests
     // class can be used to replace a peasant inside a Monarch, to emulate that
     // peasant process dying. Any time the monarch tries to do something to this
     // peasant, it'll throw an exception.
+
     struct DeadPeasant : implements<DeadPeasant, winrt::Microsoft::Terminal::Remoting::IPeasant>
     {
         DeadPeasant() = default;
-        void AssignID(uint64_t /*id*/) { throw winrt::hresult_error(winrt::hresult{ (int32_t)0x800706ba }); };
-        uint64_t GetID() { throw winrt::hresult_error(winrt::hresult{ (int32_t)0x800706ba }); };
-        winrt::hstring WindowName() { throw winrt::hresult_error(winrt::hresult{ (int32_t)0x800706ba }); };
-        winrt::hstring ActiveTabTitle() { throw winrt::hresult_error(winrt::hresult{ (int32_t)0x800706ba }); };
-        void ActiveTabTitle(const winrt::hstring& /*value*/) { throw winrt::hresult_error(winrt::hresult{ (int32_t)0x800706ba }); };
-        uint64_t GetPID() { throw winrt::hresult_error(winrt::hresult{ (int32_t)0x800706ba }); };
-        bool ExecuteCommandline(const Remoting::CommandlineArgs& /*args*/) { throw winrt::hresult_error(winrt::hresult{ (int32_t)0x800706ba }); }
-        void ActivateWindow(const Remoting::WindowActivatedArgs& /*args*/) { throw winrt::hresult_error(winrt::hresult{ (int32_t)0x800706ba }); }
-        void RequestIdentifyWindows() { throw winrt::hresult_error(winrt::hresult{ (int32_t)0x800706ba }); };
-        void DisplayWindowId() { throw winrt::hresult_error(winrt::hresult{ (int32_t)0x800706ba }); };
-        Remoting::CommandlineArgs InitialArgs() { throw winrt::hresult_error(winrt::hresult{ (int32_t)0x800706ba }); }
-        Remoting::WindowActivatedArgs GetLastActivatedArgs() { throw winrt::hresult_error(winrt::hresult{ (int32_t)0x800706ba }); }
-        void RequestRename(const Remoting::RenameRequestArgs& /*args*/) { throw winrt::hresult_error(winrt::hresult{ (int32_t)0x800706ba }); }
-        void Summon(const Remoting::SummonWindowBehavior& /*args*/) { throw winrt::hresult_error(winrt::hresult{ (int32_t)0x800706ba }); };
-        void RequestShowNotificationIcon() { throw winrt::hresult_error(winrt::hresult{ (int32_t)0x800706ba }); };
-        void RequestHideNotificationIcon() { throw winrt::hresult_error(winrt::hresult{ (int32_t)0x800706ba }); };
-        winrt::hstring GetWindowLayout() { throw winrt::hresult_error(winrt::hresult{ (int32_t)0x800706ba }); };
-        void RequestQuitAll() { throw winrt::hresult_error(winrt::hresult{ (int32_t)0x800706ba }); };
-        void Quit() { throw winrt::hresult_error(winrt::hresult{ (int32_t)0x800706ba }); };
+        void AssignID(uint64_t /*id*/) DIE;
+        uint64_t GetID() DIE;
+        winrt::hstring WindowName() DIE;
+        winrt::hstring ActiveTabTitle() DIE;
+        void ActiveTabTitle(const winrt::hstring& /*value*/) DIE;
+        uint64_t GetPID() DIE;
+        bool ExecuteCommandline(const Remoting::CommandlineArgs& /*args*/) DIE;
+        void ActivateWindow(const Remoting::WindowActivatedArgs& /*args*/) DIE;
+        void RequestIdentifyWindows() DIE;
+        void DisplayWindowId() DIE;
+        Remoting::CommandlineArgs InitialArgs() DIE;
+        Remoting::WindowActivatedArgs GetLastActivatedArgs() DIE;
+        void RequestRename(const Remoting::RenameRequestArgs& /*args*/) DIE;
+        void Summon(const Remoting::SummonWindowBehavior& /*args*/) DIE;
+        void RequestShowNotificationIcon() DIE;
+        void RequestHideNotificationIcon() DIE;
+        winrt::hstring GetWindowLayout() DIE;
+        void RequestQuitAll() DIE;
+        void Quit() DIE;
         TYPED_EVENT(WindowActivated, winrt::Windows::Foundation::IInspectable, Remoting::WindowActivatedArgs);
         TYPED_EVENT(ExecuteCommandlineRequested, winrt::Windows::Foundation::IInspectable, Remoting::CommandlineArgs);
         TYPED_EVENT(IdentifyWindowsRequested, winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable);
@@ -90,6 +96,31 @@ namespace RemotingUnitTests
         TYPED_EVENT(QuitAllRequested, winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable);
         TYPED_EVENT(QuitRequested, winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable);
         TYPED_EVENT(GetWindowLayoutRequested, winrt::Windows::Foundation::IInspectable, Remoting::GetWindowLayoutArgs);
+    };
+
+    // Same idea.
+    struct DeadMonarch : implements<DeadMonarch, winrt::Microsoft::Terminal::Remoting::IMonarch>
+    {
+        DeadMonarch() = default;
+        uint64_t GetPID() DIE;
+        uint64_t AddPeasant(Remoting::IPeasant /*peasant*/) DIE;
+        uint64_t GetNumberOfPeasants() DIE;
+        Remoting::ProposeCommandlineResult ProposeCommandline(Remoting::CommandlineArgs /*args*/) DIE;
+        void HandleActivatePeasant(Remoting::WindowActivatedArgs /*args*/) DIE;
+        void SummonWindow(Remoting::SummonWindowSelectionArgs /*args*/) DIE;
+        void SignalClose(uint64_t /*peasantId*/) DIE;
+
+        void SummonAllWindows() DIE;
+        bool DoesQuakeWindowExist() DIE;
+        winrt::Windows::Foundation::Collections::IVectorView<Remoting::PeasantInfo> GetPeasantInfos() DIE;
+        winrt::Windows::Foundation::Collections::IVector<winrt::hstring> GetAllWindowLayouts() DIE;
+
+        TYPED_EVENT(FindTargetWindowRequested, winrt::Windows::Foundation::IInspectable, Remoting::FindTargetWindowArgs);
+        TYPED_EVENT(ShowNotificationIconRequested, winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable);
+        TYPED_EVENT(HideNotificationIconRequested, winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable);
+        TYPED_EVENT(WindowCreated, winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable);
+        TYPED_EVENT(WindowClosed, winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable);
+        TYPED_EVENT(QuitAllRequested, winrt::Windows::Foundation::IInspectable, Remoting::QuitAllRequestedArgs);
     };
 
     class RemotingTests
@@ -144,6 +175,8 @@ namespace RemotingUnitTests
         TEST_METHOD(TestSummonMostRecentIsQuake);
 
         TEST_METHOD(TestSummonAfterWindowClose);
+
+        TEST_METHOD(TestWhatHappens);
 
         TEST_CLASS_SETUP(ClassSetup)
         {
@@ -2520,6 +2553,38 @@ namespace RemotingUnitTests
         args.OnCurrentDesktop(true);
         m0->SummonWindow(args);
         VERIFY_IS_TRUE(args.FoundMatch());
+    }
+
+    void RemotingTests::TestWhatHappens()
+    {
+        Log::Comment(L"TODO!");
+
+        const winrt::guid guid1{ Utils::GuidFromString(L"{11111111-1111-1111-1111-111111111111}") };
+        const winrt::guid guid2{ Utils::GuidFromString(L"{22222222-2222-2222-2222-222222222222}") };
+
+        constexpr auto monarch0PID = 12345u;
+        // constexpr auto peasant1PID = 23456u;
+
+        auto m0 = make_private<Remoting::implementation::Monarch>(monarch0PID);
+        // auto p1 = make_private<Remoting::implementation::Peasant>(peasant1PID);
+        // p1->WindowName(L"one");
+        // VERIFY_ARE_EQUAL(0, p1->GetID());
+
+        {
+            Remoting::CommandlineArgs args{ { L"wt.exe" }, { L"-Embedding" } };
+            const auto result = m0->ProposeCommandline(args);
+            auto shouldCreateWindow = result.ShouldCreateWindow();
+            VERIFY_IS_TRUE(shouldCreateWindow);
+        }
+
+        auto m1 = make_self<DeadMonarch>();
+        {
+            Remoting::CommandlineArgs args{ { L"wt.exe" }, { L"-Embedding" } };
+            DebugBreak();
+            const auto result = m1->ProposeCommandline(args);
+            auto shouldCreateWindow = result.ShouldCreateWindow();
+            VERIFY_IS_TRUE(shouldCreateWindow);
+        }
     }
 
 }


### PR DESCRIPTION
This fixes a pair of inbox bugs, hopefully.

* MSFT:35731327
  * There's a small window where a peasant is being created when a monarch is exiting. When that happens, the new peasant will try to tell itself (the new monarch) when the peasant was last activated, but because the window hasn't actually finished instantiating, the peasant doesn't yet have a LastActivatedArgs to tell the monarch about.
* MSFT:32518679 (ARM version) / MSFT:32279047 (AMD64 version)
  * This one's tricky. Not totally sure this is the fix, bug assuming my hypothesis is correct, this should fix it. Regardless, this does fix a bug that was in the code.
  * If the king dies right as another window is starting, right while the new window is starting to ProposeCommandline to the monarch, the monarch could die. If it does, the new window just explodes too. Not what you want. 


Vaguely tested the second bug manually, by setting breakpoints in the monarch, starting a defterm, then exiting the monarch while the handoff was in process. That now creates a new window, so that's at least something. `RemotingTests::TestProposeCommandlineWithDeadMonarch` was the closest I could get to testing that. 

The first bug only got an eye check. Not sure how to repro, but I figured yeet and hopefully we get it. 

* [x] Closes #12624