### PR TITLE
Remove our dependency on Microsoft.Toolkit.Win32.UI.XamlApplication

### DIFF
--- a/dep/nuget/packages.config
+++ b/dep/nuget/packages.config
@@ -2,7 +2,6 @@
 <!-- The packages.config acts as the global version for all of the NuGet packages contained within. -->
 <packages>
   <!-- Native packages -->
-  <package id="Microsoft.Toolkit.Win32.UI.XamlApplication" version="6.1.3" targetFramework="native" />
   <package id="Microsoft.Internal.PGO-Helpers.Cpp" version="0.2.34" targetFramework="native" />
   <package id="Microsoft.Taef" version="10.60.210621002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210825.3" targetFramework="native" />

--- a/scratch/ScratchIslandApp/SampleApp/App.h
+++ b/scratch/ScratchIslandApp/SampleApp/App.h
@@ -12,12 +12,22 @@ namespace winrt::SampleApp::implementation
     {
     public:
         App();
+        void Initialize();
+        void Close();
         void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs const&);
+
+        bool IsDisposed() const
+        {
+            return _bIsClosed;
+        }
 
         SampleApp::SampleAppLogic Logic();
 
     private:
         bool _isUwp = false;
+        winrt::Windows::UI::Xaml::Hosting::WindowsXamlManager _windowsXamlManager = nullptr;
+        winrt::Windows::Foundation::Collections::IVector<winrt::Windows::UI::Xaml::Markup::IXamlMetadataProvider> _providers = winrt::single_threaded_vector<Windows::UI::Xaml::Markup::IXamlMetadataProvider>();
+        bool _bIsClosed = false;
     };
 }
 

--- a/scratch/ScratchIslandApp/SampleApp/App.idl
+++ b/scratch/ScratchIslandApp/SampleApp/App.idl
@@ -7,10 +7,12 @@ namespace SampleApp
 {
     // ADD ARBITRARY APP LOGIC TO SampleAppLogic.idl, NOT HERE.
     // This is for XAML platform setup only.
-    [default_interface] runtimeclass App : Microsoft.Toolkit.Win32.UI.XamlHost.XamlApplication
+    [default_interface] runtimeclass App : Windows.UI.Xaml.Application, Windows.Foundation.IClosable
     {
         App();
 
         SampleAppLogic Logic { get; };
+
+        Boolean IsDisposed { get; };
     }
 }

--- a/scratch/ScratchIslandApp/SampleApp/App.xaml
+++ b/scratch/ScratchIslandApp/SampleApp/App.xaml
@@ -2,20 +2,19 @@
     Copyright (c) Microsoft Corporation. All rights reserved. Licensed under
     the MIT License. See LICENSE in the project root for license information.
 -->
-<Toolkit:XamlApplication x:Class="SampleApp.App"
-                         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                         xmlns:TA="using:SampleApp"
-                         xmlns:Toolkit="using:Microsoft.Toolkit.Win32.UI.XamlHost"
-                         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                         xmlns:local="using:SampleApp"
-                         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                         mc:Ignorable="d">
+<Application x:Class="SampleApp.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:TA="using:SampleApp"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="using:SampleApp"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
     <!--
         If you want to prove this works, then add `RequestedTheme="Light"` to
         the properties on the XamlApplication
     -->
-    <Toolkit:XamlApplication.Resources>
+    <Application.Resources>
 
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -67,5 +66,5 @@
         </ResourceDictionary>
 
 
-    </Toolkit:XamlApplication.Resources>
-</Toolkit:XamlApplication>
+    </Application.Resources>
+</Application>

--- a/scratch/ScratchIslandApp/SampleApp/SampleAppLib.vcxproj
+++ b/scratch/ScratchIslandApp/SampleApp/SampleAppLib.vcxproj
@@ -20,7 +20,6 @@
 
   <PropertyGroup Label="NuGet Dependencies">
     <TerminalCppWinrt>true</TerminalCppWinrt>
-    <TerminalXamlApplicationToolkit>true</TerminalXamlApplicationToolkit>
   </PropertyGroup>
   <Import Project="..\..\..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.props" />
@@ -128,6 +127,16 @@
       <Private>false</Private>
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
     </Reference>
