### PR TITLE
Match SearchBox AutoProp.Name to placeholder text

### DIFF
--- a/src/cascadia/TerminalControl/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalControl/Resources/en-US/Resources.resw
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -134,7 +134,7 @@
     <comment>The tooltip text for the search forward button.</comment>
   </data>
   <data name="SearchBox_TextBox.PlaceholderText" xml:space="preserve">
-    <value>Find...</value>
+    <value>Find</value>
     <comment>The placeholder text in the search box control.</comment>
   </data>
   <data name="DragFileCaption" xml:space="preserve">
@@ -158,8 +158,8 @@
     <comment>The name of the search backward button for accessibility.</comment>
   </data>
   <data name="SearchBox_TextBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Search Text</value>
-    <comment>The name of the text box on the search box control for accessibility.</comment>
+    <value>Find</value>
+    <comment>The name of the text box on the search box control for accessibility. This should match "SearchBox_TextBox.PlaceholderText"</comment>
   </data>
   <data name="TerminalControl_ControlType" xml:space="preserve">
     <value>terminal</value>

--- a/src/cascadia/TerminalControl/SearchBoxControl.cpp
+++ b/src/cascadia/TerminalControl/SearchBoxControl.cpp
@@ -4,6 +4,7 @@
 #include "pch.h"
 #include "SearchBoxControl.h"
 #include "SearchBoxControl.g.cpp"
+#include <LibraryResources.h>
 
 using namespace winrt;
 using namespace winrt::Windows::UI::Xaml;
@@ -19,11 +20,15 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         this->CharacterReceived({ this, &SearchBoxControl::_CharacterHandler });
         this->KeyDown({ this, &SearchBoxControl::_KeyDownHandler });
 
-        _focusableElements.insert(TextBox());
+        auto textBox = TextBox();
+        _focusableElements.insert(textBox);
         _focusableElements.insert(CloseButton());
         _focusableElements.insert(CaseSensitivityButton());
         _focusableElements.insert(GoForwardButton());
         _focusableElements.insert(GoBackwardButton());
+
+        // GH#14398: Visible text should match the placeholder text
+        Automation::AutomationProperties::SetName(textBox, RS_(L"SearchBox_TextBox/PlaceholderText"));
     }
 
     // Method Description:


### PR DESCRIPTION
## Summary of the Pull Request
Voice Access allows for functionality like "click \<name\>" to automatically move the cursor and click on a control. The Search Box had an AutoProp.Name that didn't match the placeholder text, leading to confusion because Voice Access wouldn't be able to find a control named "Find...".

To fix this, we simply aligned the placeholder text and the AutoProp.Name to be "Find". The elipses were removed because no dialog is opened.

The fix was accomplished in two ways to ensure that this is backportable:
1. via code, directly set the AutoProp.Name to match the placeholder text. 
2. in the resources file, explicitly match the AutoProp.Name to the placeholder text. This allows this change to be backportable in the event that the code above wasn't backported.

## References
#14398