### PR TITLE
AtlasEngine: Remove experimental tag and add tracing

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2237,7 +2237,7 @@
           "description": "Use to set a path to a pixel shader to use with the Terminal. Overrides `experimental.retroTerminalEffect`. This is an experimental feature, and its continued existence is not guaranteed.",
           "type": "string"
         },
-        "compatibility.useAtlasEngine": {
+        "useAtlasEngine": {
           "description": "Windows Terminal 1.16 and later ship with a new, performant text renderer. Set this to false to revert back to the old text renderer.",
           "type": "boolean",
           "default": true

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2237,10 +2237,10 @@
           "description": "Use to set a path to a pixel shader to use with the Terminal. Overrides `experimental.retroTerminalEffect`. This is an experimental feature, and its continued existence is not guaranteed.",
           "type": "string"
         },
-        "experimental.useAtlasEngine": {
-          "description": "Enable using the experimental new rendering engine for this profile. This is an experimental feature, and its continued existence is not guaranteed.",
+        "compatibility.useAtlasEngine": {
+          "description": "Windows Terminal 1.16 and later ship with a new, performant text renderer. Set this to false to revert back to the old text renderer.",
           "type": "boolean",
-          "default": false
+          "default": true
         },
         "fontFace": {
           "default": "Cascadia Mono",

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -374,7 +374,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
         else if (clickedItemTag == renderingTag)
         {
-            contentFrame().Navigate(xaml_typename<Editor::Rendering>(), winrt::make<RenderingViewModel>(_settingsClone.GlobalSettings()));
+            contentFrame().Navigate(xaml_typename<Editor::Rendering>(), winrt::make<RenderingViewModel>(_settingsClone));
             const auto crumb = winrt::make<Breadcrumb>(box_value(clickedItemTag), RS_(L"Nav_Rendering/Content"), BreadcrumbSubPage::None);
             _breadcrumbs.Append(crumb);
         }

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
@@ -119,7 +119,7 @@
                 </local:SettingContainer>
 
                 <!--  AtlasEngine  -->
-                <local:SettingContainer x:Uid="Profile_UseAtlasEngine"
+                <local:SettingContainer x:Uid="Profile_Compatibility_UseAtlasEngine"
                                         ClearSettingValue="{x:Bind Profile.ClearUseAtlasEngine}"
                                         HasSettingValue="{x:Bind Profile.HasUseAtlasEngine, Mode=OneWay}"
                                         SettingOverrideSource="{x:Bind Profile.UseAtlasEngineOverrideSource, Mode=OneWay}">

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Advanced.xaml
@@ -119,7 +119,7 @@
                 </local:SettingContainer>
 
                 <!--  AtlasEngine  -->
-                <local:SettingContainer x:Uid="Profile_Compatibility_UseAtlasEngine"
+                <local:SettingContainer x:Uid="Profile_UseAtlasEngine"
                                         ClearSettingValue="{x:Bind Profile.ClearUseAtlasEngine}"
                                         HasSettingValue="{x:Bind Profile.HasUseAtlasEngine, Mode=OneWay}"
                                         SettingOverrideSource="{x:Bind Profile.UseAtlasEngineOverrideSource, Mode=OneWay}">

--- a/src/cascadia/TerminalSettingsEditor/Rendering.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Rendering.xaml
@@ -23,6 +23,12 @@
             <TextBlock x:Uid="Globals_RenderingDisclaimer"
                        Style="{StaticResource DisclaimerStyle}" />
 
+            <!--  AtlasEngine  -->
+            <local:SettingContainer x:Uid="Profile_UseAtlasEngine">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.UseAtlasEngine, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
+
             <!--  Force Full Repaint  -->
             <local:SettingContainer x:Uid="Globals_ForceFullRepaint">
                 <ToggleSwitch IsOn="{x:Bind ViewModel.ForceFullRepaintRendering, Mode=TwoWay}"

--- a/src/cascadia/TerminalSettingsEditor/RenderingViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/RenderingViewModel.cpp
@@ -10,8 +10,8 @@ using namespace winrt::Microsoft::Terminal::Settings::Model;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
-    RenderingViewModel::RenderingViewModel(Model::GlobalAppSettings globalSettings) :
-        _GlobalSettings{ globalSettings }
+    RenderingViewModel::RenderingViewModel(Model::CascadiaSettings settings) noexcept :
+        _settings{ std::move(settings) }
     {
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/RenderingViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/RenderingViewModel.h
@@ -5,20 +5,19 @@
 
 #include "RenderingViewModel.g.h"
 #include "ViewModelHelpers.h"
-#include "Utils.h"
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
     struct RenderingViewModel : RenderingViewModelT<RenderingViewModel>, ViewModelHelper<RenderingViewModel>
     {
-    public:
-        RenderingViewModel(Model::GlobalAppSettings globalSettings);
+        explicit RenderingViewModel(Model::CascadiaSettings settings) noexcept;
 
-        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, ForceFullRepaintRendering);
-        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_GlobalSettings, SoftwareRendering);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_settings.ProfileDefaults(), UseAtlasEngine);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_settings.GlobalSettings(), ForceFullRepaintRendering);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_settings.GlobalSettings(), SoftwareRendering);
 
     private:
-        Model::GlobalAppSettings _GlobalSettings;
+        Model::CascadiaSettings _settings{ nullptr };
     };
 };
 

