### PR TITLE
Debounce window state changes caused by the PTY

### DIFF
--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -4,7 +4,7 @@
 #include "pch.h"
 #include "NonClientIslandWindow.h"
 #include "NotificationIcon.h"
-#include <til/throttled_func.h>
+#include <ThrottledFunc.h>
 
 class AppHost
 {
@@ -33,7 +33,7 @@ private:
     bool _useNonClientArea{ false };
 
     std::optional<til::throttled_func_trailing<>> _getWindowLayoutThrottler;
-    std::optional<til::throttled_func_trailing<bool>> _showHideWindowThrottler;
+    std::shared_ptr<ThrottledFuncTrailing<bool>> _showHideWindowThrottler;
     winrt::Windows::Foundation::IAsyncAction _SaveWindowLayouts();
     winrt::fire_and_forget _SaveWindowLayoutsRepeat();
 

--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -33,6 +33,7 @@ private:
     bool _useNonClientArea{ false };
 
     std::optional<til::throttled_func_trailing<>> _getWindowLayoutThrottler;
+    std::optional<til::throttled_func_trailing<bool>> _showHideWindowThrottler;
     winrt::Windows::Foundation::IAsyncAction _SaveWindowLayouts();
     winrt::fire_and_forget _SaveWindowLayoutsRepeat();
 


### PR DESCRIPTION
Use a throttled update to update our window state. Throttling should prevent scenarios where the Terminal window state and PTY window state get de-sync'd, and cause the window to minimize/restore constantly in a loop.  "Should" is doing a lot of work in this sentence. 

A 200ms delay was chosen because it's the typical animation timeout in Windows. This does result in a delay between the PTY requesting a change to the window state and the Terminal realizing it, but should mitigate issues where the Terminal and PTY get desync'd.


I think we're overall not super confident that this fixes the root causes of the issue. Rather, we're hopeful that a small amount of throttling here should leave time for the Terminal and pty to sync back up. We're comfortable enough with that as a bandaid for 1.14 preview, to see how this behaves in the wild. 