+
+    <Reference Include="$(WindowsSDK_MetadataPathVersioned)\Windows.UI.Xaml.Hosting.HostingContract\*\*.winmd">
+      <WinMDFile>true</WinMDFile>
+      <CopyLocal>false</CopyLocal>
+      <ReferenceGrouping>$(TargetPlatformMoniker)</ReferenceGrouping>
+      <ReferenceGroupingDisplayName>$(TargetPlatformDisplayName)</ReferenceGroupingDisplayName>
+      <ResolvedFrom>CppWinRTImplicitlyExpandTargetPlatform</ResolvedFrom>
+      <IsSystemReference>True</IsSystemReference>
+    </Reference>
+
   </ItemGroup>
   <!-- ====================== Compiler & Linker Flags ===================== -->
   <ItemDefinitionGroup>

--- a/scratch/ScratchIslandApp/SampleApp/dll/SampleApp.vcxproj
+++ b/scratch/ScratchIslandApp/SampleApp/dll/SampleApp.vcxproj
@@ -13,7 +13,6 @@
   </PropertyGroup>
   <PropertyGroup Label="NuGet Dependencies">
     <TerminalCppWinrt>true</TerminalCppWinrt>
-    <TerminalXamlApplicationToolkit>true</TerminalXamlApplicationToolkit>
   </PropertyGroup>
   <Import Project="..\..\..\..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.props" />

--- a/scratch/ScratchIslandApp/SampleApp/pch.h
+++ b/scratch/ScratchIslandApp/SampleApp/pch.h
@@ -46,7 +46,6 @@
 #include "winrt/Windows.UI.Xaml.Markup.h"
 #include "winrt/Windows.UI.ViewManagement.h"
 
-#include <winrt/Microsoft.Toolkit.Win32.UI.XamlHost.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.Primitives.h>
 #include <winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>

--- a/src/cascadia/LocalTests_TerminalApp/TerminalApp.LocalTests.vcxproj
+++ b/src/cascadia/LocalTests_TerminalApp/TerminalApp.LocalTests.vcxproj
@@ -23,7 +23,6 @@
 
   <PropertyGroup Label="NuGet Dependencies">
     <!-- TerminalCppWinrt is intentionally not set -->
-    <TerminalXamlApplicationToolkit>true</TerminalXamlApplicationToolkit>
   </PropertyGroup>
 
   <Import Project="$(SolutionDir)\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />

--- a/src/cascadia/TerminalApp/App.cpp
+++ b/src/cascadia/TerminalApp/App.cpp
@@ -12,19 +12,12 @@ using namespace winrt::Windows::UI::Xaml;
 using namespace winrt::Windows::UI::Xaml::Controls;
 using namespace winrt::Windows::UI::Xaml::Navigation;
 
+namespace xaml = ::winrt::Windows::UI::Xaml;
+
 namespace winrt::TerminalApp::implementation
 {
     App::App()
     {
-        // This is the same trick that Initialize() is about to use to figure out whether we're coming
-        // from a UWP context or from a Win32 context
-        // See https://github.com/windows-toolkit/Microsoft.Toolkit.Win32/blob/52611c57d89554f357f281d0c79036426a7d9257/Microsoft.Toolkit.Win32.UI.XamlApplication/XamlApplication.cpp#L42
-        const auto dispatcherQueue = ::winrt::Windows::System::DispatcherQueue::GetForCurrentThread();
-        if (dispatcherQueue)
-        {
-            _isUwp = true;
-        }
-
         Initialize();
 
         // Disable XAML's automatic backplating of text when in High Contrast
@@ -33,10 +26,48 @@ namespace winrt::TerminalApp::implementation
         HighContrastAdjustment(::winrt::Windows::UI::Xaml::ApplicationHighContrastAdjustment::None);
     }
 
+    void App::Initialize()
+    {
+        const auto dispatcherQueue = winrt::Windows::System::DispatcherQueue::GetForCurrentThread();
+        if (!dispatcherQueue)
+        {
+            _windowsXamlManager = xaml::Hosting::WindowsXamlManager::InitializeForCurrentThread();
+        }
+        else
+        {
+            _isUwp = true;
+        }
+    }
+
     AppLogic App::Logic()
     {
         static AppLogic logic;
         return logic;
+    }
+
+    void App::Close()
+    {
+        if (_bIsClosed)
+        {
+            return;
+        }
+
+        _bIsClosed = true;
+
+        if (_windowsXamlManager)
+        {
+            _windowsXamlManager.Close();
+        }
+        _windowsXamlManager = nullptr;
+
+        Exit();
+        {
+            MSG msg = {};
+            while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE))
+            {
+                ::DispatchMessageW(&msg);
+            }
+        }
     }
 
     /// <summary>

--- a/src/cascadia/TerminalApp/App.h
+++ b/src/cascadia/TerminalApp/App.h
@@ -5,6 +5,7 @@
 
 #include "App.g.h"
 #include "App.base.h"
