### PR TITLE
Hide the use of MIDI behind velocity

### DIFF
--- a/src/audio/midi/MidiAudio.cpp
+++ b/src/audio/midi/MidiAudio.cpp
@@ -21,16 +21,25 @@ namespace
 
         MidiOut() noexcept
         {
-            midiOutOpen(&handle, MIDI_MAPPER, NULL, NULL, CALLBACK_NULL);
-            OutputMessage(PROGRAM_CHANGE, SQUARE_WAVE_SYNTH);
+            if constexpr (Feature_DECPSViaMidiPlayer::IsEnabled())
+            {
+                midiOutOpen(&handle, MIDI_MAPPER, NULL, NULL, CALLBACK_NULL);
+                OutputMessage(PROGRAM_CHANGE, SQUARE_WAVE_SYNTH);
+            }
         }
         ~MidiOut() noexcept
         {
-            midiOutClose(handle);
+            if constexpr (Feature_DECPSViaMidiPlayer::IsEnabled())
+            {
+                midiOutClose(handle);
+            }
         }
         void OutputMessage(const int b1, const int b2, const int b3 = 0, const int b4 = 0) noexcept
         {
-            midiOutShortMsg(handle, MAKELONG(MAKEWORD(b1, b2), MAKEWORD(b3, b4)));
+            if constexpr (Feature_DECPSViaMidiPlayer::IsEnabled())
+            {
+                midiOutShortMsg(handle, MAKELONG(MAKEWORD(b1, b2), MAKEWORD(b3, b4)));
+            }
         }
 
         MidiOut(const MidiOut&) = delete;

--- a/src/cascadia/TerminalControl/TerminalControlLib.vcxproj
+++ b/src/cascadia/TerminalControl/TerminalControlLib.vcxproj
@@ -147,7 +147,8 @@
     <PRIResource Include="Resources\en-US\Resources.resw" />
     <OCResourceDirectory Include="Resources" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(WindowsTerminalBranding)'=='' or '$(WindowsTerminalBranding)'=='Dev' or '$(WindowsTerminalBranding)'=='Preview'">
+    <!-- GH#13252 Only vend this dependency for Dev and Preview builds. -->
     <SDKReference Include="Microsoft.Midi.GmDls, Version=10.0.22000.0" />
   </ItemGroup>
   <!-- ========================= Project References ======================== -->

--- a/src/features.xml
+++ b/src/features.xml
@@ -116,4 +116,16 @@
             <brandingToken>Preview</brandingToken>
         </alwaysDisabledBrandingTokens>
     </feature>
+
+    <feature>
+        <name>Feature_DECPSViaMidiPlayer</name>
+        <description>Enables playing sound via DECPS using the MIDI player.</description>
+        <stage>AlwaysDisabled</stage>
+        <!-- We're disabling this for WindowsInbox and Stable because it requires an additional
+             package dependency or library dependency. -->
+        <alwaysEnabledBrandingTokens>
+            <brandingToken>Dev</brandingToken>
+            <brandingToken>Preview</brandingToken>
+        </alwaysEnabledBrandingTokens>
+    </feature>
 </featureStaging>


### PR DESCRIPTION
* conhost requires an additional dependency in Windows, which might
  cause us trouble in WPG
* Terminal requires an additional *package* dependency, which *will*
  cause us trouble in WPG (since GmDls is about 3MB)

I chose to scope the feature checks to MidiOut directly, as I wanted to
keep the delay behavior in MidiAudio::PlayNote. This is negotiable.

References #13252