### PR TITLE
[1.15] Scroll to sln marker for Mark Mode & SelectAll

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -424,6 +424,7 @@ private:
     std::pair<til::point, til::point> _PivotSelection(const til::point targetPos, bool& targetStart) const;
     std::pair<til::point, til::point> _ExpandSelectionAnchors(std::pair<til::point, til::point> anchors) const;
     til::point _ConvertToBufferCell(const til::point viewportPos) const;
+    void _ScrollToPoint(const til::point pos);
     void _MoveByChar(SelectionDirection direction, til::point& pos);
     void _MoveByWord(SelectionDirection direction, til::point& pos);
     void _MoveByViewport(SelectionDirection direction, til::point& pos);


### PR DESCRIPTION
Adds `ScrollToPoint()` from #13405 to be able to scroll to the selection marker when (1) mark mode is entered and (2) `selectAll` is called.

This change is a combination of #13656 and a minor part of #13405.
Epic: #4993 