### PR TITLE
Auto-focus window renamer textbox on open

### DIFF
--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -844,6 +844,22 @@ namespace winrt::TerminalApp::implementation
         }
 
         _UpdateTeachingTipTheme(WindowRenamer().try_as<winrt::Windows::UI::Xaml::FrameworkElement>());
+
+        // WindowRenamer().Opened([weakThis = get_weak()](auto&&, auto&&) {
+        //     if (auto self{ weakThis.get() })
+        //     {
+        //         self->WindowRenamerTextBox().Focus(FocusState::Programmatic);
+        //     }
+        // });
+
+        _renamerLayoutUpdatedRevoker = WindowRenamerTextBox().LayoutUpdated(winrt::auto_revoke, [weakThis = get_weak()](auto&&, auto&&) {
+            // Only let this succeed once.
+            if (auto self{ weakThis.get() })
+            {
+                self->_renamerLayoutUpdatedRevoker.revoke();
+                self->WindowRenamerTextBox().Focus(FocusState::Programmatic);
+            }
+        });
         WindowRenamer().IsOpen(true);
 
         // PAIN: We can't immediately focus the textbox in the TeachingTip. It's

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -856,7 +856,7 @@ namespace winrt::TerminalApp::implementation
         // LayoutUpdated event, as a notification that the TextBox was added to
         // the tree. HOWEVER:
         //   * The _first_ time this is fired, when the box is _first_ opened,
-        //     yeeting focus doesn't work on the first LayoutUpdated. It does
+        //     tossing focus doesn't work on the first LayoutUpdated. It does
         //     work on the second LayoutUpdated. Okay, so we'll wait for two
         //     LayoutUpdated events, and focus on the second.
         //   * On subsequent opens: We only ever get a single LayoutUpdated.
