### PR TITLE
Fix console aliases not working

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -193,7 +193,6 @@ chh
 chk
 CHT
 Cic
-CLA
 Clcompile
 CLE
 cleartype
@@ -479,7 +478,6 @@ defterm
 DELAYLOAD
 DELETEONRELEASE
 Delt
-demoable
 depersist
 deprioritized
 deserializers
@@ -536,7 +534,6 @@ DSSCL
 DSwap
 DTest
 DTTERM
-DUMMYUNIONNAME
 dup'ed
 dvi
 dwl
@@ -589,7 +586,6 @@ ETW
 EUDC
 EVENTID
 eventing
-everytime
 evflags
 evt
 execd
@@ -797,7 +793,6 @@ HIBYTE
 hicon
 HIDEWINDOW
 hinst
-Hirots
 HISTORYBUFS
 HISTORYNODUP
 HISTORYSIZE
@@ -898,7 +893,6 @@ INSERTMODE
 INTERACTIVITYBASE
 INTERCEPTCOPYPASTE
 INTERNALNAME
-inthread
 intsafe
 INVALIDARG
 INVALIDATERECT
@@ -1255,14 +1249,12 @@ ntm
 nto
 ntrtl
 ntstatus
-ntsubauth
 NTSYSCALLAPI
 nttree
 nturtl
 ntuser
 NTVDM
 ntverp
-NTWIN
 nugetversions
 nullability
 nullness
@@ -1301,8 +1293,6 @@ opencode
 opencon
 openconsole
 openconsoleproxy
-OPENIF
-OPENLINK
 openps
 openvt
 ORIGINALFILENAME
@@ -1355,9 +1345,7 @@ pcg
 pch
 PCIDLIST
 PCIS
-PCLIENT
 PCLONG
-PCOBJECT
 pcon
 PCONSOLE
 PCONSOLEENDTASK
@@ -1369,7 +1357,6 @@ pcshell
 PCSHORT
 PCSR
 PCSTR
-PCUNICODE
 PCWCH
 PCWCHAR
 PCWSTR
@@ -1418,7 +1405,6 @@ PLOGICAL
 pnm
 PNMLINK
 pntm
-PNTSTATUS
 POBJECT
 Podcast
 POINTSLIST
@@ -1437,7 +1423,6 @@ ppf
 ppguid
 ppidl
 PPROC
-PPROCESS
 ppropvar
 ppsi
 ppsl
@@ -1501,7 +1486,6 @@ ptrs
 ptsz
 PTYIn
 PUCHAR
-PUNICODE
 pwch
 PWDDMCONSOLECONTEXT
 pws
@@ -1563,7 +1547,6 @@ REGISTEROS
 REGISTERVDM
 regkey
 REGSTR
-reingest
 RELBINPATH
 remoting
 renamer
@@ -1858,6 +1841,7 @@ TDP
 TEAMPROJECT
 tearoff
 Teb
+Techo
 tellp
 teraflop
 terminalcore
@@ -2000,7 +1984,6 @@ unittesting
 unittests
 unk
 unknwn
-unmark
 UNORM
 unparseable
 unregistering

--- a/src/host/inputReadHandleData.cpp
+++ b/src/host/inputReadHandleData.cpp
@@ -20,7 +20,7 @@ bool INPUT_READ_HANDLE_DATA::IsInputPending() const
 
 bool INPUT_READ_HANDLE_DATA::IsMultilineInput() const
 {
-    FAIL_FAST_IF(!_isInputPending); // we shouldn't have multiline input without a pending input.
+    assert(_isInputPending); // we shouldn't have multiline input without a pending input.
     return _isMultilineInput;
 }
 

--- a/src/host/readDataCooked.cpp
+++ b/src/host/readDataCooked.cpp
@@ -1035,7 +1035,7 @@ void COOKED_READ_DATA::SavePendingInput(const size_t index, const bool multiline
             {
                 // ProcessAliases() is supposed to end each line with \r\n. If it doesn't we might as well fail-fast.
                 const auto firstLineEnd = input.find(UNICODE_LINEFEED) + 1;
-                input = input.substr(0, firstLineEnd);
+                input = input.substr(0, std::min(input.size(), firstLineEnd));
             }
         }
     }
@@ -1050,7 +1050,7 @@ void COOKED_READ_DATA::SavePendingInput(const size_t index, const bool multiline
         const auto inputSizeAfter = input.size();
         const auto amountConsumed = inputSizeBefore - inputSizeAfter;
         input = { _backupLimit, _bytesRead / sizeof(wchar_t) };
-        input = input.substr(amountConsumed);
+        input = input.substr(std::min(input.size(), amountConsumed));
         GetInputReadHandleData()->SaveMultilinePendingInput(input);
     }
     else if (!input.empty())

