### PR TITLE
GdiEngine: Invalidate entire rows at a time

### DIFF
--- a/src/renderer/gdi/invalidate.cpp
+++ b/src/renderer/gdi/invalidate.cpp
@@ -180,8 +180,8 @@ HRESULT GdiEngine::_InvalidRestrict() noexcept
     // Do restriction only if retrieving the client rect was successful.
     RETURN_HR_IF(E_FAIL, !(GetClientRect(_hwndTargetWindow, rcClient.as_win32_rect())));
 
-    _rcInvalid.left = std::clamp(_rcInvalid.left, rcClient.left, rcClient.right);
-    _rcInvalid.right = std::clamp(_rcInvalid.right, rcClient.left, rcClient.right);
+    _rcInvalid.left = rcClient.left;
+    _rcInvalid.right = rcClient.right;
     _rcInvalid.top = std::clamp(_rcInvalid.top, rcClient.top, rcClient.bottom);
     _rcInvalid.bottom = std::clamp(_rcInvalid.bottom, rcClient.top, rcClient.bottom);
 


### PR DESCRIPTION
This fixes an issue were overwriting parts of a row would only trigger
that specific portion of the row to be redrawn. This isn't just
problematic for combining characters, but also for things like
the new `TestDbcsBisectWriteCells` test introduced in #13626.

Benchmarks showed no impact on performance whatsoever.

## Validation Steps Performed
* Pick this commit into #13626
* Run the `TestDbcsBisectWriteCells` test and break before OpenConsole exits
* A correct "QいかなZYXWVUTに" output is visible ✅