### PR TITLE
Search web for selected text

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -1711,7 +1711,7 @@
       ]
     },
     "SearchWebAction": {
-      "description": "Search online for selected text",
+      "description": "Search the web for selected text",
       "allOf": [
         {
           "$ref": "#/$defs/ShortcutAction"
@@ -1724,12 +1724,7 @@
             },
             "queryUrl": {
               "type": "string",
-              "description": "URL of the web page to launch (the selected text is appended to it)"
-            },
-            "wrapWithQuotes": {
-              "type": "boolean",
-              "default": true,
-              "description": "When true (default), the selected text is wrapped with quotes"
+              "description": "URL of the web page to launch, %s is replaced with the selected text"
             }
           }
         }

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -421,6 +421,7 @@
         "scrollToMark",
         "clearMark",
         "clearAllMarks",
+        "searchWeb",
         "experimental.colorSelection",
         "unbound"
       ],
@@ -1709,6 +1710,34 @@
         }
       ]
     },
+    "SearchWebAction": {
+      "description": "Search online for selected text",
+      "allOf": [
+        {
+          "$ref": "#/$defs/ShortcutAction"
+        },
+        {
+          "properties": {
+            "action": {
+              "type": "string",
+              "const": "searchWeb"
+            },
+            "queryUrl": {
+              "type": "string",
+              "description": "URL of the web page to launch (the selected text is appended to it)"
+            },
+            "wrapWithQuotes": {
+              "type": "boolean",
+              "default": true,
+              "description": "When true (default), the selected text is wrapped with quotes"
+            }
+          }
+        }
+      ],
+      "required": [
+        "queryUrl"
+      ]
+    },
     "AdjustOpacityAction": {
       "description": "Changes the opacity of the active Terminal window. If `relative` is specified, then this action will increase/decrease relative to the current opacity.",
       "allOf": [
@@ -2003,6 +2032,9 @@
             },
             {
               "$ref": "#/$defs/ColorSelectionAction"
+            },
+            {
+              "$ref": "#/$defs/SearchWebAction"
             },
             {
               "type": "null"

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1040,15 +1040,15 @@ namespace winrt::TerminalApp::implementation
                         // make it compact by replacing consecutive whitespaces with a single space
                         searchText = std::regex_replace(searchText, std::wregex(LR"(\s+)"), L" ");
 
-                        if (realArgs.WrapWithQuotes())
+                        std::wstring queryUrl = realArgs.QueryUrl().empty() ? _settings.GlobalSettings().SearchWebDefaultQueryUrl().c_str() : realArgs.QueryUrl().c_str();
+
+                        constexpr std::wstring_view queryToken{ L"%s" };
+                        if (const auto pos{ queryUrl.find(queryToken) }; pos != std::wstring_view::npos)
                         {
-                            searchText.insert(searchText.begin(), L'"');
-                            searchText.push_back(L'"');
+                            queryUrl.replace(pos, queryToken.length(), Windows::Foundation::Uri::EscapeComponent(searchText));
                         }
 
-                        const auto queryUrl = realArgs.QueryUrl().empty() ? _settings.GlobalSettings().SearchWebDefaultQueryUrl() : realArgs.QueryUrl();
-                        const auto finalString = queryUrl + Windows::Foundation::Uri::EscapeComponent(searchText);
-                        winrt::Microsoft::Terminal::Control::OpenHyperlinkEventArgs shortcut{ finalString };
+                        winrt::Microsoft::Terminal::Control::OpenHyperlinkEventArgs shortcut{ queryUrl };
                         _OpenHyperlinkHandler(termControl, shortcut);
                         args.Handled(true);
                     }

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1046,7 +1046,7 @@ namespace winrt::TerminalApp::implementation
                             searchText.push_back(L'"');
                         }
 
