### PR TITLE
Add support for scroll bar 'always' setting

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2350,7 +2350,8 @@
           "description": "Defines the visibility of the scrollbar.",
           "enum": [
             "visible",
-            "hidden"
+            "hidden",
+            "always"
           ],
           "type": "string"
         },

--- a/src/cascadia/TerminalControl/IControlSettings.idl
+++ b/src/cascadia/TerminalControl/IControlSettings.idl
@@ -9,7 +9,8 @@ namespace Microsoft.Terminal.Control
     enum ScrollbarState
     {
         Visible = 0,
-        Hidden
+        Hidden,
+        Always
     };
 
     enum TextAntialiasingMode

--- a/src/cascadia/TerminalControl/ScrollBarVisualStateManager.cpp
+++ b/src/cascadia/TerminalControl/ScrollBarVisualStateManager.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "pch.h"
+#include "ScrollBarVisualStateManager.h"
+#include "ScrollBarVisualStateManager.g.cpp"
+
+namespace winrt::Microsoft::Terminal::Control::implementation
+{
+    ScrollBarVisualStateManager::ScrollBarVisualStateManager() :
+        _termControl(nullptr)
+    {
+    }
+
+    bool ScrollBarVisualStateManager::GoToStateCore(
+        winrt::Windows::UI::Xaml::Controls::Control const& control,
+        winrt::Windows::UI::Xaml::FrameworkElement const& templateRoot,
+        winrt::hstring const& stateName,
+        winrt::Windows::UI::Xaml::VisualStateGroup const& group,
+        winrt::Windows::UI::Xaml::VisualState const& state, bool useTransitions)
+    {
+        if (!_termControl)
+        {
+            for (auto parent = winrt::Windows::UI::Xaml::Media::VisualTreeHelper::GetParent(control);
+                 parent != nullptr;
+                 parent = winrt::Windows::UI::Xaml::Media::VisualTreeHelper::GetParent(parent))
+            {
+                if (parent.try_as(_termControl))
+                {
+                    break;
+                }
+            }
+        }
+
+        WINRT_ASSERT(_termControl);
+
+        auto scrollState = _termControl.Settings().ScrollState();
+        if (scrollState == ScrollbarState::Always)
+        {
+            // If we're in Always mode, and the control is trying to collapse,
+            // go back to expanded
+            if (stateName == L"Collapsed" || stateName == L"CollapsedWithoutAnimation")
+            {
+                for (auto foundState : group.States())
+                {
+                    if (foundState.Name() == L"ExpandedWithoutAnimation")
+                    {
+                        return base_type::GoToStateCore(control, templateRoot, foundState.Name(), group, foundState, false);
+                    }
+                }
+            }
+        }
+
+        return base_type::GoToStateCore(control, templateRoot, stateName, group, state, useTransitions);
+    }
+}

--- a/src/cascadia/TerminalControl/ScrollBarVisualStateManager.cpp
+++ b/src/cascadia/TerminalControl/ScrollBarVisualStateManager.cpp
@@ -17,7 +17,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         winrt::Windows::UI::Xaml::FrameworkElement const& templateRoot,
         winrt::hstring const& stateName,
         winrt::Windows::UI::Xaml::VisualStateGroup const& group,
