### PR TITLE
Update Microsoft.UI.XAML to 2.7.3

### DIFF
--- a/build/packages.config
+++ b/build/packages.config
@@ -3,8 +3,6 @@
   <package id="MUXCustomBuildTasks" version="1.0.48" targetFramework="native" />
   <package id="Microsoft.Taef" version="10.60.210621002" targetFramework="native" />
   <package id="Microsoft.Internal.PGO-Helpers.Cpp" version="0.2.34" targetFramework="native" />
-  <!-- This cannot be included in another project that depends on XAML (as it would be a duplicate package ID) -->
-  <package id="Microsoft.UI.Xaml" version="2.7.3" targetFramework="native" />
   <package id="Microsoft.Debugging.Tools.PdbStr" version="20220617.1556.0" targetFramework="native" />
   <package id="Microsoft.Debugging.Tools.SrcTool" version="20220617.1556.0" targetFramework="native" />
 </packages>

--- a/common.openconsole.props
+++ b/common.openconsole.props
@@ -11,21 +11,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!--
-    For the Windows 10 build, we're targeting the prerelease version of Microsoft.UI.Xaml.
-    This version emits every XAML DLL directly into our package.
-    This is a workaround for us not having deliverable MSFT-21242953 on this version of Windows.
-
-    This version should be tracked in all project packages.config files for projects that depend on Xaml.
-    -->
-    <TerminalMUXVersion>2.7.3-prerelease.220816001</TerminalMUXVersion>
-    <!--
-    For the Windows 11-specific build, we're targeting the public version of Microsoft.UI.Xaml.
-    This version emits a package dependency instead of embedding the dependency in our own package.
-
-    This version should be tracked in build/packages.config.
-    -->
-    <TerminalMUXVersion Condition="'$(TerminalTargetWindowsVersion)'=='Win11'">2.7.3</TerminalMUXVersion>
+    <TerminalMUXVersion>2.7.3</TerminalMUXVersion>
   </PropertyGroup>
 
 </Project>

--- a/dep/nuget/packages.config
+++ b/dep/nuget/packages.config
@@ -10,7 +10,6 @@
   <package id="Microsoft.VCRTForwarders.140" version="1.0.4" targetFramework="native" />
   <package id="Microsoft.Internal.Windows.Terminal.ThemeHelpers" version="0.6.220404001" targetFramework="native" />
   <package id="Microsoft.VisualStudio.Setup.Configuration.Native" version="2.3.2262" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.UI.Xaml" version="2.7.3-prerelease.220816001" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220201.1" targetFramework="native" developmentDependency="true" />
 
   <!-- Managed packages -->

--- a/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
@@ -301,7 +301,6 @@
     <PRIResource Include="Resources\en-US\Resources.resw" />
     <PRIResource Include="Resources\en-US\ContextMenu.resw" />
     <OCResourceDirectory Include="Resources" />
-    <None Include="packages.config" />
   </ItemGroup>
   <!-- ========================= Project References ======================== -->
   <ItemGroup>
@@ -339,7 +338,6 @@
       <Private>true</Private>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-
   </ItemGroup>
   <PropertyGroup>
     <!-- This is a hack to get the ARM64 CI build working. See
@@ -397,10 +395,8 @@
   </ItemDefinitionGroup>
   <!-- ========================= Globals ======================== -->
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.post.props" />
-
   <!-- This -must- go after cppwinrt.build.post.props because that includes many VS-provided props including appcontainer.common.props, which stomps on what cppwinrt.targets did. -->
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.targets" />
-
   <!--
     By default, the PRI file will contain resource paths beginning with the
     project name. Since we enabled XBF embedding, this *also* includes App.xbf.

--- a/src/cascadia/TerminalApp/TerminalAppLib.vcxproj.filters
+++ b/src/cascadia/TerminalApp/TerminalAppLib.vcxproj.filters
@@ -5,6 +5,7 @@
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="Resources\en-US\Resources.resw" />
+    <PRIResource Include="Resources\en-US\ContextMenu.resw" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="init.cpp" />
@@ -21,9 +22,6 @@
     <ClCompile Include="ColorHelper.cpp" />
     <ClCompile Include="DebugTapConnection.cpp" />
     <ClCompile Include="Jumplist.cpp" />
-    <ClCompile Include="Tab.cpp">
-      <Filter>tab</Filter>
-    </ClCompile>
     <ClCompile Include="SettingsTab.cpp">
       <Filter>tab</Filter>
     </ClCompile>
@@ -61,9 +59,6 @@
     <ClInclude Include="DebugTapConnection.h" />
     <ClInclude Include="ColorHelper.h" />
     <ClInclude Include="Jumplist.h" />
