### PR TITLE
Fix a potential deadlock for PtySignal::SetParent

### DIFF
--- a/src/host/PtySignalInputThread.hpp
+++ b/src/host/PtySignalInputThread.hpp
@@ -64,8 +64,8 @@ namespace Microsoft::Console
         [[nodiscard]] bool _GetData(_Out_writes_bytes_(cbBuffer) void* const pBuffer, const DWORD cbBuffer);
         void _DoResizeWindow(const ResizeWindowData& data);
         void _DoSetWindowParent(const SetParentData& data);
-        void _DoClearBuffer();
-        void _DoShowHide(const bool show);
+        void _DoClearBuffer() const;
+        void _DoShowHide(const ShowHideData& data);
         void _Shutdown();
 
         wil::unique_hfile _hFile;


### PR DESCRIPTION
This changeset consists of two parts:
* Refactor `PtySignalInputThread` to move more code from `_InputThread`
  into the various `_Do*` handlers. This allows us to precisely control
  console locking behavior which is the cause of this bug.
* Add the 1-line fix to `_DoSetWindowParent` to unlock the console before
  calling foreign functions (`SetWindowLongPtrW` in this case).

This fix is theoretical in nature, based on a memory dump from an affected user
and most likely fixes: https://developercommunity.visualstudio.com/t/10199439

## Validation Steps Performed
* ConPTY tests complete. ✅