### PR TITLE
Re-enable AuditMode for TerminalCore

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -61,7 +61,7 @@ Terminal::Terminal() :
         {
             return;
         }
-        auto wstr = _KeyEventsToText(inEventsToWrite);
+        const auto wstr = _KeyEventsToText(inEventsToWrite);
         _pfnWriteInput(wstr);
     };
 
@@ -251,12 +251,12 @@ void Terminal::EraseScrollback()
     engine.Dispatch().EraseInDisplay(DispatchTypes::EraseType::Scrollback);
 }
 
-bool Terminal::IsXtermBracketedPasteModeEnabled() const
+bool Terminal::IsXtermBracketedPasteModeEnabled() const noexcept
 {
     return _bracketedPasteMode;
 }
 
-std::wstring_view Terminal::GetWorkingDirectory()
+std::wstring_view Terminal::GetWorkingDirectory() noexcept
 {
     return _workingDirectory;
 }
@@ -437,7 +437,7 @@ std::wstring_view Terminal::GetWorkingDirectory()
             {
                 try
                 {
-                    auto& row = newTextBuffer->GetRowByOffset(::base::ClampSub(proposedTop, 1));
+                    const auto& row = newTextBuffer->GetRowByOffset(::base::ClampSub(proposedTop, 1));
                     if (row.WasWrapForced())
                     {
                         proposedTop--;
@@ -499,7 +499,7 @@ void Terminal::Write(std::wstring_view stringView)
 {
     auto lock = LockForWriting();
 
-    auto& cursor = _activeBuffer().GetCursor();
+    const auto& cursor = _activeBuffer().GetCursor();
     const til::point cursorPosBefore{ cursor.GetPosition() };
 
     _stateMachine->ProcessString(stringView);
@@ -518,8 +518,8 @@ void Terminal::Write(std::wstring_view stringView)
 
 void Terminal::WritePastedText(std::wstring_view stringView)
 {
-    auto option = ::Microsoft::Console::Utils::FilterOption::CarriageReturnNewline |
-                  ::Microsoft::Console::Utils::FilterOption::ControlCodes;
+    const auto option = ::Microsoft::Console::Utils::FilterOption::CarriageReturnNewline |
+                        ::Microsoft::Console::Utils::FilterOption::ControlCodes;
 
     auto filtered = ::Microsoft::Console::Utils::FilterStringForPaste(stringView, option);
     if (IsXtermBracketedPasteModeEnabled())
@@ -760,7 +760,7 @@ bool Terminal::SendKeyEvent(const WORD vkey,
         return false;
     }
 
-    KeyEvent keyEv{ keyDown, 1, vkey, sc, ch, states.Value() };
+    const KeyEvent keyEv{ keyDown, 1, vkey, sc, ch, states.Value() };
     return _terminalInput->HandleKey(&keyEv);
 }
 
@@ -832,8 +832,8 @@ bool Terminal::SendCharEvent(const wchar_t ch, const WORD scanCode, const Contro
     // character up event, only a character received event. So fake sending both
     // to the terminal input translator. Unless it's in win32-input-mode, it'll
     // ignore the keyup.
-    KeyEvent keyDown{ true, 1, vkey, scanCode, ch, states.Value() };
-    KeyEvent keyUp{ false, 1, vkey, scanCode, ch, states.Value() };
+    const KeyEvent keyDown{ true, 1, vkey, scanCode, ch, states.Value() };
+    const KeyEvent keyUp{ false, 1, vkey, scanCode, ch, states.Value() };
     const auto handledDown = _terminalInput->HandleKey(&keyDown);
     const auto handledUp = _terminalInput->HandleKey(&keyUp);
     return handledDown || handledUp;
@@ -856,12 +856,12 @@ void Terminal::FocusChanged(const bool focused) noexcept
 // - Invalidates the regions described in the given pattern tree for the rendering purposes
 // Arguments:
 // - The interval tree containing regions that need to be invalidated
-void Terminal::_InvalidatePatternTree(interval_tree::IntervalTree<til::point, size_t>& tree)
+void Terminal::_InvalidatePatternTree(const interval_tree::IntervalTree<til::point, size_t>& tree)
 {
     const auto vis = _VisibleStartIndex();
     auto invalidate = [=](const PointTree::interval& interval) {
-        til::point startCoord{ interval.start.x, interval.start.y + vis };
-        til::point endCoord{ interval.stop.x, interval.stop.y + vis };
+        const til::point startCoord{ interval.start.x, interval.start.y + vis };
+        const til::point endCoord{ interval.stop.x, interval.stop.y + vis };
         _InvalidateFromCoords(startCoord, endCoord);
     };
     tree.visit_all(invalidate);
@@ -875,7 +875,7 @@ void Terminal::_InvalidateFromCoords(const til::point start, const til::point en
 {
     if (start.Y == end.Y)
     {
-        til::inclusive_rect region{ start.X, start.Y, end.X, end.Y };
+        const til::inclusive_rect region{ start.X, start.Y, end.X, end.Y };
         _activeBuffer().TriggerRedraw(Viewport::FromInclusive(region));
     }
     else
@@ -1125,7 +1125,7 @@ void Terminal::_WriteBuffer(const std::wstring_view& stringView)
             // If "wch" was a surrogate character, we just consumed 2 code units above.
             // -> Increment "i" by 1 in that case and thus by 2 in total in this iteration.
             proposedCursorPosition.X += cellDistance;
-            i += inputDistance - 1;
+            i += gsl::narrow_cast<size_t>(inputDistance - 1);
         }
         else
         {
@@ -1278,7 +1278,7 @@ void Terminal::_AdjustCursorPosition(const til::point proposedPosition)
         // We have to report the delta here because we might have circled the text buffer.
         // That didn't change the viewport and therefore the TriggerScroll(void)
         // method can't detect the delta on its own.
-        til::point delta{ 0, -rowsPushedOffTopOfBuffer };
+        const til::point delta{ 0, -rowsPushedOffTopOfBuffer };
         _activeBuffer().TriggerScroll(delta);
     }
 }
@@ -1420,7 +1420,7 @@ bool Terminal::IsCursorBlinkingAllowed() const noexcept
 // - This is called by TerminalControl (through a throttled function) when the visible
 //   region changes (for example by text entering the buffer or scrolling)
 // - INVARIANT: this function can only be called if the caller has the writing lock on the terminal
-void Terminal::UpdatePatternsUnderLock() noexcept
+void Terminal::UpdatePatternsUnderLock()
 {
     auto oldTree = _patternIntervalTree;
     _patternIntervalTree = _activeBuffer().GetPatterns(_VisibleStartIndex(), _VisibleEndIndex());
@@ -1432,7 +1432,7 @@ void Terminal::UpdatePatternsUnderLock() noexcept
 // - Clears and invalidates the interval pattern tree
 // - This is called to prevent the renderer from rendering patterns while the
 //   visible region is changing
-void Terminal::ClearPatternTree() noexcept
+void Terminal::ClearPatternTree()
 {
     auto oldTree = _patternIntervalTree;
     _patternIntervalTree = {};
@@ -1442,7 +1442,7 @@ void Terminal::ClearPatternTree() noexcept
 // Method Description:
 // - Returns the tab color
 // If the starting color exists, its value is preferred
-const std::optional<til::color> Terminal::GetTabColor() const noexcept
+const std::optional<til::color> Terminal::GetTabColor() const
 {
     if (_startingTabColor.has_value())
     {
@@ -1473,7 +1473,7 @@ const size_t Microsoft::Terminal::Core::Terminal::GetTaskbarProgress() const noe
     return _taskbarProgress;
 }
 
-Scheme Terminal::GetColorScheme() const noexcept
+Scheme Terminal::GetColorScheme() const
 {
     Scheme s;
 
@@ -1606,7 +1606,7 @@ void Terminal::ClearMark()
     // workaround to force the control to redraw any scrollbar marks
     _NotifyScrollEvent();
 }
-void Terminal::ClearAllMarks()
+void Terminal::ClearAllMarks() noexcept
 {
     _scrollMarks.clear();
     // Tell the control that the scrollbar has somehow changed. Used as a
@@ -1614,13 +1614,13 @@ void Terminal::ClearAllMarks()
     _NotifyScrollEvent();
 }
 
-const std::vector<Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark>& Terminal::GetScrollMarks() const
+const std::vector<DispatchTypes::ScrollMark>& Terminal::GetScrollMarks() const noexcept
 {
     // TODO: GH#11000 - when the marks are stored per-buffer, get rid of this.
     // We want to return _no_ marks when we're in the alt buffer, to effectively
     // hide them. We need to return a reference, so we can't just ctor an empty
     // list here just for when we're in the alt buffer.
-    static std::vector<DispatchTypes::ScrollMark> _altBufferMarks{};
+    static constexpr std::vector<DispatchTypes::ScrollMark> _altBufferMarks{};
     return _inAltBuffer() ? _altBufferMarks : _scrollMarks;
 }
 

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -82,8 +82,8 @@ public:
     void SetFontInfo(const FontInfo& fontInfo);
     void SetCursorStyle(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::CursorStyle cursorStyle);
     void EraseScrollback();
-    bool IsXtermBracketedPasteModeEnabled() const;
-    std::wstring_view GetWorkingDirectory();
+    bool IsXtermBracketedPasteModeEnabled() const noexcept;
+    std::wstring_view GetWorkingDirectory() noexcept;
 
     til::point GetViewportRelativeCursorPosition() const noexcept;
 
@@ -105,7 +105,7 @@ public:
     RenderSettings& GetRenderSettings() noexcept { return _renderSettings; };
     const RenderSettings& GetRenderSettings() const noexcept { return _renderSettings; };
 
-    const std::vector<Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark>& GetScrollMarks() const;
+    const std::vector<Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark>& GetScrollMarks() const noexcept;
     void AddMark(const Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark& mark,
                  const til::point& start,
                  const til::point& end);
@@ -114,22 +114,22 @@ public:
     // These methods are defined in TerminalApi.cpp
     void PrintString(const std::wstring_view string) override;
     void ReturnResponse(const std::wstring_view response) override;
-    Microsoft::Console::VirtualTerminal::StateMachine& GetStateMachine() override;
-    TextBuffer& GetTextBuffer() override;
-    til::rect GetViewport() const override;
-    void SetViewportPosition(const til::point position) override;
-    void SetTextAttributes(const TextAttribute& attrs) override;
-    void SetAutoWrapMode(const bool wrapAtEOL) override;
-    void SetScrollingRegion(const til::inclusive_rect& scrollMargins) override;
+    Microsoft::Console::VirtualTerminal::StateMachine& GetStateMachine() noexcept override;
+    TextBuffer& GetTextBuffer() noexcept override;
+    til::rect GetViewport() const noexcept override;
+    void SetViewportPosition(const til::point position) noexcept override;
+    void SetTextAttributes(const TextAttribute& attrs) noexcept override;
+    void SetAutoWrapMode(const bool wrapAtEOL) noexcept override;
+    void SetScrollingRegion(const til::inclusive_rect& scrollMargins) noexcept override;
     void WarningBell() override;
-    bool GetLineFeedMode() const override;
+    bool GetLineFeedMode() const noexcept override;
     void LineFeed(const bool withReturn) override;
     void SetWindowTitle(const std::wstring_view title) override;
-    CursorType GetUserDefaultCursorStyle() const override;
-    bool ResizeWindow(const til::CoordType width, const til::CoordType height) override;
-    void SetConsoleOutputCP(const unsigned int codepage) override;
-    unsigned int GetConsoleOutputCP() const override;
-    void EnableXtermBracketedPasteMode(const bool enabled) override;
+    CursorType GetUserDefaultCursorStyle() const noexcept override;
+    bool ResizeWindow(const til::CoordType width, const til::CoordType height) noexcept override;
+    void SetConsoleOutputCP(const unsigned int codepage) noexcept override;
+    unsigned int GetConsoleOutputCP() const noexcept override;
+    void EnableXtermBracketedPasteMode(const bool enabled) noexcept override;
     void CopyToClipboard(std::wstring_view content) override;
     void SetTaskbarProgress(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::TaskbarState state, const size_t progress) override;
     void SetWorkingDirectory(std::wstring_view uri) override;
@@ -140,13 +140,13 @@ public:
 
     void AddMark(const Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark& mark) override;
 
-    bool IsConsolePty() const override;
-    bool IsVtInputEnabled() const override;
-    void NotifyAccessibilityChange(const til::rect& changedRect) override;
+    bool IsConsolePty() const noexcept override;
+    bool IsVtInputEnabled() const noexcept override;
+    void NotifyAccessibilityChange(const til::rect& changedRect) noexcept override;
 #pragma endregion
 
     void ClearMark();
-    void ClearAllMarks();
+    void ClearAllMarks() noexcept;
     til::color GetColorForMark(const Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark& mark) const;
 
 #pragma region ITerminalInput
@@ -192,9 +192,9 @@ public:
     bool IsCursorDoubleWidth() const override;
     const std::vector<Microsoft::Console::Render::RenderOverlay> GetOverlays() const noexcept override;
     const bool IsGridLineDrawingAllowed() noexcept override;
-    const std::wstring GetHyperlinkUri(uint16_t id) const noexcept override;
-    const std::wstring GetHyperlinkCustomId(uint16_t id) const noexcept override;
-    const std::vector<size_t> GetPatternId(const til::point location) const noexcept override;
+    const std::wstring GetHyperlinkUri(uint16_t id) const override;
+    const std::wstring GetHyperlinkCustomId(uint16_t id) const override;
+    const std::vector<size_t> GetPatternId(const til::point location) const override;
 #pragma endregion
 
 #pragma region IUiaData
@@ -224,12 +224,12 @@ public:
     void SetCursorOn(const bool isOn);
     bool IsCursorBlinkingAllowed() const noexcept;
 
-    void UpdatePatternsUnderLock() noexcept;
-    void ClearPatternTree() noexcept;
+    void UpdatePatternsUnderLock();
+    void ClearPatternTree();
 
-    const std::optional<til::color> GetTabColor() const noexcept;
+    const std::optional<til::color> GetTabColor() const;
 
-    winrt::Microsoft::Terminal::Core::Scheme GetColorScheme() const noexcept;
+    winrt::Microsoft::Terminal::Core::Scheme GetColorScheme() const;
     void ApplyScheme(const winrt::Microsoft::Terminal::Core::Scheme& scheme);
 
     const size_t GetTaskbarState() const noexcept;
@@ -283,7 +283,7 @@ public:
     void UpdateSelection(SelectionDirection direction, SelectionExpansion mode, ControlKeyStates mods);
     void SelectAll();
     SelectionInteractionMode SelectionMode() const noexcept;
-    void SwitchSelectionEndpoint();
+    void SwitchSelectionEndpoint() noexcept;
     void ExpandSelectionToWord();
     void ToggleMarkMode();
     void SelectHyperlink(const SearchDirection dir);
@@ -391,7 +391,7 @@ private:
     //      Either way, we should make this behavior controlled by a setting.
 
     interval_tree::IntervalTree<til::point, size_t> _patternIntervalTree;
-    void _InvalidatePatternTree(interval_tree::IntervalTree<til::point, size_t>& tree);
+    void _InvalidatePatternTree(const interval_tree::IntervalTree<til::point, size_t>& tree);
     void _InvalidateFromCoords(const til::point start, const til::point end);
 
     // Since virtual keys are non-zero, you assume that this field is empty/invalid if it is.
@@ -434,14 +434,14 @@ private:
     // These methods are defined in TerminalSelection.cpp
     std::vector<til::inclusive_rect> _GetSelectionRects() const noexcept;
     std::vector<til::point_span> _GetSelectionSpans() const noexcept;
-    std::pair<til::point, til::point> _PivotSelection(const til::point targetPos, bool& targetStart) const;
+    std::pair<til::point, til::point> _PivotSelection(const til::point targetPos, bool& targetStart) const noexcept;
     std::pair<til::point, til::point> _ExpandSelectionAnchors(std::pair<til::point, til::point> anchors) const;
     til::point _ConvertToBufferCell(const til::point viewportPos) const;
     void _ScrollToPoint(const til::point pos);
     void _MoveByChar(SelectionDirection direction, til::point& pos);
     void _MoveByWord(SelectionDirection direction, til::point& pos);
-    void _MoveByViewport(SelectionDirection direction, til::point& pos);
-    void _MoveByBuffer(SelectionDirection direction, til::point& pos);
+    void _MoveByViewport(SelectionDirection direction, til::point& pos) noexcept;
+    void _MoveByBuffer(SelectionDirection direction, til::point& pos) noexcept;
 #pragma endregion
 
 #ifdef UNIT_TESTING

--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -24,22 +24,22 @@ void Terminal::ReturnResponse(const std::wstring_view response)
     }
 }
 
-Microsoft::Console::VirtualTerminal::StateMachine& Terminal::GetStateMachine()
+Microsoft::Console::VirtualTerminal::StateMachine& Terminal::GetStateMachine() noexcept
 {
     return *_stateMachine;
 }
 
-TextBuffer& Terminal::GetTextBuffer()
+TextBuffer& Terminal::GetTextBuffer() noexcept
 {
     return _activeBuffer();
 }
 
-til::rect Terminal::GetViewport() const
+til::rect Terminal::GetViewport() const noexcept
 {
     return til::rect{ _GetMutableViewport().ToInclusive() };
 }
 
-void Terminal::SetViewportPosition(const til::point position)
+void Terminal::SetViewportPosition(const til::point position) noexcept
 {
     // The viewport is fixed at 0,0 for the alt buffer, so this is a no-op.
     if (!_inAltBuffer())
@@ -50,17 +50,17 @@ void Terminal::SetViewportPosition(const til::point position)
     }
 }
 
-void Terminal::SetTextAttributes(const TextAttribute& attrs)
+void Terminal::SetTextAttributes(const TextAttribute& attrs) noexcept
 {
     _activeBuffer().SetCurrentAttributes(attrs);
 }
 
-void Terminal::SetAutoWrapMode(const bool /*wrapAtEOL*/)
+void Terminal::SetAutoWrapMode(const bool /*wrapAtEOL*/) noexcept
 {
     // TODO: This will be needed to support DECAWM.
 }
 
-void Terminal::SetScrollingRegion(const til::inclusive_rect& /*scrollMargins*/)
+void Terminal::SetScrollingRegion(const til::inclusive_rect& /*scrollMargins*/) noexcept
 {
     // TODO: This will be needed to fully support DECSTBM.
 }
@@ -70,7 +70,7 @@ void Terminal::WarningBell()
     _pfnWarningBell();
 }
 
-bool Terminal::GetLineFeedMode() const
+bool Terminal::GetLineFeedMode() const noexcept
 {
     // TODO: This will be needed to support LNM.
     return false;
@@ -101,29 +101,29 @@ void Terminal::SetWindowTitle(const std::wstring_view title)
     }
 }
 
-CursorType Terminal::GetUserDefaultCursorStyle() const
+CursorType Terminal::GetUserDefaultCursorStyle() const noexcept
 {
     return _defaultCursorShape;
 }
 
-bool Terminal::ResizeWindow(const til::CoordType /*width*/, const til::CoordType /*height*/)
+bool Terminal::ResizeWindow(const til::CoordType /*width*/, const til::CoordType /*height*/) noexcept
 {
     // TODO: This will be needed to support various resizing sequences. See also GH#1860.
     return false;
 }
 
-void Terminal::SetConsoleOutputCP(const unsigned int /*codepage*/)
+void Terminal::SetConsoleOutputCP(const unsigned int /*codepage*/) noexcept
 {
     // TODO: This will be needed to support 8-bit charsets and DOCS sequences.
 }
 
-unsigned int Terminal::GetConsoleOutputCP() const
+unsigned int Terminal::GetConsoleOutputCP() const noexcept
 {
     // TODO: See SetConsoleOutputCP above.
     return CP_UTF8;
 }
 
-void Terminal::EnableXtermBracketedPasteMode(const bool enabled)
+void Terminal::EnableXtermBracketedPasteMode(const bool enabled) noexcept
 {
     _bracketedPasteMode = enabled;
 }
@@ -214,7 +214,7 @@ void Terminal::UseAlternateScreenBuffer()
     // Copy our cursor state to the new buffer's cursor
     {
         // Update the alt buffer's cursor style, visibility, and position to match our own.
-        auto& myCursor = _mainBuffer->GetCursor();
+        const auto& myCursor = _mainBuffer->GetCursor();
         auto& tgtCursor = _altBuffer->GetCursor();
         tgtCursor.SetStyle(myCursor.GetSize(), myCursor.GetType());
         tgtCursor.SetIsVisible(myCursor.IsVisible());
@@ -256,7 +256,7 @@ void Terminal::UseMainScreenBuffer()
     // Copy our cursor state back to the main buffer's cursor
     {
         // Update the alt buffer's cursor style, visibility, and position to match our own.
-        auto& myCursor = _altBuffer->GetCursor();
+        const auto& myCursor = _altBuffer->GetCursor();
         auto& tgtCursor = _mainBuffer->GetCursor();
         tgtCursor.SetStyle(myCursor.GetSize(), myCursor.GetType());
         tgtCursor.SetIsVisible(myCursor.IsVisible());
@@ -318,17 +318,17 @@ void Terminal::ShowWindow(bool showOrHide)
     }
 }
 
-bool Terminal::IsConsolePty() const
+bool Terminal::IsConsolePty() const noexcept
 {
     return false;
 }
 
-bool Terminal::IsVtInputEnabled() const
+bool Terminal::IsVtInputEnabled() const noexcept
 {
     return false;
 }
 
-void Terminal::NotifyAccessibilityChange(const til::rect& /*changedRect*/)
+void Terminal::NotifyAccessibilityChange(const til::rect& /*changedRect*/) noexcept
 {
     // This is only needed in conhost. Terminal handles accessibility in another way.
 }

--- a/src/cascadia/TerminalCore/TerminalSelection.cpp
+++ b/src/cascadia/TerminalCore/TerminalSelection.cpp
@@ -249,7 +249,7 @@ void Terminal::SetSelectionEnd(const til::point viewportPos, std::optional<Selec
 // - targetStart: if true, target will be the new start. Otherwise, target will be the new end.
 // Return Value:
 // - the new start/end for a selection
-std::pair<til::point, til::point> Terminal::_PivotSelection(const til::point targetPos, bool& targetStart) const
+std::pair<til::point, til::point> Terminal::_PivotSelection(const til::point targetPos, bool& targetStart) const noexcept
 {
     if (targetStart = _activeBuffer().GetSize().CompareInBounds(targetPos, _selection->pivot) <= 0)
     {
@@ -345,7 +345,7 @@ void Terminal::ToggleMarkMode()
 
 // Method Description:
 // - switch the targeted selection endpoint with the other one (i.e. start <--> end)
-void Terminal::SwitchSelectionEndpoint()
+void Terminal::SwitchSelectionEndpoint() noexcept
 {
     if (IsSelectionActive())
     {
@@ -410,7 +410,7 @@ void Terminal::SelectHyperlink(const SearchDirection dir)
     // but as we progressively search through more of the buffer, this will change.
     // Keep track of the search area here, and use the lambda below to convert points to the search area coordinate space.
     auto searchArea = _GetVisibleViewport();
-    auto convertToSearchArea = [&searchArea](const til::point pt) {
+    auto convertToSearchArea = [&searchArea](const til::point pt) noexcept {
         auto copy = pt;
         searchArea.ConvertToOrigin(&copy);
         return copy;
@@ -454,7 +454,7 @@ void Terminal::SelectHyperlink(const SearchDirection dir)
             {
                 // moving backwards excludes the currently selected range,
                 // simply return the last one in the list as it's ordered
-                const auto range = list.back();
+                const auto& range = list.back();
                 resultFromList = { range.start, range.stop };
             }
         }
@@ -551,6 +551,8 @@ Terminal::UpdateSelectionParams Terminal::ConvertKeyEventToUpdateSelectionParams
                 return UpdateSelectionParams{ std::in_place, SelectionDirection::Left, SelectionExpansion::Buffer };
             case VK_END:
                 return UpdateSelectionParams{ std::in_place, SelectionDirection::Right, SelectionExpansion::Buffer };
+            default:
+                break;
             }
         }
         else
@@ -575,6 +577,8 @@ Terminal::UpdateSelectionParams Terminal::ConvertKeyEventToUpdateSelectionParams
                 return UpdateSelectionParams{ std::in_place, SelectionDirection::Up, SelectionExpansion::Char };
             case VK_DOWN:
                 return UpdateSelectionParams{ std::in_place, SelectionDirection::Down, SelectionExpansion::Char };
+            default:
+                break;
             }
         }
     }
@@ -763,7 +767,7 @@ void Terminal::_MoveByWord(SelectionDirection direction, til::point& pos)
     }
 }
 
-void Terminal::_MoveByViewport(SelectionDirection direction, til::point& pos)
+void Terminal::_MoveByViewport(SelectionDirection direction, til::point& pos) noexcept
 {
     const auto bufferSize{ _activeBuffer().GetSize() };
     switch (direction)
@@ -792,7 +796,7 @@ void Terminal::_MoveByViewport(SelectionDirection direction, til::point& pos)
     }
 }
 
-void Terminal::_MoveByBuffer(SelectionDirection direction, til::point& pos)
+void Terminal::_MoveByBuffer(SelectionDirection direction, til::point& pos) noexcept
 {
     const auto bufferSize{ _activeBuffer().GetSize() };
     switch (direction)
@@ -892,7 +896,7 @@ void Terminal::_ScrollToPoint(const til::point pos)
 // - attr - the text attributes to apply
 void Terminal::ColorSelection(const til::point coordStart, const til::point coordEnd, const TextAttribute attr)
 {
-    size_t spanLength = _activeBuffer().SpanLength(coordStart, coordEnd);
+    const auto spanLength = _activeBuffer().SpanLength(coordStart, coordEnd);
 
     _activeBuffer().Write(OutputCellIterator(attr, spanLength), coordStart);
 }

--- a/src/cascadia/TerminalCore/lib/terminalcore-lib.vcxproj
+++ b/src/cascadia/TerminalCore/lib/terminalcore-lib.vcxproj
@@ -16,11 +16,6 @@
     <TerminalCppWinrt>true</TerminalCppWinrt>
   </PropertyGroup>
 
-  <!-- Imported WinRT generated files must go up here to get excluded from Audit correctly. -->
-  <PropertyGroup Condition="'$(Configuration)'=='AuditMode'">
-    <CAExcludePath>"$(SolutionDir)\src\cascadia\TerminalCore\Generated Files\winrt";$(SolutionDir)src\cascadia\TerminalCore;$(CAExcludePath)</CAExcludePath>
-  </PropertyGroup>
-
   <Import Project="..\..\..\..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.props" />
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.pre.props" />

--- a/src/cascadia/TerminalCore/terminalrenderdata.cpp
+++ b/src/cascadia/TerminalCore/terminalrenderdata.cpp
@@ -73,7 +73,7 @@ CursorType Terminal::GetCursorStyle() const noexcept
 bool Terminal::IsCursorDoubleWidth() const
 {
     const auto position = _activeBuffer().GetCursor().GetPosition();
-    TextBufferTextIterator it(TextBufferCellIterator(_activeBuffer(), position));
+    const TextBufferTextIterator it(TextBufferCellIterator(_activeBuffer(), position));
     return IsGlyphFullWidth(*it);
 }
 
@@ -87,12 +87,12 @@ const bool Terminal::IsGridLineDrawingAllowed() noexcept
     return true;
 }
 
-const std::wstring Microsoft::Terminal::Core::Terminal::GetHyperlinkUri(uint16_t id) const noexcept
+const std::wstring Microsoft::Terminal::Core::Terminal::GetHyperlinkUri(uint16_t id) const
 {
     return _activeBuffer().GetHyperlinkUriFromId(id);
 }
 
-const std::wstring Microsoft::Terminal::Core::Terminal::GetHyperlinkCustomId(uint16_t id) const noexcept
+const std::wstring Microsoft::Terminal::Core::Terminal::GetHyperlinkCustomId(uint16_t id) const
 {
     return _activeBuffer().GetCustomIdFromId(id);
 }
@@ -103,7 +103,7 @@ const std::wstring Microsoft::Terminal::Core::Terminal::GetHyperlinkCustomId(uin
 // - The location
 // Return value:
 // - The pattern IDs of the location
-const std::vector<size_t> Terminal::GetPatternId(const til::point location) const noexcept
+const std::vector<size_t> Terminal::GetPatternId(const til::point location) const
 {
     // Look through our interval tree for this location
     const auto intervals = _patternIntervalTree.findOverlapping({ location.X + 1, location.Y }, location);

--- a/src/host/renderData.cpp
+++ b/src/host/renderData.cpp
@@ -304,7 +304,7 @@ const std::wstring_view RenderData::GetConsoleTitle() const noexcept
 // - The hyperlink ID
 // Return Value:
 // - The URI
-const std::wstring RenderData::GetHyperlinkUri(uint16_t id) const noexcept
+const std::wstring RenderData::GetHyperlinkUri(uint16_t id) const
 {
     const auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     return gci.GetActiveOutputBuffer().GetTextBuffer().GetHyperlinkUriFromId(id);
@@ -316,14 +316,14 @@ const std::wstring RenderData::GetHyperlinkUri(uint16_t id) const noexcept
 // - The hyperlink ID
 // Return Value:
 // - The custom ID if there was one, empty string otherwise
-const std::wstring RenderData::GetHyperlinkCustomId(uint16_t id) const noexcept
+const std::wstring RenderData::GetHyperlinkCustomId(uint16_t id) const
 {
     const auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     return gci.GetActiveOutputBuffer().GetTextBuffer().GetCustomIdFromId(id);
 }
 
 // For now, we ignore regex patterns in conhost
-const std::vector<size_t> RenderData::GetPatternId(const til::point /*location*/) const noexcept
+const std::vector<size_t> RenderData::GetPatternId(const til::point /*location*/) const
 {
     return {};
 }

--- a/src/host/renderData.hpp
+++ b/src/host/renderData.hpp
@@ -50,10 +50,10 @@ public:
 
     const std::wstring_view GetConsoleTitle() const noexcept override;
 
-    const std::wstring GetHyperlinkUri(uint16_t id) const noexcept override;
-    const std::wstring GetHyperlinkCustomId(uint16_t id) const noexcept override;
+    const std::wstring GetHyperlinkUri(uint16_t id) const override;
+    const std::wstring GetHyperlinkCustomId(uint16_t id) const override;
 
-    const std::vector<size_t> GetPatternId(const til::point location) const noexcept override;
+    const std::vector<size_t> GetPatternId(const til::point location) const override;
 #pragma endregion
 
 #pragma region IUiaData

--- a/src/host/ut_host/VtIoTests.cpp
+++ b/src/host/ut_host/VtIoTests.cpp
@@ -382,17 +382,17 @@ public:
         return true;
     }
 
-    const std::wstring GetHyperlinkUri(uint16_t /*id*/) const noexcept
+    const std::wstring GetHyperlinkUri(uint16_t /*id*/) const
     {
         return {};
     }
 
-    const std::wstring GetHyperlinkCustomId(uint16_t /*id*/) const noexcept
+    const std::wstring GetHyperlinkCustomId(uint16_t /*id*/) const
     {
         return {};
     }
 
-    const std::vector<size_t> GetPatternId(const til::point /*location*/) const noexcept
+    const std::vector<size_t> GetPatternId(const til::point /*location*/) const
     {
         return {};
     }

--- a/src/renderer/inc/IRenderData.hpp
+++ b/src/renderer/inc/IRenderData.hpp
@@ -59,10 +59,10 @@ namespace Microsoft::Console::Render
         virtual const bool IsGridLineDrawingAllowed() noexcept = 0;
         virtual const std::wstring_view GetConsoleTitle() const noexcept = 0;
 
-        virtual const std::wstring GetHyperlinkUri(uint16_t id) const noexcept = 0;
-        virtual const std::wstring GetHyperlinkCustomId(uint16_t id) const noexcept = 0;
+        virtual const std::wstring GetHyperlinkUri(uint16_t id) const = 0;
+        virtual const std::wstring GetHyperlinkCustomId(uint16_t id) const = 0;
 
-        virtual const std::vector<size_t> GetPatternId(const til::point location) const noexcept = 0;
+        virtual const std::vector<size_t> GetPatternId(const til::point location) const = 0;
 
     protected:
         IRenderData() = default;


### PR DESCRIPTION
AuditMode was accidentally disabled in 1c6aa4d, around 2 years ago.
This should fix this issue and address all the warnings it now generates.

Related to #14129.