### PR TITLE
Remove location-specific suffixed from the zh- lang specifiers

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.cpp
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.cpp
@@ -37,8 +37,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         L"qps-PLOCA",
         L"qps-PLOCM",
         L"ru",
-        L"zh-Hans-CN",
-        L"zh-Hant-TW",
+        L"zh-Hans",
+        L"zh-Hant",
     };
 
     GlobalAppearance::GlobalAppearance()


### PR DESCRIPTION
This only impacts the UI. We can take a workitem to rename the loc data
later. When the user specifies zh-Hans/zh-Hant, the resource mapper does
the right thing.

Related to #8984