### PR TITLE
Include keyboard modalities when processing key events

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2163,6 +2163,23 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             }
         }
 
+        constexpr std::array<KeyModifier, 3> modalities{ {
+            { VirtualKey::CapitalLock, ControlKeyStates::CapslockOn },
+            { VirtualKey::NumberKeyLock, ControlKeyStates::NumlockOn },
+            { VirtualKey::Scroll, ControlKeyStates::ScrolllockOn },
+        } };
+
+        for (const auto& mod : modalities)
+        {
+            const auto state = window.GetKeyState(mod.vkey);
+            const auto isLocked = WI_IsFlagSet(state, CoreVirtualKeyStates::Locked);
+
+            if (isLocked)
+            {
+                flags |= mod.flags;
+            }
+        }
+
         return flags;
     }
 


### PR DESCRIPTION
Followed reproduction steps from linked issue #12818, wt.exe shows
expected behaviour for capslock, scrolllock and numlock (assuming
numlock is an "enhanced" key):

```
C:\Users\Kaas\source\Playground\x64\Debug>Playground.exe
KeyState:   Up, KeyCode: 0x0d, ScanCode: 0x1c, Unicode:   (0x000d), Modifiers: 0x0000
KeyState: Down, KeyCode: 0x41, ScanCode: 0x1e, Unicode: a (0x0061), Modifiers: 0x0000
KeyState:   Up, KeyCode: 0x41, ScanCode: 0x1e, Unicode: a (0x0061), Modifiers: 0x0000
KeyState: Down, KeyCode: 0x53, ScanCode: 0x1f, Unicode: s (0x0073), Modifiers: 0x0000
KeyState:   Up, KeyCode: 0x53, ScanCode: 0x1f, Unicode: s (0x0073), Modifiers: 0x0000
KeyState: Down, KeyCode: 0x44, ScanCode: 0x20, Unicode: d (0x0064), Modifiers: 0x0000
KeyState:   Up, KeyCode: 0x44, ScanCode: 0x20, Unicode: d (0x0064), Modifiers: 0x0000
KeyState: Down, KeyCode: 0x14, ScanCode: 0x3a, Unicode:   (0x0000), Modifiers: 0x0080
KeyState:   Up, KeyCode: 0x14, ScanCode: 0x3a, Unicode:   (0x0000), Modifiers: 0x0080
KeyState: Down, KeyCode: 0x41, ScanCode: 0x1e, Unicode: A (0x0041), Modifiers: 0x0080
KeyState:   Up, KeyCode: 0x41, ScanCode: 0x1e, Unicode: A (0x0041), Modifiers: 0x0080
KeyState: Down, KeyCode: 0x53, ScanCode: 0x1f, Unicode: S (0x0053), Modifiers: 0x0080
KeyState:   Up, KeyCode: 0x53, ScanCode: 0x1f, Unicode: S (0x0053), Modifiers: 0x0080
KeyState: Down, KeyCode: 0x44, ScanCode: 0x20, Unicode: D (0x0044), Modifiers: 0x0080
KeyState:   Up, KeyCode: 0x44, ScanCode: 0x20, Unicode: D (0x0044), Modifiers: 0x0080
KeyState: Down, KeyCode: 0x91, ScanCode: 0x46, Unicode:   (0x0000), Modifiers: 0x00c0
KeyState:   Up, KeyCode: 0x91, ScanCode: 0x46, Unicode:   (0x0000), Modifiers: 0x00c0
KeyState: Down, KeyCode: 0x53, ScanCode: 0x1f, Unicode: S (0x0053), Modifiers: 0x00c0
KeyState:   Up, KeyCode: 0x53, ScanCode: 0x1f, Unicode: S (0x0053), Modifiers: 0x00c0
KeyState: Down, KeyCode: 0x90, ScanCode: 0x45, Unicode:   (0x0000), Modifiers: 0x01e0
KeyState:   Up, KeyCode: 0x90, ScanCode: 0x45, Unicode:   (0x0000), Modifiers: 0x01e0
KeyState: Down, KeyCode: 0x4e, ScanCode: 0x31, Unicode: N (0x004e), Modifiers: 0x00e0
KeyState:   Up, KeyCode: 0x4e, ScanCode: 0x31, Unicode: N (0x004e), Modifiers: 0x00e0
KeyState: Down, KeyCode: 0x90, ScanCode: 0x45, Unicode:   (0x0000), Modifiers: 0x01c0
KeyState:   Up, KeyCode: 0x90, ScanCode: 0x45, Unicode:   (0x0000), Modifiers: 0x01c0
KeyState: Down, KeyCode: 0x91, ScanCode: 0x46, Unicode:   (0x0000), Modifiers: 0x0080
KeyState:   Up, KeyCode: 0x91, ScanCode: 0x46, Unicode:   (0x0000), Modifiers: 0x0080
KeyState: Down, KeyCode: 0x14, ScanCode: 0x3a, Unicode:   (0x0000), Modifiers: 0x0000
KeyState:   Up, KeyCode: 0x14, ScanCode: 0x3a, Unicode:   (0x0000), Modifiers: 0x0000
KeyState: Down, KeyCode: 0x51, ScanCode: 0x10, Unicode: q (0x0071), Modifiers: 0x0000
```

Closes #12818