### PR TITLE
AtlasEngine: Fix multiple minor issues

### DIFF
--- a/src/renderer/atlas/AtlasEngine.api.cpp
+++ b/src/renderer/atlas/AtlasEngine.api.cpp
@@ -648,8 +648,11 @@ void AtlasEngine::_resolveFontMetrics(const wchar_t* requestedFaceName, const Fo
     auto advanceWidth = 0.5f * fontSizeInPx;
     {
         static constexpr u32 codePoint = '0';
+
         u16 glyphIndex;
-        if (SUCCEEDED(fontFace->GetGlyphIndicesW(&codePoint, 1, &glyphIndex)))
+        THROW_IF_FAILED(fontFace->GetGlyphIndicesW(&codePoint, 1, &glyphIndex));
+
+        if (glyphIndex)
         {
             DWRITE_GLYPH_METRICS glyphMetrics{};
             THROW_IF_FAILED(fontFace->GetDesignGlyphMetrics(&glyphIndex, 1, &glyphMetrics, FALSE));

--- a/src/renderer/atlas/Backend.cpp
+++ b/src/renderer/atlas/Backend.cpp
@@ -4,8 +4,6 @@
 #include "pch.h"
 #include "Backend.h"
 
-#include <dwmapi.h>
-
 TIL_FAST_MATH_BEGIN
 
 // Disable a bunch of warnings which get in the way of writing performant code.

--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -707,9 +707,16 @@ void BackendD3D::_resetGlyphAtlas(const RenderingPayload& p)
 
     stbrp_init_target(&_rectPacker, u, v, _rectPackerData.data(), _rectPackerData.size());
 
+    // This is a little imperfect, because it only releases the memory of the glyph mappings, not the memory held by
+    // any DirectWrite fonts. On the other side, the amount of fonts on a system is always finite, where "finite"
+    // is pretty low, relatively speaking. Additionally this allows us to cache the boxGlyphs map indefinitely.
+    // It's not great, but it's not terrible.
     for (auto& slot : _glyphAtlasMap.container())
     {
-        slot.inner.reset();
+        if (slot.inner)
+        {
+            slot.inner->glyphs.clear();
+        }
     }
 
     _d2dBeginDrawing();

--- a/src/renderer/atlas/common.h
+++ b/src/renderer/atlas/common.h
@@ -553,5 +553,4 @@ namespace Microsoft::Console::Render::Atlas
         virtual void Render(RenderingPayload& payload) = 0;
         virtual bool RequiresContinuousRedraw() noexcept = 0;
     };
-
 }


### PR DESCRIPTION
This commit fixes 3 bugs that I found while working on another feature:
* `GetGlyphIndices` doesn't return an error when the codepoint couldn't
  be found, it simply returns a glyph index of 0.
* `_resetGlyphAtlas` failed to reset the `linear_flat_set` "load" to 0
  which would result in an unbounded memory growth over time.
* `linear_flat_set` was missing move constructors/operators, which
  would've led to crashes, etc., but thankfully we haven't made use
  of these operators yet. But better fix it now than never.