### PR TITLE
Fixe arg parsing when one-character argument is followed by `;`

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/CommandlineTest.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/CommandlineTest.cpp
@@ -349,6 +349,21 @@ namespace TerminalAppLocalTests
             VERIFY_ARE_EQUAL("wt.exe", commandlines.at(3).Args().at(0));
             VERIFY_ARE_EQUAL("baz", commandlines.at(3).Args().at(1));
         }
+        {
+            std::vector<const wchar_t*> rawCommands{ L"wt.exe", L"-p", L"u;", L"nt", L"-p", L"u" };
+
+            auto commandlines = AppCommandlineArgs::BuildCommands(rawCommands);
+            VERIFY_ARE_EQUAL(2u, commandlines.size());
+            VERIFY_ARE_EQUAL(3u, commandlines.at(0).Argc());
+            VERIFY_ARE_EQUAL("wt.exe", commandlines.at(0).Args().at(0));
+            VERIFY_ARE_EQUAL("-p", commandlines.at(0).Args().at(1));
+            VERIFY_ARE_EQUAL("u", commandlines.at(0).Args().at(2));
+            VERIFY_ARE_EQUAL(4u, commandlines.at(1).Argc());
+            VERIFY_ARE_EQUAL("wt.exe", commandlines.at(1).Args().at(0));
+            VERIFY_ARE_EQUAL("nt", commandlines.at(1).Args().at(1));
+            VERIFY_ARE_EQUAL("-p", commandlines.at(1).Args().at(2));
+            VERIFY_ARE_EQUAL("u", commandlines.at(1).Args().at(3));
+        }
     }
 
     void CommandlineTest::TestEscapeDelimiters()

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -809,7 +809,11 @@ void AppCommandlineArgs::_addCommandsForArg(std::vector<Commandline>& commands, 
         else
         {
             // Harder case: There was a match.
-            const auto matchedFirstChar = match.position(0) == 0;
+
+            // Regex will include the last character of the string before the delimiter. (see _commandDelimiterRegex)
+            // If the match was at the beginning of the string then there is no last character
+            // so we can use the length of the match to determine if it was at the beginning.
+            const auto matchedFirstChar = match[0].length() == 1;
             // If the match was at the beginning of the string, then the
             // next arg should be "", since there was no content before the
             // delimiter. Otherwise, add one, since the regex will include


### PR DESCRIPTION
## Summary of the Pull Request
Changes the way `_addCommandsForArg` determines if the delimiter was at the beginning of the argument so that it accounts for the fact that match includes the last character of the string before it.

## PR Checklist
* [x] Closes #13277

## Validation Steps Performed
`wt -p "u"; nt -p "u"` does not cause an error