### PR TITLE
Add support for line renditions in the DX renderer

### DIFF
--- a/src/renderer/dx/CustomTextRenderer.h
+++ b/src/renderer/dx/CustomTextRenderer.h
@@ -32,7 +32,9 @@ namespace Microsoft::Console::Render
             cellSize(cellSize),
             targetSize(targetSize),
             cursorInfo(cursorInfo),
-            options(options)
+            options(options),
+            topClipOffset(0),
+            bottomClipOffset(0)
         {
         }
 
@@ -48,6 +50,8 @@ namespace Microsoft::Console::Render
         D2D_SIZE_F targetSize;
         std::optional<CursorOptions> cursorInfo;
         D2D1_DRAW_TEXT_OPTIONS options;
+        FLOAT topClipOffset;
+        FLOAT bottomClipOffset;
     };
 
     // Helper to choose which Direct2D method to use when drawing the cursor rectangle

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -53,7 +53,7 @@ namespace
 {
     bool operator==(const D2D1::Matrix3x2F& lhs, const D2D1::Matrix3x2F& rhs) noexcept
     {
-        return ::memcmp(lhs.m, rhs.m, sizeof(lhs.m)) == 0;
+        return ::memcmp(&lhs.m[0][0], &rhs.m[0][0], sizeof(lhs.m)) == 0;
     };
 }
 
