### PR TITLE
Deduplicate INPUT_RECORD based ApiRoutines

### DIFF
--- a/src/host/ApiRoutines.h
+++ b/src/host/ApiRoutines.h
@@ -49,29 +49,13 @@ public:
     [[nodiscard]] HRESULT GetNumberOfConsoleInputEventsImpl(const InputBuffer& context,
                                                             ULONG& events) noexcept override;
 
-    [[nodiscard]] HRESULT PeekConsoleInputAImpl(IConsoleInputObject& context,
-                                                std::deque<std::unique_ptr<IInputEvent>>& outEvents,
-                                                const size_t eventsToRead,
-                                                INPUT_READ_HANDLE_DATA& readHandleState,
-                                                std::unique_ptr<IWaitRoutine>& waiter) noexcept override;
-
-    [[nodiscard]] HRESULT PeekConsoleInputWImpl(IConsoleInputObject& context,
-                                                std::deque<std::unique_ptr<IInputEvent>>& outEvents,
-                                                const size_t eventsToRead,
-                                                INPUT_READ_HANDLE_DATA& readHandleState,
-                                                std::unique_ptr<IWaitRoutine>& waiter) noexcept override;
-
-    [[nodiscard]] HRESULT ReadConsoleInputAImpl(IConsoleInputObject& context,
-                                                std::deque<std::unique_ptr<IInputEvent>>& outEvents,
-                                                const size_t eventsToRead,
-                                                INPUT_READ_HANDLE_DATA& readHandleState,
-                                                std::unique_ptr<IWaitRoutine>& waiter) noexcept override;
-
-    [[nodiscard]] HRESULT ReadConsoleInputWImpl(IConsoleInputObject& context,
-                                                std::deque<std::unique_ptr<IInputEvent>>& outEvents,
-                                                const size_t eventsToRead,
-                                                INPUT_READ_HANDLE_DATA& readHandleState,
-                                                std::unique_ptr<IWaitRoutine>& waiter) noexcept override;
+    [[nodiscard]] HRESULT GetConsoleInputImpl(IConsoleInputObject& context,
+                                              InputEventQueue& outEvents,
+                                              const size_t eventReadCount,
+                                              INPUT_READ_HANDLE_DATA& readHandleState,
+                                              const bool IsUnicode,
+                                              const bool IsPeek,
+                                              std::unique_ptr<IWaitRoutine>& waiter) noexcept override;
 
     [[nodiscard]] HRESULT ReadConsoleAImpl(IConsoleInputObject& context,
                                            std::span<char> buffer,

--- a/src/host/VtApiRoutines.cpp
+++ b/src/host/VtApiRoutines.cpp
@@ -105,46 +105,16 @@ void VtApiRoutines::_SynchronizeCursor(std::unique_ptr<IWaitRoutine>& waiter) no
     }
 }
 
-[[nodiscard]] HRESULT VtApiRoutines::PeekConsoleInputAImpl(IConsoleInputObject& context,
-                                                           std::deque<std::unique_ptr<IInputEvent>>& outEvents,
-                                                           const size_t eventsToRead,
-                                                           INPUT_READ_HANDLE_DATA& readHandleState,
-                                                           std::unique_ptr<IWaitRoutine>& waiter) noexcept
+[[nodiscard]] HRESULT VtApiRoutines::GetConsoleInputImpl(
+    IConsoleInputObject& context,
+    InputEventQueue& outEvents,
+    const size_t eventReadCount,
+    INPUT_READ_HANDLE_DATA& readHandleState,
+    const bool IsUnicode,
+    const bool IsPeek,
+    std::unique_ptr<IWaitRoutine>& waiter) noexcept
 {
-    const auto hr = m_pUsualRoutines->PeekConsoleInputAImpl(context, outEvents, eventsToRead, readHandleState, waiter);
-    _SynchronizeCursor(waiter);
-    return hr;
-}
-
-[[nodiscard]] HRESULT VtApiRoutines::PeekConsoleInputWImpl(IConsoleInputObject& context,
-                                                           std::deque<std::unique_ptr<IInputEvent>>& outEvents,
-                                                           const size_t eventsToRead,
-                                                           INPUT_READ_HANDLE_DATA& readHandleState,
-                                                           std::unique_ptr<IWaitRoutine>& waiter) noexcept
-{
-    const auto hr = m_pUsualRoutines->PeekConsoleInputWImpl(context, outEvents, eventsToRead, readHandleState, waiter);
-    _SynchronizeCursor(waiter);
-    return hr;
-}
-
-[[nodiscard]] HRESULT VtApiRoutines::ReadConsoleInputAImpl(IConsoleInputObject& context,
-                                                           std::deque<std::unique_ptr<IInputEvent>>& outEvents,
-                                                           const size_t eventsToRead,
-                                                           INPUT_READ_HANDLE_DATA& readHandleState,
-                                                           std::unique_ptr<IWaitRoutine>& waiter) noexcept
-{
-    const auto hr = m_pUsualRoutines->ReadConsoleInputAImpl(context, outEvents, eventsToRead, readHandleState, waiter);
-    _SynchronizeCursor(waiter);
-    return hr;
-}
-
-[[nodiscard]] HRESULT VtApiRoutines::ReadConsoleInputWImpl(IConsoleInputObject& context,
-                                                           std::deque<std::unique_ptr<IInputEvent>>& outEvents,
-                                                           const size_t eventsToRead,
-                                                           INPUT_READ_HANDLE_DATA& readHandleState,
-                                                           std::unique_ptr<IWaitRoutine>& waiter) noexcept
-{
-    const auto hr = m_pUsualRoutines->ReadConsoleInputWImpl(context, outEvents, eventsToRead, readHandleState, waiter);
+    const auto hr = m_pUsualRoutines->GetConsoleInputImpl(context, outEvents, eventReadCount, readHandleState, IsUnicode, IsPeek, waiter);
     _SynchronizeCursor(waiter);
     return hr;
 }

