### PR TITLE
Fix the selected color scheme list item container background being blue in Windows 10

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -70,6 +70,9 @@
                   PreviewKeyDown="ListView_PreviewKeyDown"
                   SelectedItem="{x:Bind ViewModel.CurrentScheme, Mode=TwoWay}"
                   SelectionMode="Single">
+            <ListView.Resources>
+                <SolidColorBrush x:Key="ListViewItemBackgroundSelected" Color="{ThemeResource SystemListLowColor}" />
+            </ListView.Resources>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="local:ColorSchemeViewModel">
                     <Grid MaxWidth="1000"

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -71,7 +71,9 @@
                   SelectedItem="{x:Bind ViewModel.CurrentScheme, Mode=TwoWay}"
                   SelectionMode="Single">
             <ListView.Resources>
-                <SolidColorBrush x:Key="ListViewItemBackgroundSelected" Color="{ThemeResource SystemListLowColor}" />
+                <!--  We need this here because otherwise the background is blue in Windows 10  -->
+                <SolidColorBrush x:Key="ListViewItemBackgroundSelected"
+                                 Color="{ThemeResource SystemListLowColor}" />
             </ListView.Resources>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="local:ColorSchemeViewModel">


### PR DESCRIPTION
Specify the resource to use for the list view item background when selected.

References #14693 

## Validation Steps Performed
Background is no longer blue, it is light gray (like in Windows 11). Screenshots below.