### PR TITLE
Format URLs for display when we show the tooltip

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -257,6 +257,7 @@ condrv
 conechokey
 conemu
 configurability
+confusables
 conhost
 conime
 conimeinfo

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -3019,7 +3019,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                 winrt::hstring uriText = _core.HoveredUriText();
                 try
                 {
-                    // DisplayUri will filter out non-printables and confusables.
+                    // DisplayUri will filter out non-printable characters and confusables.
                     Windows::Foundation::Uri parsedUri{ uriText };
                     uriText = parsedUri.DisplayUri();
                 }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -3016,7 +3016,19 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             auto lastHoveredCell = _core.HoveredCell();
             if (lastHoveredCell)
             {
-                const auto uriText = _core.HoveredUriText();
+                winrt::hstring uriText = _core.HoveredUriText();
+                try
+                {
+                    // DisplayUri will filter out non-printables and confusables.
+                    Windows::Foundation::Uri parsedUri{ uriText };
+                    uriText = parsedUri.DisplayUri();
+                }
+                catch (...)
+                {
+                    LOG_CAUGHT_EXCEPTION();
+                    uriText = {};
+                }
+
                 if (!uriText.empty())
                 {
                     const auto panel = SwapChainPanel();


### PR DESCRIPTION
This will reduce the incidence of confusables, RTL, and non-printables messing with the display of the URL.