### PR TITLE
Use a "virtual CWD" for each terminal window

### DIFF
--- a/src/cascadia/Remoting/Peasant.idl
+++ b/src/cascadia/Remoting/Peasant.idl
@@ -10,7 +10,7 @@ namespace Microsoft.Terminal.Remoting
         CommandlineArgs(String[] args, String cwd, UInt32 showWindowCommand);
 
         String[] Commandline { get; set; };
-        String CurrentDirectory();
+        String CurrentDirectory { get; };
         UInt32 ShowWindowCommand { get; };
     };
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1227,21 +1227,12 @@ namespace winrt::TerminalApp::implementation
             // construction, because the connection might not spawn the child
             // process until later, on another thread, after we've already
             // restored the CWD to its original value.
-            auto newWorkingDirectory{ settings.StartingDirectory() };
-            const bool looksLikeLinux = newWorkingDirectory.size() == 1 &&
-                                        (newWorkingDirectory[0] == L'~' || newWorkingDirectory[0] == L'/');
-            // We only want to resolve the new WD against the CWD if it doesn't look like a Linux path (see GH#592)
-            if (!looksLikeLinux)
-            {
-                const auto currentVirtualDir{ _WindowProperties.VirtualWorkingDirectory() };
-                const auto cwdString{ std::wstring_view{ currentVirtualDir } };
-                const auto requestedStartingDir{ settings.StartingDirectory() };
-
-                std::filesystem::path cwd{ cwdString };
-                cwd /= std::wstring_view{ requestedStartingDir };
-
-                newWorkingDirectory = winrt::hstring{ cwd.wstring() };
-            }
+            const auto currentVirtualDir{ _WindowProperties.VirtualWorkingDirectory() };
+            const auto cwdString{ std::wstring_view{ currentVirtualDir } };
+            const auto requestedStartingDir{ settings.StartingDirectory() };
+            auto newWorkingDirectory = winrt::hstring{
+                Utils::EvaluateStartingDirectory(cwdString, std::wstring_view{ requestedStartingDir })
+            };
 
             auto conhostConn = TerminalConnection::ConptyConnection();
             auto valueSet = TerminalConnection::ConptyConnection::CreateSettings(settings.Commandline(),

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1232,9 +1232,13 @@ namespace winrt::TerminalApp::implementation
             // We only want to resolve the new WD against the CWD if it doesn't look like a Linux path (see GH#592)
             if (!looksLikeLinux)
             {
-                const auto cwdString{ _WindowProperties.VirtualWorkingDirectory().c_str() };
+                const auto currentVirtualDir{ _WindowProperties.VirtualWorkingDirectory() };
+                const auto cwdString{ std::wstring_view{ currentVirtualDir } };
+                const auto requestedStartingDir{ settings.StartingDirectory() };
+
                 std::filesystem::path cwd{ cwdString };
-                cwd /= settings.StartingDirectory().c_str();
+                cwd /= std::wstring_view{ requestedStartingDir };
+
                 newWorkingDirectory = winrt::hstring{ cwd.wstring() };
             }
 

--- a/src/cascadia/TerminalApp/TerminalPage.idl
+++ b/src/cascadia/TerminalApp/TerminalPage.idl
@@ -51,6 +51,8 @@ namespace TerminalApp
         String WindowNameForDisplay { get; };
         String WindowIdForDisplay { get; };
 
+        String VirtualWorkingDirectory { get; set; };
+
         Boolean IsQuakeWindow();
     };
 

--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -1016,7 +1016,7 @@ namespace winrt::TerminalApp::implementation
     //   or 0. (see TerminalWindow::_ParseArgs)
     int32_t TerminalWindow::SetStartupCommandline(array_view<const winrt::hstring> args, winrt::hstring cwd)
     {
-        _WindowProperties->SetInitialCwd(cwd);
+        _WindowProperties->SetInitialCwd(std::move(cwd));
 
         // This is called in AppHost::ctor(), before we've created the window
         // (or called TerminalWindow::Initialize)

--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -1013,8 +1013,10 @@ namespace winrt::TerminalApp::implementation
     // Return Value:
     // - the result of the first command who's parsing returned a non-zero code,
     //   or 0. (see TerminalWindow::_ParseArgs)
-    int32_t TerminalWindow::SetStartupCommandline(array_view<const winrt::hstring> args)
+    int32_t TerminalWindow::SetStartupCommandline(array_view<const winrt::hstring> args, winrt::hstring cwd)
     {
+        _WindowProperties->SetInitialCwd(cwd);
+
         // This is called in AppHost::ctor(), before we've created the window
         // (or called TerminalWindow::Initialize)
         const auto result = _appArgs.ParseArgs(args);
@@ -1336,6 +1338,7 @@ namespace winrt::TerminalApp::implementation
             CATCH_LOG();
         }
     }
