### PR TITLE
Misc visual fixes

### DIFF
--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -46,7 +46,7 @@
                                      Color="{ThemeResource SystemErrorTextColor}" />
 
                     <!--  Suppress top padding  -->
-                    <Thickness x:Key="TabViewHeaderPadding">9,0,8,0</Thickness>
+                    <Thickness x:Key="TabViewHeaderPadding">9,0,5,0</Thickness>
 
                     <!--  Remove when implementing WinUI 2.6  -->
                     <Thickness x:Key="FlyoutContentPadding">12</Thickness>

--- a/src/cascadia/TerminalApp/ColorPickupFlyout.cpp
+++ b/src/cascadia/TerminalApp/ColorPickupFlyout.cpp
@@ -34,8 +34,7 @@ namespace winrt::TerminalApp::implementation
     void ColorPickupFlyout::ColorButton_Click(IInspectable const& sender, Windows::UI::Xaml::RoutedEventArgs const&)
     {
         auto button{ sender.as<Windows::UI::Xaml::Controls::Button>() };
-        auto rectangle{ button.Content().as<Windows::UI::Xaml::Shapes::Rectangle>() };
-        auto rectClr{ rectangle.Fill().as<Windows::UI::Xaml::Media::SolidColorBrush>() };
+        auto rectClr{ button.Background().as<Windows::UI::Xaml::Media::SolidColorBrush>() };
         _ColorSelectedHandlers(rectClr.Color());
         Hide();
     }

--- a/src/cascadia/TerminalApp/ColorPickupFlyout.xaml
+++ b/src/cascadia/TerminalApp/ColorPickupFlyout.xaml
@@ -25,7 +25,8 @@
                                        MaximumRowsOrColumns="4"
                                        Orientation="Horizontal">
                     <VariableSizedWrapGrid.Resources>
-                        <Style TargetType="Button">
+                        <Style x:Key="ColorButtonStyle"
+                               TargetType="Button">
                             <Setter Property="BorderBrush" Value="{ThemeResource ButtonBorderBrush}" />
                             <Setter Property="BorderThickness" Value="{ThemeResource ButtonBorderThemeThickness}" />
                             <Setter Property="Margin" Value="2" />
@@ -101,6 +102,8 @@
                                 </Setter.Value>
                             </Setter>
                         </Style>
+                        <Style BasedOn="{StaticResource ColorButtonStyle}"
+                               TargetType="Button" />
                     </VariableSizedWrapGrid.Resources>
 
                     <Button x:Uid="CrimsonColorButton"

--- a/src/cascadia/TerminalApp/ColorPickupFlyout.xaml
+++ b/src/cascadia/TerminalApp/ColorPickupFlyout.xaml
@@ -5,6 +5,8 @@
         xmlns:local="using:TerminalApp"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+        Placement="Bottom"
+        ShouldConstrainToRootBounds="False"
         mc:Ignorable="d">
     <Flyout.FlyoutPresenterStyle>
         <Style TargetType="FlyoutPresenter">
@@ -24,8 +26,8 @@
                                        Orientation="Horizontal">
                     <VariableSizedWrapGrid.Resources>
                         <Style TargetType="Rectangle">
-                            <Setter Property="Width" Value="30" />
-                            <Setter Property="Height" Value="30" />
+                            <Setter Property="Width" Value="32" />
+                            <Setter Property="Height" Value="32" />
                         </Style>
                         <Style TargetType="Button">
                             <Setter Property="Padding" Value="-1" />
@@ -157,14 +159,14 @@
                 <Button x:Name="ClearColorButton"
                         x:Uid="TabColorClearButton"
                         Grid.Column="0"
-                        Margin="2"
+                        Margin="2,2,4,2"
                         HorizontalAlignment="Stretch"
                         Click="ClearColorButton_Click"
                         Content="Reset" />
                 <ToggleButton x:Name="CustomColorButton"
                               x:Uid="TabColorCustomButton"
                               Grid.Column="1"
-                              Margin="2"
+                              Margin="4,2,2,2"
                               HorizontalAlignment="Stretch"
                               Click="ShowColorPickerButton_Click"
                               Content="Custom"
@@ -180,7 +182,6 @@
             </Grid.RowDefinitions>
             <muxc:ColorPicker x:Name="customColorPicker"
                               Grid.Row="0"
-                              Margin="0,0,0,12"
                               ColorChanged="ColorPicker_ColorChanged"
                               FontSize="10"
                               IsAlphaEnabled="False"

--- a/src/cascadia/TerminalApp/ColorPickupFlyout.xaml
+++ b/src/cascadia/TerminalApp/ColorPickupFlyout.xaml
@@ -27,6 +27,7 @@
                     <VariableSizedWrapGrid.Resources>
                         <Style x:Key="ColorButtonStyle"
                                TargetType="Button">
+                            <Setter Property="BackgroundSizing" Value="OuterBorderEdge" />
                             <Setter Property="BorderBrush" Value="{ThemeResource ButtonBorderBrush}" />
                             <Setter Property="BorderThickness" Value="{ThemeResource ButtonBorderThemeThickness}" />
                             <Setter Property="Margin" Value="2" />
