### PR TITLE
Fix uninitialized memory bug in GdiEngine

### DIFF
--- a/src/interactivity/win32/WindowIme.cpp
+++ b/src/interactivity/win32/WindowIme.cpp
@@ -42,7 +42,7 @@ RECT GetImeSuggestionWindowPos()
     ClientToScreen(ServiceLocator::LocateConsoleWindow()->GetWindowHandle(), &ptSuggestion);
 
     // Move into suggestion rectangle.
-    RECT rcSuggestion;
+    RECT rcSuggestion{};
     rcSuggestion.top = rcSuggestion.bottom = ptSuggestion.y;
     rcSuggestion.left = rcSuggestion.right = ptSuggestion.x;
 

--- a/src/interactivity/win32/window.cpp
+++ b/src/interactivity/win32/window.cpp
@@ -999,7 +999,7 @@ void Window::s_CalculateWindowRect(const til::size coordWindowInChars,
 
 til::rect Window::GetWindowRect() const noexcept
 {
-    RECT rc;
+    RECT rc{};
     ::GetWindowRect(GetWindowHandle(), &rc);
     return til::rect{ rc };
 }

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -640,7 +640,7 @@ try
         case SwapChainMode::ForHwnd:
         {
             // use the HWND's dimensions for the swap chain dimensions.
-            RECT rect;
+            RECT rect{};
             RETURN_IF_WIN32_BOOL_FALSE(GetClientRect(_hwndTarget, &rect));
 
             _swapChainDesc.Width = rect.right - rect.left;
@@ -1222,7 +1222,7 @@ CATCH_RETURN();
     {
     case SwapChainMode::ForHwnd:
     {
-        RECT clientRect;
+        RECT clientRect{};
         LOG_IF_WIN32_BOOL_FALSE(GetClientRect(_hwndTarget, &clientRect));
 
         return til::rect{ clientRect }.size();

--- a/src/renderer/gdi/paint.cpp
+++ b/src/renderer/gdi/paint.cpp
@@ -121,7 +121,7 @@ bool GdiEngine::FontHasWesternScript(HDC hdc)
     szGutter.cx = _szMemorySurface.cx % coordFontSize.X;
     szGutter.cy = _szMemorySurface.cy % coordFontSize.Y;
 
-    RECT rcScrollLimit;
+    RECT rcScrollLimit{};
     RETURN_IF_FAILED(LongSub(_szMemorySurface.cx, szGutter.cx, &rcScrollLimit.right));
     RETURN_IF_FAILED(LongSub(_szMemorySurface.cy, szGutter.cy, &rcScrollLimit.bottom));
 

--- a/src/renderer/gdi/state.cpp
+++ b/src/renderer/gdi/state.cpp
@@ -147,7 +147,7 @@ GdiEngine::~GdiEngine()
 #if DBG
     if (_debugWindow != INVALID_HANDLE_VALUE && _debugWindow != nullptr)
     {
-        RECT rc;
+        RECT rc{};
         THROW_IF_WIN32_BOOL_FALSE(GetWindowRect(_hwndTargetWindow, &rc));
 
         THROW_IF_WIN32_BOOL_FALSE(SetWindowPos(_debugWindow, nullptr, 0, 0, rc.right - rc.left, rc.bottom - rc.top, SWP_NOMOVE));


### PR DESCRIPTION
ed27737 contains a regression were a `RECT` in `GdiEngine` wasn't properly
initialized anymore. Due to this, rendering during scrolling behaved erratic.

To find other cases of this bug in ed27737 the following regex was used:
```
^-.* = \{\s*\d*\s*\};
```

It appears that only `GdiEngine` was affected by a bug of this kind,
but just to be sure, this PR reverts all other instances.
This bug was likely caused when I tried to undo some of the changes in
ed27737 to make the PR smaller, but failed to revert the code properly.

## PR Checklist
* [x] Closes #13270
* [x] I work here

## Validation Steps Performed
I'm unable to reproduce the issue on my hardware and am unable to test
this change, but the uninitialized struct is clearly a bug regardless.

Co-authored-by: James Holderness <j4_james@hotmail.com>