### PR TITLE
Add automation heading level 1 to fix about dialog

### DIFF
--- a/src/cascadia/TerminalApp/AboutDialog.xaml
+++ b/src/cascadia/TerminalApp/AboutDialog.xaml
@@ -17,7 +17,8 @@
 
     <StackPanel Orientation="Vertical">
         <TextBlock IsTextSelectionEnabled="True">
-            <Run Text="{x:Bind ApplicationDisplayName}" AutomationProperties.HeadingLevel="1" /> <LineBreak />
+            <Run Text="{x:Bind ApplicationDisplayName}"
+                 AutomationProperties.HeadingLevel="1" /> <LineBreak />
             <Run x:Uid="AboutDialog_VersionLabel" />
             <Run Text="{x:Bind ApplicationVersion}" />
         </TextBlock>

--- a/src/cascadia/TerminalApp/AboutDialog.xaml
+++ b/src/cascadia/TerminalApp/AboutDialog.xaml
@@ -17,8 +17,8 @@
 
     <StackPanel Orientation="Vertical">
         <TextBlock IsTextSelectionEnabled="True">
-            <Run Text="{x:Bind ApplicationDisplayName}"
-                 AutomationProperties.HeadingLevel="1" /> <LineBreak />
+            <Run AutomationProperties.HeadingLevel="1"
+                 Text="{x:Bind ApplicationDisplayName}" /> <LineBreak />
             <Run x:Uid="AboutDialog_VersionLabel" />
             <Run Text="{x:Bind ApplicationVersion}" />
         </TextBlock>

--- a/src/cascadia/TerminalApp/AboutDialog.xaml
+++ b/src/cascadia/TerminalApp/AboutDialog.xaml
@@ -17,7 +17,7 @@
 
     <StackPanel Orientation="Vertical">
         <TextBlock IsTextSelectionEnabled="True">
-            <Run Text="{x:Bind ApplicationDisplayName}" /> <LineBreak />
+            <Run Text="{x:Bind ApplicationDisplayName}" AutomationProperties.HeadingLevel="1" /> <LineBreak />
             <Run x:Uid="AboutDialog_VersionLabel" />
             <Run Text="{x:Bind ApplicationVersion}" />
         </TextBlock>


### PR DESCRIPTION
Add automation heading level 1 to fix the about dialog by adding an automation property.

Allows screen reader to pick up that this is a heading and read properly.

Closes #11912