### PR TITLE
Prevent the virtual viewport bottom being updated incorrectly

### DIFF
--- a/src/host/outputStream.cpp
+++ b/src/host/outputStream.cpp
@@ -304,8 +304,8 @@ bool ConhostInternalGetSet::ResizeWindow(const size_t width, const size_t height
     csbiex.cbSize = sizeof(CONSOLE_SCREEN_BUFFER_INFOEX);
     api->GetConsoleScreenBufferInfoExImpl(screenInfo, csbiex);
 
-    const auto oldViewport = Viewport::FromInclusive(csbiex.srWindow);
-    const auto newViewport = Viewport::FromDimensions(oldViewport.Origin(), sColumns, sRows);
+    const auto oldViewport = screenInfo.GetVirtualViewport();
+    auto newViewport = Viewport::FromDimensions(oldViewport.Origin(), sColumns, sRows);
     // Always resize the width of the console
     csbiex.dwSize.X = sColumns;
     // Only set the screen buffer's height if it's currently less than
@@ -313,6 +313,16 @@ bool ConhostInternalGetSet::ResizeWindow(const size_t width, const size_t height
     if (sRows > csbiex.dwSize.Y)
     {
         csbiex.dwSize.Y = sRows;
+    }
+
+    // If the cursor row is now past the bottom of the viewport, we'll have to
+    // move the viewport down to bring it back into view. However, we don't want
+    // to do this in pty mode, because the conpty resize operation is dependent
+    // on the viewport *not* being adjusted.
+    const short cursorOverflow = csbiex.dwCursorPosition.Y - newViewport.BottomInclusive();
+    if (cursorOverflow > 0 && !IsConsolePty())
+    {
+        newViewport = Viewport::Offset(newViewport, { 0, cursorOverflow });
     }
 
     // SetWindowInfo expect inclusive rects

--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -1751,7 +1751,7 @@ void SCREEN_INFORMATION::SetCursorDBMode(const bool DoubleCursor)
     return STATUS_SUCCESS;
 }
 
-void SCREEN_INFORMATION::MakeCursorVisible(const COORD CursorPosition, const bool updateBottom)
+void SCREEN_INFORMATION::MakeCursorVisible(const COORD CursorPosition)
 {
     COORD WindowOrigin;
 
@@ -1783,7 +1783,7 @@ void SCREEN_INFORMATION::MakeCursorVisible(const COORD CursorPosition, const boo
 
     if (WindowOrigin.X != 0 || WindowOrigin.Y != 0)
     {
-        LOG_IF_FAILED(SetViewportOrigin(false, WindowOrigin, updateBottom));
+        LOG_IF_FAILED(SetViewportOrigin(false, WindowOrigin, false));
     }
 }
 

--- a/src/host/screenInfo.hpp
+++ b/src/host/screenInfo.hpp
@@ -191,7 +191,7 @@ public:
     void SetCursorDBMode(const bool DoubleCursor);
     [[nodiscard]] NTSTATUS SetCursorPosition(const COORD Position, const bool TurnOn);
 
-    void MakeCursorVisible(const COORD CursorPosition, const bool updateBottom = true);
+    void MakeCursorVisible(const COORD CursorPosition);
 
     Microsoft::Console::Types::Viewport GetRelativeScrollMargins() const;
     Microsoft::Console::Types::Viewport GetAbsoluteScrollMargins() const;

--- a/src/host/selection.cpp
+++ b/src/host/selection.cpp
@@ -609,5 +609,5 @@ void Selection::SelectAll()
     SelectNewRegion(coordNewSelStart, coordNewSelEnd);
 
     // restore the old window position
-    LOG_IF_FAILED(screenInfo.SetViewportOrigin(true, coordWindowOrigin, true));
+    LOG_IF_FAILED(screenInfo.SetViewportOrigin(true, coordWindowOrigin, false));
 }

--- a/src/host/selection.cpp
+++ b/src/host/selection.cpp
@@ -213,7 +213,7 @@ void Selection::ExtendSelection(_In_ COORD coordBufferPos)
         }
 
         // scroll if necessary to make cursor visible.
