### PR TITLE
Simplify Utf16Parser

### DIFF
--- a/src/types/inc/Utf16Parser.hpp
+++ b/src/types/inc/Utf16Parser.hpp
@@ -15,17 +15,9 @@ Author(s):
 #pragma once
 
 #include <vector>
-#include <optional>
-#include <bitset>
 
 class Utf16Parser final
 {
-private:
-    static constexpr unsigned short IndicatorBitCount = 6;
-    static constexpr unsigned short WcharShiftAmount = sizeof(wchar_t) * 8 - IndicatorBitCount;
-    static constexpr std::bitset<IndicatorBitCount> LeadingSurrogateMask = { 54 }; // 110 110 indicates a leading surrogate
-    static constexpr std::bitset<IndicatorBitCount> TrailingSurrogateMask = { 55 }; // 110 111 indicates a trailing surrogate
-
 public:
     static std::vector<std::vector<wchar_t>> Parse(std::wstring_view wstr);
     static std::wstring_view ParseNext(std::wstring_view wstr) noexcept;
@@ -36,11 +28,9 @@ public:
     // - wch - the wchar to check
     // Return Value:
     // - true if wch is a leading surrogate, false otherwise
-    static inline bool IsLeadingSurrogate(const wchar_t wch) noexcept
+    static constexpr bool IsLeadingSurrogate(const wchar_t wch) noexcept
     {
-        const wchar_t bits = wch >> WcharShiftAmount;
-        const std::bitset<IndicatorBitCount> possBits = { bits };
-        return (possBits ^ LeadingSurrogateMask).none();
+        return wch >= 0xD800 && wch <= 0xDBFF;
     }
 
     // Routine Description:
@@ -49,10 +39,8 @@ public:
     // - wch - the wchar to check
     // Return Value:
     // - true if wch is a trailing surrogate, false otherwise
-    static inline bool IsTrailingSurrogate(const wchar_t wch) noexcept
+    static constexpr bool IsTrailingSurrogate(const wchar_t wch) noexcept
     {
-        const wchar_t bits = wch >> WcharShiftAmount;
-        const std::bitset<IndicatorBitCount> possBits = { bits };
-        return (possBits ^ TrailingSurrogateMask).none();
+        return wch >= 0xDC00 && wch <= 0xDFFF;
     }
 };


### PR DESCRIPTION
This trivial commit simplifies `Utf16Parser::IsLeading/TrailingSurrogate`
methods, by replacing `<bitset>` with a simple, equivalent range check.