### PR TITLE
add missing breaks

### DIFF
--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -538,6 +538,7 @@ long IslandWindow::_calculateTotalSize(const bool isWidth, const long clientSize
             return 0;
         }
         CATCH_LOG();
+        break;
     case WM_THEMECHANGED:
         UpdateWindowIconForActiveMetrics(_window.get());
         return 0;
@@ -595,6 +596,7 @@ long IslandWindow::_calculateTotalSize(const bool isWidth, const long clientSize
                 return 0;
             }
         }
+        break;
     }
     case CM_NOTIFY_FROM_NOTIFICATION_AREA:
     {


### PR DESCRIPTION
## Summary of the Pull Request

This PR adds some missing `break` commands in `IslandWindow::MessageHandler` switch statement.

## PR Checklist
* [x] Closes #12923
* [x] CLA signed
* [x] I've discussed this with core contributors already.

