### PR TITLE
Fix WindowEmperor exiting too early

### DIFF
--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -140,10 +140,16 @@ void WindowEmperor::_createNewWindowThread(const Remoting::WindowRequestedArgs& 
     std::thread t([weakThis, window]() {
         try
         {
-            auto cleanup = wil::scope_exit([&]() {
+            const auto decrementWindowCount = wil::scope_exit([&]() {
                 if (auto self{ weakThis.lock() })
                 {
-                    self->_windowExitedHandler(window->Peasant().GetID());
+                    self->_decrementWindowCount();
+                }
+            });
+            auto removeWindow = wil::scope_exit([&]() {
+                if (auto self{ weakThis.lock() })
+                {
+                    self->_removeWindow(window->PeasantID());
                 }
             });
 
@@ -160,7 +166,7 @@ void WindowEmperor::_createNewWindowThread(const Remoting::WindowRequestedArgs& 
             // remove the window from our list of windows, before we release the
             // AppHost (and subsequently, the host's Logic() member that we use
             // elsewhere).
-            cleanup.reset();
+            removeWindow.reset();
 
             // Now that we no longer care about this thread's window, let it
             // release it's app host and flush the rest of the XAML queue.
@@ -204,17 +210,20 @@ void WindowEmperor::_windowStartedHandlerPostXAML(const std::shared_ptr<WindowTh
         lockedWindows->push_back(sender);
     }
 }
-void WindowEmperor::_windowExitedHandler(uint64_t senderID)
+
+void WindowEmperor::_removeWindow(uint64_t senderID)
 {
     auto lockedWindows{ _windows.lock() };
 
     // find the window in _windows who's peasant's Id matches the peasant's Id
     // and remove it
-    std::erase_if(*lockedWindows,
-                  [&](const auto& w) {
-                      return w->Peasant().GetID() == senderID;
-                  });
+    std::erase_if(*lockedWindows, [&](const auto& w) {
+        return w->PeasantID() == senderID;
+    });
+}
 
+void WindowEmperor::_decrementWindowCount()
+{
     // When we run out of windows, exit our process if and only if:
     // * We're not allowed to run headless OR
     // * we've explicitly been told to "quit", which should fully exit the Terminal.
@@ -226,6 +235,7 @@ void WindowEmperor::_windowExitedHandler(uint64_t senderID)
         _close();
     }
 }
+
 // Method Description:
 // - Set up all sorts of handlers now that we've determined that we're a process
 //   that will end up hosting the windows. These include:

--- a/src/cascadia/WindowsTerminal/WindowEmperor.h
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.h
@@ -55,7 +55,8 @@ private:
     bool _quitting{ false };
 
     void _windowStartedHandlerPostXAML(const std::shared_ptr<WindowThread>& sender);
-    void _windowExitedHandler(uint64_t senderID);
+    void _removeWindow(uint64_t senderID);
+    void _decrementWindowCount();
 
     void _becomeMonarch();
     void _numberOfWindowsChanged(const winrt::Windows::Foundation::IInspectable&, const winrt::Windows::Foundation::IInspectable&);

--- a/src/cascadia/WindowsTerminal/WindowThread.cpp
+++ b/src/cascadia/WindowsTerminal/WindowThread.cpp
@@ -128,7 +128,8 @@ int WindowThread::_messagePump()
     }
     return 0;
 }
-winrt::Microsoft::Terminal::Remoting::Peasant WindowThread::Peasant()
+
+uint64_t WindowThread::PeasantID()
 {
-    return _peasant;
+    return _peasant.GetID();
 }

--- a/src/cascadia/WindowsTerminal/WindowThread.h
+++ b/src/cascadia/WindowsTerminal/WindowThread.h
@@ -17,7 +17,7 @@ public:
     int RunMessagePump();
     void RundownForExit();
 
-    winrt::Microsoft::Terminal::Remoting::Peasant Peasant();
+    uint64_t PeasantID();
 
     WINRT_CALLBACK(UpdateSettingsRequested, winrt::delegate<void()>);
 


### PR DESCRIPTION
`WindowEmperor` would exit as soon as the last window would enter
`RundownForExit()`, which is too early and triggers leak checks.
This commit splits up the shutdown up into deregistering the window from
the list of windows and into actually decrementing the window count.

Closes #15306

## Validation Steps Performed
* D2D leak warnings seem to disappear ✅