-    <ClInclude Include="Tab.h">
-      <Filter>tab</Filter>
-    </ClInclude>
     <ClInclude Include="SettingsTab.h">
       <Filter>tab</Filter>
     </ClInclude>
@@ -117,9 +112,7 @@
     <Midl Include="PaletteItemTemplateSelector.idl" />
     <Midl Include="TabBase.idl" />
     <Midl Include="EmptyStringVisibilityConverter.idl" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
+    <Midl Include="TaskbarState.idl" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="MinMaxCloseControl.xaml">

--- a/src/cascadia/TerminalApp/packages.config
+++ b/src/cascadia/TerminalApp/packages.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.UI.Xaml" version="2.7.2-prerelease.220406002" targetFramework="native" />
-</packages>

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
@@ -355,12 +355,12 @@
   </ItemGroup>
   <!-- ========================= Misc Files ======================== -->
   <ItemGroup>
+    <None Include="packages.config" />
     <PRIResource Include="Resources\en-US\Resources.resw">
       <SubType>Designer</SubType>
     </PRIResource>
     <OCResourceDirectory Include="Resources" />
     <None Include="$(ProjectName).def" />
-    <None Include="packages.config" />
   </ItemGroup>
   <!-- ========================= Project References ======================== -->
   <ItemGroup>
@@ -379,7 +379,6 @@
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalConnection\TerminalConnection.vcxproj">
       <Private>false</Private>
     </ProjectReference>
-
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\dll\TerminalControl.vcxproj">
       <!-- Private:false and ReferenceOutputAssembly:false, in combination with
       the manual reference to TerminalControl.winmd below make sure that this
@@ -392,7 +391,6 @@
       <Private>false</Private>
     </ProjectReference>
   </ItemGroup>
-
   <ItemGroup>
     <!-- Manually add a reference to TerminalControl here. We need this so
     MDMERGE will know where the TermControl types are defined. However, we need
@@ -411,17 +409,19 @@
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
     </Reference>
   </ItemGroup>
-
   <ItemDefinitionGroup>
     <Link>
       <AdditionalDependencies>shell32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.post.props" />
-
   <!-- This -must- go after cppwinrt.build.post.props because that includes many VS-provided props including appcontainer.common.props, which stomps on what cppwinrt.targets did. -->
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.targets" />
-
   <Import Project="$(SolutionDir)build\rules\CollectWildcardResources.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.UI.Xaml.2.7.3\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.UI.Xaml.2.7.3\build\native\Microsoft.UI.Xaml.targets'))" />
+  </Target>
 </Project>

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj.filters
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj.filters
@@ -25,14 +25,13 @@
     <Midl Include="GlobalAppearanceViewModel.idl" />
     <Midl Include="LaunchViewModel.idl" />
     <Midl Include="EnumEntry.idl" />
-    <Midl Include="Converters.idl">
-      <Filter>Converters</Filter>
-    </Midl>
     <Midl Include="SettingContainer.idl" />
+    <Midl Include="Converters.idl" />
+    <Midl Include="Profiles.idl" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
     <None Include="$(ProjectName).def" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="CommonResources.xaml" />

--- a/src/cascadia/TerminalSettingsEditor/packages.config
+++ b/src/cascadia/TerminalSettingsEditor/packages.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.UI.Xaml" version="2.7.1" targetFramework="native" />
-</packages>

--- a/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
+++ b/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CA5CAD1A-1754-4A9D-93D7-857A9D17CB1B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -15,7 +14,6 @@
     <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
     <PgoTarget>true</PgoTarget>
   </PropertyGroup>
-
   <PropertyGroup Label="NuGet Dependencies">
     <TerminalCppWinrt>true</TerminalCppWinrt>
     <TerminalXamlApplicationToolkit>true</TerminalXamlApplicationToolkit>
@@ -23,17 +21,14 @@
     <TerminalThemeHelpers>true</TerminalThemeHelpers>
     <TerminalMUX>true</TerminalMUX>
   </PropertyGroup>
-
   <Import Project="..\..\..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.props" />
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.pre.props" />
-
   <ItemDefinitionGroup>
     <ClCompile>
       <SDLCheck>true</SDLCheck>
     </ClCompile>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(OpenConsoleDir)\src\inc;$(OpenConsoleDir)\dep;$(OpenConsoleDir)\dep\Console;$(OpenConsoleDir)\dep\Win32K;$(OpenConsoleDir)\dep\gsl\include;%(AdditionalIncludeDirectories);</AdditionalIncludeDirectories>
