### PR TITLE
Remove the `useMica` key

### DIFF
--- a/src/cascadia/LocalTests_SettingsModel/ThemeTests.cpp
+++ b/src/cascadia/LocalTests_SettingsModel/ThemeTests.cpp
@@ -64,8 +64,7 @@ namespace SettingsModelLocalTests
             },
             "window":
             {
-                "applicationTheme": "light",
-                "useMica": true
+                "applicationTheme": "light"
             }
         })" };
 
@@ -81,7 +80,6 @@ namespace SettingsModelLocalTests
 
         VERIFY_IS_NOT_NULL(theme->Window());
         VERIFY_ARE_EQUAL(winrt::Windows::UI::Xaml::ElementTheme::Light, theme->Window().RequestedTheme());
-        VERIFY_ARE_EQUAL(true, theme->Window().UseMica());
     }
 
     void ThemeTests::ParseEmptyTheme()
@@ -163,8 +161,7 @@ namespace SettingsModelLocalTests
                     },
                     "window":
                     {
-                        "applicationTheme": "light",
-                        "useMica": true
+                        "applicationTheme": "light"
                     }
                 },
                 {
@@ -175,16 +172,14 @@ namespace SettingsModelLocalTests
                     },
                     "window":
                     {
-                        "applicationTheme": "light",
-                        "useMica": true
+                        "applicationTheme": "light"
                     }
                 },
                 {
                     "name": "backgroundOmittedEntirely",
                     "window":
                     {
-                        "applicationTheme": "light",
-                        "useMica": true
+                        "applicationTheme": "light"
                     }
                 }
             ]
@@ -239,8 +234,7 @@ namespace SettingsModelLocalTests
                     "tabRow": {},
                     "window":
                     {
-                        "applicationTheme": "light",
-                        "useMica": true
+                        "applicationTheme": "light"
                     }
                 }
             ]

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -122,9 +122,8 @@ Author(s):
     X(winrt::Microsoft::Terminal::Settings::Model::TabRowTheme, TabRow, "tabRow", nullptr) \
     X(winrt::Microsoft::Terminal::Settings::Model::TabTheme, Tab, "tab", nullptr)
 
-#define MTSM_THEME_WINDOW_SETTINGS(X)                                                                                              \
-    X(winrt::Windows::UI::Xaml::ElementTheme, RequestedTheme, "applicationTheme", winrt::Windows::UI::Xaml::ElementTheme::Default) \
-    X(bool, UseMica, "useMica", false)
+#define MTSM_THEME_WINDOW_SETTINGS(X) \
+    X(winrt::Windows::UI::Xaml::ElementTheme, RequestedTheme, "applicationTheme", winrt::Windows::UI::Xaml::ElementTheme::Default)
 
 #define MTSM_THEME_TABROW_SETTINGS(X)                                                             \
     X(winrt::Microsoft::Terminal::Settings::Model::ThemeColor, Background, "background", nullptr) \

--- a/src/cascadia/TerminalSettingsModel/Theme.idl
+++ b/src/cascadia/TerminalSettingsModel/Theme.idl
@@ -36,7 +36,6 @@ namespace Microsoft.Terminal.Settings.Model
 
     runtimeclass WindowTheme {
         Windows.UI.Xaml.ElementTheme RequestedTheme { get; };
-        Boolean UseMica { get; };
     }
 
     runtimeclass TabRowTheme {


### PR DESCRIPTION
It's not making it for 1.16, so it's out.
Closes a bullet point in #13725
