### PR TITLE
Update roadmap for 1.13, 1.14.

### DIFF
--- a/.github/actions/spelling/allow/allow.txt
+++ b/.github/actions/spelling/allow/allow.txt
@@ -28,6 +28,7 @@ Fitt
 formattings
 ftp
 fvar
+gantt
 gcc
 geeksforgeeks
 ghe

--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ repository.
 
 ---
 
-## Windows Terminal 2.0 Roadmap
+## Windows Terminal Roadmap
 
-The plan for delivering Windows Terminal 2.0 [is described
-here](/doc/terminal-v2-roadmap.md) and will be updated as the project proceeds.
+The plan for the Windows Terminal [is described here](/doc/roadmap-2022.md) and
+will be updated as the project proceeds.
 
 ## Project Build Status
 

--- a/doc/roadmap-2022.md
+++ b/doc/roadmap-2022.md
@@ -22,20 +22,62 @@ Below is the schedule for when milestones will be included in release builds of 
 | Milestone End Date | Milestone Name | Preview Release Blog Post |
 | ------------------ | -------------- | ------------------------- |
 | 2020-06-18 | [1.1] in Windows Terminal Preview | [Windows Terminal Preview 1.1 Release](https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-1-release/) |
-| 2020-07-31 | [1.2] in Windows Terminal Preview<br>[1.1] in Windows Terminal | [Windows Terminal Preview 1.2 Release](https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-2-release/) |
-| 2020-08-31 | [1.3] in Windows Terminal Preview<br>[1.2] in Windows Terminal | [Windows Terminal Preview 1.3 Release](https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-3-release/) |
-| 2020-09-30 | [1.4] in Windows Terminal Preview<br>[1.3] in Windows Terminal | [Windows Terminal Preview 1.4 Release](https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-4-release/) |
-| 2020-11-30 | [1.5] in Windows Terminal Preview<br>[1.4] in Windows Terminal | [Windows Terminal Preview 1.5 Release](https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-5-release/) |
-| 2021-01-31 | [1.6] in Windows Terminal Preview<br>[1.5] in Windows Terminal | [Windows Terminal Preview 1.6 Release](https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-6-release/) |
-| 2021-03-01 | [1.7] in Windows Terminal Preview<br>[1.6] in Windows Terminal | [Windows Terminal Preview 1.7 Release](https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-7-release/) |
-| 2021-04-14 | [1.8] in Windows Terminal Preview<br>[1.7] in Windows Terminal | [Windows Terminal Preview 1.8 Release](https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-8-release/) |
-| 2021-05-31 | [1.9] in Windows Terminal Preview<br>[1.8] in Windows Terminal | [Windows Terminal Preview 1.9 Release](https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-9-release/) |
-| 2021-07-14 | [1.10] in Windows Terminal Preview<br>[1.9] in Windows Terminal | [Windows Terminal Preview 1.10 Release](https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-10-release/) |
-| 2021-08-31 | [1.11] in Windows Terminal Preview<br>[1.10] in Windows Terminal | [Windows Terminal Preview 1.11 Release](https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-11-release/) |
-| 2021-10-20 | [1.12] in Windows Terminal Preview<br>[1.11] in Windows Terminal | [Windows Terminal Preview 1.12 Release](https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-12-release/) |
-|  | [1.13] in Windows Terminal Preview<br>[1.12] in Windows Terminal |  |
-|  | [1.14] in Windows Terminal Preview<br>[1.13] in Windows Terminal |  |
+| 2020-07-31 | [1.2] in Windows Terminal Preview<br>[1.1] in Windows Terminal | [Windows Terminal Preview 1.2 Release] |
+| 2020-08-31 | [1.3] in Windows Terminal Preview<br>[1.2] in Windows Terminal | [Windows Terminal Preview 1.3 Release] |
+| 2020-09-30 | [1.4] in Windows Terminal Preview<br>[1.3] in Windows Terminal | [Windows Terminal Preview 1.4 Release] |
+| 2020-11-30 | [1.5] in Windows Terminal Preview<br>[1.4] in Windows Terminal | [Windows Terminal Preview 1.5 Release] |
+| 2021-01-31 | [1.6] in Windows Terminal Preview<br>[1.5] in Windows Terminal | [Windows Terminal Preview 1.6 Release] |
+| 2021-03-01 | [1.7] in Windows Terminal Preview<br>[1.6] in Windows Terminal | [Windows Terminal Preview 1.7 Release] |
+| 2021-04-14 | [1.8] in Windows Terminal Preview<br>[1.7] in Windows Terminal | [Windows Terminal Preview 1.8 Release] |
+| 2021-05-31 | [1.9] in Windows Terminal Preview<br>[1.8] in Windows Terminal | [Windows Terminal Preview 1.9 Release] |
+| 2021-07-14 | [1.10] in Windows Terminal Preview<br>[1.9] in Windows Terminal | [Windows Terminal Preview 1.10 Release] |
+| 2021-08-31 | [1.11] in Windows Terminal Preview<br>[1.10] in Windows Terminal | [Windows Terminal Preview 1.11 Release] |
+| 2021-10-20 | [1.12] in Windows Terminal Preview<br>[1.11] in Windows Terminal | [Windows Terminal Preview 1.12 Release] |
+| 2022-02-03 | [1.13] in Windows Terminal Preview<br>[1.12] in Windows Terminal | [Windows Terminal Preview 1.13 Release] |
+| 2022-05-24 | [1.14] in Windows Terminal Preview<br>[1.13] in Windows Terminal | [Windows Terminal Preview 1.14 Release] |
+|  | [1.15] in Windows Terminal Preview<br>[1.14] in Windows Terminal |  |
+|  | [1.16] in Windows Terminal Preview<br>[1.15] in Windows Terminal |  |
+|  | [1.17] in Windows Terminal Preview<br>[1.16] in Windows Terminal |  |
 
