### PR TITLE
Initialize all members of Terminal

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -37,24 +37,7 @@ static std::wstring _KeyEventsToText(std::deque<std::unique_ptr<IInputEvent>>& i
 }
 
 #pragma warning(suppress : 26455) // default constructor is throwing, too much effort to rearrange at this time.
-Terminal::Terminal() :
-    _mutableViewport{ Viewport::Empty() },
-    _title{},
-    _pfnWriteInput{ nullptr },
-    _altBuffer{ nullptr },
-    _scrollOffset{ 0 },
-    _snapOnInput{ true },
-    _altGrAliasing{ true },
-    _blockSelection{ false },
-    _selectionMode{ SelectionInteractionMode::None },
-    _selectionIsTargetingUrl{ false },
-    _selection{ std::nullopt },
-    _selectionEndpoint{ static_cast<SelectionEndpoint>(0) },
-    _anchorInactiveSelectionEndpoint{ false },
-    _taskbarState{ 0 },
-    _taskbarProgress{ 0 },
-    _trimBlockSelection{ false },
-    _autoMarkPrompts{ false }
+Terminal::Terminal()
 {
     auto passAlongInput = [&](std::deque<std::unique_ptr<IInputEvent>>& inEventsToWrite) {
         if (!_pfnWriteInput)

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -64,11 +64,6 @@ class Microsoft::Terminal::Core::Terminal final :
 
 public:
     Terminal();
-    ~Terminal() = default;
-    Terminal(const Terminal&) = default;
-    Terminal(Terminal&&) = default;
-    Terminal& operator=(const Terminal&) = default;
-    Terminal& operator=(Terminal&&) = default;
 
     void Create(til::size viewportSize,
                 til::CoordType scrollbackLines,
@@ -272,6 +267,7 @@ public:
 
     enum class SelectionEndpoint
     {
+        None = 0,
         Start = 0x1,
         End = 0x2
     };
@@ -325,19 +321,19 @@ private:
     std::wstring _startingTitle;
     std::optional<til::color> _startingTabColor;
 
-    CursorType _defaultCursorShape;
+    CursorType _defaultCursorShape = CursorType::Legacy;
 
-    bool _snapOnInput;
-    bool _altGrAliasing;
-    bool _suppressApplicationTitle;
-    bool _bracketedPasteMode;
-    bool _trimBlockSelection;
-    bool _autoMarkPrompts;
+    bool _snapOnInput = true;
+    bool _altGrAliasing = true;
+    bool _suppressApplicationTitle = false;
+    bool _bracketedPasteMode = false;
+    bool _trimBlockSelection = false;
+    bool _autoMarkPrompts = false;
 
-    size_t _taskbarState;
-    size_t _taskbarProgress;
+    size_t _taskbarState = 0;
+    size_t _taskbarProgress = 0;
 
-    size_t _hyperlinkPatternId;
+    size_t _hyperlinkPatternId = 0;
 
     std::wstring _workingDirectory;
 
@@ -356,27 +352,27 @@ private:
         til::point pivot;
     };
     std::optional<SelectionAnchors> _selection;
-    bool _blockSelection;
+    bool _blockSelection = false;
     std::wstring _wordDelimiters;
-    SelectionExpansion _multiClickSelectionMode;
-    SelectionInteractionMode _selectionMode;
-    bool _selectionIsTargetingUrl;
-    SelectionEndpoint _selectionEndpoint;
-    bool _anchorInactiveSelectionEndpoint;
+    SelectionExpansion _multiClickSelectionMode = SelectionExpansion::Char;
+    SelectionInteractionMode _selectionMode = SelectionInteractionMode::None;
+    bool _selectionIsTargetingUrl = false;
+    SelectionEndpoint _selectionEndpoint = SelectionEndpoint::None;
+    bool _anchorInactiveSelectionEndpoint = false;
 #pragma endregion
 
     std::unique_ptr<TextBuffer> _mainBuffer;
     std::unique_ptr<TextBuffer> _altBuffer;
     Microsoft::Console::Types::Viewport _mutableViewport;
-    til::CoordType _scrollbackLines;
-    bool _detectURLs{ false };
+    til::CoordType _scrollbackLines = 0;
+    bool _detectURLs = false;
 
     til::size _altBufferSize;
-    std::optional<til::size> _deferredResize{ std::nullopt };
+    std::optional<til::size> _deferredResize;
 
     // _scrollOffset is the number of lines above the viewport that are currently visible
     // If _scrollOffset is 0, then the visible region of the buffer is the viewport.
-    int _scrollOffset;
+    til::CoordType _scrollOffset = 0;
     // TODO this might not be the value we want to store.
     // We might want to store the height in the scrollback that's currently visible.
     // Think on this some more.


### PR DESCRIPTION
The following members were not initialized during construction:
* `CursorType _defaultCursorShape`
* `bool _suppressApplicationTitle`
* `bool _bracketedPasteMode`
* `size_t _hyperlinkPatternId`
* `SelectionExpansion _multiClickSelectionMode`
* `til::CoordType _scrollbackLines`

Unlike gcc and clang, MSVC is fairly tame when it comes to removing code
tainted by undefined behavior, so the most likely affect this had is that
we were reading uninitialized memory.

Related to #14129.