### PR TITLE
[Conhost] Notify UIA when letter deleted via backspace

### DIFF
--- a/src/host/_stream.cpp
+++ b/src/host/_stream.cpp
@@ -769,7 +769,10 @@ using Microsoft::Console::VirtualTerminal::StateMachine;
             // See GH:12735, MSFT:31748387
             if (screenInfo.HasAccessibilityEventing())
             {
-                screenInfo.NotifyAccessibilityEventing(CursorPosition.X, CursorPosition.Y, CursorPosition.X + 1, CursorPosition.Y);
+                if (IConsoleWindow* pConsoleWindow = ServiceLocator::LocateConsoleWindow())
+                {
+                    LOG_IF_FAILED(pConsoleWindow->SignalUia(UIA_Text_TextChangedEventId));
+                }
             }
             break;
         }

--- a/src/host/_stream.cpp
+++ b/src/host/_stream.cpp
@@ -765,7 +765,8 @@ using Microsoft::Console::VirtualTerminal::StateMachine;
                     Status = AdjustCursorPosition(screenInfo, CursorPosition, dwFlags & WC_KEEP_CURSOR_VISIBLE, psScrollY);
                 }
             }
-            // Notify accessibility
+            // Notify accessibility to read the backspaced character.
+            // See GH:12735, MSFT:31748387
             if (screenInfo.HasAccessibilityEventing())
             {
                 screenInfo.NotifyAccessibilityEventing(CursorPosition.X, CursorPosition.Y, CursorPosition.X + 1, CursorPosition.Y);

--- a/src/host/_stream.cpp
+++ b/src/host/_stream.cpp
@@ -765,6 +765,11 @@ using Microsoft::Console::VirtualTerminal::StateMachine;
                     Status = AdjustCursorPosition(screenInfo, CursorPosition, dwFlags & WC_KEEP_CURSOR_VISIBLE, psScrollY);
                 }
             }
+            // Notify accessibility
+            if (screenInfo.HasAccessibilityEventing())
+            {
+                screenInfo.NotifyAccessibilityEventing(CursorPosition.X, CursorPosition.Y, CursorPosition.X + 1, CursorPosition.Y);
+            }
             break;
         }
         case UNICODE_TAB:


### PR DESCRIPTION
## Summary of the Pull Request
Fixes a bug in ConHost where Narrator wouldn't read the deleted letter after the user pressed backspace.

## References
MSFT:31748387

## Detailed Description of the Pull Request / Additional comments
`WriteCharsLegacy()` already calls `NotifyAccessibilityEventing()` when text is inserted into the buffer ([see code](https://github.com/microsoft/terminal/blob/855e1360c0ff810decf862f1d90e15b5f49e7bbd/src/host/_stream.cpp#L559-L563)). However, when backspace is pressed, the entire if-condition is skipped over, resulting in the accessibility event not being fired. `WriteCharsLegacy()` has a separate branch that is dedicated to handling backspace, so I added a call to the relevant logic to notify UIA at the end of that.

## Validation Steps Performed
✅ <kbd>Backspace</kbd> deletes a character and Narrator reads it
✅ <kbd>Backspace</kbd> still works with NVDA and JAWS (unchanged behavior)
✅ if the input buffer had wrapped text, the above scenario works as expected
✅ scenario works for CMD, PowerShell Core, and WSL