+#include <winrt/Windows.UI.Xaml.Hosting.h>
 
 namespace winrt::TerminalApp::implementation
 {
@@ -13,11 +14,22 @@ namespace winrt::TerminalApp::implementation
     public:
         App();
         void OnLaunched(const Windows::ApplicationModel::Activation::LaunchActivatedEventArgs&);
+        void Initialize();
 
         TerminalApp::AppLogic Logic();
 
+        void Close();
+
+        bool IsDisposed() const
+        {
+            return _bIsClosed;
+        }
+
     private:
         bool _isUwp = false;
+        winrt::Windows::UI::Xaml::Hosting::WindowsXamlManager _windowsXamlManager = nullptr;
+        winrt::Windows::Foundation::Collections::IVector<winrt::Windows::UI::Xaml::Markup::IXamlMetadataProvider> _providers = winrt::single_threaded_vector<Windows::UI::Xaml::Markup::IXamlMetadataProvider>();
+        bool _bIsClosed = false;
     };
 }
 

--- a/src/cascadia/TerminalApp/App.idl
+++ b/src/cascadia/TerminalApp/App.idl
@@ -7,10 +7,12 @@ namespace TerminalApp
 {
     // ADD ARBITRARY APP LOGIC TO AppLogic.idl, NOT HERE.
     // This is for XAML platform setup only.
-    [default_interface] runtimeclass App : Microsoft.Toolkit.Win32.UI.XamlHost.XamlApplication
+    [default_interface] runtimeclass App : Windows.UI.Xaml.Application, Windows.Foundation.IClosable
     {
         App();
 
         AppLogic Logic { get; };
+
+        Boolean IsDisposed { get; };
     }
 }

--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -2,11 +2,10 @@
     Copyright (c) Microsoft Corporation. All rights reserved. Licensed under
     the MIT License. See LICENSE in the project root for license information.
 -->
-<Toolkit:XamlApplication x:Class="TerminalApp.App"
+<Application x:Class="TerminalApp.App"
                          xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                          xmlns:TA="using:TerminalApp"
-                         xmlns:Toolkit="using:Microsoft.Toolkit.Win32.UI.XamlHost"
                          xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                          xmlns:local="using:TerminalApp"
                          xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -15,7 +14,7 @@
         If you want to prove this works, then add `RequestedTheme="Light"` to
         the properties on the XamlApplication
     -->
-    <Toolkit:XamlApplication.Resources>
+    <Application.Resources>
 
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -202,5 +201,5 @@
         </ResourceDictionary>
 
 
-    </Toolkit:XamlApplication.Resources>
-</Toolkit:XamlApplication>
+    </Application.Resources>
+</Application>

--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -3,13 +3,13 @@
     the MIT License. See LICENSE in the project root for license information.
 -->
 <Application x:Class="TerminalApp.App"
-                         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                         xmlns:TA="using:TerminalApp"
-                         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                         xmlns:local="using:TerminalApp"
-                         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                         mc:Ignorable="d">
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:TA="using:TerminalApp"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="using:TerminalApp"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
     <!--
         If you want to prove this works, then add `RequestedTheme="Light"` to
         the properties on the XamlApplication

--- a/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
@@ -19,7 +19,6 @@
   </PropertyGroup>
   <PropertyGroup Label="NuGet Dependencies">
     <TerminalCppWinrt>true</TerminalCppWinrt>
-    <TerminalXamlApplicationToolkit>true</TerminalXamlApplicationToolkit>
     <TerminalMUX>true</TerminalMUX>
   </PropertyGroup>
   <Import Project="..\..\..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
@@ -381,6 +380,14 @@
       <IsWinMDFile>true</IsWinMDFile>
       <Private>false</Private>
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+    </Reference>
+    <Reference Include="$(WindowsSDK_MetadataPathVersioned)\Windows.UI.Xaml.Hosting.HostingContract\*\*.winmd">
+      <WinMDFile>true</WinMDFile>
+      <CopyLocal>false</CopyLocal>
+      <ReferenceGrouping>$(TargetPlatformMoniker)</ReferenceGrouping>
+      <ReferenceGroupingDisplayName>$(TargetPlatformDisplayName)</ReferenceGroupingDisplayName>
+      <ResolvedFrom>CppWinRTImplicitlyExpandTargetPlatform</ResolvedFrom>
+      <IsSystemReference>True</IsSystemReference>
     </Reference>
   </ItemGroup>
   <!-- ====================== Compiler & Linker Flags ===================== -->

