### PR TITLE
Minor grammar fix

### DIFF
--- a/scratch/ScratchIslandApp/SampleApp/dll/SampleApp.vcxproj
+++ b/scratch/ScratchIslandApp/SampleApp/dll/SampleApp.vcxproj
@@ -44,7 +44,7 @@
   </ItemGroup>
   <!-- ========================= Project References ======================== -->
   <ItemGroup>
-    <!-- Reference SampleAppLib here, so we can use it's App.winmd as
+    <!-- Reference SampleAppLib here, so we can use its App.winmd as
     our App.winmd. This didn't work correctly in VS2017, you'd need to
     manually reference the lib -->
     <ProjectReference Include="$(OpenConsoleDir)scratch\ScratchIslandApp\SampleApp\SampleAppLib.vcxproj">

--- a/src/cascadia/LocalTests_SettingsModel/DeserializationTests.cpp
+++ b/src/cascadia/LocalTests_SettingsModel/DeserializationTests.cpp
@@ -1530,7 +1530,7 @@ namespace SettingsModelLocalTests
         VERIFY_ARE_EQUAL(0u, settings->Warnings().Size());
         VERIFY_ARE_EQUAL(3u, settings->AllProfiles().Size());
         // Because the "parent" command didn't have a name, it couldn't be
-        // placed into the list of commands. It and it's children are just
+        // placed into the list of commands. It and its children are just
         // ignored.
         VERIFY_ARE_EQUAL(0u, settings->ActionMap().NameMap().Size());
     }

--- a/src/cascadia/LocalTests_SettingsModel/SettingsModel.LocalTests.vcxproj
+++ b/src/cascadia/LocalTests_SettingsModel/SettingsModel.LocalTests.vcxproj
@@ -8,7 +8,7 @@
     dependencies, like MUX, can be aggregated correctly, and resources properly
     combined into a resources.pri file.
 
-    TestHostApp will manually copy the output of this project into it's own
+    TestHostApp will manually copy the output of this project into its own
     OutDir, so we can run the tests from there. -->
 
   <PropertyGroup>

--- a/src/cascadia/LocalTests_TerminalApp/TerminalApp.LocalTests.vcxproj
+++ b/src/cascadia/LocalTests_TerminalApp/TerminalApp.LocalTests.vcxproj
@@ -8,7 +8,7 @@
     dependencies, like MUX, can be aggregated correctly, and resources properly
     combined into a resources.pri file.
 
-    TestHostApp will manually copy the output of this project into it's own
+    TestHostApp will manually copy the output of this project into its own
     OutDir, so we can run the tests from there. -->
 
   <PropertyGroup>

--- a/src/cascadia/Remoting/Peasant.cpp
+++ b/src/cascadia/Remoting/Peasant.cpp
@@ -148,7 +148,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
     }
 
     // Method Description:
-    // - Tell this window to display it's window ID. We'll raise a
+    // - Tell this window to display its window ID. We'll raise a
     //   DisplayWindowIdRequested event, which will get handled in the AppHost,
     //   and used to tell the app to display the ID toast.
     // Arguments:

--- a/src/cascadia/Remoting/ProposeCommandlineResult.h
+++ b/src/cascadia/Remoting/ProposeCommandlineResult.h
@@ -12,7 +12,7 @@ Abstract:
   ShouldCreateWindow is false, that implies that some other window process was
   given the commandline for handling, and the caller should just exit.
 - If ShouldCreateWindow is true, the Id property may or may not contain an ID
-  that the new window should use as it's ID.
+  that the new window should use as its ID.
 
 --*/
 

