### PR TITLE
Vectorize StateMachine::ProcessString

### DIFF
--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -1811,8 +1811,9 @@ bool StateMachine::FlushToTerminal()
 // Disable vectorization-unfriendly warnings.
 #pragma warning(push)
 #pragma warning(disable : 26429) // Symbol '...' is never tested for nullness, it can be marked as not_null (f.23).
-#pragma warning(disable : 26481) // Don't use pointer arithmetic. Use span instead (bounds.1).
 #pragma warning(disable : 26472) // Don't use a static_cast for arithmetic conversions. Use brace initialization, gsl::narrow_cast or gsl::narrow (type.1).
+#pragma warning(disable : 26481) // Don't use pointer arithmetic. Use span instead (bounds.1).
+#pragma warning(disable : 26490) // Don't use reinterpret_cast (type.1).
 
 // Returns true for C0 characters and C1 [single-character] CSI.
 constexpr bool isActionableFromGround(const wchar_t wch) noexcept

--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -18,8 +18,7 @@ StateMachine::StateMachine(std::unique_ptr<IStateMachineEngine> engine, const bo
     _parameters{},
     _parameterLimitReached(false),
     _oscString{},
-    _cachedSequence{ std::nullopt },
-    _processingIndividually(false)
+    _cachedSequence{ std::nullopt }
 {
     _ActionClear();
 }
@@ -363,18 +362,6 @@ static constexpr bool _isPmIndicator(const wchar_t wch) noexcept
 static constexpr bool _isApcIndicator(const wchar_t wch) noexcept
 {
     return wch == L'_'; // 0x5F
-}
-
-// Routine Description:
-// - Determines if a character indicates an action that should be taken in the ground state -
-//     These are C0 characters and the C1 [single-character] CSI.
-// Arguments:
-// - wch - Character to check.
-// Return Value:
-// - True if it is. False if it isn't.
-static constexpr bool _isActionableFromGround(const wchar_t wch) noexcept
-{
-    return (wch <= AsciiChars::US) || _isC1ControlCharacter(wch) || _isDelete(wch);
 }
 
 #pragma warning(pop)
@@ -1821,6 +1808,118 @@ bool StateMachine::FlushToTerminal()
     return success;
 }
 
