### PR TITLE
AtlasEngine: Fix various bugs found in testing

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -75,7 +75,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         void SizeChanged(const double width, const double height);
         void ScaleChanged(const double scale);
-        uint64_t SwapChainHandle() const;
 
         void AdjustFontSize(int fontSizeDelta);
         void ResetFontSize();
@@ -315,7 +314,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
 #pragma region RendererCallbacks
         void _rendererWarning(const HRESULT hr);
-        void _renderEngineSwapChainChanged();
+        void _renderEngineSwapChainChanged(const HANDLE handle);
         void _rendererBackgroundColorChanged();
         void _rendererTabColorChanged();
 #pragma endregion

--- a/src/cascadia/TerminalControl/ControlCore.idl
+++ b/src/cascadia/TerminalControl/ControlCore.idl
@@ -76,8 +76,6 @@ namespace Microsoft.Terminal.Control
         IControlAppearance UnfocusedAppearance { get; };
         Boolean HasUnfocusedAppearance();
 
-        UInt64 SwapChainHandle { get; };
-
         Windows.Foundation.Size FontSize { get; };
         String FontFaceName { get; };
         UInt16 FontWeight { get; };

--- a/src/renderer/atlas/AtlasEngine.api.cpp
+++ b/src/renderer/atlas/AtlasEngine.api.cpp
@@ -291,6 +291,11 @@ HRESULT AtlasEngine::Enable() noexcept
     return S_OK;
 }
 
+[[nodiscard]] std::wstring_view AtlasEngine::GetPixelShaderPath() noexcept
+{
+    return _api.customPixelShaderPath;
+}
+
 [[nodiscard]] bool AtlasEngine::GetRetroTerminalEffect() const noexcept
 {
     return _api.useRetroTerminalEffect;
@@ -299,17 +304,6 @@ HRESULT AtlasEngine::Enable() noexcept
 [[nodiscard]] float AtlasEngine::GetScaling() const noexcept
 {
     return static_cast<float>(_api.dpi) / static_cast<float>(USER_DEFAULT_SCREEN_DPI);
-}
-
-[[nodiscard]] HANDLE AtlasEngine::GetSwapChainHandle()
-{
-    if (WI_IsFlagSet(_api.invalidations, ApiInvalidations::Device))
-    {
-        _createResources();
-        WI_ClearFlag(_api.invalidations, ApiInvalidations::Device);
-    }
-
-    return _api.swapChainHandle.get();
 }
 
 [[nodiscard]] Microsoft::Console::Types::Viewport AtlasEngine::GetViewportInCharacters(const Types::Viewport& viewInPixels) const noexcept
@@ -337,7 +331,7 @@ void AtlasEngine::SetAntialiasingMode(const D2D1_TEXT_ANTIALIAS_MODE antialiasin
     }
 }
 
-void AtlasEngine::SetCallback(std::function<void()> pfn) noexcept
+void AtlasEngine::SetCallback(std::function<void(HANDLE)> pfn) noexcept
 {
     _api.swapChainChangedCallback = std::move(pfn);
 }
@@ -426,10 +420,6 @@ void AtlasEngine::SetWarningCallback(std::function<void(HRESULT)> pfn) noexcept
     }
 
     return S_OK;
-}
-
-void AtlasEngine::ToggleShaderEffects() noexcept
-{
 }
 
 [[nodiscard]] HRESULT AtlasEngine::UpdateFont(const FontInfoDesired& fontInfoDesired, FontInfo& fontInfo, const std::unordered_map<std::wstring_view, uint32_t>& features, const std::unordered_map<std::wstring_view, float>& axes) noexcept

--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <d2d1.h>
+#include <d2d1_1.h>
 #include <d3d11_1.h>
 #include <dwrite_3.h>
 
@@ -60,14 +60,14 @@ namespace Microsoft::Console::Render
 
         // DxRenderer - getter
         HRESULT Enable() noexcept override;
+        [[nodiscard]] std::wstring_view GetPixelShaderPath() noexcept override;
         [[nodiscard]] bool GetRetroTerminalEffect() const noexcept override;
         [[nodiscard]] float GetScaling() const noexcept override;
