### PR TITLE
Update the scrollbar postiton on `scrollToMark`

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -2017,8 +2017,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         }
         }
 
-        auto viewHeight = ViewHeight();
-        auto bufferSize = BufferHeight();
+        const auto viewHeight = ViewHeight();
+        const auto bufferSize = BufferHeight();
 
         // UserScrollViewport, to update the Terminal about where the viewport should be
         // then raise a _terminalScrollPositionChanged to inform the control to update the scrollbar.

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -2017,19 +2017,27 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         }
         }
 
+        auto viewHeight = ViewHeight();
+        auto bufferSize = BufferHeight();
+
+        // UserScrollViewport, to update the Terminal about where the veiwport should be
+        // then raise a _terminalScrollPositionChanged to inform the control to update the scrollbar.
         if (tgt.has_value())
         {
             UserScrollViewport(tgt->start.y);
+            _terminalScrollPositionChanged(tgt->start.y, viewHeight, bufferSize);
         }
         else
         {
             if (direction == ScrollToMarkDirection::Last || direction == ScrollToMarkDirection::Next)
             {
                 UserScrollViewport(BufferHeight());
+                _terminalScrollPositionChanged(BufferHeight(), viewHeight, bufferSize);
             }
             else if (direction == ScrollToMarkDirection::First || direction == ScrollToMarkDirection::Previous)
             {
                 UserScrollViewport(0);
+                _terminalScrollPositionChanged(0, viewHeight, bufferSize);
             }
         }
     }

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -2020,7 +2020,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         auto viewHeight = ViewHeight();
         auto bufferSize = BufferHeight();
 
-        // UserScrollViewport, to update the Terminal about where the veiwport should be
+        // UserScrollViewport, to update the Terminal about where the viewport should be
         // then raise a _terminalScrollPositionChanged to inform the control to update the scrollbar.
         if (tgt.has_value())
         {


### PR DESCRIPTION
When I moved this into ControlCore, I forgot that UserScrollViewport is usually triggered by the scrollbar updating, so it doesn't ask the UI to update. Since this logic is in ControlCore, it's sorta in a weird place where it needs to communicate both up and down:
* update the `Terminal`'s viewport position
* update the `TermControl`'s scrollbar position

Checklist:

* [x] Closes a bug bash bug
* [x] Missed in #12948 
* See also #11000