### PR TITLE
Add support for DECARM (Auto Repeat Mode)

### DIFF
--- a/src/terminal/adapter/DispatchTypes.hpp
+++ b/src/terminal/adapter/DispatchTypes.hpp
@@ -381,6 +381,7 @@ namespace Microsoft::Console::VirtualTerminal::DispatchTypes
         DECSCNM_ScreenMode = DECPrivateMode(5),
         DECOM_OriginMode = DECPrivateMode(6),
         DECAWM_AutoWrapMode = DECPrivateMode(7),
+        DECARM_AutoRepeatMode = DECPrivateMode(8),
         ATT610_StartCursorBlink = DECPrivateMode(12),
         DECTCEM_TextCursorEnableMode = DECPrivateMode(25),
         XTERM_EnableDECCOLMSupport = DECPrivateMode(40),

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1013,6 +1013,9 @@ bool AdaptDispatch::_ModeParamsHelper(const DispatchTypes::ModeParams param, con
     case DispatchTypes::ModeParams::DECAWM_AutoWrapMode:
         success = SetAutoWrapMode(enable);
         break;
+    case DispatchTypes::ModeParams::DECARM_AutoRepeatMode:
+        success = _SetInputMode(TerminalInput::Mode::AutoRepeat, enable);
+        break;
     case DispatchTypes::ModeParams::ATT610_StartCursorBlink:
         success = EnableCursorBlinking(enable);
         break;
@@ -1863,6 +1866,9 @@ bool AdaptDispatch::HardReset()
 
     // Reset the Backarrow Key mode
     _SetInputMode(TerminalInput::Mode::BackarrowKey, false);
+
+    // Set the keyboard Auto Repeat mode
+    _SetInputMode(TerminalInput::Mode::AutoRepeat, true);
 
     // Delete all current tab stops and reapply
     _ResetTabStops();

--- a/src/terminal/adapter/ut_adapter/inputTest.cpp
+++ b/src/terminal/adapter/ut_adapter/inputTest.cpp
@@ -44,6 +44,7 @@ public:
     TEST_METHOD(DifferentModifiersTest);
     TEST_METHOD(CtrlNumTest);
     TEST_METHOD(BackarrowKeyModeTest);
+    TEST_METHOD(AutoRepeatModeTest);
 
     wchar_t GetModifierChar(const bool fShift, const bool fAlt, const bool fCtrl)
     {
@@ -850,4 +851,57 @@ void InputTest::BackarrowKeyModeTest()
 
     s_expectedInput = L"\x1b\x8";
     TestKey(pInput, LEFT_ALT_PRESSED | LEFT_CTRL_PRESSED | SHIFT_PRESSED, vkey);
+}
+
+void InputTest::AutoRepeatModeTest()
+{
+    Log::Comment(L"Starting test...");
+
+    auto receivedChars = std::wstring{};
+    const auto pInput = new TerminalInput([&](auto& inEvents) {
+        for (auto& record : IInputEvent::ToInputRecords(inEvents))
+        {
+            receivedChars.push_back(record.Event.KeyEvent.uChar.UnicodeChar);
+        }
+    });
+
+    const auto repeatKey = [&](auto vKey, auto unicodeChar, int repeatCount) {
+        auto irTest = INPUT_RECORD{ 0 };
+        irTest.EventType = KEY_EVENT;
+        irTest.Event.KeyEvent.wRepeatCount = 1;
+        irTest.Event.KeyEvent.wVirtualKeyCode = vKey;
+        irTest.Event.KeyEvent.uChar.UnicodeChar = unicodeChar;
+        irTest.Event.KeyEvent.bKeyDown = TRUE;
+
+        // We're simulating a key being held down so that it repeats, by sending
+        // multiple KeyDown events followed by a single KeyUp event.
+
+        for (auto i = 0; i < repeatCount; i++)
+        {
+            auto keyDownEvent = IInputEvent::Create(irTest);
+            VERIFY_IS_TRUE(pInput->HandleKey(keyDownEvent.get()));
+        }
+
+        irTest.Event.KeyEvent.bKeyDown = FALSE;
+        auto keyUpEvent = IInputEvent::Create(irTest);
+        VERIFY_IS_FALSE(pInput->HandleKey(keyUpEvent.get()));
+    };
+
+    Log::Comment(L"Sending repeating keypresses with DECARM disabled.");
+
+    pInput->SetInputMode(TerminalInput::Mode::AutoRepeat, false);
+    receivedChars.clear();
+    repeatKey('A', L'a', 5);
+    repeatKey('B', L'b', 5);
+    repeatKey('C', L'c', 5);
+    VERIFY_ARE_EQUAL(L"abc", receivedChars);
+
+    Log::Comment(L"Sending repeating keypresses with DECARM enabled.");
+
+    pInput->SetInputMode(TerminalInput::Mode::AutoRepeat, true);
+    receivedChars.clear();
+    repeatKey('A', L'a', 5);
+    repeatKey('B', L'b', 5);
+    repeatKey('C', L'c', 5);
+    VERIFY_ARE_EQUAL(L"aaaaabbbbbccccc", receivedChars);
 }

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -553,8 +553,23 @@ bool TerminalInput::HandleKey(const IInputEvent* const pInEvent)
     // Only need to handle key down. See raw key handler (see RawReadWaitRoutine in stream.cpp)
     if (!keyEvent.IsKeyDown())
     {
+        // If this is a release of the last recorded key press, we can reset that.
+        if (keyEvent.GetVirtualKeyCode() == _lastVirtualKeyCode)
+        {
+            _lastVirtualKeyCode = 0;
+        }
         return false;
     }
+
+    // If this is a repeat of the last recorded key press, and Auto Repeat Mode
+    // is disabled, then we should suppress this event.
+    if (keyEvent.GetVirtualKeyCode() == _lastVirtualKeyCode && !_inputMode.test(Mode::AutoRepeat))
+    {
+        // Note that we must return true here to say we've handled the event,
+        // otherwise the key press can still end up being submitted.
+        return true;
+    }
+    _lastVirtualKeyCode = keyEvent.GetVirtualKeyCode();
 
     // The VK_BACK key depends on the state of Backarrow Key mode (DECBKM).
     // If the mode is set, we should send BS. If reset, we should send DEL.

--- a/src/terminal/input/terminalInput.hpp
+++ b/src/terminal/input/terminalInput.hpp
@@ -39,6 +39,7 @@ namespace Microsoft::Console::VirtualTerminal
         enum class Mode : size_t
         {
             Ansi,
+            AutoRepeat,
             Keypad,
             CursorKey,
             BackarrowKey,
@@ -92,7 +93,9 @@ namespace Microsoft::Console::VirtualTerminal
         // storage location for the leading surrogate of a utf-16 surrogate pair
         std::optional<wchar_t> _leadingSurrogate;
 
-        til::enumset<Mode> _inputMode{ Mode::Ansi };
+        WORD _lastVirtualKeyCode{ 0 };
+
+        til::enumset<Mode> _inputMode{ Mode::Ansi, Mode::AutoRepeat };
         bool _forceDisableWin32InputMode{ false };
 
         void _SendChar(const wchar_t ch);


### PR DESCRIPTION
This PR adds support for the `DECARM` (Auto Repeat Mode) sequence, which
controls whether a keypress automatically repeats if you keep it held
down for long enough.

Note that this won't fully work in Windows Terminal until issue #8440 is
resolved.

Every time we receive a `KeyDown` event, we record the virtual key code
to track that as the last key pressed. If we receive a `KeyUp` event the
matches that last key code, we reset that field. Then if the Auto Repeat
Mode is reset, and we receive a `KeyDown` event that matches the last
key code, we simply ignore it.

## Validation Steps Performed

I've manually tested the `DECARM` functionality in Vttest and confirmed
that it's working as expected. Although note that in Windows Terminal
this only applies to non-alphanumeric keys for now (e.g. Tab, BackSpace,
arrow keys, etc.)

I've also added a basic unit test that verifies that repeated key
presses are suppressed when the `DECARM` mode is disabled.

Closes #13919