### PR TITLE
[SUI] Polish Launch Parameters setting controls

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
+++ b/src/cascadia/TerminalSettingsEditor/CommonResources.xaml
@@ -131,7 +131,7 @@
     <!--  Number Box  -->
     <Style x:Key="NumberBoxSettingStyle"
            TargetType="muxc:NumberBox">
-        <Setter Property="SpinButtonPlacementMode" Value="Inline" />
+        <Setter Property="SpinButtonPlacementMode" Value="Compact" />
         <Setter Property="HorizontalAlignment" Value="Left" />
     </Style>
 

--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -227,25 +227,41 @@
                                    Grid.Row="1"
                                    Grid.Column="0"
                                    VerticalAlignment="Center" />
-                        <StackPanel Grid.Row="1"
-                                    Grid.Column="1">
-                            <StackPanel Orientation="Horizontal"
-                                        Spacing="4">
-                                <muxc:NumberBox x:Name="PosXBox"
-                                                x:Uid="Globals_InitialPosXBox"
-                                                IsEnabled="{x:Bind local:Converters.InvertBoolean(ViewModel.UseDefaultLaunchPosition), Mode=OneWay}"
-                                                Style="{StaticResource LaunchSizeNumberBoxStyle}"
-                                                Value="{x:Bind ViewModel.InitialPosX, Mode=TwoWay}" />
-                                <muxc:NumberBox x:Name="PosYBox"
-                                                x:Uid="Globals_InitialPosYBox"
-                                                IsEnabled="{x:Bind local:Converters.InvertBoolean(ViewModel.UseDefaultLaunchPosition), Mode=OneWay}"
-                                                Style="{StaticResource LaunchSizeNumberBoxStyle}"
-                                                Value="{x:Bind ViewModel.InitialPosY, Mode=TwoWay}" />
-                            </StackPanel>
+                        <Grid Grid.Row="1"
+                              Grid.Column="1"
+                              ColumnSpacing="4">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <!--  Match the width of these NumberBoxes to the Width of the LaunchModeComboBox above minus the Grid's ColumnSpacing  -->
+                            <muxc:NumberBox x:Name="PosXBox"
+                                            x:Uid="Globals_InitialPosXBox"
+                                            Grid.Row="0"
+                                            Grid.Column="0"
+                                            Width="118"
+                                            IsEnabled="{x:Bind local:Converters.InvertBoolean(ViewModel.UseDefaultLaunchPosition), Mode=OneWay}"
+                                            Style="{StaticResource LaunchSizeNumberBoxStyle}"
+                                            Value="{x:Bind ViewModel.InitialPosX, Mode=TwoWay}" />
+                            <muxc:NumberBox x:Name="PosYBox"
+                                            x:Uid="Globals_InitialPosYBox"
+                                            Grid.Row="0"
+                                            Grid.Column="1"
+                                            Width="118"
+                                            IsEnabled="{x:Bind local:Converters.InvertBoolean(ViewModel.UseDefaultLaunchPosition), Mode=OneWay}"
+                                            Style="{StaticResource LaunchSizeNumberBoxStyle}"
+                                            Value="{x:Bind ViewModel.InitialPosY, Mode=TwoWay}" />
                             <CheckBox x:Name="UseDefaultLaunchPositionCheckbox"
                                       x:Uid="Globals_DefaultLaunchPositionCheckbox"
+                                      Grid.Row="1"
+                                      Grid.Column="0"
+                                      Grid.ColumnSpan="2"
                                       IsChecked="{x:Bind ViewModel.UseDefaultLaunchPosition, Mode=TwoWay}" />
-                        </StackPanel>
+                        </Grid>
                         <TextBlock x:Uid="Globals_CenterOnLaunch"
                                    Grid.Row="2"
                                    Grid.Column="0"

--- a/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/LaunchViewModel.cpp
@@ -49,7 +49,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // Append the launch position part
         if (UseDefaultLaunchPosition())
         {
-            result = fmt::format(L"{}, {}", launchModeString, RS_(L"Globals_LaunchModeDefault/Content"));
+            result = fmt::format(L"{}, {}", launchModeString, RS_(L"Globals_DefaultLaunchPositionCheckbox/Content"));
         }
         else
         {

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -356,8 +356,8 @@
     <comment>The string to be displayed when there is no current value in the y-coordinate number box.</comment>
   </data>
   <data name="Globals_DefaultLaunchPositionCheckbox.Content" xml:space="preserve">
-    <value>Use system default</value>
-    <comment>A checkbox for the "launch position" setting. Toggling this control sets the launch position to the system default.</comment>
+    <value>Let system position window</value>
+    <comment>A checkbox for the "launch position" setting. Toggling this control sets the launch position to whatever the operating system decides.</comment>
   </data>
   <data name="Globals_DefaultLaunchPositionCheckbox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>If enabled, use the system default launch position.</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -356,8 +356,8 @@
     <comment>The string to be displayed when there is no current value in the y-coordinate number box.</comment>
   </data>
   <data name="Globals_DefaultLaunchPositionCheckbox.Content" xml:space="preserve">
-    <value>Let system position window</value>
-    <comment>A checkbox for the "launch position" setting. Toggling this control sets the launch position to whatever the operating system decides.</comment>
+    <value>Let Windows decide</value>
+    <comment>A checkbox for the "launch position" setting. Toggling this control sets the launch position to whatever the Windows operating system decides.</comment>
   </data>
   <data name="Globals_DefaultLaunchPositionCheckbox.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>If enabled, use the system default launch position.</value>


### PR DESCRIPTION
## Summary of the Pull Request
Performs some cleanup in the Settings UI for the Launch Parameters settings:
1. Updates all `NumberBox` controls in the Settings UI to have a `Compact` `SpinButtonPlacementMode` instead of an inline one. This alleviates the XAML bug where the spin button would appear over the number box's input value.
2. Fixes an issue where a long X/Y value would resize the settings controls weirdly. This was fixed by introducing a `Grid` inside the main grid and applying a width to the number boxes.
3. Rename "Use system default" checkbox to be more clear. Propagate the new localized string into expander preview.


Closes #14558

