### PR TITLE
Fix focus issue when profile selected from nested menu entry

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -855,6 +855,10 @@ namespace winrt::TerminalApp::implementation
         newTabFlyout.Opening([this](auto&&, auto&&) {
             _FocusCurrentTab(true);
         });
+        // Necessary for fly-out sub items to get focus on a tab before collapsing. Related to #15049
+        newTabFlyout.Closing([this](auto&&, auto&&) {
+            _FocusCurrentTab(true);
+        });
         _newTabButton.Flyout(newTabFlyout);
     }
 


### PR DESCRIPTION
Original bug report #15049
Relates to feature #1571 

MenuFlyoutSubItem, when collapsing from profile selection, move focus back to the titlebar. 
An extra Closing event handler is needed to keep focus on the command shell.

Closes #15049 
