### PR TITLE
Fix various unit/feature test bugs

### DIFF
--- a/src/host/ft_host/API_DimensionsTests.cpp
+++ b/src/host/ft_host/API_DimensionsTests.cpp
@@ -3,6 +3,8 @@
 
 #include "precomp.h"
 
+#include <ShellScalingApi.h>
+
 using namespace WEX::TestExecution;
 using namespace WEX::Logging;
 using namespace WEX::Common;
@@ -113,9 +115,13 @@ void DimensionsTests::TestGetLargestConsoleWindowSize()
 
     // Do not reserve space for scroll bars.
 
+    const auto dpi = GetDpiForWindow(hWindow);
+    const auto fontX = MulDiv(cfi.dwFontSize.X, dpi, USER_DEFAULT_SCREEN_DPI);
+    const auto fontY = MulDiv(cfi.dwFontSize.Y, dpi, USER_DEFAULT_SCREEN_DPI);
+
     // Now take width and height and divide them by the size of a character to get the max character count.
-    coordExpected.X = (SHORT)((rcPixels.right - rcPixels.left) / cfi.dwFontSize.X);
-    coordExpected.Y = (SHORT)((rcPixels.bottom - rcPixels.top) / cfi.dwFontSize.Y);
+    coordExpected.X = (SHORT)((rcPixels.right - rcPixels.left) / fontX);
+    coordExpected.Y = (SHORT)((rcPixels.bottom - rcPixels.top) / fontY);
 
     // Now finally ask the console what it thinks its largest size should be and compare.
     const auto coordLargest = GetLargestConsoleWindowSize(Common::_hConsole);

--- a/src/host/ft_host/API_FontTests.cpp
+++ b/src/host/ft_host/API_FontTests.cpp
@@ -263,9 +263,9 @@ void FontTests::TestSetFontAdjustsWindow()
     szConsolas.cy = rc.bottom - rc.top;
     Log::Comment(NoThrowString().Format(L"Client rect size is (X: %d, Y: %d)", szConsolas.cx, szConsolas.cy));
 
-    Log::Comment(L"Adjust console window to Lucida Console 12.");
+    Log::Comment(L"Adjust console window to Lucida Console 8.");
     wcscpy_s(cfiex.FaceName, L"Lucida Console");
-    cfiex.dwFontSize.Y = 12;
+    cfiex.dwFontSize.Y = 8;
 
     VERIFY_WIN32_BOOL_SUCCEEDED(OneCoreDelay::SetCurrentConsoleFontEx(hConsoleOutput, FALSE, &cfiex));
     Sleep(250);

--- a/src/host/ft_host/InitTests.cpp
+++ b/src/host/ft_host/InitTests.cpp
@@ -68,6 +68,8 @@ END_MODULE()
 
 MODULE_SETUP(ModuleSetup)
 {
+    SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+
     // The sources files inside windows use a C define to say it's inside windows and we should be
     // testing against the inbox conhost. This is awesome for inbox TAEF RI gate tests so it uses
     // the one generated from the same build.

--- a/src/terminal/adapter/ut_adapter/inputTest.cpp
+++ b/src/terminal/adapter/ut_adapter/inputTest.cpp
@@ -540,7 +540,7 @@ void InputTest::TerminalInputNullKeyTests()
 
     Log::Comment(L"Sending every possible VKEY at the input stream for interception during key DOWN.");
 
-    BYTE vkey = '2';
+    BYTE vkey = LOBYTE(VkKeyScanW(0));
     Log::Comment(NoThrowString().Format(L"Testing key, state =0x%x, 0x%x", vkey, uiKeystate));
 
     INPUT_RECORD irTest = { 0 };

--- a/src/terminal/parser/ut_parser/InputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/InputEngineTest.cpp
@@ -416,31 +416,30 @@ void InputEngineTest::C0Test()
     testState._stateMachine = _stateMachine.get();
 
     Log::Comment(L"Sending 0x0-0x19 to parser to make sure they're translated correctly back to C-key");
-    DisableVerifyExceptions disable;
+
     for (wchar_t wch = '\x0'; wch < '\x20'; wch++)
     {
         auto inputSeq = std::wstring(&wch, 1);
         // In general, he actual key that we're going to generate for a C0 char
         //      is char+0x40 and with ctrl pressed.
-        wchar_t expectedWch = wch + 0x40;
+        wchar_t sentWch = wch;
+        wchar_t expectedWch = wch;
         auto writeCtrl = true;
-        // These two are weird exceptional cases.
+
+        // Exceptional cases.
         switch (wch)
         {
         case L'\r': // Enter
-            expectedWch = wch;
             writeCtrl = false;
             break;
         case L'\x1b': // Escape
-            expectedWch = wch;
             writeCtrl = false;
             break;
         case L'\t': // Tab
             writeCtrl = false;
             break;
         case L'\b': // backspace
-            wch = '\x7f';
-            expectedWch = '\x7f';
+            sentWch = '\x7f';
             break;
         }
 
@@ -462,23 +461,23 @@ void InputEngineTest::C0Test()
         }
 
         // Just make sure we write the same thing telnetd did:
-        if (wch == UNICODE_ETX)
+        if (sentWch == UNICODE_ETX)
         {
             Log::Comment(NoThrowString().Format(
                 L"We used to expect 0x%x, 0x%x, 0x%x, 0x%x here",
                 vkey,
                 scanCode,
-                wch,
+                sentWch,
                 dwModifierState));
             vkey = 'C';
             scanCode = 0;
-            wch = UNICODE_ETX;
+            sentWch = UNICODE_ETX;
             dwModifierState = LEFT_CTRL_PRESSED;
             Log::Comment(NoThrowString().Format(
                 L"Now we expect 0x%x, 0x%x, 0x%x, 0x%x here",
                 vkey,
                 scanCode,
-                wch,
+                sentWch,
                 dwModifierState));
             testState._expectSendCtrlC = true;
         }
@@ -487,7 +486,7 @@ void InputEngineTest::C0Test()
             testState._expectSendCtrlC = false;
         }
 
-        Log::Comment(NoThrowString().Format(L"Testing char 0x%x", wch));
+        Log::Comment(NoThrowString().Format(L"Testing char 0x%x", sentWch));
         Log::Comment(NoThrowString().Format(L"Input Sequence=\"%s\"", inputSeq.c_str()));
 
         INPUT_RECORD inputRec;
@@ -498,7 +497,7 @@ void InputEngineTest::C0Test()
         inputRec.Event.KeyEvent.wRepeatCount = 1;
         inputRec.Event.KeyEvent.wVirtualKeyCode = vkey;
         inputRec.Event.KeyEvent.wVirtualScanCode = scanCode;
-        inputRec.Event.KeyEvent.uChar.UnicodeChar = wch;
+        inputRec.Event.KeyEvent.uChar.UnicodeChar = sentWch;
 
         testState.vExpectedInput.push_back(inputRec);
 


### PR DESCRIPTION
This commit fixes various bugs in our unit/feature test suite:
* 2 tests failed at 150% scale.
* The "null key" (@ on a US keyboard) isn't necessarily Shift+2.
  The proper way to get it is with `LOBYTE(VkKeyScanW(0))`
* `InputEngineTest::C0Test` never worked as it overwrote
  the loop variable, exiting the loop early