### PR TITLE
Update XamlStyler version

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "XamlStyler.Console": {
-      "version": "3.2008.4",
+      "version": "3.2206.4",
       "commands": [
         "xstyler"
       ]

--- a/build/pipelines/templates/check-formatting.yml
+++ b/build/pipelines/templates/check-formatting.yml
@@ -2,7 +2,7 @@
 jobs:
 - job: CodeFormatCheck
   displayName: Proper Code Formatting Check
-  pool: { vmImage: windows-2019 }
+  pool: { vmImage: windows-2022 }
 
   steps:
   - checkout: self


### PR DESCRIPTION
Updates the version of XamlStyler to one with support for .NET 6.0. The version used before this depended on .NET 3.1, [which goes out of support on 2022-12-13.](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core)

This shouldn't be controversial as .NET 6.0 is included with VS 2022, unlike .NET 3.1.