### PR TITLE
atlas: only enable continuous redraw if the shader needs it

### DIFF
--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -696,9 +696,30 @@ void AtlasEngine::_createResources()
                 /* ppCode      */ blob.addressof(),
                 /* ppErrorMsgs */ error.addressof());
 
+            // Unless we can determine otherwise, assume this shader requires evaluation every frame
+            _r.requiresContinuousRedraw = true;
+
             if (SUCCEEDED(hr))
             {
                 THROW_IF_FAILED(_r.device->CreatePixelShader(blob->GetBufferPointer(), blob->GetBufferSize(), nullptr, _r.customPixelShader.put()));
+
+                // Try to determine whether the shader uses the Time variable
+                wil::com_ptr<ID3D11ShaderReflection> reflector;
+                if (SUCCEEDED(D3DReflect(blob->GetBufferPointer(), blob->GetBufferSize(), IID_PPV_ARGS(reflector.put()))))
+                {
+                    if (ID3D11ShaderReflectionConstantBuffer* constantBufferReflector = reflector->GetConstantBufferByIndex(0)) // shader buffer
+                    {
+                        if (ID3D11ShaderReflectionVariable* variableReflector = constantBufferReflector->GetVariableByIndex(0)) // time
+                        {
+                            D3D11_SHADER_VARIABLE_DESC variableDescriptor;
+                            if (SUCCEEDED(variableReflector->GetDesc(&variableDescriptor)))
+                            {
+                                // only if time is used
+                                _r.requiresContinuousRedraw = WI_IsFlagSet(variableDescriptor.uFlags, D3D_SVF_USED);
+                            }
+                        }
+                    }
+                }
             }
             else
             {
@@ -710,18 +731,17 @@ void AtlasEngine::_createResources()
                 {
                     LOG_HR(hr);
                 }
-
                 if (_api.warningCallback)
                 {
                     _api.warningCallback(D2DERR_SHADER_COMPILE_FAILED);
                 }
             }
-
-            _r.requiresContinuousRedraw = true;
         }
         else if (_api.useRetroTerminalEffect)
         {
             THROW_IF_FAILED(_r.device->CreatePixelShader(&custom_shader_ps[0], sizeof(custom_shader_ps), nullptr, _r.customPixelShader.put()));
+            // We know the built-in retro shader doesn't require continuous redraw.
+            _r.requiresContinuousRedraw = false;
         }
 
         if (_r.customPixelShader)

--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -705,14 +705,14 @@ void AtlasEngine::_createResources()
 
                 // Try to determine whether the shader uses the Time variable
                 wil::com_ptr<ID3D11ShaderReflection> reflector;
-                if (SUCCEEDED(D3DReflect(blob->GetBufferPointer(), blob->GetBufferSize(), IID_PPV_ARGS(reflector.put()))))
+                if (SUCCEEDED_LOG(D3DReflect(blob->GetBufferPointer(), blob->GetBufferSize(), IID_PPV_ARGS(reflector.put()))))
                 {
                     if (ID3D11ShaderReflectionConstantBuffer* constantBufferReflector = reflector->GetConstantBufferByIndex(0)) // shader buffer
                     {
                         if (ID3D11ShaderReflectionVariable* variableReflector = constantBufferReflector->GetVariableByIndex(0)) // time
                         {
                             D3D11_SHADER_VARIABLE_DESC variableDescriptor;
-                            if (SUCCEEDED(variableReflector->GetDesc(&variableDescriptor)))
+                            if (SUCCEEDED_LOG(variableReflector->GetDesc(&variableDescriptor)))
                             {
                                 // only if time is used
                                 _r.requiresContinuousRedraw = WI_IsFlagSet(variableDescriptor.uFlags, D3D_SVF_USED);


### PR DESCRIPTION
We do this by detecting whether the shader is using variable 0 in
constant buffer 0 (typically "time", but it can go by many names.)

Closes #13901
