### PR TITLE
Reorder the color chips grid in the color schemes page

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -56,126 +56,122 @@
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
-                            <Grid Grid.Column="0"
+                            <Border  Background="{x:Bind local:Converters.ColorToBrush(BackgroundColor.Color), Mode=OneWay}"
+                                     Height="56"
+                                     Padding="8"
+                                     CornerRadius="4">
+                                <Grid Grid.Column="0"
                                   VerticalAlignment="Center"
                                   ColumnSpacing="4"
                                   RowSpacing="4">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                </Grid.RowDefinitions>
-                                <Border Grid.RowSpan="2"
-                                        Grid.Column="0"
-                                        Background="{x:Bind local:Converters.ColorToBrush(BackgroundColor.Color), Mode=OneWay}"
-                                        CornerRadius="2">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+                                    <ContentControl Grid.Row="0"
+                                                Grid.Column="0"
+                                                Content="{x:Bind ColorEntryAt(0), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                    <ContentControl Grid.Row="0"
+                                                Grid.Column="1"
+                                                Content="{x:Bind ColorEntryAt(1), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                    <ContentControl Grid.Row="0"
+                                                Grid.Column="2"
+                                                Content="{x:Bind ColorEntryAt(2), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                    <ContentControl Grid.Row="0"
+                                                Grid.Column="3"
+                                                Content="{x:Bind ColorEntryAt(3), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                    <ContentControl Grid.Row="0"
+                                                Grid.Column="4"
+                                                Content="{x:Bind ColorEntryAt(4), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                    <ContentControl Grid.Row="0"
+                                                Grid.Column="5"
+                                                Content="{x:Bind ColorEntryAt(5), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                    <ContentControl Grid.Row="0"
+                                                Grid.Column="6"
+                                                Content="{x:Bind ColorEntryAt(6), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                    <ContentControl Grid.Row="0"
+                                                Grid.Column="7"
+                                                Content="{x:Bind ColorEntryAt(7), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                    <ContentControl Grid.Row="1"
+                                                Grid.Column="0"
+                                                Content="{x:Bind ColorEntryAt(8), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                    <ContentControl Grid.Row="1"
+                                                Grid.Column="1"
+                                                Content="{x:Bind ColorEntryAt(9), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                    <ContentControl Grid.Row="1"
+                                                Grid.Column="2"
+                                                Content="{x:Bind ColorEntryAt(10), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                    <ContentControl Grid.Row="1"
+                                                Grid.Column="3"
+                                                Content="{x:Bind ColorEntryAt(11), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                    <ContentControl Grid.Row="1"
+                                                Grid.Column="4"
+                                                Content="{x:Bind ColorEntryAt(12), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                    <ContentControl Grid.Row="1"
+                                                Grid.Column="5"
+                                                Content="{x:Bind ColorEntryAt(13), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                    <ContentControl Grid.Row="1"
+                                                Grid.Column="6"
+                                                Content="{x:Bind ColorEntryAt(14), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                    <ContentControl Grid.Row="1"
+                                                Grid.Column="7"
+                                                Content="{x:Bind ColorEntryAt(15), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
                                     <TextBlock Padding="10,0,10,0"
+                                               Grid.Column="8"
+                                               Grid.RowSpan="2"
                                                HorizontalAlignment="Center"
                                                VerticalAlignment="Center"
                                                AutomationProperties.AccessibilityView="Raw"
                                                FontFamily="Cascadia Code"
                                                Foreground="{x:Bind local:Converters.ColorToBrush(ForegroundColor.Color), Mode=OneWay}"
