### PR TITLE
Make the text selection not dismiss after copying text

### DIFF
--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -2077,7 +2077,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         }
 
         const auto successfulCopy = _interactivity.CopySelectionToClipboard(singleLine, formats);
-        _core.ClearSelection();
         return successfulCopy;
     }
 


### PR DESCRIPTION
## Summary of the Pull Request
Currently, when pressing Ctrl + C to copy the selected text, the selection disappears.
This commit prevents the selection to disappear after doing Ctrl + C.

## References and Relevant Issues
https://github.com/microsoft/terminal/issues/15371

## PR Checklist
- [x] Closes https://github.com/microsoft/terminal/issues/15371
- [x] Tests ~~added~~/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
