### PR TITLE
vPack: fix submit branch, add github token from consvc

### DIFF
--- a/build/config/GitCheckin.json
+++ b/build/config/GitCheckin.json
@@ -4,7 +4,7 @@
         "collection": "microsoft",
         "project": "OS",
         "repo": "os.2020",
-        "name": "official/rs_wdx_dxp_windev",
+        "name": "official/rs_we_adept_e4d2",
         "workitem": "38106206",
         "CheckinFiles": [
           {

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -708,6 +708,7 @@ jobs:
         description: VPack for the Windows Terminal Application
         pushPkgName: WindowsTerminal.app
         owner: conhost
+        githubToken: $(GitHubTokenForVpackProvenance)
     - task: PublishPipelineArtifact@1
       displayName: 'Copy VPack Manifest to Drop'
       inputs:


### PR DESCRIPTION
Our Windows branch name changed, and I took this opportunity to resolve
an issue where vpack builds would occasionally fail due to GitHub rate
limiting the Azure DevOps IP addresses.