-                                               Text="AaBbCc" />
-                                </Border>
-                                <ContentControl Grid.Row="0"
-                                                Grid.Column="1"
-                                                Content="{x:Bind ColorEntryAt(0), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
-                                <ContentControl Grid.Row="0"
-                                                Grid.Column="2"
-                                                Content="{x:Bind ColorEntryAt(1), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
-                                <ContentControl Grid.Row="0"
-                                                Grid.Column="3"
-                                                Content="{x:Bind ColorEntryAt(2), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
-                                <ContentControl Grid.Row="0"
-                                                Grid.Column="4"
-                                                Content="{x:Bind ColorEntryAt(3), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
-                                <ContentControl Grid.Row="0"
-                                                Grid.Column="5"
-                                                Content="{x:Bind ColorEntryAt(4), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
-                                <ContentControl Grid.Row="0"
-                                                Grid.Column="6"
-                                                Content="{x:Bind ColorEntryAt(5), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
-                                <ContentControl Grid.Row="0"
-                                                Grid.Column="7"
-                                                Content="{x:Bind ColorEntryAt(6), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
-                                <ContentControl Grid.Row="0"
-                                                Grid.Column="8"
-                                                Content="{x:Bind ColorEntryAt(7), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
-                                <ContentControl Grid.Row="1"
-                                                Grid.Column="1"
-                                                Content="{x:Bind ColorEntryAt(8), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
-                                <ContentControl Grid.Row="1"
-                                                Grid.Column="2"
-                                                Content="{x:Bind ColorEntryAt(9), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
-                                <ContentControl Grid.Row="1"
-                                                Grid.Column="3"
-                                                Content="{x:Bind ColorEntryAt(10), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
-                                <ContentControl Grid.Row="1"
-                                                Grid.Column="4"
-                                                Content="{x:Bind ColorEntryAt(11), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
-                                <ContentControl Grid.Row="1"
-                                                Grid.Column="5"
-                                                Content="{x:Bind ColorEntryAt(12), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
-                                <ContentControl Grid.Row="1"
-                                                Grid.Column="6"
-                                                Content="{x:Bind ColorEntryAt(13), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
-                                <ContentControl Grid.Row="1"
-                                                Grid.Column="7"
-                                                Content="{x:Bind ColorEntryAt(14), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
-                                <ContentControl Grid.Row="1"
-                                                Grid.Column="8"
-                                                Content="{x:Bind ColorEntryAt(15), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
-                            </Grid>
-                            <TextBlock Grid.Column="1"
-                                       VerticalAlignment="Center"
-                                       Margin="12,0,0,0"
-                                       Style="{StaticResource SettingsPageItemHeaderStyle}"
-                                       Text="{x:Bind Name, Mode=OneWay}" />
-                            <Border Grid.Column="2"
+                                               Text="{x:Bind Name, Mode=OneWay}" />
+                                </Grid>
+                            </Border>
+                            <Border Grid.Column="1"
                                     Margin="10,0,0,0"
                                     Padding="2,0,2,0"
                                     HorizontalAlignment="Left"

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -56,6 +56,7 @@
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
+                            <!--  Set the height of the inner grid as 48 to be 3/4 of the ListViewItem height  -->
                             <Grid Grid.Column="0"
                                   Height="48"
                                   Padding="12,11,8,8"

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -56,120 +56,119 @@
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
-                            <Border Height="48"
-                                    Padding="12,8,8,8"
-                                    Background="{x:Bind local:Converters.ColorToBrush(BackgroundColor.Color), Mode=OneWay}"
-                                    CornerRadius="4">
-                                <Grid Grid.Column="0"
-                                      VerticalAlignment="Center"
-                                      ColumnSpacing="2"
-                                      RowSpacing="2">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto" />
-                                        <RowDefinition Height="Auto" />
-                                    </Grid.RowDefinitions>
-                                    <ContentControl Grid.Row="0"
-                                                    Grid.Column="0"
-                                                    Content="{x:Bind ColorEntryAt(0), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="0"
-                                                    Grid.Column="1"
-                                                    Content="{x:Bind ColorEntryAt(1), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="0"
-                                                    Grid.Column="2"
-                                                    Content="{x:Bind ColorEntryAt(2), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="0"
-                                                    Grid.Column="3"
-                                                    Content="{x:Bind ColorEntryAt(3), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="0"
-                                                    Grid.Column="4"
-                                                    Content="{x:Bind ColorEntryAt(4), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="0"
-                                                    Grid.Column="5"
-                                                    Content="{x:Bind ColorEntryAt(5), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="0"
-                                                    Grid.Column="6"
-                                                    Content="{x:Bind ColorEntryAt(6), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="0"
-                                                    Grid.Column="7"
-                                                    Content="{x:Bind ColorEntryAt(7), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="1"
-                                                    Grid.Column="0"
-                                                    Content="{x:Bind ColorEntryAt(8), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="1"
-                                                    Grid.Column="1"
-                                                    Content="{x:Bind ColorEntryAt(9), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="1"
-                                                    Grid.Column="2"
-                                                    Content="{x:Bind ColorEntryAt(10), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="1"
-                                                    Grid.Column="3"
-                                                    Content="{x:Bind ColorEntryAt(11), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="1"
-                                                    Grid.Column="4"
-                                                    Content="{x:Bind ColorEntryAt(12), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="1"
-                                                    Grid.Column="5"
-                                                    Content="{x:Bind ColorEntryAt(13), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="1"
-                                                    Grid.Column="6"
-                                                    Content="{x:Bind ColorEntryAt(14), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <ContentControl Grid.Row="1"
-                                                    Grid.Column="7"
-                                                    Content="{x:Bind ColorEntryAt(15), Mode=OneWay}"
-                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                    IsTabStop="False" />
-                                    <TextBlock Grid.RowSpan="2"
-                                               Grid.Column="8"
-                                               Padding="10,0,10,0"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               AutomationProperties.AccessibilityView="Raw"
-                                               FontFamily="Cascadia Code"
-                                               Foreground="{x:Bind local:Converters.ColorToBrush(ForegroundColor.Color), Mode=OneWay}"
-                                               Text="{x:Bind Name, Mode=OneWay}" />
-                                </Grid>
-                            </Border>
+                            <Grid Grid.Column="0"
+                                  Height="48"
+                                  Padding="12,11,8,8"
+                                  VerticalAlignment="Center"
+                                  Background="{x:Bind local:Converters.ColorToBrush(BackgroundColor.Color), Mode=OneWay}"
+                                  ColumnSpacing="2"
+                                  CornerRadius="4"
+                                  RowSpacing="2">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
+                                <ContentControl Grid.Row="0"
+                                                Grid.Column="0"
+                                                Content="{x:Bind ColorEntryAt(0), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                <ContentControl Grid.Row="0"
+                                                Grid.Column="1"
+                                                Content="{x:Bind ColorEntryAt(1), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                <ContentControl Grid.Row="0"
+                                                Grid.Column="2"
+                                                Content="{x:Bind ColorEntryAt(2), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                <ContentControl Grid.Row="0"
+                                                Grid.Column="3"
+                                                Content="{x:Bind ColorEntryAt(3), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                <ContentControl Grid.Row="0"
+                                                Grid.Column="4"
+                                                Content="{x:Bind ColorEntryAt(4), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                <ContentControl Grid.Row="0"
+                                                Grid.Column="5"
+                                                Content="{x:Bind ColorEntryAt(5), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                <ContentControl Grid.Row="0"
+                                                Grid.Column="6"
+                                                Content="{x:Bind ColorEntryAt(6), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                <ContentControl Grid.Row="0"
+                                                Grid.Column="7"
+                                                Content="{x:Bind ColorEntryAt(7), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                <ContentControl Grid.Row="1"
+                                                Grid.Column="0"
+                                                Content="{x:Bind ColorEntryAt(8), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                <ContentControl Grid.Row="1"
+                                                Grid.Column="1"
+                                                Content="{x:Bind ColorEntryAt(9), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                <ContentControl Grid.Row="1"
+                                                Grid.Column="2"
+                                                Content="{x:Bind ColorEntryAt(10), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                <ContentControl Grid.Row="1"
+                                                Grid.Column="3"
+                                                Content="{x:Bind ColorEntryAt(11), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                <ContentControl Grid.Row="1"
+                                                Grid.Column="4"
+                                                Content="{x:Bind ColorEntryAt(12), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                <ContentControl Grid.Row="1"
+                                                Grid.Column="5"
+                                                Content="{x:Bind ColorEntryAt(13), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                <ContentControl Grid.Row="1"
+                                                Grid.Column="6"
+                                                Content="{x:Bind ColorEntryAt(14), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                <ContentControl Grid.Row="1"
+                                                Grid.Column="7"
+                                                Content="{x:Bind ColorEntryAt(15), Mode=OneWay}"
+                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                IsTabStop="False" />
+                                <TextBlock Grid.RowSpan="2"
+                                           Grid.Column="8"
+                                           Padding="10,0,10,0"
+                                           HorizontalAlignment="Center"
+                                           VerticalAlignment="Center"
+                                           AutomationProperties.AccessibilityView="Raw"
+                                           FontFamily="Cascadia Code"
+                                           Foreground="{x:Bind local:Converters.ColorToBrush(ForegroundColor.Color), Mode=OneWay}"
+                                           Text="{x:Bind Name, Mode=OneWay}" />
+                            </Grid>
                             <Border Grid.Column="1"
                                     Margin="10,0,0,0"
                                     Padding="2,0,2,0"

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -55,28 +55,10 @@
                               Style="{StaticResource SchemeGridStyle}">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0"
