### PR TITLE
Add a warning when a proportional font is selected

### DIFF
--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -914,7 +914,7 @@ namespace winrt::TerminalApp::implementation
                 }
             } while (focusedObject);
         }
-        
+
         return false;
     }
 

--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -900,6 +900,12 @@ namespace winrt::TerminalApp::implementation
                     if (!focusedObject)
                     {
                         focusedObject = winrt::Windows::UI::Xaml::Media::VisualTreeHelper::GetParent(focusedElement);
+
+                        // We were unable to find a focused object. Default to the xaml root so that the alt+space menu still works.
+                        if (!focusedObject)
+                        {
+                            focusedObject = _root.try_as<IInspectable>();
+                        }
                     }
                 }
                 else
@@ -908,6 +914,7 @@ namespace winrt::TerminalApp::implementation
                 }
             } while (focusedObject);
         }
+        
         return false;
     }
 

--- a/src/cascadia/TerminalSettingsEditor/Appearances.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.cpp
@@ -186,7 +186,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     DependencyProperty Appearances::_AppearanceProperty{ nullptr };
 
     Appearances::Appearances() :
-        _ShowAllFonts{ false }
+        _ShowAllFonts{ false },
+        _ShowProportionalFontWarning{ false }
     {
         InitializeComponent();
 
@@ -315,6 +316,14 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         const auto selectedItem{ e.AddedItems().GetAt(0) };
         const auto newFontFace{ unbox_value<Editor::Font>(selectedItem) };
         Appearance().FontFace(newFontFace.LocalizedName());
+        if (!UsingMonospaceFont())
+        {
+            ShowProportionalFontWarning(true);
+        }
+        else
+        {
+            ShowProportionalFontWarning(false);
+        }
     }
 
     void Appearances::_ViewModelChanged(const DependencyObject& d, const DependencyPropertyChangedEventArgs& /*args*/)
@@ -376,6 +385,10 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
                 {
                     _PropertyChangedHandlers(*this, PropertyChangedEventArgs{ L"CurrentAdjustIndistinguishableColors" });
                 }
+                else if (settingName == L"ShowProportionalFontWarning")
+                {
+                    _PropertyChangedHandlers(*this, PropertyChangedEventArgs{ L"ShowProportionalFontWarning" });
+                }
                 // YOU THERE ADDING A NEW APPEARANCE SETTING
                 // Make sure you add a block like
                 //
@@ -407,6 +420,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             _PropertyChangedHandlers(*this, PropertyChangedEventArgs{ L"UsingMonospaceFont" });
             _PropertyChangedHandlers(*this, PropertyChangedEventArgs{ L"CurrentIntenseTextStyle" });
             _PropertyChangedHandlers(*this, PropertyChangedEventArgs{ L"CurrentAdjustIndistinguishableColors" });
+            _PropertyChangedHandlers(*this, PropertyChangedEventArgs{ L"ShowProportionalFontWarning" });
+
         }
     }
 
@@ -487,4 +502,19 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         // whereas SelectedItem identifies which one was selected by the user.
         return FontWeightComboBox().SelectedItem() == _CustomFontWeight;
     }
+
+    bool Appearances::ShowProportionalFontWarning() const noexcept
+    {
+        return _ShowProportionalFontWarning;
+    }
+
+    void Appearances::ShowProportionalFontWarning(const bool& value)
+    {
+        if (_ShowProportionalFontWarning != value)
+        {
+            _ShowProportionalFontWarning = value;
+            _PropertyChangedHandlers(*this, PropertyChangedEventArgs{ L"ShowProportionalFontWarning" });
+        }
+    }
+
 }

--- a/src/cascadia/TerminalSettingsEditor/Appearances.h
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.h
@@ -113,6 +113,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         bool ShowAllFonts() const noexcept;
         void ShowAllFonts(const bool& value);
 
+        bool ShowProportionalFontWarning() const noexcept;
+        void ShowProportionalFontWarning(const bool& value);
+
         fire_and_forget BackgroundImage_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& e);
         void BIAlignment_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& e);
         void FontFace_SelectionChanged(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Controls::SelectionChangedEventArgs& e);
@@ -130,13 +133,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         DEPENDENCY_PROPERTY(Editor::AppearanceViewModel, Appearance);
         WINRT_PROPERTY(Editor::ProfileViewModel, SourceProfile, nullptr);
         WINRT_PROPERTY(IHostedInWindow, WindowRoot, nullptr);
