### PR TITLE
Stop throwing exceptions for FontIcons

### DIFF
--- a/src/cascadia/TerminalSettingsModel/IconPathConverter.cpp
+++ b/src/cascadia/TerminalSettingsModel/IconPathConverter.cpp
@@ -62,7 +62,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     template<typename TIconSource>
     TIconSource _getColoredBitmapIcon(const winrt::hstring& path)
     {
-        if (!path.empty())
+        // FontIcon uses glyphs in the private use area, whereas valid URIs only contain ASCII characters.
+        // To skip throwing on Uri construction, we can quickly check if the first character is ASCII.
+        if (!path.empty() && path.front() < 128)
         {
             try
             {


### PR DESCRIPTION
While having a debugger attached, opening the settings tab generates an
uncomfortable amount of exceptions. This change reduces this by a lot.

## Validation Steps Performed
* Icons still appear ✅