-                        const auto queryUrl = realArgs.QueryUrl().empty() ? _settings.GlobalSettings().SearchWebQueryUrlDefault() : realArgs.QueryUrl();
+                        const auto queryUrl = realArgs.QueryUrl().empty() ? _settings.GlobalSettings().SearchWebDefaultQueryUrl() : realArgs.QueryUrl();
                         const auto finalString = queryUrl + Windows::Foundation::Uri::EscapeComponent(searchText);
                         winrt::Microsoft::Terminal::Control::OpenHyperlinkEventArgs shortcut{ finalString };
                         _OpenHyperlinkHandler(termControl, shortcut);

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1043,7 +1043,8 @@ namespace winrt::TerminalApp::implementation
 
                         if (realArgs.WrapWithQuotes())
                         {
-                            searchText = L"\"" + searchText + L"\"";
+                            searchText.insert(searchText.begin(), L'"');
+                            searchText.push_back(L'"');
                         }
 
                         const auto finalString = queryUrl + Windows::Foundation::Uri::EscapeComponent(searchText);

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1021,6 +1021,37 @@ namespace winrt::TerminalApp::implementation
         args.Handled(true);
     }
 
+    void TerminalPage::_HandleSearchForText(const IInspectable& /*sender*/,
+                                            const ActionEventArgs& args)
+    {
+        if (args)
+        {
+            if (const auto& realArgs = args.ActionArgs().try_as<SearchForTextArgs>())
+            {
+                const auto queryUrl = realArgs.QueryUrl();
+                if (const auto termControl{ _GetActiveControl() })
+                {
+                    if (termControl.HasSelection())
+                    {
+                        const auto selections{ termControl.SelectedText(true) };
+                        if (selections.Size() == 1) // TODO! should theoretically be able to work for multiple lines of selection
+                        {
+                            auto selectedText = selections.GetAt(0);
+                            if (realArgs.WrapWithQuotes())
+                            {
+                                selectedText = L"\"" + selectedText + L"\"";
+                            }
+                            const auto finalString = queryUrl + Windows::Foundation::Uri::EscapeComponent(selectedText);
+                            winrt::Microsoft::Terminal::Control::OpenHyperlinkEventArgs shortcut{ finalString };
+                            _OpenHyperlinkHandler(termControl, shortcut);
+                            args.Handled(true);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     void TerminalPage::_HandleGlobalSummon(const IInspectable& /*sender*/,
                                            const ActionEventArgs& args)
     {

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1034,18 +1034,22 @@ namespace winrt::TerminalApp::implementation
                     if (termControl.HasSelection())
                     {
                         const auto selections{ termControl.SelectedText(true) };
-                        if (selections.Size() == 1) // TODO! should theoretically be able to work for multiple lines of selection
+
+                        // concatenate the selection into a single line
+                        auto searchText = std::accumulate(selections.begin(), selections.end(), std::wstring());
+
+                        // make it compact by replacing consecutive whitespaces with a single space
+                        searchText = std::regex_replace(searchText, std::wregex(LR"(\s+)"), L" ");
+
+                        if (realArgs.WrapWithQuotes())
                         {
-                            auto selectedText = selections.GetAt(0);
-                            if (realArgs.WrapWithQuotes())
-                            {
-                                selectedText = L"\"" + selectedText + L"\"";
-                            }
-                            const auto finalString = queryUrl + Windows::Foundation::Uri::EscapeComponent(selectedText);
-                            winrt::Microsoft::Terminal::Control::OpenHyperlinkEventArgs shortcut{ finalString };
-                            _OpenHyperlinkHandler(termControl, shortcut);
-                            args.Handled(true);
+                            searchText = L"\"" + searchText + L"\"";
                         }
+
+                        const auto finalString = queryUrl + Windows::Foundation::Uri::EscapeComponent(searchText);
+                        winrt::Microsoft::Terminal::Control::OpenHyperlinkEventArgs shortcut{ finalString };
+                        _OpenHyperlinkHandler(termControl, shortcut);
+                        args.Handled(true);
                     }
                 }
             }

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -214,6 +214,9 @@
   <data name="SplitPaneText" xml:space="preserve">
     <value>Split Pane</value>
   </data>
+  <data name="SearchWebText" xml:space="preserve">
+    <value>Web Search</value>
+  </data>  
   <data name="TabColorChoose" xml:space="preserve">
     <value>Color...</value>
   </data>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4578,7 +4578,7 @@ namespace winrt::TerminalApp::implementation
     }
 
     void TerminalPage::_PopulateContextMenu(const IInspectable& sender,
-                                            const bool /*withSelection*/)
+                                            const bool withSelection)
     {
         // withSelection can be used to add actions that only appear if there's
         // selected text, like "search the web". In this initial draft, it's not
@@ -4633,6 +4633,11 @@ namespace winrt::TerminalApp::implementation
         if (_GetFocusedTabImpl()->GetLeafPaneCount() > 1)
         {
             makeItem(RS_(L"PaneClose"), L"\xE89F", ActionAndArgs{ ShortcutAction::ClosePane, nullptr });
+        }
+
+        if (withSelection)
+        {
+            makeItem(RS_(L"SearchWebText"), L"\xF6FA", ActionAndArgs{ ShortcutAction::SearchForText, nullptr });
         }
 
         makeItem(RS_(L"TabClose"), L"\xE711", ActionAndArgs{ ShortcutAction::CloseTab, CloseTabArgs{ _GetFocusedTabIndex().value() } });

--- a/src/cascadia/TerminalControl/ControlCore.h
+++ b/src/cascadia/TerminalControl/ControlCore.h
@@ -145,6 +145,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         int ViewHeight() const;
         int BufferHeight() const;
 
+        bool HasSelection() const;
+        Windows::Foundation::Collections::IVector<winrt::hstring> SelectedText(bool trimTrailingWhitespace) const;
+
         bool BracketedPasteEnabled() const noexcept;
 
         Windows::Foundation::Collections::IVector<Control::ScrollMark> ScrollMarks() const;
@@ -188,9 +191,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         bool ShouldSendAlternateScroll(const unsigned int uiButton, const int32_t delta) const;
         Core::Point CursorPosition() const;
 
-        bool HasSelection() const;
         bool CopyOnSelect() const;
-        Windows::Foundation::Collections::IVector<winrt::hstring> SelectedText(bool trimTrailingWhitespace) const;
         Control::SelectionData SelectionInfo() const;
         void SetSelectionAnchor(const til::point position);
         void SetEndSelectionPoint(const til::point position);

--- a/src/cascadia/TerminalControl/ControlCore.idl
+++ b/src/cascadia/TerminalControl/ControlCore.idl
@@ -124,8 +124,6 @@ namespace Microsoft.Terminal.Control
         void Search(String text, Boolean goForward, Boolean caseSensitive);
         Microsoft.Terminal.Core.Color BackgroundColor { get; };
 
-        Boolean HasSelection { get; };
-        IVector<String> SelectedText(Boolean trimTrailingWhitespace);
         SelectionData SelectionInfo { get; };
         SelectionInteractionMode SelectionMode();
 

--- a/src/cascadia/TerminalControl/EventArgs.h
+++ b/src/cascadia/TerminalControl/EventArgs.h
@@ -180,3 +180,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         WINRT_PROPERTY(bool, ClearMarkers, false);
     };
 }
+
+namespace winrt::Microsoft::Terminal::Control::factory_implementation
+{
+    BASIC_FACTORY(OpenHyperlinkEventArgs);
+}

--- a/src/cascadia/TerminalControl/EventArgs.idl
+++ b/src/cascadia/TerminalControl/EventArgs.idl
@@ -40,6 +40,7 @@ namespace Microsoft.Terminal.Control
 
     runtimeclass OpenHyperlinkEventArgs
     {
+        OpenHyperlinkEventArgs(String uri);
         String Uri { get; };
     }
 

--- a/src/cascadia/TerminalControl/ICoreState.idl
+++ b/src/cascadia/TerminalControl/ICoreState.idl
@@ -45,6 +45,9 @@ namespace Microsoft.Terminal.Control
         Int32 ViewHeight { get; };
         Int32 BufferHeight { get; };
 
+        Boolean HasSelection { get; };
+        IVector<String> SelectedText(Boolean trimTrailingWhitespace);
+
         Boolean BracketedPasteEnabled { get; };
 
         Microsoft.Terminal.TerminalConnection.ConnectionState ConnectionState { get; };

--- a/src/cascadia/TerminalControl/TermControl.cpp
+++ b/src/cascadia/TerminalControl/TermControl.cpp
@@ -3335,6 +3335,15 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         return _core.Opacity();
     }
 
+    bool TermControl::HasSelection() const
+    {
+        return _core.HasSelection();
+    }
+    Windows::Foundation::Collections::IVector<winrt::hstring> TermControl::SelectedText(bool trimTrailingWhitespace) const
+    {
+        return _core.SelectedText(trimTrailingWhitespace);
+    }
+
     // Method Description:
     // - Called when the core raises a FoundMatch event. That's done in response
     //   to us starting a search query with ControlCore::Search.

--- a/src/cascadia/TerminalControl/TermControl.h
+++ b/src/cascadia/TerminalControl/TermControl.h
@@ -69,6 +69,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         int ViewHeight() const;
         int BufferHeight() const;
 
+        bool HasSelection() const;
+        Windows::Foundation::Collections::IVector<winrt::hstring> SelectedText(bool trimTrailingWhitespace) const;
+
         bool BracketedPasteEnabled() const noexcept;
 
         double BackgroundOpacity() const;

--- a/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
@@ -72,6 +72,7 @@ static constexpr std::string_view IdentifyWindowKey{ "identifyWindow" };
 static constexpr std::string_view IdentifyWindowsKey{ "identifyWindows" };
 static constexpr std::string_view RenameWindowKey{ "renameWindow" };
 static constexpr std::string_view OpenWindowRenamerKey{ "openWindowRenamer" };
+static constexpr std::string_view SearchForTextKey{ "searchWeb" };
 static constexpr std::string_view GlobalSummonKey{ "globalSummon" };
 static constexpr std::string_view QuakeModeKey{ "quakeMode" };
 static constexpr std::string_view FocusPaneKey{ "focusPane" };
@@ -403,6 +404,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
                 { ShortcutAction::RenameWindow, RS_(L"ResetWindowNameCommandKey") },
                 { ShortcutAction::OpenWindowRenamer, RS_(L"OpenWindowRenamerCommandKey") },
                 { ShortcutAction::GlobalSummon, MustGenerate },
+                { ShortcutAction::SearchForText, MustGenerate },
                 { ShortcutAction::QuakeMode, RS_(L"QuakeModeCommandKey") },
                 { ShortcutAction::FocusPane, MustGenerate },
                 { ShortcutAction::OpenSystemMenu, RS_(L"OpenSystemMenuCommandKey") },

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
@@ -37,6 +37,7 @@
 #include "PrevTabArgs.g.cpp"
 #include "NextTabArgs.g.cpp"
 #include "RenameWindowArgs.g.cpp"
+#include "SearchForTextArgs.g.cpp"
 #include "GlobalSummonArgs.g.cpp"
 #include "FocusPaneArgs.g.cpp"
 #include "ExportBufferArgs.g.cpp"
@@ -763,6 +764,14 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
             };
         }
         return RS_(L"ResetWindowNameCommandKey");
