### PR TITLE
unhide nuget `packages/` for VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -103,7 +103,9 @@
     "files.exclude": {
         "**/bin/**": true,
         "**/obj/**": true,
-        "**/packages/**": true,
         "**/Generated Files/**": true
+    },
+    "search.exclude": {
+        "**/packages/**": true
     }
 }


### PR DESCRIPTION
Don't exclude nuget `packages/` in vscode. Excluding via `file.exclude` also excludes them from c++ language extension's `includePath` and generates missing include files and header errors.

We might still like to exclude them from full text search, so we do it using `search.exclude`.

Closes #15578