-        screenInfo.MakeCursorVisible(coordBufferPos, false);
+        screenInfo.MakeCursorVisible(coordBufferPos);
 
         _dwSelectionFlags |= CONSOLE_SELECTION_NOT_EMPTY;
         _srSelectionRect.Left = _srSelectionRect.Right = _coordSelectionAnchor.X;
@@ -224,7 +224,7 @@ void Selection::ExtendSelection(_In_ COORD coordBufferPos)
     else
     {
         // scroll if necessary to make cursor visible.
-        screenInfo.MakeCursorVisible(coordBufferPos, false);
+        screenInfo.MakeCursorVisible(coordBufferPos);
     }
 
     // remember previous selection rect

--- a/src/host/selectionInput.cpp
+++ b/src/host/selectionInput.cpp
@@ -927,7 +927,7 @@ bool Selection::_HandleMarkModeSelectionNav(const INPUT_KEY_INFO* const pInputKe
 
             cursor.SetHasMoved(true);
             _coordSelectionAnchor = textBuffer.GetCursor().GetPosition();
-            ScreenInfo.MakeCursorVisible(_coordSelectionAnchor, false);
+            ScreenInfo.MakeCursorVisible(_coordSelectionAnchor);
             _srSelectionRect.Left = _srSelectionRect.Right = _coordSelectionAnchor.X;
             _srSelectionRect.Top = _srSelectionRect.Bottom = _coordSelectionAnchor.Y;
         }

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -227,6 +227,12 @@ class ScreenBufferTests
     TEST_METHOD(TestAddHyperlinkCustomIdDifferentUri);
 
     TEST_METHOD(UpdateVirtualBottomWhenCursorMovesBelowIt);
+    TEST_METHOD(UpdateVirtualBottomWithSetConsoleCursorPosition);
+    TEST_METHOD(UpdateVirtualBottomAfterInternalSetViewportSize);
+    TEST_METHOD(UpdateVirtualBottomAfterResizeWithReflow);
+    TEST_METHOD(DontChangeVirtualBottomWithOffscreenLinefeed);
+    TEST_METHOD(DontChangeVirtualBottomAfterResizeWindow);
+    TEST_METHOD(DontChangeVirtualBottomWithMakeCursorVisible);
     TEST_METHOD(RetainHorizontalOffsetWhenMovingToBottom);
 
     TEST_METHOD(TestWriteConsoleVTQuirkMode);
@@ -6133,6 +6139,272 @@ void ScreenBufferTests::UpdateVirtualBottomWhenCursorMovesBelowIt()
     Log::Comment(L"But after moving to the virtual viewport, we should align with the new virtual bottom");
     VERIFY_SUCCEEDED(si.SetViewportOrigin(true, si.GetVirtualViewport().Origin(), true));
     VERIFY_ARE_EQUAL(newVirtualBottom, si.GetViewport().BottomInclusive());