+    }
+
+    winrt::hstring SearchForTextArgs::GenerateName() const
+    {
+        return winrt::hstring{
+            fmt::format(std::wstring_view(RS_(L"SearchForTextCommandKey")),
+                        QueryUrl().c_str())
+        };
     }
 
     winrt::hstring GlobalSummonArgs::GenerateName() const

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.cpp
@@ -770,7 +770,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     {
         return winrt::hstring{
             fmt::format(std::wstring_view(RS_(L"SearchForTextCommandKey")),
-                        QueryUrl().c_str())
+                        Windows::Foundation::Uri(QueryUrl()).Domain().c_str())
         };
     }
 

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -39,6 +39,7 @@
 #include "PrevTabArgs.g.h"
 #include "NextTabArgs.g.h"
 #include "RenameWindowArgs.g.h"
+#include "SearchForTextArgs.g.h"
 #include "GlobalSummonArgs.g.h"
 #include "FocusPaneArgs.g.h"
 #include "ExportBufferArgs.g.h"
@@ -226,6 +227,11 @@ private:                                                                    \
 ////////////////////////////////////////////////////////////////////////////////
 #define RENAME_WINDOW_ARGS(X) \
     X(winrt::hstring, Name, "name", false, L"")
+
+////////////////////////////////////////////////////////////////////////////////
+#define SEARCH_FOR_TEXT_ARGS(X)                         \
+    X(winrt::hstring, QueryUrl, "queryUrl", false, L"") \
+    X(bool, WrapWithQuotes, "wrapWithQuotes", false, true)
 
 ////////////////////////////////////////////////////////////////////////////////
 #define GLOBAL_SUMMON_ARGS(X)                                                               \
