### PR TITLE
Re-enable the setting to adjust the colors of indistinguishable text

### DIFF
--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -109,7 +109,7 @@ Author(s):
     X(hstring, ColorSchemeName, "colorScheme", L"Campbell")                                                                                                        \
     X(hstring, BackgroundImagePath, "backgroundImage")                                                                                                             \
     X(Model::IntenseStyle, IntenseTextStyle, "intenseTextStyle", Model::IntenseStyle::Bright)                                                                      \
-    X(bool, AdjustIndistinguishableColors, "adjustIndistinguishableColors", true)
+    X(bool, AdjustIndistinguishableColors, "adjustIndistinguishableColors", false)
 
 // Intentionally omitted Appearance settings:
 // * ForegroundKey, BackgroundKey, SelectionBackgroundKey, CursorColorKey: all optional colors

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -109,7 +109,7 @@ Author(s):
     X(hstring, ColorSchemeName, "colorScheme", L"Campbell")                                                                                                        \
     X(hstring, BackgroundImagePath, "backgroundImage")                                                                                                             \
     X(Model::IntenseStyle, IntenseTextStyle, "intenseTextStyle", Model::IntenseStyle::Bright)                                                                      \
-    X(bool, AdjustIndistinguishableColors, "adjustIndistinguishableColors", false)
+    X(bool, AdjustIndistinguishableColors, "adjustIndistinguishableColors", true)
 
 // Intentionally omitted Appearance settings:
 // * ForegroundKey, BackgroundKey, SelectionBackgroundKey, CursorColorKey: all optional colors

--- a/src/features.xml
+++ b/src/features.xml
@@ -79,10 +79,7 @@
     <feature>
         <name>Feature_AdjustIndistinguishableText</name>
         <description>If enabled, the foreground color will, when necessary, be automatically adjusted to make it more visible.</description>
-        <stage>AlwaysDisabled</stage>
-        <alwaysEnabledBrandingTokens>
-            <brandingToken>Dev</brandingToken>
-        </alwaysEnabledBrandingTokens>
+        <stage>AlwaysEnabled</stage>
     </feature>
     
     <feature>

