### PR TITLE
Add tooltips to context menus

### DIFF
--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -232,19 +232,19 @@
     <value>Warnings were found while parsing your keybindings:</value>
   </data>
   <data name="TooManyKeysForChord" xml:space="preserve">
-    <value>• Found a keybinding with too many strings for the "keys" array. There should only be one string value in the "keys" array.</value>
-    <comment>{Locked="\"keys\"","•"} This glyph is a bullet, used in a bulleted list.</comment>
+    <value>&#x2022; Found a keybinding with too many strings for the "keys" array. There should only be one string value in the "keys" array.</value>
+    <comment>{Locked="\"keys\"","&#x2022;"} This glyph is a bullet, used in a bulleted list.</comment>
   </data>
   <data name="FailedToParseSubCommands" xml:space="preserve">
-    <value>• Failed to parse all subcommands of nested command.</value>
+    <value>&#x2022; Failed to parse all subcommands of nested command.</value>
   </data>
   <data name="MissingRequiredParameter" xml:space="preserve">
-    <value>• Found a keybinding that was missing a required parameter value. This keybinding will be ignored.</value>
-    <comment>{Locked="•"} This glyph is a bullet, used in a bulleted list.</comment>
+    <value>&#x2022; Found a keybinding that was missing a required parameter value. This keybinding will be ignored.</value>
+    <comment>{Locked="&#x2022;"} This glyph is a bullet, used in a bulleted list.</comment>
   </data>
   <data name="UnknownTheme" xml:space="preserve">
-    <value>• The specified "theme" was not found in the list of themes. Temporarily falling back to the default value.</value>
-    <comment>{Locked="•"} This glyph is a bullet, used in a bulleted list.</comment>
+    <value>&#x2022; The specified "theme" was not found in the list of themes. Temporarily falling back to the default value.</value>
+    <comment>{Locked="&#x2022;"} This glyph is a bullet, used in a bulleted list.</comment>
   </data>
   <data name="LegacyGlobalsProperty" xml:space="preserve">
     <value>The "globals" property is deprecated - your settings might need updating. </value>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -232,19 +232,19 @@
     <value>Warnings were found while parsing your keybindings:</value>
   </data>
   <data name="TooManyKeysForChord" xml:space="preserve">
-    <value>&#x2022; Found a keybinding with too many strings for the "keys" array. There should only be one string value in the "keys" array.</value>
-    <comment>{Locked="\"keys\"","&#x2022;"} This glyph is a bullet, used in a bulleted list.</comment>
+    <value>• Found a keybinding with too many strings for the "keys" array. There should only be one string value in the "keys" array.</value>
+    <comment>{Locked="\"keys\"","•"} This glyph is a bullet, used in a bulleted list.</comment>
   </data>
   <data name="FailedToParseSubCommands" xml:space="preserve">
-    <value>&#x2022; Failed to parse all subcommands of nested command.</value>
+    <value>• Failed to parse all subcommands of nested command.</value>
   </data>
   <data name="MissingRequiredParameter" xml:space="preserve">
-    <value>&#x2022; Found a keybinding that was missing a required parameter value. This keybinding will be ignored.</value>
-    <comment>{Locked="&#x2022;"} This glyph is a bullet, used in a bulleted list.</comment>
+    <value>• Found a keybinding that was missing a required parameter value. This keybinding will be ignored.</value>
+    <comment>{Locked="•"} This glyph is a bullet, used in a bulleted list.</comment>
   </data>
   <data name="UnknownTheme" xml:space="preserve">
-    <value>&#x2022; The specified "theme" was not found in the list of themes. Temporarily falling back to the default value.</value>
-    <comment>{Locked="&#x2022;"} This glyph is a bullet, used in a bulleted list.</comment>
+    <value>• The specified "theme" was not found in the list of themes. Temporarily falling back to the default value.</value>
+    <comment>{Locked="•"} This glyph is a bullet, used in a bulleted list.</comment>
   </data>
   <data name="LegacyGlobalsProperty" xml:space="preserve">
     <value>The "globals" property is deprecated - your settings might need updating. </value>
