### PR TITLE
Ensure TermControl is not closing when firing UIA events

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -109,12 +109,12 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         // These three throttled functions are triggered by terminal output and interact with the UI.
         // Since Close() is the point after which we are removed from the UI, but before the
-        // destructor has run, we MUST check control->IsClosing() before actually doing anything.
+        // destructor has run, we MUST check control->_IsClosing() before actually doing anything.
         _playWarningBell = std::make_shared<ThrottledFuncLeading>(
             dispatcher,
             TerminalWarningBellInterval,
             [weakThis = get_weak()]() {
-                if (auto control{ weakThis.get() }; !control->IsClosing())
+                if (auto control{ weakThis.get() }; !control->_IsClosing())
                 {
                     control->_WarningBellHandlers(*control, nullptr);
                 }
@@ -124,7 +124,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             dispatcher,
             ScrollBarUpdateInterval,
             [weakThis = get_weak()](const auto& update) {
-                if (auto control{ weakThis.get() }; !control->IsClosing())
+                if (auto control{ weakThis.get() }; !control->_IsClosing())
                 {
                     control->_throttledUpdateScrollbar(update);
                 }
@@ -223,7 +223,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     void TermControl::SearchMatch(const bool goForward)
     {
-        if (IsClosing())
+        if (_IsClosing())
         {
             return;
         }
@@ -329,7 +329,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - newSettings: the new settings to set
     void TermControl::_UpdateSettingsFromUIThread()
     {
-        if (IsClosing())
+        if (_IsClosing())
         {
             return;
         }
@@ -345,7 +345,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - newAppearance: the new appearance to set
     void TermControl::_UpdateAppearanceFromUIThread(Control::IControlAppearance newAppearance)
     {
-        if (IsClosing())
+        if (_IsClosing())
         {
             return;
         }
@@ -704,7 +704,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // MSFT 33353327: We're purposefully not using _initializedTerminal to ensure we're fully initialized.
         // Doing so makes us return nullptr when XAML requests an automation peer.
         // Instead, we need to give XAML an automation peer, then fix it later.
-        if (!IsClosing())
+        if (!_IsClosing())
         {
             // create a custom automation peer with this code pattern:
             // (https://docs.microsoft.com/en-us/windows/uwp/design/accessibility/custom-automation-peers)
@@ -926,7 +926,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_CharacterHandler(const winrt::Windows::Foundation::IInspectable& /*sender*/,
                                         const Input::CharacterReceivedRoutedEventArgs& e)
     {
-        if (IsClosing())
+        if (_IsClosing())
         {
             return;
         }
@@ -1075,7 +1075,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // win32-input-mode, then we'll send all these keystrokes to the
         // terminal - it's smart enough to ignore the keys it doesn't care
         // about.
-        if (IsClosing() || vkey == VK_LWIN || vkey == VK_RWIN)
+        if (_IsClosing() || vkey == VK_LWIN || vkey == VK_RWIN)
         {
             e.Handled(true);
             return;
@@ -1260,7 +1260,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_PointerPressedHandler(const Windows::Foundation::IInspectable& sender,
                                              const Input::PointerRoutedEventArgs& args)
     {
-        if (IsClosing())
+        if (_IsClosing())
         {
             return;
         }
@@ -1315,7 +1315,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_PointerMovedHandler(const Windows::Foundation::IInspectable& /*sender*/,
                                            const Input::PointerRoutedEventArgs& args)
     {
-        if (IsClosing())
+        if (_IsClosing())
         {
             return;
         }
@@ -1397,7 +1397,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_PointerReleasedHandler(const Windows::Foundation::IInspectable& sender,
                                               const Input::PointerRoutedEventArgs& args)
     {
-        if (IsClosing())
+        if (_IsClosing())
         {
             return;
         }
@@ -1441,7 +1441,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_MouseWheelHandler(const Windows::Foundation::IInspectable& /*sender*/,
                                          const Input::PointerRoutedEventArgs& args)
     {
-        if (IsClosing())
+        if (_IsClosing())
         {
             return;
         }
@@ -1533,7 +1533,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_ScrollbarChangeHandler(const Windows::Foundation::IInspectable& /*sender*/,
                                               const Controls::Primitives::RangeBaseValueChangedEventArgs& args)
     {
-        if (_isInternalScrollBarUpdate || IsClosing())
+        if (_isInternalScrollBarUpdate || _IsClosing())
         {
             // The update comes from ourselves, more specifically from the
             // terminal. So we don't have to update the terminal because it
@@ -1675,7 +1675,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_GotFocusHandler(const Windows::Foundation::IInspectable& /* sender */,
                                        const RoutedEventArgs& /* args */)
     {
-        if (IsClosing())
+        if (_IsClosing())
         {
             return;
         }
@@ -1731,7 +1731,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_LostFocusHandler(const Windows::Foundation::IInspectable& /* sender */,
                                         const RoutedEventArgs& /* args */)
     {
-        if (IsClosing())
+        if (_IsClosing())
         {
             return;
         }
@@ -1776,7 +1776,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_SwapChainSizeChanged(const winrt::Windows::Foundation::IInspectable& /*sender*/,
                                             const SizeChangedEventArgs& e)
     {
-        if (!_initializedTerminal || IsClosing())
+        if (!_initializedTerminal || _IsClosing())
         {
             return;
         }
@@ -1833,7 +1833,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_CursorTimerTick(const Windows::Foundation::IInspectable& /* sender */,
                                        const Windows::Foundation::IInspectable& /* e */)
     {
-        if (!IsClosing())
+        if (!_IsClosing())
         {
             _core.BlinkCursor();
         }
@@ -1847,7 +1847,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_BlinkTimerTick(const Windows::Foundation::IInspectable& /* sender */,
                                       const Windows::Foundation::IInspectable& /* e */)
     {
-        if (!IsClosing())
+        if (!_IsClosing())
         {
             _core.BlinkAttributeTick();
         }
@@ -1907,7 +1907,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // This can come in off the COM thread - hop back to the UI thread.
         auto weakThis{ get_weak() };
         co_await wil::resume_foreground(Dispatcher());
-        if (auto control{ weakThis.get() }; !control->IsClosing())
+        if (auto control{ weakThis.get() }; !control->_IsClosing())
         {
             control->TSFInputControl().TryRedrawCanvas();
         }
@@ -1943,7 +1943,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     //             if we should defer which formats are copied to the global setting
     bool TermControl::CopySelectionToClipboard(bool singleLine, const Windows::Foundation::IReference<CopyFormat>& formats)
     {
-        if (IsClosing())
+        if (_IsClosing())
         {
             return false;
         }
@@ -1987,9 +1987,14 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     void TermControl::Close()
     {
-        if (!IsClosing())
+        if (!_IsClosing())
         {
             _closing = true;
+            if (_automationPeer)
+            {
+                auto autoPeerImpl{ winrt::get_self<implementation::TermControlAutomationPeer>(_automationPeer) };
+                autoPeerImpl->IsClosing(true);
+            }
 
             _RestorePointerCursorHandlers(*this, nullptr);
 
@@ -2406,7 +2411,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - <none>
     void TermControl::_CompositionCompleted(winrt::hstring text)
     {
-        if (IsClosing())
+        if (_IsClosing())
         {
             return;
         }
@@ -2480,7 +2485,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     winrt::fire_and_forget TermControl::_DragDropHandler(Windows::Foundation::IInspectable /*sender*/,
                                                          DragEventArgs e)
     {
-        if (IsClosing())
+        if (_IsClosing())
         {
             co_return;
         }
@@ -2654,7 +2659,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_DragOverHandler(const Windows::Foundation::IInspectable& /*sender*/,
                                        const DragEventArgs& e)
     {
-        if (IsClosing())
+        if (_IsClosing())
         {
             return;
         }
@@ -2840,7 +2845,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             // Stop the timer and switch off the light
             _bellLightTimer.Stop();
 
-            if (!IsClosing())
+            if (!_IsClosing())
             {
                 VisualBellLight::SetIsTarget(RootGrid(), false);
             }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -1993,7 +1993,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             if (_automationPeer)
             {
                 auto autoPeerImpl{ winrt::get_self<implementation::TermControlAutomationPeer>(_automationPeer) };
-                autoPeerImpl->IsClosing(true);
+                autoPeerImpl->Close();
             }
 
             _RestorePointerCursorHandlers(*this, nullptr);

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -109,12 +109,12 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         // These three throttled functions are triggered by terminal output and interact with the UI.
         // Since Close() is the point after which we are removed from the UI, but before the
-        // destructor has run, we MUST check control->_IsClosing() before actually doing anything.
+        // destructor has run, we MUST check control->IsClosing() before actually doing anything.
         _playWarningBell = std::make_shared<ThrottledFuncLeading>(
             dispatcher,
             TerminalWarningBellInterval,
             [weakThis = get_weak()]() {
-                if (auto control{ weakThis.get() }; !control->_IsClosing())
+                if (auto control{ weakThis.get() }; !control->IsClosing())
                 {
                     control->_WarningBellHandlers(*control, nullptr);
                 }
@@ -124,7 +124,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             dispatcher,
             ScrollBarUpdateInterval,
             [weakThis = get_weak()](const auto& update) {
-                if (auto control{ weakThis.get() }; !control->_IsClosing())
+                if (auto control{ weakThis.get() }; !control->IsClosing())
                 {
                     control->_throttledUpdateScrollbar(update);
                 }
@@ -223,7 +223,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     void TermControl::SearchMatch(const bool goForward)
     {
-        if (_IsClosing())
+        if (IsClosing())
         {
             return;
         }
@@ -329,7 +329,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - newSettings: the new settings to set
     void TermControl::_UpdateSettingsFromUIThread()
     {
-        if (_IsClosing())
+        if (IsClosing())
         {
             return;
         }
@@ -345,7 +345,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - newAppearance: the new appearance to set
     void TermControl::_UpdateAppearanceFromUIThread(Control::IControlAppearance newAppearance)
     {
-        if (_IsClosing())
+        if (IsClosing())
         {
             return;
         }
@@ -704,7 +704,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // MSFT 33353327: We're purposefully not using _initializedTerminal to ensure we're fully initialized.
         // Doing so makes us return nullptr when XAML requests an automation peer.
         // Instead, we need to give XAML an automation peer, then fix it later.
-        if (!_IsClosing())
+        if (!IsClosing())
         {
             // create a custom automation peer with this code pattern:
             // (https://docs.microsoft.com/en-us/windows/uwp/design/accessibility/custom-automation-peers)
@@ -926,7 +926,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_CharacterHandler(const winrt::Windows::Foundation::IInspectable& /*sender*/,
                                         const Input::CharacterReceivedRoutedEventArgs& e)
     {
-        if (_IsClosing())
+        if (IsClosing())
         {
             return;
         }
@@ -1075,7 +1075,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // win32-input-mode, then we'll send all these keystrokes to the
         // terminal - it's smart enough to ignore the keys it doesn't care
         // about.
-        if (_IsClosing() || vkey == VK_LWIN || vkey == VK_RWIN)
+        if (IsClosing() || vkey == VK_LWIN || vkey == VK_RWIN)
         {
             e.Handled(true);
             return;
@@ -1260,7 +1260,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_PointerPressedHandler(const Windows::Foundation::IInspectable& sender,
                                              const Input::PointerRoutedEventArgs& args)
     {
-        if (_IsClosing())
+        if (IsClosing())
         {
             return;
         }
@@ -1315,7 +1315,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_PointerMovedHandler(const Windows::Foundation::IInspectable& /*sender*/,
                                            const Input::PointerRoutedEventArgs& args)
     {
-        if (_IsClosing())
+        if (IsClosing())
         {
             return;
         }
@@ -1397,7 +1397,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_PointerReleasedHandler(const Windows::Foundation::IInspectable& sender,
                                               const Input::PointerRoutedEventArgs& args)
     {
-        if (_IsClosing())
+        if (IsClosing())
         {
             return;
         }
@@ -1441,7 +1441,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_MouseWheelHandler(const Windows::Foundation::IInspectable& /*sender*/,
                                          const Input::PointerRoutedEventArgs& args)
     {
-        if (_IsClosing())
+        if (IsClosing())
         {
             return;
         }
@@ -1533,7 +1533,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_ScrollbarChangeHandler(const Windows::Foundation::IInspectable& /*sender*/,
                                               const Controls::Primitives::RangeBaseValueChangedEventArgs& args)
     {
-        if (_isInternalScrollBarUpdate || _IsClosing())
+        if (_isInternalScrollBarUpdate || IsClosing())
         {
             // The update comes from ourselves, more specifically from the
             // terminal. So we don't have to update the terminal because it
@@ -1675,7 +1675,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_GotFocusHandler(const Windows::Foundation::IInspectable& /* sender */,
                                        const RoutedEventArgs& /* args */)
     {
-        if (_IsClosing())
+        if (IsClosing())
         {
             return;
         }
@@ -1731,7 +1731,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_LostFocusHandler(const Windows::Foundation::IInspectable& /* sender */,
                                         const RoutedEventArgs& /* args */)
     {
-        if (_IsClosing())
+        if (IsClosing())
         {
             return;
         }
@@ -1776,7 +1776,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_SwapChainSizeChanged(const winrt::Windows::Foundation::IInspectable& /*sender*/,
                                             const SizeChangedEventArgs& e)
     {
-        if (!_initializedTerminal || _IsClosing())
+        if (!_initializedTerminal || IsClosing())
         {
             return;
         }
@@ -1833,7 +1833,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_CursorTimerTick(const Windows::Foundation::IInspectable& /* sender */,
                                        const Windows::Foundation::IInspectable& /* e */)
     {
-        if (!_IsClosing())
+        if (!IsClosing())
         {
             _core.BlinkCursor();
         }
@@ -1847,7 +1847,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_BlinkTimerTick(const Windows::Foundation::IInspectable& /* sender */,
                                       const Windows::Foundation::IInspectable& /* e */)
     {
-        if (!_IsClosing())
+        if (!IsClosing())
         {
             _core.BlinkAttributeTick();
         }
@@ -1907,7 +1907,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // This can come in off the COM thread - hop back to the UI thread.
         auto weakThis{ get_weak() };
         co_await wil::resume_foreground(Dispatcher());
-        if (auto control{ weakThis.get() }; !control->_IsClosing())
+        if (auto control{ weakThis.get() }; !control->IsClosing())
         {
             control->TSFInputControl().TryRedrawCanvas();
         }
@@ -1943,7 +1943,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     //             if we should defer which formats are copied to the global setting
     bool TermControl::CopySelectionToClipboard(bool singleLine, const Windows::Foundation::IReference<CopyFormat>& formats)
     {
-        if (_IsClosing())
+        if (IsClosing())
         {
             return false;
         }
@@ -1987,7 +1987,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     void TermControl::Close()
     {
-        if (!_IsClosing())
+        if (!IsClosing())
         {
             _closing = true;
 
@@ -2406,7 +2406,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - <none>
     void TermControl::_CompositionCompleted(winrt::hstring text)
     {
-        if (_IsClosing())
+        if (IsClosing())
         {
             return;
         }
@@ -2480,7 +2480,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     winrt::fire_and_forget TermControl::_DragDropHandler(Windows::Foundation::IInspectable /*sender*/,
                                                          DragEventArgs e)
     {
-        if (_IsClosing())
+        if (IsClosing())
         {
             co_return;
         }
@@ -2654,7 +2654,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_DragOverHandler(const Windows::Foundation::IInspectable& /*sender*/,
                                        const DragEventArgs& e)
     {
-        if (_IsClosing())
+        if (IsClosing())
         {
             return;
         }
@@ -2840,7 +2840,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             // Stop the timer and switch off the light
             _bellLightTimer.Stop();
 
-            if (!_IsClosing())
+            if (!IsClosing())
             {
                 VisualBellLight::SetIsTarget(RootGrid(), false);
             }

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -136,18 +136,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         void AdjustOpacity(const double opacity, const bool relative);
 
-        inline bool IsClosing() const noexcept
-        {
-#ifndef NDEBUG
-            // _closing isn't atomic and may only be accessed from the main thread.
-            if (const auto dispatcher = Dispatcher())
-            {
-                assert(dispatcher.HasThreadAccess());
-            }
-#endif
-            return _closing;
-        }
-
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
 
         // -------------------------------- WinRT Events ---------------------------------
@@ -230,6 +218,18 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         bool _showMarksInScrollbar{ false };
 
         bool _isBackgroundLight{ false };
+
+        inline bool _IsClosing() const noexcept
+        {
+#ifndef NDEBUG
+            // _closing isn't atomic and may only be accessed from the main thread.
+            if (const auto dispatcher = Dispatcher())
+            {
+                assert(dispatcher.HasThreadAccess());
+            }
+#endif
+            return _closing;
+        }
 
         void _UpdateSettingsFromUIThread();
         void _UpdateAppearanceFromUIThread(Control::IControlAppearance newAppearance);

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -136,6 +136,18 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         void AdjustOpacity(const double opacity, const bool relative);
 
+        inline bool IsClosing() const noexcept
+        {
+#ifndef NDEBUG
+            // _closing isn't atomic and may only be accessed from the main thread.
+            if (const auto dispatcher = Dispatcher())
+            {
+                assert(dispatcher.HasThreadAccess());
+            }
+#endif
+            return _closing;
+        }
+
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
 
         // -------------------------------- WinRT Events ---------------------------------
@@ -218,18 +230,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         bool _showMarksInScrollbar{ false };
 
         bool _isBackgroundLight{ false };
-
-        inline bool _IsClosing() const noexcept
-        {
-#ifndef NDEBUG
-            // _closing isn't atomic and may only be accessed from the main thread.
-            if (const auto dispatcher = Dispatcher())
-            {
-                assert(dispatcher.HasThreadAccess());
-            }
-#endif
-            return _closing;
-        }
 
         void _UpdateSettingsFromUIThread();
         void _UpdateAppearanceFromUIThread(Control::IControlAppearance newAppearance);

--- a/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
+++ b/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
@@ -117,6 +117,11 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         }
     }
 
+    void TermControlAutomationPeer::IsClosing(bool closing)
+    {
+        _closing = closing;
+    }
+
     // Method Description:
     // - Signals the ui automation client that the terminal's selection has changed and should be updated
     // Arguments:
@@ -134,7 +139,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         dispatcher.RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, [weakThis{ get_weak() }]() {
             if (auto strongThis{ weakThis.get() })
             {
-                if (auto control{ strongThis->_termControl.get() }; control && !control->IsClosing())
+                if (auto control{ strongThis->_termControl.get() }; control && !strongThis->_closing)
                 {
                     // The event that is raised when the text selection is modified.
                     strongThis->RaiseAutomationEvent(AutomationEvents::TextPatternOnTextSelectionChanged);
@@ -160,7 +165,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         dispatcher.RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, [weakThis{ get_weak() }]() {
             if (auto strongThis{ weakThis.get() })
             {
-                if (auto control{ strongThis->_termControl.get() }; control && !control->IsClosing())
+                if (auto control{ strongThis->_termControl.get() }; control && !strongThis->_closing)
                 {
                     // The event that is raised when textual content is modified.
                     strongThis->RaiseAutomationEvent(AutomationEvents::TextPatternOnTextChanged);
@@ -186,7 +191,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         dispatcher.RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, [weakThis{ get_weak() }]() {
             if (auto strongThis{ weakThis.get() })
             {
-                if (auto control{ strongThis->_termControl.get() }; control && !control->IsClosing())
+                if (auto control{ strongThis->_termControl.get() }; control && !strongThis->_closing)
                 {
                     // The event that is raised when the text was changed in an edit control.
                     // Do NOT fire a TextEditTextChanged. Generally, an app on the other side
@@ -248,7 +253,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         dispatcher.RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, [weakThis{ get_weak() }, sanitizedCopy{ hstring{ sanitized } }]() {
             if (auto strongThis{ weakThis.get() })
             {
-                if (auto control{ strongThis->_termControl.get() }; control && !control->IsClosing())
+                if (auto control{ strongThis->_termControl.get() }; control && !strongThis->_closing)
                 {
                     try
                     {

--- a/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
+++ b/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
@@ -134,7 +134,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         dispatcher.RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, [weakThis{ get_weak() }]() {
             if (auto strongThis{ weakThis.get() })
             {
-                if (auto control{ strongThis->_termControl.get() })
+                if (auto control{ strongThis->_termControl.get() }; control && !control->IsClosing())
                 {
                     // The event that is raised when the text selection is modified.
                     strongThis->RaiseAutomationEvent(AutomationEvents::TextPatternOnTextSelectionChanged);
@@ -160,7 +160,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         dispatcher.RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, [weakThis{ get_weak() }]() {
             if (auto strongThis{ weakThis.get() })
             {
-                if (auto control{ strongThis->_termControl.get() })
+                if (auto control{ strongThis->_termControl.get() }; control && !control->IsClosing())
                 {
                     // The event that is raised when textual content is modified.
                     strongThis->RaiseAutomationEvent(AutomationEvents::TextPatternOnTextChanged);
@@ -186,7 +186,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         dispatcher.RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, [weakThis{ get_weak() }]() {
             if (auto strongThis{ weakThis.get() })
             {
-                if (auto control{ strongThis->_termControl.get() })
+                if (auto control{ strongThis->_termControl.get() }; control && !control->IsClosing())
                 {
                     // The event that is raised when the text was changed in an edit control.
                     // Do NOT fire a TextEditTextChanged. Generally, an app on the other side
@@ -248,7 +248,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         dispatcher.RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, [weakThis{ get_weak() }, sanitizedCopy{ hstring{ sanitized } }]() {
             if (auto strongThis{ weakThis.get() })
             {
-                if (auto control{ strongThis->_termControl.get() })
+                if (auto control{ strongThis->_termControl.get() }; control && !control->IsClosing())
                 {
                     try
                     {

--- a/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
+++ b/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
@@ -121,7 +121,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
         // GH#13978: If the TermControl has already been removed from the UI tree, XAML might run into weird bugs.
         // This will prevent the `dispatcher.RunAsync` calls below from raising UIA events on the main thread.
-        _termControl.reset();
+        _termControl = {};
     }
 
     // Method Description:

--- a/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
+++ b/src/cascadia/TerminalControl/TermControlAutomationPeer.cpp
@@ -72,7 +72,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                                          Control::InteractivityAutomationPeer impl) :
         TermControlAutomationPeerT<TermControlAutomationPeer>(*owner.get()), // pass owner to FrameworkElementAutomationPeer
         _termControl{ owner },
-        _contentAutomationPeer{ impl }
+        _contentAutomationPeer{ impl },
+        _closing{ false }
     {
         UpdateControlBounds();
         SetControlPadding(padding);

--- a/src/cascadia/TerminalControl/TermControlAutomationPeer.h
+++ b/src/cascadia/TerminalControl/TermControlAutomationPeer.h
@@ -49,7 +49,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void UpdateControlBounds();
         void SetControlPadding(const Core::Padding padding);
         void RecordKeyEvent(const WORD vkey);
-        void IsClosing(bool closing);
+        void Close();
 
 #pragma region FrameworkElementAutomationPeer
         hstring GetClassNameCore() const;
@@ -82,6 +82,5 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         winrt::weak_ref<Microsoft::Terminal::Control::implementation::TermControl> _termControl;
         Control::InteractivityAutomationPeer _contentAutomationPeer;
         til::shared_mutex<std::deque<wchar_t>> _keyEvents;
-        bool _closing;
     };
 }

--- a/src/cascadia/TerminalControl/TermControlAutomationPeer.h
+++ b/src/cascadia/TerminalControl/TermControlAutomationPeer.h
@@ -49,6 +49,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void UpdateControlBounds();
         void SetControlPadding(const Core::Padding padding);
         void RecordKeyEvent(const WORD vkey);
+        void IsClosing(bool closing);
 
 #pragma region FrameworkElementAutomationPeer
         hstring GetClassNameCore() const;
@@ -81,5 +82,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         winrt::weak_ref<Microsoft::Terminal::Control::implementation::TermControl> _termControl;
         Control::InteractivityAutomationPeer _contentAutomationPeer;
         til::shared_mutex<std::deque<wchar_t>> _keyEvents;
+        bool _closing;
     };
 }


### PR DESCRIPTION
The `SignalTextChanged` crash seems to be occurring due to the `TermControlAutomationPeer` being destructed by the time the UIA event is actually dispatched. Even though we're already checking if TCAP and TermControl still exist, it could be that the TermControl is being closed as text is being output.

The proposed fix here is to record when the closing process starts and exposing that information directly to the TCAP. If TCAP sees that we're in the process of closing, don't bother sending a UIA event.


Closes #13978