### PR TITLE
AtlasEngine: Add support for locl variants

### DIFF
--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -534,6 +534,17 @@ void AtlasEngine::_recreateFontDependentResources()
     _api.replacementCharacterGlyphIndex = 0;
     _api.replacementCharacterLookedUp = false;
 
+    {
+        wchar_t localeName[LOCALE_NAME_MAX_LENGTH];
+
+        if (FAILED(GetUserDefaultLocaleName(&localeName[0], LOCALE_NAME_MAX_LENGTH)))
+        {
+            memcpy(&localeName[0], L"en-US", 12);
+        }
+
+        _api.userLocaleName = std::wstring{ &localeName[0] };
+    }
+
     if (_p.s->font->fontAxisValues.empty())
     {
         for (auto& axes : _api.textFormatAxes)
@@ -799,7 +810,7 @@ void AtlasEngine::_mapComplex(IDWriteFontFace2* mappedFontFace, u32 idx, u32 len
                 /* isSideways          */ false,
                 /* isRightToLeft       */ 0,
                 /* scriptAnalysis      */ &a.analysis,
-                /* localeName          */ nullptr,
+                /* localeName          */ _api.userLocaleName.c_str(),
                 /* numberSubstitution  */ nullptr,
                 /* features            */ &features,
                 /* featureRangeLengths */ &featureRangeLengths,
@@ -851,7 +862,7 @@ void AtlasEngine::_mapComplex(IDWriteFontFace2* mappedFontFace, u32 idx, u32 len
             /* isSideways          */ false,
             /* isRightToLeft       */ 0,
             /* scriptAnalysis      */ &a.analysis,
-            /* localeName          */ nullptr,
+            /* localeName          */ _api.userLocaleName.c_str(),
             /* features            */ &features,
             /* featureRangeLengths */ &featureRangeLengths,
             /* featureRanges       */ featureRanges,

--- a/src/renderer/atlas/AtlasEngine.h
+++ b/src/renderer/atlas/AtlasEngine.h
@@ -131,6 +131,8 @@ namespace Microsoft::Console::Render::Atlas
             std::vector<wchar_t> bufferLine;
             std::vector<u16> bufferLineColumn;
 
+            std::wstring userLocaleName;
+
             std::array<Buffer<DWRITE_FONT_AXIS_VALUE>, 4> textFormatAxes;
             std::vector<TextAnalysisSinkResult> analysisResults;
             Buffer<u16> clusterMap;


### PR DESCRIPTION
Get the locale from `GetUserDefaultLocaleName` and pass it to
DirectWrite's `GetGlyphs` / `GetGlyphPlacements`.

Closes #13685

## Validation Steps Performed
* Set font to Cascadia Code
* Set locale to "pl-PL"
* Type "Ć"
* The acute is less angled and almost vertical ✅