### PR TITLE
Hide the VT Passthrough Mode switch from the Settings UI in Preview

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
@@ -300,7 +300,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     bool ProfileViewModel::VtPassthroughAvailable() const noexcept
     {
-        return Feature_VtPassthroughMode::IsEnabled();
+        return Feature_VtPassthroughMode::IsEnabled() && Feature_VtPassthroughModeSettingInUI::IsEnabled();
     }
 
     bool ProfileViewModel::UseParentProcessDirectory()

--- a/src/features.xml
+++ b/src/features.xml
@@ -97,6 +97,16 @@
     </feature>
 
     <feature>
+        <name>Feature_VtPassthroughModeSettingInUI</name>
+        <description>Enables the setting gated by Feature_VtPassthroughMode to appear in the UI</description>
+        <stage>AlwaysDisabled</stage>
+        <alwaysEnabledBrandingTokens>
+            <brandingToken>Dev</brandingToken>
+	    <!-- Unlike Feature_VtPassthroughMode, this is not enabled in Preview -->
+        </alwaysEnabledBrandingTokens>
+    </feature>
+
+    <feature>
         <name>Feature_IsolatedMonarchMode</name>
         <description>Enables a test flag for MSFT:38540483. When enabled, if we ever create a null Monarch, we'll stealthily try to fall back to an in-proc monarch instance.</description>
         <stage>AlwaysEnabled</stage>


### PR DESCRIPTION
The setting will still be available, but be considered even more
"advanced" than the advanced section of the settings.