### PR TITLE
Make sure focused tab text color accounts for alpha

### DIFF
--- a/src/cascadia/TerminalApp/TabBase.cpp
+++ b/src/cascadia/TerminalApp/TabBase.cpp
@@ -356,16 +356,12 @@ namespace winrt::TerminalApp::implementation
         Media::SolidColorBrush hoverTabBrush{};
         Media::SolidColorBrush subtleFillColorSecondaryBrush;
         Media::SolidColorBrush subtleFillColorTertiaryBrush;
+
         // calculate the luminance of the current color and select a font
         // color based on that
         // see https://www.w3.org/TR/WCAG20/#relativeluminancedef
         if (TerminalApp::ColorHelper::IsBrightColor(color))
         {
-            fontBrush.Color(winrt::Windows::UI::Colors::Black());
-            auto secondaryFontColor = winrt::Windows::UI::Colors::Black();
-            // For alpha value see: https://github.com/microsoft/microsoft-ui-xaml/blob/7a33ad772d77d908aa6b316ec24e6d2eb3ebf571/dev/CommonStyles/Common_themeresources_any.xaml#L269
-            secondaryFontColor.A = 0x9E;
-            secondaryFontBrush.Color(secondaryFontColor);
             auto subtleFillColorSecondary = winrt::Windows::UI::Colors::Black();
             subtleFillColorSecondary.A = 0x09;
             subtleFillColorSecondaryBrush.Color(subtleFillColorSecondary);
@@ -375,17 +371,31 @@ namespace winrt::TerminalApp::implementation
         }
         else
         {
-            fontBrush.Color(winrt::Windows::UI::Colors::White());
-            auto secondaryFontColor = winrt::Windows::UI::Colors::White();
-            // For alpha value see: https://github.com/microsoft/microsoft-ui-xaml/blob/7a33ad772d77d908aa6b316ec24e6d2eb3ebf571/dev/CommonStyles/Common_themeresources_any.xaml#L14
-            secondaryFontColor.A = 0xC5;
-            secondaryFontBrush.Color(secondaryFontColor);
             auto subtleFillColorSecondary = winrt::Windows::UI::Colors::White();
             subtleFillColorSecondary.A = 0x0F;
             subtleFillColorSecondaryBrush.Color(subtleFillColorSecondary);
             auto subtleFillColorTertiary = winrt::Windows::UI::Colors::White();
             subtleFillColorTertiary.A = 0x0A;
             subtleFillColorTertiaryBrush.Color(subtleFillColorTertiary);
+        }
+
+        // The tab font should be based on the evaluated appearance of the tab color layered on tab row.
+        const auto layeredTabColor = til::color{ color }.layer_over(_tabRowColor);
+        if (TerminalApp::ColorHelper::IsBrightColor(layeredTabColor))
+        {
+            fontBrush.Color(winrt::Windows::UI::Colors::Black());
+            auto secondaryFontColor = winrt::Windows::UI::Colors::Black();
+            // For alpha value see: https://github.com/microsoft/microsoft-ui-xaml/blob/7a33ad772d77d908aa6b316ec24e6d2eb3ebf571/dev/CommonStyles/Common_themeresources_any.xaml#L269
+            secondaryFontColor.A = 0x9E;
+            secondaryFontBrush.Color(secondaryFontColor);
+        }
+        else
+        {
+            fontBrush.Color(winrt::Windows::UI::Colors::White());
+            auto secondaryFontColor = winrt::Windows::UI::Colors::White();
+            // For alpha value see: https://github.com/microsoft/microsoft-ui-xaml/blob/7a33ad772d77d908aa6b316ec24e6d2eb3ebf571/dev/CommonStyles/Common_themeresources_any.xaml#L14
+            secondaryFontColor.A = 0xC5;
+            secondaryFontBrush.Color(secondaryFontColor);
         }
 
         selectedTabBrush.Color(color);


### PR DESCRIPTION
Basically what it says on the tin. For transparent tabs, we should layer on to the tab row to evaluate what the actual color of the tab will be. We did this for deselected tabs, but not for selected ones.

Gif below.

Closes #14561