### PR TITLE
Add "legacy" themes

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearanceViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearanceViewModel.cpp
@@ -43,6 +43,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     constexpr std::wstring_view systemThemeName{ L"system" };
     constexpr std::wstring_view darkThemeName{ L"dark" };
     constexpr std::wstring_view lightThemeName{ L"light" };
+    constexpr std::wstring_view legacySystemThemeName{ L"legacySystem" };
+    constexpr std::wstring_view legacyDarkThemeName{ L"legacyDark" };
+    constexpr std::wstring_view legacyLightThemeName{ L"legacyLight" };
 
     GlobalAppearanceViewModel::GlobalAppearanceViewModel(Model::GlobalAppSettings globalSettings) :
         _GlobalSettings{ globalSettings },
@@ -247,6 +250,18 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         else if (theme.Name() == systemThemeName)
         {
             return RS_(L"Globals_ThemeSystem/Content");
+        }
+        else if (theme.Name() == legacyDarkThemeName)
+        {
+            return RS_(L"Globals_ThemeDarkLegacy/Content");
+        }
+        else if (theme.Name() == legacyLightThemeName)
+        {
+            return RS_(L"Globals_ThemeLightLegacy/Content");
+        }
+        else if (theme.Name() == legacySystemThemeName)
+        {
+            return RS_(L"Globals_ThemeSystemLegacy/Content");
         }
         return theme.Name();
     }

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -536,15 +536,27 @@
   </data>
   <data name="Globals_ThemeDark.Content" xml:space="preserve">
     <value>Dark</value>
-    <comment>An option to choose from for the "tab width mode" setting. When selected, the app is in dark theme and darker colors are used throughout the app.</comment>
+    <comment>An option to choose from for the "theme" setting. When selected, the app is in dark theme and darker colors are used throughout the app.</comment>
   </data>
   <data name="Globals_ThemeSystem.Content" xml:space="preserve">
     <value>Use Windows theme</value>
-    <comment>An option to choose from for the "tab width mode" setting. When selected, the app uses the theme selected in the Windows operating system.</comment>
+    <comment>An option to choose from for the "theme" setting. When selected, the app uses the theme selected in the Windows operating system.</comment>
   </data>
   <data name="Globals_ThemeLight.Content" xml:space="preserve">
     <value>Light</value>
-    <comment>An option to choose from for the "tab width mode" setting. When selected, the app is in light theme and lighter colors are used throughout the app.</comment>
+    <comment>An option to choose from for the "theme" setting. When selected, the app is in light theme and lighter colors are used throughout the app.</comment>
+  </data>
+  <data name="Globals_ThemeDarkLegacy.Content" xml:space="preserve">
+    <value>Dark (Legacy)</value>
+    <comment>An option to choose from for the "theme" setting. When selected, the app is in dark theme and darker colors are used throughout the app. This is an older version of the "dark" theme</comment>
+  </data>
+  <data name="Globals_ThemeSystemLegacy.Content" xml:space="preserve">
+    <value>Use Windows theme (Legacy)</value>
+    <comment>An option to choose from for the "theme" setting. When selected, the app uses the theme selected in the Windows operating system. This is an older version of the "Use Windows theme" theme</comment>
+  </data>
+  <data name="Globals_ThemeLightLegacy.Content" xml:space="preserve">
+    <value>Light (Legacy)</value>
+    <comment>An option to choose from for the "theme" setting. When selected, the app is in light theme and lighter colors are used throughout the app. This is an older version of the "light" theme</comment>
   </data>
   <data name="Globals_WordDelimiters.Header" xml:space="preserve">
     <value>Word delimiters</value>

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -957,10 +957,16 @@ void CascadiaSettings::_researchOnLoad()
         // light: 1
         // dark: 2
         // a custom theme: 3
