### PR TITLE
Add experimental setting to make bg images fit the whole tab

### DIFF
--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -921,13 +921,9 @@ namespace winrt::TerminalApp::implementation
 
     void TerminalPage::_UpdateBackground(const winrt::Microsoft::Terminal::Settings::Model::Profile& profile)
     {
-        if (profile)
+        if (profile && _settings.GlobalSettings().BgImageForWindow())
         {
-            auto controlSettings = TerminalSettings::CreateWithProfile(_settings, profile, *_bindings);
-            if (_settings.GlobalSettings().BgImageForWindow())
-            {
-                _SetBackgroundImage(controlSettings.DefaultSettings());
-            }
+            _SetBackgroundImage(profile.DefaultAppearance());
         }
     }
 

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -152,6 +152,10 @@ namespace winrt::TerminalApp::implementation
                 // SetTaskbarProgress event here, to get tell the hosting
                 // application to re-query this value from us.
                 page->_SetTaskbarProgressHandlers(*page, nullptr);
+
+                
+                auto profile = tab->GetFocusedProfile();
+                page->_UpdateBackground(profile);
             }
         });
 
@@ -905,8 +909,27 @@ namespace winrt::TerminalApp::implementation
             {
                 _TitleChangedHandlers(*this, tab.Title());
             }
+
+            auto tab_impl = _GetTerminalTabImpl(tab);
+            if (tab_impl)
+            {
+                auto profile = tab_impl->GetFocusedProfile();
+                _UpdateBackground(profile);
+            }
         }
         CATCH_LOG();
+    }
+
+    void TerminalPage::_UpdateBackground(const winrt::Microsoft::Terminal::Settings::Model::Profile& profile)
+    {
+        if (profile)
+        {
+            auto controlSettings = TerminalSettings::CreateWithProfile(_settings, profile, *_bindings);
+            if (_settings.GlobalSettings().BgImageForWindow())
+            {
+                _SetBackgroundImage(controlSettings.DefaultSettings());
+            }
+        }
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -153,7 +153,6 @@ namespace winrt::TerminalApp::implementation
                 // application to re-query this value from us.
                 page->_SetTaskbarProgressHandlers(*page, nullptr);
 
-                
                 auto profile = tab->GetFocusedProfile();
                 page->_UpdateBackground(profile);
             }

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -921,7 +921,7 @@ namespace winrt::TerminalApp::implementation
 
     void TerminalPage::_UpdateBackground(const winrt::Microsoft::Terminal::Settings::Model::Profile& profile)
     {
-        if (profile && _settings.GlobalSettings().BgImageForWindow())
+        if (profile && _settings.GlobalSettings().UseBackgroundImageForWindow())
         {
             _SetBackgroundImage(profile.DefaultAppearance());
         }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2595,7 +2595,7 @@ namespace winrt::TerminalApp::implementation
             profileGuidSettingsMap.insert_or_assign(newProfile.Guid(), std::pair{ newProfile, nullptr });
         }
 
-        if (_settings.GlobalSettings().BgImageForWindow())
+        if (_settings.GlobalSettings().UseBackgroundImageForWindow())
         {
             const auto focusedTab{ _GetFocusedTabImpl() };
             if (focusedTab)

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2473,11 +2473,6 @@ namespace winrt::TerminalApp::implementation
             connection.Resize(controlSettings.DefaultSettings().InitialRows(), controlSettings.DefaultSettings().InitialCols());
         }
 