+
     uint64_t WindowProperties::WindowId() const noexcept
     {
         return _WindowId;

--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -1010,6 +1010,7 @@ namespace winrt::TerminalApp::implementation
     //   returned.
     // Arguments:
     // - args: an array of strings to process as a commandline. These args can contain spaces
+    // - cwd: The CWD that this window should treat as its own "virtual" CWD
     // Return Value:
     // - the result of the first command who's parsing returned a non-zero code,
     //   or 0. (see TerminalWindow::_ParseArgs)

--- a/src/cascadia/TerminalApp/TerminalWindow.h
+++ b/src/cascadia/TerminalApp/TerminalWindow.h
@@ -48,7 +48,12 @@ namespace winrt::TerminalApp::implementation
         winrt::hstring WindowNameForDisplay() const noexcept;
         bool IsQuakeWindow() const noexcept;
 
+        WINRT_OBSERVABLE_PROPERTY(winrt::hstring, VirtualWorkingDirectory, _PropertyChangedHandlers, L"");
+
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
+
+    public:
+        void SetInitialCwd(const winrt::hstring& cwd) { _VirtualWorkingDirectory = cwd; };
 
     private:
         winrt::hstring _WindowName{};
@@ -71,7 +76,7 @@ namespace winrt::TerminalApp::implementation
 
         bool HasCommandlineArguments() const noexcept;
 
-        int32_t SetStartupCommandline(array_view<const winrt::hstring> actions);
+        int32_t SetStartupCommandline(array_view<const winrt::hstring> actions, winrt::hstring cwd);
         void SetStartupContent(const winrt::hstring& content, const Windows::Foundation::IReference<Windows::Foundation::Rect>& contentBounds);
         int32_t ExecuteCommandline(array_view<const winrt::hstring> actions, const winrt::hstring& cwd);
         void SetSettingsStartupArgs(const std::vector<winrt::Microsoft::Terminal::Settings::Model::ActionAndArgs>& actions);

--- a/src/cascadia/TerminalApp/TerminalWindow.h
+++ b/src/cascadia/TerminalApp/TerminalWindow.h
@@ -54,7 +54,7 @@ namespace winrt::TerminalApp::implementation
 
     public:
         // Used for setting the initial CWD, before we have XAML set up for property change notifications.
-        void SetInitialCwd(const winrt::hstring& cwd) { _VirtualWorkingDirectory = cwd; };
+        void SetInitialCwd(winrt::hstring cwd) { _VirtualWorkingDirectory = std::move(cwd); };
 
     private:
         winrt::hstring _WindowName{};

--- a/src/cascadia/TerminalApp/TerminalWindow.h
+++ b/src/cascadia/TerminalApp/TerminalWindow.h
@@ -53,6 +53,7 @@ namespace winrt::TerminalApp::implementation
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
 
     public:
+        // Used for setting the initial CWD, before we have XAML set up for property change notifications.
         void SetInitialCwd(const winrt::hstring& cwd) { _VirtualWorkingDirectory = cwd; };
 
     private:

--- a/src/cascadia/TerminalApp/TerminalWindow.idl
+++ b/src/cascadia/TerminalApp/TerminalWindow.idl
@@ -53,7 +53,7 @@ namespace TerminalApp
 
         Boolean HasCommandlineArguments();
 
-        Int32 SetStartupCommandline(String[] commands);
+        Int32 SetStartupCommandline(String[] commands, String cwd);
         void SetStartupContent(String json, Windows.Foundation.IReference<Windows.Foundation.Rect> bounds);
         Int32 ExecuteCommandline(String[] commands, String cwd);
         String ParseCommandlineMessage { get; };

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -175,7 +175,7 @@ void AppHost::_HandleCommandlineArgs(const Remoting::WindowRequestedArgs& window
         }
         else if (args)
         {
-            const auto result = _windowLogic.SetStartupCommandline(args.Commandline());
+            const auto result = _windowLogic.SetStartupCommandline(args.Commandline(), args.CurrentDirectory());
             const auto message = _windowLogic.ParseCommandlineMessage();
             if (!message.empty())
             {

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -71,7 +71,11 @@ bool WindowEmperor::HandleCommandlineArgs()
 {
     std::vector<winrt::hstring> args;
     _buildArgsFromCommandline(args);
-    auto cwd{ wil::GetCurrentDirectoryW<std::wstring>() };
+    const auto cwd{ wil::GetCurrentDirectoryW<std::wstring>() };
+
+    // ALWAYS change the _real_ CWD of the Terminal to system32, so that we
+    // don't lock the directory we were spawned in.
+    LOG_IF_WIN32_BOOL_FALSE(SetCurrentDirectory(L"%SystemRoot%\\System32"));
 
     // Get the requested initial state of the window from our startup info. For
     // something like `start /min`, this will set the wShowWindow member to

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -73,9 +73,15 @@ bool WindowEmperor::HandleCommandlineArgs()
     _buildArgsFromCommandline(args);
     const auto cwd{ wil::GetCurrentDirectoryW<std::wstring>() };
 
-    // ALWAYS change the _real_ CWD of the Terminal to system32, so that we
-    // don't lock the directory we were spawned in.
-    LOG_IF_WIN32_BOOL_FALSE(SetCurrentDirectory(L"%SystemRoot%\\System32"));
+    {
+        // ALWAYS change the _real_ CWD of the Terminal to system32, so that we
+        // don't lock the directory we were spawned in.
+        std::wstring system32{};
+        if (SUCCEEDED_LOG(wil::GetSystemDirectoryW<std::wstring>(system32)))
+        {
+            LOG_IF_WIN32_BOOL_FALSE(SetCurrentDirectoryW(system32.c_str()));
+        }
+    }
 
     // Get the requested initial state of the window from our startup info. For
     // something like `start /min`, this will set the wShowWindow member to

--- a/src/types/inc/utils.hpp
+++ b/src/types/inc/utils.hpp
@@ -112,4 +112,7 @@ namespace Microsoft::Console::Utils
     // testing easier.
     std::wstring_view TrimPaste(std::wstring_view textView) noexcept;
 
+    // Same deal, but in TerminalPage::_evaluatePathForCwd
+    std::wstring EvaluateStartingDirectory(std::wstring_view cwd, std::wstring_view startingDirectory);
+
 }

--- a/src/types/ut_types/UtilsTests.cpp
+++ b/src/types/ut_types/UtilsTests.cpp
@@ -558,15 +558,55 @@ void UtilsTests::TestEvaluateStartingDirectory()
         VERIFY_ARE_EQUAL(expected, EvaluateStartingDirectory(cwd, startingDir));
     };
 
+    // A NOTE: EvaluateStartingDirectory makes no attempt to cannonicalize the
+    // path. So if you do any sort of relative paths, it'll literally just
+    // append.
+
     {
         std::wstring cwd = L"C:\\Windows\\System32";
 
+        // Literally blank
+        test(L"C:\\Windows\\System32\\", cwd, L"");
+
+        // Absolute Windows path
         test(L"C:\\Windows", cwd, L"C:\\Windows");
-        test(L"C:\\Windows\\System32\\System32", cwd, L".\\System32"); // ?
+        test(L"C:/Users/migrie", cwd, L"C:/Users/migrie");
+
+        // Relative Windows path
+        test(L"C:\\Windows\\System32\\.", cwd, L"."); // ?
+        test(L"C:\\Windows\\System32\\.\\System32", cwd, L".\\System32"); // ?
+        test(L"C:\\Windows\\System32\\./dev", cwd, L"./dev");
+
+        // WSL '~' path
         test(L"~", cwd, L"~");
         test(L"~/dev", cwd, L"~/dev");
+
+        // WSL or Windows / path - this will ultimately be evaluated by the connection
         test(L"/", cwd, L"/");
         test(L"/dev", cwd, L"/dev");
-        test(L"C:\\Windows\\System32\\dev", cwd, L"./dev");
+    }
+
+    {
+        std::wstring cwd = L"C:/Users/migrie";
+
+        // Literally blank
+        test(L"C:/Users/migrie\\", cwd, L"");
+
+        // Absolute Windows path
+        test(L"C:\\Windows", cwd, L"C:\\Windows");
+        test(L"C:/Users/migrie", cwd, L"C:/Users/migrie");
+
+        // Relative Windows path
+        test(L"C:/Users/migrie\\.", cwd, L"."); // ?
+        test(L"C:/Users/migrie\\.\\System32", cwd, L".\\System32"); // ?
+        test(L"C:/Users/migrie\\./dev", cwd, L"./dev");
+
+        // WSL '~' path
+        test(L"~", cwd, L"~");
+        test(L"~/dev", cwd, L"~/dev");
+
+        // WSL or Windows / path - this will ultimately be evaluated by the connection
+        test(L"/", cwd, L"/");
+        test(L"/dev", cwd, L"/dev");
     }
 }

--- a/src/types/ut_types/UtilsTests.cpp
+++ b/src/types/ut_types/UtilsTests.cpp
@@ -33,6 +33,8 @@ class UtilsTests
     TEST_METHOD(TestTrimTrailingWhitespace);
     TEST_METHOD(TestDontTrimTrailingWhitespace);
 
+    TEST_METHOD(TestEvaluateStartingDirectory);
+
     void _VerifyXTermColorResult(const std::wstring_view wstr, DWORD colorValue);
     void _VerifyXTermColorInvalid(const std::wstring_view wstr);
 };
