### PR TITLE
Update the titlebar visibility when we gain/lose focus too

### DIFF
--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -1344,7 +1344,7 @@ winrt::fire_and_forget AppHost::_RenameWindowRequested(const winrt::Windows::Fou
     }
 }
 
-double _opacityFromBrush(const winrt::Windows::UI::Xaml::Media::Brush& brush)
+static double _opacityFromBrush(const winrt::Windows::UI::Xaml::Media::Brush& brush)
 {
     if (auto acrylic = brush.try_as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
     {

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -1344,6 +1344,19 @@ winrt::fire_and_forget AppHost::_RenameWindowRequested(const winrt::Windows::Fou
     }
 }
 
+double _opacityFromBrush(const winrt::Windows::UI::Xaml::Media::Brush& brush)
+{
+    if (auto acrylic = brush.try_as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
+    {
+        return acrylic.TintOpacity();
+    }
+    else if (auto solidColor = brush.try_as<winrt::Windows::UI::Xaml::Media::SolidColorBrush>())
+    {
+        return solidColor.Opacity();
+    }
+    return 1.0;
+}
+
 void AppHost::_updateTheme()
 {
     auto theme = _logic.Theme();
@@ -1351,7 +1364,10 @@ void AppHost::_updateTheme()
     _window->OnApplicationThemeChanged(theme.RequestedTheme());
 
     const auto b = _logic.TitlebarBrush();
-    const auto opacity = b ? ThemeColor::ColorFromBrush(b).A / 255.0 : 0.0;
+    const auto color = ThemeColor::ColorFromBrush(b);
+    const auto colorOpacity = b ? color.A / 255.0 : 0.0;
+    const auto brushOpacity = _opacityFromBrush(b);
+    const auto opacity = std::min(colorOpacity, brushOpacity);
     _window->UseMica(theme.Window() ? theme.Window().UseMica() : false, opacity);
 }
 
@@ -1619,6 +1635,7 @@ void AppHost::_PropertyChangedHandler(const winrt::Windows::Foundation::IInspect
         {
             auto nonClientWindow{ static_cast<NonClientIslandWindow*>(_window.get()) };
             nonClientWindow->SetTitlebarBackground(_logic.TitlebarBrush());
+            _updateTheme();
         }
     }
 }


### PR DESCRIPTION
We forgot to updateTheme again when we change the titlebar color. That would result in us setting the titlebar visibility only when the settings were reloaded, but if the unfocused BG was opaque, and the focused was transparent, we'd use the current _unfocused_ color to set the titlebar visibility. 

Also, this fixes a bug with `tabRow.BG: terminalBackground`

from teams for brevity 

> tabRow.BG = terminalBackground might not work, and here's why
>
> the termcontrol's BG brush might be (r,g,b, 255), with an Opacity of 0
> 
> so my "use mica when the brush's A is <1.0" doesn't work
> 

closes #14563 