### PR TITLE
Rename newTabPosition values

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -1976,15 +1976,14 @@
           "type": "string"
         },
         "newTabPosition": {
-          "default": "atTheEnd",
-          "description": "Specifies position of the new tab. Possible values are \"atTheEnd\" and \"afterCurrentTab\".",
+          "default": "afterLastTab",
+          "description": "Position of newly created tabs. Possible values are \"afterLastTab\" and \"afterCurrentTab\".",
           "enum": [
-            "atTheEnd",
+            "afterLastTab",
             "afterCurrentTab"
           ],
-          "type": "string"
-        }
-      },
+          "type": "string"        
+        },
         "autoHideWindow": {
           "default": false,
           "description": "If enabled, Terminal window will be hidden as soon as it loses focus.",

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -236,20 +236,20 @@
     <comment>A description for what the "always show tabs" setting does. Presented near "Globals_AlwaysShowTabs.Header".</comment>
   </data>
   <data name="Globals_NewTabPosition.Header" xml:space="preserve">
-    <value>Position of the new tab</value>
-    <comment>Header for a control to select position of new tab.</comment>
+    <value>Position of newly created tabs</value>
+    <comment>Header for a control to select position of newly created tabs.</comment>
   </data>
   <data name="Globals_NewTabPosition.HelpText" xml:space="preserve">
-    <value>Specifies position of the new tab</value>
-    <comment>A description for what the "Position of the new tab" setting does.</comment>
+    <value>Specifies where new tabs appear in the tab row</value>
+    <comment>A description for what the "Position of newly created tabs" setting does.</comment>
   </data>
-  <data name="Globals_NewTabPositionAtTheEnd.Content" xml:space="preserve">
-    <value>At the end</value>
-    <comment>An option to choose from for the "Position of the new tab" setting. When selected new tab appears at the end.</comment>
+  <data name="Globals_NewTabPositionAfterLastTab.Content" xml:space="preserve">
+    <value>After the last tab</value>
+    <comment>An option to choose from for the "Position of newly created tabs" setting. When selected new tab appears after the last tab.</comment>
   </data>
   <data name="Globals_NewTabPositionAfterCurrentTab.Content" xml:space="preserve">
-    <value>After current tab</value>
-    <comment>An option to choose from for the "Position of the new tab" setting. When selected new tab appears after currently selected tab.</comment>
+    <value>After the current tab</value>
+    <comment>An option to choose from for the "Position of newly created tabs" setting. When selected new tab appears after the current tab.</comment>
   </data>
   <data name="Globals_CopyOnSelect.Header" xml:space="preserve">
     <value>Automatically copy selection to clipboard</value>

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -44,7 +44,7 @@ namespace Microsoft.Terminal.Settings.Model
 
     enum NewTabPosition
     {
-        AtTheEnd,
+        AfterLastTab,
         AfterCurrentTab,
     };
 

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -31,7 +31,7 @@ Author(s):
     X(bool, TrimBlockSelection, "trimBlockSelection", true)                                                                                                \
     X(bool, DetectURLs, "experimental.detectURLs", true)                                                                                                   \
     X(bool, AlwaysShowTabs, "alwaysShowTabs", true)                                                                                                        \
-    X(Model::NewTabPosition, NewTabPosition, "newTabPosition", Model::NewTabPosition::AtTheEnd)                                                            \
+    X(Model::NewTabPosition, NewTabPosition, "newTabPosition", Model::NewTabPosition::AfterLastTab)                                                            \
     X(bool, ShowTitleInTitlebar, "showTerminalTitleInTitlebar", true)                                                                                      \
     X(bool, ConfirmCloseAllTabs, "confirmCloseAllTabs", true)                                                                                              \
     X(hstring, Theme, "theme")                                                                                                                             \

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -31,7 +31,7 @@ Author(s):
     X(bool, TrimBlockSelection, "trimBlockSelection", true)                                                                                                \
     X(bool, DetectURLs, "experimental.detectURLs", true)                                                                                                   \
     X(bool, AlwaysShowTabs, "alwaysShowTabs", true)                                                                                                        \
-    X(Model::NewTabPosition, NewTabPosition, "newTabPosition", Model::NewTabPosition::AfterLastTab)                                                            \
+    X(Model::NewTabPosition, NewTabPosition, "newTabPosition", Model::NewTabPosition::AfterLastTab)                                                        \
     X(bool, ShowTitleInTitlebar, "showTerminalTitleInTitlebar", true)                                                                                      \
     X(bool, ConfirmCloseAllTabs, "confirmCloseAllTabs", true)                                                                                              \
     X(hstring, Theme, "theme")                                                                                                                             \

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -240,7 +240,7 @@ JSON_ENUM_MAPPER(::winrt::Windows::UI::Xaml::ElementTheme)
 JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Settings::Model::NewTabPosition)
 {
     JSON_MAPPINGS(2) = {
-        pair_type{ "atTheEnd", ValueType::AtTheEnd },
+        pair_type{ "afterLastTab", ValueType::AfterLastTab },
         pair_type{ "afterCurrentTab", ValueType::AfterCurrentTab },
     };
 };


### PR DESCRIPTION
Renames `newTabPosition` strings and enums.
Also fixes the schema, noted in https://github.com/microsoft/terminal/pull/13469#discussion_r928138496

Closes #13597