### PR TITLE
Only add the `ProfileVM.DeleteProfile` handler once

### DIFF
--- a/.github/actions/spelling/allow/allow.txt
+++ b/.github/actions/spelling/allow/allow.txt
@@ -38,6 +38,7 @@ hostnames
 hyperlink
 hyperlinking
 hyperlinks
+iconify
 img
 inlined
 It'd

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -419,9 +419,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         _PreNavigateHelper();
 
-        // Add an event handler for when the user wants to delete a profile.
-        profile.DeleteProfile({ this, &MainPage::_DeleteProfile });
-
         _SetupProfileEventHandling(state);
 
         contentFrame().Navigate(xaml_typename<Editor::Profiles_Base>(), state);
@@ -566,6 +563,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 }
             }
         });
+
+        // Add an event handler for when the user wants to delete a profile.
+        profile.DeleteProfile({ this, &MainPage::_DeleteProfile });
+
         return profileNavItem;
     }
 


### PR DESCRIPTION
Turns out if you add that Delete handler there, then every time you navigate to the profile, we'll add another Delete handler to the list of handlers. That's bad - that'll cause us to try and delete the profile multiple times.

The repro I had before was 100%, now it's fixed.

* [x] Closes #13017