### PR TITLE
An attempted fix for the `SignalTextChanged` crash

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -707,7 +707,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                              margins.Top,
                                              margins.Right,
                                              margins.Bottom };
-                _automationPeer = winrt::make<implementation::TermControlAutomationPeer>(this, padding, interactivityAutoPeer);
+                auto foo = get_weak();
+                _automationPeer = winrt::make<implementation::TermControlAutomationPeer>(get_weak(), padding, interactivityAutoPeer);
                 return _automationPeer;
             }
         }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -707,7 +707,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                              margins.Top,
                                              margins.Right,
                                              margins.Bottom };
-                auto foo = get_weak();
                 _automationPeer = winrt::make<implementation::TermControlAutomationPeer>(get_weak(), padding, interactivityAutoPeer);
                 return _automationPeer;
             }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -707,7 +707,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                              margins.Top,
                                              margins.Right,
                                              margins.Bottom };
-                _automationPeer = winrt::make<implementation::TermControlAutomationPeer>(get_weak(), padding, interactivityAutoPeer);
+                _automationPeer = winrt::make<implementation::TermControlAutomationPeer>(get_strong(), padding, interactivityAutoPeer);
                 return _automationPeer;
             }
         }

--- a/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
+++ b/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
@@ -298,13 +298,15 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // fallback to title if profile name is empty
         if (auto control{ _termControl.get() })
         {
-            auto profileName = control->GetProfileName();
+            const auto profileName = control->GetProfileName();
             if (profileName.empty())
             {
                 return control->Title();
             }
             else
+            {
                 return profileName;
+            }
         }
 
         return L"";
@@ -312,7 +314,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     hstring TermControlAutomationPeer::GetHelpTextCore() const
     {
-        if (auto control{ _termControl.get() })
+        if (const auto control{ _termControl.get() })
         {
             return control->Title();
         }

--- a/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
+++ b/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
@@ -67,7 +67,7 @@ static constexpr bool IsReadable(std::wstring_view text)
 
 namespace winrt::Microsoft::Terminal::Control::implementation
 {
-    TermControlAutomationPeer::TermControlAutomationPeer(winrt::weak_ref<TermControl> owner,
+    TermControlAutomationPeer::TermControlAutomationPeer(winrt::com_ptr<TermControl> owner,
                                                          const Core::Padding padding,
                                                          Control::InteractivityAutomationPeer impl) :
         TermControlAutomationPeerT<TermControlAutomationPeer>(*owner.get()), // pass owner to FrameworkElementAutomationPeer

--- a/src/cascadia/TerminalControl/TermControlAutomationPeer.h
+++ b/src/cascadia/TerminalControl/TermControlAutomationPeer.h
@@ -42,7 +42,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         ::Microsoft::Console::Types::IUiaEventDispatcher
     {
     public:
-        TermControlAutomationPeer(winrt::weak_ref<Microsoft::Terminal::Control::implementation::TermControl> owner,
+        TermControlAutomationPeer(winrt::com_ptr<Microsoft::Terminal::Control::implementation::TermControl> owner,
                                   const Core::Padding padding,
                                   Control::InteractivityAutomationPeer implementation);
 

--- a/src/cascadia/TerminalControl/TermControlAutomationPeer.h
+++ b/src/cascadia/TerminalControl/TermControlAutomationPeer.h
@@ -42,7 +42,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         ::Microsoft::Console::Types::IUiaEventDispatcher
     {
     public:
-        TermControlAutomationPeer(Microsoft::Terminal::Control::implementation::TermControl* owner,
+        TermControlAutomationPeer(winrt::weak_ref<Microsoft::Terminal::Control::implementation::TermControl> owner,
                                   const Core::Padding padding,
                                   Control::InteractivityAutomationPeer implementation);
 
@@ -78,7 +78,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 #pragma endregion
 
     private:
-        winrt::Microsoft::Terminal::Control::implementation::TermControl* _termControl;
+        winrt::weak_ref<Microsoft::Terminal::Control::implementation::TermControl> _termControl;
         Control::InteractivityAutomationPeer _contentAutomationPeer;
         std::deque<wchar_t> _keyEvents;
     };


### PR DESCRIPTION
This is conjecture - I was totally unable to repro the original crash here.
Based on the stacks in MSFT:39994969, it looks like we try to fire off a
`RaiseAutomationEvent`, which calls through UIA core, eventually to the point of
calling `ComPtr<WUX::Automation::Peers::IAutomationPeer>::{dtor}`. I'm guessing
based on the stacks that the TermControl has already been released and cleaned
up. However, the lambda in the `RunAsync` calls here only takes a ref to the
TCAP. The TCAP has an outstanding reference (maybe on the other side of the UIA
fence), and gets successfully resolved as strong, but when calling to
`RaiseAutomationEvent`, the `owner` we passed in is gonezo.

This explicitly passes a `weak_ref` to `TermControlAutomationPeer`, rather than
a raw ptr, so we can actually check if the control is still alive before _we_
dereference it. If it is, great, we've got a strong ref to it now and it won't
get torn down.

Again, this is hearsay. Without a repro, the only way we can confirm this is
gone is by just hoping the crashes go away. 🤞

* Might close #13357 (we'll reopen if it doesn't?)
* narrator still works
