### PR TITLE
Update bug template to help find the version number accurately

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yml
@@ -14,7 +14,7 @@ body:
     label: Windows Terminal version
     placeholder: "1.7.3651.0"
     description: |
-      You can find the version in the about dialog, or by running `wt -v` at the commandline (for the Stable/Preview version you’re reporting a bug about).
+      You can copy the version number from the About dialog. Open the About dialog by opening the menu with the "V" button (to the right of the "+" button that opens a new tab) and choosing About from the end of the list.
   validations:
     required: false
     


### PR DESCRIPTION
Due to https://github.com/microsoft/terminal/issues/14335 using `wt -v` is not recommended. BTW, it might be nice if Ctrl-Shift-P and typing "about" or "version" gave the version, too.
