### PR TITLE
Skip whitespace removal for multiline pastes

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2163,17 +2163,11 @@ namespace winrt::TerminalApp::implementation
 
             if (_settings.GlobalSettings().TrimPaste())
             {
-                std::wstring_view textView{ text };
-                const auto pos = textView.find_last_not_of(L"\t\n\v\f\r ");
-                if (pos == textView.npos)
+                text = { Utils::TrimPaste(text) };
+                if (text.empty())
                 {
                     // Text is all white space, nothing to paste
                     co_return;
-                }
-                else if (const auto toRemove = textView.size() - 1 - pos; toRemove > 0)
-                {
-                    textView.remove_suffix(toRemove);
-                    text = { textView };
                 }
             }
 

--- a/src/types/inc/utils.hpp
+++ b/src/types/inc/utils.hpp
@@ -106,4 +106,9 @@ namespace Microsoft::Console::Utils
     std::tuple<std::wstring, std::wstring> MangleStartingDirectoryForWSL(std::wstring_view commandLine,
                                                                          std::wstring_view startingDirectory);
 
+    // Similar to MangleStartingDirectoryForWSL, this function is only ever used
+    // in TerminalPage::_PasteFromClipboardHandler, but putting it here makes
+    // testing easier.
+    std::wstring_view TrimPaste(std::wstring_view textView);
+
 }

--- a/src/types/inc/utils.hpp
+++ b/src/types/inc/utils.hpp
@@ -109,6 +109,6 @@ namespace Microsoft::Console::Utils
     // Similar to MangleStartingDirectoryForWSL, this function is only ever used
     // in TerminalPage::_PasteFromClipboardHandler, but putting it here makes
     // testing easier.
-    std::wstring_view TrimPaste(std::wstring_view textView);
+    std::wstring_view TrimPaste(std::wstring_view textView) noexcept;
 
 }

--- a/src/types/ut_types/UtilsTests.cpp
+++ b/src/types/ut_types/UtilsTests.cpp
@@ -30,6 +30,9 @@ class UtilsTests
     TEST_METHOD(TestMangleWSLPaths);
 #endif
 
+    TEST_METHOD(TestTrimTrailingWhitespace);
+    TEST_METHOD(TestDontTrimTrailingWhitespace);
+
     void _VerifyXTermColorResult(const std::wstring_view wstr, DWORD colorValue);
     void _VerifyXTermColorInvalid(const std::wstring_view wstr);
 };
@@ -505,3 +508,24 @@ void UtilsTests::TestMangleWSLPaths()
     }
 }
 #endif
+
+void UtilsTests::TestTrimTrailingWhitespace()
+{
+    // Tests for GH #11473
+    VERIFY_ARE_EQUAL(L"Foo", TrimPaste(L"Foo   "));
+    VERIFY_ARE_EQUAL(L"Foo", TrimPaste(L"Foo\n"));
+    VERIFY_ARE_EQUAL(L"Foo", TrimPaste(L"Foo\n\n"));
+    VERIFY_ARE_EQUAL(L"Foo", TrimPaste(L"Foo\r\n"));
+    VERIFY_ARE_EQUAL(L"Foo Bar", TrimPaste(L"Foo Bar\n"));
+    VERIFY_ARE_EQUAL(L"Foo\tBar", TrimPaste(L"Foo\tBar\n"));
+    VERIFY_ARE_EQUAL(L"Foo Bar", TrimPaste(L"Foo Bar\t"));
+    VERIFY_ARE_EQUAL(L"Foo Bar", TrimPaste(L"Foo Bar\t\t"));
+    VERIFY_ARE_EQUAL(L"Foo Bar", TrimPaste(L"Foo Bar\t\n"));
+}
+void UtilsTests::TestDontTrimTrailingWhitespace()
+{
+    // Tests for GH #12387
+    VERIFY_ARE_EQUAL(L"Foo\nBar\n", TrimPaste(L"Foo\nBar\n"));
+    VERIFY_ARE_EQUAL(L"Foo  Baz\nBar\n", TrimPaste(L"Foo  Baz\nBar\n"));
+    VERIFY_ARE_EQUAL(L"Foo\tBaz\nBar\n", TrimPaste(L"Foo\tBaz\nBar\n"));
+}

