### PR TITLE
AtlasEngine: Fix a correctness bug

### DIFF
--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -828,6 +828,7 @@ namespace Microsoft::Console::Render
             u32 cursorColor = INVALID_COLOR;
             u16 cursorType = gsl::narrow_cast<u16>(CursorType::Legacy);
             u8 heightPercentage = 20;
+            u8 _padding = 0;
 
             ATLAS_POD_OPS(CachedCursorOptions)
         };


### PR DESCRIPTION
`ATLAS_POD_OPS` doesn't check for `has_unique_object_representations` and so a
bug exists where `CachedCursorOptions` comparisons invoke undefined behavior.