### PR TITLE
Cache ProposeCommandlineResult locally

### DIFF
--- a/src/cascadia/Remoting/ProposeCommandlineResult.h
+++ b/src/cascadia/Remoting/ProposeCommandlineResult.h
@@ -25,6 +25,11 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
     struct ProposeCommandlineResult : public ProposeCommandlineResultT<ProposeCommandlineResult>
     {
     public:
+        ProposeCommandlineResult(const Remoting::ProposeCommandlineResult& other) :
+            _Id{ other.Id() },
+            _WindowName{ other.WindowName() },
+            _ShouldCreateWindow{ other.ShouldCreateWindow() } {};
+
         WINRT_PROPERTY(Windows::Foundation::IReference<uint64_t>, Id);
         WINRT_PROPERTY(winrt::hstring, WindowName);
         WINRT_PROPERTY(bool, ShouldCreateWindow, true);

--- a/src/cascadia/Remoting/SummonWindowBehavior.h
+++ b/src/cascadia/Remoting/SummonWindowBehavior.h
@@ -6,7 +6,11 @@ Class Name:
 - SummonWindowBehavior.h
 
 Abstract:
-- TODO!
+- This is a helper class for encapsulating all the information about how a
+  window should be summoned. Includes info like if we should switch desktops or
+  monitors, if we should dropdown (and how fast), and if we should toggle to
+  hidden if we're already visible. Used by the Monarch to tell a Peasant how it
+  should behave.
 
 --*/
 

--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -102,7 +102,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         // monarch, and see what happens here.
 
         bool proposedCommandline = false;
-        winrt::com_ptr<implementation::ProposeCommandlineResult> result{ nullptr };
+        Remoting::ProposeCommandlineResult result{ nullptr };
         while (!proposedCommandline)
         {
             try
@@ -114,7 +114,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                 // `result.ShouldCreateWindow` below, we don't want to explode
                 // (since _proposeToMonarch is not try/caught).
                 Remoting::ProposeCommandlineResult outOfProcResult = _monarch.ProposeCommandline(args);
-                result = winrt::make_self<implementation::ProposeCommandlineResult>(outOfProcResult);
+                result = winrt::make<implementation::ProposeCommandlineResult>(outOfProcResult);
 
                 proposedCommandline = true;
             }
@@ -195,12 +195,12 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
 
         // Here, the monarch (not us) has replied to the message. Get the
         // valuables out of the response:
-        _shouldCreateWindow = result->ShouldCreateWindow();
-        if (result->Id())
+        _shouldCreateWindow = result.ShouldCreateWindow();
+        if (result.Id())
         {
-            givenID = result->Id().Value();
+            givenID = result.Id().Value();
         }
-        givenName = result->WindowName();
+        givenName = result.WindowName();
 
         // TraceLogging doesn't have a good solution for logging an
         // optional. So we have to repeat the calls here:


### PR DESCRIPTION
This is like, 2-4% of our crashes. Impossible to say for sure, but this _looks_ like it's the root cause. This is just another one of our `HandleCommandlineArgs` buckets, hopefully the last.

* [x] Hopefully should close out MSFT:38542548
* [ ] No I didn't write tests, impossible to test
* [x] it builds