### PR TITLE
Fix use of tabs instead of spaces in ColorSchemesPageViewModel.idl

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ColorSchemesPageViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemesPageViewModel.idl
@@ -28,6 +28,6 @@ namespace Microsoft.Terminal.Settings.Editor
         ColorSchemesSubPage CurrentPage;
         Windows.Foundation.Collections.IObservableVector<ColorSchemeViewModel> AllColorSchemes { get; };
 
-		void SchemeListItemClicked(IInspectable sender, Windows.UI.Xaml.Controls.ItemClickEventArgs args);
+        void SchemeListItemClicked(IInspectable sender, Windows.UI.Xaml.Controls.ItemClickEventArgs args);
     }
 }


### PR DESCRIPTION
Didn't know the code formatter won't hit `idl` files