### PR TITLE
Add a fun new preview text in the SUI, enable the cursor

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -997,7 +997,11 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             // _cursorTimer doesn't exist, and it would never turn on the
             // cursor. To mitigate, we'll initialize the cursor's 'on' state
             // with `_focused` here.
-            _core.CursorOn(_focused);
+            _core.CursorOn(_focused || DisplayCursorWhileBlurred);
+            if (DisplayCursorWhileBlurred)
+            {
+                _cursorTimer->Start();
+            }
         }
         else
         {
@@ -1873,7 +1877,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             TSFInputControl().NotifyFocusLeave();
         }
 
-        if (_cursorTimer)
+        if (_cursorTimer && !DisplayCursorWhileBlurred)
         {
             _cursorTimer->Stop();
             _core.CursorOn(false);

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -182,6 +182,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
         WINRT_OBSERVABLE_PROPERTY(winrt::Windows::UI::Xaml::Media::Brush, BackgroundBrush, _PropertyChangedHandlers, nullptr);
 
+    public:
+        til::property<bool> DisplayCursorWhileBlurred{ false };
+
     private:
         friend struct TermControlT<TermControl>; // friend our parent so it can bind private event handlers
 

--- a/src/cascadia/TerminalControl/TermControl.idl
+++ b/src/cascadia/TerminalControl/TermControl.idl
@@ -111,6 +111,8 @@ namespace Microsoft.Terminal.Control
         // opacity set by the settings should call this instead.
         Double BackgroundOpacity { get; };
 
+        Boolean DisplayCursorWhileBlurred;
+
         Windows.UI.Xaml.Media.Brush BackgroundBrush { get; };
 
         void ColorSelection(SelectionColor fg, SelectionColor bg, Microsoft.Terminal.Core.MatchMode matchMode);

--- a/src/cascadia/TerminalSettingsEditor/PreviewConnection.cpp
+++ b/src/cascadia/TerminalSettingsEditor/PreviewConnection.cpp
@@ -10,11 +10,11 @@ using namespace ::winrt::Windows::Foundation;
 
 static constexpr std::wstring_view PreviewText{
     L"Windows Terminal\r\n"
-    L"C:\\> \e[93mgit\e[m diff\r\n"
-    L"\e[1mdiff --git a/hi b/hi\e[m\r\n"
-    L"\e[36m@@ -0,1 +0,1 @@\e[m\r\n"
-    L"\e[31m-    Windows Console\e[m\r\n"
-    L"\e[32m-    Windows Terminal!\e[m\r\n"
+    L"C:\\> \x1b[93mgit\x1b[m diff\r\n"
+    L"\x1b[1mdiff --git a/hi b/hi\x1b[m\r\n"
+    L"\x1b[36m@@ -0,1 +0,1 @@\x1b[m\r\n"
+    L"\x1b[31m-    Windows Console\x1b[m\r\n"
+    L"\x1b[32m-    Windows Terminal!\x1b[m\r\n"
 };
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation

--- a/src/cascadia/TerminalSettingsEditor/PreviewConnection.cpp
+++ b/src/cascadia/TerminalSettingsEditor/PreviewConnection.cpp
@@ -8,7 +8,14 @@
 using namespace ::winrt::Microsoft::Terminal::TerminalConnection;
 using namespace ::winrt::Windows::Foundation;
 
-static constexpr std::wstring_view PreviewText{ L"Windows Terminal\r\nCopyright (c) Microsoft Corporation\r\n\nC:\\Windows\\Terminal> " };
+static constexpr std::wstring_view PreviewText{
+    L"Windows Terminal\r\n"
+    L"C:\\> \e[93mgit\e[m diff\r\n"
+    L"\e[1mdiff --git a/hi b/hi\e[m\r\n"
+    L"\e[36m@@ -0,1 +0,1 @@\e[m\r\n"
+    L"\e[31m-    Windows Console\e[m\r\n"
+    L"\e[32m-    Windows Terminal!\e[m\r\n"
+};
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {

--- a/src/cascadia/TerminalSettingsEditor/PreviewConnection.cpp
+++ b/src/cascadia/TerminalSettingsEditor/PreviewConnection.cpp
@@ -8,15 +8,17 @@
 using namespace ::winrt::Microsoft::Terminal::TerminalConnection;
 using namespace ::winrt::Windows::Foundation;
 
+// clang-format off
 static constexpr std::wstring_view PreviewText{
     L"Windows Terminal\r\n"
-    L"C:\\> \x1b[93mgit\x1b[m diff \x1b[90m-w\x1b[m\r\n"
-    L"\x1b[1mdiff --git a/win b/win\x1b[m\r\n"
+    L"C:\\> \x1b[93m" L"git\x1b[m diff \x1b[90m-w\x1b[m\r\n"
+    L"\x1b[1m" L"diff --git a/win b/win\x1b[m\r\n"
     L"\x1b[36m@@ -1 +1 @@\x1b[m\r\n"
     L"\x1b[31m-    Windows Console\x1b[m\r\n"
     L"\x1b[32m-    Windows Terminal!\x1b[m\r\n"
     L"C:\\> \x1b[93mWrite-Host \x1b[36m\"\xd83e\xde9f!\"\x1b[1D\x1b[m"
 };
+// clang-format on
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 {

--- a/src/cascadia/TerminalSettingsEditor/PreviewConnection.cpp
+++ b/src/cascadia/TerminalSettingsEditor/PreviewConnection.cpp
@@ -10,11 +10,12 @@ using namespace ::winrt::Windows::Foundation;
 
 static constexpr std::wstring_view PreviewText{
     L"Windows Terminal\r\n"
-    L"C:\\> \x1b[93mgit\x1b[m diff\r\n"
-    L"\x1b[1mdiff --git a/hi b/hi\x1b[m\r\n"
-    L"\x1b[36m@@ -0,1 +0,1 @@\x1b[m\r\n"
+    L"C:\\> \x1b[93mgit\x1b[m diff \x1b[90m-w\x1b[m\r\n"
+    L"\x1b[1mdiff --git a/win b/win\x1b[m\r\n"
+    L"\x1b[36m@@ -1 +1 @@\x1b[m\r\n"
     L"\x1b[31m-    Windows Console\x1b[m\r\n"
     L"\x1b[32m-    Windows Terminal!\x1b[m\r\n"
+    L"C:\\> \x1b[93mWrite-Host \x1b[36m\"\xd83e\xde9f!\"\x1b[1D\x1b[m"
 };
 
 namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
@@ -23,8 +24,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void PreviewConnection::Start() noexcept
     {
-        // First send a sequence to disable cursor blinking
-        _TerminalOutputHandlers(L"\x1b[?12l");
         // Send the preview text
         _TerminalOutputHandlers(PreviewText);
     }

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.cpp
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.cpp
@@ -39,6 +39,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
             _previewControl = Control::TermControl(settings, settings, make<PreviewConnection>());
             _previewControl.IsEnabled(false);
             _previewControl.AllowFocusWhenDisabled(false);
+            _previewControl.DisplayCursorWhileBlurred(true);
             ControlPreview().Child(_previewControl);
         }
 

--- a/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Profiles_Appearance.xaml
@@ -47,8 +47,8 @@
                 <!--  Control Preview  -->
                 <Border MaxWidth="{StaticResource StandardControlMaxWidth}">
                     <Border x:Name="ControlPreview"
-                            Width="350"
-                            Height="160"
+                            Width="400"
+                            Height="180"
                             Margin="0,0,0,12"
                             HorizontalAlignment="Left"
                             BorderBrush="{ThemeResource SystemControlForegroundBaseMediumLowBrush}"


### PR DESCRIPTION
Our existing preview text was not very helpful in learning how different settings impacted the display of text in Terminal.

This new preview text contains:
* Bold text, which is controlled by intenseTextStyle
* Colors
* Emoji
* A cursor, which overlaps a single character to show inversion behavior