### PR TITLE
Fix circular TermControl reference

### DIFF
--- a/src/cascadia/TerminalControl/ScrollBarVisualStateManager.cpp
+++ b/src/cascadia/TerminalControl/ScrollBarVisualStateManager.cpp
@@ -7,11 +7,6 @@
 
 namespace winrt::Microsoft::Terminal::Control::implementation
 {
-    ScrollBarVisualStateManager::ScrollBarVisualStateManager() :
-        _termControl(nullptr)
-    {
-    }
-
     bool ScrollBarVisualStateManager::GoToStateCore(
         winrt::Windows::UI::Xaml::Controls::Control const& control,
         winrt::Windows::UI::Xaml::FrameworkElement const& templateRoot,
@@ -20,22 +15,25 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         winrt::Windows::UI::Xaml::VisualState const& state,
         bool useTransitions)
     {
-        if (!_termControl)
+        if (!_settings)
         {
+            TermControl termControl{ nullptr };
+
             for (auto parent = winrt::Windows::UI::Xaml::Media::VisualTreeHelper::GetParent(control);
                  parent != nullptr;
                  parent = winrt::Windows::UI::Xaml::Media::VisualTreeHelper::GetParent(parent))
             {
-                if (parent.try_as(_termControl))
+                if (parent.try_as(termControl))
                 {
+                    _settings = termControl.Settings();
                     break;
                 }
             }
         }
 
-        WINRT_ASSERT(_termControl);
+        WINRT_ASSERT(_settings);
 
-        auto scrollState = _termControl.Settings().ScrollState();
+        const auto scrollState = _settings.ScrollState();
         if (scrollState == ScrollbarState::Always)
         {
             // If we're in Always mode, and the control is trying to collapse,

--- a/src/cascadia/TerminalControl/ScrollBarVisualStateManager.h
+++ b/src/cascadia/TerminalControl/ScrollBarVisualStateManager.h
@@ -20,12 +20,10 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 {
     struct ScrollBarVisualStateManager : ScrollBarVisualStateManagerT<ScrollBarVisualStateManager>
     {
-        ScrollBarVisualStateManager();
-
         bool GoToStateCore(winrt::Windows::UI::Xaml::Controls::Control const& control, winrt::Windows::UI::Xaml::FrameworkElement const& templateRoot, hstring const& stateName, winrt::Windows::UI::Xaml::VisualStateGroup const& group, winrt::Windows::UI::Xaml::VisualState const& state, bool useTransitions);
 
     private:
-        winrt::Microsoft::Terminal::Control::TermControl _termControl;
+        Control::IControlSettings _settings{ nullptr };
     };
 }
 


### PR DESCRIPTION
This regression was introduced in b3c9f01. Since `TermControl` is the XAML
object that owns its scrollbar and the scrollbar's `VisualStateManager`
a strong reference back to the `TermControl` results in a circular reference.

## Validation Steps Performed
* Set a breakpoint on `TermControl::~TermControl()`
* Breakpoint hits on tab close ✅