### PR TITLE
Re-add support for Mica, transparent titlebars

### DIFF
--- a/src/cascadia/LocalTests_SettingsModel/ThemeTests.cpp
+++ b/src/cascadia/LocalTests_SettingsModel/ThemeTests.cpp
@@ -64,7 +64,8 @@ namespace SettingsModelLocalTests
             },
             "window":
             {
-                "applicationTheme": "light"
+                "applicationTheme": "light",
+                "useMica": true
             }
         })" };
 
@@ -80,6 +81,7 @@ namespace SettingsModelLocalTests
 
         VERIFY_IS_NOT_NULL(theme->Window());
         VERIFY_ARE_EQUAL(winrt::Windows::UI::Xaml::ElementTheme::Light, theme->Window().RequestedTheme());
+        VERIFY_ARE_EQUAL(true, theme->Window().UseMica());
     }
 
     void ThemeTests::ParseEmptyTheme()
@@ -161,7 +163,8 @@ namespace SettingsModelLocalTests
                     },
                     "window":
                     {
-                        "applicationTheme": "light"
+                        "applicationTheme": "light",
+                        "useMica": true
                     }
                 },
                 {
@@ -172,14 +175,16 @@ namespace SettingsModelLocalTests
                     },
                     "window":
                     {
-                        "applicationTheme": "light"
+                        "applicationTheme": "light",
+                        "useMica": true
                     }
                 },
                 {
                     "name": "backgroundOmittedEntirely",
                     "window":
                     {
-                        "applicationTheme": "light"
+                        "applicationTheme": "light",
+                        "useMica": true
                     }
                 }
             ]
@@ -234,7 +239,8 @@ namespace SettingsModelLocalTests
                     "tabRow": {},
                     "window":
                     {
-                        "applicationTheme": "light"
+                        "applicationTheme": "light",
+                        "useMica": true
                     }
                 }
             ]

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -631,7 +631,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         //
         // Firing it manually makes sure it does.
         _BackgroundBrush = RootGrid().Background();
-        _PropertyChangedHandlers(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"BackgroundBrush" });
+        _PropertyChangedHandlers(*this, Data::PropertyChangedEventArgs{ L"BackgroundBrush" });
 
         _isBackgroundLight = _isColorLight(bg);
     }
@@ -653,7 +653,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
         const auto opacity{ _core.Opacity() };
         const auto useAcrylic{ _core.UseAcrylic() };
-
+        auto changed = false;
         // GH#11743, #11619: If we're changing whether or not acrylic is used,
         // then just entirely reinitialize the brush. The primary way that this
         // happens is on Windows 10, where we need to enable acrylic when the
@@ -667,6 +667,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                 _InitializeBackgroundBrush();
                 return;
             }
+            changed = acrylic.TintOpacity() != opacity;
             acrylic.TintOpacity(opacity);
         }
         else if (auto solidColor = RootGrid().Background().try_as<Media::SolidColorBrush>())
@@ -676,7 +677,14 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                 _InitializeBackgroundBrush();
                 return;
             }
+            changed = solidColor.Opacity() != opacity;
             solidColor.Opacity(opacity);
+        }
+        // Send a BG brush changed event, so you can mouse wheel the
+        // transparency of the titlebar too.
+        if (changed)
+        {
+            _PropertyChangedHandlers(*this, Data::PropertyChangedEventArgs{ L"BackgroundBrush" });
         }
     }
 

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -123,8 +123,9 @@ Author(s):
     X(winrt::Microsoft::Terminal::Settings::Model::TabRowTheme, TabRow, "tabRow", nullptr) \
     X(winrt::Microsoft::Terminal::Settings::Model::TabTheme, Tab, "tab", nullptr)
 
