### PR TITLE
When generating a stacked changelog, note which branch/es contain a commit

### DIFF
--- a/tools/ReleaseEngineering/New-TerminalStackedChangelog.ps1
+++ b/tools/ReleaseEngineering/New-TerminalStackedChangelog.ps1
@@ -80,7 +80,7 @@ For($c = 0; $c -Lt $i; $c++) {
     "   " + ("|" * $c) + "/ " + $RevisionRanges[$c]
 }
 
-$Unique = $Entries | Group-Object Subject #| %{ $_.Group[0] | Add-Member Count $_.Count -Force -PassThru }
+$Unique = $Entries | Group-Object Subject
 
 $Unique | % {
     $en = $_.Group[0]

--- a/tools/ReleaseEngineering/New-TerminalStackedChangelog.ps1
+++ b/tools/ReleaseEngineering/New-TerminalStackedChangelog.ps1
@@ -34,12 +34,12 @@ Function Test-MicrosoftPerson($email) {
 
 Function Generate-Thanks($Entry) {
     # We don't need to thank ourselves for doing our jobs
-    If ($_.Microsoft) {
+    If ($Entry.Microsoft) {
         ""
-    } ElseIf (-Not [string]::IsNullOrEmpty($_.PossibleUsername)) {
-        " (thanks @{0}!)" -f $_.PossibleUsername
+    } ElseIf (-Not [string]::IsNullOrEmpty($Entry.PossibleUsername)) {
+        " (thanks @{0}!)" -f $Entry.PossibleUsername
     } Else {
-        " (thanks @<{0}>!)" -f $_.Email
+        " (thanks @<{0}>!)" -f $Entry.Email
     }
 }
 
@@ -54,6 +54,7 @@ Function Get-PossibleUserName($email) {
 
 $Entries = @()
 
+$i = 0
 ForEach ($RevisionRange in $RevisionRanges) {
     # --pretty=format notes:
     #   - %an: author name
@@ -70,15 +71,23 @@ ForEach ($RevisionRange in $RevisionRanges) {
         Subject = $_.Subject;
         Microsoft = (Test-MicrosoftPerson $_.Email);
         PossibleUsername = (Get-PossibleUserName $_.Email);
+        RevRangeID = $i;
     } }
+    $i++
 }
 
-$Unique = $Entries | Group-Object Subject | %{ $_.Group[0] | Add-Member Count $_.Count -Force -PassThru }
+For($c = 0; $c -Lt $i; $c++) {
+    "   " + ("|" * $c) + "/ " + $RevisionRanges[$c]
+}
+
+$Unique = $Entries | Group-Object Subject #| %{ $_.Group[0] | Add-Member Count $_.Count -Force -PassThru }
 
 $Unique | % {
-    $c = ""
-    If ($_.Count -Gt 1) {
-        $c = "[{0}] " -f $_.Count
+    $en = $_.Group[0]
+    $revSpec = (" " * $i)
+    $_.Group | % {
+        $revSpec = $revSpec.remove($_.RevRangeID, 1).insert($_.RevRangeID, "X")
     }
-    "* {0}{1}{2}" -f ($c, $_.Subject, (Generate-Thanks $_))
+    $c = "[{0}] " -f $revSpec
+    "* {0}{1}{2}" -f ($c, $en.Subject, (Generate-Thanks $en))
 }


### PR DESCRIPTION
New-TerminalStackedChangelog used to generate logs that looked like this:

```
* [3] A commit that was seen 3 times
* A commit that was only seen once
* [2] Some other commit
```

Now it will generate logs that look like this:

```
   / base..branch-1
   |/ base..branch-2
   ||/ base..branch-3
* [XXX] A commit that was seen 3 times
* [ X ] A commit that was only seen once
* [XX ] Some other commit
```

This format is more expressive, as it indicates _which branches_ contain which commits.

As a reminder, my release note writing style starts with a stacked changelog. It's how I tell (1) which commits are in the new preview release only, (2) which commits are in the new preview and the new stable release and (3) which commits were already released in a previous stable release.

Changes from 1 get included in the new changelog, changes from 2 get included in both and changes from 3 get deleted because they have already been released.