@@ -41,9 +42,7 @@
                                         <Grid>
                                             <Border x:Name="ColorButtonBackground"
                                                     Background="{TemplateBinding Background}"
-                                                    CornerRadius="{TemplateBinding CornerRadius}" />
-                                            <Border x:Name="ColorButtonForeground"
-                                                    BackgroundSizing="OuterBorderEdge"
+                                                    BackgroundSizing="{TemplateBinding BackgroundSizing}"
                                                     BorderBrush="{TemplateBinding BorderBrush}"
                                                     BorderThickness="{TemplateBinding BorderThickness}"
                                                     CornerRadius="{TemplateBinding CornerRadius}" />
@@ -53,12 +52,12 @@
 
                                                     <VisualState x:Name="PointerOver">
                                                         <Storyboard>
-                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColorButtonForeground"
-                                                                                           Storyboard.TargetProperty="Background">
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColorButtonBackground"
+                                                                                           Storyboard.TargetProperty="Opacity">
                                                                 <DiscreteObjectKeyFrame KeyTime="0"
-                                                                                        Value="{ThemeResource ButtonBackgroundPointerOver}" />
+                                                                                        Value="0.9" />
                                                             </ObjectAnimationUsingKeyFrames>
-                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColorButtonForeground"
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColorButtonBackground"
                                                                                            Storyboard.TargetProperty="BorderBrush">
                                                                 <DiscreteObjectKeyFrame KeyTime="0"
                                                                                         Value="{ThemeResource ButtonBorderBrushPointerOver}" />
@@ -68,12 +67,12 @@
 
                                                     <VisualState x:Name="Pressed">
                                                         <Storyboard>
-                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColorButtonForeground"
-                                                                                           Storyboard.TargetProperty="Background">
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColorButtonBackground"
+                                                                                           Storyboard.TargetProperty="Opacity">
                                                                 <DiscreteObjectKeyFrame KeyTime="0"
-                                                                                        Value="{ThemeResource ButtonBackgroundPressed}" />
+                                                                                        Value="0.8" />
                                                             </ObjectAnimationUsingKeyFrames>
-                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColorButtonForeground"
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColorButtonBackground"
                                                                                            Storyboard.TargetProperty="BorderBrush">
                                                                 <DiscreteObjectKeyFrame KeyTime="0"
                                                                                         Value="{ThemeResource ButtonBorderBrushPressed}" />
@@ -83,12 +82,12 @@
 
                                                     <VisualState x:Name="Disabled">
                                                         <Storyboard>
-                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColorButtonForeground"
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColorButtonBackground"
                                                                                            Storyboard.TargetProperty="Background">
                                                                 <DiscreteObjectKeyFrame KeyTime="0"
                                                                                         Value="{ThemeResource ButtonBackgroundDisabled}" />
                                                             </ObjectAnimationUsingKeyFrames>
-                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColorButtonForeground"
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColorButtonBackground"
                                                                                            Storyboard.TargetProperty="BorderBrush">
                                                                 <DiscreteObjectKeyFrame KeyTime="0"
                                                                                         Value="{ThemeResource ButtonBorderBrushDisabled}" />

--- a/src/cascadia/TerminalApp/ColorPickupFlyout.xaml
+++ b/src/cascadia/TerminalApp/ColorPickupFlyout.xaml
@@ -25,161 +25,172 @@
                                        MaximumRowsOrColumns="4"
                                        Orientation="Horizontal">
                     <VariableSizedWrapGrid.Resources>
-                        <Style TargetType="Rectangle">
-                            <Setter Property="Width" Value="32" />
-                            <Setter Property="Height" Value="32" />
-                        </Style>
                         <Style TargetType="Button">
-                            <Setter Property="Padding" Value="-1" />
+                            <Setter Property="BorderBrush" Value="{ThemeResource ButtonBorderBrush}" />
+                            <Setter Property="BorderThickness" Value="{ThemeResource ButtonBorderThemeThickness}" />
                             <Setter Property="Margin" Value="2" />
                             <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