+// Disable vectorization-unfriendly warnings.
+#pragma warning(push)
+#pragma warning(disable : 26429) // Symbol '...' is never tested for nullness, it can be marked as not_null (f.23).
+#pragma warning(disable : 26481) // Don't use pointer arithmetic. Use span instead (bounds.1).
+#pragma warning(disable : 26472) // Don't use a static_cast for arithmetic conversions. Use brace initialization, gsl::narrow_cast or gsl::narrow (type.1).
+
+// Returns true for C0 characters and C1 [single-character] CSI.
+constexpr bool isActionableFromGround(const wchar_t wch) noexcept
+{
+    // This is equivalent to:
+    //   return (wch <= 0x1f) || (wch >= 0x7f && wch <= 0x9f);
+    // It's written like this to get MSVC to emit optimal assembly for findActionableFromGround.
+    // It lacks the ability to turn boolean operators into binary operations and also happens
+    // to fail to optimize the printable-ASCII range check into a subtraction & comparison.
+    return (wch <= 0x1f) | (static_cast<wchar_t>(wch - 0x7f) <= 0x20);
+}
+
+[[msvc::forceinline]] static size_t findActionableFromGroundPlain(const wchar_t* beg, const wchar_t* end, const wchar_t* it) noexcept
+{
+#pragma loop(no_vector)
+    for (; it < end && !isActionableFromGround(*it); ++it)
+    {
+    }
+    return it - beg;
+}
+
+static size_t findActionableFromGround(const wchar_t* data, size_t count) noexcept
+{
+    // The following vectorized code replicates isActionableFromGround which is equivalent to:
+    //   (wch <= 0x1f) || (wch >= 0x7f && wch <= 0x9f)
+    // or rather its more machine friendly equivalent:
+    //   (wch <= 0x1f) | ((wch - 0x7f) <= 0x20)
+#if defined(TIL_SSE_INTRINSICS)
+
+    auto it = data;
+
+    for (const auto end = data + (count & ~size_t{ 7 }); it < end; it += 8)
+    {
+        const auto wch = _mm_loadu_si128(reinterpret_cast<const __m128i*>(it));
+        const auto z = _mm_setzero_si128();
+
+        // Dealing with unsigned numbers in SSE2 is annoying because it has poor support for that.
+        // We'll use subtractions with saturation ("SubS") to work around that. A check like
+        // a < b can be implemented as "max(0, a - b) == 0" and "max(0, a - b)" is what "SubS" is.
+
+        // Check for (wch < 0x20)
+        auto a = _mm_subs_epu16(wch, _mm_set1_epi16(0x1f));
+        // Check for "(wch >= 0x7f && wch <= 0x9f)" by adding 0x10000-0x7f, which overflows to a
+        // negative number if "wch >= 0x7f" and then subtracting 0x9f-0x7f with saturation to an
+        // unsigned number (= can't go lower than 0), which results in all numbers up to 0x9f to be 0.
+        auto b = _mm_subs_epu16(_mm_add_epi32(wch, _mm_set1_epi16(static_cast<short>(0xff81))), _mm_set1_epi16(0x20));
+        a = _mm_cmpeq_epi16(a, z);
+        b = _mm_cmpeq_epi16(b, z);
+
+        const auto c = _mm_or_si128(a, b);
+        const auto mask = _mm_movemask_epi8(c);
+
+        if (mask)
+        {
+            unsigned long offset;
+            _BitScanForward(&offset, mask);
+            it += offset / 2;
+            return it - data;
+        }
+    }
+
+    return findActionableFromGroundPlain(data, data + count, it);
+
+#elif defined(TIL_ARM_NEON_INTRINSICS)
+
+    auto it = data;
+    uint64_t mask;
+
+    for (const auto end = data + (count & ~size_t{ 7 }); it < end;)
+    {
+        const auto wch = vld1q_u16(it);
+        const auto a = vcleq_u16(wch, vdupq_n_u16(0x1f));
+        const auto b = vcleq_u16(vsubq_u16(wch, vdupq_n_u16(0x7f)), vdupq_n_u16(0x20));
+        const auto c = vorrq_u16(a, b);
+
+        mask = vgetq_lane_u64(c, 0);
+        if (mask)
+        {
+            goto exitWithMask;
+        }
+        it += 4;
+
+        mask = vgetq_lane_u64(c, 1);
+        if (mask)
+        {
+            goto exitWithMask;
+        }
+        it += 4;
+    }
+
+    return findActionableFromGroundPlain(data, data + count, it);
+
+exitWithMask:
+    unsigned long offset;
+    _BitScanForward64(&offset, mask);
+    it += offset / 16;
+    return it - data;
+
+#else
+
+    return findActionableFromGroundPlain(data, data + count, p);
+
+#endif
+}
+
+#pragma warning(pop)
+
 // Routine Description:
 // - Helper for entry to the state machine. Will take an array of characters
 //     and print as many as it can without encountering a character indicating
@@ -1832,79 +1931,54 @@ bool StateMachine::FlushToTerminal()
 // - <none>
 void StateMachine::ProcessString(const std::wstring_view string)
 {
-    size_t start = 0;
-    auto current = start;
-
+    size_t i = 0;
     _currentString = string;
     _runOffset = 0;
     _runSize = 0;
 
-    while (current < string.size())
+    if (_state != VTStates::Ground)
     {
-        // The run will be everything from the start INCLUDING the current one
-        // in case we process the current character and it turns into a passthrough
-        // fallback that picks up this _run inside `FlushToTerminal` above.
-        _runOffset = start;
-        _runSize = current - start + 1;
+        // Jump straight to where we need to.
+#pragma warning(suppress : 26438) // Avoid 'goto'(es .76).
+        goto processStringLoopVtStart;
+    }
 
-        if (_processingIndividually)
+    while (i < string.size())
+    {
         {
-            // Note whether we're dealing with the last character in the buffer.
-            _processingLastCharacter = (current + 1 >= string.size());
+            _runOffset = i;
+            // Pointer arithmetic is perfectly fine for our hot path.
+#pragma warning(suppress : 26481) // Don't use pointer arithmetic. Use span instead (bounds.1).)
+            _runSize = findActionableFromGround(string.data() + i, string.size() - i);
+
+            if (_runSize)
+            {
+                _ActionPrintString(_CurrentRun());
+
+                i += _runSize;
+                _runOffset = i;
+                _runSize = 0;
+            }
+        }
+
+    processStringLoopVtStart:
+        if (i >= string.size())
+        {
+            break;
+        }
+
+        do
+        {
+            _runSize++;
+            _processingLastCharacter = i + 1 >= string.size();
             // If we're processing characters individually, send it to the state machine.
-            ProcessCharacter(til::at(string, current));
-            ++current;
-            if (_state == VTStates::Ground) // Then check if we're back at ground. If we are, the next character (pwchCurr)
-            { //   is the start of the next run of characters that might be printable.
-                _processingIndividually = false;
-                start = current;
-            }
-        }
-        else
-        {
-            if (_isActionableFromGround(til::at(string, current))) // If the current char is the start of an escape sequence, or should be executed in ground state...
-            {
-                if (_runSize > 0)
-                {
-                    // Because the run above is composed INCLUDING current, we must
-                    // trim it off here since we just determined it's actionable
-                    // and only pass through everything before it.
-                    _runSize -= 1;
-                    _ActionPrintString(_CurrentRun()); // ... print all the chars leading up to it as part of the run...
-                }
-
-                _processingIndividually = true; // begin processing future characters individually...
-                start = current;
-                continue;
-            }
-            else
-            {
-                ++current; // Otherwise, add this char to the current run to be printed.
-            }
-        }
+            ProcessCharacter(til::at(string, i));
+            ++i;
+        } while (i < string.size() && _state != VTStates::Ground);
     }
 
