### PR TITLE
Make path-string conversions cheaper

### DIFF
--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -41,9 +41,8 @@ namespace
                 // Make a temporary monarch CLSID based on the unpackaged install root
                 std::filesystem::path modulePath{ wil::GetModuleFileNameW<std::wstring>(wil::GetModuleInstanceHandle()) };
                 modulePath.remove_filename();
-                std::wstring pathRootAsString{ modulePath.wstring() };
 
-                return Utils::CreateV5Uuid(processRootHashedGuidBase, std::as_bytes(std::span{ pathRootAsString }));
+                return Utils::CreateV5Uuid(processRootHashedGuidBase, std::as_bytes(std::span{ modulePath.native() }));
             }();
             return processRootHashedGuid;
         }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -420,7 +420,7 @@ namespace winrt::TerminalApp::implementation
             }
 
             NewTerminalArgs args;
-            args.StartingDirectory(winrt::hstring{ path.wstring() });
+            args.StartingDirectory(winrt::hstring{ path.native() });
             this->_OpenNewTerminalViaDropdown(args);
 
             TraceLoggingWrite(
@@ -1188,7 +1188,7 @@ namespace winrt::TerminalApp::implementation
                 connection = TerminalConnection::ConptyConnection{};
             }
 
-            auto valueSet = TerminalConnection::ConptyConnection::CreateSettings(azBridgePath.wstring(),
+            auto valueSet = TerminalConnection::ConptyConnection::CreateSettings(azBridgePath.native(),
                                                                                  L".",
                                                                                  L"Azure",
                                                                                  nullptr,
@@ -1233,7 +1233,7 @@ namespace winrt::TerminalApp::implementation
                 auto cwdString{ wil::GetCurrentDirectoryW<std::wstring>() };
                 std::filesystem::path cwd{ cwdString };
                 cwd /= settings.StartingDirectory().c_str();
-                newWorkingDirectory = winrt::hstring{ cwd.wstring() };
+                newWorkingDirectory = winrt::hstring{ cwd.native() };
             }
 
             auto conhostConn = TerminalConnection::ConptyConnection();

--- a/src/cascadia/TerminalSettingsModel/PowershellCoreProfileGenerator.cpp
+++ b/src/cascadia/TerminalSettingsModel/PowershellCoreProfileGenerator.cpp
@@ -157,7 +157,7 @@ static void _accumulateTraditionalLayoutPowerShellInstancesInDirectory(std::wstr
             const auto executable = versionedPath / PWSH_EXE;
             if (std::filesystem::exists(executable))
             {
-                const auto preview = versionedPath.filename().wstring().find(L"-preview") != std::wstring::npos;
+                const auto preview = versionedPath.filename().native().find(L"-preview") != std::wstring::npos;
                 const auto previewFlag = preview ? PowerShellFlags::Preview : PowerShellFlags::None;
                 out.emplace_back(PowerShellInstance{ std::stoi(versionedPath.filename()),
                                                      PowerShellFlags::Traditional | flags | previewFlag,

--- a/src/types/utils.cpp
+++ b/src/types/utils.cpp
@@ -729,7 +729,7 @@ std::tuple<std::wstring, std::wstring> Utils::MangleStartingDirectoryForWSL(std:
             const auto terminator{ commandLine.find_first_of(LR"(" )", 1) }; // look past the first character in case it starts with "
             const auto start{ til::at(commandLine, 0) == L'"' ? 1 : 0 };
             const std::filesystem::path executablePath{ commandLine.substr(start, terminator - start) };
-            const auto executableFilename{ executablePath.filename().wstring() };
+            const auto executableFilename{ executablePath.filename() };
             if (executableFilename == L"wsl" || executableFilename == L"wsl.exe")
             {
                 // We've got a WSL -- let's just make sure it's the right one.
@@ -784,7 +784,7 @@ std::tuple<std::wstring, std::wstring> Utils::MangleStartingDirectoryForWSL(std:
                 }
 
                 return {
-                    fmt::format(LR"("{}" --cd "{}" {})", executablePath.wstring(), mangledDirectory, arguments),
+                    fmt::format(LR"("{}" --cd "{}" {})", executablePath.native(), mangledDirectory, arguments),
                     std::wstring{}
                 };
             }

--- a/src/winconpty/winconpty.cpp
+++ b/src/winconpty/winconpty.cpp
@@ -81,7 +81,7 @@ static wchar_t* _ConsoleHostPath()
             // We tried the architecture infix version and failed, fall back to conhost.
             return _InboxConsoleHostPath();
         }
-        auto modulePathAsString{ modulePath.wstring() };
+        const auto& modulePathAsString = modulePath.native();
         return wil::make_process_heap_string_nothrow(modulePathAsString.data(), modulePathAsString.size());
 #endif // __INSIDE_WINDOWS
     }();


### PR DESCRIPTION
`native()` returns a `const std::wstring&`, whereas `wstring()`
returns a copy. Use the former to make path conversions cheaper.