### PR TITLE
Fix a couple of issues with color scheme MVVM

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -91,7 +91,6 @@
                     <!--  Select a color scheme  -->
                     <ComboBox x:Name="ColorSchemeComboBox"
                               ItemsSource="{x:Bind ViewModel.AllColorSchemes, Mode=OneWay}"
-                              SelectedIndex="0"
                               SelectedItem="{x:Bind ViewModel.CurrentScheme, Mode=TwoWay}"
                               Style="{StaticResource ComboBoxSettingStyle}">
                         <ComboBox.ItemTemplate>

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemesPageViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemesPageViewModel.cpp
@@ -97,6 +97,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
 
         _AllColorSchemes = single_threaded_observable_vector<Editor::ColorSchemeViewModel>(std::move(allColorSchemes));
+        _PropertyChangedHandlers(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"AllColorSchemes" });
     }
 
     void ColorSchemesPageViewModel::RequestEnterRename()

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemesPageViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemesPageViewModel.cpp
@@ -31,6 +31,12 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         _settings = settings;
 
+        // Exit rename mode if we're in it
+        if (_InRenameMode)
+        {
+            InRenameMode(false);
+        }
+
         // We want to re-initialize our AllColorSchemes list, but we want to make sure
         // we still have the same CurrentScheme as before (if that scheme still exists)
 

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemesPageViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemesPageViewModel.cpp
@@ -32,10 +32,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _settings = settings;
 
         // Exit rename mode if we're in it
-        if (_InRenameMode)
-        {
-            InRenameMode(false);
-        }
+        InRenameMode(false);
 
         // We want to re-initialize our AllColorSchemes list, but we want to make sure
         // we still have the same CurrentScheme as before (if that scheme still exists)


### PR DESCRIPTION
## Summary of the Pull Request
- When 'discard changes' is hit, we re-initialize our list of color scheme view models but forgot to tell xaml about it, this commit fixes that. 
- Make sure to exit rename mode when 'update settings' gets called

## References
color schemes mvvm added in #13179 

## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed
Hitting discard changes doesn't cause an inconsistency with the currently selected scheme anymore