### PR TITLE
Only try to hand off to ConhostV1 if building for Windows

### DIFF
--- a/src/features.xml
+++ b/src/features.xml
@@ -68,6 +68,15 @@
     </feature>
 
     <feature>
+        <name>Feature_LegacyConhost</name>
+        <description>conhost should support ForceV2=false, and try to load conhostv1.dll</description>
+        <stage>AlwaysDisabled</stage>
+        <alwaysEnabledBrandingTokens>
+            <brandingToken>WindowsInbox</brandingToken>
+        </alwaysEnabledBrandingTokens>
+    </feature>
+
+    <feature>
         <name>Feature_AtlasEngine</name>
         <description>If enabled, AtlasEngine is used by default</description>
         <stage>AlwaysEnabled</stage>

--- a/src/host/exe/exemain.cpp
+++ b/src/host/exe/exemain.cpp
@@ -52,6 +52,27 @@ class DefaultOutOfProcModuleWithRegistrationFlag : public OutOfProcModuleWithReg
 // Holds the wwinmain open until COM tells us there are no more server connections
 wil::unique_event _comServerExitEvent;
 
+[[nodiscard]] static HRESULT ValidateServerHandle(const HANDLE handle)
+{
+    // Make sure this is a console file.
+    FILE_FS_DEVICE_INFORMATION DeviceInformation;
+    IO_STATUS_BLOCK IoStatusBlock;
+    const auto Status = NtQueryVolumeInformationFile(handle, &IoStatusBlock, &DeviceInformation, sizeof(DeviceInformation), FileFsDeviceInformation);
+    if (FAILED_NTSTATUS(Status))
+    {
+        RETURN_NTSTATUS(Status);
+    }
+    else if (DeviceInformation.DeviceType != FILE_DEVICE_CONSOLE)
+    {
+        return E_INVALIDARG;
+    }
+    else
+    {
+        return S_OK;
+    }
+}
+
+#if TIL_FEATURE_LEGACYCONHOST_ENABLED
 static bool useV2 = true;
 static bool ConhostV2ForcedInRegistry()
 {
@@ -99,26 +120,6 @@ static bool ConhostV2ForcedInRegistry()
     }
 
     return fShouldUseConhostV2;
-}
-
-[[nodiscard]] static HRESULT ValidateServerHandle(const HANDLE handle)
-{
-    // Make sure this is a console file.
-    FILE_FS_DEVICE_INFORMATION DeviceInformation;
-    IO_STATUS_BLOCK IoStatusBlock;
-    const auto Status = NtQueryVolumeInformationFile(handle, &IoStatusBlock, &DeviceInformation, sizeof(DeviceInformation), FileFsDeviceInformation);
-    if (FAILED_NTSTATUS(Status))
-    {
-        RETURN_NTSTATUS(Status);
-    }
-    else if (DeviceInformation.DeviceType != FILE_DEVICE_CONSOLE)
-    {
-        return E_INVALIDARG;
-    }
-    else
-    {
-        return S_OK;
-    }
 }
 
 static bool ShouldUseLegacyConhost(const ConsoleArguments& args)
@@ -185,6 +186,7 @@ static bool ShouldUseLegacyConhost(const ConsoleArguments& args)
 
     return hr;
 }
+#endif // TIL_FEATURE_LEGACYCONHOST_ENABLED
 
 // Routine Description:
 // - Called back when COM says there is nothing left for our server to do and we can tear down.
@@ -303,6 +305,7 @@ int CALLBACK wWinMain(
         else
 #endif
         {
+#if TIL_FEATURE_LEGACYCONHOST_ENABLED
             if (ShouldUseLegacyConhost(args))
             {
                 useV2 = false;
@@ -321,6 +324,7 @@ int CALLBACK wWinMain(
                 }
             }
             if (useV2)
+#endif // TIL_FEATURE_LEGACYCONHOST_ENABLED
             {
                 if (args.ShouldCreateServerHandle())
                 {


### PR DESCRIPTION
Some of our automated tooling detects this as being a private API that we're accessing via LoadLibrary/GetProcAddress. It's not *wrong*, but it's also not *right*.

It's easier for us to just not do it (and save all the code for it!) in OpenConsole.