### PR TITLE
Move the Close... actions to a nested menu on the tab

### DIFF
--- a/src/cascadia/TerminalApp/TabBase.cpp
+++ b/src/cascadia/TerminalApp/TabBase.cpp
@@ -70,8 +70,9 @@ namespace winrt::TerminalApp::implementation
     // Arguments:
     // - flyout - the menu flyout to which the close items must be appended
     // Return Value:
-    // - <none>
-    void TabBase::_AppendCloseMenuItems(winrt::Windows::UI::Xaml::Controls::MenuFlyout flyout)
+    // - the sub-item that we use for all the nested "close" entries. This
+    //   enables subclasses to add their own entries to this menu.
+    winrt::Windows::UI::Xaml::Controls::MenuFlyoutSubItem TabBase::_AppendCloseMenuItems(winrt::Windows::UI::Xaml::Controls::MenuFlyout flyout)
     {
         auto weakThis{ get_weak() };
 
@@ -120,15 +121,16 @@ namespace winrt::TerminalApp::implementation
         WUX::Controls::ToolTipService::SetToolTip(closeTabMenuItem, box_value(closeTabToolTip));
         Automation::AutomationProperties::SetHelpText(closeTabMenuItem, closeTabToolTip);
 
-        // GH#8238 append the close menu items to the flyout itself until crash in XAML is fixed
-        //Controls::MenuFlyoutSubItem closeSubMenu;
-        //closeSubMenu.Text(RS_(L"TabCloseSubMenu"));
-        //closeSubMenu.Items().Append(_closeTabsAfterMenuItem);
-        //closeSubMenu.Items().Append(_closeOtherTabsMenuItem);
-        //flyout.Items().Append(closeSubMenu);
-        flyout.Items().Append(_closeTabsAfterMenuItem);
-        flyout.Items().Append(_closeOtherTabsMenuItem);
+        // Create a sub-menu for our extended close items.
+        Controls::MenuFlyoutSubItem closeSubMenu;
+        closeSubMenu.Text(RS_(L"TabCloseSubMenu"));
+        closeSubMenu.Items().Append(_closeTabsAfterMenuItem);
+        closeSubMenu.Items().Append(_closeOtherTabsMenuItem);
+        flyout.Items().Append(closeSubMenu);
+
         flyout.Items().Append(closeTabMenuItem);
+
+        return closeSubMenu;
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TabBase.h
+++ b/src/cascadia/TerminalApp/TabBase.h
@@ -65,7 +65,7 @@ namespace winrt::TerminalApp::implementation
 
         virtual void _MakeTabViewItem();
 
-        void _AppendCloseMenuItems(winrt::Windows::UI::Xaml::Controls::MenuFlyout flyout);
+        winrt::Windows::UI::Xaml::Controls::MenuFlyoutSubItem _AppendCloseMenuItems(winrt::Windows::UI::Xaml::Controls::MenuFlyout flyout);
         void _EnableCloseMenuItems();
         void _CloseTabsAfter();
         void _CloseOtherTabs();

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -1404,7 +1404,7 @@ namespace winrt::TerminalApp::implementation
         contextMenuFlyout.Items().Append(renameTabMenuItem);
         contextMenuFlyout.Items().Append(duplicateTabMenuItem);
         contextMenuFlyout.Items().Append(splitTabMenuItem);
-        contextMenuFlyout.Items().Append(closePaneMenuItem);
+
         contextMenuFlyout.Items().Append(exportTabMenuItem);
         contextMenuFlyout.Items().Append(findMenuItem);
         contextMenuFlyout.Items().Append(menuSeparator);
@@ -1423,7 +1423,9 @@ namespace winrt::TerminalApp::implementation
                 }
             }
         });
-        _AppendCloseMenuItems(contextMenuFlyout);
+        auto closeSubMenu = _AppendCloseMenuItems(contextMenuFlyout);
+        closeSubMenu.Items().Append(closePaneMenuItem);
+
         TabViewItem().ContextFlyout(contextMenuFlyout);
     }
 


### PR DESCRIPTION
A resurrection of the original nested "Close" menu from #7728. We discovered that nested flyouts crash in #8238. Those are fixed now though! So we can bring this back. 

This also includes the "Close Pane" item from #15198.


#### on a tab with panes:
![image](https://user-images.githubusercontent.com/18356694/234910218-b96c6861-7cc7-4746-953c-2740a774b1d1.png)

#### on a tab without panes:
![image](https://user-images.githubusercontent.com/18356694/234910277-8b9221bc-ebaf-4e38-855c-7e35d6cd4411.png)
