### PR TITLE
Fix deleting the last profile crashing Terminal

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -594,7 +594,15 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // navigate to the profile next to this one
         const auto newSelectedItem{ menuItems.GetAt(index < menuItems.Size() - 1 ? index : index - 1) };
         SettingsNav().SelectedItem(newSelectedItem);
-        _Navigate(newSelectedItem.try_as<MUX::Controls::NavigationViewItem>().Tag().try_as<Editor::ProfileViewModel>(), BreadcrumbSubPage::None, true);
+        const auto newTag = newSelectedItem.as<MUX::Controls::NavigationViewItem>().Tag();
+        if (const auto profileViewModel = newTag.try_as<ProfileViewModel>())
+        {
+            _Navigate(*profileViewModel, BreadcrumbSubPage::None);
+        }
+        else
+        {
+            _Navigate(newTag.as<hstring>(), BreadcrumbSubPage::None);
+        }
     }
 
     IObservableVector<IInspectable> MainPage::Breadcrumbs() noexcept


### PR DESCRIPTION
## Summary of the Pull Request
When a profile gets deleted, we were navigating to the next item assuming it was a profile when it may not be. This commit fixes this by checking the tag of the next menu item before we navigate to it. 

## PR Checklist
* [x] Closes #13125 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I work here

## Validation Steps Performed
Deleting the last profile in the SUI doesn't cause a crash