### PR TITLE
Fix profile commandlines being overwritten by profile.defaults

### DIFF
--- a/src/cascadia/LocalTests_SettingsModel/ProfileTests.cpp
+++ b/src/cascadia/LocalTests_SettingsModel/ProfileTests.cpp
@@ -40,7 +40,6 @@ namespace SettingsModelLocalTests
         TEST_METHOD(LayerProfilesOnArray);
         TEST_METHOD(DuplicateProfileTest);
         TEST_METHOD(TestGenGuidsForProfiles);
-
         TEST_METHOD(TestCorrectOldDefaultShellPaths);
     };
 
@@ -367,31 +366,43 @@ namespace SettingsModelLocalTests
             ]
         })" };
         static constexpr std::string_view userProfiles{ R"({
-            "profiles": [
+            "profiles": {
+                "defaults":
                 {
-                    "name" : "powershell 1",
-                    "commandline": "powershell.exe",
-                    "guid" : "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}"
+                    "commandline": "pwsh.exe"
                 },
-                {
-                    "name" : "powershell 2",
-                    "commandline": "powershell.exe",
-                    "guid" : "{61c54bbd-0000-5271-96e7-009a87ff44bf}"
-                },
-                {
-                    "name" : "cmd 1",
-                    "commandline": "cmd.exe",
-                    "guid" : "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}"
-                },
-                {
-                    "name" : "cmd 2",
-                    "commandline": "cmd.exe",
-                    "guid" : "{0caa0dad-0000-5f56-a8ff-afceeeaa6101}"
-                }
-            ]
+                "list":
+                [
+                    {
+                        "name" : "powershell 1",
+                        "commandline": "powershell.exe",
+                        "guid" : "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}"
+                    },
+                    {
+                        "name" : "powershell 2",
+                        "commandline": "powershell.exe",
+                        "guid" : "{61c54bbd-0000-5271-96e7-009a87ff44bf}"
+                    },
+                    {
+                        "name" : "cmd 1",
+                        "commandline": "cmd.exe",
+                        "guid" : "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}"
+                    },
+                    {
+                        "name" : "cmd 2",
+                        "commandline": "cmd.exe",
+                        "guid" : "{0caa0dad-0000-5f56-a8ff-afceeeaa6101}"
+                    }
+                ]
+            }
         })" };
 
