### PR TITLE
[UIA] Prevent erroneous `L'\0'` padding in `GetText(INT_MAX)`

### DIFF
--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -1009,7 +1009,7 @@ std::wstring UiaTextRangeBase::_getTextValue(til::CoordType maxLength) const
         else if (textRects.size() == 1)
         {
             const auto rect = textRects.front();
-            textData.reserve(rect.right - rect.left + 1);
+            textData.reserve(base::ClampedNumeric<size_t>(rect.right) - rect.left + 1);
         }
         else
         {
@@ -1019,7 +1019,7 @@ std::wstring UiaTextRangeBase::_getTextValue(til::CoordType maxLength) const
             const auto lastRect = textRects.back();
             const auto lastWidth = lastRect.right - lastRect.left + 1;
 
-            const auto otherWidth = textRects.size() - 2 * bufferSize.Width();
+            const auto otherWidth = base::ClampedNumeric<size_t>(textRects.size()) - 2 * bufferSize.Width();
             textData.reserve(firstWidth + otherWidth + lastWidth);
         }
 
@@ -1037,7 +1037,7 @@ std::wstring UiaTextRangeBase::_getTextValue(til::CoordType maxLength) const
                 textData.push_back(UNICODE_LINEFEED);
             }
 
-            if (textData.size() >= maxLength)
+            if (maxLength > 0 && textData.size() >= gsl::narrow_cast<size_t>(maxLength))
             {
                 textData.resize(maxLength);
                 break;

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -1023,7 +1023,7 @@ std::wstring UiaTextRangeBase::_getTextValue(til::CoordType maxLength) const
     //     they probably just want the whole thing (so don't resize)
     if (const auto s = gsl::narrow_cast<size_t>(maxLength); s < textData.size())
     {
-        textData.resize(maxLength);
+        textData.resize(s);
     }
 
     return textData;

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -1013,7 +1013,9 @@ std::wstring UiaTextRangeBase::_getTextValue(til::CoordType maxLength) const
         }
     }
 
-    if (maxLength >= 0)
+    // if the caller asked for INT_MAX,
+    // they probably just want the whole thing
+    if (maxLength >= 0 && maxLength != INT_MAX)
     {
         textData.resize(maxLength);
     }

--- a/src/types/UiaTextRangeBase.cpp
+++ b/src/types/UiaTextRangeBase.cpp
@@ -1009,13 +1009,19 @@ std::wstring UiaTextRangeBase::_getTextValue(til::CoordType maxLength) const
         textData.reserve(textDataSize);
         for (const auto& text : bufferData.text)
         {
+            if (textData.size() >= maxLength)
+            {
+                // early exit; we're already at/past max length
+                break;
+            }
             textData += text;
         }
     }
 
-    // if the caller asked for INT_MAX,
-    // they probably just want the whole thing
-    if (maxLength >= 0 && maxLength != INT_MAX)
+    // - size_t(-1) gets converted to 0xffff...
+    // - if the maxLength is more than what we have,
+    //     they probably just want the whole thing (so don't resize)
+    if (const auto s = gsl::narrow_cast<size_t>(maxLength); s < textData.size())
     {
         textData.resize(maxLength);
     }


### PR DESCRIPTION
Apparently, calling `GetText(INT_MAX)` causes a HUGE memory spike for a few seconds each time this is called. The [UIA docs](https://docs.microsoft.com/en-us/windows/win32/api/uiautomationcore/nf-uiautomationcore-itextrangeprovider-gettext#parameters) say to put `-1` if no limit is required, but I assume a few people have been hit by this before.

This addresses this issue (and similar ones) in two ways:
1. as we iterate over the lines of text, if we're already past the max length, just break out of the loop
2. _only_ resize if the max length is actually less than the current length. This prevents us padding the string with `L'\0'` erroneously (which is probably what causes the memory spike).