-                            <Setter Property="BorderBrush" Value="{StaticResource SystemBaseLowColor}" />
+                            <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+                            <Setter Property="FocusVisualMargin" Value="-3" />
+                            <Setter Property="Width" Value="32" />
+                            <Setter Property="Height" Value="32" />
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="Button">
+                                        <Grid>
+                                            <Border x:Name="ColorButtonBackground"
+                                                    Background="{TemplateBinding Background}"
+                                                    CornerRadius="{TemplateBinding CornerRadius}" />
+                                            <Border x:Name="ColorButtonForeground"
+                                                    BackgroundSizing="OuterBorderEdge"
+                                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                                    CornerRadius="{TemplateBinding CornerRadius}" />
+                                            <VisualStateManager.VisualStateGroups>
+                                                <VisualStateGroup x:Name="CommonStates">
+                                                    <VisualState x:Name="Normal" />
+
+                                                    <VisualState x:Name="PointerOver">
+                                                        <Storyboard>
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColorButtonForeground"
+                                                                                           Storyboard.TargetProperty="Background">
+                                                                <DiscreteObjectKeyFrame KeyTime="0"
+                                                                                        Value="{ThemeResource ButtonBackgroundPointerOver}" />
+                                                            </ObjectAnimationUsingKeyFrames>
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColorButtonForeground"
+                                                                                           Storyboard.TargetProperty="BorderBrush">
+                                                                <DiscreteObjectKeyFrame KeyTime="0"
+                                                                                        Value="{ThemeResource ButtonBorderBrushPointerOver}" />
+                                                            </ObjectAnimationUsingKeyFrames>
+                                                        </Storyboard>
+                                                    </VisualState>
+
+                                                    <VisualState x:Name="Pressed">
+                                                        <Storyboard>
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColorButtonForeground"
+                                                                                           Storyboard.TargetProperty="Background">
+                                                                <DiscreteObjectKeyFrame KeyTime="0"
+                                                                                        Value="{ThemeResource ButtonBackgroundPressed}" />
+                                                            </ObjectAnimationUsingKeyFrames>
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColorButtonForeground"
+                                                                                           Storyboard.TargetProperty="BorderBrush">
+                                                                <DiscreteObjectKeyFrame KeyTime="0"
+                                                                                        Value="{ThemeResource ButtonBorderBrushPressed}" />
+                                                            </ObjectAnimationUsingKeyFrames>
+                                                        </Storyboard>
+                                                    </VisualState>
+
+                                                    <VisualState x:Name="Disabled">
+                                                        <Storyboard>
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColorButtonForeground"
+                                                                                           Storyboard.TargetProperty="Background">
+                                                                <DiscreteObjectKeyFrame KeyTime="0"
+                                                                                        Value="{ThemeResource ButtonBackgroundDisabled}" />
+                                                            </ObjectAnimationUsingKeyFrames>
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColorButtonForeground"
+                                                                                           Storyboard.TargetProperty="BorderBrush">
+                                                                <DiscreteObjectKeyFrame KeyTime="0"
+                                                                                        Value="{ThemeResource ButtonBorderBrushDisabled}" />
+                                                            </ObjectAnimationUsingKeyFrames>
+                                                        </Storyboard>
+                                                    </VisualState>
+                                                </VisualStateGroup>
+                                            </VisualStateManager.VisualStateGroups>
+                                        </Grid>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
                         </Style>
                     </VariableSizedWrapGrid.Resources>
+
                     <Button x:Uid="CrimsonColorButton"
                             AutomationProperties.Name="Crimson"
-                            Click="ColorButton_Click">
-                        <Button.Content>
-                            <Rectangle Fill="Crimson" />
-                        </Button.Content>
-                    </Button>
+                            Background="Crimson"
+                            Click="ColorButton_Click" />
                     <Button x:Uid="SteelBlueColorButton"
                             AutomationProperties.Name="SteelBlue"
-                            Click="ColorButton_Click">
-                        <Button.Content>
-                            <Rectangle Fill="SteelBlue" />
-                        </Button.Content>
-                    </Button>
+                            Background="SteelBlue"
+                            Click="ColorButton_Click" />
                     <Button x:Uid="MediumSeaGreenColorButton"
                             AutomationProperties.Name="MediumSeaGreen"
-                            Click="ColorButton_Click">
-                        <Button.Content>
-                            <Rectangle Fill="MediumSeaGreen" />
-                        </Button.Content>
-                    </Button>
+                            Background="MediumSeaGreen"
+                            Click="ColorButton_Click" />
                     <Button x:Uid="DarkOrangeColorButton"
                             AutomationProperties.Name="DarkOrange"
-                            Click="ColorButton_Click">
-                        <Button.Content>
-                            <Rectangle Fill="DarkOrange" />
-                        </Button.Content>
-                    </Button>
+                            Background="DarkOrange"
+                            Click="ColorButton_Click" />
                     <Button x:Uid="MediumVioletRedColorButton"
                             AutomationProperties.Name="MediumVioletRed"
-                            Click="ColorButton_Click">
-                        <Button.Content>
-                            <Rectangle Fill="MediumVioletRed" />
-                        </Button.Content>
-                    </Button>
+                            Background="MediumVioletRed"
+                            Click="ColorButton_Click" />
                     <Button x:Uid="DodgerBlueColorButton"
                             AutomationProperties.Name="DodgerBlue"
-                            Click="ColorButton_Click">
-                        <Button.Content>
-                            <Rectangle Fill="DodgerBlue" />
-                        </Button.Content>
-                    </Button>
+                            Background="DodgerBlue"
+                            Click="ColorButton_Click" />
                     <Button x:Uid="LimeGreenColorButton"
                             AutomationProperties.Name="LimeGreen"
-                            Click="ColorButton_Click">
-                        <Button.Content>
-                            <Rectangle Fill="LimeGreen" />
-                        </Button.Content>
-                    </Button>
+                            Background="LimeGreen"
+                            Click="ColorButton_Click" />
                     <Button x:Uid="YellowColorButton"
                             AutomationProperties.Name="Yellow"
