### PR TITLE
AtlasEngine: Fix grayscale blending shader

### DIFF
--- a/src/renderer/atlas/dwrite.hlsl
+++ b/src/renderer/atlas/dwrite.hlsl
@@ -81,7 +81,8 @@ float4 DWrite_GrayscaleBlend(float4 gammaRatios, float grayscaleEnhancedContrast
     float blendEnhancedContrast = contrastBoost + DWrite_ApplyLightOnDarkContrastAdjustment(grayscaleEnhancedContrast, foregroundStraight);
     float intensity = DWrite_CalcColorIntensity(foregroundStraight);
     float contrasted = DWrite_EnhanceContrast(glyphAlpha, blendEnhancedContrast);
-    return foregroundColor * DWrite_ApplyAlphaCorrection(contrasted, intensity, gammaRatios);
+    float alphaCorrected = DWrite_ApplyAlphaCorrection(contrasted, intensity, gammaRatios);
+    return alphaCorrected * foregroundColor;
 }
 
 // Call this function to get the same gamma corrected alpha blending effect

--- a/src/renderer/atlas/shader_ps.hlsl
+++ b/src/renderer/atlas/shader_ps.hlsl
@@ -147,7 +147,8 @@ float4 main(float4 pos: SV_Position): SV_Target
                 // See DWrite_GrayscaleBlend
                 float intensity = DWrite_CalcColorIntensity(foregroundStraight);
                 float contrasted = DWrite_EnhanceContrast(glyph.a, blendEnhancedContrast);
-                color = fg * DWrite_ApplyAlphaCorrection(contrasted, intensity, gammaRatios);
+                float4 alphaCorrected = DWrite_ApplyAlphaCorrection(contrasted, intensity, gammaRatios);
+                color = alphaBlendPremultiplied(color, alphaCorrected * fg);
             }
         }
     }


### PR DESCRIPTION
5964060 contains a regression were the grayscale blending algorithm used the
gamma corrected foreground color as the pixel color, instead of blending that
color with the background color first. Due to that the background color
got lost / got set to black. This breaks any dark-on-bright outputs.

## PR Checklist
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed
All 3 "antialiasing" settings work just like in DxEngine. ✅