### PR TITLE
Switch WT and OpenConsole to the Segment Heap

### DIFF
--- a/src/cascadia/WindowsTerminal/WindowsTerminal.manifest
+++ b/src/cascadia/WindowsTerminal/WindowsTerminal.manifest
@@ -27,6 +27,7 @@
     <windowsSettings>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
       <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+      <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
     </windowsSettings>
   </application>
 </assembly>

--- a/src/host/exe/openconsole.exe.manifest
+++ b/src/host/exe/openconsole.exe.manifest
@@ -15,6 +15,7 @@
     <application xmlns="urn:schemas-microsoft-com:asm.v3">
         <windowsSettings>
             <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+            <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
             <!--Enable longPath support-->
         </windowsSettings>
     </application>

--- a/src/host/exe/openconsole.exe.manifest
+++ b/src/host/exe/openconsole.exe.manifest
@@ -16,7 +16,6 @@
         <windowsSettings>
             <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
             <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
-            <!--Enable longPath support-->
         </windowsSettings>
     </application>
 


### PR DESCRIPTION
To quote an internal wiki:

> It generally provides improved footprint and performance over the
> existing default heap for native win32 applications.

It is apparently the default heap on ARM64, and for all UWPs.

This heap has different allocation and compaction characteristics.
I am not sure how it will impact terminal.