### PR TITLE
Fix exception spam if UIA is running

### DIFF
--- a/src/renderer/uia/UiaRenderer.cpp
+++ b/src/renderer/uia/UiaRenderer.cpp
@@ -299,14 +299,9 @@ void UiaEngine::WaitUntilCanRender() noexcept
         // the output isn't cut off.
         static constexpr size_t sapiLimit{ 1000 };
         const std::wstring_view output{ _queuedOutput };
-        for (size_t offset = 0;; offset += sapiLimit)
+        for (size_t offset = 0; offset < output.size(); offset += sapiLimit)
         {
-            const auto croppedText{ output.substr(offset, sapiLimit) };
-            if (croppedText.empty())
-            {
-                break;
-            }
-            _dispatcher->NotifyNewOutput(croppedText);
+            _dispatcher->NotifyNewOutput(output.substr(offset, sapiLimit));
         }
     }
     CATCH_LOG();


### PR DESCRIPTION
`std::basic_string_view::substr` throws an exception if the first argument
(offset) is out of range. If UIA is running, this creates _a lot_ of exceptions
and associated log output. This trivial change takes care of that.