--- a/src/types/ut_types/UtilsTests.cpp
+++ b/src/types/ut_types/UtilsTests.cpp
@@ -525,9 +525,9 @@ void UtilsTests::TestTrimTrailingWhitespace()
     VERIFY_ARE_EQUAL(L"Foo Bar", TrimPaste(L"Foo Bar\t"), L"Trim when there is a tab at the end.");
     VERIFY_ARE_EQUAL(L"Foo Bar", TrimPaste(L"Foo Bar\t\t"), L"Trim when there are tabs at the end.");
     VERIFY_ARE_EQUAL(L"Foo Bar", TrimPaste(L"Foo Bar\t\n"), L"Trim when there are tabs at the start of the whitespace at the end.");
-    VERIFY_ARE_EQUAL(L"Foo\tBar", TrimPaste(L"Foo\tbar\t\n"), L"Trim when there are tabs in the middle of the string, and in the whitespace at the end.");
-    VERIFY_ARE_EQUAL(L"Foo\tBar", TrimPaste(L"Foo\tbar\n\t"), L"Trim when there are tabs in the middle of the string, and in the whitespace at the end.");
-    VERIFY_ARE_EQUAL(L"Foo\tBar", TrimPaste(L"Foo\tbar\t\n\t"), L"Trim when there are tabs in the middle of the string, and in the whitespace at the end.");
+    VERIFY_ARE_EQUAL(L"Foo\tBar", TrimPaste(L"Foo\tBar\t\n"), L"Trim when there are tabs in the middle of the string, and in the whitespace at the end.");
+    VERIFY_ARE_EQUAL(L"Foo\tBar", TrimPaste(L"Foo\tBar\n\t"), L"Trim when there are tabs in the middle of the string, and in the whitespace at the end.");
+    VERIFY_ARE_EQUAL(L"Foo\tBar", TrimPaste(L"Foo\tBar\t\n\t"), L"Trim when there are tabs in the middle of the string, and in the whitespace at the end.");
 }
 void UtilsTests::TestDontTrimTrailingWhitespace()
 {

--- a/src/types/ut_types/UtilsTests.cpp
+++ b/src/types/ut_types/UtilsTests.cpp
@@ -511,6 +511,9 @@ void UtilsTests::TestMangleWSLPaths()
 
 void UtilsTests::TestTrimTrailingWhitespace()
 {
+    // Continue on failures
+    const WEX::TestExecution::DisableVerifyExceptions disableExceptionsScope;
+
     // Tests for GH #11473
     VERIFY_ARE_EQUAL(L"Foo", TrimPaste(L"Foo   "));
     VERIFY_ARE_EQUAL(L"Foo", TrimPaste(L"Foo\n"));
@@ -518,14 +521,28 @@ void UtilsTests::TestTrimTrailingWhitespace()
     VERIFY_ARE_EQUAL(L"Foo", TrimPaste(L"Foo\r\n"));
     VERIFY_ARE_EQUAL(L"Foo Bar", TrimPaste(L"Foo Bar\n"));
     VERIFY_ARE_EQUAL(L"Foo\tBar", TrimPaste(L"Foo\tBar\n"));
-    VERIFY_ARE_EQUAL(L"Foo Bar", TrimPaste(L"Foo Bar\t"));
-    VERIFY_ARE_EQUAL(L"Foo Bar", TrimPaste(L"Foo Bar\t\t"));
-    VERIFY_ARE_EQUAL(L"Foo Bar", TrimPaste(L"Foo Bar\t\n"));
+
+    VERIFY_ARE_EQUAL(L"Foo Bar", TrimPaste(L"Foo Bar\t"), L"Trim when there is a tab at the end.");
+    VERIFY_ARE_EQUAL(L"Foo Bar", TrimPaste(L"Foo Bar\t\t"), L"Trim when there are tabs at the end.");
+    VERIFY_ARE_EQUAL(L"Foo Bar", TrimPaste(L"Foo Bar\t\n"), L"Trim when there are tabs at the start of the whitespace at the end.");
+    VERIFY_ARE_EQUAL(L"Foo\tBar", TrimPaste(L"Foo\tbar\t\n"), L"Trim when there are tabs in the middle of the string, and in the whitespace at the end.");
+    VERIFY_ARE_EQUAL(L"Foo\tBar", TrimPaste(L"Foo\tbar\n\t"), L"Trim when there are tabs in the middle of the string, and in the whitespace at the end.");
+    VERIFY_ARE_EQUAL(L"Foo\tBar", TrimPaste(L"Foo\tbar\t\n\t"), L"Trim when there are tabs in the middle of the string, and in the whitespace at the end.");
 }
 void UtilsTests::TestDontTrimTrailingWhitespace()
 {
+    // Continue on failures
+    const WEX::TestExecution::DisableVerifyExceptions disableExceptionsScope;
+
+    VERIFY_ARE_EQUAL(L"Foo\tBar", TrimPaste(L"Foo\tBar"));
+
     // Tests for GH #12387
     VERIFY_ARE_EQUAL(L"Foo\nBar\n", TrimPaste(L"Foo\nBar\n"));
     VERIFY_ARE_EQUAL(L"Foo  Baz\nBar\n", TrimPaste(L"Foo  Baz\nBar\n"));
-    VERIFY_ARE_EQUAL(L"Foo\tBaz\nBar\n", TrimPaste(L"Foo\tBaz\nBar\n"));
+    VERIFY_ARE_EQUAL(L"Foo\tBaz\nBar\n", TrimPaste(L"Foo\tBaz\nBar\n"), L"Don't trim when there's a trailing newline, and tabs in the middle");
+    VERIFY_ARE_EQUAL(L"Foo\tBaz\nBar\t\n", TrimPaste(L"Foo\tBaz\nBar\t\n"), L"Don't trim when there's a trailing newline, and tabs in the middle");
+
+    // We need to both
+    // * trim when there's a tab followed by only whitespace
+    // * not trim then there's a tab in the middle, and the string ends in whitespace
 }

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -795,10 +795,5 @@ std::wstring_view Utils::TrimPaste(std::wstring_view textView) noexcept
         return textView;
     }
 
