### PR TITLE
Add line breaks in the debug tap output

### DIFF
--- a/src/cascadia/TerminalApp/DebugTapConnection.cpp
+++ b/src/cascadia/TerminalApp/DebugTapConnection.cpp
@@ -111,7 +111,15 @@ namespace winrt::Microsoft::TerminalApp::implementation
 
     void DebugTapConnection::_OutputHandler(const hstring str)
     {
-        _TerminalOutputHandlers(til::visualize_control_codes(str));
+        auto output = til::visualize_control_codes(str);
+        // To make the output easier to read, we introduce a line break whenever
+        // an LF control is encountered. But at this point, the LF would have
+        // been converted to U+240A (␊), so that's what we need to search for.
+        for (size_t lfPos = 0; (lfPos = output.find(L'\u240A', lfPos)) != std::wstring::npos;)
+        {
+            output.insert(++lfPos, L"\r\n");
+        }
+        _TerminalOutputHandlers(output);
     }
 
     // Called by the DebugInputTapConnection to print user input


### PR DESCRIPTION
## Summary of the Pull Request

When the debug tap converts control characters into visible glyphs, it
ends up losing the structure of the output, and that can sometimes make
things difficult to read. This PR attempts to alleviate that problem by
reinjecting an actual line break in the debug stream whenever an `LF`
control is received.

## PR Checklist
* [x] Closes #12312
* [x] CLA signed.
* [ ] Tests added/passed
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] I've discussed this with core contributors already. Issue number
where discussion took place: #12312

## Validation Steps Performed

I've tested the updated debug tab with a number of different shells, and
also a couple of different apps. When there aren't many linefeeds in the
output, it's obviously not going to make much of a difference, but when
there are, I think it definitely improves the readability.