### PR TITLE
Clear out g.pRender on cleanup so further tests don't explode

### DIFF
--- a/src/inc/test/CommonState.hpp
+++ b/src/inc/test/CommonState.hpp
@@ -86,8 +86,9 @@ public:
 
     void CleanupGlobalRenderer()
     {
-        const Globals& g = Microsoft::Console::Interactivity::ServiceLocator::LocateGlobals();
+        Globals& g = Microsoft::Console::Interactivity::ServiceLocator::LocateGlobals();
         delete g.pRender;
+        g.pRender = nullptr;
     }
 
     void PrepareGlobalScreenBuffer(const short viewWidth = s_csWindowWidth,


### PR DESCRIPTION
The x86 Conhost UTs were failing because--when run in a specific order
(SearchTests, then SelectionInputTests)--PrepareGlobalScreenBuffer would
attempt to enable painting on a renderer that was dead and gone and
pushing up daisies.