### PR TITLE
Remove the pending update version from the About dialog

### DIFF
--- a/src/cascadia/TerminalApp/AboutDialog.h
+++ b/src/cascadia/TerminalApp/AboutDialog.h
@@ -14,19 +14,16 @@ namespace winrt::TerminalApp::implementation
 
         winrt::hstring ApplicationDisplayName();
         winrt::hstring ApplicationVersion();
-        bool UpdatesAvailable() const;
-        winrt::hstring PendingUpdateVersion() const;
 
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
+        WINRT_OBSERVABLE_PROPERTY(bool, UpdatesAvailable, _PropertyChangedHandlers, false);
         WINRT_OBSERVABLE_PROPERTY(bool, CheckingForUpdates, _PropertyChangedHandlers, false);
 
     private:
         friend struct AboutDialogT<AboutDialog>; // for Xaml to bind events
 
         std::chrono::system_clock::time_point _lastUpdateCheck{};
-        winrt::hstring _pendingUpdateVersion;
 
-        void _SetPendingUpdateVersion(const winrt::hstring& pendingUpdateVersion);
         void _ThirdPartyNoticesOnClick(const IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& eventArgs);
         void _SendFeedbackOnClick(const IInspectable& sender, const Windows::UI::Xaml::Controls::ContentDialogButtonClickEventArgs& eventArgs);
         winrt::fire_and_forget _queueUpdateCheck();

--- a/src/cascadia/TerminalApp/AboutDialog.idl
+++ b/src/cascadia/TerminalApp/AboutDialog.idl
@@ -12,6 +12,5 @@ namespace TerminalApp
 
         Boolean CheckingForUpdates { get; };
         Boolean UpdatesAvailable { get; };
-        String PendingUpdateVersion { get; };
     }
 }

--- a/src/cascadia/TerminalApp/AboutDialog.xaml
+++ b/src/cascadia/TerminalApp/AboutDialog.xaml
@@ -40,9 +40,7 @@
                         Orientation="Vertical"
                         Visibility="{x:Bind UpdatesAvailable, Mode=OneWay}">
                 <TextBlock IsTextSelectionEnabled="False">
-                    <Run x:Uid="AboutDialog_UpdateAvailableLabel" /> <LineBreak />
-                    <Run x:Uid="AboutDialog_VersionLabel" />
-                    <Run Text="{x:Bind PendingUpdateVersion, Mode=OneWay}" />
+                    <Run x:Uid="AboutDialog_UpdateAvailableLabel" />
                 </TextBlock>
                 <!-- <Button x:Uid="AboutDialog_InstallUpdateButton"
                         Margin="0" />-->


### PR DESCRIPTION
It turns out that the store API *doesn't* tell us what the new version is. We were loading up our own package and checking its version instead.

The best we can do is tell users that an update--any update--is available.