### PR TITLE
Upgrade clang-format to 15.0.7

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,8 +2,13 @@
 Language: Cpp
 BasedOnStyle: Microsoft
 AccessModifierOffset: -4
+AlignEscapedNewlines: Left
 AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortFunctionsOnASingleLine: All
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
 BraceWrapping:
   AfterCaseLabel: true
   AfterUnion: true
@@ -13,8 +18,10 @@ BreakConstructorInitializers: AfterColon
 BreakInheritanceList: AfterColon
 ColumnLimit: 0
 CommentPragmas: "suppress"
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
 Cpp11BracedListStyle: false
 FixNamespaceComments: false
+IncludeBlocks: Regroup
 IncludeCategories:
     - Regex: '^.*(precomp|pch|stdafx)'
       Priority: -1
@@ -24,6 +31,7 @@ IncludeCategories:
       Priority: 2
     - Regex: '.*'
       Priority: 3
+KeepEmptyLinesAtTheStartOfBlocks: false
 MacroBlockBegin: "BEGIN_TEST_METHOD_PROPERTIES|BEGIN_MODULE|BEGIN_TEST_CLASS|BEGIN_TEST_METHOD"
 MacroBlockEnd: "END_TEST_METHOD_PROPERTIES|END_MODULE|END_TEST_CLASS|END_TEST_METHOD"
 NamespaceIndentation: All
@@ -31,3 +39,5 @@ PointerAlignment: Left
 ReflowComments: false
 SortIncludes: false
 SpaceAfterTemplateKeyword: false
+SpacesInAngles: false
+SpacesInContainerLiterals: false

--- a/.clang-format
+++ b/.clang-format
@@ -1,59 +1,20 @@
-
+---
+Language: Cpp
+BasedOnStyle: Microsoft
 AccessModifierOffset: -4
-AlignAfterOpenBracket: Align
-AllowAllArgumentsOnNextLine: true
-AlignConsecutiveMacros: false
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
-AllowAllConstructorInitializersOnNextLine: true
-AlignEscapedNewlines: Left
-AlignOperands: true
 AlignTrailingComments: false
-AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortBlocksOnASingleLine: Never
 AllowShortFunctionsOnASingleLine: All
-AllowShortCaseLabelsOnASingleLine: false
-AllowShortIfStatementsOnASingleLine: Never
-#AllowShortLambdasOnASingleLine: Inline
-AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: Yes
-BinPackArguments: false
-BinPackParameters: false
 BraceWrapping:
   AfterCaseLabel: true
-  AfterClass: true
-  AfterControlStatement: true
-  AfterEnum: true
-  AfterFunction: true
-  AfterNamespace: true
-  AfterObjCDeclaration: true
-  AfterStruct: true
   AfterUnion: true
   AfterExternBlock: false
-  BeforeCatch: true
-  BeforeElse: true
-  IndentBraces: false
-  SplitEmptyFunction: true
-  SplitEmptyRecord: true
-  SplitEmptyNamespace: true
-BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: false
 BreakConstructorInitializers: AfterColon
 BreakInheritanceList: AfterColon
 ColumnLimit: 0
 CommentPragmas: "suppress"
-CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
-ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
 Cpp11BracedListStyle: false
-DeriveLineEnding: true
-DerivePointerAlignment: false
 FixNamespaceComments: false
-IncludeBlocks: Regroup
 IncludeCategories:
     - Regex: '^.*(precomp|pch|stdafx)'
       Priority: -1
@@ -63,35 +24,10 @@ IncludeCategories:
       Priority: 2
     - Regex: '.*'
       Priority: 3
-IndentCaseLabels: false
-IndentPPDirectives: None
-IndentWidth: 4
-IndentWrappedFunctionNames: false
-KeepEmptyLinesAtTheStartOfBlocks: false
 MacroBlockBegin: "BEGIN_TEST_METHOD_PROPERTIES|BEGIN_MODULE|BEGIN_TEST_CLASS|BEGIN_TEST_METHOD"
 MacroBlockEnd: "END_TEST_METHOD_PROPERTIES|END_MODULE|END_TEST_CLASS|END_TEST_METHOD"