@@ -745,5 +745,41 @@
   <data name="CommandPalette_MatchesAvailable" xml:space="preserve">
     <value>Suggestions found: {0}</value>
     <comment>{0} will be replaced with a number.</comment>
+  </data>
+  <data name="AboutToolTip" xml:space="preserve">
+    <value>Open the About dialog</value>
+  </data>
+  <data name="ChooseColorToolTip" xml:space="preserve">
+    <value>Open the color picker to choose the color of this tab</value>
+  </data>
+  <data name="CommandPaletteToolTip" xml:space="preserve">
+    <value>Open the command palette</value>
+  </data>
+  <data name="DuplicateTabToolTip" xml:space="preserve">
+    <value>Open a new tab using the active profile in the current directory</value>
+  </data>
+  <data name="ExportTabToolTip" xml:space="preserve">
+    <value>Export the contents of the text buffer into a text file</value>
+  </data>
+  <data name="FindToolTip" xml:space="preserve">
+    <value>Open the search dialog</value>
+  </data>
+  <data name="RenameTabToolTip" xml:space="preserve">
+    <value>Rename this tab</value>
+  </data>
+  <data name="SettingsToolTip" xml:space="preserve">
+    <value>Open the settings page</value>
+  </data>
+  <data name="SplitTabToolTip" xml:space="preserve">
+    <value>Open a new pane using the active profile in the current directory</value>
+  </data>
+  <data name="TabCloseAfterToolTip" xml:space="preserve">
+    <value>Close all tabs to the right of this tab</value>
+  </data>
+  <data name="TabCloseOtherToolTip" xml:space="preserve">
+    <value>Close all tabs except this tab</value>
+  </data>
+  <data name="TabCloseToolTip" xml:space="preserve">
+    <value>Close this tab</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -747,7 +747,7 @@
     <comment>{0} will be replaced with a number.</comment>
   </data>
   <data name="AboutToolTip" xml:space="preserve">
-    <value>Open the About dialog</value>
+    <value>Open a dialog containing product information</value>
   </data>
   <data name="ChooseColorToolTip" xml:space="preserve">
     <value>Open the color picker to choose the color of this tab</value>

--- a/src/cascadia/TerminalApp/TabBase.cpp
+++ b/src/cascadia/TerminalApp/TabBase.cpp
@@ -92,10 +92,10 @@ namespace winrt::TerminalApp::implementation
             }
         });
         _closeOtherTabsMenuItem.Text(RS_(L"TabCloseOther"));
-        auto _closeOtherTabsToolTip = RS_(L"TabCloseOtherToolTip");
+        const auto closeOtherTabsToolTip = RS_(L"TabCloseOtherToolTip");
 
-        WUX::Controls::ToolTipService::SetToolTip(_closeOtherTabsMenuItem, box_value(_closeOtherTabsToolTip));
-        Automation::AutomationProperties::SetHelpText(_closeOtherTabsMenuItem, _closeOtherTabsToolTip);
+        WUX::Controls::ToolTipService::SetToolTip(_closeOtherTabsMenuItem, box_value(closeOtherTabsToolTip));
+        Automation::AutomationProperties::SetHelpText(_closeOtherTabsMenuItem, closeOtherTabsToolTip);
 
         // Close
         Controls::MenuFlyoutItem closeTabMenuItem;

--- a/src/cascadia/TerminalApp/TabBase.cpp
+++ b/src/cascadia/TerminalApp/TabBase.cpp
@@ -79,6 +79,10 @@ namespace winrt::TerminalApp::implementation
             }
         });
         _closeTabsAfterMenuItem.Text(RS_(L"TabCloseAfter"));
