### PR TITLE
Correctness: Remove JsonUtils and IconConverter's 2-phase lookup bugs

### DIFF
--- a/src/cascadia/LocalTests_SettingsModel/SettingsModel.LocalTests.vcxproj
+++ b/src/cascadia/LocalTests_SettingsModel/SettingsModel.LocalTests.vcxproj
@@ -73,8 +73,6 @@
     <ClCompile>
       <AdditionalIncludeDirectories>..;$(OpenConsoleDir)\dep;$(OpenConsoleDir)\dep\jsoncpp\json;$(OpenConsoleDir)src\inc;$(OpenConsoleDir)src\inc\test;$(WinRT_IncludePath)\..\cppwinrt\winrt;"$(OpenConsoleDir)\src\cascadia\TerminalSettingsModel\Generated Files";%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <!-- Required for JsonUtils.h. -->
-      <AdditionalOptions>%(AdditionalOptions) /Zc:twoPhase-</AdditionalOptions>
       <!-- Manually disable unreachable code warning, because jconcpp has a ton of that. -->
       <DisableSpecificWarnings>4702;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>

--- a/src/cascadia/LocalTests_TerminalApp/TestHostApp/TestHostApp.vcxproj
+++ b/src/cascadia/LocalTests_TerminalApp/TestHostApp/TestHostApp.vcxproj
@@ -53,9 +53,8 @@
 
   <ItemDefinitionGroup>
     <ClCompile>
-      <!-- Disable C++20 and two-phase name lookup for C++/CLI & C++/CX code. -->
+      <!-- Disable C++20 for C++/CLI & C++/CX code. -->
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalOptions>%(AdditionalOptions) /Zc:twoPhase-</AdditionalOptions>
       <DisableSpecificWarnings>4453;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(IntermediateOutputPath)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>INLINE_TEST_METHOD_MARKUP;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/cascadia/LocalTests_TerminalApp/TestHostApp/TestHostApp.vcxproj
+++ b/src/cascadia/LocalTests_TerminalApp/TestHostApp/TestHostApp.vcxproj
@@ -53,8 +53,9 @@
 
   <ItemDefinitionGroup>
     <ClCompile>
-      <!-- Disable C++20 for C++/CLI & C++/CX code. -->
+      <!-- Disable C++20 and two-phase name lookup for C++/CLI & C++/CX code. -->
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions>%(AdditionalOptions) /Zc:twoPhase-</AdditionalOptions>
       <DisableSpecificWarnings>4453;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(IntermediateOutputPath)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>INLINE_TEST_METHOD_MARKUP;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/cascadia/TerminalSettingsModel/IconPathConverter.cpp
+++ b/src/cascadia/TerminalSettingsModel/IconPathConverter.cpp
@@ -81,7 +81,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             try
             {
                 winrt::Windows::Foundation::Uri iconUri{ path };
-                BitmapIconSource<TIconSource>::type iconSource;
+                typename BitmapIconSource<TIconSource>::type iconSource;
                 // Make sure to set this to false, so we keep the RGB data of the
                 // image. Otherwise, the icon will be white for all the
                 // non-transparent pixels in the image.
@@ -93,6 +93,16 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         }
 
         return nullptr;
+    }
+
+    _TIL_INLINEPREFIX winrt::hstring _expandIconPath(hstring iconPath)
+    {
+        if (iconPath.empty())
+        {
+            return iconPath;
+        }
+        winrt::hstring envExpandedPath{ wil::ExpandEnvironmentStringsW<std::wstring>(iconPath.c_str()) };
+        return envExpandedPath;
     }
 
     // Method Description:
