### PR TITLE
Use the tab's active title for `Export Text`

### DIFF
--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -420,7 +420,7 @@ namespace winrt::TerminalApp::implementation
                     // GH#11356 - we can't use the UWP apis for writing the file,
                     // because they don't work elevated (shocker) So just use the
                     // shell32 file picker manually.
-                    path = co_await SaveFilePicker(*_hostingHwnd, [control](auto&& dialog) {
+                    path = co_await SaveFilePicker(*_hostingHwnd, [&tab](auto&& dialog) {
                         THROW_IF_FAILED(dialog->SetClientGuid(clientGuidExportFile));
                         try
                         {
@@ -434,7 +434,7 @@ namespace winrt::TerminalApp::implementation
                         THROW_IF_FAILED(dialog->SetDefaultExtension(L"txt"));
 
                         // Default to using the tab title as the file name
-                        std::wstring filename{ control.Title() };
+                        std::wstring filename{ tab.Title() };
                         filename = til::clean_filename(filename);
                         THROW_IF_FAILED(dialog->SetFileName((filename + L".txt").c_str()));
                     });

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -420,7 +420,9 @@ namespace winrt::TerminalApp::implementation
                     // GH#11356 - we can't use the UWP apis for writing the file,
                     // because they don't work elevated (shocker) So just use the
                     // shell32 file picker manually.
-                    path = co_await SaveFilePicker(*_hostingHwnd, [&tab](auto&& dialog) {
+                    std::wstring filename{ tab.Title() };
+                    filename = til::clean_filename(filename);
+                    path = co_await SaveFilePicker(*_hostingHwnd, [filename](auto&& dialog) {
                         THROW_IF_FAILED(dialog->SetClientGuid(clientGuidExportFile));
                         try
                         {
@@ -434,8 +436,6 @@ namespace winrt::TerminalApp::implementation
                         THROW_IF_FAILED(dialog->SetDefaultExtension(L"txt"));
 
                         // Default to using the tab title as the file name
-                        std::wstring filename{ tab.Title() };
-                        filename = til::clean_filename(filename);
                         THROW_IF_FAILED(dialog->SetFileName((filename + L".txt").c_str()));
                     });
                 }

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -422,7 +422,7 @@ namespace winrt::TerminalApp::implementation
                     // shell32 file picker manually.
                     std::wstring filename{ tab.Title() };
                     filename = til::clean_filename(filename);
-                    path = co_await SaveFilePicker(*_hostingHwnd, [filename](auto&& dialog) {
+                    path = co_await SaveFilePicker(*_hostingHwnd, [filename = std::move(filename)](auto&& dialog) {
                         THROW_IF_FAILED(dialog->SetClientGuid(clientGuidExportFile));
                         try
                         {


### PR DESCRIPTION
Takes title from the tab instead of the TermControl

Closes #13909