### PR TITLE
Use the Windows.UI.ViewManagement APIs to get the accent color

### DIFF
--- a/src/cascadia/TerminalSettingsModel/Theme.cpp
+++ b/src/cascadia/TerminalSettingsModel/Theme.cpp
@@ -28,9 +28,6 @@ namespace winrt
 
 static constexpr std::string_view NameKey{ "name" };
 
-static constexpr wchar_t RegKeyDwm[] = L"Software\\Microsoft\\Windows\\DWM";
-static constexpr wchar_t RegKeyAccentColor[] = L"AccentColor";
-
 #define THEME_SETTINGS_COPY(type, name, jsonKey, ...) \
     result->_##name = _##name;
 

--- a/src/cascadia/TerminalSettingsModel/pch.h
+++ b/src/cascadia/TerminalSettingsModel/pch.h
@@ -32,6 +32,7 @@
 #include <winrt/Windows.Storage.h>
 #include <winrt/Windows.System.h>
 #include <winrt/Windows.UI.Core.h>
+#include <winrt/Windows.UI.ViewManagement.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
 


### PR DESCRIPTION
Judging by the source (which is admittedly rather complex), the accent color value returned by this API is the same one that DWM stores in the registry. Doing it this way obviates the need for us to do a themed resource map lookup, pass a XAML resource map into MTSM, and dump somebody's secret registry keys into the open.