+}
+
+void ScreenBufferTests::UpdateVirtualBottomWithSetConsoleCursorPosition()
+{
+    auto& g = ServiceLocator::LocateGlobals();
+    auto& gci = g.getConsoleInformation();
+    auto& si = gci.GetActiveOutputBuffer();
+    auto& cursor = si.GetTextBuffer().GetCursor();
+
+    Log::Comment(L"Pan down so the initial viewport is a couple of pages down");
+    const auto initialOrigin = COORD{ 0, si.GetViewport().Height() * 2 };
+    VERIFY_SUCCEEDED(si.SetViewportOrigin(true, initialOrigin, true));
+    VERIFY_ARE_EQUAL(initialOrigin, si.GetViewport().Origin());
+
+    Log::Comment(L"Make sure the initial virtual bottom is at the bottom of the viewport");
+    const auto initialVirtualBottom = si.GetViewport().BottomInclusive();
+    VERIFY_ARE_EQUAL(initialVirtualBottom, si._virtualBottom);
+
+    Log::Comment(L"Pan to the top of the buffer without changing the virtual bottom");
+    VERIFY_SUCCEEDED(si.SetViewportOrigin(true, { 0, 0 }, false));
+    VERIFY_ARE_EQUAL(initialVirtualBottom, si._virtualBottom);
+
+    Log::Comment(L"Set the cursor position to the initial origin");
+    VERIFY_SUCCEEDED(g.api->SetConsoleCursorPositionImpl(si, initialOrigin));
+    VERIFY_ARE_EQUAL(initialOrigin, cursor.GetPosition());
+
+    Log::Comment(L"Confirm that the viewport has moved down");
+    VERIFY_ARE_EQUAL(initialOrigin, si.GetViewport().Origin());
+
+    Log::Comment(L"Confirm that the virtual bottom has not changed");
+    VERIFY_ARE_EQUAL(initialVirtualBottom, si._virtualBottom);
+
+    Log::Comment(L"Pan further down so the viewport is below the cursor");
+    const auto belowCursor = COORD{ 0, cursor.GetPosition().Y + 10 };
+    VERIFY_SUCCEEDED(si.SetViewportOrigin(true, belowCursor, false));
+    VERIFY_ARE_EQUAL(belowCursor, si.GetViewport().Origin());
+
+    Log::Comment(L"Set the cursor position one line down, still inside the virtual viewport");
+    const auto oneLineDown = COORD{ 0, cursor.GetPosition().Y + 1 };
+    VERIFY_SUCCEEDED(g.api->SetConsoleCursorPositionImpl(si, oneLineDown));
+    VERIFY_ARE_EQUAL(oneLineDown, cursor.GetPosition());
+
+    Log::Comment(L"Confirm that the viewport has moved back to the initial origin");
+    VERIFY_ARE_EQUAL(initialOrigin, si.GetViewport().Origin());
+
+    Log::Comment(L"Confirm that the virtual bottom has not changed");
+    VERIFY_ARE_EQUAL(initialVirtualBottom, si._virtualBottom);
+
+    Log::Comment(L"Set the cursor position to the top of the buffer");
+    const auto topOfBuffer = COORD{ 0, 0 };
+    VERIFY_SUCCEEDED(g.api->SetConsoleCursorPositionImpl(si, topOfBuffer));
+    VERIFY_ARE_EQUAL(topOfBuffer, cursor.GetPosition());
+
+    Log::Comment(L"Confirm that the viewport has moved to the top of the buffer");
+    VERIFY_ARE_EQUAL(topOfBuffer, si.GetViewport().Origin());
+
+    Log::Comment(L"Confirm that the virtual bottom has also moved up");
+    VERIFY_ARE_EQUAL(si.GetViewport().BottomInclusive(), si._virtualBottom);
+}
+
+void ScreenBufferTests::UpdateVirtualBottomAfterInternalSetViewportSize()
+{
+    auto& g = ServiceLocator::LocateGlobals();
+    auto& gci = g.getConsoleInformation();
+    auto& si = gci.GetActiveOutputBuffer();
+    auto& cursor = si.GetTextBuffer().GetCursor();
+    auto& stateMachine = si.GetStateMachine();
+
+    Log::Comment(L"Pan down so the initial viewport is a couple of pages down");
+    const auto initialOrigin = COORD{ 0, si.GetViewport().Height() * 2 };
+    VERIFY_SUCCEEDED(si.SetViewportOrigin(true, initialOrigin, true));
+    VERIFY_ARE_EQUAL(initialOrigin, si.GetViewport().Origin());
+
+    Log::Comment(L"Make sure the initial virtual bottom is at the bottom of the viewport");
+    const auto initialVirtualBottom = si.GetViewport().BottomInclusive();
+    VERIFY_ARE_EQUAL(initialVirtualBottom, si._virtualBottom);
+
+    Log::Comment(L"Set the cursor to the bottom of the current page");
+    stateMachine.ProcessString(L"\033[9999H");
+    VERIFY_ARE_EQUAL(initialVirtualBottom, cursor.GetPosition().Y);
+
+    Log::Comment(L"Pan to the top of the buffer without changing the virtual bottom");
+    VERIFY_SUCCEEDED(si.SetViewportOrigin(true, { 0, 0 }, false));
+    VERIFY_ARE_EQUAL(initialVirtualBottom, si._virtualBottom);
+
+    Log::Comment(L"Shrink the viewport height by two lines");
+    auto viewportSize = si.GetViewport().Dimensions();
+    viewportSize.Y -= 2;
+    si._InternalSetViewportSize(&viewportSize, false, false);
+    VERIFY_ARE_EQUAL(viewportSize, si.GetViewport().Dimensions());
+
+    Log::Comment(L"Confirm that the virtual bottom has not changed");
+    VERIFY_ARE_EQUAL(initialVirtualBottom, si._virtualBottom);
+
+    Log::Comment(L"Position the viewport just above the virtual bottom");
+    short viewportTop = si._virtualBottom - viewportSize.Y;
+    VERIFY_SUCCEEDED(si.SetViewportOrigin(true, { 0, viewportTop }, false));
+    VERIFY_ARE_EQUAL(si._virtualBottom - 1, si.GetViewport().BottomInclusive());
+
+    Log::Comment(L"Expand the viewport height so it 'passes through' the virtual bottom");
+    viewportSize.Y += 2;
+    si._InternalSetViewportSize(&viewportSize, false, false);
+    VERIFY_ARE_EQUAL(viewportSize, si.GetViewport().Dimensions());
+
+    Log::Comment(L"Confirm that the virtual bottom has aligned with the viewport bottom");
+    VERIFY_ARE_EQUAL(si._virtualBottom, si.GetViewport().BottomInclusive());
+
+    Log::Comment(L"Position the viewport bottom just below the virtual bottom");
+    viewportTop = si._virtualBottom - viewportSize.Y + 2;
+    VERIFY_SUCCEEDED(si.SetViewportOrigin(true, { 0, viewportTop }, false));
+    VERIFY_ARE_EQUAL(si._virtualBottom + 1, si.GetViewport().BottomInclusive());
+
+    Log::Comment(L"Shrink the viewport height so it 'passes through' the virtual bottom");
+    viewportSize.Y -= 2;
+    si._InternalSetViewportSize(&viewportSize, false, false);
+    VERIFY_ARE_EQUAL(viewportSize, si.GetViewport().Dimensions());
+
+    Log::Comment(L"Confirm that the virtual bottom has aligned with the viewport bottom");
+    VERIFY_ARE_EQUAL(si._virtualBottom, si.GetViewport().BottomInclusive());
+}
+
+void ScreenBufferTests::UpdateVirtualBottomAfterResizeWithReflow()
+{
+    auto& g = ServiceLocator::LocateGlobals();
+    auto& gci = g.getConsoleInformation();
+    auto& si = gci.GetActiveOutputBuffer();
+    auto& cursor = si.GetTextBuffer().GetCursor();
+    auto& stateMachine = si.GetStateMachine();
+
+    Log::Comment(L"Output a couple of pages of content");
+    auto bufferSize = si.GetTextBuffer().GetSize().Dimensions();
+    const auto viewportSize = si.GetViewport().Dimensions();
+    const auto line = std::wstring(bufferSize.X - 1, L'X') + L'\n';
+    for (auto i = 0; i < viewportSize.Y * 2; i++)
+    {
+        stateMachine.ProcessString(line);
+    }
+
+    Log::Comment(L"Set the cursor to the top of the current page");
+    stateMachine.ProcessString(L"\033[H");
+    VERIFY_ARE_EQUAL(si.GetViewport().Origin(), cursor.GetPosition());
+
+    Log::Comment(L"Pan to the top of the buffer without changing the virtual bottom");
+    VERIFY_SUCCEEDED(si.SetViewportOrigin(true, { 0, 0 }, false));
+
+    Log::Comment(L"Shrink the viewport width by a half");
+    bufferSize.X /= 2;
+    VERIFY_NT_SUCCESS(si.ResizeWithReflow(bufferSize));
+
+    Log::Comment(L"Confirm that the virtual viewport includes the last non-space row");
+    const auto lastNonSpaceRow = si.GetTextBuffer().GetLastNonSpaceCharacter().Y;
+    VERIFY_IS_GREATER_THAN_OR_EQUAL(si._virtualBottom, lastNonSpaceRow);
+}
+
+void ScreenBufferTests::DontChangeVirtualBottomWithOffscreenLinefeed()
+{
+    auto& g = ServiceLocator::LocateGlobals();
+    auto& gci = g.getConsoleInformation();
+    auto& si = gci.GetActiveOutputBuffer();
+    auto& cursor = si.GetTextBuffer().GetCursor();
+    auto& stateMachine = si.GetStateMachine();
+
+    Log::Comment(L"Pan down so the initial viewport is a couple of pages down");
+    const auto initialOrigin = COORD{ 0, si.GetViewport().Height() * 2 };
+    VERIFY_SUCCEEDED(si.SetViewportOrigin(true, initialOrigin, true));
+    VERIFY_ARE_EQUAL(initialOrigin, si.GetViewport().Origin());
+
+    Log::Comment(L"Make sure the initial virtual bottom is at the bottom of the viewport");
+    const auto initialVirtualBottom = si.GetViewport().BottomInclusive();
+    VERIFY_ARE_EQUAL(initialVirtualBottom, si._virtualBottom);
+
+    Log::Comment(L"Set the cursor to the top of the current page");
+    stateMachine.ProcessString(L"\033[H");
+    VERIFY_ARE_EQUAL(initialOrigin, cursor.GetPosition());
+
+    Log::Comment(L"Pan to the top of the buffer without changing the virtual bottom");
+    VERIFY_SUCCEEDED(si.SetViewportOrigin(true, { 0, 0 }, false));
+    VERIFY_ARE_EQUAL(initialVirtualBottom, si._virtualBottom);
+
+    Log::Comment(L"Output a line feed");
+    stateMachine.ProcessString(L"\n");
+
+    Log::Comment(L"Confirm that the virtual bottom has not changed");
+    VERIFY_ARE_EQUAL(initialVirtualBottom, si._virtualBottom);
+}
+
+void ScreenBufferTests::DontChangeVirtualBottomAfterResizeWindow()
+{
+    auto& g = ServiceLocator::LocateGlobals();
+    auto& gci = g.getConsoleInformation();
+    auto& si = gci.GetActiveOutputBuffer();
+    auto& cursor = si.GetTextBuffer().GetCursor();
+    auto& stateMachine = si.GetStateMachine();
+
+    Log::Comment(L"Pan down so the initial viewport is a couple of pages down");
+    const auto initialOrigin = COORD{ 0, si.GetViewport().Height() * 2 };
+    VERIFY_SUCCEEDED(si.SetViewportOrigin(true, initialOrigin, true));
+    VERIFY_ARE_EQUAL(initialOrigin, si.GetViewport().Origin());
+
+    Log::Comment(L"Make sure the initial virtual bottom is at the bottom of the viewport");
+    const auto initialVirtualBottom = si.GetViewport().BottomInclusive();
+    VERIFY_ARE_EQUAL(initialVirtualBottom, si._virtualBottom);
+
+    Log::Comment(L"Set the cursor to the bottom of the current page");
+    stateMachine.ProcessString(L"\033[9999H");
+    VERIFY_ARE_EQUAL(initialVirtualBottom, cursor.GetPosition().Y);
+
+    Log::Comment(L"Pan to the top of the buffer without changing the virtual bottom");
+    VERIFY_SUCCEEDED(si.SetViewportOrigin(true, { 0, 0 }, false));
+    VERIFY_ARE_EQUAL(initialVirtualBottom, si._virtualBottom);
+
+    Log::Comment(L"Shrink the viewport height");
+    std::wstringstream ss;
+    auto viewportWidth = si.GetViewport().Width();
+    auto viewportHeight = si.GetViewport().Height() - 2;
+    ss << L"\x1b[8;" << viewportHeight << L";" << viewportWidth << L"t";
+    stateMachine.ProcessString(ss.str());
+    VERIFY_ARE_EQUAL(viewportHeight, si.GetViewport().Height());
+
+    Log::Comment(L"Confirm that the virtual bottom has not changed");
+    VERIFY_ARE_EQUAL(initialVirtualBottom, si._virtualBottom);
+}
+
+void ScreenBufferTests::DontChangeVirtualBottomWithMakeCursorVisible()
+{
+    auto& g = ServiceLocator::LocateGlobals();
+    auto& gci = g.getConsoleInformation();
+    auto& si = gci.GetActiveOutputBuffer();
+    auto& cursor = si.GetTextBuffer().GetCursor();
+    auto& stateMachine = si.GetStateMachine();
+
+    Log::Comment(L"Pan down so the initial viewport is a couple of pages down");
+    const auto initialOrigin = COORD{ 0, si.GetViewport().Height() * 2 };
+    VERIFY_SUCCEEDED(si.SetViewportOrigin(true, initialOrigin, true));
+    VERIFY_ARE_EQUAL(initialOrigin, si.GetViewport().Origin());
+
+    Log::Comment(L"Make sure the initial virtual bottom is at the bottom of the viewport");
+    const auto initialVirtualBottom = si.GetViewport().BottomInclusive();
+    VERIFY_ARE_EQUAL(initialVirtualBottom, si._virtualBottom);
+
+    Log::Comment(L"Set the cursor to the top of the current page");
+    stateMachine.ProcessString(L"\033[H");
+    VERIFY_ARE_EQUAL(initialOrigin, cursor.GetPosition());
+
+    Log::Comment(L"Pan to the top of the buffer without changing the virtual bottom");
+    VERIFY_SUCCEEDED(si.SetViewportOrigin(true, { 0, 0 }, false));
+    VERIFY_ARE_EQUAL(initialVirtualBottom, si._virtualBottom);
+
+    Log::Comment(L"Make the cursor visible");
+    si.MakeCurrentCursorVisible();
+    VERIFY_ARE_EQUAL(si.GetViewport().BottomInclusive(), cursor.GetPosition().Y);
+
+    Log::Comment(L"Confirm that the virtual bottom has not changed");
+    VERIFY_ARE_EQUAL(initialVirtualBottom, si._virtualBottom);
+
+    Log::Comment(L"Pan further down so the viewport is below the cursor");
+    const auto belowCursor = COORD{ 0, cursor.GetPosition().Y + 10 };
+    VERIFY_SUCCEEDED(si.SetViewportOrigin(true, belowCursor, false));
+    VERIFY_ARE_EQUAL(belowCursor, si.GetViewport().Origin());
+
+    Log::Comment(L"Make the cursor visible");
+    si.MakeCurrentCursorVisible();
+    VERIFY_ARE_EQUAL(si.GetViewport().Top(), cursor.GetPosition().Y);
+
+    Log::Comment(L"Confirm that the virtual bottom has not changed");
+    VERIFY_ARE_EQUAL(initialVirtualBottom, si._virtualBottom);
 }
 
 void ScreenBufferTests::RetainHorizontalOffsetWhenMovingToBottom()

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -80,6 +80,8 @@ class ScreenBufferTests
         auto defaultSize = COORD{ CommonState::s_csWindowWidth, CommonState::s_csWindowHeight };
         currentBuffer.SetViewport(Viewport::FromDimensions(defaultSize), true);
         VERIFY_ARE_EQUAL(COORD({ 0, 0 }), currentBuffer.GetTextBuffer().GetCursor().GetPosition());
