### PR TITLE
Remove boolean success return values from TextBuffer

### DIFF
--- a/src/buffer/out/Row.cpp
+++ b/src/buffer/out/Row.cpp
@@ -435,10 +435,9 @@ OutputCellIterator ROW::WriteCells(OutputCellIterator it, const til::CoordType c
     return it;
 }
 
-bool ROW::SetAttrToEnd(const til::CoordType columnBegin, const TextAttribute attr)
+void ROW::SetAttrToEnd(const til::CoordType columnBegin, const TextAttribute attr)
 {
     _attr.replace(_clampedColumnInclusive(columnBegin), _attr.size(), attr);
-    return true;
 }
 
 void ROW::ReplaceAttributes(const til::CoordType beginIndex, const til::CoordType endIndex, const TextAttribute& newAttr)

--- a/src/buffer/out/Row.hpp
+++ b/src/buffer/out/Row.hpp
@@ -133,7 +133,7 @@ public:
 
     void ClearCell(til::CoordType column);
     OutputCellIterator WriteCells(OutputCellIterator it, til::CoordType columnBegin, std::optional<bool> wrap = std::nullopt, std::optional<til::CoordType> limitRight = std::nullopt);
-    bool SetAttrToEnd(til::CoordType columnBegin, TextAttribute attr);
+    void SetAttrToEnd(til::CoordType columnBegin, TextAttribute attr);
     void ReplaceAttributes(til::CoordType beginIndex, til::CoordType endIndex, const TextAttribute& newAttr);
     void ReplaceCharacters(til::CoordType columnBegin, til::CoordType width, const std::wstring_view& chars);
     void ReplaceText(RowWriteState& state);

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -112,13 +112,13 @@ public:
                                  const std::optional<bool> setWrap = std::nullopt,
                                  const std::optional<til::CoordType> limitRight = std::nullopt);
 
-    bool InsertCharacter(const wchar_t wch, const DbcsAttribute dbcsAttribute, const TextAttribute attr);
-    bool InsertCharacter(const std::wstring_view chars, const DbcsAttribute dbcsAttribute, const TextAttribute attr);
-    bool IncrementCursor();
-    bool NewlineCursor();
+    void InsertCharacter(const wchar_t wch, const DbcsAttribute dbcsAttribute, const TextAttribute attr);
+    void InsertCharacter(const std::wstring_view chars, const DbcsAttribute dbcsAttribute, const TextAttribute attr);
+    void IncrementCursor();
+    void NewlineCursor();
 
     // Scroll needs access to this to quickly rotate around the buffer.
-    bool IncrementCircularBuffer(const TextAttribute& fillAttributes = {});
+    void IncrementCircularBuffer(const TextAttribute& fillAttributes = {});
 
     til::point GetLastNonSpaceCharacter(std::optional<const Microsoft::Console::Types::Viewport> viewOptional = std::nullopt) const;
 
@@ -240,7 +240,7 @@ private:
     void _SetWrapOnCurrentRow();
     void _AdjustWrapOnCurrentRow(const bool fSet);
     // Assist with maintaining proper buffer state for Double Byte character sequences
-    bool _PrepareForDoubleByteSequence(const DbcsAttribute dbcsAttribute);
+    void _PrepareForDoubleByteSequence(const DbcsAttribute dbcsAttribute);
     bool _AssertValidDoubleByteSequence(const DbcsAttribute dbcsAttribute);
     void _ExpandTextRow(til::inclusive_rect& selectionRow) const;
     DelimiterClass _GetDelimiterClassAt(const til::point pos, const std::wstring_view wordDelimiters) const;

--- a/src/host/_stream.h
+++ b/src/host/_stream.h
@@ -35,10 +35,7 @@ Arguments:
 
 Return Value:
 --*/
-[[nodiscard]] NTSTATUS AdjustCursorPosition(SCREEN_INFORMATION& screenInfo,
-                                            _In_ til::point coordCursor,
-                                            const BOOL fKeepCursorVisible,
-                                            _Inout_opt_ til::CoordType* psScrollY);
+void AdjustCursorPosition(SCREEN_INFORMATION& screenInfo, _In_ til::point coordCursor, const BOOL fKeepCursorVisible, _Inout_opt_ til::CoordType* psScrollY);
 
 /*++
 Routine Description:

--- a/src/host/cmdline.cpp
+++ b/src/host/cmdline.cpp
@@ -268,8 +268,7 @@ void RedrawCommandLine(COOKED_READ_DATA& cookedReadData)
         {
             CursorPosition.x++;
         }
-        Status = AdjustCursorPosition(cookedReadData.ScreenInfo(), CursorPosition, TRUE, nullptr);
-        FAIL_FAST_IF_NTSTATUS_FAILED(Status);
+        AdjustCursorPosition(cookedReadData.ScreenInfo(), CursorPosition, TRUE, nullptr);
     }
 }
 
@@ -1298,8 +1297,7 @@ til::point CommandLine::DeleteFromRightOfCursor(COOKED_READ_DATA& cookedReadData
 
     if (UpdateCursorPosition && cookedReadData.IsEchoInput())
     {
-        Status = AdjustCursorPosition(cookedReadData.ScreenInfo(), cursorPosition, true, nullptr);
-        FAIL_FAST_IF_NTSTATUS_FAILED(Status);
+        AdjustCursorPosition(cookedReadData.ScreenInfo(), cursorPosition, true, nullptr);
     }
 
     return STATUS_SUCCESS;

--- a/src/host/output.h
+++ b/src/host/output.h
@@ -47,7 +47,7 @@ void ScrollRegion(SCREEN_INFORMATION& screenInfo,
 
 VOID SetConsoleWindowOwner(const HWND hwnd, _Inout_opt_ ConsoleProcessHandle* pProcessData);
 
-bool StreamScrollRegion(SCREEN_INFORMATION& screenInfo);
+void StreamScrollRegion(SCREEN_INFORMATION& screenInfo);
 
 // For handling process handle state, not the window state itself.
 void CloseConsoleProcessState();

--- a/src/host/readDataCooked.cpp
+++ b/src/host/readDataCooked.cpp
@@ -757,12 +757,7 @@ bool COOKED_READ_DATA::ProcessInput(const wchar_t wchOrig,
                 // adjust cursor position for WriteChars
                 _originalCursorPosition.y += ScrollY;
                 CursorPosition.y += ScrollY;
-                status = AdjustCursorPosition(_screenInfo, CursorPosition, TRUE, nullptr);
-                if (FAILED_NTSTATUS(status))
-                {
-                    _bytesRead = 0;
-                    return true;
-                }
+                AdjustCursorPosition(_screenInfo, CursorPosition, TRUE, nullptr);
             }
         }
     }


### PR DESCRIPTION
I've removed these because it made some of my new code pretty
convoluted for now good reason as most of these functions aren't
exception safe to begin with. Basically, their boolean status
is often just a pretense because they can crash or throw anyways.

Furthermore, `WriteCharsLegacy` failed to check the status code
returned by `AdjustCursorPosition` in some of its parts too.

In the future we should instead probably strive to continue
make our legacy code more exception safe.