### PR TITLE
Enable AtlasEngine by default in Preview

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -256,7 +256,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                 return false;
             }
 
-            if (Feature_AtlasEngine::IsEnabled() && _settings->UseAtlasEngine())
+            if (_settings->UseAtlasEngine())
             {
                 _renderEngine = std::make_unique<::Microsoft::Console::Render::AtlasEngine>();
             }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2087,7 +2087,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // GH#10211 - UNDER NO CIRCUMSTANCE should this fail. If it does, the
         // whole app will crash instantaneously on launch, which is no good.
         double scale;
-        if (Feature_AtlasEngine::IsEnabled() && settings.UseAtlasEngine())
+        if (settings.UseAtlasEngine())
         {
             auto engine = std::make_unique<::Microsoft::Console::Render::AtlasEngine>();
             LOG_IF_FAILED(engine->UpdateDpi(dpi));

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.cpp
@@ -293,11 +293,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         return _unfocusedAppearanceViewModel;
     }
 
-    bool ProfileViewModel::AtlasEngineAvailable() const noexcept
-    {
-        return Feature_AtlasEngine::IsEnabled();
-    }
-
     bool ProfileViewModel::VtPassthroughAvailable() const noexcept
     {
         return Feature_VtPassthroughMode::IsEnabled() && Feature_VtPassthroughModeSettingInUI::IsEnabled();

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.h
@@ -72,7 +72,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         bool ShowUnfocusedAppearance();
         void CreateUnfocusedAppearance();
         void DeleteUnfocusedAppearance();
-        bool AtlasEngineAvailable() const noexcept;
         bool VtPassthroughAvailable() const noexcept;
 
         VIEW_MODEL_OBSERVABLE_PROPERTY(ProfileSubPage, CurrentPage);

--- a/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/ProfileViewModel.idl
@@ -62,7 +62,6 @@ namespace Microsoft.Terminal.Settings.Editor
         Boolean EditableUnfocusedAppearance { get; };
         Boolean ShowUnfocusedAppearance { get; };
         AppearanceViewModel UnfocusedAppearance { get; };
-        Boolean AtlasEngineAvailable { get; };
         Boolean VtPassthroughAvailable { get; };
 
         void CreateUnfocusedAppearance();

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
@@ -122,8 +122,7 @@
                 <local:SettingContainer x:Uid="Profile_UseAtlasEngine"
                                         ClearSettingValue="{x:Bind Profile.ClearUseAtlasEngine}"
                                         HasSettingValue="{x:Bind Profile.HasUseAtlasEngine, Mode=OneWay}"
-                                        SettingOverrideSource="{x:Bind Profile.UseAtlasEngineOverrideSource, Mode=OneWay}"
-                                        Visibility="{x:Bind Profile.AtlasEngineAvailable}">
+                                        SettingOverrideSource="{x:Bind Profile.UseAtlasEngineOverrideSource, Mode=OneWay}">
                     <ToggleSwitch IsOn="{x:Bind Profile.UseAtlasEngine, Mode=TwoWay}"
                                   Style="{StaticResource ToggleSwitchInExpanderStyle}" />
                 </local:SettingContainer>

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -77,7 +77,7 @@ Author(s):
     X(CloseOnExitMode, CloseOnExit, "closeOnExit", CloseOnExitMode::Automatic)                                                                                 \
     X(hstring, TabTitle, "tabTitle")                                                                                                                           \
     X(Model::BellStyle, BellStyle, "bellStyle", BellStyle::Audible)                                                                                            \
-    X(bool, UseAtlasEngine, "experimental.useAtlasEngine", false)                                                                                              \
+    X(bool, UseAtlasEngine, "experimental.useAtlasEngine", Feature_AtlasEngineByDefault::IsEnabled())                                                          \
     X(Windows::Foundation::Collections::IVector<winrt::hstring>, BellSound, "bellSound", nullptr)                                                              \
     X(bool, Elevate, "elevate", false)                                                                                                                         \
     X(bool, VtPassthrough, "experimental.connection.passthroughMode", false)                                                                                   \

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -77,7 +77,7 @@ Author(s):
     X(CloseOnExitMode, CloseOnExit, "closeOnExit", CloseOnExitMode::Automatic)                                                                                 \
     X(hstring, TabTitle, "tabTitle")                                                                                                                           \
     X(Model::BellStyle, BellStyle, "bellStyle", BellStyle::Audible)                                                                                            \
-    X(bool, UseAtlasEngine, "experimental.useAtlasEngine", Feature_AtlasEngineByDefault::IsEnabled())                                                          \
+    X(bool, UseAtlasEngine, "experimental.useAtlasEngine", Feature_AtlasEngine::IsEnabled())                                                                   \
     X(Windows::Foundation::Collections::IVector<winrt::hstring>, BellSound, "bellSound", nullptr)                                                              \
     X(bool, Elevate, "elevate", false)                                                                                                                         \
     X(bool, VtPassthrough, "experimental.connection.passthroughMode", false)                                                                                   \

--- a/src/features.xml
+++ b/src/features.xml
@@ -125,4 +125,15 @@
         </alwaysEnabledBrandingTokens>
     </feature>
 
+    <feature>
+        <name>Feature_AtlasEngineByDefault</name>
+        <description>Enables the atlas rendering engine on profiles by default.</description>
+        <stage>AlwaysDisabled</stage>
+        <!-- Did it this way instead of "release tokens" to ensure it won't go into Windows Inbox either... -->
+        <alwaysEnabledBrandingTokens>
+            <brandingToken>Dev</brandingToken>
+            <brandingToken>Preview</brandingToken>
+        </alwaysEnabledBrandingTokens>
+    </feature>
+
 </featureStaging>

--- a/src/features.xml
+++ b/src/features.xml
@@ -59,7 +59,7 @@
 
     <feature>
         <name>Feature_AtlasEngine</name>
-        <description>If enabled, AtlasEngine and the experimental.useAtlasEngine setting are compiled into the project</description>
+        <description>If enabled, AtlasEngine is used by default</description>
         <stage>AlwaysEnabled</stage>
         <alwaysDisabledBrandingTokens>
             <brandingToken>Release</brandingToken>
@@ -117,17 +117,6 @@
     <feature>
         <name>Feature_ScrollbarMarks</name>
         <description>Enables the experimental scrollbar marks feature.</description>
-        <stage>AlwaysDisabled</stage>
-        <!-- Did it this way instead of "release tokens" to ensure it won't go into Windows Inbox either... -->
-        <alwaysEnabledBrandingTokens>
-            <brandingToken>Dev</brandingToken>
-            <brandingToken>Preview</brandingToken>
-        </alwaysEnabledBrandingTokens>
-    </feature>
-
-    <feature>
-        <name>Feature_AtlasEngineByDefault</name>
-        <description>Enables the atlas rendering engine on profiles by default.</description>
         <stage>AlwaysDisabled</stage>
         <!-- Did it this way instead of "release tokens" to ensure it won't go into Windows Inbox either... -->
         <alwaysEnabledBrandingTokens>

--- a/src/features.xml
+++ b/src/features.xml
@@ -34,6 +34,16 @@
             <brandingToken>WindowsInbox</brandingToken>
         </alwaysDisabledBrandingTokens>
     </feature>
+
+    <feature>
+        <name>Feature_ConhostAtlasEngine</name>
+        <description>Controls whether conhost supports the Atlas engine</description>
+        <stage>AlwaysEnabled</stage>
+        <alwaysDisabledBrandingTokens>
+            <brandingToken>WindowsInbox</brandingToken>
+        </alwaysDisabledBrandingTokens>
+    </feature>
+
     <feature>
         <name>Feature_DxEngineShaderSupport</name>
         <description>Controls whether the DX engine is built with shader support.</description>

--- a/src/interactivity/win32/window.cpp
+++ b/src/interactivity/win32/window.cpp
@@ -25,10 +25,7 @@
 
 #include "../../renderer/base/renderer.hpp"
 #include "../../renderer/gdi/gdirenderer.hpp"
-
-#if TIL_FEATURE_ATLASENGINE_ENABLED
 #include "../../renderer/atlas/AtlasEngine.h"
-#endif
 #if TIL_FEATURE_CONHOSTDXENGINE_ENABLED
 #include "../../renderer/dx/DxRenderer.hpp"
 #endif
@@ -74,9 +71,7 @@ Window::~Window()
 #if TIL_FEATURE_CONHOSTDXENGINE_ENABLED
     delete pDxEngine;
 #endif
-#if TIL_FEATURE_ATLASENGINE_ENABLED
     delete pAtlasEngine;
-#endif
 #endif
 }
 
