### PR TITLE
[1.14] Fix keyboard selection and copyOnSelect interaction

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -933,13 +933,14 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // Method Description:
     // - Given a copy-able selection, get the selected text from the buffer and send it to the
     //     Windows Clipboard (CascadiaWin32:main.cpp).
-    // - CopyOnSelect does NOT clear the selection
     // Arguments:
     // - singleLine: collapse all of the text to one line
     // - formats: which formats to copy (defined by action's CopyFormatting arg). nullptr
     //             if we should defer which formats are copied to the global setting
+    // - clearSelection: if true, clear the selection. Used for CopyOnSelect.
     bool ControlCore::CopySelectionToClipboard(bool singleLine,
-                                               const Windows::Foundation::IReference<CopyFormat>& formats)
+                                               const Windows::Foundation::IReference<CopyFormat>& formats,
+                                               bool clearSelection)
     {
         // no selection --> nothing to copy
         if (!_terminal->IsSelectionActive())
@@ -979,7 +980,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                                     bgColor) :
                                  "";
 
-        if (!_settings->CopyOnSelect())
+        if (clearSelection)
         {
             _terminal->ClearSelection();
             _renderer->TriggerSelection();
@@ -999,6 +1000,11 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         auto lock = _terminal->LockForWriting();
         _terminal->SelectAll();
         _renderer->TriggerSelection();
+    }
+
+    const bool ControlCore::IsInQuickEditMode() const noexcept
+    {
+        return _terminal->IsInQuickEditMode();
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -79,8 +79,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         void SendInput(const winrt::hstring& wstr);
         void PasteText(const winrt::hstring& hstr);
-        bool CopySelectionToClipboard(bool singleLine, const Windows::Foundation::IReference<CopyFormat>& formats);
+        bool CopySelectionToClipboard(bool singleLine, const Windows::Foundation::IReference<CopyFormat>& formats, bool clearSelection = true);
         void SelectAll();
+        const bool IsInQuickEditMode() const noexcept;
 
         void GotFocus();
         void LostFocus();

--- a/src/cascadia/TerminalControl/ControlInteractivity.cpp
+++ b/src/cascadia/TerminalControl/ControlInteractivity.cpp
@@ -142,13 +142,14 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // Method Description:
     // - Given a copy-able selection, get the selected text from the buffer and send it to the
     //     Windows Clipboard (CascadiaWin32:main.cpp).
-    // - CopyOnSelect does NOT clear the selection
     // Arguments:
     // - singleLine: collapse all of the text to one line
     // - formats: which formats to copy (defined by action's CopyFormatting arg). nullptr
     //             if we should defer which formats are copied to the global setting
+    // - clearSelection: if true, clear the selection after copying it. Used for CopyOnSelect.
     bool ControlInteractivity::CopySelectionToClipboard(bool singleLine,
-                                                        const Windows::Foundation::IReference<CopyFormat>& formats)
+                                                        const Windows::Foundation::IReference<CopyFormat>& formats,
+                                                        bool clearSelection)
     {
         if (_core)
         {
@@ -164,7 +165,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             // Mark the current selection as copied
             _selectionNeedsToBeCopied = false;
 
-            return _core->CopySelectionToClipboard(singleLine, formats);
+            return _core->CopySelectionToClipboard(singleLine, formats, clearSelection);
         }
 
         return false;
@@ -257,14 +258,26 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         }
         else if (WI_IsFlagSet(buttonState, MouseButtonState::IsRightButtonDown))
         {
-            // CopyOnSelect right click always pastes
-            if (_core->CopyOnSelect() || !_core->HasSelection())
+            if (_core->CopyOnSelect())
             {
+                // CopyOnSelect:
+                // 1. keyboard selection? --> copy the new content first
+                // 2. right click always pastes!
+                if (_core->IsInQuickEditMode())
+                {
+                    CopySelectionToClipboard(shiftEnabled, nullptr);
+                }
                 RequestPasteTextFromClipboard();
+            }
+            else if (_core->HasSelection())
+            {
+                // copy selected text
+                CopySelectionToClipboard(shiftEnabled, nullptr);
             }
             else
             {
-                CopySelectionToClipboard(shiftEnabled, nullptr);
+                // no selection --> paste
+                RequestPasteTextFromClipboard();
             }
         }
     }
@@ -383,7 +396,10 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             isLeftMouseRelease &&
             _selectionNeedsToBeCopied)
         {
-            CopySelectionToClipboard(false, nullptr);
+            // IMPORTANT!
+            // Set clearSelection to false here!
+            // Otherwise, the selection will be cleared immediately after you make it.
+            CopySelectionToClipboard(false, nullptr, /*clearSelection*/ false);
         }
 
         _singleClickTouchdownPos = std::nullopt;

