### PR TITLE
Remove `default_interface` from Monarch

### DIFF
--- a/src/cascadia/Remoting/Monarch.idl
+++ b/src/cascadia/Remoting/Monarch.idl
@@ -68,7 +68,7 @@ namespace Microsoft.Terminal.Remoting
         event Windows.Foundation.TypedEventHandler<Object, QuitAllRequestedArgs> QuitAllRequested;
     };
 
-    [default_interface] runtimeclass Monarch : IMonarch
+    runtimeclass Monarch : [default] IMonarch
     {
         Monarch();
     };

--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -341,8 +341,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         //
         // * If we're running unpackaged: the .winmd must be a sibling of the .exe
         // * If we're running packaged: the .winmd must be in the package root
-        _monarch = create_instance<Remoting::Monarch>(Monarch_clsid,
-                                                      CLSCTX_LOCAL_SERVER);
+        _monarch = create_instance<Remoting::IMonarch>(Monarch_clsid,
+                                                       CLSCTX_LOCAL_SERVER);
     }
 
     // NOTE: This can throw! Callers include:

--- a/src/cascadia/Remoting/WindowManager.h
+++ b/src/cascadia/Remoting/WindowManager.h
@@ -64,7 +64,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
         bool _shouldCreateWindow{ false };
         bool _isKing{ false };
         DWORD _registrationHostClass{ 0 };
-        winrt::Microsoft::Terminal::Remoting::Monarch _monarch{ nullptr };
+        winrt::Microsoft::Terminal::Remoting::IMonarch _monarch{ nullptr };
         winrt::Microsoft::Terminal::Remoting::Peasant _peasant{ nullptr };
 
         wil::unique_event _monarchWaitInterrupt;


### PR DESCRIPTION
This is all of course, conjecture. This crash is totally wild and makes no sense at all. But, we're hoping that this fixes it. This should also make calls to the Monarch a little easier.

You may be asking yourself - why aren't I doing this for the Peasant too? Well, because the Peasant simply doesn't crash like the monarch does. I'm not gonna touch something that's not broken _during ask mode_.

* [x] Closes #12774, hopefully.
* [x] tests pass.
