### PR TITLE
Restore type inference and integer casting changes in VtEngine

### DIFF
--- a/src/renderer/vt/paint.cpp
+++ b/src/renderer/vt/paint.cpp
@@ -454,12 +454,10 @@ using namespace Microsoft::Console::Types;
     // we trimmed the spaces off here, we'd print all the "~"s one after another
     // on the same line.
     static const TextAttribute defaultAttrs{};
-    const bool removeSpaces = !lineWrapped && (useEraseChar // we determined earlier that ECH is optimal
+    const auto removeSpaces = !lineWrapped && (useEraseChar // we determined earlier that ECH is optimal
                                                || (_clearedAllThisFrame && _lastTextAttributes == defaultAttrs) // OR we cleared the last frame to the default attributes (specifically)
                                                || (_newBottomLine && printingBottomLine && bgMatched)); // OR we just scrolled a new line onto the bottom of the screen with the correct attributes
-    const size_t cchActual = removeSpaces ?
-                                 (cchLine - numSpaces) :
-                                 cchLine;
+    const auto cchActual = removeSpaces ? nonSpaceLength : cchLine;
 
     const auto columnsActual = removeSpaces ?
                                    (totalWidth - numSpaces) :


### PR DESCRIPTION
PR #13665 reverted this part of paint.cpp to a time before #13097 and #12975.
This commit restores those changes.