### PR TITLE
Fix some simple C# linter warnings

### DIFF
--- a/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalControl.xaml.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Terminal.Wpf
     /// </summary>
     public partial class TerminalControl : UserControl
     {
+        private int accumulatedDelta = 0;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TerminalControl"/> class.
         /// </summary>
@@ -31,20 +33,6 @@ namespace Microsoft.Terminal.Wpf
             this.scrollbar.MouseWheel += this.Scrollbar_MouseWheel;
 
             this.GotFocus += this.TerminalControl_GotFocus;
-        }
-
-        /// <inheritdoc/>
-        protected override AutomationPeer OnCreateAutomationPeer()
-        {
-            var peer = FrameworkElementAutomationPeer.FromElement(this);
-            if (peer == null)
-            {
-                // Provide our own automation peer here that just sets IsContentElement/IsControlElement to false
-                // (aka AccessibilityView = Raw). This makes it not pop up in the UIA tree.
-                peer = new TermControlAutomationPeer(this);
-            }
-
-            return peer;
         }
 
         /// <summary>
@@ -82,8 +70,6 @@ namespace Microsoft.Terminal.Wpf
         {
             get => this.termContainer.TerminalRendererSize;
         }
-
-        private int accumulatedDelta = 0;
 
         /// <summary>
         /// Sets the theme for the terminal. This includes font family, size, color, as well as background and foreground colors.
@@ -162,6 +148,20 @@ namespace Microsoft.Terminal.Wpf
             this.termContainer.Resize(rendersize);
 
             return (this.Rows, this.Columns);
+        }
+
+        /// <inheritdoc/>
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            var peer = FrameworkElementAutomationPeer.FromElement(this);
+            if (peer == null)
+            {
+                // Provide our own automation peer here that just sets IsContentElement/IsControlElement to false
+                // (aka AccessibilityView = Raw). This makes it not pop up in the UIA tree.
+                peer = new TermControlAutomationPeer(this);
+            }
+
+            return peer;
         }
 
         /// <inheritdoc/>
@@ -284,7 +284,8 @@ namespace Microsoft.Terminal.Wpf
 
         private class TermControlAutomationPeer : UserControlAutomationPeer
         {
-            public TermControlAutomationPeer(UserControl owner) : base(owner)
+            public TermControlAutomationPeer(UserControl owner)
+                : base(owner)
             {
             }
 


### PR DESCRIPTION
Azure Devops jumps to these as the first "error" when you open a failing build. But these are warnings, not errors. So you're left hunting for the real error. _If only someone had scrollbar marks for indicating lines with error messages..._

May as well clean them up. 