-    if (const auto toRemove = textView.size() - 1 - lastNonSpace; toRemove > 0)
-    {
-        textView.remove_suffix(toRemove);
-    }
-
-    return textView;
+    return textView.substr(0, lastNonSpace + 1);
 }

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -780,7 +780,7 @@ std::wstring_view Utils::TrimPaste(std::wstring_view textView)
 
     const bool isOnlyWhitespace = lastNonSpace == textView.npos;
     const bool isMultiline = firstNewline < lastNonSpace;
-    
+
     if (isOnlyWhitespace)
     {
         // Text is all white space, nothing to paste

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -772,3 +772,18 @@ std::tuple<std::wstring, std::wstring> Utils::MangleStartingDirectoryForWSL(std:
                                     std::wstring{ startingDirectory }
     };
 }
+
+std::wstring_view Utils::TrimPaste(std::wstring_view textView)
+{
+    const auto pos = textView.find_last_not_of(L"\t\n\v\f\r ");
+    if (pos == textView.npos)
+    {
+        // Text is all white space, nothing to paste
+        return L"";
+    }
+    else if (const auto toRemove = textView.size() - 1 - pos; toRemove > 0)
+    {
+        textView.remove_suffix(toRemove);
+    }
+    return textView;
+}

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -773,7 +773,7 @@ std::tuple<std::wstring, std::wstring> Utils::MangleStartingDirectoryForWSL(std:
     };
 }
 
