### PR TITLE
Fix engine size not being changed on DPI changes

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -242,11 +242,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         winrt::fire_and_forget _asyncCloseConnection();
 
-        void _setFontSize(int fontSize);
+        bool _setFontSizeUnderLock(int fontSize);
         void _updateFont(const bool initialUpdate = false);
         void _refreshSizeUnderLock();
-        void _doResizeUnderLock(const double newWidth,
-                                const double newHeight);
 
         void _sendInputToConnection(std::wstring_view wstr);
 


### PR DESCRIPTION
Previously we would only call `SetWindowSize` and `TriggerRedrawAll` if the
viewport size in characters changed. This commit removes the limitation.
Since the if-condition limiting full redraws is now gone, this commit
moves the responsibility of limiting the calls up the call chain.
With `_refreshSizeUnderLock` now being a heavier function call
than before, some surrounding code was thus refactored.

## PR Checklist
* [x] Closes #11317
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed

Test relevant for #11317:
* Print text, filling the entire window
* Move the window from a 150% scale to a 300% scale monitor
* The application works as expected ✅

Regression tests:
* Text zoom with Ctrl+Plus/Minus/0 works as before ✅
* Resizing a window works as before ✅
* No deadlocks, etc. during settings updates ✅