### PR TITLE
Add a proper reference from TermCore to MidiAudio

### DIFF
--- a/src/cascadia/TerminalCore/lib/terminalcore-lib.vcxproj
+++ b/src/cascadia/TerminalCore/lib/terminalcore-lib.vcxproj
@@ -46,6 +46,9 @@
     <ProjectReference Include="$(OpenConsoleDir)src\renderer\dx\lib\dx.vcxproj">
       <Project>{48d21369-3d7b-4431-9967-24e81292cf62}</Project>
     </ProjectReference>
+    <ProjectReference Include="$(OpenConsoleDir)src\audio\midi\lib\midi.vcxproj">
+      <Project>{3c67784e-1453-49c2-9660-483e2cc7f7ad}</Project>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
It was just by luck that TerminalCore usually built after MidiAudio