-                                       VerticalAlignment="Center"
-                                       Style="{StaticResource SettingsPageItemHeaderStyle}"
-                                       Text="{x:Bind Name, Mode=OneWay}" />
-                            <Border Grid.Column="1"
-                                    Margin="10,0,0,0"
-                                    Padding="2,0,2,0"
-                                    HorizontalAlignment="Left"
-                                    VerticalAlignment="Center"
-                                    Background="{ThemeResource SystemAltMediumLowColor}"
-                                    BorderBrush="{ThemeResource SystemControlForegroundBaseMediumBrush}"
-                                    BorderThickness="1"
-                                    CornerRadius="1"
-                                    Visibility="{x:Bind IsDefaultScheme, Mode=OneWay}">
-                                <TextBlock x:Uid="ColorScheme_DefaultTag"
-                                           Grid.Column="1"
-                                           Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
-                            </Border>
-                            <Grid Grid.Column="2"
+                            <Grid Grid.Column="0"
                                   VerticalAlignment="Center"
                                   ColumnSpacing="4"
                                   RowSpacing="4">
@@ -188,6 +170,25 @@
                                                 ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
                                                 IsTabStop="False" />
                             </Grid>
+                            <TextBlock Grid.Column="1"
+                                       VerticalAlignment="Center"
+                                       Margin="12,0,0,0"
+                                       Style="{StaticResource SettingsPageItemHeaderStyle}"
+                                       Text="{x:Bind Name, Mode=OneWay}" />
+                            <Border Grid.Column="2"
+                                    Margin="10,0,0,0"
+                                    Padding="2,0,2,0"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    Background="{ThemeResource SystemAltMediumLowColor}"
+                                    BorderBrush="{ThemeResource SystemControlForegroundBaseMediumBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="1"
+                                    Visibility="{x:Bind IsDefaultScheme, Mode=OneWay}">
+                                <TextBlock x:Uid="ColorScheme_DefaultTag"
+                                           Grid.Column="1"
+                                           Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+                            </Border>
                         </Grid>
                     </DataTemplate>
                 </ListView.ItemTemplate>

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -20,8 +20,8 @@
 
             <DataTemplate x:Key="ColorPreviewChipTemplate"
                           x:DataType="local:ColorTableEntry">
