### PR TITLE
Minor cleanups after #14745

### DIFF
--- a/src/server/ApiMessage.cpp
+++ b/src/server/ApiMessage.cpp
@@ -131,17 +131,15 @@ CATCH_RETURN();
 
 // Routine Description:
 // - This routine retrieves the output buffer associated with this message. It will allocate one if needed.
-//   The allocated will be bigger than the actual output size by the requested factor.
 // - Before completing the message, ReleaseMessageBuffers must be called to free any allocation performed by this routine.
 // Arguments:
-// - Factor - Supplies the factor to multiply the allocated buffer by.
+// - Message - Supplies the message whose output buffer will be retrieved.
 // - Buffer - Receives a pointer to the output buffer.
 // - Size - Receives the size, in bytes, of the output buffer.
-//  Return Value:
+// Return Value:
 // - HRESULT indicating if the output buffer was successfully retrieved.
-[[nodiscard]] HRESULT _CONSOLE_API_MSG::GetAugmentedOutputBuffer(const ULONG cbFactor,
-                                                                 _Outptr_result_bytebuffer_(*pcbSize) PVOID* const ppvBuffer,
-                                                                 _Out_ PULONG pcbSize)
+[[nodiscard]] HRESULT _CONSOLE_API_MSG::GetOutputBuffer(_Outptr_result_bytebuffer_(*pcbSize) void** const ppvBuffer,
+                                                        _Out_ ULONG* const pcbSize)
 try
 {
     // Initialize the buffer if it hasn't been initialized yet.
@@ -150,7 +148,6 @@ try
         RETURN_HR_IF(E_FAIL, State.WriteOffset > Descriptor.OutputSize);
 
         auto cbWriteSize = Descriptor.OutputSize - State.WriteOffset;
-        RETURN_IF_FAILED(ULongMult(cbWriteSize, cbFactor, &cbWriteSize));
 
         // If we were previously called with a huge buffer we have an equally large _outputBuffer.
         // We shouldn't just keep this huge buffer around, if no one needs it anymore.
@@ -175,21 +172,6 @@ try
     return S_OK;
 }
 CATCH_RETURN();
-
-// Routine Description:
-// - This routine retrieves the output buffer associated with this message. It will allocate one if needed.
-// - Before completing the message, ReleaseMessageBuffers must be called to free any allocation performed by this routine.
-// Arguments:
-// - Message - Supplies the message whose output buffer will be retrieved.
-// - Buffer - Receives a pointer to the output buffer.
-// - Size - Receives the size, in bytes, of the output buffer.
-// Return Value:
-// - HRESULT indicating if the output buffer was successfully retrieved.
-[[nodiscard]] HRESULT _CONSOLE_API_MSG::GetOutputBuffer(_Outptr_result_bytebuffer_(*pcbSize) void** const ppvBuffer,
-                                                        _Out_ ULONG* const pcbSize)
-{
-    return GetAugmentedOutputBuffer(1, ppvBuffer, pcbSize);
-}
 
 // Routine Description:
 // - This routine releases output or input buffers that might have been allocated

--- a/src/server/ApiMessage.h
+++ b/src/server/ApiMessage.h
@@ -41,9 +41,6 @@ typedef struct _CONSOLE_API_MSG
     ConsoleHandleData* GetObjectHandle() const;
 
     [[nodiscard]] HRESULT ReadMessageInput(const ULONG cbOffset, _Out_writes_bytes_(cbSize) PVOID pvBuffer, const ULONG cbSize);
-    [[nodiscard]] HRESULT GetAugmentedOutputBuffer(const ULONG cbFactor,
-                                                   _Outptr_result_bytebuffer_(*pcbSize) PVOID* ppvBuffer,
-                                                   _Out_ PULONG pcbSize);
     [[nodiscard]] HRESULT GetOutputBuffer(_Outptr_result_bytebuffer_(*pcbSize) void** const ppvBuffer, _Out_ ULONG* const pcbSize);
     [[nodiscard]] HRESULT GetInputBuffer(_Outptr_result_bytebuffer_(*pcbSize) void** const ppvBuffer, _Out_ ULONG* const pcbSize);
 


### PR DESCRIPTION
#14745 removed the only user of `GetAugmentedOutputBuffer`.