### PR TITLE
Add support for the rectangular area operations

### DIFF
--- a/src/buffer/out/TextAttribute.cpp
+++ b/src/buffer/out/TextAttribute.cpp
@@ -379,7 +379,7 @@ void TextAttribute::SetDefaultBackground() noexcept
 //     except the Protected attribute.
 void TextAttribute::SetDefaultRenditionAttributes() noexcept
 {
-    _attrs &= CharacterAttributes::Protected;
+    _attrs &= ~CharacterAttributes::Rendition;
 }
 
 // Method Description:

--- a/src/buffer/out/TextAttribute.hpp
+++ b/src/buffer/out/TextAttribute.hpp
@@ -104,6 +104,10 @@ public:
     void SetReverseVideo(bool isReversed) noexcept;
     void SetProtected(bool isProtected) noexcept;
 
+    constexpr void SetCharacterAttributes(const CharacterAttributes attrs) noexcept
+    {
+        _attrs = attrs;
+    }
     constexpr CharacterAttributes GetCharacterAttributes() const noexcept
     {
         return _attrs;

--- a/src/inc/conattrs.hpp
+++ b/src/inc/conattrs.hpp
@@ -30,6 +30,7 @@ enum class CharacterAttributes : uint16_t
     BottomGridline = COMMON_LVB_UNDERSCORE, // 0x8000
 
     All = 0xFFFF, // All character attributes
+    Rendition = All & ~Protected // Only rendition attributes (everything except Protected)
 };
 DEFINE_ENUM_FLAG_OPERATORS(CharacterAttributes);
 

--- a/src/inc/conattrs.hpp
+++ b/src/inc/conattrs.hpp
@@ -27,7 +27,9 @@ enum class CharacterAttributes : uint16_t
     RightGridline = COMMON_LVB_GRID_RVERTICAL, // 0x1000
     Protected = 0x2000,
     ReverseVideo = COMMON_LVB_REVERSE_VIDEO, // 0x4000
-    BottomGridline = COMMON_LVB_UNDERSCORE // 0x8000
+    BottomGridline = COMMON_LVB_UNDERSCORE, // 0x8000
+
+    All = 0xFFFF, // All character attributes
 };
 DEFINE_ENUM_FLAG_OPERATORS(CharacterAttributes);
 

--- a/src/terminal/adapter/DispatchTypes.hpp
+++ b/src/terminal/adapter/DispatchTypes.hpp
@@ -259,6 +259,13 @@ namespace Microsoft::Console::VirtualTerminal::DispatchTypes
         Scrollback = 3
     };
 
+    enum class ChangeExtent : VTInt
+    {
+        Default = 0,
+        Stream = 1,
+        Rectangle = 2
+    };
+
     enum class TaskbarState : VTInt
     {
         Clear = 0,

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -94,6 +94,7 @@ public:
     virtual bool SelectiveEraseInLine(const DispatchTypes::EraseType eraseType) = 0; // DECSEL
 
     virtual bool FillRectangularArea(const VTParameter ch, const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) = 0; // DECFRA
+    virtual bool EraseRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) = 0; // DECERA
 
     virtual bool SetGraphicsRendition(const VTParameters options) = 0; // SGR
     virtual bool SetLineRendition(const LineRendition rendition) = 0; // DECSWL, DECDWL, DECDHL

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -93,6 +93,7 @@ public:
     virtual bool SelectiveEraseInDisplay(const DispatchTypes::EraseType eraseType) = 0; // DECSED
     virtual bool SelectiveEraseInLine(const DispatchTypes::EraseType eraseType) = 0; // DECSEL
 
+    virtual bool CopyRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right, const VTInt page, const VTInt dstTop, const VTInt dstLeft, const VTInt dstPage) = 0; // DECCRA
     virtual bool FillRectangularArea(const VTParameter ch, const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) = 0; // DECFRA
     virtual bool EraseRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) = 0; // DECERA
     virtual bool SelectiveEraseRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) = 0; // DECSERA

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -94,6 +94,7 @@ public:
     virtual bool SelectiveEraseInLine(const DispatchTypes::EraseType eraseType) = 0; // DECSEL
 
     virtual bool ChangeAttributesRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right, const VTParameters attrs) = 0; // DECCARA
+    virtual bool ReverseAttributesRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right, const VTParameters attrs) = 0; // DECRARA
     virtual bool CopyRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right, const VTInt page, const VTInt dstTop, const VTInt dstLeft, const VTInt dstPage) = 0; // DECCRA
     virtual bool FillRectangularArea(const VTParameter ch, const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) = 0; // DECFRA
     virtual bool EraseRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) = 0; // DECERA

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -93,6 +93,7 @@ public:
     virtual bool SelectiveEraseInDisplay(const DispatchTypes::EraseType eraseType) = 0; // DECSED
     virtual bool SelectiveEraseInLine(const DispatchTypes::EraseType eraseType) = 0; // DECSEL
 
+    virtual bool ChangeAttributesRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right, const VTParameters attrs) = 0; // DECCARA
     virtual bool CopyRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right, const VTInt page, const VTInt dstTop, const VTInt dstLeft, const VTInt dstPage) = 0; // DECCRA
     virtual bool FillRectangularArea(const VTParameter ch, const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) = 0; // DECFRA
     virtual bool EraseRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) = 0; // DECERA

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -97,6 +97,7 @@ public:
     virtual bool FillRectangularArea(const VTParameter ch, const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) = 0; // DECFRA
     virtual bool EraseRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) = 0; // DECERA
     virtual bool SelectiveEraseRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) = 0; // DECSERA
+    virtual bool SelectAttributeChangeExtent(const DispatchTypes::ChangeExtent changeExtent) = 0; // DECSACE
 
     virtual bool SetGraphicsRendition(const VTParameters options) = 0; // SGR
     virtual bool SetLineRendition(const LineRendition rendition) = 0; // DECSWL, DECDWL, DECDHL

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -95,6 +95,7 @@ public:
 
     virtual bool FillRectangularArea(const VTParameter ch, const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) = 0; // DECFRA
     virtual bool EraseRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) = 0; // DECERA
+    virtual bool SelectiveEraseRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) = 0; // DECSERA
 
     virtual bool SetGraphicsRendition(const VTParameters options) = 0; // SGR
     virtual bool SetLineRendition(const LineRendition rendition) = 0; // DECSWL, DECDWL, DECDHL

--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -93,6 +93,8 @@ public:
     virtual bool SelectiveEraseInDisplay(const DispatchTypes::EraseType eraseType) = 0; // DECSED
     virtual bool SelectiveEraseInLine(const DispatchTypes::EraseType eraseType) = 0; // DECSEL
 
+    virtual bool FillRectangularArea(const VTParameter ch, const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) = 0; // DECFRA
+
     virtual bool SetGraphicsRendition(const VTParameters options) = 0; // SGR
     virtual bool SetLineRendition(const LineRendition rendition) = 0; // DECSWL, DECDWL, DECDHL
     virtual bool SetCharacterProtectionAttribute(const VTParameters options) = 0; // DECSCA

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -860,6 +860,26 @@ bool AdaptDispatch::FillRectangularArea(const VTParameter ch, const VTInt top, c
 }
 
 // Routine Description:
+// - DECERA - Erases a rectangular area, replacing all cells with a space
+//     character and the default rendition attributes.
+// Arguments:
+// - top - The first row of the area.
+// - left - The first column of the area.
+// - bottom - The last row of the area (inclusive).
+// - right - The last column of the area (inclusive).
+// Return Value:
+// - True.
+bool AdaptDispatch::EraseRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right)
+{
+    auto& textBuffer = _api.GetTextBuffer();
+    const auto eraseRect = _CalculateRectArea(top, left, bottom, right, textBuffer.GetSize().Dimensions());
+    auto eraseAttributes = textBuffer.GetCurrentAttributes();
+    eraseAttributes.SetStandardErase();
+    _FillRect(textBuffer, eraseRect, L' ', eraseAttributes);
+    return true;
+}
+
+// Routine Description:
 // - DECSWL/DECDWL/DECDHL - Sets the line rendition attribute for the current line.
 // Arguments:
 // - rendition - Determines whether the line will be rendered as single width, double

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -5,6 +5,7 @@
 
 #include "adaptDispatch.hpp"
 #include "../../renderer/base/renderer.hpp"
