### PR TITLE
Add an empty PGO rule to the wpf test harness app

### DIFF
--- a/src/cascadia/WpfTerminalTestNetCore/WpfTerminalTestNetCore.csproj
+++ b/src/cascadia/WpfTerminalTestNetCore/WpfTerminalTestNetCore.csproj
@@ -26,4 +26,7 @@
     </Content>
   </ItemGroup>
 
+  <!-- Install an empty one for CSPROJ projects as they don't PGO. -->
+  <Target Name="MergePGOCounts" />
+
 </Project>


### PR DESCRIPTION
This should fix the PGO build.