+
+### Release outline
+
+Below is a VERY vague outline of the remaining calendar year that was drafted late May 2022. This was drafted for internal planning purposes, as a guide. It is not meant to represent official dates. More often than not, releases are synced to official features landing, rather than arbitrary dates. Drift from this initial draft is entirely expected.
+
+```mermaid
+gantt
+    title Proposed Terminal Releases 1.14-1.18
+    dateFormat  YYYY-MM-DD
+    axisFormat  %d %b
+    section Terminal 1.14
+        Lockdown&bake           :done, 2022-05-06, 2w
+        Release 1.14            :milestone, 2022-05-24
+    section Terminal 1.15
+        Features                :active, a1, 2022-05-06, 4w
+        Bugfix                  :a2, after a1  , 2w
+        Lockdown&bake           :after a2  , 2w
+        Release 1.15            :milestone, 2022-07-05, 0
+        1.15 becomes Stable     :milestone, after b3, 0
+    section Terminal 1.16
+        Features                :b1, after a2, 4w
+        Bugfix                  :b2, after b1  , 2w
+        Lockdown&bake           :b3, after b2  , 2w
+        Release 1.16            :milestone, after b3, 0
+        1.16 becomes Stable     :milestone, after c3, 0
+    section Terminal 1.17
+        Features                :c1, after b2, 4w
+        Bugfix                  :c2, after c1  , 2w
+        Lockdown&bake           :c3, after c2  , 2w
+        Release 1.17            :milestone, after c3, 0
+        1.17 becomes Stable     :milestone, after d3, 0
+    section Terminal 1.18
+        Features                :d1, after c2, 4w
+        Bugfix                  :d2, after d1  , 2w
+        Lockdown&bake           :d3, after d2  , 2w
+        Release 1.18            :milestone, after d3, 0
+```
+
+Again, these dates do not represent confirmed release dates, they are merely planning guidelines.
 
 ## Issue Triage & Prioritization
 
@@ -62,7 +104,9 @@ Incoming issues/asks/etc. are triaged several times a week, labeled appropriatel
 [1.12]: https://github.com/microsoft/terminal/milestone/38
 [1.13]: https://github.com/microsoft/terminal/milestone/39
 [1.14]: https://github.com/microsoft/terminal/milestone/41
-
+[1.15]: https://github.com/microsoft/terminal/milestone/47
+[1.16]: https://github.com/microsoft/terminal/milestone/48
+[1.17]: https://github.com/microsoft/terminal/milestone/49
 
 [22H1]: https://github.com/microsoft/terminal/milestone/43
 [22H2]: https://github.com/microsoft/terminal/milestone/44
