### PR TITLE
AtlasEngine: Fix ConstBuffer invalidation for background color changes

### DIFF
--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -566,7 +566,9 @@ CATCH_RETURN()
 [[nodiscard]] HRESULT AtlasEngine::UpdateDrawingBrushes(const TextAttribute& textAttributes, const RenderSettings& renderSettings, const gsl::not_null<IRenderData*> /*pData*/, const bool usingSoftFont, const bool isSettingDefaultBrushes) noexcept
 try
 {
-    const auto [fg, bg] = renderSettings.GetAttributeColorsWithAlpha(textAttributes);
+    auto [fg, bg] = renderSettings.GetAttributeColorsWithAlpha(textAttributes);
+    fg |= 0xff000000;
+    bg |= _api.backgroundOpaqueMixin;
 
     if (!isSettingDefaultBrushes)
     {
@@ -588,7 +590,7 @@ try
             WI_ClearAllFlags(flags, CellFlags::UnderlineDotted | CellFlags::UnderlineDouble);
         }
 
-        const u32x2 newColors{ gsl::narrow_cast<u32>(fg | 0xff000000), gsl::narrow_cast<u32>(bg | _api.backgroundOpaqueMixin) };
+        const u32x2 newColors{ gsl::narrow_cast<u32>(fg), gsl::narrow_cast<u32>(bg) };
         const AtlasKeyAttributes attributes{ 0, textAttributes.IsIntense(), textAttributes.IsItalic(), 0 };
 
         if (_api.attributes != attributes)
@@ -602,7 +604,7 @@ try
     }
     else if (textAttributes.BackgroundIsDefault() && bg != _r.backgroundColor)
     {
-        _r.backgroundColor = bg | _api.backgroundOpaqueMixin;
+        _r.backgroundColor = bg;
         WI_SetFlag(_r.invalidations, RenderInvalidations::ConstBuffer);
     }
 


### PR DESCRIPTION
The `bg != _r.backgroundColor` invalidation check wasn't symmetric with
us setting `_r.backgroundColor` to `bg | _api.backgroundOpaqueMixin`.
Due to this, when the `backgroundOpaqueMixin` changed,
we didn't always update the const buffer appropriately.

## PR Checklist
* [x] Closes #11773
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed
* Enable window transparency (`backgroundOpaqueMixin == 0x00000000`)
* Maximize window (ensure we have gutters in the first place)
* Disable window transparency (`backgroundOpaqueMixin == 0xff000000`)
* Gutters are filled ✅