### PR TITLE
Add the Puppet shell, google cloud SKD and AWS Shell to the ThirdPartyToolProfiles.md

### DIFF
--- a/doc/user-docs/ThirdPartyToolProfiles.md
+++ b/doc/user-docs/ThirdPartyToolProfiles.md
@@ -100,6 +100,20 @@ Assuming that you've installed MSYS2 into `C:\\msys64`:
 
 For more details, see [this page](https://www.msys2.org/docs/terminals/#windows-terminal) on the MSYS2 documentation.
 
+
+## Puppet Shell
+
+Assuming that you've installed Puppet into `C:\Program Files\Puppet Labs`:
+
+```json
+{
+    "commandline": "cmd.exe /k \"C:\\Program Files\\Puppet Labs\\Puppet\\bin\\puppet_shell.bat\"",
+    "name": "Puppet Shell",
+    "icon": "C:\\Program Files\\Puppet Labs\\Puppet\\misc\\puppet.ico",
+    "startingDirectory": "%USERPROFILE%"
+}
+```
+
 ## Developer Command Prompt for Visual Studio
 
 Assuming that you've installed VS 2019 Professional:
@@ -108,7 +122,7 @@ Assuming that you've installed VS 2019 Professional:
 {
     "name": "Developer Command Prompt for VS 2019",
     "commandline": "cmd.exe /k \"C:/Program Files (x86)/Microsoft Visual Studio/2019/Professional/Common7/Tools/VsDevCmd.bat\"",
-    "startingDirectory": "%USERPROFILE%"
+    "startingDirectory": "C:\\ProgramData\\PuppetLabs"
 }
 ```
 

--- a/doc/user-docs/ThirdPartyToolProfiles.md
+++ b/doc/user-docs/ThirdPartyToolProfiles.md
@@ -16,6 +16,20 @@ Assuming that you've installed Anaconda into `%USERPROFILE%\Anaconda3`:
 }
 ```
 
+## AWS Shell
+
+Assuming that you've installed via pip to python 3.1 into `C:\Python310\Scripts`:
+
+```json
+{
+    "commandline": "cmd.exe /k \"C:\\Python310\\Scripts\\aws-shell.exe",
+    "name": "AWS Shell",
+    "icon": "C:\\Python310\\Scripts\\AWS.ico",
+    "startingDirectory": "%USERPROFILE%"
+}
+```
+
+
 ## cmder
 
 Assuming that you've installed cmder into `%CMDER_ROOT%`:
@@ -82,6 +96,19 @@ Assuming that you've installed Git Bash into `C:\\Program Files (x86)\\Git`:
     "commandline": "%ProgramFiles(x86)%\\Git\\bin\\bash.exe -li",
     "icon": "%ProgramFiles(x86)%\\Git\\mingw32\\share\\git\\git-for-windows.ico",
     "startingDirectory": "%USERPROFILE%"
+}
+```
+
+## Google Cloud SDK
+
+Assuming that you've installed Google Cloud SDK into `C:\Program Files (x86)\Google`:
+
+```json
+{
+    "commandline": "cmd.exe /k \"C:\\Program Files (x86)\\Google\\Cloud SDK\\cloud_env.bat\"",
+    "name": "Google Cloud SDK",
+    "icon": "C:\\Program Files (x86)\\Google\\Cloud SDK\\supercloud-16x16.ico",
+    "startingDirectory": "C:\\Program Files (x86)\\Google\\Cloud SDK"
 }
 ```
 


### PR DESCRIPTION
## Summary of the Pull Request
This pull request adds to the docs how to add the puppet shell as a terminal.

## References
https://puppet.com/docs/puppet/7/services_commands_windows.html#start_menu_items
https://cloud.google.com/sdk/docs/install
https://aws.amazon.com/cli/

## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments
This shows how to add the puppet shell, Google Cloud SDK and AWS Shell as a terminal profiles to the third-party documentation pages.

## Validation Steps Performed
These are the terminal settings I use on my laptop.