+#include "../../types/inc/GlyphWidth.hpp"
 #include "../../types/inc/Viewport.hpp"
 #include "../../types/inc/utils.hpp"
 #include "../../inc/unicode.hpp"
@@ -1064,7 +1065,7 @@ bool AdaptDispatch::CopyRectangularArea(const VTInt top, const VTInt left, const
 bool AdaptDispatch::FillRectangularArea(const VTParameter ch, const VTInt top, const VTInt left, const VTInt bottom, const VTInt right)
 {
     auto& textBuffer = _api.GetTextBuffer();
-    const auto fillRect = _CalculateRectArea(top, left, bottom, right, textBuffer.GetSize().Dimensions());
+    auto fillRect = _CalculateRectArea(top, left, bottom, right, textBuffer.GetSize().Dimensions());
 
     // The standard only allows for characters in the range of the GL and GR
     // character set tables, but we also support additional Unicode characters
@@ -1077,6 +1078,12 @@ bool AdaptDispatch::FillRectangularArea(const VTParameter ch, const VTInt top, c
     {
         const auto fillChar = _termOutput.TranslateKey(gsl::narrow_cast<wchar_t>(charValue));
         const auto fillAttributes = textBuffer.GetCurrentAttributes();
+        if (IsGlyphFullWidth(fillChar))
+        {
+            // If the fill char is full width, we need to halve the width of the
+            // fill area, otherwise it'll occupy twice as much space as expected.
+            fillRect.right = fillRect.left + fillRect.width() / 2;
+        }
         _FillRect(textBuffer, fillRect, fillChar, fillAttributes);
     }
 

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -970,7 +970,7 @@ bool AdaptDispatch::ReverseAttributesRectangularArea(const VTInt top, const VTIn
         {
             // A zero or default option is a special case that reverses all the
             // rendition bits. But note that this shouldn't be triggered by an
-            // empty attribute list, so we we explicitly exclude that case in
+            // empty attribute list, so we explicitly exclude that case in
             // the empty check above.
             if (attrs.at(i).value_or(0) == 0)
             {

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -880,6 +880,24 @@ bool AdaptDispatch::EraseRectangularArea(const VTInt top, const VTInt left, cons
 }
 
 // Routine Description:
+// - DECSERA - Selectively erases a rectangular area, replacing unprotected
+//     cells with a space character, but retaining the rendition attributes.
+// Arguments:
+// - top - The first row of the area.
+// - left - The first column of the area.
+// - bottom - The last row of the area (inclusive).
+// - right - The last column of the area (inclusive).
+// Return Value:
+// - True.
+bool AdaptDispatch::SelectiveEraseRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right)
+{
+    auto& textBuffer = _api.GetTextBuffer();
+    const auto eraseRect = _CalculateRectArea(top, left, bottom, right, textBuffer.GetSize().Dimensions());
+    _SelectiveEraseRect(textBuffer, eraseRect);
+    return true;
+}
+
+// Routine Description:
 // - DECSWL/DECDWL/DECDHL - Sets the line rendition attribute for the current line.
 // Arguments:
 // - rendition - Determines whether the line will be rendered as single width, double

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1070,7 +1070,7 @@ bool AdaptDispatch::FillRectangularArea(const VTParameter ch, const VTInt top, c
     // The standard only allows for characters in the range of the GL and GR
     // character set tables, but we also support additional Unicode characters
     // from the BMP if the code page is UTF-8. Default and 0 are treated as 32.
-    const auto charValue = !ch.has_value() || ch.value() == 0 ? 32 : ch.value();
+    const auto charValue = ch.value_or(0) == 0 ? 32 : ch.value();
     const auto glChar = (charValue >= 32 && charValue <= 126);
     const auto grChar = (charValue >= 160 && charValue <= 255);
     const auto unicodeChar = (charValue >= 256 && charValue <= 65535 && _api.GetConsoleOutputCP() == CP_UTF8);

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -56,6 +56,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool InsertCharacter(const VTInt count) override; // ICH
         bool DeleteCharacter(const VTInt count) override; // DCH
         bool FillRectangularArea(const VTParameter ch, const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) override; // DECFRA
+        bool EraseRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) override; // DECERA
         bool SetGraphicsRendition(const VTParameters options) override; // SGR
         bool SetLineRendition(const LineRendition rendition) override; // DECSWL, DECDWL, DECDHL
         bool SetCharacterProtectionAttribute(const VTParameters options) override; // DECSCA

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -188,7 +188,6 @@ namespace Microsoft::Console::VirtualTerminal
         struct ChangeOps
         {
             CharacterAttributes andAttrMask = CharacterAttributes::All;
-            CharacterAttributes orAttrMask = CharacterAttributes::Normal;
             CharacterAttributes xorAttrMask = CharacterAttributes::Normal;
             std::optional<TextColor> foreground;
             std::optional<TextColor> background;

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -56,6 +56,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool InsertCharacter(const VTInt count) override; // ICH
         bool DeleteCharacter(const VTInt count) override; // DCH
         bool ChangeAttributesRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right, const VTParameters attrs) override; // DECCARA
+        bool ReverseAttributesRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right, const VTParameters attrs) override; // DECRARA
         bool CopyRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right, const VTInt page, const VTInt dstTop, const VTInt dstLeft, const VTInt dstPage) override; // DECCRA
         bool FillRectangularArea(const VTParameter ch, const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) override; // DECFRA
         bool EraseRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) override; // DECERA

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -189,6 +189,8 @@ namespace Microsoft::Console::VirtualTerminal
         void _ApplyCursorMovementFlags(Cursor& cursor) noexcept;
         void _FillRect(TextBuffer& textBuffer, const til::rect& fillRect, const wchar_t fillChar, const TextAttribute fillAttrs);
         void _SelectiveEraseRect(TextBuffer& textBuffer, const til::rect& eraseRect);
+        void _ChangeRectAttributes(TextBuffer& textBuffer, const til::rect& changeRect, std::function<void(TextAttribute&)> changeOp);
+        void _ChangeRectOrStreamAttributes(const til::rect& changeArea, std::function<void(TextAttribute&)> changeOp);
         til::rect _CalculateRectArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right, const til::size bufferSize);
         void _EraseScrollback();
         void _EraseAll();
@@ -254,5 +256,10 @@ namespace Microsoft::Console::VirtualTerminal
         size_t _SetRgbColorsHelper(const VTParameters options,
                                    TextAttribute& attr,
                                    const bool isForeground) noexcept;
+        size_t _ApplyGraphicsOption(const VTParameters options,
+                                    const size_t optionIndex,
+                                    TextAttribute& attr) noexcept;
+        void _ApplyGraphicsOptions(const VTParameters options,
+                                   TextAttribute& attr) noexcept;
     };
 }

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -185,14 +185,22 @@ namespace Microsoft::Console::VirtualTerminal
             static constexpr Offset Backward(const VTInt value) { return { -value, false }; };
             static constexpr Offset Unchanged() { return Forward(0); };
         };