--- a/src/renderer/base/RenderSettings.cpp
+++ b/src/renderer/base/RenderSettings.cpp
@@ -78,8 +78,8 @@ void RenderSettings::ResetColorTable() noexcept
 //   color pair to the adjusted foreground for that color pair
 void RenderSettings::MakeAdjustedColorArray() noexcept
 {
-    // The color table has 16 colors, but the adjusted color table needs to be 18
-    // to include the default background and default foreground colors
+    // The color table has 16 colors, but the adjusted color table needs to be 19
+    // to include the default background, default foreground and bright default foreground colors
     std::array<COLORREF, 19> colorTableWithDefaults;
     std::copy_n(std::begin(_colorTable), 16, std::begin(colorTableWithDefaults));
     colorTableWithDefaults[AdjustedFgIndex] = GetColorAlias(ColorAlias::DefaultForeground);

--- a/src/renderer/base/RenderSettings.cpp
+++ b/src/renderer/base/RenderSettings.cpp
@@ -13,6 +13,7 @@ using Microsoft::Console::Utils::InitializeColorTable;
 
 static constexpr size_t AdjustedFgIndex{ 16 };
 static constexpr size_t AdjustedBgIndex{ 17 };
+static constexpr size_t AdjustedBrightFgIndex{ 18 };
 
 RenderSettings::RenderSettings() noexcept
 {
@@ -79,15 +80,19 @@ void RenderSettings::MakeAdjustedColorArray() noexcept
 {
     // The color table has 16 colors, but the adjusted color table needs to be 18
     // to include the default background and default foreground colors
-    std::array<COLORREF, 18> colorTableWithDefaults;
+    std::array<COLORREF, 19> colorTableWithDefaults;
     std::copy_n(std::begin(_colorTable), 16, std::begin(colorTableWithDefaults));
     colorTableWithDefaults[AdjustedFgIndex] = GetColorAlias(ColorAlias::DefaultForeground);
     colorTableWithDefaults[AdjustedBgIndex] = GetColorAlias(ColorAlias::DefaultBackground);
 
-    for (auto fgIndex = 0; fgIndex < 18; ++fgIndex)
+    // We need to use TextColor to calculate the bright default fg
+    TextColor defaultFg;
+    colorTableWithDefaults[AdjustedBrightFgIndex] = defaultFg.GetColor(_colorTable, GetColorAliasIndex(ColorAlias::DefaultForeground), true);
+
+    for (auto fgIndex = 0; fgIndex < 19; ++fgIndex)
     {
         const auto fg = til::at(colorTableWithDefaults, fgIndex);
-        for (auto bgIndex = 0; bgIndex < 18; ++bgIndex)
+        for (auto bgIndex = 0; bgIndex < 19; ++bgIndex)
         {
             if (fgIndex == bgIndex)
             {
@@ -203,7 +208,6 @@ std::pair<COLORREF, COLORREF> RenderSettings::GetAttributeColors(const TextAttri
     if (Feature_AdjustIndistinguishableText::IsEnabled() &&
         GetRenderMode(Mode::DistinguishableColors) &&
         !dimFg &&
-        !brightenFg &&
         !attr.IsInvisible() &&
         (fgTextColor.IsDefault() || fgTextColor.IsLegacy()) &&
         (bgTextColor.IsDefault() || bgTextColor.IsLegacy()))
@@ -211,10 +215,23 @@ std::pair<COLORREF, COLORREF> RenderSettings::GetAttributeColors(const TextAttri
         const auto bgIndex = bgTextColor.IsDefault() ? AdjustedBgIndex : bgTextColor.GetIndex();
         auto fgIndex = fgTextColor.IsDefault() ? AdjustedFgIndex : fgTextColor.GetIndex();
 
+        if (brightenFg)
+        {
+            // There is a special case for intense here - we need to get the bright version of the foreground color
+            if (fgTextColor.IsIndex16() && (fgIndex < 8))
+            {
+                fgIndex += 8;
+            }
+            else if (fgTextColor.IsDefault())
+            {
+                fgIndex = AdjustedBrightFgIndex;
+            }
+        }
+
         if (swapFgAndBg)
         {
             const auto fg = _adjustedForegroundColors[fgIndex][bgIndex];
-            const auto bg = fgTextColor.GetColor(_colorTable, defaultFgIndex);
+            const auto bg = fgTextColor.GetColor(_colorTable, defaultFgIndex, brightenFg);
             return { fg, bg };
         }
         else

--- a/src/renderer/base/RenderSettings.cpp
+++ b/src/renderer/base/RenderSettings.cpp
@@ -192,21 +192,17 @@ std::pair<COLORREF, COLORREF> RenderSettings::GetAttributeColors(const TextAttri
     const auto swapFgAndBg = attr.IsReverseVideo() ^ GetRenderMode(Mode::ScreenReversed);
 
     // We want to nudge the foreground color to make it more perceivable only for the
-    // default color pairs within the color table
+    // default color pairs within the color table, and only if there's no additional text attributes
     if (Feature_AdjustIndistinguishableText::IsEnabled() &&
         GetRenderMode(Mode::DistinguishableColors) &&
         !dimFg &&
+        !brightenFg &&
+        !attr.IsInvisible() &&
         (fgTextColor.IsDefault() || fgTextColor.IsLegacy()) &&
         (bgTextColor.IsDefault() || bgTextColor.IsLegacy()))
     {
         const auto bgIndex = bgTextColor.IsDefault() ? AdjustedBgIndex : bgTextColor.GetIndex();
         auto fgIndex = fgTextColor.IsDefault() ? AdjustedFgIndex : fgTextColor.GetIndex();
-
-        if (fgTextColor.IsIndex16() && (fgIndex < 8) && brightenFg)
-        {
-            // There is a special case for intense here - we need to get the bright version of the foreground color
-            fgIndex += 8;
-        }
 
         if (swapFgAndBg)
         {

--- a/src/renderer/base/RenderSettings.cpp
+++ b/src/renderer/base/RenderSettings.cpp
@@ -193,6 +193,13 @@ std::pair<COLORREF, COLORREF> RenderSettings::GetAttributeColors(const TextAttri
 
     // We want to nudge the foreground color to make it more perceivable only for the
     // default color pairs within the color table, and only if there's no additional text attributes
+
+    // The reason we don't want to nudge when there's additional attributes is because of certain
+    // interactions like "bright" + "reverse". We cannot nudge after reversing because we, as of now,
+    // have no easy way to calculate what the bright background is when the background is default. We
+    // also cannot nudge before reversing because then we are reversing the resultant background rather
+    // than the resultant foreground, and this can lead to weird situations where certain regions of
+    // text have different backgrounds.
     if (Feature_AdjustIndistinguishableText::IsEnabled() &&
         GetRenderMode(Mode::DistinguishableColors) &&
         !dimFg &&

--- a/src/renderer/base/RenderSettings.cpp
+++ b/src/renderer/base/RenderSettings.cpp
@@ -197,14 +197,7 @@ std::pair<COLORREF, COLORREF> RenderSettings::GetAttributeColors(const TextAttri
     const auto swapFgAndBg = attr.IsReverseVideo() ^ GetRenderMode(Mode::ScreenReversed);
 
     // We want to nudge the foreground color to make it more perceivable only for the
-    // default color pairs within the color table, and only if there's no additional text attributes
-
-    // The reason we don't want to nudge when there's additional attributes is because of certain
-    // interactions like "bright" + "reverse". We cannot nudge after reversing because we, as of now,
-    // have no easy way to calculate what the bright background is when the background is default. We
-    // also cannot nudge before reversing because then we are reversing the resultant background rather
-    // than the resultant foreground, and this can lead to weird situations where certain regions of
-    // text have different backgrounds.
+    // default color pairs within the color table
     if (Feature_AdjustIndistinguishableText::IsEnabled() &&
         GetRenderMode(Mode::DistinguishableColors) &&
         !dimFg &&

--- a/src/renderer/inc/RenderSettings.hpp
+++ b/src/renderer/inc/RenderSettings.hpp
@@ -47,7 +47,7 @@ namespace Microsoft::Console::Render
         til::enumset<Mode> _renderMode{ Mode::BlinkAllowed, Mode::IntenseIsBright };
         std::array<COLORREF, TextColor::TABLE_SIZE> _colorTable;
         std::array<size_t, static_cast<size_t>(ColorAlias::ENUM_COUNT)> _colorAliasIndices;
-        std::array<std::array<COLORREF, 18>, 18> _adjustedForegroundColors;
+        std::array<std::array<COLORREF, 19>, 19> _adjustedForegroundColors;
         size_t _blinkCycle = 0;
         mutable bool _blinkIsInUse = false;
         bool _blinkShouldBeFaint = false;

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -2291,6 +2291,11 @@ bool AdaptDispatch::AssignColor(const DispatchTypes::ColorItem item, const VTInt
     case DispatchTypes::ColorItem::NormalText:
         _renderSettings.SetColorAliasIndex(ColorAlias::DefaultForeground, fgIndex);
         _renderSettings.SetColorAliasIndex(ColorAlias::DefaultBackground, bgIndex);
+        if (_renderSettings.GetRenderMode(RenderSettings::Mode::DistinguishableColors))
+        {
+            // Re-calculate the adjusted colors now that these aliases have been changed
+            _renderSettings.MakeAdjustedColorArray();
+        }
         break;
     case DispatchTypes::ColorItem::WindowFrame:
         _renderSettings.SetColorAliasIndex(ColorAlias::FrameForeground, fgIndex);

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -2221,6 +2221,11 @@ bool AdaptDispatch::SetClipboard(const std::wstring_view content)
 bool AdaptDispatch::SetColorTableEntry(const size_t tableIndex, const DWORD dwColor)
 {
     _renderSettings.SetColorTableEntry(tableIndex, dwColor);
+    if (_renderSettings.GetRenderMode(RenderSettings::Mode::DistinguishableColors))
+    {
+        // Re-calculate the adjusted colors now that one of the entries has been changed
+        _renderSettings.MakeAdjustedColorArray();
+    }
 
     // If we're a conpty, always return false, so that we send the updated color
     //      value to the terminal. Still handle the sequence so apps that use


### PR DESCRIPTION
## Summary of the Pull Request
Re-enable the setting to adjust indistinguishable text, with some changes:

- We now pre-calculate the nudged values for 'default bright foreground' as well
- When a color table entry is manually set (i.e. via VT sequences) we re-calculate the nudged values

## References
#11095 #12160

## PR Checklist
* [x] Closes #11917
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.

## Validation Steps Performed
Indistinguishable text gets adjusted again