### PR TITLE
Skip generating a profile for rancher-desktop

### DIFF
--- a/src/cascadia/TerminalSettingsModel/WslDistroGenerator.cpp
+++ b/src/cascadia/TerminalSettingsModel/WslDistroGenerator.cpp
@@ -11,6 +11,7 @@
 
 static constexpr std::wstring_view WslHomeDirectory{ L"~" };
 static constexpr std::wstring_view DockerDistributionPrefix{ L"docker-desktop" };
+static constexpr std::wstring_view RancherDistributionPrefix{ L"rancher-desktop" };
 
 // The WSL entries are structured as such:
 // HKCU\Software\Microsoft\Windows\CurrentVersion\Lxss
@@ -78,9 +79,9 @@ static void namesToProfiles(const std::vector<std::wstring>& names, std::vector<
 {
     for (const auto& distName : names)
     {
-        if (til::starts_with(distName, DockerDistributionPrefix))
+        if (til::starts_with(distName, DockerDistributionPrefix) || til::starts_with(distName, RancherDistributionPrefix))
         {
-            // Docker for Windows creates some utility distributions to handle Docker commands.
+            // Docker for Windows and Rancher for Windows creates some utility distributions to handle Docker commands.
             // Pursuant to GH#3556, because they are _not_ user-facing we want to hide them.
             continue;
         }


### PR DESCRIPTION
Don't generate a profile for rancher-desktop utility WSL distro

Adds a check for rancher-desktop as well as docker. As mentioned in the discussion of this issue. This becomes much more difficult to maintain once other folks inevitably start to follow this pattern. But the easy win was up for grabs so I took it :)

Closes #12757 