### PR TITLE
[High Contrast] Fix red SUI background

### DIFF
--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -154,6 +154,8 @@
                             <StaticResource x:Key="UnfocusedBorderBrush"
                                             ResourceKey="ApplicationPageBackgroundThemeBrush" />
 
+                            <StaticResource x:Key="SettingsPageBackground"
+                                            ResourceKey="SolidBackgroundFillColorTertiary" />
 
                         </ResourceDictionary>
 
@@ -168,6 +170,9 @@
 
                             <StaticResource x:Key="UnfocusedBorderBrush"
                                             ResourceKey="ApplicationPageBackgroundThemeBrush" />
+
+                            <StaticResource x:Key="SettingsPageBackground"
+                                            ResourceKey="SolidBackgroundFillColorTertiary" />
                         </ResourceDictionary>
 
                         <ResourceDictionary x:Key="HighContrast">
@@ -185,6 +190,9 @@
                             -->
                             <StaticResource x:Key="TabViewBackground"
                                             ResourceKey="SystemColorButtonFaceColorBrush" />
+
+                            <StaticResource x:Key="SettingsPageBackground"
+                                            ResourceKey="SystemColorWindowColorBrush" />
                         </ResourceDictionary>
 
                     </ResourceDictionary.ThemeDictionaries>

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -9,7 +9,7 @@
       xmlns:local="using:Microsoft.Terminal.Settings.Editor"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-      Background="{ThemeResource SolidBackgroundFillColorTertiary}"
+      Background="{ThemeResource SettingsPageBackground}"
       mc:Ignorable="d">
 
     <Page.Resources>


### PR DESCRIPTION
Fixes the SUI background being red in high contrast mode. The issue was
that `SolidBackgroundFillColorTertiary` purposefully has a bad High
Contrast color[^1].

The fix was to be explicit in the theme resources so that
`SolidBackgroundFillColorTertiary` is used in light and dark mode, but
the standard high contrast one is used in high contrast mode. Since the
page is the top-level XAML element in the Editor project, I had to
introduce this in the App.xaml resources so that the page can find the
theme resource.

Closes #13065 
Closes #13070

[^1]: https://github.com/microsoft/microsoft-ui-xaml/blob/40df43a61c013a6763f47dd7d89ed54f35999340/dev/CommonStyles/Common_themeresources_any.xaml#L650-L651