### PR TITLE
Fix a subtle issue with PropertyChanged in ViewModels

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ColorSchemeViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemeViewModel.h
@@ -28,15 +28,16 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         Editor::ColorTableEntry ColorEntryAt(uint32_t index);
 
-        WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
+        // DON'T YOU DARE ADD A `WINRT_CALLBACK(PropertyChanged` TO A CLASS DERIVED FROM ViewModelHelper. Do this instead:
+        using ViewModelHelper<ColorSchemeViewModel>::PropertyChanged;
 
         WINRT_PROPERTY(Windows::Foundation::Collections::IVector<Editor::ColorTableEntry>, NonBrightColorTable, nullptr);
         WINRT_PROPERTY(Windows::Foundation::Collections::IVector<Editor::ColorTableEntry>, BrightColorTable, nullptr);
 
-        WINRT_OBSERVABLE_PROPERTY(Editor::ColorTableEntry, ForegroundColor, _PropertyChangedHandlers, nullptr);
-        WINRT_OBSERVABLE_PROPERTY(Editor::ColorTableEntry, BackgroundColor, _PropertyChangedHandlers, nullptr);
-        WINRT_OBSERVABLE_PROPERTY(Editor::ColorTableEntry, CursorColor, _PropertyChangedHandlers, nullptr);
-        WINRT_OBSERVABLE_PROPERTY(Editor::ColorTableEntry, SelectionBackgroundColor, _PropertyChangedHandlers, nullptr);
+        WINRT_OBSERVABLE_PROPERTY(Editor::ColorTableEntry, ForegroundColor, _propertyChangedHandlers, nullptr);
+        WINRT_OBSERVABLE_PROPERTY(Editor::ColorTableEntry, BackgroundColor, _propertyChangedHandlers, nullptr);
+        WINRT_OBSERVABLE_PROPERTY(Editor::ColorTableEntry, CursorColor, _propertyChangedHandlers, nullptr);
+        WINRT_OBSERVABLE_PROPERTY(Editor::ColorTableEntry, SelectionBackgroundColor, _propertyChangedHandlers, nullptr);
 
     private:
         winrt::hstring _Name;

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemesPageViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemesPageViewModel.cpp
@@ -67,8 +67,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         if (_CurrentScheme != newSelectedScheme)
         {
             _CurrentScheme = newSelectedScheme;
-            _PropertyChangedHandlers(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"CurrentScheme" });
-            _PropertyChangedHandlers(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"CanDeleteCurrentScheme" });
+            _propertyChangedHandlers(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"CurrentScheme" });
+            _propertyChangedHandlers(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"CanDeleteCurrentScheme" });
         }
     }
 
@@ -100,7 +100,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
 
         _AllColorSchemes = single_threaded_observable_vector<Editor::ColorSchemeViewModel>(std::move(allColorSchemes));
-        _PropertyChangedHandlers(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"AllColorSchemes" });
+        _propertyChangedHandlers(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"AllColorSchemes" });
     }
 
     void ColorSchemesPageViewModel::RequestEnterRename()

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemesPageViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemesPageViewModel.h
@@ -28,10 +28,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         bool CanDeleteCurrentScheme() const;
 
-        WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
+        // DON'T YOU DARE ADD A `WINRT_CALLBACK(PropertyChanged` TO A CLASS DERIVED FROM ViewModelHelper. Do this instead:
+        using ViewModelHelper<ColorSchemesPageViewModel>::PropertyChanged;
 
-        WINRT_OBSERVABLE_PROPERTY(bool, InRenameMode, _PropertyChangedHandlers, false);
-        WINRT_OBSERVABLE_PROPERTY(Windows::Foundation::Collections::IObservableVector<Editor::ColorSchemeViewModel>, AllColorSchemes, _PropertyChangedHandlers, nullptr);
+        WINRT_OBSERVABLE_PROPERTY(bool, InRenameMode, _propertyChangedHandlers, false);
+        WINRT_OBSERVABLE_PROPERTY(Windows::Foundation::Collections::IObservableVector<Editor::ColorSchemeViewModel>, AllColorSchemes, _propertyChangedHandlers, nullptr);
 
     private:
         Editor::ColorSchemeViewModel _CurrentScheme{ nullptr };

--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearanceViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearanceViewModel.h
@@ -14,7 +14,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     public:
         GlobalAppearanceViewModel(Model::GlobalAppSettings globalSettings);
 
-        WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
+        // DON'T YOU DARE ADD A `WINRT_CALLBACK(PropertyChanged` TO A CLASS DERIVED FROM ViewModelHelper. Do this instead:
+        using ViewModelHelper<GlobalAppearanceViewModel>::PropertyChanged;
+
         WINRT_PROPERTY(Windows::Foundation::Collections::IObservableVector<Model::Theme>, ThemeList, nullptr);
         GETSET_BINDABLE_ENUM_SETTING(NewTabPosition, Model::NewTabPosition, _GlobalSettings.NewTabPosition);
         GETSET_BINDABLE_ENUM_SETTING(TabWidthMode, winrt::Microsoft::UI::Xaml::Controls::TabViewWidthMode, _GlobalSettings.TabWidthMode);

--- a/src/cascadia/TerminalSettingsEditor/InteractionViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/InteractionViewModel.h
@@ -14,7 +14,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     public:
         InteractionViewModel(Model::GlobalAppSettings globalSettings);
 
-        WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
+        // DON'T YOU DARE ADD A `WINRT_CALLBACK(PropertyChanged` TO A CLASS DERIVED FROM ViewModelHelper. Do this instead:
+        using ViewModelHelper<InteractionViewModel>::PropertyChanged;
 
         GETSET_BINDABLE_ENUM_SETTING(TabSwitcherMode, Model::TabSwitcherMode, _GlobalSettings.TabSwitcherMode);
         GETSET_BINDABLE_ENUM_SETTING(CopyFormat, winrt::Microsoft::Terminal::Control::CopyFormat, _GlobalSettings.CopyFormatting);

--- a/src/cascadia/TerminalSettingsEditor/ViewModelHelpers.h
+++ b/src/cascadia/TerminalSettingsEditor/ViewModelHelpers.h
@@ -33,7 +33,7 @@ protected:
         _NotifyChanges(std::forward<Args>(more)...);
     }
 
-private:
+protected:
     winrt::event<::winrt::Windows::UI::Xaml::Data::PropertyChangedEventHandler> _propertyChangedHandlers;
 };
 


### PR DESCRIPTION
While debugging #13694, we discovered a very subtle bug we had accidentally introduced in a few places. `ViewModelHelper` defines a `PropertyChanged` event, backed by a `_propertyChangedHandlers` `event`. All opbservable properties in the viewmodels are supposed to run through that event. However, if you do `WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler)` in a derived class, it'll override that original method with the new one. XAML will subscribe to the second one, which is backed by `_PropertyChangedHandlers`, but the properties will still raise notifications on the callbacks registered to `_propertyChangedHandlers`. 

This change makes it more explicit in these derived classes, that the `PropertyChanged` method exposed by these classes is indeed the one that's implemented in the base class. 

This is a bit of a footgun, for sure. AuditMode would have apparently caught this, as we'd be overriding a method without using the `override` keyword.

Unblocks #13694.