### PR TITLE
A very sensible Pane refactoring

### DIFF
--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -104,15 +104,12 @@ Pane::Pane(std::shared_ptr<Pane> first,
 
 void Pane::_setupControlEvents()
 {
-    _controlEvents._connectionStateChanged = _control.ConnectionStateChanged({ this, &Pane::_ControlConnectionStateChangedHandler });
-    _controlEvents._warningBell = _control.WarningBell({ this, &Pane::_ControlWarningBellHandler });
-    _controlEvents._closeTerminalRequested = _control.CloseTerminalRequested({ this, &Pane::_CloseTerminalRequestedHandler });
+    _controlEvents._ConnectionStateChanged = _control.ConnectionStateChanged(winrt::auto_revoke, { this, &Pane::_ControlConnectionStateChangedHandler });
+    _controlEvents._WarningBell = _control.WarningBell(winrt::auto_revoke, { this, &Pane::_ControlWarningBellHandler });
+    _controlEvents._CloseTerminalRequested = _control.CloseTerminalRequested(winrt::auto_revoke, { this, &Pane::_CloseTerminalRequestedHandler });
 }
 void Pane::_removeControlEvents()
 {
-    _control.ConnectionStateChanged(_controlEvents._connectionStateChanged);
-    _control.WarningBell(_controlEvents._warningBell);
-    _control.CloseTerminalRequested(_controlEvents._closeTerminalRequested);
     _controlEvents = {};
 }
 

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -246,9 +246,9 @@ private:
 
     struct ControlEventTokens
     {
-        winrt::event_token _connectionStateChanged{ 0 };
-        winrt::event_token _warningBell{ 0 };
-        winrt::event_token _closeTerminalRequested{ 0 };
+        winrt::Microsoft::Terminal::Control::TermControl::ConnectionStateChanged_revoker _ConnectionStateChanged;
+        winrt::Microsoft::Terminal::Control::TermControl::WarningBell_revoker _WarningBell;
+        winrt::Microsoft::Terminal::Control::TermControl::CloseTerminalRequested_revoker _CloseTerminalRequested;
     } _controlEvents;
     void _setupControlEvents();
     void _removeControlEvents();

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -241,11 +241,17 @@ private:
     std::weak_ptr<Pane> _parentChildPath{};
 
     bool _lastActive{ false };
-    winrt::event_token _connectionStateChangedToken{ 0 };
     winrt::event_token _firstClosedToken{ 0 };
     winrt::event_token _secondClosedToken{ 0 };
-    winrt::event_token _warningBellToken{ 0 };
-    winrt::event_token _closeTerminalRequestedToken{ 0 };
+
+    struct ControlEventTokens
+    {
+        winrt::event_token _connectionStateChanged{ 0 };
+        winrt::event_token _warningBell{ 0 };
+        winrt::event_token _closeTerminalRequested{ 0 };
+    } _controlEvents;
+    void _setupControlEvents();
+    void _removeControlEvents();
 
     winrt::Windows::UI::Xaml::UIElement::GotFocus_revoker _gotFocusRevoker;
     winrt::Windows::UI::Xaml::UIElement::LostFocus_revoker _lostFocusRevoker;


### PR DESCRIPTION
It seemed dangerous to just have places all over Pane where we manipulate the whole cadre of TermControl events. Seemed ripe for a copypasta error. This moves that around, so there's only two methods for messing with the TermControl callbacks: `_setupControlEvents` and `_removeControlEvents`.

Closes: nothing. This was an off-the-cuff commit that seemed valuable. 