### PR TITLE
Launch the settings in the PGO harness

### DIFF
--- a/src/cascadia/WindowsTerminal_UIATests/SmokeTests.cs
+++ b/src/cascadia/WindowsTerminal_UIATests/SmokeTests.cs
@@ -175,5 +175,20 @@ namespace WindowsTerminal.UIA.Tests
                 Globals.WaitForLongTimeout();
             }
         }
+
+        [TestMethod]
+        [TestProperty("IsPGO", "true")]
+        public void RunOpenSettingsUI()
+        {
+            using (TerminalApp app = new TerminalApp(TestContext))
+            {
+                var root = app.GetRoot();
+
+                root.SendKeys(Keys.LeftControl + ",");
+                Globals.WaitForTimeout();
+
+                Globals.WaitForLongTimeout();
+            }
+        }
     }
 }


### PR DESCRIPTION
When we moved the settings UI to lazy initialization in #15628, we broke PGO. Apparently, we were PGOing the tiny part of Settings that was being loaded on every launch (e.g. the XAML metadata provider 🤦)

Let's actually PGO launching the settings.