### PR TITLE
Modernize til::static_map with C++20

### DIFF
--- a/src/cascadia/TerminalSettingsModel/KeyChordSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/KeyChordSerialization.cpp
@@ -124,7 +124,7 @@ static int32_t parseNumericCode(const std::wstring_view& str, const std::wstring
 static KeyChord _fromString(std::wstring_view wstr)
 {
     using nameToVkeyPair = std::pair<std::wstring_view, int32_t>;
-    static const til::static_map nameToVkey{
+    static constinit til::static_map nameToVkey{
     // The above VKEY_NAME_PAIRS macro contains a list of key-binding names for each virtual key.
     // This god-awful macro inverts VKEY_NAME_PAIRS and creates a static map of key-binding names to virtual keys.
     // clang-format off
@@ -240,7 +240,7 @@ static KeyChord _fromString(std::wstring_view wstr)
 static std::wstring _toString(const KeyChord& chord)
 {
     using vkeyToNamePair = std::pair<int32_t, std::wstring_view>;
-    static const til::static_map vkeyToName{
+    static constinit til::static_map vkeyToName{
     // The above VKEY_NAME_PAIRS macro contains a list of key-binding strings for each virtual key.
     // This macro picks the first (most preferred) name and creates a static map of virtual keys to key-binding names.
 #define GENERATOR(vkey, name1, ...) vkeyToNamePair{ vkey, name1 },

--- a/src/inc/til/static_map.h
+++ b/src/inc/til/static_map.h
@@ -8,13 +8,8 @@
 // There is no requirement that keys be sorted, as it will
 // use constexpr std::sort during construction.
 //
-// Until we can use C++20, this is no cheaper than using
-// a static std::unordered_map that is initialized at
-// startup or on first use.
-// To build something that can be constexpr as of C++17,
-// use til::presorted_static_map and make certain that
-// your pairs are sorted as they would have been sorted
-// by your comparator.
+// Use til::presorted_static_map and make certain that
+// your pairs are sorted if you want to skip the std::sort.
 // A failure to sort your keys will result in unusual
 // runtime behavior, but no error messages will be
 // generated.
@@ -32,31 +27,30 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
         };
     }
 
-    template<typename K, typename V, typename Compare = std::less<K>, size_t N = 0, typename SortedInput = details::unsorted_input_t>
+    template<typename K, typename V, size_t N, typename SortedInput = details::unsorted_input_t>
     class static_map
     {
     public:
         using const_iterator = typename std::array<std::pair<K, V>, N>::const_iterator;
 
         template<typename... Args>
-        constexpr explicit static_map(const Args&... args) noexcept :
-            _predicate{},
-            _array{ { args... } }
+        constexpr explicit static_map(Args&&... args) noexcept :
+            _array{ { std::forward<Args>(args)... } }
         {
             static_assert(sizeof...(Args) == N);
             if constexpr (!SortedInput::value)
             {
-                const auto compareKeys = [&](const auto& p1, const auto& p2) { return _predicate(p1.first, p2.first); };
-                std::sort(_array.begin(), _array.end(), compareKeys); // compile-time sorting starting C++20
+                std::sort(_array.begin(), _array.end());
             }
         }
 
-        [[nodiscard]] constexpr const_iterator find(const K& key) const noexcept
+        [[nodiscard]] constexpr const_iterator find(const auto& key) const noexcept
         {
-            const auto compareKey = [&](const auto& p) { return _predicate(p.first, key); };
-            const auto iter{ std::partition_point(_array.begin(), _array.end(), compareKey) };
+            const auto iter = std::partition_point(_array.begin(), _array.end(), [&](const auto& p) {
+                return p.first < key;
+            });
 
-            if (iter == _array.end() || _predicate(key, iter->first))
+            if (iter == _array.end() || key != iter->first)
             {
                 return _array.end();
             }
@@ -69,7 +63,7 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
             return _array.end();
         }
 
-        [[nodiscard]] constexpr const V& at(const K& key) const
+        [[nodiscard]] constexpr const V& at(const auto& key) const
         {
             const auto iter{ find(key) };
 
@@ -87,25 +81,26 @@ namespace til // Terminal Implementation Library. Also: "Today I Learned"
         }
 
     private:
-        Compare _predicate;
         std::array<std::pair<K, V>, N> _array;
     };
 
-    template<typename K, typename V, typename Compare = std::less<K>, size_t N = 0>
-    class presorted_static_map : public static_map<K, V, Compare, N, details::presorted_input_t>
+    template<typename K, typename V, size_t N>
+    class presorted_static_map : public static_map<K, V, N, details::presorted_input_t>
     {
     public:
         template<typename... Args>
-        constexpr explicit presorted_static_map(const Args&... args) noexcept :
-            static_map<K, V, Compare, N, details::presorted_input_t>{ args... } {};
+        constexpr explicit presorted_static_map(Args&&... args) noexcept :
+            static_map<K, V, N, details::presorted_input_t>{ std::forward<Args>(args)... }
+        {
+        }
     };
 
     // this is a deduction guide that ensures two things:
     // 1. static_map's member types are all the same
     // 2. static_map's fourth template argument (otherwise undeduced) is how many pairs it contains
     template<typename First, typename... Rest>
-    static_map(First, Rest...) -> static_map<std::conditional_t<std::conjunction_v<std::is_same<First, Rest>...>, typename First::first_type, void>, typename First::second_type, std::less<typename First::first_type>, 1 + sizeof...(Rest), details::unsorted_input_t>;
+    static_map(First, Rest...) -> static_map<std::conditional_t<std::conjunction_v<std::is_same<First, Rest>...>, typename First::first_type, void>, typename First::second_type, 1 + sizeof...(Rest)>;
 
     template<typename First, typename... Rest>
-    presorted_static_map(First, Rest...) -> presorted_static_map<std::conditional_t<std::conjunction_v<std::is_same<First, Rest>...>, typename First::first_type, void>, typename First::second_type, std::less<typename First::first_type>, 1 + sizeof...(Rest)>;
+    presorted_static_map(First, Rest...) -> presorted_static_map<std::conditional_t<std::conjunction_v<std::is_same<First, Rest>...>, typename First::first_type, void>, typename First::second_type, 1 + sizeof...(Rest)>;
 }

--- a/src/types/colorTable.cpp
+++ b/src/types/colorTable.cpp
@@ -267,7 +267,7 @@ static constexpr std::array<til::color, 256> standard256ColorTable{
     til::color{ 0xEE, 0xEE, 0xEE },
 };
 
-static constexpr til::presorted_static_map xorgAppVariantColorTable{
+static constinit til::presorted_static_map xorgAppVariantColorTable{
     std::pair{ "antiquewhite"sv, std::array<til::color, 5>{ til::color{ 250, 235, 215 }, til::color{ 255, 239, 219 }, til::color{ 238, 223, 204 }, til::color{ 205, 192, 176 }, til::color{ 139, 131, 120 } } },
     std::pair{ "aquamarine"sv, std::array<til::color, 5>{ til::color{ 127, 255, 212 }, til::color{ 127, 255, 212 }, til::color{ 118, 238, 198 }, til::color{ 102, 205, 170 }, til::color{ 69, 139, 116 } } },
     std::pair{ "azure"sv, std::array<til::color, 5>{ til::color{ 240, 255, 255 }, til::color{ 240, 255, 255 }, til::color{ 224, 238, 238 }, til::color{ 193, 205, 205 }, til::color{ 131, 139, 139 } } },
@@ -348,7 +348,7 @@ static constexpr til::presorted_static_map xorgAppVariantColorTable{
     std::pair{ "yellow"sv, std::array<til::color, 5>{ til::color{ 255, 255, 0 }, til::color{ 255, 255, 0 }, til::color{ 238, 238, 0 }, til::color{ 205, 205, 0 }, til::color{ 139, 139, 0 } } },
 };
 
-static constexpr til::presorted_static_map xorgAppColorTable{
+static constinit til::presorted_static_map xorgAppColorTable{
     std::pair{ "aliceblue"sv, til::color{ 240, 248, 255 } },
     std::pair{ "aqua"sv, til::color{ 0, 255, 255 } },
     std::pair{ "beige"sv, til::color{ 245, 245, 220 } },


### PR DESCRIPTION
I wanted to show `til::static_map` to someone and noticed it hasn't been
updated since we updated to C++20. We can now make use of `constexpr`
`std::sort` and `constinit` to skip the initialization of the maps in
`KeyChordSerialization.cpp`. Also, I removed the comparator argument
to make the map a little more compact.