### PR TITLE
Two sets of localtest fixes for July 2022

### DIFF
--- a/src/cascadia/LocalTests_SettingsModel/SerializationTests.cpp
+++ b/src/cascadia/LocalTests_SettingsModel/SerializationTests.cpp
@@ -253,9 +253,14 @@ namespace SettingsModelLocalTests
                                                 { "command": { "action": "adjustFontSize", "delta": 1 }, "keys": "ctrl+c" },
                                                 { "command": { "action": "adjustFontSize", "delta": 1 }, "keys": "ctrl+d" }
                                             ])" };
+        // GH#13323 - these can be fragile. In the past, the order these get
+        // reserialized as has been not entirely stable. We don't really care
+        // about the order they get re-serialized in, but the tests aren't
+        // clever enough to compare the structure, only the literal string
+        // itself. Feel free to change as needed.
         static constexpr std::string_view actionsString4B{ R"([
-                                                { "command": { "action": "findMatch", "direction": "next" }, "keys": "ctrl+shift+s" },
-                                                { "command": { "action": "findMatch", "direction": "prev" }, "keys": "ctrl+shift+r" }
+                                                { "command": { "action": "findMatch", "direction": "prev" }, "keys": "ctrl+shift+r" },
+                                                { "command": { "action": "adjustFontSize", "delta": 1 }, "keys": "ctrl+d" }
                                             ])" };
 
         // command with name and icon and multiple key chords

--- a/src/cascadia/LocalTests_SettingsModel/SerializationTests.cpp
+++ b/src/cascadia/LocalTests_SettingsModel/SerializationTests.cpp
@@ -460,7 +460,9 @@ namespace SettingsModelLocalTests
             ],
             "actions": [
                 { "command": { "action": "sendInput", "input": "VT Griese Mode" }, "keys": "ctrl+k" }
-            ]
+            ],
+            "theme": "system",
+            "themes": []
         })" };
 
         const auto settings{ winrt::make_self<implementation::CascadiaSettings>(settingsString) };

--- a/src/cascadia/LocalTests_SettingsModel/SerializationTests.cpp
+++ b/src/cascadia/LocalTests_SettingsModel/SerializationTests.cpp
@@ -254,7 +254,7 @@ namespace SettingsModelLocalTests
                                                 { "command": { "action": "adjustFontSize", "delta": 1 }, "keys": "ctrl+d" }
                                             ])" };
         // GH#13323 - these can be fragile. In the past, the order these get
-        // reserialized as has been not entirely stable. We don't really care
+        // re-serialized as has been not entirely stable. We don't really care
         // about the order they get re-serialized in, but the tests aren't
         // clever enough to compare the structure, only the literal string
         // itself. Feel free to change as needed.

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -1158,6 +1158,7 @@ void CascadiaSettings::_validateThemeExists()
 {
     if (_globals->Themes().Size() == 0)
     {
+        // GH #13474
         // We didn't even load the deafult themes. This should only be possible
         // in the tests that don't even pass in defaults.json. No matter. Create
         // a default theme under `system` and just stick it in there.

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -1156,6 +1156,17 @@ void CascadiaSettings::ExportFile(winrt::hstring path, winrt::hstring content)
 
 void CascadiaSettings::_validateThemeExists()
 {
+    if (_globals->Themes().Size() == 0)
+    {
+        // We didn't even load the deafult themes. This should only be possible
+        // in the tests that don't even pass in defaults.json. No matter. Create
+        // a default theme under `system` and just stick it in there.
+        auto newTheme = winrt::make_self<Theme>();
+        newTheme->Name(L"system");
+        _globals->AddTheme(*newTheme);
+        _globals->Theme(L"system");
+    }
+
     if (!_globals->Themes().HasKey(_globals->Theme()))
     {
         _warnings.Append(SettingsLoadWarnings::UnknownTheme);

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -1159,7 +1159,7 @@ void CascadiaSettings::_validateThemeExists()
     if (_globals->Themes().Size() == 0)
     {
         // GH #13474
-        // We didn't even load the deafult themes. This should only be possible
+        // We didn't even load the default themes. This should only be possible
         // in the tests that don't even pass in defaults.json. No matter. Create
         // a default theme under `system` and just stick it in there.
         auto newTheme = winrt::make_self<Theme>();

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -1158,10 +1158,12 @@ void CascadiaSettings::_validateThemeExists()
 {
     if (_globals->Themes().Size() == 0)
     {
-        // GH #13474
         // We didn't even load the default themes. This should only be possible
-        // in the tests that don't even pass in defaults.json. No matter. Create
+        // if the defaults.json didn't include any themes, or if no
+        // defaults.json was loaded at all. The second case is especially common
+        // in tests (that don't bother with a defaults.json). No matter. Create
         // a default theme under `system` and just stick it in there.
+
         auto newTheme = winrt::make_self<Theme>();
         newTheme->Name(L"system");
         _globals->AddTheme(*newTheme);


### PR DESCRIPTION
Cleans up a couple local test failures.

* [x] Closes #13474: So, I clearly hadn't ran the local tests at the end of the themes PR. We needed a sensible fallback to SOME theme, even if there wasn't one provided in the user json. This is only really hit in the tests (that don't also include `defaults.json`.
* [x] Closes #13323: Meh, the ordering of the keys in this test doesn't matter. Ordering is a map implementation detail. This is fine.
* [x] Ran tests locally