### PR TITLE
AtlasEngine: Round cell sizes to nearest instead of up

### DIFF
--- a/src/renderer/atlas/AtlasEngine.api.cpp
+++ b/src/renderer/atlas/AtlasEngine.api.cpp
@@ -606,21 +606,22 @@ void AtlasEngine::_resolveFontMetrics(const wchar_t* requestedFaceName, const Fo
     // Point sizes are commonly treated at a 72 DPI scale
     // (including by OpenType), whereas DirectWrite uses 96 DPI.
     // Since we want the height in px we multiply by the display's DPI.
-    const auto fontSize = std::ceilf(requestedSize.Y / 72.0f * _api.dpi);
+    const auto fontSizeInPx = std::roundf(requestedSize.Y / 72.0f * _api.dpi);
 
-    const auto designUnitsPerPx = fontSize / static_cast<float>(metrics.designUnitsPerEm);
+    const auto designUnitsPerPx = fontSizeInPx / static_cast<float>(metrics.designUnitsPerEm);
     const auto ascent = static_cast<float>(metrics.ascent) * designUnitsPerPx;
     const auto descent = static_cast<float>(metrics.descent) * designUnitsPerPx;
     const auto lineGap = static_cast<float>(metrics.lineGap) * designUnitsPerPx;
-    const auto advanceWidth = static_cast<float>(glyphMetrics.advanceWidth) * designUnitsPerPx;
     const auto underlinePosition = static_cast<float>(-metrics.underlinePosition) * designUnitsPerPx;
     const auto underlineThickness = static_cast<float>(metrics.underlineThickness) * designUnitsPerPx;
     const auto strikethroughPosition = static_cast<float>(-metrics.strikethroughPosition) * designUnitsPerPx;
     const auto strikethroughThickness = static_cast<float>(metrics.strikethroughThickness) * designUnitsPerPx;
 
+    const auto advanceWidth = static_cast<float>(glyphMetrics.advanceWidth) * designUnitsPerPx;
+
     const auto halfGap = lineGap / 2.0f;
-    const auto baseline = std::ceilf(ascent + halfGap);
-    const auto lineHeight = std::ceilf(baseline + descent + halfGap);
+    const auto baseline = std::roundf(ascent + halfGap);
+    const auto lineHeight = std::roundf(baseline + descent + halfGap);
     const auto underlinePos = std::roundf(baseline + underlinePosition);
     const auto underlineWidth = std::max(1.0f, std::roundf(underlineThickness));
     const auto strikethroughPos = std::roundf(baseline + strikethroughPosition);
@@ -649,7 +650,7 @@ void AtlasEngine::_resolveFontMetrics(const wchar_t* requestedFaceName, const Fo
     // Our cells can't overlap each other so we additionally clamp the bottom line to be inside the cell boundaries.
     doubleUnderlinePosBottom = std::min(doubleUnderlinePosBottom, lineHeight - thinLineWidth);
 
-    const auto cellWidth = gsl::narrow<u16>(std::ceilf(advanceWidth));
+    const auto cellWidth = gsl::narrow<u16>(std::roundf(advanceWidth));
     const auto cellHeight = gsl::narrow<u16>(lineHeight);
 
     {
@@ -686,7 +687,7 @@ void AtlasEngine::_resolveFontMetrics(const wchar_t* requestedFaceName, const Fo
 
         fontMetrics->fontCollection = std::move(fontCollection);
         fontMetrics->fontName = std::move(fontName);
-        fontMetrics->fontSizeInDIP = fontSize / static_cast<float>(_api.dpi) * 96.0f;
+        fontMetrics->fontSizeInDIP = fontSizeInPx / static_cast<float>(_api.dpi) * 96.0f;
         fontMetrics->baselineInDIP = baseline / static_cast<float>(_api.dpi) * 96.0f;
         fontMetrics->advanceScale = cellWidth / advanceWidth;
         fontMetrics->cellSize = { cellWidth, cellHeight };

--- a/src/renderer/atlas/AtlasEngine.r.cpp
+++ b/src/renderer/atlas/AtlasEngine.r.cpp
@@ -443,14 +443,14 @@ void AtlasEngine::_drawGlyph(const AtlasQueueItem& item) const
         offset.x = clampedOverhang.left - clampedOverhang.right;
         offset.y = clampedOverhang.top - clampedOverhang.bottom;
 
-        if (actualSize.x > layoutBox.x)
+        if ((actualSize.x - layoutBox.x) > _r.dipPerPixel)
         {
             scalingRequired = true;
             offset.x = (overhang.left - overhang.right) * 0.5f;
             scale.x = layoutBox.x / actualSize.x;
             scale.y = scale.x;
         }
-        if (actualSize.y > layoutBox.y)
+        if ((actualSize.y - layoutBox.y) > _r.dipPerPixel)
         {
             scalingRequired = true;
             offset.y = (overhang.top - overhang.bottom) * 0.5f;


### PR DESCRIPTION
After some deliberation I noticed that rounding the glyph advance up to yield
the cell width is at least just as wrong as rounding it. This is because
we draw glyphs centered, meaning that (at least in theory) anti-aliased
pixels might clip outside of the layout box on _both_ sides of the glyph
adding not 1 but 2 extra pixels to the glyph size. Instead of just `ceilf`
we would have had to use `ceilf(advanceWidth / 2) * 2` to account for that.

This commit simplifies our issue by just going with what other applications do:
Round all sizes (cell width and height) to the nearest pixel size.

Closes #13812

## Validation Steps Performed
* Set a breakpoint on `scaling Required == true` in `AtlasEngine::_drawGlyph`
* Test an assortment of Cascadia Mono, Consolas, MS Gothic, Lucida Console
  at various font sizes (6, 7, 8, 10, 12, 24, ...)
* Ensure breakpoint isn't hit ✅
  This tells us that no glyph resizing was necessary