### PR TITLE
Add common nuget import to Fuzz project so that it compiles

### DIFF
--- a/src/host/ft_fuzzer/Host.FuzzWrapper.vcxproj
+++ b/src/host/ft_fuzzer/Host.FuzzWrapper.vcxproj
@@ -9,6 +9,7 @@
     <ConfigurationType>Application</ConfigurationType>
   </PropertyGroup>
   <Import Project="..\..\common.build.pre.props" />
+  <Import Project="..\..\common.nugetversions.props" />
   <ItemGroup>
     <ClInclude Include="..\precomp.h" />
   </ItemGroup>
@@ -87,4 +88,5 @@
   </ItemDefinitionGroup>
   <!-- Careful reordering these. Some default props (contained in these files) are order sensitive. -->
   <Import Project="..\..\common.build.post.props" />
+  <Import Project="..\..\common.nugetversions.targets" />
 </Project>


### PR DESCRIPTION
Adds the common nuget import to the Fuzz project so that it compiles.

## References
Broken in #12778, Issue identified by #12796

## Validation Steps Performed
`Host.FuzzWrapper` project builds.