### PR TITLE
Fix two race conditions around pseudo window visibility

### DIFF
--- a/src/host/VtIo.cpp
+++ b/src/host/VtIo.cpp
@@ -257,22 +257,10 @@ bool VtIo::IsUsingVt() const
             g.pRender->AddRenderEngine(_pVtRenderEngine.get());
             g.getConsoleInformation().GetActiveOutputBuffer().SetTerminalConnection(_pVtRenderEngine.get());
             g.getConsoleInformation().GetActiveInputBuffer()->SetTerminalConnection(_pVtRenderEngine.get());
-            ServiceLocator::SetPseudoWindowCallback([&](bool showOrHide) -> void {
-                // MSFT:40853556 Grab the shutdown lock here, so that another
-                // thread can't trigger a CloseOutput and release the
-                // _pVtRenderEngine out from underneath us.
-                //
-                // I'm doing this instead of just
-                // SetPseudoWindowCallback(nullptr), so that we don't just move
-                // the A/V race to in between checking
-                // _pseudoWindowMessageCallback and actually calling it.
-                std::lock_guard<std::mutex> lk(_shutdownLock);
-                if (_pVtRenderEngine)
-                {
-                    // Set the remote window visibility to the request
-                    LOG_IF_FAILED(_pVtRenderEngine->SetWindowVisibility(showOrHide));
-                }
-            });
+
+            // Force the whole window to be put together first.
+            // We don't really need the handle, we just want to leverage the setup steps.
+            ServiceLocator::LocatePseudoWindow();
         }
         CATCH_RETURN();
     }
@@ -338,6 +326,26 @@ bool VtIo::IsUsingVt() const
 void VtIo::CreatePseudoWindow()
 {
     _pPtySignalInputThread->CreatePseudoWindow();
+}
+
+void VtIo::SetWindowVisibility(bool showOrHide) noexcept
+{
+    // MSFT:40853556 Grab the shutdown lock here, so that another
+    // thread can't trigger a CloseOutput and release the
+    // _pVtRenderEngine out from underneath us.
+    std::lock_guard<std::mutex> lk(_shutdownLock);
+
+    if (!_pVtRenderEngine)
+    {
+        return;
+    }
+
+    auto& gci = ::Microsoft::Console::Interactivity::ServiceLocator::LocateGlobals().getConsoleInformation();
+
+    gci.LockConsole();
+    auto unlock = wil::scope_exit([&] { gci.UnlockConsole(); });
+
+    LOG_IF_FAILED(_pVtRenderEngine->SetWindowVisibility(showOrHide));
 }
 
 // Method Description:

--- a/src/host/VtIo.hpp
+++ b/src/host/VtIo.hpp
@@ -53,6 +53,7 @@ namespace Microsoft::Console::VirtualTerminal
         [[nodiscard]] HRESULT ManuallyClearScrollback() const noexcept;
 
         void CreatePseudoWindow();
+        void SetWindowVisibility(bool showOrHide) noexcept;
 
     private:
         // After CreateIoHandlers is called, these will be invalid.

--- a/src/interactivity/base/InteractivityFactory.cpp
+++ b/src/interactivity/base/InteractivityFactory.cpp
@@ -5,6 +5,8 @@
 
 #include "InteractivityFactory.hpp"
 
+#include "../inc/ServiceLocator.hpp"
+
 #ifdef BUILD_ONECORE_INTERACTIVITY
 #include "..\onecore\AccessibilityNotifier.hpp"
 #include "..\onecore\ConsoleControl.hpp"
@@ -372,18 +374,6 @@ using namespace Microsoft::Console::Interactivity;
 }
 
 // Method Description:
-// - Gives the pseudo console window a target to relay show/hide window messages
-// Arguments:
-// - func - A function that will take a true for "show" and false for "hide" and
-//          relay that information to the attached terminal to adjust its window state.
-// Return Value:
-// - <none>
-void InteractivityFactory::SetPseudoWindowCallback(std::function<void(bool)> func)
-{
-    _pseudoWindowMessageCallback = func;
-}
-
-// Method Description:
 // - Static window procedure for pseudo console windows
 // - Processes set-up on create to stow the "this" pointer to specific instantiations and routes
 //   to the specific object on future calls.
@@ -492,9 +482,10 @@ void InteractivityFactory::_WritePseudoWindowCallback(bool showOrHide)
     // A hosting terminal window should only "restore" itself in response to
     // this message, if it's already minimized. If the window is maximized a
     // restore will restore-down the window instead.
