### PR TITLE
OpenHere: stop failing if there's no site...

### DIFF
--- a/src/cascadia/ShellExtension/OpenTerminalHere.cpp
+++ b/src/cascadia/ShellExtension/OpenTerminalHere.cpp
@@ -156,6 +156,13 @@ IFACEMETHODIMP OpenTerminalHere::GetSite(REFIID riid, void** site) noexcept
 
 HRESULT OpenTerminalHere::GetLocationFromSite(IShellItem** location) const noexcept
 {
+    wil::assign_null_to_opt_param(location);
+
+    if (!site_)
+    {
+        return S_FALSE;
+    }
+
     wil::com_ptr_nothrow<IServiceProvider> serviceProvider;
     RETURN_IF_FAILED(site_.query_to(serviceProvider.put()));
     wil::com_ptr_nothrow<IFolderView> folderView;


### PR DESCRIPTION
It cannot be known why there is no site.
We should at least not crash.

Fixes MSFT-41571451