### PR TITLE
Fix some issues with the launch parameters in the SUI

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
@@ -43,20 +43,23 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     winrt::hstring LaunchViewModel::LaunchParametersCurrentValue()
     {
         const auto launchModeString = CurrentLaunchMode().as<EnumEntry>()->EnumName();
-        const auto centerOnLaunchString = CenterOnLaunch() ? RS_(L"Globals_CenterOnLaunchOn") : RS_(L"Globals_CenterOnLaunchOff");
 
         winrt::hstring result;
 
+        // Append the launch position part
         if (UseDefaultLaunchPosition())
         {
-            result = fmt::format(L"{}, {}, {}", launchModeString, RS_(L"Globals_LaunchModeDefault/Content"), centerOnLaunchString);
+            result = fmt::format(L"{}, {}", launchModeString, RS_(L"Globals_LaunchModeDefault/Content"));
         }
         else
         {
             const std::wstring xPosString = isnan(InitialPosX()) ? RS_(L"Globals_LaunchModeDefault/Content").c_str() : std::to_wstring(gsl::narrow_cast<int>(InitialPosX()));
             const std::wstring yPosString = isnan(InitialPosY()) ? RS_(L"Globals_LaunchModeDefault/Content").c_str() : std::to_wstring(gsl::narrow_cast<int>(InitialPosY()));
-            result = fmt::format(L"{}, ({},{}), {}", launchModeString, xPosString, yPosString, centerOnLaunchString);
+            result = fmt::format(L"{}, ({},{})", launchModeString, xPosString, yPosString);
         }
+
+        // Append the CenterOnLaunch part
+        result = CenterOnLaunch() ? fmt::format(L"{}, {}", result, RS_(L"Globals_CenterOnLaunchCentered")).c_str() : result;
         return result;
     }
 
@@ -111,7 +114,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         {
             InitialPosX(NAN);
             InitialPosY(NAN);
-            _NotifyChanges(L"InitialPosX", L"InitialPosY");
         }
         _NotifyChanges(L"UseDefaultLaunchPosition", L"LaunchParametersCurrentValue");
     }

--- a/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
@@ -59,7 +59,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
 
         // Append the CenterOnLaunch part
-        result = CenterOnLaunch() ? fmt::format(L"{}, {}", result, RS_(L"Globals_CenterOnLaunchCentered")).c_str() : result;
+        result = CenterOnLaunch() ? winrt::hstring{ fmt::format(L"{}, {}", result, RS_(L"Globals_CenterOnLaunchCentered")) } : result;
         return result;
     }
 

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -480,7 +480,7 @@
   </data>
   <data name="Globals_CenterOnLaunchCentered" xml:space="preserve">
     <value>Centered</value>
-    <comment>What the "On" value for the center on launch setting represents.</comment>
+    <comment>Shorthand, explanatory text displayed when the user has enabled the feature indicated by "Globals_CenterOnLaunch.Text".</comment>
   </data>
   <data name="Globals_CenterOnLaunch.Text" xml:space="preserve">
     <value>Center on launch</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -478,13 +478,9 @@
     <value>When enabled, this enables the launch of Terminal at machine startup.</value>
     <comment>A description for what the "start on user login" setting does. Presented near "Globals_StartOnUserLogin.Header".</comment>
   </data>
-  <data name="Globals_CenterOnLaunchOn" xml:space="preserve">
-    <value>On</value>
-    <comment>The "On" value for the center on launch setting.</comment>
-  </data>
-  <data name="Globals_CenterOnLaunchOff" xml:space="preserve">
-    <value>Off</value>
-    <comment>The "Off" value for the center on launch setting.</comment>
+  <data name="Globals_CenterOnLaunchCentered" xml:space="preserve">
+    <value>Centered</value>
+    <comment>What the "On" value for the center on launch setting represents.</comment>
   </data>
   <data name="Globals_CenterOnLaunch.Text" xml:space="preserve">
     <value>Center on launch</value>


### PR DESCRIPTION
Addressing post-hoc comments on the launch parameters expander in the SUI (added in #13605)

- Use more contextually appropriate strings (`Centered` instead of `On` / `Off`)
- Don't emit an extra `NotifyChanges`

References #13605 