-    if (_pseudoWindowMessageCallback)
+    auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
+    if (const auto io = gci.GetVtIo())
     {
-        _pseudoWindowMessageCallback(showOrHide);
+        io->SetWindowVisibility(showOrHide);
     }
 }
 

--- a/src/interactivity/base/InteractivityFactory.hpp
+++ b/src/interactivity/base/InteractivityFactory.hpp
@@ -27,7 +27,6 @@ namespace Microsoft::Console::Interactivity
         [[nodiscard]] NTSTATUS CreateSystemConfigurationProvider(_Inout_ std::unique_ptr<ISystemConfigurationProvider>& provider);
 
         [[nodiscard]] NTSTATUS CreatePseudoWindow(HWND& hwnd, const HWND owner);
-        void SetPseudoWindowCallback(std::function<void(bool)> func);
 
         // Wndproc
         [[nodiscard]] static LRESULT CALLBACK s_PseudoWindowProc(_In_ HWND hwnd,
@@ -41,6 +40,5 @@ namespace Microsoft::Console::Interactivity
 
     private:
         void _WritePseudoWindowCallback(bool showOrHide);
-        std::function<void(bool)> _pseudoWindowMessageCallback;
     };
 }

--- a/src/interactivity/base/ServiceLocator.cpp
+++ b/src/interactivity/base/ServiceLocator.cpp
@@ -306,27 +306,6 @@ Globals& ServiceLocator::LocateGlobals()
 }
 
 // Method Description:
-// - Installs a callback method to receive notifications when the pseudo console
-//   window is shown or hidden by an attached client application (so we can
-//   translate it and forward it to the attached terminal, in case it would like
-//   to react accordingly.)
-// Arguments:
-// - func - Callback function that takes True as Show and False as Hide.
-// Return Value:
-// - <none>
-void ServiceLocator::SetPseudoWindowCallback(std::function<void(bool)> func)
-{
-    // Force the whole window to be put together first.
-    // We don't really need the handle, we just want to leverage the setup steps.
-    (void)LocatePseudoWindow();
-
-    if (s_interactivityFactory)
-    {
-        s_interactivityFactory->SetPseudoWindowCallback(func);
-    }
-}
-
-// Method Description:
 // - Retrieves the pseudo console window, or attempts to instantiate one.
 // Arguments:
 // - owner: (defaults to 0 `HWND_DESKTOP`) the HWND that should be the initial

--- a/src/interactivity/inc/IInteractivityFactory.hpp
+++ b/src/interactivity/inc/IInteractivityFactory.hpp
@@ -40,7 +40,6 @@ namespace Microsoft::Console::Interactivity
         [[nodiscard]] virtual NTSTATUS CreateAccessibilityNotifier(_Inout_ std::unique_ptr<IAccessibilityNotifier>& notifier) = 0;
         [[nodiscard]] virtual NTSTATUS CreateSystemConfigurationProvider(_Inout_ std::unique_ptr<ISystemConfigurationProvider>& provider) = 0;
 
-        virtual void SetPseudoWindowCallback(std::function<void(bool)> func) = 0;
         [[nodiscard]] virtual NTSTATUS CreatePseudoWindow(HWND& hwnd, const HWND owner) = 0;
     };
 }

--- a/src/interactivity/inc/ServiceLocator.hpp
+++ b/src/interactivity/inc/ServiceLocator.hpp
@@ -84,7 +84,6 @@ namespace Microsoft::Console::Interactivity
 
         static Globals& LocateGlobals();
 
-        static void SetPseudoWindowCallback(std::function<void(bool)> func);
         static HWND LocatePseudoWindow(const HWND owner = nullptr /*HWND_DESKTOP = 0*/);
 
     protected:


### PR DESCRIPTION
This commit fixes two race conditions:
* `SetPseudoWindowCallback` set the `_pseudoWindowMessageCallback`
  callback after the Win32 message thread was already spawned.
  This issue was fixed by instead using the `ServiceLocator` to get
  a hold of the global `VtIo` instance which is created statically.
* `XtermEngine::SetWindowVisibility` was called without holding the
  console lock. This issue was fixed by simply acquiring it first.

Closes MSFT:40913882

## Validation Steps Performed
* Add `IsConsoleLocked()` assertion in `VtEngine::_Write`
* Run Windows Terminal
* No assertion failures ✅