### PR TITLE
Properly filter focus events from the console API

### DIFF
--- a/src/host/input.cpp
+++ b/src/host/input.cpp
@@ -195,8 +195,7 @@ void HandleFocusEvent(const BOOL fSetFocus)
 
     try
     {
-        const auto EventsWritten = gci.pInputBuffer->Write(std::make_unique<FocusEvent>(!!fSetFocus));
-        FAIL_FAST_IF(EventsWritten != 1);
+        gci.pInputBuffer->WriteFocusEvent(fSetFocus);
     }
     catch (...)
     {

--- a/src/host/inputBuffer.hpp
+++ b/src/host/inputBuffer.hpp
@@ -81,6 +81,9 @@ public:
     size_t Write(_Inout_ std::unique_ptr<IInputEvent> inEvent);
     size_t Write(_Inout_ std::deque<std::unique_ptr<IInputEvent>>& inEvents);
 
+    void WriteFocusEvent(bool focused) noexcept;
+    bool WriteMouseEvent(til::point position, unsigned int button, short keyState, short wheelDelta);
+
     bool IsInVirtualTerminalInputMode() const;
     Microsoft::Console::VirtualTerminal::TerminalInput& GetTerminalInput();
     void SetTerminalConnection(_In_ Microsoft::Console::Render::VtEngine* const pTtyConnection);

--- a/src/terminal/adapter/InteractDispatch.cpp
+++ b/src/terminal/adapter/InteractDispatch.cpp
@@ -240,7 +240,7 @@ bool InteractDispatch::FocusChanged(const bool focused) const
 
         WI_UpdateFlag(gci.Flags, CONSOLE_HAS_FOCUS, shouldActuallyFocus);
         gci.ProcessHandleList.ModifyConsoleProcessFocus(shouldActuallyFocus);
-        gci.pInputBuffer->Write(std::make_unique<FocusEvent>(focused));
+        gci.pInputBuffer->WriteFocusEvent(focused);
     }
     // Does nothing outside of ConPTY. If there's a real HWND, then the HWND is solely in charge.
 

--- a/src/terminal/adapter/ut_adapter/inputTest.cpp
+++ b/src/terminal/adapter/ut_adapter/inputTest.cpp
@@ -328,14 +328,9 @@ void InputTest::TestFocusEvents()
         auto inputEvent = IInputEvent::Create(irTest);
         VERIFY_ARE_EQUAL(false, pInput->HandleKey(inputEvent.get()), L"Verify FOCUS_EVENT from API was NOT handled.");
     }
-    {
-        auto inputEvent = std::make_unique<FocusEvent>(false);
-        VERIFY_ARE_EQUAL(false, pInput->HandleKey(inputEvent.get()), L"Verify FocusEvent from any other source was NOT handled.");
-    }
-    {
-        auto inputEvent = std::make_unique<FocusEvent>(true);
-        VERIFY_ARE_EQUAL(false, pInput->HandleKey(inputEvent.get()), L"Verify FocusEvent from any other source was NOT handled.");
-    }
+
+    VERIFY_ARE_EQUAL(false, pInput->HandleFocus(false), L"Verify FocusEvent from any other source was NOT handled.");
+    VERIFY_ARE_EQUAL(false, pInput->HandleFocus(true), L"Verify FocusEvent from any other source was NOT handled.");
 
     Log::Comment(L"Enable focus event handling");
 
@@ -351,16 +346,11 @@ void InputTest::TestFocusEvents()
         auto inputEvent = IInputEvent::Create(irTest);
         VERIFY_ARE_EQUAL(false, pInput->HandleKey(inputEvent.get()), L"Verify FOCUS_EVENT from API was NOT handled.");
     }
-    {
-        s_expectedInput = L"\x1b[O";
-        auto inputEvent = std::make_unique<FocusEvent>(false);
-        VERIFY_ARE_EQUAL(true, pInput->HandleKey(inputEvent.get()), L"Verify FocusEvent from any other source was handled.");
-    }
-    {
-        s_expectedInput = L"\x1b[I";
-        auto inputEvent = std::make_unique<FocusEvent>(true);
-        VERIFY_ARE_EQUAL(true, pInput->HandleKey(inputEvent.get()), L"Verify FocusEvent from any other source was handled.");
-    }
+
+    s_expectedInput = L"\x1b[O";
+    VERIFY_ARE_EQUAL(true, pInput->HandleFocus(false), L"Verify FocusEvent from any other source was handled.");
+    s_expectedInput = L"\x1b[I";
+    VERIFY_ARE_EQUAL(true, pInput->HandleFocus(true), L"Verify FocusEvent from any other source was handled.");
 }
 
 void InputTest::TerminalInputModifierKeyTests()

--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -523,22 +523,6 @@ bool TerminalInput::HandleKey(const IInputEvent* const pInEvent)
         return false;
     }
 
-    // GH#11682: If this was a focus event, we can handle this. Steal the
-    // focused state, and return true if we're actually in focus event mode.
-    if (pInEvent->EventType() == InputEventType::FocusEvent)
-    {
-        const auto& focusEvent = *static_cast<const FocusEvent* const>(pInEvent);
-
-        // BODGY
-        // GH#13238 - Filter out focus events that came from the API.
-        if (focusEvent.CameFromApi())
-        {
-            return false;
-        }
-
-        return HandleFocus(focusEvent.GetFocus());
-    }
-
     // On key presses, prepare to translate to VT compatible sequences
     if (pInEvent->EventType() != InputEventType::KeyEvent)
     {

--- a/src/types/inc/IInputEvent.hpp
+++ b/src/types/inc/IInputEvent.hpp
@@ -515,14 +515,12 @@ class FocusEvent : public IInputEvent
 {
 public:
     constexpr FocusEvent(const FOCUS_EVENT_RECORD& record) :
-        _focus{ !!record.bSetFocus },
-        _cameFromApi{ true }
+        _focus{ !!record.bSetFocus }
     {
     }
 
     constexpr FocusEvent(const bool focus) :
-        _focus{ focus },
-        _cameFromApi{ false }
+        _focus{ focus }
     {
     }
 
@@ -542,15 +540,8 @@ public:
 
     void SetFocus(const bool focus) noexcept;
 
-    // BODGY - see FocusEvent.cpp for details.
-    constexpr bool CameFromApi() const noexcept
-    {
-        return _cameFromApi;
-    }
-
 private:
     bool _focus;
-    bool _cameFromApi;
 
 #ifdef UNIT_TESTING
     friend std::wostream& operator<<(std::wostream& stream, const FocusEvent* const pFocusEvent);


### PR DESCRIPTION
This is an improved fix for #13238. Instead of handling focus events in
the `TerminalInput::HandleKey` function and the need to filter them
out depending on where they came from, we simply don't call `HandleKey`
in the first place. This makes the somewhat unreliable `CameFromApi`
function unnecessary and the code a bit more robust.

This change is required because `CameFromApi` is not representable
in a `INPUT_RECORD` and I'm getting rid of `IInputEvent`.

## Validation Steps Performed
* No `[O` when exiting nvim ✅
* Mouse input in nvim works ✅