--- a/src/host/VtApiRoutines.h
+++ b/src/host/VtApiRoutines.h
@@ -52,29 +52,13 @@ public:
     [[nodiscard]] HRESULT GetNumberOfConsoleInputEventsImpl(const InputBuffer& context,
                                                             ULONG& events) noexcept override;
 
-    [[nodiscard]] HRESULT PeekConsoleInputAImpl(IConsoleInputObject& context,
-                                                std::deque<std::unique_ptr<IInputEvent>>& outEvents,
-                                                const size_t eventsToRead,
-                                                INPUT_READ_HANDLE_DATA& readHandleState,
-                                                std::unique_ptr<IWaitRoutine>& waiter) noexcept override;
-
-    [[nodiscard]] HRESULT PeekConsoleInputWImpl(IConsoleInputObject& context,
-                                                std::deque<std::unique_ptr<IInputEvent>>& outEvents,
-                                                const size_t eventsToRead,
-                                                INPUT_READ_HANDLE_DATA& readHandleState,
-                                                std::unique_ptr<IWaitRoutine>& waiter) noexcept override;
-
-    [[nodiscard]] HRESULT ReadConsoleInputAImpl(IConsoleInputObject& context,
-                                                std::deque<std::unique_ptr<IInputEvent>>& outEvents,
-                                                const size_t eventsToRead,
-                                                INPUT_READ_HANDLE_DATA& readHandleState,
-                                                std::unique_ptr<IWaitRoutine>& waiter) noexcept override;
-
-    [[nodiscard]] HRESULT ReadConsoleInputWImpl(IConsoleInputObject& context,
-                                                std::deque<std::unique_ptr<IInputEvent>>& outEvents,
-                                                const size_t eventsToRead,
-                                                INPUT_READ_HANDLE_DATA& readHandleState,
-                                                std::unique_ptr<IWaitRoutine>& waiter) noexcept override;
+    [[nodiscard]] HRESULT GetConsoleInputImpl(IConsoleInputObject& context,
+                                              InputEventQueue& outEvents,
+                                              const size_t eventReadCount,
+                                              INPUT_READ_HANDLE_DATA& readHandleState,
+                                              const bool IsUnicode,
+                                              const bool IsPeek,
+                                              std::unique_ptr<IWaitRoutine>& waiter) noexcept override;
 
     [[nodiscard]] HRESULT ReadConsoleAImpl(IConsoleInputObject& context,
                                            std::span<char> buffer,

--- a/src/host/readDataDirect.cpp
+++ b/src/host/readDataDirect.cpp
@@ -22,8 +22,7 @@
 // - THROW: Throws E_INVALIDARG for invalid pointers.
 DirectReadData::DirectReadData(_In_ InputBuffer* const pInputBuffer,
                                _In_ INPUT_READ_HANDLE_DATA* const pInputReadHandleData,
-                               const size_t eventReadCount,
-                               _In_ std::deque<std::unique_ptr<IInputEvent>> partialEvents) :
+                               const size_t eventReadCount) :
     ReadData(pInputBuffer, pInputReadHandleData),
     _eventReadCount{ eventReadCount }
 {

--- a/src/host/readDataDirect.hpp
+++ b/src/host/readDataDirect.hpp
@@ -33,8 +33,7 @@ class DirectReadData final : public ReadData
 public:
     DirectReadData(_In_ InputBuffer* const pInputBuffer,
                    _In_ INPUT_READ_HANDLE_DATA* const pInputReadHandleData,
-                   const size_t eventReadCount,
-                   _In_ std::deque<std::unique_ptr<IInputEvent>> partialEvents);
+                   const size_t eventReadCount);
 
     DirectReadData(DirectReadData&&) = default;
 