@@ -231,12 +226,10 @@ void Window::_UpdateSystemMetrics() const
             g.pRender->AddRenderEngine(pDxEngine);
             break;
 #endif
-#if TIL_FEATURE_ATLASENGINE_ENABLED
         case UseDx::AtlasEngine:
             pAtlasEngine = new AtlasEngine();
             g.pRender->AddRenderEngine(pAtlasEngine);
             break;
-#endif
         default:
             pGdiEngine = new GdiEngine();
             g.pRender->AddRenderEngine(pGdiEngine);
@@ -344,13 +337,11 @@ void Window::_UpdateSystemMetrics() const
             }
             else
 #endif
-#if TIL_FEATURE_ATLASENGINE_ENABLED
                 if (pAtlasEngine)
             {
                 status = NTSTATUS_FROM_WIN32(HRESULT_CODE((pAtlasEngine->SetHwnd(hWnd))));
             }
             else
-#endif
             {
                 status = NTSTATUS_FROM_WIN32(HRESULT_CODE((pGdiEngine->SetHwnd(hWnd))));
             }

--- a/src/interactivity/win32/window.cpp
+++ b/src/interactivity/win32/window.cpp
@@ -25,7 +25,10 @@
 
 #include "../../renderer/base/renderer.hpp"
 #include "../../renderer/gdi/gdirenderer.hpp"
