### PR TITLE
Fix the 'RunMakeKillTabs' PGO test

### DIFF
--- a/src/cascadia/WindowsTerminal_UIATests/SmokeTests.cs
+++ b/src/cascadia/WindowsTerminal_UIATests/SmokeTests.cs
@@ -155,13 +155,13 @@ namespace WindowsTerminal.UIA.Tests
             {
                 var root = app.GetRoot();
 
-                root.SendKeys(Keys.LeftAlt + Keys.LeftShift + "T");
+                root.SendKeys(Keys.LeftControl + Keys.LeftShift + "T");
                 Globals.WaitForTimeout();
-                root.SendKeys(Keys.LeftAlt + Keys.LeftShift + "T");
+                root.SendKeys(Keys.LeftControl + Keys.LeftShift + "T");
                 Globals.WaitForTimeout();
-                root.SendKeys(Keys.LeftAlt + Keys.LeftShift + "T");
+                root.SendKeys(Keys.LeftControl + Keys.LeftShift + "T");
                 Globals.WaitForTimeout();
-                root.SendKeys(Keys.LeftAlt + Keys.LeftShift + "T");
+                root.SendKeys(Keys.LeftControl + Keys.LeftShift + "T");
                 Globals.WaitForTimeout();
                 root.SendKeys(Keys.LeftControl + Keys.LeftShift + "W");
                 Globals.WaitForTimeout();


### PR DESCRIPTION
## Summary of the Pull Request
For some reason, the PGO tests (specifically the `RunMakeKillTabs` test) started to fail after #12979 merged. After closer inspection, the test was actually improperly written. We should be using <kbd>ctrl+shift+t</kbd> to open new tabs, not <kbd>alt+shift+t</kbd>. Presumably, the <kbd>alt</kbd> was copied over from the previous test, because they look _very_ similar.

So I went ahead and fixed the test, and it now (1) tests what it's intended to test and (2) doesn't fail. Why did #12979 cause the tests to fail? idk, but it works now.

## References
#10071 - Introduce PGO Tests

## Validation Steps Performed
Ran PGO tests locally and confirmed that it works.
Ran PGO pipeline and confirmed that it works.