### PR TITLE
Don't dismiss the command palette when the new tab menu closes

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -851,7 +851,14 @@ namespace winrt::TerminalApp::implementation
         });
         // Necessary for fly-out sub items to get focus on a tab before collapsing. Related to #15049
         newTabFlyout.Closing([this](auto&&, auto&&) {
-            _FocusCurrentTab(true);
+            if (const auto p = CommandPaletteElement(); p && p.Visibility() == Visibility::Visible)
+            {
+                // Don't focus the terminal, that'll dismiss the command palette.
+            }
+            else
+            {
+                _FocusCurrentTab(true);
+            }
         });
         _newTabButton.Flyout(newTabFlyout);
     }

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -276,6 +276,8 @@ namespace winrt::TerminalApp::implementation
         winrt::Microsoft::Terminal::TerminalConnection::ConptyConnection::NewConnection_revoker _newConnectionRevoker;
 
         __declspec(noinline) CommandPalette _loadCommandPaletteSlowPath();
+        bool _commandPaletteIs(winrt::Windows::UI::Xaml::Visibility visibility);
+
         winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::UI::Xaml::Controls::ContentDialogResult> _ShowDialogHelper(const std::wstring_view& name);
 
         void _ShowAboutDialog();


### PR DESCRIPTION
Transient UIs are hard.

Regressed in #15077.

Closes #15305
