### PR TITLE
Make cmd palette 'go back' button return to previously selected action

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -525,9 +525,9 @@ namespace winrt::TerminalApp::implementation
     }
 
     // Method Description:
-    // This event is called when the user clicks on an ChevronLeft button right
+    // This event is called when the user clicks on a ChevronLeft button right
     // next to the ParentCommandName (e.g. New Tab...) above the subcommands list.
-    // It'll go up a level when the users click the button.
+    // It'll go up a single level when the user clicks the button.
     // Arguments:
     // - sender: the button that got clicked
     // Return Value:
@@ -536,12 +536,38 @@ namespace winrt::TerminalApp::implementation
                                                 const Windows::UI::Xaml::RoutedEventArgs&)
     {
         _PreviewActionHandlers(*this, nullptr);
-        _nestedActionStack.Clear();
-        ParentCommandName(L"");
         _currentNestedCommands.Clear();
         _searchBox().Focus(FocusState::Programmatic);
+
+        const auto previousAction{ _nestedActionStack.GetAt(_nestedActionStack.Size() - 1) };
+        _nestedActionStack.RemoveAtEnd();
+
+        // Repopulate nested commands when the root has not been reached yet
+        if (_nestedActionStack.Size() > 0)
+        {
+            const auto newPreviousAction{ _nestedActionStack.GetAt(_nestedActionStack.Size() - 1) };
+            const auto actionPaletteItem{ newPreviousAction.Item().try_as<winrt::TerminalApp::ActionPaletteItem>() };
+
+            ParentCommandName(actionPaletteItem.Command().Name());
+            for (const auto& nameAndCommand : actionPaletteItem.Command().NestedCommands())
+            {
+                const auto action = nameAndCommand.Value();
+                auto nestedActionPaletteItem{ winrt::make<winrt::TerminalApp::implementation::ActionPaletteItem>(action) };
+                auto nestedFilteredCommand{ winrt::make<FilteredCommand>(nestedActionPaletteItem) };
+                _currentNestedCommands.Append(nestedFilteredCommand);
+            }
+        }
+        else
+        {
+            ParentCommandName(L"");
+        }
         _updateFilteredActions();
-        _filteredActionsView().SelectedIndex(0);
+
+        const auto lastSelectedIt = std::find_if(begin(_filteredActions), end(_filteredActions), [&](const auto& filteredCommand) {
+            return filteredCommand.Item().Name() == previousAction.Item().Name();
+        });
+        const auto lastSelectedIndex = static_cast<int32_t>(std::distance(begin(_filteredActions), lastSelectedIt));
+        _scrollToIndex(lastSelectedIt != end(_filteredActions) ? lastSelectedIndex : 0);
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -96,6 +96,8 @@ namespace winrt::TerminalApp::implementation
 
         void _updateFilteredActions();
 
+        void _updateCurrentNestedCommands(const winrt::Microsoft::Terminal::Settings::Model::Command& parentCommand);
+
         std::vector<winrt::TerminalApp::FilteredCommand> _collectFilteredActions();
 
         void _close();


### PR DESCRIPTION
The behaviour of the 'go back' button in the command palette was changed to return to the previously selected element rather than the root.

Instead of returning to the root, the go back button now returns to the previously selected item in the filtered action list. The previously selected item is selected by default and the view is scoped to the item.

## Validation Steps Performed
Manually tested by going back and forth between nested actions in the command palette.

Closes #13457