-                            Click="ColorButton_Click">
-                        <Button.Content>
-                            <Rectangle Fill="Yellow" />
-                        </Button.Content>
-                    </Button>
+                            Background="Yellow"
+                            Click="ColorButton_Click" />
                     <Button x:Uid="BlueVioletColorButton"
                             AutomationProperties.Name="BlueViolet"
-                            Click="ColorButton_Click">
-                        <Button.Content>
-                            <Rectangle Fill="BlueViolet" />
-                        </Button.Content>
-                    </Button>
+                            Background="BlueViolet"
+                            Click="ColorButton_Click" />
                     <Button x:Uid="SlateBlueColorButton"
                             AutomationProperties.Name="SlateBlue"
-                            Click="ColorButton_Click">
-                        <Button.Content>
-                            <Rectangle Fill="SlateBlue" />
-                        </Button.Content>
-                    </Button>
+                            Background="SlateBlue"
+                            Click="ColorButton_Click" />
                     <Button x:Uid="LimeColorButton"
                             AutomationProperties.Name="Lime"
-                            Click="ColorButton_Click">
-                        <Button.Content>
-                            <Rectangle Fill="Lime" />
-                        </Button.Content>
-                    </Button>
+                            Background="Lime"
+                            Click="ColorButton_Click" />
                     <Button x:Uid="TanColorButton"
                             AutomationProperties.Name="Tan"
-                            Click="ColorButton_Click">
-                        <Button.Content>
-                            <Rectangle Fill="Tan" />
-                        </Button.Content>
-                    </Button>
+                            Background="Tan"
+                            Click="ColorButton_Click" />
                     <Button x:Uid="MagentaColorButton"
                             AutomationProperties.Name="Magenta"
-                            Click="ColorButton_Click">
-                        <Button.Content>
-                            <Rectangle Fill="Magenta" />
-                        </Button.Content>
-                    </Button>
+                            Background="Magenta"
+                            Click="ColorButton_Click" />
                     <Button x:Uid="CyanColorButton"
                             AutomationProperties.Name="Cyan"
-                            Click="ColorButton_Click">
-                        <Button.Content>
-                            <Rectangle Fill="Cyan" />
-                        </Button.Content>
-                    </Button>
+                            Background="Cyan"
+                            Click="ColorButton_Click" />
                     <Button x:Uid="SkyBlueColorButton"
                             AutomationProperties.Name="SkyBlue"
-                            Click="ColorButton_Click">
-                        <Button.Content>
-                            <Rectangle Fill="SkyBlue" />
-                        </Button.Content>
-                    </Button>
+                            Background="SkyBlue"
+                            Click="ColorButton_Click" />
                     <Button x:Uid="DarkGrayColorButton"
                             AutomationProperties.Name="DarkGray"
-                            Click="ColorButton_Click">
-                        <Button.Content>
-                            <Rectangle Fill="DarkGray" />
-                        </Button.Content>
-                    </Button>
+                            Background="DarkGray"
+                            Click="ColorButton_Click" />
                 </VariableSizedWrapGrid>
             </Grid>
-            <Grid Margin="0,12,0,0"
-                  Padding="-2">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
+            <StackPanel Margin="0,12,0,0"
+                        Orientation="Horizontal"
+                        Spacing="8">
                 <Button x:Name="ClearColorButton"
                         x:Uid="TabColorClearButton"
                         Grid.Column="0"
-                        Margin="2,2,4,2"
                         HorizontalAlignment="Stretch"
                         Click="ClearColorButton_Click"
                         Content="Reset" />
                 <ToggleButton x:Name="CustomColorButton"
                               x:Uid="TabColorCustomButton"
                               Grid.Column="1"
-                              Margin="4,2,2,2"
                               HorizontalAlignment="Stretch"
                               Click="ShowColorPickerButton_Click"
                               Content="Custom"
                               IsChecked="False" />
-            </Grid>
+            </StackPanel>
         </StackPanel>
-        <Grid x:Name="customColorPanel"
-              Margin="16,0,0,0"
-              Visibility="Collapsed">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
+        <StackPanel x:Name="customColorPanel"
+                    Margin="16,0,0,0"
+                    Spacing="12"
+                    Visibility="Collapsed">
             <muxc:ColorPicker x:Name="customColorPicker"
                               Grid.Row="0"
                               ColorChanged="ColorPicker_ColorChanged"
@@ -199,6 +210,6 @@
                     Click="CustomColorButton_Click"
                     Content="OK"
                     Style="{ThemeResource AccentButtonStyle}" />
-        </Grid>
+        </StackPanel>
     </StackPanel>
 </Flyout>

--- a/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
+++ b/src/cascadia/TerminalApp/MinMaxCloseControl.xaml
@@ -19,11 +19,12 @@
         <ResourceDictionary>
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Light">
+                    <Color x:Key="CloseButtonColor">#C42B1C</Color>
                     <x:Double x:Key="CaptionButtonStrokeWidth">1.0</x:Double>
                     <StaticResource x:Key="CaptionButtonBackgroundPointerOver"
