### PR TITLE
fix: WpfTerminalControl allow Connection set to null

### DIFF
--- a/src/cascadia/WpfTerminalControl/TerminalContainer.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalContainer.cs
@@ -113,10 +113,23 @@ namespace Microsoft.Terminal.Wpf
                 {
                     this.connection.TerminalOutput -= this.Connection_TerminalOutput;
                 }
-
+                this.Connection_TerminalOutput(this, new TerminalOutputEventArgs("\x001bc\x1b]104\x1b\\")); //reset console/clear screen - https://github.com/microsoft/terminal/pull/15062#issuecomment-1505654110
+                var wasNull = this.connection == null;
                 this.connection = value;
-                this.connection.TerminalOutput += this.Connection_TerminalOutput;
-                this.connection.Start();
+                if (this.connection != null)
+                {
+                    if (wasNull)
+                    {
+                         this.Connection_TerminalOutput(this, new TerminalOutputEventArgs("\x1b[?25h")); //show cursor
+                    }
+                    this.connection.TerminalOutput += this.Connection_TerminalOutput;
+                    this.connection.Start();
+                }
+                else
+                {
+                    this.Connection_TerminalOutput(this, new TerminalOutputEventArgs("\x1b[?25l")); //hide cursor
+                }
+                    
             }
         }
 


### PR DESCRIPTION
Hides the cursor when null, shows it when not.
Clear the screen any time the connection is changed.

## Summary of the Pull Request
Prevents the WPF Control from crashing when set back to null, clears the console and hides the mouse as well.
## References and Relevant Issues
#15061

## Detailed Description of the Pull Request / Additional comments

It say 3 ansi commands as well now:
1) When the Connection is set to null the cursor is hidden (reflects what the default state is)
2) When the Connection is set to a value and it was null before we show the cursor (not a breaking change as requires it to have been null which previously would cause a crash, except for for set)
3) When the Connection is changed the screen is cleared.  A breaking change officially although not sure if there are use cases where this behavior is not desired.  For added safety we could make sure we are not being set to the same value we currently are.

None of the ansi commands are needed, users could do it all themselves as well, the behavior largely seemed natural though.  I didn't see any ansi constants anywhere so they are just hard coded with comments, but not sure if there is an established better practice.

Closes #15061
