### PR TITLE
Disable acrylic material (temporarily) when opacity is set to 100%

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -584,10 +584,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // Windows 10.
         // We'll also turn the acrylic back off when they're fully opaque, which
         // is what the Terminal did prior to 1.12.
-        if (!IsVintageOpacityAvailable())
-        {
-            _runtimeUseAcrylic = newOpacity < 1.0;
-        }
+        UseAcrylic(opacity < 1.0 && (!IsVintageOpacityAvailable() || _settings->UseAcrylic()));
 
         // Update the renderer as well. It might need to fall back from
         // cleartype -> grayscale if the BG is transparent / acrylic.
@@ -711,16 +708,12 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         auto lock = _terminal->LockForWriting();
 
-        _runtimeOpacity = std::nullopt;
-        _runtimeUseAcrylic = std::nullopt;
-
         // GH#11285 - If the user is on Windows 10, and they wanted opacity, but
         // didn't explicitly request acrylic, then opt them in to acrylic.
         // On Windows 11+, this isn't needed, because we can have vintage opacity.
-        if (!IsVintageOpacityAvailable() && _settings->Opacity() < 1.0 && !_settings->UseAcrylic())
-        {
-            _runtimeUseAcrylic = true;
-        }
+        // Instead, disable acrylic while the opacity is 100%
+        _runtimeUseAcrylic = _settings->Opacity() < 1.0 && (!IsVintageOpacityAvailable() || _settings->UseAcrylic());
+        _runtimeOpacity = std::nullopt;
 
         const auto sizeChanged = _setFontSizeUnderLock(_settings->FontSize());
 

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -576,7 +576,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         }
 
         // Update our runtime opacity value
-        Opacity(newOpacity);
+        _runtimeOpacity = newOpacity;
 
         // GH#11285 - If the user is on Windows 10, and they changed the
         // transparency of the control s.t. it should be partially opaque, then
@@ -584,7 +584,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // Windows 10.
         // We'll also turn the acrylic back off when they're fully opaque, which
         // is what the Terminal did prior to 1.12.
-        UseAcrylic(newOpacity < 1.0 && (!IsVintageOpacityAvailable() || _settings->UseAcrylic()));
+        _runtimeUseAcrylic = newOpacity < 1.0 && (!IsVintageOpacityAvailable() || _settings->UseAcrylic());
 
         // Update the renderer as well. It might need to fall back from
         // cleartype -> grayscale if the BG is transparent / acrylic.

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -584,7 +584,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // Windows 10.
         // We'll also turn the acrylic back off when they're fully opaque, which
         // is what the Terminal did prior to 1.12.
-        UseAcrylic(opacity < 1.0 && (!IsVintageOpacityAvailable() || _settings->UseAcrylic()));
+        UseAcrylic(newOpacity < 1.0 && (!IsVintageOpacityAvailable() || _settings->UseAcrylic()));
 
         // Update the renderer as well. It might need to fall back from
         // cleartype -> grayscale if the BG is transparent / acrylic.

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1965,13 +1965,12 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
         // If we're:
         // * Not fully opaque
-        // * On an acrylic background (of any opacity)
         // * rendering on top of an image
         //
         // then the renderer should not render "default background" text with a
         // fully opaque background. Doing that would cover up our nice
         // transparency, or our acrylic, or our image.
-        return Opacity() < 1.0f || UseAcrylic() || !_settings->BackgroundImage().empty() || _settings->UseBackgroundImageForWindow();
+        return Opacity() < 1.0f || !_settings->BackgroundImage().empty() || _settings->UseBackgroundImageForWindow();
     }
 
     uint64_t ControlCore::OwningHwnd()

--- a/src/cascadia/UnitTests_Control/ControlCoreTests.cpp
+++ b/src/cascadia/UnitTests_Control/ControlCoreTests.cpp
@@ -141,8 +141,7 @@ namespace ControlUnitTests
             // GH#603: Adjusting opacity shouldn't change whether or not we
             // requested acrylic.
 
-            auto expectedUseAcrylic = winrt::Microsoft::Terminal::Control::implementation::ControlCore::IsVintageOpacityAvailable() ? true :
-                                                                                                                                      (expectedOpacity < 1.0 ? true : false);
+            auto expectedUseAcrylic = expectedOpacity < 1.0;
             VERIFY_ARE_EQUAL(expectedUseAcrylic, core->UseAcrylic());
             VERIFY_ARE_EQUAL(true, core->_settings->UseAcrylic());
         };

--- a/src/cascadia/UnitTests_Control/ControlInteractivityTests.cpp
+++ b/src/cascadia/UnitTests_Control/ControlInteractivityTests.cpp
@@ -144,8 +144,8 @@ namespace ControlUnitTests
             // The Settings object's opacity shouldn't be changed
             VERIFY_ARE_EQUAL(0.5, settings->Opacity());
 
-            auto expectedUseAcrylic = winrt::Microsoft::Terminal::Control::implementation::ControlCore::IsVintageOpacityAvailable() ? useAcrylic :
-                                                                                                                                      (expectedOpacity < 1.0 ? true : false);
+            auto expectedUseAcrylic = expectedOpacity < 1.0 &&
+                                      (!winrt::Microsoft::Terminal::Control::implementation::ControlCore::IsVintageOpacityAvailable() || useAcrylic);
             VERIFY_ARE_EQUAL(useAcrylic, settings->UseAcrylic());
             VERIFY_ARE_EQUAL(expectedUseAcrylic, core->UseAcrylic());
         };


### PR DESCRIPTION
If the opacity is set to 100%, the background becomes solid instead of 'fully opaque acrylic'. If the opacity is below 100% the acrylic material is re-enabled (depending on the user's settings).

## Validation Steps Performed

I updated two unit tests to reflect the change in behavior and manually tested the transition from <100% opacity to 100% opacity (and vice versa) on win11.

Steps:
1. Start with 100% opacity and acrylic material enabled.
2. Decrease opacity and observe acrylic effect.
3. Increase opacity back to 100% and disable the acrylic effect.
4. Decrease opacity and notice that acrylic effect is no longer there.

Closes #12880 