+        struct ChangeOps
+        {
+            CharacterAttributes andAttrMask = CharacterAttributes::All;
+            CharacterAttributes orAttrMask = CharacterAttributes::Normal;
+            CharacterAttributes xorAttrMask = CharacterAttributes::Normal;
+            std::optional<TextColor> foreground;
+            std::optional<TextColor> background;
+        };
 
         std::pair<int, int> _GetVerticalMargins(const til::rect& viewport, const bool absolute);
         bool _CursorMovePosition(const Offset rowOffset, const Offset colOffset, const bool clampInMargins);
         void _ApplyCursorMovementFlags(Cursor& cursor) noexcept;
         void _FillRect(TextBuffer& textBuffer, const til::rect& fillRect, const wchar_t fillChar, const TextAttribute fillAttrs);
         void _SelectiveEraseRect(TextBuffer& textBuffer, const til::rect& eraseRect);
-        void _ChangeRectAttributes(TextBuffer& textBuffer, const til::rect& changeRect, std::function<void(TextAttribute&)> changeOp);
-        void _ChangeRectOrStreamAttributes(const til::rect& changeArea, std::function<void(TextAttribute&)> changeOp);
+        void _ChangeRectAttributes(TextBuffer& textBuffer, const til::rect& changeRect, const ChangeOps& changeOps);
+        void _ChangeRectOrStreamAttributes(const til::rect& changeArea, const ChangeOps& changeOps);
         til::rect _CalculateRectArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right, const til::size bufferSize);
         void _EraseScrollback();
         void _EraseAll();

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -55,6 +55,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool SelectiveEraseInLine(const DispatchTypes::EraseType eraseType) override; // DECSEL
         bool InsertCharacter(const VTInt count) override; // ICH
         bool DeleteCharacter(const VTInt count) override; // DCH
+        bool ChangeAttributesRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right, const VTParameters attrs) override; // DECCARA
         bool CopyRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right, const VTInt page, const VTInt dstTop, const VTInt dstLeft, const VTInt dstPage) override; // DECCRA
         bool FillRectangularArea(const VTParameter ch, const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) override; // DECFRA
         bool EraseRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) override; // DECERA

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -55,6 +55,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool SelectiveEraseInLine(const DispatchTypes::EraseType eraseType) override; // DECSEL
         bool InsertCharacter(const VTInt count) override; // ICH
         bool DeleteCharacter(const VTInt count) override; // DCH
+        bool CopyRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right, const VTInt page, const VTInt dstTop, const VTInt dstLeft, const VTInt dstPage) override; // DECCRA
         bool FillRectangularArea(const VTParameter ch, const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) override; // DECFRA
         bool EraseRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) override; // DECERA
         bool SelectiveEraseRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) override; // DECSERA

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -59,6 +59,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool FillRectangularArea(const VTParameter ch, const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) override; // DECFRA
         bool EraseRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) override; // DECERA
         bool SelectiveEraseRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) override; // DECSERA
+        bool SelectAttributeChangeExtent(const DispatchTypes::ChangeExtent changeExtent) noexcept override; // DECSACE
         bool SetGraphicsRendition(const VTParameters options) override; // SGR
         bool SetLineRendition(const LineRendition rendition) override; // DECSWL, DECDWL, DECDHL
         bool SetCharacterProtectionAttribute(const VTParameters options) override; // DECSCA
@@ -218,6 +219,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _ReportSGRSetting() const;
         void _ReportDECSTBMSetting();
         void _ReportDECSCASetting() const;
+        void _ReportDECSACESetting() const;
 
         StringHandler _CreateDrcsPassthroughHandler(const DispatchTypes::DrcsCharsetSize charsetSize);
         StringHandler _CreatePassthroughHandler();
@@ -244,8 +246,8 @@ namespace Microsoft::Console::VirtualTerminal
         til::inclusive_rect _scrollMargins;
 
         bool _isOriginModeRelative;
-
         bool _isDECCOLMAllowed;
+        bool _isChangeExtentRectangular;
 
         SgrStack _sgrStack;
 

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -57,6 +57,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool DeleteCharacter(const VTInt count) override; // DCH
         bool FillRectangularArea(const VTParameter ch, const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) override; // DECFRA
         bool EraseRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) override; // DECERA
+        bool SelectiveEraseRectangularArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) override; // DECSERA
         bool SetGraphicsRendition(const VTParameters options) override; // SGR
         bool SetLineRendition(const LineRendition rendition) override; // DECSWL, DECDWL, DECDHL
         bool SetCharacterProtectionAttribute(const VTParameters options) override; // DECSCA

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -55,6 +55,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool SelectiveEraseInLine(const DispatchTypes::EraseType eraseType) override; // DECSEL
         bool InsertCharacter(const VTInt count) override; // ICH
         bool DeleteCharacter(const VTInt count) override; // DCH
+        bool FillRectangularArea(const VTParameter ch, const VTInt top, const VTInt left, const VTInt bottom, const VTInt right) override; // DECFRA
         bool SetGraphicsRendition(const VTParameters options) override; // SGR
         bool SetLineRendition(const LineRendition rendition) override; // DECSWL, DECDWL, DECDHL
         bool SetCharacterProtectionAttribute(const VTParameters options) override; // DECSCA
@@ -184,6 +185,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _ApplyCursorMovementFlags(Cursor& cursor) noexcept;
         void _FillRect(TextBuffer& textBuffer, const til::rect& fillRect, const wchar_t fillChar, const TextAttribute fillAttrs);
         void _SelectiveEraseRect(TextBuffer& textBuffer, const til::rect& eraseRect);
+        til::rect _CalculateRectArea(const VTInt top, const VTInt left, const VTInt bottom, const VTInt right, const til::size bufferSize);
         void _EraseScrollback();
         void _EraseAll();
         void _ScrollRectVertically(TextBuffer& textBuffer, const til::rect& scrollRect, const VTInt delta);

--- a/src/terminal/adapter/adaptDispatchGraphics.cpp
+++ b/src/terminal/adapter/adaptDispatchGraphics.cpp
@@ -63,6 +63,210 @@ size_t AdaptDispatch::_SetRgbColorsHelper(const VTParameters options,
 }
 
 // Routine Description:
