### PR TITLE
[1.14] Remove most uses of `CompareInBounds`

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1528,15 +1528,15 @@ const til::point TextBuffer::GetGlyphEnd(const til::point pos, bool accessibilit
 bool TextBuffer::MoveToNextGlyph(til::point& pos, bool allowExclusiveEnd, std::optional<til::point> limitOptional) const
 {
     const auto bufferSize = GetSize();
-    bool pastEndExclusive = false;
-    const auto limit = [bufferSize, limitOptional](bool& pastEndExclusive) {
-        const auto endExclusive{ bufferSize.EndExclusive() };
-        const auto val = limitOptional.value_or(endExclusive);
-        pastEndExclusive = val > endExclusive;
-        return pastEndExclusive ? endExclusive : val;
-    }(pastEndExclusive);
+    bool pastEndInclusive = false;
+    const auto limit = [bufferSize, limitOptional](bool& pastEndInclusive) {
+        const auto endInclusive{ bufferSize.BottomRightInclusive() };
+        const auto val = limitOptional.value_or(endInclusive);
+        pastEndInclusive = val > endInclusive;
+        return pastEndInclusive ? endInclusive : val;
+    }(pastEndInclusive);
 
-    const auto distanceToLimit{ bufferSize.CompareInBounds(pos, limit) + (pastEndExclusive ? 1 : 0) };
+    const auto distanceToLimit{ bufferSize.CompareInBounds(pos, limit) + (pastEndInclusive ? 1 : 0) };
     if (distanceToLimit >= 0)
     {
         // Corner Case: we're on/past the limit

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -1528,13 +1528,17 @@ const til::point TextBuffer::GetGlyphEnd(const til::point pos, bool accessibilit
 bool TextBuffer::MoveToNextGlyph(til::point& pos, bool allowExclusiveEnd, std::optional<til::point> limitOptional) const
 {
     const auto bufferSize = GetSize();
-    bool pastEndInclusive = false;
-    const auto limit = [bufferSize, limitOptional](bool& pastEndInclusive) {
+    bool pastEndInclusive;
+    til::point limit;
+    {
+        // if the limit is past the end of the buffer,
+        // 1) clamp limit to end of buffer
+        // 2) set pastEndInclusive
         const auto endInclusive{ bufferSize.BottomRightInclusive() };
         const auto val = limitOptional.value_or(endInclusive);
         pastEndInclusive = val > endInclusive;
-        return pastEndInclusive ? endInclusive : val;
-    }(pastEndInclusive);
+        limit = pastEndInclusive ? endInclusive : val;
+    }
 
     const auto distanceToLimit{ bufferSize.CompareInBounds(pos, limit) + (pastEndInclusive ? 1 : 0) };
     if (distanceToLimit >= 0)

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -182,7 +182,7 @@ void Terminal::SetSelectionEnd(const COORD viewportPos, std::optional<SelectionE
 // - the new start/end for a selection
 std::pair<COORD, COORD> Terminal::_PivotSelection(const COORD targetPos, bool& targetStart) const
 {
-    if (targetStart = _activeBuffer().GetSize().CompareInBounds(targetPos, _selection->pivot) <= 0)
+    if (targetStart = targetPos <= _selection->pivot)
     {
         // target is before pivot
         // treat target as start
@@ -371,7 +371,7 @@ void Terminal::_MoveByWord(SelectionDirection direction, COORD& pos)
     {
     case SelectionDirection::Left:
         const auto wordStartPos{ _activeBuffer().GetWordStart(pos, _wordDelimiters) };
-        if (_activeBuffer().GetSize().CompareInBounds(_selection->pivot, pos) < 0)
+        if (_selection->pivot < pos)
         {
             // If we're moving towards the pivot, move one more cell
             pos = wordStartPos;
@@ -392,7 +392,7 @@ void Terminal::_MoveByWord(SelectionDirection direction, COORD& pos)
         break;
     case SelectionDirection::Right:
         const auto wordEndPos{ _activeBuffer().GetWordEnd(pos, _wordDelimiters) };
-        if (_activeBuffer().GetSize().CompareInBounds(pos, _selection->pivot) < 0)
+        if (pos < _selection->pivot)
         {
             // If we're moving towards the pivot, move one more cell
             pos = _activeBuffer().GetWordEnd(pos, _wordDelimiters);

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -5,6 +5,9 @@
 #include "Terminal.hpp"
 #include "unicode.hpp"
 
+#define TIL_POINT_WRAP(coord) \
+    til::point { coord.X, coord.Y }
+
 using namespace Microsoft::Terminal::Core;
 
 /* Selection Pivot Description:
@@ -182,7 +185,7 @@ void Terminal::SetSelectionEnd(const COORD viewportPos, std::optional<SelectionE
 // - the new start/end for a selection
 std::pair<COORD, COORD> Terminal::_PivotSelection(const COORD targetPos, bool& targetStart) const
 {
-    if (targetStart = targetPos <= _selection->pivot)
+    if (targetStart = TIL_POINT_WRAP(targetPos) <= TIL_POINT_WRAP(_selection->pivot))
     {
         // target is before pivot
         // treat target as start
@@ -371,7 +374,7 @@ void Terminal::_MoveByWord(SelectionDirection direction, COORD& pos)
     {
     case SelectionDirection::Left:
         const auto wordStartPos{ _activeBuffer().GetWordStart(pos, _wordDelimiters) };
-        if (_selection->pivot < pos)
+        if (TIL_POINT_WRAP(_selection->pivot) < TIL_POINT_WRAP(pos))
         {
             // If we're moving towards the pivot, move one more cell
             pos = wordStartPos;
@@ -392,7 +395,7 @@ void Terminal::_MoveByWord(SelectionDirection direction, COORD& pos)
         break;
     case SelectionDirection::Right:
         const auto wordEndPos{ _activeBuffer().GetWordEnd(pos, _wordDelimiters) };
-        if (pos < _selection->pivot)
+        if (TIL_POINT_WRAP(pos) < TIL_POINT_WRAP(_selection->pivot))
         {
             // If we're moving towards the pivot, move one more cell
             pos = _activeBuffer().GetWordEnd(pos, _wordDelimiters);

--- a/src/interactivity/win32/ut_interactivity_win32/UiaTextRangeTests.cpp
+++ b/src/interactivity/win32/ut_interactivity_win32/UiaTextRangeTests.cpp
@@ -484,9 +484,9 @@ class UiaTextRangeTests
 
         Log::Comment(L"_start and end should be 2 units apart. Sign depends on order of comparison.");
         THROW_IF_FAILED(utr1->CompareEndpoints(TextPatternRangeEndpoint_End, utr2.Get(), TextPatternRangeEndpoint_End, &comparison));
-        VERIFY_IS_TRUE(comparison == -2);
+        VERIFY_IS_TRUE(comparison == -1);
         THROW_IF_FAILED(utr2->CompareEndpoints(TextPatternRangeEndpoint_End, utr1.Get(), TextPatternRangeEndpoint_End, &comparison));
-        VERIFY_IS_TRUE(comparison == 2);
+        VERIFY_IS_TRUE(comparison == 1);
     }
 
     TEST_METHOD(ExpandToEnclosingUnit)

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -248,11 +248,10 @@ try
     // TODO GH#5406: create a different UIA parent object for each TextBuffer
     //   This is a temporary solution to comparing two UTRs from different TextBuffers
     //   Ensure both endpoints fit in the current buffer.
-    const auto bufferSize = _pData->GetTextBuffer().GetSize();
-    RETURN_HR_IF(E_FAIL, !bufferSize.IsInBounds(mine) || !bufferSize.IsInBounds(other));
 
-    // compare them
-    *pRetVal = bufferSize.CompareInBounds(mine, other);
+    // directly calculate the distance between the two endpoints
+    *pRetVal = (mine.Y - other.Y) * _pData->GetTextBuffer().GetSize().Width();
+    *pRetVal += (mine.X - other.X);
 
     UiaTracing::TextRange::CompareEndpoints(*this, endpoint, *range, targetEndpoint, *pRetVal);
     return S_OK;

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -246,12 +246,13 @@ try
     const auto mine = GetEndpoint(endpoint);
 
     // TODO GH#5406: create a different UIA parent object for each TextBuffer
-    //   This is a temporary solution to comparing two UTRs from different TextBuffers
-    //   Ensure both endpoints fit in the current buffer.
+    //   We should return E_FAIL if we detect that the endpoints are from two different TextBuffer objects.
+    //   For now, we're fine to not do that because we're not using any code that can FAIL_FAST anymore.
 
-    // directly calculate the distance between the two endpoints
-    *pRetVal = (mine.Y - other.Y) * _pData->GetTextBuffer().GetSize().Width();
-    *pRetVal += (mine.X - other.X);
+    // compare them
+    *pRetVal = mine < other ? -1 :
+               mine > other ? 1 :
+                              0;
 
     UiaTracing::TextRange::CompareEndpoints(*this, endpoint, *range, targetEndpoint, *pRetVal);
     return S_OK;

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -70,7 +70,7 @@ try
     RETURN_IF_FAILED(RuntimeClassInitialize(pData, pProvider, wordDelimiters));
 
     // start is before/at end, so this is valid
-    if (_pData->GetTextBuffer().GetSize().CompareInBounds(start, end, true) <= 0)
+    if (start <= end)
     {
         _start = start;
         _end = end;
@@ -166,7 +166,7 @@ bool UiaTextRangeBase::SetEndpoint(TextPatternRangeEndpoint endpoint, const COOR
     case TextPatternRangeEndpoint_End:
         _end = val;
         // if end is before start...
-        if (bufferSize.CompareInBounds(_end, _start, true) < 0)
+        if (_end < _start)
         {
             // make this range degenerate at end
             _start = _end;
@@ -175,7 +175,7 @@ bool UiaTextRangeBase::SetEndpoint(TextPatternRangeEndpoint endpoint, const COOR
     case TextPatternRangeEndpoint_Start:
         _start = val;
         // if start is after end...
-        if (bufferSize.CompareInBounds(_start, _end, true) > 0)
+        if (_start > _end)
         {
             // make this range degenerate at start
             _end = _start;
@@ -249,10 +249,10 @@ try
     //   This is a temporary solution to comparing two UTRs from different TextBuffers
     //   Ensure both endpoints fit in the current buffer.
     const auto bufferSize = _pData->GetTextBuffer().GetSize();
-    RETURN_HR_IF(E_FAIL, !bufferSize.IsInBounds(mine, true) || !bufferSize.IsInBounds(other, true));
+    RETURN_HR_IF(E_FAIL, !bufferSize.IsInBounds(mine) || !bufferSize.IsInBounds(other));
 
     // compare them
-    *pRetVal = bufferSize.CompareInBounds(mine, other, true);
+    *pRetVal = bufferSize.CompareInBounds(mine, other);
 
     UiaTracing::TextRange::CompareEndpoints(*this, endpoint, *range, targetEndpoint, *pRetVal);
     return S_OK;
@@ -293,7 +293,7 @@ void UiaTextRangeBase::_expandToEnclosingUnit(TextUnit unit)
     // If we're past document end,
     // set us to ONE BEFORE the document end.
     // This allows us to expand properly.
-    if (bufferSize.CompareInBounds(_start, documentEnd.to_win32_coord(), true) >= 0)
+    if (_start >= documentEnd)
     {
         _start = documentEnd.to_win32_coord();
         bufferSize.DecrementInBounds(_start, true);
@@ -652,8 +652,8 @@ try
         bufferSize.IncrementInBounds(end, true);
 
         // make sure what was found is within the bounds of the current range
-        if ((searchDirection == Search::Direction::Forward && bufferSize.CompareInBounds(end, _end, true) < 0) ||
-            (searchDirection == Search::Direction::Backward && bufferSize.CompareInBounds(start, _start) > 0))
+        if ((searchDirection == Search::Direction::Forward && end < _end) ||
+            (searchDirection == Search::Direction::Backward && start > _start))
         {
             RETURN_IF_FAILED(Clone(ppRetVal));
             auto& range = static_cast<UiaTextRangeBase&>(**ppRetVal);
@@ -870,7 +870,7 @@ IFACEMETHODIMP UiaTextRangeBase::GetBoundingRectangles(_Outptr_result_maybenull_
 
         // startAnchor: the earliest COORD we will get a bounding rect for
         auto startAnchor = GetEndpoint(TextPatternRangeEndpoint_Start);
-        if (bufferSize.CompareInBounds(startAnchor, viewportOrigin, true) < 0)
+        if (startAnchor < viewportOrigin)
         {
             // earliest we can be is the origin
             startAnchor = viewportOrigin;
@@ -878,7 +878,7 @@ IFACEMETHODIMP UiaTextRangeBase::GetBoundingRectangles(_Outptr_result_maybenull_
 
         // endAnchor: the latest COORD we will get a bounding rect for
         auto endAnchor = GetEndpoint(TextPatternRangeEndpoint_End);
-        if (bufferSize.CompareInBounds(endAnchor, viewportEnd, true) > 0)
+        if (endAnchor > viewportEnd)
         {
             // latest we can be is the viewport end
             endAnchor = viewportEnd;
@@ -887,7 +887,7 @@ IFACEMETHODIMP UiaTextRangeBase::GetBoundingRectangles(_Outptr_result_maybenull_
         // _end is exclusive, let's be inclusive so we don't have to think about it anymore for bounding rects
         bufferSize.DecrementInBounds(endAnchor, true);
 
-        if (IsDegenerate() || bufferSize.CompareInBounds(_start, viewportEnd, true) > 0 || bufferSize.CompareInBounds(_end, viewportOrigin, true) < 0)
+        if (IsDegenerate() || _start > viewportEnd || _end < viewportOrigin)
         {
             // An empty array is returned for a degenerate (empty) text range.
             // reference: https://docs.microsoft.com/en-us/windows/win32/api/uiautomationclient/nf-uiautomationclient-iuiautomationtextrange-getboundingrectangles
@@ -994,10 +994,7 @@ std::wstring UiaTextRangeBase::_getTextValue(std::optional<unsigned int> maxLeng
         // TODO GH#5406: create a different UIA parent object for each TextBuffer
         // nvaccess/nvda#11428: Ensure our endpoints are in bounds
         // otherwise, we'll FailFast catastrophically
-        if (!bufferSize.IsInBounds(_start, true) || !bufferSize.IsInBounds(_end, true))
-        {
-            THROW_HR(E_FAIL);
-        }
+        THROW_HR_IF(E_FAIL, !bufferSize.IsInBounds(_start) || !bufferSize.IsInBounds(_end));
 
         // convert _end to be inclusive
         auto inclusiveEnd = _end;
@@ -1044,12 +1041,12 @@ try
     // If so, clamp each endpoint to the end of the document.
     constexpr auto endpoint = TextPatternRangeEndpoint::TextPatternRangeEndpoint_Start;
     const auto bufferSize{ _pData->GetTextBuffer().GetSize() };
-    const auto documentEnd = _getDocumentEnd().to_win32_coord();
-    if (bufferSize.CompareInBounds(_start, documentEnd, true) > 0)
+    const auto documentEnd = _getDocumentEnd();
+    if (_start > documentEnd)
     {
         _start = documentEnd;
     }
-    if (bufferSize.CompareInBounds(_end, documentEnd, true) > 0)
+    if (_end > documentEnd)
     {
         _end = documentEnd;
     }
@@ -1119,11 +1116,11 @@ IFACEMETHODIMP UiaTextRangeBase::MoveEndpointByUnit(_In_ TextPatternRangeEndpoin
     }
     CATCH_LOG();
 
-    if (bufferSize.CompareInBounds(_start, documentEnd, true) > 0)
+    if (_start > documentEnd)
     {
         _start = documentEnd;
     }
-    if (bufferSize.CompareInBounds(_end, documentEnd, true) > 0)
+    if (_end > documentEnd)
     {
         _end = documentEnd;
     }
@@ -1173,7 +1170,7 @@ try
     const auto bufferSize = _pData->GetTextBuffer().GetSize();
     const auto mine = GetEndpoint(endpoint);
     const auto other = range->GetEndpoint(targetEndpoint);
-    RETURN_HR_IF(E_FAIL, !bufferSize.IsInBounds(mine, true) || !bufferSize.IsInBounds(other, true));
+    RETURN_HR_IF(E_FAIL, !bufferSize.IsInBounds(mine) || !bufferSize.IsInBounds(other));
 
     SetEndpoint(endpoint, range->GetEndpoint(targetEndpoint));
 
@@ -1199,10 +1196,7 @@ try
     else
     {
         const auto bufferSize = _pData->GetTextBuffer().GetSize();
-        if (!bufferSize.IsInBounds(_start, true) || !bufferSize.IsInBounds(_end, true))
-        {
-            return E_FAIL;
-        }
+        RETURN_HR_IF(E_FAIL, !bufferSize.IsInBounds(_start) || !bufferSize.IsInBounds(_end));
         auto inclusiveEnd = _end;
         bufferSize.DecrementInBounds(inclusiveEnd);
         _pData->SelectNewRegion(_start, inclusiveEnd);
@@ -1516,7 +1510,7 @@ void UiaTextRangeBase::_moveEndpointByUnitWord(_In_ const int moveCount,
         {
         case MovementDirection::Forward:
         {
-            if (bufferSize.CompareInBounds(nextPos, documentEnd.to_win32_coord(), true) >= 0)
+            if (nextPos >= documentEnd)
             {
                 success = false;
             }
@@ -1737,7 +1731,7 @@ void UiaTextRangeBase::_moveEndpointByUnitDocument(_In_ const int moveCount,
         }
         CATCH_LOG();
 
-        if (preventBoundary || bufferSize.CompareInBounds(target, documentEnd, true) >= 0)
+        if (preventBoundary || target >= documentEnd)
         {
             return;
         }


### PR DESCRIPTION
## Summary of the Pull Request
Replaces most uses of `Viewport::CompareInBounds()` with `til::point`'s `<` and `>` operators. `CompareInBounds` has been the cause of a bunch of UIA crashes over the years. Replacing them entirely ensures that the `FAILFAST_IF` isn't ever touched.

This was a bit tricky to do because I wanted to ensure the same functionality was maintained. Since we still have a ton of `COORD`s floating around, I just cast to `til::point` when we're about to do a comparison. We _could_ do smarter changes, but I'm concerned that could cause a bug we could miss.

## References
#13183
#13244 - same PR but for `main`