### PR TITLE
Fix build without precompiled headers (/p:PrecompiledHeaders=Create)

### DIFF
--- a/src/common.build.pre.props
+++ b/src/common.build.pre.props
@@ -91,7 +91,7 @@
 
   <ItemDefinitionGroup>
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(PrecompiledHeader)' == ''">Use</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <TreatSpecificWarningsAsErrors>4189;4100;4242;4389;4244</TreatSpecificWarningsAsErrors>
       <!--<WarningLevel>EnableAllWarnings</WarningLevel>-->

--- a/src/terminal/adapter/adaptDispatchGraphics.cpp
+++ b/src/terminal/adapter/adaptDispatchGraphics.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#include <precomp.h>
+#include "precomp.h"
 
 #include "adaptDispatch.hpp"
 #include "../../types/inc/utils.hpp"

--- a/src/terminal/adapter/telemetry.cpp
+++ b/src/terminal/adapter/telemetry.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#include <precomp.h>
+#include "precomp.h"
 
 #include "telemetry.hpp"

--- a/src/terminal/parser/telemetry.cpp
+++ b/src/terminal/parser/telemetry.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#include <precomp.h>
+#include "precomp.h"
 
 #include "telemetry.hpp"
 

--- a/src/tools/lnkd/main.cpp
+++ b/src/tools/lnkd/main.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#include <precomp.h>
+#include "precomp.h"
 
 void PrintUsage()
 {

--- a/src/tools/pixels/main.cpp
+++ b/src/tools/pixels/main.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#include <precomp.h>
+#include "precomp.h"
 
 #include <windowsinternalstring.h>
 

--- a/src/tools/test/main.cpp
+++ b/src/tools/test/main.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#include <precomp.h>
+#include "precomp.h"
 #include <windows.h>
 #include <wincon.h>
 


### PR DESCRIPTION
## Summary of the Pull Request

This pull request fixes makes the csproj PrecompiledHeaders property overridable at the msbuild command-line (/p:PrecompiledHeaders=Create). The previous default value is kept (/p:PrecompiledHeaders=Use) which enables precompiled headers.

Building without precompiled headers revealed 6 occurrences where include <precomp.h> was used instead of include "precomp.h", which broke the build. Those broken includes are fixed with this pull request.

Precompiled headers in Windows Terminal produce extremely large files (some over 1GB) which causes problems with the limited space available in GitHub Actions Windows runners. Precompiled headers are supposed to be a means of optimization, but in the case of Windows Terminal, it creates new problems. The default is still to use them, but it's good to have the option to build without precompiled headers.

## Validation

As for validation, I made a special branch on my GitHub Actions workflow to build Windows Terminal for x64 and arm64 with and without precompiled headers so we can compare the total build time:
https://github.com/awakecoding/wt-distro/actions/runs/3253700300/jobs/5341196693
