### PR TITLE
AtlasEngine: Fix cursor invalidation for BackendD2D

### DIFF
--- a/src/renderer/atlas/BackendD2D.cpp
+++ b/src/renderer/atlas/BackendD2D.cpp
@@ -538,6 +538,7 @@ void BackendD2D::_resizeCursorBitmap(const RenderingPayload& p, const til::size 
     cursorRenderTarget->SetAntialiasMode(D2D1_ANTIALIAS_MODE_ALIASED);
 
     cursorRenderTarget->BeginDraw();
+    cursorRenderTarget->Clear();
     {
         const D2D1_RECT_F rect{ 0, 0, sizeF.width, sizeF.height };
         const auto brush = _brushWithColor(0xffffffff);


### PR DESCRIPTION
TIL: `CreateCompatibleRenderTarget` does not initialize the bitmap
it returns. You got to do that yourself just like in D3D.

## Validation Steps Performed
* Set `ATLAS_DEBUG_FORCE_D2D_MODE` to 1
* Changing the cursor in the settings immediately updates it ✅