### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/addToProject.yml
+++ b/.github/workflows/addToProject.yml
@@ -7,6 +7,7 @@ on:
       - labeled
       - unlabeled
 
+permissions: {}
 jobs:
   add-to-project:
     name: Add issue to project


### PR DESCRIPTION

This PR adds explicit [permissions section] to workflows. This is a
security best practice because by default workflows run with [extended
set of permissions] (except from `on: pull_request` [from external
forks]). By specifying any permission explicitly all others are set to
none. By using the principle of least privilege the damage a compromised
workflow can do (because of an [injection] or compromised third party
tool or action) is restricted.

It is recommended to have [most strict permissions on the top level] and
grant write permissions on [job level] case by case.

[permissions section]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
[extended set of permissions]: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
[from external forks]: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
[injection]: https://securitylab.github.com/research/github-actions-untrusted-input/
[most strict permissions on the top level]: https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
[job level]: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs