### PR TITLE
Prefer member function find over std::find

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2628,9 +2628,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                         }
                     }
 
-                    const auto containsSpaces = std::find(fullPath.begin(),
-                                                          fullPath.end(),
-                                                          L' ') != fullPath.end();
+                    const auto containsSpaces = fullPath.find(L' ') != fullPath.end();
 
                     if (containsSpaces)
                     {


### PR DESCRIPTION
Member function is O(log(n)) while static is O(n)