@@ -2325,7 +2325,7 @@ void DxEngine::UpdateHyperlinkHoveredId(const uint16_t hoveredId) noexcept
                                                      const size_t viewportLeft) noexcept
 {
     auto lineTransform = D2D1::Matrix3x2F{ 0, 0, 0, 0, 0, 0 };
-    auto fontSize = _fontRenderData->GlyphCell();
+    const auto fontSize = _fontRenderData->GlyphCell();
     // The X delta is to account for the horizontal viewport offset.
     lineTransform.dx = viewportLeft ? -1.0f * viewportLeft * fontSize.width : 0.0f;
     switch (lineRendition)

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -49,6 +49,14 @@ D3D11_INPUT_ELEMENT_DESC _shaderInputLayout[] = {
     { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 }
 };
 
+namespace
+{
+    bool operator==(const D2D1::Matrix3x2F& lhs, const D2D1::Matrix3x2F& rhs) noexcept
+    {
+        return ::memcmp(lhs.m, rhs.m, sizeof(lhs.m)) == 0;
+    };
+}
+
 #pragma hdrstop
 
 using namespace Microsoft::Console::Render;
@@ -77,6 +85,8 @@ DxEngine::DxEngine() :
     _foregroundColor{ 0 },
     _backgroundColor{ 0 },
     _selectionBackground{},
+    _currentLineRendition{ LineRendition::SingleWidth },
+    _currentLineTransform{ D2D1::Matrix3x2F::Identity() },
     _haveDeviceResources{ false },
     _swapChainHandle{ INVALID_HANDLE_VALUE },
     _swapChainDesc{ 0 },
@@ -2278,5 +2288,81 @@ void DxEngine::UpdateHyperlinkHoveredId(const uint16_t hoveredId) noexcept
 [[nodiscard]] HRESULT DxEngine::PrepareRenderInfo(const RenderFrameInfo& info) noexcept
 {
     _drawingContext->cursorInfo = info.cursorInfo;
+    return S_OK;
+}
+
+// Routine Description
+// - Resets the world transform to the identity matrix.
+// Arguments:
+// - <none>
+// Return Value:
+// - S_OK if successful. S_FALSE if already reset. E_FAIL if there was an error.
+[[nodiscard]] HRESULT DxEngine::ResetLineTransform() noexcept
+{
+    // Return early if the current transform is already the identity matrix.
+    RETURN_HR_IF(S_FALSE, _currentLineTransform.IsIdentity());
+    // Reset the active transform to the identity matrix.
+    _drawingContext->renderTarget->SetTransform(D2D1::Matrix3x2F::Identity());
+    // Reset the clipping offsets.
+    _drawingContext->topClipOffset = 0;
+    _drawingContext->bottomClipOffset = 0;
+    // Reset the current state.
+    _currentLineTransform = D2D1::Matrix3x2F::Identity();
+    _currentLineRendition = LineRendition::SingleWidth;
+    return S_OK;
+}
+
+// Routine Description
+// - Applies an appropriate transform for the given line rendition and viewport offset.
+// Arguments:
+// - lineRendition - The line rendition specifying the scaling of the line.
+// - targetRow - The row on which the line is expected to be rendered.
+// - viewportLeft - The left offset of the current viewport.
+// Return Value:
+// - S_OK if successful. S_FALSE if already set. E_FAIL if there was an error.
+[[nodiscard]] HRESULT DxEngine::PrepareLineTransform(const LineRendition lineRendition,
+                                                     const size_t targetRow,
+                                                     const size_t viewportLeft) noexcept
+{
+    auto lineTransform = D2D1::Matrix3x2F{ 0, 0, 0, 0, 0, 0 };
+    auto fontSize = _fontRenderData->GlyphCell();
+    // The X delta is to account for the horizontal viewport offset.
+    lineTransform.dx = viewportLeft ? -1.0f * viewportLeft * fontSize.width : 0.0f;
+    switch (lineRendition)
+    {
+    case LineRendition::SingleWidth:
+        lineTransform.m11 = 1; // single width
+        lineTransform.m22 = 1; // single height
+        break;
+    case LineRendition::DoubleWidth:
+        lineTransform.m11 = 2; // double width
+        lineTransform.m22 = 1; // single height
+        break;
+    case LineRendition::DoubleHeightTop:
+        lineTransform.m11 = 2; // double width
+        lineTransform.m22 = 2; // double height
+        // The Y delta is to negate the offset caused by the scaled height.
+        lineTransform.dy = -1.0f * targetRow * fontSize.height;
+        break;
+    case LineRendition::DoubleHeightBottom:
+        lineTransform.m11 = 2; // double width
+        lineTransform.m22 = 2; // double height
+        // The Y delta is to negate the offset caused by the scaled height.
+        // An extra row is added because we need the bottom half of the line.
+        lineTransform.dy = -1.0f * (targetRow + 1) * fontSize.height;
+        break;
+    }
+    // Return early if the new matrix is the same as the current transform.
+    RETURN_HR_IF(S_FALSE, _currentLineRendition == lineRendition && _currentLineTransform == lineTransform);
+    // Set the active transform with the new matrix.
+    _drawingContext->renderTarget->SetTransform(lineTransform);
+    // If the line rendition is double height, we need to adjust the top or bottom
+    // of the clipping rect to clip half the height of the rendered characters.
+    const auto halfHeight = _drawingContext->cellSize.height / 2;
+    _drawingContext->topClipOffset = lineRendition == LineRendition::DoubleHeightBottom ? halfHeight : 0;
+    _drawingContext->bottomClipOffset = lineRendition == LineRendition::DoubleHeightTop ? halfHeight : 0;
+    // Save the current state.
+    _currentLineTransform = lineTransform;
+    _currentLineRendition = lineRendition;
     return S_OK;
 }

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -93,6 +93,11 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT PrepareRenderInfo(const RenderFrameInfo& info) noexcept override;
 
+        [[nodiscard]] HRESULT ResetLineTransform() noexcept override;
+        [[nodiscard]] HRESULT PrepareLineTransform(const LineRendition lineRendition,
+                                                   const size_t targetRow,
+                                                   const size_t viewportLeft) noexcept override;
+
         [[nodiscard]] HRESULT PaintBackground() noexcept override;
         [[nodiscard]] HRESULT PaintBufferLine(const gsl::span<const Cluster> clusters,
                                               const COORD coord,
@@ -166,6 +171,9 @@ namespace Microsoft::Console::Render
         D2D1_COLOR_F _foregroundColor;
         D2D1_COLOR_F _backgroundColor;
         D2D1_COLOR_F _selectionBackground;
+
+        LineRendition _currentLineRendition;
+        D2D1::Matrix3x2F _currentLineTransform;
 
         uint16_t _hyperlinkHoveredId;
 


### PR DESCRIPTION
This PR adds support for the VT line rendition attributes in the DirectX
renderer, which allows for double-width and double-height line
renditions.

Line renditions were first implemented in conhost (with the GDI
renderer) in PR #8664.  Supporting them in the DX renderer now is a
small step towards #11595.

The DX implementation is very similar to the GDI one. When a particular
line rendition is requested, we create a transform that is applied to
the render target. And in the case of double-height renditions, we also
initialize some clipping offsets to allow for the fact that we only
render half of a line at a time.

One additional complication exists when drawing the cursor, which
requires a two part process where it first renders to a command list,
and then draw the command list in a second step. We need to temporarily
reset the transform in that first stage otherwise it ends up being
applied twice.

I've manually tested the renderer in conhost by setting the `UseDx`
registry entry and confirmed that it passes the _Vttest_ double-size
tests as well as several of my own tests. I've also checked that the
renderer can now handle horizontal scrolling, which is a feature we get
for free with the transforms.