### PR TITLE
Exclude the NuGet prerelease suffix in branded release-* builds

### DIFF
--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -71,8 +71,9 @@ variables:
   # release-*         | 1.12.20220427          | 1.13.20220427-preview
   # all others        | 1.14.20220427-mybranch | 1.14.20220427-mybranch
   ${{ if startsWith(variables['Build.SourceBranchName'], 'release-') }}:
-    NoNuGetPackBetaVersion: ${{ eq(parameters.branding, 'Release') }}
     NuGetPackBetaVersion: preview
+    ${{ if eq(parameters.branding, 'Release') }}:
+      NoNuGetPackBetaVersion: true
 
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 resources:

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -71,9 +71,10 @@ variables:
   # release-*         | 1.12.20220427          | 1.13.20220427-preview
   # all others        | 1.14.20220427-mybranch | 1.14.20220427-mybranch
   ${{ if startsWith(variables['Build.SourceBranchName'], 'release-') }}:
-    NuGetPackBetaVersion: preview
     ${{ if eq(parameters.branding, 'Release') }}:
       NoNuGetPackBetaVersion: true
+    ${{ else }}:
+      NuGetPackBetaVersion: preview
 
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 resources:

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -72,7 +72,7 @@ variables:
   # all others        | 1.14.20220427-mybranch | 1.14.20220427-mybranch
   ${{ if startsWith(variables['Build.SourceBranchName'], 'release-') }}:
     NoNuGetPackBetaVersion: ${{ eq(parameters.branding, 'Release') }}
-    NuGetPackBetaBranchName: preview
+    NuGetPackBetaVersion: preview
 
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 resources:

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -60,9 +60,19 @@ parameters:
 
 variables:
   TerminalInternalPackageVersion: "0.0.7"
-  # Disable branch name in nuget packages
-  # We can't tell it to ignore release-*, so let's just turn it off
-  NoNuGetPackBetaVersion: true
+  # If we are building a branch called "release-*", change the NuGet suffix
+  # to "preview". If we don't do that, XES will set the suffix to "release1"
+  # because it truncates the value after the first period.
+  # We also want to disable the suffix entirely if we're Release branded while
+  # on a release branch.
+  # In effect:
+  # BRANCH / BRANDING | Release                | Preview
+  # ------------------|------------------------|------------------------
+  # release-*         | 1.12.20220427          | 1.13.20220427-preview
+  # all others        | 1.14.20220427-mybranch | 1.14.20220427-mybranch
+  ${{ if startsWith(variables['Build.SourceBranchName'], 'release-') }}:
+    NoNuGetPackBetaVersion: ${{ eq(parameters.branding, 'Release') }}
+    NuGetPackBetaBranchName: preview
 
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 resources:

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -60,6 +60,9 @@ parameters:
 
 variables:
   TerminalInternalPackageVersion: "0.0.7"
+  # Disable branch name in nuget packages
+  # We can't tell it to ignore release-*, so let's just turn it off
+  NoNuGetPackBetaVersion: true
 
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 resources:


### PR DESCRIPTION
If we are building a branch called "release-*", we will also change the
NuGet suffix to "preview". If we don't do that, XES will set the suffix
to "release1" because it truncates the value after the first period. In
general, though, we want to disable the suffix entirely if we're Release
branded while on a release branch.

In effect:
BRANCH / BRANDING | Release                | Preview
------------------|------------------------|------------------------
release-*         | 1.12.20220427          | 1.13.20220427-preview
all others        | 1.14.20220427-mybranch | 1.14.20220427-mybranch
