### PR TITLE
Manually focus the scheme dropdown when deleting a scheme

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
@@ -302,6 +302,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
         _ColorSchemeList.RemoveAt(removedSchemeIndex);
 
+        DeleteButton().Flyout().Hide();
+
         // GH#11971, part 2. If we delete a scheme, and the next scheme we've
         // loaded is an inbox one that _can't_ be deleted, then we need to toss
         // focus to something sensible, rather than letting it fall out to the
@@ -309,11 +311,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         //
         // When deleting a scheme and the next scheme _is_ deletable, this isn't
         // an issue, we'll already correctly focus the Delete button.
-        if (!CanDeleteCurrentScheme())
-        {
-            SelectionBackgroundButton().Focus(FocusState::Programmatic);
-        }
-        DeleteButton().Flyout().Hide();
+        //
+        // However, it seems even more useful for focus to ALWAYS land on the
+        // scheme dropdown box. This forces Narrator to read the name of the
+        // newly selected color scheme, which seemed more useful.
+        ColorSchemeComboBox().Focus(FocusState::Programmatic);
     }
 
     void ColorSchemes::AddNew_Click(IInspectable const& /*sender*/, RoutedEventArgs const& /*e*/)

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
@@ -301,6 +301,18 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             ColorSchemeComboBox().SelectedIndex(removedSchemeIndex - 1);
         }
         _ColorSchemeList.RemoveAt(removedSchemeIndex);
+
+        // GH#11971, part 2. If we delete a scheme, and the next scheme we've
+        // loaded is an inbox one that _can't_ be deleted, then we need to toss
+        // focus to something sensible, rather than letting it fall out to the
+        // tab item.
+        //
+        // When deleting a scheme and the next scheme _is_ deletable, this isn't
+        // an issue, we'll already correctly focus the Delete button.
+        if (!CanDeleteCurrentScheme())
+        {
+            SelectionBackgroundButton().Focus(FocusState::Programmatic);
+        }
         DeleteButton().Flyout().Hide();
     }
 


### PR DESCRIPTION
If we delete a scheme, and the next scheme we've loaded is an inbox one
that _can't_ be deleted, then we need to toss focus to something
sensible, rather than letting it fall out to the tab item.

When deleting a scheme and the next scheme _is_ deletable, this isn't an
issue, we'll already correctly focus the Delete button.

125e9c479018ac648c80554ef3ce69f7b637857d focused the SelectionBackground
button, which is the _previous_ focusable control, rather than the
following one.

However, it seems even more useful for focus to ALWAYS land on the
scheme dropdown box. This forces Narrator to read the name of the newly
selected color scheme, which seemed more useful.

I'm waiting on feedback from a11y team to see if this solution is
acceptable.

* [x] Is for #11971
