### PR TITLE
Provide a more detailed Device Attributes report

### DIFF
--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -1373,16 +1373,36 @@ bool AdaptDispatch::DeviceStatusReport(const DispatchTypes::StatusType statusTyp
 }
 
 // Routine Description:
-// - DA - Reports the identity of this Virtual Terminal machine to the caller.
-//      - In our case, we'll report back to acknowledge we understand, but reveal no "hardware" upgrades like physical terminals of old.
+// - DA - Reports the service class or conformance level that the terminal
+//   supports, and the set of implemented extensions.
 // Arguments:
 // - <none>
 // Return Value:
 // - True.
 bool AdaptDispatch::DeviceAttributes()
 {
-    // See: http://vt100.net/docs/vt100-ug/chapter3.html#DA
-    _api.ReturnResponse(L"\x1b[?1;0c");
+    // This first parameter of the response is 61, representing a conformance
+    // level of 1. The subsequent parameters identify the supported feature
+    // extensions.
+    //
+    // 1 = 132 column mode (ConHost only)
+    // 6 = Selective erase
+    // 7 = Soft fonts
+    // 22 = Color text
+    // 23 = Greek character sets
+    // 24 = Turkish character sets
+    // 28 = Rectangular area operations
+    // 32 = Text macros
+    // 42 = ISO Latin - 2 character set
+
+    if (_api.IsConsolePty())
+    {
+        _api.ReturnResponse(L"\x1b[?61;6;7;22;23;24;28;32;42c");
+    }
+    else
+    {
+        _api.ReturnResponse(L"\x1b[?61;1;6;7;22;23;24;28;32;42c");
+    }
     return true;
 }
 

--- a/src/terminal/adapter/ut_adapter/adapterTest.cpp
+++ b/src/terminal/adapter/ut_adapter/adapterTest.cpp
@@ -1534,7 +1534,7 @@ public:
         _testGetSet->PrepData();
         VERIFY_IS_TRUE(_pDispatch->DeviceAttributes());
 
-        auto pwszExpectedResponse = L"\x1b[?1;0c";
+        auto pwszExpectedResponse = L"\x1b[?61;1;6;7;22;23;24;28;32;42c";
         _testGetSet->ValidateInputEvent(pwszExpectedResponse);
 
         Log::Comment(L"Test 2: Verify failure when ReturnResponse doesn't work.");


### PR DESCRIPTION
This is an update of our Primary Device Attributes report, which better
indicates the feature extensions that we now support.

## Detailed Description of the Pull Request / Additional comments

This first parameter of the response is 61, representing a conformance
level of 1. The subsequent parameters identify the supported feature
extensions.

1 = 132 column mode
6 = Selective erase
7 = Soft fonts
22 = Color text
23 = Greek character sets
24 = Turkish character sets
28 = Rectangular area operations
32 = Text macros
42 = ISO Latin-2 character set

Most of these features are handled entirely within `AdaptDispatch`, so
they apply to all clients. However, 132 column mode is only supported by
ConHost, so we don't report that for conpty clients.

And note that soft fonts won't necessarily work in all conpty clients,
but we don't have an easy way of determining that, so we just report
soft font support for everyone.

## Validation Steps Performed

I've manually verified that the `DA1` report is returning the expected
response in Vttest, both from ConHost and Windows Terminal.

I've also updated the `DeviceAttributesTests` in the adapter tests to
account for the new expected response.

Closes #14491