### PR TITLE
AtlasEngine: Fix han unification issues

### DIFF
--- a/src/renderer/atlas/AtlasEngine.cpp
+++ b/src/renderer/atlas/AtlasEngine.cpp
@@ -705,7 +705,7 @@ void AtlasEngine::_flushBufferLine()
 
 void AtlasEngine::_mapCharacters(const wchar_t* text, const u32 textLength, u32* mappedLength, IDWriteFontFace2** mappedFontFace) const
 {
-    TextAnalysisSource analysisSource{ text, textLength };
+    TextAnalysisSource analysisSource{ _api.userLocaleName.c_str(), text, textLength };
     const auto& textFormatAxis = _api.textFormatAxes[static_cast<size_t>(_api.attributes)];
 
     // We don't read from scale anyways.
@@ -760,7 +760,7 @@ void AtlasEngine::_mapComplex(IDWriteFontFace2* mappedFontFace, u32 idx, u32 len
 {
     _api.analysisResults.clear();
 
-    TextAnalysisSource analysisSource{ _api.bufferLine.data(), gsl::narrow<UINT32>(_api.bufferLine.size()) };
+    TextAnalysisSource analysisSource{ _api.userLocaleName.c_str(), _api.bufferLine.data(), gsl::narrow<UINT32>(_api.bufferLine.size()) };
     TextAnalysisSink analysisSink{ _api.analysisResults };
     THROW_IF_FAILED(_p.textAnalyzer->AnalyzeScript(&analysisSource, idx, length, &analysisSink));
 

--- a/src/renderer/atlas/DWriteTextAnalysis.cpp
+++ b/src/renderer/atlas/DWriteTextAnalysis.cpp
@@ -9,9 +9,10 @@
 
 using namespace Microsoft::Console::Render::Atlas;
 
-TextAnalysisSource::TextAnalysisSource(const wchar_t* _text, const UINT32 _textLength) noexcept :
-    _text{ _text },
-    _textLength{ _textLength }
+TextAnalysisSource::TextAnalysisSource(const wchar_t* locale, const wchar_t* text, const UINT32 textLength) noexcept :
+    _locale{ locale },
+    _text{ text },
+    _textLength{ textLength }
 {
 }
 
@@ -94,7 +95,7 @@ HRESULT TextAnalysisSource::GetLocaleName(UINT32 textPosition, UINT32* textLengt
     __assume(localeName != nullptr);
 
     *textLength = _textLength - textPosition;
-    *localeName = nullptr;
+    *localeName = _locale;
     return S_OK;
 }
 

--- a/src/renderer/atlas/DWriteTextAnalysis.h
+++ b/src/renderer/atlas/DWriteTextAnalysis.h
@@ -9,7 +9,7 @@ namespace Microsoft::Console::Render::Atlas
 {
     struct TextAnalysisSource final : IDWriteTextAnalysisSource
     {
-        TextAnalysisSource(const wchar_t* _text, const UINT32 _textLength) noexcept;
+        TextAnalysisSource(const wchar_t* locale, const wchar_t* text, const UINT32 textLength) noexcept;
 #ifndef NDEBUG
         ~TextAnalysisSource();
 #endif
@@ -24,6 +24,7 @@ namespace Microsoft::Console::Render::Atlas
         HRESULT __stdcall GetNumberSubstitution(UINT32 textPosition, UINT32* textLength, IDWriteNumberSubstitution** numberSubstitution) noexcept override;
 
     private:
+        const wchar_t* _locale;
         const wchar_t* _text;
         const UINT32 _textLength;
 #ifndef NDEBUG


### PR DESCRIPTION
This commit ensures that we pass the user's locale to `MapCharacters`.

## Validation Steps Performed
See: https://heistak.github.io/your-code-displays-japanese-wrong/
After modifying the `userLocaleName` to contain `ja-JP`, `zh-CN` and
`zh-TW`, printing "刃直海角骨入" produces the expected, localized result.