### PR TITLE
Override center on launch setting when position specified on cmdline

### DIFF
--- a/src/cascadia/TerminalApp/AppLogic.cpp
+++ b/src/cascadia/TerminalApp/AppLogic.cpp
@@ -762,7 +762,8 @@ namespace winrt::TerminalApp::implementation
             // Load settings if we haven't already
             LoadSettings();
         }
-        return _settings.GlobalSettings().CenterOnLaunch();
+        // If the position has been specified on the commandline, don't center on launch
+        return _settings.GlobalSettings().CenterOnLaunch() && !_appArgs.GetPosition().has_value();
     }
 
     winrt::Windows::UI::Xaml::ElementTheme AppLogic::GetRequestedTheme()


### PR DESCRIPTION
Override the center on launch setting when a position is specified on the commandline.

## Validation Steps Performed
1. Set center on launch in the SUI.
2. Run `wtd` - the new window is centered.
3. Run `wtd --pos 100,200` - the new window is positioned at (100,200).

Closes #14176