@@ -710,6 +716,8 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
     ACTION_ARGS_STRUCT(NextTabArgs, NEXT_TAB_ARGS);
 
     ACTION_ARGS_STRUCT(RenameWindowArgs, RENAME_WINDOW_ARGS);
+
+    ACTION_ARGS_STRUCT(SearchForTextArgs, SEARCH_FOR_TEXT_ARGS);
 
     struct GlobalSummonArgs : public GlobalSummonArgsT<GlobalSummonArgs>
     {

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -230,8 +230,7 @@ private:                                                                    \
 
 ////////////////////////////////////////////////////////////////////////////////
 #define SEARCH_FOR_TEXT_ARGS(X)                         \
-    X(winrt::hstring, QueryUrl, "queryUrl", false, L"") \
-    X(bool, WrapWithQuotes, "wrapWithQuotes", false, true)
+    X(winrt::hstring, QueryUrl, "queryUrl", false, L"")
 
 ////////////////////////////////////////////////////////////////////////////////
 #define GLOBAL_SUMMON_ARGS(X)                                                               \

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.h
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.h
@@ -229,7 +229,7 @@ private:                                                                    \
     X(winrt::hstring, Name, "name", false, L"")
 
 ////////////////////////////////////////////////////////////////////////////////
-#define SEARCH_FOR_TEXT_ARGS(X)                         \
+#define SEARCH_FOR_TEXT_ARGS(X) \
     X(winrt::hstring, QueryUrl, "queryUrl", false, L"")
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -352,7 +352,6 @@ namespace Microsoft.Terminal.Settings.Model
     [default_interface] runtimeclass SearchForTextArgs : IActionArgs
     {
         String QueryUrl { get; };
-        Boolean WrapWithQuotes { get; };
     };
 
     [default_interface] runtimeclass GlobalSummonArgs : IActionArgs

--- a/src/cascadia/TerminalSettingsModel/ActionArgs.idl
+++ b/src/cascadia/TerminalSettingsModel/ActionArgs.idl
@@ -349,6 +349,12 @@ namespace Microsoft.Terminal.Settings.Model
         String Name { get; };
     };
 
