### PR TITLE
AtlasEngine: Fix calculation of advanceScale

### DIFF
--- a/src/renderer/atlas/AtlasEngine.api.cpp
+++ b/src/renderer/atlas/AtlasEngine.api.cpp
@@ -711,7 +711,7 @@ void AtlasEngine::_resolveFontMetrics(const wchar_t* requestedFaceName, const Fo
         fontMetrics->fontName = std::move(fontName);
         fontMetrics->fontSizeInDIP = fontSizeInDIP;
         fontMetrics->baselineInDIP = baseline / static_cast<float>(_api.dpi) * 96.0f;
-        fontMetrics->advanceScale = cellWidth / adjustedWidth;
+        fontMetrics->advanceScale = cellWidth / advanceWidth;
         fontMetrics->cellSize = { cellWidth, cellHeight };
         fontMetrics->fontWeight = fontWeightU16;
         fontMetrics->underlinePos = underlinePosU16;


### PR DESCRIPTION
Woops. Closes #14878

## Validation Steps Performed
* Font Family: Iosevka Term (v19.0.1)
* Font Size: 11pt (or 10px cell height in conhost)
* Display Scale: 100%
* "--------------" leaves no gap between the text and the cursor ✅