-        if (_settings.GlobalSettings().BgImageForWindow())
-        {
-            _SetBackgroundImage(controlSettings.DefaultSettings());
-        }
-
         TerminalConnection::ITerminalConnection debugConnection{ nullptr };
         if (_settings.GlobalSettings().DebugFeaturesEnabled())
         {
@@ -2526,9 +2521,9 @@ namespace winrt::TerminalApp::implementation
     // - newAppearance
     // Return Value:
     // - <none>
-    void TerminalPage::_SetBackgroundImage(const winrt::Microsoft::Terminal::Control::IControlAppearance& newAppearance)
+    void TerminalPage::_SetBackgroundImage(const winrt::Microsoft::Terminal::Settings::Model::IAppearanceConfig& newAppearance)
     {
-        if (newAppearance.BackgroundImage().empty())
+        if (newAppearance.BackgroundImagePath().empty())
         {
             _tabContent.Background(nullptr);
             return;
@@ -2537,7 +2532,7 @@ namespace winrt::TerminalApp::implementation
         Windows::Foundation::Uri imageUri{ nullptr };
         try
         {
-            imageUri = Windows::Foundation::Uri{ newAppearance.BackgroundImage() };
+            imageUri = Windows::Foundation::Uri{ newAppearance.BackgroundImagePath() };
         }
         catch (...)
         {
@@ -2608,8 +2603,7 @@ namespace winrt::TerminalApp::implementation
                 auto profile = focusedTab->GetFocusedProfile();
                 if (profile)
                 {
-                    auto controlSettings = TerminalSettings::CreateWithProfile(_settings, profile, *_bindings);
-                    _SetBackgroundImage(controlSettings.DefaultSettings());
+                    _SetBackgroundImage(profile.DefaultAppearance());
                 }
             }
         }

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -255,7 +255,7 @@ namespace winrt::TerminalApp::implementation
         void _UpdateTabView();
         void _UpdateTabWidthMode();
         void _UpdateCommandsForPalette();
-        void _SetBackgroundImage(const winrt::Microsoft::Terminal::Control::IControlAppearance& newAppearance);
+        void _SetBackgroundImage(const winrt::Microsoft::Terminal::Settings::Model::IAppearanceConfig& newAppearance);
 
         static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, Microsoft::Terminal::Settings::Model::Command> _ExpandCommands(Windows::Foundation::Collections::IMapView<winrt::hstring, Microsoft::Terminal::Settings::Model::Command> commandsToExpand,
                                                                                                                                             Windows::Foundation::Collections::IVectorView<Microsoft::Terminal::Settings::Model::Profile> profiles,

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -255,6 +255,7 @@ namespace winrt::TerminalApp::implementation
         void _UpdateTabView();
         void _UpdateTabWidthMode();
         void _UpdateCommandsForPalette();
+        void _SetBackgroundImage(const winrt::Microsoft::Terminal::Control::IControlAppearance& newAppearance);
 
         static winrt::Windows::Foundation::Collections::IMap<winrt::hstring, Microsoft::Terminal::Settings::Model::Command> _ExpandCommands(Windows::Foundation::Collections::IMapView<winrt::hstring, Microsoft::Terminal::Settings::Model::Command> commandsToExpand,
                                                                                                                                             Windows::Foundation::Collections::IVectorView<Microsoft::Terminal::Settings::Model::Profile> profiles,
@@ -362,6 +363,7 @@ namespace winrt::TerminalApp::implementation
         void _OnTabCloseRequested(const IInspectable& sender, const Microsoft::UI::Xaml::Controls::TabViewTabCloseRequestedEventArgs& eventArgs);
         void _OnFirstLayout(const IInspectable& sender, const IInspectable& eventArgs);
         void _UpdatedSelectedTab(const winrt::TerminalApp::TabBase& tab);
+        void _UpdateBackground(const winrt::Microsoft::Terminal::Settings::Model::Profile& profile);
 
         void _OnDispatchCommandRequested(const IInspectable& sender, const Microsoft::Terminal::Settings::Model::Command& command);
         void _OnCommandLineExecutionRequested(const IInspectable& sender, const winrt::hstring& commandLine);

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -72,8 +72,7 @@
               HorizontalAlignment="Stretch"
               VerticalAlignment="Stretch">
             <Grid.Background>
-                <ImageBrush>
-                </ImageBrush>
+                <ImageBrush />
             </Grid.Background>
         </Grid>
 

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -70,7 +70,12 @@
         <Grid x:Name="TabContent"
               Grid.Row="2"
               HorizontalAlignment="Stretch"
-              VerticalAlignment="Stretch" />
+              VerticalAlignment="Stretch">
+            <Grid.Background>
+                <ImageBrush>
+                </ImageBrush>
+            </Grid.Background>
+        </Grid>
 
         <!--
             GH#12775 et. al: After switching to ControlsV2, it seems that

--- a/src/cascadia/TerminalApp/pch.h
+++ b/src/cascadia/TerminalApp/pch.h
@@ -44,6 +44,7 @@
 #include <winrt/Windows.UI.Xaml.Input.h>
 #include <winrt/Windows.UI.Xaml.Markup.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
+#include <winrt/Windows.UI.Xaml.Media.Imaging.h>
 #include <winrt/Windows.UI.Xaml.Media.Animation.h>
 #include <winrt/Windows.Media.h>
 #include <winrt/Windows.Media.Core.h>

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1693,6 +1693,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // then the renderer should not render "default background" text with a
         // fully opaque background. Doing that would cover up our nice
         // transparency, or our acrylic, or our image.
-        return Opacity() < 1.0f || UseAcrylic() || !_settings->BackgroundImage().empty() || _settings->BgImageForWindow();
+        return Opacity() < 1.0f || UseAcrylic() || !_settings->BackgroundImage().empty() || _settings->UseBackgroundImageForWindow();
     }
 }

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1693,6 +1693,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // then the renderer should not render "default background" text with a
         // fully opaque background. Doing that would cover up our nice
         // transparency, or our acrylic, or our image.
-        return Opacity() < 1.0f || UseAcrylic() || !_settings->BackgroundImage().empty();
+        return Opacity() < 1.0f || UseAcrylic() || !_settings->BackgroundImage().empty() || _settings->BgImageForWindow();
     }
 }