-        [[nodiscard]] HANDLE GetSwapChainHandle() override;
         [[nodiscard]] Types::Viewport GetViewportInCharacters(const Types::Viewport& viewInPixels) const noexcept override;
         [[nodiscard]] Types::Viewport GetViewportInPixels(const Types::Viewport& viewInCharacters) const noexcept override;
         // DxRenderer - setter
         void SetAntialiasingMode(D2D1_TEXT_ANTIALIAS_MODE antialiasingMode) noexcept override;
-        void SetCallback(std::function<void()> pfn) noexcept override;
+        void SetCallback(std::function<void(HANDLE)> pfn) noexcept override;
         void EnableTransparentBackground(const bool isTransparent) noexcept override;
         void SetForceFullRepaintRendering(bool enable) noexcept override;
         [[nodiscard]] HRESULT SetHwnd(HWND hwnd) noexcept override;
@@ -77,7 +77,6 @@ namespace Microsoft::Console::Render
         void SetSoftwareRendering(bool enable) noexcept override;
         void SetWarningCallback(std::function<void(HRESULT)> pfn) noexcept override;
         [[nodiscard]] HRESULT SetWindowSize(til::size pixels) noexcept override;
-        void ToggleShaderEffects() noexcept override;
         [[nodiscard]] HRESULT UpdateFont(const FontInfoDesired& pfiFontInfoDesired, FontInfo& fiFontInfo, const std::unordered_map<std::wstring_view, uint32_t>& features, const std::unordered_map<std::wstring_view, float>& axes) noexcept override;
         void UpdateHyperlinkHoveredId(uint16_t hoveredId) noexcept override;
 
@@ -1008,7 +1007,7 @@ namespace Microsoft::Console::Render
             // D2D resources
             wil::com_ptr<ID3D11Texture2D> atlasBuffer;
             wil::com_ptr<ID3D11ShaderResourceView> atlasView;
-            wil::com_ptr<ID2D1RenderTarget> d2dRenderTarget;
+            wil::com_ptr<ID2D1DeviceContext> d2dRenderTarget;
             wil::com_ptr<ID2D1SolidColorBrush> brush;
             wil::com_ptr<IDWriteTextFormat> textFormats[2][2];
             Buffer<DWRITE_FONT_AXIS_VALUE> textFormatAxes[2][2];
@@ -1038,7 +1037,6 @@ namespace Microsoft::Console::Render
             CachedCursorOptions cursorOptions;
             RenderInvalidations invalidations = RenderInvalidations::None;
 
-            til::rect previousDirtyRectInPx;
             til::rect dirtyRect;
             i16 scrollOffset = 0;
             bool d2dMode = false;
@@ -1095,7 +1093,7 @@ namespace Microsoft::Console::Render
             i16 scrollOffset = 0;
 
             std::function<void(HRESULT)> warningCallback;
-            std::function<void()> swapChainChangedCallback;
+            std::function<void(HANDLE)> swapChainChangedCallback;
             wil::unique_handle swapChainHandle;
             HWND hwnd = nullptr;
             u16 dpi = USER_DEFAULT_SCREEN_DPI; // changes are flagged as ApiInvalidations::Font|Size

--- a/src/renderer/atlas/AtlasEngine.r.cpp
+++ b/src/renderer/atlas/AtlasEngine.r.cpp
@@ -66,7 +66,7 @@ try
     const til::rect fullRect{ 0, 0, _r.cellCount.x, _r.cellCount.y };
 
     // A change in the selection or background color (etc.) forces a full redraw.
-    if (WI_IsFlagSet(_r.invalidations, RenderInvalidations::ConstBuffer))
+    if (WI_IsFlagSet(_r.invalidations, RenderInvalidations::ConstBuffer) || _r.customPixelShader)
     {
         _r.dirtyRect = fullRect;
     }
@@ -1056,7 +1056,6 @@ void AtlasEngine::_d2dFillRectangle(u16r rect, u32 color)
         .bottom = static_cast<float>(rect.bottom) * _r.cellSizeDIP.y,
     };
     const auto brush = _brushWithColor(color);
-    // TODO: This does blending, it should do copy
     _r.d2dRenderTarget->FillRectangle(r, brush);
 }
 

