### PR TITLE
Force the bundle major version to be over 3000

### DIFF
--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -328,7 +328,7 @@ jobs:
         $VersionEpoch = 3000
         $Components = "$(XES_APPXMANIFESTVERSION)" -Split "."
         $Components[0] += $VersionEpoch
-        $BundleVersion = $Version -Join "."
+        $BundleVersion = $Components -Join "."
         .\build\scripts\Create-AppxBundle.ps1 -InputPath "$(System.ArtifactsDirectory)" -ProjectName CascadiaPackage -BundleVersion $BundleVersion -OutputPath "$(System.ArtifactsDirectory)\Microsoft.WindowsTerminal_$(TerminalTargetWindowsVersion)_$(XES_APPXMANIFESTVERSION)_8wekyb3d8bbwe.msixbundle"
       displayName: Create WindowsTerminal*.msixbundle
     - task: EsrpCodeSigning@1

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -138,38 +138,38 @@ jobs:
       feedListDownload: 2b3f8893-a6e8-411f-b197-a9e05576da48
       packageListDownload: e82d490c-af86-4733-9dc4-07b772033204
       versionListDownload: $(TerminalInternalPackageVersion)
-  - task: TouchdownBuildTask@1
-    displayName: Download Localization Files
-    inputs:
-      teamId: 7105
-      authId: $(TouchdownAppId)
-      authKey: $(TouchdownAppKey)
-      resourceFilePath: >-
-        src\cascadia\TerminalApp\Resources\en-US\Resources.resw
-
-        src\cascadia\TerminalApp\Resources\en-US\ContextMenu.resw
-
-        src\cascadia\TerminalControl\Resources\en-US\Resources.resw
-
-        src\cascadia\TerminalConnection\Resources\en-US\Resources.resw
-
-        src\cascadia\TerminalSettingsModel\Resources\en-US\Resources.resw
-
-        src\cascadia\TerminalSettingsEditor\Resources\en-US\Resources.resw
-
-        src\cascadia\CascadiaPackage\Resources\en-US\Resources.resw
-      appendRelativeDir: true
-      localizationTarget: false
-      pseudoSetting: Included
-  - task: PowerShell@2
-    displayName: Move Loc files one level up
-    inputs:
-      targetType: inline
-      script: >-
-        $Files = Get-ChildItem . -R -Filter 'Resources.resw' | ? FullName -Like '*en-US\*\Resources.resw'
-
-        $Files | % { Move-Item -Verbose $_.Directory $_.Directory.Parent.Parent -EA:Ignore }
-      pwsh: true
+        #  - task: TouchdownBuildTask@1
+        #    displayName: Download Localization Files
+        #    inputs:
+        #      teamId: 7105
+        #      authId: $(TouchdownAppId)
+        #      authKey: $(TouchdownAppKey)
+        #      resourceFilePath: >-
+        #        src\cascadia\TerminalApp\Resources\en-US\Resources.resw
+        #
+        #        src\cascadia\TerminalApp\Resources\en-US\ContextMenu.resw
+        #
+        #        src\cascadia\TerminalControl\Resources\en-US\Resources.resw
+        #
+        #        src\cascadia\TerminalConnection\Resources\en-US\Resources.resw
+        #
+        #        src\cascadia\TerminalSettingsModel\Resources\en-US\Resources.resw
+        #
+        #        src\cascadia\TerminalSettingsEditor\Resources\en-US\Resources.resw
+        #
+        #        src\cascadia\CascadiaPackage\Resources\en-US\Resources.resw
+        #      appendRelativeDir: true
+        #      localizationTarget: false
+        #      pseudoSetting: Included
+        #  - task: PowerShell@2
+        #    displayName: Move Loc files one level up
+        #    inputs:
+        #      targetType: inline
+        #      script: >-
+        #        $Files = Get-ChildItem . -R -Filter 'Resources.resw' | ? FullName -Like '*en-US\*\Resources.resw'
+        #
+        #        $Files | % { Move-Item -Verbose $_.Directory $_.Directory.Parent.Parent -EA:Ignore }
+        #      pwsh: true
   - task: PowerShell@2
     displayName: Copy the Context Menu Loc Resources to CascadiaPackage
     inputs:

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -138,38 +138,38 @@ jobs:
       feedListDownload: 2b3f8893-a6e8-411f-b197-a9e05576da48
       packageListDownload: e82d490c-af86-4733-9dc4-07b772033204
       versionListDownload: $(TerminalInternalPackageVersion)
