### PR TITLE
Actually use the persisted position with `centerOnLaunch:true`

### DIFF
--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -740,9 +740,19 @@ namespace winrt::TerminalApp::implementation
     {
         // If
         // * the position has been specified on the commandline,
+        // * we're re-opening from a persisted layout,
         // * We're opening the window as a part of tear out (and _contentBounds were set)
         // then don't center on launch
-        return !_contentBounds && _settings.GlobalSettings().CenterOnLaunch() && !_appArgs.GetPosition().has_value();
+        bool hadPersistedPosition = false;
+        if (const auto layout = LoadPersistedLayout())
+        {
+            hadPersistedPosition = (bool)layout.InitialPosition();
+        }
+
+        return !_contentBounds &&
+               !hadPersistedPosition &&
+               _settings.GlobalSettings().CenterOnLaunch() &&
+               !_appArgs.GetPosition().has_value();
     }
 
     // Method Description:


### PR DESCRIPTION
Fixes an issue when using both:

```json
    "centerOnLaunch": true,
    "firstWindowPreference": "persistedWindowLayout",
```

In this case, the Terminal would ignore the persisted location and still just center on launch. This has been really annoying while testing tear-out, as we keep re-opening all my debug windows as a stack on top of each other. 