### PR TITLE
Fix missing paths when items dropped from archive

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2544,17 +2544,17 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                         const auto buffer = co_await stream.ReadAsync(buf, streamSize, InputStreamOptions::None);
 
                         const HGLOBAL hGlobal = buffer.data();
-                        const auto count = DragQueryFile((HDROP)hGlobal, 0xFFFFFFFF, nullptr, 0);
+                        const auto count = DragQueryFileW(static_cast<HDROP>(hGlobal), 0xFFFFFFFF, nullptr, 0);
                         fullPaths.reserve(count);
 
                         for (unsigned int i = 0; i < count; i++)
                         {
                             WCHAR szPath[MAX_PATH];
-                            const auto charsCopied = DragQueryFile((HDROP)hGlobal, i, szPath, MAX_PATH);
+                            const auto charsCopied = DragQueryFileW(static_cast<HDROP>(hGlobal), i, szPath, MAX_PATH);
 
                             if (charsCopied > 0)
                             {
-                                fullPaths.push_back(std::wstring{ szPath });
+                                fullPaths.emplace_back(szPath);
                             }
                         }
                     }
@@ -2564,12 +2564,13 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                     fullPaths.reserve(items.Size());
                     for (auto item : items)
                     {
-                        fullPaths.push_back(std::wstring{ item.Path() });
+                        fullPaths.emplace_back(item.Path());
+
                     }
                 }
 
                 std::wstring allPathsString;
