### PR TITLE
Fix `wt -w _quake` by not throwing when setting the window name

### DIFF
--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -1155,6 +1155,10 @@ namespace winrt::TerminalApp::implementation
     {
         const auto oldIsQuakeMode = _WindowProperties->IsQuakeWindow();
         _WindowProperties->WindowName(name);
+        if (!_root)
+        {
+            return;
+        }
         const auto newIsQuakeMode = _WindowProperties->IsQuakeWindow();
         if (newIsQuakeMode != oldIsQuakeMode)
         {
@@ -1210,8 +1214,15 @@ namespace winrt::TerminalApp::implementation
         if (_WindowName != value)
         {
             _WindowName = value;
-            _PropertyChangedHandlers(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"WindowName" });
-            _PropertyChangedHandlers(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"WindowNameForDisplay" });
+            // If we get initialized with a window name, this will be called
+            // before XAML is stood up, and constructing a
+            // PropertyChangedEventArgs will throw.
+            try
+            {
+                _PropertyChangedHandlers(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"WindowName" });
+                _PropertyChangedHandlers(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"WindowNameForDisplay" });
+            }
+            CATCH_LOG();
         }
     }
     uint64_t WindowProperties::WindowId() const noexcept

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -297,7 +297,6 @@ void AppHost::Initialize()
         withWindow->Initialize(_window->GetHandle());
     }
 
-
     if (_useNonClientArea)
     {
         // Register our callback for when the app's non-client content changes.

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -297,6 +297,7 @@ void AppHost::Initialize()
         withWindow->Initialize(_window->GetHandle());
     }
 
+
     if (_useNonClientArea)
     {
         // Register our callback for when the app's non-client content changes.


### PR DESCRIPTION
If we get initialized with a window name, this will be called before XAML is stood up, and constructing a PropertyChangedEventArgs will throw. So don't.


Regressed in #14843 

Related to #5000, #14957 