### PR TITLE
Don't use memcmp() to compare TextAttributes, instead just reorder the data member comparisons

### DIFF
--- a/src/buffer/out/TextAttribute.hpp
+++ b/src/buffer/out/TextAttribute.hpp
@@ -178,8 +178,8 @@ private:
 #endif
 };
 
-// The numner 14 is historical/arbitrary but verifies the assumptions documented earlier in the comments
-// about size and alignment of the fields of the class. The offsertof() macro does not work with private
+// The number 14 is historical/arbitrary but verifies the assumptions documented earlier in the comments
+// about size and alignment of the fields of the class. The offsetof() macro does not work with private
 // data members so about the best we can do is verify that the entire pile of fields adds up to the
 // same number=.
 static_assert(sizeof(TextAttribute) == 14);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
This PR is a very small non-semantic change to change the code for comparing TextAttribute instances so that the members are compared in their "physical" order rather than in whatever order the original author chose.

The effect of this is to generate significantly better code for the comparisons. The out-of-order comparisons forced the compiler to load the first cache line, cherry pick the first word of it, then load the second cache line, cherry pick a part of it, and then proceed further along.

This led to another contributor being led to want to write code that used memcmp() to perform the comparison which is usually a sign that things have gone very very wrong. Fortunately this appears to be a simpler solution which gets the vc++ compiler at least to generate the right code.

I have not tried other compilers, only the 14.31.31103 toolkit.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 

There are other issues in PR #10566 that I'll stay away from but this is simple and straightforward. I also added a compile-time assertion in the header and some comments. I assume the comments are goodness; the static assertion may be a problem on other platforms, I cannot verify.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->

Sorry I don't have anything more detailed than the above plus the code.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->

I looked at the generated code under cdb before making the fix and then after.