+        auto _closeTabsAfterToolTip = RS_(L"TabCloseAfterToolTip");
+
+        WUX::Controls::ToolTipService::SetToolTip(_closeTabsAfterMenuItem, box_value(_closeTabsAfterToolTip));
+        Automation::AutomationProperties::SetHelpText(_closeTabsAfterMenuItem, _closeTabsAfterToolTip);
 
         // Close other tabs
         _closeOtherTabsMenuItem.Click([weakThis](auto&&, auto&&) {
@@ -88,6 +92,10 @@ namespace winrt::TerminalApp::implementation
             }
         });
         _closeOtherTabsMenuItem.Text(RS_(L"TabCloseOther"));
+        auto _closeOtherTabsToolTip = RS_(L"TabCloseOtherToolTip");
+
+        WUX::Controls::ToolTipService::SetToolTip(_closeOtherTabsMenuItem, box_value(_closeOtherTabsToolTip));
+        Automation::AutomationProperties::SetHelpText(_closeOtherTabsMenuItem, _closeOtherTabsToolTip);
 
         // Close
         Controls::MenuFlyoutItem closeTabMenuItem;
@@ -103,6 +111,10 @@ namespace winrt::TerminalApp::implementation
         });
         closeTabMenuItem.Text(RS_(L"TabClose"));
         closeTabMenuItem.Icon(closeSymbol);
+        auto closeTabToolTip = RS_(L"TabCloseToolTip");
+
+        WUX::Controls::ToolTipService::SetToolTip(closeTabMenuItem, box_value(closeTabToolTip));
+        Automation::AutomationProperties::SetHelpText(closeTabMenuItem, closeTabToolTip);
 
         // GH#8238 append the close menu items to the flyout itself until crash in XAML is fixed
         //Controls::MenuFlyoutSubItem closeSubMenu;

--- a/src/cascadia/TerminalApp/TabBase.cpp
+++ b/src/cascadia/TerminalApp/TabBase.cpp
@@ -79,10 +79,10 @@ namespace winrt::TerminalApp::implementation
             }
         });
         _closeTabsAfterMenuItem.Text(RS_(L"TabCloseAfter"));
-        auto _closeTabsAfterToolTip = RS_(L"TabCloseAfterToolTip");
+        const auto closeTabsAfterToolTip = RS_(L"TabCloseAfterToolTip");
 
-        WUX::Controls::ToolTipService::SetToolTip(_closeTabsAfterMenuItem, box_value(_closeTabsAfterToolTip));
-        Automation::AutomationProperties::SetHelpText(_closeTabsAfterMenuItem, _closeTabsAfterToolTip);
+        WUX::Controls::ToolTipService::SetToolTip(_closeTabsAfterMenuItem, box_value(closeTabsAfterToolTip));
+        Automation::AutomationProperties::SetHelpText(_closeTabsAfterMenuItem, closeTabsAfterToolTip);
 
         // Close other tabs
         _closeOtherTabsMenuItem.Click([weakThis](auto&&, auto&&) {

--- a/src/cascadia/TerminalApp/TabBase.cpp
+++ b/src/cascadia/TerminalApp/TabBase.cpp
@@ -111,7 +111,7 @@ namespace winrt::TerminalApp::implementation
         });
         closeTabMenuItem.Text(RS_(L"TabClose"));
         closeTabMenuItem.Icon(closeSymbol);
-        auto closeTabToolTip = RS_(L"TabCloseToolTip");
+        const auto closeTabToolTip = RS_(L"TabCloseToolTip");
 
         WUX::Controls::ToolTipService::SetToolTip(closeTabMenuItem, box_value(closeTabToolTip));
         Automation::AutomationProperties::SetHelpText(closeTabMenuItem, closeTabToolTip);

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -967,7 +967,7 @@ namespace winrt::TerminalApp::implementation
             // Create the about button.
             auto aboutFlyout = WUX::Controls::MenuFlyoutItem{};
             aboutFlyout.Text(RS_(L"AboutMenuItem"));
