### PR TITLE
Prevent Fuzz pipeline failure by refactoring nuget restore pipeline steps

### DIFF
--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -100,36 +100,7 @@ jobs:
         If ($Arch -Eq "x86") { $Arch = "Win32" }
 
         Write-Host "##vso[task.setvariable variable=RationalizedBuildPlatform]${Arch}"
-  - task: NuGetToolInstaller@1
-    displayName: Use NuGet 5.10
-    inputs:
-      versionSpec: 5.10
-  - task: NuGetAuthenticate@0
-  # In the Microsoft Azure DevOps tenant, NuGetCommand is ambiguous.
-  # This should be `task: NuGetCommand@2`
-  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    displayName: Restore NuGet packages for extraneous build actions
-    inputs:
-      command: restore
-      feedsToUse: config
-      configPath: NuGet.config
-      restoreSolution: build/packages.config
-      restoreDirectory: '$(Build.SourcesDirectory)\packages'
-  - task: NuGetCommand@2
-    displayName: NuGet custom
-    inputs:
-      command: custom
-      selectOrConfig: config
-      nugetConfigPath: NuGet.Config
-      arguments: restore OpenConsole.sln -SolutionDirectory $(Build.SourcesDirectory)
-  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    displayName: Restore NuGet packages for global nuget
-    inputs:
-      command: restore
-      feedsToUse: config
-      configPath: NuGet.config
-      restoreSolution: dep/nuget/packages.config
-      restoreDirectory: '$(Build.SourcesDirectory)\packages'
+  - template: .\templates\restore-nuget-steps.yml
   # Pull the Windows SDK for the developer tools like the debuggers so we can index sources later
   - template: .\templates\install-winsdk-steps.yml
   - task: UniversalPackages@0

--- a/build/pipelines/templates/build-console-audit-job.yml
+++ b/build/pipelines/templates/build-console-audit-job.yml
@@ -21,43 +21,7 @@ jobs:
     clean: true
     fetchDepth: 1
 
-  - task: NuGetToolInstaller@0
-    displayName: Ensure NuGet 4.8.1
-    inputs:
-      versionSpec: 4.8.1
-
-  # In the Microsoft Azure DevOps tenant, NuGetCommand is ambiguous.
-  # This should be `task: NuGetCommand@2`
-  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    displayName: Restore NuGet packages for extraneous build actions
-    inputs:
-      command: restore
-      feedsToUse: config
-      configPath: NuGet.config
-      restoreSolution: build/packages.config
-      restoreDirectory: '$(Build.SourcesDirectory)\packages'
-
-  # In the Microsoft Azure DevOps tenant, NuGetCommand is ambiguous.
-  # This should be `task: NuGetCommand@2`
-  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    displayName: Restore NuGet packages
-    inputs:
-      command: restore
-      feedsToUse: config
-      configPath: NuGet.config
-      restoreSolution: OpenConsole.sln
-      restoreDirectory: '$(Build.SourcesDirectory)\packages'
-
-  # In the Microsoft Azure DevOps tenant, NuGetCommand is ambiguous.
-  # This should be `task: NuGetCommand@2`
-  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    displayName: Restore NuGet packages for global nuget
-    inputs:
-      command: restore
-      feedsToUse: config
-      configPath: NuGet.config
-      restoreSolution: dep/nuget/packages.config
-      restoreDirectory: '$(Build.SourcesDirectory)\packages'
+  - template: restore-nuget-steps.yml
 
   - task: VSBuild@1
     displayName: 'Build solution **\OpenConsole.sln'

--- a/build/pipelines/templates/build-console-compliance-job.yml
+++ b/build/pipelines/templates/build-console-compliance-job.yml
@@ -30,36 +30,7 @@ jobs:
         If ($Arch -Eq "x86") { $Arch = "Win32" }
 
         Write-Host "##vso[task.setvariable variable=RationalizedBuildPlatform]${Arch}"
-  - task: NuGetToolInstaller@1
-    displayName: Use NuGet 5.10
-    inputs:
-      versionSpec: 5.10
-  - task: NuGetAuthenticate@0
-  # In the Microsoft Azure DevOps tenant, NuGetCommand is ambiguous.
-  # This should be `task: NuGetCommand@2`
-  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    displayName: Restore NuGet packages for extraneous build actions
-    inputs:
-      command: restore
-      feedsToUse: config
-      configPath: NuGet.config
-      restoreSolution: build/packages.config
-      restoreDirectory: '$(Build.SourcesDirectory)\packages'
-  - task: NuGetCommand@2
-    displayName: NuGet custom
-    inputs:
-      command: custom
-      selectOrConfig: config
-      nugetConfigPath: NuGet.Config
-      arguments: restore OpenConsole.sln -SolutionDirectory $(Build.SourcesDirectory)
-  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    displayName: Restore NuGet packages for global nuget
-    inputs:
-      command: restore
-      feedsToUse: config
-      configPath: NuGet.config
-      restoreSolution: dep/nuget/packages.config
-      restoreDirectory: '$(Build.SourcesDirectory)\packages'
+  - steps: restore-nuget-steps.yml
   - task: UniversalPackages@0
     displayName: Download terminal-internal Universal Package
     inputs:

