### PR TITLE
Add system menu support from SUI & read-only panes

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3336,6 +3336,7 @@ namespace winrt::TerminalApp::implementation
 
             // GH#8767 - let unhandled keys in the SUI try to run commands too.
             sui.KeyDown({ this, &TerminalPage::_KeyDownHandler });
+            sui.OpenSystemMenu([&](auto&& sender, auto&& args) { _OpenSystemMenuHandlers(sender, args); });
 
             sui.OpenJson([weakThis{ get_weak() }](auto&& /*s*/, winrt::Microsoft::Terminal::Settings::Model::SettingsTarget e) {
                 if (auto page{ weakThis.get() })

--- a/src/cascadia/TerminalControl/IDirectKeyListener.idl
+++ b/src/cascadia/TerminalControl/IDirectKeyListener.idl
@@ -4,8 +4,8 @@
 namespace Microsoft.Terminal.Control
 {
     // C++/winrt makes it difficult to share this idl between two projects,
-    // Instead, we just pin the uuid and include it in both TermControl and App
-    // If you update this one, please update TerminalApp\IDirectKeyListener.idl.
+    // Instead, we just pin the uuid and include it in both TermControl, App, and Editor
+    // If you update this one, please update TerminalApp's and TerminalSettingsEditor's IDirectKeyListener.idl.
     // If you change this interface, please update the guid.
     // If you press F7 or Alt and get a runtime error, go make sure both copies are the same.
     [uuid("0ddf4edc-3fda-4dee-97ca-a417ee3dd510")] interface IDirectKeyListener {

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -960,12 +960,12 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     bool TermControl::OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool down)
     {
         // Short-circuit isReadOnly check to avoid warning dialog
+        const auto modifiers{ _GetPressedModifierKeys() };
         if (_core.IsInReadOnlyMode())
         {
-            return false;
+            return _TryHandleKeyBinding(gsl::narrow_cast<WORD>(vkey), scanCode, modifiers);
         }
 
-        const auto modifiers{ _GetPressedModifierKeys() };
         auto handled = false;
 
         if (vkey == VK_MENU && !down)

--- a/src/cascadia/TerminalSettingsEditor/IDirectKeyListener.idl
+++ b/src/cascadia/TerminalSettingsEditor/IDirectKeyListener.idl
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-namespace TerminalApp
+namespace Microsoft.Terminal.Settings.Editor
 {
     // C++/winrt makes it difficult to share this idl between two projects,
     // Instead, we just pin the uuid and include it in both TermControl, App, and Editor
-    // If you update this one, please update TerminalControl's and TerminalSettingsEditor's IDirectKeyListener.idl
+    // If you update this one, please update TerminalApp's and TerminalControl's IDirectKeyListener.idl.
     // If you change this interface, please update the guid.
     // If you press F7 or Alt and get a runtime error, go make sure both copies are the same.
     [uuid("0ddf4edc-3fda-4dee-97ca-a417ee3dd510")] interface IDirectKeyListener {
         Boolean OnDirectKeyEvent(UInt32 vkey, UInt8 scanCode, Boolean down);
-    }
+    };
 }

--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -7,6 +7,11 @@
 #include "Breadcrumb.g.h"
 #include "Utils.h"
 
+namespace Microsoft::Terminal::Core
+{
+    class ControlKeyStates;
+}
+
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
     struct Breadcrumb : BreadcrumbT<Breadcrumb>
@@ -30,6 +35,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         void UpdateSettings(const Model::CascadiaSettings& settings);
 
+        bool OnDirectKeyEvent(const uint32_t vkey, const uint8_t scanCode, const bool down);
         void OpenJsonKeyDown(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Input::KeyRoutedEventArgs& args);
         void OpenJsonTapped(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Input::TappedRoutedEventArgs& args);
         void SettingsNav_Loaded(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
@@ -47,6 +53,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         Windows::Foundation::Collections::IObservableVector<IInspectable> Breadcrumbs() noexcept;
 
         TYPED_EVENT(OpenJson, Windows::Foundation::IInspectable, Model::SettingsTarget);
+        TYPED_EVENT(OpenSystemMenu, IInspectable, IInspectable);
 
     private:
         Windows::Foundation::Collections::IObservableVector<IInspectable> _breadcrumbs;
@@ -55,6 +62,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         std::optional<HWND> _hostingHwnd;
 
+        static ::Microsoft::Terminal::Core::ControlKeyStates _GetPressedModifierKeys() noexcept;
         void _InitializeProfilesList();
         void _CreateAndNavigateToNewProfile(const uint32_t index, const Model::Profile& profile);
         winrt::Microsoft::UI::Xaml::Controls::NavigationViewItem _CreateProfileNavViewItem(const Editor::ProfileViewModel& profile);

--- a/src/cascadia/TerminalSettingsEditor/MainPage.idl
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.idl
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import "IDirectKeyListener.idl";
+
 namespace Microsoft.Terminal.Settings.Editor
 {
     // Due to a XAML Compiler bug, it is hard for us to propagate an HWND into a XAML-using runtimeclass.
@@ -28,7 +30,7 @@ namespace Microsoft.Terminal.Settings.Editor
         BreadcrumbSubPage SubPage;
     }
 
-    [default_interface] runtimeclass MainPage : Windows.UI.Xaml.Controls.Page, IHostedInWindow
+    [default_interface] runtimeclass MainPage : Windows.UI.Xaml.Controls.Page, IHostedInWindow, IDirectKeyListener
     {
         MainPage(Microsoft.Terminal.Settings.Model.CascadiaSettings settings);
 
@@ -42,5 +44,7 @@ namespace Microsoft.Terminal.Settings.Editor
         Windows.Foundation.Collections.IObservableVector<IInspectable> Breadcrumbs { get; };
 
         Windows.UI.Xaml.Media.Brush BackgroundBrush { get; };
+
+        event Windows.Foundation.TypedEventHandler<Object, Object> OpenSystemMenu;
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
+++ b/src/cascadia/TerminalSettingsEditor/Microsoft.Terminal.Settings.Editor.vcxproj
@@ -312,6 +312,7 @@
       <DependentUpon>Launch.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Midl>
+    <Midl Include="IDirectKeyListener.idl" />
     <Midl Include="Interaction.idl">
       <DependentUpon>Interaction.xaml</DependentUpon>
       <SubType>Code</SubType>


### PR DESCRIPTION
## Summary of the Pull Request
Adds support for the system menu to appear from the Settings UI and read-only panes.

## PR Checklist
Closes #11970

## Detailed Description of the Pull Request / Additional comments
This is another case of needing the DirectKeyListener. Alt+Space just doesn't go through the normal key event handler, so we needed to add support for it in both of these places.

## Validation Steps Performed
- [X] Tested ALT+SPACE from settings UI
- [X] Tested ALT+SPACE from read-only pane