### PR TITLE
Add automation properties to expander-style settings

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/SettingContainer.cpp
+++ b/src/cascadia/TerminalSettingsEditor/SettingContainer.cpp
@@ -122,19 +122,39 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         _UpdateOverrideSystem();
 
-        // Apply automation properties as necessary
+        // Get the correct base to apply automation properties to
+        DependencyObject base{ nullptr };
         if (const auto& child{ GetTemplateChild(L"Expander") })
         {
             if (const auto& expander{ child.try_as<Microsoft::UI::Xaml::Controls::Expander>() })
             {
-                _ApplyNameAndFullDescription(child);
+                base = child;
             }
         }
         else if (const auto& content{ Content() })
         {
             if (const auto& obj{ content.try_as<DependencyObject>() })
             {
-                _ApplyNameAndFullDescription(obj);
+                base = obj;
+            }
+        }
+
+        if (base)
+        {
+            // apply header as name (automation property)
+            if (const auto& header{ Header() })
+            {
+                if (const auto headerText{ header.try_as<hstring>() })
+                {
+                    Automation::AutomationProperties::SetName(base, *headerText);
+                }
+            }
+
+            // apply help text as tooltip and full description (automation property)
+            if (const auto& helpText{ HelpText() }; !helpText.empty())
+            {
+                Controls::ToolTipService::SetToolTip(base, box_value(helpText));
+                Automation::AutomationProperties::SetFullDescription(base, helpText);
             }
         }
 
@@ -147,29 +167,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                     textBlock.Visibility(Visibility::Collapsed);
                 }
             }
-        }
-    }
-
-    // Method Description:
-    // - Helper for applying the name and full description
-    //   automation properties to a dependency object
-    // Arguments:
-    // - d: the DependencyObject to apply the automation properties to
-    void SettingContainer::_ApplyNameAndFullDescription(const DependencyObject& d)
-    {
-        if (const auto& header{ Header() })
-        {
-            if (const auto headerText{ header.try_as<hstring>() })
-            {
-                Automation::AutomationProperties::SetName(d, *headerText);
-            }
-        }
-
-        // apply help text as tooltip and full description (automation property)
-        if (const auto& helpText{ HelpText() }; !helpText.empty())
-        {
-            Controls::ToolTipService::SetToolTip(d, box_value(helpText));
-            Automation::AutomationProperties::SetFullDescription(d, helpText);
         }
     }
 

--- a/src/cascadia/TerminalSettingsEditor/SettingContainer.cpp
+++ b/src/cascadia/TerminalSettingsEditor/SettingContainer.cpp
@@ -146,6 +146,30 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             }
         }
 
+        if (const auto& child{ GetTemplateChild(L"Expander") })
+        {
+            if (const auto& expander{ child.try_as<Microsoft::UI::Xaml::Controls::Expander>() })
+            {
+                // apply header text as name (automation property)
+                if (const auto& header{ Header() })
+                {
+                    const auto headerText{ header.try_as<hstring>() };
+                    if (headerText && !headerText->empty())
+                    {
+                        Automation::AutomationProperties::SetName(expander, *headerText);
+                    }
+                }
+
+                // apply help text as tooltip and full description (automation property)
+                const auto& helpText{ HelpText() };
+                if (!helpText.empty())
+                {
+                    Controls::ToolTipService::SetToolTip(expander, box_value(helpText));
+                    Automation::AutomationProperties::SetFullDescription(expander, helpText);
+                }
+            }
+        }
+
         if (HelpText().empty())
         {
             if (const auto& child{ GetTemplateChild(L"HelpTextBlock") })

--- a/src/cascadia/TerminalSettingsEditor/SettingContainer.cpp
+++ b/src/cascadia/TerminalSettingsEditor/SettingContainer.cpp
@@ -122,46 +122,19 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         _UpdateOverrideSystem();
 
+        // Apply automation properties as necessary
         if (const auto& child{ GetTemplateChild(L"Expander") })
         {
             if (const auto& expander{ child.try_as<Microsoft::UI::Xaml::Controls::Expander>() })
             {
-                // apply header text as name (automation property)
-                if (const auto& header{ Header() })
-                {
-                    if (const auto headerText{ header.try_as<hstring>() })
-                    {
-                        Automation::AutomationProperties::SetName(expander, *headerText);
-                    }
-                }
-
-                // apply help text as tooltip and full description (automation property)
-                if (const auto& helpText{ HelpText() }; !helpText.empty())
-                {
-                    Controls::ToolTipService::SetToolTip(expander, box_value(helpText));
-                    Automation::AutomationProperties::SetFullDescription(expander, helpText);
-                }
+                _ApplyNameAndFullDescription(child);
             }
         }
         else if (const auto& content{ Content() })
         {
             if (const auto& obj{ content.try_as<DependencyObject>() })
             {
-                // apply header text as name (automation property)
-                if (const auto& header{ Header() })
-                {
-                    if (const auto headerText{ header.try_as<hstring>() })
-                    {
-                        Automation::AutomationProperties::SetName(obj, *headerText);
-                    }
-                }
-
-                // apply help text as tooltip and full description (automation property)
-                if (const auto& helpText{ HelpText() }; !helpText.empty())
-                {
-                    Controls::ToolTipService::SetToolTip(obj, box_value(helpText));
-                    Automation::AutomationProperties::SetFullDescription(obj, helpText);
-                }
+                _ApplyNameAndFullDescription(obj);
             }
         }
 
@@ -174,6 +147,29 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                     textBlock.Visibility(Visibility::Collapsed);
                 }
             }