--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -109,7 +109,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
             try
             {
                 // MSFT:38542548 _We believe_ that this is the source of the
-                // crash here. After we get the result, stash it's values into a
+                // crash here. After we get the result, stash its values into a
                 // local copy, so that we can check them later. If the Monarch
                 // dies between now and the inspection of
                 // `result.ShouldCreateWindow` below, we don't want to explode
@@ -488,7 +488,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
             {
                 try
                 {
-                    // Wrap this in it's own try/catch, because this can throw.
+                    // Wrap this in its own try/catch, because this can throw.
                     _createMonarchAndCallbacks();
                 }
                 catch (...)
@@ -572,7 +572,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
             // monarch.
             try
             {
-                // This might fail to even ask the monarch for it's PID.
+                // This might fail to even ask the monarch for its PID.
                 wil::unique_handle hMonarch{ OpenProcess(PROCESS_ALL_ACCESS,
                                                          FALSE,
                                                          static_cast<DWORD>(_monarch.GetPID())) };
@@ -647,7 +647,7 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
             catch (...)
             {
                 // Theoretically, if window[1] dies when we're trying to get
-                // it's PID we'll get here. If we just try to do the election
+                // its PID we'll get here. If we just try to do the election
                 // once here, it's possible we might elect window[2], but have
                 // it die before we add ourselves as a peasant. That
                 // _performElection call will throw, and we wouldn't catch it

--- a/src/cascadia/Remoting/dll/Microsoft.Terminal.Remoting.vcxproj
+++ b/src/cascadia/Remoting/dll/Microsoft.Terminal.Remoting.vcxproj
@@ -49,7 +49,7 @@
     <ProjectReference Include="$(OpenConsoleDir)src\types\lib\types.vcxproj">
       <Project>{18D09A24-8240-42D6-8CB6-236EEE820263}</Project>
     </ProjectReference>
-    <!-- Reference Microsoft.Terminal.RemotingLib here, so we can use it's winmd as
+    <!-- Reference Microsoft.Terminal.RemotingLib here, so we can use its winmd as
     our winmd. This didn't work correctly in VS2017, you'd need to
     manually reference the lib -->
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\Remoting\Microsoft.Terminal.RemotingLib.vcxproj">

--- a/src/cascadia/TerminalApp/App.xaml
+++ b/src/cascadia/TerminalApp/App.xaml
@@ -138,7 +138,7 @@
                                 evaluated as SolidBackgroundFillColorBase. If we try
                                 to use those resources directly though, we don't get
                                 the properly themed versions. Presumably because the
-                                App itself can't have it's RequestedTheme changed at
+                                App itself can't have its RequestedTheme changed at
                                 runtime.
                                 
                                 However, after more discussion with the WinUI

--- a/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
+++ b/src/cascadia/TerminalApp/AppCommandlineArgs.cpp
@@ -97,7 +97,7 @@ int AppCommandlineArgs::ParseCommand(const Commandline& command)
 }
 
 // Method Description:
-// - Calls App::exit() for the provided command, and collects it's output into
+// - Calls App::exit() for the provided command, and collects its output into
 //   our _exitMessage buffer.
 // Arguments:
 // - command: Either the root App object, or a subcommand for which to call exit() on.

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -1296,7 +1296,7 @@ TermControl Pane::GetTerminalControl()
 }
 
 // Method Description:
-// - Recursively remove the "Active" state from this Pane and all it's children.
+// - Recursively remove the "Active" state from this Pane and all its children.
 // - Updates our visuals to match our new state, including highlighting our borders.
 // Arguments:
 // - <none>
@@ -2572,7 +2572,7 @@ void Pane::Maximize(std::shared_ptr<Pane> zoomedPane)
         }
 
         // Always recurse into both children. If the (un)zoomed pane was one of
-        // our direct children, we'll still want to update it's borders.
+        // our direct children, we'll still want to update its borders.
         _firstChild->Maximize(zoomedPane);
         _secondChild->Maximize(zoomedPane);
     }
@@ -2609,7 +2609,7 @@ void Pane::Restore(std::shared_ptr<Pane> zoomedPane)
         }
 
         // Always recurse into both children. If the (un)zoomed pane was one of