@@ -129,7 +139,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             {
                 try
                 {
-                    FontIconSource<TIconSource>::type icon;
+                    typename FontIconSource<TIconSource>::type icon;
                     const auto ch = iconPath[0];
 
                     // The range of MDL2 Icons isn't explicitly defined, but
@@ -160,22 +170,12 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             // Swapping between nullptr IconSources and non-null IconSources causes a crash
             // to occur, but swapping between IconSources with a null source and non-null IconSources
             // work perfectly fine :shrug:.
-            BitmapIconSource<TIconSource>::type icon;
+            typename BitmapIconSource<TIconSource>::type icon;
             icon.UriSource(nullptr);
             iconSource = icon;
         }
 
         return iconSource;
-    }
-
-    static winrt::hstring _expandIconPath(hstring iconPath)
-    {
-        if (iconPath.empty())
-        {
-            return iconPath;
-        }
-        winrt::hstring envExpandedPath{ wil::ExpandEnvironmentStringsW<std::wstring>(iconPath.c_str()) };
-        return envExpandedPath;
     }
 
     // Method Description:

--- a/src/cascadia/TerminalSettingsModel/JsonUtils.h
+++ b/src/cascadia/TerminalSettingsModel/JsonUtils.h
@@ -47,6 +47,18 @@ inline std::string JsonKey(const std::string_view key)
 
 namespace Microsoft::Terminal::Settings::Model::JsonUtils
 {
+    template<typename T>
+    struct ConversionTrait
+    {
+        // Forward-declare these so the linker can pick up specializations from elsewhere!
+        T FromJson(const Json::Value&);
+        bool CanConvert(const Json::Value& json);
+
+        Json::Value ToJson(const T& val);
+
+        std::string TypeDescription() const { return "<unknown>"; }
+    };
+
     namespace Detail
     {
         // Function Description:
@@ -238,18 +250,6 @@ namespace Microsoft::Terminal::Settings::Model::JsonUtils
         SetValueForKey(json, key, target, ConversionTrait<std::decay_t<T>>{});
     }
 
-    template<typename T>
-    struct ConversionTrait
-    {
-        // Forward-declare these so the linker can pick up specializations from elsewhere!
-        T FromJson(const Json::Value&);
-        bool CanConvert(const Json::Value& json);
-
-        Json::Value ToJson(const T& val);
-
-        std::string TypeDescription() const { return "<unknown>"; }
-    };
-
     template<>
     struct ConversionTrait<std::string>
     {
@@ -295,6 +295,62 @@ namespace Microsoft::Terminal::Settings::Model::JsonUtils
         std::string TypeDescription() const
         {
             return "string";
+        }
+    };
+
+    template<>
+    struct ConversionTrait<GUID>
+    {
+        GUID FromJson(const Json::Value& json)
+        {
+            return ::Microsoft::Console::Utils::GuidFromString(til::u8u16(Detail::GetStringView(json)).c_str());
+        }
+
+        bool CanConvert(const Json::Value& json)
+        {
+            if (!json.isString())
+            {
+                return false;
+            }
+
+            const auto string{ Detail::GetStringView(json) };
+            return string.length() == 38 && string.front() == '{' && string.back() == '}';
+        }
+
+        Json::Value ToJson(const GUID& val)
+        {
+            return til::u16u8(::Microsoft::Console::Utils::GuidToString(val));
+        }
+
+        std::string TypeDescription() const
+        {
+            return "guid";
+        }
+    };
+
+    // GUID and winrt::guid are mutually convertible,
+    // but IReference<winrt::guid> throws some of this off
+    template<>
+    struct ConversionTrait<winrt::guid>
+    {
+        winrt::guid FromJson(const Json::Value& json) const
+        {
+            return static_cast<winrt::guid>(ConversionTrait<GUID>{}.FromJson(json));
+        }
+
+        bool CanConvert(const Json::Value& json) const
+        {
+            return ConversionTrait<GUID>{}.CanConvert(json);
+        }
+
+        Json::Value ToJson(const winrt::guid& val)
+        {
+            return ConversionTrait<GUID>{}.ToJson(val);
+        }
+
+        std::string TypeDescription() const
+        {
+            return ConversionTrait<GUID>{}.TypeDescription();
         }
     };
 
@@ -681,62 +737,6 @@ namespace Microsoft::Terminal::Settings::Model::JsonUtils
         std::string TypeDescription() const
         {
             return "number";
-        }
-    };
-
-    template<>
-    struct ConversionTrait<GUID>
-    {
-        GUID FromJson(const Json::Value& json)
-        {
-            return ::Microsoft::Console::Utils::GuidFromString(til::u8u16(Detail::GetStringView(json)).c_str());
-        }
-
-        bool CanConvert(const Json::Value& json)
-        {
-            if (!json.isString())
-            {
-                return false;
-            }
-
-            const auto string{ Detail::GetStringView(json) };
-            return string.length() == 38 && string.front() == '{' && string.back() == '}';
-        }
-
-        Json::Value ToJson(const GUID& val)
-        {
-            return til::u16u8(::Microsoft::Console::Utils::GuidToString(val));
-        }
-
-        std::string TypeDescription() const
-        {
-            return "guid";
-        }
-    };
-
-    // GUID and winrt::guid are mutually convertible,
-    // but IReference<winrt::guid> throws some of this off
-    template<>
-    struct ConversionTrait<winrt::guid>
-    {
-        winrt::guid FromJson(const Json::Value& json) const
-        {
-            return static_cast<winrt::guid>(ConversionTrait<GUID>{}.FromJson(json));
-        }
-
-        bool CanConvert(const Json::Value& json) const
-        {
-            return ConversionTrait<GUID>{}.CanConvert(json);
-        }
-
-        Json::Value ToJson(const winrt::guid& val)
-        {
-            return ConversionTrait<GUID>{}.ToJson(val);
-        }
-
-        std::string TypeDescription() const
-        {
-            return ConversionTrait<GUID>{}.TypeDescription();
         }
     };
 

