### PR TITLE
Clean up more warnings

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/AddProfile.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AddProfile.xaml
@@ -60,7 +60,7 @@
                                     <IconSourceElement Grid.Column="0"
                                                        Width="16"
                                                        Height="16"
-                                                       IconSource="{x:Bind Icon, Mode=OneWay, Converter={StaticResource IconSourceConverter}}" />
+                                                       IconSource="{x:Bind Icon, Converter={StaticResource IconSourceConverter}}" />
 
                                     <TextBlock Grid.Column="1"
                                                Text="{x:Bind Name}" />

--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -57,7 +57,7 @@
                                     <IconSourceElement Grid.Column="0"
                                                        Width="16"
                                                        Height="16"
-                                                       IconSource="{x:Bind Icon, Mode=OneWay, Converter={StaticResource IconSourceConverter}}" />
+                                                       IconSource="{x:Bind Icon, Converter={StaticResource IconSourceConverter}}" />
 
                                     <TextBlock Grid.Column="1"
                                                Text="{x:Bind Name}" />
@@ -104,7 +104,7 @@
                                                        Width="24"
                                                        Height="24"
                                                        VerticalAlignment="Center"
-                                                       IconSource="{x:Bind Icon, Mode=OneWay, Converter={StaticResource IconSourceConverter}}" />
+                                                       IconSource="{x:Bind Icon, Converter={StaticResource IconSourceConverter}}" />
 
                                     <TextBlock Grid.Row="0"
                                                Grid.Column="1"

--- a/src/cascadia/WpfTerminalControl/TerminalContainer.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalContainer.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Terminal.Wpf
     using System;
     using System.Runtime.InteropServices;
     using System.Windows;
-    using System.Windows.Automation;
     using System.Windows.Automation.Peers;
     using System.Windows.Interop;
     using System.Windows.Media;
@@ -54,30 +53,6 @@ namespace Microsoft.Terminal.Wpf
                     NativeMethods.TerminalBlinkCursor(this.terminal);
                 }
             };
-        }
-
-        /// <summary>
-        /// WPF's HwndHost likes to mark the WM_GETOBJECT message as handled to
-        /// force the usage of the WPF automation peer. We explicitly mark it as
-        /// not handled and don't return an automation peer in "OnCreateAutomationPeer" below.
-        /// This forces the message to go down to the HwndTerminal where we return terminal's UiaProvider.
-        /// </summary>
-        /// <inheritdoc/>
-        protected override IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
-        {
-            if (msg == (int)NativeMethods.WindowMessage.WM_GETOBJECT)
-            {
-                handled = false;
-                return IntPtr.Zero;
-            }
-
-            return base.WndProc(hwnd, msg, wParam, lParam, ref handled);
-        }
-
-        /// <inheritdoc/>
-        protected override AutomationPeer OnCreateAutomationPeer()
-        {
-            return null;
         }
 
         /// <summary>
@@ -272,6 +247,30 @@ namespace Microsoft.Terminal.Wpf
             {
                 this.connection?.Resize((uint)rows, (uint)columns);
             }
+        }
+
+        /// <summary>
+        /// WPF's HwndHost likes to mark the WM_GETOBJECT message as handled to
+        /// force the usage of the WPF automation peer. We explicitly mark it as
+        /// not handled and don't return an automation peer in "OnCreateAutomationPeer" below.
+        /// This forces the message to go down to the HwndTerminal where we return terminal's UiaProvider.
+        /// </summary>
+        /// <inheritdoc/>
+        protected override IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            if (msg == (int)NativeMethods.WindowMessage.WM_GETOBJECT)
+            {
+                handled = false;
+                return IntPtr.Zero;
+            }
+
+            return base.WndProc(hwnd, msg, wParam, lParam, ref handled);
+        }
+
+        /// <inheritdoc/>
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return null;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
* These `Icon` bindings were to `Profile`s which aren't Observable, but it also doesn't matter
* More c# warnings

hopefully we'll just jump straight to real errors now.