### PR TITLE
Fix reordering tabs mysteriously shuffling the actual backing tabs

### DIFF
--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -1079,18 +1079,57 @@ namespace winrt::TerminalApp::implementation
     }
 
     void TerminalPage::_TabDragStarted(const IInspectable& /*sender*/,
-                                       const IInspectable& /*eventArgs*/)
+                                       const winrt::Microsoft::UI::Xaml::Controls::TabViewTabDragStartingEventArgs& eventArgs)
     {
         _rearranging = true;
         _rearrangeFrom = std::nullopt;
         _rearrangeTo = std::nullopt;
+
+        const auto& draggedTvi{ eventArgs.Tab() };
+        uint32_t tabIndexFromControl{};
+        const auto tabItems{ _tabView.TabItems() };
+        if (tabItems.IndexOf(draggedTvi, tabIndexFromControl))
+        {
+            // If IndexOf returns true, we've actually got an index
+            _rearrangeFrom = tabIndexFromControl;
+        }
     }
 
     void TerminalPage::_TabDragCompleted(const IInspectable& /*sender*/,
-                                         const IInspectable& /*eventArgs*/)
+                                         const winrt::Microsoft::UI::Xaml::Controls::TabViewTabDragCompletedEventArgs& eventArgs)
     {
+        // FIRST
+        // * Get the `from` index. Get this by finding the TabBase of the
+        //   TabViewItem that's been dropped, and finding the index of it in
+        //   _tabs.
+        //
+        const auto& draggedTvi{ eventArgs.Tab() };
+
+        uint32_t tabIndexFromControl{};
+        // winrt::TerminalApp::TabBase tabBase{nullptr};
+        const auto tabItems{ _tabView.TabItems() };
+        if (tabItems.IndexOf(draggedTvi, tabIndexFromControl))
+        {
+            // If IndexOf returns true, we've actually got an index
+            // tabBase = _tabs.GetAt(tabIndexFromControl);
+            _rearrangeTo = tabIndexFromControl;
+        }
+        // if (tabBase ==nullptr)
+        //     {return;}
+
+        // winrt::com_ptr<TabBase> tabImpl;
+        // tabImpl.copy_from(winrt::get_self<TabBase>(tabBase));
+        // if (tabImpl ==nullptr)
+        // {
+        //     return;
+        // }
+
         auto& from{ _rearrangeFrom };
         auto& to{ _rearrangeTo };
+
+        // SECOND
+        // * get the `to` index. To do that, get the index of the dropped
+        //   TabViewItem in the TabView's items
 
         if (from.has_value() && to.has_value() && to != from)
         {

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -1060,10 +1060,10 @@ namespace winrt::TerminalApp::implementation
         // Start tracking the index of the tab that is being dragged. In
         // `_TabDragCompleted`, we'll use this to determine how to reorder our
         // internal tabs list.
-        const auto& draggedTvi{ eventArgs.Tab() };
+        const auto& draggedTabViewItem{ eventArgs.Tab() };
         uint32_t tabIndexFromControl{};
         const auto tabItems{ _tabView.TabItems() };
-        if (tabItems.IndexOf(draggedTvi, tabIndexFromControl))
+        if (tabItems.IndexOf(draggedTabViewItem, tabIndexFromControl))
         {
             // If IndexOf returns true, we've actually got an index
             _rearrangeFrom = tabIndexFromControl;
@@ -1073,11 +1073,11 @@ namespace winrt::TerminalApp::implementation
     void TerminalPage::_TabDragCompleted(const IInspectable& /*sender*/,
                                          const winrt::MUX::Controls::TabViewTabDragCompletedEventArgs& eventArgs)
     {
-        const auto& draggedTvi{ eventArgs.Tab() };
+        const auto& draggedTabViewItem{ eventArgs.Tab() };
 
         uint32_t tabIndexFromControl{};
         const auto tabItems{ _tabView.TabItems() };
-        if (tabItems.IndexOf(draggedTvi, tabIndexFromControl))
+        if (tabItems.IndexOf(draggedTabViewItem, tabIndexFromControl))
         {
             _rearrangeTo = tabIndexFromControl;
         }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4739,13 +4739,30 @@ namespace winrt::TerminalApp::implementation
                 }
             }
 
+            const auto otherId{ winrt::unbox_value_or<uint32_t>(windowIdObj, 0) };
+            const auto myId{ _WindowProperties.WindowId() };
+            otherId;
+            // if (otherId == myId)
+            // {
+            //     // dragged from us to ourselves
+
+            //     uint32_t tabIndexFromTab{};
+            //     if (_tabs.IndexOf(*_stashed.draggedTab, tabIndexFromTab))
+            //     {
+            //         _rearrangeFrom = tabIndexFromTab;
+            //         _rearrangeTo = index;
+            //     }
+            // }
+            // else
+            // {
             // `this` is safe to use
-            const auto request = winrt::make_self<RequestReceiveContentArgs>(src, _WindowProperties.WindowId(), index);
+            const auto request = winrt::make_self<RequestReceiveContentArgs>(src, myId, index);
 
             // This will go up to the monarch, who will then dispatch the request
             // back down to the source TerminalPage, who will then perform a
             // RequestMoveContent to move their tab to us.
             _RequestReceiveContentHandlers(*this, *request);
+            // }
         }
     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -245,7 +245,6 @@ namespace winrt::TerminalApp::implementation
         });
         _tabView.SelectionChanged({ this, &TerminalPage::_OnTabSelectionChanged });
         _tabView.TabCloseRequested({ this, &TerminalPage::_OnTabCloseRequested });
