### PR TITLE
Make ToolsVersion more consistent in our project files

### DIFF
--- a/build/pgo/Terminal.PGO.DB.nuspec
+++ b/build/pgo/Terminal.PGO.DB.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Microsoft.Internal.Windows.Terminal.PGODatabase</id>

--- a/build/rules/Branding.targets
+++ b/build/rules/Branding.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <_WTBrandingPreprocessorToken Condition="'$(WindowsTerminalBranding)'=='Preview'">WT_BRANDING_PREVIEW</_WTBrandingPreprocessorToken>
     <_WTBrandingPreprocessorToken Condition="'$(WindowsTerminalBranding)'=='Release'">WT_BRANDING_RELEASE</_WTBrandingPreprocessorToken>

--- a/build/rules/CollectWildcardResources.targets
+++ b/build/rules/CollectWildcardResources.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
   </PropertyGroup>
 

--- a/build/rules/GenerateFeatureFlags.proj
+++ b/build/rules/GenerateFeatureFlags.proj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- THIS PROJECT CANNOT BE LOADED INTO THE SOLUTION. -->
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
 

--- a/build/rules/GenerateSxsManifestsFromWinmds.targets
+++ b/build/rules/GenerateSxsManifestsFromWinmds.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BeforeLinkTargets Condition="'$(WindowsTargetPlatformVersion)' &gt;= '10.0.18362.0'">
       $(BeforeLinkTargets);

--- a/common.openconsole.props
+++ b/common.openconsole.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!--
   This props file is a workaround for the fact that for wapproj projects,

--- a/custom.props
+++ b/custom.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- This file is read by XES, which we use in our Release builds. -->
   <PropertyGroup Label="Version">
     <!--

