### PR TITLE
Send focus events even in ReadOnly mode

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1912,23 +1912,24 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - This is related to work done for GH#2988.
     void ControlCore::GotFocus()
     {
-        // GH#13461 - temporarily turn off read-only mode, send the focus event,
-        // then turn it back on. Even in focus mode, focus events are fine to
-        // send. We don't want to pop a warning every time the control is
-        // focused.
-        const auto tmp = _isReadOnly;
-        _isReadOnly = false;
-        _terminal->FocusChanged(true);
-        _isReadOnly = tmp;
+        _focusChanged(true);
     }
 
     // See GotFocus.
     void ControlCore::LostFocus()
     {
-        const auto tmp = _isReadOnly;
-        _isReadOnly = false;
-        _terminal->FocusChanged(false);
-        _isReadOnly = tmp;
+        _focusChanged(false);
+    }
+
+    void ControlCore::_focusChanged(bool focused)
+    {
+        // GH#13461 - temporarily turn off read-only mode, send the focus event,
+        // then turn it back on. Even in focus mode, focus events are fine to
+        // send. We don't want to pop a warning every time the control is
+        // focused.
+        const auto previous = std::exchange(_isReadOnly, false);
+        const auto restore = wil::scope_exit([&]() { _isReadOnly = tmp; });
+        _terminal->FocusChanged(focused);
     }
 
     bool ControlCore::_isBackgroundTransparent()

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1912,13 +1912,23 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - This is related to work done for GH#2988.
     void ControlCore::GotFocus()
     {
+        // GH#13461 - temporarily turn off read-only mode, send the focus event,
+        // then turn it back on. Even in focus mode, focus events are fine to
+        // send. We don't want to pop a warning every time the control is
+        // focused.
+        const auto tmp = _isReadOnly;
+        _isReadOnly = false;
         _terminal->FocusChanged(true);
+        _isReadOnly = tmp;
     }
 
     // See GotFocus.
     void ControlCore::LostFocus()
     {
+        const auto tmp = _isReadOnly;
+        _isReadOnly = false;
         _terminal->FocusChanged(false);
+        _isReadOnly = tmp;
     }
 
     bool ControlCore::_isBackgroundTransparent()

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1928,7 +1928,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // send. We don't want to pop a warning every time the control is
         // focused.
         const auto previous = std::exchange(_isReadOnly, false);
-        const auto restore = wil::scope_exit([&]() { _isReadOnly = tmp; });
+        const auto restore = wil::scope_exit([&]() { _isReadOnly = previous; });
         _terminal->FocusChanged(focused);
     }
 

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -311,6 +311,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void _setOpacity(const double opacity);
 
         bool _isBackgroundTransparent();
+        void _focusChanged(bool focused);
 
         inline bool _IsClosing() const noexcept
         {


### PR DESCRIPTION
Does what it says on the tin. When we get focused, temporarily turn off readonly mode, as to not pop the dialog when the focus sequence is eventually sent to the connection. 

* closes #13461 