### PR TITLE
Ensure X/Y controls are updated when default launch pos selected

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
@@ -115,7 +115,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             InitialPosX(NAN);
             InitialPosY(NAN);
         }
-        _NotifyChanges(L"UseDefaultLaunchPosition", L"LaunchParametersCurrentValue");
+        _NotifyChanges(L"UseDefaultLaunchPosition", L"LaunchParametersCurrentValue", L"InitialPosX", L"InitialPosY");
     }
 
     bool LaunchViewModel::UseDefaultLaunchPosition()


### PR DESCRIPTION
Ensures the X & Y XAML controls are updated when the default launch position checkbox is toggled.
References #14518