### PR TITLE
Fix a hang when writing wide glyphs into a 1 column terminal

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -272,10 +272,6 @@ bool TextBuffer::_AssertValidDoubleByteSequence(const DbcsAttribute dbcsAttribut
 // - false otherwise (out of memory)
 bool TextBuffer::_PrepareForDoubleByteSequence(const DbcsAttribute dbcsAttribute)
 {
-    // This function corrects most errors. If this is false, we had an uncorrectable one which
-    // older versions of conhost simply let pass by unflinching.
-    LOG_HR_IF(E_NOT_VALID_STATE, !(_AssertValidDoubleByteSequence(dbcsAttribute))); // Shouldn't be uncorrectable sequences unless something is very wrong.
-
     auto fSuccess = true;
     // Now compensate if we don't have enough space for the upcoming double byte sequence
     // We only need to compensate for leading bytes


### PR DESCRIPTION
The code changes are mostly self-explanatory: Just skip glyphs
that can never be inserted. I implemented it slightly incorrectly
(a newline will be inserted every time you write such a wide glyph),
but it's a niche issue and I think the simplicity of the fix is
more important than its exact correctness.

It also contains a fix for some severe log spam due to
`_PrepareForDoubleByteSequence` complaining in this situation.
The spam is so bad that it freezes the app for a few seconds
during text buffer reflow.

Closes #7416

## Validation Steps Performed
* Open an extra pane and run `TerminalStress.exe` in there
* Resize to 1 column
* Doesn't hang ✅