-                <Border Width="15"
-                        Height="15"
+                <Border Width="12"
+                        Height="12"
                         Background="{x:Bind local:Converters.ColorToBrush(Color)}"
                         CornerRadius="2" />
             </DataTemplate>
@@ -40,7 +40,6 @@
         <StackPanel Style="{StaticResource SettingsStackStyle}">
             <TextBlock x:Uid="ColorSchemesDisclaimer"
                        Style="{StaticResource DisclaimerStyle}" />
-
             <ListView x:Name="ColorSchemeListView"
                       MaxWidth="{StaticResource StandardControlMaxWidth}"
                       ItemsSource="{x:Bind ViewModel.AllColorSchemes, Mode=OneWay}"
@@ -57,14 +56,14 @@
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
-                            <Border  Background="{x:Bind local:Converters.ColorToBrush(BackgroundColor.Color), Mode=OneWay}"
-                                     Height="56"
-                                     Padding="8"
-                                     CornerRadius="4">
+                            <Border Height="48"
+                                    Padding="12,8,8,8"
+                                    Background="{x:Bind local:Converters.ColorToBrush(BackgroundColor.Color), Mode=OneWay}"
+                                    CornerRadius="4">
                                 <Grid Grid.Column="0"
-                                  VerticalAlignment="Center"
-                                  ColumnSpacing="4"
-                                  RowSpacing="4">
+                                      VerticalAlignment="Center"
+                                      ColumnSpacing="2"
+                                      RowSpacing="2">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto" />
                                         <ColumnDefinition Width="Auto" />