+// - Helper to apply a single graphic rendition option to an attribute.
+// Arguments:
+// - options - An array of options.
+// - optionIndex - The start index of the option that will be applied.
+// - attr - The attribute that will be updated with the applied option.
+// Return Value:
+// - The number of entries in the array that were consumed.
+size_t AdaptDispatch::_ApplyGraphicsOption(const VTParameters options,
+                                           const size_t optionIndex,
+                                           TextAttribute& attr) noexcept
+{
+    const GraphicsOptions opt = options.at(optionIndex);
+    switch (opt)
+    {
+    case Off:
+        attr.SetDefaultForeground();
+        attr.SetDefaultBackground();
+        attr.SetDefaultRenditionAttributes();
+        return 1;
+    case ForegroundDefault:
+        attr.SetDefaultForeground();
+        return 1;
+    case BackgroundDefault:
+        attr.SetDefaultBackground();
+        return 1;
+    case Intense:
+        attr.SetIntense(true);
+        return 1;
+    case RGBColorOrFaint:
+        attr.SetFaint(true);
+        return 1;
+    case NotIntenseOrFaint:
+        attr.SetIntense(false);
+        attr.SetFaint(false);
+        return 1;
+    case Italics:
+        attr.SetItalic(true);
+        return 1;
+    case NotItalics:
+        attr.SetItalic(false);
+        return 1;
+    case BlinkOrXterm256Index:
+    case RapidBlink: // We just interpret rapid blink as an alias of blink.
+        attr.SetBlinking(true);
+        return 1;
+    case Steady:
+        attr.SetBlinking(false);
+        return 1;
+    case Invisible:
+        attr.SetInvisible(true);
+        return 1;
+    case Visible:
+        attr.SetInvisible(false);
+        return 1;
+    case CrossedOut:
+        attr.SetCrossedOut(true);
+        return 1;
+    case NotCrossedOut:
+        attr.SetCrossedOut(false);
+        return 1;
+    case Negative:
+        attr.SetReverseVideo(true);
+        return 1;
+    case Positive:
+        attr.SetReverseVideo(false);
+        return 1;
+    case Underline:
+        attr.SetUnderlined(true);
+        return 1;
+    case DoublyUnderlined:
+        attr.SetDoublyUnderlined(true);
+        return 1;
+    case NoUnderline:
+        attr.SetUnderlined(false);
+        attr.SetDoublyUnderlined(false);
+        return 1;
+    case Overline:
+        attr.SetOverlined(true);
+        return 1;
+    case NoOverline:
+        attr.SetOverlined(false);
+        return 1;
+    case ForegroundBlack:
+        attr.SetIndexedForeground(TextColor::DARK_BLACK);
+        return 1;
+    case ForegroundBlue:
+        attr.SetIndexedForeground(TextColor::DARK_BLUE);
+        return 1;
+    case ForegroundGreen:
+        attr.SetIndexedForeground(TextColor::DARK_GREEN);
+        return 1;
+    case ForegroundCyan:
+        attr.SetIndexedForeground(TextColor::DARK_CYAN);
+        return 1;
+    case ForegroundRed:
+        attr.SetIndexedForeground(TextColor::DARK_RED);
+        return 1;
+    case ForegroundMagenta:
+        attr.SetIndexedForeground(TextColor::DARK_MAGENTA);
+        return 1;
+    case ForegroundYellow:
+        attr.SetIndexedForeground(TextColor::DARK_YELLOW);
+        return 1;
+    case ForegroundWhite:
+        attr.SetIndexedForeground(TextColor::DARK_WHITE);
+        return 1;
+    case BackgroundBlack:
+        attr.SetIndexedBackground(TextColor::DARK_BLACK);
+        return 1;
+    case BackgroundBlue:
+        attr.SetIndexedBackground(TextColor::DARK_BLUE);
+        return 1;
+    case BackgroundGreen:
+        attr.SetIndexedBackground(TextColor::DARK_GREEN);
+        return 1;
+    case BackgroundCyan:
+        attr.SetIndexedBackground(TextColor::DARK_CYAN);
+        return 1;
+    case BackgroundRed:
+        attr.SetIndexedBackground(TextColor::DARK_RED);
+        return 1;
+    case BackgroundMagenta:
+        attr.SetIndexedBackground(TextColor::DARK_MAGENTA);
+        return 1;
+    case BackgroundYellow:
+        attr.SetIndexedBackground(TextColor::DARK_YELLOW);
+        return 1;
+    case BackgroundWhite:
+        attr.SetIndexedBackground(TextColor::DARK_WHITE);
+        return 1;
+    case BrightForegroundBlack:
+        attr.SetIndexedForeground(TextColor::BRIGHT_BLACK);
+        return 1;
+    case BrightForegroundBlue:
+        attr.SetIndexedForeground(TextColor::BRIGHT_BLUE);
+        return 1;
+    case BrightForegroundGreen:
+        attr.SetIndexedForeground(TextColor::BRIGHT_GREEN);
+        return 1;
+    case BrightForegroundCyan:
+        attr.SetIndexedForeground(TextColor::BRIGHT_CYAN);
+        return 1;
+    case BrightForegroundRed:
+        attr.SetIndexedForeground(TextColor::BRIGHT_RED);
+        return 1;
+    case BrightForegroundMagenta:
+        attr.SetIndexedForeground(TextColor::BRIGHT_MAGENTA);
+        return 1;
+    case BrightForegroundYellow:
+        attr.SetIndexedForeground(TextColor::BRIGHT_YELLOW);
+        return 1;
+    case BrightForegroundWhite:
+        attr.SetIndexedForeground(TextColor::BRIGHT_WHITE);
+        return 1;
+    case BrightBackgroundBlack:
+        attr.SetIndexedBackground(TextColor::BRIGHT_BLACK);
+        return 1;
+    case BrightBackgroundBlue:
+        attr.SetIndexedBackground(TextColor::BRIGHT_BLUE);
+        return 1;
+    case BrightBackgroundGreen:
+        attr.SetIndexedBackground(TextColor::BRIGHT_GREEN);
+        return 1;
+    case BrightBackgroundCyan:
+        attr.SetIndexedBackground(TextColor::BRIGHT_CYAN);
+        return 1;
+    case BrightBackgroundRed:
+        attr.SetIndexedBackground(TextColor::BRIGHT_RED);
+        return 1;
+    case BrightBackgroundMagenta:
+        attr.SetIndexedBackground(TextColor::BRIGHT_MAGENTA);
+        return 1;
+    case BrightBackgroundYellow:
+        attr.SetIndexedBackground(TextColor::BRIGHT_YELLOW);
+        return 1;
+    case BrightBackgroundWhite:
+        attr.SetIndexedBackground(TextColor::BRIGHT_WHITE);
+        return 1;
+    case ForegroundExtended:
+        return 1 + _SetRgbColorsHelper(options.subspan(optionIndex + 1), attr, true);
+    case BackgroundExtended:
+        return 1 + _SetRgbColorsHelper(options.subspan(optionIndex + 1), attr, false);
+    default:
+        return 1;
+    }
+}
+
+// Routine Description:
+// - Helper to apply a number of graphic rendition options to an attribute.
+// Arguments:
+// - options - An array of options that will be applied in sequence.
+// - attr - The attribute that will be updated with the applied options.
+// Return Value:
+// - <none>
+void AdaptDispatch::_ApplyGraphicsOptions(const VTParameters options,
+                                          TextAttribute& attr) noexcept
+{
+    for (size_t i = 0; i < options.size();)
+    {
+        i += _ApplyGraphicsOption(options, i, attr);
+    }
+}
+
+// Routine Description:
 // - SGR - Modifies the graphical rendering options applied to the next
 //   characters written into the buffer.
 //       - Options include colors, invert, underlines, and other "font style"