--- a/src/cascadia/TerminalControl/ControlInteractivity.h
+++ b/src/cascadia/TerminalControl/ControlInteractivity.h
@@ -80,7 +80,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 #pragma endregion
 
         bool CopySelectionToClipboard(bool singleLine,
-                                      const Windows::Foundation::IReference<CopyFormat>& formats);
+                                      const Windows::Foundation::IReference<CopyFormat>& formats,
+                                      bool clearSelection = true);
         void RequestPasteTextFromClipboard();
         void SetEndSelectionPoint(const Core::Point pixelPosition);
         bool ManglePathsForWsl();

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -45,6 +45,7 @@ Terminal::Terminal() :
     _snapOnInput{ true },
     _altGrAliasing{ true },
     _blockSelection{ false },
+    _quickEditMode{ false },
     _selection{ std::nullopt },
     _taskbarState{ 0 },
     _taskbarProgress{ 0 },

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -241,6 +241,7 @@ public:
     void SetBlockSelection(const bool isEnabled) noexcept;
     void UpdateSelection(SelectionDirection direction, SelectionExpansion mode);
     void SelectAll();
+    const bool IsInQuickEditMode() const noexcept;
 
     using UpdateSelectionParams = std::optional<std::pair<SelectionDirection, SelectionExpansion>>;
     static UpdateSelectionParams ConvertKeyEventToUpdateSelectionParams(const ControlKeyStates mods, const WORD vkey);
@@ -313,6 +314,7 @@ private:
     bool _blockSelection;
     std::wstring _wordDelimiters;
     SelectionExpansion _multiClickSelectionMode;
+    bool _quickEditMode;
 #pragma endregion
 
     std::unique_ptr<TextBuffer> _mainBuffer;

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -241,7 +241,7 @@ public:
     void SetBlockSelection(const bool isEnabled) noexcept;
     void UpdateSelection(SelectionDirection direction, SelectionExpansion mode);
     void SelectAll();
-    const bool IsInQuickEditMode() const noexcept;
+    bool IsInQuickEditMode() const noexcept;
 
     using UpdateSelectionParams = std::optional<std::pair<SelectionDirection, SelectionExpansion>>;
     static UpdateSelectionParams ConvertKeyEventToUpdateSelectionParams(const ControlKeyStates mods, const WORD vkey);

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -96,7 +96,7 @@ const bool Terminal::IsBlockSelection() const noexcept
     return _blockSelection;
 }
 
-const bool Terminal::IsInQuickEditMode() const noexcept
+bool Terminal::IsInQuickEditMode() const noexcept
 {
     return _quickEditMode;
 }

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -310,16 +310,7 @@ void Terminal::UpdateSelection(SelectionDirection direction, SelectionExpansion 
         break;
     }
 
-    // 2.B) Clamp the movement to the mutable viewport
-    const auto bufferSize = _activeBuffer().GetSize();
-    const auto mutableViewport = _GetMutableViewport();
-    const COORD bottomRightInclusive{ mutableViewport.RightInclusive(), mutableViewport.BottomInclusive() };
-    if (bufferSize.CompareInBounds(targetPos, bottomRightInclusive) > 0)
-    {
-        targetPos = bottomRightInclusive;
-    }
-
-    // 3. Actually modify the selection state
+    // 3. Actually modify the selection
     // NOTE: targetStart doesn't matter here
     auto targetStart = false;
     _quickEditMode = true;

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -96,6 +96,11 @@ const bool Terminal::IsBlockSelection() const noexcept
     return _blockSelection;
 }
 
+const bool Terminal::IsInQuickEditMode() const noexcept
+{
+    return _quickEditMode;
+}
+
 // Method Description:
 // - Perform a multi-click selection at viewportPos expanding according to the expansionMode
 // Arguments:
@@ -314,9 +319,10 @@ void Terminal::UpdateSelection(SelectionDirection direction, SelectionExpansion 
         targetPos = bottomRightInclusive;
     }
 
-    // 3. Actually modify the selection
+    // 3. Actually modify the selection state
     // NOTE: targetStart doesn't matter here
     auto targetStart = false;
+    _quickEditMode = true;
     std::tie(_selection->start, _selection->end) = _PivotSelection(targetPos, targetStart);
 
     // 4. Scroll (if necessary)
@@ -482,6 +488,7 @@ void Terminal::_MoveByBuffer(SelectionDirection direction, COORD& pos)
 void Terminal::ClearSelection()
 {
     _selection = std::nullopt;
+    _quickEditMode = false;
 }
 
 // Method Description:


### PR DESCRIPTION
## Summary of the Pull Request
⚠️This targets release-1.14⚠️
Backport of #13358

This PR fixes a number of interactions between `copyOnSelect` and keyboard selection. Sometimes the selection just wouldn't be cleared or copied appropriately. 

I wrote a whole flowchart of expected behavior with copy on select:
- enable `copyOnSelect`
   - make a selection with the mouse
      - ✅ right-click should copy the text --> clear the selection --> paste
   - use keyboard selection to quick-edit the existing selection
      - ✅ `copy` action should clear the selection
      - ✅ right-click should copy the text --> clear the selection --> paste