@@ -81,88 +80,88 @@
                                         <RowDefinition Height="Auto" />
                                     </Grid.RowDefinitions>
                                     <ContentControl Grid.Row="0"
-                                                Grid.Column="0"
-                                                Content="{x:Bind ColorEntryAt(0), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
+                                                    Grid.Column="0"
+                                                    Content="{x:Bind ColorEntryAt(0), Mode=OneWay}"
+                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                    IsTabStop="False" />
                                     <ContentControl Grid.Row="0"
-                                                Grid.Column="1"
-                                                Content="{x:Bind ColorEntryAt(1), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
+                                                    Grid.Column="1"
+                                                    Content="{x:Bind ColorEntryAt(1), Mode=OneWay}"
+                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                    IsTabStop="False" />
                                     <ContentControl Grid.Row="0"
-                                                Grid.Column="2"
-                                                Content="{x:Bind ColorEntryAt(2), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
+                                                    Grid.Column="2"
+                                                    Content="{x:Bind ColorEntryAt(2), Mode=OneWay}"
+                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                    IsTabStop="False" />
                                     <ContentControl Grid.Row="0"
-                                                Grid.Column="3"
-                                                Content="{x:Bind ColorEntryAt(3), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
+                                                    Grid.Column="3"
+                                                    Content="{x:Bind ColorEntryAt(3), Mode=OneWay}"
+                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                    IsTabStop="False" />
                                     <ContentControl Grid.Row="0"
-                                                Grid.Column="4"
-                                                Content="{x:Bind ColorEntryAt(4), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
+                                                    Grid.Column="4"
+                                                    Content="{x:Bind ColorEntryAt(4), Mode=OneWay}"
+                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                    IsTabStop="False" />
                                     <ContentControl Grid.Row="0"
-                                                Grid.Column="5"
-                                                Content="{x:Bind ColorEntryAt(5), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
+                                                    Grid.Column="5"
+                                                    Content="{x:Bind ColorEntryAt(5), Mode=OneWay}"
+                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                    IsTabStop="False" />
                                     <ContentControl Grid.Row="0"
-                                                Grid.Column="6"
-                                                Content="{x:Bind ColorEntryAt(6), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
+                                                    Grid.Column="6"
+                                                    Content="{x:Bind ColorEntryAt(6), Mode=OneWay}"
+                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                    IsTabStop="False" />
                                     <ContentControl Grid.Row="0"