-                                    ResourceKey="SystemControlBackgroundBaseLowBrush" />
+                                    ResourceKey="SubtleFillColorSecondary" />
                     <StaticResource x:Key="CaptionButtonBackgroundPressed"
-                                    ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
+                                    ResourceKey="SubtleFillColorTertiary" />
                     <StaticResource x:Key="CaptionButtonStroke"
                                     ResourceKey="SystemControlForegroundBaseHighBrush" />
                     <StaticResource x:Key="CaptionButtonStrokeColor"
@@ -36,23 +37,26 @@
                                      Color="Transparent" />
                     <Color x:Key="CaptionButtonBackgroundColor">Transparent</Color>
                     <SolidColorBrush x:Key="CloseButtonBackgroundPointerOver"
-                                     Color="#e81123" />
+                                     Color="{ThemeResource CloseButtonColor}" />
                     <SolidColorBrush x:Key="CloseButtonStrokePointerOver"
                                      Color="White" />
                     <SolidColorBrush x:Key="CloseButtonBackgroundPressed"
-                                     Color="#f1707a" />
+                                     Opacity="0.9"
+                                     Color="{ThemeResource CloseButtonColor}" />
                     <SolidColorBrush x:Key="CloseButtonStrokePressed"
-                                     Color="Black" />
+                                     Opacity="0.7"
+                                     Color="White" />
                     <SolidColorBrush x:Key="CloseButtonBackground"
                                      Color="#00e81123" />
                     <Color x:Key="CloseButtonBackgroundColor">#00e81123</Color>
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Dark">
+                    <Color x:Key="CloseButtonColor">#C42B1C</Color>
                     <x:Double x:Key="CaptionButtonStrokeWidth">1.0</x:Double>
                     <StaticResource x:Key="CaptionButtonBackgroundPointerOver"
-                                    ResourceKey="SystemControlBackgroundBaseLowBrush" />
+                                    ResourceKey="SubtleFillColorSecondary" />
                     <StaticResource x:Key="CaptionButtonBackgroundPressed"
-                                    ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
+                                    ResourceKey="SubtleFillColorTertiary" />
                     <StaticResource x:Key="CaptionButtonStroke"
                                     ResourceKey="SystemControlForegroundBaseHighBrush" />
                     <StaticResource x:Key="CaptionButtonStrokeColor"
@@ -65,19 +69,21 @@
                                      Color="Transparent" />
                     <Color x:Key="CaptionButtonBackgroundColor">Transparent</Color>
                     <SolidColorBrush x:Key="CloseButtonBackgroundPointerOver"
-                                     Color="#e81123" />
+                                     Color="{ThemeResource CloseButtonColor}" />
                     <SolidColorBrush x:Key="CloseButtonStrokePointerOver"
                                      Color="White" />
                     <SolidColorBrush x:Key="CloseButtonBackgroundPressed"
-                                     Color="#f1707a" />
+                                     Opacity="0.9"
+                                     Color="{ThemeResource CloseButtonColor}" />
                     <SolidColorBrush x:Key="CloseButtonStrokePressed"
-                                     Color="Black" />
+                                     Opacity="0.7"
+                                     Color="White" />
                     <SolidColorBrush x:Key="CloseButtonBackground"
                                      Color="#00e81123" />
                     <Color x:Key="CloseButtonBackgroundColor">#00e81123</Color>
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="HighContrast">
-                    <x:Double x:Key="CaptionButtonStrokeWidth">3.0</x:Double>
+                    <x:Double x:Key="CaptionButtonStrokeWidth">2.0</x:Double>
                     <SolidColorBrush x:Key="CaptionButtonBackground"
                                      Color="{ThemeResource SystemColorButtonFaceColor}" />
                     <StaticResource x:Key="CaptionButtonBackgroundColor"
@@ -165,7 +171,7 @@
                                                     <ColorAnimation Storyboard.TargetName="ButtonBaseElement"
                                                                     Storyboard.TargetProperty="(UIElement.Background).(SolidColorBrush.Color)"
                                                                     To="{ThemeResource CaptionButtonBackgroundColor}"
-                                                                    Duration="0:0:0.2" />
+                                                                    Duration="0:0:0.15" />
                                                     <ColorAnimation Storyboard.TargetName="Path"
                                                                     Storyboard.TargetProperty="(UIElement.Stroke).(SolidColorBrush.Color)"
                                                                     To="{ThemeResource CaptionButtonStrokeColor}"

--- a/src/cascadia/TerminalApp/TabHeaderControl.xaml
+++ b/src/cascadia/TerminalApp/TabHeaderControl.xaml
@@ -13,22 +13,6 @@
              MinHeight="16"
              mc:Ignorable="d">
 
-    <UserControl.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.ThemeDictionaries>
-                <ResourceDictionary x:Key="Light">
-                    <Thickness x:Key="TextControlBorderThemeThicknessFocused">0,0,0,1</Thickness>
-                </ResourceDictionary>
-                <ResourceDictionary x:Key="Dark">
-                    <Thickness x:Key="TextControlBorderThemeThicknessFocused">0,0,0,1</Thickness>
-                </ResourceDictionary>
-                <ResourceDictionary x:Key="HighContrast">
-                    <Thickness x:Key="TextControlBorderThemeThicknessFocused">0,0,0,1</Thickness>
-                </ResourceDictionary>
-            </ResourceDictionary.ThemeDictionaries>
-        </ResourceDictionary>
-    </UserControl.Resources>
-
     <StackPanel x:Name="HeaderStackPanel"
                 Orientation="Horizontal">
         <mux:ProgressRing x:Name="HeaderProgressRing"