-        #  - task: TouchdownBuildTask@1
-        #    displayName: Download Localization Files
-        #    inputs:
-        #      teamId: 7105
-        #      authId: $(TouchdownAppId)
-        #      authKey: $(TouchdownAppKey)
-        #      resourceFilePath: >-
-        #        src\cascadia\TerminalApp\Resources\en-US\Resources.resw
-        #
-        #        src\cascadia\TerminalApp\Resources\en-US\ContextMenu.resw
-        #
-        #        src\cascadia\TerminalControl\Resources\en-US\Resources.resw
-        #
-        #        src\cascadia\TerminalConnection\Resources\en-US\Resources.resw
-        #
-        #        src\cascadia\TerminalSettingsModel\Resources\en-US\Resources.resw
-        #
-        #        src\cascadia\TerminalSettingsEditor\Resources\en-US\Resources.resw
-        #
-        #        src\cascadia\CascadiaPackage\Resources\en-US\Resources.resw
-        #      appendRelativeDir: true
-        #      localizationTarget: false
-        #      pseudoSetting: Included
-        #  - task: PowerShell@2
-        #    displayName: Move Loc files one level up
-        #    inputs:
-        #      targetType: inline
-        #      script: >-
-        #        $Files = Get-ChildItem . -R -Filter 'Resources.resw' | ? FullName -Like '*en-US\*\Resources.resw'
-        #
-        #        $Files | % { Move-Item -Verbose $_.Directory $_.Directory.Parent.Parent -EA:Ignore }
-        #      pwsh: true
+  - task: TouchdownBuildTask@1
+    displayName: Download Localization Files
+    inputs:
+      teamId: 7105
+      authId: $(TouchdownAppId)
+      authKey: $(TouchdownAppKey)
+      resourceFilePath: >-
+        src\cascadia\TerminalApp\Resources\en-US\Resources.resw
+
+        src\cascadia\TerminalApp\Resources\en-US\ContextMenu.resw
+
+        src\cascadia\TerminalControl\Resources\en-US\Resources.resw
+
+        src\cascadia\TerminalConnection\Resources\en-US\Resources.resw
+
+        src\cascadia\TerminalSettingsModel\Resources\en-US\Resources.resw
+
+        src\cascadia\TerminalSettingsEditor\Resources\en-US\Resources.resw
+
+        src\cascadia\CascadiaPackage\Resources\en-US\Resources.resw
+      appendRelativeDir: true
+      localizationTarget: false
+      pseudoSetting: Included
+  - task: PowerShell@2
+    displayName: Move Loc files one level up
+    inputs:
+      targetType: inline
+      script: >-
+        $Files = Get-ChildItem . -R -Filter 'Resources.resw' | ? FullName -Like '*en-US\*\Resources.resw'
+
+        $Files | % { Move-Item -Verbose $_.Directory $_.Directory.Parent.Parent -EA:Ignore }
+      pwsh: true
   - task: PowerShell@2
     displayName: Copy the Context Menu Loc Resources to CascadiaPackage
     inputs:

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -321,11 +321,16 @@ jobs:
         displayName: Download Artifacts ${{ platform }} $(TerminalTargetWindowsVersion)
         inputs:
           artifactName: appx-${{ platform }}-Release-$(TerminalTargetWindowsVersion)
-    - task: PowerShell@2
+    # Add 3000 to the major version component, but only for the bundle.
+    # This is to ensure that it is newer than "2022.xx.yy.zz" or whatever the original bundle versions were before
+    # we switched to uniform naming.
+    - pwsh: |-
+        $VersionEpoch = 3000
+        $Components = "$(XES_APPXMANIFESTVERSION)" -Split "."
+        $Components[0] += $VersionEpoch
+        $BundleVersion = $Version -Join "."
+        .\build\scripts\Create-AppxBundle.ps1 -InputPath "$(System.ArtifactsDirectory)" -ProjectName CascadiaPackage -BundleVersion $BundleVersion -OutputPath "$(System.ArtifactsDirectory)\Microsoft.WindowsTerminal_$(TerminalTargetWindowsVersion)_$(XES_APPXMANIFESTVERSION)_8wekyb3d8bbwe.msixbundle"
       displayName: Create WindowsTerminal*.msixbundle
-      inputs:
-        filePath: build\scripts\Create-AppxBundle.ps1
-        arguments: -InputPath "$(System.ArtifactsDirectory)" -ProjectName CascadiaPackage -BundleVersion $(XES_APPXMANIFESTVERSION) -OutputPath "$(System.ArtifactsDirectory)\Microsoft.WindowsTerminal_$(TerminalTargetWindowsVersion)_$(XES_APPXMANIFESTVERSION)_8wekyb3d8bbwe.msixbundle"
     - task: EsrpCodeSigning@1
       displayName: Submit *.msixbundle to ESRP for code signing
       inputs:

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -326,8 +326,8 @@ jobs:
     # we switched to uniform naming.
     - pwsh: |-
         $VersionEpoch = 3000
-        $Components = "$(XES_APPXMANIFESTVERSION)" -Split "."
-        $Components[0] += $VersionEpoch
+        $Components = "$(XES_APPXMANIFESTVERSION)" -Split "\."
+        $Components[0] = ([int]$Components[0] + $VersionEpoch)
         $BundleVersion = $Components -Join "."
         .\build\scripts\Create-AppxBundle.ps1 -InputPath "$(System.ArtifactsDirectory)" -ProjectName CascadiaPackage -BundleVersion $BundleVersion -OutputPath "$(System.ArtifactsDirectory)\Microsoft.WindowsTerminal_$(TerminalTargetWindowsVersion)_$(XES_APPXMANIFESTVERSION)_8wekyb3d8bbwe.msixbundle"
       displayName: Create WindowsTerminal*.msixbundle


### PR DESCRIPTION
Before #12691, the msixbundle version was of the format YYYY.MM.DD.0.
After #12691, it became the same as the build of Terminal it contained.

This caused some trouble for _some_ systems: major version 1 is much,
much smaller than 2022.

Adding 3000 to the major version component, _only for the bundle_, gets
around this. Ugh.

Fixes #12816.