### PR TITLE
AtlasEngine: Improve glyph generation performance

### DIFF
--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -929,8 +929,7 @@ void AtlasEngine::_recreateFontDependentResources()
     {
         // We're likely resizing the atlas anyways and can
         // thus also release any of these buffers prematurely.
-        _r.d2dRenderTarget.reset(); // depends on _r.atlasScratchpad
-        _r.atlasScratchpad.reset();
+        _r.d2dRenderTarget.reset(); // depends on _r.atlasBuffer
         _r.atlasView.reset();
         _r.atlasBuffer.reset();
     }
@@ -970,8 +969,6 @@ void AtlasEngine::_recreateFontDependentResources()
         _r.strikethroughPos = _api.fontMetrics.strikethroughPos;
         _r.lineThickness = _api.fontMetrics.lineThickness;
         _r.dpi = _api.dpi;
-        _r.maxEncounteredCellCount = 0;
-        _r.scratchpadCellWidth = 0;
     }
     {
         // See AtlasEngine::UpdateFont.
@@ -1446,7 +1443,6 @@ void AtlasEngine::_emplaceGlyph(IDWriteFontFace* fontFace, size_t bufferPos1, si
         const auto it = _r.glyphs.insert(std::move(key), std::move(value));
         valueRef = &it->second;
         _r.glyphQueue.emplace_back(&it->first, &it->second);
-        _r.maxEncounteredCellCount = std::max(_r.maxEncounteredCellCount, cellCount);
     }
 
     // For some reason MSVC doesn't understand that valueRef is overwritten in the branch above, resulting in:

--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -857,11 +857,9 @@ namespace Microsoft::Console::Render
         void _setShaderResources() const;
         void _updateConstantBuffer() const noexcept;
         void _adjustAtlasSize();
-        void _reserveScratchpadSize(u16 minWidth);
         void _processGlyphQueue();
         void _drawGlyph(const AtlasQueueItem& item) const;
         void _drawCursor();
-        void _copyScratchpadTile(uint32_t scratchpadIndex, u16x2 target, uint32_t copyFlags = 0) const noexcept;
 
         static constexpr bool debugGlyphGenerationPerformance = false;
         static constexpr bool debugGeneralPerformance = false || debugGlyphGenerationPerformance;
@@ -906,7 +904,6 @@ namespace Microsoft::Console::Render
             // D2D resources
             wil::com_ptr<ID3D11Texture2D> atlasBuffer;
             wil::com_ptr<ID3D11ShaderResourceView> atlasView;
-            wil::com_ptr<ID3D11Texture2D> atlasScratchpad;
             wil::com_ptr<ID2D1RenderTarget> d2dRenderTarget;
             wil::com_ptr<ID2D1Brush> brush;
             wil::com_ptr<IDWriteTextFormat> textFormats[2][2];
@@ -921,8 +918,6 @@ namespace Microsoft::Console::Render
             u16 strikethroughPos = 0;
             u16 lineThickness = 0;
             u16 dpi = USER_DEFAULT_SCREEN_DPI; // invalidated by ApiInvalidations::Font, caches _api.dpi
-            u16 maxEncounteredCellCount = 0;
-            u16 scratchpadCellWidth = 0;
             u16x2 atlasSizeInPixel; // invalidated by ApiInvalidations::Font
             TileHashMap glyphs;
             TileAllocator tileAllocator;


### PR DESCRIPTION
#13458 added the ability to reuse tiles from our glyph atlas texture
so that we stop running out of GPU memory for complex Unicode.
This however can result in our glyph generation being a performance issue in
edge cases, to the point that the application may feel outright unuseable.

CJK glyphs for instance can easily exceed the maximum atlas texture size
(twice the window size), but take a significant amount of CPU and GPU time to
rasterize and draw, which results in "jelly scrolling" down to ~1 FPS.
This PR improves the situation of the latter half by directly drawing
glyphs into the texture atlas without an intermediate scratchpad texture.

This reduces GPU usage by 96% on my system (33% -> 2%) which improves general
render performance by ~100% (15 -> 30 FPS). CPU usage remains the same however,
but that's not really something we can do anything about at this time.
The atlas texture is already our primary means to reduce the CPU cost after all.

## Validation Steps Performed
* Disable V-Sync for OpenConsole in NVIDIA Control Panel
* Enable `debugGlyphGenerationPerformance`
* Print the entire CJK block U+4E00..U+9FFF
* Measure the above GPU usage and FPS improvements ✅
  (Alternatively: Just scroll around and judge the "jellyness".)