### PR TITLE
Spelling / Grammar

### DIFF
--- a/doc/specs/#1790 - Font features and axes-spec.md
+++ b/doc/specs/#1790 - Font features and axes-spec.md
@@ -60,7 +60,7 @@ Users will be able to add a new setting to their font objects (added in [#10433]
 There is one point to note here about clashing. For example, if a user has the old "weight" setting defined _as well as_ a "wght" axis defined, we will only use the "wght" axis value. We prioritize that value for a few reasons:
 
 1. It is the more recent addition to our settings model. Thus, it is likely that a user that has defined both values probably just forgot to remove the old value.
-2. It is the more precise value, it is a specific float value whereas the the old "weight" setting is an enum (that eventually gets mapped to a float value).
+2. It is the more precise value, it is a specific float value whereas the old "weight" setting is an enum (that eventually gets mapped to a float value).
 
 ## Capabilities
 

--- a/doc/specs/#5000 - Process Model 2.0/#1032 - Elevation Quality of Life Improvements.md
+++ b/doc/specs/#5000 - Process Model 2.0/#1032 - Elevation Quality of Life Improvements.md
@@ -75,7 +75,7 @@ Some things we considered during this investigation:
   - We could theoretically build an RPC tunnel between content and window
     processes, and use the RPC connection to marshal the content process to the
     elevated window. However, then _we_ would need to be responsible for
-    securing access the the RPC endpoint, and we feel even less confident doing
+    securing access the RPC endpoint, and we feel even less confident doing
     that.
   - Attempts were also made to use a window-broker-content architecture, with
     the broker process having a static CLSID in the registry, and having the
@@ -456,7 +456,7 @@ accessible.
 
 Unfortunately, these issues are OS bugs that are largely out of our own control.
 We will continue to apply pressure to the centennial app team internally as we
-encounter these issues. They are are team best equipped to resolve these issues.
+encounter these issues. They are the team best equipped to resolve these issues.
 
 ### Default Terminal & auto-elevation
 

--- a/doc/specs/#5000 - Process Model 2.0/#5000 - Process Model 2.0.md
+++ b/doc/specs/#5000 - Process Model 2.0/#5000 - Process Model 2.0.md
@@ -317,7 +317,7 @@ Some things we considered during this investigation:
   - We could theoretically build an RPC tunnel between content and window
     processes, and use the RPC connection to marshal the content process to the
     elevated window. However, then _we_ would need to be responsible for
-    securing access the the RPC endpoint, and we feel even less confident doing
+    securing access the RPC endpoint, and we feel even less confident doing
     that.
   - Attempts were also made to use a window-broker-content architecture, with
     the broker process having a static CLSID in the registry, and having the

--- a/doc/specs/#607 - Commandline Arguments for the Windows Terminal.md
+++ b/doc/specs/#607 - Commandline Arguments for the Windows Terminal.md
@@ -35,7 +35,7 @@ through commandline arguments.
 
 ## User Stories
 
-Lets consider some different ways that a user or developer might want want to
+Lets consider some different ways that a user or developer might want to
 use commandline arguments, to help guide the design.
 
 1. A user wants to open the Windows Terminal with their default profile.

--- a/src/buffer/out/AttrRow.cpp
+++ b/src/buffer/out/AttrRow.cpp
@@ -95,7 +95,7 @@ void ATTR_ROW::ReplaceAttrs(const TextAttribute& toBeReplacedAttr, const TextAtt
 
 // Routine Description:
 // - Takes an attribute, and merges it into this row from beginIndex (inclusive) to endIndex (exclusive).
-// - For example, if the current row was was [{4, BLUE}], the merge arguments were
+// - For example, if the current row was [{4, BLUE}], the merge arguments were
 //   { beginIndex = 1, endIndex = 3, newAttr = RED }, then the row would modified to be
 //   [{ 1, BLUE}, {2, RED}, {1, BLUE}].
 // Arguments:

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -2645,7 +2645,7 @@ bool Pane::FocusPane(const std::shared_ptr<Pane> pane)
 }
 
 // Method Description:
-// - Check if this pane contains the the argument as a child anywhere along the tree.
+// - Check if this pane contains the argument as a child anywhere along the tree.
 // Arguments:
 // - child: the child to search for.
 // Return Value:

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -472,7 +472,7 @@ std::shared_ptr<Pane> Pane::NavigateDirection(const std::shared_ptr<Pane> source
     }
 
     // Since the direction is the same as our split, it is possible that we must
-    // move focus from from one child to another child.
+    // move focus from one child to another child.
     // We now must keep track of state while we recurse.
     // If we have it, get the size of this pane.
     const auto scaleX = _root.ActualWidth() > 0 ? gsl::narrow_cast<float>(_root.ActualWidth()) : 1.f;

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -598,7 +598,7 @@ namespace winrt::TerminalApp::implementation
     // - Sets focus to the desired tab. Returns false if the provided tabIndex
     //   is greater than the number of tabs we have.
     // - During startup, we'll immediately set the selected tab as focused.
-    // - After startup, we'll dispatch an async method to set the the selected
+    // - After startup, we'll dispatch an async method to set the selected
     //   item of the TabView, which will then also trigger a
     //   TabView::SelectionChanged, handled in
     //   TerminalPage::_OnTabSelectionChanged

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -140,7 +140,7 @@ void Terminal::InsertCharacter(const size_t count)
     // NOTE: the code below is _extremely_ similar to DeleteCharacter
     // We will want to use this same logic and implement a helper function instead
     // that does the 'move a region from here to there' operation
-    // TODO: Github issue #2163
+    // TODO: GitHub issue #2163
     SHORT dist;
     THROW_IF_FAILED(SizeTToShort(count, &dist));
     const auto cursorPos = _buffer->GetCursor().GetPosition();

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -495,7 +495,7 @@ void NonClientIslandWindow::_UpdateMaximizedState()
 }
 
 // Method Description:
-// - Called when the the windows goes from restored to maximized or from
+// - Called when the windows goes from restored to maximized or from
 //   maximized to restored. Updates the maximize button's icon and the frame
 //   margins.
 void NonClientIslandWindow::_OnMaximizeChange() noexcept

--- a/src/host/CopyFromCharPopup.cpp
+++ b/src/host/CopyFromCharPopup.cpp
@@ -15,7 +15,7 @@ CopyFromCharPopup::CopyFromCharPopup(SCREEN_INFORMATION& screenInfo) :
 }
 
 // Routine Description:
