### PR TITLE
Enable WINRT_LEAN_AND_MEAN

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -20,6 +20,24 @@ using namespace winrt::Windows::Foundation;
 using namespace winrt::Windows::Foundation::Collections;
 using namespace winrt::Microsoft::Terminal::Settings::Model;
 
+namespace
+{
+struct hash_winrt_object_as_pointer
+{
+    size_t operator()(const ::winrt::Windows::Foundation::IUnknown& value) const noexcept
+    {
+        const void* abi_value = get_abi(value.try_as<::winrt::Windows::Foundation::IUnknown>());
+        return std::hash<void*>{}(abi_value);
+    }
+};
+}
+
+namespace std
+{
+    template <> struct hash<::winrt::Windows::UI::Xaml::DataTemplate> : public hash_winrt_object_as_pointer {};
+    template <> struct hash<::winrt::Windows::UI::Xaml::Controls::Primitives::SelectorItem> : public hash_winrt_object_as_pointer {};
+}
+
 namespace winrt::TerminalApp::implementation
 {
     CommandPalette::CommandPalette() :

--- a/src/cascadia/TerminalApp/CommandPalette.cpp
+++ b/src/cascadia/TerminalApp/CommandPalette.cpp
@@ -20,24 +20,6 @@ using namespace winrt::Windows::Foundation;
 using namespace winrt::Windows::Foundation::Collections;
 using namespace winrt::Microsoft::Terminal::Settings::Model;
 
-namespace
-{
-struct hash_winrt_object_as_pointer
-{
-    size_t operator()(const ::winrt::Windows::Foundation::IUnknown& value) const noexcept
-    {
-        const void* abi_value = get_abi(value.try_as<::winrt::Windows::Foundation::IUnknown>());
-        return std::hash<void*>{}(abi_value);
-    }
-};
-}
-
-namespace std
-{
-    template <> struct hash<::winrt::Windows::UI::Xaml::DataTemplate> : public hash_winrt_object_as_pointer {};
-    template <> struct hash<::winrt::Windows::UI::Xaml::Controls::Primitives::SelectorItem> : public hash_winrt_object_as_pointer {};
-}
-
 namespace winrt::TerminalApp::implementation
 {
     CommandPalette::CommandPalette() :

--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -18,8 +18,14 @@ struct hash_winrt_object_as_pointer
 
 namespace std
 {
-    template <> struct hash<::winrt::Windows::UI::Xaml::DataTemplate> : public hash_winrt_object_as_pointer {};
-    template <> struct hash<::winrt::Windows::UI::Xaml::Controls::Primitives::SelectorItem> : public hash_winrt_object_as_pointer {};
+    template<>
+    struct hash<::winrt::Windows::UI::Xaml::DataTemplate> : public hash_winrt_object_as_pointer
+    {
+    };
+    template<>
+    struct hash<::winrt::Windows::UI::Xaml::Controls::Primitives::SelectorItem> : public hash_winrt_object_as_pointer
+    {
+    };
 }
 
 // fwdecl unittest classes

--- a/src/cascadia/TerminalApp/CommandPalette.h
+++ b/src/cascadia/TerminalApp/CommandPalette.h
@@ -7,6 +7,21 @@
 #include "CommandPalette.g.h"
 #include "AppCommandlineArgs.h"
 
+struct hash_winrt_object_as_pointer
+{
+    size_t operator()(const ::winrt::Windows::Foundation::IUnknown& value) const noexcept
+    {
+        void* const abi_value = winrt::get_abi(value.try_as<::winrt::Windows::Foundation::IUnknown>());
+        return std::hash<void*>{}(abi_value);
+    }
+};
+
+namespace std
+{
+    template <> struct hash<::winrt::Windows::UI::Xaml::DataTemplate> : public hash_winrt_object_as_pointer {};
+    template <> struct hash<::winrt::Windows::UI::Xaml::Controls::Primitives::SelectorItem> : public hash_winrt_object_as_pointer {};
+}
+
 // fwdecl unittest classes
 namespace TerminalAppLocalTests
 {

--- a/src/cppwinrt.build.pre.props
+++ b/src/cppwinrt.build.pre.props
@@ -73,6 +73,8 @@
       <DisableSpecificWarnings>5104;28204;%(DisableSpecificWarnings)</DisableSpecificWarnings>
 
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+
+      <PreprocessorDefinitions>WINRT_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem Condition="'%(SubSystem)'==''">Console</SubSystem>


### PR DESCRIPTION
`WINRT_LEAN_AND_MEAN` removes a bunch of less often used parts of the C++/WinRT headers:

- `std::hash` specializations for every object
- `operator <<(ostream)` overloads for any `IStringable`
- Interface producers for interfaces that are marked "exclusive"

There's only one place where we were using even one of these.

Enabling this saves us (optimistically) 30 seconds of build time on the CI agents and shrinks our largest PCH (TerminalApp, x64, Debug) by about 150MiB.

It's not huge, but it's not nothing.