### PR TITLE
Default to XamlRoot when unable to find focused object

### DIFF
--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -914,7 +914,7 @@ namespace winrt::TerminalApp::implementation
                 }
             } while (focusedObject);
         }
-        
+
         return false;
     }
 

--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -900,6 +900,12 @@ namespace winrt::TerminalApp::implementation
                     if (!focusedObject)
                     {
                         focusedObject = winrt::Windows::UI::Xaml::Media::VisualTreeHelper::GetParent(focusedElement);
+
+                        // We were unable to find a focused object. Default to the xaml root so that the alt+space menu still works.
+                        if (!focusedObject)
+                        {
+                            focusedObject = _root.try_as<IInspectable>();
+                        }
                     }
                 }
                 else
@@ -908,6 +914,7 @@ namespace winrt::TerminalApp::implementation
                 }
             } while (focusedObject);
         }
+        
         return false;
     }
 


### PR DESCRIPTION
Default to XamlRoot when unable to find a focused object in DirectKeyEvents

This may not be the most appropriate "fix" for this. Certainly open to criticism and feedback. We are trapping the alt+space key chord on the win32 side and forwarding it to the xaml side. There we try to find a focused object by walking the xaml tree. If we are unable to find a focused object we return false and do nothing.  I suspect that the area that has focus that prevents this from working normally is on the win32 side.  Since we want to handle the system menu anyway and are explicitly trapping that key combo and forwarding it on I thought this was the best approach. If we cant find a focused object default to the xaml root.

## Validation Steps Performed
System menu opens as it should.

Closes #14397 