### PR TITLE
AtlasEngine: Fix animated shaders

### DIFF
--- a/src/renderer/atlas/AtlasEngine.r.cpp
+++ b/src/renderer/atlas/AtlasEngine.r.cpp
@@ -32,11 +32,6 @@ using namespace Microsoft::Console::Render::Atlas;
 [[nodiscard]] HRESULT AtlasEngine::Present() noexcept
 try
 {
-    if (!_p.dirtyRectInPx)
-    {
-        return S_OK;
-    }
-
     if (!_p.dxgi.adapter || !_p.dxgi.factory->IsCurrent())
     {
         _recreateAdapter();
@@ -420,6 +415,12 @@ void AtlasEngine::_waitUntilCanRender() noexcept
 
 void AtlasEngine::_present()
 {
+    // Present1() dislikes being called with an empty dirty rect.
+    if (!_p.dirtyRectInPx)
+    {
+        return;
+    }
+
     const til::rect fullRect{ 0, 0, _p.swapChain.targetSize.x, _p.swapChain.targetSize.y };
 
     DXGI_PRESENT_PARAMETERS params{};


### PR DESCRIPTION
We need to avoid calling `Present1()` with an empty dirty rect, but the
backends are what determines the resulting dirty rect, so we need to
first run the backend code and then decide if we `Present1()` or not.

## Validation Steps Performed
* `Animate_scan.hlsl` shows a smoothly animated line ✅