### PR TITLE
Fix broken TestHostApp build

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/TestHostApp/TestHostApp.vcxproj
+++ b/src/cascadia/LocalTests_TerminalApp/TestHostApp/TestHostApp.vcxproj
@@ -51,7 +51,8 @@
 
   <ItemDefinitionGroup>
     <ClCompile>
-      <!-- Disable two-phase name lookup for C++/CLI & C++/CX code. -->
+      <!-- Disable C++20 and two-phase name lookup for C++/CLI & C++/CX code. -->
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalOptions>%(AdditionalOptions) /Zc:twoPhase-</AdditionalOptions>
       <DisableSpecificWarnings>4453;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(IntermediateOutputPath)</AdditionalIncludeDirectories>


### PR DESCRIPTION
This regressed recently in cfaa315.
Initially I tried to migrate TestHostApp to C++/WinRT, but due to the
unbearable compile times I've reverted it back to C++/CX (>20x difference).
Unfortunately I then forgot to fix the underlying issue before submitting a PR.

## PR Checklist
* [x] Closes #12673
* [x] I work here
* [x] Tests added/passed