### PR TITLE
Fix a crash when entering lots of text in the Japanese IME

### DIFF
--- a/src/host/conimeinfo.cpp
+++ b/src/host/conimeinfo.cpp
@@ -343,14 +343,19 @@ std::vector<OutputCell>::const_iterator ConsoleImeInfo::_WriteConversionArea(con
 
     // We must attempt to compensate for ending on a leading byte. We can't split a full-width character across lines.
     // As such, if the last item is a leading byte, back the end up by one.
-    FAIL_FAST_IF(lineEnd <= lineBegin); // We should have at least 1 space we can back up.
-
     // Get the last cell in the run and if it's a leading byte, move the end position back one so we don't
     // try to insert it.
     const auto lastCell = lineEnd - 1;
     if (lastCell->DbcsAttr().IsLeading())
     {
         lineEnd--;
+    }
+
+    // GH#12730 - if the lineVec would now be empty, just return early. Failing
+    // to do so will later cause a crash trying to construct an empty view.
+    if (lineEnd <= lineBegin)
+    {
+        return lineEnd;
     }
 
     // Copy out the substring into a vector.


### PR DESCRIPTION
As noted in the issue. There's a case where backing up the `lineEnd` can result in the `lineEnd` pointing at exactly the `lineBegin`, which results in an empty view, which causes all sorts of pain later. 

Instead, just return early in this case.

* tested with an 80x24 conhost
* tested with an 79x24 conhost


I also tried making this a FAILFAST or a THROW_HR, but the failfast immediately died (of course it did), and the throw would result in a few frames where the composition was just... entirely not displayed? Probably not what we wanted.

* [x] Closes #12730