### PR TITLE
Add jump list support for indirect icon references

### DIFF
--- a/src/cascadia/TerminalApp/Jumplist.cpp
+++ b/src/cascadia/TerminalApp/Jumplist.cpp
@@ -162,15 +162,15 @@ winrt::com_ptr<IShellLinkW> Jumplist::_createShellLink(const std::wstring_view n
         const std::wstring iconPath{ path.substr(0, commaPosition) };
 
         // We dont want the comma included so add 1 to its position
-        const std::wstring iconIndexString{ path.substr(commaPosition + 1) };
-        std::wstringstream stringStream;
-        stringStream << iconIndexString;
-        int iconIndex = 0;
-        stringStream >> iconIndex;
-        if (iconIndex != 0)
+        int iconIndex = til::to_int(path.substr(commaPosition + 1));
+        if (iconIndex != til::to_int_error)
         {
             THROW_IF_FAILED(sh->SetIconLocation(iconPath.data(), iconIndex));
         }
+    }
+    else if (til::ends_with(path, L"exe") || til::ends_with(path, L"dll"))
+    {
+        THROW_IF_FAILED(sh->SetIconLocation(path.data(), 0));
     }
     else
     {

--- a/src/cascadia/TerminalApp/Jumplist.cpp
+++ b/src/cascadia/TerminalApp/Jumplist.cpp
@@ -162,9 +162,9 @@ winrt::com_ptr<IShellLinkW> Jumplist::_createShellLink(const std::wstring_view n
         const std::wstring iconPath{ path.substr(0, commaPosition) };
 
         // We dont want the comma included so add 1 to its position
-        const std::wstring iconStr{ path.substr(commaPosition + 1, path.length() - commaPosition) };
-        const int iconNumber = std::stoi(iconStr);
-        THROW_IF_FAILED(sh->SetIconLocation(iconPath.data(), iconNumber));
+        const std::wstring iconIndexString{ path.substr(commaPosition + 1, path.length() - commaPosition) };
+        const int iconIndex = std::stoi(iconIndexString);
+        THROW_IF_FAILED(sh->SetIconLocation(iconPath.data(), iconIndex));
     }
     else
     {

--- a/src/cascadia/TerminalApp/Jumplist.cpp
+++ b/src/cascadia/TerminalApp/Jumplist.cpp
@@ -162,9 +162,15 @@ winrt::com_ptr<IShellLinkW> Jumplist::_createShellLink(const std::wstring_view n
         const std::wstring iconPath{ path.substr(0, commaPosition) };
 
         // We dont want the comma included so add 1 to its position
-        const std::wstring iconIndexString{ path.substr(commaPosition + 1, path.length() - commaPosition) };
-        const int iconIndex = std::stoi(iconIndexString);
-        THROW_IF_FAILED(sh->SetIconLocation(iconPath.data(), iconIndex));
+        const std::wstring iconIndexString{ path.substr(commaPosition + 1) };
+        std::wstringstream stringStream;
+        stringStream << iconIndexString;
+        int iconIndex = 0;
+        stringStream >> iconIndex;
+        if (iconIndex != 0)
+        {
+            THROW_IF_FAILED(sh->SetIconLocation(iconPath.data(), iconIndex));
+        }
     }
     else
     {

--- a/src/cascadia/TerminalApp/Jumplist.cpp
+++ b/src/cascadia/TerminalApp/Jumplist.cpp
@@ -170,6 +170,7 @@ winrt::com_ptr<IShellLinkW> Jumplist::_createShellLink(const std::wstring_view n
     }
     else if (til::ends_with(path, L"exe") || til::ends_with(path, L"dll"))
     {
+        // We have a binary path but no index/id. Default to 0
         THROW_IF_FAILED(sh->SetIconLocation(path.data(), 0));
     }
     else

--- a/src/cascadia/TerminalSettingsModel/IconPathConverter.cpp
+++ b/src/cascadia/TerminalSettingsModel/IconPathConverter.cpp
@@ -297,8 +297,12 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         if (commaIndex != std::wstring::npos)
         {
             // Convert the string iconIndex to an int
-            const auto index = til::to_ulong(pathView.substr(commaIndex + 1));
-            if (index == til::to_ulong_error)
+            const auto indexString = pathView.substr(commaIndex + 1);
+            std::wstringstream stringStream;
+            stringStream << indexString;
+            int index = 0;
+            stringStream >> index;
+            if (index == 0)
             {
                 return std::nullopt;
             }

--- a/src/cascadia/TerminalSettingsModel/IconPathConverter.cpp
+++ b/src/cascadia/TerminalSettingsModel/IconPathConverter.cpp
@@ -296,13 +296,9 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
 
         if (commaIndex != std::wstring::npos)
         {
-            // Convert the string iconIndex to an int
-            const auto indexString = pathView.substr(commaIndex + 1);
-            std::wstringstream stringStream;
-            stringStream << indexString;
-            int index = 0;
-            stringStream >> index;
-            if (index == 0)
+            // Convert the string iconIndex to a signed int to support negative numbers which represent an Icon's ID.
+            const auto index{ til::to_int(pathView.substr(commaIndex + 1)) };
+            if (index == til::to_int_error)
             {
                 return std::nullopt;
             }

--- a/src/inc/til/string.h
+++ b/src/inc/til/string.h
@@ -116,6 +116,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
     }
 
     inline constexpr unsigned long to_ulong_error = ULONG_MAX;
+    inline constexpr int to_int_error = INT_MAX;
 
     // Just like std::wcstoul, but without annoying locales and null-terminating strings.
     // It has been fuzz-tested against clang's strtoul implementation.
@@ -373,4 +374,20 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             return compare_string_ordinal(lhs, rhs) == CSTR_LESS_THAN;
         }
     };
+
+    // Implement to_int in terms of to_ulong by negating its result. to_ulong does not expect
+    // to be passed signed numbers and will return an error accordingly. That error when
+    // compared against -1 evaluates to true. We account for that by returning to_int_error if to_ulong
+    // returns an error.
+    constexpr int to_int(const std::wstring_view& str, unsigned long base = 0) noexcept
+    {
+        const auto signPosition = str.find(L"-");
+        if (signPosition != std::wstring_view::npos)
+        {
+            const auto result = to_ulong(str.substr(signPosition + 1), base);
+            return result == to_ulong_error ? to_int_error : result * -1;
+        }
+
+        return to_ulong(str, base) == to_ulong_error ? to_int_error : to_ulong(str, base);
+    }
 }

--- a/src/inc/til/string.h
+++ b/src/inc/til/string.h
@@ -381,13 +381,17 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
     // returns an error.
     constexpr int to_int(const std::wstring_view& str, unsigned long base = 0) noexcept
     {
+        auto result = to_ulong_error;
         const auto signPosition = str.find(L"-");
-        if (signPosition != std::wstring_view::npos)
+        const bool hasSign = signPosition != std::wstring_view::npos;
+        result = hasSign ? to_ulong(str.substr(signPosition + 1), base) : to_ulong(str, base);
+
+        // Check that result is valid and will fit in an int.
+        if (result == to_ulong_error || (result > INT_MAX))
         {
-            const auto result = to_ulong(str.substr(signPosition + 1), base);
-            return result == to_ulong_error ? to_int_error : result * -1;
+            return to_int_error;
         }
 
-        return to_ulong(str, base) == to_ulong_error ? to_int_error : to_ulong(str, base);
+        return hasSign ? result * -1 : result;
     }
 }


### PR DESCRIPTION
Adds support to jump list generation for icon paths that include an indirect reference e.g. `c:\windows\system32\shell32.dll,214`

If given a path that has an indirect icon reference parse the path into component parts `filePath` and `iconIndex` and use `IShellLinkW::SetIconLocation` to set the Icon for the entry. Otherwise do what we always do.

This PR also introduces `til::to_int`, which is based on `til::to_ulong` and supports signed integers.

## Validation Steps Performed
Icons were visible in the jump list and in terminal next to the profiles.

Closes #15205 