-MaxEmptyLinesToKeep: 1
 NamespaceIndentation: All
 PointerAlignment: Left
 ReflowComments: false
 SortIncludes: false
-SortUsingDeclarations: true
-SpaceAfterCStyleCast: false
-SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: false
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeCpp11BracedList: false
-SpaceBeforeCtorInitializerColon: true
-SpaceBeforeInheritanceColon: true
-SpaceBeforeParens: ControlStatements
-SpaceBeforeRangeBasedForLoopColon: true
-SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
-SpacesInAngles: false
-SpacesInCStyleCastParentheses: false
-SpacesInContainerLiterals: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
-Standard: Latest
-TabWidth: 4
-UseTab: Never

--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -176,7 +176,6 @@ CConsole
 CConversion
 CCRT
 cdd
-CDeclaration
 CEdit
 CELLSIZE
 cfae
@@ -332,7 +331,7 @@ Cspace
 csrmsg
 CSRSS
 csrutil
-cstyle
+CSTYLE
 CSwitch
 CTerminal
 CText

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -32,13 +32,19 @@ namespace ControlUnitTests
     class ControlInteractivityTests;
 };
 
-#define RUNTIME_SETTING(type, name, setting)                      \
-private:                                                          \
-    std::optional<type> _runtime##name{ std::nullopt };           \
-    void name(const type newValue) { _runtime##name = newValue; } \
-                                                                  \
-public:                                                           \
-    type name() const { return til::coalesce_value(_runtime##name, setting); }
+#define RUNTIME_SETTING(type, name, setting)                 \
+private:                                                     \
+    std::optional<type> _runtime##name{ std::nullopt };      \
+    void name(const type newValue)                           \
+    {                                                        \
+        _runtime##name = newValue;                           \
+    }                                                        \
+                                                             \
+public:                                                      \
+    type name() const                                        \
+    {                                                        \
+        return til::coalesce_value(_runtime##name, setting); \
+    }
 
 namespace winrt::Microsoft::Terminal::Control::implementation
 {

--- a/src/cascadia/TerminalControl/ControlSettings.h
+++ b/src/cascadia/TerminalControl/ControlSettings.h
@@ -65,9 +65,15 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // appearance is being used should be more careful. Fortunately, this
         // situation is generally only used when a control is first created, or
         // when calling UpdateSettings.
-#define APPEARANCE_GEN(type, name, ...)                               \
-    type name() const noexcept { return _focusedAppearance->name(); } \
-    void name(const type& value) noexcept { _focusedAppearance->name(value); }
+#define APPEARANCE_GEN(type, name, ...)    \
+    type name() const noexcept             \
+    {                                      \
+        return _focusedAppearance->name(); \
+    }                                      \
+    void name(const type& value) noexcept  \
+    {                                      \
+        _focusedAppearance->name(value);   \
+    }
 
         CORE_APPEARANCE_SETTINGS(APPEARANCE_GEN)
         CONTROL_APPEARANCE_SETTINGS(APPEARANCE_GEN)

--- a/src/cascadia/TerminalSettingsEditor/ViewModelHelpers.h
+++ b/src/cascadia/TerminalSettingsEditor/ViewModelHelpers.h
@@ -37,19 +37,25 @@ protected:
     winrt::event<::winrt::Windows::UI::Xaml::Data::PropertyChangedEventHandler> _propertyChangedHandlers;
 };
 
-#define _BASE_OBSERVABLE_PROJECTED_SETTING(target, name)  \
-public:                                                   \
-    auto name() const noexcept { return target.name(); }; \
-    template<typename T>                                  \
-    void name(const T& value)                             \
-    {                                                     \
-        if (name() != value)                              \
-        {                                                 \
-            target.name(value);                           \
-            _NotifyChanges(L"Has" #name, L## #name);      \
-        }                                                 \
-    }                                                     \
-    bool Has##name() { return target.Has##name(); }
+#define _BASE_OBSERVABLE_PROJECTED_SETTING(target, name) \
+public:                                                  \
+    auto name() const noexcept                           \
+    {                                                    \
+        return target.name();                            \
+    };                                                   \
+    template<typename T>                                 \
+    void name(const T& value)                            \
+    {                                                    \
+        if (name() != value)                             \
+        {                                                \
+            target.name(value);                          \
+            _NotifyChanges(L"Has" #name, L## #name);     \
+        }                                                \
+    }                                                    \
+    bool Has##name()                                     \
+    {                                                    \
+        return target.Has##name();                       \
+    }
 
 // Defines a setting that reflects another object's same-named
 // setting.
@@ -64,7 +70,10 @@ public:                                                   \
             _NotifyChanges(L"Has" #name, L## #name); \
         }                                            \
     }                                                \
-    auto name##OverrideSource() { return target.name##OverrideSource(); }
+    auto name##OverrideSource()                      \
+    {                                                \
+        return target.name##OverrideSource();        \
+    }
 
 // Defines a setting that reflects another object's same-named
 // setting, but which cannot be erased.
@@ -76,7 +85,10 @@ public:                                                   \
 // except it leverages _NotifyChanges.
 #define VIEW_MODEL_OBSERVABLE_PROPERTY(type, name, ...) \
 public:                                                 \
-    type name() const noexcept { return _##name; };     \
+    type name() const noexcept                          \
+    {                                                   \
+        return _##name;                                 \
+    };                                                  \
     void name(const type& value)                        \
     {                                                   \
         if (_##name != value)                           \

--- a/src/cascadia/TerminalSettingsEditor/ViewModelHelpers.idl.h
+++ b/src/cascadia/TerminalSettingsEditor/ViewModelHelpers.idl.h
@@ -9,7 +9,10 @@
         get;                                           \
         set;                                           \
     };                                                 \
-    Boolean Has##Name { get; }
+    Boolean Has##Name                                  \
+    {                                                  \
+        get;                                           \
+    }
 
 #define OBSERVABLE_PROJECTED_SETTING(Type, Name)    \
     _BASE_OBSERVABLE_PROJECTED_SETTING(Type, Name); \

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -56,12 +56,18 @@
 
 #include "ActionArgsMagic.h"
 
-#define ACTION_ARG(type, name, ...)                                                                    \
-public:                                                                                                \
-    type name() const noexcept { return _##name.has_value() ? _##name.value() : type{ __VA_ARGS__ }; } \
-    void name(const type& value) noexcept { _##name = value; }                                         \
-                                                                                                       \
-private:                                                                                               \
+#define ACTION_ARG(type, name, ...)                                         \
+public:                                                                     \
+    type name() const noexcept                                              \
+    {                                                                       \
+        return _##name.has_value() ? _##name.value() : type{ __VA_ARGS__ }; \
+    }                                                                       \
+    void name(const type& value) noexcept                                   \
+    {                                                                       \
+        _##name = value;                                                    \
+    }                                                                       \
+                                                                            \
+private:                                                                    \
     std::optional<type> _##name{ std::nullopt };
 
 // Notes on defining ActionArgs and ActionEventArgs:

--- a/src/cascadia/TerminalSettingsModel/IInheritable.idl.h
+++ b/src/cascadia/TerminalSettingsModel/IInheritable.idl.h
@@ -9,7 +9,10 @@
         get;                                  \
         set;                                  \
     };                                        \
-    Boolean Has##Name { get; };               \
+    Boolean Has##Name                         \
+    {                                         \
+        get;                                  \
+    };                                        \
     void Clear##Name()
 
 #define INHERITABLE_SETTING(Type, Name) \

--- a/src/cascadia/inc/cppwinrt_utils.h
+++ b/src/cascadia/inc/cppwinrt_utils.h
@@ -32,9 +32,15 @@ protected:                                               \
 // Winrt events need a method for adding a callback to the event and removing
 //      the callback. This macro will define them both for you, because they
 //      don't really vary from event to event.
-#define DEFINE_EVENT(className, name, eventHandler, args)                                         \
-    winrt::event_token className::name(const args& handler) { return eventHandler.add(handler); } \
-    void className::name(const winrt::event_token& token) noexcept { eventHandler.remove(token); }
+#define DEFINE_EVENT(className, name, eventHandler, args)          \
+    winrt::event_token className::name(const args& handler)        \
+    {                                                              \
+        return eventHandler.add(handler);                          \
+    }                                                              \
+    void className::name(const winrt::event_token& token) noexcept \
+    {                                                              \
+        eventHandler.remove(token);                                \
+    }
 
 // This is a helper macro to make declaring events easier.
 // This will declare the event handler and the methods for adding and removing a
@@ -53,9 +59,15 @@ private:                                                                        
 //      the callback. This macro will define them both for you, because they
 //      don't really vary from event to event.
 // Use this if you have a Windows.Foundation.TypedEventHandler
-#define DEFINE_EVENT_WITH_TYPED_EVENT_HANDLER(className, name, eventHandler, sender, args)                                                        \
-    winrt::event_token className::name(const Windows::Foundation::TypedEventHandler<sender, args>& handler) { return eventHandler.add(handler); } \
-    void className::name(const winrt::event_token& token) noexcept { eventHandler.remove(token); }
+#define DEFINE_EVENT_WITH_TYPED_EVENT_HANDLER(className, name, eventHandler, sender, args)                  \
+    winrt::event_token className::name(const Windows::Foundation::TypedEventHandler<sender, args>& handler) \
+    {                                                                                                       \
+        return eventHandler.add(handler);                                                                   \
+    }                                                                                                       \
+    void className::name(const winrt::event_token& token) noexcept                                          \
+    {                                                                                                       \
+        eventHandler.remove(token);                                                                         \
+    }
 
 // This is a helper macro for both declaring the signature of an event, and
 // defining the body. Winrt events need a method for adding a callback to the
@@ -63,12 +75,18 @@ private:                                                                        
 // signatures and define them both for you, because they don't really vary from
 // event to event.
 // Use this in a classes header if you have a Windows.Foundation.TypedEventHandler
-#define TYPED_EVENT(name, sender, args)                                                                                                            \
-public:                                                                                                                                            \
-    winrt::event_token name(const winrt::Windows::Foundation::TypedEventHandler<sender, args>& handler) { return _##name##Handlers.add(handler); } \
-    void name(const winrt::event_token& token) { _##name##Handlers.remove(token); }                                                                \
-                                                                                                                                                   \
-private:                                                                                                                                           \
+#define TYPED_EVENT(name, sender, args)                                                                 \
+public:                                                                                                 \
+    winrt::event_token name(const winrt::Windows::Foundation::TypedEventHandler<sender, args>& handler) \
+    {                                                                                                   \
+        return _##name##Handlers.add(handler);                                                          \
+    }                                                                                                   \
+    void name(const winrt::event_token& token)                                                          \
+    {                                                                                                   \
+        _##name##Handlers.remove(token);                                                                \
+    }                                                                                                   \
+                                                                                                        \
+private:                                                                                                \
     winrt::event<winrt::Windows::Foundation::TypedEventHandler<sender, args>> _##name##Handlers;
 
 // This is a helper macro for both declaring the signature of a callback (nee event) and
@@ -77,12 +95,18 @@ private:                                                                        
 // signatures and define them both for you, because they don't really vary from
 // event to event.
 // Use this in a class's header if you have a "delegate" type in your IDL.
-#define WINRT_CALLBACK(name, args)                                                          \
-public:                                                                                     \
-    winrt::event_token name(const args& handler) { return _##name##Handlers.add(handler); } \
-    void name(const winrt::event_token& token) { _##name##Handlers.remove(token); }         \
-                                                                                            \
-protected:                                                                                  \
+#define WINRT_CALLBACK(name, args)               \
+public:                                          \
+    winrt::event_token name(const args& handler) \
+    {                                            \
+        return _##name##Handlers.add(handler);   \
+    }                                            \
+    void name(const winrt::event_token& token)   \
+    {                                            \
+        _##name##Handlers.remove(token);         \
+    }                                            \
+                                                 \
+protected:                                       \
     winrt::event<args> _##name##Handlers;
 
 // This is a helper macro for both declaring the signature and body of an event
@@ -91,16 +115,28 @@ protected:                                                                      
 // "proxied" to the handling type. Case in point: many of the events on App are
 // just forwarded straight to TerminalPage. This macro will both declare the
 // method signatures and define them both for you.
-#define FORWARDED_TYPED_EVENT(name, sender, args, handler, handlerName)                                                        \
-public:                                                                                                                        \
-    winrt::event_token name(const Windows::Foundation::TypedEventHandler<sender, args>& h) { return handler->handlerName(h); } \
-    void name(const winrt::event_token& token) noexcept { handler->handlerName(token); }
+#define FORWARDED_TYPED_EVENT(name, sender, args, handler, handlerName)                    \
+public:                                                                                    \
+    winrt::event_token name(const Windows::Foundation::TypedEventHandler<sender, args>& h) \
+    {                                                                                      \
+        return handler->handlerName(h);                                                    \
+    }                                                                                      \
+    void name(const winrt::event_token& token) noexcept                                    \
+    {                                                                                      \
+        handler->handlerName(token);                                                       \
+    }
 
 // Same thing, but handler is a projected type, not an implementation
-#define PROJECTED_FORWARDED_TYPED_EVENT(name, sender, args, handler, handlerName)                                             \
-public:                                                                                                                       \
-    winrt::event_token name(const Windows::Foundation::TypedEventHandler<sender, args>& h) { return handler.handlerName(h); } \
-    void name(const winrt::event_token& token) noexcept { handler.handlerName(token); }
+#define PROJECTED_FORWARDED_TYPED_EVENT(name, sender, args, handler, handlerName)          \
+public:                                                                                    \
+    winrt::event_token name(const Windows::Foundation::TypedEventHandler<sender, args>& h) \
+    {                                                                                      \
+        return handler.handlerName(h);                                                     \
+    }                                                                                      \
+    void name(const winrt::event_token& token) noexcept                                    \
+    {                                                                                      \
+        handler.handlerName(token);                                                        \
+    }
 
 // This is a bit like *FORWARDED_TYPED_EVENT. When you use a forwarded event,
 // the handler gets added to the object that's raising the event. For example,
@@ -121,17 +157,26 @@ public:                                                                         
 //    _core.TitleChanged({ get_weak(), &TermControl::_bubbleTitleChanged });
 #define BUBBLED_FORWARDED_TYPED_EVENT(name, sender, args) \
     TYPED_EVENT(name, sender, args)                       \
-    void _bubble##name(const sender& s, const args& a) { _##name##Handlers(s, a); }
+    void _bubble##name(const sender& s, const args& a)    \
+    {                                                     \
+        _##name##Handlers(s, a);                          \
+    }
 
 // Use this macro to quick implement both the getter and setter for a property.
 // This should only be used for simple types where there's no logic in the
 // getter/setter beyond just accessing/updating the value.
-#define WINRT_PROPERTY(type, name, ...)                        \
-public:                                                        \
-    type name() const noexcept { return _##name; }             \
-    void name(const type& value) noexcept { _##name = value; } \
-                                                               \
-private:                                                       \
+#define WINRT_PROPERTY(type, name, ...)   \
+public:                                   \
+    type name() const noexcept            \
+    {                                     \
+        return _##name;                   \
+    }                                     \
+    void name(const type& value) noexcept \
+    {                                     \
+        _##name = value;                  \
+    }                                     \
+                                          \
+private:                                  \
     type _##name{ __VA_ARGS__ };
 
 // Use this macro to quickly implement both the getter and setter for an
@@ -143,7 +188,10 @@ private:                                                       \
 // (like when the class is being initialized).
 #define WINRT_OBSERVABLE_PROPERTY(type, name, event, ...)                                 \
 public:                                                                                   \
-    type name() const noexcept { return _##name; };                                       \
+    type name() const noexcept                                                            \
+    {                                                                                     \
+        return _##name;                                                                   \
+    };                                                                                    \
     void name(const type& value)                                                          \
     {                                                                                     \
         if (_##name != value)                                                             \

--- a/src/inc/til/bytes.h
+++ b/src/inc/til/bytes.h
@@ -40,7 +40,7 @@ namespace til
     }
 
     template<ContiguousBytes Target, ContiguousView Source>
-    requires TriviallyCopyable<typename Source::value_type>
+        requires TriviallyCopyable<typename Source::value_type>
     constexpr void bytes_transfer(Target& target, Source& source)
     {
         using TargetType = typename Target::value_type;

--- a/src/inc/til/pmr.h
+++ b/src/inc/til/pmr.h
@@ -39,7 +39,7 @@ namespace til::pmr
             {
                 if (align > __STDCPP_DEFAULT_NEW_ALIGNMENT__)
                 {
-                    return ::operator new (bytes, std::align_val_t{ align });
+                    return ::operator new(bytes, std::align_val_t{ align });
                 }
 
                 return ::operator new(bytes);
@@ -49,7 +49,7 @@ namespace til::pmr
             {
                 if (align > __STDCPP_DEFAULT_NEW_ALIGNMENT__)
                 {
-                    return ::operator delete (ptr, bytes, std::align_val_t{ align });
+                    return ::operator delete(ptr, bytes, std::align_val_t{ align });
                 }
 
                 ::operator delete(ptr, bytes);

--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -94,14 +94,35 @@ namespace Microsoft::Console::Render
         return __builtin_memcmp(this, &rhs, sizeof(rhs)) != 0; \
     }
 
-#define ATLAS_FLAG_OPS(type, underlying)                                                                                                                    \
-    friend constexpr type operator~(type v) noexcept { return static_cast<type>(~static_cast<underlying>(v)); }                                             \
-    friend constexpr type operator|(type lhs, type rhs) noexcept { return static_cast<type>(static_cast<underlying>(lhs) | static_cast<underlying>(rhs)); } \
-    friend constexpr type operator&(type lhs, type rhs) noexcept { return static_cast<type>(static_cast<underlying>(lhs) & static_cast<underlying>(rhs)); } \
-    friend constexpr type operator^(type lhs, type rhs) noexcept { return static_cast<type>(static_cast<underlying>(lhs) ^ static_cast<underlying>(rhs)); } \
-    friend constexpr void operator|=(type& lhs, type rhs) noexcept { lhs = lhs | rhs; }                                                                     \
-    friend constexpr void operator&=(type& lhs, type rhs) noexcept { lhs = lhs & rhs; }                                                                     \
-    friend constexpr void operator^=(type& lhs, type rhs) noexcept { lhs = lhs ^ rhs; }
+#define ATLAS_FLAG_OPS(type, underlying)                                                       \
+    friend constexpr type operator~(type v) noexcept                                           \
+    {                                                                                          \
+        return static_cast<type>(~static_cast<underlying>(v));                                 \
+    }                                                                                          \
+    friend constexpr type operator|(type lhs, type rhs) noexcept                               \
+    {                                                                                          \
+        return static_cast<type>(static_cast<underlying>(lhs) | static_cast<underlying>(rhs)); \
+    }                                                                                          \
+    friend constexpr type operator&(type lhs, type rhs) noexcept                               \
+    {                                                                                          \
+        return static_cast<type>(static_cast<underlying>(lhs) & static_cast<underlying>(rhs)); \
+    }                                                                                          \
+    friend constexpr type operator^(type lhs, type rhs) noexcept                               \
+    {                                                                                          \
+        return static_cast<type>(static_cast<underlying>(lhs) ^ static_cast<underlying>(rhs)); \
+    }                                                                                          \
+    friend constexpr void operator|=(type& lhs, type rhs) noexcept                             \
+    {                                                                                          \
+        lhs = lhs | rhs;                                                                       \
+    }                                                                                          \
+    friend constexpr void operator&=(type& lhs, type rhs) noexcept                             \
+    {                                                                                          \
+        lhs = lhs & rhs;                                                                       \
+    }                                                                                          \
+    friend constexpr void operator^=(type& lhs, type rhs) noexcept                             \
+    {                                                                                          \
+        lhs = lhs ^ rhs;                                                                       \
+    }
 
         template<typename T>
         struct vec2

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="clang-format.win-x86" version="13.0.1" targetFramework="native" />
+  <package id="clang-format.win-x86" version="15.0.7" targetFramework="native" />
 </packages>


### PR DESCRIPTION
Upgrading clang-format lead to a few changes in the formatting
of code inside macros. Apart from the upgrade, I've also spent
some time removing all options from .clang-format that are
redundant with `BasedOnStyle: Microsoft`.