### PR TITLE
Return success if ReadCharacterInput read >0 characters

### DIFF
--- a/src/host/stream.cpp
+++ b/src/host/stream.cpp
@@ -445,7 +445,7 @@ try
     {
         wchar_t wch;
         status = GetChar(&inputBuffer, &wch, wait, nullptr, nullptr, nullptr);
-        if (!NT_SUCCESS(status))
+        if (FAILED_NTSTATUS(status))
         {
             break;
         }
@@ -457,7 +457,7 @@ try
     }
 
     bytesRead = buffer.size() - writer.size();
-    return status;
+    return wait ? status : STATUS_SUCCESS;
 }
 NT_CATCH_RETURN()
 

--- a/src/host/stream.cpp
+++ b/src/host/stream.cpp
@@ -436,15 +436,15 @@ try
 
     inputBuffer.ConsumeCached(unicode, writer);
 
-    // We don't need to wait for input if `ConsumeCached` read something already, which is
-    // indicated by the writer having been advanced (= it's shorter than the original buffer).
-    auto wait = writer.size() == buffer.size();
+    auto noDataReadYet = writer.size() == buffer.size();
     auto status = STATUS_SUCCESS;
 
     while (writer.size() >= charSize)
     {
         wchar_t wch;
-        status = GetChar(&inputBuffer, &wch, wait, nullptr, nullptr, nullptr);
+        // We don't need to wait for input if `ConsumeCached` read something already, which is
+        // indicated by the writer having been advanced (= it's shorter than the original buffer).
+        status = GetChar(&inputBuffer, &wch, noDataReadYet, nullptr, nullptr, nullptr);
         if (FAILED_NTSTATUS(status))
         {
             break;
@@ -453,11 +453,13 @@ try
         std::wstring_view wchView{ &wch, 1 };
         inputBuffer.Consume(unicode, wchView, writer);
 
-        wait = false;
+        noDataReadYet = false;
     }
 
     bytesRead = buffer.size() - writer.size();
-    return wait ? status : STATUS_SUCCESS;
+    // Once we read some data off the InputBuffer it can't be read again, so we
+    // need to make sure to return a success status to the client in that case.
+    return noDataReadYet ? status : STATUS_SUCCESS;
 }
 NT_CATCH_RETURN()
 


### PR DESCRIPTION
This is a regression caused by 599b550. If I'm reading `stream.cpp`
in cf87590 right, it returns `STATUS_SUCCESS` if `ReadCharacterInput`
read at least 1 character. I think? this PR makes the code behave
exactly equivalent. The old code is a bit of an "acquired taste"
so it's a bit hard to tell.

Closes #15116

## PR Checklist
* Run `more long_text_file.txt` in cmd
* Press Spacebar
* Scrolls down ✅
* Press Q
* Exits ✅