### PR TITLE
Stop committing the whole buffer when determining if it's empty

### DIFF
--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -166,27 +166,20 @@ ROW& TextBuffer::_getRowByOffsetDirect(size_t offset)
     return *reinterpret_cast<ROW*>(row);
 }
 
-// This function is "direct" because it trusts the caller to know that this row
-// could be the scratchpad row.
-size_t TextBuffer::_estimateOffsetOfLastCommittedRowDirect() const noexcept
+// Returns the "user-visible" index of the last committed row, which can be used
+// to short-circuit some algorithms that try to scan the entire buffer.
+til::CoordType TextBuffer::_estimateOffsetOfLastCommittedRow() const noexcept
 {
     if (_commitWatermark == _buffer.get())
     {
         // Estimation failed. Act as though we have at least one non-scratchpad row committed.
         // The caller will be passing this offset back to GetRowByOffset or similar later, which
         // will commit it.
-        return 1;
+        return 0;
     }
     const auto lastRowOffset = ((_commitWatermark - 1) - _buffer.get()) / _bufferRowStride;
-    return gsl::narrow_cast<size_t>(lastRowOffset);
-}
-
-// Returns the "user-visible" index of the last committed row, which can be used
-// to short-circuit some algorithms that try to scan the entire buffer..
-size_t TextBuffer::_estimateOffsetOfLastCommittedRow() const noexcept
-{
     // Take into account the scratchpad row.
-    return _estimateOffsetOfLastCommittedRowDirect() - 1;
+    return gsl::narrow_cast<til::CoordType>(lastRowOffset - 1);
 }
 
 // Retrieves a row from the buffer by its offset from the first row of the text buffer
@@ -830,7 +823,7 @@ til::point TextBuffer::GetLastNonSpaceCharacter(std::optional<const Microsoft::C
 
     til::point coordEndOfText;
     // Search the given viewport by starting at the bottom.
-    coordEndOfText.y = std::min(viewport.BottomInclusive(), gsl::narrow_cast<til::CoordType>(_estimateOffsetOfLastCommittedRow()));
+    coordEndOfText.y = std::min(viewport.BottomInclusive(), _estimateOffsetOfLastCommittedRow());
 
     const auto& currRow = GetRowByOffset(coordEndOfText.y);
     // The X position of the end of the valid text is the Right draw boundary (which is one beyond the final valid character)

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -168,7 +168,7 @@ ROW& TextBuffer::_getRowByOffsetDirect(size_t offset)
 
 // This function is "direct" because it trusts the caller to know that this row
 // could be the scratchpad row.
-size_t TextBuffer::_estimateOffsetOfLastCommittedRowDirect() const
+size_t TextBuffer::_estimateOffsetOfLastCommittedRowDirect() const noexcept
 {
     if (_commitWatermark == _buffer.get())
     {
@@ -177,16 +177,16 @@ size_t TextBuffer::_estimateOffsetOfLastCommittedRowDirect() const
         // will commit it.
         return 1;
     }
-    const auto lastRowOffset = static_cast<ptrdiff_t>((_commitWatermark - 1) - _buffer.get()) / _bufferRowStride;
+    const auto lastRowOffset = ((_commitWatermark - 1) - _buffer.get()) / _bufferRowStride;
     return gsl::narrow_cast<size_t>(lastRowOffset);
 }
 
 // Returns the "user-visible" index of the last committed row, which can be used
 // to short-circuit some algorithms that try to scan the entire buffer..
-size_t TextBuffer::_estimateOffsetOfLastCommittedRow() const
+size_t TextBuffer::_estimateOffsetOfLastCommittedRow() const noexcept
 {
     // Take into account the scratchpad row.
-    return ((_estimateOffsetOfLastCommittedRowDirect() + _height - 1) % _height);
+    return _estimateOffsetOfLastCommittedRowDirect() - 1;
 }
 
 // Retrieves a row from the buffer by its offset from the first row of the text buffer

--- a/src/buffer/out/textBuffer.cpp
+++ b/src/buffer/out/textBuffer.cpp
@@ -2635,7 +2635,7 @@ HRESULT TextBuffer::Reflow(TextBuffer& oldBuffer,
     // printable char gets reset. See GH #12567
     auto newRowY = newCursor.GetPosition().y + 1;
     const auto newHeight = newBuffer.GetSize().Height();
-    const auto oldHeight = oldBuffer.GetSize().Height();
+    const auto oldHeight = oldBuffer._estimateOffsetOfLastCommittedRow() + 1;
     for (;
          iOldRow < oldHeight && newRowY < newHeight;
          iOldRow++)

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -234,8 +234,7 @@ private:
     void _construct(const std::byte* until) noexcept;
     void _destroy() const noexcept;
     ROW& _getRowByOffsetDirect(size_t offset);
-    size_t _estimateOffsetOfLastCommittedRowDirect() const noexcept;
-    size_t _estimateOffsetOfLastCommittedRow() const noexcept;
+    til::CoordType _estimateOffsetOfLastCommittedRow() const noexcept;
 
     void _SetFirstRowIndex(const til::CoordType FirstRowIndex) noexcept;
     til::point _GetPreviousFromCursor() const;

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -234,8 +234,8 @@ private:
     void _construct(const std::byte* until) noexcept;
     void _destroy() const noexcept;
     ROW& _getRowByOffsetDirect(size_t offset);
-    size_t _estimateOffsetOfLastCommittedRowDirect() const;
-    size_t _estimateOffsetOfLastCommittedRow() const;
+    size_t _estimateOffsetOfLastCommittedRowDirect() const noexcept;
+    size_t _estimateOffsetOfLastCommittedRow() const noexcept;
 
     void _SetFirstRowIndex(const til::CoordType FirstRowIndex) noexcept;
     til::point _GetPreviousFromCursor() const;

--- a/src/buffer/out/textBuffer.hpp
+++ b/src/buffer/out/textBuffer.hpp
@@ -234,6 +234,8 @@ private:
     void _construct(const std::byte* until) noexcept;
     void _destroy() const noexcept;
     ROW& _getRowByOffsetDirect(size_t offset);
+    size_t _estimateOffsetOfLastCommittedRowDirect() const;
+    size_t _estimateOffsetOfLastCommittedRow() const;
 
     void _SetFirstRowIndex(const til::CoordType FirstRowIndex) noexcept;
     til::point _GetPreviousFromCursor() const;


### PR DESCRIPTION
As a shortcut, GetLastNonSpaceCharacter can start with the last committed row. It's guaranteed that there isn't anything of worth below that point, so why bother checking?

Without this, Terminal immediately commits the entire 9031-line buffer on startup while trying to--get this!--clear the screen!