### PR TITLE
Make package builds from main end with -experimental

### DIFF
--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -69,16 +69,23 @@ variables:
   # because it truncates the value after the first period.
   # We also want to disable the suffix entirely if we're Release branded while
   # on a release branch.
+  # main is special, however. XES ignores main. Since we never produce actual
+  # shipping builds from main, we want to force it to have a beta label as
+  # well.
+  #
   # In effect:
-  # BRANCH / BRANDING | Release                | Preview
-  # ------------------|------------------------|------------------------
-  # release-*         | 1.12.20220427          | 1.13.20220427-preview
-  # all others        | 1.14.20220427-mybranch | 1.14.20220427-mybranch
+  # BRANCH / BRANDING | Release                    | Preview
+  # ------------------|----------------------------|-----------------------------
+  # release-*         | 1.12.20220427              | 1.13.20220427-preview
+  # main              | 1.14.20220427-experimental | 1.14.20220427-experimental
+  # all others        | 1.14.20220427-mybranch     | 1.14.20220427-mybranch
   ${{ if startsWith(variables['Build.SourceBranchName'], 'release-') }}:
     ${{ if eq(parameters.branding, 'Release') }}:
       NoNuGetPackBetaVersion: true
     ${{ else }}:
       NuGetPackBetaVersion: preview
+  ${{ elseif eq(variables['Build.SourceBranchName'], 'main') }}:
+    NuGetPackBetaVersion: experimental
   # The NuGet packages have to use *somebody's* DLLs. We used to force them to
   # use the Win10 build outputs, but if there isn't a Win10 build we should use
   # the Win11 one.


### PR DESCRIPTION
Yes, more version shenanigans. I'm probably done now.

Here's an update to the table from the original version work:

BRANCH / BRANDING | Release                    | Preview
------------------|----------------------------|----------------------------
release-*         | 1.12.20220427              | 1.13.20220427-preview
main              | 1.14.20220427-experimental | 1.14.20220427-experimental
all others        | 1.14.20220427-mybranch     | 1.14.20220427-mybranch
