### PR TITLE
Consolidate NTSTATUS and remove INLINE_NSTATUS_FROM_WIN32

### DIFF
--- a/src/cascadia/TerminalAzBridge/pch.h
+++ b/src/cascadia/TerminalAzBridge/pch.h
@@ -24,8 +24,6 @@ Abstract:
 #define NOCOMM
 #include <unknwn.h>
 
-#define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
-
 #include <windows.h>
 
 #include "../inc/LibraryIncludes.h"

--- a/src/cascadia/UnitTests_TerminalCore/ConptyRoundtripTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ConptyRoundtripTests.cpp
@@ -3164,15 +3164,15 @@ void ConptyRoundtripTests::NewLinesAtBottomWithBackground()
 void doWriteCharsLegacy(SCREEN_INFORMATION& screenInfo, const std::wstring_view string, DWORD flags = 0)
 {
     auto dwNumBytes = string.size() * sizeof(wchar_t);
-    VERIFY_SUCCESS_NTSTATUS(WriteCharsLegacy(screenInfo,
-                                             string.data(),
-                                             string.data(),
-                                             string.data(),
-                                             &dwNumBytes,
-                                             nullptr,
-                                             screenInfo.GetTextBuffer().GetCursor().GetPosition().x,
-                                             flags,
-                                             nullptr));
+    VERIFY_NT_SUCCESS(WriteCharsLegacy(screenInfo,
+                                       string.data(),
+                                       string.data(),
+                                       string.data(),
+                                       &dwNumBytes,
+                                       nullptr,
+                                       screenInfo.GetTextBuffer().GetCursor().GetPosition().x,
+                                       flags,
+                                       nullptr));
 }
 
 void ConptyRoundtripTests::WrapNewLineAtBottom()

--- a/src/cascadia/UnitTests_TerminalCore/pch.h
+++ b/src/cascadia/UnitTests_TerminalCore/pch.h
@@ -17,6 +17,25 @@ Author(s):
 
 #pragma once
 
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN // If this is not defined, windows.h includes commdlg.h which defines FindText globally and conflicts with UIAutomation ITextRangeProvider.
+#endif
+
+#define NOMINMAX
+
+// Define and then undefine WIN32_NO_STATUS because windows.h has no guard to prevent it from double defing certain statuses
+// when included with ntstatus.h
+#define WIN32_NO_STATUS
+#include <windows.h>
+#undef WIN32_NO_STATUS
+
+#include <winternl.h>
+
+#pragma warning(push)
+#pragma warning(disable:4430) // Must disable 4430 "default int" warning for C++ because ntstatus.h is inflexible SDK definition.
+#include <ntstatus.h>
+#pragma warning(pop)
+
 #define BLOCK_TIL
 // This includes support libraries from the CRT, STL, WIL, and GSL
 #include "LibraryIncludes.h"
@@ -48,13 +67,7 @@ Author(s):
 // <Conhost includes>
 // These are needed because the roundtrip tests included in this library also
 // re-use some conhost code that depends on these.
-
 #include "conddkrefs.h"
-// From ntdef.h, but that can't be included or it'll fight over PROBE_ALIGNMENT and other such arch specific defs
-typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
-/*lint -save -e624 */ // Don't complain about different typedefs.
-typedef NTSTATUS* PNTSTATUS;
-/*lint -restore */ // Resume checking for different typedefs.
 // </Conhost Includes>
 
 #include <cppwinrt_utils.h>

--- a/src/cascadia/UnitTests_TerminalCore/pch.h
+++ b/src/cascadia/UnitTests_TerminalCore/pch.h
@@ -32,7 +32,7 @@ Author(s):
 #include <winternl.h>
 
 #pragma warning(push)
-#pragma warning(disable:4430) // Must disable 4430 "default int" warning for C++ because ntstatus.h is inflexible SDK definition.
+#pragma warning(disable : 4430) // Must disable 4430 "default int" warning for C++ because ntstatus.h is inflexible SDK definition.
 #include <ntstatus.h>
 #pragma warning(pop)
 

--- a/src/cascadia/UnitTests_TerminalCore/pch.h
+++ b/src/cascadia/UnitTests_TerminalCore/pch.h
@@ -55,7 +55,6 @@ typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 /*lint -save -e624 */ // Don't complain about different typedefs.
 typedef NTSTATUS* PNTSTATUS;
 /*lint -restore */ // Resume checking for different typedefs.
-#define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
 // </Conhost Includes>
 
 #include <cppwinrt_utils.h>

--- a/src/cascadia/WindowsTerminal/pch.h
+++ b/src/cascadia/WindowsTerminal/pch.h
@@ -25,8 +25,6 @@ Abstract:
 
 #include <unknwn.h>
 
-#define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
-
 #include <windows.h>
 #include <UIAutomation.h>
 #include <cstdlib>

--- a/src/host/CommandListPopup.cpp
+++ b/src/host/CommandListPopup.cpp
@@ -294,7 +294,7 @@ void CommandListPopup::_cycleSelectionToMatchingCommands(COOKED_READ_DATA& cooke
         DWORD modifiers = 0;
 
         Status = _getUserInput(cookedReadData, popupKeys, modifiers, wch);
-        if (!SUCCEEDED_NTSTATUS(Status))
+        if (FAILED_NTSTATUS(Status))
         {
             return Status;
         }

--- a/src/host/CommandListPopup.cpp
+++ b/src/host/CommandListPopup.cpp
@@ -294,7 +294,7 @@ void CommandListPopup::_cycleSelectionToMatchingCommands(COOKED_READ_DATA& cooke
         DWORD modifiers = 0;
 
         Status = _getUserInput(cookedReadData, popupKeys, modifiers, wch);
-        if (!NT_SUCCESS(Status))
+        if (!SUCCEEDED_NTSTATUS(Status))
         {
             return Status;
         }

--- a/src/host/CommandNumberPopup.cpp
+++ b/src/host/CommandNumberPopup.cpp
@@ -123,7 +123,7 @@ void CommandNumberPopup::_handleReturn(COOKED_READ_DATA& cookedReadData) noexcep
     for (;;)
     {
         Status = _getUserInput(cookedReadData, popupKeys, modifiers, wch);
-        if (!NT_SUCCESS(Status))
+        if (!SUCCEEDED_NTSTATUS(Status))
         {
             return Status;
         }

--- a/src/host/CommandNumberPopup.cpp
+++ b/src/host/CommandNumberPopup.cpp
@@ -123,7 +123,7 @@ void CommandNumberPopup::_handleReturn(COOKED_READ_DATA& cookedReadData) noexcep
     for (;;)
     {
         Status = _getUserInput(cookedReadData, popupKeys, modifiers, wch);
-        if (!SUCCEEDED_NTSTATUS(Status))
+        if (FAILED_NTSTATUS(Status))
         {
             return Status;
         }

--- a/src/host/CopyFromCharPopup.cpp
+++ b/src/host/CopyFromCharPopup.cpp
@@ -26,7 +26,7 @@ CopyFromCharPopup::CopyFromCharPopup(SCREEN_INFORMATION& screenInfo) :
     auto PopupKeys = false;
     DWORD modifiers = 0;
     auto Status = _getUserInput(cookedReadData, PopupKeys, modifiers, Char);
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         return Status;
     }

--- a/src/host/CopyFromCharPopup.cpp
+++ b/src/host/CopyFromCharPopup.cpp
@@ -26,7 +26,7 @@ CopyFromCharPopup::CopyFromCharPopup(SCREEN_INFORMATION& screenInfo) :
     auto PopupKeys = false;
     DWORD modifiers = 0;
     auto Status = _getUserInput(cookedReadData, PopupKeys, modifiers, Char);
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         return Status;
     }

--- a/src/host/CopyToCharPopup.cpp
+++ b/src/host/CopyToCharPopup.cpp
@@ -56,7 +56,7 @@ void CopyToCharPopup::_copyToChar(COOKED_READ_DATA& cookedReadData, const std::w
     auto popupKey = false;
     DWORD modifiers = 0;
     auto Status = _getUserInput(cookedReadData, popupKey, modifiers, wch);
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         return Status;
     }

--- a/src/host/CopyToCharPopup.cpp
+++ b/src/host/CopyToCharPopup.cpp
@@ -56,7 +56,7 @@ void CopyToCharPopup::_copyToChar(COOKED_READ_DATA& cookedReadData, const std::w
     auto popupKey = false;
     DWORD modifiers = 0;
     auto Status = _getUserInput(cookedReadData, popupKey, modifiers, wch);
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         return Status;
     }

--- a/src/host/_stream.cpp
+++ b/src/host/_stream.cpp
@@ -264,7 +264,7 @@ using Microsoft::Console::VirtualTerminal::StateMachine;
 
     const auto cursorMovedPastViewport = coordCursor.y > screenInfo.GetViewport().BottomInclusive();
     const auto cursorMovedPastVirtualViewport = coordCursor.y > screenInfo.GetVirtualViewport().BottomInclusive();
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         // if at right or bottom edge of window, scroll right or down one char.
         if (cursorMovedPastViewport)
@@ -276,7 +276,7 @@ using Microsoft::Console::VirtualTerminal::StateMachine;
         }
     }
 
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         if (fKeepCursorVisible)
         {
@@ -872,7 +872,7 @@ using Microsoft::Console::VirtualTerminal::StateMachine;
             break;
         }
         }
-        if (!NT_SUCCESS(Status))
+        if (!SUCCEEDED_NTSTATUS(Status))
         {
             return Status;
         }
@@ -942,7 +942,7 @@ using Microsoft::Console::VirtualTerminal::StateMachine;
         size_t TempNumSpaces = 0;
 
         {
-            if (NT_SUCCESS(Status))
+            if (SUCCEEDED_NTSTATUS(Status))
             {
                 FAIL_FAST_IF(!(WI_IsFlagSet(screenInfo.OutputMode, ENABLE_PROCESSED_OUTPUT)));
                 FAIL_FAST_IF(!(WI_IsFlagSet(screenInfo.OutputMode, ENABLE_VIRTUAL_TERMINAL_PROCESSING)));

--- a/src/host/_stream.cpp
+++ b/src/host/_stream.cpp
@@ -872,7 +872,7 @@ using Microsoft::Console::VirtualTerminal::StateMachine;
             break;
         }
         }
-        if (!SUCCEEDED_NTSTATUS(Status))
+        if (FAILED_NTSTATUS(Status))
         {
             return Status;
         }

--- a/src/host/conddkrefs.h
+++ b/src/host/conddkrefs.h
@@ -15,93 +15,11 @@ and it's easier to include a copy of the infrequently changing defs here.
 
 #ifndef _DDK_INCLUDED
 
+#include <winternl.h>
+
 extern "C" {
 
 #pragma region wdm.h(public DDK)
-//
-// Define the base asynchronous I/O argument types
-//
-
-//
-// ClientId
-//
-
-typedef struct _CLIENT_ID
-{
-    HANDLE UniqueProcess;
-    HANDLE UniqueThread;
-} CLIENT_ID;
-typedef CLIENT_ID* PCLIENT_ID;
-
-// POBJECT_ATTRIBUTES
-
-//
-// Unicode strings are counted 16-bit character strings. If they are
-// NULL terminated, Length does not include trailing NULL.
-//
-
-typedef struct _UNICODE_STRING
-{
-    USHORT Length;
-    USHORT MaximumLength;
-#ifdef MIDL_PASS
-    [size_is(MaximumLength / 2), length_is((Length) / 2)] USHORT* Buffer;
-#else // MIDL_PASS
-    _Field_size_bytes_part_(MaximumLength, Length) PWCH Buffer;
-#endif // MIDL_PASS
-} UNICODE_STRING;
-typedef UNICODE_STRING* PUNICODE_STRING;
-typedef const UNICODE_STRING* PCUNICODE_STRING;
-
-// OBJECT_ATTRIBUTES
-
-// clang-format off
-#define OBJ_INHERIT             0x00000002L
-#define OBJ_PERMANENT           0x00000010L
-#define OBJ_EXCLUSIVE           0x00000020L
-#define OBJ_CASE_INSENSITIVE    0x00000040L
-#define OBJ_OPENIF              0x00000080L
-#define OBJ_OPENLINK            0x00000100L
-#define OBJ_KERNEL_HANDLE       0x00000200L
-#define OBJ_FORCE_ACCESS_CHECK  0x00000400L
-#define OBJ_VALID_ATTRIBUTES    0x000007F2L
-// clang-format on
-
-typedef struct _OBJECT_ATTRIBUTES
-{
-    ULONG Length;
-    HANDLE RootDirectory;
-    PUNICODE_STRING ObjectName;
-    ULONG Attributes;
-    PVOID SecurityDescriptor; // Points to type SECURITY_DESCRIPTOR
-    PVOID SecurityQualityOfService; // Points to type SECURITY_QUALITY_OF_SERVICE
-} OBJECT_ATTRIBUTES;
-typedef OBJECT_ATTRIBUTES* POBJECT_ATTRIBUTES;
-typedef CONST OBJECT_ATTRIBUTES* PCOBJECT_ATTRIBUTES;
-
-//++
-//
-// VOID
-// InitializeObjectAttributes(
-//     _Out_ POBJECT_ATTRIBUTES p,
-//     _In_ PUNICODE_STRING n,
-//     _In_ ULONG a,
-//     _In_ HANDLE r,
-//     _In_ PSECURITY_DESCRIPTOR s
-//     )
-//
-//--
-
-#define InitializeObjectAttributes(p, n, a, r, s) \
-    do                                            \
-    {                                             \
-        (p)->Length = sizeof(OBJECT_ATTRIBUTES);  \
-        (p)->RootDirectory = r;                   \
-        (p)->Attributes = a;                      \
-        (p)->ObjectName = n;                      \
-        (p)->SecurityDescriptor = s;              \
-        (p)->SecurityQualityOfService = nullptr;  \
-    } while (0)
 
 // UNICODE_STRING
 
@@ -136,21 +54,6 @@ public:
             _RTL_CONSTANT_STRING_remove_const_macro(s)              \
     }
 }
-
-// OBJ_CASE_INSENSITIVE
-// OBJ_INHERIT
-// InitializeObjectAttributes
-
-typedef struct _IO_STATUS_BLOCK
-{
-    union
-    {
-        NTSTATUS Status;
-        PVOID Pointer;
-    } DUMMYUNIONNAME;
-
-    ULONG_PTR Information;
-} IO_STATUS_BLOCK, *PIO_STATUS_BLOCK;
 
 //
 // Define the file system information class values

--- a/src/host/conserv.h
+++ b/src/host/conserv.h
@@ -25,7 +25,6 @@ Revision History:
 #include "tracing.hpp"
 
 #define NT_TESTNULL(var) (((var) == nullptr) ? STATUS_NO_MEMORY : STATUS_SUCCESS)
-#define NT_TESTNULL_GLE(var) (((var) == nullptr) ? NTSTATUS_FROM_WIN32(GetLastError()) : STATUS_SUCCESS);
 
 /*
  * Used to store some console attributes for the console.  This is a means

--- a/src/host/consoleInformation.cpp
+++ b/src/host/consoleInformation.cpp
@@ -119,7 +119,7 @@ ULONG CONSOLE_INFORMATION::GetCSRecursionCount() const noexcept
     }
 
     auto Status = DoCreateScreenBuffer();
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         goto ErrorExit2;
     }

--- a/src/host/consoleInformation.cpp
+++ b/src/host/consoleInformation.cpp
@@ -119,7 +119,7 @@ ULONG CONSOLE_INFORMATION::GetCSRecursionCount() const noexcept
     }
 
     auto Status = DoCreateScreenBuffer();
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         goto ErrorExit2;
     }
@@ -130,7 +130,7 @@ ULONG CONSOLE_INFORMATION::GetCSRecursionCount() const noexcept
 
     gci.ConsoleIme.RefreshAreaAttributes();
 
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         return STATUS_SUCCESS;
     }

--- a/src/host/directio.cpp
+++ b/src/host/directio.cpp
@@ -1125,7 +1125,7 @@ void EventsToUnicode(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& inEvents,
                                                      Cursor::CURSOR_SMALL_SIZE,
                                                      &ScreenInfo);
 
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         goto Exit;
     }
@@ -1135,7 +1135,7 @@ void EventsToUnicode(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& inEvents,
                                                                 Information->ShareMode,
                                                                 handle));
 
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         goto Exit;
     }
@@ -1143,7 +1143,7 @@ void EventsToUnicode(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& inEvents,
     SCREEN_INFORMATION::s_InsertScreenBuffer(ScreenInfo);
 
 Exit:
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         delete ScreenInfo;
     }

--- a/src/host/directio.cpp
+++ b/src/host/directio.cpp
@@ -201,7 +201,7 @@ void EventsToUnicode(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& inEvents,
                                                       eventReadCount,
                                                       std::move(partialEvents));
         }
-        else if (NT_SUCCESS(Status))
+        else if (SUCCEEDED_NTSTATUS(Status))
         {
             // split key events to oem chars if necessary
             if (!IsUnicode)
@@ -1125,7 +1125,7 @@ void EventsToUnicode(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& inEvents,
                                                      Cursor::CURSOR_SMALL_SIZE,
                                                      &ScreenInfo);
 
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         goto Exit;
     }
@@ -1135,7 +1135,7 @@ void EventsToUnicode(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& inEvents,
                                                                 Information->ShareMode,
                                                                 handle));
 
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         goto Exit;
     }
@@ -1143,7 +1143,7 @@ void EventsToUnicode(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& inEvents,
     SCREEN_INFORMATION::s_InsertScreenBuffer(ScreenInfo);
 
 Exit:
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         delete ScreenInfo;
     }

--- a/src/host/exe/exemain.cpp
+++ b/src/host/exe/exemain.cpp
@@ -66,7 +66,7 @@ static bool ConhostV2ForcedInRegistry()
 
     // open HKCU\Console
     wil::unique_hkey hConsoleSubKey;
-    LONG lStatus = NTSTATUS_FROM_WIN32(RegOpenKeyExW(HKEY_CURRENT_USER, L"Console", 0, KEY_READ, &hConsoleSubKey));
+    LONG lStatus = RegOpenKeyExW(HKEY_CURRENT_USER, L"Console", 0, KEY_READ, &hConsoleSubKey);
     if (ERROR_SUCCESS == lStatus)
     {
         // now get the value of the ForceV2 reg value, if it exists

--- a/src/host/exe/exemain.cpp
+++ b/src/host/exe/exemain.cpp
@@ -107,7 +107,7 @@ static bool ConhostV2ForcedInRegistry()
     FILE_FS_DEVICE_INFORMATION DeviceInformation;
     IO_STATUS_BLOCK IoStatusBlock;
     const auto Status = NtQueryVolumeInformationFile(handle, &IoStatusBlock, &DeviceInformation, sizeof(DeviceInformation), FileFsDeviceInformation);
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         RETURN_NTSTATUS(Status);
     }

--- a/src/host/exe/exemain.cpp
+++ b/src/host/exe/exemain.cpp
@@ -107,7 +107,7 @@ static bool ConhostV2ForcedInRegistry()
     FILE_FS_DEVICE_INFORMATION DeviceInformation;
     IO_STATUS_BLOCK IoStatusBlock;
     const auto Status = NtQueryVolumeInformationFile(handle, &IoStatusBlock, &DeviceInformation, sizeof(DeviceInformation), FileFsDeviceInformation);
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         RETURN_NTSTATUS(Status);
     }

--- a/src/host/input.cpp
+++ b/src/host/input.cpp
@@ -341,7 +341,7 @@ void ProcessCtrlEvents()
          * query. In this case, use best effort to send the close event but
          * ignore any errors.
          */
