### PR TITLE
Theoretical fix for some crashes

### DIFF
--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -90,7 +90,7 @@ void IslandWindow::Close()
     // something like ShowWindow, and have that come back on the IslandWindow
     // message loop, where it'll end up asking XAML something that XAML is no
     // longer able to answer.
-    SetWindowLongPtr(_window.get(), GWLP_USERDATA, nullptr);
+    SetWindowLongPtr(_window.get(), GWLP_USERDATA, (LONG_PTR)nullptr);
 
     if (_source)
     {

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -90,7 +90,7 @@ void IslandWindow::Close()
     // something like ShowWindow, and have that come back on the IslandWindow
     // message loop, where it'll end up asking XAML something that XAML is no
     // longer able to answer.
-    SetWindowLongPtr(_window.get(), GWLP_USERDATA, (LONG_PTR)nullptr);
+    SetWindowLongPtr(_window.get(), GWLP_USERDATA, 0);
 
     if (_source)
     {

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -82,6 +82,16 @@ void IslandWindow::Close()
         // </BODGY>
     }
 
+    // GH#15454: Unset the user data for the window. This will prevent future
+    // callbacks that come onto our window message loop from being sent to the
+    // IslandWindow (or other derived class's) implementation.
+    //
+    // Specifically, this prevents a pending coroutine from being able to call
+    // something like ShowWindow, and have that come back on the IslandWindow
+    // message loop, where it'll end up asking XAML something that XAML is no
+    // longer able to answer.
+    SetWindowLongPtr(_window.get(), GWLP_USERDATA, nullptr);
+
     if (_source)
     {
         _source.Close();


### PR DESCRIPTION
RE: 
* #15454
* MSFT:44725712 "WindowsTerminal.exe!NonClientIslandWindow::OnSize"
* MSFT:44754014 "NonClientIslandWindow::GetTotalNonClientExclusiveSize"

I think this should fix all of those, but I want to ship and verify live, since I can't repro this locally. 