### PR TITLE
[1.14/5] Propagate the color scheme resw changes from df671377

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.cpp
@@ -36,22 +36,22 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     static constexpr std::wstring_view SelectionBackgroundColorTag{ L"SelectionBackground" };
 
     static const std::array<hstring, 16> TableColorNames = {
-        RS_(L"ColorScheme_Black/Header"),
-        RS_(L"ColorScheme_Red/Header"),
-        RS_(L"ColorScheme_Green/Header"),
-        RS_(L"ColorScheme_Yellow/Header"),
-        RS_(L"ColorScheme_Blue/Header"),
-        RS_(L"ColorScheme_Purple/Header"),
-        RS_(L"ColorScheme_Cyan/Header"),
-        RS_(L"ColorScheme_White/Header"),
-        RS_(L"ColorScheme_BrightBlack/Header"),
-        RS_(L"ColorScheme_BrightRed/Header"),
-        RS_(L"ColorScheme_BrightGreen/Header"),
-        RS_(L"ColorScheme_BrightYellow/Header"),
-        RS_(L"ColorScheme_BrightBlue/Header"),
-        RS_(L"ColorScheme_BrightPurple/Header"),
-        RS_(L"ColorScheme_BrightCyan/Header"),
-        RS_(L"ColorScheme_BrightWhite/Header")
+        RS_(L"ColorScheme_Black/Text"),
+        RS_(L"ColorScheme_Red/Text"),
+        RS_(L"ColorScheme_Green/Text"),
+        RS_(L"ColorScheme_Yellow/Text"),
+        RS_(L"ColorScheme_Blue/Text"),
+        RS_(L"ColorScheme_Purple/Text"),
+        RS_(L"ColorScheme_Cyan/Text"),
+        RS_(L"ColorScheme_White/Text"),
+        RS_(L"ColorScheme_BrightBlack/Text"),
+        RS_(L"ColorScheme_BrightRed/Text"),
+        RS_(L"ColorScheme_BrightGreen/Text"),
+        RS_(L"ColorScheme_BrightYellow/Text"),
+        RS_(L"ColorScheme_BrightBlue/Text"),
+        RS_(L"ColorScheme_BrightPurple/Text"),
+        RS_(L"ColorScheme_BrightCyan/Text"),
+        RS_(L"ColorScheme_BrightWhite/Text")
     };
 
     static const std::array<std::wstring, 9> InBoxSchemes = {
@@ -187,7 +187,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         if (std::find(std::begin(InBoxSchemes), std::end(InBoxSchemes), schemeName) != std::end(InBoxSchemes))
         {
             // load disclaimer for in-box profiles
-            disclaimer = RS_(L"ColorScheme_DeleteButtonDisclaimerInBox");
+            disclaimer = RS_(L"ColorScheme_DeleteButtonDisclaimerInBox/Text");
         }
         DeleteButtonDisclaimer().Text(disclaimer);
 

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -139,43 +139,43 @@
     <value>Background</value>
     <comment>This is the header for a control that lets the user select the background color for text displayed on the screen.</comment>
   </data>
-  <data name="ColorScheme_Black.Header" xml:space="preserve">
+  <data name="ColorScheme_Black.Text" xml:space="preserve">
     <value>Black</value>
     <comment>This is the header for a control that lets the user select the black color for text displayed on the screen.</comment>
   </data>
-  <data name="ColorScheme_Blue.Header" xml:space="preserve">
+  <data name="ColorScheme_Blue.Text" xml:space="preserve">
     <value>Blue</value>
     <comment>This is the header for a control that lets the user select the blue color for text displayed on the screen.</comment>
   </data>
-  <data name="ColorScheme_BrightBlack.Header" xml:space="preserve">
+  <data name="ColorScheme_BrightBlack.Text" xml:space="preserve">
     <value>Bright black</value>
     <comment>This is the header for a control that lets the user select the bright black color for text displayed on the screen.</comment>
   </data>
-  <data name="ColorScheme_BrightBlue.Header" xml:space="preserve">
+  <data name="ColorScheme_BrightBlue.Text" xml:space="preserve">
     <value>Bright blue</value>
     <comment>This is the header for a control that lets the user select the bright blue color for text displayed on the screen.</comment>
   </data>
-  <data name="ColorScheme_BrightCyan.Header" xml:space="preserve">
+  <data name="ColorScheme_BrightCyan.Text" xml:space="preserve">
     <value>Bright cyan</value>
     <comment>This is the header for a control that lets the user select the bright cyan color for text displayed on the screen.</comment>
   </data>
-  <data name="ColorScheme_BrightGreen.Header" xml:space="preserve">
+  <data name="ColorScheme_BrightGreen.Text" xml:space="preserve">
     <value>Bright green</value>
     <comment>This is the header for a control that lets the user select the bright green color for text displayed on the screen.</comment>
   </data>
-  <data name="ColorScheme_BrightPurple.Header" xml:space="preserve">
+  <data name="ColorScheme_BrightPurple.Text" xml:space="preserve">
     <value>Bright purple</value>
     <comment>This is the header for a control that lets the user select the bright purple color for text displayed on the screen.</comment>
   </data>
-  <data name="ColorScheme_BrightRed.Header" xml:space="preserve">
+  <data name="ColorScheme_BrightRed.Text" xml:space="preserve">
     <value>Bright red</value>
     <comment>This is the header for a control that lets the user select the bright red color for text displayed on the screen.</comment>
   </data>
-  <data name="ColorScheme_BrightWhite.Header" xml:space="preserve">
+  <data name="ColorScheme_BrightWhite.Text" xml:space="preserve">
     <value>Bright white</value>
     <comment>This is the header for a control that lets the user select the bright white color for text displayed on the screen.</comment>
   </data>
-  <data name="ColorScheme_BrightYellow.Header" xml:space="preserve">
+  <data name="ColorScheme_BrightYellow.Text" xml:space="preserve">
     <value>Bright yellow</value>
     <comment>This is the header for a control that lets the user select the bright yellow color for text displayed on the screen.</comment>
   </data>
@@ -183,7 +183,7 @@
     <value>Cursor color</value>
     <comment>This is the header for a control that lets the user select the text cursor's color displayed on the screen.</comment>
   </data>
-  <data name="ColorScheme_Cyan.Header" xml:space="preserve">
+  <data name="ColorScheme_Cyan.Text" xml:space="preserve">
     <value>Cyan</value>
     <comment>This is the header for a control that lets the user select the cyan color for text displayed on the screen.</comment>
   </data>
@@ -191,11 +191,11 @@
     <value>Foreground</value>
     <comment>This is the header for a control that lets the user select the foreground color for text displayed on the screen.</comment>
   </data>
-  <data name="ColorScheme_Green.Header" xml:space="preserve">
+  <data name="ColorScheme_Green.Text" xml:space="preserve">
     <value>Green</value>
     <comment>This is the header for a control that lets the user select the green color for text displayed on the screen.</comment>
   </data>
-  <data name="ColorScheme_Purple.Header" xml:space="preserve">
+  <data name="ColorScheme_Purple.Text" xml:space="preserve">
     <value>Purple</value>
     <comment>This is the header for a control that lets the user select the purple color for text displayed on the screen.</comment>
   </data>
@@ -203,15 +203,15 @@
     <value>Selection background</value>
     <comment>This is the header for a control that lets the user select the background color for selected text displayed on the screen.</comment>
   </data>
-  <data name="ColorScheme_Red.Header" xml:space="preserve">
+  <data name="ColorScheme_Red.Text" xml:space="preserve">
     <value>Red</value>
     <comment>This is the header for a control that lets the user select the red color for text displayed on the screen.</comment>
   </data>
-  <data name="ColorScheme_White.Header" xml:space="preserve">
+  <data name="ColorScheme_White.Text" xml:space="preserve">
     <value>White</value>
     <comment>This is the header for a control that lets the user select the white color for text displayed on the screen.</comment>
   </data>
-  <data name="ColorScheme_Yellow.Header" xml:space="preserve">
+  <data name="ColorScheme_Yellow.Text" xml:space="preserve">
     <value>Yellow</value>
     <comment>This is the header for a control that lets the user select the yellow color for text displayed on the screen.</comment>
   </data>
@@ -1198,7 +1198,7 @@
     <value>Rename</value>
     <comment>Text label for a button that can be used to begin the renaming process.</comment>
   </data>
-  <data name="ColorScheme_DeleteButtonDisclaimerInBox" xml:space="preserve">
+  <data name="ColorScheme_DeleteButtonDisclaimerInBox.Text" xml:space="preserve">
     <value>This color scheme cannot be deleted or renamed because it is included by default.</value>
     <comment>Disclaimer presented next to the delete button when it is disabled.</comment>
   </data>


### PR DESCRIPTION
Due to the way our localization pipeline works, we cannot delete
resources in main until the resources in question are totally flushed
out of the active-servicing release branches. Unfortunately, in #13179,
we _did_ remove resource keys. Because the Color Schemes page in 1.14
and 1.15 uses the resources directly (rather than by way of x:Uid), it
is easier for us to backport the resource changes now than to
reintroduce the old keys on main.

Closes #13606