-        winrt::Windows::UI::Xaml::VisualState const& state, bool useTransitions)
+        winrt::Windows::UI::Xaml::VisualState const& state,
+        bool useTransitions)
     {
         if (!_termControl)
         {

--- a/src/cascadia/TerminalControl/ScrollBarVisualStateManager.h
+++ b/src/cascadia/TerminalControl/ScrollBarVisualStateManager.h
@@ -5,7 +5,7 @@
 // - ScrollBarVisualStateManager.h
 //
 // Abstract:
-// - This is a custom VisualStateManager that keeps the scroll bar from 
+// - This is a custom VisualStateManager that keeps the scroll bar from
 //   going into the collapsed mode when the user wants the scroll bar
 //   to always be displayed.
 //

--- a/src/cascadia/TerminalControl/ScrollBarVisualStateManager.h
+++ b/src/cascadia/TerminalControl/ScrollBarVisualStateManager.h
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+// Module Name:
+// - ScrollBarVisualStateManager.h
+//
+// Abstract:
+// - This is a custom VisualStateManager that keeps the scroll bar from 
+//   going into the collapsed mode when the user wants the scroll bar
+//   to always be displayed.
+//
+
+#pragma once
+#include "winrt/Windows.UI.Xaml.h"
+#include "winrt/Windows.UI.Xaml.Controls.h"
+
+#include "ScrollBarVisualStateManager.g.h"
+
+namespace winrt::Microsoft::Terminal::Control::implementation
+{
+    struct ScrollBarVisualStateManager : ScrollBarVisualStateManagerT<ScrollBarVisualStateManager>
+    {
+        ScrollBarVisualStateManager();
+
+        bool GoToStateCore(winrt::Windows::UI::Xaml::Controls::Control const& control, winrt::Windows::UI::Xaml::FrameworkElement const& templateRoot, hstring const& stateName, winrt::Windows::UI::Xaml::VisualStateGroup const& group, winrt::Windows::UI::Xaml::VisualState const& state, bool useTransitions);
+
+    private:
+        winrt::Microsoft::Terminal::Control::TermControl _termControl;
+    };
+}
+
+namespace winrt::Microsoft::Terminal::Control::factory_implementation
+{
+    struct ScrollBarVisualStateManager : ScrollBarVisualStateManagerT<ScrollBarVisualStateManager, implementation::ScrollBarVisualStateManager>
+    {
+    };
+}

--- a/src/cascadia/TerminalControl/ScrollBarVisualStateManager.idl
+++ b/src/cascadia/TerminalControl/ScrollBarVisualStateManager.idl
@@ -1,0 +1,8 @@
+namespace Microsoft.Terminal.Control
+{
+    [default_interface]
+    runtimeclass ScrollBarVisualStateManager : Windows.UI.Xaml.VisualStateManager
+    {
+        ScrollBarVisualStateManager();
+    }
+}

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2117,7 +2117,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         double width = cols * actualFontSize.X;
 
         // Reserve additional space if scrollbar is intended to be visible
-        if (scrollState == ScrollbarState::Visible || scrollState == ScrollbarState::Always)
+        if (scrollState != ScrollbarState::Hidden)
         {
             width += scrollbarSize;
         }
@@ -2161,8 +2161,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             double width = fontSize.Width;
             double height = fontSize.Height;
             // Reserve additional space if scrollbar is intended to be visible
-            auto currentScrollState = _core.Settings().ScrollState();
-            if (currentScrollState == ScrollbarState::Visible || currentScrollState == ScrollbarState::Always)
+            if (_core.Settings().ScrollState() != ScrollbarState::Hidden)
             {
                 width += ScrollBar().ActualWidth();
             }
@@ -2205,8 +2204,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                                            padding.Left + padding.Right :
                                                            padding.Top + padding.Bottom);
 
-        auto currentScrollState = _core.Settings().ScrollState();
-        if (widthOrHeight && (currentScrollState == ScrollbarState::Visible || currentScrollState == ScrollbarState::Always))
+        if (widthOrHeight && _core.Settings().ScrollState() != ScrollbarState::Hidden)
         {
             nonTerminalArea += gsl::narrow_cast<float>(ScrollBar().ActualWidth());
         }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2117,7 +2117,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         double width = cols * actualFontSize.X;
 
         // Reserve additional space if scrollbar is intended to be visible
-        if (scrollState == ScrollbarState::Visible)
+        if (scrollState == ScrollbarState::Visible || scrollState == ScrollbarState::Always)
         {
             width += scrollbarSize;
         }
@@ -2161,7 +2161,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             double width = fontSize.Width;
             double height = fontSize.Height;
             // Reserve additional space if scrollbar is intended to be visible
-            if (_core.Settings().ScrollState() == ScrollbarState::Visible)
+            auto currentScrollState = _core.Settings().ScrollState();
+            if (currentScrollState == ScrollbarState::Visible || currentScrollState == ScrollbarState::Always)
             {
                 width += ScrollBar().ActualWidth();
             }
@@ -2204,7 +2205,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                                            padding.Left + padding.Right :
                                                            padding.Top + padding.Bottom);
 
-        if (widthOrHeight && _core.Settings().ScrollState() == ScrollbarState::Visible)
+        auto currentScrollState = _core.Settings().ScrollState();
+        if (widthOrHeight && (currentScrollState == ScrollbarState::Visible || currentScrollState == ScrollbarState::Always))
         {
             nonTerminalArea += gsl::narrow_cast<float>(ScrollBar().ActualWidth());
         }

--- a/src/cascadia/TerminalControl/TermControl.xaml
+++ b/src/cascadia/TerminalControl/TermControl.xaml
@@ -410,7 +410,7 @@
                             </Grid.Resources>
 
                             <VisualStateManager.CustomVisualStateManager>
