### PR TITLE
Switch to function pointers

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -2311,8 +2311,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     void ControlCore::_contextMenuSelectMark(
         const til::point& pos,
-        const std::function<bool(const DispatchTypes::ScrollMark&)>& filter,
-        const std::function<til::point_span(const DispatchTypes::ScrollMark&)>& getSpan)
+        bool (*filter)(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark&),
+        til::point_span (*getSpan)(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark&))
     {
         // Do nothing if the caller didn't give us a way to get the span to select for this mark.
         if (!getSpan)
@@ -2358,7 +2358,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     bool ControlCore::_clickedOnMark(
         const til::point& pos,
-        const std::function<bool(const DispatchTypes::ScrollMark&)>& filter)
+        bool (*filter)(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark&))
     {
         // Don't show this if the click was on the selection
         if (_terminal->IsSelectionActive() &&

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -2311,8 +2311,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     void ControlCore::_contextMenuSelectMark(
         const til::point& pos,
-        bool (*filter)(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark&),
-        til::point_span (*getSpan)(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark&))
+        bool (*filter)(const DispatchTypes::ScrollMark&),
+        til::point_span (*getSpan)(const DispatchTypes::ScrollMark&))
     {
         // Do nothing if the caller didn't give us a way to get the span to select for this mark.
         if (!getSpan)
@@ -2358,7 +2358,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     bool ControlCore::_clickedOnMark(
         const til::point& pos,
-        bool (*filter)(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark&))
+        bool (*filter)(const DispatchTypes::ScrollMark&))
     {
         // Don't show this if the click was on the selection
         if (_terminal->IsSelectionActive() &&

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -364,10 +364,10 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         void _contextMenuSelectMark(
             const til::point& pos,
-            const std::function<bool(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark&)>& filter,
-            const std::function<til::point_span(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark&)>& getSpan);
+            bool (*filter)(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark&),
+            til::point_span (*getSpan)(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark&));
 
-        bool _clickedOnMark(const til::point& pos, const std::function<bool(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark&)>& filter);
+        bool _clickedOnMark(const til::point& pos, bool(*filter)(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark&));
 
         inline bool _IsClosing() const noexcept
         {

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -367,7 +367,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             bool (*filter)(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark&),
             til::point_span (*getSpan)(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark&));
 
-        bool _clickedOnMark(const til::point& pos, bool(*filter)(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark&));
+        bool _clickedOnMark(const til::point& pos, bool (*filter)(const ::Microsoft::Console::VirtualTerminal::DispatchTypes::ScrollMark&));
 
         inline bool _IsClosing() const noexcept
         {


### PR DESCRIPTION
Apparently, `std::function` is bad and we should feel bad. I friggen hate the c++ function pointer syntax, but [I do what I'm told](https://getyarn.io/yarn-clip/85c318d8-f4a7-4da6-ae20-23d7b737e71c)

I missed this comment in #15020. Sorry!
