### PR TITLE
Make sure the virtual viewport doesn't go negative

### DIFF
--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -1465,10 +1465,13 @@ bool SCREEN_INFORMATION::IsMaximizedY() const
     if (SUCCEEDED(hr))
     {
         // Make sure the new virtual bottom is far enough down to include both
-        // the cursor row and the last non-space row.
+        // the cursor row and the last non-space row. It also shouldn't be less
+        // than the height of the viewport, otherwise the top of the virtual
+        // viewport would end up negative.
         const auto cursorRow = newTextBuffer->GetCursor().GetPosition().Y;
         const auto lastNonSpaceRow = newTextBuffer->GetLastNonSpaceCharacter().Y;
-        _virtualBottom = std::max({ cursorRow, lastNonSpaceRow });
+        const auto viewportBottom = gsl::narrow_cast<short>(_viewport.Height() - 1);
+        _virtualBottom = std::max({ cursorRow, lastNonSpaceRow, viewportBottom });
 
         // Adjust the viewport so the cursor doesn't wildly fly off up or down.
         const auto sCursorHeightInViewportAfter = cursorRow - _viewport.Top();


### PR DESCRIPTION
## Summary of the Pull Request

When calculating the position of the virtual bottom after a resize with
reflow, it was possible for it to end up less than the height of the
viewport. This meant that the top of the virtual viewport would be
negative, which resulted in other operations failing further down the
line. This PR updates the virtual bottom calculation to fix that
scenario.

## References

This was probably a regression introduced in PR #12972.

## PR Checklist
* [x] Closes #13034
* [x] CLA signed.
* [x] Tests added/passed
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] I've discussed this with core contributors already. Issue number where discussion took place: #13034

## Validation Steps Performed

I wasn't able to replicate the exact case described in issue #13034,
because I don't have Windows 11, so can't configure the default
terminal. However, I was able to reproduce a similar failure using a
`SetConsoleScreenBufferInfoEx` call, and I've confirmed that this PR
has fixed that.

I've also added another screen buffer test to make sure the
`ResizeWithReflow` method doesn't shrink the virtual bottom when
resizing at the top of the buffer.