### PR TITLE
Fix missing call to UpdateViewport::UpdateViewport during tearout

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -251,8 +251,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // Bubble this up, so our new control knows how big we want the font.
         _FontSizeChangedHandlers(actualNewSize.width, actualNewSize.height, true);
 
-        // Turn the rendering back on now that we're ready to go.
-        _renderer->EnablePainting();
         _AttachedHandlers(*this, nullptr);
     }
 

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -251,6 +251,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // Bubble this up, so our new control knows how big we want the font.
         _FontSizeChangedHandlers(actualNewSize.width, actualNewSize.height, true);
 
+        // The renderer will be re-enabled in Initialize
+
         _AttachedHandlers(*this, nullptr);
     }
 

--- a/src/renderer/base/renderer.cpp
+++ b/src/renderer/base/renderer.cpp
@@ -638,6 +638,7 @@ void Renderer::EnablePainting()
     // When the renderer is constructed, the initial viewport won't be available yet,
     // but once EnablePainting is called it should be safe to retrieve.
     _viewport = _pData->GetViewport();
+    _forceUpdateViewport = true;
 
     // When running the unit tests, we may be using a render without a render thread.
     if (_pThread)

--- a/src/renderer/base/renderer.hpp
+++ b/src/renderer/base/renderer.hpp
@@ -131,7 +131,7 @@ namespace Microsoft::Console::Render
         std::function<void()> _pfnFrameColorChanged;
         std::function<void()> _pfnRendererEnteredErrorState;
         bool _destructing = false;
-        bool _forceUpdateViewport = true;
+        bool _forceUpdateViewport = false;
 
 #ifdef UNIT_TESTING
         friend class ConptyOutputTests;


### PR DESCRIPTION
This bug causes AtlasEngine to render buffer contents with an incorrect
`cellCount`, which may either cause it to draw the contents only
partially, or potentially access the TextBuffer contents out of bounds.

`EnablePainting` sets the `_viewport` to the current viewport for some
unfortunate (and quite buggy/incorrect) caching purposes, which causes
`_CheckViewportAndScroll()` to think that the viewport hasn't changed
in the new window. We can ensure `_CheckViewportAndScroll()` works
by also setting `_forceUpdateViewport` to `true`.

Part of #14957

## PR Checklist
* Tear out a tab from a smaller window to a larger window
* Renderer contents adept to the larger window size ✅