### PR TITLE
Another attempt at fixing nearby font loading

### DIFF
--- a/src/renderer/base/FontCache.h
+++ b/src/renderer/base/FontCache.h
@@ -62,12 +62,15 @@ namespace Microsoft::Console::Render::FontCache
 
                 wil::com_ptr<IDWriteFontSetBuilder1> fontSetBuilder;
                 THROW_IF_FAILED(factory5->CreateFontSetBuilder(fontSetBuilder.addressof()));
-                THROW_IF_FAILED(fontSetBuilder->AddFontSet(systemFontSet.get()));
 
                 for (const auto& file : nearbyFontFiles)
                 {
                     LOG_IF_FAILED(fontSetBuilder->AddFontFile(file.get()));
                 }
+
+                // IDWriteFontSetBuilder ignores any families that have already been added.
+                // By adding the system font collection last, we ensure our nearby fonts take precedence.
+                THROW_IF_FAILED(fontSetBuilder->AddFontSet(systemFontSet.get()));
 
                 wil::com_ptr<IDWriteFontSet> fontSet;
                 THROW_IF_FAILED(fontSetBuilder->CreateFontSet(fontSet.addressof()));


### PR DESCRIPTION
The original research for a solution all the way back in #11032 contained an
unfortunate flaw. The nearby font loading code was written under the assumption
that Cascadia is missing in the system font collection, leading to our issues.
Adding nearby fonts last into the collection would thus ensure that we use
the system fonts whenever possible, but only have nearby fonts as a fallback.

This didn't work and we figured that we'd have to always prefer loading nearby
fonts over system fonts. #12554 tried to achieve this, but failed to change
the order in which the font set is built. In order to prefer nearby fonts
over system ones, we have to add the system font collection last.

## PR Checklist

* [x] Closes #11648
* [x] I work here
* [x] Tests added/passed
* [x] Embarrassment for my incompetence

## Validation Steps Performed

* Put Jetbrains Mono into the AppX directory of the Debug build
* Jetbrains Mono shows up in the font selector and is useable

Additionally a more complex mini-test was built:
Using FontForge I've cloned arial.ttf and removed all characters except for
the letter "0". Afterwards I've build a custom font collection the same way
we do it in Terminal, extracted a `FontFace` named "Arial" and called
`IDWriteFont::HasCharacter` for the letter "1".
Loading the system font collection first results in `TRUE` and loading it last
results in `FALSE` (since my custom arial.ttf doesn't have the letter "1").
This confirms that we need to load the system font collection last.