### PR TITLE
Various fixes and improvements for ConsoleTypes.natvis

### DIFF
--- a/tools/ConsoleTypes.natvis
+++ b/tools/ConsoleTypes.natvis
@@ -10,16 +10,8 @@
     </Type>
 
     <Type Name="TextAttribute">
-        <!-- You can't do too much trickiness inside the DisplayString format
-                string, so we'd have to add entries for each flag if we really
-                wanted them to show up like that. -->
-        <DisplayString>{{FG: {_foreground}, BG: {_background}, Legacy: {_wAttrLegacy}, {_extendedAttrs}}</DisplayString>
-        <Expand>
-            <Item Name="Legacy">_wAttrLegacy</Item>
-            <Item Name="FG">_foreground</Item>
-            <Item Name="BG">_background</Item>
-            <Item Name="Extended">_extendedAttrs</Item>
-        </Expand>
+        <DisplayString Condition="_hyperlinkId == 0">{{FG: {_foreground}, BG: {_background}, Attr: {_attrs}}</DisplayString>
+        <DisplayString Condition="_hyperlinkId != 0">{{FG: {_foreground}, BG: {_background}, Attr: {_attrs}, Hyperlink: {_hyperlinkId}}</DisplayString>
     </Type>
 
     <Type Name="Microsoft::Console::Types::Viewport">
@@ -59,15 +51,15 @@
     </Type>
 
     <Type Name="til::size">
-        <DisplayString>{{W: {_width,d} x H: {_height,d} -> A: {_width * _height, d}}}</DisplayString>
+        <DisplayString>{{W: {width} x H: {height} -> A: {width * height}}}</DisplayString>
     </Type>
 
     <Type Name="til::point">
-        <DisplayString>{{X: {_x,d}, Y: {_y,d}}}</DisplayString>
+        <DisplayString>{{X: {x}, Y: {y}}}</DisplayString>
     </Type>
 
     <Type Name="til::rect">
-        <DisplayString>{{L: {_topLeft._x}, T: {_topLeft._y}, R: {_bottomRight._x} B: {_bottomRight._y}   [W: {_bottomRight._x - _topLeft._x} x H: {_bottomRight._y - _topLeft._y} -> A: {(_bottomRight._x - _topLeft._x) * (_bottomRight._y - _topLeft._y)}]}}</DisplayString>
+        <DisplayString>{{L: {left}, T: {top}, R: {right} B: {bottom}   [W: {right - left} x H: {bottom - top} -> A: {(right - left) * (bottom - top)}]}}</DisplayString>
     </Type>
 
     <Type Name="til::color">
@@ -119,6 +111,18 @@
                 <Size>_capacity</Size>
                 <ValuePointer>_map._Mypair._Myval2</ValuePointer>
             </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="TextBuffer">
+        <DisplayString>{{ width={_width}, height={_height} }}</DisplayString>
+        <Expand>
+            <Item Name="_firstRow">_firstRow</Item>
+            <Item Name="scratchpad">*(ROW*)_buffer.__ptr_.__value_</Item>
+            <IndexListItems>
+                <Size>(_commitWatermark - _buffer.__ptr_.__value_ - 1) / _bufferRowStride</Size>
+                <ValueNode>*(ROW*)(_buffer.__ptr_.__value_ + _bufferRowStride * ($i + 1))</ValueNode>
+            </IndexListItems>
         </Expand>
     </Type>
 


### PR DESCRIPTION
Fixes the broken types for `TextAttribute`, `til::size`, `til::point`
and `til::rect` and adds a new type for `TextBuffer` which without
this would now be much harder to inspect due to introduction of
the manual virtual memory management in 612b00c.