### PR TITLE
Fix conhost crashing on `--headless` without `--signal`

### DIFF
--- a/src/host/VtIo.cpp
+++ b/src/host/VtIo.cpp
@@ -325,7 +325,14 @@ bool VtIo::IsUsingVt() const
 // - Refer to GH#13066 for details.
 void VtIo::CreatePseudoWindow()
 {
-    _pPtySignalInputThread->CreatePseudoWindow();
+    if (_pPtySignalInputThread)
+    {
+        _pPtySignalInputThread->CreatePseudoWindow();
+    }
+    else
+    {
+        ServiceLocator::LocatePseudoWindow();
+    }
 }
 
 void VtIo::SetWindowVisibility(bool showOrHide) noexcept


### PR DESCRIPTION
It's not supported, and it shouldn't be. 

But this is the absolutely most minimal way to get the crash to go away. 

Closes #13914 