### PR TITLE
Project build with space in filepath fix

### DIFF
--- a/build/rules/GenerateSxsManifestsFromWinmds.targets
+++ b/build/rules/GenerateSxsManifestsFromWinmds.targets
@@ -30,7 +30,7 @@
           DependsOnTargets="_ConsoleMapWinmdsToManifestFiles">
 
     <!-- This target is batched and a new Exec is spawned for each entry in _ConsoleWinmdManifest. -->
-    <Exec Command="mt.exe -winmd:%(_ConsoleWinmdManifest.WinMDPath) -dll:%(_ConsoleWinmdManifest.Implementation) -out:%(_ConsoleWinmdManifest.Identity)" />
+    <Exec Command="mt.exe -winmd:&quot;%(_ConsoleWinmdManifest.WinMDPath)&quot; -dll:%(_ConsoleWinmdManifest.Implementation) -out:&quot;%(_ConsoleWinmdManifest.Identity)&quot;" />
 
     <ItemGroup>
       <!-- Emit the generated manifest into the Link inputs. -->

--- a/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj
+++ b/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj
@@ -327,7 +327,7 @@
 
   <!-- PowerShell version check, outputs error if the wrong version is installed. -->
   <Target Name="_WindowsPowershellVersionCheck" BeforeTargets="BeforeClCompile">
-    <Exec Command="powershell.exe -NoProfile -ExecutionPolicy Unrestricted &quot;&amp;&apos;$(OpenConsoleDir)\tools\WindowsCheckPSVersion.ps1&apos;&quot;" />
+    <Exec Command="powershell.exe -NoProfile -ExecutionPolicy Unrestricted -File &quot;$(OpenConsoleDir)\tools\WindowsCheckPSVersion.ps1&quot;" />
   </Target>
   <Target Name="_PowershellVersionCheck" BeforeTargets="BeforeClCompile">
     <Exec Command="pwsh.exe -NoProfile -ExecutionPolicy Unrestricted &quot;$(OpenConsoleDir)\tools\CheckPSVersion.ps1&quot;" />

--- a/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj
+++ b/src/cascadia/TerminalSettingsModel/Microsoft.Terminal.Settings.ModelLib.vcxproj
@@ -327,7 +327,7 @@
 
   <!-- PowerShell version check, outputs error if the wrong version is installed. -->
   <Target Name="_WindowsPowershellVersionCheck" BeforeTargets="BeforeClCompile">
-    <Exec Command="powershell.exe -NoProfile -ExecutionPolicy Unrestricted &quot;$(OpenConsoleDir)\tools\WindowsCheckPSVersion.ps1&quot;" />
+    <Exec Command="powershell.exe -NoProfile -ExecutionPolicy Unrestricted &quot;&amp;&apos;$(OpenConsoleDir)\tools\WindowsCheckPSVersion.ps1&apos;&quot;" />
   </Target>
   <Target Name="_PowershellVersionCheck" BeforeTargets="BeforeClCompile">
     <Exec Command="pwsh.exe -NoProfile -ExecutionPolicy Unrestricted &quot;$(OpenConsoleDir)\tools\CheckPSVersion.ps1&quot;" />

--- a/src/cascadia/WindowsTerminal_UIATests/WindowsTerminal.UIA.Tests.csproj
+++ b/src/cascadia/WindowsTerminal_UIATests/WindowsTerminal.UIA.Tests.csproj
@@ -126,7 +126,7 @@
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy $(SolutionDir)\dep\WinAppDriver\* $(OutDir)\</PostBuildEvent>
+    <PostBuildEvent>copy &quot;$(SolutionDir)\dep\WinAppDriver\*&quot; &quot;$(OutDir)\&quot;</PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\..\common.nugetversions.targets" />
 </Project>

--- a/src/common.nugetversions.targets
+++ b/src/common.nugetversions.targets
@@ -27,7 +27,7 @@
       Condition="'$(BuildingInsideVisualStudio)' == 'true'">
 
     <!--Have the [nuget.exe] tool do a restore on the global [packages.config] file for the repository.-->
-    <Exec Command="$(Terminal_NuGetEXE) install $(Terminal_GlobalPackagesConfigPath)" />
+    <Exec Command="$(Terminal_NuGetEXE) install &quot;$(Terminal_GlobalPackagesConfigPath)&quot;" />
 
     <!--Copy this version of [packages.config] to the output directory to allow us to skip this work in the future if nothing changed.-->
     <Copy SourceFiles="$(Terminal_GlobalPackagesConfigPath)"


### PR DESCRIPTION
## Summary of the Pull Request
Fixing a problem where the repo build failed when the project location path contained space character.

## References and Relevant Issues
Closes #15370 

## Detailed Description of the Pull Request / Additional comments
Placing missing quote, amp and apos symbols when calling commands with filepath parameters.

## Validation Steps Performed
Built locally.

## PR Checklist
- [x] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [x] Schema updated (if necessary)