-            auto aboutToolTip = RS_(L"AboutToolTip");
+            const auto aboutToolTip = RS_(L"AboutToolTip");
 
             WUX::Controls::ToolTipService::SetToolTip(aboutFlyout, box_value(aboutToolTip));
             Automation::AutomationProperties::SetHelpText(aboutFlyout, aboutToolTip);

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -923,7 +923,7 @@ namespace winrt::TerminalApp::implementation
                 // Create the settings button.
                 auto settingsItem = WUX::Controls::MenuFlyoutItem{};
                 settingsItem.Text(RS_(L"SettingsMenuItem"));
-                auto settingsToolTip = RS_(L"SettingsToolTip");
+                const auto settingsToolTip = RS_(L"SettingsToolTip");
 
                 WUX::Controls::ToolTipService::SetToolTip(settingsItem, box_value(settingsToolTip));
                 Automation::AutomationProperties::SetHelpText(settingsItem, settingsToolTip);

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -944,7 +944,7 @@ namespace winrt::TerminalApp::implementation
                 // Create the command palette button.
                 auto commandPaletteFlyout = WUX::Controls::MenuFlyoutItem{};
                 commandPaletteFlyout.Text(RS_(L"CommandPaletteMenuItem"));
-                auto commandPaletteToolTip = RS_(L"CommandPaletteToolTip");
+                const auto commandPaletteToolTip = RS_(L"CommandPaletteToolTip");
 
                 WUX::Controls::ToolTipService::SetToolTip(commandPaletteFlyout, box_value(commandPaletteToolTip));
                 Automation::AutomationProperties::SetHelpText(commandPaletteFlyout, commandPaletteToolTip);

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -923,6 +923,10 @@ namespace winrt::TerminalApp::implementation
                 // Create the settings button.
                 auto settingsItem = WUX::Controls::MenuFlyoutItem{};
                 settingsItem.Text(RS_(L"SettingsMenuItem"));
+                auto settingsToolTip = RS_(L"SettingsToolTip");
+
+                WUX::Controls::ToolTipService::SetToolTip(settingsItem, box_value(settingsToolTip));
+                Automation::AutomationProperties::SetHelpText(settingsItem, settingsToolTip);
 
                 WUX::Controls::SymbolIcon ico{};
                 ico.Symbol(WUX::Controls::Symbol::Setting);
@@ -940,6 +944,10 @@ namespace winrt::TerminalApp::implementation
                 // Create the command palette button.
                 auto commandPaletteFlyout = WUX::Controls::MenuFlyoutItem{};
                 commandPaletteFlyout.Text(RS_(L"CommandPaletteMenuItem"));
+                auto commandPaletteToolTip = RS_(L"CommandPaletteToolTip");
+
+                WUX::Controls::ToolTipService::SetToolTip(commandPaletteFlyout, box_value(commandPaletteToolTip));
+                Automation::AutomationProperties::SetHelpText(commandPaletteFlyout, commandPaletteToolTip);
 
                 WUX::Controls::FontIcon commandPaletteIcon{};
                 commandPaletteIcon.Glyph(L"\xE945");
@@ -959,6 +967,10 @@ namespace winrt::TerminalApp::implementation
             // Create the about button.
             auto aboutFlyout = WUX::Controls::MenuFlyoutItem{};
             aboutFlyout.Text(RS_(L"AboutMenuItem"));
+            auto aboutToolTip = RS_(L"AboutToolTip");
+
+            WUX::Controls::ToolTipService::SetToolTip(aboutFlyout, box_value(aboutToolTip));
+            Automation::AutomationProperties::SetHelpText(aboutFlyout, aboutToolTip);
 
             WUX::Controls::SymbolIcon aboutIcon{};
             aboutIcon.Symbol(WUX::Controls::Symbol::Help);

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -1273,7 +1273,7 @@ namespace winrt::TerminalApp::implementation
             duplicateTabMenuItem.Text(RS_(L"DuplicateTabText"));
             duplicateTabMenuItem.Icon(duplicateTabSymbol);
 
