### PR TITLE
[UIA] Dispatch a TextChanged event on new output

### DIFF
--- a/src/renderer/uia/UiaRenderer.cpp
+++ b/src/renderer/uia/UiaRenderer.cpp
@@ -175,6 +175,7 @@ try
     {
         _newOutput.append(newText);
         _newOutput.push_back(L'\n');
+        _textBufferChanged = true;
     }
     return S_OK;
 }


### PR DESCRIPTION
For some reason, Windows Terminal stops dispatching UIA TextChanged events sometimes. There isn't a reliable repro for this bug.

However, under NVDA's logger, it appears that when the bug does occur, we still dispatch UIA notifications (which may be ignored by NVDA in some configurations). A "quick fix" here is to dispatch a TextChanged event if we're going to dispatch a notification. Since we're just enabling a flag, we won't send two events at once.

Closes #10911