@@ -75,187 +279,8 @@ size_t AdaptDispatch::_SetRgbColorsHelper(const VTParameters options,
 bool AdaptDispatch::SetGraphicsRendition(const VTParameters options)
 {
     auto attr = _api.GetTextBuffer().GetCurrentAttributes();
-
-    // Run through the graphics options and apply them
-    for (size_t i = 0; i < options.size(); i++)
-    {
-        const GraphicsOptions opt = options.at(i);
-        switch (opt)
-        {
-        case Off:
-            attr.SetDefaultForeground();
-            attr.SetDefaultBackground();
-            attr.SetDefaultRenditionAttributes();
-            break;
-        case ForegroundDefault:
-            attr.SetDefaultForeground();
-            break;
-        case BackgroundDefault:
-            attr.SetDefaultBackground();
-            break;
-        case Intense:
-            attr.SetIntense(true);
-            break;
-        case RGBColorOrFaint:
-            attr.SetFaint(true);
-            break;
-        case NotIntenseOrFaint:
-            attr.SetIntense(false);
-            attr.SetFaint(false);
-            break;
-        case Italics:
-            attr.SetItalic(true);
-            break;
-        case NotItalics:
-            attr.SetItalic(false);
-            break;
-        case BlinkOrXterm256Index:
-        case RapidBlink: // We just interpret rapid blink as an alias of blink.
-            attr.SetBlinking(true);
-            break;
-        case Steady:
-            attr.SetBlinking(false);
-            break;
-        case Invisible:
-            attr.SetInvisible(true);
-            break;
-        case Visible:
-            attr.SetInvisible(false);
-            break;
-        case CrossedOut:
-            attr.SetCrossedOut(true);
-            break;
-        case NotCrossedOut:
-            attr.SetCrossedOut(false);
-            break;
-        case Negative:
-            attr.SetReverseVideo(true);
-            break;
-        case Positive:
-            attr.SetReverseVideo(false);
-            break;
-        case Underline:
-            attr.SetUnderlined(true);
-            break;
-        case DoublyUnderlined:
-            attr.SetDoublyUnderlined(true);
-            break;
-        case NoUnderline:
-            attr.SetUnderlined(false);
-            attr.SetDoublyUnderlined(false);
-            break;
-        case Overline:
-            attr.SetOverlined(true);
-            break;
-        case NoOverline:
-            attr.SetOverlined(false);
-            break;
-        case ForegroundBlack:
-            attr.SetIndexedForeground(TextColor::DARK_BLACK);
-            break;
-        case ForegroundBlue:
-            attr.SetIndexedForeground(TextColor::DARK_BLUE);
-            break;
-        case ForegroundGreen:
-            attr.SetIndexedForeground(TextColor::DARK_GREEN);
-            break;
-        case ForegroundCyan:
-            attr.SetIndexedForeground(TextColor::DARK_CYAN);
-            break;
-        case ForegroundRed:
-            attr.SetIndexedForeground(TextColor::DARK_RED);
-            break;
-        case ForegroundMagenta:
-            attr.SetIndexedForeground(TextColor::DARK_MAGENTA);
-            break;
-        case ForegroundYellow:
-            attr.SetIndexedForeground(TextColor::DARK_YELLOW);
-            break;
-        case ForegroundWhite:
-            attr.SetIndexedForeground(TextColor::DARK_WHITE);
-            break;
-        case BackgroundBlack:
-            attr.SetIndexedBackground(TextColor::DARK_BLACK);
-            break;
-        case BackgroundBlue:
-            attr.SetIndexedBackground(TextColor::DARK_BLUE);
-            break;
-        case BackgroundGreen:
-            attr.SetIndexedBackground(TextColor::DARK_GREEN);
-            break;
-        case BackgroundCyan:
-            attr.SetIndexedBackground(TextColor::DARK_CYAN);
-            break;
-        case BackgroundRed:
-            attr.SetIndexedBackground(TextColor::DARK_RED);
-            break;
-        case BackgroundMagenta:
-            attr.SetIndexedBackground(TextColor::DARK_MAGENTA);
-            break;
-        case BackgroundYellow:
-            attr.SetIndexedBackground(TextColor::DARK_YELLOW);
-            break;
-        case BackgroundWhite:
-            attr.SetIndexedBackground(TextColor::DARK_WHITE);
-            break;
-        case BrightForegroundBlack:
-            attr.SetIndexedForeground(TextColor::BRIGHT_BLACK);
-            break;
-        case BrightForegroundBlue:
-            attr.SetIndexedForeground(TextColor::BRIGHT_BLUE);
-            break;
-        case BrightForegroundGreen:
-            attr.SetIndexedForeground(TextColor::BRIGHT_GREEN);
-            break;
-        case BrightForegroundCyan:
-            attr.SetIndexedForeground(TextColor::BRIGHT_CYAN);
-            break;
-        case BrightForegroundRed:
-            attr.SetIndexedForeground(TextColor::BRIGHT_RED);
-            break;
-        case BrightForegroundMagenta:
-            attr.SetIndexedForeground(TextColor::BRIGHT_MAGENTA);
-            break;
-        case BrightForegroundYellow:
-            attr.SetIndexedForeground(TextColor::BRIGHT_YELLOW);
-            break;
-        case BrightForegroundWhite:
-            attr.SetIndexedForeground(TextColor::BRIGHT_WHITE);
-            break;
-        case BrightBackgroundBlack:
-            attr.SetIndexedBackground(TextColor::BRIGHT_BLACK);
-            break;
-        case BrightBackgroundBlue:
-            attr.SetIndexedBackground(TextColor::BRIGHT_BLUE);
-            break;
-        case BrightBackgroundGreen:
-            attr.SetIndexedBackground(TextColor::BRIGHT_GREEN);
-            break;
-        case BrightBackgroundCyan:
-            attr.SetIndexedBackground(TextColor::BRIGHT_CYAN);
-            break;
-        case BrightBackgroundRed:
-            attr.SetIndexedBackground(TextColor::BRIGHT_RED);
-            break;
-        case BrightBackgroundMagenta:
-            attr.SetIndexedBackground(TextColor::BRIGHT_MAGENTA);
-            break;
-        case BrightBackgroundYellow:
-            attr.SetIndexedBackground(TextColor::BRIGHT_YELLOW);
-            break;
-        case BrightBackgroundWhite:
-            attr.SetIndexedBackground(TextColor::BRIGHT_WHITE);
-            break;
-        case ForegroundExtended:
-            i += _SetRgbColorsHelper(options.subspan(i + 1), attr, true);
-            break;
-        case BackgroundExtended:
-            i += _SetRgbColorsHelper(options.subspan(i + 1), attr, false);
-            break;
-        }
-    }
+    _ApplyGraphicsOptions(options, attr);
     _api.SetTextAttributes(attr);
-
     return true;
 }
 

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -86,6 +86,7 @@ public:
     bool SelectiveEraseInDisplay(const DispatchTypes::EraseType /*eraseType*/) override { return false; } // DECSED
     bool SelectiveEraseInLine(const DispatchTypes::EraseType /*eraseType*/) override { return false; } // DECSEL
 
+    bool CopyRectangularArea(const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/, const VTInt /*page*/, const VTInt /*dstTop*/, const VTInt /*dstLeft*/, const VTInt /*dstPage*/) override { return false; } // DECCRA
     bool FillRectangularArea(const VTParameter /*ch*/, const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/) override { return false; } // DECFRA
     bool EraseRectangularArea(const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/) override { return false; } // DECERA
     bool SelectiveEraseRectangularArea(const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/) override { return false; } // DECSERA

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -86,6 +86,8 @@ public:
     bool SelectiveEraseInDisplay(const DispatchTypes::EraseType /*eraseType*/) override { return false; } // DECSED
     bool SelectiveEraseInLine(const DispatchTypes::EraseType /*eraseType*/) override { return false; } // DECSEL
 
+    bool FillRectangularArea(const VTParameter /*ch*/, const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/) override { return false; } // DECFRA
+
     bool SetGraphicsRendition(const VTParameters /*options*/) override { return false; } // SGR
     bool SetLineRendition(const LineRendition /*rendition*/) override { return false; } // DECSWL, DECDWL, DECDHL
     bool SetCharacterProtectionAttribute(const VTParameters /*options*/) override { return false; } // DECSCA

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -87,6 +87,7 @@ public:
     bool SelectiveEraseInLine(const DispatchTypes::EraseType /*eraseType*/) override { return false; } // DECSEL
 
     bool ChangeAttributesRectangularArea(const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/, const VTParameters /*attrs*/) override { return false; } // DECCARA
+    bool ReverseAttributesRectangularArea(const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/, const VTParameters /*attrs*/) override { return false; } // DECRARA
     bool CopyRectangularArea(const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/, const VTInt /*page*/, const VTInt /*dstTop*/, const VTInt /*dstLeft*/, const VTInt /*dstPage*/) override { return false; } // DECCRA
     bool FillRectangularArea(const VTParameter /*ch*/, const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/) override { return false; } // DECFRA
     bool EraseRectangularArea(const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/) override { return false; } // DECERA

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -86,6 +86,7 @@ public:
     bool SelectiveEraseInDisplay(const DispatchTypes::EraseType /*eraseType*/) override { return false; } // DECSED
     bool SelectiveEraseInLine(const DispatchTypes::EraseType /*eraseType*/) override { return false; } // DECSEL
 
+    bool ChangeAttributesRectangularArea(const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/, const VTParameters /*attrs*/) override { return false; } // DECCARA
     bool CopyRectangularArea(const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/, const VTInt /*page*/, const VTInt /*dstTop*/, const VTInt /*dstLeft*/, const VTInt /*dstPage*/) override { return false; } // DECCRA
     bool FillRectangularArea(const VTParameter /*ch*/, const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/) override { return false; } // DECFRA
     bool EraseRectangularArea(const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/) override { return false; } // DECERA

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -90,6 +90,7 @@ public:
     bool FillRectangularArea(const VTParameter /*ch*/, const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/) override { return false; } // DECFRA
     bool EraseRectangularArea(const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/) override { return false; } // DECERA
     bool SelectiveEraseRectangularArea(const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/) override { return false; } // DECSERA
+    bool SelectAttributeChangeExtent(const DispatchTypes::ChangeExtent /*changeExtent*/) override { return false; } // DECSACE
 
     bool SetGraphicsRendition(const VTParameters /*options*/) override { return false; } // SGR
     bool SetLineRendition(const LineRendition /*rendition*/) override { return false; } // DECSWL, DECDWL, DECDHL

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -87,6 +87,7 @@ public:
     bool SelectiveEraseInLine(const DispatchTypes::EraseType /*eraseType*/) override { return false; } // DECSEL
 
     bool FillRectangularArea(const VTParameter /*ch*/, const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/) override { return false; } // DECFRA
+    bool EraseRectangularArea(const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/) override { return false; } // DECERA
 
     bool SetGraphicsRendition(const VTParameters /*options*/) override { return false; } // SGR
     bool SetLineRendition(const LineRendition /*rendition*/) override { return false; } // DECSWL, DECDWL, DECDHL

--- a/src/terminal/adapter/termDispatch.hpp
+++ b/src/terminal/adapter/termDispatch.hpp
@@ -88,6 +88,7 @@ public:
 
     bool FillRectangularArea(const VTParameter /*ch*/, const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/) override { return false; } // DECFRA
     bool EraseRectangularArea(const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/) override { return false; } // DECERA
+    bool SelectiveEraseRectangularArea(const VTInt /*top*/, const VTInt /*left*/, const VTInt /*bottom*/, const VTInt /*right*/) override { return false; } // DECSERA
 
     bool SetGraphicsRendition(const VTParameters /*options*/) override { return false; } // SGR
     bool SetLineRendition(const LineRendition /*rendition*/) override { return false; } // DECSWL, DECDWL, DECDHL

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -636,6 +636,10 @@ bool OutputStateMachineEngine::ActionCsiDispatch(const VTID id, const VTParamete
         success = _dispatch->ChangeAttributesRectangularArea(parameters.at(0), parameters.at(1), parameters.at(2).value_or(0), parameters.at(3).value_or(0), parameters.subspan(4));
         TermTelemetry::Instance().Log(TermTelemetry::Codes::DECCARA);
         break;
+    case CsiActionCodes::DECRARA_ReverseAttributesRectangularArea:
+        success = _dispatch->ReverseAttributesRectangularArea(parameters.at(0), parameters.at(1), parameters.at(2).value_or(0), parameters.at(3).value_or(0), parameters.subspan(4));
+        TermTelemetry::Instance().Log(TermTelemetry::Codes::DECRARA);
+        break;
     case CsiActionCodes::DECCRA_CopyRectangularArea:
         success = _dispatch->CopyRectangularArea(parameters.at(0), parameters.at(1), parameters.at(2).value_or(0), parameters.at(3).value_or(0), parameters.at(4), parameters.at(5), parameters.at(6), parameters.at(7));
         TermTelemetry::Instance().Log(TermTelemetry::Codes::DECCRA);

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -640,6 +640,10 @@ bool OutputStateMachineEngine::ActionCsiDispatch(const VTID id, const VTParamete
         success = _dispatch->EraseRectangularArea(parameters.at(0), parameters.at(1), parameters.at(2).value_or(0), parameters.at(3).value_or(0));
         TermTelemetry::Instance().Log(TermTelemetry::Codes::DECERA);
         break;
+    case CsiActionCodes::DECSERA_SelectiveEraseRectangularArea:
+        success = _dispatch->SelectiveEraseRectangularArea(parameters.at(0), parameters.at(1), parameters.at(2).value_or(0), parameters.at(3).value_or(0));
+        TermTelemetry::Instance().Log(TermTelemetry::Codes::DECSERA);
+        break;
     case CsiActionCodes::DECAC_AssignColor:
         success = _dispatch->AssignColor(parameters.at(0), parameters.at(1).value_or(0), parameters.at(2).value_or(0));
         TermTelemetry::Instance().Log(TermTelemetry::Codes::DECAC);

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -632,6 +632,10 @@ bool OutputStateMachineEngine::ActionCsiDispatch(const VTID id, const VTParamete
         success = _dispatch->PopGraphicsRendition();
         TermTelemetry::Instance().Log(TermTelemetry::Codes::XTPOPSGR);
         break;
+    case CsiActionCodes::DECFRA_FillRectangularArea:
+        success = _dispatch->FillRectangularArea(parameters.at(0), parameters.at(1), parameters.at(2), parameters.at(3).value_or(0), parameters.at(4).value_or(0));
+        TermTelemetry::Instance().Log(TermTelemetry::Codes::DECFRA);
+        break;
     case CsiActionCodes::DECAC_AssignColor:
         success = _dispatch->AssignColor(parameters.at(0), parameters.at(1).value_or(0), parameters.at(2).value_or(0));
         TermTelemetry::Instance().Log(TermTelemetry::Codes::DECAC);

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -632,6 +632,10 @@ bool OutputStateMachineEngine::ActionCsiDispatch(const VTID id, const VTParamete
         success = _dispatch->PopGraphicsRendition();
         TermTelemetry::Instance().Log(TermTelemetry::Codes::XTPOPSGR);
         break;
+    case CsiActionCodes::DECCARA_ChangeAttributesRectangularArea:
+        success = _dispatch->ChangeAttributesRectangularArea(parameters.at(0), parameters.at(1), parameters.at(2).value_or(0), parameters.at(3).value_or(0), parameters.subspan(4));
+        TermTelemetry::Instance().Log(TermTelemetry::Codes::DECCARA);
+        break;
     case CsiActionCodes::DECCRA_CopyRectangularArea:
         success = _dispatch->CopyRectangularArea(parameters.at(0), parameters.at(1), parameters.at(2).value_or(0), parameters.at(3).value_or(0), parameters.at(4), parameters.at(5), parameters.at(6), parameters.at(7));
         TermTelemetry::Instance().Log(TermTelemetry::Codes::DECCRA);

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -632,6 +632,10 @@ bool OutputStateMachineEngine::ActionCsiDispatch(const VTID id, const VTParamete
         success = _dispatch->PopGraphicsRendition();
         TermTelemetry::Instance().Log(TermTelemetry::Codes::XTPOPSGR);
         break;
+    case CsiActionCodes::DECCRA_CopyRectangularArea:
+        success = _dispatch->CopyRectangularArea(parameters.at(0), parameters.at(1), parameters.at(2).value_or(0), parameters.at(3).value_or(0), parameters.at(4), parameters.at(5), parameters.at(6), parameters.at(7));
+        TermTelemetry::Instance().Log(TermTelemetry::Codes::DECCRA);
+        break;
     case CsiActionCodes::DECFRA_FillRectangularArea:
         success = _dispatch->FillRectangularArea(parameters.at(0), parameters.at(1), parameters.at(2), parameters.at(3).value_or(0), parameters.at(4).value_or(0));
         TermTelemetry::Instance().Log(TermTelemetry::Codes::DECFRA);

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -636,6 +636,10 @@ bool OutputStateMachineEngine::ActionCsiDispatch(const VTID id, const VTParamete
         success = _dispatch->FillRectangularArea(parameters.at(0), parameters.at(1), parameters.at(2), parameters.at(3).value_or(0), parameters.at(4).value_or(0));
         TermTelemetry::Instance().Log(TermTelemetry::Codes::DECFRA);
         break;
+    case CsiActionCodes::DECERA_EraseRectangularArea:
+        success = _dispatch->EraseRectangularArea(parameters.at(0), parameters.at(1), parameters.at(2).value_or(0), parameters.at(3).value_or(0));
+        TermTelemetry::Instance().Log(TermTelemetry::Codes::DECERA);
+        break;
     case CsiActionCodes::DECAC_AssignColor:
         success = _dispatch->AssignColor(parameters.at(0), parameters.at(1).value_or(0), parameters.at(2).value_or(0));
         TermTelemetry::Instance().Log(TermTelemetry::Codes::DECAC);

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -648,6 +648,10 @@ bool OutputStateMachineEngine::ActionCsiDispatch(const VTID id, const VTParamete
         success = _dispatch->SelectiveEraseRectangularArea(parameters.at(0), parameters.at(1), parameters.at(2).value_or(0), parameters.at(3).value_or(0));
         TermTelemetry::Instance().Log(TermTelemetry::Codes::DECSERA);
         break;
+    case CsiActionCodes::DECSACE_SelectAttributeChangeExtent:
+        success = _dispatch->SelectAttributeChangeExtent(parameters.at(0));
+        TermTelemetry::Instance().Log(TermTelemetry::Codes::DECSACE);
+        break;
     case CsiActionCodes::DECAC_AssignColor:
         success = _dispatch->AssignColor(parameters.at(0), parameters.at(1).value_or(0), parameters.at(2).value_or(0));
         TermTelemetry::Instance().Log(TermTelemetry::Codes::DECAC);

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -151,6 +151,7 @@ namespace Microsoft::Console::VirtualTerminal
             DECERA_EraseRectangularArea = VTID("$z"),
             DECSERA_SelectiveEraseRectangularArea = VTID("${"),
             DECSCPP_SetColumnsPerPage = VTID("$|"),
+            DECSACE_SelectAttributeChangeExtent = VTID("*x"),
             DECAC_AssignColor = VTID(",|"),
             DECPS_PlaySound = VTID(",~")
         };

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -147,6 +147,7 @@ namespace Microsoft::Console::VirtualTerminal
             XT_PushSgr = VTID("#{"),
             XT_PopSgr = VTID("#}"),
             DECCARA_ChangeAttributesRectangularArea = VTID("$r"),
+            DECRARA_ReverseAttributesRectangularArea = VTID("$t"),
             DECCRA_CopyRectangularArea = VTID("$v"),
             DECFRA_FillRectangularArea = VTID("$x"),
             DECERA_EraseRectangularArea = VTID("$z"),

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -146,6 +146,7 @@ namespace Microsoft::Console::VirtualTerminal
             XT_PopSgrAlias = VTID("#q"),
             XT_PushSgr = VTID("#{"),
             XT_PopSgr = VTID("#}"),
+            DECCRA_CopyRectangularArea = VTID("$v"),
             DECFRA_FillRectangularArea = VTID("$x"),
             DECERA_EraseRectangularArea = VTID("$z"),
             DECSERA_SelectiveEraseRectangularArea = VTID("${"),

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -146,6 +146,7 @@ namespace Microsoft::Console::VirtualTerminal
             XT_PopSgrAlias = VTID("#q"),
             XT_PushSgr = VTID("#{"),
             XT_PopSgr = VTID("#}"),
+            DECCARA_ChangeAttributesRectangularArea = VTID("$r"),
             DECCRA_CopyRectangularArea = VTID("$v"),
             DECFRA_FillRectangularArea = VTID("$x"),
             DECERA_EraseRectangularArea = VTID("$z"),

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -148,6 +148,7 @@ namespace Microsoft::Console::VirtualTerminal
             XT_PopSgr = VTID("#}"),
             DECFRA_FillRectangularArea = VTID("$x"),
             DECERA_EraseRectangularArea = VTID("$z"),
+            DECSERA_SelectiveEraseRectangularArea = VTID("${"),
             DECSCPP_SetColumnsPerPage = VTID("$|"),
             DECAC_AssignColor = VTID(",|"),
             DECPS_PlaySound = VTID(",~")

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -146,6 +146,7 @@ namespace Microsoft::Console::VirtualTerminal
             XT_PopSgrAlias = VTID("#q"),
             XT_PushSgr = VTID("#{"),
             XT_PopSgr = VTID("#}"),
+            DECFRA_FillRectangularArea = VTID("$x"),
             DECSCPP_SetColumnsPerPage = VTID("$|"),
             DECAC_AssignColor = VTID(",|"),
             DECPS_PlaySound = VTID(",~")

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -147,6 +147,7 @@ namespace Microsoft::Console::VirtualTerminal
             XT_PushSgr = VTID("#{"),
             XT_PopSgr = VTID("#}"),
             DECFRA_FillRectangularArea = VTID("$x"),
+            DECERA_EraseRectangularArea = VTID("$z"),
             DECSCPP_SetColumnsPerPage = VTID("$|"),
             DECAC_AssignColor = VTID(",|"),
             DECPS_PlaySound = VTID(",~")

--- a/src/terminal/parser/telemetry.cpp
+++ b/src/terminal/parser/telemetry.cpp
@@ -284,6 +284,7 @@ void TermTelemetry::WriteFinalTraceLog() const
                                       TraceLoggingUInt32(_uiTimesUsed[XTPUSHSGR], "XTPUSHSGR"),
                                       TraceLoggingUInt32(_uiTimesUsed[XTPOPSGR], "XTPOPSGR"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECCARA], "DECCARA"),
+                                      TraceLoggingUInt32(_uiTimesUsed[DECRARA], "DECRARA"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECCRA], "DECCRA"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECFRA], "DECFRA"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECERA], "DECERA"),

--- a/src/terminal/parser/telemetry.cpp
+++ b/src/terminal/parser/telemetry.cpp
@@ -287,6 +287,7 @@ void TermTelemetry::WriteFinalTraceLog() const
                                       TraceLoggingUInt32(_uiTimesUsed[DECFRA], "DECFRA"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECERA], "DECERA"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECSERA], "DECSERA"),
+                                      TraceLoggingUInt32(_uiTimesUsed[DECSACE], "DECSACE"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECAC], "DECAC"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECPS], "DECPS"),
                                       TraceLoggingUInt32Array(_uiTimesFailed, ARRAYSIZE(_uiTimesFailed), "Failed"),

