### PR TITLE
Register the GetWindowLayoutRequested handler only when ready

### DIFF
--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -388,7 +388,7 @@ void AppHost::Initialize()
     // to move to. If we set up this callback in the ctor, then it is possible
     // for there to be a time slice where
     // * the monarch creates the peasant for us,
-    // * we get ctor'ed (registering the callback)
+    // * we get constructed (registering the callback)
     // * then the monarch attempts to query all _peasants_ for their layout,
     //   coming back to ask us even before XAML has been created.
     _GetWindowLayoutRequestedToken = _peasant.GetWindowLayoutRequested([this](auto&&,


### PR DESCRIPTION
Moves our `GetWindowLayoutRequested` handler AFTER the xaml island is started. The `AppHost::_GetWindowLayoutAsync` handler requires us to be able to work on our UI thread, which requires that we have a `Dispatcher` ready for us to move to. If we set up this callback in the ctor, then it is possible for there to be a time slice where
* the monarch creates the peasant for us,
* we get ctor'ed (registering the callback)
* then the monarch attempts to query all _peasants_ for their layout, coming back to ask us even before XAML has been created.

I believe this was the source of the crash that was reported in a mail thread. It actually happened to me once while debugging another branch. Alas, this was realy hard to hit in the first place, so I'm not _totally_ certain this fixes it.

Related to #14957