-
         GETSET_BINDABLE_ENUM_SETTING(BackgroundImageStretchMode, Windows::UI::Xaml::Media::Stretch, Appearance().BackgroundImageStretchMode);
 
         GETSET_BINDABLE_ENUM_SETTING(IntenseTextStyle, Microsoft::Terminal::Settings::Model::IntenseStyle, Appearance().IntenseTextStyle);
 
     private:
         bool _ShowAllFonts;
+        bool _ShowProportionalFontWarning;
         void _UpdateBIAlignmentControl(const int32_t val);
         std::array<Windows::UI::Xaml::Controls::Primitives::ToggleButton, 9> _BIAlignmentButtons;
 
@@ -146,6 +149,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         Windows::UI::Xaml::Data::INotifyPropertyChanged::PropertyChanged_revoker _ViewModelChangedRevoker;
         static void _ViewModelChanged(const Windows::UI::Xaml::DependencyObject& d, const Windows::UI::Xaml::DependencyPropertyChangedEventArgs& e);
         void _UpdateWithNewViewModel();
+        
     };
 };
 

--- a/src/cascadia/TerminalSettingsEditor/Appearances.idl
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.idl
@@ -32,6 +32,7 @@ namespace Microsoft.Terminal.Settings.Editor
         Boolean UseDesktopBGImage;
         Boolean BackgroundImageSettingsVisible { get; };
 
+
         void ClearColorScheme();
         ColorSchemeViewModel CurrentColorScheme;
         Windows.Foundation.Collections.IObservableVector<ColorSchemeViewModel> SchemesList;
@@ -64,6 +65,7 @@ namespace Microsoft.Terminal.Settings.Editor
 
         Boolean UsingMonospaceFont { get; };
         Boolean ShowAllFonts;
+        Boolean ShowProportionalFontWarning;
 
         IInspectable CurrentCursorShape;
         Boolean IsVintageCursor { get; };

--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -179,11 +179,13 @@
             </local:SettingContainer>
 
             <!--  Font Face  -->
+
             <local:SettingContainer x:Uid="Profile_FontFace"
                                     ClearSettingValue="{x:Bind Appearance.ClearFontFace}"
                                     HasSettingValue="{x:Bind Appearance.HasFontFace, Mode=OneWay}"
                                     SettingOverrideSource="{x:Bind Appearance.FontFaceOverrideSource, Mode=OneWay}"
                                     Visibility="{x:Bind Appearance.IsDefault, Mode=OneWay}">
+
                 <StackPanel Margin="0,8,0,0">
                     <!--
                         Binding the ItemsSource to a separate variable that switches between the
@@ -210,6 +212,10 @@
                               IsEnabled="{x:Bind UsingMonospaceFont, Mode=OneWay}" />
                 </StackPanel>
             </local:SettingContainer>
+            <muxc:InfoBar x:Uid="Proflile_FontFace_ProportionalFontWarning"
+                          IsOpen="{x:Bind ShowProportionalFontWarning, Mode=OneWay}"
+                          Severity="Warning"/>
+
 
             <!--  Font Size  -->
             <local:SettingContainer x:Uid="Profile_FontSize"

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -1609,4 +1609,12 @@
     <value>Learn more.</value>
     <comment>A hyperlink displayed near Settings_PortableModeNote.Text that the user can follow for more information.</comment>
   </data>
+	<data name="Proflile_FontFace_ProportionalFontWarning.Title" xml:space="preserve">
+    <value>Warning:</value>
+    <comment>Title for the warning info bar used when a non monospace font face is chosen to indicate that there may be visual artifacts</comment>
+  </data>
+	<data name="Proflile_FontFace_ProportionalFontWarning.Message" xml:space="preserve">
+    <value>Choosing a non-monospaced font will likely result in visual artifacts. Use at your own discretion.</value>
+    <comment>Warning info bar used when a non monospace font face is chosen to indicate that there may be visual artifacts</comment>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request
Add an infobar warning when a non-monospaced font is selected.
## References and Relevant Issues
#13389 
## Detailed Description of the Pull Request / Additional comments
I initially had the `IsOpen` property of the infobar bound to the `ShowAllFonts` checkbox property. However, I felt we could do better by adding a property for it since there was already a method defined to inspect whether the selected font was in the `MonoSpaceFontList`.
## Validation Steps Performed
Warning shows up when a non-monospaced font is selected either globally or on individual profiles. All existing tests continue to pass.
<img width="868" alt="image" src="https://user-images.githubusercontent.com/2086722/232594214-cd42397b-ce9d-499c-aa73-3feaa45e850e.png">

## PR Checklist
- [ ] Closes #13389 
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