-// - This routine handles the delete from cursor to char char popup.  It returns when we're out of input or the user has entered a char.
+// - This routine handles the delete from cursor to char popup.  It returns when we're out of input or the user has entered a char.
 // Return Value:
 // - CONSOLE_STATUS_WAIT - we ran out of input, so a wait block was created
 // - CONSOLE_STATUS_READ_COMPLETE - user hit return

--- a/src/host/exe/CConsoleHandoff.cpp
+++ b/src/host/exe/CConsoleHandoff.cpp
@@ -22,7 +22,7 @@ static HRESULT _duplicateHandle(const HANDLE in, HANDLE& out)
 }
 
 // Routine Description:
-// - Takes the incoming information from COM and and prepares a console hosting session in this process.
+// - Takes the incoming information from COM and prepares a console hosting session in this process.
 // Arguments:
 // - server - Console driver server handle
 // - inputEvent - Event already established that we signal when new input data is available in case the driver is waiting on us

--- a/src/host/ft_host/API_TitleTests.cpp
+++ b/src/host/ft_host/API_TitleTests.cpp
@@ -199,7 +199,7 @@ void TitleTests::TestGetConsoleTitleA()
     // Run the call and test it out.
     TestGetConsoleTitleAVerifyHelper(chReadBuffer.get(), cchReadBuffer, cchTryToRead, 0, S_OK, chReadExpected.get(), cchReadBuffer);
 
-    Log::Comment(L"Test 2: Say we have have exactly the string length with no null space.");
+    Log::Comment(L"Test 2: Say we have exactly the string length with no null space.");
     cchTryToRead = cchTestTitle;
 
     // Prepare the buffers and expected data
@@ -214,7 +214,7 @@ void TitleTests::TestGetConsoleTitleA()
     // Run the call and test it out.
     TestGetConsoleTitleAVerifyHelper(chReadBuffer.get(), cchReadBuffer, cchTryToRead, (DWORD)cchTestTitle, S_OK, chReadExpected.get(), cchReadBuffer);
 
-    Log::Comment(L"Test 3: Say we have have the string length plus one null space.");
+    Log::Comment(L"Test 3: Say we have the string length plus one null space.");
     cchTryToRead = cchTestTitle + 1;
 
     // Prepare the buffers and expected data
@@ -283,7 +283,7 @@ void TitleTests::TestGetConsoleTitleW()
     // Run the call and test it out.
     TestGetConsoleTitleWVerifyHelper(wchReadBuffer.get(), cchReadBuffer, cchTryToRead, (DWORD)cchTestTitle, S_OK, wchReadExpected.get(), cchReadBuffer);
 
-    Log::Comment(L"Test 2: Say we have have exactly the string length with no null space.");
+    Log::Comment(L"Test 2: Say we have exactly the string length with no null space.");
     cchTryToRead = cchTestTitle;
 
     // Prepare the buffers and expected data
@@ -298,7 +298,7 @@ void TitleTests::TestGetConsoleTitleW()
     // Run the call and test it out.
     TestGetConsoleTitleWVerifyHelper(wchReadBuffer.get(), cchReadBuffer, cchTryToRead, (DWORD)cchTestTitle, S_OK, wchReadExpected.get(), cchReadBuffer);
 
