### PR TITLE
Fix til::color::layer_over

### DIFF
--- a/src/inc/til/color.h
+++ b/src/inc/til/color.h
@@ -140,20 +140,17 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
         // See https://en.wikipedia.org/wiki/Alpha_compositing#Description
         constexpr color layer_over(const color& destination) const
         {
-            const auto sourceAlpha = a / 255.0f;
-            const auto destinationAlpha = destination.a / 255.0f;
-            const auto aInverse = 1.0f - sourceAlpha;
-
-            const auto resultA = sourceAlpha + destination.a * aInverse;
-            const auto resultR = (r * sourceAlpha + destination.r * destinationAlpha * aInverse) / resultA;
-            const auto resultG = (g * sourceAlpha + destination.g * destinationAlpha * aInverse) / resultA;
-            const auto resultB = (b * sourceAlpha + destination.b * destinationAlpha * aInverse) / resultA;
+            const auto aInverse = (255 - a) / 255.0f;
+            const auto resultA = a + destination.a * aInverse;
+            const auto resultR = (r * a + destination.r * destination.a * aInverse) / resultA;
+            const auto resultG = (g * a + destination.g * destination.a * aInverse) / resultA;
+            const auto resultB = (b * a + destination.b * destination.a * aInverse) / resultA;
 
             return {
-                static_cast<uint8_t>(255.0f * (resultR + 0.5f)),
-                static_cast<uint8_t>(255.0f * (resultG + 0.5f)),
-                static_cast<uint8_t>(255.0f * (resultB + 0.5f)),
-                static_cast<uint8_t>(255.0f * (resultA + 0.5f)),
+                static_cast<uint8_t>(resultR + 0.5f),
+                static_cast<uint8_t>(resultG + 0.5f),
+                static_cast<uint8_t>(resultB + 0.5f),
+                static_cast<uint8_t>(resultA + 0.5f),
             };
         }
 

--- a/src/inc/til/color.h
+++ b/src/inc/til/color.h
@@ -144,16 +144,16 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             const auto destinationAlpha = destination.a / 255.0f;
             const auto aInverse = 1.0f - sourceAlpha;
 
-            const auto resultA = a + destination.a * aInverse;
+            const auto resultA = sourceAlpha + destination.a * aInverse;
             const auto resultR = (r * sourceAlpha + destination.r * destinationAlpha * aInverse) / resultA;
             const auto resultG = (g * sourceAlpha + destination.g * destinationAlpha * aInverse) / resultA;
             const auto resultB = (b * sourceAlpha + destination.b * destinationAlpha * aInverse) / resultA;
 
             return {
-                static_cast<uint8_t>(resultR + 0.5f),
-                static_cast<uint8_t>(resultG + 0.5f),
-                static_cast<uint8_t>(resultB + 0.5f),
-                static_cast<uint8_t>(resultA + 0.5f),
+                static_cast<uint8_t>(255.0f * (resultR + 0.5f)),
+                static_cast<uint8_t>(255.0f * (resultG + 0.5f)),
+                static_cast<uint8_t>(255.0f * (resultB + 0.5f)),
+                static_cast<uint8_t>(255.0f * (resultA + 0.5f)),
             };
         }
 

--- a/src/til/ut_til/ColorTests.cpp
+++ b/src/til/ut_til/ColorTests.cpp
@@ -108,4 +108,19 @@ class ColorTests
         VERIFY_ARE_EQUAL(0xfe, colorWithAlpha.b);
         VERIFY_ARE_EQUAL(0x7f, colorWithAlpha.a);
     }
+
+    TEST_METHOD(LayerOver)
+    {
+        static constexpr til::color orange{ 255, 165, 0, 255 };
+        static constexpr til::color blue{ 0, 205, 255, 255 };
+        static constexpr til::color orangeWithAlpha{ 255, 165, 0, 165 };
+        static constexpr til::color blueWithAlpha{ 0, 205, 255, 205 };
+
+        VERIFY_ARE_EQUAL(orange, orange.layer_over(blue));
+        VERIFY_ARE_EQUAL(blue, blue.layer_over(orange));
+        VERIFY_ARE_EQUAL(til::color(165, 179, 90, 255), orangeWithAlpha.layer_over(blue));
+        VERIFY_ARE_EQUAL(til::color(177, 177, 78, 237), orangeWithAlpha.layer_over(blueWithAlpha));
+        VERIFY_ARE_EQUAL(til::color(50, 197, 205, 255), blueWithAlpha.layer_over(orange));
+        VERIFY_ARE_EQUAL(til::color(35, 200, 220, 237), blueWithAlpha.layer_over(orangeWithAlpha));
+    }
 };


### PR DESCRIPTION
The color of inactive tab text is incorrect since #13689 due to the introduction
of `til::color::layer_over` which incorrectly calculated the RGB values.

## Validation Steps Performed
* Added unit tests ✅

Co-authored-by: Leonard Hecker <lhecker@microsoft.com>