-            auto duplicateTabToolTip = RS_(L"DuplicateTabToolTip");
+            const auto duplicateTabToolTip = RS_(L"DuplicateTabToolTip");
 
             WUX::Controls::ToolTipService::SetToolTip(duplicateTabMenuItem, box_value(duplicateTabToolTip));
             Automation::AutomationProperties::SetHelpText(duplicateTabMenuItem, duplicateTabToolTip);

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -1230,7 +1230,7 @@ namespace winrt::TerminalApp::implementation
         chooseColorMenuItem.Text(RS_(L"TabColorChoose"));
         chooseColorMenuItem.Icon(colorPickSymbol);
 
-        auto chooseColorToolTip = RS_(L"ChooseColorToolTip");
+        const auto chooseColorToolTip = RS_(L"ChooseColorToolTip");
 
         WUX::Controls::ToolTipService::SetToolTip(chooseColorMenuItem, box_value(chooseColorToolTip));
         Automation::AutomationProperties::SetHelpText(chooseColorMenuItem, chooseColorToolTip);

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -1317,7 +1317,7 @@ namespace winrt::TerminalApp::implementation
             exportTabMenuItem.Text(RS_(L"ExportTabText"));
             exportTabMenuItem.Icon(exportTabSymbol);
 
-            auto exportTabToolTip = RS_(L"ExportTabToolTip");
+            const auto exportTabToolTip = RS_(L"ExportTabToolTip");
 
             WUX::Controls::ToolTipService::SetToolTip(exportTabMenuItem, box_value(exportTabToolTip));
             Automation::AutomationProperties::SetHelpText(exportTabMenuItem, exportTabToolTip);

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -1230,6 +1230,11 @@ namespace winrt::TerminalApp::implementation
         chooseColorMenuItem.Text(RS_(L"TabColorChoose"));
         chooseColorMenuItem.Icon(colorPickSymbol);
 
+        auto chooseColorToolTip = RS_(L"ChooseColorToolTip");
+
+        WUX::Controls::ToolTipService::SetToolTip(chooseColorMenuItem, box_value(chooseColorToolTip));
+        Automation::AutomationProperties::SetHelpText(chooseColorMenuItem, chooseColorToolTip);
+
         Controls::MenuFlyoutItem renameTabMenuItem;
         {
             // "Rename Tab"
@@ -1245,6 +1250,11 @@ namespace winrt::TerminalApp::implementation
             });
             renameTabMenuItem.Text(RS_(L"RenameTabText"));
             renameTabMenuItem.Icon(renameTabSymbol);
+
+            auto renameTabToolTip = RS_(L"RenameTabToolTip");
+
+            WUX::Controls::ToolTipService::SetToolTip(renameTabMenuItem, box_value(renameTabToolTip));
+            Automation::AutomationProperties::SetHelpText(renameTabMenuItem, renameTabToolTip);
         }
 
         Controls::MenuFlyoutItem duplicateTabMenuItem;
@@ -1262,6 +1272,11 @@ namespace winrt::TerminalApp::implementation
             });
             duplicateTabMenuItem.Text(RS_(L"DuplicateTabText"));
             duplicateTabMenuItem.Icon(duplicateTabSymbol);
+
+            auto duplicateTabToolTip = RS_(L"DuplicateTabToolTip");
+
+            WUX::Controls::ToolTipService::SetToolTip(duplicateTabMenuItem, box_value(duplicateTabToolTip));
+            Automation::AutomationProperties::SetHelpText(duplicateTabMenuItem, duplicateTabToolTip);
         }
 
         Controls::MenuFlyoutItem splitTabMenuItem;
@@ -1279,11 +1294,16 @@ namespace winrt::TerminalApp::implementation
             });
             splitTabMenuItem.Text(RS_(L"SplitTabText"));
             splitTabMenuItem.Icon(splitTabSymbol);