-    Log::Comment(L"Test 3: Say we have have the string length plus one null space.");
+    Log::Comment(L"Test 3: Say we have the string length plus one null space.");
     cchTryToRead = cchTestTitle + 1;
 
     // Prepare the buffers and expected data

--- a/src/host/ft_host/Message_KeyPressTests.cpp
+++ b/src/host/ft_host/Message_KeyPressTests.cpp
@@ -136,7 +136,7 @@ class KeyPressTests
                         repeatCount);
         }
 
-        // make sure the the keypresses got processed and coalesced
+        // make sure the keypresses got processed and coalesced
         events = 0;
         successBool = GetNumberOfConsoleInputEvents(inputHandle, &events);
         VERIFY_IS_TRUE(!!successBool);

--- a/src/host/ft_uia/AccessibilityTests.cs
+++ b/src/host/ft_uia/AccessibilityTests.cs
@@ -570,7 +570,7 @@ namespace Conhost.UIA.Tests
                 Action<TextPatternRange> testBottomBoundary = delegate (TextPatternRange range)
                 {
                     // the range is at the bottom of the screen buffer, we
-                    // shouldn't be able to move the endpoint endpoint down
+                    // shouldn't be able to move the endpoint down
                     int moveAmount = range.MoveEndpointByUnit(TextPatternRangeEndpoint.End, TextUnit.Line, 1);
                     Verify.AreEqual(0, moveAmount);
 

--- a/src/host/settings.cpp
+++ b/src/host/settings.cpp
@@ -297,7 +297,7 @@ void Settings::Validate()
     _dwScreenBufferSize.X = std::max(_dwScreenBufferSize.X, 1i16);
     _dwScreenBufferSize.Y = std::max(_dwScreenBufferSize.Y, 1i16);
 
-    // minimum window size size 1x1
+    // minimum window size 1x1
     _dwWindowSize.X = std::max(_dwWindowSize.X, 1i16);
     _dwWindowSize.Y = std::max(_dwWindowSize.Y, 1i16);
 

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -4756,7 +4756,7 @@ void ScreenBufferTests::SetAutoWrapMode()
     short startLine = 0;
     cursor.SetPosition({ 80 - 3, startLine });
     stateMachine.ProcessString(L"abcdef");
-    // Half of the the content should wrap onto the next line.
+    // Half of the content should wrap onto the next line.
     VERIFY_IS_TRUE(_ValidateLineContains({ 80 - 3, startLine }, L"abc", attributes));
     VERIFY_IS_TRUE(_ValidateLineContains({ 0, startLine + 1 }, L"def", attributes));
     VERIFY_ARE_EQUAL(COORD({ 3, startLine + 1 }), cursor.GetPosition());
@@ -4777,7 +4777,7 @@ void ScreenBufferTests::SetAutoWrapMode()
     startLine = 4;
     cursor.SetPosition({ 80 - 3, startLine });
     stateMachine.ProcessString(L"abcdef");
-    // Half of the the content should wrap onto the next line.
+    // Half of the content should wrap onto the next line.
     VERIFY_IS_TRUE(_ValidateLineContains({ 80 - 3, startLine }, L"abc", attributes));
     VERIFY_IS_TRUE(_ValidateLineContains({ 0, startLine + 1 }, L"def", attributes));
     VERIFY_ARE_EQUAL(COORD({ 3, startLine + 1 }), cursor.GetPosition());

--- a/src/renderer/dx/CustomTextRenderer.cpp
+++ b/src/renderer/dx/CustomTextRenderer.cpp
@@ -57,7 +57,7 @@ using namespace Microsoft::Console::Render;
 
 // Routine Description:
 // - Implementation of IDWritePixelSnapping::GetCurrentTransform
-// - Retrieves the the matrix transform to be used while laying pixels onto the
+// - Retrieves the matrix transform to be used while laying pixels onto the
 //   drawing context
 // Arguments:
 // - clientDrawingContext - Pointer to structure of information required to draw


### PR DESCRIPTION
Mostly this is dropping doubled words. There's one brand fix.

## Detailed Description of the Pull Request / Additional comments

I'm close to shipping an [upgrade to check-spelling](https://github.com/check-spelling/check-spelling/releases/tag/v0.0.20-alpha5), but in testing it against this repository, I see one behavior change that I'd like to resolve. So, while I try to figure out how, I figured I'd at least leave the fixes submitted.

(I have some ideas, as I've been slowly working towards a solution to this problem, but it isn't a simple one line change.)

## Validation Steps Performed

[Ran check-spelling v0.0.20-alpha5](https://github.com/check-spelling/terminal/actions/runs/2100515961) w/ a refresh of the configuration based on https://github.com/check-spelling/spell-check-this/tree/prerelease/.github/workflows/

(It identified one minor bug which is fixed in 0.0.20-alpha6 - unreleased.)