### PR TITLE
Disable /fp:fast by default

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2738,8 +2738,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         {
             _bellLightAnimation = Window::Current().Compositor().CreateScalarKeyFrameAnimation();
             // Add key frames and a duration to our bell light animation
-            _bellLightAnimation.InsertKeyFrame(0.0, 4.0);
-            _bellLightAnimation.InsertKeyFrame(1.0, 1.9);
+            _bellLightAnimation.InsertKeyFrame(0.0f, 4.0f);
+            _bellLightAnimation.InsertKeyFrame(1.0f, 1.9f);
             _bellLightAnimation.Duration(winrt::Windows::Foundation::TimeSpan(std::chrono::milliseconds(TerminalWarningBellInterval)));
         }
 
@@ -2748,8 +2748,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         {
             _bellDarkAnimation = Window::Current().Compositor().CreateScalarKeyFrameAnimation();
             // reversing the order of the intensity values produces a similar effect as the light version
-            _bellDarkAnimation.InsertKeyFrame(0.0, 1.0);
-            _bellDarkAnimation.InsertKeyFrame(1.0, 2.0);
+            _bellDarkAnimation.InsertKeyFrame(0.0f, 1.0f);
+            _bellDarkAnimation.InsertKeyFrame(1.0f, 2.0f);
             _bellDarkAnimation.Duration(winrt::Windows::Foundation::TimeSpan(std::chrono::milliseconds(TerminalWarningBellInterval)));
         }
 

--- a/src/common.build.pre.props
+++ b/src/common.build.pre.props
@@ -123,9 +123,9 @@
       <UseStandardPreprocessor>true</UseStandardPreprocessor>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
-      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:externConstexpr /Zc:lambda /Zc:throwingNew</AdditionalOptions>
+      <!-- /fp:contract used to default to on before VS 17.0. If enabled it allows FMA for floats. -->
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:externConstexpr /Zc:lambda /Zc:throwingNew /fp:contract</AdditionalOptions>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <FloatingPointModel>Fast</FloatingPointModel>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>EXTERNAL_BUILD;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/inc/til.h
+++ b/src/inc/til.h
@@ -119,3 +119,15 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             }                                             \
         }                                                 \
     } while (0, 0)
+
+// clang-format off
+#define TIL_FAST_MATH_BEGIN                \
+    _Pragma("float_control(push)")         \
+    _Pragma("float_control(precise, off)") \
+    _Pragma("float_control(except, off)")  \
+    _Pragma("fenv_access(off)")            \
+    _Pragma("fp_contract(on)")
+
+#define TIL_FAST_MATH_END \
+    _Pragma("float_control(pop)")
+// clang-format on

--- a/src/project.inc
+++ b/src/project.inc
@@ -32,7 +32,7 @@ USE_NATIVE_EH           = 1
 
 USE_STD_CPP20           = 1
 MSC_WARNING_LEVEL       = /W4 /WX
-USER_C_FLAGS            = $(USER_C_FLAGS) /fp:fast /utf-8
+USER_C_FLAGS            = $(USER_C_FLAGS) /fp:contract /utf-8
 
 # -------------------------------------
 # Common Console Includes and Libraries

--- a/src/til/ut_til/SizeTests.cpp
+++ b/src/til/ut_til/SizeTests.cpp
@@ -303,7 +303,7 @@ class SizeTests
         Log::Comment(L"1.) Scale results in value that is too large.");
         {
             const til::size sz{ 5, 10 };
-            constexpr auto scale = std::numeric_limits<float>().max();
+            constexpr auto scale = 1e12f;
 
             auto fn = [&]() {
                 sz.scale(til::math::ceiling, scale);

--- a/src/types/ColorFix.cpp
+++ b/src/types/ColorFix.cpp
@@ -9,6 +9,8 @@
 
 #include "inc/ColorFix.hpp"
 
+TIL_FAST_MATH_BEGIN
+
 static constexpr double gMinThreshold = 12.0;
 static constexpr double gExpThreshold = 20.0;
 static constexpr double gLStep = 5.0;
@@ -225,3 +227,5 @@ COLORREF ColorFix::GetPerceivableColor(COLORREF fg, COLORREF bg)
     }
     return frontLab.rgb;
 }
+
+TIL_FAST_MATH_END


### PR DESCRIPTION
Lately I've been a bit concerned about issues resulting from b036cab enabling
`/fp:fast` throughout the entire project. This commit reverts that change and:
* Enables `/fp:contract` which defaults to off since VS 17.0
  This re-enables FMA for floats on ARM64. Since this doesn't affect NANs, etc.
  I don't expect any issues apart from a slight change in float accuracy.
* Introduces `TIL_FAST_MATH_BEGIN` with which `/fp:fast` can be selectively
  enabled for code that benefits from it like `ColorFix.cpp`.

Without `TIL_FAST_MATH_BEGIN` `ColorFix` is about twice as slow
(which is actually very noticeable in real life).
This PR doesn't produce any noticeable performance regressions.

## Validation Steps Performed
* Patch `RenderSettings.hpp` to include `Mode::AlwaysDistinguishableColors`
* Run a color intense application in AtlasEngine and observe CPU usage