--- a/src/terminal/parser/telemetry.cpp
+++ b/src/terminal/parser/telemetry.cpp
@@ -283,6 +283,7 @@ void TermTelemetry::WriteFinalTraceLog() const
                                       TraceLoggingUInt32(_uiTimesUsed[DECALN], "DECALN"),
                                       TraceLoggingUInt32(_uiTimesUsed[XTPUSHSGR], "XTPUSHSGR"),
                                       TraceLoggingUInt32(_uiTimesUsed[XTPOPSGR], "XTPOPSGR"),
+                                      TraceLoggingUInt32(_uiTimesUsed[DECFRA], "DECFRA"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECAC], "DECAC"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECPS], "DECPS"),
                                       TraceLoggingUInt32Array(_uiTimesFailed, ARRAYSIZE(_uiTimesFailed), "Failed"),

--- a/src/terminal/parser/telemetry.cpp
+++ b/src/terminal/parser/telemetry.cpp
@@ -285,6 +285,7 @@ void TermTelemetry::WriteFinalTraceLog() const
                                       TraceLoggingUInt32(_uiTimesUsed[XTPOPSGR], "XTPOPSGR"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECFRA], "DECFRA"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECERA], "DECERA"),
+                                      TraceLoggingUInt32(_uiTimesUsed[DECSERA], "DECSERA"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECAC], "DECAC"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECPS], "DECPS"),
                                       TraceLoggingUInt32Array(_uiTimesFailed, ARRAYSIZE(_uiTimesFailed), "Failed"),

