### PR TITLE
This is a test of the add-to-project action

### DIFF
--- a/.github/workflows/addToProject.yml
+++ b/.github/workflows/addToProject.yml
@@ -1,0 +1,19 @@
+name: Add triaged bugs & tasks to project board
+# https://github.com/actions/add-to-project
+
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/microsoft/projects/159
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: Issue-Feature, Needs-Triage, Needs-Author-Feedback, Issue-Scenario
+          label-operator: NOT


### PR DESCRIPTION
docs: https://github.com/marketplace/actions/add-to-github-projects?version=v0.3.0

Hey maybe we should use more actions. This was thrown out during the last GH sync. Hopefully this doesn't explode.

This _should_ add all issues that don't have one of `Issue-Feature`, `Needs-Triage`, `Needs-Author-Feedback`, `Issue-Scenario` to the project board. That should just leave all the bugs and tasks that have been triaged.

I didn't go for 

```yml
          labeled: Issue-Task, Issue-Bug
          label-operator: OR
```

since those would include untriaged ones.

There's also no way to filter on milestone currently, so this will likely add icebox issues. We'll need to remove those manually as needed.