### PR TITLE
Add mutex to keyEvents in TermControlAutomationPeer

### DIFF
--- a/src/cascadia/TerminalControl/TermControlAutomationPeer.h
+++ b/src/cascadia/TerminalControl/TermControlAutomationPeer.h
@@ -80,6 +80,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     private:
         winrt::weak_ref<Microsoft::Terminal::Control::implementation::TermControl> _termControl;
         Control::InteractivityAutomationPeer _contentAutomationPeer;
-        std::deque<wchar_t> _keyEvents;
+        til::shared_mutex<std::deque<wchar_t>> _keyEvents;
     };
 }

--- a/src/cascadia/TerminalControl/pch.h
+++ b/src/cascadia/TerminalControl/pch.h
@@ -65,6 +65,7 @@ TRACELOGGING_DECLARE_PROVIDER(g_hTerminalControlProvider);
 #include <WinUser.h>
 
 #include "til.h"
+#include <til/mutex.h>
 
 #include "ThrottledFunc.h"
 


### PR DESCRIPTION
Some investigation revealed that `_keyEvents` would get a `NULL_POINTER_READ` error. On the main thread, `RecordKeyEvent()` would be called, which mainly updates `_keyEvents`. On the renderer thread, `NotifyNewOutput()` would be called, which starts by iterating through `_keyEvents` and slowly clearing it out. On occasion, these two threads are modifying `_keyEvents` simultaneously, causing a crash.

The fix is to add a mutex on this variable. 

Closes #14592

