### PR TITLE
Introduce PseudoConsoleWindow a11y provider

### DIFF
--- a/src/interactivity/base/InteractivityFactory.cpp
+++ b/src/interactivity/base/InteractivityFactory.cpp
@@ -29,88 +29,6 @@
 using namespace std;
 using namespace Microsoft::Console::Interactivity;
 
-HRESULT PseudoConsoleWindowAccessibilityProvider::RuntimeClassInitialize(HWND pseudoConsoleHwnd) noexcept
-{
-    RETURN_HR_IF_NULL(E_INVALIDARG, pseudoConsoleHwnd);
-    _pseudoConsoleHwnd = pseudoConsoleHwnd;
-    return S_OK;
-}
-
-IFACEMETHODIMP PseudoConsoleWindowAccessibilityProvider::get_ProviderOptions(_Out_ ProviderOptions* pOptions)
-{
-    RETURN_HR_IF_NULL(E_INVALIDARG, pOptions);
-    *pOptions = ProviderOptions_ServerSideProvider;
-    return S_OK;
-}
-
-IFACEMETHODIMP PseudoConsoleWindowAccessibilityProvider::GetPatternProvider(_In_ PATTERNID /*iid*/,
-                                                                            _COM_Outptr_result_maybenull_ IUnknown** ppInterface)
-{
-    RETURN_HR_IF_NULL(E_INVALIDARG, ppInterface);
-    *ppInterface = nullptr;
-    return S_OK;
-}
-
-IFACEMETHODIMP PseudoConsoleWindowAccessibilityProvider::GetPropertyValue(_In_ PROPERTYID propertyId,
-                                                                          _Out_ VARIANT* pVariant)
-{
-    RETURN_HR_IF_NULL(E_INVALIDARG, pVariant);
-
-    pVariant->vt = VT_EMPTY;
-
-    // Returning the default will leave the property as the default
-    // so we only really need to touch it for the properties we want to implement
-    if (propertyId == UIA_ControlTypePropertyId)
-    {
-        pVariant->vt = VT_I4;
-        pVariant->lVal = UIA_WindowControlTypeId;
-    }
-    else if (propertyId == UIA_NamePropertyId)
-    {
-        pVariant->bstrVal = SysAllocString(AutomationPropertyName);
-        if (pVariant->bstrVal != nullptr)
-        {
-            pVariant->vt = VT_BSTR;
-        }
-    }
-    else if (propertyId == UIA_IsControlElementPropertyId)
-    {
-        pVariant->vt = VT_BOOL;
-        pVariant->boolVal = VARIANT_FALSE;
-    }
-    else if (propertyId == UIA_IsContentElementPropertyId)
-    {
-        pVariant->vt = VT_BOOL;
-        pVariant->boolVal = VARIANT_FALSE;
-    }
-    else if (propertyId == UIA_IsKeyboardFocusablePropertyId)
-    {
-        pVariant->vt = VT_BOOL;
-        pVariant->boolVal = VARIANT_FALSE;
-    }
-    else if (propertyId == UIA_HasKeyboardFocusPropertyId)
-    {
-        pVariant->vt = VT_BOOL;
-        pVariant->boolVal = VARIANT_FALSE;
-    }
-    else if (propertyId == UIA_ProviderDescriptionPropertyId)
-    {
-        pVariant->bstrVal = SysAllocString(ProviderDescriptionPropertyName);
-        if (pVariant->bstrVal != nullptr)
-        {
-            pVariant->vt = VT_BSTR;
-        }
-    }
-    return S_OK;
-}
-
-IFACEMETHODIMP PseudoConsoleWindowAccessibilityProvider::get_HostRawElementProvider(_COM_Outptr_result_maybenull_ IRawElementProviderSimple** ppProvider)
-{
-    RETURN_HR_IF_NULL(E_INVALIDARG, ppProvider);
-    RETURN_HR_IF_NULL(gsl::narrow_cast<HRESULT>(UIA_E_ELEMENTNOTAVAILABLE), _pseudoConsoleHwnd);
-    return UiaHostProviderFromHwnd(_pseudoConsoleHwnd, ppProvider);
-}
-
 #pragma region Public Methods
 
 [[nodiscard]] NTSTATUS InteractivityFactory::CreateConsoleControl(_Inout_ std::unique_ptr<IConsoleControl>& control)