-        _tabView.TabItemsChanged({ this, &TerminalPage::_OnTabItemsChanged });
 
         _tabView.TabDragStarting({ this, &TerminalPage::_onTabDragStarting });
         _tabView.TabStripDragOver({ this, &TerminalPage::_onTabStripDragOver });
@@ -4720,6 +4719,8 @@ namespace winrt::TerminalApp::implementation
         co_await wil::resume_foreground(Dispatcher());
         if (const auto& page{ weakThis.get() })
         {
+            // `this` is safe to use
+            // 
             // First we need to get the position in the List to drop to
             auto index = -1;
 
@@ -4739,30 +4740,13 @@ namespace winrt::TerminalApp::implementation
                 }
             }
 
-            const auto otherId{ winrt::unbox_value_or<uint32_t>(windowIdObj, 0) };
             const auto myId{ _WindowProperties.WindowId() };
-            otherId;
-            // if (otherId == myId)
-            // {
-            //     // dragged from us to ourselves
-
-            //     uint32_t tabIndexFromTab{};
-            //     if (_tabs.IndexOf(*_stashed.draggedTab, tabIndexFromTab))
-            //     {
-            //         _rearrangeFrom = tabIndexFromTab;
-            //         _rearrangeTo = index;
-            //     }
-            // }
-            // else
-            // {
-            // `this` is safe to use
             const auto request = winrt::make_self<RequestReceiveContentArgs>(src, myId, index);
 
             // This will go up to the monarch, who will then dispatch the request
             // back down to the source TerminalPage, who will then perform a
             // RequestMoveContent to move their tab to us.
             _RequestReceiveContentHandlers(*this, *request);
-            // }
         }
     }
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4720,7 +4720,7 @@ namespace winrt::TerminalApp::implementation
         if (const auto& page{ weakThis.get() })
         {
             // `this` is safe to use
-            // 
+            //
             // First we need to get the position in the List to drop to
             auto index = -1;
 

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -417,7 +417,6 @@ namespace winrt::TerminalApp::implementation
 
         void _OnTabClick(const IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& eventArgs);
         void _OnTabSelectionChanged(const IInspectable& sender, const Windows::UI::Xaml::Controls::SelectionChangedEventArgs& eventArgs);
-        void _OnTabItemsChanged(const IInspectable& sender, const Windows::Foundation::Collections::IVectorChangedEventArgs& eventArgs);
         void _OnTabCloseRequested(const IInspectable& sender, const Microsoft::UI::Xaml::Controls::TabViewTabCloseRequestedEventArgs& eventArgs);
         void _OnFirstLayout(const IInspectable& sender, const IInspectable& eventArgs);
         void _UpdatedSelectedTab(const winrt::TerminalApp::TabBase& tab);

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -412,8 +412,8 @@ namespace winrt::TerminalApp::implementation
 
         fire_and_forget _LaunchSettings(const Microsoft::Terminal::Settings::Model::SettingsTarget target);
 
-        void _TabDragStarted(const IInspectable& sender, const IInspectable& eventArgs);
-        void _TabDragCompleted(const IInspectable& sender, const IInspectable& eventArgs);
+        void _TabDragStarted(const IInspectable& sender, const winrt::Microsoft::UI::Xaml::Controls::TabViewTabDragStartingEventArgs& eventArgs);
+        void _TabDragCompleted(const IInspectable& sender, const winrt::Microsoft::UI::Xaml::Controls::TabViewTabDragCompletedEventArgs& eventArgs);
 
         void _OnTabClick(const IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& eventArgs);
         void _OnTabSelectionChanged(const IInspectable& sender, const Windows::UI::Xaml::Controls::SelectionChangedEventArgs& eventArgs);

--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -740,19 +740,9 @@ namespace winrt::TerminalApp::implementation
     {
         // If
         // * the position has been specified on the commandline,
-        // * we're re-opening from a persisted layout,
         // * We're opening the window as a part of tear out (and _contentBounds were set)
         // then don't center on launch
-        bool hadPersistedPosition = false;
-        if (const auto layout = LoadPersistedLayout())
-        {
-            hadPersistedPosition = (bool)layout.InitialPosition();
-        }
-
-        return !_contentBounds &&
-               !hadPersistedPosition &&
-               _settings.GlobalSettings().CenterOnLaunch() &&
-               !_appArgs.GetPosition().has_value();
+        return !_contentBounds && _settings.GlobalSettings().CenterOnLaunch() && !_appArgs.GetPosition().has_value();
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -740,9 +740,19 @@ namespace winrt::TerminalApp::implementation
     {
         // If
         // * the position has been specified on the commandline,
+        // * we're re-opening from a persisted layout,
         // * We're opening the window as a part of tear out (and _contentBounds were set)
         // then don't center on launch
-        return !_contentBounds && _settings.GlobalSettings().CenterOnLaunch() && !_appArgs.GetPosition().has_value();
+        bool hadPersistedPosition = false;
+        if (const auto layout = LoadPersistedLayout())
+        {
+            hadPersistedPosition = (bool)layout.InitialPosition();
+        }
+
+        return !_contentBounds &&
+               !hadPersistedPosition &&
+               _settings.GlobalSettings().CenterOnLaunch() &&
+               !_appArgs.GetPosition().has_value();
     }
 
     // Method Description:


### PR DESCRIPTION
TL;DR: we stopped getting `TabView.TabItemsChanged`. This meant that the tab view would change its apparent order, but we wouldn't change the backing tab order. 

I'm fixing this by grabbing the index of the tab that starts the drag, and the index of the tab view item at the end of the drag, and using that to reorder our backing list. 

Closes #15121

Upstream https://github.com/microsoft/microsoft-ui-xaml/issues/8388

Regressed in #15078 - I'm pretty confident about this, since I've got a 1.18.931 build of the Terminal with tear-out, but not MUX 2.8.

