### PR TITLE
Make TerminalOutputEventArgs an abstract class

### DIFF
--- a/src/cascadia/WpfTerminalControl/TerminalOutputEventArgs.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalOutputEventArgs.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Terminal.Wpf
     /// <summary>
     /// Event args for output from the terminal backend.
     /// </summary>
-    public class TerminalOutputEventArgs : EventArgs
+    public abstract class TerminalOutputEventArgs : EventArgs
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TerminalOutputEventArgs"/> class.


### PR DESCRIPTION
It should be an abstract class because we purely use its subclasses and do not use the class directly.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [X] Tests added/passed