--- a/build/pipelines/templates/build-console-fuzzing.yml
+++ b/build/pipelines/templates/build-console-fuzzing.yml
@@ -21,30 +21,7 @@ jobs:
     submodules: true
     clean: true
 
-  - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 5.2.0'
-    inputs:
-      versionSpec: 5.2.0
-
-  # In the Microsoft Azure DevOps tenant, NuGetCommand is ambiguous.
-  # This should be `task: NuGetCommand@2`
-  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    displayName: Restore NuGet packages for solution
-    inputs:
-      command: restore
-      feedsToUse: config
-      configPath: NuGet.config
-      restoreSolution: OpenConsole.sln
-      restoreDirectory: '$(Build.SourcesDirectory)\packages'
-
-  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    displayName: Restore NuGet packages for extraneous build actions
-    inputs:
-      command: restore
-      feedsToUse: config
-      configPath: NuGet.config
-      restoreSolution: build/packages.config
-      restoreDirectory: '$(Build.SourcesDirectory)\packages'
+  - template: restore-nuget-steps.yml
 
   # The environment variable VCToolsInstallDir isn't defined on lab machines, so we need to retrieve it ourselves.
   - script: |

--- a/build/pipelines/templates/build-console-steps.yml
+++ b/build/pipelines/templates/build-console-steps.yml
@@ -7,41 +7,7 @@ steps:
   clean: true
   fetchDepth: 1
 
-- task: NuGetToolInstaller@0
-  displayName: 'Use NuGet 5.2.0'
-  inputs:
-    versionSpec: 5.2.0
-
-- task: NuGetAuthenticate@0
-
-# In the Microsoft Azure DevOps tenant, NuGetCommand is ambiguous.
-# This should be `task: NuGetCommand@2`
-- task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-  displayName: Restore NuGet packages for extraneous build actions
-  inputs:
-    command: restore
-    feedsToUse: config
-    configPath: NuGet.config
-    restoreSolution: build/packages.config
-    restoreDirectory: '$(Build.SourcesDirectory)\packages'
-
-- task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-  displayName: Restore NuGet packages for solution
-  inputs:
-    command: restore
-    feedsToUse: config
-    configPath: NuGet.config
-    restoreSolution: OpenConsole.sln
-    restoreDirectory: '$(Build.SourcesDirectory)\packages'
-
-- task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-  displayName: Restore NuGet packages for global nuget
-  inputs:
-    command: restore
-    feedsToUse: config
-    configPath: NuGet.config
-    restoreSolution: dep/nuget/packages.config
-    restoreDirectory: '$(Build.SourcesDirectory)\packages'
+- template: restore-nuget-steps.yml
 
 # The environment variable VCToolsInstallDir isn't defined on lab machines, so we need to retrieve it ourselves.
 - script: |

--- a/build/pipelines/templates/restore-nuget-steps.yml
+++ b/build/pipelines/templates/restore-nuget-steps.yml
@@ -1,0 +1,36 @@
+steps:
+- task: NuGetToolInstaller@0
+  displayName: 'Use NuGet 5.2.0'
+  inputs:
+    versionSpec: 5.2.0
+
+- task: NuGetAuthenticate@0
+
+# In the Microsoft Azure DevOps tenant, NuGetCommand is ambiguous.
+# This should be `task: NuGetCommand@2`
+- task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+  displayName: Restore NuGet packages for extraneous build actions
+  inputs:
+    command: restore
+    feedsToUse: config
+    configPath: NuGet.config
+    restoreSolution: build/packages.config
+    restoreDirectory: '$(Build.SourcesDirectory)\packages'
+
+- task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+  displayName: Restore NuGet packages for solution
+  inputs:
+    command: restore
+    feedsToUse: config
+    configPath: NuGet.config
+    restoreSolution: OpenConsole.sln
+    restoreDirectory: '$(Build.SourcesDirectory)\packages'
+
+- task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+  displayName: Restore NuGet packages for global nuget
+  inputs:
+    command: restore
+    feedsToUse: config
+    configPath: NuGet.config
+    restoreSolution: dep/nuget/packages.config
+    restoreDirectory: '$(Build.SourcesDirectory)\packages'


### PR DESCRIPTION
## Summary of the Pull Request
Prevents the Fuzz pipeline from failing by refactoring the nuget restore pipeline steps.

## References
Broken in #12778.

## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx