### PR TITLE
Make sure VT reports still work when DECARM is disabled

### DIFF
--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -552,7 +552,7 @@ bool TerminalInput::HandleKey(const IInputEvent* const pInEvent)
     }
 
     // Check if this key matches the last recorded key code.
-    const auto matchingLastKeyPress = _lastVirtualKeyCode && _lastVirtualKeyCode.value() == keyEvent.GetVirtualKeyCode();
+    const auto matchingLastKeyPress = _lastVirtualKeyCode == keyEvent.GetVirtualKeyCode();
 
     // Only need to handle key down. See raw key handler (see RawReadWaitRoutine in stream.cpp)
     if (!keyEvent.IsKeyDown())

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -551,20 +551,23 @@ bool TerminalInput::HandleKey(const IInputEvent* const pInEvent)
         return true;
     }
 
+    // Check if this key matches the last recorded key code.
+    const auto matchingLastKeyPress = _lastVirtualKeyCode && _lastVirtualKeyCode.value() == keyEvent.GetVirtualKeyCode();
+
     // Only need to handle key down. See raw key handler (see RawReadWaitRoutine in stream.cpp)
     if (!keyEvent.IsKeyDown())
     {
         // If this is a release of the last recorded key press, we can reset that.
-        if (keyEvent.GetVirtualKeyCode() == _lastVirtualKeyCode)
+        if (matchingLastKeyPress)
         {
-            _lastVirtualKeyCode = 0;
+            _lastVirtualKeyCode = std::nullopt;
         }
         return false;
     }
 
     // If this is a repeat of the last recorded key press, and Auto Repeat Mode
     // is disabled, then we should suppress this event.
-    if (keyEvent.GetVirtualKeyCode() == _lastVirtualKeyCode && !_inputMode.test(Mode::AutoRepeat))
+    if (matchingLastKeyPress && !_inputMode.test(Mode::AutoRepeat))
     {
         // Note that we must return true here to say we've handled the event,
         // otherwise the key press can still end up being submitted.

--- a/src/terminal/input/terminalInput.hpp
+++ b/src/terminal/input/terminalInput.hpp
@@ -93,7 +93,7 @@ namespace Microsoft::Console::VirtualTerminal
         // storage location for the leading surrogate of a utf-16 surrogate pair
         std::optional<wchar_t> _leadingSurrogate;
 
-        WORD _lastVirtualKeyCode{ 0 };
+        std::optional<WORD> _lastVirtualKeyCode;
 
         til::enumset<Mode> _inputMode{ Mode::Ansi, Mode::AutoRepeat };
         bool _forceDisableWin32InputMode{ false };


### PR DESCRIPTION
The way `DECARM` was initially implemented, we checked for repeated key
presses by matching the last recorded virtual key code, and used a 0 key
code to indicate that no key was pressed. This caused the VT query
responses to fail, because they generated key events with a 0 key code,
and that would end up being detected as a repeated key that should be
suppressed.

This PR fixes that issue by using a `std::optional` to track the last
key code, so if no key has been pressed we can represent that with
`std::nullopt`, and there's no way that can be confused with a genuine
key press.

The `DECARM` mode was introduced in PR #13981.

## Validation Steps Performed
I've manually tested in Vttest to confirm that the query reports are now
working again, even when `DECARM` is disabled. I've also checked that
`DECARM` itself it still working as expected.

Closes #14208