--- a/src/server/ApiDispatchers.cpp
+++ b/src/server/ApiDispatchers.cpp
@@ -151,47 +151,15 @@
     const auto pInputReadHandleData = pHandleData->GetClientInput();
 
     std::unique_ptr<IWaitRoutine> waiter;
-    HRESULT hr;
-    std::deque<std::unique_ptr<IInputEvent>> outEvents;
-    const auto eventsToRead = cRecords;
-    if (a->Unicode)
-    {
-        if (fIsPeek)
-        {
-            hr = m->_pApiRoutines->PeekConsoleInputWImpl(*pInputBuffer,
-                                                         outEvents,
-                                                         eventsToRead,
-                                                         *pInputReadHandleData,
-                                                         waiter);
-        }
-        else
-        {
-            hr = m->_pApiRoutines->ReadConsoleInputWImpl(*pInputBuffer,
-                                                         outEvents,
-                                                         eventsToRead,
-                                                         *pInputReadHandleData,
-                                                         waiter);
-        }
-    }
-    else
-    {
-        if (fIsPeek)
-        {
-            hr = m->_pApiRoutines->PeekConsoleInputAImpl(*pInputBuffer,
-                                                         outEvents,
-                                                         eventsToRead,
-                                                         *pInputReadHandleData,
-                                                         waiter);
-        }
-        else
-        {
-            hr = m->_pApiRoutines->ReadConsoleInputAImpl(*pInputBuffer,
-                                                         outEvents,
-                                                         eventsToRead,
-                                                         *pInputReadHandleData,
-                                                         waiter);
-        }
-    }
+    InputEventQueue outEvents;
+    auto hr = m->_pApiRoutines->GetConsoleInputImpl(
+        *pInputBuffer,
+        outEvents,
+        cRecords,
+        *pInputReadHandleData,
+        a->Unicode,
+        fIsPeek,
+        waiter);
 
     // We must return the number of records in the message payload (to alert the client)
     // as well as in the message headers (below in SetReplyInformation) to alert the driver.

--- a/src/server/IApiRoutines.h
+++ b/src/server/IApiRoutines.h
@@ -66,29 +66,13 @@ public:
     [[nodiscard]] virtual HRESULT GetNumberOfConsoleInputEventsImpl(const IConsoleInputObject& context,
                                                                     ULONG& events) noexcept = 0;
 
-    [[nodiscard]] virtual HRESULT PeekConsoleInputAImpl(IConsoleInputObject& context,
-                                                        std::deque<std::unique_ptr<IInputEvent>>& outEvents,
-                                                        const size_t eventsToRead,
-                                                        INPUT_READ_HANDLE_DATA& readHandleState,
-                                                        std::unique_ptr<IWaitRoutine>& waiter) noexcept = 0;
-
-    [[nodiscard]] virtual HRESULT PeekConsoleInputWImpl(IConsoleInputObject& context,
-                                                        std::deque<std::unique_ptr<IInputEvent>>& outEvents,
-                                                        const size_t eventsToRead,
-                                                        INPUT_READ_HANDLE_DATA& readHandleState,
-                                                        std::unique_ptr<IWaitRoutine>& waiter) noexcept = 0;
-
-    [[nodiscard]] virtual HRESULT ReadConsoleInputAImpl(IConsoleInputObject& context,
-                                                        std::deque<std::unique_ptr<IInputEvent>>& outEvents,
-                                                        const size_t eventsToRead,
-                                                        INPUT_READ_HANDLE_DATA& readHandleState,
-                                                        std::unique_ptr<IWaitRoutine>& waiter) noexcept = 0;
-
-    [[nodiscard]] virtual HRESULT ReadConsoleInputWImpl(IConsoleInputObject& context,
-                                                        std::deque<std::unique_ptr<IInputEvent>>& outEvents,
-                                                        const size_t eventsToRead,
-                                                        INPUT_READ_HANDLE_DATA& readHandleState,
-                                                        std::unique_ptr<IWaitRoutine>& waiter) noexcept = 0;
+    [[nodiscard]] virtual HRESULT GetConsoleInputImpl(IConsoleInputObject& context,
+                                                      InputEventQueue& outEvents,
+                                                      const size_t eventReadCount,
+                                                      INPUT_READ_HANDLE_DATA& readHandleState,
+                                                      const bool IsUnicode,
+                                                      const bool IsPeek,
+                                                      std::unique_ptr<IWaitRoutine>& waiter) noexcept = 0;
 
     [[nodiscard]] virtual HRESULT ReadConsoleAImpl(IConsoleInputObject& context,
                                                    std::span<char> buffer,


### PR DESCRIPTION
`(Peek|Read)ConsoleInput(A|W)Impl` make a distinction that doesn't make
a lot of sense in our code base: On the calling side (`ApiDispatchers`)
there's just one function calling all 4 (`ServerGetConsoleInput`) and
on the callee side they all 4 just call `_DoGetConsoleInput` anyways.

## Validation Steps Performed
* It compiles ✅