### PR TITLE
Fix new AuditMode failures up to VS 17.7 Preview 2

### DIFF
--- a/.github/actions/spelling/candidate.patterns
+++ b/.github/actions/spelling/candidate.patterns
@@ -371,8 +371,6 @@ ipfs://[0-9a-z]*
 \b(?:[0-9a-fA-F]{0,4}:){3,7}[0-9a-fA-F]{0,4}\b
 # c99 hex digits (not the full format, just one I've seen)
 0x[0-9a-fA-F](?:\.[0-9a-fA-F]*|)[pP]
-# Punycode
-\bxn--[-0-9a-z]+
 # sha
 sha\d+:[0-9]*[a-f]{3,}[0-9a-f]*
 # sha-... -- uses a fancy capture

--- a/src/common.build.pre.props
+++ b/src/common.build.pre.props
@@ -120,11 +120,12 @@
         C26445: Do not assign std::span or std::string_view to a reference. They are cheap to construct and are not owners of the underlying data. (gsl.view).
           Even for MSVC v19.32 this is actually far from true. Copying (as opposed to referencing) larger
           than register-sized structures is fairly expensive. Example: https://godbolt.org/z/oPco88PaP
-        C26813: Use 'bitwise and' to check if a flag is set.
-          The MSVC v19.31 toolset has a bug where a pointer to an enum is incorrectly flagged with C26813.
-          It's supposed to be fixed with VS 17.2.1 and 17.3.0 and later respectively.
+        C26434: Method 'A' hides a non-virtual method 'B' (c.128).
+        C26456: Operator 'A' hides a non-virtual operator 'B' (c.128)
+          I think these rules are for when you fully bought into OOP?
+          We didn't and it breaks WRL and large parts of conhost code.
       -->
-      <DisableSpecificWarnings>4201;4312;4467;5105;26445;26813;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4201;4312;4467;5105;26434;26445;26456;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <PreprocessorDefinitions>_WINDOWS;EXTERNAL_BUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <PrecompiledHeaderFile>precomp.h</PrecompiledHeaderFile>

--- a/src/host/readData.hpp
+++ b/src/host/readData.hpp
@@ -32,20 +32,9 @@ public:
     ReadData(_In_ InputBuffer* const pInputBuffer,
              _In_ INPUT_READ_HANDLE_DATA* const pInputReadHandleData);
 
-    virtual ~ReadData();
+    ~ReadData() override;
 
-    ReadData(const ReadData&) = delete;
     ReadData(ReadData&&);
-    ReadData& operator=(const ReadData&) & = delete;
-    ReadData& operator=(ReadData&&) & = delete;
-
-    virtual void MigrateUserBuffersOnTransitionToBackgroundWait(const void* oldBuffer, void* newBuffer) = 0;
-    virtual bool Notify(const WaitTerminationReason TerminationReason,
-                        const bool fIsUnicode,
-                        _Out_ NTSTATUS* const pReplyStatus,
-                        _Out_ size_t* const pNumBytes,
-                        _Out_ DWORD* const pControlKeyState,
-                        _Out_ void* const pOutputData) = 0;
 
     InputBuffer* GetInputBuffer() const;
     INPUT_READ_HANDLE_DATA* GetInputReadHandleData() const;

--- a/src/host/renderData.hpp
+++ b/src/host/renderData.hpp
@@ -54,8 +54,8 @@ public:
     const bool IsBlockSelection() const noexcept override;
     void ClearSelection() override;
     void SelectNewRegion(const til::point coordStart, const til::point coordEnd) override;
-    const til::point GetSelectionAnchor() const noexcept;
-    const til::point GetSelectionEnd() const noexcept;
-    void ColorSelection(const til::point coordSelectionStart, const til::point coordSelectionEnd, const TextAttribute attr);
+    const til::point GetSelectionAnchor() const noexcept override;
+    const til::point GetSelectionEnd() const noexcept override;
+    void ColorSelection(const til::point coordSelectionStart, const til::point coordSelectionEnd, const TextAttribute attr) override;
     const bool IsUiaDataInitialized() const noexcept override { return true; }
 };

--- a/src/host/server.h
+++ b/src/host/server.h
@@ -117,7 +117,7 @@ public:
     void SetActiveOutputBuffer(SCREEN_INFORMATION& screenBuffer);
     bool HasActiveOutputBuffer() const;
 
-    InputBuffer* const GetActiveInputBuffer() const;
+    InputBuffer* const GetActiveInputBuffer() const override;
 
     bool IsInVtIoMode() const;
     bool HasPendingCookedRead() const noexcept;

--- a/src/renderer/dx/CustomTextLayout.cpp
+++ b/src/renderer/dx/CustomTextLayout.cpp
@@ -406,7 +406,7 @@ CATCH_RETURN()
         // Get the features to apply to the font
         const auto& features = _fontRenderData->DefaultFontFeatures();
 #pragma warning(suppress : 26492) // Don't use const_cast to cast away const or volatile (type.3).
