### PR TITLE
VsDevCmdGenerator: respect the user's startingDirectory

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -1764,6 +1764,7 @@ srv
 srvinit
 srvpipe
 ssa
+startdir
 STARTF
 STARTUPINFO
 STARTUPINFOEX

--- a/src/cascadia/TerminalSettingsModel/VsDevCmdGenerator.cpp
+++ b/src/cascadia/TerminalSettingsModel/VsDevCmdGenerator.cpp
@@ -42,6 +42,9 @@ std::wstring VsDevCmdGenerator::GetProfileCommandLine(const VsSetupConfiguration
     commandLine.reserve(256);
     commandLine.append(LR"(cmd.exe /k ")");
     commandLine.append(GetDevCmdScriptPath(instance));
+    // The "-startdir" parameter will prevent "vsdevcmd" from automatically
+    // setting the shell path so the path in the profile will be used instead.
+    commandLine.append(LR"(" -startdir=none)");
 #if defined(_M_ARM64)
     commandLine.append(LR"(" -arch=arm64 -host_arch=x64)");
 #elif defined(_M_AMD64)


### PR DESCRIPTION
The PowerShell equivalent was added in the initial pull request, #7774.

Closes #13721