### PR TITLE
Make the Pane inactive border respect the `theme.window.applicationTheme`

### DIFF
--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -153,7 +153,7 @@
                                              Color="#2e2e2e" />
 
                             <StaticResource x:Key="UnfocusedBorderBrush"
-                                            ResourceKey="ApplicationPageBackgroundThemeBrush" />
+                                            ResourceKey="TabViewBackground" />
 
                             <SolidColorBrush x:Key="SettingsUiTabBrush"
                                              Color="#0c0c0c" />
@@ -169,7 +169,7 @@
                                              Color="#e8e8e8" />
 
                             <StaticResource x:Key="UnfocusedBorderBrush"
-                                            ResourceKey="ApplicationPageBackgroundThemeBrush" />
+                                            ResourceKey="TabViewBackground" />
 
                             <SolidColorBrush x:Key="SettingsUiTabBrush"
                                              Color="#ffffff" />

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -136,6 +136,8 @@ public:
 
     bool ContainsReadOnly() const;
 
+    static void SetupResources(const winrt::Windows::UI::Xaml::ElementTheme& requestedTheme);
+
     // Method Description:
     // - A helper method for ad-hoc recursion on a pane tree. Walks the pane
     //   tree, calling a function on each pane in a depth-first pattern.
@@ -336,8 +338,6 @@ private:
         }
         return false;
     }
-
-    static void _SetupResources();
 
     struct PanePoint
     {

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4175,6 +4175,22 @@ namespace winrt::TerminalApp::implementation
         const auto theme = _settings.GlobalSettings().CurrentTheme();
         auto requestedTheme{ theme.RequestedTheme() };
 
+        {
+            // Update the brushes that Pane's use...
+            Pane::SetupResources(requestedTheme);
+            // ... then trigger a visual update for all the bane borders to
+            // apply the new ones.
+            for (const auto& tab : _tabs)
+            {
+                if (auto terminalTab{ _GetTerminalTabImpl(tab) })
+                {
+                    terminalTab->GetRootPane()->WalkTree([&](auto&& pane) {
+                        pane->UpdateVisuals();
+                    });
+                }
+            }
+        }
+
         const auto res = Application::Current().Resources();
 
         // Use our helper to lookup the theme-aware version of the resource.

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4178,7 +4178,7 @@ namespace winrt::TerminalApp::implementation
         {
             // Update the brushes that Pane's use...
             Pane::SetupResources(requestedTheme);
-            // ... then trigger a visual update for all the bane borders to
+            // ... then trigger a visual update for all the pane borders to
             // apply the new ones.
             for (const auto& tab : _tabs)
             {


### PR DESCRIPTION
We couldn't do this before, because `App::Current().Resources().Lookup()` would always return the OS theme version of a resource. That thread has lengthy details on why.

FORTUNATELY FOR US, this isn't the first time we've dealt with this. We've come up with a workaround in the past, and we can just use it again here. 

Closes #3917

This will also make #3061 easy 😉 