### PR TITLE
Relax shader strictness in RELEASE mode

### DIFF
--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -379,7 +379,7 @@ void Terminal::ExpandSelectionToWord()
         _selection->pivot = _selection->start;
         _selection->end = buffer.GetWordEnd(_selection->end, _wordDelimiters);
 
-        // if we're targetting both endpoints, instead just target "end"
+        // if we're targeting both endpoints, instead just target "end"
         if (WI_IsFlagSet(_selectionEndpoint, SelectionEndpoint::Start) && WI_IsFlagSet(_selectionEndpoint, SelectionEndpoint::End))
         {
             _selectionEndpoint = SelectionEndpoint::End;

--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -681,11 +681,23 @@ void AtlasEngine::_createResources()
                 break;
             }
 
-            static constexpr auto flags = D3DCOMPILE_PACK_MATRIX_COLUMN_MAJOR | D3DCOMPILE_ENABLE_STRICTNESS | D3DCOMPILE_WARNINGS_ARE_ERRORS
+            static constexpr auto flags =
+                    D3DCOMPILE_PACK_MATRIX_COLUMN_MAJOR
 #ifdef NDEBUG
-                                          | D3DCOMPILE_OPTIMIZATION_LEVEL3;
+                    | D3DCOMPILE_OPTIMIZATION_LEVEL3
+                    ;
 #else
-                                          | D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+                    // Only enable strictness and warnings in DEBUG mode
+                    //  as these settings makes it very difficult to develop
+                    //  shaders as windows terminal is not telling the user
+                    //  what's wrong, windows terminal just fails.
+                    //  Keep it in DEBUG mode to catch errors in shaders
+                    //  shipped with windows terminal
+                    | D3DCOMPILE_ENABLE_STRICTNESS
+                    | D3DCOMPILE_WARNINGS_ARE_ERRORS
+                    | D3DCOMPILE_DEBUG
+                    | D3DCOMPILE_SKIP_OPTIMIZATION
+                    ;
 #endif
 
             wil::com_ptr<ID3DBlob> error;

--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -682,22 +682,17 @@ void AtlasEngine::_createResources()
             }
 
             static constexpr auto flags =
-                    D3DCOMPILE_PACK_MATRIX_COLUMN_MAJOR
+                D3DCOMPILE_PACK_MATRIX_COLUMN_MAJOR
 #ifdef NDEBUG
-                    | D3DCOMPILE_OPTIMIZATION_LEVEL3
-                    ;
+                | D3DCOMPILE_OPTIMIZATION_LEVEL3;
 #else
-                    // Only enable strictness and warnings in DEBUG mode
-                    //  as these settings makes it very difficult to develop
-                    //  shaders as windows terminal is not telling the user
-                    //  what's wrong, windows terminal just fails.
-                    //  Keep it in DEBUG mode to catch errors in shaders
-                    //  shipped with windows terminal
-                    | D3DCOMPILE_ENABLE_STRICTNESS
-                    | D3DCOMPILE_WARNINGS_ARE_ERRORS
-                    | D3DCOMPILE_DEBUG
-                    | D3DCOMPILE_SKIP_OPTIMIZATION
-                    ;
+                // Only enable strictness and warnings in DEBUG mode
+                //  as these settings makes it very difficult to develop
+                //  shaders as windows terminal is not telling the user
+                //  what's wrong, windows terminal just fails.
+                //  Keep it in DEBUG mode to catch errors in shaders
+                //  shipped with windows terminal
+                | D3DCOMPILE_ENABLE_STRICTNESS | D3DCOMPILE_WARNINGS_ARE_ERRORS | D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
 #endif
 
             wil::com_ptr<ID3DBlob> error;


### PR DESCRIPTION
Disables strictness and warnings as errors for custom pixel shaders in
RELEASE. Windows terminal is not telling the user why the shader won't
compile which makes it very frustrating for the shader hacker.

After trying the recent preview none of my shaders loaded anymore in
Windows Terminal Preview which made me very sad. I had no idea what was
wrong with them. After cloning the git repo, building it, fighting an
issue that prevent DEBUG SDK from being used I finally was able to
identify some issues that were blocking my shaders.

> error X3556: integer modulus may be much slower, try using uints if possible.
> error X4000: use of potentially uninitialized variable (rayCylinder)

While the first one is a good warning I don't think it is an error and
the tools I use didn't flag it so was hard to know.

The second one I was staring at the code and was unable to identify what
exactly was causing the issues, I fumbled with the code a few times and
just felt the fun drain away.

IMHO: I want it to be fun to develop shaders for windows terminal.
Fighting invisible errors are not fun. I am not after building
production shaders for Windows Terminal, I want some cool effects. So
while I am as a .NET developer always runs with Warning as errors I
don't think it's the right option here. Especially since Windows
Terminal doesn't tell what is the problem.

However, I understand if the shaders you ship with Windows Terminal
should be free of errors and silly mistakes, so I kept the stricter
setting in DEBUG mode.

## Validation Steps Performed

Loaded Windows Terminal in RELEASE and DEBUG mode and validated that
RELEASE mode had reduced strictness but DEBUG retained the previous more
restrictive mode.