-std::wstring_view Utils::TrimPaste(std::wstring_view textView)
+std::wstring_view Utils::TrimPaste(std::wstring_view textView) noexcept
 {
     const auto lastNonSpace = textView.find_last_not_of(L"\t\n\v\f\r ");
     const auto firstNewline = textView.find_first_of(L"\n\v\f\r");

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -775,13 +775,35 @@ std::tuple<std::wstring, std::wstring> Utils::MangleStartingDirectoryForWSL(std:
 
 std::wstring_view Utils::TrimPaste(std::wstring_view textView)
 {
-    const auto pos = textView.find_last_not_of(L"\t\n\v\f\r ");
-    if (pos == textView.npos)
+    const auto lastNonSpace = textView.find_last_not_of(L"\t\n\v\f\r ");
+    const auto firstNewline = textView.find_first_of(L"\n\v\f\r");
+    const auto firstTab = textView.find_first_of(L"\t");
+    const bool onlyWhitespace = lastNonSpace == textView.npos;
+    const bool hasNewline = firstNewline != textView.npos;
+    // We want to trim trailing tabs when:
+    // * there is a tab in the string
+    // * it's after the last non-whitespace char
+    //
+    // So "Foo Bar\t\n" gets trimmed but "foo\tbar\n" doesn't.
+    const bool trimTab = (firstTab != textView.npos) &&
+                         (hasNewline) &&
+                         (!onlyWhitespace) &&
+                         (firstTab > lastNonSpace || firstTab >= firstNewline);
+
+    if (onlyWhitespace)
     {
         // Text is all white space, nothing to paste
         return L"";
     }
-    else if (const auto toRemove = textView.size() - 1 - pos; toRemove > 0)
+    else if (!trimTab && firstNewline != textView.npos && (lastNonSpace + 1 != firstNewline))
+    {
+        // In this case, there was trailing whitespace, but there was also a
+        // newline somewhere in the middle of the text. In this case, the user
+        // totally wanted to paste multiple lines of text, and that likely
+        // includes the trailing newline.
+        // DON'T trim it in this case.
+    }
+    else if (const auto toRemove = textView.size() - 1 - lastNonSpace; trimTab || toRemove > 0)
     {
         textView.remove_suffix(toRemove);
     }

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -777,35 +777,28 @@ std::wstring_view Utils::TrimPaste(std::wstring_view textView)
 {
     const auto lastNonSpace = textView.find_last_not_of(L"\t\n\v\f\r ");
     const auto firstNewline = textView.find_first_of(L"\n\v\f\r");
-    const auto firstTab = textView.find_first_of(L"\t");
-    const bool onlyWhitespace = lastNonSpace == textView.npos;
-    const bool hasNewline = firstNewline != textView.npos;
-    // We want to trim trailing tabs when:
-    // * there is a tab in the string
-    // * it's after the last non-whitespace char
-    //
-    // So "Foo Bar\t\n" gets trimmed but "foo\tbar\n" doesn't.
-    const bool trimTab = (firstTab != textView.npos) &&
-                         (hasNewline) &&
-                         (!onlyWhitespace) &&
-                         (firstTab > lastNonSpace || firstTab >= firstNewline);
 
-    if (onlyWhitespace)
+    const bool isOnlyWhitespace = lastNonSpace == textView.npos;
+    const bool isMultiline = firstNewline < lastNonSpace;
+    
+    if (isOnlyWhitespace)
     {
         // Text is all white space, nothing to paste
         return L"";
     }
-    else if (!trimTab && firstNewline != textView.npos && (lastNonSpace + 1 != firstNewline))
+
+    if (isMultiline)
     {
-        // In this case, there was trailing whitespace, but there was also a
-        // newline somewhere in the middle of the text. In this case, the user
-        // totally wanted to paste multiple lines of text, and that likely
-        // includes the trailing newline.
+        // In this case, the user totally wanted to paste multiple lines of text,
+        // and that likely includes the trailing newline.
         // DON'T trim it in this case.
+        return textView;
     }
-    else if (const auto toRemove = textView.size() - 1 - lastNonSpace; trimTab || toRemove > 0)
+
+    if (const auto toRemove = textView.size() - 1 - lastNonSpace; toRemove > 0)
     {
         textView.remove_suffix(toRemove);
     }
+
     return textView;
 }


### PR DESCRIPTION
## Summary of the Pull Request
Skips whitespace removal if pasted string is multiline

## PR Checklist
* [x] Closes #12387
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed
Tests passed
The last command in multiline paste now executes