### PR TITLE
Fix AtlasEngine not being used in the appearance settings

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.cpp
@@ -16,14 +16,9 @@ using namespace winrt::Windows::UI::Xaml::Navigation;
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {
-    Profiles_Appearance::Profiles_Appearance() :
-        _previewControl{ Control::TermControl(Model::TerminalSettings{}, nullptr, make<PreviewConnection>()) }
+    Profiles_Appearance::Profiles_Appearance()
     {
         InitializeComponent();
-
-        _previewControl.IsEnabled(false);
-        _previewControl.AllowFocusWhenDisabled(false);
-        ControlPreview().Child(_previewControl);
     }
 
     void Profiles_Appearance::OnNavigatedTo(const NavigationEventArgs& e)
@@ -38,25 +33,22 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             ProfileViewModel::UpdateFontList();
         }
 
+        if (!_previewControl)
+        {
+            const auto settings = _Profile.TermSettings();
+            _previewControl = Control::TermControl(settings, settings, make<PreviewConnection>());
+            _previewControl.IsEnabled(false);
+            _previewControl.AllowFocusWhenDisabled(false);
+            ControlPreview().Child(_previewControl);
+        }
+
         // Subscribe to some changes in the view model
         // These changes should force us to update our own set of "Current<Setting>" members,
         // and propagate those changes to the UI
-        _ViewModelChangedRevoker = _Profile.PropertyChanged(winrt::auto_revoke, [=](auto&&, const PropertyChangedEventArgs& /*args*/) {
-            _previewControl.UpdateControlSettings(_Profile.TermSettings(), _Profile.TermSettings());
-        });
-
+        _ViewModelChangedRevoker = _Profile.PropertyChanged(winrt::auto_revoke, { this, &Profiles_Appearance::_onProfilePropertyChanged });
         // The Appearances object handles updating the values in the settings UI, but
         // we still need to listen to the changes here just to update the preview control
-        _AppearanceViewModelChangedRevoker = _Profile.DefaultAppearance().PropertyChanged(winrt::auto_revoke, [=](auto&&, const PropertyChangedEventArgs& /*args*/) {
-            _previewControl.UpdateControlSettings(_Profile.TermSettings(), _Profile.TermSettings());
-        });
-
-        // There is a possibility that the control has not fully initialized yet,
-        // so wait for it to initialize before updating the settings (so we know
-        // that the renderer is set up)
-        _previewControl.Initialized([&](auto&& /*s*/, auto&& /*e*/) {
-            _previewControl.UpdateControlSettings(_Profile.TermSettings(), _Profile.TermSettings());
-        });
+        _AppearanceViewModelChangedRevoker = _Profile.DefaultAppearance().PropertyChanged(winrt::auto_revoke, { this, &Profiles_Appearance::_onProfilePropertyChanged });
     }
 
     void Profiles_Appearance::OnNavigatedFrom(const NavigationEventArgs& /*e*/)
@@ -73,5 +65,11 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     void Profiles_Appearance::DeleteUnfocusedAppearance_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*e*/)
     {
         _Profile.DeleteUnfocusedAppearance();
+    }
+
+    void Profiles_Appearance::_onProfilePropertyChanged(const IInspectable&, const PropertyChangedEventArgs&) const
+    {
+        const auto settings = _Profile.TermSettings();
+        _previewControl.UpdateControlSettings(settings, settings);
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.h
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.h
@@ -25,7 +25,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         WINRT_PROPERTY(Editor::ProfileViewModel, Profile, nullptr);
 
     private:
-        Microsoft::Terminal::Control::TermControl _previewControl;
+        void _onProfilePropertyChanged(const IInspectable&, const PropertyChangedEventArgs&) const;
+
+        Microsoft::Terminal::Control::TermControl _previewControl{ nullptr };
         Windows::UI::Xaml::Data::INotifyPropertyChanged::PropertyChanged_revoker _ViewModelChangedRevoker;
         Windows::UI::Xaml::Data::INotifyPropertyChanged::PropertyChanged_revoker _AppearanceViewModelChangedRevoker;
         Editor::IHostedInWindow _windowRoot;


### PR DESCRIPTION
`TermControl` cannot change the text rendering engine after its
construction. Fix the issue by deferring the construction until
after we got the initial profile settings.

## Validation Steps Performed
* A line height of 0.5 shows up with overlapping rows ✅