### PR TITLE
Prevent conhost scrollbar overlapping content

### DIFF
--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -682,7 +682,7 @@ VOID SCREEN_INFORMATION::InternalUpdateScrollBars()
         }
 
         pWindow->UpdateScrollBar(true,
-                                 _IsAltBuffer() || gci.IsTerminalScrolling(),
+                                 _IsAltBuffer(),
                                  _viewport.Height(),
                                  gci.IsTerminalScrolling() ? _virtualBottom : buffer.BottomInclusive(),
                                  _viewport.Top());


### PR DESCRIPTION
Prior to this PR, the conhost vertical scrollbar would be forced to be
visible whenever the "Disable Scroll-Forward" option was set. It was
assumed that it would be needed as soon as the current viewport was
filled, so it was better to start off visible and disabled.

When the viewport height and buffer height are the same, though, the
scrollbar is never needed, and conhost compensates for that by making
the window narrower. But since we were still forcing the scrollbar to be
visible, that would result in it overlapping content in the rightmost
columns.

This PR attempts to fix that issue by simply leaving the scrollbar to
decide the visibility itself. This is perhaps not as aesthetically
pleasing when it starts off hidden and then later becomes visible, but
that seems better than having it overlap the content.

I've manually confirmed this fixes the problem reported in issue #2449.

Closes #2449