### PR TITLE
Prevent ConPTY from de-snapping the terminal

### DIFF
--- a/src/interactivity/base/InteractivityFactory.cpp
+++ b/src/interactivity/base/InteractivityFactory.cpp
@@ -484,7 +484,7 @@ void InteractivityFactory::_WritePseudoWindowCallback(bool showOrHide)
     // window. There seem to be many issues with this so far, and the quickest
     // route to mitigate them seems to be limiting the interaction here to
     // allowing ConPTY to minimize the terminal only. This will still allow
-    // bodgy scripts to hide the Terminal via GetConsoleWindow(), but should
+    // applications to hide the Terminal via GetConsoleWindow(), but should
     // broadly prevent any other impact of this feature.
     //
     // Should we need to restore this functionality in the future, we should

--- a/src/interactivity/base/InteractivityFactory.cpp
+++ b/src/interactivity/base/InteractivityFactory.cpp
@@ -478,7 +478,18 @@ void InteractivityFactory::SetPseudoWindowCallback(std::function<void(bool)> fun
 // - <none>
 void InteractivityFactory::_WritePseudoWindowCallback(bool showOrHide)
 {
-    if (_pseudoWindowMessageCallback)
+    // BODGY
+    //
+    // GH#13158 - At least temporarily, only allow the PTY to HIDE the terminal
+    // window. There seem to be many issues with this so far, and the quickest
+    // route to mitigate them seems to be limiting the interaction here to
+    // allowing ConPTY to minimize the terminal only. This will still allow
+    // bodgy scripts to hide the Terminal via GetConsoleWindow(), but should
+    // broadly prevent any other impact of this feature.
+    //
+    // Should we need to restore this functionality in the future, we should
+    // only do so with great caution.
+    if (_pseudoWindowMessageCallback && showOrHide == false)
     {
         _pseudoWindowMessageCallback(showOrHide);
     }


### PR DESCRIPTION
This is a big hammer to put out this fire. We're keeping the hiding around for now, cause we think that's likely the one that the internal tests use that we really care about here. If we need to bring this back, we can. 


* [x] Closes #13158
* [x] Closes #13162
* [x] Validated these both manually 
* [x] `[Native]::ShowWindow([Native]::GetConsoleWindow(), 6)` still works

