### PR TITLE
Upgrade clang-format to 13.0.1

### DIFF
--- a/src/api-ms-win-core-synch-l1-2-0/main.cpp
+++ b/src/api-ms-win-core-synch-l1-2-0/main.cpp
@@ -28,7 +28,7 @@ namespace
     class [[nodiscard]] SRWLockGuard
     {
     public:
-        explicit SRWLockGuard(SRWLOCK & lock) noexcept :
+        explicit SRWLockGuard(SRWLOCK& lock) noexcept :
             _lock(&lock)
         {
             AcquireSRWLockExclusive(_lock);
@@ -42,7 +42,7 @@ namespace
         SRWLockGuard(const SRWLockGuard&) = delete;
         SRWLockGuard& operator=(const SRWLockGuard&) = delete;
 
-        SRWLockGuard(SRWLockGuard &&) = delete;
+        SRWLockGuard(SRWLockGuard&&) = delete;
         SRWLockGuard& operator=(SRWLockGuard&&) = delete;
 
     private:
@@ -77,7 +77,7 @@ namespace
         GuardedWaitContext(const GuardedWaitContext&) = delete;
         GuardedWaitContext& operator=(const GuardedWaitContext&) = delete;
 
-        GuardedWaitContext(GuardedWaitContext &&) = delete;
+        GuardedWaitContext(GuardedWaitContext&&) = delete;
         GuardedWaitContext& operator=(GuardedWaitContext&&) = delete;
     };
 

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -864,7 +864,7 @@ namespace winrt::TerminalApp::implementation
             }
         });
 
-        events.taskbarToken = control.SetTaskbarProgress([dispatcher, weakThis](auto&&, auto &&) -> winrt::fire_and_forget {
+        events.taskbarToken = control.SetTaskbarProgress([dispatcher, weakThis](auto&&, auto&&) -> winrt::fire_and_forget {
             co_await wil::resume_foreground(dispatcher);
             // Check if Tab's lifetime has expired
             if (auto tab{ weakThis.get() })
@@ -1069,7 +1069,7 @@ namespace winrt::TerminalApp::implementation
         // Add a Closed event handler to the Pane. If the pane closes out from
         // underneath us, and it's zoomed, we want to be able to make sure to
         // update our state accordingly to un-zoom that pane. See GH#7252.
-        auto closedToken = pane->Closed([weakThis, weakPane](auto&& /*s*/, auto && /*e*/) -> winrt::fire_and_forget {
+        auto closedToken = pane->Closed([weakThis, weakPane](auto&& /*s*/, auto&& /*e*/) -> winrt::fire_and_forget {
             if (auto tab{ weakThis.get() })
             {
                 if (tab->_zoomedPane)

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -506,8 +506,8 @@ void NonClientIslandWindow::_OnMaximizeChange() noexcept
         const auto isIconified = WI_IsFlagSet(windowStyle, WS_ICONIC);
 
         const auto state = _isMaximized ? winrt::TerminalApp::WindowVisualState::WindowVisualStateMaximized :
-                                          isIconified ? winrt::TerminalApp::WindowVisualState::WindowVisualStateIconified :
-                                                        winrt::TerminalApp::WindowVisualState::WindowVisualStateNormal;
+                           isIconified  ? winrt::TerminalApp::WindowVisualState::WindowVisualStateIconified :
+                                          winrt::TerminalApp::WindowVisualState::WindowVisualStateNormal;
 
         try
         {

--- a/src/propsheet/dbcs.cpp
+++ b/src/propsheet/dbcs.cpp
@@ -63,8 +63,7 @@ void MakeAltRasterFont(
 }
 
 [[nodiscard]] NTSTATUS
-    InitializeDbcsMisc(
-        VOID)
+InitializeDbcsMisc(VOID)
 {
     return TrueTypeFontList::s_Initialize();
 }
@@ -158,8 +157,7 @@ GetAltFaceName(
 }
 
 [[nodiscard]] NTSTATUS
-    DestroyDbcsMisc(
-        VOID)
+DestroyDbcsMisc(VOID)
 {
     return TrueTypeFontList::s_Destroy();
 }

--- a/src/propsheet/misc.cpp
+++ b/src/propsheet/misc.cpp
@@ -119,9 +119,7 @@ AddFaceNode(
     return pNew;
 }
 
-VOID
-    DestroyFaceNodes(
-        VOID)
+VOID DestroyFaceNodes(VOID)
 {
     PFACENODE pNext, pTmp;
 
@@ -435,16 +433,12 @@ CreateBoldFont:
     return FE_FONTOK; // and continue enumeration
 }
 
-VOID
-    InitializeFonts(
-        VOID)
+VOID InitializeFonts(VOID)
 {
     LOG_IF_FAILED(EnumerateFonts(EF_DEFFACE)); // Just the Default font
 }
 
-VOID
-    DestroyFonts(
-        VOID)
+VOID DestroyFonts(VOID)
 {
     ULONG FontIndex;
 

--- a/src/propsheet/preview.cpp
+++ b/src/propsheet/preview.cpp
@@ -43,8 +43,7 @@ POINT NonClientSize;
 RECT WindowRect;
 DWORD PreviewFlags;
 
-VOID
-    UpdatePreviewRect(VOID)
+VOID UpdatePreviewRect(VOID)
 
 /*++
 

--- a/src/renderer/gdi/state.cpp
+++ b/src/renderer/gdi/state.cpp
@@ -301,7 +301,9 @@ GdiEngine::~GdiEngine()
 
     // If the font type has changed, select an appropriate font variant or soft font.
     const auto usingItalicFont = textAttributes.IsItalic();
-    const auto fontType = usingSoftFont ? FontType::Soft : usingItalicFont ? FontType::Italic : FontType::Default;
+    const auto fontType = usingSoftFont   ? FontType::Soft :
+                          usingItalicFont ? FontType::Italic :
+                                            FontType::Default;
     if (fontType != _lastFontType)
     {
         switch (fontType)

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="clang-format.win-x86" version="10.0.0" targetFramework="native" />
+  <package id="clang-format.win-x86" version="13.0.1" targetFramework="native" />
 </packages>


### PR DESCRIPTION
This commit fixes some formatting bugs by upgrading clang-format and ensures
that our code is again formatted the same way Visual Studio 2022 would do it.