### PR TITLE
Add an action for manually invoking the control context menu

### DIFF
--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1228,4 +1228,14 @@ namespace winrt::TerminalApp::implementation
             args.Handled(handled);
         }
     }
+
+    void TerminalPage::_HandleShowContextMenu(const IInspectable& /*sender*/,
+                                              const ActionEventArgs& args)
+    {
+        if (const auto& control{ _GetActiveControl() })
+        {
+            control.ShowContextMenu();
+        }
+        args.Handled(true);
+    }
 }

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2512,7 +2512,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         const til::point clientCursorPos{ terminalPos * fontSize };
 
         // Get scale factor for view
-        const double scaleFactor = DisplayInformation::GetForCurrentView().RawPixelsPerViewPixel();
+        const double scaleFactor = SwapChainPanel().CompositionScaleX();
 
         const til::point clientCursorInDips{ til::math::flooring, clientCursorPos.x / scaleFactor, clientCursorPos.y / scaleFactor };
 

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2513,23 +2513,25 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         return flags;
     }
 
-    til::point TermControl::_toControlOrigin(const til::point& terminalPos)
+    til::point TermControl::_toControlOrigin(const til::point terminalPos)
     {
-        const til::size fontSize{ til::math::flooring, CharacterDimensions() };
+        const auto fontSize{ CharacterDimensions() };
 
         // Convert text buffer cursor position to client coordinate position
         // within the window. This point is in _pixels_
-        const til::point clientCursorPos{ terminalPos * fontSize };
+        const double clientCursorPosX = terminalPos.x * fontSize.Width;
+        const double clientCursorPosY = terminalPos.y * fontSize.Height;
 
         // Get scale factor for view
         const double scaleFactor = SwapChainPanel().CompositionScaleX();
 
-        const til::point clientCursorInDips{ til::math::flooring, clientCursorPos.x / scaleFactor, clientCursorPos.y / scaleFactor };
+        const double clientCursorInDipsX = clientCursorPosX / scaleFactor;
+        const double clientCursorInDipsY = clientCursorPosY / scaleFactor;
 
         auto padding{ GetPadding() };
-        til::point relativeToOrigin{ til::math::flooring,
-                                     clientCursorInDips.x + padding.Left,
-                                     clientCursorInDips.y + padding.Top };
+        til::point relativeToOrigin{ til::math::rounding,
+                                     clientCursorInDipsX + padding.Left,
+                                     clientCursorInDipsY + padding.Top };
         return relativeToOrigin;
     }
 

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2505,20 +2505,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     til::point TermControl::_toControlOrigin(const til::point& terminalPos)
     {
-        // // Convert the terminal position in chars to a pixel position
-        // const til::size fontSize{ til::math::rounding, _core.FontSize() };
-        // const til::point inPixelsRelativeToViewport{ terminalPos * fontSize };
-        // // Now, to DIPs
-        // const auto scale = SwapChainPanel().CompositionScaleX();
-        // const til::point inDipsRelativeToViewport{ til::math::rounding, inPixelsRelativeToViewport.x / scale, inPixelsRelativeToViewport.y / scale };
-        // // Now, add padding
-        // const til::size marginsInDips{ til::math::rounding, GetPadding().Left, GetPadding().Top };
-
-        // const til::point relativeToMarginInDips{
-        //     inDipsRelativeToViewport + marginsInDips
-        // };
-        // return relativeToMarginInDips;
-
         const til::size fontSize{ til::math::flooring, CharacterDimensions() };
 
         // Convert text buffer cursor position to client coordinate position

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2503,6 +2503,40 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         return flags;
     }
 
