### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/dep/CLI11/cgmanifest.json
+++ b/dep/CLI11/cgmanifest.json
@@ -1,13 +1,15 @@
-{"Registrations":[
+{
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "component": {
-       "type": "git",
-       "git": {
-         "repositoryUrl": "https://github.com/CLIUtils/CLI11",
-         "commitHash": "dd0d8e4fe729e5b1110232c7a5c9566dad884686"
-         }
-       }
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/CLIUtils/CLI11",
+          "commitHash": "dd0d8e4fe729e5b1110232c7a5c9566dad884686"
+        }
+      }
     }
- ],
- "Version": 1
+  ],
+  "Version": 1
 }

--- a/dep/jsoncpp/cgmanifest.json
+++ b/dep/jsoncpp/cgmanifest.json
@@ -1,13 +1,15 @@
-{"Registrations":[
+{
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "component": {
-       "type": "git",
-       "git": {
-         "repositoryUrl": "https://github.com/open-source-parsers/jsoncpp",
-         "commitHash": "6aba23f4a8628d599a9ef7fa4811c4ff6e4070e2"
-         }
-       }
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/open-source-parsers/jsoncpp",
+          "commitHash": "6aba23f4a8628d599a9ef7fa4811c4ff6e4070e2"
+        }
+      }
     }
- ],
- "Version": 1
+  ],
+  "Version": 1
 }

--- a/oss/boost/cgmanifest.json
+++ b/oss/boost/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "component": {

--- a/oss/chromium/cgmanifest.json
+++ b/oss/chromium/cgmanifest.json
@@ -1,13 +1,15 @@
-{"Registrations":[ 
+{
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
-      "component": { 
-       "type": "git", 
-       "git": { 
-         "repositoryUrl": "https://github.com/chromium/chromium", 
-         "commitHash": "d8710dd959da8e3be56f20af8cc94fbf560fbb6b" 
-         }
-       }
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/chromium/chromium",
+          "commitHash": "d8710dd959da8e3be56f20af8cc94fbf560fbb6b"
+        }
+      }
     }
- ],
- "Version": 1
+  ],
+  "Version": 1
 }

--- a/oss/dynamic_bitset/cgmanifest.json
+++ b/oss/dynamic_bitset/cgmanifest.json
@@ -1,13 +1,15 @@
-{"Registrations":[ 
+{
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
-      "component": { 
-       "type": "git", 
-       "git": { 
-         "repositoryUrl": "https://github.com/pinam45/dynamic_bitset", 
-         "commitHash": "00f2d066ce9deebf28b006636150e5a882beb83f" 
-         }
-       }
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/pinam45/dynamic_bitset",
+          "commitHash": "00f2d066ce9deebf28b006636150e5a882beb83f"
+        }
+      }
     }
- ],
- "Version": 1
+  ],
+  "Version": 1
 }

--- a/oss/fmt/cgmanifest.json
+++ b/oss/fmt/cgmanifest.json
@@ -1,13 +1,15 @@
-{"Registrations":[ 
+{
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
-      "component": { 
-       "type": "git", 
-       "git": { 
-         "repositoryUrl": "https://github.com/fmtlib/fmt", 
-         "commitHash": "7bdf0628b1276379886c7f6dda2cef2b3b374f0b" 
-         }
-       }
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/fmtlib/fmt",
+          "commitHash": "7bdf0628b1276379886c7f6dda2cef2b3b374f0b"
+        }
+      }
     }
- ],
- "Version": 1
+  ],
+  "Version": 1
 }

--- a/oss/interval_tree/cgmanifest.json
+++ b/oss/interval_tree/cgmanifest.json
@@ -1,13 +1,15 @@
-{"Registrations":[ 
+{
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
-      "component": { 
-       "type": "git",
+      "component": {
+        "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/ekg/intervaltree",
           "commitHash": "b90527f9e6d51cd36ecbb50429e4524d3a418ea5"
         }
-       }
+      }
     }
- ],
- "Version": 1
+  ],
+  "Version": 1
 }

--- a/oss/libpopcnt/cgmanifest.json
+++ b/oss/libpopcnt/cgmanifest.json
@@ -1,13 +1,15 @@
-{"Registrations":[ 
+{
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
-      "component": { 
-       "type": "git", 
-       "git": { 
-         "repositoryUrl": "https://github.com/kimwalisch/libpopcnt", 
-         "commitHash": "043a99fba31121a70bcb2f589faa17f534ae6085" 
-         }
-       }
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/kimwalisch/libpopcnt",
+          "commitHash": "043a99fba31121a70bcb2f589faa17f534ae6085"
+        }
+      }
     }
- ],
- "Version": 1
+  ],
+  "Version": 1
 }

--- a/oss/pcg/cgmanifest.json
+++ b/oss/pcg/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "component": {

--- a/oss/wyhash/cgmanifest.json
+++ b/oss/wyhash/cgmanifest.json
@@ -1,14 +1,15 @@
 {
-    "Registrations": [
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/wangyi-fudan/wyhash",
-                    "commitHash": "e77036ac1943369dc03e611cde52a8570f8ceefe"
-                }
-            }
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/wangyi-fudan/wyhash",
+          "commitHash": "e77036ac1943369dc03e611cde52a8570f8ceefe"
         }
-    ],
-    "Version": 1
+      }
+    }
+  ],
+  "Version": 1
 }

--- a/oss/xorg_apps_rgb/cgmanifest.json
+++ b/oss/xorg_apps_rgb/cgmanifest.json
@@ -1,13 +1,15 @@
-{"Registrations":[ 
+{
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
-      "component": { 
-       "type": "git", 
-       "git": { 
-         "repositoryUrl": "https://gitlab.freedesktop.org/xorg/app/rgb.git", 
-         "commitHash": "97820e748eb496a1f6d3fc3bf89688f0ce1f64f9" 
-         }
-       }
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://gitlab.freedesktop.org/xorg/app/rgb.git",
+          "commitHash": "97820e748eb496a1f6d3fc3bf89688f0ce1f64f9"
+        }
+      }
     }
- ],
- "Version": 1
+  ],
+  "Version": 1
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.