### PR TITLE
Strip XAML files from the MSIX payload

### DIFF
--- a/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
+++ b/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
@@ -135,6 +135,10 @@
       <!-- 16.3.0 - remove non-resources.pri PRI files since we just forced them back in. -->
       <AppxPackagePayload Remove="@(AppxPackagePayload)" Condition="'%(Extension)' == '.pri' and '%(Filename)' != 'resources'" />
       <AppxUploadPackagePayload Remove="@(AppxUploadPackagePayload)" Condition="'%(Extension)' == '.pri' and '%(Filename)' != 'resources'" />
+
+      <!-- Remove all of the xaml files, because we are using embedded xbf payloads (saves about 500kb on disk!) -->
+      <AppxPackagePayload Remove="@(AppxPackagePayload)" Condition="'%(Extension)' == '.xaml'" />
+      <AppxUploadPackagePayload Remove="@(AppxUploadPackagePayload)" Condition="'%(Extension)' == '.xaml'" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
These files are vestigial, because we are also shipping (either as loose
files or embedded in resources.pri) precompiled xbf/xaml binary format
files.

This saves us almost 500kb on disk.

Fixes #11687

Validation
----------
I ran a local build and saw that it produced a working Terminal, packaged
and unpackaged.