### PR TITLE
Enable ctrl+shift click to run terminal elevated from context menu

### DIFF
--- a/src/cascadia/ShellExtension/OpenTerminalHere.cpp
+++ b/src/cascadia/ShellExtension/OpenTerminalHere.cpp
@@ -27,7 +27,7 @@ HRESULT OpenTerminalHere::Invoke(IShellItemArray* psiItemArray,
                                  IBindCtx* /*pBindContext*/)
 try
 {
-    const auto runElevated = IsControlPressed();
+    const auto runElevated = IsControlPressed() && IsShiftPressed();
 
     wil::com_ptr_nothrow<IShellItem> psi;
     RETURN_IF_FAILED(GetBestLocationFromSelectionOrSite(psiItemArray, psi.put()));
@@ -214,4 +214,16 @@ bool OpenTerminalHere::IsControlPressed()
     const auto rightControl = GetKeyState(VK_RCONTROL);
 
     return WI_IsFlagSet(control, ControlPressed) || WI_IsFlagSet(leftControl, ControlPressed) || WI_IsFlagSet(rightControl, ControlPressed);
+}
+
+//Check if either shift key is pressed during shell extension activation
+bool OpenTerminalHere::IsShiftPressed()
+{
+    const auto ShiftPressed = 1U;
+
+    const auto shift = GetKeyState(VK_SHIFT);
+    const auto leftShift = GetKeyState(VK_LSHIFT);
+    const auto rightShift = GetKeyState(VK_RSHIFT);
+
+    return WI_IsFlagSet(shift, ShiftPressed) || WI_IsFlagSet(leftShift, ShiftPressed) || WI_IsFlagSet(rightShift, ShiftPressed);
 }

--- a/src/cascadia/ShellExtension/OpenTerminalHere.cpp
+++ b/src/cascadia/ShellExtension/OpenTerminalHere.cpp
@@ -27,7 +27,7 @@ HRESULT OpenTerminalHere::Invoke(IShellItemArray* psiItemArray,
                                  IBindCtx* /*pBindContext*/)
 try
 {
-    const auto runElevated = IsControlPressed() && IsShiftPressed();
+    const auto runElevated = IsControlAndShiftPressed();
 
     wil::com_ptr_nothrow<IShellItem> psi;
     RETURN_IF_FAILED(GetBestLocationFromSelectionOrSite(psiItemArray, psi.put()));
@@ -204,26 +204,14 @@ HRESULT OpenTerminalHere::GetBestLocationFromSelectionOrSite(IShellItemArray* ps
     return S_OK;
 }
 
-// This method checks if any of the ctrl keys are pressed during activation of the shell extension
-bool OpenTerminalHere::IsControlPressed()
+// Check is both ctrl and shift keys are pressed during activation of the shell extension
+bool OpenTerminalHere::IsControlAndShiftPressed()
 {
-    const auto ControlPressed = 1U;
+    short control = 0;
+    short shift = 0;
+    control = GetAsyncKeyState(VK_CONTROL);
+    shift = GetAsyncKeyState(VK_SHIFT);
 
-    const auto control = GetKeyState(VK_CONTROL);
-    const auto leftControl = GetKeyState(VK_LCONTROL);
-    const auto rightControl = GetKeyState(VK_RCONTROL);
-
-    return WI_IsFlagSet(control, ControlPressed) || WI_IsFlagSet(leftControl, ControlPressed) || WI_IsFlagSet(rightControl, ControlPressed);
-}
-
-//Check if either shift key is pressed during shell extension activation
-bool OpenTerminalHere::IsShiftPressed()
-{
-    const auto ShiftPressed = 1U;
-
-    const auto shift = GetKeyState(VK_SHIFT);
-    const auto leftShift = GetKeyState(VK_LSHIFT);
-    const auto rightShift = GetKeyState(VK_RSHIFT);
-
-    return WI_IsFlagSet(shift, ShiftPressed) || WI_IsFlagSet(leftShift, ShiftPressed) || WI_IsFlagSet(rightShift, ShiftPressed);
+    //GetAsyncKeyState returns a value with the most significant bit set to 1 if the key is pressed. This is the sign bit.
+    return control < 0 && shift < 0;
 }

--- a/src/cascadia/ShellExtension/OpenTerminalHere.h
+++ b/src/cascadia/ShellExtension/OpenTerminalHere.h
@@ -58,8 +58,7 @@ struct
 private:
     HRESULT GetLocationFromSite(IShellItem** location) const noexcept;
     HRESULT GetBestLocationFromSelectionOrSite(IShellItemArray* psiArray, IShellItem** location) const noexcept;
-    bool IsControlPressed();
-    bool IsShiftPressed();
+    bool IsControlAndShiftPressed();
 
     wil::com_ptr_nothrow<IUnknown> site_;
 };

--- a/src/cascadia/ShellExtension/OpenTerminalHere.h
+++ b/src/cascadia/ShellExtension/OpenTerminalHere.h
@@ -59,6 +59,7 @@ private:
     HRESULT GetLocationFromSite(IShellItem** location) const noexcept;
     HRESULT GetBestLocationFromSelectionOrSite(IShellItemArray* psiArray, IShellItem** location) const noexcept;
     bool IsControlPressed();
+    bool IsShiftPressed();
 
     wil::com_ptr_nothrow<IUnknown> site_;
 };


### PR DESCRIPTION
## This pull request adds the requirement for the shift key to be pressed in addition to the control key.

## 14810 PR 14873

## This is follow up work from my last pull request that was merged that only required the control key to be pressed to launch the terminal as admin from the shell context menu. After some discussion it was decided that the shift key should be required as well as that is the norm on Windows.

## Validation Steps Performed
Tested all combinations of shift+ctrl and verified that the terminal only requests elevation when a shift and control key are pressed together. The shell launches regularly if not.

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
