### PR TITLE
env: always expand PATH vars

### DIFF
--- a/src/inc/til/env.h
+++ b/src/inc/til/env.h
@@ -315,8 +315,8 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
                             {
                                 bool isPathVar = is_path_var(valueName);
 
-                                // On some systems we've seen that the Path variable is REG_SZ instead
-                                // of REG_EXPAND_SZ. We should always treat it as REG_EXPAND_SZ.
+                                // On some systems we've seen variables that are REG_SZ instead
+                                // of REG_EXPAND_SZ. We should always treat them as REG_EXPAND_SZ.
                                 if (isPathVar && type == REG_SZ)
                                 {
                                     type = REG_EXPAND_SZ;

--- a/src/inc/til/env.h
+++ b/src/inc/til/env.h
@@ -313,7 +313,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
 
                             if (valueNameSize)
                             {
-                                bool isPathVar = is_path_var(valueName);
+                                const bool isPathVar = is_path_var(valueName);
 
                                 // On some systems we've seen path variables that are REG_SZ instead
                                 // of REG_EXPAND_SZ. We should always treat them as REG_EXPAND_SZ.

--- a/src/inc/til/env.h
+++ b/src/inc/til/env.h
@@ -313,6 +313,15 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
 
                             if (valueNameSize)
                             {
+                                bool isPathVar = is_path_var(valueName);
+
+                                // On some systems we've seen that the Path variable is REG_SZ instead
+                                // of REG_EXPAND_SZ. We should always treat it as REG_EXPAND_SZ.
+                                if (isPathVar && type == REG_SZ)
+                                {
+                                    type = REG_EXPAND_SZ;
+                                }
+
                                 std::wstring data;
                                 if (pass == 0 && (type == REG_SZ) && valueDataSize >= sizeof(wchar_t))
                                 {
@@ -335,7 +344,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
 
                                 if (!data.empty())
                                 {
-                                    if (is_path_var(valueName))
+                                    if (isPathVar)
                                     {
                                         concat_var(valueName, std::move(data));
                                     }

--- a/src/inc/til/env.h
+++ b/src/inc/til/env.h
@@ -315,7 +315,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
                             {
                                 bool isPathVar = is_path_var(valueName);
 
-                                // On some systems we've seen variables that are REG_SZ instead
+                                // On some systems we've seen path variables that are REG_SZ instead
                                 // of REG_EXPAND_SZ. We should always treat them as REG_EXPAND_SZ.
                                 if (isPathVar && type == REG_SZ)
                                 {


### PR DESCRIPTION
Make sure we always expand path env vars, even if they're REG_SZ in the registry.

## Detailed Description of the Pull Request / Additional comments
On some systems path vars are REG_SZ instead of REG_EXPAND_SZ. We need to make sure we always expand them. We looked at the system code, and it also makes to sure to always expand them.

## Validation Steps Performed
Built locally and made sure the problem went away. Also stepped through in the debugger to make sure things were working correctly.

Closes #15442