-        const auto themeChoice = themeInUse == L"system" ? 0 :
-                                                           themeInUse == L"light" ? 1 :
-                                                                                    themeInUse == L"dark" ? 2 :
-                                                                                                            3;
+        // system (legacy): 4
+        // light (legacy): 5
+        // dark (legacy): 6
+        const auto themeChoice = themeInUse == L"system"       ? 0 :
+                                 themeInUse == L"light"        ? 1 :
+                                 themeInUse == L"dark"         ? 2 :
+                                 themeInUse == L"legacyDark"   ? 4 :
+                                 themeInUse == L"legacyLight"  ? 5 :
+                                 themeInUse == L"legacySystem" ? 6 :
+                                                                 3;
 
         TraceLoggingWrite(
             g_hSettingsModelProvider,

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -52,6 +52,9 @@ static constexpr std::string_view ThemesKey{ "themes" };
 constexpr std::wstring_view systemThemeName{ L"system" };
 constexpr std::wstring_view darkThemeName{ L"dark" };
 constexpr std::wstring_view lightThemeName{ L"light" };
+constexpr std::wstring_view legacySystemThemeName{ L"legacySystem" };
+constexpr std::wstring_view legacyDarkThemeName{ L"legacyDark" };
+constexpr std::wstring_view legacyLightThemeName{ L"legacyLight" };
 
 static constexpr std::wstring_view jsonExtension{ L".json" };
 static constexpr std::wstring_view FragmentsSubDirectory{ L"\\Fragments" };
@@ -562,8 +565,9 @@ void SettingsLoader::_parse(const OriginTag origin, const winrt::hstring& source
         {
             if (const auto theme = Theme::FromJson(themeJson))
             {
+                const auto& name{ theme->Name() };
                 if (origin != OriginTag::InBox &&
-                    (theme->Name() == systemThemeName || theme->Name() == lightThemeName || theme->Name() == darkThemeName))
+                    (name == systemThemeName || name == lightThemeName || name == darkThemeName || name == legacySystemThemeName || name == legacyDarkThemeName || name == legacyLightThemeName))
                 {
                     // If the theme didn't come from the in-box themes, and its
                     // name was one of the reserved names, then just ignore it.
@@ -954,9 +958,9 @@ void CascadiaSettings::_researchOnLoad()
         // dark: 2
         // a custom theme: 3
         const auto themeChoice = themeInUse == L"system" ? 0 :
-                                 themeInUse == L"light"  ? 1 :
-                                 themeInUse == L"dark"   ? 2 :
-                                                           3;
+                                                           themeInUse == L"light" ? 1 :
+                                                                                    themeInUse == L"dark" ? 2 :
+                                                                                                            3;
 
         TraceLoggingWrite(
             g_hSettingsModelProvider,

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -316,6 +316,38 @@
                 "background": "terminalBackground",
                 "unfocusedBackground": "#00000000"
             }
+        },
+        {
+            "name": "legacyDark",
+            "tab":
+            {
+                "background": null,
+                "unfocusedBackground": null
+            },
+            "window":
+            {
+                "applicationTheme": "dark"
+            }
+        },
+        {
+            "name": "legacyLight",
+            "tab":
+            {
+                "background": null,
+                "unfocusedBackground": null
+            },
+            "window":
+            {
+                "applicationTheme": "light"
+            }
+        },
+        {
+            "name": "legacySystem",
+            "tab":
+            {
+                "background": null,
+                "unfocusedBackground": null
+            }
         }
     ],
     "actions":

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -319,35 +319,33 @@
         },
         {
             "name": "legacyDark",
-            "tab":
-            {
+            "tab": {
                 "background": null,
                 "unfocusedBackground": null
             },
-            "window":
-            {
+            "window": {
                 "applicationTheme": "dark"
             }
         },
         {
             "name": "legacyLight",
-            "tab":
-            {
+            "tab": {
                 "background": null,
                 "unfocusedBackground": null
             },
-            "window":
-            {
+            "window": {
                 "applicationTheme": "light"
             }
         },
         {
             "name": "legacySystem",
-            "tab":
-            {
+            "tab": {
                 "background": null,
                 "unfocusedBackground": null
-            }
+            },
+            "window": {
+                "applicationTheme": "system"
+            },
         }
     ],
     "actions":


### PR DESCRIPTION
This is a minimal version of the requests for #14858. In that thread we discussed FULL reverting the default themes to the old ones. In later discussion, we decided _meh_, let's just ship the legacy themes too, so it's easy to go back if you should choose. The default still remains the sane `dark`, but the `legacy*` themes are all right there, and given the same special treatment as the other inbox themes.

Closes #14858
Closes #14844
