### PR TITLE
Make SUI breadcrumb readable by screen readers

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -16,6 +16,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             _Label{ label },
             _SubPage{ subPage } {}
 
+        hstring ToString() { return _Label; }
+
         WINRT_PROPERTY(IInspectable, Tag);
         WINRT_PROPERTY(winrt::hstring, Label);
         WINRT_PROPERTY(BreadcrumbSubPage, SubPage);

--- a/src/cascadia/TerminalSettingsEditor/MainPage.idl
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.idl
@@ -21,7 +21,7 @@ namespace Microsoft.Terminal.Settings.Editor
         ColorSchemes_Edit
     };
 
-    runtimeclass Breadcrumb
+    runtimeclass Breadcrumb : Windows.Foundation.IStringable
     {
         IInspectable Tag;
         String Label;


### PR DESCRIPTION
The breadcrumbs in the SUI were not readable by screen readers because they are represented as a button with a text block inside of it. Turns out, if you make the DataTemplate's item `IStringable` (meaning it has a `ToString()`), it all magically works! Allowing the screen reader to read the button as text.

Closes #13826