@@ -76,9 +71,6 @@
   <ItemGroup>
     <Manifest Include="WindowsTerminal.manifest" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
   <!-- Dependencies -->
   <ItemGroup>
     <!-- Even though we do have proper recursive dependencies, we want to keep some of these here
@@ -86,18 +78,15 @@
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\dll\TerminalControl.vcxproj" />
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalConnection\TerminalConnection.vcxproj" />
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalSettingsModel\dll\Microsoft.Terminal.Settings.Model.vcxproj" />
-
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalApp\dll\TerminalApp.vcxproj" />
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\Remoting\dll\Microsoft.Terminal.Remoting.vcxproj" />
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalSettingsEditor\Microsoft.Terminal.Settings.Editor.vcxproj" />
-
     <ProjectReference Include="$(OpenConsoleDir)src\types\lib\types.vcxproj" />
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\WinRTUtils\WinRTUtils.vcxproj">
       <Project>{CA5CAD1A-039A-4929-BA2A-8BEB2E4106FE}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
-
   <!-- Manually add a reference to Core here. We need this so MDMERGE will know
   where the Core types are defined. However, we need to do it exactly like this,
   because the Core project is a lib not a dll, so it can't be ProjectReference'd
@@ -119,10 +108,12 @@
     <PropertyPageSchema Include="$(VCTargetsPath)$(LangID)\debugger_general.xml" />
     <PropertyPageSchema Include="$(VCTargetsPath)$(LangID)\debugger_local_windows.xml" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
-
   <!--
   BODGY
 
@@ -136,12 +127,10 @@
   -->
   <ItemDefinitionGroup>
     <Link>
-        <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
   </ItemDefinitionGroup>
-
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.post.props" />
-
   <!-- Override GetPackagingOutputs to roll up all our dependencies.
        This ensures that when the WAP packaging project asks what files go into
        the package, we tell it.
@@ -152,24 +141,19 @@
     <_ContinueOnError Condition="'$(BuildingProject)' != 'true'">false</_ContinueOnError>
   </PropertyGroup>
   <Target Name="GetPackagingOutputs" Returns="@(PackagingOutputs)">
-    <MSBuild
-      Projects="@(ProjectReferenceWithConfiguration)"
-      Targets="GetPackagingOutputs"
-      BuildInParallel="$(BuildInParallel)"
-      Properties="%(ProjectReferenceWithConfiguration.SetConfiguration); %(ProjectReferenceWithConfiguration.SetPlatform)"
-      Condition="'@(ProjectReferenceWithConfiguration)' != ''
-                 and '%(ProjectReferenceWithConfiguration.BuildReference)' == 'true'
-                 and '%(ProjectReferenceWithConfiguration.ReferenceOutputAssembly)' == 'true'"
-      ContinueOnError="$(_ContinueOnError)">
-      <Output TaskParameter="TargetOutputs" ItemName="_PackagingOutputsFromOtherProjects"/>
+    <MSBuild Projects="@(ProjectReferenceWithConfiguration)" Targets="GetPackagingOutputs" BuildInParallel="$(BuildInParallel)" Properties="%(ProjectReferenceWithConfiguration.SetConfiguration); %(ProjectReferenceWithConfiguration.SetPlatform)" Condition="'@(ProjectReferenceWithConfiguration)' != ''&#xD;&#xA;                 and '%(ProjectReferenceWithConfiguration.BuildReference)' == 'true'&#xD;&#xA;                 and '%(ProjectReferenceWithConfiguration.ReferenceOutputAssembly)' == 'true'" ContinueOnError="$(_ContinueOnError)">
+      <Output TaskParameter="TargetOutputs" ItemName="_PackagingOutputsFromOtherProjects" />
     </MSBuild>
-
     <ItemGroup>
       <PackagingOutputs Include="@(_PackagingOutputsFromOtherProjects)" />
     </ItemGroup>
-
   </Target>
   <Import Project="$(OpenConsoleDir)\build\rules\GenerateSxsManifestsFromWinmds.targets" />
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.targets" />
-
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.UI.Xaml.2.7.3\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.UI.Xaml.2.7.3\build\native\Microsoft.UI.Xaml.targets'))" />
+  </Target>
 </Project>

--- a/src/cascadia/WindowsTerminal/packages.config
+++ b/src/cascadia/WindowsTerminal/packages.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.UI.Xaml" version="2.7.1" targetFramework="native" />
-</packages>


### PR DESCRIPTION
No need to stay at a prerelease version anymore, or have different versions of the same package for different parts of the program. We should use 2.7.3 throughout. 