### PR TITLE
Use DIPs for the window bounds when tearing out

### DIFF
--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -613,11 +613,11 @@ namespace winrt::TerminalApp::implementation
         if (_contentBounds)
         {
             // If we've been created as a torn-out window, then we'll need to
-            // use that size instead. _contentBounds is in raw pixels. Huzzah!
-            // Just return that.
+            // use that size instead. _contentBounds is in DIPs. Scale
+            // accordingly to the new pixel size.
             return {
-                _contentBounds.Value().Width,
-                _contentBounds.Value().Height
+                _contentBounds.Value().Width * scale,
+                _contentBounds.Value().Height * scale
             };
         }
 

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -1280,11 +1280,13 @@ void AppHost::_handleMoveContent(const winrt::Windows::Foundation::IInspectable&
         dragPositionInPixels.y -= nonClientFrame.top;
         windowSize = windowSize - nonClientFrame.size();
 
+        // Convert to DIPs for the size, so that dragging across a DPI boundary
+        // retains the correct dimensions.
+        const auto sizeInDips = windowSize.scale(til::math::rounding, 1.0f / scale);
+        til::rect inDips{ dragPositionInPixels, sizeInDips };
+
         // Use the drag event as the new position, and the size of the actual window.
-        rect = winrt::Windows::Foundation::Rect{ static_cast<float>(dragPositionInPixels.x),
-                                                 static_cast<float>(dragPositionInPixels.y),
-                                                 static_cast<float>(windowSize.width),
-                                                 static_cast<float>(windowSize.height) };
+        rect = winrt::Windows::Foundation::Rect{ inDips.to_winrt_rect() };
         windowBoundsReference = rect;
     }
 

--- a/src/inc/til/size.h
+++ b/src/inc/til/size.h
@@ -75,6 +75,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
         }
 
         template<typename TilMath, typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
+        [[nodiscard]]
         constexpr size scale(TilMath math, const T scale) const
         {
             return {
@@ -84,6 +85,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             };
         }
 
+        [[nodiscard]]
         constexpr size divide_ceil(const size other) const
         {
             // The integer ceil division `((a - 1) / b) + 1` only works for numbers >0.


### PR DESCRIPTION
Fixes a bug where you'd drag across the boundary and the new window would be at the wrong size

related to #14957