### PR TITLE
Fix VS profile command generation

### DIFF
--- a/src/cascadia/TerminalSettingsModel/VsDevCmdGenerator.cpp
+++ b/src/cascadia/TerminalSettingsModel/VsDevCmdGenerator.cpp
@@ -44,11 +44,12 @@ std::wstring VsDevCmdGenerator::GetProfileCommandLine(const VsSetupConfiguration
     commandLine.append(GetDevCmdScriptPath(instance));
     // The "-startdir" parameter will prevent "vsdevcmd" from automatically
     // setting the shell path so the path in the profile will be used instead.
-    commandLine.append(LR"(" -startdir=none)");
 #if defined(_M_ARM64)
-    commandLine.append(LR"(" -arch=arm64 -host_arch=x64)");
+    commandLine.append(LR"(" -startdir=none -arch=arm64 -host_arch=x64)");
 #elif defined(_M_AMD64)
-    commandLine.append(LR"(" -arch=x64 -host_arch=x64)");
+    commandLine.append(LR"(" -startdir=none -arch=x64 -host_arch=x64)");
+#else
+    commandLine.append(LR"(" -startdir=none)");
 #endif
     return commandLine;
 }


### PR DESCRIPTION
This regressed in f06cd17. It seems like the change went untested,
because it appends an extra " after -startdir=none.
This changeset also avoids calling `append()` twice.

Closes #15436

## Validation Steps Performed
* VS Developer Command Prompt works ✅