### PR TITLE
Improve Launch MVVM

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -73,8 +73,8 @@
                                         x:Uid="Globals_DefaultTerminal"
                                         x:Load="false">
                     <ComboBox x:Name="DefaultTerminal"
-                              ItemsSource="{x:Bind ViewModel.Settings.DefaultTerminals}"
-                              SelectedItem="{x:Bind ViewModel.Settings.CurrentDefaultTerminal, Mode=TwoWay}"
+                              ItemsSource="{x:Bind ViewModel.DefaultTerminals}"
+                              SelectedItem="{x:Bind ViewModel.CurrentDefaultTerminal, Mode=TwoWay}"
                               Style="{StaticResource ComboBoxSettingStyle}">
                         <ComboBox.ItemTemplate>
                             <DataTemplate x:DataType="SettingsModel:DefaultTerminal">
@@ -137,7 +137,7 @@
 
                 <!--  Start on User Login  -->
                 <local:SettingContainer x:Uid="Globals_StartOnUserLogin">
-                    <ToggleSwitch IsOn="{x:Bind ViewModel.Settings.GlobalSettings.StartOnUserLogin, Mode=TwoWay}"
+                    <ToggleSwitch IsOn="{x:Bind ViewModel.StartOnUserLogin, Mode=TwoWay}"
                                   Style="{StaticResource ToggleSwitchInExpanderStyle}" />
                 </local:SettingContainer>
 
@@ -192,7 +192,7 @@
                                         Grid.Column="1"
                                         VerticalAlignment="Center"
                                         Style="{StaticResource LaunchSizeNumberBoxStyle}"
-                                        Value="{x:Bind ViewModel.Settings.GlobalSettings.InitialCols, Mode=TwoWay}" />
+                                        Value="{x:Bind ViewModel.InitialCols, Mode=TwoWay}" />
                         <TextBlock x:Uid="Globals_InitialRows"
                                    Grid.Row="1"
                                    Grid.Column="0"
@@ -203,7 +203,7 @@
                                         Grid.Column="1"
                                         VerticalAlignment="Center"
                                         Style="{StaticResource LaunchSizeNumberBoxStyle}"
-                                        Value="{x:Bind ViewModel.Settings.GlobalSettings.InitialRows, Mode=TwoWay}" />
+                                        Value="{x:Bind ViewModel.InitialRows, Mode=TwoWay}" />
                     </Grid>
                 </local:SettingContainer>
             </StackPanel>

--- a/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
@@ -37,11 +37,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _Settings.GlobalSettings().DefaultProfile(profile.Guid());
     }
 
-    winrt::Windows::Foundation::Collections::IObservableVector<winrt::Windows::Foundation::IInspectable> LaunchViewModel::DefaultProfiles() const
+    winrt::Windows::Foundation::Collections::IObservableVector<Model::Profile> LaunchViewModel::DefaultProfiles() const
     {
         const auto allProfiles = _Settings.AllProfiles();
 
-        std::vector<IInspectable> profiles;
+        std::vector<Model::Profile> profiles;
         profiles.reserve(allProfiles.Size());
 
         // Remove profiles from the selection which have been explicitly deleted.
@@ -69,18 +69,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _Settings.CurrentDefaultTerminal(defaultTerminal);
     }
 
-    winrt::Windows::Foundation::Collections::IObservableVector<winrt::Windows::Foundation::IInspectable> LaunchViewModel::DefaultTerminals() const
+    winrt::Windows::Foundation::Collections::IObservableVector<Model::DefaultTerminal> LaunchViewModel::DefaultTerminals() const
     {
-        const auto allTerminals = _Settings.DefaultTerminals();
-
-        std::vector<IInspectable> terminals;
-        terminals.reserve(allTerminals.Size());
-
-        for (const auto& terminal : allTerminals)
-        {
-            terminals.emplace_back(terminal);
-        }
-
-        return winrt::single_threaded_observable_vector(std::move(terminals));
+        return _Settings.DefaultTerminals();
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
@@ -25,11 +25,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         INITIALIZE_BINDABLE_ENUM_SETTING(WindowingBehavior, WindowingMode, WindowingMode, L"Globals_WindowingBehavior", L"Content");
     }
 
