### PR TITLE
Remove "Requires relaunch" from "use acrylic in tab row" text

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -439,7 +439,7 @@
     <comment>A description for what the "show titlebar" setting does. Presented near "Globals_ShowTitlebar.Header".</comment>
   </data>
   <data name="Globals_AcrylicTabRow.Header" xml:space="preserve">
-    <value>Use acrylic material in the tab row (requires relaunch)</value>
+    <value>Use acrylic material in the tab row</value>
     <comment>Header for a control to toggle whether "acrylic material" is used. "Acrylic material" is a Microsoft-specific term: https://docs.microsoft.com/en-us/windows/apps/design/style/acrylic</comment>
   </data>
   <data name="Globals_AcrylicTabRow.HelpText" xml:space="preserve">


### PR DESCRIPTION
what it says on the can. 

* [x] closes #14182

![image](https://user-images.githubusercontent.com/18356694/205180310-e08c3fb2-0e99-41a4-ba60-7eba09fbb328.png)
