### PR TITLE
Also do the VisualState dance on the tab item

### DIFF
--- a/src/cascadia/TerminalApp/TabBase.cpp
+++ b/src/cascadia/TerminalApp/TabBase.cpp
@@ -566,9 +566,22 @@ namespace winrt::TerminalApp::implementation
     // - <none>
     void TabBase::_RefreshVisualState()
     {
+        const auto& item{ TabViewItem() };
+
         const auto& reqTheme = TabViewItem().RequestedTheme();
-        TabViewItem().RequestedTheme(ElementTheme::Light);
-        TabViewItem().RequestedTheme(ElementTheme::Dark);
-        TabViewItem().RequestedTheme(reqTheme);
+        item.RequestedTheme(ElementTheme::Light);
+        item.RequestedTheme(ElementTheme::Dark);
+        item.RequestedTheme(reqTheme);
+
+        if (TabViewItem().IsSelected())
+        {
+            VisualStateManager::GoToState(item, L"Normal", true);
+            VisualStateManager::GoToState(item, L"Selected", true);
+        }
+        else
+        {
+            VisualStateManager::GoToState(item, L"Selected", true);
+            VisualStateManager::GoToState(item, L"Normal", true);
+        }
     }
 }

--- a/src/cascadia/TerminalApp/TabBase.cpp
+++ b/src/cascadia/TerminalApp/TabBase.cpp
@@ -558,8 +558,13 @@ namespace winrt::TerminalApp::implementation
     // BODGY
     // - Toggles the requested theme of the tab view item,
     //   so that changes to the tab color are reflected immediately
-    // - Prior to MUX 2.8, we toggled the visual state here, but that seemingly
+    // - Prior to MUX 2.8, we only toggled the visual state here, but that seemingly
     //   doesn't work in 2.8.
+    // - Just changing the Theme also doesn't seem to work by itself - there
+    //   seems to be a way for the tab to set the deselected foreground onto
+    //   itself as it becomes selected. If the mouse isn't over the tab, that
+    //   can result in mismatched fg/bg's (see GH#15184). So that's right, we
+    //   need to do both.
     // Arguments:
     // - <none>
     // Return Value:


### PR DESCRIPTION
Just changing the Theme also doesn't seem to work by itself - there seems to be a way for the tab to set the deselected foreground onto itself as it becomes selected. If the mouse isn't over the tab, that can result in mismatched fg/bg's 

Regressed around #15078 

Closes #15184