--- a/src/terminal/parser/telemetry.cpp
+++ b/src/terminal/parser/telemetry.cpp
@@ -283,6 +283,7 @@ void TermTelemetry::WriteFinalTraceLog() const
                                       TraceLoggingUInt32(_uiTimesUsed[DECALN], "DECALN"),
                                       TraceLoggingUInt32(_uiTimesUsed[XTPUSHSGR], "XTPUSHSGR"),
                                       TraceLoggingUInt32(_uiTimesUsed[XTPOPSGR], "XTPOPSGR"),
+                                      TraceLoggingUInt32(_uiTimesUsed[DECCARA], "DECCARA"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECCRA], "DECCRA"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECFRA], "DECFRA"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECERA], "DECERA"),

--- a/src/terminal/parser/telemetry.cpp
+++ b/src/terminal/parser/telemetry.cpp
@@ -283,6 +283,7 @@ void TermTelemetry::WriteFinalTraceLog() const
                                       TraceLoggingUInt32(_uiTimesUsed[DECALN], "DECALN"),
                                       TraceLoggingUInt32(_uiTimesUsed[XTPUSHSGR], "XTPUSHSGR"),
                                       TraceLoggingUInt32(_uiTimesUsed[XTPOPSGR], "XTPOPSGR"),