+    til::point TermControl::_toControlOrigin(const til::point& terminalPos)
+    {
+        // // Convert the terminal position in chars to a pixel position
+        // const til::size fontSize{ til::math::rounding, _core.FontSize() };
+        // const til::point inPixelsRelativeToViewport{ terminalPos * fontSize };
+        // // Now, to DIPs
+        // const auto scale = SwapChainPanel().CompositionScaleX();
+        // const til::point inDipsRelativeToViewport{ til::math::rounding, inPixelsRelativeToViewport.x / scale, inPixelsRelativeToViewport.y / scale };
+        // // Now, add padding
+        // const til::size marginsInDips{ til::math::rounding, GetPadding().Left, GetPadding().Top };
+
+        // const til::point relativeToMarginInDips{
+        //     inDipsRelativeToViewport + marginsInDips
+        // };
+        // return relativeToMarginInDips;
+
+        const til::size fontSize{ til::math::flooring, CharacterDimensions() };
+
+        // Convert text buffer cursor position to client coordinate position
+        // within the window. This point is in _pixels_
+        const til::point clientCursorPos{ terminalPos * fontSize };
+
+        // Get scale factor for view
+        const double scaleFactor = DisplayInformation::GetForCurrentView().RawPixelsPerViewPixel();
+
+        const til::point clientCursorInDips{ til::math::flooring, clientCursorPos.x / scaleFactor, clientCursorPos.y / scaleFactor };
+
+        auto padding{ GetPadding() };
+        til::point relativeToOrigin{ til::math::flooring,
+                                     clientCursorInDips.x + padding.Left,
+                                     clientCursorInDips.y + padding.Top };
+        return relativeToOrigin;
+    }
+
     // Method Description:
     // - Gets the corresponding viewport pixel position for the cursor
     //    by excluding the padding.
@@ -3334,10 +3368,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void TermControl::_contextMenuHandler(IInspectable /*sender*/,
                                           Control::ContextMenuRequestedEventArgs args)
     {
-        Controls::Primitives::FlyoutShowOptions myOption{};
-        myOption.ShowMode(Controls::Primitives::FlyoutShowMode::Standard);
-        myOption.Placement(Controls::Primitives::FlyoutPlacementMode::TopEdgeAlignedLeft);
-
         // Position the menu where the pointer is. This was the best way I found how.
         const til::point absolutePointerPos{ til::math::rounding, CoreWindow::GetForCurrentThread().PointerPosition() };
         const til::point absoluteWindowOrigin{ til::math::rounding,
@@ -3347,8 +3377,16 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         const til::point controlOrigin{ til::math::flooring,
                                         this->TransformToVisual(nullptr).TransformPoint(Windows::Foundation::Point(0, 0)) };
 
-        const auto pos = (absolutePointerPos - absoluteWindowOrigin - controlOrigin).to_winrt_point();
-        myOption.Position(pos);
+        const auto pos = (absolutePointerPos - absoluteWindowOrigin - controlOrigin);
+        _showContextMenuAt(pos);
+    }
+
+    void TermControl::_showContextMenuAt(const til::point& controlRelativePos)
+    {
+        Controls::Primitives::FlyoutShowOptions myOption{};
+        myOption.ShowMode(Controls::Primitives::FlyoutShowMode::Standard);
+        myOption.Placement(Controls::Primitives::FlyoutPlacementMode::TopEdgeAlignedLeft);
+        myOption.Position(controlRelativePos.to_winrt_point());
 
         // The "Select command" and "Select output" buttons should only be
         // visible if shell integration is actually turned on.
@@ -3362,6 +3400,22 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         (_core.HasSelection() ? SelectionContextMenu() :
                                 ContextMenu())
             .ShowAt(*this, myOption);
+    }
+
+    void TermControl::ShowContextMenu()
+    {
+        const bool hasSelection = _core.HasSelection();
+        til::point cursorPos{
+            hasSelection ? _core.SelectionInfo().EndPos :
+                           _core.CursorPosition()
+        };
+        // Offset this position a bit:
+        // * {+0,+1} if there's a selection. The selection endpoint is already
+        //   exclusive, so add one row to align to the bottom of the selection
+        // * {+1,+1} if there's no selection, to be on the bottom-right corner of
+        //   the cursor position
+        cursorPos += til::point{ hasSelection ? 0 : 1, 1 };
+        _showContextMenuAt(_toControlOrigin(cursorPos));
     }
 
     void TermControl::_PasteCommandHandler(const IInspectable& /*sender*/,

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -143,6 +143,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         void AdjustOpacity(const double opacity, const bool relative);
 
+        void ShowContextMenu();
+
         void Detach();
 
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
@@ -316,7 +318,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         static void _ClearKeyboardState(const WORD vkey, const WORD scanCode) noexcept;
         bool _TrySendKeyEvent(const WORD vkey, const WORD scanCode, ::Microsoft::Terminal::Core::ControlKeyStates modifiers, const bool keyDown);
 
+        til::point _toControlOrigin(const til::point& terminalPosition);
         const til::point _toTerminalOrigin(winrt::Windows::Foundation::Point cursorPosition);
+
         double _GetAutoScrollSpeed(double cursorDistanceFromBorder) const;
 
         void _Search(const winrt::hstring& text, const bool goForward, const bool caseSensitive);
@@ -342,6 +346,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void _throttledUpdateScrollbar(const ScrollBarUpdate& update);
 
         void _contextMenuHandler(IInspectable sender, Control::ContextMenuRequestedEventArgs args);
+        void _showContextMenuAt(const til::point& controlRelativePos);
 
         void _PasteCommandHandler(const IInspectable& sender, const IInspectable& args);
         void _CopyCommandHandler(const IInspectable& sender, const IInspectable& args);

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -322,7 +322,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         static void _ClearKeyboardState(const WORD vkey, const WORD scanCode) noexcept;
         bool _TrySendKeyEvent(const WORD vkey, const WORD scanCode, ::Microsoft::Terminal::Core::ControlKeyStates modifiers, const bool keyDown);
 
-        til::point _toControlOrigin(const til::point& terminalPosition);
+        til::point _toControlOrigin(const til::point terminalPosition);
         const til::point _toTerminalOrigin(winrt::Windows::Foundation::Point cursorPosition);
 
         double _GetAutoScrollSpeed(double cursorDistanceFromBorder) const;

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -112,6 +112,8 @@ namespace Microsoft.Terminal.Control
 
         void ColorSelection(SelectionColor fg, SelectionColor bg, Microsoft.Terminal.Core.MatchMode matchMode);
 
+        void ShowContextMenu();
+
         void Detach();
     }
 }

