### PR TITLE
Update target .NET version to .NET 6

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <packageSources>
         <clear />

--- a/src/cascadia/WpfTerminalTestNetCore/WpfTerminalTestNetCore.csproj
+++ b/src/cascadia/WpfTerminalTestNetCore/WpfTerminalTestNetCore.csproj
@@ -1,25 +1,17 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <RuntimeFrameworkVersion>6.0.9</RuntimeFrameworkVersion>
     <UseWPF>true</UseWPF>
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <CsWinRTIncludes>Microsoft.Terminal.Core</CsWinRTIncludes>
-    <CsWinRTGeneratedFilesDir>$(OutDir)</CsWinRTGeneratedFilesDir>
-  </PropertyGroup>
-
-	<PropertyGroup>
-		<RestoreSources>
-			https://api.nuget.org/v3/index.json;
-		</RestoreSources>
-	</PropertyGroup>
-
   <ItemGroup>
-    <ProjectReference Include="$(SolutionDir)src\cascadia\PublicTerminalCore\PublicTerminalCore.vcxproj" />
+    <ProjectReference Include="$(SolutionDir)src\cascadia\PublicTerminalCore\PublicTerminalCore.vcxproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
     <ProjectReference Include="$(SolutionDir)src\cascadia\WpfTerminalControl\WpfTerminalControl.csproj" />
   </ItemGroup>
 
@@ -32,9 +24,6 @@
     <Content Include="$(SolutionDir)bin\$(UnreasonablePlatform)\$(Configuration)\PublicTerminalCore.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
.NET 6 is the latest LTS, and we should use that instead of .NET Core 3.1