### PR TITLE
Add a pivot to the tab color picker

### DIFF
--- a/src/cascadia/TerminalApp/ColorPickupFlyout.h
+++ b/src/cascadia/TerminalApp/ColorPickupFlyout.h
@@ -7,11 +7,12 @@ namespace winrt::TerminalApp::implementation
     {
         ColorPickupFlyout();
 
+        void Flyout_Opened(const Windows::Foundation::IInspectable& sender, const Windows::Foundation::IInspectable& args);
         void ColorButton_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
-        void ShowColorPickerButton_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
         void CustomColorButton_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
         void ClearColorButton_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
         void ColorPicker_ColorChanged(const Microsoft::UI::Xaml::Controls::ColorPicker&, const Microsoft::UI::Xaml::Controls::ColorChangedEventArgs& args);
+        void Pivot_SelectionChanged(const Windows::Foundation::IInspectable&, const Windows::UI::Xaml::Controls::SelectionChangedEventArgs& args);
 
         WINRT_CALLBACK(ColorCleared, TerminalApp::ColorClearedArgs);
         WINRT_CALLBACK(ColorSelected, TerminalApp::ColorSelectedArgs);

--- a/src/cascadia/TerminalApp/ColorPickupFlyout.xaml
+++ b/src/cascadia/TerminalApp/ColorPickupFlyout.xaml
@@ -5,25 +5,38 @@
         xmlns:local="using:TerminalApp"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+        Opened="Flyout_Opened"
         Placement="Bottom"
         ShouldConstrainToRootBounds="False"
         mc:Ignorable="d">
-    <Flyout.FlyoutPresenterStyle>
-        <Style TargetType="FlyoutPresenter">
-            <Setter Property="MinWidth" Value="0" />
-            <Setter Property="MaxWidth" Value="9999" />
-            <Setter Property="Padding" Value="{StaticResource FlyoutContentPadding}" />
-            <Setter Property="Margin" Value="8,4,8,8" />
-            <Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
-        </Style>
-    </Flyout.FlyoutPresenterStyle>
-    <StackPanel Orientation="Horizontal">
-        <StackPanel XYFocusKeyboardNavigation="Enabled">
-            <Grid Padding="-2">
-                <VariableSizedWrapGrid Margin="0"
+    <Pivot x:Name="FlyoutPivot"
+           SelectionChanged="Pivot_SelectionChanged">
+        <Pivot.HeaderTemplate>
+            <DataTemplate>
+                <TextBlock FontSize="16"
+                           Text="{Binding}" />
+            </DataTemplate>
+        </Pivot.HeaderTemplate>
+        <PivotItem x:Uid="TabColorPivot_Standard"
+                   HorizontalContentAlignment="Center"
+                   Tag="Standard">
+            <Grid x:Name="StandardColorPanel"
+                  RowSpacing="8">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="auto" />
+                    <RowDefinition Height="auto" />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="auto" />
+                </Grid.ColumnDefinitions>
+                <VariableSizedWrapGrid Grid.Row="0"
+                                       Grid.Column="0"
+                                       Margin="0"
                                        HorizontalAlignment="Center"
                                        MaximumRowsOrColumns="4"
-                                       Orientation="Horizontal">
+                                       Orientation="Horizontal"
+                                       TabFocusNavigation="Once"
+                                       XYFocusKeyboardNavigation="Enabled">
                     <VariableSizedWrapGrid.Resources>
                         <Style x:Name="ColorPickerColorButtonStyle"
                                BasedOn="{StaticResource ColorButtonStyle}"
@@ -99,48 +112,33 @@
                             Background="DarkGray"
                             Click="ColorButton_Click" />
                 </VariableSizedWrapGrid>
-            </Grid>
-            <StackPanel Margin="0,12,0,0"
-                        Orientation="Horizontal"
-                        Spacing="8">
                 <Button x:Name="ClearColorButton"
                         x:Uid="TabColorClearButton"
+                        Grid.Row="1"
                         Grid.Column="0"
                         HorizontalAlignment="Stretch"
-                        Click="ClearColorButton_Click"
-                        Content="Reset" />
-                <ToggleButton x:Name="CustomColorButton"
-                              x:Uid="TabColorCustomButton"
-                              Grid.Column="1"
-                              HorizontalAlignment="Stretch"
-                              Click="ShowColorPickerButton_Click"
-                              Content="Custom"
-                              IsChecked="False" />
+                        Click="ClearColorButton_Click" />
+            </Grid>
+        </PivotItem>
+        <PivotItem x:Uid="TabColorPivot_Custom"
+                   HorizontalContentAlignment="Center"
+                   Tag="Custom">
+            <StackPanel x:Name="CustomColorPanel">
+                <muxc:ColorPicker x:Name="CustomColorPicker"
+                                  ColorChanged="ColorPicker_ColorChanged"
+                                  IsAlphaEnabled="False"
+                                  IsAlphaSliderVisible="False"
+                                  IsAlphaTextInputVisible="False"
+                                  IsColorChannelTextInputVisible="True"
+                                  IsColorSliderVisible="True"
+                                  IsHexInputVisible="True"
+                                  IsMoreButtonVisible="True" />
+                <Button x:Name="OkButton"
+                        MinWidth="130"
+                        HorizontalAlignment="Right"
+                        Click="CustomColorButton_Click"
+                        Style="{ThemeResource AccentButtonStyle}" />
             </StackPanel>
-        </StackPanel>
-        <StackPanel x:Name="customColorPanel"
-                    Margin="16,0,0,0"
-                    Spacing="12"
-                    Visibility="Collapsed">
-            <muxc:ColorPicker x:Name="customColorPicker"
-                              Grid.Row="0"
-                              ColorChanged="ColorPicker_ColorChanged"
-                              FontSize="10"
-                              IsAlphaEnabled="False"
-                              IsAlphaSliderVisible="False"
-                              IsAlphaTextInputVisible="False"
-                              IsColorChannelTextInputVisible="True"
-                              IsColorSliderVisible="True"
-                              IsHexInputVisible="True"
-                              IsMoreButtonVisible="True" />
-            <Button x:Name="OkButton"
-                    x:Uid="OkButton"
-                    Grid.Row="1"
-                    MinWidth="130"
-                    HorizontalAlignment="Right"
-                    Click="CustomColorButton_Click"
-                    Content="OK"
-                    Style="{ThemeResource AccentButtonStyle}" />
-        </StackPanel>
-    </StackPanel>
+        </PivotItem>
+    </Pivot>
 </Flyout>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -212,7 +212,7 @@
     <value>Custom...</value>
   </data>
   <data name="TabColorClearButton.Content" xml:space="preserve">
-    <value>Reset</value>
+    <value>Reset tab color</value>
   </data>
   <data name="RenameTabText" xml:space="preserve">
     <value>Rename Tab</value>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -739,4 +739,12 @@
     <value>Suggestions found: {0}</value>
     <comment>{0} will be replaced with a number.</comment>
   </data>
+  <data name="TabColorPivot_Custom.Header" xml:space="preserve">
+    <value>Custom</value>
+    <comment>Header for a set of UI controls to pick a custom color (rather than predefined).</comment>
+  </data>
+  <data name="TabColorPivot_Standard.Header" xml:space="preserve">
+    <value>Standard</value>
+    <comment>Header for a set of UI controls with standard customization of a tab color.</comment>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request
The "Custom" button on the color picker is a bit strange (at least with regards to accessibility). It's a magical toggle button that reveals/hides content but doesn't interact with the formerly existing content. Instead, I've added a Pivot control to introduce two "modes": "Standard" and "Custom". This aligns with the experience on MS Word's color selection for text.

With regards to accessibility, the role of the "Custom button" won't matter anymore because it won't exist.

While I was here, I also added did a little bit of code cleanup by sprinkling a few `const` around and removing some unnecessary XAML code.

Additionally, the "Reset" button was renamed to be more descriptive and be able to close #12044.

## References
Closes #12045
Closes #12044 

## Validation Steps Performed
- color picker works
- acceptable keyboard navigation on the color picker