### PR TITLE
Fix bad code in fuzzing_directed.h

### DIFF
--- a/src/terminal/parser/ft_fuzzer/fuzzing_directed.h
+++ b/src/terminal/parser/ft_fuzzer/fuzzing_directed.h
@@ -962,7 +962,7 @@ namespace fuzz
         __inline virtual _Type** operator&() throw()
         {
             m_ftEffectiveTraits |= TRAIT_TRANSFER_ALLOCATION;
-            return (this->m_fFuzzed) ? &(this->m_t) : &CFuzzType<_Type, _Args...>::m_tInit;
+            return (this->m_fFuzzed) ? &(this->m_t) : &(this->m_tInit);
         }
 
     private:


### PR DESCRIPTION
2b202ce6 changed this code to fix 2-phase name lookup, but accidentally
changed `&m_tInit` to `&CFuzzType::m_tInit` (pointer-to-member¹)
instead of `&this->m_tInit` (a regular pointer to some value).
This should not be confused with `&(CFuzzType::m_tInit)`
of course which is _not_ a pointer-to-member.

¹ To simplify things, a pointer-to-member is basically the byte offset of a
member within a struct. For instance given `struct T { char a, b, c, d; }` then
`&T::c` would commonly "store" the value 2, equivalent to `offsetof(T, c)`.

Closes #13501