### PR TITLE
AtlasEngine: Fix debugGlyphGenerationPerformance

### DIFF
--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -903,7 +903,8 @@ namespace Microsoft::Console::Render
         void _drawCursor();
 
         static constexpr bool debugGlyphGenerationPerformance = false;
-        static constexpr bool debugGeneralPerformance = false || debugGlyphGenerationPerformance;
+        static constexpr bool debugTextParsingPerformance = false || debugGlyphGenerationPerformance;
+        static constexpr bool debugGeneralPerformance = false || debugTextParsingPerformance;
 
         static constexpr u16 u16min = 0x0000;
         static constexpr u16 u16max = 0xffff;


### PR DESCRIPTION
`debugGlyphGenerationPerformance` used to only test the performance of
text segmentation/parsing, so I renamed it to `debugTextParsingPerformance`.
The new `debugGlyphGenerationPerformance` actually clears the glyph atlas now.

Additionally this fixes a bug with `debugGeneralPerformance`:
If a `DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT` is requested,
it needs to be used. Since `debugGeneralPerformance` is for testing without
V-Sync, we need to ensure that the waitable object is properly disabled.