### PR TITLE
Fix a crash when duplicating tabs with elevate:true

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4247,16 +4247,16 @@ namespace winrt::TerminalApp::implementation
         {
             return false;
         }
-        
+
         const auto defaultSettings = controlSettings.DefaultSettings();
-        
+
         // If we don't even want to elevate we can return early.
         // If we're already elevated we can also return, because it doesn't get any more elevated than that.
         if (!defaultSettings.Elevate() || IsRunningElevated())
         {
             return false;
         }
-        
+
         // Manually set the Profile of the NewTerminalArgs to the guid we've
         // resolved to. If there was a profile in the NewTerminalArgs, this
         // will be that profile's GUID. If there wasn't, then we'll use


### PR DESCRIPTION
When `elevate` is set to `true`, `_maybeElevate` would try to
modify `newTerminalArgs` and crash, because during tab duplication
there aren't any `newTerminalArgs`. This issue may happen for instance
when receiving hand-off from a non-elevated client and then trying
to duplicate that tab.

Closes #15534

## Validation Steps Performed
* Launch with `"elevate": false`
* Set `"elevate": true`
* Duplicate a tab
* Doesn't crash ✅