--- a/doc/feature_flags.md
+++ b/doc/feature_flags.md
@@ -5,7 +5,7 @@ Feature flags are controlled by an XML document stored at `src/features.xml`.
 ## Example Document
 
 ```xml
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <featureStaging xmlns="http://microsoft.com/TilFeatureStaging-Schema.xsd">
     <feature>
         <!-- This will produce Feature_XYZ::IsEnabled() and TIL_FEATURE_XYZ_ENABLED (preprocessor) -->

--- a/samples/ConPTY/EchoCon/EchoCon/EchoCon.vcxproj
+++ b/samples/ConPTY/EchoCon/EchoCon/EchoCon.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>

--- a/samples/ConPTY/GUIConsole/GUIConsole.WPF/GUIConsole.WPF.csproj
+++ b/samples/ConPTY/GUIConsole/GUIConsole.WPF/GUIConsole.WPF.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/samples/ConPTY/MiniTerm/MiniTerm/MiniTerm.csproj
+++ b/samples/ConPTY/MiniTerm/MiniTerm/MiniTerm.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/scratch/ScratchIslandApp/Package/Package.wapproj
+++ b/scratch/ScratchIslandApp/Package/Package.wapproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
   <Import Project="$(OpenConsoleDir)src\wap-common.build.pre.props" />
   <PropertyGroup Label="Configuration">

--- a/scratch/ScratchIslandApp/SampleApp/SampleAppLib.vcxproj
+++ b/scratch/ScratchIslandApp/SampleApp/SampleAppLib.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{a4394404-37f7-41c1-802b-49788d3720e3}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/scratch/ScratchIslandApp/SampleApp/dll/SampleApp.vcxproj
+++ b/scratch/ScratchIslandApp/SampleApp/dll/SampleApp.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{26c51792-41a3-4fe0-ab5e-8b69d557bf91}</ProjectGuid>
     <ProjectName>SampleApp</ProjectName>

--- a/scratch/ScratchIslandApp/WindowExe/WindowExe.vcxproj
+++ b/scratch/ScratchIslandApp/WindowExe/WindowExe.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.props" Condition="Exists('..\..\..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.props')" />
 
   <PropertyGroup Label="Globals">

--- a/src/StaticAnalysis.ruleset
+++ b/src/StaticAnalysis.ruleset
@@ -1,20 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Console Rules" Description="These rules enforce static analysis on console code." ToolsVersion="15.0">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Console Rules" Description="These rules enforce static analysis on console code." ToolsVersion="17.0">
 
   <Include Path="cppcorecheckrules.ruleset" Action="Error" />
 
-  <Rules AnalyzerId="Microsoft.Analyzers.NativeCodeAnalysis" RuleNamespace="Microsoft.Rules.Native">	
-    <Rule Id="C6001" Action="Error" />	
-    <Rule Id="C6011" Action="Error" />	
+  <Rules AnalyzerId="Microsoft.Analyzers.NativeCodeAnalysis" RuleNamespace="Microsoft.Rules.Native">
+    <Rule Id="C6001" Action="Error" />
+    <Rule Id="C6011" Action="Error" />
     <!-- We can't do dynamic cast because RTTI is off. -->
     <!-- RTTI is off because Windows OS policies believe RTTI has too much binary size impact for the value and is less portable than RTTI-off modules. -->
     <Rule Id="C26466" Action="None" />
     <!-- This one has caught us off guard as it suddenly showed up. Re-enablement is going to be in #2941 -->
     <Rule Id="C26814" Action="None" />
-
     <!-- There are *so many* enums that should be enum classes. -->
     <Rule Id="C26812" Action="None" />
   </Rules>
-  
 
 </RuleSet>

--- a/src/audio/midi/lib/midi.vcxproj
+++ b/src/audio/midi/lib/midi.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{3c67784e-1453-49c2-9660-483e2cc7f7ad}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/buffer/out/lib/bufferout.vcxproj
+++ b/src/buffer/out/lib/bufferout.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{0CF235BD-2DA0-407E-90EE-C467E8BBC714}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/buffer/out/ut_textbuffer/TextBuffer.Unit.Tests.vcxproj
+++ b/src/buffer/out/ut_textbuffer/TextBuffer.Unit.Tests.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{531C23E7-4B76-4C08-8BBD-04164CB628C9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
+++ b/src/cascadia/CascadiaPackage/CascadiaPackage.wapproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
   <Import Project="$(OpenConsoleDir)src\wap-common.build.pre.props" />
   <PropertyGroup Label="Configuration">

--- a/src/cascadia/CascadiaResources.build.items
+++ b/src/cascadia/CascadiaResources.build.items
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="16.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <!-- License Info -->
     <Content Include="$(OpenConsoleDir)src\cascadia\CascadiaPackage\NOTICE.html">

--- a/src/cascadia/ElevateShim/elevate-shim.vcxproj
+++ b/src/cascadia/ElevateShim/elevate-shim.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{416fd703-baa7-4f6e-9361-64f550ec8fca}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/cascadia/LocalTests_SettingsModel/SettingsModel.LocalTests.vcxproj
+++ b/src/cascadia/LocalTests_SettingsModel/SettingsModel.LocalTests.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- A note about this project: We're building the test code dll from this
     project, but it _MUST_ be run in conjunction with the TestHostApp project.

--- a/src/cascadia/LocalTests_TerminalApp/TerminalApp.LocalTests.vcxproj
+++ b/src/cascadia/LocalTests_TerminalApp/TerminalApp.LocalTests.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- A note about this project: We're building the test code dll from this
     project, but it _MUST_ be run in conjunction with the TestHostApp project.

--- a/src/cascadia/LocalTests_TerminalApp/TestHostApp/TestHostApp.vcxproj
+++ b/src/cascadia/LocalTests_TerminalApp/TestHostApp/TestHostApp.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A021EDFF-45C8-4DC2-BEF7-36E1B3B8CFE8}</ProjectGuid>
     <ProjectName>TestHostApp</ProjectName>

--- a/src/cascadia/Remoting/Microsoft.Terminal.RemotingLib.vcxproj
+++ b/src/cascadia/Remoting/Microsoft.Terminal.RemotingLib.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{43ce4ce5-0010-4b99-9569-672670d26e26}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/cascadia/Remoting/dll/Microsoft.Terminal.Remoting.vcxproj
+++ b/src/cascadia/Remoting/dll/Microsoft.Terminal.Remoting.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{27b5aaeb-a548-44cf-9777-f8baa32af7ae}</ProjectGuid>
     <ProjectName>Microsoft.Terminal.Remoting</ProjectName>

--- a/src/cascadia/ShellExtension/WindowsTerminalShellExt.vcxproj
+++ b/src/cascadia/ShellExtension/WindowsTerminalShellExt.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{f2ed628a-db22-446f-a081-4cc845b51a2b}</ProjectGuid>
     <ProjectName>WindowsTerminalShellExt</ProjectName>

--- a/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CA5CAD1A-9A12-429C-B551-8562EC954746}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/cascadia/TerminalApp/dll/TerminalApp.vcxproj
+++ b/src/cascadia/TerminalApp/dll/TerminalApp.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CA5CAD1A-44BD-4AC7-AC72-F16E576FDD12}</ProjectGuid>
     <ProjectName>TerminalApp</ProjectName>

--- a/src/cascadia/TerminalAzBridge/TerminalAzBridge.vcxproj
+++ b/src/cascadia/TerminalAzBridge/TerminalAzBridge.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Label="Globals">
     <ProjectGuid>{067F0A06-FCB7-472C-96E9-B03B54E8E18D}</ProjectGuid>

--- a/src/cascadia/TerminalConnection/TerminalConnection.vcxproj
+++ b/src/cascadia/TerminalConnection/TerminalConnection.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CA5CAD1A-C46D-4588-B1C0-40F31AE9100B}</ProjectGuid>
     <ProjectName>TerminalConnection</ProjectName>

--- a/src/cascadia/TerminalConnection/TerminalConnection.vcxproj.filters
+++ b/src/cascadia/TerminalConnection/TerminalConnection.vcxproj.filters
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Resources">
       <UniqueIdentifier>accd3aa8-1ba0-4223-9bbe-0c431709210b</UniqueIdentifier>

--- a/src/cascadia/TerminalControl/TerminalControlLib.vcxproj
+++ b/src/cascadia/TerminalControl/TerminalControlLib.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CA5CAD1A-44BD-4AC7-AC72-6CA5B3AB89ED}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/cascadia/TerminalControl/dll/TerminalControl.vcxproj
+++ b/src/cascadia/TerminalControl/dll/TerminalControl.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CA5CAD1A-F542-4635-A069-7CAEFB930070}</ProjectGuid>
     <ProjectName>Microsoft.Terminal.Control</ProjectName>

--- a/src/cascadia/TerminalCore/lib/terminalcore-lib.vcxproj
+++ b/src/cascadia/TerminalCore/lib/terminalcore-lib.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CA5CAD1A-ABCD-429C-B551-8562EC954746}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/cascadia/TerminalCore/terminalcore-common.vcxitems
+++ b/src/cascadia/TerminalCore/terminalcore-common.vcxitems
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup>
     <ClCompile Include="..\TerminalRenderData.cpp" />

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
     We're explicitly telling our references to be non-private so that they won't
     be copied into our folder. In the case of Microsoft.Ui.Xaml, it seems to copy

--- a/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj
+++ b/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0"
-  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CA5CAD1A-d7ec-4107-b7c6-79cb77ae2907}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/cascadia/TerminalSettingsModel/dll/Microsoft.Terminal.Settings.Model.vcxproj
+++ b/src/cascadia/TerminalSettingsModel/dll/Microsoft.Terminal.Settings.Model.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CA5CAD1A-082C-4476-9F33-94B339494076}</ProjectGuid>
     <ProjectName>Microsoft.Terminal.Settings.Model</ProjectName>

--- a/src/cascadia/UnitTests_Control/Control.UnitTests.vcxproj
+++ b/src/cascadia/UnitTests_Control/Control.UnitTests.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{C323DAEE-B307-4C7B-ACE5-7293CBEFCB5B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/cascadia/UnitTests_Remoting/Remoting.UnitTests.vcxproj
+++ b/src/cascadia/UnitTests_Remoting/Remoting.UnitTests.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- A note about this project: We're building the test code dll from this
     project, but it _MUST_ be run in conjunction with the TestHostApp project.

--- a/src/cascadia/UnitTests_TerminalCore/UnitTests.vcxproj
+++ b/src/cascadia/UnitTests_TerminalCore/UnitTests.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{2C2BEEF4-9333-4D05-B12A-1905CBF112F9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/cascadia/WinRTUtils/WinRTUtils.vcxproj
+++ b/src/cascadia/WinRTUtils/WinRTUtils.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CA5CAD1A-039A-4929-BA2A-8BEB2E4106FE}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
+++ b/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CA5CAD1A-1754-4A9D-93D7-857A9D17CB1B}</ProjectGuid>

--- a/src/cascadia/WindowsTerminal_UIATests/WindowsTerminal.UIA.Tests.csproj
+++ b/src/cascadia/WindowsTerminal_UIATests/WindowsTerminal.UIA.Tests.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{F19DACD5-0C6E-40DC-B6E4-767A3200542C}</ProjectGuid>
     <OutputType>Library</OutputType>

--- a/src/cascadia/ut_app/TerminalApp.UnitTests.vcxproj
+++ b/src/cascadia/ut_app/TerminalApp.UnitTests.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{CA5CAD1A-9333-4D05-B12A-1905CBF112F9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/cascadia/wt/wt.vcxproj
+++ b/src/cascadia/wt/wt.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{506fd703-baa7-4f6e-9361-64f550ec8fca}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/common.build.post.props
+++ b/src/common.build.post.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Natvis Include="$(SolutionDir)tools\ConsoleTypes.natvis" />
   </ItemGroup>

--- a/src/common.build.pre.props
+++ b/src/common.build.pre.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- By default, binplace our output under the bin/ directory in the root of
        the project. -->
   <PropertyGroup>

--- a/src/common.build.tests.props
+++ b/src/common.build.tests.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>INLINE_TEST_METHOD_MARKUP;UNIT_TESTING;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/common.nugetversions.props
+++ b/src/common.nugetversions.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- PGO -->
   <Import Condition="'$(PgoTarget)' == 'true' And '$(Platform)'=='x64' And '$(PGOBuildMode)'!='' And Exists('$(SolutionDir)\build\PGO\Terminal.PGO.props')" Project="$(SolutionDir)\build\PGO\Terminal.PGO.props" />
 
@@ -18,25 +18,25 @@
   <PropertyGroup>
     <AppiumWebDriverPathRoot>$(MSBuildThisFileDirectory)..\packages\Appium.WebDriver.3.0.0.2</AppiumWebDriverPathRoot>
   </PropertyGroup>
-  
+
   <!-- CastleCore -->
   <PropertyGroup>
     <CastleCorePathRoot>$(MSBuildThisFileDirectory)..\packages\Castle.Core.4.1.1</CastleCorePathRoot>
   </PropertyGroup>
-  
+
   <!-- NewtonsoftJSON -->
   <PropertyGroup>
     <NewtonsoftJSONPathRoot>$(MSBuildThisFileDirectory)..\packages\Newtonsoft.Json.13.0.1</NewtonsoftJSONPathRoot>
   </PropertyGroup>
-  
+
   <!-- SeleniumWebDriver -->
   <PropertyGroup>
     <SeleniumWebDriverPathRoot>$(MSBuildThisFileDirectory)..\packages\Selenium.WebDriver.3.5.0</SeleniumWebDriverPathRoot>
   </PropertyGroup>
-  
+
   <!-- SeleniumSupport -->
   <PropertyGroup>
     <SeleniumSupportPathRoot>$(MSBuildThisFileDirectory)..\packages\Selenium.Support.3.5.0</SeleniumSupportPathRoot>
   </PropertyGroup>
-  
+
 </Project>

--- a/src/cppwinrt.build.post.props
+++ b/src/cppwinrt.build.post.props
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)common.build.post.props" />
 </Project>

--- a/src/cppwinrt.build.pre.props
+++ b/src/cppwinrt.build.pre.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <!-- this will trigger the use of a project-specific out dir -->
@@ -13,7 +13,7 @@
     <CppWinRTEnabled>true</CppWinRTEnabled>
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <DefaultLanguage>en-US</DefaultLanguage>
-    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>
 

--- a/src/dep/fmt/fmt.vcxproj
+++ b/src/dep/fmt/fmt.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{6bae5851-50d5-4934-8d5e-30361a8a40f3}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/features.xml
+++ b/src/features.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <featureStaging xmlns="http://microsoft.com/TilFeatureStaging-Schema.xsd">
     <!-- See doc/feature_flags.md for more info.  -->
     <feature>
@@ -81,7 +81,7 @@
         <description>If enabled, the foreground color will, when necessary, be automatically adjusted to make it more visible.</description>
         <stage>AlwaysEnabled</stage>
     </feature>
-    
+
     <feature>
         <name>Feature_VtPassthroughMode</name>
         <description>Enables passthrough option per profile in Terminal and ConPTY ability to use passthrough API dispatch engine</description>

--- a/src/host/exe/Host.EXE.vcxproj
+++ b/src/host/exe/Host.EXE.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{9CBD7DFA-1754-4A9D-93D7-857A9D17CB1B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/host/ft_fuzzer/Host.FuzzWrapper.vcxproj
+++ b/src/host/ft_fuzzer/Host.FuzzWrapper.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{05d9052f-d78f-478f-968a-2de38a6db996}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/host/ft_host/Host.FeatureTests.vcxproj
+++ b/src/host/ft_host/Host.FeatureTests.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{8CDB8850-7484-4EC7-B45B-181F85B2EE54}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/host/ft_uia/Host.Tests.UIA.csproj
+++ b/src/host/ft_uia/Host.Tests.UIA.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{C17E1BF3-9D34-4779-9458-A8EF98CC5662}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -149,7 +149,7 @@
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy &quot;$(SolutionDir)\dep\WinAppDriver\*&quot; &quot;$(OutDir)\&quot;</PostBuildEvent>
+    <PostBuildEvent>copy "$(SolutionDir)\dep\WinAppDriver\*" "$(OutDir)\"</PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\..\common.nugetversions.targets" />
 </Project>

--- a/src/host/host-common.vcxitems
+++ b/src/host/host-common.vcxitems
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="..\alias.cpp" />
     <ClCompile Include="..\cmdline.cpp" />

--- a/src/host/lib/hostlib.vcxproj
+++ b/src/host/lib/hostlib.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{06EC74CB-9A12-429C-B551-8562EC954746}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/host/proxy/Host.Proxy.vcxproj
+++ b/src/host/proxy/Host.Proxy.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{71CC9D78-BA29-4D93-946F-BEF5D9A3A6EF}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -21,7 +21,7 @@
   <Import Project="$(SolutionDir)src\common.build.pre.props" />
   <ItemGroup>
     <Midl Include="IConsoleHandoff.idl">
-      <!-- 
+      <!--
         In Razzle, IDL files generate %FileName%.h
         In Visual Studio, IDL files generate %FileName%_h.h
         Visual Studio is easier to override than Razzle.

--- a/src/host/ut_host/Host.UnitTests.vcxproj
+++ b/src/host/ut_host/Host.UnitTests.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{531C23E7-4B76-4C08-8AAD-04164CB628C9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/host/ut_lib/host.unittest.vcxproj
+++ b/src/host/ut_lib/host.unittest.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{06EC74CB-9A12-429C-B551-8562EC954747}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/interactivity/base/lib/InteractivityBase.vcxproj
+++ b/src/interactivity/base/lib/InteractivityBase.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{06EC74CB-9A12-429C-B551-8562EC964846}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/interactivity/onecore/lib/onecore.LIB.vcxproj
+++ b/src/interactivity/onecore/lib/onecore.LIB.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{06EC74CB-9A12-428C-B551-8537EC964726}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/interactivity/win32/lib/win32.LIB.vcxproj
+++ b/src/interactivity/win32/lib/win32.LIB.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{06EC74CB-9A12-429C-B551-8532EC964726}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/interactivity/win32/ut_interactivity_win32/Interactivity.Win32.UnitTests.vcxproj
+++ b/src/interactivity/win32/ut_interactivity_win32/Interactivity.Win32.UnitTests.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{d3b92829-26cb-411a-bda2-7f5da3d25dd4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/internal/internal.vcxproj
+++ b/src/internal/internal.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{EF3E32A7-5FF6-42B4-B6E2-96CD7D033F00}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/propsheet/propsheet.vcxproj
+++ b/src/propsheet/propsheet.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{5D23E8E1-3C64-4CC1-A8F7-6861677F7239}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/propslib/propslib.vcxproj
+++ b/src/propslib/propslib.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{345FD5A4-B32B-4F29-BD1C-B033BD2C35CC}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/renderer/atlas/atlas.vcxproj
+++ b/src/renderer/atlas/atlas.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{8222900C-8B6C-452A-91AC-BE95DB04B95F}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/renderer/base/lib/base.vcxproj
+++ b/src/renderer/base/lib/base.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{AF0A096A-8B3A-4949-81EF-7DF8F0FEE91F}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/renderer/dx/lib/dx.vcxproj
+++ b/src/renderer/dx/lib/dx.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{48D21369-3D7B-4431-9967-24E81292CF62}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/renderer/dx/ut_dx/Dx.Unit.Tests.vcxproj
+++ b/src/renderer/dx/ut_dx/Dx.Unit.Tests.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{95B136F9-B238-490C-A7C5-5843C1FECAC4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/renderer/gdi/lib/gdi.vcxproj
+++ b/src/renderer/gdi/lib/gdi.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{1C959542-BAC2-4E55-9A6D-13251914CBB9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/renderer/uia/lib/uia.vcxproj
+++ b/src/renderer/uia/lib/uia.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{48D21369-3D7B-4431-9967-24E81292CF63}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/renderer/vt/lib/vt.vcxproj
+++ b/src/renderer/vt/lib/vt.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{990F2657-8580-4828-943F-5DD657D11842}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/renderer/vt/ut_lib/vt.unittest.vcxproj
+++ b/src/renderer/vt/ut_lib/vt.unittest.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{990F2657-8580-4828-943F-5DD657D11843}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/renderer/vt/vt-renderer-common.vcxitems
+++ b/src/renderer/vt/vt-renderer-common.vcxitems
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
     Contains all the files for the VtRenderer Project.
     They need to be consumed by two different projects - lib/vt.vcxproj and

--- a/src/renderer/wddmcon/lib/wddmcon.vcxproj
+++ b/src/renderer/wddmcon/lib/wddmcon.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{75C6F576-18E9-4566-978A-F0A301CAC090}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/server/lib/server.vcxproj
+++ b/src/server/lib/server.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{18D09A24-8240-42D6-8CB6-236EEE820262}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/terminal/adapter/lib/adapter.vcxproj
+++ b/src/terminal/adapter/lib/adapter.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{DCF55140-EF6A-4736-A403-957E4F7430BB}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/terminal/adapter/ut_adapter/Adapter.UnitTests.vcxproj
+++ b/src/terminal/adapter/ut_adapter/Adapter.UnitTests.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{6AF01638-84CF-4B65-9870-484DFFCAC772}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/terminal/input/lib/terminalinput.vcxproj
+++ b/src/terminal/input/lib/terminalinput.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{1CF55140-EF6A-4736-A403-957E4F7430BB}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/terminal/parser/ft_fuzzer/VTCommandFuzzer.vcxproj
+++ b/src/terminal/parser/ft_fuzzer/VTCommandFuzzer.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{96927B31-D6E8-4ABD-B03E-A5088A30BEBE}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/terminal/parser/ft_fuzzwrapper/FuzzWrapper.vcxproj
+++ b/src/terminal/parser/ft_fuzzwrapper/FuzzWrapper.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{F210A4AE-E02A-4BFC-80BB-F50A672FE763}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/terminal/parser/lib/parser.vcxproj
+++ b/src/terminal/parser/lib/parser.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3AE13314-1939-4DFA-9C14-38CA0834050C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/terminal/parser/parser-common.vcxitems
+++ b/src/terminal/parser/parser-common.vcxitems
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
     Contains all the files for the Parser Project.
    -->

--- a/src/terminal/parser/ut_parser/Parser.UnitTests.vcxproj
+++ b/src/terminal/parser/ut_parser/Parser.UnitTests.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{12144E07-FE63-4D33-9231-748B8D8C3792}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/til/ut_til/til.unit.tests.vcxproj
+++ b/src/til/ut_til/til.unit.tests.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{767268EE-174A-46FE-96F0-EEE698A1BBC9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/tools/MonarchPeasantPackage/MonarchPeasantPackage.wapproj
+++ b/src/tools/MonarchPeasantPackage/MonarchPeasantPackage.wapproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '15.0'">
     <VisualStudioVersion>15.0</VisualStudioVersion>
   </PropertyGroup>

--- a/src/tools/MonarchPeasantSample/MonarchPeasantSample.vcxproj
+++ b/src/tools/MonarchPeasantSample/MonarchPeasantSample.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Label="Globals">
     <ProjectGuid>{21b7ea5e-1ef8-49b6-ac07-11714af0e37d}</ProjectGuid>

--- a/src/tools/MonarchPeasantSample/PropertySheet.props
+++ b/src/tools/MonarchPeasantSample/PropertySheet.props
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
     <!--
-    To customize common C++/WinRT project properties: 
+    To customize common C++/WinRT project properties:
     * right-click the project node
     * expand the Common Properties item
     * select the C++/WinRT property page
 
     For more advanced scenarios, and complete documentation, please see:
-    https://github.com/Microsoft/cppwinrt/tree/master/nuget 
+    https://github.com/Microsoft/cppwinrt/tree/master/nuget
     -->
   <PropertyGroup />
   <ItemDefinitionGroup />

--- a/src/tools/U8U16Test/U8U16Test.vcxproj
+++ b/src/tools/U8U16Test/U8U16Test.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <MinimalCoreWin>true</MinimalCoreWin>
     <VCProjectVersion>15.0</VCProjectVersion>

--- a/src/tools/buffersize/buffersize.vcxproj
+++ b/src/tools/buffersize/buffersize.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{ED82003F-FC5D-4E94-8B47-F480018ED064}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/tools/closetest/CloseTest.vcxproj
+++ b/src/tools/closetest/CloseTest.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C7A6A5D9-60BE-4AEB-A5F6-AFE352F86CBB}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/tools/echokey/ConEchoKey.vcxproj
+++ b/src/tools/echokey/ConEchoKey.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{814CBEEE-894E-4327-A6E1-740504850098}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/tools/fontlist/FontList.vcxproj
+++ b/src/tools/fontlist/FontList.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{919544AC-D39B-463F-8414-3C3C67CF727C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/tools/nihilist/Nihilist.vcxproj
+++ b/src/tools/nihilist/Nihilist.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{FC802440-AD6A-4919-8F2C-7701F2B38D79}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/tools/scratch/Scratch.vcxproj
+++ b/src/tools/scratch/Scratch.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{ED82003F-FC5D-4E94-8B36-F480018ED064}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/tools/vtapp/VTApp.csproj
+++ b/src/tools/vtapp/VTApp.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <ProjectGuid>{099193A0-1E43-4BBC-BA7F-7B351E1342DF}</ProjectGuid>

--- a/src/tools/vtpipeterm/VtPipeTerm.vcxproj
+++ b/src/tools/vtpipeterm/VtPipeTerm.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{814DBDDE-894E-4327-A6E1-740504850098}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/tsf/tsf.vcxproj
+++ b/src/tsf/tsf.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{2FD12FBB-1DDB-46D8-B818-1023C624CACA}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/types/lib/types.vcxproj
+++ b/src/types/lib/types.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{18D09A24-8240-42D6-8CB6-236EEE820263}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/types/ut_types/Types.Unit.Tests.vcxproj
+++ b/src/types/ut_types/Types.Unit.Tests.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{34de34d3-1cd6-4ee3-8bd9-a26b5b27ec73}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/wap-common.build.post.props
+++ b/src/wap-common.build.post.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
   <ItemGroup>

--- a/src/wap-common.build.pre.props
+++ b/src/wap-common.build.pre.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition="'$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '15.0'">
-    <VisualStudioVersion>15.0</VisualStudioVersion>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '17.0'">
+    <VisualStudioVersion>17.0</VisualStudioVersion>
   </PropertyGroup>
 
   <ItemGroup Label="ProjectConfigurations">

--- a/src/winconpty/dll/winconptydll.vcxproj
+++ b/src/winconpty/dll/winconptydll.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{a22ec5f6-7851-4b88-ac52-47249d437a52}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -29,37 +29,37 @@
       <ModuleDefinitionFile>winconpty.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
-      <!-- Override GetPackagingOutputs to roll up our DLL.	
-       This is a heavily stripped version of the one in Microsoft.*.AppxPackage.targets.	
-  -->	
-  <PropertyGroup>	
-    <_ContinueOnError Condition="'$(BuildingProject)' == 'true'">true</_ContinueOnError>	
-    <_ContinueOnError Condition="'$(BuildingProject)' != 'true'">false</_ContinueOnError>	
-  </PropertyGroup>	
-  <Target Name="GetPackagingOutputs" Returns="@(PackagingOutputs)">	
-    <CallTarget Targets="BuiltProjectOutputGroup">	
-      <Output TaskParameter="TargetOutputs" ItemName="_BuiltProjectOutputGroupOutput" />	
-    </CallTarget>	
-    <ItemGroup>	
-      <_PackagingOutputsUnexpanded Include="%(_BuiltProjectOutputGroupOutput.FinalOutputPath)">	
-        <TargetPath>%(_BuiltProjectOutputGroupOutput.TargetPath)</TargetPath>	
-        <OutputGroup>BuiltProjectOutputGroup</OutputGroup>	
-        <ProjectName>$(ProjectName)</ProjectName>	
-      </_PackagingOutputsUnexpanded>	
-    </ItemGroup>	
-    <CallTarget Targets="DebugSymbolsProjectOutputGroup">	
-      <Output TaskParameter="TargetOutputs" ItemName="_DebugSymbolsProjectOutputGroupOutput" />	
-    </CallTarget>	
-    <ItemGroup>	
-      <_PackagingOutputsUnexpanded Include="%(_DebugSymbolsProjectOutputGroupOutput.FinalOutputPath)">	
-        <OutputGroup>DebugSymbolsProjectOutputGroup</OutputGroup>	
-        <ProjectName>$(ProjectName)</ProjectName>	
-      </_PackagingOutputsUnexpanded>	
-    </ItemGroup>	
-    <ItemGroup>	
-      <PackagingOutputs Include="@(_PackagingOutputsUnexpanded)">	
-        <TargetPath>%(Filename)%(Extension)</TargetPath>	
-      </PackagingOutputs>	
-    </ItemGroup>	
+      <!-- Override GetPackagingOutputs to roll up our DLL.
+       This is a heavily stripped version of the one in Microsoft.*.AppxPackage.targets.
+  -->
+  <PropertyGroup>
+    <_ContinueOnError Condition="'$(BuildingProject)' == 'true'">true</_ContinueOnError>
+    <_ContinueOnError Condition="'$(BuildingProject)' != 'true'">false</_ContinueOnError>
+  </PropertyGroup>
+  <Target Name="GetPackagingOutputs" Returns="@(PackagingOutputs)">
+    <CallTarget Targets="BuiltProjectOutputGroup">
+      <Output TaskParameter="TargetOutputs" ItemName="_BuiltProjectOutputGroupOutput" />
+    </CallTarget>
+    <ItemGroup>
+      <_PackagingOutputsUnexpanded Include="%(_BuiltProjectOutputGroupOutput.FinalOutputPath)">
+        <TargetPath>%(_BuiltProjectOutputGroupOutput.TargetPath)</TargetPath>
+        <OutputGroup>BuiltProjectOutputGroup</OutputGroup>
+        <ProjectName>$(ProjectName)</ProjectName>
+      </_PackagingOutputsUnexpanded>
+    </ItemGroup>
+    <CallTarget Targets="DebugSymbolsProjectOutputGroup">
+      <Output TaskParameter="TargetOutputs" ItemName="_DebugSymbolsProjectOutputGroupOutput" />
+    </CallTarget>
+    <ItemGroup>
+      <_PackagingOutputsUnexpanded Include="%(_DebugSymbolsProjectOutputGroupOutput.FinalOutputPath)">
+        <OutputGroup>DebugSymbolsProjectOutputGroup</OutputGroup>
+        <ProjectName>$(ProjectName)</ProjectName>
+      </_PackagingOutputsUnexpanded>
+    </ItemGroup>
+    <ItemGroup>
+      <PackagingOutputs Include="@(_PackagingOutputsUnexpanded)">
+        <TargetPath>%(Filename)%(Extension)</TargetPath>
+      </PackagingOutputs>
+    </ItemGroup>
   </Target>
 </Project>

--- a/src/winconpty/ft_pty/winconpty.FeatureTests.vcxproj
+++ b/src/winconpty/ft_pty/winconpty.FeatureTests.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{024052DE-83FB-4653-AEA4-90790D29D5BD}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/src/winconpty/lib/winconptylib.vcxproj
+++ b/src/winconpty/lib/winconptylib.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{58a03bb2-df5a-4b66-91a0-7ef3ba01269a}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -26,37 +26,37 @@
   <!-- Careful reordering these. Some default props (contained in these files) are order sensitive. -->
   <Import Project="$(SolutionDir)src\common.build.post.props" />
   <Import Project="$(SolutionDir)src\common.nugetversions.targets" />
-  <!-- Override GetPackagingOutputs to roll up our DLL.	
-       This is a heavily stripped version of the one in Microsoft.*.AppxPackage.targets.	
-  -->	
-  <PropertyGroup>	
-    <_ContinueOnError Condition="'$(BuildingProject)' == 'true'">true</_ContinueOnError>	
-    <_ContinueOnError Condition="'$(BuildingProject)' != 'true'">false</_ContinueOnError>	
-  </PropertyGroup>	
-  <Target Name="GetPackagingOutputs" Returns="@(PackagingOutputs)">	
-    <CallTarget Targets="BuiltProjectOutputGroup">	
-      <Output TaskParameter="TargetOutputs" ItemName="_BuiltProjectOutputGroupOutput" />	
-    </CallTarget>	
-    <ItemGroup>	
-      <_PackagingOutputsUnexpanded Include="%(_BuiltProjectOutputGroupOutput.FinalOutputPath)">	
-        <TargetPath>%(_BuiltProjectOutputGroupOutput.TargetPath)</TargetPath>	
-        <OutputGroup>BuiltProjectOutputGroup</OutputGroup>	
-        <ProjectName>$(ProjectName)</ProjectName>	
-      </_PackagingOutputsUnexpanded>	
-    </ItemGroup>	
-    <CallTarget Targets="DebugSymbolsProjectOutputGroup">	
-      <Output TaskParameter="TargetOutputs" ItemName="_DebugSymbolsProjectOutputGroupOutput" />	
-    </CallTarget>	
-    <ItemGroup>	
-      <_PackagingOutputsUnexpanded Include="%(_DebugSymbolsProjectOutputGroupOutput.FinalOutputPath)">	
-        <OutputGroup>DebugSymbolsProjectOutputGroup</OutputGroup>	
-        <ProjectName>$(ProjectName)</ProjectName>	
-      </_PackagingOutputsUnexpanded>	
-    </ItemGroup>	
-    <ItemGroup>	
-      <PackagingOutputs Include="@(_PackagingOutputsUnexpanded)">	
-        <TargetPath>%(Filename)%(Extension)</TargetPath>	
-      </PackagingOutputs>	
-    </ItemGroup>	
+  <!-- Override GetPackagingOutputs to roll up our DLL.
+       This is a heavily stripped version of the one in Microsoft.*.AppxPackage.targets.
+  -->
+  <PropertyGroup>
+    <_ContinueOnError Condition="'$(BuildingProject)' == 'true'">true</_ContinueOnError>
+    <_ContinueOnError Condition="'$(BuildingProject)' != 'true'">false</_ContinueOnError>
+  </PropertyGroup>
+  <Target Name="GetPackagingOutputs" Returns="@(PackagingOutputs)">
+    <CallTarget Targets="BuiltProjectOutputGroup">
+      <Output TaskParameter="TargetOutputs" ItemName="_BuiltProjectOutputGroupOutput" />
+    </CallTarget>
+    <ItemGroup>
+      <_PackagingOutputsUnexpanded Include="%(_BuiltProjectOutputGroupOutput.FinalOutputPath)">
+        <TargetPath>%(_BuiltProjectOutputGroupOutput.TargetPath)</TargetPath>
+        <OutputGroup>BuiltProjectOutputGroup</OutputGroup>
+        <ProjectName>$(ProjectName)</ProjectName>
+      </_PackagingOutputsUnexpanded>
+    </ItemGroup>
+    <CallTarget Targets="DebugSymbolsProjectOutputGroup">
+      <Output TaskParameter="TargetOutputs" ItemName="_DebugSymbolsProjectOutputGroupOutput" />
+    </CallTarget>
+    <ItemGroup>
+      <_PackagingOutputsUnexpanded Include="%(_DebugSymbolsProjectOutputGroupOutput.FinalOutputPath)">
+        <OutputGroup>DebugSymbolsProjectOutputGroup</OutputGroup>
+        <ProjectName>$(ProjectName)</ProjectName>
+      </_PackagingOutputsUnexpanded>
+    </ItemGroup>
+    <ItemGroup>
+      <PackagingOutputs Include="@(_PackagingOutputsUnexpanded)">
+        <TargetPath>%(Filename)%(Extension)</TargetPath>
+      </PackagingOutputs>
+    </ItemGroup>
   </Target>
 </Project>

--- a/src/winconpty/package/managed/Microsoft.Windows.Console.ConPTY.props
+++ b/src/winconpty/package/managed/Microsoft.Windows.Console.ConPTY.props
@@ -1,5 +1,5 @@
-<?xml version="1.0"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- C# uses normalizes PlatformTarget, whereas C++ does not normalize Platform -->
     <ConptyNativePlatform Condition="'$(ConptyNativePlatform)'==''">$(PlatformTarget)</ConptyNativePlatform>

--- a/src/winconpty/package/managed/Microsoft.Windows.Console.ConPTY.targets
+++ b/src/winconpty/package/managed/Microsoft.Windows.Console.ConPTY.targets
@@ -1,5 +1,5 @@
-<?xml version="1.0"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <None Condition="'$(ConptyRequiresx86Host)'=='true'" Include="$(MSBuildThisFileDirectory)\native\runtimes\x86\OpenConsole.exe">
       <Link>x86\OpenConsole.exe</Link>

--- a/src/winconpty/package/native/Microsoft.Windows.Console.ConPTY.props
+++ b/src/winconpty/package/native/Microsoft.Windows.Console.ConPTY.props
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisProjectDirectory)\..\Microsoft.Windows.Console.ConPTY.props" />
 </Project>

--- a/src/winconpty/package/native/Microsoft.Windows.Console.ConPTY.targets
+++ b/src/winconpty/package/native/Microsoft.Windows.Console.ConPTY.targets
@@ -1,5 +1,5 @@
-<?xml version="1.0"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)..\..\inc\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/tools/FeatureStagingSchema.xsd
+++ b/tools/FeatureStagingSchema.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xs:schema targetNamespace="http://microsoft.com/TilFeatureStaging-Schema.xsd"
     elementFormDefault="qualified"
     xmlns="http://microsoft.com/TilFeatureStaging-Schema.xsd"


### PR DESCRIPTION
While working on another PR related to this I noticed that my VS
generates `.vcxproj` files that are a bit different to the ones we have.
This commit is a quick search & replace of all our project files to make
(primarily) their `ToolsVersion` more in line with what VS does itself:
No `ToolsVersion` for `.vcxproj`, `ToolsVersion="15.0"`
for `.csproj` and `ToolsVersion="4.0"` for `.filters` files.