### PR TITLE
Code sign the contents of the Terminal package

### DIFF
--- a/build/config/ESRPSigning_Terminal.json
+++ b/build/config/ESRPSigning_Terminal.json
@@ -1,0 +1,115 @@
+{
+    "Version": "1.0.0",
+    "UseMinimatch": false,
+    "SignBatches": [
+        {
+            "MatchedPath": [
+                // Namespaced DLLs
+                "Microsoft.Terminal.*.dll",
+
+                // ConPTY and DefTerm
+                "OpenConsole.exe",
+                "OpenConsoleProxy.dll",
+
+                // VCRT Forwarders
+                "*_app.dll",
+
+                // Legacy DLLs with old names
+                "TerminalApp.dll",
+                "TerminalConnection.dll",
+                "TerminalThemeHelpers.dll",
+                "WindowsTerminalShellExt.dll",
+
+                // The rest
+                "TerminalAzBridge.exe",
+                "wt.exe",
+                "WindowsTerminal.exe",
+                "elevate-shim.exe"
+            ],
+            "SigningInfo": {
+                "Operations": [
+                    {
+                        "KeyCode": "CP-230012",
+                        "OperationSetCode": "SigntoolSign",
+                        "Parameters": [
+                            {
+                                "parameterName": "OpusName",
+                                "parameterValue": "Microsoft"
+                            },
+                            {
+                                "parameterName": "OpusInfo",
+                                "parameterValue": "http://www.microsoft.com"
+                            },
+                            {
+                                "parameterName": "FileDigest",
+                                "parameterValue": "/fd \"SHA256\""
+                            },
+                            {
+                                "parameterName": "PageHash",
+                                "parameterValue": "/NPH"
+                            },
+                            {
+                                "parameterName": "TimeStamp",
+                                "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                            }
+                        ],
+                        "ToolName": "sign",
+                        "ToolVersion": "1.0"
+                    },
+                    {
+                        "KeyCode": "CP-230012",
+                        "OperationSetCode": "SigntoolVerify",
+                        "Parameters": [],
+                        "ToolName": "sign",
+                        "ToolVersion": "1.0"
+                    }
+                ]
+            }
+        },
+        {
+            // THIRD PARTY SOFTWARE
+            "MatchedPath": [
+                "cpprest*.dll"
+            ],
+            "SigningInfo": {
+                "Operations": [
+                    {
+                        "KeyCode": "CP-231522",
+                        "OperationSetCode": "SigntoolSign",
+                        "Parameters": [
+                            {
+                                "parameterName": "OpusName",
+                                "parameterValue": "Microsoft"
+                            },
+                            {
+                                "parameterName": "OpusInfo",
+                                "parameterValue": "http://www.microsoft.com"
+                            },
+                            {
+                                "parameterName": "FileDigest",
+                                "parameterValue": "/fd \"SHA256\""
+                            },
+                            {
+                                "parameterName": "PageHash",
+                                "parameterValue": "/NPH"
+                            },
+                            {
+                                "parameterName": "TimeStamp",
+                                "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                            }
+                        ],
+                        "ToolName": "sign",
+                        "ToolVersion": "1.0"
+                    },
+                    {
+                        "KeyCode": "CP-231522",
+                        "OperationSetCode": "SigntoolVerify",
+                        "Parameters": [],
+                        "ToolName": "sign",
+                        "ToolVersion": "1.0"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/build/config/ESRPSigning_Terminal.json
+++ b/build/config/ESRPSigning_Terminal.json
@@ -6,6 +6,7 @@
             "MatchedPath": [
                 // Namespaced DLLs
                 "Microsoft.Terminal.*.dll",
+                "Microsoft.Terminal.*.winmd",
 
                 // ConPTY and DefTerm
                 "OpenConsole.exe",
@@ -16,6 +17,7 @@
 
                 // Legacy DLLs with old names
                 "TerminalApp.dll",
+                "TerminalApp.winmd",
                 "TerminalConnection.dll",
                 "TerminalThemeHelpers.dll",
                 "WindowsTerminalShellExt.dll",

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -63,6 +63,7 @@ parameters:
       - Win11
 
 variables:
+  MakeAppxPath: 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\MakeAppx.exe'
   TerminalInternalPackageVersion: "0.0.7"
   # If we are building a branch called "release-*", change the NuGet suffix
   # to "preview". If we don't do that, XES will set the suffix to "release1"
@@ -270,6 +271,27 @@ jobs:
       displayName: 'Generate SBOM manifest'
       inputs:
        BuildDropPath: '$(System.ArtifactsDirectory)/appx'
+
+    - pwsh: |-
+        $Package = (Get-ChildItem "$(Build.ArtifactStagingDirectory)/appx" -Recurse -Filter "Cascadia*.msix" | Select -First 1)
+        $PackageFilename = $Package.FullName
+        Write-Host "##vso[task.setvariable variable=WindowsTerminalPackagePath]${PackageFilename}"
+        & "$(MakeAppxPath)" unpack /p $PackageFilename /d "$(Build.SourcesDirectory)\UnpackedTerminalPackage"
+      displayName: Unpack the new Terminal package for signing
+
+    - task: EsrpCodeSigning@1
+      displayName: Submit Terminal's binaries for signing
+      inputs:
+        ConnectedServiceName: 9d6d2960-0793-4d59-943e-78dcb434840a
+        FolderPath: '$(Build.SourcesDirectory)\UnpackedTerminalPackage'
+        signType: batchSigning
+        batchSignPolicyFile: '$(Build.SourcesDirectory)\build\config\ESRPSigning_Terminal.json'
+
+    - pwsh: |-
+        $PackageFilename = "$(WindowsTerminalPackagePath)"
+        & "$(MakeAppxPath)" pack /h SHA256 /o /p $PackageFilename /d "$(Build.SourcesDirectory)\UnpackedTerminalPackage"
+      displayName: Re-pack the new Terminal package after signing
+
     - task: PublishBuildArtifacts@1
       displayName: Publish Artifact (appx)
       inputs:

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -289,6 +289,7 @@ jobs:
 
     - pwsh: |-
         $PackageFilename = "$(WindowsTerminalPackagePath)"
+        Remove-Item "$(Build.SourcesDirectory)\UnpackedTerminalPackage\CodeSignSummary*"
         & "$(MakeAppxPath)" pack /h SHA256 /o /p $PackageFilename /d "$(Build.SourcesDirectory)\UnpackedTerminalPackage"
       displayName: Re-pack the new Terminal package after signing
 


### PR DESCRIPTION
Up until now, we have been relying on the catalog signature produced for our MSIX package.
There are some things (Packaged COM, Process Explorer as of 2022) that cannot handle catalog-signed
files. It's easier and safer for us to simply sign all the executables we produce before packaging them.

Unfortunately, we can't do it before we package them. We have to unpack and re-pack our package.

In the future, this will allow us to provide a codesigned distribution that is not in an MSIX package.

## Validation Steps Performed
Ran a build and checked out the contents of the package. They were all signed!

Closes #13294
Closes #12695
Closes #9670