### PR TITLE
Added Close Pane to Context Menu

### DIFF
--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -763,15 +763,12 @@
   </data>
   <data name="AboutDialog_CheckingForUpdatesLabel.Text" xml:space="preserve">
     <value>Checking for updates...</value>
-    <comment></comment>
   </data>
   <data name="AboutDialog_UpdateAvailableLabel.Text" xml:space="preserve">
     <value>An update is available.</value>
-    <comment></comment>
   </data>
   <data name="AboutDialog_InstallUpdateButton.Content" xml:space="preserve">
     <value>Install now</value>
-    <comment></comment>
   </data>
   <data name="DuplicateRemainingProfilesEntry" xml:space="preserve">
     <value>The "newTabMenu" field contains more than one entry of type "remainingProfiles". Only the first one will be considered.</value>
@@ -819,5 +816,11 @@
   </data>
   <data name="NewTabMenuFolderEmpty" xml:space="preserve">
     <value>Empty...</value>
+  </data>
+  <data name="ClosePaneText" xml:space="preserve">
+    <value>Close Pane</value>
+  </data>
+  <data name="ClosePaneToolTip" xml:space="preserve">
+    <value>Close the active pane if multiple panes are present</value>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -33,7 +33,7 @@ namespace winrt::TerminalApp::implementation
 
         _closePaneMenuItem.Visibility(WUX::Visibility::Collapsed);
 
-        auto firstId = _nextPaneId; 
+        auto firstId = _nextPaneId;
 
         _rootPane->WalkTree([&](std::shared_ptr<Pane> pane) {
             // update the IDs on each pane
@@ -1129,7 +1129,7 @@ namespace winrt::TerminalApp::implementation
                     tab->Content(tab->_rootPane->GetRootElement());
                     tab->ExitZoom();
                 }
-               
+
                 if (tab->GetLeafPaneCount() == 2)
                 {
                     tab->_closePaneMenuItem.Visibility(WUX::Visibility::Collapsed);
@@ -1336,7 +1336,6 @@ namespace winrt::TerminalApp::implementation
 
             WUX::Controls::ToolTipService::SetToolTip(closePaneMenuItem, box_value(closePaneToolTip));
             Automation::AutomationProperties::SetHelpText(closePaneMenuItem, closePaneToolTip);
-
         }
 
         Controls::MenuFlyoutItem exportTabMenuItem;

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -1053,6 +1053,11 @@ namespace winrt::TerminalApp::implementation
             _mruPanes.insert(_mruPanes.begin(), paneId.value());
         }
 
+        if (_rootPane->GetLeafPaneCount() == 1)
+        {
+            _closePaneMenuItem.Visibility(WUX::Visibility::Collapsed);
+        }
+
         _RecalculateAndApplyReadOnly();
 
         // Raise our own ActivePaneChanged event.
@@ -1128,11 +1133,6 @@ namespace winrt::TerminalApp::implementation
 
                     tab->Content(tab->_rootPane->GetRootElement());
                     tab->ExitZoom();
-                }
-
-                if (tab->GetLeafPaneCount() == 2)
-                {
-                    tab->_closePaneMenuItem.Visibility(WUX::Visibility::Collapsed);
                 }
 
                 if (auto pane = weakPane.lock())
@@ -1319,9 +1319,6 @@ namespace winrt::TerminalApp::implementation
         Controls::MenuFlyoutItem closePaneMenuItem = _closePaneMenuItem;
         {
             // "Close Pane"
-            Controls::FontIcon closeTabSymbol;
-            closeTabSymbol.FontFamily(Media::FontFamily{ L"Segoe Fluent Icons, Segoe MDL2 Assets" });
-            closeTabSymbol.Glyph(L"\xF246"); // ViewDashboard
 
             closePaneMenuItem.Click([weakThis](auto&&, auto&&) {
                 if (auto tab{ weakThis.get() })
@@ -1330,7 +1327,6 @@ namespace winrt::TerminalApp::implementation
                 }
             });
             closePaneMenuItem.Text(RS_(L"ClosePaneText"));
-            closePaneMenuItem.Icon(closeTabSymbol);
 
             const auto closePaneToolTip = RS_(L"ClosePaneToolTip");
 

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -1319,7 +1319,6 @@ namespace winrt::TerminalApp::implementation
         Controls::MenuFlyoutItem closePaneMenuItem = _closePaneMenuItem;
         {
             // "Close Pane"
-
             closePaneMenuItem.Click([weakThis](auto&&, auto&&) {
                 if (auto tab{ weakThis.get() })
                 {

--- a/src/cascadia/TerminalApp/TerminalTab.h
+++ b/src/cascadia/TerminalApp/TerminalTab.h
@@ -113,6 +113,8 @@ namespace winrt::TerminalApp::implementation
         std::shared_ptr<Pane> _activePane{ nullptr };
         std::shared_ptr<Pane> _zoomedPane{ nullptr };
 
+        Windows::UI::Xaml::Controls::MenuFlyoutItem _closePaneMenuItem;
+
         winrt::hstring _lastIconPath{};
         std::optional<winrt::Windows::UI::Color> _runtimeTabColor{};
         winrt::TerminalApp::TabHeaderControl _headerControl{};


### PR DESCRIPTION
## Summary of the Pull Request
Adding a 'Close Pane' menu item in the context menu.

## References and Relevant Issues
#13580 

## Detailed Description of the Pull Request / Additional comments
If a user decides to split a tab to create multiple panes through the context menu, they should be able to then close the pane via the context menu too. This PR introduces a new context menu item, 'Close Pane', that only appears when a user has 2 or more panes in a tab. When a user clicks close pane, the _active_pane will be closed.

## Validation Steps Performed
![close_pane_terminal](https://user-images.githubusercontent.com/98557455/232649000-8b521070-4f1b-4da9-8092-6ff802e91e2c.gif)

As it's my first PR, I still need to understand how to go through the testing suite.

## PR Checklist
- [x] Closes #13580 
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
