### PR TITLE
Remove the 1px gap under inactive tabs

### DIFF
--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -47,6 +47,7 @@
 
                     <!--  Suppress top padding  -->
                     <Thickness x:Key="TabViewHeaderPadding">9,0,5,0</Thickness>
+                    <Thickness x:Key="TabViewItemBorderThickness">1,1,1,0</Thickness>
 
                     <!--  Shadow that can be used by any control.  -->
                     <ThemeShadow x:Name="SharedShadow" />


### PR DESCRIPTION
As noted in https://github.com/microsoft/microsoft-ui-xaml/issues/7674#issuecomment-1234088616

Screenshot below.

* [x] Closes a single element of #13725
