### PR TITLE
Fix issue with pasting while tab renaming also sending the paste command to terminal

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2318,6 +2318,18 @@ namespace winrt::TerminalApp::implementation
     fire_and_forget TerminalPage::_PasteFromClipboardHandler(const IInspectable /*sender*/,
                                                              const PasteFromClipboardEventArgs eventArgs)
     {
+        // Checking here if we are currently renaming any tab so that we should not paste content into our tab.
+        for (const auto item : _tabs)
+        {
+            if (const auto tabItem = item.try_as<TerminalTab>())
+            {
+                if (tabItem->InRename())
+                {
+                    co_return;
+                }
+            }
+        }
+
         const auto data = Clipboard::GetContent();
 
         // This will switch the execution of the function to a background (not

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -1555,6 +1555,11 @@ namespace winrt::TerminalApp::implementation
         return _zoomedPane != nullptr;
     }
 
+    bool TerminalTab::InRename()
+    {
+        return _headerControl.InRename();
+    }
+
     // Method Description:
     // - Toggle read-only mode on the active pane
     // - If a parent pane is selected, this will ensure that all children have

--- a/src/cascadia/TerminalApp/TerminalTab.h
+++ b/src/cascadia/TerminalApp/TerminalTab.h
@@ -82,6 +82,8 @@ namespace winrt::TerminalApp::implementation
         void EnterZoom();
         void ExitZoom();
 
+        bool InRename();
+
         std::vector<Microsoft::Terminal::Settings::Model::ActionAndArgs> BuildStartupActions() const override;
 
         int GetLeafPaneCount() const noexcept;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The issue was that pasting while renaming a tab is also sending that text to the terminal. The proposed fix is to ignore paste commands while we are renaming a tab.

Other solutions I considered where looking for shell focus to undermine sending paste commands (how would you paste something if the shell is not focused) or diving deeper into the events to actually prevent it from bubbling up so far. Due to complexity and possible problems however, I went with just looking for renaming tabs instead.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #14381 
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/Terminal) and sign the CLA
* [ ] Tests added/passed
* [ ] Documentation updated. If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
* [ ] Schema updated.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Start Terminal
2. Rename tab
3. Press Ctrl+C and see if the shell gets pasted content