### PR TITLE
Ensure reading the buffer content actually returns the content

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1744,7 +1744,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             const auto strEnd = rowText.find_last_not_of(UNICODE_SPACE);
             if (strEnd != decltype(rowText)::npos)
             {
-                str.append(rowText.substr(strEnd + 1));
+                str.append(rowText.substr(0, strEnd + 1));
             }
 
             if (!row.WasWrapForced())

--- a/src/cascadia/UnitTests_Control/ControlCoreTests.cpp
+++ b/src/cascadia/UnitTests_Control/ControlCoreTests.cpp
@@ -36,6 +36,7 @@ namespace ControlUnitTests
         TEST_METHOD(TestClearScrollback);
         TEST_METHOD(TestClearScreen);
         TEST_METHOD(TestClearAll);
+        TEST_METHOD(TestReadEntireBuffer);
 
         TEST_CLASS_SETUP(ModuleSetup)
         {
@@ -338,6 +339,24 @@ namespace ControlUnitTests
         // clear scrollback.
         //
         // The ConptyRoundtripTests test the actual clearing of the contents.
+    }
+
+    void ControlCoreTests::TestReadEntireBuffer()
+    {
+        auto [settings, conn] = _createSettingsAndConnection();
+        Log::Comment(L"Create ControlCore object");
+        auto core = createCore(*settings, *conn);
+        VERIFY_IS_NOT_NULL(core);
+        _standardInit(core);
+
+        Log::Comment(L"Print some text");
+        conn->WriteInput(L"This is some text     \r\n");
+        conn->WriteInput(L"with varying amounts  \r\n");
+        conn->WriteInput(L"of whitespace         \r\n");
+
+        Log::Comment(L"Check the buffer contents");
+        VERIFY_ARE_EQUAL(L"This is some text\r\nwith varying amounts\r\nof whitespace\r\n",
+                         core->ReadEntireBuffer());
     }
 
 }


### PR DESCRIPTION
## Summary of the Pull Request
Ensures that reading the buffer content actually returns the content.

## References
Regressed in #13626.

## PR Checklist
* [x] Closes #14378
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [x] Tests added/passed

## Validation Steps Performed
Added a test.