### PR TITLE
Update tab hover colors

### DIFF
--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -1452,7 +1452,6 @@ namespace winrt::TerminalApp::implementation
             subtleFillColorTertiaryBrush.Color(subtleFillColorTertiary);
         }
 
-        hoverTabBrush.Color(TerminalApp::ColorHelper::GetAccentColor(color));
         selectedTabBrush.Color(color);
 
         // currently if a tab has a custom color, a deselected state is
@@ -1460,6 +1459,9 @@ namespace winrt::TerminalApp::implementation
         auto deselectedTabColor = color;
         deselectedTabColor.A = 64;
         deselectedTabBrush.Color(deselectedTabColor);
+
+        deselectedTabColor.A = 128;
+        hoverTabBrush.Color(deselectedTabColor);
 
         // currently if a tab has a custom color, a deselected state is
         // signified by using the same color with a bit of transparency

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -1456,16 +1456,12 @@ namespace winrt::TerminalApp::implementation
 
         // currently if a tab has a custom color, a deselected state is
         // signified by using the same color with a bit of transparency
-        auto deselectedTabColor = color;
-        deselectedTabColor.A = 64;
-        deselectedTabBrush.Color(deselectedTabColor);
+        deselectedTabBrush.Color(color);
+        deselectedTabBrush.Opacity(0.3);
 
-        deselectedTabColor.A = 128;
-        hoverTabBrush.Color(deselectedTabColor);
+        hoverTabBrush.Color(color);
+        hoverTabBrush.Opacity(0.6);
 
-        // currently if a tab has a custom color, a deselected state is
-        // signified by using the same color with a bit of transparency
-        //
         // Prior to MUX 2.7, we set TabViewItemHeaderBackground, but now we can
         // use TabViewItem().Background() for that. HOWEVER,
         // TabViewItem().Background() only sets the color of the tab background


### PR DESCRIPTION
The hover tab color used to be generated from the selected tab color, which would end up lighter or darker, and white-gray colors would end up pink.
It is now simply the selected tab color with 60% opacity. This is also how brushes are created for accent buttons and color buttons (although with different opacity levels).
