### PR TITLE
[1.14] Fix moving selection past scroll area

### DIFF
--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -306,11 +306,12 @@ void Terminal::UpdateSelection(SelectionDirection direction, SelectionExpansion 
     }
 
     // 2.B) Clamp the movement to the mutable viewport
-    if (const auto mutableViewport = _GetMutableViewport(); targetPos > mutableViewport.BottomRightInclusive())
+    const auto bufferSize = _activeBuffer().GetSize();
+    if (const auto mutableViewport = _GetMutableViewport(); bufferSize.CompareInBounds(targetPos, { mutableViewport.RightInclusive(), mutableViewport.BottomInclusive() }) > 0)
     {
         targetPos.Y = mutableViewport.BottomInclusive();
     }
-    else if (const auto bufferSize = _activeBuffer().GetSize(); targetPos < bufferSize.Origin())
+    else if (bufferSize.CompareInBounds(targetPos, bufferSize.Origin()) < 0)
     {
         targetPos.Y = bufferSize.Top();
     }

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -306,14 +306,13 @@ void Terminal::UpdateSelection(SelectionDirection direction, SelectionExpansion 
     }
 
     // 2.B) Clamp the movement to the mutable viewport
-    const auto mutableViewport{ _GetMutableViewport() };
-    if (targetPos > mutableViewport.BottomRightInclusive())
+    if (const auto mutableViewport = _GetMutableViewport(); targetPos > mutableViewport.BottomRightInclusive())
     {
-        targetPos = mutableViewport.BottomRightInclusive();
+        targetPos.Y = mutableViewport.BottomInclusive();
     }
-    else if (targetPos < mutableViewport.Origin())
+    else if (const auto bufferSize = _activeBuffer().GetSize(); targetPos < bufferSize.Origin())
     {
-        targetPos = mutableViewport.Origin();
+        targetPos.Y = bufferSize.Top();
     }
 
     // 3. Actually modify the selection

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -288,7 +288,7 @@ void Terminal::UpdateSelection(SelectionDirection direction, SelectionExpansion 
     const auto movingEnd{ _selection->start == _selection->pivot };
     auto targetPos{ movingEnd ? _selection->end : _selection->start };
 
-    // 2. Perform the movement
+    // 2.A) Perform the movement
     switch (mode)
     {
     case SelectionExpansion::Char:
@@ -305,15 +305,26 @@ void Terminal::UpdateSelection(SelectionDirection direction, SelectionExpansion 
         break;
     }
 
+    // 2.B) Clamp the movement to the mutable viewport
+    const auto mutableViewport{ _GetMutableViewport() };
+    if (targetPos > mutableViewport.BottomRightInclusive())
+    {
+        targetPos = mutableViewport.BottomRightInclusive();
+    }
+    else if (targetPos < mutableViewport.Origin())
+    {
+        targetPos = mutableViewport.Origin();
+    }
+
     // 3. Actually modify the selection
     // NOTE: targetStart doesn't matter here
     auto targetStart = false;
     std::tie(_selection->start, _selection->end) = _PivotSelection(targetPos, targetStart);
 
     // 4. Scroll (if necessary)
-    if (const auto viewport = _GetVisibleViewport(); !viewport.IsInBounds(targetPos))
+    if (const auto visibleViewport = _GetVisibleViewport(); !visibleViewport.IsInBounds(targetPos))
     {
-        if (const auto amtAboveView = viewport.Top() - targetPos.Y; amtAboveView > 0)
+        if (const auto amtAboveView = visibleViewport.Top() - targetPos.Y; amtAboveView > 0)
         {
             // anchor is above visible viewport, scroll by that amount
             _scrollOffset += amtAboveView;
@@ -321,7 +332,7 @@ void Terminal::UpdateSelection(SelectionDirection direction, SelectionExpansion 
         else
         {
             // anchor is below visible viewport, scroll by that amount
-            const auto amtBelowView = targetPos.Y - viewport.BottomInclusive();
+            const auto amtBelowView = targetPos.Y - visibleViewport.BottomInclusive();
             _scrollOffset -= amtBelowView;
         }
         _NotifyScrollEvent();


### PR DESCRIPTION
## Summary of the Pull Request
1.14 port of #13318

Introduced in #10824, this fixes a bug where you could use keyboard selection to move below the scroll area. Instead, we now clamp movement to the mutable viewport (aka the scrollable area). Specifically, we only clamp the y-coordinate to make the experience similar to that of mouse selection.

## Validation Steps Performed
✅ (no output) try to move past bottom of viewport
✅ (with output, at bottom of scroll area) try to move past viewport
✅ (with output, NOT at bottom of scroll area) try to move past viewport
✅ try to move past top of viewport
