### PR TITLE
Respect the "/max" parameter when starting console apps with defterm enabled

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3312,7 +3312,18 @@ namespace winrt::TerminalApp::implementation
             const IInspectable unused{ nullptr };
             _SetAsDefaultDismissHandler(unused, unused);
 
-            if (connection.ShowWindow() == 3)
+            // TEMPORARY SOLUTION
+            // If the connection has requested for the window to be maximized,
+            // manually maximize it here. Ideally, we should be _initializing_
+            // the session maximized, instead of manually maximizing it after initialization.
+            // However, because of the current way our defterm handoff works,
+            // we are unable to get the connection info before the console session
+            // has already started.
+
+            // Make sure that there were no other tabs already existing (in
+            // the case that we are in glomming mode), because we don't want
+            // to be maximizing other existing sessions that did not ask for it.
+            if (_tabs.Size() == 1 && connection.ShowWindow() == 3)
             {
                 RequestSetMaximized(true);
             }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3317,7 +3317,7 @@ namespace winrt::TerminalApp::implementation
             // manually maximize it here. Ideally, we should be _initializing_
             // the session maximized, instead of manually maximizing it after initialization.
             // However, because of the current way our defterm handoff works,
-            // we are unable to get the connection info before the console session
+            // we are unable to get the connection info before the terminal session
             // has already started.
 
             // Make sure that there were no other tabs already existing (in

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3323,7 +3323,7 @@ namespace winrt::TerminalApp::implementation
             // Make sure that there were no other tabs already existing (in
             // the case that we are in glomming mode), because we don't want
             // to be maximizing other existing sessions that did not ask for it.
-            if (_tabs.Size() == 1 && connection.ShowWindow() == 3)
+            if (_tabs.Size() == 1 && connection.ShowWindow() == SW_SHOWMAXIMIZED)
             {
                 RequestSetMaximized(true);
             }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3311,6 +3311,11 @@ namespace winrt::TerminalApp::implementation
 
             const IInspectable unused{ nullptr };
             _SetAsDefaultDismissHandler(unused, unused);
+
+            if (connection.ShowWindow() == 3)
+            {
+                RequestSetMaximized(true);
+            }
             return S_OK;
         }
         CATCH_RETURN()

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -219,6 +219,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         _startupInfo.iconPath = winrt::hstring{ startupInfo.pszIconPath, SysStringLen(startupInfo.pszIconPath) };
         SysFreeString(startupInfo.pszIconPath);
         _startupInfo.iconIndex = startupInfo.iconIndex;
+        _startupInfo.showWindow = startupInfo.wShowWindow;
 
         try
         {
@@ -298,6 +299,11 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
     winrt::hstring ConptyConnection::StartingTitle() const
     {
         return _startupInfo.title;
+    }
+
+    WORD ConptyConnection::ShowWindow() const
+    {
+        return _startupInfo.showWindow;
     }
 
     void ConptyConnection::Start()

--- a/src/cascadia/TerminalConnection/ConptyConnection.cpp
+++ b/src/cascadia/TerminalConnection/ConptyConnection.cpp
@@ -301,7 +301,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         return _startupInfo.title;
     }
 
-    WORD ConptyConnection::ShowWindow() const
+    WORD ConptyConnection::ShowWindow() const noexcept
     {
         return _startupInfo.showWindow;
     }

--- a/src/cascadia/TerminalConnection/ConptyConnection.h
+++ b/src/cascadia/TerminalConnection/ConptyConnection.h
@@ -46,6 +46,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         winrt::guid Guid() const noexcept;
         winrt::hstring Commandline() const;
         winrt::hstring StartingTitle() const;
+        WORD ShowWindow() const;
 
         static void StartInboundListener();
         static void StopInboundListener();
@@ -102,6 +103,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
             winrt::hstring title{};
             winrt::hstring iconPath{};
             int32_t iconIndex{};
+            WORD showWindow{};
 
         } _startupInfo{};
 

--- a/src/cascadia/TerminalConnection/ConptyConnection.h
+++ b/src/cascadia/TerminalConnection/ConptyConnection.h
@@ -46,7 +46,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         winrt::guid Guid() const noexcept;
         winrt::hstring Commandline() const;
         winrt::hstring StartingTitle() const;
-        WORD ShowWindow() const;
+        WORD ShowWindow() const noexcept;
 
         static void StartInboundListener();
         static void StopInboundListener();

--- a/src/cascadia/TerminalConnection/ConptyConnection.idl
+++ b/src/cascadia/TerminalConnection/ConptyConnection.idl
@@ -13,6 +13,7 @@ namespace Microsoft.Terminal.TerminalConnection
         Guid Guid { get; };
         String Commandline { get; };
         String StartingTitle { get; };
+        UInt16 ShowWindow { get; };
 
         void ClearBuffer();
 

--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -584,6 +584,8 @@ try
         icon.index
     };
 
+    myStartupInfo.wShowWindow = settings.GetShowWindow();
+
     RETURN_IF_FAILED(handoff->EstablishPtyHandoff(inPipeTheirSide.get(),
                                                   outPipeTheirSide.get(),
                                                   signalPipeTheirSide.get(),


### PR DESCRIPTION
## Summary of the Pull Request

- Pipe the `ShowWindow` value through to `ConptyConnection`
- When `TerminalPage` receives the new connection, it checks the `ShowWindow` value and maximizes *IF* there were no other pre-existing tabs (in glomming mode, we don't want to maximize sessions that did not ask for it)

## References
#12154 

## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments
This is just a temporary solution until we change our defterm handoff process. Because of the way the process currently works, we have no way of knowing that the connection has requested the window to be maximized until after we have already started a terminal session. This means that we have to manually maximize the window upon receiving the connection, instead of having the session _start_ maximized, as it probably should. 

## Validation Steps Performed
`start /max python` with defterm enabled opens up python in a maximized WT window