### PR TITLE
Fix Helix failures by updating the SDK

### DIFF
--- a/build/Helix/global.json
+++ b/build/Helix/global.json
@@ -1,5 +1,5 @@
 {
   "msbuild-sdks": {
-    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20277.5"
+    "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.22525.5"
   }
 }


### PR DESCRIPTION
This mirrors microsoft/WinUI !8045797 and appears to resolve our recent Helix
pipeline failures, due to a python script issue (see Helix logs).
