### PR TITLE
Fix small_vector issues when assigning it to itself

### DIFF
--- a/src/inc/til/small_vector.h
+++ b/src/inc/til/small_vector.h
@@ -749,7 +749,7 @@ namespace til
             _size = other._size;
         }
 
-        void _move_assign(small_vector& other)
+        void _move_assign(small_vector& other) noexcept
         {
             if (other._capacity == N)
             {

--- a/src/inc/til/small_vector.h
+++ b/src/inc/til/small_vector.h
@@ -330,7 +330,9 @@ namespace til
         using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
         small_vector() noexcept :
-            _data{ &_buffer[0] }
+            _data{ &_buffer[0] },
+            _capacity{ N },
+            _size{ 0 }
         {
         }
 
@@ -357,56 +359,38 @@ namespace til
         small_vector(const small_vector& other) :
             small_vector{}
         {
-            operator=(other);
+            _copy_assign(other);
         }
 
         // NOTE: If an exception is thrown while copying, the vector is left empty.
         small_vector& operator=(const small_vector& other)
         {
-            clear();
-            reserve(other._size);
-
-            std::uninitialized_copy(other.begin(), other.end(), _uninitialized_begin());
-            _size = other._size;
+            if (this != &other)
+            {
+                clear();
+                _copy_assign(other);
+            }
 
             return *this;
         }
 
-        small_vector(small_vector&& other) noexcept :
-            small_vector{}
+        small_vector(small_vector&& other) noexcept
         {
-            operator=(std::move(other));
+            _move_assign(other);
         }
 
         small_vector& operator=(small_vector&& other) noexcept
         {
-            std::destroy(begin(), end());
-            if (_capacity != N)
+            if (this != &other)
             {
-                _deallocate(_data);
-            }
+                std::destroy(begin(), end());
+                if (_capacity != N)
+                {
+                    _deallocate(_data);
+                }
 
-            if (other._capacity == N)
-            {
-                _data = &_buffer[0];
-                _capacity = N;
-                _size = other._size;
-                // The earlier static_assert(std::is_nothrow_move_constructible_v<T>)
-                // ensures that we don't exit in a weird state with invalid `_size`.
-#pragma warning(suppress : 26447) // The function is declared 'noexcept' but calls function '...' which may throw exceptions (f.6).
-                std::uninitialized_move(other.begin(), other.end(), _uninitialized_begin());
-                std::destroy(other.begin(), other.end());
+                _move_assign(other);
             }
-            else
-            {
-                _data = other._data;
-                _capacity = other._capacity;
-                _size = other._size;
-            }
-
-            other._data = &other._buffer[0];
-            other._capacity = N;
-            other._size = 0;
 
             return *this;
         }
@@ -758,6 +742,38 @@ namespace til
 #endif
         }
 
+        void _copy_assign(const small_vector& other)
+        {
+            reserve(other._size);
+            std::uninitialized_copy(other.begin(), other.end(), _uninitialized_begin());
+            _size = other._size;
+        }
+
+        void _move_assign(small_vector& other)
+        {
+            if (other._capacity == N)
+            {
+                _data = &_buffer[0];
+                _capacity = N;
+                _size = other._size;
+                // The earlier static_assert(std::is_nothrow_move_constructible_v<T>)
+                // ensures that we don't exit in a weird state with invalid `_size`.
+#pragma warning(suppress : 26447) // The function is declared 'noexcept' but calls function '...' which may throw exceptions (f.6).
+                std::uninitialized_move(other.begin(), other.end(), _uninitialized_begin());
+                std::destroy(other.begin(), other.end());
+            }
+            else
+            {
+                _data = other._data;
+                _capacity = other._capacity;
+                _size = other._size;
+            }
+
+            other._data = &other._buffer[0];
+            other._capacity = N;
+            other._size = 0;
+        }
+
         size_type _ensure_fits(size_type add)
         {
             const auto new_size = _size + add;
@@ -880,8 +896,8 @@ namespace til
         }
 
         T* _data;
-        size_t _capacity = N;
-        size_t _size = 0;
+        size_t _capacity;
+        size_t _size;
         T _buffer[N];
     };
 }

--- a/src/til/ut_til/SmallVectorTests.cpp
+++ b/src/til/ut_til/SmallVectorTests.cpp
@@ -368,4 +368,24 @@ class SmallVectorTests
         til::small_vector<int, 5> expected{ { -1, -1, 0, 1, 2, 3, 3, 3, 4, 5, 5 } };
         VERIFY_ARE_EQUAL(expected, actual);
     }
+
+    TEST_METHOD(CopyOntoItself)
+    {
+        til::small_vector<Copyable_int, 5> actual(3);
+        actual.operator=(actual);
+
+        const til::small_vector<Copyable_int, 5> expected(3);
+        VERIFY_ARE_EQUAL(expected, actual);
+    }
+
+    TEST_METHOD(MoveOntoItself)
+    {
+        til::small_vector<Movable_int, 5> actual;
+        actual.resize(3);
+        actual.operator=(std::move(actual));
+
+        til::small_vector<Movable_int, 5> expected;
+        expected.resize(3);
+        VERIFY_ARE_EQUAL(expected, actual);
+    }
 };


### PR DESCRIPTION
This commit achieves fixes the issue as described in the title by
checking whether the `this` and `other` pointer are identical.
As an added bonus it makes the copy and move constructors slightly
cheaper, as they don't try to destruct existing data anymore,
which doesn't exist anyways.

## Validation Steps Performed
* It blends ✅