### PR TITLE
Check for null lParam in WM_SETTINGSCHANGE

### DIFF
--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -663,7 +663,7 @@ long IslandWindow::_calculateTotalSize(const bool isWidth, const long clientSize
         // Currently, we only support checking when the OS theme changes. In
         // that case, wParam is 0. Re-evaluate when we decide to reload env vars
         // (GH#1125)
-        if (wparam == 0)
+        if (wparam == 0 && lparam != 0)
         {
             const std::wstring param{ (wchar_t*)lparam };
             // ImmersiveColorSet seems to be the notification that the OS theme


### PR DESCRIPTION
Fix access violation on lParam when constructing wstring.

Per the [WM_SETTINGSCHANGE docs], NULL is a valid value for lParam. A
null lParam was observed when using the 'Switch User' feature of Windows
while developing the Terminal app.

## Validation Steps Performed
Reproduced the scenario w/ the check in place and verified no crash.

Closes #14652

[WM_SETTINGSCHANGE docs]: https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-settingchange
