### PR TITLE
RelEng: Teach ServicingPipeline to infer the version if it's null

### DIFF
--- a/tools/ReleaseEngineering/ServicingPipeline.ps1
+++ b/tools/ReleaseEngineering/ServicingPipeline.ps1
@@ -61,6 +61,17 @@ Function Reject() {
     $Host.ExitNestedPrompt()
 }
 
+If ([String]::IsNullOrEmpty($Version)) {
+    $BranchVersionRegex = [Regex]"^release-(\d+(\.\d+)+)$"
+    $Branch = & git rev-parse --abbrev-ref HEAD
+    $Version = $BranchVersionRegex.Match($Branch).Groups[1].Value
+    If ([String]::IsNullOrEmpty($Version)) {
+        Write-Error "No version specified, and we can't infer it from the name of your branch ($Branch)."
+        Exit 1
+    }
+    Write-Host "Inferred servicing version $Version"
+}
+
 $Script:TodoColumnName = "To Cherry Pick"
 $Script:DoneColumnName = "Cherry Picked"
 $Script:RejectColumnName = "Rejected"


### PR DESCRIPTION
```
% .\tools\ReleaseEngineering\ServicingPipeline.ps1
Inferred servicing version 1.14
PICK f025c53dbab37a5a55ac23a51aba03e36467315f: Remove the fallback to wsl.exe when HKCU\...\Lxss doesn't exist (#13436)
 OK
```