### PR TITLE
HC A11y - Make sure we have a sensible HC color for the titlebar

### DIFF
--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -103,7 +103,7 @@
                                 provide a Light&dark version of a resource, but not the
                                 HighContrast version, the resource loader will fall back to the
                                 Light value.
-
+                                
                                 SystemColorButtonFaceColorBrush is the default background color for WinUI's TabViewBackground under high contrast mode.
                             -->
                             <StaticResource x:Key="TabViewBackground"


### PR DESCRIPTION
You'd think that if a key wasn't present in a ThemeDictionary, it'd fall back to the original value. You'd be wrong - if you provide a Light&dark version of a resource, but not the HighContrast version, the resource loader will fall back to the _Light_ value. Of course.

Before (left top), after (right bottom)
![image](https://user-images.githubusercontent.com/18356694/161997751-2ed8d053-488a-47fa-a289-8d7b465bd0b0.png)

Closes MSFT:38264744