-#define MTSM_THEME_WINDOW_SETTINGS(X) \
-    X(winrt::Windows::UI::Xaml::ElementTheme, RequestedTheme, "applicationTheme", winrt::Windows::UI::Xaml::ElementTheme::Default)
+#define MTSM_THEME_WINDOW_SETTINGS(X)                                                                                              \
+    X(winrt::Windows::UI::Xaml::ElementTheme, RequestedTheme, "applicationTheme", winrt::Windows::UI::Xaml::ElementTheme::Default) \
+    X(bool, UseMica, "useMica", false)
 
 #define MTSM_THEME_TABROW_SETTINGS(X)                                                             \
     X(winrt::Microsoft::Terminal::Settings::Model::ThemeColor, Background, "background", nullptr) \

--- a/src/cascadia/TerminalSettingsModel/Theme.cpp
+++ b/src/cascadia/TerminalSettingsModel/Theme.cpp
@@ -148,35 +148,6 @@ winrt::WUX::Media::Brush ThemeColor::Evaluate(const winrt::WUX::ResourceDictiona
     }
     case ThemeColorType::TerminalBackground:
     {
-        // If we're evaluating this color for the tab row, there are some rules
-        // we have to follow, unfortunately. We can't allow a transparent
-        // background, so we have to make sure to fill that in with Opacity(1.0)
-        // manually.
-        //
-        // So for that case, just make a new brush with the relevant properties
-        // set.
-        if (forTitlebar)
-        {
-            if (auto acrylic = terminalBackground.try_as<winrt::WUX::Media::AcrylicBrush>())
-            {
-                winrt::WUX::Media::AcrylicBrush newBrush{};
-                newBrush.TintColor(acrylic.TintColor());
-                newBrush.FallbackColor(acrylic.FallbackColor());
-                newBrush.TintLuminosityOpacity(acrylic.TintLuminosityOpacity());
-
-                newBrush.TintOpacity(acrylic.TintOpacity());
-                newBrush.BackgroundSource(winrt::WUX::Media::AcrylicBackgroundSource::HostBackdrop);
-                return newBrush;
-            }
-            else if (auto solidColor = terminalBackground.try_as<winrt::WUX::Media::SolidColorBrush>())
-            {
-                winrt::WUX::Media::SolidColorBrush newBrush{};
-                newBrush.Color(til::color{ solidColor.Color() });
-                newBrush.Opacity(solidColor.Opacity());
-                return newBrush;
-            }
-        }
-
         return terminalBackground;
     }
     }