-        if (NT_SUCCESS(Status))
+        if (SUCCEEDED_NTSTATUS(Status))
         {
             Status = ServiceLocator::LocateConsoleControl()
                          ->EndTask(r.dwProcessID,

--- a/src/host/ntprivapi.cpp
+++ b/src/host/ntprivapi.cpp
@@ -5,6 +5,19 @@
 
 #include "NtPrivApi.hpp"
 
+namespace
+{
+    struct PROCESS_BASIC_INFORMATION_EXPANDED
+    {
+        NTSTATUS ExitStatus;
+        PVOID PebBaseAddress;
+        ULONG_PTR AffinityMask;
+        LONG BasePriority;
+        ULONG_PTR UniqueProcessId;
+        ULONG_PTR InheritedFromUniqueProcessId;
+    };
+}
+
 [[nodiscard]] NTSTATUS NtPrivApi::s_GetProcessParentId(_Inout_ PULONG ProcessId)
 {
     // TODO: Get Parent current not really available without winternl + NtQueryInformationProcess. http://osgvsowi/8394495
@@ -18,7 +31,7 @@
     HANDLE ProcessHandle;
     auto Status = s_NtOpenProcess(&ProcessHandle, PROCESS_QUERY_LIMITED_INFORMATION, &oa, &ClientId);
 
-    PROCESS_BASIC_INFORMATION BasicInfo = { 0 };
+    PROCESS_BASIC_INFORMATION_EXPANDED BasicInfo = { 0 };
     if (SUCCEEDED_NTSTATUS(Status))
     {
         Status = s_NtQueryInformationProcess(ProcessHandle, ProcessBasicInformation, &BasicInfo, sizeof(BasicInfo), nullptr);
@@ -38,13 +51,13 @@
 [[nodiscard]] NTSTATUS NtPrivApi::s_NtOpenProcess(_Out_ PHANDLE ProcessHandle,
                                                   _In_ ACCESS_MASK DesiredAccess,
                                                   _In_ POBJECT_ATTRIBUTES ObjectAttributes,
-                                                  _In_opt_ PCLIENT_ID ClientId)
+                                                  _In_opt_ CLIENT_ID* ClientId)
 {
     auto hNtDll = _Instance()._hNtDll;
 
     if (hNtDll != nullptr)
     {
-        typedef NTSTATUS (*PfnNtOpenProcess)(HANDLE ProcessHandle, ACCESS_MASK DesiredAccess, POBJECT_ATTRIBUTES ObjectAttributes, PCLIENT_ID ClientId);
+        typedef NTSTATUS (*PfnNtOpenProcess)(HANDLE ProcessHandle, ACCESS_MASK DesiredAccess, POBJECT_ATTRIBUTES ObjectAttributes, CLIENT_ID * ClientId);
 
         static auto pfn = (PfnNtOpenProcess)GetProcAddress(hNtDll, "NtOpenProcess");
 

--- a/src/host/ntprivapi.cpp
+++ b/src/host/ntprivapi.cpp
@@ -22,6 +22,7 @@ namespace
 {
     // TODO: Get Parent current not really available without winternl + NtQueryInformationProcess. http://osgvsowi/8394495
     OBJECT_ATTRIBUTES oa;
+#pragma warning(suppress : 26477) // This macro contains a bare NULL
     InitializeObjectAttributes(&oa, nullptr, 0, nullptr, nullptr);
 
     CLIENT_ID ClientId;

--- a/src/host/ntprivapi.cpp
+++ b/src/host/ntprivapi.cpp
@@ -39,7 +39,7 @@ namespace
         LOG_IF_FAILED(s_NtClose(ProcessHandle));
     }
 
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         *ProcessId = 0;
         return Status;

--- a/src/host/ntprivapi.cpp
+++ b/src/host/ntprivapi.cpp
@@ -19,13 +19,13 @@
     auto Status = s_NtOpenProcess(&ProcessHandle, PROCESS_QUERY_LIMITED_INFORMATION, &oa, &ClientId);
 
     PROCESS_BASIC_INFORMATION BasicInfo = { 0 };
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         Status = s_NtQueryInformationProcess(ProcessHandle, ProcessBasicInformation, &BasicInfo, sizeof(BasicInfo), nullptr);
         LOG_IF_FAILED(s_NtClose(ProcessHandle));
     }
 
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         *ProcessId = 0;
         return Status;

--- a/src/host/ntprivapi.hpp
+++ b/src/host/ntprivapi.hpp
@@ -15,30 +15,6 @@ Author(s):
 
 #include "conddkrefs.h"
 
-// From winternl.h
-
-typedef enum _PROCESSINFOCLASS
-{
-    ProcessBasicInformation = 0,
-    ProcessDebugPort = 7,
-    ProcessWow64Information = 26,
-    ProcessImageFileName = 27,
-    ProcessBreakOnTermination = 29
-} PROCESSINFOCLASS;
-
-typedef struct _PROCESS_BASIC_INFORMATION
-{
-    NTSTATUS ExitStatus;
-    PVOID PebBaseAddress;
-    ULONG_PTR AffinityMask;
-    LONG BasePriority;
-    ULONG_PTR UniqueProcessId;
-    ULONG_PTR InheritedFromUniqueProcessId;
-} PROCESS_BASIC_INFORMATION;
-typedef PROCESS_BASIC_INFORMATION* PPROCESS_BASIC_INFORMATION;
-
-// end From winternl.h
-
 class NtPrivApi sealed
 {
 public:
@@ -50,7 +26,7 @@ private:
     [[nodiscard]] static NTSTATUS s_NtOpenProcess(_Out_ PHANDLE ProcessHandle,
                                                   _In_ ACCESS_MASK DesiredAccess,
                                                   _In_ POBJECT_ATTRIBUTES ObjectAttributes,
-                                                  _In_opt_ PCLIENT_ID ClientId);
+                                                  _In_opt_ CLIENT_ID* ClientId);
 
     [[nodiscard]] static NTSTATUS s_NtQueryInformationProcess(_In_ HANDLE ProcessHandle,
                                                               _In_ PROCESSINFOCLASS ProcessInformationClass,

--- a/src/host/output.cpp
+++ b/src/host/output.cpp
@@ -49,7 +49,7 @@ using namespace Microsoft::Console::Interactivity;
     // TODO: MSFT 9355013: This needs to be resolved. We increment it once with no handle to ensure it's never cleaned up
     // and one always exists for the renderer (and potentially other functions.)
     // It's currently a load-bearing piece of code. http://osgvsowi/9355013
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         gci.ScreenBuffers[0].IncrementOriginalScreenBuffer();
     }

--- a/src/host/popup.cpp
+++ b/src/host/popup.cpp
@@ -309,7 +309,7 @@ void Popup::SetUserInputFunction(UserInputFunction function) noexcept
                           nullptr,
                           &popupKey,
                           &modifiers);
-    if (!SUCCEEDED_NTSTATUS(Status) && Status != CONSOLE_STATUS_WAIT)
+    if (FAILED_NTSTATUS(Status) && Status != CONSOLE_STATUS_WAIT)
     {
         cookedReadData.BytesRead() = 0;
     }

--- a/src/host/popup.cpp
+++ b/src/host/popup.cpp
@@ -309,7 +309,7 @@ void Popup::SetUserInputFunction(UserInputFunction function) noexcept
                           nullptr,
                           &popupKey,
                           &modifiers);
-    if (!NT_SUCCESS(Status) && Status != CONSOLE_STATUS_WAIT)
+    if (!SUCCEEDED_NTSTATUS(Status) && Status != CONSOLE_STATUS_WAIT)
     {
         cookedReadData.BytesRead() = 0;
     }

--- a/src/host/precomp.h
+++ b/src/host/precomp.h
@@ -88,7 +88,7 @@ TRACELOGGING_DECLARE_PROVIDER(g_hConhostV2EventTraceProvider);
 #include "../inc/conattrs.hpp"
 
 // TODO: MSFT 9355094 Find a better way of doing this. http://osgvsowi/9355094
-[[nodiscard]] inline NTSTATUS NTSTATUS_FROM_HRESULT(HRESULT hr)
+[[nodiscard]] inline constexpr NTSTATUS NTSTATUS_FROM_HRESULT(HRESULT hr) noexcept
 {
     return NTSTATUS_FROM_WIN32(HRESULT_CODE(hr));
 }

--- a/src/host/precomp.h
+++ b/src/host/precomp.h
@@ -88,7 +88,7 @@ TRACELOGGING_DECLARE_PROVIDER(g_hConhostV2EventTraceProvider);
 #include "../inc/conattrs.hpp"
 
 // TODO: MSFT 9355094 Find a better way of doing this. http://osgvsowi/9355094
-[[nodiscard]] inline constexpr NTSTATUS NTSTATUS_FROM_HRESULT(HRESULT hr) noexcept
+[[nodiscard]] constexpr NTSTATUS NTSTATUS_FROM_HRESULT(HRESULT hr) noexcept
 {
     return NTSTATUS_FROM_WIN32(HRESULT_CODE(hr));
 }

--- a/src/host/readDataCooked.cpp
+++ b/src/host/readDataCooked.cpp
@@ -618,7 +618,7 @@ bool COOKED_READ_DATA::ProcessInput(const wchar_t wchOrig,
                                                   _originalCursorPosition.x,
                                                   WC_DESTRUCTIVE_BACKSPACE | WC_KEEP_CURSOR_VISIBLE | WC_PRINTABLE_CONTROL_CHARS,
                                                   nullptr);
-                        if (!SUCCEEDED_NTSTATUS(status))
+                        if (FAILED_NTSTATUS(status))
                         {
                             RIPMSG1(RIP_WARNING, "WriteCharsLegacy failed %x", status);
                         }
@@ -731,7 +731,7 @@ bool COOKED_READ_DATA::ProcessInput(const wchar_t wchOrig,
                                       _originalCursorPosition.x,
                                       dwFlags,
                                       &ScrollY);
-            if (!SUCCEEDED_NTSTATUS(status))
+            if (FAILED_NTSTATUS(status))
             {
                 RIPMSG1(RIP_WARNING, "WriteCharsLegacy failed 0x%x", status);
                 _bytesRead = 0;
@@ -758,7 +758,7 @@ bool COOKED_READ_DATA::ProcessInput(const wchar_t wchOrig,
                 _originalCursorPosition.y += ScrollY;
                 CursorPosition.y += ScrollY;
                 status = AdjustCursorPosition(_screenInfo, CursorPosition, TRUE, nullptr);
-                if (!SUCCEEDED_NTSTATUS(status))
+                if (FAILED_NTSTATUS(status))
                 {
                     _bytesRead = 0;
                     return true;
@@ -789,7 +789,7 @@ bool COOKED_READ_DATA::ProcessInput(const wchar_t wchOrig,
                                               _originalCursorPosition.x,
                                               WC_DESTRUCTIVE_BACKSPACE | WC_KEEP_CURSOR_VISIBLE | WC_PRINTABLE_CONTROL_CHARS,
                                               nullptr);
-                    if (!SUCCEEDED_NTSTATUS(status))
+                    if (FAILED_NTSTATUS(status))
                     {
                         RIPMSG1(RIP_WARNING, "WriteCharsLegacy failed 0x%x", status);
                     }
@@ -936,7 +936,7 @@ void COOKED_READ_DATA::SavePendingInput(const size_t index, const bool multiline
                          &commandLineEditingKeys,
                          nullptr,
                          &keyState);
-        if (!SUCCEEDED_NTSTATUS(Status))
+        if (FAILED_NTSTATUS(Status))
         {
             if (Status != CONSOLE_STATUS_WAIT)
             {
@@ -966,7 +966,7 @@ void COOKED_READ_DATA::SavePendingInput(const size_t index, const bool multiline
             {
                 break;
             }
-            if (!SUCCEEDED_NTSTATUS(Status))
+            if (FAILED_NTSTATUS(Status))
             {
                 if (Status == CONSOLE_STATUS_WAIT_NO_BLOCK)
                 {

--- a/src/host/readDataCooked.cpp
+++ b/src/host/readDataCooked.cpp
@@ -536,7 +536,7 @@ bool COOKED_READ_DATA::ProcessInput(const wchar_t wchOrig,
                                               _originalCursorPosition.x,
                                               WC_DESTRUCTIVE_BACKSPACE | WC_KEEP_CURSOR_VISIBLE | WC_PRINTABLE_CONTROL_CHARS,
                                               &ScrollY);
-                    if (NT_SUCCESS(status))
+                    if (SUCCEEDED_NTSTATUS(status))
                     {
                         _originalCursorPosition.y += ScrollY;
                     }
@@ -618,7 +618,7 @@ bool COOKED_READ_DATA::ProcessInput(const wchar_t wchOrig,
                                                   _originalCursorPosition.x,
                                                   WC_DESTRUCTIVE_BACKSPACE | WC_KEEP_CURSOR_VISIBLE | WC_PRINTABLE_CONTROL_CHARS,
                                                   nullptr);
-                        if (!NT_SUCCESS(status))
+                        if (!SUCCEEDED_NTSTATUS(status))
                         {
                             RIPMSG1(RIP_WARNING, "WriteCharsLegacy failed %x", status);
                         }
@@ -731,7 +731,7 @@ bool COOKED_READ_DATA::ProcessInput(const wchar_t wchOrig,
                                       _originalCursorPosition.x,
                                       dwFlags,
                                       &ScrollY);
-            if (!NT_SUCCESS(status))
+            if (!SUCCEEDED_NTSTATUS(status))
             {
                 RIPMSG1(RIP_WARNING, "WriteCharsLegacy failed 0x%x", status);
                 _bytesRead = 0;
@@ -758,7 +758,7 @@ bool COOKED_READ_DATA::ProcessInput(const wchar_t wchOrig,
                 _originalCursorPosition.y += ScrollY;
                 CursorPosition.y += ScrollY;
                 status = AdjustCursorPosition(_screenInfo, CursorPosition, TRUE, nullptr);
-                if (!NT_SUCCESS(status))
+                if (!SUCCEEDED_NTSTATUS(status))
                 {
                     _bytesRead = 0;
                     return true;
@@ -789,7 +789,7 @@ bool COOKED_READ_DATA::ProcessInput(const wchar_t wchOrig,
                                               _originalCursorPosition.x,
                                               WC_DESTRUCTIVE_BACKSPACE | WC_KEEP_CURSOR_VISIBLE | WC_PRINTABLE_CONTROL_CHARS,
                                               nullptr);
-                    if (!NT_SUCCESS(status))
+                    if (!SUCCEEDED_NTSTATUS(status))
                     {
                         RIPMSG1(RIP_WARNING, "WriteCharsLegacy failed 0x%x", status);
                     }
@@ -936,7 +936,7 @@ void COOKED_READ_DATA::SavePendingInput(const size_t index, const bool multiline
                          &commandLineEditingKeys,
                          nullptr,
                          &keyState);
-        if (!NT_SUCCESS(Status))
+        if (!SUCCEEDED_NTSTATUS(Status))
         {
             if (Status != CONSOLE_STATUS_WAIT)
             {
@@ -966,7 +966,7 @@ void COOKED_READ_DATA::SavePendingInput(const size_t index, const bool multiline
             {
                 break;
             }
-            if (!NT_SUCCESS(Status))
+            if (!SUCCEEDED_NTSTATUS(Status))
             {
                 if (Status == CONSOLE_STATUS_WAIT_NO_BLOCK)
                 {

--- a/src/host/readDataRaw.cpp
+++ b/src/host/readDataRaw.cpp
@@ -146,7 +146,7 @@ bool RAW_READ_DATA::Notify(const WaitTerminationReason TerminationReason,
                                     nullptr);
         }
 
-        if (!NT_SUCCESS(*pReplyStatus) || fSkipFinally)
+        if (!SUCCEEDED_NTSTATUS(*pReplyStatus) || fSkipFinally)
         {
             if (*pReplyStatus == CONSOLE_STATUS_WAIT)
             {
@@ -167,7 +167,7 @@ bool RAW_READ_DATA::Notify(const WaitTerminationReason TerminationReason,
                                         nullptr,
                                         nullptr,
                                         nullptr);
-                if (!NT_SUCCESS(*pReplyStatus))
+                if (!SUCCEEDED_NTSTATUS(*pReplyStatus))
                 {
                     *pReplyStatus = STATUS_SUCCESS;
                     break;

--- a/src/host/readDataRaw.cpp
+++ b/src/host/readDataRaw.cpp
@@ -146,7 +146,7 @@ bool RAW_READ_DATA::Notify(const WaitTerminationReason TerminationReason,
                                     nullptr);
         }
 
-        if (!SUCCEEDED_NTSTATUS(*pReplyStatus) || fSkipFinally)
+        if (FAILED_NTSTATUS(*pReplyStatus) || fSkipFinally)
         {
             if (*pReplyStatus == CONSOLE_STATUS_WAIT)
             {
@@ -167,7 +167,7 @@ bool RAW_READ_DATA::Notify(const WaitTerminationReason TerminationReason,
                                         nullptr,
                                         nullptr,
                                         nullptr);
-                if (!SUCCEEDED_NTSTATUS(*pReplyStatus))
+                if (FAILED_NTSTATUS(*pReplyStatus))
                 {
                     *pReplyStatus = STATUS_SUCCESS;
                     break;

--- a/src/host/registry.cpp
+++ b/src/host/registry.cpp
@@ -37,7 +37,7 @@ void Registry::GetEditKeys(_In_opt_ HKEY hConsoleKey) const
     if (hConsoleKey == nullptr)
     {
         Status = RegistrySerialization::s_OpenConsoleKey(&hCurrentUserKey, &hConsoleKey);
-        if (!NT_SUCCESS(Status))
+        if (!SUCCEEDED_NTSTATUS(Status))
         {
             return;
         }
@@ -51,7 +51,7 @@ void Registry::GetEditKeys(_In_opt_ HKEY hConsoleKey) const
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status) && dwValue <= 1)
+    if (SUCCEEDED_NTSTATUS(Status) && dwValue <= 1)
     {
         gci.SetAltF4CloseAllowed(!!dwValue);
     }
@@ -81,7 +81,7 @@ void Registry::GetEditKeys(_In_opt_ HKEY hConsoleKey) const
                                                  REG_DWORD,
                                                  reinterpret_cast<BYTE*>(&dwValue),
                                                  nullptr);
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         // the key isn't a REG_DWORD, try to read it as a REG_SZ
         const size_t bufferSize = 64;
@@ -93,7 +93,7 @@ void Registry::GetEditKeys(_In_opt_ HKEY hConsoleKey) const
                                                      REG_SZ,
                                                      reinterpret_cast<BYTE*>(awchBuffer),
                                                      &cbWritten);
-        if (NT_SUCCESS(Status))
+        if (SUCCEEDED_NTSTATUS(Status))
         {
             // we read something, set it as the word delimiters
             const std::wstring regWordDelimiters{ awchBuffer, cbWritten / sizeof(wchar_t) };
@@ -151,7 +151,7 @@ void Registry::_LoadMappedProperties(_In_reads_(cPropertyMappings) const Registr
         }
 
         // Don't log "file not found" messages. It's fine to not find a registry key. Log other types.
-        if (!NT_SUCCESS(Status) && NTSTATUS_FROM_WIN32(ERROR_FILE_NOT_FOUND) != Status)
+        if (!SUCCEEDED_NTSTATUS(Status) && NTSTATUS_FROM_WIN32(ERROR_FILE_NOT_FOUND) != Status)
         {
             LOG_NTSTATUS(Status);
         }
@@ -170,7 +170,7 @@ void Registry::LoadGlobalsFromRegistry()
     HKEY hConsoleKey;
     auto status = RegistrySerialization::s_OpenConsoleKey(&hCurrentUserKey, &hConsoleKey);
 
-    if (NT_SUCCESS(status))
+    if (SUCCEEDED_NTSTATUS(status))
     {
         _LoadMappedProperties(RegistrySerialization::s_GlobalPropMappings, RegistrySerialization::s_GlobalPropMappingsSize, hConsoleKey);
 
@@ -201,7 +201,7 @@ void Registry::LoadFromRegistry(_In_ PCWSTR const pwszConsoleTitle)
     HKEY hCurrentUserKey;
     HKEY hConsoleKey;
     auto Status = RegistrySerialization::s_OpenConsoleKey(&hCurrentUserKey, &hConsoleKey);
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         return;
     }
@@ -220,7 +220,7 @@ void Registry::LoadFromRegistry(_In_ PCWSTR const pwszConsoleTitle)
     delete[] TranslatedConsoleTitle;
     TranslatedConsoleTitle = nullptr;
 
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         TranslatedConsoleTitle = TranslateConsoleTitle(pwszConsoleTitle, TRUE, FALSE);
 
@@ -236,7 +236,7 @@ void Registry::LoadFromRegistry(_In_ PCWSTR const pwszConsoleTitle)
         TranslatedConsoleTitle = nullptr;
     }
 
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         RegCloseKey(hConsoleKey);
         RegCloseKey(hCurrentUserKey);
@@ -251,7 +251,7 @@ void Registry::LoadFromRegistry(_In_ PCWSTR const pwszConsoleTitle)
     const auto loadDWORD = [=](const auto valueName) {
         DWORD value;
         const auto status = RegistrySerialization::s_QueryValue(hTitleKey, valueName, sizeof(value), REG_DWORD, (PBYTE)&value, nullptr);
-        return NT_SUCCESS(status) ? std::optional{ value } : std::nullopt;
+        return SUCCEEDED_NTSTATUS(status) ? std::optional{ value } : std::nullopt;
     };
 
     // Window Origin Autopositioning Setting

--- a/src/host/registry.cpp
+++ b/src/host/registry.cpp
@@ -37,7 +37,7 @@ void Registry::GetEditKeys(_In_opt_ HKEY hConsoleKey) const
     if (hConsoleKey == nullptr)
     {
         Status = RegistrySerialization::s_OpenConsoleKey(&hCurrentUserKey, &hConsoleKey);
-        if (!SUCCEEDED_NTSTATUS(Status))
+        if (FAILED_NTSTATUS(Status))
         {
             return;
         }
@@ -81,7 +81,7 @@ void Registry::GetEditKeys(_In_opt_ HKEY hConsoleKey) const
                                                  REG_DWORD,
                                                  reinterpret_cast<BYTE*>(&dwValue),
                                                  nullptr);
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         // the key isn't a REG_DWORD, try to read it as a REG_SZ
         const size_t bufferSize = 64;
@@ -151,7 +151,7 @@ void Registry::_LoadMappedProperties(_In_reads_(cPropertyMappings) const Registr
         }
 
         // Don't log "file not found" messages. It's fine to not find a registry key. Log other types.
-        if (!SUCCEEDED_NTSTATUS(Status) && NTSTATUS_FROM_WIN32(ERROR_FILE_NOT_FOUND) != Status)
+        if (FAILED_NTSTATUS(Status) && NTSTATUS_FROM_WIN32(ERROR_FILE_NOT_FOUND) != Status)
         {
             LOG_NTSTATUS(Status);
         }
@@ -201,7 +201,7 @@ void Registry::LoadFromRegistry(_In_ PCWSTR const pwszConsoleTitle)
     HKEY hCurrentUserKey;
     HKEY hConsoleKey;
     auto Status = RegistrySerialization::s_OpenConsoleKey(&hCurrentUserKey, &hConsoleKey);
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         return;
     }
@@ -220,7 +220,7 @@ void Registry::LoadFromRegistry(_In_ PCWSTR const pwszConsoleTitle)
     delete[] TranslatedConsoleTitle;
     TranslatedConsoleTitle = nullptr;
 
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         TranslatedConsoleTitle = TranslateConsoleTitle(pwszConsoleTitle, TRUE, FALSE);
 
@@ -236,7 +236,7 @@ void Registry::LoadFromRegistry(_In_ PCWSTR const pwszConsoleTitle)
         TranslatedConsoleTitle = nullptr;
     }
 
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         RegCloseKey(hConsoleKey);
         RegCloseKey(hCurrentUserKey);

--- a/src/host/screenInfo.cpp
+++ b/src/host/screenInfo.cpp
@@ -126,7 +126,7 @@ SCREEN_INFORMATION::~SCREEN_INFORMATION()
 
         const auto status = pScreen->_InitializeOutputStateMachine();
 
-        if (NT_SUCCESS(status))
+        if (SUCCEEDED_NTSTATUS(status))
         {
             *ppScreen = pScreen;
         }
@@ -1562,7 +1562,7 @@ bool SCREEN_INFORMATION::IsMaximizedY() const
         status = NTSTATUS_FROM_HRESULT(ResizeTraditional(coordNewScreenSize));
     }
 
-    if (NT_SUCCESS(status))
+    if (SUCCEEDED_NTSTATUS(status))
     {
         if (HasAccessibilityEventing())
         {
@@ -1901,7 +1901,7 @@ const SCREEN_INFORMATION& SCREEN_INFORMATION::GetMainBuffer() const
                                                      GetPopupAttributes(),
                                                      Cursor::CURSOR_SMALL_SIZE,
                                                      ppsiNewScreenBuffer);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         // Update the alt buffer's cursor style, visibility, and position to match our own.
         auto& myCursor = GetTextBuffer().GetCursor();
@@ -2005,7 +2005,7 @@ void SCREEN_INFORMATION::_handleDeferredResize(SCREEN_INFORMATION& siMain)
 
     SCREEN_INFORMATION* psiNewAltBuffer;
     auto Status = _CreateAltBuffer(&psiNewAltBuffer);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         // if this is already an alternate buffer, we want to make the new
         // buffer the alt on our main buffer, not on ourself, because there

--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -255,7 +255,7 @@ static bool s_IsOnDesktop()
     // Allocate console will read the global ServiceLocator::LocateGlobals().getConsoleInformation
     // for the settings we just set.
     auto Status = CONSOLE_INFORMATION::AllocateConsole({ Title, TitleLength / sizeof(wchar_t) });
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         return Status;
     }
@@ -810,7 +810,7 @@ PWSTR TranslateConsoleTitle(_In_ PCWSTR pwszConsoleTitle, const BOOL fUnexpand, 
     CONSOLE_SERVER_MSG Data = { 0 };
     // Try to receive the data sent by the client.
     auto Status = NTSTATUS_FROM_HRESULT(Message->ReadMessageInput(0, &Data, sizeof(Data)));
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         return Status;
     }
@@ -904,7 +904,7 @@ PWSTR TranslateConsoleTitle(_In_ PCWSTR pwszConsoleTitle, const BOOL fUnexpand, 
     // CreateInstance method), and the TextBuffer needs to be constructed with
     // a reference to the renderer, so the renderer must be created first.
     auto Status = SetUpConsole(&p->ConsoleInfo, p->TitleLength, p->Title, p->CurDir, p->AppName);
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         return Status;
     }
@@ -940,7 +940,7 @@ PWSTR TranslateConsoleTitle(_In_ PCWSTR pwszConsoleTitle, const BOOL fUnexpand, 
 
             CloseHandle(Thread); // This doesn't stop the thread from running.
 
-            if (!SUCCEEDED_NTSTATUS(g.ntstatusConsoleInputInitStatus))
+            if (FAILED_NTSTATUS(g.ntstatusConsoleInputInitStatus))
             {
                 Status = g.ntstatusConsoleInputInitStatus;
             }

--- a/src/host/srvinit.cpp
+++ b/src/host/srvinit.cpp
@@ -116,7 +116,7 @@ static bool s_IsOnDesktop()
         const auto status = Microsoft::Console::Interactivity::ApiDetector::DetectNtUserWindow(&level);
         LOG_IF_NTSTATUS_FAILED(status);
 
-        if (NT_SUCCESS(status))
+        if (SUCCEEDED_NTSTATUS(status))
         {
             switch (level)
             {
@@ -255,7 +255,7 @@ static bool s_IsOnDesktop()
     // Allocate console will read the global ServiceLocator::LocateGlobals().getConsoleInformation
     // for the settings we just set.
     auto Status = CONSOLE_INFORMATION::AllocateConsole({ Title, TitleLength / sizeof(wchar_t) });
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         return Status;
     }
@@ -297,7 +297,7 @@ void ConsoleCheckDebug()
     wil::unique_hkey hConsole;
     auto status = RegistrySerialization::s_OpenConsoleKey(&hCurrentUser, &hConsole);
 
-    if (NT_SUCCESS(status))
+    if (SUCCEEDED_NTSTATUS(status))
     {
         DWORD dwData = 0;
         status = RegistrySerialization::s_QueryValue(hConsole.get(),
@@ -307,7 +307,7 @@ void ConsoleCheckDebug()
                                                      (BYTE*)&dwData,
                                                      nullptr);
 
-        if (NT_SUCCESS(status))
+        if (SUCCEEDED_NTSTATUS(status))
         {
             if (dwData != 0)
             {
@@ -810,7 +810,7 @@ PWSTR TranslateConsoleTitle(_In_ PCWSTR pwszConsoleTitle, const BOOL fUnexpand, 
     CONSOLE_SERVER_MSG Data = { 0 };
     // Try to receive the data sent by the client.
     auto Status = NTSTATUS_FROM_HRESULT(Message->ReadMessageInput(0, &Data, sizeof(Data)));
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         return Status;
     }
@@ -904,7 +904,7 @@ PWSTR TranslateConsoleTitle(_In_ PCWSTR pwszConsoleTitle, const BOOL fUnexpand, 
     // CreateInstance method), and the TextBuffer needs to be constructed with
     // a reference to the renderer, so the renderer must be created first.
     auto Status = SetUpConsole(&p->ConsoleInfo, p->TitleLength, p->Title, p->CurDir, p->AppName);
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         return Status;
     }
@@ -912,7 +912,7 @@ PWSTR TranslateConsoleTitle(_In_ PCWSTR pwszConsoleTitle, const BOOL fUnexpand, 
     // Allow the renderer to paint once the rest of the console is hooked up.
     g.pRender->EnablePainting();
 
-    if (NT_SUCCESS(Status) && ConsoleConnectionDeservesVisibleWindow(p))
+    if (SUCCEEDED_NTSTATUS(Status) && ConsoleConnectionDeservesVisibleWindow(p))
     {
         HANDLE Thread = nullptr;
 
@@ -940,7 +940,7 @@ PWSTR TranslateConsoleTitle(_In_ PCWSTR pwszConsoleTitle, const BOOL fUnexpand, 
 
             CloseHandle(Thread); // This doesn't stop the thread from running.
 
-            if (!NT_SUCCESS(g.ntstatusConsoleInputInitStatus))
+            if (!SUCCEEDED_NTSTATUS(g.ntstatusConsoleInputInitStatus))
             {
                 Status = g.ntstatusConsoleInputInitStatus;
             }
@@ -973,7 +973,7 @@ PWSTR TranslateConsoleTitle(_In_ PCWSTR pwszConsoleTitle, const BOOL fUnexpand, 
     // Potentially start the VT IO (if needed)
     // Make sure to do this after the i/o buffers have been created.
     // We'll need the size of the screen buffer in the vt i/o initialization
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         auto hr = gci.GetVtIo()->CreateIoHandlers();
         if (hr == S_FALSE)

--- a/src/host/stream.cpp
+++ b/src/host/stream.cpp
@@ -67,7 +67,7 @@ using Microsoft::Console::Interactivity::ServiceLocator;
                                     true, // unicode
                                     true); // stream
 
-        if (!NT_SUCCESS(Status))
+        if (!SUCCEEDED_NTSTATUS(Status))
         {
             return Status;
         }
@@ -579,7 +579,7 @@ til::CoordType RetrieveNumberOfSpaces(_In_ til::CoordType sOriginalCursorPositio
                                                      reinterpret_cast<wchar_t*>(buffer.data()));
         }
 
-        if (!NT_SUCCESS(Status))
+        if (!SUCCEEDED_NTSTATUS(Status))
         {
             bytesRead = 0;
             return Status;
@@ -600,7 +600,7 @@ til::CoordType RetrieveNumberOfSpaces(_In_ til::CoordType sOriginalCursorPositio
                              nullptr,
                              nullptr,
                              nullptr);
-            if (!NT_SUCCESS(Status))
+            if (!SUCCEEDED_NTSTATUS(Status))
             {
                 break;
             }

--- a/src/host/stream.cpp
+++ b/src/host/stream.cpp
@@ -67,7 +67,7 @@ using Microsoft::Console::Interactivity::ServiceLocator;
                                     true, // unicode
                                     true); // stream
 
-        if (!SUCCEEDED_NTSTATUS(Status))
+        if (FAILED_NTSTATUS(Status))
         {
             return Status;
         }
@@ -579,7 +579,7 @@ til::CoordType RetrieveNumberOfSpaces(_In_ til::CoordType sOriginalCursorPositio
                                                      reinterpret_cast<wchar_t*>(buffer.data()));
         }
 
-        if (!SUCCEEDED_NTSTATUS(Status))
+        if (FAILED_NTSTATUS(Status))
         {
             bytesRead = 0;
             return Status;
@@ -600,7 +600,7 @@ til::CoordType RetrieveNumberOfSpaces(_In_ til::CoordType sOriginalCursorPositio
                              nullptr,
                              nullptr,
                              nullptr);
-            if (!SUCCEEDED_NTSTATUS(Status))
+            if (FAILED_NTSTATUS(Status))
             {
                 break;
             }

--- a/src/host/ut_host/InputBufferTests.cpp
+++ b/src/host/ut_host/InputBufferTests.cpp
@@ -189,11 +189,11 @@ class InputBufferTests
         // the single event should have a repeat count for each
         // coalesced event
         std::unique_ptr<IInputEvent> outEvent;
-        VERIFY_SUCCESS_NTSTATUS(inputBuffer.Read(outEvent,
-                                                 true,
-                                                 false,
-                                                 false,
-                                                 false));
+        VERIFY_NT_SUCCESS(inputBuffer.Read(outEvent,
+                                           true,
+                                           false,
+                                           false,
+                                           false));
 
         VERIFY_ARE_NOT_EQUAL(nullptr, outEvent.get());
         const auto pKeyEvent = static_cast<const KeyEvent* const>(outEvent.get());
@@ -288,12 +288,12 @@ class InputBufferTests
         // make sure that the non key events were the ones removed
         std::deque<std::unique_ptr<IInputEvent>> outEvents;
         auto amountToRead = RECORD_INSERT_COUNT / 2;
-        VERIFY_SUCCESS_NTSTATUS(inputBuffer.Read(outEvents,
-                                                 amountToRead,
-                                                 false,
-                                                 false,
-                                                 false,
-                                                 false));
+        VERIFY_NT_SUCCESS(inputBuffer.Read(outEvents,
+                                           amountToRead,
+                                           false,
+                                           false,
+                                           false,
+                                           false));
         VERIFY_ARE_EQUAL(amountToRead, outEvents.size());
 
         for (size_t i = 0; i < outEvents.size(); ++i)
@@ -319,12 +319,12 @@ class InputBufferTests
         // read them back out
         std::deque<std::unique_ptr<IInputEvent>> outEvents;
         auto amountToRead = RECORD_INSERT_COUNT;
-        VERIFY_SUCCESS_NTSTATUS(inputBuffer.Read(outEvents,
-                                                 amountToRead,
-                                                 false,
-                                                 false,
-                                                 false,
-                                                 false));
+        VERIFY_NT_SUCCESS(inputBuffer.Read(outEvents,
+                                           amountToRead,
+                                           false,
+                                           false,
+                                           false,
+                                           false));
         VERIFY_ARE_EQUAL(amountToRead, outEvents.size());
         VERIFY_ARE_EQUAL(inputBuffer.GetNumberOfReadyEvents(), 0u);
         for (size_t i = 0; i < RECORD_INSERT_COUNT; ++i)
@@ -350,12 +350,12 @@ class InputBufferTests
         // peek at events
         std::deque<std::unique_ptr<IInputEvent>> outEvents;
         auto amountToRead = RECORD_INSERT_COUNT;
-        VERIFY_SUCCESS_NTSTATUS(inputBuffer.Read(outEvents,
-                                                 amountToRead,
-                                                 true,
-                                                 false,
-                                                 false,
-                                                 false));
+        VERIFY_NT_SUCCESS(inputBuffer.Read(outEvents,
+                                           amountToRead,
+                                           true,
+                                           false,
+                                           false,
+                                           false));
 
         VERIFY_ARE_EQUAL(amountToRead, outEvents.size());
         VERIFY_ARE_EQUAL(inputBuffer.GetNumberOfReadyEvents(), RECORD_INSERT_COUNT);
@@ -479,12 +479,12 @@ class InputBufferTests
         // grab the first set of events and ensure they match prependRecords
         std::deque<std::unique_ptr<IInputEvent>> outEvents;
         auto amountToRead = RECORD_INSERT_COUNT;
-        VERIFY_SUCCESS_NTSTATUS(inputBuffer.Read(outEvents,
-                                                 amountToRead,
-                                                 false,
-                                                 false,
-                                                 false,
-                                                 false));
+        VERIFY_NT_SUCCESS(inputBuffer.Read(outEvents,
+                                           amountToRead,
+                                           false,
+                                           false,
+                                           false,
+                                           false));
         VERIFY_ARE_EQUAL(amountToRead, outEvents.size());
         VERIFY_ARE_EQUAL(inputBuffer.GetNumberOfReadyEvents(), RECORD_INSERT_COUNT);
         for (unsigned int i = 0; i < RECORD_INSERT_COUNT; ++i)
@@ -494,12 +494,12 @@ class InputBufferTests
 
         outEvents.clear();
         // verify the rest of the records
-        VERIFY_SUCCESS_NTSTATUS(inputBuffer.Read(outEvents,
-                                                 amountToRead,
-                                                 false,
-                                                 false,
-                                                 false,
-                                                 false));
+        VERIFY_NT_SUCCESS(inputBuffer.Read(outEvents,
+                                           amountToRead,
+                                           false,
+                                           false,
+                                           false,
+                                           false));
         VERIFY_ARE_EQUAL(inputBuffer.GetNumberOfReadyEvents(), 0u);
         VERIFY_ARE_EQUAL(amountToRead, outEvents.size());
         for (unsigned int i = 0; i < RECORD_INSERT_COUNT; ++i)
@@ -577,12 +577,12 @@ class InputBufferTests
 
         std::deque<std::unique_ptr<IInputEvent>> outEvents;
         size_t amountToRead = 2;
-        VERIFY_SUCCESS_NTSTATUS(inputBuffer.Read(outEvents,
-                                                 amountToRead,
-                                                 true,
-                                                 false,
-                                                 false,
-                                                 false));
+        VERIFY_NT_SUCCESS(inputBuffer.Read(outEvents,
+                                           amountToRead,
+                                           true,
+                                           false,
+                                           false,
+                                           false));
     }
 
     TEST_METHOD(WritingToEmptyBufferSignalsWaitEvent)
@@ -617,12 +617,12 @@ class InputBufferTests
         std::deque<std::unique_ptr<IInputEvent>> outEvents;
 
         VERIFY_ARE_EQUAL(inputBuffer.Write(IInputEvent::Create(record)), 1u);
-        VERIFY_SUCCESS_NTSTATUS(inputBuffer.Read(outEvents,
-                                                 1,
-                                                 false,
-                                                 false,
-                                                 true,
-                                                 true));
+        VERIFY_NT_SUCCESS(inputBuffer.Read(outEvents,
+                                           1,
+                                           false,
+                                           false,
+                                           true,
+                                           true));
         VERIFY_ARE_EQUAL(outEvents.size(), 1u);
         VERIFY_ARE_EQUAL(inputBuffer._storage.size(), 1u);
         VERIFY_ARE_EQUAL(static_cast<const KeyEvent&>(*inputBuffer._storage.front()).GetRepeatCount(), repeatCount - 1);
@@ -637,12 +637,12 @@ class InputBufferTests
         std::deque<std::unique_ptr<IInputEvent>> outEvents;
 
         VERIFY_ARE_EQUAL(inputBuffer.Write(IInputEvent::Create(record)), 1u);
-        VERIFY_SUCCESS_NTSTATUS(inputBuffer.Read(outEvents,
-                                                 1,
-                                                 true,
-                                                 false,
-                                                 true,
-                                                 true));
+        VERIFY_NT_SUCCESS(inputBuffer.Read(outEvents,
+                                           1,
+                                           true,
+                                           false,
+                                           true,
+                                           true));
         VERIFY_ARE_EQUAL(outEvents.size(), 1u);
         VERIFY_ARE_EQUAL(inputBuffer._storage.size(), 1u);
         VERIFY_ARE_EQUAL(static_cast<const KeyEvent&>(*inputBuffer._storage.front()).GetRepeatCount(), repeatCount);

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -2843,16 +2843,16 @@ void ScreenBufferTests::BackspaceDefaultAttrsWriteCharsLegacy()
     {
         auto str = L"X";
         size_t seqCb = 2;
-        VERIFY_SUCCESS_NTSTATUS(WriteCharsLegacy(si, str, str, str, &seqCb, nullptr, cursor.GetPosition().x, writeCharsLegacyMode, nullptr));
-        VERIFY_SUCCESS_NTSTATUS(WriteCharsLegacy(si, str, str, str, &seqCb, nullptr, cursor.GetPosition().x, writeCharsLegacyMode, nullptr));
+        VERIFY_NT_SUCCESS(WriteCharsLegacy(si, str, str, str, &seqCb, nullptr, cursor.GetPosition().x, writeCharsLegacyMode, nullptr));
+        VERIFY_NT_SUCCESS(WriteCharsLegacy(si, str, str, str, &seqCb, nullptr, cursor.GetPosition().x, writeCharsLegacyMode, nullptr));
         str = L"\x08";
-        VERIFY_SUCCESS_NTSTATUS(WriteCharsLegacy(si, str, str, str, &seqCb, nullptr, cursor.GetPosition().x, writeCharsLegacyMode, nullptr));
+        VERIFY_NT_SUCCESS(WriteCharsLegacy(si, str, str, str, &seqCb, nullptr, cursor.GetPosition().x, writeCharsLegacyMode, nullptr));
     }
     else
     {
         const auto str = L"XX\x08";
         size_t seqCb = 6;
-        VERIFY_SUCCESS_NTSTATUS(WriteCharsLegacy(si, str, str, str, &seqCb, nullptr, cursor.GetPosition().x, writeCharsLegacyMode, nullptr));
+        VERIFY_NT_SUCCESS(WriteCharsLegacy(si, str, str, str, &seqCb, nullptr, cursor.GetPosition().x, writeCharsLegacyMode, nullptr));
     }
 
     TextAttribute expectedDefaults{};
@@ -3488,7 +3488,7 @@ void ScreenBufferTests::DontResetColorsAboveVirtualBottom()
     auto& cursor = si.GetTextBuffer().GetCursor();
     const auto& renderSettings = gci.GetRenderSettings();
 
-    VERIFY_SUCCESS_NTSTATUS(si.SetViewportOrigin(true, { 0, 1 }, true));
+    VERIFY_NT_SUCCESS(si.SetViewportOrigin(true, { 0, 1 }, true));
     cursor.SetPosition({ 0, si.GetViewport().BottomInclusive() });
     Log::Comment(NoThrowString().Format(
         L"cursor=%s", VerifyOutputTraits<til::point>::ToString(cursor.GetPosition()).GetBuffer()));
@@ -3521,7 +3521,7 @@ void ScreenBufferTests::DontResetColorsAboveVirtualBottom()
     }
 
     Log::Comment(NoThrowString().Format(L"Emulate scrolling up with the mouse"));
-    VERIFY_SUCCESS_NTSTATUS(si.SetViewportOrigin(true, { 0, 0 }, false));
+    VERIFY_NT_SUCCESS(si.SetViewportOrigin(true, { 0, 0 }, false));
 
     Log::Comment(NoThrowString().Format(
         L"cursor=%s", VerifyOutputTraits<til::point>::ToString(cursor.GetPosition()).GetBuffer()));
@@ -6580,7 +6580,7 @@ void ScreenBufferTests::UpdateVirtualBottomWhenCursorMovesBelowIt()
     Log::Comment(L"Now write several lines of content using WriteCharsLegacy");
     const auto content = L"1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n";
     auto numBytes = wcslen(content) * sizeof(wchar_t);
-    VERIFY_SUCCESS_NTSTATUS(WriteCharsLegacy(si, content, content, content, &numBytes, nullptr, 0, 0, nullptr));
+    VERIFY_NT_SUCCESS(WriteCharsLegacy(si, content, content, content, &numBytes, nullptr, 0, 0, nullptr));
 
     Log::Comment(L"Confirm that the cursor position has moved down 10 lines");
     const auto newCursorPos = til::point{ initialCursorPos.x, initialCursorPos.y + 10 };

--- a/src/host/ut_host/ScreenBufferTests.cpp
+++ b/src/host/ut_host/ScreenBufferTests.cpp
@@ -266,7 +266,7 @@ void ScreenBufferTests::SingleAlternateBufferCreationTest()
     VERIFY_IS_NULL(psiOriginal->_psiMainBuffer);
 
     auto Status = psiOriginal->UseAlternateScreenBuffer();
-    if (VERIFY_IS_TRUE(NT_SUCCESS(Status)))
+    if (VERIFY_NT_SUCCESS(Status))
     {
         Log::Comment(L"First alternate buffer successfully created");
         const auto psiFirstAlternate = &gci.GetActiveOutputBuffer();
@@ -299,7 +299,7 @@ void ScreenBufferTests::MultipleAlternateBufferCreationTest()
 
     const auto psiOriginal = &gci.GetActiveOutputBuffer();
     auto Status = psiOriginal->UseAlternateScreenBuffer();
-    if (VERIFY_IS_TRUE(NT_SUCCESS(Status)))
+    if (VERIFY_NT_SUCCESS(Status))
     {
         Log::Comment(L"First alternate buffer successfully created");
         const auto psiFirstAlternate = &gci.GetActiveOutputBuffer();
@@ -310,7 +310,7 @@ void ScreenBufferTests::MultipleAlternateBufferCreationTest()
         VERIFY_IS_NULL(psiFirstAlternate->_psiAlternateBuffer);
 
         Status = psiFirstAlternate->UseAlternateScreenBuffer();
-        if (VERIFY_IS_TRUE(NT_SUCCESS(Status)))
+        if (VERIFY_NT_SUCCESS(Status))
         {
             Log::Comment(L"Second alternate buffer successfully created");
             auto psiSecondAlternate = &gci.GetActiveOutputBuffer();
@@ -344,7 +344,7 @@ void ScreenBufferTests::MultipleAlternateBuffersFromMainCreationTest()
         L" alternate from the main, before returning to the main buffer.");
     const auto psiOriginal = &gci.GetActiveOutputBuffer();
     auto Status = psiOriginal->UseAlternateScreenBuffer();
-    if (VERIFY_IS_TRUE(NT_SUCCESS(Status)))
+    if (VERIFY_NT_SUCCESS(Status))
     {
         Log::Comment(L"First alternate buffer successfully created");
         const auto psiFirstAlternate = &gci.GetActiveOutputBuffer();
@@ -355,7 +355,7 @@ void ScreenBufferTests::MultipleAlternateBuffersFromMainCreationTest()
         VERIFY_IS_NULL(psiFirstAlternate->_psiAlternateBuffer);
 
         Status = psiOriginal->UseAlternateScreenBuffer();
-        if (VERIFY_IS_TRUE(NT_SUCCESS(Status)))
+        if (VERIFY_NT_SUCCESS(Status))
         {
             Log::Comment(L"Second alternate buffer successfully created");
             const auto psiSecondAlternate = &gci.GetActiveOutputBuffer();
@@ -2362,7 +2362,7 @@ void ScreenBufferTests::TestAltBufferCursorState()
     VERIFY_IS_NULL(original._psiMainBuffer);
 
     auto Status = original.UseAlternateScreenBuffer();
-    if (VERIFY_IS_TRUE(NT_SUCCESS(Status)))
+    if (VERIFY_NT_SUCCESS(Status))
     {
         Log::Comment(L"Alternate buffer successfully created");
         auto& alternate = gci.GetActiveOutputBuffer();
@@ -2407,7 +2407,7 @@ void ScreenBufferTests::TestAltBufferVtDispatching()
     VERIFY_IS_NULL(mainBuffer._psiMainBuffer);
 
     auto Status = mainBuffer.UseAlternateScreenBuffer();
-    if (VERIFY_IS_TRUE(NT_SUCCESS(Status)))
+    if (VERIFY_NT_SUCCESS(Status))
     {
         Log::Comment(L"Alternate buffer successfully created");
         auto& alternate = gci.GetActiveOutputBuffer();
@@ -5343,7 +5343,7 @@ void ScreenBufferTests::RestoreDownAltBufferWithTerminalScrolling()
     VERIFY_IS_NULL(siMain._psiAlternateBuffer);
 
     Log::Comment(L"Create an alternate buffer");
-    if (VERIFY_IS_TRUE(NT_SUCCESS(siMain.UseAlternateScreenBuffer())))
+    if (VERIFY_NT_SUCCESS(siMain.UseAlternateScreenBuffer()))
     {
         VERIFY_IS_NOT_NULL(siMain._psiAlternateBuffer);
         auto& altBuffer = *siMain._psiAlternateBuffer;
@@ -5508,7 +5508,7 @@ void ScreenBufferTests::ClearAlternateBuffer()
     VerifyText(siMain.GetTextBuffer());
 
     Log::Comment(L"Create an alternate buffer");
-    if (VERIFY_IS_TRUE(NT_SUCCESS(siMain.UseAlternateScreenBuffer())))
+    if (VERIFY_NT_SUCCESS(siMain.UseAlternateScreenBuffer()))
     {
         VERIFY_IS_NOT_NULL(siMain._psiAlternateBuffer);
         auto& altBuffer = *siMain._psiAlternateBuffer;

--- a/src/host/ut_host/TextBufferTests.cpp
+++ b/src/host/ut_host/TextBufferTests.cpp
@@ -1561,7 +1561,7 @@ void TextBufferTests::TestBackspaceStringsAPI()
         L"Using WriteCharsLegacy, write \\b \\b as a single string."));
     {
         const auto str = L"\b \b";
-        VERIFY_SUCCESS_NTSTATUS(WriteCharsLegacy(si, str, str, str, &seqCb, nullptr, cursor.GetPosition().x, 0, nullptr));
+        VERIFY_NT_SUCCESS(WriteCharsLegacy(si, str, str, str, &seqCb, nullptr, cursor.GetPosition().x, 0, nullptr));
 
         VERIFY_ARE_EQUAL(cursor.GetPosition().x, x0);
         VERIFY_ARE_EQUAL(cursor.GetPosition().y, y0);
@@ -1592,19 +1592,19 @@ void TextBufferTests::TestBackspaceStringsAPI()
         L"Using WriteCharsLegacy, write \\b \\b as separate strings."));
     {
         const auto str = L"a";
-        VERIFY_SUCCESS_NTSTATUS(WriteCharsLegacy(si, str, str, str, &seqCb, nullptr, cursor.GetPosition().x, 0, nullptr));
+        VERIFY_NT_SUCCESS(WriteCharsLegacy(si, str, str, str, &seqCb, nullptr, cursor.GetPosition().x, 0, nullptr));
     }
     {
         const auto str = L"\b";
-        VERIFY_SUCCESS_NTSTATUS(WriteCharsLegacy(si, str, str, str, &seqCb, nullptr, cursor.GetPosition().x, 0, nullptr));
+        VERIFY_NT_SUCCESS(WriteCharsLegacy(si, str, str, str, &seqCb, nullptr, cursor.GetPosition().x, 0, nullptr));
     }
     {
         const auto str = L" ";
-        VERIFY_SUCCESS_NTSTATUS(WriteCharsLegacy(si, str, str, str, &seqCb, nullptr, cursor.GetPosition().x, 0, nullptr));
+        VERIFY_NT_SUCCESS(WriteCharsLegacy(si, str, str, str, &seqCb, nullptr, cursor.GetPosition().x, 0, nullptr));
     }
     {
         const auto str = L"\b";
-        VERIFY_SUCCESS_NTSTATUS(WriteCharsLegacy(si, str, str, str, &seqCb, nullptr, cursor.GetPosition().x, 0, nullptr));
+        VERIFY_NT_SUCCESS(WriteCharsLegacy(si, str, str, str, &seqCb, nullptr, cursor.GetPosition().x, 0, nullptr));
     }
 
     VERIFY_ARE_EQUAL(cursor.GetPosition().x, x0);

--- a/src/host/utils.cpp
+++ b/src/host/utils.cpp
@@ -69,11 +69,11 @@ std::wstring _LoadString(const UINT id)
     LANGID LangId;
 
     const auto Status = GetConsoleLangId(gci.OutputCP, &LangId);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         ItemLength = s_LoadStringEx(ServiceLocator::LocateGlobals().hInstance, id, ItemString, ARRAYSIZE(ItemString), LangId);
     }
-    if (!NT_SUCCESS(Status) || ItemLength == 0)
+    if (!SUCCEEDED_NTSTATUS(Status) || ItemLength == 0)
     {
         ItemLength = LoadStringW(ServiceLocator::LocateGlobals().hInstance, id, ItemString, ARRAYSIZE(ItemString));
     }

--- a/src/host/utils.cpp
+++ b/src/host/utils.cpp
@@ -73,7 +73,7 @@ std::wstring _LoadString(const UINT id)
     {
         ItemLength = s_LoadStringEx(ServiceLocator::LocateGlobals().hInstance, id, ItemString, ARRAYSIZE(ItemString), LangId);
     }
-    if (!SUCCEEDED_NTSTATUS(Status) || ItemLength == 0)
+    if (FAILED_NTSTATUS(Status) || ItemLength == 0)
     {
         ItemLength = LoadStringW(ServiceLocator::LocateGlobals().hInstance, id, ItemString, ARRAYSIZE(ItemString));
     }

--- a/src/inc/HostAndPropsheetIncludes.h
+++ b/src/inc/HostAndPropsheetIncludes.h
@@ -19,8 +19,6 @@ typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 /*lint -save -e624 */  // Don't complain about different typedefs.
 typedef NTSTATUS *PNTSTATUS;
 /*lint -restore */  // Resume checking for different typedefs.
-#define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
-
 // End From ntdef.h
 
 #define INLINE_NTSTATUS_FROM_WIN32 1 // Must use inline NTSTATUS or it will call the wrapped function twice.

--- a/src/inc/HostAndPropsheetIncludes.h
+++ b/src/inc/HostAndPropsheetIncludes.h
@@ -14,14 +14,8 @@
 #include <windows.h>
 #undef WIN32_NO_STATUS
 
-// From ntdef.h, but that can't be included or it'll fight over PROBE_ALIGNMENT and other such arch specific defs
-typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
-/*lint -save -e624 */  // Don't complain about different typedefs.
-typedef NTSTATUS *PNTSTATUS;
-/*lint -restore */  // Resume checking for different typedefs.
-// End From ntdef.h
+#include <winternl.h>
 
-#define INLINE_NTSTATUS_FROM_WIN32 1 // Must use inline NTSTATUS or it will call the wrapped function twice.
 #pragma warning(push)
 #pragma warning(disable:4430) // Must disable 4430 "default int" warning for C++ because ntstatus.h is inflexible SDK definition.
 #include <ntstatus.h>

--- a/src/inc/test/CommonState.hpp
+++ b/src/inc/test/CommonState.hpp
@@ -20,8 +20,6 @@ unit testing projects in the codebase without a bunch of overhead.
 
 #pragma once
 
-#define VERIFY_SUCCESS_NTSTATUS(x) VERIFY_IS_TRUE(NT_SUCCESS(x))
-
 #include "../host/globals.h"
 #include "../host/inputReadHandleData.h"
 #include "../interactivity/inc/ServiceLocator.hpp"

--- a/src/interactivity/base/ApiDetector.cpp
+++ b/src/interactivity/base/ApiDetector.cpp
@@ -48,7 +48,7 @@ using namespace Microsoft::Console::Interactivity;
     HMODULE hModule = nullptr;
 
     status = TryLoadWellKnownLibrary(lpApiHost, &hModule);
-    if (NT_SUCCESS(status) && lpProcedure)
+    if (SUCCEEDED_NTSTATUS(status) && lpProcedure)
     {
         status = TryLocateProcedure(hModule, lpProcedure);
     }
@@ -96,7 +96,7 @@ using namespace Microsoft::Console::Interactivity;
     //       versioning API's behave sanely.
 
     status = TryLoadWellKnownLibrary(lpLibrary, LOAD_LIBRARY_SEARCH_SYSTEM32_NO_FORWARDER, phModule);
-    if (!NT_SUCCESS(status) && GetLastError() == ERROR_INVALID_PARAMETER)
+    if (!SUCCEEDED_NTSTATUS(status) && GetLastError() == ERROR_INVALID_PARAMETER)
     {
         status = TryLoadWellKnownLibrary(lpLibrary, LOAD_LIBRARY_SEARCH_SYSTEM32, phModule);
     }
@@ -141,7 +141,7 @@ using namespace Microsoft::Console::Interactivity;
 
 void ApiDetector::SetLevelAndFreeIfNecessary(_In_ NTSTATUS status, _In_ HMODULE hModule, _Out_ ApiLevel* level)
 {
-    if (NT_SUCCESS(status))
+    if (SUCCEEDED_NTSTATUS(status))
     {
         *level = ApiLevel::Win32;
     }

--- a/src/interactivity/base/ApiDetector.cpp
+++ b/src/interactivity/base/ApiDetector.cpp
@@ -96,7 +96,7 @@ using namespace Microsoft::Console::Interactivity;
     //       versioning API's behave sanely.
 
     status = TryLoadWellKnownLibrary(lpLibrary, LOAD_LIBRARY_SEARCH_SYSTEM32_NO_FORWARDER, phModule);
-    if (!SUCCEEDED_NTSTATUS(status) && GetLastError() == ERROR_INVALID_PARAMETER)
+    if (FAILED_NTSTATUS(status) && GetLastError() == ERROR_INVALID_PARAMETER)
     {
         status = TryLoadWellKnownLibrary(lpLibrary, LOAD_LIBRARY_SEARCH_SYSTEM32, phModule);
     }

--- a/src/interactivity/base/InteractivityFactory.cpp
+++ b/src/interactivity/base/InteractivityFactory.cpp
@@ -38,7 +38,7 @@ using namespace Microsoft::Console::Interactivity;
     ApiLevel level;
     status = ApiDetector::DetectNtUserWindow(&level);
 
-    if (NT_SUCCESS(status))
+    if (SUCCEEDED_NTSTATUS(status))
     {
         std::unique_ptr<IConsoleControl> newControl;
         try
@@ -64,7 +64,7 @@ using namespace Microsoft::Console::Interactivity;
             status = NTSTATUS_FROM_HRESULT(wil::ResultFromCaughtException());
         }
 
-        if (NT_SUCCESS(status))
+        if (SUCCEEDED_NTSTATUS(status))
         {
             control.swap(newControl);
         }
@@ -80,7 +80,7 @@ using namespace Microsoft::Console::Interactivity;
     ApiLevel level;
     status = ApiDetector::DetectNtUserWindow(&level);
 
-    if (NT_SUCCESS(status))
+    if (SUCCEEDED_NTSTATUS(status))
     {
         std::unique_ptr<IConsoleInputThread> newThread;
         try
@@ -106,7 +106,7 @@ using namespace Microsoft::Console::Interactivity;
             status = NTSTATUS_FROM_HRESULT(wil::ResultFromCaughtException());
         }
 
-        if (NT_SUCCESS(status))
+        if (SUCCEEDED_NTSTATUS(status))
         {
             thread.swap(newThread);
         }
@@ -122,7 +122,7 @@ using namespace Microsoft::Console::Interactivity;
     ApiLevel level;
     status = ApiDetector::DetectNtUserWindow(&level);
 
-    if (NT_SUCCESS(status))
+    if (SUCCEEDED_NTSTATUS(status))
     {
         std::unique_ptr<IHighDpiApi> newApi;
         try
@@ -148,7 +148,7 @@ using namespace Microsoft::Console::Interactivity;
             status = NTSTATUS_FROM_HRESULT(wil::ResultFromCaughtException());
         }
 
-        if (NT_SUCCESS(status))
+        if (SUCCEEDED_NTSTATUS(status))
         {
             api.swap(newApi);
         }
@@ -164,7 +164,7 @@ using namespace Microsoft::Console::Interactivity;
     ApiLevel level;
     status = ApiDetector::DetectNtUserWindow(&level);
 
-    if (NT_SUCCESS(status))
+    if (SUCCEEDED_NTSTATUS(status))
     {
         std::unique_ptr<IWindowMetrics> newMetrics;
         try
@@ -190,7 +190,7 @@ using namespace Microsoft::Console::Interactivity;
             status = NTSTATUS_FROM_HRESULT(wil::ResultFromCaughtException());
         }
 
-        if (NT_SUCCESS(status))
+        if (SUCCEEDED_NTSTATUS(status))
         {
             metrics.swap(newMetrics);
         }
@@ -206,7 +206,7 @@ using namespace Microsoft::Console::Interactivity;
     ApiLevel level;
     status = ApiDetector::DetectNtUserWindow(&level);
 
-    if (NT_SUCCESS(status))
+    if (SUCCEEDED_NTSTATUS(status))
     {
         std::unique_ptr<IAccessibilityNotifier> newNotifier;
         try
@@ -232,7 +232,7 @@ using namespace Microsoft::Console::Interactivity;
             status = NTSTATUS_FROM_HRESULT(wil::ResultFromCaughtException());
         }
 
-        if (NT_SUCCESS(status))
+        if (SUCCEEDED_NTSTATUS(status))
         {
             notifier.swap(newNotifier);
         }
@@ -248,7 +248,7 @@ using namespace Microsoft::Console::Interactivity;
     ApiLevel level;
     status = ApiDetector::DetectNtUserWindow(&level);
 
-    if (NT_SUCCESS(status))
+    if (SUCCEEDED_NTSTATUS(status))
     {
         std::unique_ptr<ISystemConfigurationProvider> NewProvider;
         try
@@ -274,7 +274,7 @@ using namespace Microsoft::Console::Interactivity;
             status = NTSTATUS_FROM_HRESULT(wil::ResultFromCaughtException());
         }
 
-        if (NT_SUCCESS(status))
+        if (SUCCEEDED_NTSTATUS(status))
         {
             provider.swap(NewProvider);
         }
@@ -300,7 +300,7 @@ using namespace Microsoft::Console::Interactivity;
     ApiLevel level;
     auto status = ApiDetector::DetectNtUserWindow(&level);
 
-    if (NT_SUCCESS(status))
+    if (SUCCEEDED_NTSTATUS(status))
     {
         try
         {

--- a/src/interactivity/base/RemoteConsoleControl.cpp
+++ b/src/interactivity/base/RemoteConsoleControl.cpp
@@ -35,7 +35,8 @@ template<typename T>
     DWORD bytesWritten = 0;
     if (!WriteFile(pipe, &packet, sizeof(packet), &bytesWritten, nullptr))
     {
-        NT_RETURN_NTSTATUS(static_cast<NTSTATUS>(NTSTATUS_FROM_WIN32(::GetLastError())));
+        const auto gle = ::GetLastError();
+        NT_RETURN_NTSTATUS(static_cast<NTSTATUS>(NTSTATUS_FROM_WIN32(gle)));
     }
 
     if (bytesWritten != sizeof(packet))

--- a/src/interactivity/base/ServiceLocator.cpp
+++ b/src/interactivity/base/ServiceLocator.cpp
@@ -138,11 +138,11 @@ void ServiceLocator::RundownAndExit(const HRESULT hr)
         {
             status = ServiceLocator::LoadInteractivityFactory();
         }
-        if (NT_SUCCESS(status))
+        if (SUCCEEDED_NTSTATUS(status))
         {
             status = s_interactivityFactory->CreateConsoleInputThread(s_consoleInputThread);
 
-            if (NT_SUCCESS(status))
+            if (SUCCEEDED_NTSTATUS(status))
             {
                 *thread = s_consoleInputThread.get();
             }
@@ -232,7 +232,7 @@ IConsoleControl* ServiceLocator::LocateConsoleControl()
             status = ServiceLocator::LoadInteractivityFactory();
         }
 
-        if (NT_SUCCESS(status))
+        if (SUCCEEDED_NTSTATUS(status))
         {
             status = s_interactivityFactory->CreateConsoleControl(s_consoleControl);
         }
@@ -259,7 +259,7 @@ IHighDpiApi* ServiceLocator::LocateHighDpiApi()
             status = ServiceLocator::LoadInteractivityFactory();
         }
 
-        if (NT_SUCCESS(status))
+        if (SUCCEEDED_NTSTATUS(status))
         {
             status = s_interactivityFactory->CreateHighDpiApi(s_highDpiApi);
         }
@@ -281,7 +281,7 @@ IWindowMetrics* ServiceLocator::LocateWindowMetrics()
             status = ServiceLocator::LoadInteractivityFactory();
         }
 
-        if (NT_SUCCESS(status))
+        if (SUCCEEDED_NTSTATUS(status))
         {
             status = s_interactivityFactory->CreateWindowMetrics(s_windowMetrics);
         }
@@ -308,7 +308,7 @@ ISystemConfigurationProvider* ServiceLocator::LocateSystemConfigurationProvider(
             status = ServiceLocator::LoadInteractivityFactory();
         }
 
-        if (NT_SUCCESS(status))
+        if (SUCCEEDED_NTSTATUS(status))
         {
             status = s_interactivityFactory->CreateSystemConfigurationProvider(s_systemConfigurationProvider);
         }
@@ -341,7 +341,7 @@ HWND ServiceLocator::LocatePseudoWindow(const HWND owner)
             status = ServiceLocator::LoadInteractivityFactory();
         }
 
-        if (NT_SUCCESS(status))
+        if (SUCCEEDED_NTSTATUS(status))
         {
             HWND hwnd;
             status = s_interactivityFactory->CreatePseudoWindow(hwnd, owner);

--- a/src/interactivity/onecore/BgfxEngine.cpp
+++ b/src/interactivity/onecore/BgfxEngine.cpp
@@ -79,7 +79,7 @@ try
 {
     const auto Status = ConIoSrvComm::GetConIoSrvComm()->RequestUpdateDisplay(0);
 
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         for (SIZE_T i = 0; i < _displayHeight; i++)
         {

--- a/src/interactivity/onecore/ConIoSrvComm.cpp
+++ b/src/interactivity/onecore/ConIoSrvComm.cpp
@@ -105,6 +105,7 @@ ConIoSrvComm::~ConIoSrvComm()
     ALPC_MESSAGE_HANDLE_INFORMATION HandleInfo;
 
     // Initialize the attributes of the port object.
+#pragma warning(suppress : 26477) // This macro contains a bare NULL
     InitializeObjectAttributes(&ObjectAttributes,
                                nullptr,
                                0,

--- a/src/interactivity/onecore/ConIoSrvComm.cpp
+++ b/src/interactivity/onecore/ConIoSrvComm.cpp
@@ -162,7 +162,7 @@ ConIoSrvComm::~ConIoSrvComm()
                                nullptr,
                                ConnectionMessageAttributes,
                                nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         const auto ViewAttributes = ALPC_GET_DATAVIEW_ATTRIBUTES(ConnectionMessageAttributes);
         const auto HandleAttributes = ALPC_GET_HANDLE_ATTRIBUTES(ConnectionMessageAttributes);
@@ -174,7 +174,7 @@ ConIoSrvComm::~ConIoSrvComm()
             Status = STATUS_UNSUCCESSFUL;
         }
 
-        if (NT_SUCCESS(Status))
+        if (SUCCEEDED_NTSTATUS(Status))
         {
             // Get each handle out. ALPC does not allow to pass indirect handles
             // all at once; they must be retrieved one by one.
@@ -188,7 +188,7 @@ ConIoSrvComm::~ConIoSrvComm()
                                                        &HandleInfo,
                                                        sizeof(HandleInfo),
                                                        nullptr);
-                if (NT_SUCCESS(Status))
+                if (SUCCEEDED_NTSTATUS(Status))
                 {
                     if (Index == 0)
                     {
@@ -464,7 +464,7 @@ VOID ConIoSrvComm::CleanupForHeadless(const NTSTATUS status)
     Message.Type = CIS_MSG_TYPE_GETDISPLAYSIZE;
 
     auto Status = SendRequestReceiveReply(&Message);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         *pCdDisplaySize = Message.GetDisplaySizeParams.DisplaySize;
         Status = Message.GetDisplaySizeParams.ReturnValue;
@@ -479,7 +479,7 @@ VOID ConIoSrvComm::CleanupForHeadless(const NTSTATUS status)
     Message.Type = CIS_MSG_TYPE_GETFONTSIZE;
 
     auto Status = SendRequestReceiveReply(&Message);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         *pCdFontSize = Message.GetFontSizeParams.FontSize;
         Status = Message.GetFontSizeParams.ReturnValue;
@@ -495,7 +495,7 @@ VOID ConIoSrvComm::CleanupForHeadless(const NTSTATUS status)
     Message.SetCursorParams.CursorInformation = *pCdCursorInformation;
 
     auto Status = SendRequestReceiveReply(&Message);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         Status = Message.SetCursorParams.ReturnValue;
     }
@@ -510,7 +510,7 @@ VOID ConIoSrvComm::CleanupForHeadless(const NTSTATUS status)
     Message.UpdateDisplayParams.RowIndex = gsl::narrow<SHORT>(RowIndex);
 
     auto Status = SendRequestReceiveReply(&Message);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         Status = Message.UpdateDisplayParams.ReturnValue;
     }
@@ -523,7 +523,7 @@ VOID ConIoSrvComm::CleanupForHeadless(const NTSTATUS status)
     NTSTATUS Status;
 
     Status = EnsureConnection();
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         CIS_MSG Message = { 0 };
         Message.Type = CIS_MSG_TYPE_MAPVIRTUALKEY;
@@ -531,7 +531,7 @@ VOID ConIoSrvComm::CleanupForHeadless(const NTSTATUS status)
         Message.MapVirtualKeyParams.MapType = uMapType;
 
         Status = SendRequestReceiveReply(&Message);
-        if (NT_SUCCESS(Status))
+        if (SUCCEEDED_NTSTATUS(Status))
         {
             *puReturnValue = Message.MapVirtualKeyParams.ReturnValue;
         }
@@ -545,14 +545,14 @@ VOID ConIoSrvComm::CleanupForHeadless(const NTSTATUS status)
     NTSTATUS Status;
 
     Status = EnsureConnection();
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         CIS_MSG Message = { 0 };
         Message.Type = CIS_MSG_TYPE_VKKEYSCAN;
         Message.VkKeyScanParams.Character = wCharacter;
 
         Status = SendRequestReceiveReply(&Message);
-        if (NT_SUCCESS(Status))
+        if (SUCCEEDED_NTSTATUS(Status))
         {
             *psReturnValue = Message.VkKeyScanParams.ReturnValue;
         }
@@ -566,14 +566,14 @@ VOID ConIoSrvComm::CleanupForHeadless(const NTSTATUS status)
     NTSTATUS Status;
 
     Status = EnsureConnection();
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         CIS_MSG Message = { 0 };
         Message.Type = CIS_MSG_TYPE_GETKEYSTATE;
         Message.GetKeyStateParams.VirtualKey = iVirtualKey;
 
         Status = SendRequestReceiveReply(&Message);
-        if (NT_SUCCESS(Status))
+        if (SUCCEEDED_NTSTATUS(Status))
         {
             *psReturnValue = Message.GetKeyStateParams.ReturnValue;
         }
@@ -603,7 +603,7 @@ UINT ConIoSrvComm::ConIoMapVirtualKeyW(UINT uCode, UINT uMapType)
     UINT ReturnValue;
     Status = RequestMapVirtualKey(uCode, uMapType, &ReturnValue);
 
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         ReturnValue = 0;
         SetLastError(ERROR_PROC_NOT_FOUND);
@@ -619,7 +619,7 @@ SHORT ConIoSrvComm::ConIoVkKeyScanW(WCHAR ch)
     SHORT ReturnValue;
     Status = RequestVkKeyScan(ch, &ReturnValue);
 
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         ReturnValue = 0;
         SetLastError(ERROR_PROC_NOT_FOUND);
@@ -635,7 +635,7 @@ SHORT ConIoSrvComm::ConIoGetKeyState(int nVirtKey)
     SHORT ReturnValue;
     Status = RequestGetKeyState(nVirtKey, &ReturnValue);
 
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         ReturnValue = 0;
         SetLastError(ERROR_PROC_NOT_FOUND);
@@ -656,13 +656,13 @@ SHORT ConIoSrvComm::ConIoGetKeyState(int nVirtKey)
     const auto DisplaySize = Metrics->GetMaxClientRectInPixels();
     auto Status = GetLastError();
 
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         // Same with the font size.
         CD_IO_FONT_SIZE FontSize{};
         Status = RequestGetFontSize(&FontSize);
 
-        if (NT_SUCCESS(Status))
+        if (SUCCEEDED_NTSTATUS(Status))
         {
             try
             {

--- a/src/interactivity/onecore/ConIoSrvComm.cpp
+++ b/src/interactivity/onecore/ConIoSrvComm.cpp
@@ -604,7 +604,7 @@ UINT ConIoSrvComm::ConIoMapVirtualKeyW(UINT uCode, UINT uMapType)
     UINT ReturnValue;
     Status = RequestMapVirtualKey(uCode, uMapType, &ReturnValue);
 
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         ReturnValue = 0;
         SetLastError(ERROR_PROC_NOT_FOUND);
@@ -620,7 +620,7 @@ SHORT ConIoSrvComm::ConIoVkKeyScanW(WCHAR ch)
     SHORT ReturnValue;
     Status = RequestVkKeyScan(ch, &ReturnValue);
 
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         ReturnValue = 0;
         SetLastError(ERROR_PROC_NOT_FOUND);
@@ -636,7 +636,7 @@ SHORT ConIoSrvComm::ConIoGetKeyState(int nVirtKey)
     SHORT ReturnValue;
     Status = RequestGetKeyState(nVirtKey, &ReturnValue);
 
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         ReturnValue = 0;
         SetLastError(ERROR_PROC_NOT_FOUND);

--- a/src/interactivity/onecore/ConsoleInputThread.cpp
+++ b/src/interactivity/onecore/ConsoleInputThread.cpp
@@ -23,7 +23,7 @@ DWORD WINAPI ConsoleInputThreadProcOneCore(LPVOID /*lpParam*/)
 
     auto Status = Server->Connect();
 
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         const auto DisplayMode = Server->GetDisplayMode();
 
@@ -32,7 +32,7 @@ DWORD WINAPI ConsoleInputThreadProcOneCore(LPVOID /*lpParam*/)
             // Create and set the console window.
             static ConsoleWindow wnd;
 
-            if (NT_SUCCESS(Status))
+            if (SUCCEEDED_NTSTATUS(Status))
             {
                 LOG_IF_FAILED(ServiceLocator::SetConsoleWindowInstance(&wnd));
 
@@ -51,7 +51,7 @@ DWORD WINAPI ConsoleInputThreadProcOneCore(LPVOID /*lpParam*/)
                     break;
                 }
 
-                if (NT_SUCCESS(Status))
+                if (SUCCEEDED_NTSTATUS(Status))
                 {
                     globals.getConsoleInformation().GetActiveOutputBuffer().RefreshFontWithRenderer();
                 }
@@ -59,7 +59,7 @@ DWORD WINAPI ConsoleInputThreadProcOneCore(LPVOID /*lpParam*/)
                 globals.ntstatusConsoleInputInitStatus = Status;
                 globals.hConsoleInputInitEvent.SetEvent();
 
-                if (NT_SUCCESS(Status))
+                if (SUCCEEDED_NTSTATUS(Status))
                 {
                     try
                     {

--- a/src/interactivity/onecore/WindowMetrics.cpp
+++ b/src/interactivity/onecore/WindowMetrics.cpp
@@ -67,11 +67,11 @@ til::rect WindowMetrics::GetMinClientRectInPixels()
 
         auto Status = Server->RequestGetDisplaySize(&DisplaySizeIoctl);
 
-        if (NT_SUCCESS(Status))
+        if (SUCCEEDED_NTSTATUS(Status))
         {
             Status = Server->RequestGetFontSize(&FontSizeIoctl);
 
-            if (NT_SUCCESS(Status))
+            if (SUCCEEDED_NTSTATUS(Status))
             {
                 DisplaySize.top = 0;
                 DisplaySize.left = 0;

--- a/src/interactivity/win32/SystemConfigurationProvider.cpp
+++ b/src/interactivity/win32/SystemConfigurationProvider.cpp
@@ -112,7 +112,7 @@ void SystemConfigurationProvider::GetSettingsFromLink(
                                                                  &iShowWindow,
                                                                  &wHotKey);
 
-            if (NT_SUCCESS(Status))
+            if (SUCCEEDED_NTSTATUS(Status))
             {
                 // Convert results back to appropriate types and set.
                 if (SUCCEEDED(IntToWord(iShowWindow, &wShowWindow)))
@@ -148,7 +148,7 @@ void SystemConfigurationProvider::GetSettingsFromLink(
                 }
             }
 
-            if (NT_SUCCESS(Status) && fReadConsoleProperties)
+            if (SUCCEEDED_NTSTATUS(Status) && fReadConsoleProperties)
             {
                 // copy settings
                 pLinkSettings->InitFromStateInfo(&csi);

--- a/src/interactivity/win32/menu.cpp
+++ b/src/interactivity/win32/menu.cpp
@@ -56,7 +56,7 @@ Menu::Menu(HMENU hMenu, HMENU hHeirMenu) :
     auto pNewMenu = new (std::nothrow) Menu(hMenu, hHeirMenu);
     status = NT_TESTNULL(pNewMenu);
 
-    if (NT_SUCCESS(status))
+    if (SUCCEEDED_NTSTATUS(status))
     {
         int ItemLength;
         // Load the submenu to the system menu.

--- a/src/interactivity/win32/window.cpp
+++ b/src/interactivity/win32/window.cpp
@@ -153,7 +153,8 @@ Window::~Window()
 
             if (s_atomWindowClass == 0)
             {
-                status = NTSTATUS_FROM_WIN32(GetLastError());
+                const auto gle = GetLastError();
+                status = NTSTATUS_FROM_WIN32(gle);
             }
         }
     }
@@ -335,24 +336,26 @@ void Window::_UpdateSystemMetrics() const
 #if TIL_FEATURE_CONHOSTDXENGINE_ENABLED
             if (pDxEngine)
             {
-                status = NTSTATUS_FROM_WIN32(HRESULT_CODE((pDxEngine->SetHwnd(hWnd))));
-
-                if (SUCCEEDED_NTSTATUS(status))
+                HRESULT hr = S_OK;
+                if (SUCCEEDED(hr = pDxEngine->SetHwnd(hWnd)))
                 {
-                    status = NTSTATUS_FROM_WIN32(HRESULT_CODE((pDxEngine->Enable())));
+                    hr = pDxEngine->Enable();
                 }
+                status = NTSTATUS_FROM_HRESULT(hr);
             }
             else
 #endif
 #if TIL_FEATURE_CONHOSTATLASENGINE_ENABLED
                 if (pAtlasEngine)
             {
-                status = NTSTATUS_FROM_WIN32(HRESULT_CODE((pAtlasEngine->SetHwnd(hWnd))));
+                const auto hr = pAtlasEngine->SetHwnd(hWnd);
+                status = NTSTATUS_FROM_HRESULT(hr);
             }
             else
 #endif
             {
-                status = NTSTATUS_FROM_WIN32(HRESULT_CODE((pGdiEngine->SetHwnd(hWnd))));
+                const auto hr = pGdiEngine->SetHwnd(hWnd);
+                status = NTSTATUS_FROM_HRESULT(hr);
             }
 
             if (SUCCEEDED_NTSTATUS(status))

--- a/src/interactivity/win32/window.cpp
+++ b/src/interactivity/win32/window.cpp
@@ -92,17 +92,17 @@ Window::~Window()
 {
     auto status = s_RegisterWindowClass();
 
-    if (NT_SUCCESS(status))
+    if (SUCCEEDED_NTSTATUS(status))
     {
         auto pNewWindow = new (std::nothrow) Window();
 
         status = NT_TESTNULL(pNewWindow);
 
-        if (NT_SUCCESS(status))
+        if (SUCCEEDED_NTSTATUS(status))
         {
             status = pNewWindow->_MakeWindow(pSettings, pScreen);
 
-            if (NT_SUCCESS(status))
+            if (SUCCEEDED_NTSTATUS(status))
             {
                 LOG_IF_FAILED(ServiceLocator::SetConsoleWindowInstance(pNewWindow));
             }
@@ -147,7 +147,7 @@ Window::~Window()
         // Load icons
         status = Icon::Instance().GetIcons(&wc.hIcon, &wc.hIconSm);
 
-        if (NT_SUCCESS(status))
+        if (SUCCEEDED_NTSTATUS(status))
         {
             s_atomWindowClass = RegisterClassExW(&wc);
 
@@ -249,7 +249,7 @@ void Window::_UpdateSystemMetrics() const
         status = NTSTATUS_FROM_HRESULT(wil::ResultFromCaughtException());
     }
 
-    if (NT_SUCCESS(status))
+    if (SUCCEEDED_NTSTATUS(status))
     {
         auto& siAttached = GetScreenInfo();
 
@@ -328,7 +328,7 @@ void Window::_UpdateSystemMetrics() const
             status = NTSTATUS_FROM_WIN32(gle);
         }
 
-        if (NT_SUCCESS(status))
+        if (SUCCEEDED_NTSTATUS(status))
         {
             _hWnd = hWnd;
 
@@ -337,7 +337,7 @@ void Window::_UpdateSystemMetrics() const
             {
                 status = NTSTATUS_FROM_WIN32(HRESULT_CODE((pDxEngine->SetHwnd(hWnd))));
 
-                if (NT_SUCCESS(status))
+                if (SUCCEEDED_NTSTATUS(status))
                 {
                     status = NTSTATUS_FROM_WIN32(HRESULT_CODE((pDxEngine->Enable())));
                 }
@@ -355,14 +355,14 @@ void Window::_UpdateSystemMetrics() const
                 status = NTSTATUS_FROM_WIN32(HRESULT_CODE((pGdiEngine->SetHwnd(hWnd))));
             }
 
-            if (NT_SUCCESS(status))
+            if (SUCCEEDED_NTSTATUS(status))
             {
                 // Set alpha on window if requested
                 ApplyWindowOpacity();
 
                 status = Menu::CreateInstance(hWnd);
 
-                if (NT_SUCCESS(status))
+                if (SUCCEEDED_NTSTATUS(status))
                 {
                     gci.ConsoleIme.RefreshAreaAttributes();
 
@@ -430,7 +430,7 @@ void Window::_CloseWindow() const
         gci.Flags |= CONSOLE_IS_ICONIC;
     }
 
-    if (NT_SUCCESS(status))
+    if (SUCCEEDED_NTSTATUS(status))
     {
         ShowWindow(hWnd, wShowWindow);
 
@@ -1274,7 +1274,7 @@ void Window::s_ReinitializeFontsForDPIChange()
     HKEY hCurrentUserKey, hConsoleKey, hTitleKey;
     // Open the current user registry key.
     auto Status = RegistrySerialization::s_OpenCurrentUserConsoleTitleKey(pwszTitle, &hCurrentUserKey, &hConsoleKey, &hTitleKey);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         // Save window size
         auto windowRect = pWindow->GetWindowRect();
@@ -1286,7 +1286,7 @@ void Window::s_ReinitializeFontsForDPIChange()
                                                       REG_DWORD,
                                                       reinterpret_cast<BYTE*>(&dwValue),
                                                       static_cast<DWORD>(sizeof(dwValue)));
-        if (NT_SUCCESS(Status))
+        if (SUCCEEDED_NTSTATUS(Status))
         {
             const auto coordScreenBufferSize = gci.GetActiveOutputBuffer().GetBufferSize().Dimensions();
             auto screenBufferWidth = coordScreenBufferSize.width;
@@ -1298,7 +1298,7 @@ void Window::s_ReinitializeFontsForDPIChange()
                                                           REG_DWORD,
                                                           reinterpret_cast<BYTE*>(&dwValue),
                                                           static_cast<DWORD>(sizeof(dwValue)));
-            if (NT_SUCCESS(Status))
+            if (SUCCEEDED_NTSTATUS(Status))
             {
                 // Save window position
                 if (fAutoPos)
@@ -1336,7 +1336,7 @@ void Window::s_ReinitializeFontsForDPIChange()
 
     // Open the current user registry key.
     auto Status = RegistrySerialization::s_OpenCurrentUserConsoleTitleKey(pwszTitle, &hCurrentUserKey, &hConsoleKey, &hTitleKey);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         // Save window opacity
         DWORD dwValue;

--- a/src/interactivity/win32/windowio.cpp
+++ b/src/interactivity/win32/windowio.cpp
@@ -992,7 +992,7 @@ NTSTATUS InitWindowsSubsystem(_Out_ HHOOK* phhook)
     // Create and activate the main window
     auto Status = Window::CreateInstance(&gci, gci.ScreenBuffers);
 
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         RIPMSG2(RIP_WARNING, "CreateWindowsWindow failed with status 0x%x, gle = 0x%x", Status, GetLastError());
         return Status;
@@ -1053,7 +1053,7 @@ DWORD WINAPI ConsoleInputThreadProcWin32(LPVOID /*lpParameter*/)
     }
 
     UnlockConsole();
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         ServiceLocator::LocateGlobals().ntstatusConsoleInputInitStatus = Status;
         ServiceLocator::LocateGlobals().hConsoleInputInitEvent.SetEvent();

--- a/src/interactivity/win32/windowio.cpp
+++ b/src/interactivity/win32/windowio.cpp
@@ -992,7 +992,7 @@ NTSTATUS InitWindowsSubsystem(_Out_ HHOOK* phhook)
     // Create and activate the main window
     auto Status = Window::CreateInstance(&gci, gci.ScreenBuffers);
 
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         RIPMSG2(RIP_WARNING, "CreateWindowsWindow failed with status 0x%x, gle = 0x%x", Status, GetLastError());
         return Status;
@@ -1053,7 +1053,7 @@ DWORD WINAPI ConsoleInputThreadProcWin32(LPVOID /*lpParameter*/)
     }
 
     UnlockConsole();
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         ServiceLocator::LocateGlobals().ntstatusConsoleInputInitStatus = Status;
         ServiceLocator::LocateGlobals().hConsoleInputInitEvent.SetEvent();

--- a/src/propsheet/console.cpp
+++ b/src/propsheet/console.cpp
@@ -105,9 +105,9 @@ void SaveConsoleSettingsIfNeeded(const HWND hwnd)
         {
             SetGlobalRegistryValues();
             if (FAILED_NTSTATUS(ShortcutSerialization::s_SetLinkValues(gpStateInfo,
-                                                                           g_fEastAsianSystem,
-                                                                           g_fForceV2,
-                                                                           gpStateInfo->fIsV2Console)))
+                                                                       g_fEastAsianSystem,
+                                                                       g_fForceV2,
+                                                                       gpStateInfo->fIsV2Console)))
             {
                 WCHAR szMessage[MAX_PATH + 100];
                 WCHAR awchBuffer[MAX_PATH] = { 0 };

--- a/src/propsheet/console.cpp
+++ b/src/propsheet/console.cpp
@@ -104,7 +104,7 @@ void SaveConsoleSettingsIfNeeded(const HWND hwnd)
         if (gpStateInfo->LinkTitle != nullptr)
         {
             SetGlobalRegistryValues();
-            if (!SUCCEEDED_NTSTATUS(ShortcutSerialization::s_SetLinkValues(gpStateInfo,
+            if (FAILED_NTSTATUS(ShortcutSerialization::s_SetLinkValues(gpStateInfo,
                                                                            g_fEastAsianSystem,
                                                                            g_fForceV2,
                                                                            gpStateInfo->fIsV2Console)))

--- a/src/propsheet/console.cpp
+++ b/src/propsheet/console.cpp
@@ -104,10 +104,10 @@ void SaveConsoleSettingsIfNeeded(const HWND hwnd)
         if (gpStateInfo->LinkTitle != nullptr)
         {
             SetGlobalRegistryValues();
-            if (!NT_SUCCESS(ShortcutSerialization::s_SetLinkValues(gpStateInfo,
-                                                                   g_fEastAsianSystem,
-                                                                   g_fForceV2,
-                                                                   gpStateInfo->fIsV2Console)))
+            if (!SUCCEEDED_NTSTATUS(ShortcutSerialization::s_SetLinkValues(gpStateInfo,
+                                                                           g_fEastAsianSystem,
+                                                                           g_fForceV2,
+                                                                           gpStateInfo->fIsV2Console)))
             {
                 WCHAR szMessage[MAX_PATH + 100];
                 WCHAR awchBuffer[MAX_PATH] = { 0 };

--- a/src/propsheet/fontdlg.cpp
+++ b/src/propsheet/fontdlg.cpp
@@ -725,7 +725,7 @@ int FontListCreate(
     /*
      * This only enumerates face names and font sizes if necessary.
      */
-    if (!SUCCEEDED_NTSTATUS(EnumerateFonts(bLB ? EF_OEMFONT : EF_TTFONT)))
+    if (FAILED_NTSTATUS(EnumerateFonts(bLB ? EF_OEMFONT : EF_TTFONT)))
     {
         return LB_ERR;
     }

--- a/src/propsheet/fontdlg.cpp
+++ b/src/propsheet/fontdlg.cpp
@@ -725,7 +725,7 @@ int FontListCreate(
     /*
      * This only enumerates face names and font sizes if necessary.
      */
-    if (!NT_SUCCESS(EnumerateFonts(bLB ? EF_OEMFONT : EF_TTFONT)))
+    if (!SUCCEEDED_NTSTATUS(EnumerateFonts(bLB ? EF_OEMFONT : EF_TTFONT)))
     {
         return LB_ERR;
     }
@@ -1196,8 +1196,8 @@ int FindCreateFont(
     {
         // retrieve default font face name for this codepage, and then set it as our current face
         WCHAR szDefaultCodepageTTFont[LF_FACESIZE] = { 0 };
-        if (NT_SUCCESS(GetTTFontFaceForCodePage(CodePage, szDefaultCodepageTTFont, ARRAYSIZE(szDefaultCodepageTTFont))) &&
-            NT_SUCCESS(StringCchCopyW(DefaultTTFaceName, ARRAYSIZE(DefaultTTFaceName), szDefaultCodepageTTFont)))
+        if (SUCCEEDED_NTSTATUS(GetTTFontFaceForCodePage(CodePage, szDefaultCodepageTTFont, ARRAYSIZE(szDefaultCodepageTTFont))) &&
+            SUCCEEDED_NTSTATUS(StringCchCopyW(DefaultTTFaceName, ARRAYSIZE(DefaultTTFaceName), szDefaultCodepageTTFont)))
         {
             pwszFace = DefaultTTFaceName;
             Size.X = 0;

--- a/src/propsheet/registry.cpp
+++ b/src/propsheet/registry.cpp
@@ -176,7 +176,7 @@ DWORD GetRegistryValues(
     //
     Status = RegistrySerialization::s_OpenConsoleKey(&hCurrentUserKey, &hConsoleKey);
 
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         return 0;
     }
@@ -194,7 +194,7 @@ DWORD GetRegistryValues(
                                                      REG_DWORD,
                                                      (PBYTE)&dwValue,
                                                      nullptr);
-        if (NT_SUCCESS(Status))
+        if (SUCCEEDED_NTSTATUS(Status))
         {
             dwRet = dwValue;
         }
@@ -214,7 +214,7 @@ DWORD GetRegistryValues(
         Status = RegistrySerialization::s_OpenKey(hConsoleKey,
                                                   pStateInfo->OriginalTitle,
                                                   &hTitleKey);
-        if (!NT_SUCCESS(Status))
+        if (!SUCCEEDED_NTSTATUS(Status))
         {
             RegCloseKey(hConsoleKey);
             RegCloseKey(hCurrentUserKey);
@@ -232,7 +232,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->ScreenAttributes = (WORD)dwValue;
     }
@@ -247,7 +247,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->PopupAttributes = (WORD)dwValue;
     }
@@ -268,7 +268,7 @@ DWORD GetRegistryValues(
                                                      REG_DWORD,
                                                      (PBYTE)&dwValue,
                                                      nullptr);
-        if (NT_SUCCESS(Status))
+        if (SUCCEEDED_NTSTATUS(Status))
         {
             pStateInfo->ColorTable[i] = dwValue;
         }
@@ -283,7 +283,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->InsertMode = !!dwValue;
     }
@@ -297,7 +297,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->QuickEdit = !!dwValue;
     }
@@ -313,7 +313,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         if (IsValidCodePage(dwValue))
         {
@@ -330,7 +330,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->ScreenBufferSize.X = LOWORD(dwValue);
         pStateInfo->ScreenBufferSize.Y = HIWORD(dwValue);
@@ -345,7 +345,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->WindowSize.X = LOWORD(dwValue);
         pStateInfo->WindowSize.Y = HIWORD(dwValue);
@@ -360,7 +360,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->WindowPosX = (SHORT)LOWORD(dwValue);
         pStateInfo->WindowPosY = (SHORT)HIWORD(dwValue);
@@ -377,7 +377,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->FontSize.X = LOWORD(dwValue);
         pStateInfo->FontSize.Y = HIWORD(dwValue);
@@ -392,7 +392,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->FontFamily = dwValue;
     }
@@ -406,7 +406,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->FontWeight = dwValue;
     }
@@ -420,7 +420,7 @@ DWORD GetRegistryValues(
                                                  REG_SZ,
                                                  (PBYTE)awchBuffer,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         RtlCopyMemory(pStateInfo->FaceName, awchBuffer, sizeof(awchBuffer));
     }
@@ -434,7 +434,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->CursorSize = dwValue;
     }
@@ -448,7 +448,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->HistoryBufferSize = dwValue;
     }
@@ -462,7 +462,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->NumberOfHistoryBuffers = dwValue;
     }
@@ -476,7 +476,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->HistoryNoDup = dwValue;
     }
@@ -490,7 +490,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->fWrapText = dwValue;
     }
@@ -504,7 +504,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->fFilterOnPaste = dwValue;
     }
@@ -518,7 +518,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->fCtrlKeyShortcutsDisabled = dwValue;
     }
@@ -532,7 +532,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->fLineSelection = dwValue;
     }
@@ -546,7 +546,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         if (dwValue <= BYTE_MAX)
         {
@@ -561,7 +561,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->CursorColor = dwValue;
     }
@@ -572,7 +572,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->CursorType = dwValue;
     }
@@ -584,7 +584,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->InterceptCopyPaste = !!dwValue;
     }
@@ -596,7 +596,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->DefaultForeground = dwValue;
     }
@@ -608,7 +608,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->DefaultBackground = dwValue;
     }
@@ -620,7 +620,7 @@ DWORD GetRegistryValues(
                                                  REG_DWORD,
                                                  (PBYTE)&dwValue,
                                                  nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pStateInfo->TerminalScrolling = dwValue;
     }
@@ -693,7 +693,7 @@ VOID SetRegistryValues(
     //
     Status = RegistrySerialization::s_OpenConsoleKey(&hCurrentUserKey, &hConsoleKey);
 
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         return;
     }
@@ -719,7 +719,7 @@ VOID SetRegistryValues(
         Status = RegistrySerialization::s_CreateKey(hConsoleKey,
                                                     pStateInfo->OriginalTitle,
                                                     &hTitleKey);
-        if (!NT_SUCCESS(Status))
+        if (!SUCCEEDED_NTSTATUS(Status))
         {
             RegCloseKey(hConsoleKey);
             RegCloseKey(hCurrentUserKey);

--- a/src/propsheet/registry.cpp
+++ b/src/propsheet/registry.cpp
@@ -176,7 +176,7 @@ DWORD GetRegistryValues(
     //
     Status = RegistrySerialization::s_OpenConsoleKey(&hCurrentUserKey, &hConsoleKey);
 
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         return 0;
     }
@@ -214,7 +214,7 @@ DWORD GetRegistryValues(
         Status = RegistrySerialization::s_OpenKey(hConsoleKey,
                                                   pStateInfo->OriginalTitle,
                                                   &hTitleKey);
-        if (!SUCCEEDED_NTSTATUS(Status))
+        if (FAILED_NTSTATUS(Status))
         {
             RegCloseKey(hConsoleKey);
             RegCloseKey(hCurrentUserKey);
@@ -693,7 +693,7 @@ VOID SetRegistryValues(
     //
     Status = RegistrySerialization::s_OpenConsoleKey(&hCurrentUserKey, &hConsoleKey);
 
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         return;
     }
@@ -719,7 +719,7 @@ VOID SetRegistryValues(
         Status = RegistrySerialization::s_CreateKey(hConsoleKey,
                                                     pStateInfo->OriginalTitle,
                                                     &hTitleKey);
-        if (!SUCCEEDED_NTSTATUS(Status))
+        if (FAILED_NTSTATUS(Status))
         {
             RegCloseKey(hConsoleKey);
             RegCloseKey(hCurrentUserKey);

--- a/src/propsheet/util.cpp
+++ b/src/propsheet/util.cpp
@@ -67,7 +67,7 @@ BOOL InitializeConsoleState()
     OEMCP = GetOEMCP();
     g_fIsComCtlV6Present = IsComCtlV6Present();
 
-    return NT_SUCCESS(InitializeDbcsMisc());
+    return SUCCEEDED_NTSTATUS(InitializeDbcsMisc());
 }
 
 void UninitializeConsoleState()

--- a/src/propslib/RegistrySerialization.cpp
+++ b/src/propslib/RegistrySerialization.cpp
@@ -107,7 +107,7 @@ const size_t RegistrySerialization::s_GlobalPropMappingsSize = ARRAYSIZE(s_Globa
                                ToWin32RegistryType(pPropMap->propertyType),
                                (PBYTE)&dwValue,
                                nullptr);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         switch (pPropMap->propertyType)
         {
@@ -163,7 +163,7 @@ const size_t RegistrySerialization::s_GlobalPropMappingsSize = ARRAYSIZE(s_Globa
 
     auto pwchString = new (std::nothrow) WCHAR[cchField];
     auto Status = NT_TESTNULL(pwchString);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         Status = s_QueryValue(hKey,
                               pPropMap->pwszValueName,
@@ -171,7 +171,7 @@ const size_t RegistrySerialization::s_GlobalPropMappingsSize = ARRAYSIZE(s_Globa
                               ToWin32RegistryType(pPropMap->propertyType),
                               (PBYTE)pwchString,
                               nullptr);
-        if (NT_SUCCESS(Status))
+        if (SUCCEEDED_NTSTATUS(Status))
         {
             // ensure pwchString is null terminated
             pwchString[cchField - 1] = UNICODE_NULL;
@@ -206,7 +206,7 @@ const size_t RegistrySerialization::s_GlobalPropMappingsSize = ARRAYSIZE(s_Globa
     // Open the current user registry key.
     NTSTATUS Status = NTSTATUS_FROM_WIN32(RegOpenCurrentUser(KEY_READ | KEY_WRITE, &currentUserKey));
 
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         // Open the console registry key.
         Status = s_OpenKey(currentUserKey.get(), CONSOLE_REGISTRY_STRING, &consoleKey);
@@ -218,7 +218,7 @@ const size_t RegistrySerialization::s_GlobalPropMappingsSize = ARRAYSIZE(s_Globa
         }
 
         // If we're successful, give the keys back.
-        if (NT_SUCCESS(Status))
+        if (SUCCEEDED_NTSTATUS(Status))
         {
             *phCurrentUserKey = currentUserKey.release();
             *phConsoleKey = consoleKey.release();
@@ -397,7 +397,7 @@ const size_t RegistrySerialization::s_GlobalPropMappingsSize = ARRAYSIZE(s_Globa
         if (hConsoleKey != hKey)
         {
             Status = s_QueryValue(hConsoleKey, pwszValueName, cbDataLength, dwType, Data, nullptr);
-            if (NT_SUCCESS(Status))
+            if (SUCCEEDED_NTSTATUS(Status))
             {
                 fDeleteKey = (memcmp(pbData, Data, cbDataLength) == 0);
             }
@@ -425,15 +425,15 @@ const size_t RegistrySerialization::s_GlobalPropMappingsSize = ARRAYSIZE(s_Globa
     NTSTATUS Status = NTSTATUS_FROM_WIN32(RegOpenKeyW(HKEY_CURRENT_USER,
                                                       nullptr,
                                                       phCurrentUserKey));
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         Status = RegistrySerialization::s_CreateKey(*phCurrentUserKey,
                                                     CONSOLE_REGISTRY_STRING,
                                                     phConsoleKey);
-        if (NT_SUCCESS(Status))
+        if (SUCCEEDED_NTSTATUS(Status))
         {
             Status = RegistrySerialization::s_CreateKey(*phConsoleKey, title, phTitleKey);
-            if (!NT_SUCCESS(Status))
+            if (!SUCCEEDED_NTSTATUS(Status))
             {
                 RegCloseKey(*phConsoleKey);
                 RegCloseKey(*phCurrentUserKey);

--- a/src/propslib/RegistrySerialization.cpp
+++ b/src/propslib/RegistrySerialization.cpp
@@ -204,7 +204,8 @@ const size_t RegistrySerialization::s_GlobalPropMappingsSize = ARRAYSIZE(s_Globa
     wil::unique_hkey consoleKey;
 
     // Open the current user registry key.
-    NTSTATUS Status = NTSTATUS_FROM_WIN32(RegOpenCurrentUser(KEY_READ | KEY_WRITE, &currentUserKey));
+    const auto win32Result = RegOpenCurrentUser(KEY_READ | KEY_WRITE, &currentUserKey);
+    NTSTATUS Status = NTSTATUS_FROM_WIN32(win32Result);
 
     if (SUCCEEDED_NTSTATUS(Status))
     {
@@ -239,7 +240,8 @@ const size_t RegistrySerialization::s_GlobalPropMappingsSize = ARRAYSIZE(s_Globa
 // - STATUS_SUCCESSFUL or appropriate NTSTATUS reply for registry operations.
 [[nodiscard]] NTSTATUS RegistrySerialization::s_OpenKey(_In_opt_ HKEY const hKey, _In_ PCWSTR const pwszSubKey, _Out_ HKEY* const phResult)
 {
-    return NTSTATUS_FROM_WIN32(RegOpenKeyW(hKey, pwszSubKey, phResult));
+    const auto result = RegOpenKeyW(hKey, pwszSubKey, phResult);
+    return NTSTATUS_FROM_WIN32(result);
 }
 
 // Routine Description:
@@ -267,7 +269,8 @@ const size_t RegistrySerialization::s_GlobalPropMappingsSize = ARRAYSIZE(s_Globa
 // - STATUS_SUCCESSFUL or appropriate NTSTATUS reply for registry operations.
 [[nodiscard]] NTSTATUS RegistrySerialization::s_CreateKey(const HKEY hKey, _In_ PCWSTR const pwszSubKey, _Out_ HKEY* const phResult)
 {
-    return NTSTATUS_FROM_WIN32(RegCreateKeyW(hKey, pwszSubKey, phResult));
+    const auto result = RegCreateKeyW(hKey, pwszSubKey, phResult);
+    return NTSTATUS_FROM_WIN32(result);
 }
 
 // Routine Description:
@@ -286,12 +289,13 @@ const size_t RegistrySerialization::s_GlobalPropMappingsSize = ARRAYSIZE(s_Globa
                                                          _In_reads_bytes_(cbDataLength) BYTE* const pbData,
                                                          const DWORD cbDataLength)
 {
-    return NTSTATUS_FROM_WIN32(RegSetKeyValueW(hKey,
-                                               nullptr,
-                                               pValueName,
-                                               dwType,
-                                               pbData,
-                                               cbDataLength));
+    const auto result = RegSetKeyValueW(hKey,
+                                        nullptr,
+                                        pValueName,
+                                        dwType,
+                                        pbData,
+                                        cbDataLength);
+    return NTSTATUS_FROM_WIN32(result);
 }
 
 // Routine Description:
@@ -357,14 +361,15 @@ const size_t RegistrySerialization::s_GlobalPropMappingsSize = ARRAYSIZE(s_Globa
     auto cbData = cbDataLength;
 
 #pragma prefast(suppress : 26015, "prefast doesn't realize that cbData == cbDataLength and cchValueName == cbValueLength/2")
-    return NTSTATUS_FROM_WIN32(RegEnumValueW(hKey,
-                                             dwIndex,
-                                             pwszValueName,
-                                             &cchValueName,
-                                             nullptr,
-                                             nullptr,
-                                             pbData,
-                                             &cbData));
+    const auto result = RegEnumValueW(hKey,
+                                      dwIndex,
+                                      pwszValueName,
+                                      &cchValueName,
+                                      nullptr,
+                                      nullptr,
+                                      pbData,
+                                      &cbData);
+    return NTSTATUS_FROM_WIN32(result);
 }
 
 // Routine Description:
@@ -422,9 +427,10 @@ const size_t RegistrySerialization::s_GlobalPropMappingsSize = ARRAYSIZE(s_Globa
                                                                                _Out_ HKEY* phConsoleKey,
                                                                                _Out_ HKEY* phTitleKey)
 {
-    NTSTATUS Status = NTSTATUS_FROM_WIN32(RegOpenKeyW(HKEY_CURRENT_USER,
-                                                      nullptr,
-                                                      phCurrentUserKey));
+    const auto win32Result = RegOpenKeyW(HKEY_CURRENT_USER,
+                                         nullptr,
+                                         phCurrentUserKey);
+    NTSTATUS Status = NTSTATUS_FROM_WIN32(win32Result);
     if (SUCCEEDED_NTSTATUS(Status))
     {
         Status = RegistrySerialization::s_CreateKey(*phCurrentUserKey,

--- a/src/propslib/RegistrySerialization.cpp
+++ b/src/propslib/RegistrySerialization.cpp
@@ -252,7 +252,7 @@ const size_t RegistrySerialization::s_GlobalPropMappingsSize = ARRAYSIZE(s_Globa
 [[nodiscard]] NTSTATUS RegistrySerialization::s_DeleteValue(const HKEY hKey, _In_ PCWSTR const pwszValueName)
 {
     const auto result = RegDeleteKeyValueW(hKey, nullptr, pwszValueName);
-    return result == ERROR_FILE_NOT_FOUND ? S_OK : NTSTATUS_FROM_WIN32(result);
+    return result == ERROR_FILE_NOT_FOUND ? STATUS_SUCCESS : NTSTATUS_FROM_WIN32(result);
 }
 
 // Routine Description:

--- a/src/propslib/RegistrySerialization.cpp
+++ b/src/propslib/RegistrySerialization.cpp
@@ -439,7 +439,7 @@ const size_t RegistrySerialization::s_GlobalPropMappingsSize = ARRAYSIZE(s_Globa
         if (SUCCEEDED_NTSTATUS(Status))
         {
             Status = RegistrySerialization::s_CreateKey(*phConsoleKey, title, phTitleKey);
-            if (!SUCCEEDED_NTSTATUS(Status))
+            if (FAILED_NTSTATUS(Status))
             {
                 RegCloseKey(*phConsoleKey);
                 RegCloseKey(*phCurrentUserKey);

--- a/src/propslib/ShortcutSerialization.cpp
+++ b/src/propslib/ShortcutSerialization.cpp
@@ -243,13 +243,13 @@ void ShortcutSerialization::s_GetLinkTitle(_In_ PCWSTR pwszShortcutFilename,
                                            const size_t cchShortcutTitle)
 {
     auto Status = (cchShortcutTitle > 0) ? STATUS_SUCCESS : STATUS_INVALID_PARAMETER_2;
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         pwszShortcutTitle[0] = L'\0';
 
         WCHAR szTemp[MAX_PATH];
         Status = StringCchCopyW(szTemp, ARRAYSIZE(szTemp), pwszShortcutFilename);
-        if (NT_SUCCESS(Status))
+        if (SUCCEEDED_NTSTATUS(Status))
         {
             // Now load the localized title for the shortcut
             IShellItem* psi;
@@ -268,11 +268,11 @@ void ShortcutSerialization::s_GetLinkTitle(_In_ PCWSTR pwszShortcutFilename,
             }
         }
 
-        if (!NT_SUCCESS(Status))
+        if (!SUCCEEDED_NTSTATUS(Status))
         {
             // default to an extension-free version of the filename passed in
             Status = StringCchCopyW(pwszShortcutTitle, cchShortcutTitle, pwszShortcutFilename);
-            if (NT_SUCCESS(Status))
+            if (SUCCEEDED_NTSTATUS(Status))
             {
                 // don't care if we can't remove the extension
                 (void)PathCchRemoveExtension(pwszShortcutTitle, cchShortcutTitle);

--- a/src/propslib/ShortcutSerialization.cpp
+++ b/src/propslib/ShortcutSerialization.cpp
@@ -268,7 +268,7 @@ void ShortcutSerialization::s_GetLinkTitle(_In_ PCWSTR pwszShortcutFilename,
             }
         }
 
-        if (!SUCCEEDED_NTSTATUS(Status))
+        if (FAILED_NTSTATUS(Status))
         {
             // default to an extension-free version of the filename passed in
             Status = StringCchCopyW(pwszShortcutTitle, cchShortcutTitle, pwszShortcutFilename);

--- a/src/propslib/TrueTypeFontList.cpp
+++ b/src/propslib/TrueTypeFontList.cpp
@@ -46,7 +46,7 @@ WORD ConvertStringToDec(
     auto Status = RegistrySerialization::s_OpenKey(HKEY_LOCAL_MACHINE,
                                                    MACHINE_REGISTRY_CONSOLE_TTFONT_WIN32_PATH,
                                                    &hkRegistry);
-    if (NT_SUCCESS(Status))
+    if (SUCCEEDED_NTSTATUS(Status))
     {
         LPTTFONTLIST pTTFontList;
 
@@ -65,7 +65,7 @@ WORD ConvertStringToDec(
                 break;
             }
 
-            if (!NT_SUCCESS(Status))
+            if (!SUCCEEDED_NTSTATUS(Status))
             {
                 break;
             }

--- a/src/propslib/TrueTypeFontList.cpp
+++ b/src/propslib/TrueTypeFontList.cpp
@@ -65,7 +65,7 @@ WORD ConvertStringToDec(
                 break;
             }
 
-            if (!SUCCEEDED_NTSTATUS(Status))
+            if (FAILED_NTSTATUS(Status))
             {
                 break;
             }

--- a/src/propslib/precomp.h
+++ b/src/propslib/precomp.h
@@ -15,7 +15,6 @@ typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 /*lint -save -e624 */ // Don't complain about different typedefs.
 typedef NTSTATUS* PNTSTATUS;
 /*lint -restore */ // Resume checking for different typedefs.
-#define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
 
 #define INLINE_NTSTATUS_FROM_WIN32 1 // Must use inline NTSTATUS or it will call the wrapped function twice.
 #pragma warning(push)

--- a/src/propslib/precomp.h
+++ b/src/propslib/precomp.h
@@ -10,13 +10,8 @@
 #include <windows.h>
 #undef WIN32_NO_STATUS
 
-// From ntdef.h, but that can't be included or it'll fight over PROBE_ALIGNMENT and other such arch specific defs
-typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
-/*lint -save -e624 */ // Don't complain about different typedefs.
-typedef NTSTATUS* PNTSTATUS;
-/*lint -restore */ // Resume checking for different typedefs.
+#include <winternl.h>
 
-#define INLINE_NTSTATUS_FROM_WIN32 1 // Must use inline NTSTATUS or it will call the wrapped function twice.
 #pragma warning(push)
 #pragma warning(disable : 4430) // Must disable 4430 "default int" warning for C++ because ntstatus.h is inflexible SDK definition.
 #include <ntstatus.h>

--- a/src/renderer/base/precomp.h
+++ b/src/renderer/base/precomp.h
@@ -22,8 +22,3 @@ Abstract:
 #include <wincon.h>
 
 #include "../../types/inc/viewport.hpp"
-
-#ifndef _NTSTATUS_DEFINED
-#define _NTSTATUS_DEFINED
-typedef _Return_type_success_(return >= 0) long NTSTATUS;
-#endif

--- a/src/renderer/base/precomp.h
+++ b/src/renderer/base/precomp.h
@@ -27,5 +27,3 @@ Abstract:
 #define _NTSTATUS_DEFINED
 typedef _Return_type_success_(return >= 0) long NTSTATUS;
 #endif
-
-#define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)

--- a/src/renderer/gdi/precomp.h
+++ b/src/renderer/gdi/precomp.h
@@ -20,22 +20,6 @@ Abstract:
 #include <windowsx.h>
 #include <usp10.h>
 
-#ifndef _NTSTATUS_DEFINED
-#define _NTSTATUS_DEFINED
-typedef _Return_type_success_(return >= 0) long NTSTATUS;
-#endif
-
-//#include <ntstatus.h>
-#define STATUS_SUCCESS ((NTSTATUS)0x00000000L) // ntsubauth
-#define FACILITY_NTWIN32 0x7
-__inline int NTSTATUS_FROM_WIN32(long x)
-{
-    return x <= 0 ? (NTSTATUS)x : (NTSTATUS)(((x)&0x0000FFFF) | (FACILITY_NTWIN32 << 16) | ERROR_SEVERITY_ERROR);
-}
-
-#define NT_TESTNULL(var) (((var) == nullptr) ? STATUS_NO_MEMORY : STATUS_SUCCESS)
-#define NT_TESTNULL_GLE(var) (((var) == nullptr) ? NTSTATUS_FROM_WIN32(GetLastError()) : STATUS_SUCCESS);
-
 #if defined(DEBUG) || defined(_DEBUG) || defined(DBG)
 #define WHEN_DBG(x) x
 #else

--- a/src/renderer/gdi/precomp.h
+++ b/src/renderer/gdi/precomp.h
@@ -25,8 +25,6 @@ Abstract:
 typedef _Return_type_success_(return >= 0) long NTSTATUS;
 #endif
 
-#define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
-
 //#include <ntstatus.h>
 #define STATUS_SUCCESS ((NTSTATUS)0x00000000L) // ntsubauth
 #define FACILITY_NTWIN32 0x7

--- a/src/renderer/vt/precomp.h
+++ b/src/renderer/vt/precomp.h
@@ -19,22 +19,6 @@ Abstract:
 #include <windows.h>
 #include <windowsx.h>
 
-#ifndef _NTSTATUS_DEFINED
-#define _NTSTATUS_DEFINED
-typedef _Return_type_success_(return >= 0) long NTSTATUS;
-#endif
-
-//#include <ntstatus.h>
-#define STATUS_SUCCESS ((NTSTATUS)0x00000000L) // ntsubauth
-#define FACILITY_NTWIN32 0x7
-__inline int NTSTATUS_FROM_WIN32(long x)
-{
-    return x <= 0 ? (NTSTATUS)x : (NTSTATUS)(((x)&0x0000FFFF) | (FACILITY_NTWIN32 << 16) | ERROR_SEVERITY_ERROR);
-}
-
-#define NT_TESTNULL(var) (((var) == nullptr) ? STATUS_NO_MEMORY : STATUS_SUCCESS)
-#define NT_TESTNULL_GLE(var) (((var) == nullptr) ? NTSTATUS_FROM_WIN32(GetLastError()) : STATUS_SUCCESS);
-
 #if defined(DEBUG) || defined(_DEBUG) || defined(DBG)
 #define WHEN_DBG(x) x
 #else

--- a/src/renderer/vt/precomp.h
+++ b/src/renderer/vt/precomp.h
@@ -24,8 +24,6 @@ Abstract:
 typedef _Return_type_success_(return >= 0) long NTSTATUS;
 #endif
 
-#define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
-
 //#include <ntstatus.h>
 #define STATUS_SUCCESS ((NTSTATUS)0x00000000L) // ntsubauth
 #define FACILITY_NTWIN32 0x7

--- a/src/renderer/wddmcon/oss_shim.h
+++ b/src/renderer/wddmcon/oss_shim.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
-
 #include "../host/conddkrefs.h"
 #include <condrv.h>
 

--- a/src/server/ApiMessage.cpp
+++ b/src/server/ApiMessage.cpp
@@ -213,7 +213,7 @@ CATCH_RETURN();
 
     if (State.OutputBuffer != nullptr)
     {
-        if (NT_SUCCESS(Complete.IoStatus.Status))
+        if (SUCCEEDED_NTSTATUS(Complete.IoStatus.Status))
         {
             CD_IO_OPERATION IoOperation;
             IoOperation.Identifier = Descriptor.Identifier;

--- a/src/server/IoDispatchers.cpp
+++ b/src/server/IoDispatchers.cpp
@@ -90,7 +90,7 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleCreateObject(_In_ PCONSOLE_API_MSG pMessa
         Status = STATUS_INVALID_PARAMETER;
     }
 
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         UnlockConsole();
         pMessage->SetReplyStatus(Status);
@@ -421,7 +421,7 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleHandleConnectionRequest(_In_ PCONSOLE_API
     LockConsole();
 
     const auto cleanup = wil::scope_exit([&]() noexcept {
-        if (!NT_SUCCESS(Status))
+        if (!SUCCEEDED_NTSTATUS(Status))
         {
             pReceiveMsg->SetReplyStatus(Status);
             if (ProcessData != nullptr)
@@ -440,7 +440,7 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleHandleConnectionRequest(_In_ PCONSOLE_API
 
     CONSOLE_API_CONNECTINFO Cac;
     Status = ConsoleInitializeConnectInfo(pReceiveMsg, &Cac);
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         return pReceiveMsg;
     }
@@ -454,7 +454,7 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleHandleConnectionRequest(_In_ PCONSOLE_API
                                                                           Cac.ProcessGroupId,
                                                                           &ProcessData));
 
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         return pReceiveMsg;
     }
@@ -476,7 +476,7 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleHandleConnectionRequest(_In_ PCONSOLE_API
     if (WI_IsFlagClear(gci.Flags, CONSOLE_INITIALIZED))
     {
         Status = ConsoleAllocateConsole(&Cac);
-        if (!NT_SUCCESS(Status))
+        if (!SUCCEEDED_NTSTATUS(Status))
         {
             return pReceiveMsg;
         }
@@ -518,7 +518,7 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleHandleConnectionRequest(_In_ PCONSOLE_API
                                                                       FILE_SHARE_READ | FILE_SHARE_WRITE,
                                                                       ProcessData->pInputHandle));
 
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         return pReceiveMsg;
     }
@@ -529,7 +529,7 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleHandleConnectionRequest(_In_ PCONSOLE_API
                                                                FILE_SHARE_READ | FILE_SHARE_WRITE,
                                                                ProcessData->pOutputHandle));
 
-    if (!NT_SUCCESS(Status))
+    if (!SUCCEEDED_NTSTATUS(Status))
     {
         return pReceiveMsg;
     }

--- a/src/server/IoDispatchers.cpp
+++ b/src/server/IoDispatchers.cpp
@@ -90,7 +90,7 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleCreateObject(_In_ PCONSOLE_API_MSG pMessa
         Status = STATUS_INVALID_PARAMETER;
     }
 
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         UnlockConsole();
         pMessage->SetReplyStatus(Status);
@@ -421,7 +421,7 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleHandleConnectionRequest(_In_ PCONSOLE_API
     LockConsole();
 
     const auto cleanup = wil::scope_exit([&]() noexcept {
-        if (!SUCCEEDED_NTSTATUS(Status))
+        if (FAILED_NTSTATUS(Status))
         {
             pReceiveMsg->SetReplyStatus(Status);
             if (ProcessData != nullptr)
@@ -440,7 +440,7 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleHandleConnectionRequest(_In_ PCONSOLE_API
 
     CONSOLE_API_CONNECTINFO Cac;
     Status = ConsoleInitializeConnectInfo(pReceiveMsg, &Cac);
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         return pReceiveMsg;
     }
@@ -454,7 +454,7 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleHandleConnectionRequest(_In_ PCONSOLE_API
                                                                           Cac.ProcessGroupId,
                                                                           &ProcessData));
 
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         return pReceiveMsg;
     }
@@ -476,7 +476,7 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleHandleConnectionRequest(_In_ PCONSOLE_API
     if (WI_IsFlagClear(gci.Flags, CONSOLE_INITIALIZED))
     {
         Status = ConsoleAllocateConsole(&Cac);
-        if (!SUCCEEDED_NTSTATUS(Status))
+        if (FAILED_NTSTATUS(Status))
         {
             return pReceiveMsg;
         }
@@ -518,7 +518,7 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleHandleConnectionRequest(_In_ PCONSOLE_API
                                                                       FILE_SHARE_READ | FILE_SHARE_WRITE,
                                                                       ProcessData->pInputHandle));
 
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         return pReceiveMsg;
     }
@@ -529,7 +529,7 @@ PCONSOLE_API_MSG IoDispatchers::ConsoleHandleConnectionRequest(_In_ PCONSOLE_API
                                                                FILE_SHARE_READ | FILE_SHARE_WRITE,
                                                                ProcessData->pOutputHandle));
 
-    if (!SUCCEEDED_NTSTATUS(Status))
+    if (FAILED_NTSTATUS(Status))
     {
         return pReceiveMsg;
     }

--- a/src/server/precomp.h
+++ b/src/server/precomp.h
@@ -27,7 +27,6 @@ Abstract:
 #include <windows.h>
 
 typedef long NTSTATUS;
-#define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
 #define STATUS_SUCCESS ((DWORD)0x0)
 #define STATUS_UNSUCCESSFUL ((DWORD)0xC0000001L)
 #define STATUS_SHARING_VIOLATION ((NTSTATUS)0xC0000043L)

--- a/src/server/precomp.h
+++ b/src/server/precomp.h
@@ -24,41 +24,16 @@ Abstract:
 #define NOMINMAX
 
 // Windows Header Files:
+#define WIN32_NO_STATUS
 #include <windows.h>
+#undef WIN32_NO_STATUS
 
-typedef long NTSTATUS;
-#define STATUS_SUCCESS ((DWORD)0x0)
-#define STATUS_UNSUCCESSFUL ((DWORD)0xC0000001L)
-#define STATUS_SHARING_VIOLATION ((NTSTATUS)0xC0000043L)
-#define STATUS_INSUFFICIENT_RESOURCES ((DWORD)0xC000009AL)
-#define STATUS_ILLEGAL_FUNCTION ((DWORD)0xC00000AFL)
-#define STATUS_PIPE_DISCONNECTED ((DWORD)0xC00000B0L)
-#define STATUS_BUFFER_TOO_SMALL ((DWORD)0xC0000023L)
-#define STATUS_NOT_FOUND ((NTSTATUS)0xC0000225L)
+#include <winternl.h>
 
-//
-// Map a WIN32 error value into an NTSTATUS
-// Note: This assumes that WIN32 errors fall in the range -32k to 32k.
-//
-
-#define FACILITY_NTWIN32 0x7
-
-#define __NTSTATUS_FROM_WIN32(x) ((NTSTATUS)(x) <= 0 ? ((NTSTATUS)(x)) : ((NTSTATUS)(((x)&0x0000FFFF) | (FACILITY_NTWIN32 << 16) | ERROR_SEVERITY_ERROR)))
-
-#ifdef INLINE_NTSTATUS_FROM_WIN32
-#ifndef __midl
-__inline NTSTATUS_FROM_WIN32(long x)
-{
-    return x <= 0 ? (NTSTATUS)x : (NTSTATUS)(((x)&0x0000FFFF) | (FACILITY_NTWIN32 << 16) | ERROR_SEVERITY_ERROR);
-}
-#else
-#define NTSTATUS_FROM_WIN32(x) __NTSTATUS_FROM_WIN32(x)
-#endif
-#else
-#define NTSTATUS_FROM_WIN32(x) __NTSTATUS_FROM_WIN32(x)
-#endif
-
-//#include <ntstatus.h>
+#pragma warning(push)
+#pragma warning(disable : 4430) // Must disable 4430 "default int" warning for C++ because ntstatus.h is inflexible SDK definition.
+#include <ntstatus.h>
+#pragma warning(pop)
 
 #include <winioctl.h>
 #include <intsafe.h>

--- a/src/winconpty/precomp.h
+++ b/src/winconpty/precomp.h
@@ -29,8 +29,6 @@ typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 /*lint -save -e624 */ // Don't complain about different typedefs.
 typedef NTSTATUS* PNTSTATUS;
 /*lint -restore */ // Resume checking for different typedefs.
-#define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
-
 // End From ntdef.h
 
 #define INLINE_NTSTATUS_FROM_WIN32 1 // Must use inline NTSTATUS or it will call the wrapped function twice.

--- a/src/winconpty/precomp.h
+++ b/src/winconpty/precomp.h
@@ -24,14 +24,8 @@ Abstract:
 #include <windows.h>
 #undef WIN32_NO_STATUS
 
-// From ntdef.h, but that can't be included or it'll fight over PROBE_ALIGNMENT and other such arch specific defs
-typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
-/*lint -save -e624 */ // Don't complain about different typedefs.
-typedef NTSTATUS* PNTSTATUS;
-/*lint -restore */ // Resume checking for different typedefs.
-// End From ntdef.h
+#include <winternl.h>
 
-#define INLINE_NTSTATUS_FROM_WIN32 1 // Must use inline NTSTATUS or it will call the wrapped function twice.
 #pragma warning(push)
 #pragma warning(disable : 4430) // Must disable 4430 "default int" warning for C++ because ntstatus.h is inflexible SDK definition.
 #include <ntstatus.h>


### PR DESCRIPTION
This PR makes the following project-wide changes/replacements as a first step in
cleaning up our use of `NTSTATUS`.

* Rewriting any uses of `NTSTATUS_FROM_WIN32` that were vulnerable to multiple evaluation bugs
  * This is required because the macro version of `NTSTATUS_FROM_WIN32` evaluates its argument twice
* Removing all our local redefinitions of `NTSTATUS` in favor of that of `winternl.h`
  * Because of this, we got to (had to?) remove some old transclusions from `conddkrefs.h`
* `NT_SUCCESS` (ours) -> `SUCCEEDED_NTSTATUS` (wil)
* `VERIFY_IS_TRUE(NT_SUCCESS())` (overly elaborate) -> `VERIFY_NT_SUCCESS` (WEX)
* `VERIFY_SUCCESS_NTSTATUS` (ours) -> `VERIFY_NT_SUCCESS` (WEX)
* One bad use of S_OK as an NTSTATUS -> `STATUS_SUCCESS`
* Removing `NTSTATUS` from any projects that do not use it