### PR TITLE
Fix conpty not emitting colored spaces on the VERY FIRST frame

### DIFF
--- a/src/cascadia/UnitTests_TerminalCore/ConptyRoundtripTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ConptyRoundtripTests.cpp
@@ -4112,7 +4112,7 @@ void ConptyRoundtripTests::AltBufferToAltBufferTest()
 
 void ConptyRoundtripTests::TestPowerLineFirstFrame()
 {
-    Log::Comment(L"This is a test for GH#8341. If we recieved colored spaces "
+    Log::Comment(L"This is a test for GH#8341. If we received colored spaces "
                  L"BEFORE the first frame, we should still emit them!");
 
     auto& g = ServiceLocator::LocateGlobals();
@@ -4147,7 +4147,7 @@ void ConptyRoundtripTests::TestPowerLineFirstFrame()
 
     // As a pwsh one-liner:
     //
-    //  "`e[37m`e[102m foo\bar `e[92m`e[100m▶ `e[37mbaz `e[90m`e[49m▶ `e[m"
+    //  "`e[37m`e[102m foo\bar `e[92m`e[100m▶ `e[37mBar `e[90m`e[49m▶ `e[m"
     //
     // Generally taken from
     // https://github.com/microsoft/terminal/issues/8341#issuecomment-731310022,
@@ -4158,13 +4158,13 @@ void ConptyRoundtripTests::TestPowerLineFirstFrame()
     sm.ProcessString(L"\x1b[92m\x1b[100m" // bright green on bright black
                      L"▶ ");
     sm.ProcessString(L"\x1b[37m" // dark white on bright black
-                     L"baz ");
+                     L"Bar ");
     sm.ProcessString(L"\x1b[90m\x1b[49m" // bright black on default
                      L"▶ ");
     sm.ProcessString(L"\x1b[m\n"); // default on default
 
     auto verifyBuffer = [&](const TextBuffer& tb) {
-        // If this test fails on charater 8, then it's because we didn't emit the space, we just moved ahead.
+        // If this test fails on character 8, then it's because we didn't emit the space, we just moved ahead.
         auto iter0 = TestUtils::VerifyLineContains(tb, { 0, 0 }, whiteOnGreen, 9u);
         TestUtils::VerifyLineContains(iter0, OutputCellIterator{ greenOnBlack, 2u });
         TestUtils::VerifyLineContains(iter0, OutputCellIterator{ whiteOnBlack, 4u });

--- a/src/cascadia/UnitTests_TerminalCore/ConptyRoundtripTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ConptyRoundtripTests.cpp
@@ -227,6 +227,8 @@ class TerminalCoreUnitTests::ConptyRoundtripTests final
     TEST_METHOD(SimpleAltBufferTest);
     TEST_METHOD(AltBufferToAltBufferTest);
 
+    TEST_METHOD(TestPowerLineFirstFrame);
+
     TEST_METHOD(AltBufferResizeCrash);
 
 private:
@@ -4106,6 +4108,67 @@ void ConptyRoundtripTests::AltBufferToAltBufferTest()
 
     Log::Comment(L"========== Checking the terminal buffer state (StillInAltBuffer) ==========");
     verifyBuffer(*termAltTb, term->_GetMutableViewport().ToExclusive(), Frame::StillInAltBuffer);
+}
+
+void ConptyRoundtripTests::TestPowerLineFirstFrame()
+{
+    Log::Comment(L"TODO!");
+
+    auto& g = ServiceLocator::LocateGlobals();
+    auto& renderer = *g.pRender;
+    auto& gci = g.getConsoleInformation();
+    auto& si = gci.GetActiveOutputBuffer();
+    auto& sm = si.GetStateMachine();
+
+    auto* hostTb = &si.GetTextBuffer();
+    auto* termTb = term->_mainBuffer.get();
+
+    _checkConptyOutput = false;
+
+    TextAttribute whiteOnGreen{};
+    whiteOnGreen.SetIndexedForeground(TextColor::DARK_WHITE);
+    whiteOnGreen.SetIndexedBackground(TextColor::BRIGHT_GREEN);
+
+    TextAttribute greenOnBlack{};
+    greenOnBlack.SetIndexedForeground(TextColor::BRIGHT_GREEN);
+    greenOnBlack.SetIndexedBackground(TextColor::BRIGHT_BLACK);
+
+    TextAttribute whiteOnBlack{};
+    whiteOnBlack.SetIndexedForeground(TextColor::DARK_WHITE);
+    whiteOnBlack.SetIndexedBackground(TextColor::BRIGHT_BLACK);
+
+    TextAttribute blackOnDefault{};
+    blackOnDefault.SetIndexedForeground(TextColor::BRIGHT_BLACK);
+
+    TextAttribute defaultOnDefault{};
+
+    Log::Comment(L"========== Fill test content ==========");
+    sm.ProcessString(L"\x1b[37m\x1b[102m" // dark white on bright green
+                     L" foo\\bar ");
+    sm.ProcessString(L"\x1b[92m\x1b[100m" // bright green on bright black
+                     L"▶ ");
+    sm.ProcessString(L"\x1b[37m" // dark white on bright black
+                     L"baz ");
+    sm.ProcessString(L"\x1b[90m\x1b[49m" // bright black on default
+                     L"▶ ");
+    sm.ProcessString(L"\x1b[m\n"); // default on default
+
+    auto verifyBuffer = [&](const TextBuffer& tb) {
+        // If this test fails on charater 8, then it's because we didn't emit the space, we just moved ahead.
+        auto iter0 = TestUtils::VerifyLineContains(tb, { 0, 0 }, whiteOnGreen, 9u);
+        TestUtils::VerifyLineContains(iter0, OutputCellIterator{ greenOnBlack, 2u });
+        TestUtils::VerifyLineContains(iter0, OutputCellIterator{ whiteOnBlack, 4u });
+        TestUtils::VerifyLineContains(iter0, OutputCellIterator{ blackOnDefault, 2u });
+    };
+
+    Log::Comment(L"========== Check host buffer ==========");
+    verifyBuffer(*hostTb);
+
+    Log::Comment(L"========== Paint first frame ==========");
+    VERIFY_SUCCEEDED(renderer.PaintFrame());
+
+    Log::Comment(L"========== Check terminal buffer ==========");
+    verifyBuffer(*termTb);
 }
 
 void ConptyRoundtripTests::AltBufferResizeCrash()

--- a/src/cascadia/UnitTests_TerminalCore/ConptyRoundtripTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ConptyRoundtripTests.cpp
@@ -4112,7 +4112,8 @@ void ConptyRoundtripTests::AltBufferToAltBufferTest()
 
 void ConptyRoundtripTests::TestPowerLineFirstFrame()
 {
-    Log::Comment(L"TODO!");
+    Log::Comment(L"This is a test for GH#8341. If we recieved colored spaces "
+                 L"BEFORE the first frame, we should still emit them!");
 
     auto& g = ServiceLocator::LocateGlobals();
     auto& renderer = *g.pRender;
@@ -4143,6 +4144,15 @@ void ConptyRoundtripTests::TestPowerLineFirstFrame()
     TextAttribute defaultOnDefault{};
 
     Log::Comment(L"========== Fill test content ==========");
+
+    // As a pwsh one-liner:
+    //
+    //  "`e[37m`e[102m foo\bar `e[92m`e[100m▶ `e[37mbaz `e[90m`e[49m▶ `e[m"
+    //
+    // Generally taken from
+    // https://github.com/microsoft/terminal/issues/8341#issuecomment-731310022,
+    // but minimized for easier testing.
+
     sm.ProcessString(L"\x1b[37m\x1b[102m" // dark white on bright green
                      L" foo\\bar ");
     sm.ProcessString(L"\x1b[92m\x1b[100m" // bright green on bright black

--- a/src/inc/TestUtils.h
+++ b/src/inc/TestUtils.h
@@ -168,15 +168,19 @@ public:
             auto actualAttrs = actual->TextAttr();
             auto expectedAttrs = expected->TextAttr();
 
-            auto mismatched = (actualChars != expectedChars || actualAttrs != expectedAttrs);
+            auto mismatched = ((!expectedChars.empty() && actualChars != expectedChars) || actualAttrs != expectedAttrs);
             if (mismatched)
             {
                 WEX::Logging::Log::Comment(WEX::Common::NoThrowString().Format(
                     L"Character or attribute at index %d was mismatched", charsProcessed));
             }
 
-            VERIFY_ARE_EQUAL(expectedChars, actualChars);
+            if (!expectedChars.empty())
+            {
+                VERIFY_ARE_EQUAL(expectedChars, actualChars);
+            }
             VERIFY_ARE_EQUAL(expectedAttrs, actualAttrs);
+
             if (mismatched)
             {
                 return false;

--- a/src/renderer/vt/paint.cpp
+++ b/src/renderer/vt/paint.cpp
@@ -448,10 +448,13 @@ using namespace Microsoft::Console::Types;
     // the lines _wrapped_. It doesn't care to manually break the lines, but if
     // we trimmed the spaces off here, we'd print all the "~"s one after another
     // on the same line.
-    const auto removeSpaces = !lineWrapped && (useEraseChar ||
-                                               _clearedAllThisFrame ||
-                                               (_newBottomLine && printingBottomLine && bgMatched));
-    const auto cchActual = removeSpaces ? nonSpaceLength : cchLine;
+
+    const bool removeSpaces = !lineWrapped && (useEraseChar // we determined earlier that ECH is optimal
+                                               || (_clearedAllThisFrame && _lastTextAttributes == TextAttribute{}) // OR we cleared the last frame to the default attributes (specifically)
+                                               || (_newBottomLine && printingBottomLine && bgMatched)); // OR we just scrolled a new line onto the bottom of the screen with the correct attributes
+    const size_t cchActual = removeSpaces ?
+                                 (cchLine - numSpaces) :
+                                 cchLine;
 
     const auto columnsActual = removeSpaces ?
                                    (totalWidth - numSpaces) :

--- a/src/renderer/vt/paint.cpp
+++ b/src/renderer/vt/paint.cpp
@@ -448,9 +448,9 @@ using namespace Microsoft::Console::Types;
     // the lines _wrapped_. It doesn't care to manually break the lines, but if
     // we trimmed the spaces off here, we'd print all the "~"s one after another
     // on the same line.
-
+    static const TextAttribute defaultAttrs{};
     const bool removeSpaces = !lineWrapped && (useEraseChar // we determined earlier that ECH is optimal
-                                               || (_clearedAllThisFrame && _lastTextAttributes == TextAttribute{}) // OR we cleared the last frame to the default attributes (specifically)
+                                               || (_clearedAllThisFrame && _lastTextAttributes == defaultAttrs) // OR we cleared the last frame to the default attributes (specifically)
                                                || (_newBottomLine && printingBottomLine && bgMatched)); // OR we just scrolled a new line onto the bottom of the screen with the correct attributes
     const size_t cchActual = removeSpaces ?
                                  (cchLine - numSpaces) :


### PR DESCRIPTION
This bug arose from a "race condition" in the first frame handling of conpty. We'd try to optimize out spaces if we've cleared the entire frame (which always happens on the first frame). However, doing that even for colored spaces meant that things like powerline prompts could be emitted to conhost during the first frame, and we'd optimize the spaces out. That's silly. 

This is hard to repro naturally, but this comment has another repro I used
https://github.com/microsoft/terminal/issues/8341#issuecomment-731310022

Modified to facilitate simpler testing, it looks like:

#### Before
![image](https://user-images.githubusercontent.com/18356694/182680119-bb22179c-a328-43f3-b64a-0d1d5773b813.png)

#### After
![image](https://user-images.githubusercontent.com/18356694/182680159-805964c5-c4cc-411a-8865-3866fca8d6e9.png)


* [x] Closes #8341
* [x] Tests added

Co-authored by @DHowett 