--- a/src/cascadia/TerminalApp/dll/TerminalApp.vcxproj
+++ b/src/cascadia/TerminalApp/dll/TerminalApp.vcxproj
@@ -14,7 +14,6 @@
   </PropertyGroup>
   <PropertyGroup Label="NuGet Dependencies">
     <TerminalCppWinrt>true</TerminalCppWinrt>
-    <TerminalXamlApplicationToolkit>true</TerminalXamlApplicationToolkit>
     <TerminalMUX>true</TerminalMUX>
   </PropertyGroup>
   <Import Project="..\..\..\..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />

--- a/src/cascadia/TerminalApp/pch.h
+++ b/src/cascadia/TerminalApp/pch.h
@@ -50,7 +50,6 @@
 #include <winrt/Windows.Media.Core.h>
 #include <winrt/Windows.Media.Playback.h>
 
-#include <winrt/Microsoft.Toolkit.Win32.UI.XamlHost.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.Primitives.h>
 #include <winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>

--- a/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
+++ b/src/cascadia/WindowsTerminal/WindowsTerminal.vcxproj
@@ -18,7 +18,6 @@
 
   <PropertyGroup Label="NuGet Dependencies">
     <TerminalCppWinrt>true</TerminalCppWinrt>
-    <TerminalXamlApplicationToolkit>true</TerminalXamlApplicationToolkit>
     <TerminalVCRTForwarders>true</TerminalVCRTForwarders>
     <TerminalThemeHelpers>true</TerminalThemeHelpers>
     <TerminalMUX>true</TerminalMUX>

--- a/src/common.nugetversions.props
+++ b/src/common.nugetversions.props
@@ -6,9 +6,6 @@
   <!-- CppWinrt -->
   <Import Project="$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.210825.3\build\native\Microsoft.Windows.CppWinRT.props" Condition="'$(TerminalCppWinrt)' == 'true' and Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.210825.3\build\native\Microsoft.Windows.CppWinRT.props')" />
 
-  <!-- XamlApplicationToolkit -->
-  <Import Project="$(MSBuildThisFileDirectory)..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.props" Condition="'$(TerminalXamlApplicationToolkit)'  == 'true' and Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.props')" />
-
   <!-- TAEF -->
   <PropertyGroup>
     <TAEFPackagePathRoot>$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.60.210621002</TAEFPackagePathRoot>

--- a/src/common.nugetversions.targets
+++ b/src/common.nugetversions.targets
@@ -40,9 +40,6 @@
     <!-- CppWinrt -->
     <Import Project="$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.210825.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="'$(TerminalCppWinrt)' == 'true' and Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.210825.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
 
-    <!-- XamlApplicationToolkit -->
-    <Import Project="$(MSBuildThisFileDirectory)..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets" Condition="'$(TerminalXamlApplicationToolkit)' == 'true' and Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets')" />
-
     <!-- TAEF -->
     <Import Project="$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets" Condition="'$(TerminalTAEF)' == 'true' and Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets')" />
     
@@ -78,10 +75,6 @@
     <!-- CppWinrt -->
     <Error Condition="'$(TerminalCppWinrt)' == 'true' AND !Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.210825.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.210825.3\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="'$(TerminalCppWinrt)' == 'true' AND !Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.210825.3\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(MSBuildThisFileDirectory)..\packages\Microsoft.Windows.CppWinRT.2.0.210825.3\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-
-    <!-- XamlApplicationToolkit -->
-    <Error Condition="'$(TerminalXamlApplicationToolkit)' == 'true' AND !Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.props')" Text="$([System.String]::Format('$(ErrorText)', '$(MSBuildThisFileDirectory)..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.props'))" />
-    <Error Condition="'$(TerminalXamlApplicationToolkit)' == 'true' AND !Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(MSBuildThisFileDirectory)..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets'))" />
 
     <!-- TAEF -->
     <Error Condition="'$(TerminalTAEF)' == 'true' AND !Exists('$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(MSBuildThisFileDirectory)..\packages\Microsoft.Taef.10.60.210621002\build\Microsoft.Taef.targets'))" />


### PR DESCRIPTION
We originally needed this library (or a separate DLL in our own project)
to handle hooking up the XAML resource loader to the providers that our
application needed. It was introduced in its nascent form in 2019, in a
PR titled "Make XAML files work."

It appears we no longer need it, and the provider hookup is being
handled by our `AppT2` base class override. I've tested this in Windows
10 Vb running unpackaged, and it seems to work totally fine. Crazy.

Removing this dependency saves us a couple hundred kilobytes on disk and
removes one consumer of the App CRT from our package.