### PR TITLE
A hypothetical fix for hidden windows

### DIFF
--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -79,7 +79,7 @@ bool WindowEmperor::HandleCommandlineArgs()
     // so we can open a new window with the same state.
     STARTUPINFOW si;
     GetStartupInfoW(&si);
-    const auto showWindow = si.wShowWindow;
+    const uint32_t showWindow = WI_IsFlagSet(si.dwFlags, STARTF_USESHOWWINDOW) ? si.wShowWindow : SW_SHOW;
 
     Remoting::CommandlineArgs eventArgs{ { args }, { cwd }, showWindow };
 


### PR DESCRIPTION
We had a report in a mail thread that someone's Terminal windows were getting created hidden, and never showing themselves.

As a theory, I'm guessing that dwFlags didn't say that we should actually use `wShowWindow`. So, to be more correct, let's actually obey that.

I'm gonna send this package to them to see if it fixes them.

Related to #14957.

Likely regressed in #13838.
