### PR TITLE
Make Mark Mode keybindings precede custom keybindings

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -277,6 +277,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void _updateFont(const bool initialUpdate = false);
         void _refreshSizeUnderLock();
         void _updateSelectionUI();
+        bool _shouldTryUpdateSelection(const WORD vkey);
 
         void _sendInputToConnection(std::wstring_view wstr);
 

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -87,6 +87,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void ToggleMarkMode();
         Control::SelectionInteractionMode SelectionMode() const;
         bool SwitchSelectionEndpoint();
+        bool TryMarkModeKeybinding(const WORD vkey,
+                                   const ::Microsoft::Terminal::Core::ControlKeyStates modifiers);
 
         void GotFocus();
         void LostFocus();

--- a/src/cascadia/TerminalControl/ControlCore.idl
+++ b/src/cascadia/TerminalControl/ControlCore.idl
@@ -14,9 +14,7 @@ namespace Microsoft.Terminal.Control
     // !! LOAD BEARING !! If you make this a struct with Booleans (like they
     // make the most sense as), then the app will crash trying to toss one of
     // these across the process boundary. I haven't the damndest idea why.
-    [flags]
-    enum MouseButtonState
-    {
+    [flags] enum MouseButtonState {
         IsLeftButtonDown = 0x1,
         IsMiddleButtonDown = 0x2,
         IsRightButtonDown = 0x4
@@ -37,9 +35,7 @@ namespace Microsoft.Terminal.Control
         Mark
     };
 
-    [flags]
-    enum SelectionEndpointTarget
-    {
+    [flags] enum SelectionEndpointTarget {
         Start = 0x1,
         End = 0x2
     };
@@ -79,13 +75,15 @@ namespace Microsoft.Terminal.Control
         Double Opacity { get; };
         Boolean UseAcrylic { get; };
 
+        Boolean TryMarkModeKeybinding(Int16 vkey,
+                                      Microsoft.Terminal.Core.ControlKeyStates modifiers);
         Boolean TrySendKeyEvent(Int16 vkey,
-                             Int16 scanCode,
-                             Microsoft.Terminal.Core.ControlKeyStates modifiers,
-                             Boolean keyDown);
+                                Int16 scanCode,
+                                Microsoft.Terminal.Core.ControlKeyStates modifiers,
+                                Boolean keyDown);
         Boolean SendCharEvent(Char ch,
-                           Int16 scanCode,
-                           Microsoft.Terminal.Core.ControlKeyStates modifiers);
+                              Int16 scanCode,
+                              Microsoft.Terminal.Core.ControlKeyStates modifiers);
         void SendInput(String text);
         void PasteText(String text);
         void SelectAll();

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1087,8 +1087,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // emit a ^T to the pipe.
         if (!modifiers.IsAltGrPressed() &&
             keyDown &&
-            (_core.TryMarkModeKeybinding(vkey, modifiers) ||
-             _TryHandleKeyBinding(vkey, scanCode, modifiers)))
+            _TryHandleKeyBinding(vkey, scanCode, modifiers))
         {
             e.Handled(true);
             return;
@@ -1114,6 +1113,14 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - modifiers: The ControlKeyStates representing the modifier key states.
     bool TermControl::_TryHandleKeyBinding(const WORD vkey, const WORD scanCode, ::Microsoft::Terminal::Core::ControlKeyStates modifiers) const
     {
+        // Mark mode has a specific set of pre-defined key bindings.
+        // If we're in mark mode, we should be prioritizing those over
+        // the custom defined key bindings.
+        if (_core.TryMarkModeKeybinding(vkey, modifiers))
+        {
+            return true;
+        }
+
         // TODO: GH#5000
         // The Core owning the keybindings is weird. That's for sure. In the
         // future, we may want to pass the keybindings into the control

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1085,7 +1085,10 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // keybindings on the keyUp, then we'll still send the keydown to the
         // connected terminal application, and something like ctrl+shift+T will
         // emit a ^T to the pipe.
-        if (!modifiers.IsAltGrPressed() && keyDown && _TryHandleKeyBinding(vkey, scanCode, modifiers))
+        if (!modifiers.IsAltGrPressed() &&
+            keyDown &&
+            (_core.TryMarkModeKeybinding(vkey, modifiers) ||
+             _TryHandleKeyBinding(vkey, scanCode, modifiers)))
         {
             e.Handled(true);
             return;


### PR DESCRIPTION
## Summary of the Pull Request
This PR moves the key handling for mark mode into a helper method that is then called before an action/key binding is attempted. 

## References
Epic: #4993 
Closes #13533

## Validation Steps Performed
- Add custom keybinding to "down" arrow key
- in mark mode --> selection updates appropriately
- out of mark mode --> keybinding executed