@@ -550,11 +468,11 @@ IFACEMETHODIMP PseudoConsoleWindowAccessibilityProvider::get_HostRawElementProvi
     {
         if (static_cast<long>(lParam) == static_cast<long>(UiaRootObjectId))
         {
-            if (nullptr == _pUiaProvider)
+            if (nullptr == _pPseudoConsoleUiaProvider)
             {
-                LOG_IF_FAILED(WRL::MakeAndInitialize<PseudoConsoleWindowAccessibilityProvider>(&_pUiaProvider, _pseudoConsoleWindowHwnd));
+                LOG_IF_FAILED(WRL::MakeAndInitialize<PseudoConsoleWindowAccessibilityProvider>(&_pPseudoConsoleUiaProvider, _pseudoConsoleWindowHwnd));
             }
-            return UiaReturnRawElementProvider(hWnd, wParam, lParam, _pUiaProvider.Get());
+            return UiaReturnRawElementProvider(hWnd, wParam, lParam, _pPseudoConsoleUiaProvider.Get());
         }
         return 0;
     }

--- a/src/interactivity/base/InteractivityFactory.cpp
+++ b/src/interactivity/base/InteractivityFactory.cpp
@@ -416,25 +416,25 @@ IFACEMETHODIMP PseudoConsoleWindowAccessibilityProvider::get_HostRawElementProvi
                 const auto exStyles = WS_EX_TOOLWINDOW | WS_EX_TRANSPARENT | WS_EX_LAYERED | WS_EX_NOACTIVATE;
 
                 // Attempt to create window.
-                _pseudoConsoleWindowHwnd = hwnd = CreateWindowExW(exStyles,
-                                                                  reinterpret_cast<LPCWSTR>(windowClassAtom),
-                                                                  nullptr,
-                                                                  windowStyle,
-                                                                  0,
-                                                                  0,
-                                                                  0,
-                                                                  0,
-                                                                  owner,
-                                                                  nullptr,
-                                                                  nullptr,
-                                                                  this);
+                hwnd = CreateWindowExW(exStyles,
+                                       reinterpret_cast<LPCWSTR>(windowClassAtom),
+                                       nullptr,
+                                       windowStyle,
+                                       0,
+                                       0,
+                                       0,
+                                       0,
+                                       owner,
+                                       nullptr,
+                                       nullptr,
+                                       this);
 
                 if (hwnd == nullptr)
                 {
                     const auto gle = GetLastError();
                     status = NTSTATUS_FROM_WIN32(gle);
                 }
-
+                _pseudoConsoleWindowHwnd = hwnd;
                 break;
             }
 #ifdef BUILD_ONECORE_INTERACTIVITY

--- a/src/interactivity/base/InteractivityFactory.hpp
+++ b/src/interactivity/base/InteractivityFactory.hpp
@@ -8,6 +8,7 @@
 #include "ApiDetector.hpp"
 
 #include "../inc/IInteractivityFactory.hpp"
+#include <wrl/implements.h>
 
 #include <map>
 
