### PR TITLE
Stop writing optional theme fields

### DIFF
--- a/src/cascadia/TerminalSettingsModel/Theme.cpp
+++ b/src/cascadia/TerminalSettingsModel/Theme.cpp
@@ -31,6 +31,35 @@ static constexpr std::string_view NameKey{ "name" };
 static constexpr wchar_t RegKeyDwm[] = L"Software\\Microsoft\\Windows\\DWM";
 static constexpr wchar_t RegKeyAccentColor[] = L"AccentColor";
 
+#define THEME_SETTINGS_COPY(type, name, jsonKey, ...) \
+    result->_##name = _##name;
+
+#define THEME_SETTINGS_TO_JSON(type, name, jsonKey, ...) \
+    JsonUtils::SetValueForKey(json, jsonKey, _##name);
+
+#define THEME_OBJECT(className, macro)                    \
+    winrt::com_ptr<className> className::Copy()           \
+    {                                                     \
+        auto result{ winrt::make_self<className>() };     \
+        macro(THEME_SETTINGS_COPY);                       \
+        return result;                                    \
+    }                                                     \
+                                                          \
+    Json::Value className::ToJson()                       \
+    {                                                     \
+        Json::Value json{ Json::ValueType::objectValue }; \
+        macro(THEME_SETTINGS_TO_JSON);                    \
+        return json;                                      \
+    }
+
+THEME_OBJECT(WindowTheme, MTSM_THEME_WINDOW_SETTINGS);
+THEME_OBJECT(TabRowTheme, MTSM_THEME_TABROW_SETTINGS);
+THEME_OBJECT(TabTheme, MTSM_THEME_TAB_SETTINGS);
+
+#undef THEME_SETTINGS_COPY
+#undef THEME_SETTINGS_TO_JSON
+#undef THEME_OBJECT
+
 winrt::Microsoft::Terminal::Settings::Model::ThemeColor ThemeColor::FromColor(const winrt::Microsoft::Terminal::Core::Color& coreColor) noexcept
 {
     auto result = winrt::make_self<implementation::ThemeColor>();
@@ -178,9 +207,6 @@ winrt::WUX::Media::Brush ThemeColor::Evaluate(const winrt::WUX::ResourceDictiona
             result->name(*_val);                                              \
     }
 
-#define THEME_SETTINGS_TO_JSON(type, name, jsonKey, ...) \
-    JsonUtils::SetValueForKey(json, jsonKey, val.name());
-
 #define THEME_OBJECT_CONVERTER(nameSpace, name, macro)                                         \
     template<>                                                                                 \
     struct ::Microsoft::Terminal::Settings::Model::JsonUtils::ConversionTrait<nameSpace::name> \
@@ -201,11 +227,7 @@ winrt::WUX::Media::Brush ThemeColor::Evaluate(const winrt::WUX::ResourceDictiona
                                                                                                \
         Json::Value ToJson(const nameSpace::name& val)                                         \
         {                                                                                      \
-            if (val == nullptr)                                                                \
-                return Json::Value::null;                                                      \
-            Json::Value json{ Json::ValueType::objectValue };                                  \
-            macro(THEME_SETTINGS_TO_JSON);                                                     \
-            return json;                                                                       \
+            return val ? winrt::get_self<name>(val)->ToJson() : Json::Value::null;             \
         }                                                                                      \
                                                                                                \
         std::string TypeDescription() const                                                    \
@@ -221,11 +243,6 @@ THEME_OBJECT_CONVERTER(winrt::Microsoft::Terminal::Settings::Model, TabTheme, MT
 #undef THEME_SETTINGS_FROM_JSON
 #undef THEME_SETTINGS_TO_JSON
 #undef THEME_OBJECT_CONVERTER
-
-Theme::Theme() noexcept :
-    Theme{ winrt::WUX::ElementTheme::Default }
-{
-}
 
 Theme::Theme(const winrt::WUX::ElementTheme& requestedTheme) noexcept
 {

--- a/src/cascadia/TerminalSettingsModel/Theme.h
+++ b/src/cascadia/TerminalSettingsModel/Theme.h
@@ -47,24 +47,13 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 #define THEME_SETTINGS_INITIALIZE(type, name, jsonKey, ...) \
     WINRT_PROPERTY(type, name, ##__VA_ARGS__)
 
-#define THEME_SETTINGS_COPY(type, name, jsonKey, ...) \
-    result->_##name = _##name;
-
-#define COPY_THEME_OBJECT(T, macro)           \
-    winrt::com_ptr<T> Copy()                  \
-    {                                         \
-        auto result{ winrt::make_self<T>() }; \
-        macro(THEME_SETTINGS_COPY);           \
-        return result;                        \
-    }
-
 #define THEME_OBJECT(className, macro)         \
     struct className : className##T<className> \
     {                                          \
-        macro(THEME_SETTINGS_INITIALIZE);      \
+        winrt::com_ptr<className> Copy();      \
+        Json::Value ToJson();                  \
                                                \
-    public:                                    \
-        COPY_THEME_OBJECT(className, macro);   \
+        macro(THEME_SETTINGS_INITIALIZE);      \
     };
 
     THEME_OBJECT(WindowTheme, MTSM_THEME_WINDOW_SETTINGS);
@@ -74,7 +63,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     struct Theme : ThemeT<Theme>
     {
     public:
-        Theme() noexcept;
+        Theme() = default;
         Theme(const winrt::Windows::UI::Xaml::ElementTheme& requestedTheme) noexcept;
 
         com_ptr<Theme> Copy() const;
@@ -95,8 +84,6 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     };
 
 #undef THEME_SETTINGS_INITIALIZE
-#undef THEME_SETTINGS_COPY
-#undef COPY_THEME_OBJECT
 #undef THEME_OBJECT
 }
 


### PR DESCRIPTION
Other settings model classes call `JsonUtils::SetValueForKey` with the
private `_##value` member as the value. Since `_##value` is an optional,
this prevented writing out unset, optional fields. The new `Themes` class
deviated from this and this commit brings it back in line with the others.

Closes #13544

## Validation Steps Performed
* Create a `{ "name": "test" }` theme
* Save settings via the UI
* Optional/Defaulted fields aren't written ✅