### PR TITLE
Resize our ContentDialog's when the window resizes

### DIFF
--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -505,7 +505,7 @@ long IslandWindow::_calculateTotalSize(const bool isWidth, const long clientSize
         //
         // https://github.com/microsoft/microsoft-ui-xaml/issues/3577
         //
-        // ContentDialog's don't resize themselves when the XAML island resizes.
+        // ContentDialogs don't resize themselves when the XAML island resizes.
         // However, if we manually resize our CoreWindow, that'll actually
         // trigger a resize of the ContentDialog.
         if (const auto& coreWindow{ winrt::Windows::UI::Core::CoreWindow::GetForCurrentThread() })

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -501,14 +501,17 @@ long IslandWindow::_calculateTotalSize(const bool isWidth, const long clientSize
             }
         }
 
+        // BODGY This is a fix for the upstream:
+        //
+        // https://github.com/microsoft/microsoft-ui-xaml/issues/3577
+        //
+        // ContentDialog's don't resize themselves when the XAML island resizes.
+        // However, if we manually resize our CoreWindow, that'll actually
+        // trigger a resize of the ContentDialog.
         if (const auto& coreWindow{ winrt::Windows::UI::Core::CoreWindow::GetForCurrentThread() })
         {
             if (const auto& interop{ coreWindow.as<ICoreWindowInterop>() })
             {
-                //
-                //
-                // https://github.com/microsoft/microsoft-ui-xaml/issues/3577
-                //
                 HWND coreWindowInterop;
                 interop->get_WindowHandle(&coreWindowInterop);
                 PostMessage(coreWindowInterop, message, wparam, lparam);

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -9,6 +9,7 @@
 #include "NotificationIcon.h"
 #include <dwmapi.h>
 #include <TerminalThemeHelpers.h>
+#include <CoreWindow.h>
 
 extern "C" IMAGE_DOS_HEADER __ImageBase;
 
@@ -499,6 +500,21 @@ long IslandWindow::_calculateTotalSize(const bool isWidth, const long clientSize
                 return 0;
             }
         }
+
+        if (const auto& coreWindow{ winrt::Windows::UI::Core::CoreWindow::GetForCurrentThread() })
+        {
+            if (const auto& interop{ coreWindow.as<ICoreWindowInterop>() })
+            {
+                //
+                //
+                // https://github.com/microsoft/microsoft-ui-xaml/issues/3577
+                //
+                HWND coreWindowInterop;
+                interop->get_WindowHandle(&coreWindowInterop);
+                PostMessage(coreWindowInterop, message, wparam, lparam);
+            }
+        }
+
         break;
     }
     case WM_MOVING:


### PR DESCRIPTION
Major thanks to @dongle-the-gadget in https://github.com/microsoft/microsoft-ui-xaml/issues/3577#issuecomment-1399250405 for coming up with this workaround.

This PR will manually forward a `WM_SIZE` message to our `CoreWindow`, to trigger the `ContentDialog` to resize itself. 

We always closed these issues as dupes of the upstream one, so this doesn't actually close anything.
HOWEVER, these are the following issues that reported this bug:
- #2380
- #4463
- #5252
- #5810
- #6181
- #7113
- #7225
- #8245
- #8496
- #8643
- #9336
- #9563
- #5808
- #10351
- #10634
- #10995
- #11770
- #13796