### PR TITLE
Fix overflow in Viewport::FromDimensions

### DIFF
--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -677,8 +677,7 @@ void Renderer::_PaintBufferOutput(_In_ IRenderEngine* const pEngine)
 
     for (const auto& dirtyRect : dirtyAreas)
     {
-        // Shortcut: don't bother redrawing if the width is 0.
-        if (dirtyRect.left == dirtyRect.right)
+        if (!dirtyRect)
         {
             continue;
         }

--- a/src/types/viewport.cpp
+++ b/src/types/viewport.cpp
@@ -46,7 +46,12 @@ Viewport Viewport::FromDimensions(const COORD origin,
                                   const short width,
                                   const short height) noexcept
 {
-    return Viewport::FromExclusive({ origin.X, origin.Y, origin.X + width, origin.Y + height });
+    return Viewport::FromInclusive({
+        origin.X,
+        origin.Y,
+        base::saturated_cast<short>(origin.X + width - 1),
+        base::saturated_cast<short>(origin.Y + height - 1),
+    });
 }
 
 // Function Description:
@@ -60,7 +65,12 @@ Viewport Viewport::FromDimensions(const COORD origin,
 Viewport Viewport::FromDimensions(const COORD origin,
                                   const COORD dimensions) noexcept
 {
-    return Viewport::FromExclusive({ origin.X, origin.Y, origin.X + dimensions.X, origin.Y + dimensions.Y });
+    return Viewport::FromInclusive({
+        origin.X,
+        origin.Y,
+        base::saturated_cast<short>(origin.X + dimensions.X - 1),
+        base::saturated_cast<short>(origin.Y + dimensions.Y - 1),
+    });
 }
 
 // Function Description:


### PR DESCRIPTION
This removes one source of potential integer overflows from the Viewport class.
Other parts were left untouched, as this entire class of overflow issues gets
 fixed all at once, as soon as we replace COORD with til::coord (etc.).

## PR Checklist
* [x] Closes #5271
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed
* Call `ScrollConsoleScreenBufferW` with out of bounds coordinates
* Doesn't crash ✅