### PR TITLE
Fix "Element not found" error during settings loading

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -2575,6 +2575,7 @@ uuidv
 UVWX
 UVWXY
 UWA
+UWAs
 uwp
 uxtheme
 vals


### PR DESCRIPTION
This commit fixes a stray exception during settings loading,
caused by a failure to obtain the app's extension catalog.

## PR Checklist
* [x] Closes #12305
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed
I'm unable to replicate the issue. ❌
However an error log was provided in #12305 with which
the function causing the exception could be determined.