@@ -68,10 +52,10 @@
                    Text="{x:Bind Title, Mode=OneWay}"
                    Visibility="Visible" />
         <TextBox x:Name="HeaderRenamerTextBox"
-                 Height="16"
+                 Height="24"
                  MinHeight="0"
                  MaxWidth="{x:Bind RenamerMaxWidth, Mode=OneWay}"
-                 Padding="4,0,4,0"
+                 Padding="4,4,4,3"
                  FontSize="12"
                  IsSpellCheckEnabled="False"
                  LostFocus="RenameBoxLostFocusHandler"

--- a/src/cascadia/TerminalApp/TabRowControl.xaml
+++ b/src/cascadia/TerminalApp/TabRowControl.xaml
@@ -114,6 +114,8 @@
                                                     ResourceKey="TabViewButtonForegroundPointerOver" />
                                 </ResourceDictionary>
                             </ResourceDictionary.ThemeDictionaries>
+                            <x:Double x:Key="SplitButtonPrimaryButtonSize">31</x:Double>
+                            <x:Double x:Key="SplitButtonSecondaryButtonSize">31</x:Double>
                         </ResourceDictionary>
                     </mux:SplitButton.Resources>
                 </mux:SplitButton>

--- a/src/cascadia/TerminalApp/TabRowControl.xaml
+++ b/src/cascadia/TerminalApp/TabRowControl.xaml
@@ -15,6 +15,7 @@
                  VerticalAlignment="Bottom"
                  HorizontalContentAlignment="Stretch"
                  AllowDropTabs="True"
+                 Background="Transparent"
                  CanDragTabs="True"
                  CanReorderTabs="True"
                  IsAddTabButtonVisible="false"
@@ -32,84 +33,91 @@
         </mux:TabView.TabStripHeader>
 
         <mux:TabView.TabStripFooter>
