### PR TITLE
 AtlasEngine: Harden against empty target sizes

### DIFF
--- a/src/renderer/atlas/BackendD3D.cpp
+++ b/src/renderer/atlas/BackendD3D.cpp
@@ -693,7 +693,6 @@ void BackendD3D::_resetGlyphAtlas(const RenderingPayload& p)
 
     const auto minAreaByFont = cellArea * 95; // Covers all printable ASCII characters
     const auto minAreaByGrowth = static_cast<u32>(_rectPacker.width) * _rectPacker.height * 2;
-    const auto min = std::max(minArea, std::max(minAreaByFont, minAreaByGrowth));
 
     // It's hard to say what the max. size of the cache should be. Optimally I think we should use as much
     // memory as is available, but the rendering code in this project is a big mess and so integrating
@@ -702,7 +701,9 @@ void BackendD3D::_resetGlyphAtlas(const RenderingPayload& p)
     // we're locked into a state, where on every render pass we're starting with a half full atlas, drawing once,
     // filling it with the remaining half and drawing again, requiring two rendering passes on each frame.
     const auto maxAreaByFont = targetArea + targetArea / 4;
-    const auto area = std::min(maxArea, std::min(maxAreaByFont, min));
+
+    auto area = std::min(maxAreaByFont, std::max(minAreaByFont, minAreaByGrowth));
+    area = clamp(area, minArea, maxArea);
 
     // This block of code calculates the size of a power-of-2 texture that has an area larger than the given `area`.
     // For instance, for an area of 985x1946 = 1916810 it would result in a u/v of 2048x1024 (area = 2097152).

--- a/src/renderer/atlas/common.h
+++ b/src/renderer/atlas/common.h
@@ -387,8 +387,8 @@ namespace Microsoft::Console::Render::Atlas
         til::generational<FontSettings> font;
         til::generational<CursorSettings> cursor;
         til::generational<MiscellaneousSettings> misc;
-        u16x2 targetSize{};
-        u16x2 cellCount{};
+        u16x2 targetSize{ 1, 1 };
+        u16x2 cellCount{ 1, 1 };
     };
 
     using GenerationalSettings = til::generational<Settings>;


### PR DESCRIPTION
The WPF control has a minor bug where it initializes the renderer
when there isn't even a window yet. When it then calls `SetWindowSize`
it'll pass the result of `GetWindowRect` which is `0,0,0,0`.
This made AtlasEngine unhappy because it restricted the glyph atlas
size to some multiple of the window size. If the window size is `0,0`
then there couldn't be a glyph atlas and so it crashed.

## Validation Steps Performed
* Fixes WPF test control crash on startup ✅