-    Model::CascadiaSettings LaunchViewModel::Settings() const
-    {
-        return _Settings;
-    }
-
     winrt::Windows::Foundation::IInspectable LaunchViewModel::CurrentDefaultProfile()
     {
         const auto defaultProfileGuid{ _Settings.GlobalSettings().DefaultProfile() };
@@ -61,5 +56,31 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
 
         return winrt::single_threaded_observable_vector(std::move(profiles));
+    }
+
+    winrt::Windows::Foundation::IInspectable LaunchViewModel::CurrentDefaultTerminal()
+    {
+        return winrt::box_value(_Settings.CurrentDefaultTerminal());
+    }
+
+    void LaunchViewModel::CurrentDefaultTerminal(const IInspectable& value)
+    {
+        const auto defaultTerminal{ winrt::unbox_value<Model::DefaultTerminal>(value) };
+        _Settings.CurrentDefaultTerminal(defaultTerminal);
+    }
+
+    winrt::Windows::Foundation::Collections::IObservableVector<winrt::Windows::Foundation::IInspectable> LaunchViewModel::DefaultTerminals() const
+    {
+        const auto allTerminals = _Settings.DefaultTerminals();
+
+        std::vector<IInspectable> terminals;
+        terminals.reserve(allTerminals.Size());
+
+        for (const auto& terminal : allTerminals)
+        {
+            terminals.emplace_back(terminal);
+        }
+
+        return winrt::single_threaded_observable_vector(std::move(terminals));
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/LaunchViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/LaunchViewModel.h
@@ -16,11 +16,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         IInspectable CurrentDefaultProfile();
         void CurrentDefaultProfile(const IInspectable& value);
-        winrt::Windows::Foundation::Collections::IObservableVector<IInspectable> DefaultProfiles() const;
+        winrt::Windows::Foundation::Collections::IObservableVector<Model::Profile> DefaultProfiles() const;
 
         IInspectable CurrentDefaultTerminal();
         void CurrentDefaultTerminal(const IInspectable& value);
-        winrt::Windows::Foundation::Collections::IObservableVector<IInspectable> DefaultTerminals() const;
+        winrt::Windows::Foundation::Collections::IObservableVector<Model::DefaultTerminal> DefaultTerminals() const;
 
         GETSET_BINDABLE_ENUM_SETTING(FirstWindowPreference, Model::FirstWindowPreference, _Settings.GlobalSettings().FirstWindowPreference);
         GETSET_BINDABLE_ENUM_SETTING(LaunchMode, Model::LaunchMode, _Settings.GlobalSettings().LaunchMode);

--- a/src/cascadia/TerminalSettingsEditor/LaunchViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/LaunchViewModel.h
@@ -13,15 +13,22 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
     public:
         LaunchViewModel(Model::CascadiaSettings settings);
-        Model::CascadiaSettings Settings() const;
 
         IInspectable CurrentDefaultProfile();
         void CurrentDefaultProfile(const IInspectable& value);
         winrt::Windows::Foundation::Collections::IObservableVector<IInspectable> DefaultProfiles() const;
 
+        IInspectable CurrentDefaultTerminal();
+        void CurrentDefaultTerminal(const IInspectable& value);
+        winrt::Windows::Foundation::Collections::IObservableVector<IInspectable> DefaultTerminals() const;
+
         GETSET_BINDABLE_ENUM_SETTING(FirstWindowPreference, Model::FirstWindowPreference, _Settings.GlobalSettings().FirstWindowPreference);
         GETSET_BINDABLE_ENUM_SETTING(LaunchMode, Model::LaunchMode, _Settings.GlobalSettings().LaunchMode);
         GETSET_BINDABLE_ENUM_SETTING(WindowingBehavior, Model::WindowingMode, _Settings.GlobalSettings().WindowingBehavior);
+
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_Settings.GlobalSettings(), StartOnUserLogin);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_Settings.GlobalSettings(), InitialRows);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_Settings.GlobalSettings(), InitialCols);
 
     private:
         Model::CascadiaSettings _Settings;

--- a/src/cascadia/TerminalSettingsEditor/LaunchViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/LaunchViewModel.idl
@@ -3,17 +3,21 @@
 
 import "EnumEntry.idl";
 
+#include "ViewModelHelpers.idl.h"
+
 namespace Microsoft.Terminal.Settings.Editor
 {
     runtimeclass LaunchViewModel : Windows.UI.Xaml.Data.INotifyPropertyChanged
     {
         LaunchViewModel(Microsoft.Terminal.Settings.Model.CascadiaSettings settings);
-        Microsoft.Terminal.Settings.Model.CascadiaSettings Settings { get; };
 
         IInspectable CurrentDefaultProfile;
         // I wish this was a IObservableVector<Microsoft.Terminal.Settings.Model.Profile>, but:
         //   https://github.com/microsoft/microsoft-ui-xaml/issues/5395
         IObservableVector<IInspectable> DefaultProfiles { get; };
+
+        IInspectable CurrentDefaultTerminal;
+        IObservableVector<IInspectable> DefaultTerminals { get; };
 
         IInspectable CurrentFirstWindowPreference;
         IObservableVector<Microsoft.Terminal.Settings.Editor.EnumEntry> FirstWindowPreferenceList { get; };
@@ -23,5 +27,9 @@ namespace Microsoft.Terminal.Settings.Editor
 
         IInspectable CurrentWindowingBehavior;
         IObservableVector<Microsoft.Terminal.Settings.Editor.EnumEntry> WindowingBehaviorList { get; };
+
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, StartOnUserLogin);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Int32, InitialRows);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Int32, InitialCols);
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/LaunchViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/LaunchViewModel.idl
@@ -12,12 +12,10 @@ namespace Microsoft.Terminal.Settings.Editor
         LaunchViewModel(Microsoft.Terminal.Settings.Model.CascadiaSettings settings);
 
         IInspectable CurrentDefaultProfile;
-        // I wish this was a IObservableVector<Microsoft.Terminal.Settings.Model.Profile>, but:
-        //   https://github.com/microsoft/microsoft-ui-xaml/issues/5395
-        IObservableVector<IInspectable> DefaultProfiles { get; };
+        IObservableVector<Microsoft.Terminal.Settings.Model.Profile> DefaultProfiles { get; };
 
         IInspectable CurrentDefaultTerminal;
-        IObservableVector<IInspectable> DefaultTerminals { get; };
+        IObservableVector<Microsoft.Terminal.Settings.Model.DefaultTerminal> DefaultTerminals { get; };
 
         IInspectable CurrentFirstWindowPreference;
         IObservableVector<Microsoft.Terminal.Settings.Editor.EnumEntry> FirstWindowPreferenceList { get; };


### PR DESCRIPTION
## Summary of the Pull Request
The xaml file no longer directly accesses the settings model object, and the settings model object is no longer exposed on the view model

## References
#13377 

## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed
Still works