### PR TITLE
settings.json parent folder functionality

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2817,7 +2817,6 @@ namespace winrt::TerminalApp::implementation
                 }
             };
 
-           
             auto openFolder = [](const auto& filePath) {
                 HINSTANCE res = ShellExecute(nullptr, nullptr, filePath.c_str(), nullptr, nullptr, SW_SHOW);
                 if (static_cast<int>(reinterpret_cast<uintptr_t>(res)) <= 32)

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2817,6 +2817,15 @@ namespace winrt::TerminalApp::implementation
                 }
             };
 
+           
+            auto openFolder = [](const auto& filePath) {
+                HINSTANCE res = ShellExecute(nullptr, nullptr, filePath.c_str(), nullptr, nullptr, SW_SHOW);
+                if (static_cast<int>(reinterpret_cast<uintptr_t>(res)) <= 32)
+                {
+                    ShellExecute(nullptr, nullptr, L"open", filePath.c_str(), nullptr, SW_SHOW);
+                }
+            };
+
             switch (target)
             {
             case SettingsTarget::DefaultsFile:
@@ -2828,6 +2837,9 @@ namespace winrt::TerminalApp::implementation
             case SettingsTarget::AllFiles:
                 openFile(CascadiaSettings::DefaultSettingsPath());
                 openFile(CascadiaSettings::SettingsPath());
+                break;
+            case SettingsTarget::SettingsFolder:
+                openFolder(CascadiaSettings::SettingsFolderPath());
                 break;
             }
         }

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -92,6 +92,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         Automation::AutomationProperties::SetHelpText(SaveButton(), RS_(L"Settings_SaveSettingsButton/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
         Automation::AutomationProperties::SetHelpText(ResetButton(), RS_(L"Settings_ResetSettingsButton/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
         Automation::AutomationProperties::SetHelpText(OpenJsonNavItem(), RS_(L"Nav_OpenJSON/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
+        Automation::AutomationProperties::SetHelpText(OpenJsonFolderNavItem(), RS_(L"Nav_OpenJSONFolder/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
 
         _breadcrumbs = single_threaded_observable_vector<IInspectable>();
     }
@@ -474,10 +475,8 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
     void MainPage::OpenJsonFolderClicked(const Windows::Foundation::IInspectable& /*sender*/, const Windows::UI::Xaml::RoutedEventArgs& /*args*/)
     {
-        
-            const auto target = SettingsTarget::SettingsFolder;
-            _OpenJsonHandlers(nullptr, target);
-        
+        const auto target = SettingsTarget::SettingsFolder;
+        _OpenJsonHandlers(nullptr, target);
     }
     void MainPage::SaveButton_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*args*/)
     {

--- a/src/cascadia/TerminalSettingsEditor/MainPage.cpp
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.cpp
@@ -472,6 +472,13 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         }
     }
 
+    void MainPage::OpenJsonFolderClicked(const Windows::Foundation::IInspectable& /*sender*/, const Windows::UI::Xaml::RoutedEventArgs& /*args*/)
+    {
+        
+            const auto target = SettingsTarget::SettingsFolder;
+            _OpenJsonHandlers(nullptr, target);
+        
+    }
     void MainPage::SaveButton_Click(const IInspectable& /*sender*/, const RoutedEventArgs& /*args*/)
     {
         _settingsClone.WriteSettingsToDisk();

--- a/src/cascadia/TerminalSettingsEditor/MainPage.h
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.h
@@ -32,6 +32,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         void OpenJsonKeyDown(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Input::KeyRoutedEventArgs& args);
         void OpenJsonTapped(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::Input::TappedRoutedEventArgs& args);
+        void OpenJsonFolderClicked(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
         void SettingsNav_Loaded(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);
         void SettingsNav_ItemInvoked(const Microsoft::UI::Xaml::Controls::NavigationView& sender, const Microsoft::UI::Xaml::Controls::NavigationViewItemInvokedEventArgs& args);
         void SaveButton_Click(const Windows::Foundation::IInspectable& sender, const Windows::UI::Xaml::RoutedEventArgs& args);

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -164,12 +164,9 @@
                 </muxc:NavigationViewItem.Icon>
                 <muxc:NavigationViewItem.ContextFlyout>
                     <MenuFlyout>
-                        <MenuFlyoutItem
-                                        x:Name="OpenJsonFolderNavItem"
-                                        Text="Open JSON folder"
-                                        ToolTipService.ToolTip="Open the folder holding your settings.json file."
-                                        Click="OpenJsonFolderClicked">
-                        </MenuFlyoutItem>
+                        <MenuFlyoutItem x:Name="OpenJsonFolderNavItem"
+                                        x:Uid="Nav_OpenJSONFolder"
+                                        Click="OpenJsonFolderClicked" />
                     </MenuFlyout>
                 </muxc:NavigationViewItem.ContextFlyout>
             </muxc:NavigationViewItem>

--- a/src/cascadia/TerminalSettingsEditor/MainPage.xaml
+++ b/src/cascadia/TerminalSettingsEditor/MainPage.xaml
@@ -162,6 +162,16 @@
                 <muxc:NavigationViewItem.Icon>
                     <FontIcon Glyph="&#xE713;" />
                 </muxc:NavigationViewItem.Icon>
+                <muxc:NavigationViewItem.ContextFlyout>
+                    <MenuFlyout>
+                        <MenuFlyoutItem
+                                        x:Name="OpenJsonFolderNavItem"
+                                        Text="Open JSON folder"
+                                        ToolTipService.ToolTip="Open the folder holding your settings.json file."
+                                        Click="OpenJsonFolderClicked">
+                        </MenuFlyoutItem>
+                    </MenuFlyout>
+                </muxc:NavigationViewItem.ContextFlyout>
             </muxc:NavigationViewItem>
         </muxc:NavigationView.FooterMenuItems>
 

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -578,6 +578,10 @@
     <value>Open JSON file</value>
     <comment>Header for a menu item. This opens the JSON file that is used to log the app's settings.</comment>
   </data>
+	<data name="Nav_OpenJSONFolder.Content" xml:space="preserve">
+    <value>Open JSON Folder</value>
+    <comment>Header for a menu item. This opens the JSON Folder where the JSON file that is used to log the app's settings sits.</comment>
+  </data>
   <data name="Nav_ProfileDefaults.Content" xml:space="preserve">
     <value>Defaults</value>
     <comment>Header for the "defaults" menu item. This navigates to a page that lets you see and modify settings that affect profiles. This is the lowest layer of profile settings that all other profile settings are based on. If a profile doesn't define a setting, this page is responsible for figuring out what that setting is supposed to be.</comment>
@@ -1304,6 +1308,10 @@
   <data name="Nav_OpenJSON.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Open your settings.json file. Alt+Click to open your defaults.json file.</value>
     <comment>{Locked="settings.json"}, {Locked="defaults.json"}</comment>
+  </data>
+	<data name="Nav_OpenJSONFolder.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Open your settings.json folder.</value>
+    <comment>Label for button to JSON Folder.</comment>
   </data>
   <data name="Rename.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Rename</value>

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -63,7 +63,8 @@ namespace Microsoft.Terminal.Settings.Model
         SettingsFile = 0,
         DefaultsFile,
         AllFiles,
-        SettingsUI
+        SettingsUI,
+        SettingsFolder
     };
 
     enum MoveTabDirection

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.h
@@ -100,6 +100,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         static Model::CascadiaSettings LoadDefaults();
         static Model::CascadiaSettings LoadAll();
 
+        static winrt::hstring SettingsFolderPath();
         static winrt::hstring SettingsPath();
         static winrt::hstring DefaultSettingsPath();
         static winrt::hstring ApplicationDisplayName();

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettings.idl
@@ -12,6 +12,7 @@ namespace Microsoft.Terminal.Settings.Model
         static CascadiaSettings LoadDefaults();
         static CascadiaSettings LoadAll();
 
+        static String SettingsFolderPath { get; };
         static String SettingsPath { get; };
         static String DefaultSettingsPath { get; };
         static Boolean IsPortableMode { get; };

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -1170,6 +1170,17 @@ winrt::hstring CascadiaSettings::SettingsPath()
     return winrt::hstring{ _settingsPath().native() };
 }
 
+// function Description:
+// Returns the full path where the settings.json file is located
+// Arguments:
+// - <none>
+// Return Value:
+// full path to settings folder
+winrt::hstring CascadiaSettings::SettingsFolderPath()
+{
+    return winrt::hstring{ GetBaseSettingsPath().native() };
+}
+
 bool CascadiaSettings::IsPortableMode()
 {
     return Model::IsPortableMode();


### PR DESCRIPTION
## Summary of the Pull Request

Added menu flyout to "Open JSON" that takes you to the JSON parent folder instead.
This is in response to #12382 
Added comments for the one function I had to implement for the path. Nothing complicated.



