### PR TITLE
Update LaunchPosition to use int32_t instead of int64_t

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
@@ -80,11 +80,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void LaunchViewModel::InitialPosX(double xCoord)
     {
-        winrt::Windows::Foundation::IReference<int64_t> xCoordRef;
+        winrt::Windows::Foundation::IReference<int32_t> xCoordRef;
         // If the value was cleared, xCoord will be NAN, so check for that
         if (!isnan(xCoord))
         {
-            xCoordRef = gsl::narrow_cast<int64_t>(xCoord);
+            xCoordRef = gsl::narrow_cast<int32_t>(xCoord);
         }
         const LaunchPosition newPos{ xCoordRef, _Settings.GlobalSettings().InitialPosition().Y };
         _Settings.GlobalSettings().InitialPosition(newPos);
@@ -93,11 +93,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void LaunchViewModel::InitialPosY(double yCoord)
     {
-        winrt::Windows::Foundation::IReference<int64_t> yCoordRef;
+        winrt::Windows::Foundation::IReference<int32_t> yCoordRef;
         // If the value was cleared, yCoord will be NAN, so check for that
         if (!isnan(yCoord))
         {
-            yCoordRef = gsl::narrow_cast<int64_t>(yCoord);
+            yCoordRef = gsl::narrow_cast<int32_t>(yCoord);
         }
         const LaunchPosition newPos{ _Settings.GlobalSettings().InitialPosition().X, yCoordRef };
         _Settings.GlobalSettings().InitialPosition(newPos);

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -15,8 +15,8 @@ namespace Microsoft.Terminal.Settings.Model
     // Docs: https://docs.microsoft.com/en-us/uwp/midl-3/intro#types
     struct LaunchPosition
     {
-        Windows.Foundation.IReference<Int64> X;
-        Windows.Foundation.IReference<Int64> Y;
+        Windows.Foundation.IReference<Int32> X;
+        Windows.Foundation.IReference<Int32> Y;
     };
 
     [flags]


### PR DESCRIPTION
Since #13730 merged, when we parse LaunchPosition we treat the
coordinates as `int32_t`. This PR updates the actual `LaunchPosition`
struct to also use `int32_t` for consistency.

## Validation Steps Performed
Terminal still builds and runs