### PR TITLE
Fix coordSizeUnscaled calculation in AtlasEngine

### DIFF
--- a/src/renderer/atlas/AtlasEngine.api.cpp
+++ b/src/renderer/atlas/AtlasEngine.api.cpp
@@ -623,11 +623,16 @@ void AtlasEngine::_resolveFontMetrics(const wchar_t* requestedFaceName, const Fo
         coordSize.X = cellWidth;
         coordSize.Y = cellHeight;
 
-        til::size coordSizeUnscaled;
-        coordSizeUnscaled.X = coordSize.X * USER_DEFAULT_SCREEN_DPI / _api.dpi;
-        coordSizeUnscaled.Y = coordSize.Y * USER_DEFAULT_SCREEN_DPI / _api.dpi;
+        if (requestedSize.X == 0)
+        {
+            // The coordSizeUnscaled parameter to SetFromEngine is used for API functions like GetConsoleFontSize.
+            // Since clients expect that settings the font height to Y yields back a font height of Y,
+            // we're scaling the X relative/proportional to the actual cellWidth/cellHeight ratio.
+            // The code below uses a poor form of integer rounding.
+            requestedSize.X = (requestedSize.Y * cellWidth + cellHeight / 2) / cellHeight;
+        }
 
-        fontInfo.SetFromEngine(requestedFaceName, requestedFamily, requestedWeight, false, coordSize, coordSizeUnscaled);
+        fontInfo.SetFromEngine(requestedFaceName, requestedFamily, requestedWeight, false, coordSize, requestedSize);
     }
 
     if (fontMetrics)


### PR DESCRIPTION
This commit fixes a bug causing the OpenConsole to get increasingly larger
every time the font is changed when the AtlasEngine is active.
The only impact this bug had on Windows Terminal is that the
`font-size` in HTML and RTF selection copies are too large.

## Validation Steps Performed
* OpenConsole window size doesn't change when
  switching between main and alt buffer ✅