### PR TITLE
Helix: Decode HTML entities in the test comment field

### DIFF
--- a/build/Helix/ProcessHelixFiles.ps1
+++ b/build/Helix/ProcessHelixFiles.ps1
@@ -70,7 +70,7 @@ foreach ($testRun in $testRuns.value)
 
     foreach ($testResult in $testResults.value)
     {
-        $info = ConvertFrom-Json $testResult.comment
+        $info = ConvertFrom-Json ([System.Web.HttpUtility]::HtmlDecode($testResult.comment))
         $helixJobId = $info.HelixJobId
         $helixWorkItemName = $info.HelixWorkItemName
 


### PR DESCRIPTION
I have observed the test comment coming back from Helix with &quot; and friends in it.

It ends badly as you might imagine.

This unescape will be a no-op if the data is already well-formed.