### PR TITLE
Hotfix block selection linebreaks in conhost

### DIFF
--- a/src/interactivity/win32/Clipboard.cpp
+++ b/src/interactivity/win32/Clipboard.cpp
@@ -251,7 +251,8 @@ void Clipboard::StoreSelectionToClipboard(const bool copyFormatting)
     const auto text = buffer.GetText(includeCRLF,
                                      trimTrailingWhitespace,
                                      selectionRects,
-                                     GetAttributeColors);
+                                     GetAttributeColors,
+                                     selection.IsKeyboardMarkSelection());
 
     CopyTextToSystemClipboard(text, copyFormatting);
 }


### PR DESCRIPTION
This regressed in a1f42e8 which only made changes to Windows Terminal
but forgot to make equivalent ones in OpenConsole/conhost.
Without this fix, line breaks in block selections are missing if the
line doesn't force a wrap via an explicit newline.

Closes #15153

## Validation Steps Performed
* Run Far or print long lines of text
* Trigger block selection via Ctrl+M or Edit > Mark
* Clipboard contains N-1 newlines lines for N selected rows ✅