+
+#if TIL_FEATURE_CONHOSTATLASENGINE_ENABLED
 #include "../../renderer/atlas/AtlasEngine.h"
+#endif
 #if TIL_FEATURE_CONHOSTDXENGINE_ENABLED
 #include "../../renderer/dx/DxRenderer.hpp"
 #endif
@@ -71,7 +74,9 @@ Window::~Window()
 #if TIL_FEATURE_CONHOSTDXENGINE_ENABLED
     delete pDxEngine;
 #endif
+#if TIL_FEATURE_CONHOSTATLASENGINE_ENABLED
     delete pAtlasEngine;
+#endif
 #endif
 }
 
@@ -226,10 +231,12 @@ void Window::_UpdateSystemMetrics() const
             g.pRender->AddRenderEngine(pDxEngine);
             break;
 #endif
+#if TIL_FEATURE_CONHOSTATLASENGINE_ENABLED
         case UseDx::AtlasEngine:
             pAtlasEngine = new AtlasEngine();
             g.pRender->AddRenderEngine(pAtlasEngine);
             break;
+#endif
         default:
             pGdiEngine = new GdiEngine();
             g.pRender->AddRenderEngine(pGdiEngine);
@@ -337,12 +344,14 @@ void Window::_UpdateSystemMetrics() const
             }
             else
 #endif
+#if TIL_FEATURE_CONHOSTATLASENGINE_ENABLED
                 if (pAtlasEngine)
             {
                 status = NTSTATUS_FROM_WIN32(HRESULT_CODE((pAtlasEngine->SetHwnd(hWnd))));
             }
             else
             {
+#endif
                 status = NTSTATUS_FROM_WIN32(HRESULT_CODE((pGdiEngine->SetHwnd(hWnd))));
             }
 

--- a/src/interactivity/win32/window.hpp
+++ b/src/interactivity/win32/window.hpp
@@ -116,7 +116,9 @@ namespace Microsoft::Console::Interactivity::Win32
 #if TIL_FEATURE_CONHOSTDXENGINE_ENABLED
         Render::DxEngine* pDxEngine = nullptr;
 #endif
+#if TIL_FEATURE_CONHOSTATLASENGINE_ENABLED
         Render::AtlasEngine* pAtlasEngine = nullptr;
+#endif
 
         [[nodiscard]] NTSTATUS _InternalSetWindowSize();
         void _UpdateWindowSize(const til::size sizeNew);

--- a/src/interactivity/win32/window.hpp
+++ b/src/interactivity/win32/window.hpp
@@ -116,9 +116,7 @@ namespace Microsoft::Console::Interactivity::Win32
 #if TIL_FEATURE_CONHOSTDXENGINE_ENABLED
         Render::DxEngine* pDxEngine = nullptr;
 #endif
-#if TIL_FEATURE_ATLASENGINE_ENABLED
         Render::AtlasEngine* pAtlasEngine = nullptr;
-#endif
 
         [[nodiscard]] NTSTATUS _InternalSetWindowSize();
         void _UpdateWindowSize(const til::size sizeNew);


### PR DESCRIPTION
Repurpose `Feature_AtlasEngine` to enable the atlas engine by default in Dev and Preview builds.
Introduce `Feature_ConhostAtlasEngine` to solely control atlas engine inclusion in conhost.

Closes #13745