--- a/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
@@ -89,6 +89,7 @@ static constexpr std::string_view MarkModeKey{ "markMode" };
 static constexpr std::string_view ToggleBlockSelectionKey{ "toggleBlockSelection" };
 static constexpr std::string_view SwitchSelectionEndpointKey{ "switchSelectionEndpoint" };
 static constexpr std::string_view ColorSelectionKey{ "experimental.colorSelection" };
+static constexpr std::string_view ShowContextMenuKey{ "showContextMenu" };
 static constexpr std::string_view ExpandSelectionToWordKey{ "expandSelectionToWord" };
 
 static constexpr std::string_view ActionKey{ "action" };
@@ -417,6 +418,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 { ShortcutAction::ToggleBlockSelection, RS_(L"ToggleBlockSelectionCommandKey") },
                 { ShortcutAction::SwitchSelectionEndpoint, RS_(L"SwitchSelectionEndpointCommandKey") },
                 { ShortcutAction::ColorSelection, MustGenerate },
+                { ShortcutAction::ShowContextMenu, RS_(L"ShowContextMenuCommandKey") },
                 { ShortcutAction::ExpandSelectionToWord, RS_(L"ExpandSelectionToWordCommandKey") },
             };
         }();

--- a/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
+++ b/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
@@ -102,6 +102,7 @@
     ON_ALL_ACTIONS(ToggleBlockSelection)    \
     ON_ALL_ACTIONS(SwitchSelectionEndpoint) \
     ON_ALL_ACTIONS(ColorSelection)          \
+    ON_ALL_ACTIONS(ShowContextMenu)         \
     ON_ALL_ACTIONS(ExpandSelectionToWord)   \
     ON_ALL_ACTIONS(CloseOtherPanes)
 

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -672,6 +672,9 @@
   <data name="ExpandSelectionToWordCommandKey" xml:space="preserve">
     <value>Expand selection to word</value>
   </data>
+  <data name="ShowContextMenuCommandKey" xml:space="preserve">
+    <value>Show context menu</value>
+  </data>
   <data name="CloseOtherPanesCommandKey" xml:space="preserve">
     <value>Close all other panes</value>
   </data>

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -461,6 +461,7 @@
         { "command": "toggleBlockSelection" },
         { "command": "switchSelectionEndpoint" },
         { "command": "expandSelectionToWord" },
+        { "command": "showContextMenu", "keys": "menu" },
 
         // Scrollback
         { "command": "scrollDown", "keys": "ctrl+shift+down" },


### PR DESCRIPTION
Adds 

```
        { "command": "showContextMenu", "keys": "menu" },
```

as a default action. This will manually invoke the control context menu (from #14775), even with the setting disabled.

As discussed with Dustin.