### PR TITLE
Manually close the ContentDialog in teardown

### DIFF
--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -421,6 +421,12 @@ void AppHost::Close()
     _revokers = {};
     _showHideWindowThrottler.reset();
     _window->Close();
+
+    if (_windowLogic)
+    {
+        _windowLogic.DismissDialog();
+        _windowLogic = nullptr;
+    }
 }
 
 // Method Description:


### PR DESCRIPTION
As discussed. Closes #15364.

Prevents one crash on Windows 10. Opens the door to may more horrors.

Co-authored by: @j4james