-    // When we leave the loop, current has been advanced to the length of the string itself
-    // (or one past the array index to the final char) so this `substr` operation doesn't +1
-    // to include the final character (unlike the one inside the top of the loop above.)
-    if (start < string.size())
-    {
-        _runOffset = start;
-        _runSize = std::string::npos;
-    }
-    else
-    {
-        _runSize = 0;
-    }
-
-    const auto run = _CurrentRun();
     // If we're at the end of the string and have remaining un-printed characters,
-    if (!_processingIndividually && !run.empty())
-    {
-        // print the rest of the characters in the string
-        _ActionPrintString(run);
-    }
-    else if (_processingIndividually)
+    if (_state != VTStates::Ground)
     {
         // One of the "weird things" in VT input is the case of something like
         // <kbd>alt+[</kbd>. In VT, that's encoded as `\x1b[`. However, that's
@@ -1924,6 +1998,7 @@ void StateMachine::ProcessString(const std::wstring_view string)
         // last character of the string. For our previous `\x1b[` scenario, that
         // means we'll make sure to call `_ActionEscDispatch('[')`., which will
         // properly decode the string as <kbd>alt+[</kbd>.
+        const auto run = _CurrentRun();
 
         if (_isEngineForInput)
         {

--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -1856,10 +1856,10 @@ static size_t findActionableFromGround(const wchar_t* data, size_t count) noexce
 
         // Check for (wch < 0x20)
         auto a = _mm_subs_epu16(wch, _mm_set1_epi16(0x1f));
-        // Check for "(wch >= 0x7f && wch <= 0x9f)" by adding 0x10000-0x7f, which overflows to a
+        // Check for "((wch - 0x7f) <= 0x20)" by adding 0x10000-0x7f, which overflows to a
         // negative number if "wch >= 0x7f" and then subtracting 0x9f-0x7f with saturation to an
         // unsigned number (= can't go lower than 0), which results in all numbers up to 0x9f to be 0.
-        auto b = _mm_subs_epu16(_mm_add_epi32(wch, _mm_set1_epi16(static_cast<short>(0xff81))), _mm_set1_epi16(0x20));
+        auto b = _mm_subs_epu16(_mm_add_epi16(wch, _mm_set1_epi16(static_cast<short>(0xff81))), _mm_set1_epi16(0x20));
         a = _mm_cmpeq_epi16(a, z);
         b = _mm_cmpeq_epi16(b, z);
 

--- a/src/terminal/parser/stateMachine.hpp
+++ b/src/terminal/parser/stateMachine.hpp
@@ -201,7 +201,6 @@ namespace Microsoft::Console::VirtualTerminal
 
         // This is tracked per state machine instance so that separate calls to Process*
         //   can start and finish a sequence.
-        bool _processingIndividually;
         bool _processingLastCharacter;
 
         std::function<void()> _onCsiCompleteCallback;


### PR DESCRIPTION
The added explicit vectorization allows us to skip plain text faster
and pass it immediately to the deeper `TextBuffer` parts.

Performance of printing enwik8.txt at the following block sizes:
4KiB (printf): 54MB/s -> 58MB/s
128KiB (cat): 103MB/s -> 116MB/s

## Validation Steps Performed
* Works on x64 ✅
* Works on ARM ✅