### PR TITLE
Apply AutoProps to TextBox settings in SUI

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/SettingContainer.cpp
+++ b/src/cascadia/TerminalSettingsEditor/SettingContainer.cpp
@@ -133,7 +133,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _UpdateOverrideSystem();
 
         // Get the correct base to apply automation properties to
-        std::vector<DependencyObject> base(2, nullptr);
+        std::vector<DependencyObject> base;
+        base.reserve(2);
         if (const auto& child{ GetTemplateChild(L"Expander") })
         {
             if (const auto& expander{ child.try_as<Microsoft::UI::Xaml::Controls::Expander>() })
@@ -143,36 +144,35 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
         if (const auto& content{ Content() })
         {
-            if (const auto& obj{ content.try_as<DependencyObject>() })
+            const auto& panel{ content.try_as<Controls::Panel>() };
+            const auto& obj{ content.try_as<DependencyObject>() };
+            if (!panel && obj)
             {
                 base.push_back(obj);
             }
         }
 
-        for (auto obj : base)
+        for (const auto& obj : base)
         {
-            if (obj)
+            // apply header as name (automation property)
+            if (const auto& header{ Header() })
             {
-                // apply header as name (automation property)
-                if (const auto& header{ Header() })
+                if (const auto headerText{ header.try_as<hstring>() })
                 {
-                    if (const auto headerText{ header.try_as<hstring>() })
-                    {
-                        Automation::AutomationProperties::SetName(obj, *headerText);
-                    }
+                    Automation::AutomationProperties::SetName(obj, *headerText);
                 }
+            }
 
-                // apply help text as tooltip and full description (automation property)
-                if (const auto& helpText{ HelpText() }; !helpText.empty())
-                {
-                    Controls::ToolTipService::SetToolTip(obj, box_value(helpText));
-                    Automation::AutomationProperties::SetFullDescription(obj, helpText);
-                }
-                else
-                {
-                    Controls::ToolTipService::SetToolTip(obj, nullptr);
-                    Automation::AutomationProperties::SetFullDescription(obj, L"");
-                }
+            // apply help text as tooltip and full description (automation property)
+            if (const auto& helpText{ HelpText() }; !helpText.empty())
+            {
+                Controls::ToolTipService::SetToolTip(obj, box_value(helpText));
+                Automation::AutomationProperties::SetFullDescription(obj, helpText);
+            }
+            else
+            {
+                Controls::ToolTipService::SetToolTip(obj, nullptr);
+                Automation::AutomationProperties::SetFullDescription(obj, L"");
             }
         }
 

--- a/src/cascadia/TerminalSettingsEditor/SettingContainer.cpp
+++ b/src/cascadia/TerminalSettingsEditor/SettingContainer.cpp
@@ -133,43 +133,46 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _UpdateOverrideSystem();
 
         // Get the correct base to apply automation properties to
-        DependencyObject base{ nullptr };
+        std::vector<DependencyObject> base(2, nullptr);
         if (const auto& child{ GetTemplateChild(L"Expander") })
         {
             if (const auto& expander{ child.try_as<Microsoft::UI::Xaml::Controls::Expander>() })
             {
-                base = child;
+                base.push_back(child);
             }
         }
-        else if (const auto& content{ Content() })
+        if (const auto& content{ Content() })
         {
             if (const auto& obj{ content.try_as<DependencyObject>() })
             {
-                base = obj;
+                base.push_back(obj);
             }
         }
 
-        if (base)
+        for (auto obj : base)
         {
-            // apply header as name (automation property)
-            if (const auto& header{ Header() })
+            if (obj)
             {
-                if (const auto headerText{ header.try_as<hstring>() })
+                // apply header as name (automation property)
+                if (const auto& header{ Header() })
                 {
-                    Automation::AutomationProperties::SetName(base, *headerText);
+                    if (const auto headerText{ header.try_as<hstring>() })
+                    {
+                        Automation::AutomationProperties::SetName(obj, *headerText);
+                    }
                 }
-            }
 
-            // apply help text as tooltip and full description (automation property)
-            if (const auto& helpText{ HelpText() }; !helpText.empty())
-            {
-                Controls::ToolTipService::SetToolTip(base, box_value(helpText));
-                Automation::AutomationProperties::SetFullDescription(base, helpText);
-            }
-            else
-            {
-                Controls::ToolTipService::SetToolTip(base, nullptr);
-                Automation::AutomationProperties::SetFullDescription(base, L"");
+                // apply help text as tooltip and full description (automation property)
+                if (const auto& helpText{ HelpText() }; !helpText.empty())
+                {
+                    Controls::ToolTipService::SetToolTip(obj, box_value(helpText));
+                    Automation::AutomationProperties::SetFullDescription(obj, helpText);
+                }
+                else
+                {
+                    Controls::ToolTipService::SetToolTip(obj, nullptr);
+                    Automation::AutomationProperties::SetFullDescription(obj, L"");
+                }
             }
         }
 

--- a/src/cascadia/TerminalSettingsEditor/SettingContainer.cpp
+++ b/src/cascadia/TerminalSettingsEditor/SettingContainer.cpp
@@ -167,7 +167,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             if (const auto& helpText{ HelpText() }; !helpText.empty())
             {
                 Automation::AutomationProperties::SetFullDescription(obj, helpText);
-=======
+            }
             else
             {
                 Controls::ToolTipService::SetToolTip(obj, nullptr);


### PR DESCRIPTION
We already were setting the automation properties on the expander, however, we were not setting it on the content when an expander was present. This change applies the automation properties to both the expander and the child content (i.e. TextBox).

Closes #13827
