### PR TITLE
Remove the win10/win11 digit from our version number. 

### DIFF
--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -1015,7 +1015,7 @@ winrt::hstring CascadiaSettings::ApplicationVersion()
     {
         const auto package{ winrt::Windows::ApplicationModel::Package::Current() };
         const auto version{ package.Id().Version() };
-        // As of about 2022, the one's digit of the Build of our version is a
+        // As of about 2022, the ones digit of the Build of our version is a
         // placeholder value to differentiate the Windows 10 build from the
         // Windows 11 build. Let's trim that out. For additional clarity,
         // let's omit the Revision, which _must_ be .0, and doesn't provide any

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -1019,7 +1019,7 @@ winrt::hstring CascadiaSettings::ApplicationVersion()
         // placeholder value to differentiate the Windows 10 build from the
         // Windows 11 build. Let's trim that out. For additional clarity,
         // let's omit the Revision, which _must_ be .0, and doesn't provide any
-        // value.to report.
+        // value to report.
         winrt::hstring formatted{ wil::str_printf<std::wstring>(L"%u.%u.%u", version.Major, version.Minor, version.Build / 10) };
         return formatted;
     }

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.cpp
@@ -1015,7 +1015,12 @@ winrt::hstring CascadiaSettings::ApplicationVersion()
     {
         const auto package{ winrt::Windows::ApplicationModel::Package::Current() };
         const auto version{ package.Id().Version() };
-        winrt::hstring formatted{ wil::str_printf<std::wstring>(L"%u.%u.%u.%u", version.Major, version.Minor, version.Build, version.Revision) };
+        // As of about 2022, the one's digit of the Build of our version is a
+        // placeholder value to differentiate the Windows 10 build from the
+        // Windows 11 build. Let's trim that out. For additional clarity,
+        // let's omit the Revision, which _must_ be .0, and doesn't provide any
+        // value.to report.
+        winrt::hstring formatted{ wil::str_printf<std::wstring>(L"%u.%u.%u", version.Major, version.Minor, version.Build / 10) };
         return formatted;
     }
     CATCH_LOG();


### PR DESCRIPTION
As of about 2022, the one's digit of the Build of our version is a placeholder value to differentiate the Windows 10 build from the Windows 11 build. Let's trim that out, it's only a source of confusion.

For additional clarity, let's omit the Revision, which _must_ be `.0`, and doesn't provide any value to report.

We will need to make sure we report releases as `1.17.ABC` now, instead of `1.17.ABC1.0`/`1.17.ABC2.0`

Let's not backport this. 1.17 will be the start of the new numbering scheme. Otherwise, `1.16.EFG` < `1.16.ABC1.0`, for an old version `ABC1` and a new version `EFG`.

* closes #14106
* As summarized here: https://github.com/microsoft/terminal/issues/14106#issuecomment-1289462310