-            <mux:SplitButton x:Name="NewTabButton"
-                             x:Uid="NewTabSplitButton"
-                             HorizontalAlignment="Left"
-                             VerticalAlignment="Stretch"
-                             AllowDrop="True"
-                             AutomationProperties.AccessibilityView="Control"
-                             BorderThickness="0"
-                             Click="OnNewTabButtonClick"
-                             Content="&#xE710;"
-                             CornerRadius="{Binding Source={ThemeResource OverlayCornerRadius}, Converter={StaticResource TopCornerRadiusFilterConverter}}"
-                             DragOver="OnNewTabButtonDragOver"
-                             Drop="OnNewTabButtonDrop"
-                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                             FontSize="12"
-                             FontWeight="SemiLight"
-                             UseLayoutRounding="true">
-                <ToolTipService.ToolTip>
-                    <ToolTip Placement="Mouse">
-                        <TextBlock IsTextSelectionEnabled="False">
-                            <Run x:Uid="NewTabRun" /> <LineBreak />
-                            <Run x:Uid="NewPaneRun"
-                                 FontStyle="Italic" /> <LineBreak />
-                            <Run x:Uid="NewWindowRun"
-                                 FontStyle="Italic" />
-                        </TextBlock>
-                    </ToolTip>
-                </ToolTipService.ToolTip>
-                <!--  U+E710 is the fancy plus icon.  -->
-                <mux:SplitButton.Resources>
-                    <!--  Override the SplitButton* resources to match the tab view's button's styles.  -->
-                    <ResourceDictionary>
-                        <ResourceDictionary.ThemeDictionaries>
-                            <ResourceDictionary x:Key="Light">
-                                <StaticResource x:Key="SplitButtonBackground"
-                                                ResourceKey="TabViewButtonBackground" />
-                                <StaticResource x:Key="SplitButtonForeground"
-                                                ResourceKey="TabViewButtonForeground" />
-                                <StaticResource x:Key="SplitButtonBackgroundPressed"
-                                                ResourceKey="TabViewItemHeaderBackgroundPressed" />
-                                <StaticResource x:Key="SplitButtonForegroundPressed"
-                                                ResourceKey="TabViewItemHeaderForegroundPressed" />
-                                <StaticResource x:Key="SplitButtonBackgroundPointerOver"
-                                                ResourceKey="TabViewItemHeaderBackgroundPointerOver" />
-                                <StaticResource x:Key="SplitButtonForegroundPointerOver"
-                                                ResourceKey="TabViewItemHeaderForegroundPointerOver" />
-                            </ResourceDictionary>
-                            <ResourceDictionary x:Key="Dark">
-                                <StaticResource x:Key="SplitButtonBackground"
-                                                ResourceKey="TabViewButtonBackground" />
-                                <StaticResource x:Key="SplitButtonForeground"
-                                                ResourceKey="TabViewButtonForeground" />
-                                <StaticResource x:Key="SplitButtonBackgroundPressed"
-                                                ResourceKey="TabViewItemHeaderBackgroundPressed" />
-                                <StaticResource x:Key="SplitButtonForegroundPressed"
-                                                ResourceKey="TabViewItemHeaderForegroundPressed" />
-                                <StaticResource x:Key="SplitButtonBackgroundPointerOver"
-                                                ResourceKey="TabViewItemHeaderBackgroundPointerOver" />
-                                <StaticResource x:Key="SplitButtonForegroundPointerOver"
-                                                ResourceKey="TabViewItemHeaderForegroundPointerOver" />
-                            </ResourceDictionary>
-                            <ResourceDictionary x:Key="HighContrast">
-                                <StaticResource x:Key="SplitButtonBackground"
-                                                ResourceKey="TabViewButtonBackground" />
-                                <StaticResource x:Key="SplitButtonForeground"
-                                                ResourceKey="TabViewButtonForeground" />
-                                <StaticResource x:Key="SplitButtonBackgroundPressed"
-                                                ResourceKey="TabViewItemHeaderBackgroundPressed" />
-                                <StaticResource x:Key="SplitButtonForegroundPressed"
-                                                ResourceKey="TabViewItemHeaderForegroundPressed" />
-                                <StaticResource x:Key="SplitButtonBackgroundPointerOver"
-                                                ResourceKey="TabViewItemHeaderBackgroundPointerOver" />
-                                <StaticResource x:Key="SplitButtonForegroundPointerOver"
-                                                ResourceKey="TabViewItemHeaderForegroundPointerOver" />
-                            </ResourceDictionary>
-                        </ResourceDictionary.ThemeDictionaries>
-                    </ResourceDictionary>
-                </mux:SplitButton.Resources>
-            </mux:SplitButton>
+            <Grid>
+                <!--  Remove this border after WinUI 2.8  -->
+                <Border Height="1"
+                        VerticalAlignment="Bottom"
+                        Background="{ThemeResource CardStrokeColorDefaultBrush}" />
+
+                <mux:SplitButton x:Name="NewTabButton"
+                                 x:Uid="NewTabSplitButton"
+                                 Height="24"
+                                 Margin="0,4"
+                                 Padding="0"
+                                 HorizontalAlignment="Left"
+                                 VerticalAlignment="Stretch"
+                                 AllowDrop="True"
+                                 AutomationProperties.AccessibilityView="Control"
+                                 BorderThickness="0"
+                                 Click="OnNewTabButtonClick"
+                                 Content="&#xE710;"
+                                 DragOver="OnNewTabButtonDragOver"
+                                 Drop="OnNewTabButtonDrop"
+                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                 FontSize="12">
+                    <ToolTipService.ToolTip>
+                        <ToolTip Placement="Mouse">
+                            <TextBlock IsTextSelectionEnabled="False">
+                                <Run x:Uid="NewTabRun" /> <LineBreak />
+                                <Run x:Uid="NewPaneRun"
+                                     FontStyle="Italic" /> <LineBreak />
+                                <Run x:Uid="NewWindowRun"
+                                     FontStyle="Italic" />
+                            </TextBlock>
+                        </ToolTip>
+                    </ToolTipService.ToolTip>
+                    <!--  U+E710 is the fancy plus icon.  -->
+                    <mux:SplitButton.Resources>
+                        <!--  Override the SplitButton* resources to match the tab view's button's styles.  -->
+                        <ResourceDictionary>
+                            <ResourceDictionary.ThemeDictionaries>
+                                <ResourceDictionary x:Key="Light">
+                                    <StaticResource x:Key="SplitButtonBackground"
+                                                    ResourceKey="TabViewButtonBackground" />
+                                    <StaticResource x:Key="SplitButtonForeground"
+                                                    ResourceKey="TabViewButtonForeground" />
+                                    <StaticResource x:Key="SplitButtonBackgroundPressed"
+                                                    ResourceKey="TabViewButtonBackgroundPressed" />
+                                    <StaticResource x:Key="SplitButtonForegroundPressed"
+                                                    ResourceKey="TabViewButtonForegroundPressed" />
+                                    <StaticResource x:Key="SplitButtonBackgroundPointerOver"
+                                                    ResourceKey="TabViewButtonBackgroundPointerOver" />
+                                    <StaticResource x:Key="SplitButtonForegroundPointerOver"
+                                                    ResourceKey="TabViewButtonForegroundPointerOver" />
+                                </ResourceDictionary>
+                                <ResourceDictionary x:Key="Dark">
+                                    <StaticResource x:Key="SplitButtonBackground"
+                                                    ResourceKey="TabViewButtonBackground" />
+                                    <StaticResource x:Key="SplitButtonForeground"
+                                                    ResourceKey="TabViewButtonForeground" />
+                                    <StaticResource x:Key="SplitButtonBackgroundPressed"
+                                                    ResourceKey="TabViewButtonBackgroundPressed" />
+                                    <StaticResource x:Key="SplitButtonForegroundPressed"
+                                                    ResourceKey="TabViewButtonForegroundPressed" />
+                                    <StaticResource x:Key="SplitButtonBackgroundPointerOver"
+                                                    ResourceKey="TabViewButtonBackgroundPointerOver" />
+                                    <StaticResource x:Key="SplitButtonForegroundPointerOver"
+                                                    ResourceKey="TabViewButtonForegroundPointerOver" />
+                                </ResourceDictionary>
+                                <ResourceDictionary x:Key="HighContrast">
+                                    <StaticResource x:Key="SplitButtonBackground"
+                                                    ResourceKey="TabViewButtonBackground" />
+                                    <StaticResource x:Key="SplitButtonForeground"
+                                                    ResourceKey="TabViewButtonForeground" />
+                                    <StaticResource x:Key="SplitButtonBackgroundPressed"
+                                                    ResourceKey="TabViewButtonBackgroundPressed" />
+                                    <StaticResource x:Key="SplitButtonForegroundPressed"
+                                                    ResourceKey="TabViewButtonForegroundPressed" />
+                                    <StaticResource x:Key="SplitButtonBackgroundPointerOver"
+                                                    ResourceKey="TabViewButtonBackgroundPointerOver" />
+                                    <StaticResource x:Key="SplitButtonForegroundPointerOver"
+                                                    ResourceKey="TabViewButtonForegroundPointerOver" />
+                                </ResourceDictionary>
+                            </ResourceDictionary.ThemeDictionaries>
+                        </ResourceDictionary>
+                    </mux:SplitButton.Resources>
+                </mux:SplitButton>
+            </Grid>
         </mux:TabView.TabStripFooter>
 
     </mux:TabView>

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -28,6 +28,7 @@
                     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
             <mux:InfoBar x:Name="KeyboardServiceWarningInfoBar"
                          x:Load="False"
