### PR TITLE
Change TSFInputControl inputScope to AlphanumericHalfWidth

### DIFF
--- a/src/cascadia/TerminalControl/TSFInputControl.cpp
+++ b/src/cascadia/TerminalControl/TSFInputControl.cpp
@@ -37,8 +37,10 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // InputPane is manually shown inside of TermControl.
         _editContext.InputPaneDisplayPolicy(CoreTextInputPaneDisplayPolicy::Manual);
 
-        // set the input scope to Text because this control is for any text.
-        _editContext.InputScope(CoreTextInputScope::Text);
+        // Set the input scope to AlphanumericHalfWidth in order to facilitate those CJK input methods to open in English mode by default.
+        // AlphanumericHalfWidth scope doesn't prevent input method from switching to composition mode, it accepts any character too.
+        // Besides, Text scope turns on typing intelligence, but that doesn't work in this project.
+        _editContext.InputScope(CoreTextInputScope::AlphanumericHalfWidth);
 
         _textRequestedRevoker = _editContext.TextRequested(winrt::auto_revoke, { this, &TSFInputControl::_textRequestedHandler });
 


### PR DESCRIPTION
Modified the scope of input control, it used to be `Text`, now it is
`AlphanumericHalfWidth`.  This input scope actually accepts any
characters, but English characters are preferred, and the soft keyboard
also displays English by default.

This should improve user friendliness for users using composition mode
input methods.

As a user who uses the composition mode input method, in applications
like windows terminal that should usually be input in English, it is
always required to manually switch to English mode by pressing Shift
before entering commands.

One keystroke is not a problem, but often for some reason there is no or
no successful switching, and additional more keystrokes are required to
clear the wrong input.

The input method that comes with windows will automatically switch to
English mode for a few programs such as conhost, but windows terminal is
not in this list.

This change should have no negative impact. Even if someone does tend to
use a shell oriented towards composition characters or non-alpha
letters, there should also were more users who in the same language are
more inclined to English characters shells, for example, cmd,
powershell, bash that comes with windows.

If there's any reason to have to keep the Text inputScope, maybe making
this setting customizable via `settings.json` would be a good idea, but
I don't see the need to do this, `AlphanumericHalfWidth` is perfect.

Closes #12731