### PR TITLE
Don't auto-dismiss the warning dialog on launch

### DIFF
--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -1264,7 +1264,7 @@ winrt::fire_and_forget AppHost::_WindowInitializedHandler(const winrt::Windows::
     // side effect of immediately dismissing the initial warning dialog, if
     // there were settings load warnings.
     //
-    // In Apphost::_WindowMoved, we'll make sure we're at least initialized
+    // In AppHost::_WindowMoved, we'll make sure we're at least initialized
     // before dismissing open dialogs.
     _isWindowInitialized = WindowInitializedState::Initialized;
 }

--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -37,7 +37,15 @@ private:
     winrt::Microsoft::Terminal::Remoting::Peasant _peasant{ nullptr };
 
     winrt::com_ptr<IVirtualDesktopManager> _desktopManager{ nullptr };
-    bool _isWindowInitialized = false;
+
+    enum WindowInitializedState : uint32_t
+    {
+        NotInitialized = 0,
+        Initializing = 1,
+        Initialized = 2,
+    };
+
+    WindowInitializedState _isWindowInitialized{ WindowInitializedState::NotInitialized };
     bool _useNonClientArea{ false };
     winrt::Microsoft::Terminal::Settings::Model::LaunchMode _launchMode{};
 


### PR DESCRIPTION
Apparently, `ShowWindow` also sends a `WM_MOVE`, which we then turn around and use to dismiss open dialogs. 

Closes #15170

Regressed in #13811