--- a/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj
+++ b/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj
@@ -311,8 +311,6 @@
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..;$(OpenConsoleDir)\dep\jsoncpp\json;%(AdditionalIncludeDirectories);</AdditionalIncludeDirectories>
-      <!-- Required for JsonUtils.h. -->
-      <AdditionalOptions>%(AdditionalOptions) /Zc:twoPhase-</AdditionalOptions>
       <!-- Manually disable unreachable code warning, because jconcpp has a ton of that. -->
       <DisableSpecificWarnings>4702;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>

--- a/src/cascadia/WinRTUtils/inc/Utils.h
+++ b/src/cascadia/WinRTUtils/inc/Utils.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <ShObjIdl_core.h>
+
 // Function Description:
 // - This function presents a File Open "common dialog" and returns its selected file asynchronously.
 // Parameters:

--- a/src/cascadia/ut_app/TerminalApp.UnitTests.vcxproj
+++ b/src/cascadia/ut_app/TerminalApp.UnitTests.vcxproj
@@ -53,8 +53,6 @@
     <ClCompile>
       <AdditionalIncludeDirectories>..;$(OpenConsoleDir)src\cascadia\inc;$(OpenConsoleDir)\dep\jsoncpp\json;$(OpenConsoleDir)src\inc;$(OpenConsoleDir)src\inc\test;$(WinRT_IncludePath)\..\cppwinrt\winrt;"$(OpenConsoleDir)\src\cascadia\TerminalApp\Generated Files";"$(OpenConsoleDir)\src\cascadia\TerminalSettingsModel\Generated Files";%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>precomp.h</PrecompiledHeaderFile>
-      <!-- Required for JsonUtils.h. -->
-      <AdditionalOptions>%(AdditionalOptions) /Zc:twoPhase-</AdditionalOptions>
       <!-- Manually disable unreachable code warning, because jconcpp has a ton of that. -->
       <DisableSpecificWarnings>4702;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>


### PR DESCRIPTION
Our templates were declared in the wrong order in JsonUtils, so all we needed to do was reorder them. The tests bear this out.

This allows us to disable two-phase template name lookup. I also fixed a minor issue that resulted in the inclusion of too many copies of expandIconPath.