--- a/src/cascadia/TerminalSettingsModel/Theme.cpp
+++ b/src/cascadia/TerminalSettingsModel/Theme.cpp
@@ -125,10 +125,6 @@ winrt::WUX::Media::Brush ThemeColor::Evaluate(const winrt::WUX::ResourceDictiona
 {
     static const auto accentColorKey{ winrt::box_value(L"SystemAccentColor") };
 
-    // NOTE: Currently, the DWM titlebar is always drawn, underneath our XAML
-    // content. If the opacity is <1.0, then you'll be able to see it, including
-    // the original caption buttons, which we don't want.
-
     switch (ColorType())
     {
     case ThemeColorType::Accent:
@@ -148,10 +144,7 @@ winrt::WUX::Media::Brush ThemeColor::Evaluate(const winrt::WUX::ResourceDictiona
     }
     case ThemeColorType::Color:
     {
-        return winrt::WUX::Media::SolidColorBrush{ /*forTitlebar ?
-                                                       Color().with_alpha(255) :*/
-                                                   Color()
-        };
+        return winrt::WUX::Media::SolidColorBrush{ Color() };
     }
     case ThemeColorType::TerminalBackground:
     {
@@ -171,25 +164,15 @@ winrt::WUX::Media::Brush ThemeColor::Evaluate(const winrt::WUX::ResourceDictiona
                 newBrush.FallbackColor(acrylic.FallbackColor());
                 newBrush.TintLuminosityOpacity(acrylic.TintLuminosityOpacity());
 
-                // Allow acrylic opacity, but it's gotta be HostBackdrop acrylic.
-                //
-                // For now, just always use 50% opacity for this. If we do ever
-                // figure out how to get rid of our titlebar under the XAML tab
-                // row (GH#10509), we can always get rid of the HostBackdrop
-                // thing, and all this copying, and just return the
-                // terminalBackground brush directly.
-                //
-                // Because we're wholesale copying the brush, we won't be able
-                // to adjust it's opacity with the mouse wheel. This seems like
-                // an acceptable tradeoff for now.
-                newBrush.TintOpacity(.5);
+                newBrush.TintOpacity(acrylic.TintOpacity());
                 newBrush.BackgroundSource(winrt::WUX::Media::AcrylicBackgroundSource::HostBackdrop);
                 return newBrush;
             }
             else if (auto solidColor = terminalBackground.try_as<winrt::WUX::Media::SolidColorBrush>())
             {
                 winrt::WUX::Media::SolidColorBrush newBrush{};
-                newBrush.Color(til::color{ solidColor.Color() } /*.with_alpha(255)*/);
+                newBrush.Color(til::color{ solidColor.Color() });
+                newBrush.Opacity(solidColor.Opacity());
                 return newBrush;
             }
         }

--- a/src/cascadia/TerminalSettingsModel/Theme.cpp
+++ b/src/cascadia/TerminalSettingsModel/Theme.cpp
@@ -148,9 +148,10 @@ winrt::WUX::Media::Brush ThemeColor::Evaluate(const winrt::WUX::ResourceDictiona
     }
     case ThemeColorType::Color:
     {
-        return winrt::WUX::Media::SolidColorBrush{ forTitlebar ?
-                                                       Color().with_alpha(255) :
-                                                       Color() };
+        return winrt::WUX::Media::SolidColorBrush{ /*forTitlebar ?
+                                                       Color().with_alpha(255) :*/
+                                                   Color()
+        };
     }
     case ThemeColorType::TerminalBackground:
     {
@@ -188,7 +189,7 @@ winrt::WUX::Media::Brush ThemeColor::Evaluate(const winrt::WUX::ResourceDictiona
             else if (auto solidColor = terminalBackground.try_as<winrt::WUX::Media::SolidColorBrush>())
             {
                 winrt::WUX::Media::SolidColorBrush newBrush{};
-                newBrush.Color(til::color{ solidColor.Color() }.with_alpha(255));
+                newBrush.Color(til::color{ solidColor.Color() } /*.with_alpha(255)*/);
                 return newBrush;
             }
         }

--- a/src/cascadia/TerminalSettingsModel/Theme.idl
+++ b/src/cascadia/TerminalSettingsModel/Theme.idl
@@ -37,6 +37,7 @@ namespace Microsoft.Terminal.Settings.Model
 
     runtimeclass WindowTheme {
         Windows.UI.Xaml.ElementTheme RequestedTheme { get; };
+        Boolean UseMica { get; };
     }
 
     runtimeclass TabRowTheme {

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -1365,8 +1365,8 @@ void AppHost::_updateTheme()
     // titlebars for showing Mica currently, we're just gonna disable it
     // entirely while we sort that out.
     //
-    // const int attribute = theme.Window().UseMica() ? /*DWMSBT_MAINWINDOW*/ 2 : /*DWMSBT_NONE*/ 1;
-    // DwmSetWindowAttribute(_window->GetHandle(), /* DWMWA_SYSTEMBACKDROP_TYPE */ 38, &attribute, sizeof(attribute));
+    const int attribute = theme.Window().UseMica() ? /*DWMSBT_MAINWINDOW*/ 2 : /*DWMSBT_NONE*/ 1;
+    DwmSetWindowAttribute(_window->GetHandle(), /* DWMWA_SYSTEMBACKDROP_TYPE */ 38, &attribute, sizeof(attribute));
 }
 
 void AppHost::_HandleSettingsChanged(const winrt::Windows::Foundation::IInspectable& /*sender*/,

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -1365,6 +1365,12 @@ void AppHost::_updateTheme()
     // titlebars for showing Mica currently, we're just gonna disable it
     // entirely while we sort that out.
     //
+
+    // TODO! We very well may need to implement this differently on different
+    // build numbers. I believe this API became public some time around 22523. I
+    // think there's a way to do it with a private API on 22000, but we should
+    // do that in post.
+
     const int attribute = theme.Window().UseMica() ? /*DWMSBT_MAINWINDOW*/ 2 : /*DWMSBT_NONE*/ 1;
     DwmSetWindowAttribute(_window->GetHandle(), /* DWMWA_SYSTEMBACKDROP_TYPE */ 38, &attribute, sizeof(attribute));
 }

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -77,7 +77,7 @@ void IslandWindow::MakeWindow() noexcept
     WINRT_VERIFY(CreateWindowEx(WS_EX_NOREDIRECTIONBITMAP | (_alwaysOnTop ? WS_EX_TOPMOST : 0),
                                 wc.lpszClassName,
                                 L"Windows Terminal",
-                                WS_OVERLAPPEDWINDOW,
+                                WS_OVERLAPPEDWINDOW & (~WS_MAXIMIZE),
                                 CW_USEDEFAULT,
                                 CW_USEDEFAULT,
                                 CW_USEDEFAULT,

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -77,7 +77,7 @@ void IslandWindow::MakeWindow() noexcept
     WINRT_VERIFY(CreateWindowEx(WS_EX_NOREDIRECTIONBITMAP | (_alwaysOnTop ? WS_EX_TOPMOST : 0),
                                 wc.lpszClassName,
                                 L"Windows Terminal",
-                                WS_OVERLAPPEDWINDOW & (~WS_MAXIMIZE),
+                                WS_OVERLAPPEDWINDOW,
                                 CW_USEDEFAULT,
                                 CW_USEDEFAULT,
                                 CW_USEDEFAULT,

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -452,10 +452,17 @@ til::rect NonClientIslandWindow::_GetDragAreaRect() const noexcept
         // matter, but UIA will still think its bounds can extend past the right
         // of the parent HWND.
         const auto x = gsl::narrow_cast<til::CoordType>(clientDragBarRect.X * scale);
+
+        // The size of the buttons doesn't change over the life of the application.
+        const auto buttonWidthInDips{ 45.0 /*_titlebar.CaptionButtonWidth()*/ };
+
+        // However, the DPI scaling might, so get the updated size of the buttons in pixels
+        const auto buttonWidthInPixels = gsl::narrow_cast<til::CoordType>(buttonWidthInDips * GetCurrentDpiScale());
+        buttonWidthInPixels;
         return {
             x,
             gsl::narrow_cast<til::CoordType>(clientDragBarRect.Y * scale),
-            gsl::narrow_cast<til::CoordType>((clientDragBarRect.Width + clientDragBarRect.X) * scale) - x,
+            gsl::narrow_cast<til::CoordType>((clientDragBarRect.Width + clientDragBarRect.X) * scale) - x /* - (buttonWidthInPixels * 3)*/,
             gsl::narrow_cast<til::CoordType>((clientDragBarRect.Height + clientDragBarRect.Y) * scale),
         };
     }
@@ -889,7 +896,7 @@ void NonClientIslandWindow::_UpdateFrameMargins() const noexcept
         //  bug and it's what a lot of Win32 apps that customize the title bar do
         //  so it should work fine.
         margins.cyTopHeight = -frame.top;
-        margins.cyTopHeight = 1;
+        margins.cyTopHeight = 0;
     }
 
     // Extend the frame into the client area. microsoft/terminal#2735 - Just log


### PR DESCRIPTION
⚠️ marked as a draft. There are a couple todos, let's hope I get to them before I have to leave. If I can't, it shouldn't be to hard to validate these

This reverts commit 19b6d35.

This re-enables support for Mica, and transparent titlebars in general. It also syncs the titlebar opacity with the control opacity for `terminalBackground`. It also somehow fixes the bug where the bottom few pixels of the max btn doesn't work to trigger the snap flyout.

Closes #10509 

Does nothing for #13631

### TODO!

Go look for `TODO!` in the code. 

* [ ] Check the mica API on 22000, windows 11 RTM
* [ ] Check how this behaves on windows 10. 