### PR TITLE
Minor improvements for SplitToOem

### DIFF
--- a/src/host/misc.cpp
+++ b/src/host/misc.cpp
@@ -191,22 +191,23 @@ BOOL CheckBisectProcessW(const SCREEN_INFORMATION& ScreenInfo,
 // Note: may throw on error
 void SplitToOem(std::deque<std::unique_ptr<IInputEvent>>& events)
 {
-    const auto codepage = ServiceLocator::LocateGlobals().getConsoleInformation().CP;
-
-    // convert events to oem codepage
+    const auto cp = ServiceLocator::LocateGlobals().getConsoleInformation().CP;
     std::deque<std::unique_ptr<IInputEvent>> convertedEvents;
-    while (!events.empty())
+
+    for (auto& currentEvent : events)
     {
-        auto currentEvent = std::move(events.front());
-        events.pop_front();
         if (currentEvent->EventType() == InputEventType::KeyEvent)
         {
             const auto pKeyEvent = static_cast<const KeyEvent* const>(currentEvent.get());
-            // convert from wchar to char
-            std::wstring wstr{ pKeyEvent->GetCharData() };
-            const auto str = ConvertToA(codepage, wstr);
+            const auto wch = pKeyEvent->GetCharData();
 
-            for (auto& ch : str)
+            char buffer[8];
+            const auto length = WideCharToMultiByte(cp, 0, &wch, 1, &buffer[0], sizeof(buffer), nullptr, nullptr);
+            THROW_LAST_ERROR_IF(length <= 0);
+
+            const std::string_view str{ &buffer[0], gsl::narrow_cast<size_t>(length) };
+
+            for (const auto& ch : str)
             {
                 auto tempEvent = std::make_unique<KeyEvent>(*pKeyEvent);
                 tempEvent->SetCharData(ch);
@@ -218,12 +219,8 @@ void SplitToOem(std::deque<std::unique_ptr<IInputEvent>>& events)
             convertedEvents.push_back(std::move(currentEvent));
         }
     }
-    // move all events back
-    while (!convertedEvents.empty())
-    {
-        events.push_back(std::move(convertedEvents.front()));
-        convertedEvents.pop_front();
-    }
+
+    events = std::move(convertedEvents);
 }
 
 // Routine Description:


### PR DESCRIPTION
When working on #14745 I noticed that `SplitToOem` was in a bit of a poor state
as well. Instead of simply iterating over its `deque` argument and writing the
results into a new `deque` it used `pop` to advance the head of both queues.
This isn't quite exception safe and rather bloaty. Additionally there's no need
to call `WideCharToMultiByte` twice on each character if we know that the most
verbose encoding is UTF-8 which can't be any more than 4 chars anyways.

Related to #8000.

## PR Checklist
* 2 unit tests cover this ✅