### PR TITLE
Add support for start /B and FreeConsole

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -817,6 +817,7 @@ HORZ
 hostable
 hostlib
 HPA
+hpcon
 HPCON
 hpj
 HPR

--- a/src/cascadia/TerminalConnection/ConptyConnection.h
+++ b/src/cascadia/TerminalConnection/ConptyConnection.h
@@ -6,15 +6,7 @@
 #include "ConptyConnection.g.h"
 #include "ConnectionStateHolder.h"
 
-#include <conpty-static.h>
-
 #include "ITerminalHandoff.h"
-
-namespace wil
-{
-    // These belong in WIL upstream, so when we reingest the change that has them we'll get rid of ours.
-    using unique_static_pseudoconsole_handle = wil::unique_any<HPCON, decltype(&::ConptyClosePseudoConsole), ::ConptyClosePseudoConsoleNoWait>;
-}
 
 namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 {
@@ -65,12 +57,13 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         WINRT_CALLBACK(TerminalOutput, TerminalOutputHandler);
 
     private:
+        static void closePseudoConsoleAsync(HPCON hPC) noexcept;
         static HRESULT NewHandoff(HANDLE in, HANDLE out, HANDLE signal, HANDLE ref, HANDLE server, HANDLE client, TERMINAL_STARTUP_INFO startupInfo) noexcept;
         static winrt::hstring _commandlineFromProcess(HANDLE process);
 
         HRESULT _LaunchAttachedClient() noexcept;
         void _indicateExitWithStatus(unsigned int status) noexcept;
-        void _ClientTerminated() noexcept;
+        void _LastConPtyClientDisconnected() noexcept;
 
         til::CoordType _rows{};
         til::CoordType _cols{};
@@ -90,8 +83,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
         wil::unique_hfile _outPipe; // The pipe for reading output from
         wil::unique_handle _hOutputThread;
         wil::unique_process_information _piClient;
-        wil::unique_static_pseudoconsole_handle _hPC;
-        wil::unique_threadpool_wait _clientExitWait;
+        wil::unique_any<HPCON, decltype(closePseudoConsoleAsync), closePseudoConsoleAsync> _hPC;
 
         til::u8state _u8State{};
         std::wstring _u16Str{};

--- a/src/host/PtySignalInputThread.cpp
+++ b/src/host/PtySignalInputThread.cpp
@@ -350,6 +350,6 @@ void PtySignalInputThread::_DoSetWindowParent(const SetParentData& data)
 // - <none>
 void PtySignalInputThread::_Shutdown()
 {
-    // Trigger process shutdown.
-    CloseConsoleProcessState();
+    auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
+    gci.GetVtIo()->SendCloseEvent();
 }

--- a/src/host/VtIo.hpp
+++ b/src/host/VtIo.hpp
@@ -32,11 +32,10 @@ namespace Microsoft::Console::VirtualTerminal
         [[nodiscard]] HRESULT StartIfNeeded();
 
         [[nodiscard]] static HRESULT ParseIoMode(const std::wstring& VtMode, _Out_ VtIoMode& ioMode);
-
         [[nodiscard]] HRESULT SuppressResizeRepaint();
         [[nodiscard]] HRESULT SetCursorPosition(const til::point coordCursor);
-
         [[nodiscard]] HRESULT SwitchScreenBuffer(const bool useAltBuffer);
+        void SendCloseEvent();
 
         void CloseInput();
         void CloseOutput();
@@ -71,14 +70,13 @@ namespace Microsoft::Console::VirtualTerminal
         bool _resizeQuirk{ false };
         bool _win32InputMode{ false };
         bool _passthroughMode{ false };
+        bool _closeEventSent{ false };
 
         std::unique_ptr<Microsoft::Console::Render::VtEngine> _pVtRenderEngine;
         std::unique_ptr<Microsoft::Console::VtInputThread> _pVtInputThread;
         std::unique_ptr<Microsoft::Console::PtySignalInputThread> _pPtySignalInputThread;
 
         [[nodiscard]] HRESULT _Initialize(const HANDLE InHandle, const HANDLE OutHandle, const std::wstring& VtMode, _In_opt_ const HANDLE SignalHandle);
-
-        void _shutdownNow();
 
 #ifdef UNIT_TESTING
         friend class VtIoTests;

--- a/src/host/output.cpp
+++ b/src/host/output.cpp
@@ -499,9 +499,6 @@ void SetActiveScreenBuffer(SCREEN_INFORMATION& screenInfo)
 // TODO: MSFT 9450717 This should join the ProcessList class when CtrlEvents become moved into the server. https://osgvsowi/9450717
 void CloseConsoleProcessState()
 {
-    LockConsole();
-    const auto unlock = wil::scope_exit([] { UnlockConsole(); });
-
     auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
 
     // If there are no connected processes, sending control events is pointless as there's no one do send them to. In

--- a/src/inc/conpty-static.h
+++ b/src/inc/conpty-static.h
@@ -28,19 +28,15 @@
 #define PSEUDOCONSOLE_PASSTHROUGH_MODE (8u)
 
 CONPTY_EXPORT HRESULT WINAPI ConptyCreatePseudoConsole(COORD size, HANDLE hInput, HANDLE hOutput, DWORD dwFlags, HPCON* phPC);
-
 CONPTY_EXPORT HRESULT WINAPI ConptyCreatePseudoConsoleAsUser(HANDLE hToken, COORD size, HANDLE hInput, HANDLE hOutput, DWORD dwFlags, HPCON* phPC);
 
 CONPTY_EXPORT HRESULT WINAPI ConptyResizePseudoConsole(HPCON hPC, COORD size);
-
 CONPTY_EXPORT HRESULT WINAPI ConptyClearPseudoConsole(HPCON hPC);
-
 CONPTY_EXPORT HRESULT WINAPI ConptyShowHidePseudoConsole(HPCON hPC, bool show);
-
 CONPTY_EXPORT HRESULT WINAPI ConptyReparentPseudoConsole(HPCON hPC, HWND newParent);
+CONPTY_EXPORT HRESULT WINAPI ConptyReleasePseudoConsole(HPCON hPC);
 
 CONPTY_EXPORT VOID WINAPI ConptyClosePseudoConsole(HPCON hPC);
-
-CONPTY_EXPORT VOID WINAPI ConptyClosePseudoConsoleNoWait(HPCON hPC);
+CONPTY_EXPORT VOID WINAPI ConptyClosePseudoConsoleTimeout(HPCON hPC, DWORD dwMilliseconds);
 
 CONPTY_EXPORT HRESULT WINAPI ConptyPackPseudoConsole(HANDLE hServerProcess, HANDLE hRef, HANDLE hSignal, HPCON* phPC);

--- a/src/winconpty/dll/winconpty.def
+++ b/src/winconpty/dll/winconpty.def
@@ -4,10 +4,11 @@ EXPORTS
     ConptyCreatePseudoConsoleAsUser
     ConptyResizePseudoConsole
     ConptyClosePseudoConsole
-    ConptyClosePseudoConsoleNoWait
+    ConptyClosePseudoConsoleTimeout
     ConptyClearPseudoConsole
     ConptyShowHidePseudoConsole
     ConptyReparentPseudoConsole
+    ConptyReleasePseudoConsole
     ConptyPackPseudoConsole
 
     ; Compatibility aliases for P/Invoke; only required for compatibility

--- a/src/winconpty/ft_pty/ConPtyTests.cpp
+++ b/src/winconpty/ft_pty/ConPtyTests.cpp
@@ -14,7 +14,7 @@ using namespace WEX::Common;
 using namespace WEX::Logging;
 using namespace WEX::TestExecution;
 
-using unique_hpcon = wil::unique_any_handle_null_only<decltype(&::ClosePseudoConsole), ::ClosePseudoConsole>;
+using unique_hpcon = wil::unique_any<HPCON, decltype(&::ClosePseudoConsole), ::ClosePseudoConsole>;
 
 struct InOut
 {
@@ -381,6 +381,5 @@ void ConPtyTests::ReleasePseudoConsole()
     VERIFY_SUCCEEDED(ConptyReleasePseudoConsole(pty.hpcon.get()));
 
     const auto output = readOutputToEOF(pty.pipes);
-    Log::Comment(NoThrowString(output.c_str()));
     VERIFY_ARE_NOT_EQUAL(std::string::npos, output.find("foobar"));
 }

--- a/src/winconpty/ft_pty/ConPtyTests.cpp
+++ b/src/winconpty/ft_pty/ConPtyTests.cpp
@@ -3,9 +3,6 @@
 
 #include "precomp.h"
 
-// We statically link with winconpty.cpp and so we need to prevent the functions
-// from being marked as __declspec(dllimport) by overriding CONPTY_IMPEXP.
-#define CONPTY_IMPEXP
 #include <conpty-static.h>
 
 #include "../winconpty.h"

--- a/src/winconpty/ft_pty/winconpty.FeatureTests.vcxproj
+++ b/src/winconpty/ft_pty/winconpty.FeatureTests.vcxproj
@@ -34,6 +34,10 @@
   <Import Project="$(SolutionDir)src\common.build.tests.props" />
   <Import Project="$(SolutionDir)src\common.nugetversions.targets" />
   <ItemDefinitionGroup>
+    <ClCompile>
+      <!-- By defining this here, we ensure that we don't try to dllimport conpty -->
+      <PreprocessorDefinitions>CONPTY_IMPEXP=;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <Link>
       <AdditionalDependencies>$(OutDir)\conptylib.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>

--- a/src/winconpty/winconpty.cpp
+++ b/src/winconpty/winconpty.cpp
@@ -112,6 +112,14 @@ HRESULT _CreatePseudoConsole(const HANDLE hToken,
     wil::unique_handle serverHandle;
     RETURN_IF_NTSTATUS_FAILED(CreateServerHandle(serverHandle.addressof(), TRUE));
 
+    // The hPtyReference we create here is used when the PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE attribute is processed.
+    // This ensures that conhost's client processes inherit the correct (= our) console handle.
+    wil::unique_handle referenceHandle;
+    RETURN_IF_NTSTATUS_FAILED(CreateClientHandle(referenceHandle.addressof(),
+                                                 serverHandle.get(),
+                                                 L"\\Reference",
+                                                 FALSE));
+
     wil::unique_handle signalPipeConhostSide;
     wil::unique_handle signalPipeOurSide;
 
@@ -226,18 +234,9 @@ HRESULT _CreatePseudoConsole(const HANDLE hToken,
         }
     }
 
-    // Move the process handle out of the PROCESS_INFORMATION into out Pseudoconsole
-    pPty->hConPtyProcess = pi.hProcess;
-    pi.hProcess = nullptr;
-
-    // The hPtyReference we create here is used when the PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE attribute is processed.
-    // This ensures that conhost's client processes inherit the correct (= our) console handle.
-    RETURN_IF_NTSTATUS_FAILED(CreateClientHandle(&pPty->hPtyReference,
-                                                 serverHandle.get(),
-                                                 L"\\Reference",
-                                                 FALSE));
-
     pPty->hSignal = signalPipeOurSide.release();
+    pPty->hPtyReference = referenceHandle.release();
+    pPty->hConPtyProcess = std::exchange(pi.hProcess, nullptr);
 
     return S_OK;
 }
@@ -352,7 +351,7 @@ HRESULT _ReparentPseudoConsole(_In_ const PseudoConsole* const pPty, _In_ const 
 // - wait: If true, waits for conhost/OpenConsole to exit first.
 // Return Value:
 // - <none>
-void _ClosePseudoConsoleMembers(_In_ PseudoConsole* pPty, BOOL wait)
+void _ClosePseudoConsoleMembers(_In_ PseudoConsole* pPty, _In_ DWORD dwMilliseconds)
 {
     if (pPty != nullptr)
     {
@@ -376,9 +375,9 @@ void _ClosePseudoConsoleMembers(_In_ PseudoConsole* pPty, BOOL wait)
         //      has yet to send before we hard kill it.
         if (_HandleIsValid(pPty->hConPtyProcess))
         {
-            if (wait)
+            if (dwMilliseconds)
             {
-                WaitForSingleObject(pPty->hConPtyProcess, INFINITE);
+                WaitForSingleObject(pPty->hConPtyProcess, dwMilliseconds);
             }
 
             CloseHandle(pPty->hConPtyProcess);
@@ -396,11 +395,11 @@ void _ClosePseudoConsoleMembers(_In_ PseudoConsole* pPty, BOOL wait)
 // - wait: If true, waits for conhost/OpenConsole to exit first.
 // Return Value:
 // - <none>
-static void _ClosePseudoConsole(_In_ PseudoConsole* pPty, BOOL wait) noexcept
+static void _ClosePseudoConsole(_In_ PseudoConsole* pPty, _In_ DWORD dwMilliseconds) noexcept
 {
     if (pPty != nullptr)
     {
-        _ClosePseudoConsoleMembers(pPty, wait);
+        _ClosePseudoConsoleMembers(pPty, dwMilliseconds);
         HeapFree(GetProcessHeap(), 0, pPty);
     }
 }
@@ -461,7 +460,7 @@ extern "C" HRESULT ConptyCreatePseudoConsoleAsUser(_In_ HANDLE hToken,
     auto pPty = (PseudoConsole*)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(PseudoConsole));
     RETURN_IF_NULL_ALLOC(pPty);
     auto cleanupPty = wil::scope_exit([&]() noexcept {
-        _ClosePseudoConsole(pPty, TRUE);
+        _ClosePseudoConsole(pPty, 0);
     });
 
     wil::unique_handle duplicatedInput;
@@ -525,13 +524,28 @@ extern "C" HRESULT WINAPI ConptyShowHidePseudoConsole(_In_ HPCON hPC, bool show)
 // - Used to support GH#2988
 extern "C" HRESULT WINAPI ConptyReparentPseudoConsole(_In_ HPCON hPC, HWND newParent)
 {
-    const PseudoConsole* const pPty = (PseudoConsole*)hPC;
-    auto hr = pPty == nullptr ? E_INVALIDARG : S_OK;
-    if (SUCCEEDED(hr))
+    return _ReparentPseudoConsole((PseudoConsole*)hPC, newParent);
+}
+
+// The \Reference handle ensures that conhost keeps running by keeping the ConDrv server pipe open.
+// After you've finished setting up your PTY via PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE, this method may be called
+// to release that handle, allowing conhost to shut down automatically once the last client has disconnected.
+// You'll know when this happens, because a ReadFile() on the output pipe will return ERROR_BROKEN_PIPE.
+extern "C" HRESULT WINAPI ConptyReleasePseudoConsole(_In_ HPCON hPC)
+{
+    const auto pPty = (PseudoConsole*)hPC;
+    if (pPty == nullptr)
     {
-        hr = _ReparentPseudoConsole(pPty, newParent);
+        return E_INVALIDARG;
     }
-    return hr;
+
+    if (_HandleIsValid(pPty->hPtyReference))
+    {
+        CloseHandle(pPty->hPtyReference);
+        pPty->hPtyReference = nullptr;
+    }
+
+    return S_OK;
 }
 
 // Function Description:
@@ -543,7 +557,7 @@ extern "C" HRESULT WINAPI ConptyReparentPseudoConsole(_In_ HPCON hPC, HWND newPa
 // Waits for conhost/OpenConsole to exit first.
 extern "C" VOID WINAPI ConptyClosePseudoConsole(_In_ HPCON hPC)
 {
-    _ClosePseudoConsole((PseudoConsole*)hPC, TRUE);
+    _ClosePseudoConsole((PseudoConsole*)hPC, INFINITE);
 }
 
 // Function Description:
@@ -553,9 +567,9 @@ extern "C" VOID WINAPI ConptyClosePseudoConsole(_In_ HPCON hPC)
 // This can fail if the conhost hosting the pseudoconsole failed to be
 //      terminated, or if the pseudoconsole was already terminated.
 // Doesn't wait for conhost/OpenConsole to exit.
-extern "C" VOID WINAPI ConptyClosePseudoConsoleNoWait(_In_ HPCON hPC)
+extern "C" VOID WINAPI ConptyClosePseudoConsoleTimeout(_In_ HPCON hPC, _In_ DWORD dwMilliseconds)
 {
-    _ClosePseudoConsole((PseudoConsole*)hPC, FALSE);
+    _ClosePseudoConsole((PseudoConsole*)hPC, dwMilliseconds);
 }
 
 // NOTE: This one is not defined in the Windows headers but is

--- a/src/winconpty/winconpty.cpp
+++ b/src/winconpty/winconpty.cpp
@@ -440,12 +440,12 @@ extern "C" HRESULT WINAPI ConptyCreatePseudoConsole(_In_ COORD size,
     return ConptyCreatePseudoConsoleAsUser(INVALID_HANDLE_VALUE, size, hInput, hOutput, dwFlags, phPC);
 }
 
-extern "C" HRESULT ConptyCreatePseudoConsoleAsUser(_In_ HANDLE hToken,
-                                                   _In_ COORD size,
-                                                   _In_ HANDLE hInput,
-                                                   _In_ HANDLE hOutput,
-                                                   _In_ DWORD dwFlags,
-                                                   _Out_ HPCON* phPC)
+extern "C" HRESULT WINAPI ConptyCreatePseudoConsoleAsUser(_In_ HANDLE hToken,
+                                                          _In_ COORD size,
+                                                          _In_ HANDLE hInput,
+                                                          _In_ HANDLE hOutput,
+                                                          _In_ DWORD dwFlags,
+                                                          _Out_ HPCON* phPC)
 {
     if (phPC == nullptr)
     {

--- a/src/winconpty/winconpty.h
+++ b/src/winconpty/winconpty.h
@@ -46,11 +46,9 @@ typedef struct _PseudoConsole
 #define PTY_SIGNAL_SHOWHIDE_WINDOW (1u)
 #define PTY_SIGNAL_CLEAR_WINDOW (2u)
 #define PTY_SIGNAL_REPARENT_WINDOW (3u)
-#define PTY_SIGNAL_SET_AUTO_EXIT (4u)
 #define PTY_SIGNAL_RESIZE_WINDOW (8u)
 
 // CreatePseudoConsole Flags
-// The other flag (PSEUDOCONSOLE_INHERIT_CURSOR) is actually defined in consoleapi.h in the OS repo
 #ifndef PSEUDOCONSOLE_INHERIT_CURSOR
 #define PSEUDOCONSOLE_INHERIT_CURSOR (0x1)
 #endif

--- a/src/winconpty/winconpty.h
+++ b/src/winconpty/winconpty.h
@@ -21,14 +21,23 @@ typedef struct _PseudoConsole
 #define PTY_SIGNAL_SHOWHIDE_WINDOW (1u)
 #define PTY_SIGNAL_CLEAR_WINDOW (2u)
 #define PTY_SIGNAL_REPARENT_WINDOW (3u)
+#define PTY_SIGNAL_SET_AUTO_EXIT (4u)
 #define PTY_SIGNAL_RESIZE_WINDOW (8u)
 
 // CreatePseudoConsole Flags
 // The other flag (PSEUDOCONSOLE_INHERIT_CURSOR) is actually defined in consoleapi.h in the OS repo
-// #define PSEUDOCONSOLE_INHERIT_CURSOR (0x1)
+#ifndef PSEUDOCONSOLE_INHERIT_CURSOR
+#define PSEUDOCONSOLE_INHERIT_CURSOR (0x1)
+#endif
+#ifndef PSEUDOCONSOLE_RESIZE_QUIRK
 #define PSEUDOCONSOLE_RESIZE_QUIRK (0x2)
+#endif
+#ifndef PSEUDOCONSOLE_WIN32_INPUT_MODE
 #define PSEUDOCONSOLE_WIN32_INPUT_MODE (0x4)
+#endif
+#ifndef PSEUDOCONSOLE_PASSTHROUGH_MODE
 #define PSEUDOCONSOLE_PASSTHROUGH_MODE (0x8)
+#endif
 
 // Implementations of the various PseudoConsole functions.
 HRESULT _CreatePseudoConsole(const HANDLE hToken,
@@ -42,7 +51,7 @@ HRESULT _ResizePseudoConsole(_In_ const PseudoConsole* const pPty, _In_ const CO
 HRESULT _ClearPseudoConsole(_In_ const PseudoConsole* const pPty);
 HRESULT _ShowHidePseudoConsole(_In_ const PseudoConsole* const pPty, const bool show);
 HRESULT _ReparentPseudoConsole(_In_ const PseudoConsole* const pPty, _In_ const HWND newParent);
-void _ClosePseudoConsoleMembers(_In_ PseudoConsole* pPty, BOOL wait);
+void _ClosePseudoConsoleMembers(_In_ PseudoConsole* pPty, _In_ DWORD dwMilliseconds);
 
 HRESULT ConptyCreatePseudoConsoleAsUser(_In_ HANDLE hToken,
                                         _In_ COORD size,

--- a/src/winconpty/winconpty.h
+++ b/src/winconpty/winconpty.h
@@ -10,8 +10,33 @@ extern "C" {
 // This structure is part of an ABI shared with the rest of the operating system.
 typedef struct _PseudoConsole
 {
+    // hSignal is a anonymous pipe used for out of band communication with conhost.
+    // It's used to send the various PTY_SIGNAL_* messages.
     HANDLE hSignal;
+    // The "server handle" in conhost represents the console IPC "pipe" over which all console
+    // messages, all client connect and disconnect events, API calls, text output, etc. flow.
+    // The full type of this handle is \Device\ConDrv\Server and is implemented in
+    // /minkernel/console/condrv/server.c. If you inspect conhost's handles it'll show up
+    // as a handle of name \Device\ConDrv, because that's the namespace of these handles.
+    //
+    // hPtyReference is derived from that handle (= a child), is named \Reference and is implemented
+    // in /minkernel/console/condrv/reference.c. While conhost is the sole owner and user of the
+    // "server handle", the "reference handle" is what console processes actually inherit in order
+    // to communicate with the console server (= conhost). When the reference count of the
+    // \Reference handle drops to 0, it'll release its reference to the server handle.
+    // The server handle in turn is implemented in such a way that the IPC pipe is broken
+    // once the reference count drops to 1, because then conhost must be the last one using it.
+    //
+    // In other words: As long as hPtyReference exists it'll keep the server handle alive
+    // and thus keep conhost alive. Closing this handle will make conhost exit as soon as all
+    // currently connected clients have disconnected and closed the reference handle as well.
+    //
+    // This benefit of this system is that it naturally works with handle inheritance in
+    // CreateProcess,  which ensures that the reference handle is safely duplicated and
+    // transmitted from a parent process to a new child process, even if the parent
+    // process exits before the OS has even finished spawning the child process.
     HANDLE hPtyReference;
+    // hConPtyProcess is a process handle to the conhost instance that we've spawned for ConPTY.
     HANDLE hConPtyProcess;
 } PseudoConsole;
 
@@ -53,12 +78,12 @@ HRESULT _ShowHidePseudoConsole(_In_ const PseudoConsole* const pPty, const bool 
 HRESULT _ReparentPseudoConsole(_In_ const PseudoConsole* const pPty, _In_ const HWND newParent);
 void _ClosePseudoConsoleMembers(_In_ PseudoConsole* pPty, _In_ DWORD dwMilliseconds);
 
-HRESULT ConptyCreatePseudoConsoleAsUser(_In_ HANDLE hToken,
-                                        _In_ COORD size,
-                                        _In_ HANDLE hInput,
-                                        _In_ HANDLE hOutput,
-                                        _In_ DWORD dwFlags,
-                                        _Out_ HPCON* phPC);
+HRESULT WINAPI ConptyCreatePseudoConsoleAsUser(_In_ HANDLE hToken,
+                                               _In_ COORD size,
+                                               _In_ HANDLE hInput,
+                                               _In_ HANDLE hOutput,
+                                               _In_ DWORD dwFlags,
+                                               _Out_ HPCON* phPC);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
2 new ConPTY APIs were added as part of this commit:
* `ClosePseudoConsoleTimeout`
  Complements `ClosePseudoConsole`, allowing users to override the `INFINITE`
  wait for OpenConsole to exit with any arbitrary timeout, including 0.
* `ConptyReleasePseudoConsole`
  This releases the `\Reference` handle held by the `HPCON`. While it makes
  launching further PTY clients via `PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE`
  impossible, it does allow conhost/OpenConsole to exit naturally once all
  console clients have disconnected. This makes it unnecessary to having to
  monitor the exit of the spawned shell/application, just to then call
  `ClosePseudoConsole`, while carefully continuing to read from the output
  pipe. Instead users can now just read from the output pipe until it is
  closed, knowing for sure that no more data will come or clients connect.
  This is especially useful in combination with `ClosePseudoConsoleTimeout`
  and a timeout of 0, to allow conhost/OpenConsole to exit asynchronously.

These new APIs are used to fix an array of bugs around Windows Terminal exiting
either too early or too late. They also make usage of the ConPTY API simpler in
most situations (when spawning a single application and waiting for it to exit).

Depends on #13882, #14041, #14160, #14282

Closes #4564
Closes #14416
Closes MSFT-42244182

## Validation Steps Performed
* Calling `FreeConsole` in a handoff'd application closes the tab ✅
* Create a .bat file containing only `start /B cmd.exe`.
  If WT stable is the default terminal the tab closes instantly ✅
  With these changes included the tab stays open with a cmd.exe prompt ✅
* New ConPTY tests ✅