### PR TITLE
Use the redirection service for recently added URLs

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -733,7 +733,7 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_SendFeedbackOnClick(const IInspectable& /*sender*/, const Windows::UI::Xaml::Controls::ContentDialogButtonClickEventArgs& /*eventArgs*/)
     {
 #if defined(WT_BRANDING_RELEASE)
-        ShellExecute(nullptr, nullptr, L"https://aka.ms/terminal-feedback-hub", nullptr, nullptr, SW_SHOW);
+        ShellExecute(nullptr, nullptr, L"https://go.microsoft.com/fwlink/?linkid=2125419", nullptr, nullptr, SW_SHOW);
 #else
         ShellExecute(nullptr, nullptr, L"https://go.microsoft.com/fwlink/?linkid=2204904", nullptr, nullptr, SW_SHOW);
 #endif

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -732,7 +732,11 @@ namespace winrt::TerminalApp::implementation
 
     void TerminalPage::_SendFeedbackOnClick(const IInspectable& /*sender*/, const Windows::UI::Xaml::Controls::ContentDialogButtonClickEventArgs& /*eventArgs*/)
     {
-        ShellExecute(nullptr, nullptr, L"https://github.com/microsoft/terminal/issues", nullptr, nullptr, SW_SHOW);
+#if defined(WT_BRANDING_RELEASE)
+        ShellExecute(nullptr, nullptr, L"https://aka.ms/terminal-feedback-hub", nullptr, nullptr, SW_SHOW);
+#else
+        ShellExecute(nullptr, nullptr, L"https://go.microsoft.com/fwlink/?linkid=2204904", nullptr, nullptr, SW_SHOW);
+#endif
     }
 
     void TerminalPage::_ThirdPartyNoticesOnClick(const IInspectable& /*sender*/, const Windows::UI::Xaml::RoutedEventArgs& /*eventArgs*/)

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -109,7 +109,7 @@
                     <Run Text="{x:Bind ApplicationVersion}" />
                 </TextBlock>
                 <HyperlinkButton x:Uid="AboutDialog_SourceCodeLink"
-                                 NavigateUri="https://github.com/microsoft/terminal" />
+                                 NavigateUri="https://go.microsoft.com/fwlink/?linkid=2203152" />
                 <HyperlinkButton x:Uid="AboutDialog_DocumentationLink"
                                  NavigateUri="https://go.microsoft.com/fwlink/?linkid=2125416" />
                 <HyperlinkButton x:Uid="AboutDialog_ReleaseNotesLink"


### PR DESCRIPTION
We shouldn't add URLs into our binaries that we can't directly control.
This commit fixes the issue for URLs recently introduced in #13510.

Closes #13541

## Validation Steps Performed
This change is trivial enough that I simply opened the new redirects
in my browser, ensuring that they open the expected websites.