+                                      TraceLoggingUInt32(_uiTimesUsed[DECCRA], "DECCRA"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECFRA], "DECFRA"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECERA], "DECERA"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECSERA], "DECSERA"),

--- a/src/terminal/parser/telemetry.cpp
+++ b/src/terminal/parser/telemetry.cpp
@@ -284,6 +284,7 @@ void TermTelemetry::WriteFinalTraceLog() const
                                       TraceLoggingUInt32(_uiTimesUsed[XTPUSHSGR], "XTPUSHSGR"),
                                       TraceLoggingUInt32(_uiTimesUsed[XTPOPSGR], "XTPOPSGR"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECFRA], "DECFRA"),
+                                      TraceLoggingUInt32(_uiTimesUsed[DECERA], "DECERA"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECAC], "DECAC"),
                                       TraceLoggingUInt32(_uiTimesUsed[DECPS], "DECPS"),
                                       TraceLoggingUInt32Array(_uiTimesFailed, ARRAYSIZE(_uiTimesFailed), "Failed"),

--- a/src/terminal/parser/telemetry.hpp
+++ b/src/terminal/parser/telemetry.hpp
@@ -110,6 +110,7 @@ namespace Microsoft::Console::VirtualTerminal
             OSCSCB,
             XTPUSHSGR,
             XTPOPSGR,
+            DECFRA,
             DECAC,
             DECPS,
             // Only use this last enum as a count of the number of codes.

--- a/src/terminal/parser/telemetry.hpp
+++ b/src/terminal/parser/telemetry.hpp
@@ -114,6 +114,7 @@ namespace Microsoft::Console::VirtualTerminal
             DECFRA,
             DECERA,
             DECSERA,
+            DECSACE,
             DECAC,
             DECPS,
             // Only use this last enum as a count of the number of codes.

--- a/src/terminal/parser/telemetry.hpp
+++ b/src/terminal/parser/telemetry.hpp
@@ -112,6 +112,7 @@ namespace Microsoft::Console::VirtualTerminal
             XTPOPSGR,
             DECFRA,
             DECERA,
+            DECSERA,
             DECAC,
             DECPS,
             // Only use this last enum as a count of the number of codes.

--- a/src/terminal/parser/telemetry.hpp
+++ b/src/terminal/parser/telemetry.hpp
@@ -110,6 +110,7 @@ namespace Microsoft::Console::VirtualTerminal
             OSCSCB,
             XTPUSHSGR,
             XTPOPSGR,
+            DECCRA,
             DECFRA,
             DECERA,
             DECSERA,

--- a/src/terminal/parser/telemetry.hpp
+++ b/src/terminal/parser/telemetry.hpp
@@ -110,6 +110,7 @@ namespace Microsoft::Console::VirtualTerminal
             OSCSCB,
             XTPUSHSGR,
             XTPOPSGR,
+            DECCARA,
             DECCRA,
             DECFRA,
             DECERA,

--- a/src/terminal/parser/telemetry.hpp
+++ b/src/terminal/parser/telemetry.hpp
@@ -111,6 +111,7 @@ namespace Microsoft::Console::VirtualTerminal
             XTPUSHSGR,
             XTPOPSGR,
             DECCARA,
+            DECRARA,
             DECCRA,
             DECFRA,
             DECERA,

--- a/src/terminal/parser/telemetry.hpp
+++ b/src/terminal/parser/telemetry.hpp
@@ -111,6 +111,7 @@ namespace Microsoft::Console::VirtualTerminal
             XTPUSHSGR,
             XTPOPSGR,
             DECFRA,
+            DECERA,
             DECAC,
             DECPS,
             // Only use this last enum as a count of the number of codes.


### PR DESCRIPTION
## Summary of the Pull Request

This PR adds support for the rectangular area escape sequences:
`DECCRA`, `DECFRA`, `DECERA`, `DECSERA`, `DECCARA`, `DECRARA`, and
`DECSACE`. They provide VT applications with an efficient way to copy,
fill, erase, or change the attributes in a rectangular area of the
screen.

## PR Checklist
* [x] Closes #14112
* [x] CLA signed.
* [x] Tests added/passed
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] I've discussed this with core contributors already. Issue number
where discussion took place: #14112

## Detailed Description of the Pull Request / Additional comments

All of these operations take a rectangle, defined by four coordinates.
These need to have defaults applied, potentially need to be clipped
and/or clamped within the active margins, and finally converted to
absolute buffer coordinates. To avoid having to repeat that boilerplate
code everywhere, I've pulled that functionality out into a shared method
which they all use.

With that out of the way, operations like `DECFRA` (fill), `DECERA`
(erase), and `DECSERA` (selective erase) are fairly simple. They're just
filling the given rectangle using the existing methods `_FillRect` and
`_SelectiveEraseRect`. `DECCRA` (copy) is a little more work, because we
didn't have existing code for that in `AdaptDispatch`, but it's mostly
just cloned from the conhost `_CopyRectangle` function.

The `DECCARA` (change attributes) and `DECRARA` (reverse attributes)
operations are different though. Their coordinates can be interpreted as
either a rectangle, or a stream of character positions (determined by
the `DECSACE` escape sequence), and they both deal with attribute
manipulation of the target area. So again I've pulled out that common
functionality into some shared methods.

They both also take a list of `SGR` options which define the attribute
changes that they need to apply to the target area. To parse that data,
I've had to refactor the `SGR` decoder from the `SetGraphicsRendition`
method so it could be used with a given `TextAttribute` instance instead
of just modifying the active attributes.

The way that works in `DECCARA`, we apply the `SGR` options to two
`TextAttribute` instances - one with all rendition bits on, and one with
all off - producing a pair of bit masks. Then by `AND`ing the target
attributes with the first bit mask, and `OR`ing them with the second, we
can efficiently achieve the same effect as if we'd applied each `SGR`
option to our target cells one by one.

In the case of `DECRARA`, we only need to create a single bit mask to
achieve the "reverse attribute" effect. That bit mask is applied to the
target cells with an `XOR` operation.

## Validation Steps Performed

Thanks to @KalleOlaviNiemitalo, we've been able to run a series of tests
on a real VT420, so we have a good idea of how these ops are intended to
work. Our implementation does a reasonably good job of matching that
behavior, but we don't yet support paging, so we don't have the `DECCRA`
ability to copy between pages, and we also don't have the concept of
"unoccupied" cells, so we can't support that aspect of the streaming
operations.

It's also worth mentioning that the VT420 doesn't have colors, so we
can't be sure exactly how they are meant to interpreted. However, based
on the way the other attribute are handled, and what we know from the
DEC STD 070 documentation, I think it's fair to assume that our handling
of colors is also reasonable.