-        const auto settings = winrt::make_self<implementation::CascadiaSettings>(userProfiles, inboxProfiles);
+        implementation::SettingsLoader loader{ userProfiles, inboxProfiles };
+        loader.MergeInboxIntoUserSettings();
+        loader.FinalizeLayering();
+        loader.FixupUserSettings();
+
+        const auto settings = winrt::make_self<implementation::CascadiaSettings>(std::move(loader));
         const auto allProfiles = settings->AllProfiles();
         VERIFY_ARE_EQUAL(4u, allProfiles.Size());
         VERIFY_ARE_EQUAL(L"powershell 1", allProfiles.GetAt(0).Name());

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -404,7 +404,6 @@ winrt::com_ptr<Profile> CascadiaSettings::_createNewProfile(const std::wstring_v
 // - <none>
 void CascadiaSettings::_validateSettings()
 {
-    _validateCorrectDefaultShellPaths();
     _validateAllSchemesExist();
     _validateMediaResources();
     _validateKeybindings();

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -60,6 +60,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         void MergeFragmentIntoUserSettings(const winrt::hstring& source, const std::string_view& content);
         void FinalizeLayering();
         bool DisableDeletedProfiles();
+        bool FixupUserSettings();
 
         ParsedSettings inboxSettings;
         ParsedSettings userSettings;
@@ -155,7 +156,6 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         void _validateMediaResources();
         void _validateKeybindings() const;
         void _validateColorSchemesInCommands() const;
-        void _validateCorrectDefaultShellPaths() const;
         bool _hasInvalidColorScheme(const Model::Command& command) const;
 
         // user settings

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -334,6 +334,9 @@ void SettingsLoader::FinalizeLayering()
 // This section of code recognizes if a profile was seen before and marks it as
 // `"hidden": true` by default and thus ensures the behavior the user expects:
 // Profiles won't show up again after they've been removed from settings.json.
+//
+// Returns true if something got changed and
+// the settings need to be saved to disk.
 bool SettingsLoader::DisableDeletedProfiles()
 {
     const auto& state = winrt::get_self<ApplicationState>(ApplicationState::SharedInstance());
@@ -359,6 +362,58 @@ bool SettingsLoader::DisableDeletedProfiles()
     }
 
     return newGeneratedProfiles;
+}
+
+// Runs migrations and fixups on user settings.
+// Returns true if something got changed and
+// the settings need to be saved to disk.
+bool SettingsLoader::FixupUserSettings()
+{
+    using namespace std::string_view_literals;
+
+    struct CommandlinePatch
+    {
+        winrt::guid guid;
+        std::wstring_view before;
+        std::wstring_view after;
+    };
+
+    static constexpr std::array commandlinePatches{
+        CommandlinePatch{ DEFAULT_COMMAND_PROMPT_GUID, L"cmd.exe", L"%SystemRoot%\\System32\\cmd.exe" },
+        CommandlinePatch{ DEFAULT_WINDOWS_POWERSHELL_GUID, L"powershell.exe", L"%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" },
+    };
+
+    bool fixedUp = false;
+
+    for (const auto& profile : userSettings.profiles)
+    {
+        if (!profile->HasCommandline())
+        {
+            continue;
+        }
+
+        for (const auto& patch : commandlinePatches)
+        {
+            if (profile->Guid() == patch.guid && til::equals_insensitive_ascii(profile->Commandline(), patch.before))
+            {
+                profile->ClearCommandline();
+
+                // GH#12842:
+                // With the commandline field on the user profile gone, it's actually unknown what
+                // commandline it'll inherit, since a user profile can have multiple parents. We have to
+                // make sure we restore the correct commandline in case we don't inherit the expected one.
+                if (profile->Commandline() != patch.after)
+                {
+                    profile->Commandline(winrt::hstring{ patch.after });
+                }
+
+                fixedUp = true;
+                break;
+            }
+        }
+    }
+
+    return fixedUp;
 }
 
 // Give a string of length N and a position of [0,N) this function returns
@@ -750,9 +805,9 @@ try
     loader.FinalizeLayering();
 
     // DisableDeletedProfiles returns true whenever we encountered any new generated/dynamic profiles.
-    // Coincidentally this is also the time we should write the new settings.json
-    // to disk (so that it contains the new profiles for manual editing by the user).
+    // Similarly FixupUserSettings returns true, when it encountered settings that were patched up.
     mustWriteToDisk |= loader.DisableDeletedProfiles();
+    mustWriteToDisk |= loader.FixupUserSettings();
 
     // If this throws, the app will catch it and use the default settings.
     const auto settings = winrt::make_self<CascadiaSettings>(std::move(loader));
@@ -1023,21 +1078,4 @@ void CascadiaSettings::_resolveDefaultProfile() const
 
     // Use the first profile as the new default.
     GlobalSettings().DefaultProfile(_allProfiles.GetAt(0).Guid());
-}
-
-void CascadiaSettings::_validateCorrectDefaultShellPaths() const
-{
-    for (auto profile : _allProfiles)
-    {
-        if (profile.Guid() == DEFAULT_COMMAND_PROMPT_GUID &&
-            profile.Commandline() == L"cmd.exe")
-        {
-            profile.ClearCommandline();
-        }
-        else if (profile.Guid() == DEFAULT_WINDOWS_POWERSHELL_GUID &&
-                 profile.Commandline() == L"powershell.exe")
-        {
-            profile.ClearCommandline();
-        }
-    }
 }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -369,8 +369,6 @@ bool SettingsLoader::DisableDeletedProfiles()
 // the settings need to be saved to disk.
 bool SettingsLoader::FixupUserSettings()
 {
-    using namespace std::string_view_literals;
-
     struct CommandlinePatch
     {
         winrt::guid guid;


### PR DESCRIPTION
#12149 introduced a bug where `ClearCommandline()` is called on any user
profile containing the non-canonical strings "cmd.exe" or "powershell.exe"
in the "commandline" field. If you happen to have set the "commandline"
field in your `profiles.defaults`, this will cause these user profiles
to adopt the base layer command-line instead of the defaults layer one.

This commit fixes the issue, by checking the command-line after the call
to `ClearCommandline()` and ensuring it's the expected string.

Additionally this moves the migration logic to `SettingsLoader` as this allows
us to write the fixed settings to disk, if any fixed had to be applied.

## PR Checklist
* [x] Closes #12842
* [x] I work here
* [x] Tests added/passed

## Validation Steps Performed
* The modified unit test fails without these changes ✅
* The modified unit test succeeds with these changes ✅
* Setting `profiles.defaults.commandline` to "pwsh.exe" and setting
  my "...\\powershell.exe" profile to use just "powershell.exe" as
  the `commandline`, doesn't cause it to use "pwsh.exe" ✅
  The fixed settings are written to settings.json ✅