+        // Make sure the virtual bottom is correctly positioned.
+        currentBuffer.UpdateBottom();
 
         return true;
     }


### PR DESCRIPTION
The "virtual bottom" marks the last line of the mutable viewport area,
which is the part of the buffer that VT sequences can write to. This
region should typically only move downwards as new lines are added to
the buffer, but there were a number of cases where it was incorrectly
being moved up, or moved down further than necessary. This PR attempts
to fix that.

There was an earlier, unsuccessful attempt to fix this in PR #9770 which
was later reverted (issue #9872 was the reason it had to be reverted).
PRs #2666, #2705, and #5317 were fixes for related virtual viewport
problems, some of which have either been extended or superseded by this
PR.

`SetConsoleCursorPositionImpl` is one of the cases that actually does
need to move the virtual viewport upwards sometimes, in particular when
the cmd shell resets the buffer with a `CLS` command. But when this
operation "snaps" the viewport to the location of the cursor, it needs
to use the virtual viewport as the frame of reference. This was
partially addressed by PR #2705, but that only applied in
terminal-scrolling mode, so I've now applied that fix regardless of the
mode.

`SetViewportOrigin` takes a flag which determines whether it will also
move the virtual bottom to match the visible viewport. In some case this
is appropriate (`SetConsoleCursorPositionImpl` being one example), but
in other cases (e.g. when panning the viewport downwards in the
`AdjustCursorPosition` function), it should only be allowed to move
downwards. We can't just not set the update flag in those cases, because
that also determines whether or not the viewport would be clamped, and
we don't want change that. So what I've done is limit
`SetViewportOrigin` to only move the virtual bottom downwards, and added
an explicit `UpdateBottom` call in those places that may also require
upward movement.

`ResizeWindow` in the `ConhostInternalGetSet` class has a similar
problem to `SetConsoleCursorPositionImpl`, in that it's updating the
viewport to account for the new size, but if that visible viewport is
scrolled back or forward, it would end up placing the virtual viewport
in the wrong place. So again the solution here was to use the virtual
viewport as the frame of reference for the position. However, if the
viewport is being shrunk, this can still result in the cursor falling
below the bottom, so we need an additional check to adjust for that.
This can't be applied in pty mode, though, because that would break the
conpty resizing operation.

`_InternalSetViewportSize` comes into play when resizing the window
manually, and again the viewport after the resize can end up truncating
the virtual bottom if not handled correctly. This was partially
addressed in the original code by clamping the new viewport above the
virtual bottom under certain conditions, and only in terminal scrolling
mode. I've replaced that with a new algorithm which links the virtual
bottom to the visible viewport bottom if the two intersect, but
otherwise leaves it unchanged. This applies regardless of the scrolling
mode.

`ResizeWithReflow` is another sizing operation that can affect the
virtual bottom. This occurs when a change of the window width requires
the buffer to be reflowed, and we need to reposition the viewport in the
newly generated buffer. Previously we were just setting the virtual
bottom to align with the new visible viewport, but that could easily
result in the buffer truncation if the visible viewport was scrolled
back at the time. We now set the virtual bottom to the last non-space
row, or the cursor row (whichever is larger). There'll be edge cases
where this is probably not ideal, but it should still work reasonably
well.

`MakeCursorVisible` was another case where the virtual bottom was being
updated (when requested with a flag) via a `SetViewportOrigin` call.
When I checked all the places it was used, though, none of them actually
required that behavior, and doing so could result in the virtual bottom
being incorrectly positioned, even after `SetViewportOrigin` was limited
to moving the virtual bottom downwards. So I've now made it so that
`MakeCursorVisible` never updates the virtual bottom.

`SelectAll` in the `Selection` class was a similar case. It was calling
`SetViewportOrigin` with the `updateBottom` flag set when that really
wasn't necessary and could result in the virtual bottom being
incorrectly set. I've changed the flag to false now.

## Validation Steps Performed

I've manually confirmed that the test cases in issue #9754 are working
now, except for the one involving margins, which is bigger problem with
`AdjustCursorPosition` which will need to be addressed separately.

I've also double checked the test cases from several other virtual
bottom issues (#1206, #1222, #5302, and #9872), and confirmed that
they're still working correctly with these changes.

And I've added a few screen buffer tests in which I've tried to cover as
many of the problematic code paths as possible.

Closes #9754