@@ -545,4 +547,26 @@ void UtilsTests::TestDontTrimTrailingWhitespace()
     // We need to both
     // * trim when there's a tab followed by only whitespace
     // * not trim then there's a tab in the middle, and the string ends in whitespace
+}
+
+void UtilsTests::TestEvaluateStartingDirectory()
+{
+    // Continue on failures
+    const WEX::TestExecution::DisableVerifyExceptions disableExceptionsScope;
+
+    auto test = [](auto& expected, auto& cwd, auto& startingDir) {
+        VERIFY_ARE_EQUAL(expected, EvaluateStartingDirectory(cwd, startingDir));
+    };
+
+    {
+        std::wstring cwd = L"C:\\Windows\\System32";
+
+        test(L"C:\\Windows", cwd, L"C:\\Windows");
+        test(L"C:\\Windows\\System32\\System32", cwd, L".\\System32"); // ?
+        test(L"~", cwd, L"~");
+        test(L"~/dev", cwd, L"~/dev");
+        test(L"/", cwd, L"/");
+        test(L"/dev", cwd, L"/dev");
+        test(L"C:\\Windows\\System32\\dev", cwd, L"./dev");
+    }
 }

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -846,9 +846,21 @@ std::wstring Utils::EvaluateStartingDirectory(
           (resultPath[0] == L'~' || resultPath[0] == L'/'));
     newCondition;
 
