### PR TITLE
Allow preview connection to take in a preview string to display

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/PreviewConnection.cpp
+++ b/src/cascadia/TerminalSettingsEditor/PreviewConnection.cpp
@@ -8,11 +8,10 @@
 using namespace ::winrt::Microsoft::Terminal::TerminalConnection;
 using namespace ::winrt::Windows::Foundation;
 
-static constexpr std::wstring_view PreviewText{ L"Windows Terminal\r\nCopyright (c) Microsoft Corporation\r\n\nC:\\Windows\\Terminal> " };
-
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
-    PreviewConnection::PreviewConnection() noexcept
+    PreviewConnection::PreviewConnection(const winrt::hstring previewString) noexcept :
+        _previewString{ previewString }
     {
     }
 
@@ -21,7 +20,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // First send a sequence to disable cursor blinking
         _TerminalOutputHandlers(L"\x1b[?12l");
         // Send the preview text
-        _TerminalOutputHandlers(PreviewText);
+        _TerminalOutputHandlers(_previewString);
     }
 
     void PreviewConnection::Initialize(const Windows::Foundation::Collections::ValueSet& /*settings*/) noexcept

--- a/src/cascadia/TerminalSettingsEditor/PreviewConnection.h
+++ b/src/cascadia/TerminalSettingsEditor/PreviewConnection.h
@@ -19,7 +19,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     class PreviewConnection : public winrt::implements<PreviewConnection, winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection>
     {
     public:
-        PreviewConnection() noexcept;
+        PreviewConnection(const winrt::hstring previewString) noexcept;
 
         void Initialize(const Windows::Foundation::Collections::ValueSet& settings) noexcept;
         void Start() noexcept;
@@ -31,5 +31,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         WINRT_CALLBACK(TerminalOutput, winrt::Microsoft::Terminal::TerminalConnection::TerminalOutputHandler);
         TYPED_EVENT(StateChanged, winrt::Microsoft::Terminal::TerminalConnection::ITerminalConnection, IInspectable);
+
+    private:
+        const winrt::hstring _previewString;
     };
 }

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.cpp
@@ -14,10 +14,12 @@
 using namespace winrt::Windows::UI::Xaml;
 using namespace winrt::Windows::UI::Xaml::Navigation;
 
+static const winrt::hstring PreviewText{ L"Windows Terminal\r\nCopyright (c) Microsoft Corporation\r\n\nC:\\Windows\\Terminal> " };
+
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
     Profiles_Appearance::Profiles_Appearance() :
-        _previewControl{ Control::TermControl(Model::TerminalSettings{}, nullptr, make<PreviewConnection>()) }
+        _previewControl{ Control::TermControl(Model::TerminalSettings{}, nullptr, make<PreviewConnection>(PreviewText)) }
     {
         InitializeComponent();
 


### PR DESCRIPTION
## Summary of the Pull Request
When only the Profiles->Appearance page was using a preview control, it was okay to have a predefined 'preview' string that the preview control would display. Now that the ColorSchemes page also wants a preview control (to showcase all 16 colors), it makes sense to allow the page that is creating the preview control to decide what the preview string should be. So, the preview connection now takes in a preview string. 

## References
This is a prerequisite for #13269 

## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I work here

## Validation Steps Performed
Profiles->Appearance preview control still works as before