+        }
+    }
+
+    // Method Description:
+    // - Helper for applying the name and full description
+    //   automation properties to a dependency object
+    // Arguments:
+    // - d: the DependencyObject to apply the automation properties to
+    void SettingContainer::_ApplyNameAndFullDescription(const DependencyObject& d)
+    {
+        if (const auto& header{ Header() })
+        {
+            if (const auto headerText{ header.try_as<hstring>() })
+            {
+                Automation::AutomationProperties::SetName(d, *headerText);
+            }
+        }
+
+        // apply help text as tooltip and full description (automation property)
+        if (const auto& helpText{ HelpText() }; !helpText.empty())
+        {
+            Controls::ToolTipService::SetToolTip(d, box_value(helpText));
+            Automation::AutomationProperties::SetFullDescription(d, helpText);
         }
     }
 

--- a/src/cascadia/TerminalSettingsEditor/SettingContainer.cpp
+++ b/src/cascadia/TerminalSettingsEditor/SettingContainer.cpp
@@ -122,30 +122,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         _UpdateOverrideSystem();
 
-        if (const auto& content{ Content() })
-        {
-            if (const auto& obj{ content.try_as<DependencyObject>() })
-            {
-                // apply header text as name (automation property)
-                if (const auto& header{ Header() })
-                {
-                    const auto headerText{ header.try_as<hstring>() };
-                    if (headerText && !headerText->empty())
-                    {
-                        Automation::AutomationProperties::SetName(obj, *headerText);
-                    }
-                }
-
-                // apply help text as tooltip and full description (automation property)
-                const auto& helpText{ HelpText() };
-                if (!helpText.empty())
-                {
-                    Controls::ToolTipService::SetToolTip(obj, box_value(helpText));
-                    Automation::AutomationProperties::SetFullDescription(obj, helpText);
-                }
-            }
-        }
-
         if (const auto& child{ GetTemplateChild(L"Expander") })
         {
             if (const auto& expander{ child.try_as<Microsoft::UI::Xaml::Controls::Expander>() })
@@ -153,19 +129,38 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 // apply header text as name (automation property)
                 if (const auto& header{ Header() })
                 {
-                    const auto headerText{ header.try_as<hstring>() };
-                    if (headerText && !headerText->empty())
+                    if (const auto headerText{ header.try_as<hstring>() })
                     {
                         Automation::AutomationProperties::SetName(expander, *headerText);
                     }
                 }
 
                 // apply help text as tooltip and full description (automation property)
-                const auto& helpText{ HelpText() };
-                if (!helpText.empty())
+                if (const auto& helpText{ HelpText() }; !helpText.empty())
                 {
                     Controls::ToolTipService::SetToolTip(expander, box_value(helpText));
                     Automation::AutomationProperties::SetFullDescription(expander, helpText);
+                }
+            }
+        }
+        else if (const auto& content{ Content() })
+        {
+            if (const auto& obj{ content.try_as<DependencyObject>() })
+            {
+                // apply header text as name (automation property)
+                if (const auto& header{ Header() })
+                {
+                    if (const auto headerText{ header.try_as<hstring>() })
+                    {
+                        Automation::AutomationProperties::SetName(obj, *headerText);
+                    }
+                }
+
+                // apply help text as tooltip and full description (automation property)
+                if (const auto& helpText{ HelpText() }; !helpText.empty())
+                {
+                    Controls::ToolTipService::SetToolTip(obj, box_value(helpText));
+                    Automation::AutomationProperties::SetFullDescription(obj, helpText);
                 }
             }
         }

--- a/src/cascadia/TerminalSettingsEditor/SettingContainer.h
+++ b/src/cascadia/TerminalSettingsEditor/SettingContainer.h
@@ -41,7 +41,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         static void _OnHasSettingValueChanged(const Windows::UI::Xaml::DependencyObject& d, const Windows::UI::Xaml::DependencyPropertyChangedEventArgs& e);
         static hstring _GenerateOverrideMessage(const IInspectable& settingOrigin);
         void _UpdateOverrideSystem();
-        void _ApplyNameAndFullDescription(const Windows::UI::Xaml::DependencyObject& d);
     };
 }
 

--- a/src/cascadia/TerminalSettingsEditor/SettingContainer.h
+++ b/src/cascadia/TerminalSettingsEditor/SettingContainer.h
@@ -41,6 +41,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         static void _OnHasSettingValueChanged(const Windows::UI::Xaml::DependencyObject& d, const Windows::UI::Xaml::DependencyPropertyChangedEventArgs& e);
         static hstring _GenerateOverrideMessage(const IInspectable& settingOrigin);
         void _UpdateOverrideSystem();
+        void _ApplyNameAndFullDescription(const Windows::UI::Xaml::DependencyObject& d);
     };
 }
 

--- a/src/cascadia/TerminalSettingsEditor/SettingContainerStyle.xaml
+++ b/src/cascadia/TerminalSettingsEditor/SettingContainerStyle.xaml
@@ -142,7 +142,8 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:SettingContainer">
-                    <muxc:Expander Margin="0,4,0,0"
+                    <muxc:Expander x:Name="Expander"
+                                   Margin="0,4,0,0"
                                    HorizontalAlignment="Stretch"
                                    HorizontalContentAlignment="Stretch"
                                    Content="{TemplateBinding Content}">


### PR DESCRIPTION
## Summary of the Pull Request
Make sure we set `Name` and `FullDescription` on expander-style settings in the SUI

## PR Checklist
* [x] Closes #13019 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I work here

## Validation Steps Performed
Accessibility insights now shows the name/full description for the expander-style settings