### PR TITLE
Update prerequisites to include VS 2022

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -26,10 +26,10 @@
     "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
     "Microsoft.VisualStudio.Component.VC.Tools.ARM64",
     "Microsoft.VisualStudio.Component.VC.ASAN",
-    "Microsoft.VisualStudio.Component.VC.v142.x86.x64",
-    "Microsoft.VisualStudio.Component.VC.v142.ARM64",
+    "Microsoft.VisualStudio.Component.VC.v143.x86.x64",
+    "Microsoft.VisualStudio.Component.VC.v143.ARM64",
     "Microsoft.VisualStudio.ComponentGroup.UWP.VC",
-    "Microsoft.VisualStudio.ComponentGroup.UWP.VC.v142",
+    "Microsoft.VisualStudio.ComponentGroup.UWP.VC.v143",
     "Microsoft.VisualStudio.Component.UWP.VC.ARM64"
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ When you hit "New Issue", select the type of issue closest to what you want to r
   Microsoft Windows [Version 10.0.18900.1001]
   ```
 
-* What tools and apps you're using (e.g. VS 2019, VSCode, etc.)
+* What tools and apps you're using (e.g. VS 2022, VSCode, etc.)
 * Don't assume we're experts in setting up YOUR environment and don't assume we are experts in `<your distro/tool of choice>`. Teach us to help you!
 * **We LOVE detailed repro steps!** What steps do we need to take to reproduce the issue? Assume we love to read repro steps. As much detail as you can stand is probably _barely_ enough detail for us!
 * If you're reporting a particular character/glyph not rendering correctly, the specific Unicode codepoint would be MOST welcome (e.g. U+1F4AF, U+4382)

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ While overhauling Windows Console, we modernized its codebase considerably,
 cleanly separating logical entities into modules and classes, introduced some
 key extensibility points, replaced several old, home-grown collections and
 containers with safer, more efficient [STL
-containers](https://docs.microsoft.com/en-us/cpp/standard-library/stl-containers?view=vs-2019),
+containers](https://docs.microsoft.com/en-us/cpp/standard-library/stl-containers?view=vs-2022),
 and made the code simpler and safer by using Microsoft's [Windows Implementation
 Libraries - WIL](https://github.com/Microsoft/wil).
 
@@ -291,14 +291,14 @@ If you would like to ask a question that you feel doesn't warrant an issue
   SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/)
   installed
 * You must have at least [VS
-  2019](https://visualstudio.microsoft.com/downloads/) installed
+  2022](https://visualstudio.microsoft.com/downloads/) installed
 * You must install the following Workloads via the VS Installer. Note: Opening
-  the solution in VS 2019 will [prompt you to install missing components
+  the solution in VS 2022 will [prompt you to install missing components
   automatically](https://devblogs.microsoft.com/setup/configure-visual-studio-across-your-organization-with-vsconfig/):
   * Desktop Development with C++
   * Universal Windows Platform Development
   * **The following Individual Components**
-    * C++ (v142) Universal Windows Platform Tools
+    * C++ (v143) Universal Windows Platform Tools
 * You must install the [.NET Framework Targeting Pack](https://docs.microsoft.com/dotnet/framework/install/guide-for-developers#to-install-the-net-framework-developer-pack-or-targeting-pack) to build test projects
 
 ## Building the Code


### PR DESCRIPTION
bd403dc made VS 2022 mandatory, but failed to update the README and .vsconfig.

Closes #13708