### PR TITLE
Fix _isDefTermSession not propagating upon pane split/close

### DIFF
--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -2510,6 +2510,10 @@ std::pair<std::shared_ptr<Pane>, std::shared_ptr<Pane>> Pane::_Split(SplitDirect
     // Clear out our ID, only leaves should have IDs
     _id = {};
 
+    // Make sure to propagate our _isDefTermSession value
+    _firstChild->_isDefTermSession = _isDefTermSession;
+    _secondChild->_isDefTermSession = _isDefTermSession;
+
     // Regardless of which child the new child is, we want to return the
     // original one first.
     if (splitType == SplitDirection::Up || splitType == SplitDirection::Left)

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -1576,11 +1576,12 @@ void Pane::_CloseChild(const bool closeFirst, const bool isDetaching)
         // Find what borders need to persist after we close the child
         _borders = _GetCommonBorders();
 
-        // take the control, profile and id of the pane that _wasn't_ closed.
+        // take the control, profile, id and isDefTermSession of the pane that _wasn't_ closed.
         _control = remainingChild->_control;
         _connectionState = remainingChild->_connectionState;
         _profile = remainingChild->_profile;
         _id = remainingChild->Id();
+        _isDefTermSession = remainingChild->_isDefTermSession;
 
         // Add our new event handler before revoking the old one.
         _connectionStateChangedToken = _control.ConnectionStateChanged({ this, &Pane::_ControlConnectionStateChangedHandler });
@@ -2472,11 +2473,12 @@ std::pair<std::shared_ptr<Pane>, std::shared_ptr<Pane>> Pane::_Split(SplitDirect
     }
     else
     {
-        //   Move our control, guid into the first one.
+        //   Move our control, guid, isDefTermSession into the first one.
         _firstChild = std::make_shared<Pane>(_profile, _control);
         _firstChild->_connectionState = std::exchange(_connectionState, ConnectionState::NotConnected);
         _profile = nullptr;
         _control = { nullptr };
+        _firstChild->_isDefTermSession = _isDefTermSession;
     }
 
     _splitState = actualSplitType;
@@ -2509,11 +2511,6 @@ std::pair<std::shared_ptr<Pane>, std::shared_ptr<Pane>> Pane::_Split(SplitDirect
 
     // Clear out our ID, only leaves should have IDs
     _id = {};
-
-    // Make sure to propagate our _isDefTermSession value
-    WalkTree([&](auto p) {
-        p->_isDefTermSession = _isDefTermSession;
-    });
 
     // Regardless of which child the new child is, we want to return the
     // original one first.

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -2511,8 +2511,9 @@ std::pair<std::shared_ptr<Pane>, std::shared_ptr<Pane>> Pane::_Split(SplitDirect
     _id = {};
 
     // Make sure to propagate our _isDefTermSession value
-    _firstChild->_isDefTermSession = _isDefTermSession;
-    _secondChild->_isDefTermSession = _isDefTermSession;
+    WalkTree([&](auto p) {
+        p->_isDefTermSession = _isDefTermSession;
+    });
 
     // Regardless of which child the new child is, we want to return the
     // original one first.

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -217,7 +217,7 @@ private:
     static winrt::Windows::UI::Xaml::Media::SolidColorBrush s_focusedBorderBrush;
     static winrt::Windows::UI::Xaml::Media::SolidColorBrush s_unfocusedBorderBrush;
 
-    // <--- SECTION FOR PROPERTIES THAT NEED TO BE TRANSFERRED BETWEEN CHILD/PARENT PANES UPON SPLITTING/CLOSING -->
+#pragma region Properties that need to be transferred between child / parent panes upon splitting / closing
     std::shared_ptr<Pane> _firstChild{ nullptr };
     std::shared_ptr<Pane> _secondChild{ nullptr };
     SplitState _splitState{ SplitState::None };
@@ -226,7 +226,7 @@ private:
     winrt::Microsoft::Terminal::TerminalConnection::ConnectionState _connectionState{ winrt::Microsoft::Terminal::TerminalConnection::ConnectionState::NotConnected };
     winrt::Microsoft::Terminal::Settings::Model::Profile _profile{ nullptr };
     bool _isDefTermSession{ false };
-    // <--- END SECTION -->
+#pragma endregion
 
     std::optional<uint32_t> _id;
     std::weak_ptr<Pane> _parentChildPath{};

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -214,21 +214,24 @@ private:
     winrt::Windows::UI::Xaml::Controls::Grid _root{};
     winrt::Windows::UI::Xaml::Controls::Border _borderFirst{};
     winrt::Windows::UI::Xaml::Controls::Border _borderSecond{};
-    winrt::Microsoft::Terminal::Control::TermControl _control{ nullptr };
-    winrt::Microsoft::Terminal::TerminalConnection::ConnectionState _connectionState{ winrt::Microsoft::Terminal::TerminalConnection::ConnectionState::NotConnected };
     static winrt::Windows::UI::Xaml::Media::SolidColorBrush s_focusedBorderBrush;
     static winrt::Windows::UI::Xaml::Media::SolidColorBrush s_unfocusedBorderBrush;
 
+    // <--- SECTION FOR PROPERTIES THAT NEED TO BE TRANSFERRED BETWEEN CHILD/PARENT PANES UPON SPLITTING/CLOSING -->
     std::shared_ptr<Pane> _firstChild{ nullptr };
     std::shared_ptr<Pane> _secondChild{ nullptr };
     SplitState _splitState{ SplitState::None };
     float _desiredSplitPosition;
+    winrt::Microsoft::Terminal::Control::TermControl _control{ nullptr };
+    winrt::Microsoft::Terminal::TerminalConnection::ConnectionState _connectionState{ winrt::Microsoft::Terminal::TerminalConnection::ConnectionState::NotConnected };
+    winrt::Microsoft::Terminal::Settings::Model::Profile _profile{ nullptr };
+    bool _isDefTermSession{ false };
+    // <--- END SECTION -->
 
     std::optional<uint32_t> _id;
     std::weak_ptr<Pane> _parentChildPath{};
 
     bool _lastActive{ false };
-    winrt::Microsoft::Terminal::Settings::Model::Profile _profile{ nullptr };
     winrt::event_token _connectionStateChangedToken{ 0 };
     winrt::event_token _firstClosedToken{ 0 };
     winrt::event_token _secondClosedToken{ 0 };
@@ -242,8 +245,6 @@ private:
     Borders _borders{ Borders::None };
 
     bool _zoomed{ false };
-
-    bool _isDefTermSession{ false };
 
     winrt::Windows::Media::Playback::MediaPlayer _bellPlayer{ nullptr };
     winrt::Windows::Media::Playback::MediaPlayer::MediaEnded_revoker _mediaEndedRevoker;


### PR DESCRIPTION
## Summary of the Pull Request
In #13560 we added a member to `Pane` that lets it know if it was spawned as a default terminal session, but did not propagate that value when the pane gets split or when the pane closes. This commit fixes that. 

## Validation Steps Performed
A session spawned by a def term invocation remembers it even as it goes through splits