-                for (auto fullPath : fullPaths)
+                for (auto& fullPath : fullPaths)
                 {
                     // Join the paths with spaces
                     if (!allPathsString.empty())

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2562,10 +2562,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                 else
                 {
                     fullPaths.reserve(items.Size());
-                    for (auto item : items)
+                    for (const auto& item : items)
                     {
                         fullPaths.emplace_back(item.Path());
-
                     }
                 }
 

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2539,18 +2539,18 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                         auto stream = fileDropData.as<IRandomAccessStream>();
                         stream.Seek(0);
 
-                        uint32_t streamSize = (uint32_t)stream.Size();
-                        Buffer buf(streamSize);
-                        auto buffer = co_await stream.ReadAsync(buf, streamSize, InputStreamOptions::None);
+                        const uint32_t streamSize = gsl::narrow_cast<uint32_t>stream.Size();
+                        const Buffer buf(streamSize);
+                        const auto buffer = co_await stream.ReadAsync(buf, streamSize, InputStreamOptions::None);
 
                         const HGLOBAL hGlobal = buffer.data();
-                        auto count = DragQueryFile((HDROP)hGlobal, 0xFFFFFFFF, nullptr, 0);
+                        const auto count = DragQueryFile((HDROP)hGlobal, 0xFFFFFFFF, nullptr, 0);
                         fullPaths.reserve(count);
 
                         for (unsigned int i = 0; i < count; i++)
                         {
                             WCHAR szPath[MAX_PATH];
-                            auto charsCopied = DragQueryFile((HDROP)hGlobal, i, szPath, MAX_PATH);
+                            const auto charsCopied = DragQueryFile((HDROP)hGlobal, i, szPath, MAX_PATH);
 
                             if (charsCopied > 0)
                             {

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2539,7 +2539,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                         auto stream = fileDropData.as<IRandomAccessStream>();
                         stream.Seek(0);
 
-                        const uint32_t streamSize = gsl::narrow_cast<uint32_t>stream.Size();
+                        const uint32_t streamSize = gsl::narrow_cast<uint32_t>(stream.Size());
                         const Buffer buf(streamSize);
                         const auto buffer = co_await stream.ReadAsync(buf, streamSize, InputStreamOptions::None);
 

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2549,12 +2549,14 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
                         for (unsigned int i = 0; i < count; i++)
                         {
-                            WCHAR szPath[MAX_PATH];
-                            const auto charsCopied = DragQueryFileW(static_cast<HDROP>(hGlobal), i, szPath, MAX_PATH);
+                            std::wstring path;
+                            path.resize(wil::max_path_length);
+                            const auto charsCopied = DragQueryFileW(static_cast<HDROP>(hGlobal), i, path.data(), wil::max_path_length);
 
                             if (charsCopied > 0)
                             {
-                                fullPaths.emplace_back(szPath);
+                                path.resize(charsCopied);
+                                fullPaths.emplace_back(std::move(path));
                             }
                         }
                     }

--- a/src/cascadia/TerminalControl/dll/TerminalControl.vcxproj
+++ b/src/cascadia/TerminalControl/dll/TerminalControl.vcxproj
@@ -11,6 +11,7 @@
     <!-- sets a bunch of Windows Universal properties -->
     <OpenConsoleUniversalApp>true</OpenConsoleUniversalApp>
     <PgoTarget>true</PgoTarget>
+
     <!-- C++/WinRT sets the depth to 1 if there is a XAML file in the project
          Unfortunately for us, we need it to be 3. When the namespace merging
          depth is 1, Microsoft.Terminal.Control becomes "Microsoft",
@@ -21,9 +22,11 @@
     -->
     <CppWinRTNamespaceMergeDepth>3</CppWinRTNamespaceMergeDepth>
   </PropertyGroup>
+
   <PropertyGroup Label="NuGet Dependencies">
     <TerminalCppWinrt>true</TerminalCppWinrt>
   </PropertyGroup>
+
   <Import Project="..\..\..\..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.props" />
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.pre.props" />
@@ -62,6 +65,7 @@
       <CopyLocalSatelliteAssemblies>true</CopyLocalSatelliteAssemblies>
     </ProjectReference>
   </ItemGroup>
+
   <ItemGroup>
     <!-- Manually add a reference to TerminalControl here. We need this so
     MDMERGE will know where the TermControl types are defined. However, we need
@@ -73,6 +77,7 @@
       <Private>false</Private>
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
     </Reference>
+
     <Reference Include="Microsoft.Terminal.TerminalConnection">
       <HintPath>$(OpenConsoleCommonOutDir)TerminalConnection\Microsoft.Terminal.TerminalConnection.winmd</HintPath>
       <IsWinMDFile>true</IsWinMDFile>
@@ -80,6 +85,7 @@
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
     </Reference>
   </ItemGroup>
+
   <ItemDefinitionGroup>
     <Link>
       <AdditionalDependencies>dwrite.lib;dxgi.lib;d2d1.lib;d3d11.lib;shcore.lib;winmm.lib;pathcch.lib;propsys.lib;uiautomationcore.lib;Shlwapi.lib;ntdll.lib;user32.lib;shell32.lib;kernel32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -90,6 +96,7 @@
       -->
       <AdditionalOptions Condition="'$(Platform)'=='Win32'">/INCLUDE:_DllMain@12 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="'$(Platform)'!='Win32'">/INCLUDE:DllMain %(AdditionalOptions)</AdditionalOptions>
+
       <Reference>
         <!-- Do not propagate microsoft.ui.xaml upwards as a private dependency. -->
         <Private>false</Private>
@@ -97,6 +104,7 @@
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.post.props" />
+
   <!-- This -must- go after cppwinrt.build.post.props because that includes many VS-provided props including appcontainer.common.props, which stomps on what cppwinrt.targets did. -->
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.targets" />
 </Project>

--- a/src/cascadia/TerminalControl/dll/TerminalControl.vcxproj
+++ b/src/cascadia/TerminalControl/dll/TerminalControl.vcxproj
@@ -11,7 +11,6 @@
     <!-- sets a bunch of Windows Universal properties -->
     <OpenConsoleUniversalApp>true</OpenConsoleUniversalApp>
     <PgoTarget>true</PgoTarget>
-
     <!-- C++/WinRT sets the depth to 1 if there is a XAML file in the project
          Unfortunately for us, we need it to be 3. When the namespace merging
          depth is 1, Microsoft.Terminal.Control becomes "Microsoft",
@@ -22,11 +21,9 @@
     -->
     <CppWinRTNamespaceMergeDepth>3</CppWinRTNamespaceMergeDepth>
   </PropertyGroup>
-
   <PropertyGroup Label="NuGet Dependencies">
     <TerminalCppWinrt>true</TerminalCppWinrt>
   </PropertyGroup>
-
   <Import Project="..\..\..\..\common.openconsole.props" Condition="'$(OpenConsoleDir)'==''" />
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.props" />
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.pre.props" />
@@ -65,7 +62,6 @@
       <CopyLocalSatelliteAssemblies>true</CopyLocalSatelliteAssemblies>
     </ProjectReference>
   </ItemGroup>
-
   <ItemGroup>
     <!-- Manually add a reference to TerminalControl here. We need this so
     MDMERGE will know where the TermControl types are defined. However, we need
@@ -77,7 +73,6 @@
       <Private>false</Private>
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
     </Reference>
-
     <Reference Include="Microsoft.Terminal.TerminalConnection">
       <HintPath>$(OpenConsoleCommonOutDir)TerminalConnection\Microsoft.Terminal.TerminalConnection.winmd</HintPath>
       <IsWinMDFile>true</IsWinMDFile>
@@ -85,10 +80,9 @@
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
     </Reference>
   </ItemGroup>
-
   <ItemDefinitionGroup>
     <Link>
-      <AdditionalDependencies>dwrite.lib;dxgi.lib;d2d1.lib;d3d11.lib;shcore.lib;winmm.lib;pathcch.lib;propsys.lib;uiautomationcore.lib;Shlwapi.lib;ntdll.lib;user32.lib;kernel32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dwrite.lib;dxgi.lib;d2d1.lib;d3d11.lib;shcore.lib;winmm.lib;pathcch.lib;propsys.lib;uiautomationcore.lib;Shlwapi.lib;ntdll.lib;user32.lib;shell32.lib;kernel32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <!--
       ControlLib contains a DllMain that we need to force the use of.
       If you don't have this, then you'll see an error like
@@ -96,7 +90,6 @@
       -->
       <AdditionalOptions Condition="'$(Platform)'=='Win32'">/INCLUDE:_DllMain@12 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="'$(Platform)'!='Win32'">/INCLUDE:DllMain %(AdditionalOptions)</AdditionalOptions>
-
       <Reference>
         <!-- Do not propagate microsoft.ui.xaml upwards as a private dependency. -->
         <Private>false</Private>
@@ -104,7 +97,6 @@
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(OpenConsoleDir)src\cppwinrt.build.post.props" />
-
   <!-- This -must- go after cppwinrt.build.post.props because that includes many VS-provided props including appcontainer.common.props, which stomps on what cppwinrt.targets did. -->
   <Import Project="$(OpenConsoleDir)src\common.nugetversions.targets" />
 </Project>

--- a/src/cascadia/TerminalControl/pch.h
+++ b/src/cascadia/TerminalControl/pch.h
@@ -48,6 +48,7 @@
 #include <winrt/Windows.ui.xaml.shapes.h>
 #include <winrt/Windows.ApplicationModel.DataTransfer.h>
 #include <winrt/Windows.Storage.h>
+#include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.UI.Xaml.Shapes.h>
 
 #include <winrt/Microsoft.Terminal.TerminalConnection.h>
@@ -59,6 +60,7 @@
 TRACELOGGING_DECLARE_PROVIDER(g_hTerminalControlProvider);
 #include <telemetry/ProjectTelemetry.h>
 
+#include <shellapi.h>
 #include <ShlObj_core.h>
 #include <WinUser.h>
 


### PR DESCRIPTION
Grab all paths from `DROPFILES` struct provided in drag event data

`GetStorageItemsAsync()` only giving up to 16 items when items are dropped from any archives
- When this occurs, we should look into `FileDrop` key for a stream of the [`DROPFILES struct`](https://learn.microsoft.com/en-us/windows/win32/shell/clipboard#cf_hdrop)
- This struct contains a null-character delimited string of paths which we can just read out

## Validation Steps Performed
* [X] Unit tests pass locally
* [X] Drag and drop paths work for both archives and non-archives files, folders, shortcuts, etc.

Closes #14628 