+
+            auto splitTabToolTip = RS_(L"SplitTabToolTip");
+            
+            WUX::Controls::ToolTipService::SetToolTip(splitTabMenuItem, box_value(splitTabToolTip));
+            Automation::AutomationProperties::SetHelpText(splitTabMenuItem, splitTabToolTip);
         }
 
         Controls::MenuFlyoutItem exportTabMenuItem;
         {
-            // "Split Tab"
+            // "Export Tab"
             Controls::FontIcon exportTabSymbol;
             exportTabSymbol.FontFamily(Media::FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" });
             exportTabSymbol.Glyph(L"\xE74E"); // Save
@@ -1296,11 +1316,16 @@ namespace winrt::TerminalApp::implementation
             });
             exportTabMenuItem.Text(RS_(L"ExportTabText"));
             exportTabMenuItem.Icon(exportTabSymbol);
+
+            auto exportTabToolTip = RS_(L"ExportTabToolTip");
+
+            WUX::Controls::ToolTipService::SetToolTip(exportTabMenuItem, box_value(exportTabToolTip));
+            Automation::AutomationProperties::SetHelpText(exportTabMenuItem, exportTabToolTip);
         }
 
         Controls::MenuFlyoutItem findMenuItem;
         {
-            // "Split Tab"
+            // "Find"
             Controls::FontIcon findSymbol;
             findSymbol.FontFamily(Media::FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" });
             findSymbol.Glyph(L"\xF78B"); // SearchMedium
@@ -1313,6 +1338,11 @@ namespace winrt::TerminalApp::implementation
             });
             findMenuItem.Text(RS_(L"FindText"));
             findMenuItem.Icon(findSymbol);
+
+            auto findToolTip = RS_(L"FindToolTip");
+
+            WUX::Controls::ToolTipService::SetToolTip(findMenuItem, box_value(findToolTip));
+            Automation::AutomationProperties::SetHelpText(findMenuItem, findToolTip);
         }
 
         // Build the menu

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -1296,7 +1296,7 @@ namespace winrt::TerminalApp::implementation
             splitTabMenuItem.Icon(splitTabSymbol);
 
             auto splitTabToolTip = RS_(L"SplitTabToolTip");
-            
+
             WUX::Controls::ToolTipService::SetToolTip(splitTabMenuItem, box_value(splitTabToolTip));
             Automation::AutomationProperties::SetHelpText(splitTabMenuItem, splitTabToolTip);
         }

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -1251,7 +1251,7 @@ namespace winrt::TerminalApp::implementation
             renameTabMenuItem.Text(RS_(L"RenameTabText"));
             renameTabMenuItem.Icon(renameTabSymbol);
 
-            auto renameTabToolTip = RS_(L"RenameTabToolTip");
+            const auto renameTabToolTip = RS_(L"RenameTabToolTip");
 
             WUX::Controls::ToolTipService::SetToolTip(renameTabMenuItem, box_value(renameTabToolTip));
             Automation::AutomationProperties::SetHelpText(renameTabMenuItem, renameTabToolTip);

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -1295,7 +1295,7 @@ namespace winrt::TerminalApp::implementation
             splitTabMenuItem.Text(RS_(L"SplitTabText"));
             splitTabMenuItem.Icon(splitTabSymbol);
 
-            auto splitTabToolTip = RS_(L"SplitTabToolTip");
+            const auto splitTabToolTip = RS_(L"SplitTabToolTip");
 
             WUX::Controls::ToolTipService::SetToolTip(splitTabMenuItem, box_value(splitTabToolTip));
             Automation::AutomationProperties::SetHelpText(splitTabMenuItem, splitTabToolTip);

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -1339,7 +1339,7 @@ namespace winrt::TerminalApp::implementation
             findMenuItem.Text(RS_(L"FindText"));
             findMenuItem.Icon(findSymbol);
 
-            auto findToolTip = RS_(L"FindToolTip");
+            const auto findToolTip = RS_(L"FindToolTip");
 
             WUX::Controls::ToolTipService::SetToolTip(findMenuItem, box_value(findToolTip));
             Automation::AutomationProperties::SetHelpText(findMenuItem, findToolTip);


### PR DESCRIPTION
Add tooltips to the tab context menu and the tab dropdown menu.

Closes #13243