-                                <local:ScrollBarVisualStateManager/>
+                                <local:ScrollBarVisualStateManager />
                             </VisualStateManager.CustomVisualStateManager>
 
                             <Grid x:Name="HorizontalRoot"

--- a/src/cascadia/TerminalControl/TermControl.xaml
+++ b/src/cascadia/TerminalControl/TermControl.xaml
@@ -408,6 +408,11 @@
                                     </Rectangle>
                                 </ControlTemplate>
                             </Grid.Resources>
+
+                            <VisualStateManager.CustomVisualStateManager>
+                                <local:ScrollBarVisualStateManager/>
+                            </VisualStateManager.CustomVisualStateManager>
+
                             <Grid x:Name="HorizontalRoot"
                                   contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
                                   Background="{TemplateBinding Background}"

--- a/src/cascadia/TerminalControl/TerminalControlLib.vcxproj
+++ b/src/cascadia/TerminalControl/TerminalControlLib.vcxproj
@@ -30,7 +30,7 @@
   <Import Project="..\..\..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.props" />
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.pre.props" />
-
+  
   <!-- ========================= Headers ======================== -->
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -39,6 +39,9 @@
     </ClInclude>
     <ClInclude Include="ControlInteractivity.h">
       <DependentUpon>ControlInteractivity.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="ScrollBarVisualStateManager.h">
+      <DependentUpon>ScrollBarVisualStateManager.idl</DependentUpon>
     </ClInclude>
     <ClInclude Include="KeyChord.h">
       <DependentUpon>KeyChord.idl</DependentUpon>
@@ -77,6 +80,9 @@
     <ClCompile Include="ControlInteractivity.cpp">
       <DependentUpon>ControlInteractivity.idl</DependentUpon>
     </ClCompile>
+    <ClCompile Include="ScrollBarVisualStateManager.cpp">
+      <DependentUpon>ScrollBarVisualStateManager.idl</DependentUpon>
+    </ClCompile>
     <ClCompile Include="EventArgs.cpp">
       <DependentUpon>EventArgs.idl</DependentUpon>
     </ClCompile>
@@ -109,6 +115,7 @@
   <ItemGroup>
     <Midl Include="ControlCore.idl" />
     <Midl Include="ControlInteractivity.idl" />
+    <Midl Include="ScrollBarVisualStateManager.idl" />
     <Midl Include="ICoreState.idl" />
     <Midl Include="IDirectKeyListener.idl" />
     <Midl Include="KeyChord.idl" />

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -936,7 +936,11 @@
   </data>
   <data name="Profile_ScrollbarVisibilityVisible.Content" xml:space="preserve">
     <value>Visible</value>
-    <comment>An option to choose from for the "scrollbar visibility" setting. When selected, the scrollbar is visible.</comment>
+    <comment>An option to choose from for the "scrollbar visibility" setting. When selected, the scrollbar is visible but may dynamically shrink.</comment>
+  </data>
+  <data name="Profile_ScrollbarVisibilityAlways.Content" xml:space="preserve">
+    <value>Always</value>
+    <comment>An option to choose from for the "scrollbar visibility" setting. When selected, the scrollbar is always visible.</comment>
   </data>
   <data name="Profile_SnapOnInput.Header" xml:space="preserve">
     <value>Scroll to input when typing</value>

--- a/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
+++ b/src/cascadia/TerminalSettingsModel/TerminalSettingsSerializationHelpers.h
@@ -70,9 +70,10 @@ JSON_ENUM_MAPPER(::winrt::Windows::UI::Xaml::Media::Stretch)
 
 JSON_ENUM_MAPPER(::winrt::Microsoft::Terminal::Control::ScrollbarState)
 {
-    static constexpr std::array<pair_type, 2> mappings = {
+    static constexpr std::array<pair_type, 3> mappings = {
         pair_type{ "visible", ValueType::Visible },
-        pair_type{ "hidden", ValueType::Hidden }
+        pair_type{ "hidden", ValueType::Hidden },
+        pair_type{ "always", ValueType::Always }
     };
 };
 


### PR DESCRIPTION
This fixes #3454 by adding support for an "always" mode for the scroll bar.

This change uses a custom VisualStateManager to keep the scroll bar from collapsing if the profile is using the 'always' setting.

## Validation Steps Performed
Tried updating settings.json directly and using the UI and making sure the scroll bar behaves as expected.

Closes #3454