### PR TITLE
Add the Theme schema for 1.16

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -107,6 +107,7 @@ bgidx
 Bgk
 BGR
 bgra
+BGRA
 BHID
 bigobj
 binplace

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -1560,7 +1560,8 @@
         {
           "pattern": "^#[A-Fa-f0-9]{3}(?:[A-Fa-f0-9]{3}(?:[A-Fa-f0-9]{2})?)?$",
           "type": "string",
-          "format": "color"
+          "format": "color",
+          "default": "#000000ff"
         },
         {
           "const": "accent",
@@ -1613,7 +1614,8 @@
       "properties": {
         "applicationTheme": {
           "description": "Which UI theme the Terminal should use for controls",
-          "oneOf": [ "light", "dark", "system" ]
+          "enum": [ "light", "dark", "system" ],
+          "type": "string"
         },
         "useMica": {
           "description": "True if the Terminal should use a Mica backdrop for the window. This will apply underneath all controls (including the terminal panes and the titlebar)",
@@ -1629,7 +1631,9 @@
         "name": {
           "type": "string",
           "description": "The name of the theme. This will be displayed in the settings UI.",
-          "noneOf": [ "light", "dark", "system" ]
+          "not": { 
+            "enum": [ "light", "dark", "system" ]
+          }
         },
         "tab": {
           "$ref": "#/$defs/TabTheme"

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -1546,6 +1546,41 @@
         }
       ]
     },
+    "TabTheme": {
+      "additionalProperties": false,
+      "description": "A set of properties for customizing the appearance of the tab row",
+      "properties": {
+        "background": {
+          "$ref": "#/$defs/ThemeColor"
+        },
+        "unfocusedBackground": {
+          "$ref": "#/$defs/ThemeColor"
+        },
+        "showCloseButton": {
+          "$ref": "#/$defs/ShowCloseButton"
+        }
+      }
+    },
+    "Theme": {
+      "additionalProperties": false,
+      "description": "A set of properties for customizing the appearance of the window. This controls things like the titlebar, the tabs, the application theme.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the theme. This will be displayed in the settings UI.",
+          "noneOf": [ "light", "dark", "system" ]
+        },
+        "tab": {
+          "$ref": "#/$defs/TabTheme"
+        },
+        "tabRow": {
+          "$ref": "#/$defs/TabRowTheme"
+        },
+        "window": {
+          "$ref": "#/$defs/WindowTheme"
+        }
+      }
+    },
     "Keybinding": {
       "additionalProperties": false,
       "properties": {
@@ -1930,14 +1965,16 @@
           "type": "string"
         },
         "theme": {
-          "default": "system",
-          "description": "Sets the theme of the application. The special value \"system\" refers to the active Windows system theme.",
-          "enum": [
-            "light",
-            "dark",
-            "system"
-          ],
+          "default": "dark",
+          "description": "Sets the theme of the application. This value should be the name of one of the themes defined in `themes`. The Terminal also includes the themes `dark`, `light`, and `system`.",
           "type": "string"
+        },
+        "themes": {
+          "description": "The list of available themes",
+          "items": {
+            "$ref": "#/$defs/Theme"
+          },
+          "type": "array"
         },
         "showTabsInTitlebar": {
           "default": true,

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -1546,18 +1546,79 @@
         }
       ]
     },
+    "ShowCloseButton": {
+      "enum": [
+        "always",
+        "hover",
+        "never"
+      ],
+      "type": "string"
+    },
+    "ThemeColor": {
+      "description": "A special kind of color for use in themes. Can be an #rrggbb color, #rrggbbaa color, or a special value. 'accent' is evaluated as the user's selected Accent color in the OS, and 'terminalBackground' will be evaluated as the background color of the active terminal pane.",
+      "oneOf": [
+        {
+          "pattern": "^#[A-Fa-f0-9]{3}(?:[A-Fa-f0-9]{3}(?:[A-Fa-f0-9]{2})?)?$",
+          "type": "string",
+          "format": "color"
+        },
+        {
+          "const": "accent",
+          "type": "string"
+        },
+        {
+          "const": "terminalBackground",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "TabTheme": {
+      "additionalProperties": false,
+      "description": "A set of properties for customizing the appearance of the tabs",
+      "properties": {
+        "background": {
+          "description": "The color of a tab when it is the active tab",
+          "$ref": "#/$defs/ThemeColor"
+        },
+        "unfocusedBackground": {
+          "description": "The color of a tab when it is not the active tab",
+          "$ref": "#/$defs/ThemeColor"
+        },
+        "showCloseButton": {
+          "description": "Controls the visibility of the close button on the tab",
+          "$ref": "#/$defs/ShowCloseButton"
+        }
+      }
+    },
+    "TabRowTheme": {
       "additionalProperties": false,
       "description": "A set of properties for customizing the appearance of the tab row",
       "properties": {
         "background": {
+          "description": "The color of the tab row when the window is the foreground window.",
           "$ref": "#/$defs/ThemeColor"
         },
         "unfocusedBackground": {
+          "description": "The color of the tab row when the window is inactive",
           "$ref": "#/$defs/ThemeColor"
+        }
+      }
+    },
+    "WindowTheme": {
+      "additionalProperties": false,
+      "description": "A set of properties for customizing the appearance of the window itself",
+      "properties": {
+        "applicationTheme": {
+          "description": "Which UI theme the Terminal should use for controls",
+          "oneOf": [ "light", "dark", "system" ]
         },
-        "showCloseButton": {
-          "$ref": "#/$defs/ShowCloseButton"
+        "useMica": {
+          "description": "True if the Terminal should use a Mica backdrop for the window. This will apply underneath all controls (including the terminal panes and the titlebar)",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -1616,11 +1616,6 @@
           "description": "Which UI theme the Terminal should use for controls",
           "enum": [ "light", "dark", "system" ],
           "type": "string"
-        },
-        "useMica": {
-          "description": "True if the Terminal should use a Mica backdrop for the window. This will apply underneath all controls (including the terminal panes and the titlebar)",
-          "type": "boolean",
-          "default": false
         }
       }
     },

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -1509,7 +1509,7 @@ void IslandWindow::_globalActivateWindow(const uint32_t dropdownDuration,
     else
     {
         // Try first to send a message to the current foreground window. If it's not responding, it may
-        // be waiting on us to finsh launching. Passing SMTO_NOTIMEOUTIFNOTHUNG means that we get the same
+        // be waiting on us to finish launching. Passing SMTO_NOTIMEOUTIFNOTHUNG means that we get the same
         // behavior as before--that is, waiting for the message loop--but we've done an early return if
         // it turns out that it was hung.
         // SendMessageTimeoutW returns nonzero if it succeeds.


### PR DESCRIPTION
This is just #14666 ported to 1.16. Only diff is that useMica is removed. 

Related to https://github.com/microsoft/terminal/issues/14560