### PR TITLE
Make conhost history deduplication case-sensitive

### DIFF
--- a/src/host/history.cpp
+++ b/src/host/history.cpp
@@ -72,14 +72,9 @@ void CommandHistory::s_ResizeAll(const size_t commands)
     }
 }
 
-static bool CaseInsensitiveEquality(wchar_t a, wchar_t b)
-{
-    return ::towlower(a) == ::towlower(b);
-}
-
 bool CommandHistory::IsAppNameMatch(const std::wstring_view other) const
 {
-    return std::equal(_appName.cbegin(), _appName.cend(), other.cbegin(), other.cend(), CaseInsensitiveEquality);
+    return CompareStringOrdinal(_appName.data(), gsl::narrow<int>(_appName.size()), other.data(), gsl::narrow<int>(other.size()), TRUE) == CSTR_EQUAL;
 }
 
 // Routine Description:
@@ -534,11 +529,7 @@ std::wstring CommandHistory::Remove(const SHORT iDel)
             const auto& storedCommand = _commands.at(indexFound);
             if ((WI_IsFlagClear(options, MatchOptions::ExactMatch) && (givenCommand.size() <= storedCommand.size())) || (givenCommand.size() == storedCommand.size()))
             {
-                if (std::equal(storedCommand.begin(),
-                               storedCommand.begin() + givenCommand.size(),
-                               givenCommand.begin(),
-                               givenCommand.end(),
-                               CaseInsensitiveEquality))
+                if (til::starts_with(storedCommand, givenCommand))
                 {
                     return true;
                 }

--- a/src/host/ut_host/CommandLineTests.cpp
+++ b/src/host/ut_host/CommandLineTests.cpp
@@ -449,13 +449,14 @@ class CommandLineTests
 
         VERIFY_SUCCEEDED(m_pHistory->Add(L"I'm a little teapot", false));
         VERIFY_SUCCEEDED(m_pHistory->Add(L"short and stout", false));
-        VERIFY_SUCCEEDED(m_pHistory->Add(L"Inflammable", false));
+        VERIFY_SUCCEEDED(m_pHistory->Add(L"inflammable", false));
+        VERIFY_SUCCEEDED(m_pHistory->Add(L"Indestructible", false));
 
         SetPrompt(cookedReadData, L"I");
 
         auto& commandLine = CommandLine::Instance();
         commandLine._cycleMatchingCommandHistoryToPrompt(cookedReadData);
-        VerifyPromptText(cookedReadData, L"Inflammable");
+        VerifyPromptText(cookedReadData, L"Indestructible");
 
         // make sure we skip to the next "I" history item
         commandLine._cycleMatchingCommandHistoryToPrompt(cookedReadData);
@@ -463,7 +464,7 @@ class CommandLineTests
 
         // should cycle back to the start of the command history
         commandLine._cycleMatchingCommandHistoryToPrompt(cookedReadData);
-        VerifyPromptText(cookedReadData, L"Inflammable");
+        VerifyPromptText(cookedReadData, L"Indestructible");
     }
 
     TEST_METHOD(CmdlineCtrlHomeFullwidthChars)

--- a/src/host/ut_host/CommandLineTests.cpp
+++ b/src/host/ut_host/CommandLineTests.cpp
@@ -449,21 +449,21 @@ class CommandLineTests
 
         VERIFY_SUCCEEDED(m_pHistory->Add(L"I'm a little teapot", false));
         VERIFY_SUCCEEDED(m_pHistory->Add(L"short and stout", false));
-        VERIFY_SUCCEEDED(m_pHistory->Add(L"inflammable", false));
+        VERIFY_SUCCEEDED(m_pHistory->Add(L"Inflammable", false));
 
-        SetPrompt(cookedReadData, L"i");
+        SetPrompt(cookedReadData, L"I");
 
         auto& commandLine = CommandLine::Instance();
         commandLine._cycleMatchingCommandHistoryToPrompt(cookedReadData);
-        VerifyPromptText(cookedReadData, L"inflammable");
+        VerifyPromptText(cookedReadData, L"Inflammable");
 
-        // make sure we skip to the next "i" history item
+        // make sure we skip to the next "I" history item
         commandLine._cycleMatchingCommandHistoryToPrompt(cookedReadData);
         VerifyPromptText(cookedReadData, L"I'm a little teapot");
 
         // should cycle back to the start of the command history
         commandLine._cycleMatchingCommandHistoryToPrompt(cookedReadData);
-        VerifyPromptText(cookedReadData, L"inflammable");
+        VerifyPromptText(cookedReadData, L"Inflammable");
     }
 
     TEST_METHOD(CmdlineCtrlHomeFullwidthChars)


### PR DESCRIPTION
The legacy console used to use case-sensitive history deduplication and
this change reverts the logic to restore ye olde history functionality.

This commit additionally changes the other remaining `std::equal` plus
`std::towlower` check into a `CompareStringOrdinal` call,
just because that's what MSDN suggests to use in such situations.

## PR Checklist
* [x] Closes #4186
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed
* Enter `test /v`
* Enter `test /V`
* Browsing through the history yields both items ✅