### PR TITLE
Fix moving selection past scroll area

### DIFF
--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -343,10 +343,7 @@ void Terminal::UpdateSelection(SelectionDirection direction, SelectionExpansion 
     }
 
     // 2.B) Clamp the movement to the mutable viewport
-    if (const auto mutableViewport = _GetMutableViewport(); targetPos > mutableViewport.BottomRightInclusive())
-    {
-        targetPos = mutableViewport.BottomRightInclusive();
-    }
+    targetPos = std::min(targetPos, _GetMutableViewport().BottomRightInclusive());
 
     // 3. Actually modify the selection
     // NOTE: targetStart doesn't matter here

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -345,11 +345,7 @@ void Terminal::UpdateSelection(SelectionDirection direction, SelectionExpansion 
     // 2.B) Clamp the movement to the mutable viewport
     if (const auto mutableViewport = _GetMutableViewport(); targetPos > mutableViewport.BottomRightInclusive())
     {
-        targetPos.Y = mutableViewport.BottomInclusive();
-    }
-    else if (const auto bufferSize = _activeBuffer().GetSize(); targetPos < bufferSize.Origin())
-    {
-        targetPos.Y = bufferSize.Top();
+        targetPos = mutableViewport.BottomRightInclusive();
     }
 
     // 3. Actually modify the selection

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -343,14 +343,13 @@ void Terminal::UpdateSelection(SelectionDirection direction, SelectionExpansion 
     }
 
     // 2.B) Clamp the movement to the mutable viewport
-    const auto mutableViewport{ _GetMutableViewport() };
-    if (targetPos > mutableViewport.BottomRightInclusive())
+    if (const auto mutableViewport = _GetMutableViewport(); targetPos > mutableViewport.BottomRightInclusive())
     {
-        targetPos = mutableViewport.BottomRightInclusive();
+        targetPos.Y = mutableViewport.BottomInclusive();
     }
-    else if (targetPos < mutableViewport.Origin())
+    else if (const auto bufferSize = _activeBuffer().GetSize(); targetPos < bufferSize.Origin())
     {
-        targetPos = mutableViewport.Origin();
+        targetPos.Y = bufferSize.Top();
     }
 
     // 3. Actually modify the selection


### PR DESCRIPTION
## Summary of the Pull Request
Introduced in #10824, this fixes a bug where you could use keyboard selection to move below the scroll area. Instead, we now clamp movement to the mutable viewport (aka the scrollable area). Specifically, we clamp to the corners (i.e. 0,0 or bottom right cell of scroll area).

## Validation Steps Performed
✅ (no output) try to move past bottom of viewport
✅ (with output, at bottom of scroll area) try to move past viewport
✅ (with output, NOT at bottom of scroll area) try to move past viewport
✅ try to move past top of viewport
