### PR TITLE
Stop the viewport being moved when in the alt buffer

### DIFF
--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -41,9 +41,13 @@ til::rect Terminal::GetViewport() const
 
 void Terminal::SetViewportPosition(const til::point position)
 {
-    const auto dimensions = _GetMutableViewport().Dimensions();
-    _mutableViewport = Viewport::FromDimensions(position.to_win32_coord(), dimensions);
-    Terminal::_NotifyScrollEvent();
+    // The viewport is fixed at 0,0 for the alt buffer, so this is a no-op.
+    if (!_inAltBuffer())
+    {
+        const auto dimensions = _GetMutableViewport().Dimensions();
+        _mutableViewport = Viewport::FromDimensions(position.to_win32_coord(), dimensions);
+        Terminal::_NotifyScrollEvent();
+    }
 }
 
 void Terminal::SetTextAttributes(const TextAttribute& attrs)


### PR DESCRIPTION
## Summary of the Pull Request

When `TerminalDispatch` was merged with `AdaptDispatch` in PR #13024,
that broke the Terminal's `EraseAll` operation in the alt buffer. The
problem was that the `EraseAll` implementation makes a call to
`SetViewportPosition` which wasn't taking the alt buffer into account,
and thus modified the main viewport instead.

This PR corrects that mistake. If we're in the alt buffer, the
`SetViewportPosition` method now does nothing, since the alt buffer
viewport should always be at 0,0.

## References

This was a regression introduced in PR #13024.

## PR Checklist
* [x] Closes #13038
* [x] CLA signed.
* [ ] Tests added/passed
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] I've discussed this with core contributors already. Issue number where discussion took place: #13038

## Validation Steps Performed

I've confirmed that the test case reported in issue #13038 is no longer
failing. I've also made sure the `ED 2` and `ED 3` sequences are still
working correctly in the main buffer.