### PR TITLE
Wrap the tooltips on the new tab button

### DIFF
--- a/src/cascadia/TerminalApp/TabRowControl.xaml
+++ b/src/cascadia/TerminalApp/TabRowControl.xaml
@@ -60,7 +60,8 @@
                                  FontSize="12">
                     <ToolTipService.ToolTip>
                         <ToolTip Placement="Mouse">
-                            <TextBlock IsTextSelectionEnabled="False">
+                            <TextBlock IsTextSelectionEnabled="False"
+                                       TextWrapping="Wrap">
                                 <Run x:Uid="NewTabRun" /> <LineBreak />
                                 <Run x:Uid="NewPaneRun"
                                      FontStyle="Italic" /> <LineBreak />


### PR DESCRIPTION
In non-en-us locales, these tooltips can get really long and get clipped.

As example: 
![image](https://user-images.githubusercontent.com/18356694/178035440-415befca-e0b6-47e3-a030-7a16ee5ae560.png)

Fixed version:
![image](https://user-images.githubusercontent.com/18356694/178035488-3dfdb7f7-aca4-4c19-a57c-38d1ff7e9d6c.png)

(yes, that's me just putting an egregious number of A's there for testing)

* Closes MSFT:39603031