-    // We only want to resolve the new WD against the CWD if it doesn't look like a Linux path (see GH#592)
-    if (oldCondition)
+    // We only want to resolve the new WD against the CWD if it doesn't look
+    // like a Linux path (see GH#592)
+
+    // Append only if it DOESN'T look like a linux-y path.
+
+    const bool newest = !(
+        // the string is at least one char AND
+        //  that first char is `~` or `/`
+        resultPath.size() >= 1 &&
+        (resultPath[0] == L'~' || resultPath[0] == L'/'));
+
+    newest;
+    // if (oldCondition)
     // if (newCondition)
+    if (newest)
     {
         std::filesystem::path cwd{ currentDirectory };
         cwd /= startingDirectory;

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -842,7 +842,7 @@ std::wstring Utils::EvaluateStartingDirectory(
     // with `~` or `/`.
     const bool looksLikeLinux =
         resultPath.size() >= 1 &&
-        (resultPath[0] == L'~' || resultPath[0] == L'/');
+        (til::at(resultPath, 0) == L'~' || til::at(resultPath, 0) == L'/');
 
     if (!looksLikeLinux)
     {

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -835,32 +835,16 @@ std::wstring Utils::EvaluateStartingDirectory(
 {
     std::wstring resultPath{ startingDirectory };
 
-    const bool oldCondition =
-        startingDirectory.size() == 0 || startingDirectory.size() == 1 &&
-                                             !(startingDirectory[0] == L'~' || startingDirectory[0] == L'/');
-
-    oldCondition;
-
-    const bool newCondition =
-        !(resultPath.size() == 1 &&
-          (resultPath[0] == L'~' || resultPath[0] == L'/'));
-    newCondition;
-
     // We only want to resolve the new WD against the CWD if it doesn't look
     // like a Linux path (see GH#592)
 
-    // Append only if it DOESN'T look like a linux-y path.
-
-    const bool newest = !(
-        // the string is at least one char AND
-        //  that first char is `~` or `/`
+    // Append only if it DOESN'T look like a linux-y path. A linux-y path starts
+    // with `~` or `/`.
+    const bool looksLikeLinux =
         resultPath.size() >= 1 &&
-        (resultPath[0] == L'~' || resultPath[0] == L'/'));
+        (resultPath[0] == L'~' || resultPath[0] == L'/');
 
-    newest;
-    // if (oldCondition)
-    // if (newCondition)
-    if (newest)
+    if (!looksLikeLinux)
     {
         std::filesystem::path cwd{ currentDirectory };
         cwd /= startingDirectory;

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -828,3 +828,31 @@ std::wstring_view Utils::TrimPaste(std::wstring_view textView) noexcept
 
     return textView.substr(0, lastNonSpace + 1);
 }
+
+std::wstring Utils::EvaluateStartingDirectory(
+    std::wstring_view currentDirectory,
+    std::wstring_view startingDirectory)
+{
+    std::wstring resultPath{ startingDirectory };
+
+    const bool oldCondition =
+        startingDirectory.size() == 0 || startingDirectory.size() == 1 &&
+                                             !(startingDirectory[0] == L'~' || startingDirectory[0] == L'/');
+
+    oldCondition;
+
+    const bool newCondition =
+        !(resultPath.size() == 1 &&
+          (resultPath[0] == L'~' || resultPath[0] == L'/'));
+    newCondition;
+
+    // We only want to resolve the new WD against the CWD if it doesn't look like a Linux path (see GH#592)
+    if (oldCondition)
+    // if (newCondition)
+    {
+        std::filesystem::path cwd{ currentDirectory };
+        cwd /= startingDirectory;
+        resultPath = cwd.wstring();
+    }
+    return resultPath;
+}

--- a/tools/bcz.cmd
+++ b/tools/bcz.cmd
@@ -32,6 +32,10 @@ if (%1) == (rel) (
     echo Manually building release
     set _LAST_BUILD_CONF=Release
 )
+if (%1) == (audit) (
+    echo Manually building audit mode
+    set _LAST_BUILD_CONF=AuditMode
+)
 if (%1) == (no_clean) (
     set _MSBUILD_TARGET=Build
 )


### PR DESCRIPTION
Before process model v3, each Terminal window was running in its own process, each with its own CWD. This allowed `startingDirectory: .` to work relative to the terminal's own CWD. However, now all windows share the same process, so there can only be one CWD. That's not great - folks who right-click "open in terminal", then "Use parent process directory" are only ever going to be able to use the CWD of the _first_ terminal opened. 

This PR remedies this issue, with a theory we had for another issue. Essentially, we'll give each Terminal window a "virtual" CWD. The Terminal isn't actually in that CWD, the terminal is in `system32`. This also will prevent the Terminal from locking the directory it was originally opened in. 

* Closes #5506
* There wasn't a 1.18 issue for "Use parent process directory is broken" yet, presumably selfhosters aren't using that feature
* Related to #14957

Many more notes on this topic in https://github.com/microsoft/terminal/issues/4637#issuecomment-1531979200


> **Warning** 
> ## Breaking change‼️

This will break a profile like 

```json
{
    "commandline": "media-test.exe",
    "name": "Use CWD for media-test",
    "startingDirectory": "."
},
```

if the user right-clicks "open in terminal", then attempts to open that profile. There's some theoretical work we could do in a follow up to fix this, but I'm inclined to say that relative paths for `commandline`s were already dangerous and should have been avoided. 