### PR TITLE
Remove `constexpr` from `_altBufferMarks`

### DIFF
--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -1603,7 +1603,7 @@ const std::vector<DispatchTypes::ScrollMark>& Terminal::GetScrollMarks() const n
     // We want to return _no_ marks when we're in the alt buffer, to effectively
     // hide them. We need to return a reference, so we can't just ctor an empty
     // list here just for when we're in the alt buffer.
-    static std::vector<DispatchTypes::ScrollMark> _altBufferMarks{};
+    static const std::vector<DispatchTypes::ScrollMark> _altBufferMarks{};
     return _inAltBuffer() ? _altBufferMarks : _scrollMarks;
 }
 

--- a/src/cascadia/TerminalCore/Terminal.cpp
+++ b/src/cascadia/TerminalCore/Terminal.cpp
@@ -1603,7 +1603,7 @@ const std::vector<DispatchTypes::ScrollMark>& Terminal::GetScrollMarks() const n
     // We want to return _no_ marks when we're in the alt buffer, to effectively
     // hide them. We need to return a reference, so we can't just ctor an empty
     // list here just for when we're in the alt buffer.
-    static constexpr std::vector<DispatchTypes::ScrollMark> _altBufferMarks{};
+    static std::vector<DispatchTypes::ScrollMark> _altBufferMarks{};
     return _inAltBuffer() ? _altBufferMarks : _scrollMarks;
 }
 


### PR DESCRIPTION
## Summary of the Pull Request
Compiler was raising the error: `expression did not evaluate to a constant.`, causing the solution to fail when building. Removing this `constexpr` fixes it.

## PR Checklist
* [ ] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed
Solution builds now