-                                                Grid.Column="7"
-                                                Content="{x:Bind ColorEntryAt(7), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
+                                                    Grid.Column="7"
+                                                    Content="{x:Bind ColorEntryAt(7), Mode=OneWay}"
+                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                    IsTabStop="False" />
                                     <ContentControl Grid.Row="1"
-                                                Grid.Column="0"
-                                                Content="{x:Bind ColorEntryAt(8), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
+                                                    Grid.Column="0"
+                                                    Content="{x:Bind ColorEntryAt(8), Mode=OneWay}"
+                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                    IsTabStop="False" />
                                     <ContentControl Grid.Row="1"
-                                                Grid.Column="1"
-                                                Content="{x:Bind ColorEntryAt(9), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
+                                                    Grid.Column="1"
+                                                    Content="{x:Bind ColorEntryAt(9), Mode=OneWay}"
+                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                    IsTabStop="False" />
                                     <ContentControl Grid.Row="1"
-                                                Grid.Column="2"
-                                                Content="{x:Bind ColorEntryAt(10), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
+                                                    Grid.Column="2"
+                                                    Content="{x:Bind ColorEntryAt(10), Mode=OneWay}"
+                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                    IsTabStop="False" />
                                     <ContentControl Grid.Row="1"
-                                                Grid.Column="3"
-                                                Content="{x:Bind ColorEntryAt(11), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
+                                                    Grid.Column="3"
+                                                    Content="{x:Bind ColorEntryAt(11), Mode=OneWay}"
+                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                    IsTabStop="False" />
                                     <ContentControl Grid.Row="1"
-                                                Grid.Column="4"
-                                                Content="{x:Bind ColorEntryAt(12), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
+                                                    Grid.Column="4"
+                                                    Content="{x:Bind ColorEntryAt(12), Mode=OneWay}"
+                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                    IsTabStop="False" />
                                     <ContentControl Grid.Row="1"
-                                                Grid.Column="5"
-                                                Content="{x:Bind ColorEntryAt(13), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
+                                                    Grid.Column="5"
+                                                    Content="{x:Bind ColorEntryAt(13), Mode=OneWay}"
+                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                    IsTabStop="False" />
                                     <ContentControl Grid.Row="1"
-                                                Grid.Column="6"
-                                                Content="{x:Bind ColorEntryAt(14), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
+                                                    Grid.Column="6"
+                                                    Content="{x:Bind ColorEntryAt(14), Mode=OneWay}"
+                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                    IsTabStop="False" />
                                     <ContentControl Grid.Row="1"
-                                                Grid.Column="7"
-                                                Content="{x:Bind ColorEntryAt(15), Mode=OneWay}"
-                                                ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
-                                                IsTabStop="False" />
-                                    <TextBlock Padding="10,0,10,0"
+                                                    Grid.Column="7"
+                                                    Content="{x:Bind ColorEntryAt(15), Mode=OneWay}"
+                                                    ContentTemplate="{StaticResource ColorPreviewChipTemplate}"
+                                                    IsTabStop="False" />
+                                    <TextBlock Grid.RowSpan="2"
                                                Grid.Column="8"
-                                               Grid.RowSpan="2"
+                                               Padding="10,0,10,0"
                                                HorizontalAlignment="Center"
                                                VerticalAlignment="Center"
                                                AutomationProperties.AccessibilityView="Raw"


### PR DESCRIPTION
XAML has an issue in windows 10 where `Width="*"` does not work properly
inside the `DataTemplate` for a `ListView`. Because of this, the color
scheme list view items looked very strange in windows 10 (see #14187).

Thanks to that, we thought up a few new designs for the color schemes
page and selected a new one that blends the color chips with a region
that shows the foreground and background color with the text preview.

Closes #14187 