### PR TITLE
Expose 'Default' tag to Screen Readers in Color Schemes page

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/ColorSchemeViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemeViewModel.cpp
@@ -50,6 +50,18 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         return _Name;
     }
 
+    // This is used in the ComboBox and ListView.
+    // It's the only way to expose the name of the inner UI item so the ComboBox can do quick search
+    //  and screen readers can read the item out loud.
+    winrt::hstring ColorSchemeViewModel::ToString()
+    {
+        if (IsDefaultScheme())
+        {
+            return hstring{ fmt::format(L"{0} ({1})", Name(), RS_(L"ColorScheme_DefaultTag/Text")) };
+        }
+        return Name();
+    }
+
     bool ColorSchemeViewModel::IsDefaultScheme()
     {
         const auto defaultAppearance = _settings.ProfileDefaults().DefaultAppearance();

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemeViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemeViewModel.h
@@ -25,10 +25,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         winrt::hstring Name();
         void Name(winrt::hstring newName);
-        hstring ToString()
-        {
-            return Name();
-        }
+        hstring ToString();
 
         bool RequestRename(winrt::hstring newName);
 

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.h
@@ -20,7 +20,6 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
 
         void AddNew_Click(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::RoutedEventArgs& e);
         void ListView_PreviewKeyDown(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::Input::KeyRoutedEventArgs& e);
-        void ListView_SelectionChanged(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::UI::Xaml::Controls::SelectionChangedEventArgs& e);
 
         WINRT_PROPERTY(Model::ColorScheme, CurrentColorScheme, nullptr);
         WINRT_OBSERVABLE_PROPERTY(Editor::ColorSchemesPageViewModel, ViewModel, _PropertyChangedHandlers, nullptr);

--- a/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
+++ b/src/cascadia/TerminalSettingsEditor/ColorSchemes.xaml
@@ -210,6 +210,7 @@
                                 Visibility="{x:Bind IsDefaultScheme, Mode=OneWay}">
                             <TextBlock x:Uid="ColorScheme_DefaultTag"
                                        Grid.Column="1"
+                                       AutomationProperties.AccessibilityView="Raw"
                                        Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
                         </Border>
                     </Grid>


### PR DESCRIPTION
## Summary of the Pull Request
This removes the "default" text box from the UI Automation tree, thus preventing screen readers from navigating to it. This was a confusing scenario for users because the "default" tag was unclear if it was a part of the previous or next color scheme (i.e. consider hearing "Campbell, default, Campbell PowerShell"; it's unclear which one is default).

This also appends the "default" string to the `ToString` function of the color scheme view model. This makes it so that the combo box and list view visually appear the same, but can be quick searched or read out by the screen reader with the 'default' tag.

## Validation Steps Performed
- [x] Verified this works on Windows 11
- [x] Verified this works on Windows 10
- Scenarios tested:
   - [x] saving settings after changing the default scheme
   - [x] saving settings.json to force a refresh in SUI

Closes #14401 