@@ -15,6 +16,34 @@
 
 namespace Microsoft::Console::Interactivity
 {
+    class PseudoConsoleWindowAccessibilityProvider final :
+        public WRL::RuntimeClass<WRL::RuntimeClassFlags<WRL::ClassicCom | WRL::InhibitFtmBase>, IRawElementProviderSimple>
+    {
+    public:
+        PseudoConsoleWindowAccessibilityProvider() = default;
+        ~PseudoConsoleWindowAccessibilityProvider() = default;
+        HRESULT RuntimeClassInitialize(HWND pseudoConsoleHwnd) noexcept;
+
+        PseudoConsoleWindowAccessibilityProvider(const PseudoConsoleWindowAccessibilityProvider&) = delete;
+        PseudoConsoleWindowAccessibilityProvider(PseudoConsoleWindowAccessibilityProvider&&) = delete;
+        PseudoConsoleWindowAccessibilityProvider& operator=(const PseudoConsoleWindowAccessibilityProvider&) = delete;
+        PseudoConsoleWindowAccessibilityProvider& operator=(PseudoConsoleWindowAccessibilityProvider&&) = delete;
+
+        // IRawElementProviderSimple methods
+        IFACEMETHODIMP get_ProviderOptions(_Out_ ProviderOptions* pOptions) override;
+        IFACEMETHODIMP GetPatternProvider(_In_ PATTERNID iid,
+                                          _COM_Outptr_result_maybenull_ IUnknown** ppInterface) override;
+        IFACEMETHODIMP GetPropertyValue(_In_ PROPERTYID idProp,
+                                        _Out_ VARIANT* pVariant) override;
+        IFACEMETHODIMP get_HostRawElementProvider(_COM_Outptr_result_maybenull_ IRawElementProviderSimple** ppProvider) override;
+
+    private:
+        HWND _pseudoConsoleHwnd;
+
+        const OLECHAR* AutomationPropertyName = L"PseudoConsoleWindow";
+        const OLECHAR* ProviderDescriptionPropertyName = L"Pseudo Console Window";
+    };
+
     class InteractivityFactory final : public IInteractivityFactory
     {
     public:
@@ -40,5 +69,8 @@ namespace Microsoft::Console::Interactivity
 
     private:
         void _WritePseudoWindowCallback(bool showOrHide);
+
+        HWND _pseudoConsoleWindowHwnd{ nullptr };
+        WRL::ComPtr<PseudoConsoleWindowAccessibilityProvider> _pUiaProvider{ nullptr };
     };
 }

--- a/src/interactivity/base/InteractivityFactory.hpp
+++ b/src/interactivity/base/InteractivityFactory.hpp
@@ -9,7 +9,6 @@
 
 #include "../inc/IInteractivityFactory.hpp"
 #include "PseudoConsoleWindowAccessibilityProvider.hpp"
-#include <wrl/implements.h>
 
 #include <map>
 

--- a/src/interactivity/base/InteractivityFactory.hpp
+++ b/src/interactivity/base/InteractivityFactory.hpp
@@ -8,6 +8,7 @@
 #include "ApiDetector.hpp"
 
 #include "../inc/IInteractivityFactory.hpp"
+#include "PseudoConsoleWindowAccessibilityProvider.hpp"
 #include <wrl/implements.h>
 
 #include <map>