-        // our direct children, we'll still want to update it's borders.
+        // our direct children, we'll still want to update its borders.
         _firstChild->Restore(zoomedPane);
         _secondChild->Restore(zoomedPane);
     }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1290,7 +1290,7 @@ namespace winrt::TerminalApp::implementation
             // The connection must be informed of the current CWD on
             // construction, because the connection might not spawn the child
             // process until later, on another thread, after we've already
-            // restored the CWD to it's original value.
+            // restored the CWD to its original value.
             auto newWorkingDirectory{ settings.StartingDirectory() };
             if (newWorkingDirectory.size() == 0 || newWorkingDirectory.size() == 1 &&
                                                        !(newWorkingDirectory[0] == L'~' || newWorkingDirectory[0] == L'/'))
@@ -2255,7 +2255,7 @@ namespace winrt::TerminalApp::implementation
 
     // Method Description:
     // - Place `copiedData` into the clipboard as text. Triggered when a
-    //   terminal control raises it's CopyToClipboard event.
+    //   terminal control raises its CopyToClipboard event.
     // Arguments:
     // - copiedData: the new string content to place on the clipboard.
     winrt::fire_and_forget TerminalPage::_CopyToClipboardHandler(const IInspectable /*sender*/,

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -82,7 +82,7 @@
         <!--
             GH#12775 et. al: After switching to ControlsV2, it seems that
             delay-loading a dialog causes the ContentDialog to be assigned a
-            Height equal to it's content size. If we DON'T assign the
+            Height equal to its content size. If we DON'T assign the
             ContentDialog a Row, I believe it's assigned Row 0 by default. So,
             when the dialog gets opened, the dialog seemingly causes a giant
             hole to appear in the body of the app.

--- a/src/cascadia/TerminalApp/dll/TerminalApp.vcxproj
+++ b/src/cascadia/TerminalApp/dll/TerminalApp.vcxproj
@@ -70,7 +70,7 @@
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\dll\TerminalControl.vcxproj" />
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalSettingsEditor\Microsoft.Terminal.Settings.Editor.vcxproj" />
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalSettingsModel\dll\Microsoft.Terminal.Settings.Model.vcxproj" />
-    <!-- Reference TerminalAppLib here, so we can use it's TerminalApp.winmd as
+    <!-- Reference TerminalAppLib here, so we can use its TerminalApp.winmd as
     our TerminalApp.winmd. This didn't work correctly in VS2017, you'd need to
     manually reference the lib -->
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalApp\TerminalAppLib.vcxproj">

--- a/src/cascadia/TerminalConnection/ConnectionInformation.cpp
+++ b/src/cascadia/TerminalConnection/ConnectionInformation.cpp
@@ -32,7 +32,7 @@ namespace winrt::Microsoft::Terminal::TerminalConnection::implementation
 
 #pragma warning(push)
 #pragma warning(disable : 26490)
-        // C++/WinRT just loves it's void**, nothing we can do here _except_ reinterpret_cast
+        // C++/WinRT just loves its void**, nothing we can do here _except_ reinterpret_cast
         auto raw = reinterpret_cast<::IInspectable**>(pointer);
 #pragma warning(pop)
 

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1767,7 +1767,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // switched to an unfocused appearance.
         //
         // IF WE DON'T HAVE AN UNFOCUSED APPEARANCE: then just ask the Terminal
-        // for it's current color table. That way, we can restore those colors
+        // for its current color table. That way, we can restore those colors
         // back.
         if (HasUnfocusedAppearance())
         {

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1801,7 +1801,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     //        when the control is visible as the DPI changes.
     //      - The CompositionScale will be the new DPI. This happens when the
     //        control wasn't focused as the window's DPI changed, so it only got
-    //        these messages after XAML updated it's scaling.
+    //        these messages after XAML updated its scaling.
     //   - 3. Finally, a CompositionScaleChanged with the _new_ DPI.
     //   - 4. We'll usually get another SizeChanged some time after this last
     //     ScaleChanged. This usually seems to happen after something triggers
@@ -2540,7 +2540,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                     // Fix path for WSL
                     // In the fullness of time, we should likely plumb this up
                     // to the TerminalApp layer, and have it make the decision
-                    // if this control should have it's path mangled (and do the
+                    // if this control should have its path mangled (and do the
                     // mangling), rather than exposing the source concept to the
                     // Control layer.
                     //

--- a/src/cascadia/TerminalControl/dll/TerminalControl.vcxproj
+++ b/src/cascadia/TerminalControl/dll/TerminalControl.vcxproj
@@ -57,7 +57,7 @@
   </ItemGroup>
   <!-- ========================= Project References ======================== -->
   <ItemGroup>
-    <!-- Reference TerminalControlLib here, so we can use it's Microsoft.Terminal.Control.winmd as
+    <!-- Reference TerminalControlLib here, so we can use its Microsoft.Terminal.Control.winmd as
     our Microsoft.Terminal.Control.winmd. This didn't work correctly in VS2017, you'd need to
     manually reference the lib -->
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalControl\TerminalControlLib.vcxproj">

--- a/src/cascadia/TerminalSettingsEditor/Utils.h
+++ b/src/cascadia/TerminalSettingsEditor/Utils.h
@@ -127,7 +127,7 @@ struct HasScrollViewer
                       const winrt::Windows::UI::Xaml::Controls::ScrollViewerViewChangingEventArgs& /*e*/)
     {
         // Inside this struct, we can't get at the XamlRoot() that our subclass
-        // implements. I mean, _we_ can, but when XAML does it's code
+        // implements. I mean, _we_ can, but when XAML does its code
         // generation, _XAML_ won't be able to figure it out.
         //
         // Fortunately for us, we don't need to! The sender is a UIElement, so

--- a/src/cascadia/TerminalSettingsModel/ActionArgsMagic.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgsMagic.h
@@ -41,7 +41,7 @@ struct InitListPlaceholder
 // some element of the class definition that will use the x-macro.
 //
 // You'll author a new arg by:
-//   1: define a new x-macro above with all it's properties
+//   1: define a new x-macro above with all its properties
 //   2. Define the class with:
 //
 //   ACTION_ARGS_STRUCT(MyFooArgs, MY_FOO_ARGS);

--- a/src/cascadia/TerminalSettingsModel/ApplicationState.cpp
+++ b/src/cascadia/TerminalSettingsModel/ApplicationState.cpp
@@ -137,7 +137,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     //   and resets it to the defaults. This will delete the state file! That's
     //   the sure-fire way to make sure the data doesn't come back. If we leave
     //   it untouched, then when we go to write the file back out, we'll first
-    //   re-read it's contents and try to overlay our new state. However,
+    //   re-read its contents and try to overlay our new state. However,
     //   nullopts won't remove keys from the JSON, so we'll end up with the
     //   original state in the file.
     // Arguments:
@@ -380,7 +380,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             // then rename that file to the final filename. That actually lets us
             // overwrite the elevate file's contents even when unelevated, because
             // we're effectively deleting the original file, then renaming a
-            // different file in it's place.
+            // different file in its place.
             //
             // We're not worried about someone else doing that though, if they do
             // that with the wrong permissions, then we'll just ignore the file and

--- a/src/cascadia/TerminalSettingsModel/FileUtils.cpp
+++ b/src/cascadia/TerminalSettingsModel/FileUtils.cpp
@@ -258,7 +258,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model
             // Programs running in an elevated context will be free to write the
             // file, and unelevated processes will be able to read the file. An
             // unelevated process could always delete the file and rename a new
-            // file in it's place (a la the way `vim.exe` saves files), but if
+            // file in its place (a la the way `vim.exe` saves files), but if
             // they do that, the new file _won't_ be owned by Administrators,
             // failing the above check.
         }

--- a/src/cascadia/TerminalSettingsModel/Theme.cpp
+++ b/src/cascadia/TerminalSettingsModel/Theme.cpp
@@ -130,7 +130,7 @@ winrt::WUX::Media::Brush ThemeColor::Evaluate(const winrt::WUX::ResourceDictiona
     case ThemeColorType::Accent:
     {
         // NOTE: There is no canonical way to get the unfocused ACCENT titlebar
-        // color in Windows. Edge uses it's own heuristic, and in Windows 11,
+        // color in Windows. Edge uses its own heuristic, and in Windows 11,
         // much of this logic is rapidly changing. We're not gonna mess with
         // that, since it seems there's no good way to reverse engineer that.
         til::color accentColor = forTitlebar ?

--- a/src/cascadia/TerminalSettingsModel/dll/Microsoft.Terminal.Settings.Model.vcxproj
+++ b/src/cascadia/TerminalSettingsModel/dll/Microsoft.Terminal.Settings.Model.vcxproj
@@ -97,7 +97,7 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
 
-    <!-- Reference Microsoft.Terminal.Settings.ModelLib here, so we can use it's winmd as
+    <!-- Reference Microsoft.Terminal.Settings.ModelLib here, so we can use its winmd as
     our winmd. This didn't work correctly in VS2017, you'd need to
     manually reference the lib -->
     <ProjectReference Include="$(OpenConsoleDir)src\cascadia\TerminalSettingsModel\Microsoft.Terminal.Settings.ModelLib.vcxproj">

--- a/src/cascadia/UnitTests_Remoting/Remoting.UnitTests.vcxproj
+++ b/src/cascadia/UnitTests_Remoting/Remoting.UnitTests.vcxproj
@@ -8,7 +8,7 @@
     dependencies, like MUX, can be aggregated correctly, and resources properly
     combined into a resources.pri file.
 
-    TestHostApp will manually copy the output of this project into it's own
+    TestHostApp will manually copy the output of this project into its own
     OutDir, so we can run the tests from there. -->
 
   <PropertyGroup>

--- a/src/cascadia/UnitTests_TerminalCore/ConptyRoundtripTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ConptyRoundtripTests.cpp
@@ -798,7 +798,7 @@ void ConptyRoundtripTests::TestResizeHeight()
         hostSm.ProcessString(L"\r\n");
     }
 
-    // Conpty doesn't have a scrollback, it's view's origin is always 0,0
+    // Conpty doesn't have a scrollback, its view's origin is always 0,0
     const auto secondHostView = si.GetViewport();
     VERIFY_ARE_EQUAL(0, secondHostView.Top());
     VERIFY_ARE_EQUAL(TerminalViewHeight, secondHostView.BottomExclusive());
@@ -905,7 +905,7 @@ void ConptyRoundtripTests::TestResizeHeight()
     // After we resize, make sure to get the new textBuffers
     std::tie(hostTb, termTb) = _performResize(newViewportSize);
 
-    // Conpty's doesn't have a scrollback, it's view's origin is always 0,0
+    // Conpty's doesn't have a scrollback, its view's origin is always 0,0
     const auto thirdHostView = si.GetViewport();
     VERIFY_ARE_EQUAL(0, thirdHostView.Top());
     VERIFY_ARE_EQUAL(newViewportSize.height, thirdHostView.BottomExclusive());
@@ -933,7 +933,7 @@ void ConptyRoundtripTests::TestResizeHeight()
     Log::Comment(NoThrowString().Format(L"Paint a frame to update the Terminal"));
     VERIFY_SUCCEEDED(renderer.PaintFrame());
 
-    // Conpty's doesn't have a scrollback, it's view's origin is always 0,0
+    // Conpty's doesn't have a scrollback, its view's origin is always 0,0
     const auto fourthHostView = si.GetViewport();
     VERIFY_ARE_EQUAL(0, fourthHostView.Top());
     VERIFY_ARE_EQUAL(newViewportSize.height, fourthHostView.BottomExclusive());
@@ -3430,7 +3430,7 @@ void ConptyRoundtripTests::WrapNewLineAtBottomLikeMSYS()
     //
     // The last line of the buffer will be used as a "prompt" line, with a
     // single ':' in it. This is similar to the way `less` typically displays
-    // it's prompt at the bottom of the buffer.
+    // its prompt at the bottom of the buffer.
 
     // First, print a whole viewport full of text.
     for (auto i = 0; i < (TerminalViewHeight) / 2; i++)

--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -358,7 +358,7 @@ void NonClientIslandWindow::Initialize()
     Controls::Grid::SetRow(_titlebar, 0);
 
     // GH#3440 - When the titlebar is loaded (officially added to our UI tree),
-    // then make sure to update it's visual state to reflect if we're in the
+    // then make sure to update its visual state to reflect if we're in the
     // maximized state on launch.
     _titlebar.Loaded([this](auto&&, auto&&) { _OnMaximizeChange(); });
 }
@@ -398,7 +398,7 @@ void NonClientIslandWindow::SetTitlebarContent(winrt::Windows::UI::Xaml::UIEleme
     // GH#4288 - add a SizeChanged handler to this content. It's possible that
     // this element's size will change after the dragbar's. When that happens,
     // the drag bar won't send another SizeChanged event, because the dragbar's
-    // _size_ didn't change, only it's position.
+    // _size_ didn't change, only its position.
     const auto fwe = content.try_as<winrt::Windows::UI::Xaml::FrameworkElement>();
     if (fwe)
     {

--- a/src/host/VtIo.cpp
+++ b/src/host/VtIo.cpp
@@ -523,7 +523,7 @@ void VtIo::EnableConptyModeForTests(std::unique_ptr<Microsoft::Console::Render::
 // - Returns true if the Resize Quirk is enabled. This changes the behavior of
 //   conpty to _not_ InvalidateAll the entire viewport on a resize operation.
 //   This is used by the Windows Terminal, because it is prepared to be
-//   connected to a conpty, and handles it's own buffer specifically for a
+//   connected to a conpty, and handles its own buffer specifically for a
 //   conpty scenario.
 // - See also: GH#3490, #4354, #4741
 // Arguments:

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -7392,7 +7392,7 @@ void ScreenBufferTests::RectangularAreaOperations()
         _FillLines(viewport.Top() + 10, viewport.BottomExclusive(), expectedChar, expectedAttr);
         // Copy a rectangle from that lower part up to the top with DECCRA.
         stateMachine.ProcessString(L"\033[11;27;14;54;1;3;27;1;4$v");
-        // Reset the lower part back to it's original content.
+        // Reset the lower part back to its original content.
         _FillLines(viewport.Top() + 10, viewport.BottomExclusive(), bufferChar, bufferAttr);
         break;
     default:

--- a/src/inc/conpty.h
+++ b/src/inc/conpty.h
@@ -29,7 +29,7 @@ bool SignalResizeWindow(const HANDLE hSignal,
 //      this pipe. For keys that don't have character representations, the
 //      caller should use the `TERM=xterm` VT sequences for encoding the input.
 //   * hOutput: The caller should read from this pipe. The headless conhost will
-//      "render" it's state to a stream of utf-8 encoded text with VT sequences.
+//      "render" its state to a stream of utf-8 encoded text with VT sequences.
 //   * hSignal: The caller can use this to resize the size of the underlying PTY
 //      using the SignalResizeWindow function.
 // Arguments:

--- a/src/inc/til/rle.h
+++ b/src/inc/til/rle.h
@@ -940,7 +940,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             {
                 begin->length = begin_pos;
                 // begin is part of the to-be-replaced range.
-                // We've used the run begin is pointing to adjust it's length.
+                // We've used the run begin is pointing to adjust its length.
                 // --> We must increment it in order to not overwrite it in [Step4].
                 ++begin;
             }

--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -516,7 +516,7 @@ namespace Microsoft::Console::Render
                 // This returns the actual byte size of a AtlasKeyData struct for the given charCount.
                 // The `wchar_t chars[2]` is only a buffer for the inlined variant after
                 // all and the actual charCount can be smaller or larger. Due to this we
-                // remove the size of the `chars` array and add it's true length on top.
+                // remove the size of the `chars` array and add its true length on top.
                 return sizeof(AtlasKeyData) - sizeof(AtlasKeyData::chars) + static_cast<size_t>(charCount) * sizeof(AtlasKeyData::chars[0]);
             }
         };
@@ -772,7 +772,7 @@ namespace Microsoft::Console::Render
                 // alternating between an 1:1 and 2:1 aspect ratio, like so:
                 //   (64,64) -> (128,64) -> (128,128) -> (256,128) -> (256,256)
                 // This behavior is strictly dependent on setMaxArea(u16x2)'s
-                // behavior. See it's comment for an explanation.
+                // behavior. See its comment for an explanation.
                 if (_size.x == _size.y)
                 {
                     _size.x *= 2;

--- a/src/renderer/vt/state.cpp
+++ b/src/renderer/vt/state.cpp
@@ -279,7 +279,7 @@ CATCH_RETURN();
         {
             // GH#3490 - When the viewport width changed, don't do anything extra here.
             // If the buffer had areas that were invalid due to the resize, then the
-            // buffer will have triggered it's own invalidations for what it knows is
+            // buffer will have triggered its own invalidations for what it knows is
             // invalid. Previously, we'd invalidate everything if the width changed,
             // because we couldn't be sure if lines were reflowed.
             _invalidMap.resize(newSize);
@@ -478,7 +478,7 @@ void VtEngine::EndResizeRequest()
 // - Configure the renderer for the resize quirk. This changes the behavior of
 //   conpty to _not_ InvalidateAll the entire viewport on a resize operation.
 //   This is used by the Windows Terminal, because it is prepared to be
-//   connected to a conpty, and handles it's own buffer specifically for a
+//   connected to a conpty, and handles its own buffer specifically for a
 //   conpty scenario.
 // - See also: GH#3490, #4354, #4741
 // Arguments:

--- a/src/terminal/parser/ut_parser/InputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/InputEngineTest.cpp
@@ -997,7 +997,7 @@ void InputEngineTest::AltIntermediateTest()
     VERIFY_IS_NOT_NULL(stateMachine);
     testState._stateMachine = stateMachine.get();
 
-    // Write a Alt+/, Ctrl+e pair to the input engine, then take it's output and
+    // Write a Alt+/, Ctrl+e pair to the input engine, then take its output and
     // run it through the terminalInput translator. We should get ^[/^E back
     // out.
     std::wstring seq = L"\x1b/";

--- a/tools/runut.cmd
+++ b/tools/runut.cmd
@@ -4,7 +4,7 @@ rem Run the console unit tests.
 rem Keep this file in sync with tests.xml
 
 rem The TerminalApp.LocalTests are actually run from the TestHostApp path.
-rem That's a cppwinrt project, that doesn't use %PLATFORM% in it's path when the
+rem That's a cppwinrt project, that doesn't use %PLATFORM% in its path when the
 rem platform is Win32/x86.
 rem set a helper for us to find that test
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
`s/it's/its/`

Note that I didn't touch the several errors in the doc and doc/spec directories, since those seem to be dated and signed email excerpts, and I don't want to violate authorial integrity. Let me know if you would like me to fix those as well.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
p 57.  Murray, L.  (1824).  English grammar.  Philadelphia :  E. T. Scott.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
I skimmed several hundred usages of the word "it's" in the code. This actually wasn't as tiresome as it sounds, since many of the code comments in this repo are entertaining and educational &mdash; the adjectives do not _necessarily_ apply in that order, but do _possibly_ apply in that order.