### PR TITLE
Fix font size rounding in the settings UI

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Appearances.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.cpp
@@ -98,6 +98,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             // issues when displaying 32-bit floats, because WinUI is unaware about their existence.
             SignificantDigitsNumberRounder rounder;
             rounder.SignificantDigits(6);
+            // BODGY: Depends on WinUI internals.
             _fontSizeBox().NumberFormatter().as<DecimalFormatter>().NumberRounder(rounder);
         }
 

--- a/src/cascadia/TerminalSettingsEditor/Appearances.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.cpp
@@ -91,6 +91,16 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         InitializeComponent();
 
+        {
+            using namespace winrt::Windows::Globalization::NumberFormatting;
+            // > .NET rounds to 12 significant digits when displaying doubles, so we will [...]
+            // ...obviously not do that, because this is an UI element for humans. This prevents
+            // issues when displaying 32-bit floats, because WinUI is unaware about their existence.
+            SignificantDigitsNumberRounder rounder;
+            rounder.SignificantDigits(6);
+            _fontSizeBox().NumberFormatter().as<DecimalFormatter>().NumberRounder(rounder);
+        }
+
         INITIALIZE_BINDABLE_ENUM_SETTING(CursorShape, CursorStyle, winrt::Microsoft::Terminal::Core::CursorStyle, L"Profile_CursorShape", L"Content");
         INITIALIZE_BINDABLE_ENUM_SETTING(AdjustIndistinguishableColors, AdjustIndistinguishableColors, winrt::Microsoft::Terminal::Core::AdjustTextMode, L"Profile_AdjustIndistinguishableColors", L"Content");
         INITIALIZE_BINDABLE_ENUM_SETTING_REVERSE_ORDER(BackgroundImageStretchMode, BackgroundImageStretchMode, winrt::Windows::UI::Xaml::Media::Stretch, L"Profile_BackgroundImageStretchMode", L"Content");

--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -93,8 +93,8 @@
                                     HasSettingValue="{x:Bind Appearance.HasFontSize, Mode=OneWay}"
                                     SettingOverrideSource="{x:Bind Appearance.FontSizeOverrideSource, Mode=OneWay}"
                                     Visibility="{x:Bind Appearance.IsDefault, Mode=OneWay}">
-                <muxc:NumberBox x:Uid="Profile_FontSizeBox"
-                                x:Name="_fontSizeBox"
+                <muxc:NumberBox x:Name="_fontSizeBox"
+                                x:Uid="Profile_FontSizeBox"
                                 AcceptsExpression="False"
                                 LargeChange="10"
                                 Maximum="128"

--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -94,6 +94,7 @@
                                     SettingOverrideSource="{x:Bind Appearance.FontSizeOverrideSource, Mode=OneWay}"
                                     Visibility="{x:Bind Appearance.IsDefault, Mode=OneWay}">
                 <muxc:NumberBox x:Uid="Profile_FontSizeBox"
+                                x:Name="_fontSizeBox"
                                 AcceptsExpression="False"
                                 LargeChange="10"
                                 Maximum="128"

--- a/src/cascadia/TerminalSettingsEditor/pch.h
+++ b/src/cascadia/TerminalSettingsEditor/pch.h
@@ -24,6 +24,7 @@
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Globalization.h>
+#include <winrt/Windows.Globalization.NumberFormatting.h>
 #include <winrt/Windows.System.h>
 #include <winrt/Windows.UI.h>
 #include <winrt/Windows.UI.Core.h>


### PR DESCRIPTION
This fixes an issue with c51bb3a, where some fractional font
sizes are displayed as something like 13.600000000001.

Closes #14024

## Validation Steps Performed
* Enter a font size of 13.6 and save
* NumberBox displays "13.6" ✅