### PR TITLE
AtlasEngine: Fix uneven baselines when scaling glyphs

### DIFF
--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -523,9 +523,9 @@ namespace Microsoft::Console::Render
         struct CachedGlyphLayout
         {
             wil::com_ptr<IDWriteTextLayout> textLayout;
-            f32x2 halfSize;
             f32x2 offset;
             f32x2 scale;
+            f32x2 scaleCenter;
             D2D1_DRAW_TEXT_OPTIONS options = D2D1_DRAW_TEXT_OPTIONS_NONE;
             bool scalingRequired = false;
 


### PR DESCRIPTION
This commit changes the glyph scale algorithm to prefer aligning glyphs to
their baseline. This improves the visual appearance of simulated italic glyphs.
However wide Emojis in narrow cells now look slightly worse without centering.

Closes #13987

## Validation Steps Performed
* Use FiraCode which has no italic variant and instead uses simulated italics
* Write italic text
* Baseline is consistent ✅