--- a/src/cascadia/TerminalControl/IControlSettings.idl
+++ b/src/cascadia/TerminalControl/IControlSettings.idl
@@ -56,5 +56,6 @@ namespace Microsoft.Terminal.Control
         // Experimental Settings
         Boolean ForceFullRepaintRendering { get; };
         Boolean SoftwareRendering { get; };
+        Boolean BgImageForWindow { get; };
     };
 }

--- a/src/cascadia/TerminalControl/IControlSettings.idl
+++ b/src/cascadia/TerminalControl/IControlSettings.idl
@@ -56,6 +56,6 @@ namespace Microsoft.Terminal.Control
         // Experimental Settings
         Boolean ForceFullRepaintRendering { get; };
         Boolean SoftwareRendering { get; };
-        Boolean BgImageForWindow { get; };
+        Boolean UseBackgroundImageForWindow { get; };
     };
 }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -308,7 +308,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         // Set TSF Foreground
         Media::SolidColorBrush foregroundBrush{};
-        if (_core.Settings().BgImageForWindow())
+        if (_core.Settings().UseBackgroundImageForWindow())
         {
             foregroundBrush.Color(Windows::UI::Colors::Transparent());
         }
@@ -401,7 +401,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - <none>
     void TermControl::_SetBackgroundImage(const IControlAppearance& newAppearance)
     {
-        if (newAppearance.BackgroundImage().empty() || _core.Settings().BgImageForWindow())
+        if (newAppearance.BackgroundImage().empty() || _core.Settings().UseBackgroundImageForWindow())
         {
             BackgroundImage().Source(nullptr);
             return;
@@ -460,7 +460,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         auto settings{ _core.Settings() };
         auto bgColor = til::color{ _core.FocusedAppearance().DefaultBackground() };
 
-        auto transparentBg = settings.BgImageForWindow();
+        auto transparentBg = settings.UseBackgroundImageForWindow();
         if (transparentBg)
         {
             bgColor = Windows::UI::Colors::Transparent();
@@ -533,7 +533,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - bg: the new color to use as the background color.
     void TermControl::_changeBackgroundColor(til::color bg)
     {
-        auto transparent_bg = _core.Settings().BgImageForWindow();
+        auto transparent_bg = _core.Settings().UseBackgroundImageForWindow();
         if (transparent_bg)
         {
             bg = Windows::UI::Colors::Transparent();

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -460,15 +460,15 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         auto settings{ _core.Settings() };
         auto bgColor = til::color{ _core.FocusedAppearance().DefaultBackground() };
 
-        auto transparent_bg = settings.BgImageForWindow();
-        if (transparent_bg)
+        auto transparentBg = settings.BgImageForWindow();
+        if (transparentBg)
         {
             bgColor = Windows::UI::Colors::Transparent();
         }
         // GH#11743: Make sure to use the Core's current UseAcrylic value, not
         // the one from the settings. The Core's runtime UseAcrylic may have
         // changed from what was in the original settings.
-        if (_core.UseAcrylic() && !transparent_bg)
+        if (_core.UseAcrylic() && !transparentBg)
         {
             // See if we've already got an acrylic background brush
             // to avoid the flicker when setting up a new one

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -205,7 +205,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         void _InitializeBackgroundBrush();
         winrt::fire_and_forget _coreBackgroundColorChanged(const IInspectable& sender, const IInspectable& args);
-        void _changeBackgroundColor(const til::color bg);
+        void _changeBackgroundColor(til::color bg);
         void _changeBackgroundOpacity();
 
         bool _InitializeTerminal();

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -72,7 +72,7 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_SETTING(Boolean, SnapToGridOnResize);
         INHERITABLE_SETTING(Boolean, ForceFullRepaintRendering);
         INHERITABLE_SETTING(Boolean, SoftwareRendering);
-        INHERITABLE_SETTING(Boolean, BgImageForWindow);
+        INHERITABLE_SETTING(Boolean, UseBackgroundImageForWindow);
         INHERITABLE_SETTING(Boolean, ForceVTInput);
         INHERITABLE_SETTING(Boolean, DebugFeaturesEnabled);
         INHERITABLE_SETTING(Boolean, StartOnUserLogin);

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -72,6 +72,7 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_SETTING(Boolean, SnapToGridOnResize);
         INHERITABLE_SETTING(Boolean, ForceFullRepaintRendering);
         INHERITABLE_SETTING(Boolean, SoftwareRendering);
+        INHERITABLE_SETTING(Boolean, BgImageForWindow);
         INHERITABLE_SETTING(Boolean, ForceVTInput);
         INHERITABLE_SETTING(Boolean, DebugFeaturesEnabled);
         INHERITABLE_SETTING(Boolean, StartOnUserLogin);

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -26,7 +26,7 @@ Author(s):
     X(bool, FocusFollowMouse, "focusFollowMouse", false)                                                                                                   \
     X(bool, ForceFullRepaintRendering, "experimental.rendering.forceFullRepaint", false)                                                                   \
     X(bool, SoftwareRendering, "experimental.rendering.software", false)                                                                                   \
-    X(bool, BgImageForWindow, "experimental.useBackgroundImageForWindow", false)                                                                           \
+    X(bool, UseBackgroundImageForWindow, "experimental.useBackgroundImageForWindow", false)                                                                \
     X(bool, ForceVTInput, "experimental.input.forceVT", false)                                                                                             \
     X(bool, TrimBlockSelection, "trimBlockSelection", true)                                                                                                \
     X(bool, DetectURLs, "experimental.detectURLs", true)                                                                                                   \

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -26,6 +26,7 @@ Author(s):
     X(bool, FocusFollowMouse, "focusFollowMouse", false)                                                                                                   \
     X(bool, ForceFullRepaintRendering, "experimental.rendering.forceFullRepaint", false)                                                                   \
     X(bool, SoftwareRendering, "experimental.rendering.software", false)                                                                                   \
+    X(bool, BgImageForWindow, "experimental.useBackgroundImageForWindow", false)                                                                           \
     X(bool, ForceVTInput, "experimental.input.forceVT", false)                                                                                             \
     X(bool, TrimBlockSelection, "trimBlockSelection", true)                                                                                                \
     X(bool, DetectURLs, "experimental.detectURLs", true)                                                                                                   \

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
@@ -284,6 +284,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         _FocusFollowMouse = globalSettings.FocusFollowMouse();
         _ForceFullRepaintRendering = globalSettings.ForceFullRepaintRendering();
         _SoftwareRendering = globalSettings.SoftwareRendering();
+        _BgImageForWindow = globalSettings.BgImageForWindow();
         _ForceVTInput = globalSettings.ForceVTInput();
         _TrimBlockSelection = globalSettings.TrimBlockSelection();
         _DetectURLs = globalSettings.DetectURLs();

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.cpp
@@ -284,7 +284,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         _FocusFollowMouse = globalSettings.FocusFollowMouse();
         _ForceFullRepaintRendering = globalSettings.ForceFullRepaintRendering();
         _SoftwareRendering = globalSettings.SoftwareRendering();
-        _BgImageForWindow = globalSettings.BgImageForWindow();
+        _UseBackgroundImageForWindow = globalSettings.UseBackgroundImageForWindow();
         _ForceVTInput = globalSettings.ForceVTInput();
         _TrimBlockSelection = globalSettings.TrimBlockSelection();
         _DetectURLs = globalSettings.DetectURLs();

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -149,6 +149,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         INHERITABLE_SETTING(Model::TerminalSettings, bool, RetroTerminalEffect, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, ForceFullRepaintRendering, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, SoftwareRendering, false);
+        INHERITABLE_SETTING(Model::TerminalSettings, bool, BgImageForWindow, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, ForceVTInput, false);
 
         INHERITABLE_SETTING(Model::TerminalSettings, hstring, PixelShaderPath);

--- a/src/cascadia/TerminalSettingsModel/TerminalSettings.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettings.h
@@ -149,7 +149,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         INHERITABLE_SETTING(Model::TerminalSettings, bool, RetroTerminalEffect, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, ForceFullRepaintRendering, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, SoftwareRendering, false);
-        INHERITABLE_SETTING(Model::TerminalSettings, bool, BgImageForWindow, false);
+        INHERITABLE_SETTING(Model::TerminalSettings, bool, UseBackgroundImageForWindow, false);
         INHERITABLE_SETTING(Model::TerminalSettings, bool, ForceVTInput, false);
 
         INHERITABLE_SETTING(Model::TerminalSettings, hstring, PixelShaderPath);

--- a/src/cascadia/inc/ControlProperties.h
+++ b/src/cascadia/inc/ControlProperties.h
@@ -68,4 +68,5 @@
     X(winrt::Microsoft::Terminal::Control::TextAntialiasingMode, AntialiasingMode, winrt::Microsoft::Terminal::Control::TextAntialiasingMode::Grayscale) \
     X(bool, ForceFullRepaintRendering, false)                                                                                                            \
     X(bool, SoftwareRendering, false)                                                                                                                    \
+    X(bool, BgImageForWindow, false)                                                                                                                     \
     X(bool, UseAtlasEngine, false)

--- a/src/cascadia/inc/ControlProperties.h
+++ b/src/cascadia/inc/ControlProperties.h
@@ -68,5 +68,5 @@
     X(winrt::Microsoft::Terminal::Control::TextAntialiasingMode, AntialiasingMode, winrt::Microsoft::Terminal::Control::TextAntialiasingMode::Grayscale) \
     X(bool, ForceFullRepaintRendering, false)                                                                                                            \
     X(bool, SoftwareRendering, false)                                                                                                                    \
-    X(bool, BgImageForWindow, false)                                                                                                                     \
+    X(bool, UseBackgroundImageForWindow, false)                                                                                                          \
     X(bool, UseAtlasEngine, false)


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fixes #6028
Setting is "experimental.useBackgroundImageForWindow"

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
https://github.com/microsoft/terminal/issues/6028
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Closes #6028
* [X] CLA signed.
* [ ] Tests added/passed
* [ ] Documentation updated. I read CONTRIBUTING.md, but I'm not sure if a spec is needed for an experimental feature such as this one.
* [ ] Schema updated. I added a JSON key, not sure where I need to update it.
* [X] I've discussed this with core contributors already. Somewhat discussed in https://github.com/microsoft/terminal/issues/6028

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here
## Detailed Description of the Pull Request / Additional comments -->

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Set ` "experimental.useBackgroundImageForWindow": true` and a bg image for one profile, then make splits and tabs and make sure the bg updates accordingly:
![xqMUWpo1JK](https://user-images.githubusercontent.com/24706838/162996037-ce2ec077-d0e8-43ab-ad5b-0e5c0354fc30.gif)
I also did the same with the setting off to make sure it still works correctly and didn't break. And I made sure opening the settings tab does not crash or show the bg image.