### PR TITLE
Fix retail build breaks with unreferenced locals (Closes #12769)

### DIFF
--- a/src/tools/closetest/closetest.cpp
+++ b/src/tools/closetest/closetest.cpp
@@ -299,6 +299,7 @@ static std::vector<DWORD> getConsoleProcessList()
     assert(count1 >= 1 && "GetConsoleProcessList failed");
     ret.resize(count1);
     const DWORD count2 = GetConsoleProcessList(&ret[0], (DWORD)ret.size());
+    UNREFERENCED_PARAMETER(count2);
     assert(count1 == count2 && "GetConsoleProcessList failed");
     return ret;
 }
@@ -375,6 +376,7 @@ static void spawnChildTree(DWORD masterPid, const std::vector<std::wstring>& ext
     assert(success && "CreateProcessW failed");
 
     const DWORD waitRet = WaitForSingleObject(readyEvent, INFINITE);
+    UNREFERENCED_PARAMETER(waitRet);
     assert(waitRet == WAIT_OBJECT_0 && "WaitForSingleObject failed");
     CloseHandle(readyEvent);
     CloseHandle(pi.hThread);
@@ -485,6 +487,7 @@ static HANDLE duplicateHandle(HANDLE srcProc, HANDLE srcHandle)
     HANDLE ret{};
     const auto success =
         DuplicateHandle(srcProc, srcHandle, GetCurrentProcess(), &ret, 0, FALSE, DUPLICATE_SAME_ACCESS);
+    UNREFERENCED_PARAMETER(success);
     assert(success && "DuplicateHandle failed");
     return ret;
 }
@@ -605,6 +608,7 @@ static int doChild(std::deque<std::wstring> argv)
     {
         const BOOL success =
             AssignProcessToJobObject(jobHandle, GetCurrentProcess());
+        UNREFERENCED_PARAMETER(success);
         assert(success && "AssignProcessToJobObject failed");
         CloseHandle(jobHandle);
         jobHandle = nullptr;


### PR DESCRIPTION
Closes #12769