### PR TITLE
Fix input corruption for high code points

### DIFF
--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -2014,7 +2014,6 @@ void StateMachine::ResetState() noexcept
 //   into the given size_t. All existing value is moved up by 10.
 // - For example, if your value had 437 and you put in the printable number 2,
 //   this function will update value to 4372.
-// - Clamps to 32767 if it gets too big.
 // Arguments:
 // - wch - Printable character to accumulate into the value (after conversion to number, of course)
 // - value - The value to update with the printable character. See example above.

--- a/src/terminal/parser/stateMachine.hpp
+++ b/src/terminal/parser/stateMachine.hpp
@@ -21,11 +21,11 @@ Abstract:
 
 namespace Microsoft::Console::VirtualTerminal
 {
-    // The DEC STD 070 reference recommends supporting up to at least 16384 for
-    // parameter values, so 32767 should be more than enough. At most we might
-    // want to increase this to 65535, since that is what XTerm and VTE support,
-    // but for now 32767 is the safest limit for our existing code base.
-    constexpr VTInt MAX_PARAMETER_VALUE = 32767;
+    // The DEC STD 070 reference recommends supporting up to at least 16384
+    // for parameter values. 65535 is what XTerm and VTE support.
+    // GH#12977: We must use 65535 to properly parse win32-input-mode
+    // sequences, which transmit the UTF-16 character value as a parameter.
+    constexpr VTInt MAX_PARAMETER_VALUE = 65535;
 
     // The DEC STD 070 reference requires that a minimum of 16 parameter values
     // are supported, but most modern terminal emulators will allow around twice

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -1589,7 +1589,7 @@ class StateMachineExternalTest final
         }
         else if (uiGiven > MAX_PARAMETER_VALUE)
         {
-            *uiExpected = MAX_PARAMETER_VALUE; // 32767 is our max value.
+            *uiExpected = MAX_PARAMETER_VALUE;
         }
     }
 


### PR DESCRIPTION
We must use 65535 as `MAX_PARAMETER_VALUE` in order for us to properly parse
win32-input-mode sequences, which transmit UTF-16 characters as parameters.

Closes #12977

## Validation Steps Performed
* Call `SendInput` with 🙁 (`L'\xD83D'`, `L'\xDE41'`)
* 🙁 appears on the input line ✅