-        DWRITE_TYPOGRAPHIC_FEATURES typographicFeatures = { const_cast<DWRITE_FONT_FEATURE*>(features.data()), gsl::narrow<uint32_t>(features.size()) };
+        const DWRITE_TYPOGRAPHIC_FEATURES typographicFeatures = { const_cast<DWRITE_FONT_FEATURE*>(features.data()), gsl::narrow<uint32_t>(features.size()) };
         DWRITE_TYPOGRAPHIC_FEATURES const* typographicFeaturesPointer = &typographicFeatures;
         const uint32_t fontFeatureLengths[] = { textLength };
 

--- a/src/renderer/dx/DxSoftFont.cpp
+++ b/src/renderer/dx/DxSoftFont.cpp
@@ -23,17 +23,6 @@ constexpr size_t BITMAP_GRID_WIDTH = 12;
 constexpr size_t BITMAP_GRID_HEIGHT = 8;
 constexpr size_t PADDING = 2;
 
-constexpr auto ANTIALIASED_INTERPOLATION = D2D1_SCALE_INTERPOLATION_MODE_HIGH_QUALITY_CUBIC;
-constexpr auto ALIASED_INTERPOLATION = D2D1_SCALE_INTERPOLATION_MODE_NEAREST_NEIGHBOR;
-
-DxSoftFont::DxSoftFont() noexcept :
-    _centeringHint{},
-    _interpolation{ ANTIALIASED_INTERPOLATION },
-    _colorMatrix{}
-{
-    _colorMatrix.m[0][3] = 1;
-}
-
 void DxSoftFont::SetFont(const std::span<const uint16_t> bitPattern,
                          const til::size sourceSize,
                          const til::size targetSize,

--- a/src/renderer/dx/DxSoftFont.h
+++ b/src/renderer/dx/DxSoftFont.h
@@ -17,7 +17,6 @@ namespace Microsoft::Console::Render
     class DxSoftFont
     {
     public:
-        DxSoftFont() noexcept;
         void SetFont(const std::span<const uint16_t> bitPattern,
                      const til::size sourceSize,
                      const til::size targetSize,
@@ -32,6 +31,9 @@ namespace Microsoft::Console::Render
         void Reset();
 
     private:
+        static constexpr auto ANTIALIASED_INTERPOLATION = D2D1_SCALE_INTERPOLATION_MODE_HIGH_QUALITY_CUBIC;
+        static constexpr auto ALIASED_INTERPOLATION = D2D1_SCALE_INTERPOLATION_MODE_NEAREST_NEIGHBOR;
+
         HRESULT _createResources(gsl::not_null<ID2D1DeviceContext*> d2dContext);
         D2D1_VECTOR_2F _scaleForTargetSize() const noexcept;
         template<typename T>
@@ -39,13 +41,13 @@ namespace Microsoft::Console::Render
         template<typename T>
         T _yOffsetForGlyph(const size_t glyphNumber) const noexcept;
 
-        size_t _glyphCount;
+        size_t _glyphCount = 0;
         til::size _sourceSize;
         til::size _targetSize;
-        size_t _centeringHint;
-        D2D1_SCALE_INTERPOLATION_MODE _interpolation;
-        D2D1_MATRIX_5X4_F _colorMatrix;
-        D2D1_SIZE_U _bitmapSize;
+        size_t _centeringHint = 0;
+        D2D1_SCALE_INTERPOLATION_MODE _interpolation = ALIASED_INTERPOLATION;
+        D2D1_MATRIX_5X4_F _colorMatrix{ ._14 = 1 };
+        D2D1_SIZE_U _bitmapSize{};
         std::vector<byte> _bitmapBits;
         ::Microsoft::WRL::ComPtr<ID2D1Bitmap> _bitmap;
         ::Microsoft::WRL::ComPtr<ID2D1Effect> _scaleEffect;

--- a/src/renderer/inc/RenderEngineBase.hpp
+++ b/src/renderer/inc/RenderEngineBase.hpp
@@ -41,7 +41,7 @@ namespace Microsoft::Console::Render
                                                    const til::CoordType targetRow,
                                                    const til::CoordType viewportLeft) noexcept override;
 
-        [[nodiscard]] virtual bool RequiresContinuousRedraw() noexcept override;
+        [[nodiscard]] bool RequiresContinuousRedraw() noexcept override;
 
         [[nodiscard]] HRESULT InvalidateFlush(_In_ const bool circled, _Out_ bool* const pForcePaint) noexcept override;
 

--- a/src/renderer/vt/vtrenderer.hpp
+++ b/src/renderer/vt/vtrenderer.hpp
@@ -228,7 +228,7 @@ namespace Microsoft::Console::Render
         [[nodiscard]] HRESULT _WriteTerminalAscii(const std::wstring_view str) noexcept;
         [[nodiscard]] HRESULT _WriteTerminalDrcs(const std::wstring_view str) noexcept;
 
-        [[nodiscard]] virtual HRESULT _DoUpdateTitle(const std::wstring_view newTitle) noexcept override;
+        [[nodiscard]] HRESULT _DoUpdateTitle(const std::wstring_view newTitle) noexcept override;
 
         /////////////////////////// Unit Testing Helpers ///////////////////////////
 #ifdef UNIT_TESTING

--- a/src/server/IWaitRoutine.h
+++ b/src/server/IWaitRoutine.h
@@ -37,6 +37,11 @@ public:
 
     virtual ~IWaitRoutine() = default;
 
+    IWaitRoutine(const IWaitRoutine&) = delete;
+    IWaitRoutine(IWaitRoutine&&) = delete;
+    IWaitRoutine& operator=(const IWaitRoutine&) & = delete;
+    IWaitRoutine& operator=(IWaitRoutine&&) & = delete;
+
     virtual void MigrateUserBuffersOnTransitionToBackgroundWait(const void* oldBuffer, void* newBuffer) = 0;
 
     virtual bool Notify(const WaitTerminationReason TerminationReason,

--- a/src/types/ScreenInfoUiaProviderBase.h
+++ b/src/types/ScreenInfoUiaProviderBase.h
@@ -59,13 +59,12 @@ namespace Microsoft::Console::Types
         IFACEMETHODIMP get_HostRawElementProvider(_COM_Outptr_result_maybenull_ IRawElementProviderSimple** ppProvider) noexcept override;
 
         // IRawElementProviderFragment methods
-        virtual IFACEMETHODIMP Navigate(_In_ NavigateDirection direction,
-                                        _COM_Outptr_result_maybenull_ IRawElementProviderFragment** ppProvider) = 0;
+        IFACEMETHODIMP Navigate(_In_ NavigateDirection direction, _COM_Outptr_result_maybenull_ IRawElementProviderFragment** ppProvider) override = 0;
         IFACEMETHODIMP GetRuntimeId(_Outptr_result_maybenull_ SAFEARRAY** ppRuntimeId) override;
-        virtual IFACEMETHODIMP get_BoundingRectangle(_Out_ UiaRect* pRect) = 0;
+        IFACEMETHODIMP get_BoundingRectangle(_Out_ UiaRect* pRect) override = 0;
         IFACEMETHODIMP GetEmbeddedFragmentRoots(_Outptr_result_maybenull_ SAFEARRAY** ppRoots) noexcept override;
         IFACEMETHODIMP SetFocus() override;
-        virtual IFACEMETHODIMP get_FragmentRoot(_COM_Outptr_result_maybenull_ IRawElementProviderFragmentRoot** ppProvider) = 0;
+        IFACEMETHODIMP get_FragmentRoot(_COM_Outptr_result_maybenull_ IRawElementProviderFragmentRoot** ppProvider) override = 0;
 
         // ITextProvider
         IFACEMETHODIMP GetSelection(_Outptr_result_maybenull_ SAFEARRAY** ppRetVal) override;

--- a/src/types/UiaTextRangeBase.hpp
+++ b/src/types/UiaTextRangeBase.hpp
@@ -82,7 +82,7 @@ namespace Microsoft::Console::Types
         bool IsDegenerate() const noexcept;
 
         // ITextRangeProvider methods
-        virtual IFACEMETHODIMP Clone(_Outptr_result_maybenull_ ITextRangeProvider** ppRetVal) = 0;
+        IFACEMETHODIMP Clone(_Outptr_result_maybenull_ ITextRangeProvider** ppRetVal) override = 0;
         IFACEMETHODIMP Compare(_In_opt_ ITextRangeProvider* pRange, _Out_ BOOL* pRetVal) noexcept override;
         IFACEMETHODIMP CompareEndpoints(_In_ TextPatternRangeEndpoint endpoint,
                                         _In_ ITextRangeProvider* pTargetRange,

--- a/src/winconpty/winconpty.cpp
+++ b/src/winconpty/winconpty.cpp
@@ -325,15 +325,20 @@ HRESULT _ReparentPseudoConsole(_In_ const PseudoConsole* const pPty, _In_ const 
     {
         return E_INVALIDARG;
     }
+
     // sneaky way to pack a short and a uint64_t in a relatively literal way.
 #pragma pack(push, 1)
     struct _signal
     {
         const unsigned short id;
         const uint64_t hwnd;
-    } data{ PTY_SIGNAL_REPARENT_WINDOW, (uint64_t)(newParent) };
+    };
 #pragma pack(pop)
 
+    const _signal data{
+        PTY_SIGNAL_REPARENT_WINDOW,
+        (uint64_t)(newParent),
+    };
     const auto fSuccess = WriteFile(pPty->hSignal, &data, sizeof(data), nullptr, nullptr);
 
     return fSuccess ? S_OK : HRESULT_FROM_WIN32(GetLastError());


### PR DESCRIPTION
* Fixes warnings related to missing `const` in 2 places, which seems
  to be something that's being detected more reliably by 17.6 now.
* Fixes `DxSoftFont` not initializing all members,
  which is also suddenly being detected by 17.6 now.
* Fixes 1 new VS 17.7 warning (C26435) by removing `virtual` from
  methods declared as `override` already.
* Disables 2 new VS 17.7 warnings that are part of C++ Core Guidelines
  c.128, because they don't really bring any benefit to this project.

As an additional bonus it disables a spellcheck warning that has been
going around ever since I put a Punycode URL in a comment.