--- a/src/host/readDataCooked.cpp
+++ b/src/host/readDataCooked.cpp
@@ -1019,27 +1019,43 @@ void COOKED_READ_DATA::SavePendingInput(const size_t index, const bool multiline
             }
 
             Tracing::s_TraceCookedRead(_clientProcess, _backupLimit, base::saturated_cast<ULONG>(idx));
-            ProcessAliases(LineCount);
 
+            // Don't be fooled by ProcessAliases only taking one argument. It rewrites multiple
+            // class members on return, including `_bytesRead`, requiring us to reconstruct `input`.
+            ProcessAliases(LineCount);
+            input = { _backupLimit, _bytesRead / sizeof(wchar_t) };
+
+            // The exact reasons for this are unclear to me (the one writing this comment), but this code used to
+            // split the contents of a multiline alias (for instance `doskey test=echo foo$Techo bar$Techo baz`)
+            // into multiple separate read outputs, ensuring that the client receives them line by line.
+            //
+            // This code first truncates the `input` to only contain the first line, so that Consume() below only
+            // writes that line into the user buffer. We'll later store the remainder in SaveMultilinePendingInput().
             if (LineCount > 1)
             {
-                input = input.substr(0, idx + 1);
+                // ProcessAliases() is supposed to end each line with \r\n. If it doesn't we might as well fail-fast.
+                const auto firstLineEnd = input.find(UNICODE_LINEFEED) + 1;
+                input = input.substr(0, firstLineEnd);
             }
         }
     }
 
+    const auto inputSizeBefore = input.size();
     GetInputBuffer()->Consume(isUnicode, input, writer);
 
-    if (!input.empty())
+    if (LineCount > 1)
     {
-        if (LineCount > 1)
-        {
-            GetInputReadHandleData()->SaveMultilinePendingInput(input);
-        }
-        else
-        {
-            GetInputReadHandleData()->SavePendingInput(input);
-        }
+        // This is a continuation of the above identical if condition.
+        // We've truncated the `input` slice and now we need to restore it.
+        const auto inputSizeAfter = input.size();
+        const auto amountConsumed = inputSizeBefore - inputSizeAfter;
+        input = { _backupLimit, _bytesRead / sizeof(wchar_t) };
+        input = input.substr(amountConsumed);
+        GetInputReadHandleData()->SaveMultilinePendingInput(input);
+    }
+    else if (!input.empty())
+    {
+        GetInputReadHandleData()->SavePendingInput(input);
     }
 
     numBytes = _userBufferSize - writer.size();

--- a/src/host/stream.cpp
+++ b/src/host/stream.cpp
@@ -295,7 +295,7 @@ try
     if (readHandleState.IsMultilineInput())
     {
         const auto firstLineEnd = input.find(UNICODE_LINEFEED) + 1;
-        input = input.substr(0, firstLineEnd);
+        input = input.substr(0, std::min(input.size(), firstLineEnd));
     }
 
     const auto inputSizeBefore = input.size();
@@ -308,7 +308,7 @@ try
     {
         const auto inputSizeAfter = input.size();
         const auto amountConsumed = inputSizeBefore - inputSizeAfter;
-        input = pending.substr(amountConsumed);
+        input = pending.substr(std::min(pending.size(), amountConsumed));
     }
 
     if (input.empty())

--- a/src/host/stream.cpp
+++ b/src/host/stream.cpp
@@ -297,11 +297,11 @@ try
         const auto firstLineEnd = input.find(UNICODE_LINEFEED) + 1;
         input = input.substr(0, firstLineEnd);
     }
-    
+
     const auto inputSizeBefore = input.size();
     std::span writer{ buffer };
     inputBuffer.Consume(unicode, input, writer);
-    
+
     // Since we truncated `input` to only include the first line,
     // we need to restore `input` here to the entirety of the remaining input.
     if (readHandleState.IsMultilineInput())


### PR DESCRIPTION
#14745 contains two regressions related to console alias handling:
* When `ProcessAliases` expands the backup buffer into (an) aliased
  command(s) it changes the `_bytesRead` field of `COOKED_READ_DATA`,
  requiring us to re-read it and reconstruct the `input` string-view.
* Multiline aliases are read line-by-line whereas #14745 didn't treat
  them any different from regular single-line inputs.

## Validation Steps Performed
In `cmd.exe` run
```
doskey test=echo foo$Techo bar$Techo baz
test
```
The output should look exactly like this:
```
C:\>doskey test=echo foo$Techo bar$Techo baz

C:\>test
foo

C:\>bar

C:\>baz

C:\>
```