+                         CornerRadius="0"
                          IsClosable="True"
                          IsIconVisible="True"
                          IsOpen="False"
@@ -42,6 +43,7 @@
             <mux:InfoBar x:Name="CloseOnExitInfoBar"
                          x:Uid="CloseOnExitInfoBar"
                          x:Load="False"
+                         CornerRadius="0"
                          IsClosable="True"
                          IsIconVisible="True"
                          IsOpen="False"
@@ -56,6 +58,7 @@
                          x:Uid="SetAsDefaultInfoBar"
                          x:Load="False"
                          CloseButtonClick="_SetAsDefaultDismissHandler"
+                         CornerRadius="0"
                          IsClosable="True"
                          IsIconVisible="True"
                          IsOpen="False"

--- a/src/cascadia/TerminalApp/TitlebarControl.xaml
+++ b/src/cascadia/TerminalApp/TitlebarControl.xaml
@@ -43,5 +43,12 @@
     <local:MinMaxCloseControl x:Name="MinMaxCloseControl"
                               Grid.Column="2"
                               HorizontalAlignment="Right" />
+
+    <!--  This border needs to be added manually until GH#10320 is fixed  -->
+    <Border Grid.Column="1"
+            Grid.ColumnSpan="2"
+            Height="1"
+            VerticalAlignment="Bottom"
+            Background="{ThemeResource CardStrokeColorDefaultBrush}" />
 </Grid>
 

--- a/src/cascadia/TerminalControl/TermControl.xaml
+++ b/src/cascadia/TerminalControl/TermControl.xaml
@@ -56,6 +56,7 @@
 
         <x:Double x:Key="ScrollBarSize">16</x:Double>
         <CornerRadius x:Key="ScrollBarCornerRadius">0</CornerRadius>
+        <CornerRadius x:Key="ScrollBarThumbCornerRadius">3</CornerRadius>
 
         <Style x:Key="ForkedScrollbarTemplate"
                TargetType="ScrollBar">
@@ -351,11 +352,9 @@
                                 <ControlTemplate x:Key="VerticalThumbTemplate"
                                                  TargetType="Thumb">
                                     <Rectangle x:Name="ThumbVisual"
-                                               contract7NotPresent:RadiusX="{Binding Source={ThemeResource ScrollBarCornerRadius}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
-                                               contract7NotPresent:RadiusY="{Binding Source={ThemeResource ScrollBarCornerRadius}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}"
-                                               contract7Present:RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
-                                               contract7Present:RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}"
                                                Fill="{TemplateBinding Background}"
+                                               RadiusX="{Binding Source={ThemeResource ScrollBarThumbCornerRadius}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
+                                               RadiusY="{Binding Source={ThemeResource ScrollBarThumbCornerRadius}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}"
                                                Stroke="{TemplateBinding BorderBrush}"
                                                StrokeThickness="{ThemeResource ScrollBarThumbStrokeThickness}">
                                         <VisualStateManager.VisualStateGroups>


### PR DESCRIPTION
Fixed various small issues:
* Made TabView bottom border span the entire window width
* Made ScrollBar inner thumb rounded again
* Made SplitButton look more like the new add tab button
* Adjusted rename box height (24px, like the official compact sizing height)
* Adjusted caption button colors to match Windows 11
* ColorPicker can now escape window bounds
* Tweaked ColorPicker buttons