### PR TITLE
Fix crash on save in rejuv'd Color Schemes page

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ColorSchemesPageViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemesPageViewModel.cpp
@@ -40,7 +40,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _MakeColorSchemeVMsHelper();
 
         // Re-select the previously selected scheme if it exists
-        if (currentSchemeName)
+        if (!currentSchemeName.empty())
         {
             const auto it = _AllColorSchemes.First();
             while (it.HasCurrent())

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemesPageViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemesPageViewModel.cpp
@@ -34,26 +34,36 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // we still have the same CurrentScheme as before (if that scheme still exists)
 
         // Store the name of the current scheme
-        const auto currentSchemeName = CurrentScheme().Name();
+        const auto hasCurrentScheme = HasCurrentScheme();
+        const auto currentSchemeName = hasCurrentScheme ? CurrentScheme().Name() : hstring{ L"" };
 
         // Re-initialize the color scheme list
         _MakeColorSchemeVMsHelper();
 
         // Re-select the previously selected scheme if it exists
-        const auto it = _AllColorSchemes.First();
-        while (it.HasCurrent())
+        if (hasCurrentScheme)
         {
-            auto scheme = *it;
-            if (scheme.Name() == currentSchemeName)
+            const auto it = _AllColorSchemes.First();
+            while (it.HasCurrent())
             {
-                CurrentScheme(scheme);
-                break;
+                auto scheme = *it;
+                if (scheme.Name() == currentSchemeName)
+                {
+                    CurrentScheme(scheme);
+                    break;
+                }
+                it.MoveNext();
             }
-            it.MoveNext();
+            if (!it.HasCurrent())
+            {
+                // we didn't find the previously selected scheme
+                CurrentScheme(nullptr);
+            }
         }
-        if (!it.HasCurrent())
+        else
         {
-            // we didn't find the previously selected scheme
+            // didn't have a scheme,
+            // so skip over looking through the schemes
             CurrentScheme(nullptr);
         }
     }

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemesPageViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemesPageViewModel.cpp
@@ -34,14 +34,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // we still have the same CurrentScheme as before (if that scheme still exists)
 
         // Store the name of the current scheme
-        const auto hasCurrentScheme = HasCurrentScheme();
-        const auto currentSchemeName = hasCurrentScheme ? CurrentScheme().Name() : hstring{ L"" };
+        const auto currentSchemeName = HasCurrentScheme() ? CurrentScheme().Name() : hstring{};
 
         // Re-initialize the color scheme list
         _MakeColorSchemeVMsHelper();
 
         // Re-select the previously selected scheme if it exists
-        if (hasCurrentScheme)
+        if (currentSchemeName)
         {
             const auto it = _AllColorSchemes.First();
             while (it.HasCurrent())


### PR DESCRIPTION
## Summary of the Pull Request
Fix a bug where if you pressed the "Save" button, WT would crash. This was caused by adding the possibility that no color scheme is selected in the main page. With no "current scheme", attempting to get its "name" would cause a null ptr exception.

The fix is simple: just check if we actually have a current scheme.
Bonus points: if we don't have a current scheme, don't bother looking throught the color schemes for a match because we'll never find one.


## References
#13269 - Color Schemes Rejuv