### PR TITLE
A more efficient copy assignment operator for Pane.LayoutSizeNode

### DIFF
--- a/src/cascadia/TerminalApp/Pane.LayoutSizeNode.cpp
+++ b/src/cascadia/TerminalApp/Pane.LayoutSizeNode.cpp
@@ -37,37 +37,10 @@ Pane::LayoutSizeNode& Pane::LayoutSizeNode::operator=(const LayoutSizeNode& othe
     size = other.size;
     isMinimumSize = other.isMinimumSize;
 
-    _AssignChildNode(firstChild, other.firstChild.get());
-    _AssignChildNode(secondChild, other.secondChild.get());
-    _AssignChildNode(nextFirstChild, other.nextFirstChild.get());
-    _AssignChildNode(nextSecondChild, other.nextSecondChild.get());
+    firstChild = other.firstChild ? std::make_unique<LayoutSizeNode>(*other.firstChild) : nullptr;
+    secondChild = other.secondChild ? std::make_unique<LayoutSizeNode>(*other.secondChild) : nullptr;
+    nextFirstChild = other.nextFirstChild ? std::make_unique<LayoutSizeNode>(*other.nextFirstChild) : nullptr;
+    nextSecondChild = other.nextSecondChild ? std::make_unique<LayoutSizeNode>(*other.nextSecondChild) : nullptr;
 
     return *this;
-}
-
-// Method Description:
-// - Performs assignment operation on a single child node reusing
-// - current one if present.
-// Arguments:
-// - nodeField: Reference to our field holding concerned node.
-// - other: Node to take the values from.
-// Return Value:
-// - <none>
-void Pane::LayoutSizeNode::_AssignChildNode(std::unique_ptr<LayoutSizeNode>& nodeField, const LayoutSizeNode* const newNode)
-{
-    if (newNode)
-    {
-        if (nodeField)
-        {
-            *nodeField = *newNode;
-        }
-        else
-        {
-            nodeField = std::make_unique<LayoutSizeNode>(*newNode);
-        }
-    }
-    else
-    {
-        nodeField.release();
-    }
 }

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -394,9 +394,6 @@ private:
         LayoutSizeNode(const LayoutSizeNode& other);
 
         LayoutSizeNode& operator=(const LayoutSizeNode& other);
-
-    private:
-        void _AssignChildNode(std::unique_ptr<LayoutSizeNode>& nodeField, const LayoutSizeNode* const newNode);
     };
 
     friend struct winrt::TerminalApp::implementation::TerminalTab;


### PR DESCRIPTION
## Summary of the Pull Request
This pull request updates the implementation of the copy assignment operator for Pane::LayoutSizeNode to a more efficient version and eliminates the need for the _AssignChildNode code block. 
## References and Relevant Issues
#11965 #11963 
## Detailed Description of the Pull Request / Additional comments
My understanding of the discussion and intent of the two linked issues is that this is a more efficient way to implement the copy assignment operator for Pane.LayoutSizeNode and eliminates the need for the code block _AssignChildNode. Since both were relatively small changes, I combined the two in one PR. If that is not desirable, I can separate them. All existing tests continue to pass.

<img width="769" alt="image" src="https://user-images.githubusercontent.com/2086722/231326683-8f685f58-5748-4d49-8a38-80ef5db3d5a2.png">

## Validation Steps Performed
All existing tests pass. No visible changes in behavior of the terminal.
## PR Checklist
- [x] Closes #11963  
- [x] Closes #11965 
- [x] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
