### PR TITLE
Allow ROW::CopyRangeFrom to be vectorized

### DIFF
--- a/.github/actions/spelling/expect/expect.txt
+++ b/.github/actions/spelling/expect/expect.txt
@@ -2062,6 +2062,7 @@ vcpkg
 vcprintf
 vcxitems
 vec
+vectorize
 vectorized
 VERCTRL
 VERTBAR

--- a/src/buffer/out/Row.hpp
+++ b/src/buffer/out/Row.hpp
@@ -171,6 +171,7 @@ private:
         void ReplaceCharacters(til::CoordType width) noexcept;
         void ReplaceText() noexcept;
         void CopyTextFrom(const std::span<const uint16_t>& charOffsets) noexcept;
+        static void _copyOffsets(uint16_t* dst, const uint16_t* src, uint16_t size, uint16_t offset) noexcept;
         void Finish();
 
         // Parent pointer.


### PR DESCRIPTION
By rewriting the first major copy loop in `CopyRangeFrom` to use
pointers/iterators instead of indices for iteration, the autovectorizer
kicks in end neatly rewrites it as an unrolled SIMD loop. This improves
performance during traditional window resizes by roughly 2x and will
be quite helpful in the future for our more complex reflow resize.

Unfortunately, MSVC unrolls the loop by 4x which is too much for our
purpose, but there's no option to change that. It's still better than
not having any vectorization however, since it kicks in at 32 columns.

It also renames the function to `CopyTextFrom` be more in line with
the others and to avoid confusion, because it doesn't copy attributes.

## Validation Steps Performed
* Traditional resizing works ✅