### PR TITLE
Allow til::from_wchars to work with chars

### DIFF
--- a/src/cascadia/TerminalSettingsModel/KeyChordSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/KeyChordSerialization.cpp
@@ -101,7 +101,7 @@ static int32_t parseNumericCode(const std::wstring_view& str, const std::wstring
         return 0;
     }
 
-    const auto value = til::from_wchars({ str.data() + prefix.size(), str.size() - prefix.size() - suffix.size() });
+    const auto value = til::to_ulong({ str.data() + prefix.size(), str.size() - prefix.size() - suffix.size() });
     if (value > 0 && value < 256)
     {
         return gsl::narrow_cast<int32_t>(value);

--- a/src/til/ut_til/string.cpp
+++ b/src/til/ut_til/string.cpp
@@ -53,9 +53,9 @@ class StringTests
         VERIFY_IS_TRUE(til::ends_with("0abc", "abc"));
     }
 
-    // Normally this would be the spot where you'd find a TEST_METHOD(from_wchars).
+    // Normally this would be the spot where you'd find a TEST_METHOD(to_ulong).
     // I didn't quite trust my coding skills and thus opted to use fuzz-testing.
-    // The below function was used to test from_wchars for unsafety and conformance with clang's strtoul.
+    // The below function was used to test to_ulong for unsafety and conformance with clang's strtoul.
     // The test was run as:
     //   clang++ -fsanitize=address,undefined,fuzzer -std=c++17 file.cpp
     // and was run for 20min across 16 jobs in parallel.
@@ -93,7 +93,7 @@ class StringTests
             return 0;
         }
 
-        const auto actual = from_wchars({ wide_buffer, size });
+        const auto actual = to_ulong({ wide_buffer, size });
         if (expected != actual)
         {
             __builtin_trap();


### PR DESCRIPTION
Rename `til::form_wchars` to `til::to_ulong` and
allow it to work with narrow `char`s.

This change will be used in #13429.

## Validation Steps Performed
* Loads `sc(...)` key bindings as expected ✅
* The change is thankfully fairly trivial if viewn with whitespace suppressed