### PR TITLE
AtlasEngine: Fix nullptr crash when using soft fonts

### DIFF
--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -1145,6 +1145,11 @@ void BackendD3D::_drawTextOverlapSplit(const RenderingPayload& p, u16 y)
 
 void BackendD3D::_initializeFontFaceEntry(AtlasFontFaceEntryInner& fontFaceEntry)
 {
+    if (!fontFaceEntry.fontFace)
+    {
+        return;
+    }
+
     ALLOW_UNINITIALIZED_BEGIN
     std::array<u32, 0x100> codepoints;
     std::array<u16, 0x100> indices;


### PR DESCRIPTION
Woops. Regressed in #15343. Fixes #15409.

## Validation Steps Performed
* Run `RenderingTests.exe`
* Soft fonts work ✅