### PR TITLE
Add an UnhandledException handler at teardown

### DIFF
--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -145,6 +145,10 @@ AppHost::~AppHost()
 
     _showHideWindowThrottler.reset();
 
+    _app.UnhandledException([](auto&& /*sender*/, const UnhandledExceptionEventArgs& args) {
+        LOG_HR_MSG(args.Exception(), winrt::to_string(args.Message()).c_str());
+        std::exit(0);
+    });
     _window = nullptr;
     _app.Close();
     _app = nullptr;

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -145,10 +145,17 @@ AppHost::~AppHost()
 
     _showHideWindowThrottler.reset();
 
+    // From a mail thread: Should a UnhandledException be raised by XAML, while
+    // we're tearing down, let's eat it, log it, and just die immediately. This
+    // will prevent unhandled XAML exceptions from crashing with a dump bucket
+    // when the window has already been closed.. We feel this is okay though,
+    // because WE'RE ALREADY IN TEARDOWN! The app is exiting. We don't want a
+    // XAML bug here to create a crash bucket.
     _app.UnhandledException([](auto&& /*sender*/, const UnhandledExceptionEventArgs& args) {
         LOG_HR_MSG(args.Exception(), winrt::to_string(args.Message()).c_str());
         std::exit(0);
     });
+
     _window = nullptr;
     _app.Close();
     _app = nullptr;


### PR DESCRIPTION
This is experimental, for sure. We've had a long battle of exceptions as the app gets closed. This should eat any XAML exceptions during teardown. It won't eat A/V's though.

I'm just throwing the PR out there. We can reject for all I care. We didn't end up needing it for the #12413 follow up. 

\<discuss>