+    [default_interface] runtimeclass SearchForTextArgs : IActionArgs
+    {
+        String QueryUrl { get; };
+        Boolean WrapWithQuotes { get; };
+    };
+
     [default_interface] runtimeclass GlobalSummonArgs : IActionArgs
     {
         String Name { get; };

--- a/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
+++ b/src/cascadia/TerminalSettingsModel/AllShortcutActions.h
@@ -85,6 +85,7 @@
     ON_ALL_ACTIONS(IdentifyWindows)         \
     ON_ALL_ACTIONS(RenameWindow)            \
     ON_ALL_ACTIONS(OpenWindowRenamer)       \
+    ON_ALL_ACTIONS(SearchForText)           \
     ON_ALL_ACTIONS(GlobalSummon)            \
     ON_ALL_ACTIONS(QuakeMode)               \
     ON_ALL_ACTIONS(FocusPane)               \
@@ -115,6 +116,7 @@
     ON_ALL_ACTIONS_WITH_ARGS(CopyText)             \
     ON_ALL_ACTIONS_WITH_ARGS(ExecuteCommandline)   \
     ON_ALL_ACTIONS_WITH_ARGS(FindMatch)            \
+    ON_ALL_ACTIONS_WITH_ARGS(SearchForText)        \
     ON_ALL_ACTIONS_WITH_ARGS(GlobalSummon)         \
     ON_ALL_ACTIONS_WITH_ARGS(MoveFocus)            \
     ON_ALL_ACTIONS_WITH_ARGS(MovePane)             \

--- a/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
+++ b/src/cascadia/TerminalSettingsModel/GlobalAppSettings.idl
@@ -100,7 +100,7 @@ namespace Microsoft.Terminal.Settings.Model
         INHERITABLE_SETTING(Boolean, EnableColorSelection);
         INHERITABLE_SETTING(Boolean, IsolatedMode);
         INHERITABLE_SETTING(Boolean, AllowHeadless);
-        INHERITABLE_SETTING(String, SearchWebQueryUrlDefault);
+        INHERITABLE_SETTING(String, SearchWebDefaultQueryUrl);
 
         Windows.Foundation.Collections.IMapView<String, ColorScheme> ColorSchemes();
         void AddColorScheme(ColorScheme scheme);

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -66,7 +66,7 @@ Author(s):
     X(winrt::Windows::Foundation::Collections::IVector<Model::NewTabMenuEntry>, NewTabMenu, "newTabMenu", winrt::single_threaded_vector<Model::NewTabMenuEntry>({ Model::RemainingProfilesEntry{} })) \
     X(bool, AllowHeadless, "compatibility.allowHeadless", false)                                                                                                                                      \
     X(bool, IsolatedMode, "compatibility.isolatedMode", false)                                                                                                                                        \
-    X(hstring, SearchWebQueryUrlDefault, "searchWebQueryUrlDefault", L"https://www.bing.com/search?q=")
+    X(hstring, SearchWebDefaultQueryUrl, "searchWebDefaultQueryUrl", L"https://www.bing.com/search?q=")
 
 #define MTSM_PROFILE_SETTINGS(X)                                                                                                                               \
     X(int32_t, HistorySize, "historySize", DEFAULT_HISTORY_SIZE)                                                                                               \

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -65,7 +65,8 @@ Author(s):
     X(bool, EnableColorSelection, "experimental.enableColorSelection", false)                                                                                                                         \
     X(winrt::Windows::Foundation::Collections::IVector<Model::NewTabMenuEntry>, NewTabMenu, "newTabMenu", winrt::single_threaded_vector<Model::NewTabMenuEntry>({ Model::RemainingProfilesEntry{} })) \
     X(bool, AllowHeadless, "compatibility.allowHeadless", false)                                                                                                                                      \
-    X(bool, IsolatedMode, "compatibility.isolatedMode", false)
+    X(bool, IsolatedMode, "compatibility.isolatedMode", false)                                                                                                                                        \
+    X(hstring, SearchWebQueryUrlDefault, "queryUrl", L"https://www.bing.com/search?q=")
 
 #define MTSM_PROFILE_SETTINGS(X)                                                                                                                               \
     X(int32_t, HistorySize, "historySize", DEFAULT_HISTORY_SIZE)                                                                                               \

--- a/src/cascadia/TerminalSettingsModel/MTSMSettings.h
+++ b/src/cascadia/TerminalSettingsModel/MTSMSettings.h
@@ -66,7 +66,7 @@ Author(s):
     X(winrt::Windows::Foundation::Collections::IVector<Model::NewTabMenuEntry>, NewTabMenu, "newTabMenu", winrt::single_threaded_vector<Model::NewTabMenuEntry>({ Model::RemainingProfilesEntry{} })) \
     X(bool, AllowHeadless, "compatibility.allowHeadless", false)                                                                                                                                      \
     X(bool, IsolatedMode, "compatibility.isolatedMode", false)                                                                                                                                        \
-    X(hstring, SearchWebDefaultQueryUrl, "searchWebDefaultQueryUrl", L"https://www.bing.com/search?q=")
+    X(hstring, SearchWebDefaultQueryUrl, "searchWebDefaultQueryUrl", L"https://www.bing.com/search?q=%22%s%22")
 
 #define MTSM_PROFILE_SETTINGS(X)                                                                                                                               \
     X(int32_t, HistorySize, "historySize", DEFAULT_HISTORY_SIZE)                                                                                               \

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -699,4 +699,20 @@
   <data name="SelectCommandPreviousCommandKey" xml:space="preserve">
     <value>Select previous command</value>
   </data>
+  <data name="SearchForTextCommandKey" xml:space="preserve">
+    <value>Search online for selected text with '{0}'</value>
+    <comment>{0} will be replaced with a user-specified URL to a web page</comment>
+  </data>
+  <data name="SearchWebCommandKey" xml:space="preserve">
+    <value>Search for selected text</value>
+    <comment>This will open a web browser to search for some user-selected text</comment>
+  </data>
+  <data name="SearchGitHubCommandKey" xml:space="preserve">
+    <value>Search GitHub for selected text</value>
+    <comment>GitHub is the name of the website https://github.com/</comment>
+  </data>
+  <data name="SearchStackOverflowCommandKey" xml:space="preserve">
+    <value>Search StackOverflow for selected text</value>
+    <comment>StackOverflow is the name of the website https://stackoverflow.com/</comment>
+  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -700,11 +700,11 @@
     <value>Select previous command</value>
   </data>
   <data name="SearchForTextCommandKey" xml:space="preserve">
-    <value>Search online for selected text with '{0}'</value>
+    <value>Search {0}</value>
     <comment>{0} will be replaced with a user-specified URL to a web page</comment>
   </data>
   <data name="SearchWebCommandKey" xml:space="preserve">
-    <value>Search for selected text</value>
+    <value>Search the web for selected text</value>
     <comment>This will open a web browser to search for some user-selected text</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsModel/Resources/en-US/Resources.resw
@@ -707,12 +707,4 @@
     <value>Search for selected text</value>
     <comment>This will open a web browser to search for some user-selected text</comment>
   </data>
-  <data name="SearchGitHubCommandKey" xml:space="preserve">
-    <value>Search GitHub for selected text</value>
-    <comment>GitHub is the name of the website https://github.com/</comment>
-  </data>
-  <data name="SearchStackOverflowCommandKey" xml:space="preserve">
-    <value>Search StackOverflow for selected text</value>
-    <comment>StackOverflow is the name of the website https://stackoverflow.com/</comment>
-  </data>
 </root>

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -466,6 +466,11 @@
         { "command": "expandSelectionToWord" },
         { "command": "showContextMenu", "keys": "menu" },
 
+        // Web Search
+        { "command": { "action": "searchWeb", "queryUrl": "https://www.bing.com/search?q=" }, "name": { "key": "SearchWebCommandKey" } },
+        { "command": { "action": "searchWeb", "queryUrl": "https://www.bing.com/search?q=site%3Agithub.com+" }, "name": { "key": "SearchGitHubCommandKey" } },
+        { "command": { "action": "searchWeb", "queryUrl": "https://www.bing.com/search?q=site%3Astackoverflow.com+" }, "name": { "key": "SearchStackOverflowCommandKey" } },
+
         // Scrollback
         { "command": "scrollDown", "keys": "ctrl+shift+down" },
         { "command": "scrollDownPage", "keys": "ctrl+shift+pgdn" },

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -467,7 +467,7 @@
         { "command": "showContextMenu", "keys": "menu" },
 
         // Web Search
-        { "command": { "action": "searchWeb", "queryUrl": "https://www.bing.com/search?q=" }, "name": { "key": "SearchWebCommandKey" } },
+        { "command": { "action": "searchWeb" }, "name": { "key": "SearchWebCommandKey" } },
 
         // Scrollback
         { "command": "scrollDown", "keys": "ctrl+shift+down" },

--- a/src/cascadia/TerminalSettingsModel/defaults.json
+++ b/src/cascadia/TerminalSettingsModel/defaults.json
@@ -468,8 +468,6 @@
 
         // Web Search
         { "command": { "action": "searchWeb", "queryUrl": "https://www.bing.com/search?q=" }, "name": { "key": "SearchWebCommandKey" } },
-        { "command": { "action": "searchWeb", "queryUrl": "https://www.bing.com/search?q=site%3Agithub.com+" }, "name": { "key": "SearchGitHubCommandKey" } },
-        { "command": { "action": "searchWeb", "queryUrl": "https://www.bing.com/search?q=site%3Astackoverflow.com+" }, "name": { "key": "SearchStackOverflowCommandKey" } },
 
         // Scrollback
         { "command": "scrollDown", "keys": "ctrl+shift+down" },


### PR DESCRIPTION
Added `searchWeb` command to search the selected text on the web.
Arguments:
- `queryUrl`: URL of the web page to launch (the selected text will be appended to it)
- `wrapWithQuotes`: whether the selected text should be wrapped with quotes (true/false)

To make the search text more "compact" and handle multi-line selections, I'm concatenating the selected lines and replacing consecutive whitespaces with a single space (we may change this with something more clever in case).

## Validation Steps Performed
Manual testing with single, multi-line, block selections.
Enable/disable the `wrapWithQuotes` argument.

Closes #10175 