### PR TITLE
Fix a bad null deref

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4100,9 +4100,9 @@ namespace winrt::TerminalApp::implementation
 
             TitlebarBrush(acrylicBrush);
         }
-        else if (const auto tabRowBg{ _activated ? theme.TabRow().Background() :
-                                                   theme.TabRow().UnfocusedBackground() };
-                 tabRowBg != nullptr && theme.TabRow() != nullptr)
+        else if (auto tabRowBg{ theme.TabRow() ? (_activated ? theme.TabRow().Background() :
+                                                               theme.TabRow().UnfocusedBackground()) :
+                                                 ThemeColor{ nullptr } })
         {
             const auto terminalBrush = [this]() -> Media::Brush {
                 if (const auto& control{ _GetActiveControl() })


### PR DESCRIPTION
Yep this is my bad. I was trying to fix a bug where only having one of `background` or `unfocusedBackground` would cause the other to never get set to the default. In attempting to force all the logic into an if statement, I messed up the order of operations. My bad 😢 

Regressed in #13456 