--- a/src/renderer/atlas/pch.h
+++ b/src/renderer/atlas/pch.h
@@ -16,7 +16,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include <d2d1.h>
+#include <d2d1_1.h>
 #include <d3d11_1.h>
 #include <d3dcompiler.h>
 #include <dwrite_3.h>

--- a/src/renderer/dx/DxRenderer.cpp
+++ b/src/renderer/dx/DxRenderer.cpp
@@ -245,19 +245,6 @@ bool DxEngine::_HasTerminalEffects() const noexcept
 }
 
 // Routine Description:
-// - Toggles terminal effects off and on. If no terminal effect is configured has no effect
-// Arguments:
-// Return Value:
-// - Void
-void DxEngine::ToggleShaderEffects() noexcept
-{
-    _terminalEffectsEnabled = !_terminalEffectsEnabled;
-    _recreateDeviceRequested = true;
-#pragma warning(suppress : 26447) // The function is declared 'noexcept' but calls function 'Log_IfFailed()' which may throw exceptions (f.6).
-    LOG_IF_FAILED(InvalidateAll());
-}
-
-// Routine Description:
 // - Loads pixel shader source depending on _retroTerminalEffect and _pixelShaderPath
 // Arguments:
 // Return Value:
@@ -744,7 +731,7 @@ try
     {
         try
         {
-            _pfn();
+            _pfn(_swapChainHandle.get());
         }
         CATCH_LOG(); // A failure in the notification function isn't a failure to prepare, so just log it and go on.
     }
@@ -996,7 +983,7 @@ try
 }
 CATCH_RETURN();
 
-void DxEngine::SetCallback(std::function<void()> pfn) noexcept
+void DxEngine::SetCallback(std::function<void(const HANDLE)> pfn) noexcept
 {
     _pfn = std::move(pfn);
 }
@@ -1024,6 +1011,11 @@ try
     }
 }
 CATCH_LOG()
+
+std::wstring_view DxEngine::GetPixelShaderPath() noexcept
+{
+    return _pixelShaderPath;
+}
 
 void DxEngine::SetPixelShaderPath(std::wstring_view value) noexcept
 try
@@ -1061,17 +1053,6 @@ try
     }
 }
 CATCH_LOG()