@@ -875,6 +875,7 @@ namespace winrt::TerminalApp::implementation
             {
                 auto& count{ self->_renamerLayoutCount };
 
+                // Don't just always increment this, we don't want to deal with overflow situations
                 if (count < 2)
                 {
                     count++;

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -846,47 +846,60 @@ namespace winrt::TerminalApp::implementation
         _UpdateTeachingTipTheme(WindowRenamer().try_as<winrt::Windows::UI::Xaml::FrameworkElement>());
 
         _renamerLayoutUpdatedRevoker.revoke();
+        // _renamerLayoutCount = 0;
 
         _renamerLayoutUpdatedRevoker = WindowRenamerTextBox().LayoutUpdated(winrt::auto_revoke, [weakThis = get_weak()](auto&&, auto&&) {
             // Only let this succeed once.
             if (auto self{ weakThis.get() })
             {
-                if (self->_renamerPopup == nullptr)
+                auto& count{ self->_renamerLayoutCount };
+                if (count < 2)
+                    count++;
+
+                if (count >= 2)
                 {
-                    // look for popup
-                    Windows::UI::Xaml::DependencyObject currentElement{ self->WindowRenamerTextBox() };
-                    do
-                    {
-                        if (currentElement = Media::VisualTreeHelper::GetParent(currentElement))
-                        {
-                            if (self->_renamerPopup = currentElement.try_as<winrt::Windows::UI::Xaml::Controls::Primitives::Popup>())
-                            {
-                                break;
-                            }
-                        }
-                    } while (currentElement);
-
-                    // const auto popups{ Media::VisualTreeHelper::GetOpenPopupsForXamlRoot(root.XamlRoot()) };
-                    // if (const auto element{ Media::VisualTreeHelper::GetParent(self->WindowRenamerTextBox()) })
-                    // {
-                    if (self->_renamerPopup)
-                    {
-                        self->_renamerLayoutUpdatedRevoker.revoke();
-
-                        self->_renamerPopup.Opened([weakThis](auto&&, auto&&) {
-                            if (auto self2{ weakThis.get() })
-                            {
-                                self2->WindowRenamerTextBox().Focus(FocusState::Programmatic);
-                            }
-                        });
-                    }
-                    // }
+                    self->_renamerLayoutUpdatedRevoker.revoke();
+                    self->WindowRenamerTextBox().Focus(FocusState::Programmatic);
+                    // self->_renamerLayoutCount = 0;
                 }
+                
             }
+            //     if (self->_renamerPopup == nullptr)
+            //     {
+            //         // look for popup
+            //         Windows::UI::Xaml::DependencyObject currentElement{ self->WindowRenamerTextBox() };
+            //         do
+            //         {
+            //             if (currentElement = Media::VisualTreeHelper::GetParent(currentElement))
+            //             {
+            //                 if (self->_renamerPopup = currentElement.try_as<winrt::Windows::UI::Xaml::Controls::Primitives::Popup>())
+            //                 {
+            //                     break;
+            //                 }
+            //             }
+            //         } while (currentElement);
+
+            //         // const auto popups{ Media::VisualTreeHelper::GetOpenPopupsForXamlRoot(root.XamlRoot()) };
+            //         // if (const auto element{ Media::VisualTreeHelper::GetParent(self->WindowRenamerTextBox()) })
+            //         // {
+            //         if (self->_renamerPopup)
+            //         {
+            //             self->_renamerLayoutUpdatedRevoker.revoke();
+
+            //             self->_renamerPopup.Opened([weakThis](auto&&, auto&&) {
+            //                 if (auto self2{ weakThis.get() })
+            //                 {
+            //                     self2->WindowRenamerTextBox().Focus(FocusState::Programmatic);
+            //                 }
+            //             });
+            //         }
+            //         // }
+            //     }
+            // }
 
             // self->WindowRenamerTextBox().Focus(FocusState::Programmatic);
         });
-
+        _renamerPressedEnter = false;
         WindowRenamer().IsOpen(true);
 
         // PAIN: We can't immediately focus the textbox in the TeachingTip. It's

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3611,6 +3611,22 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Method Description:
+    // - TODO!
+    // Arguments:
+    // - e: the KeyRoutedEventArgs describing the key that was released
+    // Return Value:
+    // - <none>
+    void TerminalPage::_WindowRenamerKeyDown(const IInspectable& /*sender*/,
+                                             winrt::Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e)
+    {
+        const auto key = e.OriginalKey();
+        if (key == Windows::System::VirtualKey::Enter)
+        {
+            _renamerPressedEnter = true;
+        }
+    }
+
+    // Method Description:
     // - Manually handle Enter and Escape for committing and dismissing a window
     //   rename. This is highly similar to the TabHeaderControl's KeyUp handler.
     // Arguments:
@@ -3620,8 +3636,8 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_WindowRenamerKeyUp(const IInspectable& sender,
                                            winrt::Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e)
     {
-        auto key = e.OriginalKey();
-        if (key == Windows::System::VirtualKey::Enter)
+        const auto key = e.OriginalKey();
+        if (key == Windows::System::VirtualKey::Enter && _renamerPressedEnter)
         {
             // User is done making changes, close the rename box
             _WindowRenamerActionClick(sender, nullptr);
@@ -3631,6 +3647,7 @@ namespace winrt::TerminalApp::implementation
             // User wants to discard the changes they made
             WindowRenamerTextBox().Text(WindowName());
             WindowRenamer().IsOpen(false);
+            _renamerPressedEnter = false;
         }
     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3611,7 +3611,11 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Method Description:
-    // - TODO!
+    // - Used to track if the user pressed enter with the renamer open. If we
+    //   immediately focus it after hitting Enter on the command palette, then
+    //   the Enter keydown will dismiss the command palette and open the
+    //   renamer, and then the enter keyup will go to the renamer. So we need to
+    //   make sure both a down and up go to the renamer.
     // Arguments:
     // - e: the KeyRoutedEventArgs describing the key that was released
     // Return Value:

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3620,12 +3620,13 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_WindowRenamerKeyUp(const IInspectable& sender,
                                            winrt::Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e)
     {
-        if (e.OriginalKey() == Windows::System::VirtualKey::Enter)
+        auto key = e.OriginalKey();
+        if (key == Windows::System::VirtualKey::Enter)
         {
             // User is done making changes, close the rename box
             _WindowRenamerActionClick(sender, nullptr);
         }
-        else if (e.OriginalKey() == Windows::System::VirtualKey::Escape)
+        else if (key == Windows::System::VirtualKey::Escape)
         {
             // User wants to discard the changes they made
             WindowRenamerTextBox().Text(WindowName());

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -414,6 +414,7 @@ namespace winrt::TerminalApp::implementation
 
         void _WindowRenamerActionClick(const IInspectable& sender, const IInspectable& eventArgs);
         void _RequestWindowRename(const winrt::hstring& newName);
+        void _WindowRenamerKeyDown(const IInspectable& sender, winrt::Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e);
         void _WindowRenamerKeyUp(const IInspectable& sender, winrt::Windows::UI::Xaml::Input::KeyRoutedEventArgs const& e);
 
         void _UpdateTeachingTipTheme(winrt::Windows::UI::Xaml::FrameworkElement element);
@@ -432,8 +433,11 @@ namespace winrt::TerminalApp::implementation
         void _SetAsDefaultOpenSettingsHandler(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::Foundation::IInspectable& args);
         static bool _IsMessageDismissed(const winrt::Microsoft::Terminal::Settings::Model::InfoBarMessage& message);
         static void _DismissMessage(const winrt::Microsoft::Terminal::Settings::Model::InfoBarMessage& message);
+
         winrt::Windows::UI::Xaml::Controls::Primitives::Popup _renamerPopup{ nullptr };
         winrt::Windows::UI::Xaml::Controls::TextBox::LayoutUpdated_revoker _renamerLayoutUpdatedRevoker;
+        int _renamerLayoutCount{ 0 };
+        bool _renamerPressedEnter{ false };
 
 #pragma region ActionHandlers
         // These are all defined in AppActionHandlers.cpp

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -215,6 +215,10 @@ namespace winrt::TerminalApp::implementation
         std::shared_ptr<Toast> _windowIdToast{ nullptr };
         std::shared_ptr<Toast> _windowRenameFailedToast{ nullptr };
 
+        winrt::Windows::UI::Xaml::Controls::TextBox::LayoutUpdated_revoker _renamerLayoutUpdatedRevoker;
+        int _renamerLayoutCount{ 0 };
+        bool _renamerPressedEnter{ false };
+
         winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::UI::Xaml::Controls::ContentDialogResult> _ShowDialogHelper(const std::wstring_view& name);
 
         void _ShowAboutDialog();
@@ -433,11 +437,6 @@ namespace winrt::TerminalApp::implementation
         void _SetAsDefaultOpenSettingsHandler(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::Foundation::IInspectable& args);
         static bool _IsMessageDismissed(const winrt::Microsoft::Terminal::Settings::Model::InfoBarMessage& message);
         static void _DismissMessage(const winrt::Microsoft::Terminal::Settings::Model::InfoBarMessage& message);
-
-        winrt::Windows::UI::Xaml::Controls::Primitives::Popup _renamerPopup{ nullptr };
-        winrt::Windows::UI::Xaml::Controls::TextBox::LayoutUpdated_revoker _renamerLayoutUpdatedRevoker;
-        int _renamerLayoutCount{ 0 };
-        bool _renamerPressedEnter{ false };
 
 #pragma region ActionHandlers
         // These are all defined in AppActionHandlers.cpp

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -432,6 +432,8 @@ namespace winrt::TerminalApp::implementation
         void _SetAsDefaultOpenSettingsHandler(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::Foundation::IInspectable& args);
         static bool _IsMessageDismissed(const winrt::Microsoft::Terminal::Settings::Model::InfoBarMessage& message);
         static void _DismissMessage(const winrt::Microsoft::Terminal::Settings::Model::InfoBarMessage& message);
+        winrt::Windows::UI::Xaml::Controls::Primitives::Popup _renamerPopup{ nullptr };
+        winrt::Windows::UI::Xaml::Controls::TextBox::LayoutUpdated_revoker _renamerLayoutUpdatedRevoker;
 
 #pragma region ActionHandlers
         // These are all defined in AppActionHandlers.cpp

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -189,7 +189,8 @@
                          Title="{x:Bind WindowIdForDisplay}"
                          x:Load="False"
                          ActionButtonClick="_WindowRenamerActionClick"
-                         ActionButtonStyle="{ThemeResource AccentButtonStyle}">
+                         ActionButtonStyle="{ThemeResource AccentButtonStyle}"
+                         IsLightDismissEnabled="True">
             <mux:TeachingTip.Content>
                 <TextBox x:Name="WindowRenamerTextBox"
                          KeyDown="_WindowRenamerKeyDown"

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -189,8 +189,7 @@
                          Title="{x:Bind WindowIdForDisplay}"
                          x:Load="False"
                          ActionButtonClick="_WindowRenamerActionClick"
-                         ActionButtonStyle="{ThemeResource AccentButtonStyle}"
-                         IsLightDismissEnabled="True">
+                         ActionButtonStyle="{ThemeResource AccentButtonStyle}">
             <mux:TeachingTip.Content>
                 <TextBox x:Name="WindowRenamerTextBox"
                          KeyUp="_WindowRenamerKeyUp"

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -192,6 +192,7 @@
                          ActionButtonStyle="{ThemeResource AccentButtonStyle}">
             <mux:TeachingTip.Content>
                 <TextBox x:Name="WindowRenamerTextBox"
+                         KeyDown="_WindowRenamerKeyDown"
                          KeyUp="_WindowRenamerKeyUp"
                          Text="{x:Bind WindowName, Mode=OneWay}" />
             </mux:TeachingTip.Content>


### PR DESCRIPTION
Does what it says on the tin. This is maximal BODGE. 

`TeachingTip` doesn't provide an `Opened` event.
(https://github.com/microsoft/microsoft-ui-xaml/issues/1607). But we
want to focus the renamer text box when it's opened. We can't do that
immediately, the TextBox technically isn't in the visual tree yet. We
have to wait for it to get added some time after we call IsOpen. How do
we do that reliably? Usually, for this kind of thing, we'd just use a
one-off LayoutUpdated event, as a notification that the TextBox was
added to the tree. HOWEVER:
* The _first_ time this is fired, when the box is _first_ opened,
  yeeting focus doesn't work on the first LayoutUpdated. It does work on
  the second LayoutUpdated. Okay, so we'll wait for two LayoutUpdated
  events, and focus on the second.
* On subsequent opens: We only ever get a single LayoutUpdated. Period.
  But, you can successfully focus it on that LayoutUpdated.

So, we'll keep track of how many LayoutUpdated's we've _ever_ gotten. If
we've had at least 2, then we can focus the text box.

We're also not using a ContentDialog for this, because in Xaml Islands a
text box in a ContentDialog won't receive _any_ keypresses. Fun!


## References
* microsoft/microsoft-ui-xaml#1607
* microsoft/microsoft-ui-xaml#6910
* microsoft/microsoft-ui-xaml#3257
* microsoft/terminal#9662

## PR Checklist
* [x] Will close out #12021, but that's an a11y bug that needs secondary
  validation
* [x] Closes #11322
* [x] I work here
* [x] Tests added/passed
* [n/a] Requires documentation to be updated

## Validation Steps Performed

Tested manually