### PR TITLE
Remove vestigial submodule entry

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "dep/gsl"]
 	path = dep/gsl
 	url = https://github.com/microsoft/gsl
-[submodule "dep/wil"]
-	path = dep/wil
-	url = https://github.com/microsoft/wil


### PR DESCRIPTION
Remove vestigial submodule entry

## References
#12778 removed the actual WIL submodule, but there was still an entry left in the `.gitmodules` file that was causing me confusion about an orphaned submodule directory I had in an old copy of the repo.

## Validation Steps Performed
 - Official validation checks passed
 - Build still works locally after a `git clean -fdx`