-
-HANDLE DxEngine::GetSwapChainHandle() noexcept
-{
-    if (!_swapChainHandle)
-    {
-#pragma warning(suppress : 26447) // The function is declared 'noexcept' but calls function 'Log_IfFailed()' which may throw exceptions (f.6).
-        LOG_IF_FAILED(_CreateDeviceResources(true));
-    }
-
-    return _swapChainHandle.get();
-}
 
 void DxEngine::_InvalidateRectangle(const til::rect& rc)
 {

--- a/src/renderer/dx/DxRenderer.hpp
+++ b/src/renderer/dx/DxRenderer.hpp
@@ -57,21 +57,18 @@ namespace Microsoft::Console::Render
 
         [[nodiscard]] HRESULT SetWindowSize(const til::size pixels) noexcept override;
 
-        void SetCallback(std::function<void()> pfn) noexcept override;
+        void SetCallback(std::function<void(const HANDLE)> pfn) noexcept override;
         void SetWarningCallback(std::function<void(const HRESULT)> pfn) noexcept override;
-
-        void ToggleShaderEffects() noexcept override;
 
         bool GetRetroTerminalEffect() const noexcept override;
         void SetRetroTerminalEffect(bool enable) noexcept override;
 
+        std::wstring_view GetPixelShaderPath() noexcept override;
         void SetPixelShaderPath(std::wstring_view value) noexcept override;
 
         void SetForceFullRepaintRendering(bool enable) noexcept override;
 
         void SetSoftwareRendering(bool enable) noexcept override;
-
-        HANDLE GetSwapChainHandle() noexcept override;
 
         // IRenderEngine Members
         [[nodiscard]] HRESULT Invalidate(const til::rect* const psrRegion) noexcept override;
@@ -162,7 +159,7 @@ namespace Microsoft::Console::Render
         float _scale;
         float _prevScale;
 
-        std::function<void()> _pfn;
+        std::function<void(const HANDLE)> _pfn;
         std::function<void(const HRESULT)> _pfnWarningCallback;
 
         bool _isEnabled;

--- a/src/renderer/inc/IRenderEngine.hpp
+++ b/src/renderer/inc/IRenderEngine.hpp
@@ -94,18 +94,14 @@ namespace Microsoft::Console::Render
 
         // DxRenderer - getter
         virtual HRESULT Enable() noexcept { return S_OK; }
+        virtual [[nodiscard]] std::wstring_view GetPixelShaderPath() noexcept { return {}; }
         virtual [[nodiscard]] bool GetRetroTerminalEffect() const noexcept { return false; }
         virtual [[nodiscard]] float GetScaling() const noexcept { return 1; }
-#pragma warning(suppress : 26440) // Function '...' can be declared 'noexcept' (f.6).
-        virtual [[nodiscard]] HANDLE GetSwapChainHandle()
-        {
-            return nullptr;
-        }
         virtual [[nodiscard]] Types::Viewport GetViewportInCharacters(const Types::Viewport& viewInPixels) const noexcept { return Types::Viewport::Empty(); }
         virtual [[nodiscard]] Types::Viewport GetViewportInPixels(const Types::Viewport& viewInCharacters) const noexcept { return Types::Viewport::Empty(); }
         // DxRenderer - setter
         virtual void SetAntialiasingMode(const D2D1_TEXT_ANTIALIAS_MODE antialiasingMode) noexcept {}
-        virtual void SetCallback(std::function<void()> pfn) noexcept {}
+        virtual void SetCallback(std::function<void(HANDLE)> pfn) noexcept {}
         virtual void EnableTransparentBackground(const bool isTransparent) noexcept {}
         virtual void SetForceFullRepaintRendering(bool enable) noexcept {}
         virtual [[nodiscard]] HRESULT SetHwnd(const HWND hwnd) noexcept { return E_NOTIMPL; }
@@ -115,7 +111,6 @@ namespace Microsoft::Console::Render
         virtual void SetSoftwareRendering(bool enable) noexcept {}
         virtual void SetWarningCallback(std::function<void(HRESULT)> pfn) noexcept {}
         virtual [[nodiscard]] HRESULT SetWindowSize(const til::size pixels) noexcept { return E_NOTIMPL; }
-        virtual void ToggleShaderEffects() noexcept {}
         virtual [[nodiscard]] HRESULT UpdateFont(const FontInfoDesired& pfiFontInfoDesired, FontInfo& fiFontInfo, const std::unordered_map<std::wstring_view, uint32_t>& features, const std::unordered_map<std::wstring_view, float>& axes) noexcept { return E_NOTIMPL; }
         virtual void UpdateHyperlinkHoveredId(const uint16_t hoveredId) noexcept {}
     };


### PR DESCRIPTION
In testing the following issues were found in AtlasEngine and fixed:
1. "Toggle terminal visual effects" action not working
2. `d2dMode` failed to work with transparent backgrounds
3. `GetSwapChainHandle()` is thread-unsafe due to it being called outside
  of the console lock and with single-threaded Direct2D enabled
4. 2 swap chain buffers are less performant than 3
5. Flip-Discard and `Present()` is less energy efficient than
  Flip-Sequential and `Present1()`
6. `d2dMode` used to copy the front to back buffer for partial rendering,
  but always redraw the entire dirty region anyways
7. Added support for DirectX 9 hardware
8. If custom shaders are used not all pixels would be presented

Closes #13906

## Validation Steps Performed
1. Toggling visual effects runs retro shader ✅
   With a custom shader set, it toggles the shader ✅
   Toggling `experimental.rendering.software` toggles the shader ✅
2. `"backgroundImage": "desktopWallpaper"` works with D2D ✅ and D3D ✅
3. Adding a `Sleep(3000)` in `_AttachDxgiSwapChainToXaml` doesn't break
   Windows 10 ✅ nor Windows 11 ✅
4. Screen animations run at 144 FPS ✅ even while moving the window ✅
5. No weird artefacts during cursor movement or scrolling ✅
6. No weird artefacts during cursor movement or scrolling ✅
7. Forcing DirectX 9.3 in `dxcpl` runs fine ✅