### PR TITLE
Added null check before rendering a string from the terminal connection

### DIFF
--- a/src/cascadia/WpfTerminalControl/TerminalContainer.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalContainer.cs
@@ -461,10 +461,11 @@ namespace Microsoft.Terminal.Wpf
 
         private void Connection_TerminalOutput(object sender, TerminalOutputEventArgs e)
         {
-            if (this.terminal == IntPtr.Zero)
+            if (this.terminal == IntPtr.Zero || string.IsNullOrEmpty(e.Data))
             {
                 return;
             }
+
             NativeMethods.TerminalSendOutput(this.terminal, e.Data);
         }
 


### PR DESCRIPTION
## Summary of the Pull Request
Watson reports show that Visual Studio terminal attempts to render a string that is null causing the renderer to crash.

More specifically, we see "NULL_POINTER_WRITE_c0000005_PublicTerminalCore.dll!TextBuffer::WriteLine" with the following stack:
PublicTerminalCore!TextBuffer::WriteLine+0x1da
PublicTerminalCore!TextBuffer::Write+0x191
PublicTerminalCore!Microsoft::Terminal::Core::Terminal::_WriteBuffer+0x1d3
PublicTerminalCore!Microsoft::Terminal::Core::Terminal::PrintString+0x9
PublicTerminalCore!TerminalDispatch::PrintString+0x22
PublicTerminalCore!Microsoft::Console::VirtualTerminal::OutputStateMachineEngine::ActionPrintString+0x42
PublicTerminalCore!Microsoft::Console::VirtualTerminal::StateMachine::ProcessString+0x123
PublicTerminalCore!TerminalSendOutput+0x68
Microsoft_DotNet_MSBuildSdkResolver!DomainBoundILStubClass.IL_STUB_PInvoke(IntPtr, System.String)+0x8f
Microsoft_Terminal_Wpf!Microsoft.Terminal.Wpf.TerminalContainer.Connection_TerminalOutput(System.Object, Microsoft.Terminal.Wpf.TerminalOutputEventArgs)+0x20
Microsoft_VisualStudio_Terminal_Implementation!Microsoft.VisualStudio.Terminal.TerminalWindowBase+<>c__DisplayClass59_0+<<BeginProcessingPtyData>b__0>d.MoveNext()+0x55f

## References
Internal bug: [Bug 1614709](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1614709): [Watson] crash64: NULL_POINTER_WRITE_c0000005_PublicTerminalCore.dll!TextBuffer::WriteLine

## Detailed Description of the Pull Request / Additional comments
Added a null check before PInvoking TerminalSendOutput.

## Validation Steps Performed
Validated locally that the check prevents null strings from rendering.