### PR TITLE
Make KeyEvent char data a little less confusing

### DIFF
--- a/src/host/dbcs.cpp
+++ b/src/host/dbcs.cpp
@@ -194,7 +194,7 @@ _Ret_range_(0, cbAnsi)
 
     memcpy(TmpUni, pwchUnicode, cchUnicode * sizeof(WCHAR));
 
-    BYTE AsciiDbcs[2];
+    CHAR AsciiDbcs[2];
     AsciiDbcs[1] = 0;
 
     ULONG i, j;

--- a/src/interactivity/win32/windowio.cpp
+++ b/src/interactivity/win32/windowio.cpp
@@ -209,7 +209,7 @@ void HandleKeyEvent(const HWND hWnd,
         }
         else
         {
-            keyEvent.SetCharData(0);
+            keyEvent.SetCharData(L'\0');
         }
     }
     else
@@ -220,7 +220,7 @@ void HandleKeyEvent(const HWND hWnd,
             return;
         }
         keyEvent.SetActiveModifierKeys(ControlKeyState);
-        keyEvent.SetCharData(0);
+        keyEvent.SetCharData(L'\0');
     }
 
     const INPUT_KEY_INFO inputKeyInfo(VirtualKeyCode, ControlKeyState);

--- a/src/types/KeyEvent.cpp
+++ b/src/types/KeyEvent.cpp
@@ -44,6 +44,14 @@ void KeyEvent::SetVirtualScanCode(const WORD virtualScanCode) noexcept
     _virtualScanCode = virtualScanCode;
 }
 
+void KeyEvent::SetCharData(const char character) noexcept
+{
+    // With MSVC char is signed by default and the conversion to wchar_t (unsigned) would turn negative
+    // chars into very large wchar_t values. While this doesn't pose a problem per se (even with such sign
+    // extension, the lower 8 bit stay the same), it makes debugging and reading key events more difficult.
+    _charData = til::as_unsigned(character);
+}
+
 void KeyEvent::SetCharData(const wchar_t character) noexcept
 {
     _charData = character;

--- a/src/types/inc/IInputEvent.hpp
+++ b/src/types/inc/IInputEvent.hpp
@@ -290,6 +290,7 @@ public:
     void SetRepeatCount(const WORD repeatCount) noexcept;
     void SetVirtualKeyCode(const WORD virtualKeyCode) noexcept;
     void SetVirtualScanCode(const WORD virtualScanCode) noexcept;
+    void SetCharData(const char character) noexcept;
     void SetCharData(const wchar_t character) noexcept;
 
     void SetActiveModifierKeys(const DWORD activeModifierKeys) noexcept;


### PR DESCRIPTION
When working on #14745 I found `KeyEvent`s a little hard to read in the
debugger. I noticed that this is because of sign extension when converting
`char`s to `wchar_t`s in `KeyEvent::SetCharData`.