@@ -70,3 +114,17 @@ Incoming issues/asks/etc. are triaged several times a week, labeled appropriatel
 [Backlog]: https://github.com/microsoft/terminal/milestone/45
 
 [Terminal v2 Roadmap]: https://github.com/microsoft/terminal/tree/main/doc/terminal-v2-roadmap.md
+
+[Windows Terminal Preview 1.2 Release]: https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-2-release/
+[Windows Terminal Preview 1.3 Release]: https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-3-release/
+[Windows Terminal Preview 1.4 Release]: https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-4-release/
+[Windows Terminal Preview 1.5 Release]: https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-5-release/
+[Windows Terminal Preview 1.6 Release]: https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-6-release/
+[Windows Terminal Preview 1.7 Release]: https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-7-release/
+[Windows Terminal Preview 1.8 Release]: https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-8-release/
+[Windows Terminal Preview 1.9 Release]: https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-9-release/
+[Windows Terminal Preview 1.10 Release]: https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-10-release/
+[Windows Terminal Preview 1.11 Release]: https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-11-release/
+[Windows Terminal Preview 1.12 Release]: https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-12-release/
+[Windows Terminal Preview 1.13 Release]: https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-13-release/
+[Windows Terminal Preview 1.14 Release]: https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-14-release/

--- a/doc/roadmap-2022.md
+++ b/doc/roadmap-2022.md
@@ -50,34 +50,32 @@ gantt
     dateFormat  YYYY-MM-DD
     axisFormat  %d %b
     section Terminal 1.14
-        Lockdown&bake           :done, 2022-05-06, 2w
+        Lock down & bake        :done, 2022-05-06, 2w
         Release 1.14            :milestone, 2022-05-24
     section Terminal 1.15
-        Features                :active, a1, 2022-05-06, 4w
-        Bugfix                  :a2, after a1  , 2w
-        Lockdown&bake           :after a2  , 2w
-        Release 1.15            :milestone, 2022-07-05, 0
+        Features                :a1, done, 2022-05-06, 4w
+        Bugfix                  :a2, active, after a1  , 1w
+        Lock down & bake        :after a2  , 1w
+        Release 1.15            :milestone, 2022-06-21, 0
         1.15 becomes Stable     :milestone, after b3, 0
     section Terminal 1.16
         Features                :b1, after a2, 4w
         Bugfix                  :b2, after b1  , 2w
-        Lockdown&bake           :b3, after b2  , 2w
+        Lock down & bake        :b3, after b2  , 2w
         Release 1.16            :milestone, after b3, 0
         1.16 becomes Stable     :milestone, after c3, 0
     section Terminal 1.17
         Features                :c1, after b2, 4w
         Bugfix                  :c2, after c1  , 2w
-        Lockdown&bake           :c3, after c2  , 2w
+        Lock down & bake        :c3, after c2  , 2w
         Release 1.17            :milestone, after c3, 0
         1.17 becomes Stable     :milestone, after d3, 0
     section Terminal 1.18
         Features                :d1, after c2, 4w
         Bugfix                  :d2, after d1  , 2w
-        Lockdown&bake           :d3, after d2  , 2w
+        Lock down & bake        :d3, after d2  , 2w
         Release 1.18            :milestone, after d3, 0
 ```
-
-Again, these dates do not represent confirmed release dates, they are merely planning guidelines.
 
 ## Issue Triage & Prioritization
 

--- a/doc/roadmap-2022.md
+++ b/doc/roadmap-2022.md
@@ -53,8 +53,8 @@ gantt
         Lock down & bake        :done, 2022-05-06, 2w
         Release 1.14            :milestone, 2022-05-24
     section Terminal 1.15
-        Features                :a1, done, 2022-05-06, 4w
-        Bugfix                  :a2, active, after a1  , 1w
+        Features                :done, a1, 2022-05-06, 4w
+        Bugfix                  :active, a2, after a1  , 1w
         Lock down & bake        :after a2  , 1w
         Release 1.15            :milestone, 2022-06-21, 0
         1.15 becomes Stable     :milestone, after b3, 0


### PR DESCRIPTION
I threw that Gannt chart that I whipped up a few weeks ago in here, but if we feel that should be pulled because it's more a set of [guidelines than actual rules](https://c.tenor.com/aeV80XD4CSgAAAAC/guidlines-pirates-of-the-caribbean.gif), then we can pull it. 

* [x] Closes #13222