### PR TITLE
AtlasEngine: Fix some Windows 10 <14393 bugs

### DIFF
--- a/src/renderer/atlas/BackendD2D.cpp
+++ b/src/renderer/atlas/BackendD2D.cpp
@@ -75,6 +75,7 @@ void BackendD2D::_handleSettingsUpdate(const RenderingPayload& p)
         {
             wil::com_ptr<ID3D11Texture2D> buffer;
             THROW_IF_FAILED(p.swapChain.swapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), reinterpret_cast<void**>(buffer.addressof())));
+            const auto surface = buffer.query<IDXGISurface>();
 
             const D2D1_RENDER_TARGET_PROPERTIES props{
                 .type = D2D1_RENDER_TARGET_TYPE_DEFAULT,
@@ -83,8 +84,8 @@ void BackendD2D::_handleSettingsUpdate(const RenderingPayload& p)
                 .dpiY = static_cast<f32>(p.s->font->dpi),
             };
             // ID2D1RenderTarget and ID2D1DeviceContext are the same and I'm tired of pretending they're not.
-            THROW_IF_FAILED(p.d2dFactory->CreateDxgiSurfaceRenderTarget(buffer.query<IDXGISurface>().get(), &props, reinterpret_cast<ID2D1RenderTarget**>(_renderTarget.addressof())));
-            _renderTarget.query_to(_renderTarget4.addressof());
+            THROW_IF_FAILED(p.d2dFactory->CreateDxgiSurfaceRenderTarget(surface.get(), &props, reinterpret_cast<ID2D1RenderTarget**>(_renderTarget.addressof())));
+            _renderTarget.try_query_to(_renderTarget4.addressof());
 
             _renderTarget->SetUnitMode(D2D1_UNIT_MODE_PIXELS);
             _renderTarget->SetAntialiasMode(D2D1_ANTIALIAS_MODE_ALIASED);

--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -782,6 +782,7 @@ void BackendD3D::_resizeGlyphAtlas(const RenderingPayload& p, const u16 u, const
 
     // We have our own glyph cache so Direct2D's cache doesn't help much.
     // This saves us 1MB of RAM, which is not much, but also not nothing.
+    if (_d2dRenderTarget4)
     {
         wil::com_ptr<ID2D1Device> device;
         _d2dRenderTarget4->GetDevice(device.addressof());
@@ -1370,12 +1371,12 @@ bool BackendD3D::_drawGlyph(const RenderingPayload& p, const AtlasFontFaceEntryI
             static_cast<f32>(rect.x + rect.w) / transform.m11,
             static_cast<f32>(rect.y + rect.h) / transform.m22,
         };
-        _d2dRenderTarget4->PushAxisAlignedClip(&clipRect, D2D1_ANTIALIAS_MODE_ALIASED);
+        _d2dRenderTarget->PushAxisAlignedClip(&clipRect, D2D1_ANTIALIAS_MODE_ALIASED);
     }
     const auto boxGlyphCleanup = wil::scope_exit([&]() {
         if (isBoxGlyph)
         {
-            _d2dRenderTarget4->PopAxisAlignedClip();
+            _d2dRenderTarget->PopAxisAlignedClip();
         }
     });
 


### PR DESCRIPTION
This fixes a couple spots where I wasn't properly checking
for the existence of some optional D2D interfaces.

## Validation Steps Performed
I haven't tested this and don't intend to do it just yet.
Windows Terminal requires build 19041 at least anyways.