### PR TITLE
Don't explode when we tear out the last tab of the window

### DIFF
--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -168,8 +168,8 @@ void AppHost::_HandleCommandlineArgs(const Remoting::WindowRequestedArgs& window
     if (_peasant)
     {
         const auto& args{ _peasant.InitialArgs() };
-
-        if (!windowArgs.Content().empty())
+        const bool startedForContent = !windowArgs.Content().empty();
+        if (startedForContent)
         {
             _windowLogic.SetStartupContent(windowArgs.Content(), windowArgs.InitialBounds());
         }
@@ -220,7 +220,8 @@ void AppHost::_HandleCommandlineArgs(const Remoting::WindowRequestedArgs& window
         // seemed to reorder bits of init so much that everything broke. So
         // we'll leave it here.
         const auto numPeasants = _windowManager.GetNumberOfPeasants();
-        if (numPeasants == 1)
+        // Don't attempt to session restore if we're just making a window for tear-out
+        if (!startedForContent && numPeasants == 1)
         {
             const auto layouts = ApplicationState::SharedInstance().PersistedWindowLayouts();
             if (_appLogic.ShouldUsePersistedLayout() &&


### PR DESCRIPTION
If you were really fast, and closed one window, and then tried to drag the only tab out of the last remaining window, the Terminal could explode. It'd attempt to restore the previous window state, and explode.

Easy way to stop this (also, be more robust): just don't attempt to restore windows during tear-out. That's obvious.

This is a part of #14957
