### PR TITLE
Update /Zc build flags to be more standard conforming

### DIFF
--- a/src/common.build.pre.props
+++ b/src/common.build.pre.props
@@ -136,10 +136,10 @@
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <ConformanceMode>true</ConformanceMode>
       <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <RemoveUnreferencedCodeData>true</RemoveUnreferencedCodeData>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
-      <!-- /fp:contract used to default to on before VS 17.0. If enabled it allows FMA for floats. -->
-      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:externConstexpr /Zc:lambda /Zc:throwingNew /fp:contract</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:__cplusplus /Zc:__STDC__ /Zc:enumTypes /Zc:externConstexpr /Zc:templateScope /Zc:throwingNew</AdditionalOptions>
       <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <ResourceCompile>

--- a/src/terminal/parser/ft_fuzzer/fuzzing_directed.h
+++ b/src/terminal/parser/ft_fuzzer/fuzzing_directed.h
@@ -337,6 +337,9 @@ namespace fuzz
         FuzzTraits m_traits{ TRAIT_DEFAULT };
     };
 
+    template<typename _Type1, typename _Type2, typename... _Args>
+    class CFuzzArraySize;
+
     // The CFuzzArray class is designed to allow fuzzing of element
     // arrays, potentially reallocating a fuzzed version of the array
     // that is either larger or smaller than the template buffer.  Whether
@@ -353,8 +356,7 @@ namespace fuzz
     class CFuzzArray : public CFuzzBase
     {
     public:
-        template<typename _Type1, typename _Type2, typename... _Args>
-        friend class CFuzzArraySize;
+        friend class CFuzzArraySize<_Type1, _Type2, _Args...>;
 
         // Creates a CFuzzArray instance that wraps a buffer specified by
         // rg, together with its size (note that this is the number of elements
@@ -643,8 +645,7 @@ namespace fuzz
     class CFuzzArraySize
     {
     public:
-        template<class _Alloc, typename _Type1, typename _Type2, typename... _Args>
-        friend class CFuzzArray;
+        friend class CFuzzArray<__FUZZING_ALLOCATOR, _Type1, _Type2, _Args...>;
 
         CFuzzArraySize(__inout _Type2& cElems) :
             m_pcElems(&cElems),
@@ -892,7 +893,7 @@ namespace fuzz
             __in ULONG cfte,
             __in _Type pt,
             __in _Args&&... args) :
-            CFuzzType(rgfte, cfte, pt, std::forward<_Args>(args)...)
+            CFuzzType<_Type, _Args...>(rgfte, cfte, pt, std::forward<_Args>(args)...)
         {
         }
 
@@ -933,7 +934,7 @@ namespace fuzz
             __in ULONG cfte,
             __in _Type* psz,
             __in _Args... args) :
-            CFuzzType(rgfte, cfte, psz, std::forward<_Args>(args)...)
+            CFuzzType<_Type, _Args...>(rgfte, cfte, psz, std::forward<_Args>(args)...)
         {
             OnFuzzedValueFromMap();
         }
@@ -1061,7 +1062,7 @@ namespace fuzz
             __in ULONG cfte,
             __in _Type flags,
             __in _Args&&... args) :
-            CFuzzType(rgfte, cfte, flags, std::forward<_Args>(args)...)
+            CFuzzType<_Type, _Args...>(rgfte, cfte, flags, std::forward<_Args>(args)...)
         {
         }
 


### PR DESCRIPTION
This commit removes some flags that we don't need anymore, and adds all
those `/Zc` (standard conformance) switches that aren't enabled by
default yet. This will help us and the MSVC team detect bugs early.

This removes:
* `/fp:contract`: With the addition of `TIL_FAST_MATH_BEGIN`
  all the code that benefits from FMA now uses `/fp:fast`.
* `/Zc:lambda`: Automatically enabled with C++20.

This adds:
* `/Zc:__cplusplus` / `/Zc:__STDC__`: Without these `__cplusplus`
  defaults to `199711L` and `__STDC__` remains undefined.
* `/Zc:enumTypes`: The C++ standard specifies that an enum with
  unspecifies size has a size that fits its members exactly.
  An enum with byte-sized members has a `sizeof` of 1 and not 4.
* `/Zc:templateScope`: Emit errors when shadowing template parameters.

And most importantly:
* `<RemoveUnreferencedCodeData>`, which is `/Zc:inline`
  Without this, MSVC treats `inline` functions sort of like external
  linkage ones. You can declare an inline function in one file and
  then just define it in another. Or use an inline function from
  another file. With this flag, the compiler can stop emitting
  COMDAT references for these which reduces object file sizes.