### PR TITLE
OpenHere: Replace explorer window lookup code w/ site lookup

### DIFF
--- a/src/cascadia/ShellExtension/OpenTerminalHere.h
+++ b/src/cascadia/ShellExtension/OpenTerminalHere.h
@@ -22,8 +22,6 @@ Author(s):
 --*/
 #pragma once
 
-#include <winrt/base.h>
-
 using namespace Microsoft::WRL;
 
 struct
@@ -58,10 +56,10 @@ struct
 #pragma endregion
 
 private:
-    HRESULT GetLocationFromSite(IShellItem** location) const;
-    HRESULT GetBestLocationFromSelectionOrSite(IShellItemArray* psiArray, IShellItem** location) const;
+    HRESULT GetLocationFromSite(IShellItem** location) const noexcept;
+    HRESULT GetBestLocationFromSelectionOrSite(IShellItemArray* psiArray, IShellItem** location) const noexcept;
 
-    winrt::com_ptr<IUnknown> site_;
+    wil::com_ptr_nothrow<IUnknown> site_;
 };
 
 CoCreatableClass(OpenTerminalHere);

--- a/src/cascadia/ShellExtension/OpenTerminalHere.h
+++ b/src/cascadia/ShellExtension/OpenTerminalHere.h
@@ -22,7 +22,7 @@ Author(s):
 --*/
 #pragma once
 
-#include <conattrs.hpp>
+#include <winrt/base.h>
 
 using namespace Microsoft::WRL;
 
@@ -34,7 +34,7 @@ struct
 #else // DEV
     __declspec(uuid("52065414-e077-47ec-a3ac-1cc5455e1b54"))
 #endif
-        OpenTerminalHere : public RuntimeClass<RuntimeClassFlags<ClassicCom | InhibitFtmBase>, IExplorerCommand>
+        OpenTerminalHere : public RuntimeClass<RuntimeClassFlags<ClassicCom | InhibitFtmBase>, IExplorerCommand, IObjectWithSite>
 {
 #pragma region IExplorerCommand
     STDMETHODIMP Invoke(IShellItemArray* psiItemArray,
@@ -52,9 +52,16 @@ struct
     STDMETHODIMP GetCanonicalName(GUID* pguidCommandName);
     STDMETHODIMP EnumSubCommands(IEnumExplorerCommand** ppEnum);
 #pragma endregion
+#pragma region IObjectWithSite
+    IFACEMETHODIMP SetSite(IUnknown* site) noexcept;
+    IFACEMETHODIMP GetSite(REFIID riid, void** site) noexcept;
+#pragma endregion
 
 private:
-    std::wstring _GetPathFromExplorer() const;
+    HRESULT GetLocationFromSite(IShellItem** location) const;
+    HRESULT GetBestLocationFromSelectionOrSite(IShellItemArray* psiArray, IShellItem** location) const;
+
+    winrt::com_ptr<IUnknown> site_;
 };
 
 CoCreatableClass(OpenTerminalHere);


### PR DESCRIPTION
When we first introduced the shell extension, it didn't work properly
for some folders (such as the Desktop, or perhaps any "background"
click) due to a bug in Windows. We worked around that bug with the help
of an awesome community member, who contributed code that would pull up
the topmost Explorer window and query its location.

That Windows bug was eventually fixed, but we still had trouble with
items appearing correctly. On Windows 11, the Open in Terminal menu item
appears and disappears at random when you right-click the desktop, but
it always appears when you right-click a folder. It sometimes appears
for Quick Access, even though it shouldn't.

We tried to fix that in #13206, but the fix caused more issues than it
solved. We reverted it for 1.15 and 1.16.

At the end of the day, it turns out that getting the path from the
toplevel explorer window is fragile. Fortunately, the shell does offer
us a way to get that information: the site chain.

This pull request replaces GetPathFromExplorer() with an implementation
of `IObjectWithSite`, which allows us to use the site chain to look up
from whence a context menu request was initiated. It also makes item
lookup generally more robust.

* ✅ Tested on Windows 11
  * ✅ Desktop
  * ✅ Folder Background
  * ✅ Folder Selected
  * ✅ Quick Access (does not appear)
  * ✅ This PC (does not appear)
* ✅ Tested on Windows 10
  * ✅ Desktop
  * ✅ Folder Background
  * ✅ Folder Selected
  * ✅ Quick Access (does not appear)
  * ✅ This PC (does not appear)

References #13206
References #13523
Closes #12578

Co-authored-by: John Lueders <johnlue@microsoft.com>