@@ -16,34 +17,6 @@
 
 namespace Microsoft::Console::Interactivity
 {
-    class PseudoConsoleWindowAccessibilityProvider final :
-        public WRL::RuntimeClass<WRL::RuntimeClassFlags<WRL::ClassicCom | WRL::InhibitFtmBase>, IRawElementProviderSimple>
-    {
-    public:
-        PseudoConsoleWindowAccessibilityProvider() = default;
-        ~PseudoConsoleWindowAccessibilityProvider() = default;
-        HRESULT RuntimeClassInitialize(HWND pseudoConsoleHwnd) noexcept;
-
-        PseudoConsoleWindowAccessibilityProvider(const PseudoConsoleWindowAccessibilityProvider&) = delete;
-        PseudoConsoleWindowAccessibilityProvider(PseudoConsoleWindowAccessibilityProvider&&) = delete;
-        PseudoConsoleWindowAccessibilityProvider& operator=(const PseudoConsoleWindowAccessibilityProvider&) = delete;
-        PseudoConsoleWindowAccessibilityProvider& operator=(PseudoConsoleWindowAccessibilityProvider&&) = delete;
-
-        // IRawElementProviderSimple methods
-        IFACEMETHODIMP get_ProviderOptions(_Out_ ProviderOptions* pOptions) override;
-        IFACEMETHODIMP GetPatternProvider(_In_ PATTERNID iid,
-                                          _COM_Outptr_result_maybenull_ IUnknown** ppInterface) override;
-        IFACEMETHODIMP GetPropertyValue(_In_ PROPERTYID idProp,
-                                        _Out_ VARIANT* pVariant) override;
-        IFACEMETHODIMP get_HostRawElementProvider(_COM_Outptr_result_maybenull_ IRawElementProviderSimple** ppProvider) override;
-
-    private:
-        HWND _pseudoConsoleHwnd;
-
-        const OLECHAR* AutomationPropertyName = L"PseudoConsoleWindow";
-        const OLECHAR* ProviderDescriptionPropertyName = L"Pseudo Console Window";
-    };
-
     class InteractivityFactory final : public IInteractivityFactory
     {
     public:
@@ -71,6 +44,6 @@ namespace Microsoft::Console::Interactivity
         void _WritePseudoWindowCallback(bool showOrHide);
 
         HWND _pseudoConsoleWindowHwnd{ nullptr };
-        WRL::ComPtr<PseudoConsoleWindowAccessibilityProvider> _pUiaProvider{ nullptr };
+        WRL::ComPtr<PseudoConsoleWindowAccessibilityProvider> _pPseudoConsoleUiaProvider{ nullptr };
     };
 }