--- a/src/cascadia/TerminalSettingsEditor/RenderingViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/RenderingViewModel.idl
@@ -9,8 +9,9 @@ namespace Microsoft.Terminal.Settings.Editor
 {
     runtimeclass RenderingViewModel : Windows.UI.Xaml.Data.INotifyPropertyChanged
     {
-        RenderingViewModel(Microsoft.Terminal.Settings.Model.GlobalAppSettings globalSettings);
+        RenderingViewModel(Microsoft.Terminal.Settings.Model.CascadiaSettings settings);
 
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, UseAtlasEngine);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, ForceFullRepaintRendering);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, SoftwareRendering);
     }

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1074,6 +1074,10 @@
     <value>Controls what happens when the application emits a BEL character.</value>
     <comment>A description for what the "bell style" setting does. Presented near "Profile_BellStyle".{Locked="BEL"}</comment>
   </data>
+  <data name="Profile_Compatibility_UseAtlasEngine.Header" xml:space="preserve">
+    <value>Use the new text renderer ("AtlasEngine")</value>
+    <comment>{Locked="AtlasEngine"}</comment>
+  </data>
   <data name="Profile_UseAtlasEngine.Header" xml:space="preserve">
     <value>Enable experimental text rendering engine</value>
     <comment>An option to enable an experimental text rendering engine</comment>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1074,13 +1074,9 @@
     <value>Controls what happens when the application emits a BEL character.</value>
     <comment>A description for what the "bell style" setting does. Presented near "Profile_BellStyle".{Locked="BEL"}</comment>
   </data>
-  <data name="Profile_Compatibility_UseAtlasEngine.Header" xml:space="preserve">
+  <data name="Profile_UseAtlasEngine.Header" xml:space="preserve">
     <value>Use the new text renderer ("AtlasEngine")</value>
     <comment>{Locked="AtlasEngine"}</comment>
-  </data>
-  <data name="Profile_UseAtlasEngine.Header" xml:space="preserve">
-    <value>Enable experimental text rendering engine</value>
-    <comment>An option to enable an experimental text rendering engine</comment>
   </data>
   <data name="Profile_VtPassthrough.Header" xml:space="preserve">
     <value>Enable experimental virtual terminal passthrough</value>

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -893,6 +893,25 @@ try
         settings->_hash = _calculateHash(settingsString, lastWriteTime);
     }
 
+    // GH#13936: We're interested in how many users opt out of useAtlasEngine,
+    // indicating major issues that would require us to disable it by default again.
+    {
+        size_t enabled[2]{};
+        for (const auto& profile : settings->_activeProfiles)
+        {
+            enabled[profile.UseAtlasEngine()]++;
+        }
+
+        TraceLoggingWrite(
+            g_hSettingsModelProvider,
+            "AtlasEngine_Usage",
+            TraceLoggingDescription("Event emitted upon settings load, containing the number of profiles opted-in/out of useAtlasEngine"),
+            TraceLoggingUIntPtr(enabled[0], "UseAtlasEngineDisabled", "Number of profiles for which AtlasEngine is disabled"),
+            TraceLoggingUIntPtr(enabled[1], "UseAtlasEngineEnabled", "Number of profiles for which AtlasEngine is enabled"),
+            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+            TelemetryPrivacyDataTag(PDT_ProductAndServiceUsage));
+    }
+
     return *settings;
 }
 catch (const SettingsException& ex)

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -78,7 +78,7 @@ Author(s):
     X(CloseOnExitMode, CloseOnExit, "closeOnExit", CloseOnExitMode::Automatic)                                                                                 \
     X(hstring, TabTitle, "tabTitle")                                                                                                                           \
     X(Model::BellStyle, BellStyle, "bellStyle", BellStyle::Audible)                                                                                            \
-    X(bool, UseAtlasEngine, "compatibility.useAtlasEngine", Feature_AtlasEngine::IsEnabled())                                                                  \
+    X(bool, UseAtlasEngine, "useAtlasEngine", Feature_AtlasEngine::IsEnabled())                                                                                \
     X(Windows::Foundation::Collections::IVector<winrt::hstring>, BellSound, "bellSound", nullptr)                                                              \
     X(bool, Elevate, "elevate", false)                                                                                                                         \
     X(bool, VtPassthrough, "experimental.connection.passthroughMode", false)                                                                                   \

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -78,7 +78,7 @@ Author(s):
     X(CloseOnExitMode, CloseOnExit, "closeOnExit", CloseOnExitMode::Automatic)                                                                                 \
     X(hstring, TabTitle, "tabTitle")                                                                                                                           \
     X(Model::BellStyle, BellStyle, "bellStyle", BellStyle::Audible)                                                                                            \
-    X(bool, UseAtlasEngine, "experimental.useAtlasEngine", Feature_AtlasEngine::IsEnabled())                                                                   \
+    X(bool, UseAtlasEngine, "compatibility.useAtlasEngine", Feature_AtlasEngine::IsEnabled())                                                                  \
     X(Windows::Foundation::Collections::IVector<winrt::hstring>, BellSound, "bellSound", nullptr)                                                              \
     X(bool, Elevate, "elevate", false)                                                                                                                         \
     X(bool, VtPassthrough, "experimental.connection.passthroughMode", false)                                                                                   \


### PR DESCRIPTION
With AtlasEngine being enabled by default in 1.16 Preview it would look weird
if the `useAtlasEngine` option would still be called "experimental".
Additionally we're interested in how many users opt out of useAtlasEngine,
indicating major issues that would require us to disable it by default again.

Related to #13936

## Validation Steps Performed
* Toggling `useAtlasEngine` works as expected ✅
* Observe new event with TVPP ✅