--- a/src/interactivity/base/PseudoConsoleWindowAccessibilityProvider.cpp
+++ b/src/interactivity/base/PseudoConsoleWindowAccessibilityProvider.cpp
@@ -44,6 +44,7 @@ IFACEMETHODIMP PseudoConsoleWindowAccessibilityProvider::GetPropertyValue(_In_ P
     {
         pVariant->vt = VT_I4;
         pVariant->lVal = UIA_WindowControlTypeId;
+        break;
     }
     case UIA_NamePropertyId:
     {
@@ -52,6 +53,7 @@ IFACEMETHODIMP PseudoConsoleWindowAccessibilityProvider::GetPropertyValue(_In_ P
         {
             pVariant->vt = VT_BSTR;
         }
+        break;
     }
     case UIA_IsControlElementPropertyId:
     case UIA_IsContentElementPropertyId:
@@ -60,6 +62,7 @@ IFACEMETHODIMP PseudoConsoleWindowAccessibilityProvider::GetPropertyValue(_In_ P
     {
         pVariant->vt = VT_BOOL;
         pVariant->boolVal = VARIANT_FALSE;
+        break;
     }
     default:
         break;

--- a/src/interactivity/base/PseudoConsoleWindowAccessibilityProvider.cpp
+++ b/src/interactivity/base/PseudoConsoleWindowAccessibilityProvider.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "precomp.h"
+
+#include "PseudoConsoleWindowAccessibilityProvider.hpp"
+
+using namespace Microsoft::Console::Interactivity;
+
+HRESULT PseudoConsoleWindowAccessibilityProvider::RuntimeClassInitialize(HWND pseudoConsoleHwnd) noexcept
+{
+    RETURN_HR_IF_NULL(E_INVALIDARG, pseudoConsoleHwnd);
+    _pseudoConsoleHwnd = pseudoConsoleHwnd;
+    return S_OK;
+}
+
+IFACEMETHODIMP PseudoConsoleWindowAccessibilityProvider::get_ProviderOptions(_Out_ ProviderOptions* pOptions)
+{
+    RETURN_HR_IF_NULL(E_INVALIDARG, pOptions);
+    *pOptions = ProviderOptions_ServerSideProvider;
+    return S_OK;
+}
+
+IFACEMETHODIMP PseudoConsoleWindowAccessibilityProvider::GetPatternProvider(_In_ PATTERNID /*iid*/,
+                                                                            _COM_Outptr_result_maybenull_ IUnknown** ppInterface)
+{
+    RETURN_HR_IF_NULL(E_INVALIDARG, ppInterface);
+    *ppInterface = nullptr;
+    return S_OK;
+}
+
+IFACEMETHODIMP PseudoConsoleWindowAccessibilityProvider::GetPropertyValue(_In_ PROPERTYID propertyId,
+                                                                          _Out_ VARIANT* pVariant)
+{
+    RETURN_HR_IF_NULL(E_INVALIDARG, pVariant);
+
+    pVariant->vt = VT_EMPTY;
+
+    // Returning the default will leave the property as the default
+    // so we only really need to touch it for the properties we want to implement
+    switch (propertyId)
+    {
+    case UIA_ControlTypePropertyId:
+    {
+        pVariant->vt = VT_I4;
+        pVariant->lVal = UIA_WindowControlTypeId;
+    }
+    case UIA_NamePropertyId:
+    {
+        pVariant->bstrVal = SysAllocString(AutomationPropertyName);
+        if (pVariant->bstrVal != nullptr)
+        {
+            pVariant->vt = VT_BSTR;
+        }
+    }
+    case UIA_IsControlElementPropertyId:
+    case UIA_IsContentElementPropertyId:
+    case UIA_IsKeyboardFocusablePropertyId:
+    case UIA_HasKeyboardFocusPropertyId:
+    {
+        pVariant->vt = VT_BOOL;
+        pVariant->boolVal = VARIANT_FALSE;
+    }
+    default:
+        break;
+    }
+    return S_OK;
+}
+
+IFACEMETHODIMP PseudoConsoleWindowAccessibilityProvider::get_HostRawElementProvider(_COM_Outptr_result_maybenull_ IRawElementProviderSimple** ppProvider)
+{
+    RETURN_HR_IF_NULL(E_INVALIDARG, ppProvider);
+    RETURN_HR_IF_NULL(gsl::narrow_cast<HRESULT>(UIA_E_ELEMENTNOTAVAILABLE), _pseudoConsoleHwnd);
+    return UiaHostProviderFromHwnd(_pseudoConsoleHwnd, ppProvider);
+}

--- a/src/interactivity/base/PseudoConsoleWindowAccessibilityProvider.cpp
+++ b/src/interactivity/base/PseudoConsoleWindowAccessibilityProvider.cpp
@@ -48,6 +48,7 @@ IFACEMETHODIMP PseudoConsoleWindowAccessibilityProvider::GetPropertyValue(_In_ P
     }
     case UIA_NamePropertyId:
     {
+        static constexpr auto AutomationPropertyName = L"Internal Console Management Window";
         pVariant->bstrVal = SysAllocString(AutomationPropertyName);
         if (pVariant->bstrVal != nullptr)
         {

--- a/src/interactivity/base/PseudoConsoleWindowAccessibilityProvider.hpp
+++ b/src/interactivity/base/PseudoConsoleWindowAccessibilityProvider.hpp
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+#include "precomp.h"
+
+namespace Microsoft::Console::Interactivity
+{
+    class PseudoConsoleWindowAccessibilityProvider final :
+        public WRL::RuntimeClass<WRL::RuntimeClassFlags<WRL::ClassicCom | WRL::InhibitFtmBase>, IRawElementProviderSimple>
+    {
+    public:
+        PseudoConsoleWindowAccessibilityProvider() = default;
+        ~PseudoConsoleWindowAccessibilityProvider() = default;
+        HRESULT RuntimeClassInitialize(HWND pseudoConsoleHwnd) noexcept;
+
+        PseudoConsoleWindowAccessibilityProvider(const PseudoConsoleWindowAccessibilityProvider&) = delete;
+        PseudoConsoleWindowAccessibilityProvider(PseudoConsoleWindowAccessibilityProvider&&) = delete;
+        PseudoConsoleWindowAccessibilityProvider& operator=(const PseudoConsoleWindowAccessibilityProvider&) = delete;
+        PseudoConsoleWindowAccessibilityProvider& operator=(PseudoConsoleWindowAccessibilityProvider&&) = delete;
+
+        // IRawElementProviderSimple methods
+        IFACEMETHODIMP get_ProviderOptions(_Out_ ProviderOptions* pOptions) override;
+        IFACEMETHODIMP GetPatternProvider(_In_ PATTERNID iid,
+                                          _COM_Outptr_result_maybenull_ IUnknown** ppInterface) override;
+        IFACEMETHODIMP GetPropertyValue(_In_ PROPERTYID idProp,
+                                        _Out_ VARIANT* pVariant) override;
+        IFACEMETHODIMP get_HostRawElementProvider(_COM_Outptr_result_maybenull_ IRawElementProviderSimple** ppProvider) override;
+
+    private:
+        HWND _pseudoConsoleHwnd;
+
+        const OLECHAR* AutomationPropertyName = L"Internal Console Management Window";
+    };
+}

--- a/src/interactivity/base/PseudoConsoleWindowAccessibilityProvider.hpp
+++ b/src/interactivity/base/PseudoConsoleWindowAccessibilityProvider.hpp
@@ -30,7 +30,5 @@ namespace Microsoft::Console::Interactivity
 
     private:
         HWND _pseudoConsoleHwnd;
-
-        const OLECHAR* AutomationPropertyName = L"Internal Console Management Window";
     };
 }

--- a/src/interactivity/base/lib/InteractivityBase.vcxproj
+++ b/src/interactivity/base/lib/InteractivityBase.vcxproj
@@ -28,6 +28,7 @@
     <ClCompile Include="..\precomp.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="..\PseudoConsoleWindowAccessibilityProvider.cpp" />
     <ClCompile Include="..\RemoteConsoleControl.cpp" />
     <ClCompile Include="..\ServiceLocator.cpp" />
     <ClCompile Include="..\VtApiRedirection.cpp" />
@@ -49,6 +50,7 @@
     <ClInclude Include="..\InteractivityFactory.hpp" />
     <ClInclude Include="..\precomp.h" />
     <ClInclude Include="..\..\inc\ServiceLocator.hpp" />
+    <ClInclude Include="..\PseudoConsoleWindowAccessibilityProvider.hpp" />
     <ClInclude Include="..\RemoteConsoleControl.hpp" />
   </ItemGroup>
   <!-- Careful reordering these. Some default props (contained in these files) are order sensitive. -->

--- a/src/interactivity/base/lib/InteractivityBase.vcxproj.filters
+++ b/src/interactivity/base/lib/InteractivityBase.vcxproj.filters
@@ -36,6 +36,12 @@
     <ClCompile Include="..\HostSignalInputThread.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\VtApiRedirection.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\PseudoConsoleWindowAccessibilityProvider.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\InteractivityFactory.hpp">
@@ -87,6 +93,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\HostSignalInputThread.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\PseudoConsoleWindowAccessibilityProvider.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/interactivity/base/sources.inc
+++ b/src/interactivity/base/sources.inc
@@ -43,6 +43,7 @@ SOURCES = \
     ..\EventSynthesis.cpp \
     ..\RemoteConsoleControl.cpp \
     ..\HostSignalInputThread.cpp \
+    ..\PseudoConsoleWindowAccessibilityProvider.cpp \
 
 INCLUDES = \
     $(INCLUDES); \


### PR DESCRIPTION
In order to modify the accessibility information for the PseudoConsoleWindow, it needs to have a UIA provider registered. This PR introduces `PseudoConsoleWindowAccessibilityProvider` and registers it as a UIA provider appropriately. The registration process is based on that of the `WindowUiaProvider` for ConHost.

Closes #14385

## Validation Steps Performed
Run Accessibility Insights FastPass on the window. The PseudoConsoleWindow no longer is tagged as missing a name.