### PR TITLE
Add support for colon separated sub-parameters

### DIFF
--- a/src/terminal/adapter/DispatchTypes.hpp
+++ b/src/terminal/adapter/DispatchTypes.hpp
@@ -255,7 +255,7 @@ namespace Microsoft::Console::VirtualTerminal
         }
 
     private:
-        static constexpr VTParameter defaultParameter;
+        static constexpr VTParameter defaultParameter{};
         static constexpr std::span defaultParameters{ &defaultParameter, 1 };
 
         std::span<const VTParameter> _params;

--- a/src/terminal/adapter/DispatchTypes.hpp
+++ b/src/terminal/adapter/DispatchTypes.hpp
@@ -162,14 +162,14 @@ namespace Microsoft::Console::VirtualTerminal
         constexpr VTParameters(const VTParameter* paramsPtr, const size_t paramsCount) noexcept :
             _params{ paramsPtr, paramsCount },
             _subParams{},
-            _subParamsRange{}
+            _subParamRanges{}
         {
         }
 
-        constexpr VTParameters(const VTParameter* paramsPtr, const size_t paramsCount, const VTParameter* subParamsPtr, const size_t subParamsCount, const std::pair<BYTE, BYTE>* subParamsRangePtr, const size_t subParamsRangeCount) noexcept :
+        constexpr VTParameters(const VTParameter* paramsPtr, const size_t paramsCount, const VTParameter* subParamsPtr, const size_t subParamsCount, const std::pair<BYTE, BYTE>* subParamRangesPtr, const size_t subParamRangesCount) noexcept :
             _params{ paramsPtr, paramsCount },
             _subParams{ subParamsPtr, subParamsCount },
-            _subParamsRange{ subParamsRangePtr, subParamsRangeCount }
+            _subParamRanges{ subParamRangesPtr, subParamRangesCount }
         {
         }
 
@@ -194,23 +194,23 @@ namespace Microsoft::Console::VirtualTerminal
         VTParameters subspan(const size_t offset) const noexcept
         {
             // We need sub parameters to always be in their original index
-            // because we store their indexes in subParamsRange. So we pass
+            // because we store their indexes in subParamRanges. So we pass
             // _subParams as is and create new span for others.
             const auto newParamsSpan = _params.subspan(std::min(offset, _params.size()));
-            const auto newSubParamsRangeSpan = _subParamsRange.subspan(std::min(offset, _params.size()));
-            return { newParamsSpan.data(), newParamsSpan.size(), _subParams.data(), _subParams.size(), newSubParamsRangeSpan.data(), newSubParamsRangeSpan.size() };
+            const auto newSubParamRangesSpan = _subParamRanges.subspan(std::min(offset, _params.size()));
+            return { newParamsSpan.data(), newParamsSpan.size(), _subParams.data(), _subParams.size(), newSubParamRangesSpan.data(), newSubParamRangesSpan.size() };
         }
 
         std::span<const VTParameter> subParamsFor(const size_t index) const noexcept
         {
             // If the parameter index is out of range, we return a sub-parameters span with no values.
-            if (index >= _subParamsRange.size())
+            if (index >= _subParamRanges.size())
             {
                 return std::span<const VTParameter>{};
             }
             else
             {
-                const auto& range = til::at(_subParamsRange, index);
+                const auto& range = til::at(_subParamRanges, index);
                 return _subParams.subspan(range.first, range.second - range.first);
             }
         }
@@ -241,7 +241,7 @@ namespace Microsoft::Console::VirtualTerminal
 
         std::span<const VTParameter> _params;
         std::span<const VTParameter> _subParams;
-        std::span<const std::pair<BYTE, BYTE>> _subParamsRange;
+        std::span<const std::pair<BYTE, BYTE>> _subParamRanges;
     };
 
     // FlaggedEnumValue is a convenience class that produces enum values (of a specified size)

--- a/src/terminal/adapter/DispatchTypes.hpp
+++ b/src/terminal/adapter/DispatchTypes.hpp
@@ -162,16 +162,19 @@ namespace Microsoft::Console::VirtualTerminal
         constexpr VTParameters(const VTParameter* paramsPtr, const size_t paramsCount) noexcept :
             _params{ paramsPtr, paramsCount },
             _subParams{},
-            _subParamRanges{}
+            _subParamRanges{},
+            _isParameterOmitted{ false }
         {
         }
 
         constexpr VTParameters(const std::span<const VTParameter> params,
-                               const std::span<const VTParameter> subParams = {},
-                               const std::span<const std::pair<BYTE, BYTE>> subParamRanges = {}) noexcept :
+                               const std::span<const VTParameter> subParams,
+                               const std::span<const std::pair<BYTE, BYTE>> subParamRanges,
+                               const bool isParamOmitted) noexcept :
             _params{ params },
             _subParams{ subParams },
-            _subParamRanges{ subParamRanges }
+            _subParamRanges{ subParamRanges },
+            _isParameterOmitted{ isParamOmitted }
         {
         }
 
@@ -200,7 +203,7 @@ namespace Microsoft::Console::VirtualTerminal
             // _subParams as is and create new span for others.
             const auto newParamsSpan = _params.subspan(std::min(offset, _params.size()));
             const auto newSubParamRangesSpan = _subParamRanges.subspan(std::min(offset, _subParamRanges.size()));
-            return { newParamsSpan, _subParams, newSubParamRangesSpan };
+            return { newParamsSpan, _subParams, newSubParamRangesSpan, _isParameterOmitted };
         }
 
         std::span<const VTParameter> subParamsFor(const size_t index) const noexcept
@@ -234,6 +237,11 @@ namespace Microsoft::Console::VirtualTerminal
             }
         }
 
+        bool isParameterOmitted() const noexcept
+        {
+            return _isParameterOmitted;
+        }
+
         template<typename T>
         bool for_each(const T&& predicate) const
         {
@@ -261,6 +269,7 @@ namespace Microsoft::Console::VirtualTerminal
         std::span<const VTParameter> _params;
         std::span<const VTParameter> _subParams;
         std::span<const std::pair<BYTE, BYTE>> _subParamRanges;
+        bool _isParameterOmitted;
     };
 
     // FlaggedEnumValue is a convenience class that produces enum values (of a specified size)

--- a/src/terminal/adapter/DispatchTypes.hpp
+++ b/src/terminal/adapter/DispatchTypes.hpp
@@ -162,19 +162,16 @@ namespace Microsoft::Console::VirtualTerminal
         constexpr VTParameters(const VTParameter* paramsPtr, const size_t paramsCount) noexcept :
             _params{ paramsPtr, paramsCount },
             _subParams{},
-            _subParamRanges{},
-            _isParameterOmitted{ false }
+            _subParamRanges{}
         {
         }
 
         constexpr VTParameters(const std::span<const VTParameter> params,
                                const std::span<const VTParameter> subParams,
-                               const std::span<const std::pair<BYTE, BYTE>> subParamRanges,
-                               const bool isParamOmitted) noexcept :
+                               const std::span<const std::pair<BYTE, BYTE>> subParamRanges) noexcept :
             _params{ params },
             _subParams{ subParams },
-            _subParamRanges{ subParamRanges },
-            _isParameterOmitted{ isParamOmitted }
+            _subParamRanges{ subParamRanges }
         {
         }
 
@@ -203,7 +200,7 @@ namespace Microsoft::Console::VirtualTerminal
             // _subParams as is and create new span for others.
             const auto newParamsSpan = _params.subspan(std::min(offset, _params.size()));
             const auto newSubParamRangesSpan = _subParamRanges.subspan(std::min(offset, _subParamRanges.size()));
-            return { newParamsSpan, _subParams, newSubParamRangesSpan, _isParameterOmitted };
+            return { newParamsSpan, _subParams, newSubParamRangesSpan };
         }
 
         std::span<const VTParameter> subParamsFor(const size_t index) const noexcept
@@ -237,11 +234,6 @@ namespace Microsoft::Console::VirtualTerminal
             }
         }
 
-        bool isParameterOmitted() const noexcept
-        {
-            return _isParameterOmitted;
-        }
-
         template<typename T>
         bool for_each(const T&& predicate) const
         {
@@ -269,7 +261,6 @@ namespace Microsoft::Console::VirtualTerminal
         std::span<const VTParameter> _params;
         std::span<const VTParameter> _subParams;
         std::span<const std::pair<BYTE, BYTE>> _subParamRanges;
-        bool _isParameterOmitted;
     };
 
     // FlaggedEnumValue is a convenience class that produces enum values (of a specified size)

--- a/src/terminal/adapter/DispatchTypes.hpp
+++ b/src/terminal/adapter/DispatchTypes.hpp
@@ -158,7 +158,7 @@ namespace Microsoft::Console::VirtualTerminal
         constexpr VTSubParameters() noexcept
         {
         }
-        
+
         constexpr VTSubParameters(const std::span<const VTParameter> subParams) noexcept :
             _subParams{ subParams }
         {
@@ -242,7 +242,7 @@ namespace Microsoft::Console::VirtualTerminal
             // _subParams as is and create new span for others.
             const auto newParamsSpan = _params.subspan(std::min(offset, _params.size()));
             const auto newSubParamRangesSpan = _subParamRanges.subspan(std::min(offset, _subParamRanges.size()));
-            return { newParamsSpan, _subParams , newSubParamRangesSpan };
+            return { newParamsSpan, _subParams, newSubParamRangesSpan };
         }
 
         VTSubParameters subParamsFor(const size_t index) const noexcept

--- a/src/terminal/adapter/DispatchTypes.hpp
+++ b/src/terminal/adapter/DispatchTypes.hpp
@@ -449,15 +449,6 @@ namespace Microsoft::Console::VirtualTerminal::DispatchTypes
         BrightBackgroundWhite = 107,
     };
 
-    // we use this in VT parser to indicate that the GraphicsOptions (parameter)
-    // accepts sub-parameters.
-    enum GraphicsOptionsWithSubParams : VTInt
-    {
-#ifdef UNIT_TESTING
-        TestOption = 12345,
-#endif
-    };
-
     enum LogicalAttributeOptions : VTInt
     {
         Default = 0,

--- a/src/terminal/adapter/DispatchTypes.hpp
+++ b/src/terminal/adapter/DispatchTypes.hpp
@@ -226,7 +226,7 @@ namespace Microsoft::Console::VirtualTerminal
             if (index < _subParamRanges.size())
             {
                 const auto& range = til::at(_subParamRanges, index);
-                return ((range.second - range.first) > range.first);
+                return range.second > range.first;
             }
             else
             {

--- a/src/terminal/adapter/DispatchTypes.hpp
+++ b/src/terminal/adapter/DispatchTypes.hpp
@@ -197,7 +197,7 @@ namespace Microsoft::Console::VirtualTerminal
             // because we store their indexes in subParamRanges. So we pass
             // _subParams as is and create new span for others.
             const auto newParamsSpan = _params.subspan(std::min(offset, _params.size()));
-            const auto newSubParamRangesSpan = _subParamRanges.subspan(std::min(offset, _params.size()));
+            const auto newSubParamRangesSpan = _subParamRanges.subspan(std::min(offset, _subParamRanges.size()));
             return { newParamsSpan.data(), newParamsSpan.size(), _subParams.data(), _subParams.size(), newSubParamRangesSpan.data(), newSubParamRangesSpan.size() };
         }
 

--- a/src/terminal/adapter/DispatchTypes.hpp
+++ b/src/terminal/adapter/DispatchTypes.hpp
@@ -152,6 +152,48 @@ namespace Microsoft::Console::VirtualTerminal
         VTInt _value;
     };
 
+    class VTSubParameters
+    {
+    public:
+        constexpr VTSubParameters() noexcept
+        {
+        }
+        
+        constexpr VTSubParameters(const std::span<const VTParameter> subParams) noexcept :
+            _subParams{ subParams }
+        {
+        }
+
+        constexpr VTParameter at(const size_t index) const noexcept
+        {
+            return til::at(_subParams, index);
+        }
+
+        VTSubParameters subspan(const size_t offset, const size_t count) const noexcept
+        {
+            const auto subParamsSpan = _subParams.subspan(offset, count);
+            return { subParamsSpan };
+        }
+
+        bool empty() const noexcept
+        {
+            return _subParams.empty();
+        }
+
+        size_t size() const noexcept
+        {
+            return _subParams.size();
+        }
+
+        constexpr operator std::span<const VTParameter>() const noexcept
+        {
+            return _subParams;
+        }
+
+    private:
+        std::span<const VTParameter> _subParams;
+    };
+
     class VTParameters
     {
     public:
@@ -200,10 +242,10 @@ namespace Microsoft::Console::VirtualTerminal
             // _subParams as is and create new span for others.
             const auto newParamsSpan = _params.subspan(std::min(offset, _params.size()));
             const auto newSubParamRangesSpan = _subParamRanges.subspan(std::min(offset, _subParamRanges.size()));
-            return { newParamsSpan, _subParams, newSubParamRangesSpan };
+            return { newParamsSpan, _subParams , newSubParamRangesSpan };
         }
 
-        std::span<const VTParameter> subParamsFor(const size_t index) const noexcept
+        VTSubParameters subParamsFor(const size_t index) const noexcept
         {
             if (index < _subParamRanges.size())
             {
@@ -212,7 +254,7 @@ namespace Microsoft::Console::VirtualTerminal
             }
             else
             {
-                return std::span<const VTParameter>{};
+                return VTSubParameters{};
             }
         }
 
@@ -259,7 +301,7 @@ namespace Microsoft::Console::VirtualTerminal
         static constexpr std::span defaultParameters{ &defaultParameter, 1 };
 
         std::span<const VTParameter> _params;
-        std::span<const VTParameter> _subParams;
+        VTSubParameters _subParams;
         std::span<const std::pair<BYTE, BYTE>> _subParamRanges;
     };
 

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -301,7 +301,7 @@ namespace Microsoft::Console::VirtualTerminal
                                     const size_t optionIndex,
                                     TextAttribute& attr) noexcept;
         void _ApplyGraphicsOptionSubParam(const VTParameter option,
-                                          const std::span<const VTParameter> subParams,
+                                          const VTSubParameters subParams,
                                           TextAttribute& attr) noexcept;
         void _ApplyGraphicsOptions(const VTParameters options,
                                    TextAttribute& attr) noexcept;

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -294,12 +294,16 @@ namespace Microsoft::Console::VirtualTerminal
 
         SgrStack _sgrStack;
 
+        bool _CanAcceptSubParam(const VTInt param) const noexcept;
         size_t _SetRgbColorsHelper(const VTParameters options,
                                    TextAttribute& attr,
                                    const bool isForeground) noexcept;
         size_t _ApplyGraphicsOption(const VTParameters options,
                                     const size_t optionIndex,
                                     TextAttribute& attr) noexcept;
+        void _ApplyGraphicsOptionSubParam(const VTParameter option,
+                                          const std::span<const VTParameter> subParams,
+                                          TextAttribute& attr) noexcept;
         void _ApplyGraphicsOptions(const VTParameters options,
                                    TextAttribute& attr) noexcept;
 

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -294,7 +294,6 @@ namespace Microsoft::Console::VirtualTerminal
 
         SgrStack _sgrStack;
 
-        bool _CanAcceptSubParam(const VTInt param) const noexcept;
         size_t _SetRgbColorsHelper(const VTParameters options,
                                    TextAttribute& attr,
                                    const bool isForeground) noexcept;

--- a/src/terminal/adapter/adaptDispatchGraphics.cpp
+++ b/src/terminal/adapter/adaptDispatchGraphics.cpp
@@ -64,6 +64,7 @@ size_t AdaptDispatch::_SetRgbColorsHelper(const VTParameters options,
 
 // Routine Description:
 // - Helper to apply a single graphic rendition option to an attribute.
+// - Calls appropriate helper to apply the option with sub parameters when necessary.
 // Arguments:
 // - options - An array of options.
 // - optionIndex - The start index of the option that will be applied.
@@ -75,6 +76,14 @@ size_t AdaptDispatch::_ApplyGraphicsOption(const VTParameters options,
                                            TextAttribute& attr) noexcept
 {
     const GraphicsOptions opt = options.at(optionIndex);
+
+    if (options.hasSubParamsFor(optionIndex))
+    {
+        const auto subParams = options.subParamsFor(optionIndex);
+        _ApplyGraphicsOptionSubParam(opt, subParams, attr);
+        return 1;
+    }
+
     switch (opt)
     {
     case Off:
@@ -279,15 +288,7 @@ void AdaptDispatch::_ApplyGraphicsOptions(const VTParameters options,
 {
     for (size_t i = 0; i < options.size();)
     {
-        if (options.hasSubParamsFor(i))
-        {
-            _ApplyGraphicsOptionSubParam(options.at(i), options.subParamsFor(i), attr);
-            i += 1;
-        }
-        else
-        {
-            i += _ApplyGraphicsOption(options, i, attr);
-        }
+        i += _ApplyGraphicsOption(options, i, attr);
     }
 }
 

--- a/src/terminal/adapter/adaptDispatchGraphics.cpp
+++ b/src/terminal/adapter/adaptDispatchGraphics.cpp
@@ -21,7 +21,7 @@ using namespace Microsoft::Console::VirtualTerminal::DispatchTypes;
 // - True, if it accepts sub parameters, or else False.
 bool AdaptDispatch::_CanAcceptSubParam(const VTInt /* param */) const noexcept
 {
-    // This is how we would've implemented it if we had sub parameters.
+    // This is how we would have implemented it if we had sub parameters.
     /*  
     using enum DispatchTypes::GraphicsOptionsWithSubParams;
     switch (param)

--- a/src/terminal/adapter/adaptDispatchGraphics.cpp
+++ b/src/terminal/adapter/adaptDispatchGraphics.cpp
@@ -269,7 +269,6 @@ void AdaptDispatch::_ApplyGraphicsOptionSubParam(const VTParameter /* option */,
 
 // Routine Description:
 // - Helper to apply a number of graphic rendition options to an attribute.
-// - Applies the changes iff all the options are valid.
 // Arguments:
 // - options - An array of options that will be applied in sequence.
 // - attr - The attribute that will be updated with the applied options.

--- a/src/terminal/adapter/adaptDispatchGraphics.cpp
+++ b/src/terminal/adapter/adaptDispatchGraphics.cpp
@@ -268,7 +268,7 @@ size_t AdaptDispatch::_ApplyGraphicsOption(const VTParameters options,
 // Return Value:
 // - <None>
 void AdaptDispatch::_ApplyGraphicsOptionSubParam(const VTParameter /* option */,
-                                                 const std::span<const VTParameter> /* subParam */,
+                                                 const VTSubParameters /* subParam */,
                                                  TextAttribute& /* attr */) noexcept
 {
     // here, we apply our "best effort" rule, while handling sub params if we don't

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -1118,8 +1118,7 @@ bool OutputStateMachineEngine::_CanSeqAcceptSubParam(const VTID id, const VTPara
         return true;
     case DECCARA_ChangeAttributesRectangularArea:
     case DECRARA_ReverseAttributesRectangularArea:
-        return !parameters.isParameterOmitted()
-               && !parameters.hasSubParamsFor(0) 
+        return !parameters.hasSubParamsFor(0) 
                && !parameters.hasSubParamsFor(1)
                && !parameters.hasSubParamsFor(2)
                && !parameters.hasSubParamsFor(3);

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -417,7 +417,7 @@ bool OutputStateMachineEngine::ActionVt52EscDispatch(const VTID id, const VTPara
 bool OutputStateMachineEngine::ActionCsiDispatch(const VTID id, const VTParameters parameters)
 {
     // Bail out if we receive subparameters, but we don't accept them in the sequence.
-    if (parameters.hasSubParams() && !_CanSeqAcceptSubParam(id)) [[unlikely]]
+    if (parameters.hasSubParams() && !_CanSeqAcceptSubParam(id, parameters)) [[unlikely]]
     {
         return false;
     }
@@ -1110,9 +1110,22 @@ bool OutputStateMachineEngine::_GetOscSetClipboard(const std::wstring_view strin
 // - id - The sequence id to check for.
 // Return Value:
 // - True, if it accepts sub parameters or else False.
-bool OutputStateMachineEngine::_CanSeqAcceptSubParam(const VTID id) noexcept
+bool OutputStateMachineEngine::_CanSeqAcceptSubParam(const VTID id, const VTParameters& parameters) noexcept
 {
-    return id == CsiActionCodes::SGR_SetGraphicsRendition;
+    switch (id)
+    {
+    case SGR_SetGraphicsRendition:
+        return true;
+    case DECCARA_ChangeAttributesRectangularArea:
+    case DECRARA_ReverseAttributesRectangularArea:
+        return !parameters.isParameterOmitted()
+               && !parameters.hasSubParamsFor(0) 
+               && !parameters.hasSubParamsFor(1)
+               && !parameters.hasSubParamsFor(2)
+               && !parameters.hasSubParamsFor(3);
+    default:
+        return false;
+    }
 }
 
 // Method Description:

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -1105,7 +1105,7 @@ bool OutputStateMachineEngine::_GetOscSetClipboard(const std::wstring_view strin
 }
 
 // Routine Description:
-// - Takes a sequence id (parameter) and determines if it accepts sub parameters.
+// - Takes a sequence id ("final byte") and determines if it accepts sub parameters.
 // Arguments:
 // - id - The sequence id to check for.
 // Return Value:

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -416,6 +416,12 @@ bool OutputStateMachineEngine::ActionVt52EscDispatch(const VTID id, const VTPara
 // - true iff we successfully dispatched the sequence.
 bool OutputStateMachineEngine::ActionCsiDispatch(const VTID id, const VTParameters parameters)
 {
+    // Bail out if we receive subparameters, but we don't accept them in the sequence.
+    if (parameters.hasSubParams() && !_CanSeqAcceptSubParam(id)) [[unlikely]]
+    {
+        return false;
+    }
+
     auto success = false;
 
     switch (id)
@@ -1096,6 +1102,17 @@ bool OutputStateMachineEngine::_GetOscSetClipboard(const std::wstring_view strin
 // Log_IfFailed has the following description: "Should be decorated WI_NOEXCEPT, but conflicts with forceinline."
 #pragma warning(suppress : 26447) // The function is declared 'noexcept' but calls function 'Log_IfFailed()' which may throw exceptions (f.6).
     return SUCCEEDED_LOG(Base64::Decode(substr, content));
+}
+
+// Routine Description:
+// - Takes a sequence id (parameter) and determines if it accepts sub parameters.
+// Arguments:
+// - id - The sequence id to check for.
+// Return Value:
+// - True, if it accepts sub parameters or else False.
+bool OutputStateMachineEngine::_CanSeqAcceptSubParam(const VTID id) noexcept
+{
+    return id == CsiActionCodes::SGR_SetGraphicsRendition;
 }
 
 // Method Description:

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -1118,10 +1118,7 @@ bool OutputStateMachineEngine::_CanSeqAcceptSubParam(const VTID id, const VTPara
         return true;
     case DECCARA_ChangeAttributesRectangularArea:
     case DECRARA_ReverseAttributesRectangularArea:
-        return !parameters.hasSubParamsFor(0) 
-               && !parameters.hasSubParamsFor(1)
-               && !parameters.hasSubParamsFor(2)
-               && !parameters.hasSubParamsFor(3);
+        return !parameters.hasSubParamsFor(0) && !parameters.hasSubParamsFor(1) && !parameters.hasSubParamsFor(2) && !parameters.hasSubParamsFor(3);
     default:
         return false;
     }

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -236,7 +236,7 @@ namespace Microsoft::Console::VirtualTerminal
                              std::wstring& params,
                              std::wstring& uri) const;
 
-        bool _CanSeqAcceptSubParam(const VTID id) noexcept;
+        bool _CanSeqAcceptSubParam(const VTID id, const VTParameters& parameters) noexcept;
 
         void _ClearLastChar() noexcept;
     };

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -236,6 +236,8 @@ namespace Microsoft::Console::VirtualTerminal
                              std::wstring& params,
                              std::wstring& uri) const;
 
+        bool _CanSeqAcceptSubParam(const VTID id) noexcept;
+
         void _ClearLastChar() noexcept;
     };
 }

--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -527,6 +527,7 @@ void StateMachine::_ActionParam(const wchar_t wch)
                 // Otherwise move to next param.
                 _parameters.push_back({});
                 _subParameterCounter = 0;
+                _subParameterLimitOverflowed = false;
                 const auto rangeStart = gsl::narrow<BYTE>(_subParameters.size());
                 _subParameterRanges.push_back({ rangeStart, rangeStart });
             }

--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -559,7 +559,6 @@ void StateMachine::_ActionSubParam(const wchar_t wch)
             _parameters.push_back({});
             const auto rangeStart = gsl::narrow<BYTE>(_subParameters.size());
             _subParameterRanges.push_back({ rangeStart, rangeStart });
-
         }
 
         // On a delimiter, increase the number of sub params we've seen.

--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -17,6 +17,7 @@ StateMachine::StateMachine(std::unique_ptr<IStateMachineEngine> engine, const bo
     _trace(Microsoft::Console::VirtualTerminal::ParserTracing()),
     _parameters{},
     _parameterLimitReached(false),
+    _subParameterLimitReached(false),
     _oscString{},
     _cachedSequence{ std::nullopt }
 {
@@ -538,8 +539,10 @@ void StateMachine::_ActionParam(const wchar_t wch)
 }
 
 // Routine Description:
-// - Triggers the SubParam action to indicate that the state machine should store this character as a part of a sub-parameter
-//   to a control sequence.
+// - Triggers the SubParam action to indicate that the state machine should 
+//   store this character as a part of a sub-parameter to a control sequence.
+// - Assumes that enough checks have been made to handle a new sub parameter,
+//   for eg., checking if sub parameter limit is not reached.
 // Arguments:
 // - wch - Character to dispatch.
 // Return Value:
@@ -547,38 +550,20 @@ void StateMachine::_ActionParam(const wchar_t wch)
 void StateMachine::_ActionSubParam(const wchar_t wch)
 {
     _trace.TraceOnAction(L"SubParam");
-
-    // Once we've reached the sub-parameter limit, additional sub-parameters are ignored.
-    if (!_subParameterLimitReached)
+    if (_isSubParameterDelimiter(wch))
     {
-        // On a delimiter, increase the number of sub-params we've seen.
-        // "Empty" sub-params should still count as a sub-param -
-        //      eg "\x1b[38:2::m" should be three sub-params
-        if (_isSubParameterDelimiter(wch))
-        {
-            // If we receive a delimiter after we've already accumulated the
-            // maximum allowed sub-parameters, then we need to set a flag to
-            // indicate that further sub-parameter characters should be ignored.
-            if (_subParameters.size() >= MAX_SUBPARAMETER_COUNT)
-            {
-                _subParameterLimitReached = true;
-            }
-            else
-            {
-                // Otherwise move to next sub-param.
-                _subParameters.push_back({});
-                // increment current range's end index.
-                _subParameterRanges.back().second++;
-            }
-        }
-        else
-        {
-            // Accumulate the character given into the last (current) sub-parameter.
-            // If the value hasn't been initialized yet, it'll start as 0.
-            auto currentParameter = _subParameters.back().value_or(0);
-            _AccumulateTo(wch, currentParameter);
-            _subParameters.back() = currentParameter;
-        }
+        // Otherwise move to next sub-param.
+        _subParameters.push_back({});
+        // increment current range's end index.
+        _subParameterRanges.back().second++;
+    }
+    else
+    {
+        // Accumulate the character given into the last (current) sub-parameter.
+        // If the value hasn't been initialized yet, it'll start as 0.
+        auto currentSubParameter = _subParameters.back().value_or(0);
+        _AccumulateTo(wch, currentSubParameter);
+        _subParameters.back() = currentSubParameter;
     }
 }
 
@@ -613,13 +598,26 @@ void StateMachine::_ActionClear()
 // Routine Description:
 // - Triggers the Ignore action to indicate that the state machine should eat this character and say nothing.
 // Arguments:
-// - wch - Character to dispatch.
+// - <none>
 // Return Value:
 // - <none>
 void StateMachine::_ActionIgnore() noexcept
 {
     // do nothing.
     _trace.TraceOnAction(L"Ignore");
+}
+
+// Routine Description:
+// - Triggers the ParamIgnore action to indicate that the state machine should eat this character and say nothing.
+// Arguments:
+// - <none>
+// Return Value:
+// - <none>
+void StateMachine::_ActionParamIgnore() noexcept
+{
+    _trace.TraceOnAction(L"ParamIgnore");
+    _parameters.pop_back();
+    _subParameterRanges.pop_back();
 }
 
 // Routine Description:
@@ -830,6 +828,22 @@ void StateMachine::_EnterCsiIgnore() noexcept
 {
     _state = VTStates::CsiIgnore;
     _trace.TraceStateChange(L"CsiIgnore");
+}
+
+// Routine Description:
+// - Moves the state machine into the CsiParamIgnore state.
+//   This state is entered:
+//   1. When we couldn't handle a character in CSI sequence because sub parameter limit is reached,
+//      indicating we should ignore the parameter along with its sub parameter(s).
+//      (From CsiParam, CsiSubParam states.)
+// Arguments:
+// - <none>
+// Return Value:
+// - <none>
+void StateMachine::_EnterCsiParamIgnore() noexcept
+{
+    _state = VTStates::CsiParamIgnore;
+    _trace.TraceStateChange(L"CsiParamIgnore");
 }
 
 // Routine Description:
@@ -1311,6 +1325,54 @@ void StateMachine::_EventCsiIgnore(const wchar_t wch)
 }
 
 // Routine Description:
+// - Processes a character event into an Action that occurs while in the CsiParamIgnore state.
+//   Events in this state will:
+//   1. Ignore C0 control characters
+//   2. Ignore Delete characters
+//   3. Ignore Intermediate characters
+//   4. Store parameter data
+//   5. Ignore sub parameter data
+//   6. Ignore intermediate invalid characters
+//   7. Return to Ground
+// Arguments:
+// - wch - Character that triggered the event
+// Return Value:
+// - <none>
+void StateMachine::_EventCsiParamIgnore(const wchar_t wch)
+{
+    _trace.TraceOnEvent(L"CsiParamIgnore");
+    if (_isC0Code(wch))
+    {
+        _ActionIgnore();
+    }
+    else if (_isDelete(wch))
+    {
+        _ActionIgnore();
+    }
+    else if (_isParameterDelimiter(wch))
+    {
+        _ActionParam(wch);
+        _EnterCsiParam();
+    }
+    else if (_isNumericParamValue(wch) || _isSubParameterDelimiter(wch))
+    {
+        _ActionIgnore();
+    }
+    else if (_isIntermediate(wch))
+    {
+        _ActionIgnore();
+    }
+    else if (_isIntermediateInvalid(wch))
+    {
+        _ActionIgnore();
+    }
+    else
+    {
+        _EnterGround();
+    }
+}
+
+// Routine Description:
 // - Processes a character event into an Action that occurs while in the CsiParam state.
 //   Events in this state will:
 //   1. Execute C0 control characters
@@ -1318,7 +1380,9 @@ void StateMachine::_EventCsiIgnore(const wchar_t wch)
 //   3. Collect Intermediate characters
 //   4. Begin to ignore all remaining parameters when an invalid character is detected (CsiIgnore)
 //   5. Store parameter data
-//   6. Store sub parameter data
+//   6. Handle sub parameter:
+//      6.1. Store the sub param if the sub parameter limit is not reached.
+//      6.2. Else, ignore the latest parameter and its sub parameter(s) by entering CsiParamIgnore.
 //   7. Dispatch a control sequence with parameters for action
 // Arguments:
 // - wch - Character that triggered the event
@@ -1341,8 +1405,16 @@ void StateMachine::_EventCsiParam(const wchar_t wch)
     }
     else if (_isSubParameterDelimiter(wch))
     {
-        _ActionSubParam(wch);
-        _EnterCsiSubParam();
+        if (_CanHandleSubParam())
+        {
+            _ActionSubParam(wch);
+            _EnterCsiSubParam();
+        }
+        else
+        {
+            _ActionParamIgnore();
+            _EnterCsiParamIgnore();
+        }
     }
     else if (_isIntermediate(wch))
     {
@@ -1366,11 +1438,14 @@ void StateMachine::_EventCsiParam(const wchar_t wch)
 //   Events in this state will:
 //   1. Execute C0 control characters
 //   2. Ignore Delete characters
-//   3. Store sub parameter data
-//   4. Store parameter data
-//   5. Collect Intermediate characters for parameter.
-//   6. Begin to ignore all remaining parameters when an invalid character is detected (CsiIgnore)
-//   7. Dispatch a control sequence with parameters for action
+//   3. Store sub parameter digit.
+//   4. Handle new sub param:
+//      4.1. Store the sub param if the sub parameter limit is not reached.
+//      4.2. Else, ignore the latest parameter and its sub parameter(s) by entering CsiParamIgnore.
+//   5. Store parameter data
+//   6. Collect Intermediate characters for parameter.
+//   7. Begin to ignore all remaining parameters when an invalid character is detected (CsiIgnore)
+//   8. Dispatch a control sequence with parameters for action
 // Arguments:
 // - wch - Character that triggered the event
 // Return Value:
@@ -1386,9 +1461,22 @@ void StateMachine::_EventCsiSubParam(const wchar_t wch)
     {
         _ActionIgnore();
     }
-    else if (_isNumericParamValue(wch) || _isSubParameterDelimiter(wch))
+    else if (_isNumericParamValue(wch))
     {
         _ActionSubParam(wch);
+    }
+    else if (_isSubParameterDelimiter(wch))
+    {
+        if (_CanHandleSubParam())
+        {
+            _ActionSubParam(wch);
+            _EnterCsiSubParam();
+        }
+        else
+        {
+            _ActionParamIgnore();
+            _EnterCsiParamIgnore();
+        }
     }
     else if (_isParameterDelimiter(wch))
     {
@@ -1864,6 +1952,8 @@ void StateMachine::ProcessCharacter(const wchar_t wch)
             return _EventCsiParam(wch);
         case VTStates::CsiSubParam:
             return _EventCsiSubParam(wch);
+        case VTStates::CsiParamIgnore:
+            return _EventCsiParamIgnore(wch);
         case VTStates::OscParam:
             return _EventOscParam(wch);
         case VTStates::OscString:
@@ -2155,6 +2245,8 @@ void StateMachine::ProcessString(const std::wstring_view string)
             case VTStates::CsiIntermediate:
             case VTStates::CsiIgnore:
             case VTStates::CsiParam:
+            case VTStates::CsiSubParam:
+            case VTStates::CsiParamIgnore:
                 _ActionCsiDispatch(*wchIter);
                 break;
             case VTStates::OscParam:
@@ -2248,6 +2340,13 @@ void StateMachine::_AccumulateTo(const wchar_t wch, VTInt& value) noexcept
     {
         value = MAX_PARAMETER_VALUE;
     }
+}
+
+bool StateMachine::_CanHandleSubParam() noexcept
+{
+    // Lazily check if limit is reached.
+    _subParameterLimitReached = _subParameterLimitReached || (_subParameters.size() >= MAX_SUBPARAMETER_COUNT);
+    return !_subParameterLimitReached;
 }
 
 template<typename TLambda>

--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -169,7 +169,7 @@ static constexpr bool _isSubParameterDelimiter(const wchar_t wch) noexcept
 }
 
 // Routine Description:
-// - Determines if a character is "control sequence" beginning indicator.
+// - Determines if a character is a "control sequence" beginning indicator.
 //   This immediately follows an escape and signifies a varying length control sequence.
 // Arguments:
 // - wch - Character to check.
@@ -466,7 +466,7 @@ void StateMachine::_ActionCsiDispatch(const wchar_t wch)
     _trace.TraceOnAction(L"CsiDispatch");
     _trace.DispatchSequenceTrace(_SafeExecute([=]() {
         return _engine->ActionCsiDispatch(_identifier.Finalize(wch),
-                                          { _parameters.data(), _parameters.size(), _subParameters.data(), _subParameters.size(), _subParametersRange.data(), _subParametersRange.size() });
+                                          { _parameters.data(), _parameters.size(), _subParameters.data(), _subParameters.size(), _subParameterRanges.data(), _subParameterRanges.size() });
     }));
 }
 
@@ -502,8 +502,8 @@ void StateMachine::_ActionParam(const wchar_t wch)
         if (_parameters.empty())
         {
             _parameters.push_back({});
-            auto rangeStart = gsl::narrow<BYTE>(_subParameters.size());
-            _subParametersRange.push_back({ rangeStart, rangeStart });
+            const auto rangeStart = gsl::narrow<BYTE>(_subParameters.size());
+            _subParameterRanges.push_back({ rangeStart, rangeStart });
         }
 
         // On a delimiter, increase the number of params we've seen.
@@ -522,8 +522,8 @@ void StateMachine::_ActionParam(const wchar_t wch)
             {
                 // Otherwise move to next param.
                 _parameters.push_back({});
-                auto rangeStart = gsl::narrow<BYTE>(_subParameters.size());
-                _subParametersRange.push_back({ rangeStart, rangeStart });
+                const auto rangeStart = gsl::narrow<BYTE>(_subParameters.size());
+                _subParameterRanges.push_back({ rangeStart, rangeStart });
             }
         }
         else
@@ -568,7 +568,7 @@ void StateMachine::_ActionSubParam(const wchar_t wch)
                 // Otherwise move to next sub-param.
                 _subParameters.push_back({});
                 // increment current range's end index.
-                _subParametersRange.back().second++;
+                _subParameterRanges.back().second++;
             }
         }
         else
@@ -599,7 +599,7 @@ void StateMachine::_ActionClear()
     _parameterLimitReached = false;
 
     _subParameters.clear();
-    _subParametersRange.clear();
+    _subParameterRanges.clear();
     _subParameterLimitReached = false;
 
     _oscString.clear();

--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -16,10 +16,13 @@ StateMachine::StateMachine(std::unique_ptr<IStateMachineEngine> engine, const bo
     _state(VTStates::Ground),
     _trace(Microsoft::Console::VirtualTerminal::ParserTracing()),
     _parameters{},
+    _subParameters{},
+    _subParameterRanges{},
     _parameterLimitReached(false),
     _subParameterLimitReached(false),
     _oscString{},
-    _cachedSequence{ std::nullopt }
+    _cachedSequence{ std::nullopt },
+    _isParameterOmitted{false}
 {
     _ActionClear();
 }
@@ -467,7 +470,7 @@ void StateMachine::_ActionCsiDispatch(const wchar_t wch)
     _trace.TraceOnAction(L"CsiDispatch");
     _trace.DispatchSequenceTrace(_SafeExecute([=]() {
         return _engine->ActionCsiDispatch(_identifier.Finalize(wch),
-                                          { _parameters, _subParameters, _subParameterRanges });
+                                          { _parameters, _subParameters, _subParameterRanges, _isParameterOmitted  });
     }));
 }
 
@@ -582,6 +585,7 @@ void StateMachine::_ActionClear()
 
     _parameters.clear();
     _parameterLimitReached = false;
+    _isParameterOmitted = false;
 
     _subParameters.clear();
     _subParameterRanges.clear();
@@ -616,6 +620,7 @@ void StateMachine::_ActionIgnore() noexcept
 void StateMachine::_ActionParamIgnore() noexcept
 {
     _trace.TraceOnAction(L"ParamIgnore");
+    _isParameterOmitted = false;
     _parameters.pop_back();
     _subParameterRanges.pop_back();
 }

--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -506,7 +506,7 @@ void StateMachine::_ActionParam(const wchar_t wch)
         if (_parameters.empty())
         {
             _parameters.push_back({});
-            const auto rangeStart = gsl::narrow<BYTE>(_subParameters.size());
+            const auto rangeStart = gsl::narrow_cast<BYTE>(_subParameters.size());
             _subParameterRanges.push_back({ rangeStart, rangeStart });
         }
 
@@ -528,7 +528,7 @@ void StateMachine::_ActionParam(const wchar_t wch)
                 _parameters.push_back({});
                 _subParameterCounter = 0;
                 _subParameterLimitOverflowed = false;
-                const auto rangeStart = gsl::narrow<BYTE>(_subParameters.size());
+                const auto rangeStart = gsl::narrow_cast<BYTE>(_subParameters.size());
                 _subParameterRanges.push_back({ rangeStart, rangeStart });
             }
         }
@@ -561,7 +561,7 @@ void StateMachine::_ActionSubParam(const wchar_t wch)
         if (_parameters.empty())
         {
             _parameters.push_back({});
-            const auto rangeStart = gsl::narrow<BYTE>(_subParameters.size());
+            const auto rangeStart = gsl::narrow_cast<BYTE>(_subParameters.size());
             _subParameterRanges.push_back({ rangeStart, rangeStart });
         }
 

--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -575,7 +575,7 @@ void StateMachine::_ActionSubParam(const wchar_t wch)
             // should be ignored.
             if (_subParameterCounter >= MAX_SUBPARAMETER_COUNT)
             {
-                _parameterLimitOverflowed = true;
+                _subParameterLimitOverflowed = true;
             }
             else
             {

--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -466,7 +466,7 @@ void StateMachine::_ActionCsiDispatch(const wchar_t wch)
     _trace.TraceOnAction(L"CsiDispatch");
     _trace.DispatchSequenceTrace(_SafeExecute([=]() {
         return _engine->ActionCsiDispatch(_identifier.Finalize(wch),
-                                          { _parameters.data(), _parameters.size(), _subParameters.data(), _subParameters.size(), _subParameterRanges.data(), _subParameterRanges.size() });
+                                          { _parameters, _subParameters, _subParameterRanges });
     }));
 }
 

--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -502,7 +502,7 @@ void StateMachine::_ActionParam(const wchar_t wch)
         if (_parameters.empty())
         {
             _parameters.push_back({});
-            auto rangeStart = static_cast<BYTE>(_subParameters.size());
+            auto rangeStart = gsl::narrow<BYTE>(_subParameters.size());
             _subParametersRange.push_back({ rangeStart, rangeStart });
         }
 
@@ -522,7 +522,7 @@ void StateMachine::_ActionParam(const wchar_t wch)
             {
                 // Otherwise move to next param.
                 _parameters.push_back({});
-                auto rangeStart = static_cast<BYTE>(_subParameters.size());
+                auto rangeStart = gsl::narrow<BYTE>(_subParameters.size());
                 _subParametersRange.push_back({ rangeStart, rangeStart });
             }
         }

--- a/src/terminal/parser/stateMachine.cpp
+++ b/src/terminal/parser/stateMachine.cpp
@@ -2170,7 +2170,6 @@ void StateMachine::ProcessString(const std::wstring_view string)
             case VTStates::CsiIgnore:
             case VTStates::CsiParam:
             case VTStates::CsiSubParam:
-            case VTStates::CsiParamIgnore:
                 _ActionCsiDispatch(*wchIter);
                 break;
             case VTStates::OscParam:

--- a/src/terminal/parser/stateMachine.hpp
+++ b/src/terminal/parser/stateMachine.hpp
@@ -197,7 +197,7 @@ namespace Microsoft::Console::VirtualTerminal
         std::vector<VTParameter> _parameters;
         bool _parameterLimitReached;
         std::vector<VTParameter> _subParameters;
-        std::vector<std::pair<BYTE /*range start*/, BYTE /*range end*/>> _subParametersRange;
+        std::vector<std::pair<BYTE /*range start*/, BYTE /*range end*/>> _subParameterRanges;
         bool _subParameterLimitReached;
 
         std::wstring _oscString;

--- a/src/terminal/parser/stateMachine.hpp
+++ b/src/terminal/parser/stateMachine.hpp
@@ -30,6 +30,7 @@ namespace Microsoft::Console::VirtualTerminal
     // are supported, but most modern terminal emulators will allow around twice
     // that number.
     constexpr size_t MAX_PARAMETER_COUNT = 32;
+    constexpr size_t MAX_SUBPARAMETER_COUNT = 32;
 
     class StateMachine final
     {
@@ -85,6 +86,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _ActionVt52EscDispatch(const wchar_t wch);
         void _ActionCollect(const wchar_t wch) noexcept;
         void _ActionParam(const wchar_t wch);
+        void _ActionSubParam(const wchar_t wch);
         void _ActionCsiDispatch(const wchar_t wch);
         void _ActionOscParam(const wchar_t wch) noexcept;
         void _ActionOscPut(const wchar_t wch);
@@ -101,6 +103,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _EnterEscapeIntermediate() noexcept;
         void _EnterCsiEntry();
         void _EnterCsiParam() noexcept;
+        void _EnterCsiSubParam() noexcept;
         void _EnterCsiIgnore() noexcept;
         void _EnterCsiIntermediate() noexcept;
         void _EnterOscParam() noexcept;
@@ -123,6 +126,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _EventCsiIntermediate(const wchar_t wch);
         void _EventCsiIgnore(const wchar_t wch);
         void _EventCsiParam(const wchar_t wch);
+        void _EventCsiSubParam(const wchar_t wch);
         void _EventOscParam(const wchar_t wch) noexcept;
         void _EventOscString(const wchar_t wch);
         void _EventOscTermination(const wchar_t wch);
@@ -152,6 +156,7 @@ namespace Microsoft::Console::VirtualTerminal
             CsiIntermediate,
             CsiIgnore,
             CsiParam,
+            CsiSubParam,
             OscParam,
             OscString,
             OscTermination,
@@ -191,6 +196,9 @@ namespace Microsoft::Console::VirtualTerminal
         VTIDBuilder _identifier;
         std::vector<VTParameter> _parameters;
         bool _parameterLimitReached;
+        std::vector<VTParameter> _subParameters;
+        std::vector<std::pair<BYTE /*range start*/, BYTE /*range end*/>> _subParametersRange;
+        bool _subParameterLimitReached;
 
         std::wstring _oscString;
         VTInt _oscParameter;

--- a/src/terminal/parser/stateMachine.hpp
+++ b/src/terminal/parser/stateMachine.hpp
@@ -96,6 +96,7 @@ namespace Microsoft::Console::VirtualTerminal
 
         void _ActionClear();
         void _ActionIgnore() noexcept;
+        void _ActionParamIgnore() noexcept;
         void _ActionInterrupt();
 
         void _EnterGround() noexcept;
@@ -103,6 +104,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _EnterEscapeIntermediate() noexcept;
         void _EnterCsiEntry();
         void _EnterCsiParam() noexcept;
+        void _EnterCsiParamIgnore() noexcept;
         void _EnterCsiSubParam() noexcept;
         void _EnterCsiIgnore() noexcept;
         void _EnterCsiIntermediate() noexcept;
@@ -125,6 +127,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _EventCsiEntry(const wchar_t wch);
         void _EventCsiIntermediate(const wchar_t wch);
         void _EventCsiIgnore(const wchar_t wch);
+        void _EventCsiParamIgnore(const wchar_t wch);
         void _EventCsiParam(const wchar_t wch);
         void _EventCsiSubParam(const wchar_t wch);
         void _EventOscParam(const wchar_t wch) noexcept;
@@ -141,6 +144,7 @@ namespace Microsoft::Console::VirtualTerminal
         void _EventSosPmApcString(const wchar_t wch) noexcept;
 
         void _AccumulateTo(const wchar_t wch, VTInt& value) noexcept;
+        bool _CanHandleSubParam() noexcept;
 
         template<typename TLambda>
         bool _SafeExecute(TLambda&& lambda);
@@ -157,6 +161,7 @@ namespace Microsoft::Console::VirtualTerminal
             CsiIgnore,
             CsiParam,
             CsiSubParam,
+            CsiParamIgnore,
             OscParam,
             OscString,
             OscTermination,

--- a/src/terminal/parser/stateMachine.hpp
+++ b/src/terminal/parser/stateMachine.hpp
@@ -205,6 +205,13 @@ namespace Microsoft::Console::VirtualTerminal
         std::vector<std::pair<BYTE /*range start*/, BYTE /*range end*/>> _subParameterRanges;
         bool _subParameterLimitReached;
 
+        // This flag is used to indicate that some parameters were omitted by the
+        // parser. This could happen if the parser was unable to parse all of the
+        // sub parameters for a given parameter. 
+        // Sequences that are sensitive to parameter omission can use this flag
+        // to determine if any parameters were omitted.
+        bool _isParameterOmitted;
+
         std::wstring _oscString;
         VTInt _oscParameter;
 

--- a/src/terminal/parser/stateMachine.hpp
+++ b/src/terminal/parser/stateMachine.hpp
@@ -96,7 +96,6 @@ namespace Microsoft::Console::VirtualTerminal
 
         void _ActionClear();
         void _ActionIgnore() noexcept;
-        void _ActionParamIgnore() noexcept;
         void _ActionInterrupt();
 
         void _EnterGround() noexcept;
@@ -104,7 +103,6 @@ namespace Microsoft::Console::VirtualTerminal
         void _EnterEscapeIntermediate() noexcept;
         void _EnterCsiEntry();
         void _EnterCsiParam() noexcept;
-        void _EnterCsiParamIgnore() noexcept;
         void _EnterCsiSubParam() noexcept;
         void _EnterCsiIgnore() noexcept;
         void _EnterCsiIntermediate() noexcept;
@@ -127,7 +125,6 @@ namespace Microsoft::Console::VirtualTerminal
         void _EventCsiEntry(const wchar_t wch);
         void _EventCsiIntermediate(const wchar_t wch);
         void _EventCsiIgnore(const wchar_t wch);
-        void _EventCsiParamIgnore(const wchar_t wch);
         void _EventCsiParam(const wchar_t wch);
         void _EventCsiSubParam(const wchar_t wch);
         void _EventOscParam(const wchar_t wch) noexcept;
@@ -144,7 +141,6 @@ namespace Microsoft::Console::VirtualTerminal
         void _EventSosPmApcString(const wchar_t wch) noexcept;
 
         void _AccumulateTo(const wchar_t wch, VTInt& value) noexcept;
-        bool _CanHandleSubParam() noexcept;
 
         template<typename TLambda>
         bool _SafeExecute(TLambda&& lambda);
@@ -200,17 +196,9 @@ namespace Microsoft::Console::VirtualTerminal
 
         VTIDBuilder _identifier;
         std::vector<VTParameter> _parameters;
-        bool _parameterLimitReached;
+        bool _parameterLimitOverflowed;
         std::vector<VTParameter> _subParameters;
         std::vector<std::pair<BYTE /*range start*/, BYTE /*range end*/>> _subParameterRanges;
-        bool _subParameterLimitReached;
-
-        // This flag is used to indicate that some parameters were omitted by the
-        // parser. This could happen if the parser was unable to parse all of the
-        // sub parameters for a given parameter. 
-        // Sequences that are sensitive to parameter omission can use this flag
-        // to determine if any parameters were omitted.
-        bool _isParameterOmitted;
 
         std::wstring _oscString;
         VTInt _oscParameter;

--- a/src/terminal/parser/stateMachine.hpp
+++ b/src/terminal/parser/stateMachine.hpp
@@ -30,7 +30,12 @@ namespace Microsoft::Console::VirtualTerminal
     // are supported, but most modern terminal emulators will allow around twice
     // that number.
     constexpr size_t MAX_PARAMETER_COUNT = 32;
-    constexpr size_t MAX_SUBPARAMETER_COUNT = 32;
+
+    // Sub parameter limit for each parameter.
+    constexpr size_t MAX_SUBPARAMETER_COUNT = 6;
+    // we limit ourself to 256 sub parameters because we use bytes to store
+    // the their indexes.
+    static_assert(MAX_PARAMETER_COUNT * MAX_SUBPARAMETER_COUNT <= 256);
 
     class StateMachine final
     {
@@ -198,6 +203,8 @@ namespace Microsoft::Console::VirtualTerminal
         bool _parameterLimitOverflowed;
         std::vector<VTParameter> _subParameters;
         std::vector<std::pair<BYTE /*range start*/, BYTE /*range end*/>> _subParameterRanges;
+        bool _subParameterLimitOverflowed;
+        BYTE _subParameterCounter;
 
         std::wstring _oscString;
         VTInt _oscParameter;

--- a/src/terminal/parser/stateMachine.hpp
+++ b/src/terminal/parser/stateMachine.hpp
@@ -157,7 +157,6 @@ namespace Microsoft::Console::VirtualTerminal
             CsiIgnore,
             CsiParam,
             CsiSubParam,
-            CsiParamIgnore,
             OscParam,
             OscString,
             OscTermination,

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -437,8 +437,8 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         VERIFY_ARE_EQUAL(mach._subParametersRange.size(), mach._parameters.size());
         VERIFY_IS_TRUE(
             (mach._subParametersRange.back().second == mach._subParameters.size() - 1) // lastIndex
-            || ( mach._subParametersRange.back().second == mach._subParameters.size()) // or lastIndex + 1
-        );  
+            || (mach._subParametersRange.back().second == mach._subParameters.size()) // or lastIndex + 1
+        );
     }
 
     TEST_METHOD(TestCsiMaxSubParamCount)

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -429,15 +429,15 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         VERIFY_IS_FALSE(mach._subParameters.at(1).has_value());
         VERIFY_ARE_EQUAL(mach._subParameters.at(2), 8);
 
-        VERIFY_ARE_EQUAL(mach._subParametersRange.at(0).first, 0);
-        VERIFY_ARE_EQUAL(mach._subParametersRange.at(0).second, 0);
-        VERIFY_ARE_EQUAL(mach._subParametersRange.at(1).first, 0);
-        VERIFY_ARE_EQUAL(mach._subParametersRange.at(1).second, 3);
+        VERIFY_ARE_EQUAL(mach._subParameterRanges.at(0).first, 0);
+        VERIFY_ARE_EQUAL(mach._subParameterRanges.at(0).second, 0);
+        VERIFY_ARE_EQUAL(mach._subParameterRanges.at(1).first, 0);
+        VERIFY_ARE_EQUAL(mach._subParameterRanges.at(1).second, 3);
 
-        VERIFY_ARE_EQUAL(mach._subParametersRange.size(), mach._parameters.size());
+        VERIFY_ARE_EQUAL(mach._subParameterRanges.size(), mach._parameters.size());
         VERIFY_IS_TRUE(
-            (mach._subParametersRange.back().second == mach._subParameters.size() - 1) // lastIndex
-            || (mach._subParametersRange.back().second == mach._subParameters.size()) // or lastIndex + 1
+            (mach._subParameterRanges.back().second == mach._subParameters.size() - 1) // lastIndex
+            || (mach._subParameterRanges.back().second == mach._subParameters.size()) // or lastIndex + 1
         );
     }
 

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -465,6 +465,29 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         mach.ProcessCharacter(L'J');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
 
+        Log::Comment(L"Recieving 100 sub parameters should lead to removal of last parameter");
+        VERIFY_IS_FALSE(mach._parameters.at(0).has_value());
+        Log::Comment(L"Receiving 100 sub parameter should set the overflow flag");
+        VERIFY_IS_TRUE(mach._parameterLimitOverflowed);
+
+        Log::Comment(L"Output a sequence with MAX_SUBPARAMETER_COUNT(32) sub parameters");
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
+        mach.ProcessCharacter(AsciiChars::ESC);
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);
+        mach.ProcessCharacter(L'[');
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiEntry);
+        mach.ProcessCharacter(L'3');
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiParam);
+        for (size_t i = 0; i < MAX_SUBPARAMETER_COUNT; i++)
+        {
+            mach.ProcessCharacter(L':');
+            VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiSubParam);
+            mach.ProcessCharacter(L'0' + i % 10);
+            VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiSubParam);
+        }
+        mach.ProcessCharacter(L'J');
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
+
         Log::Comment(L"Only MAX_SUBPARAMETER_COUNT (32) sub parameters should be stored");
         VERIFY_ARE_EQUAL(mach._subParameters.size(), MAX_SUBPARAMETER_COUNT);
         for (size_t i = 0; i < MAX_SUBPARAMETER_COUNT; i++)

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -483,7 +483,7 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
 
         // Verify that first 6 sub parameters are stored for each parameter.
         // subParameters = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5 }
-        for (size_t i = 0; i < 12 ; i++)
+        for (size_t i = 0; i < 12; i++)
         {
             VERIFY_IS_TRUE(mach._subParameters.at(i).has_value());
             VERIFY_ARE_EQUAL(mach._subParameters.at(i).value(), gsl::narrow_cast<VTInt>(i % 6));

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -465,7 +465,7 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         mach.ProcessCharacter(L'J');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
 
-        Log::Comment(L"Recieving 100 sub parameters should lead to removal of last parameter");
+        Log::Comment(L"Receiving 100 sub parameters should lead to removal of last parameter");
         VERIFY_IS_FALSE(mach._parameters.at(0).has_value());
         Log::Comment(L"Receiving 100 sub parameter should set the overflow flag");
         VERIFY_IS_TRUE(mach._parameterLimitOverflowed);

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -397,18 +397,21 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         auto engine = std::make_unique<OutputStateMachineEngine>(std::move(dispatch));
         StateMachine mach(std::move(engine));
 
+        // "\e[:3;9:5::8J"
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
         mach.ProcessCharacter(AsciiChars::ESC);
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);
         mach.ProcessCharacter(L'[');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiEntry);
-        mach.ProcessCharacter(L';');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiParam);
-        mach.ProcessCharacter(L'3');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiParam);
         mach.ProcessCharacter(L':');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiSubParam);
         mach.ProcessCharacter(L'3');
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiSubParam);
+        mach.ProcessCharacter(L';');
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiParam);
+        mach.ProcessCharacter(L'9');
+        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiParam);
+        mach.ProcessCharacter(L':');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiSubParam);
         mach.ProcessCharacter(L'5');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiSubParam);
@@ -423,16 +426,18 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
 
         VERIFY_ARE_EQUAL(mach._parameters.size(), 2u);
         VERIFY_IS_FALSE(mach._parameters.at(0).has_value());
-        VERIFY_ARE_EQUAL(mach._parameters.at(1), 3);
+        VERIFY_ARE_EQUAL(mach._parameters.at(1), 9);
 
-        VERIFY_ARE_EQUAL(mach._subParameters.at(0), 35);
-        VERIFY_IS_FALSE(mach._subParameters.at(1).has_value());
-        VERIFY_ARE_EQUAL(mach._subParameters.at(2), 8);
+        VERIFY_ARE_EQUAL(mach._subParameters.size(), 4u);
+        VERIFY_ARE_EQUAL(mach._subParameters.at(0), 3);
+        VERIFY_ARE_EQUAL(mach._subParameters.at(1), 5);
+        VERIFY_IS_FALSE(mach._subParameters.at(2).has_value());
+        VERIFY_ARE_EQUAL(mach._subParameters.at(3), 8);
 
         VERIFY_ARE_EQUAL(mach._subParameterRanges.at(0).first, 0);
-        VERIFY_ARE_EQUAL(mach._subParameterRanges.at(0).second, 0);
-        VERIFY_ARE_EQUAL(mach._subParameterRanges.at(1).first, 0);
-        VERIFY_ARE_EQUAL(mach._subParameterRanges.at(1).second, 3);
+        VERIFY_ARE_EQUAL(mach._subParameterRanges.at(0).second, 1);
+        VERIFY_ARE_EQUAL(mach._subParameterRanges.at(1).first, 1);
+        VERIFY_ARE_EQUAL(mach._subParameterRanges.at(1).second, 4);
 
         VERIFY_ARE_EQUAL(mach._subParameterRanges.size(), mach._parameters.size());
         VERIFY_IS_TRUE(
@@ -447,54 +452,46 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         auto engine = std::make_unique<OutputStateMachineEngine>(std::move(dispatch));
         StateMachine mach(std::move(engine));
 
-        Log::Comment(L"Output a sequence with 100 sub parameters");
+        Log::Comment(L"Output two parameters with 100 sub parameters each");
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
         mach.ProcessCharacter(AsciiChars::ESC);
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);
-        mach.ProcessCharacter(L'[');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiEntry);
-        mach.ProcessCharacter(L'3');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiParam);
-        for (size_t i = 0; i < 100; i++)
+        for (size_t nParam = 0; nParam < 2; nParam++)
         {
-            mach.ProcessCharacter(L':');
-            VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiSubParam);
-            mach.ProcessCharacter(L'0' + i % 10);
-            VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiSubParam);
+            mach.ProcessCharacter(L'[');
+            VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiEntry);
+            mach.ProcessCharacter(L'3');
+            VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiParam);
+            for (size_t i = 0; i < 100; i++)
+            {
+                mach.ProcessCharacter(L':');
+                VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiSubParam);
+                mach.ProcessCharacter(L'0' + i % 10);
+                VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiSubParam);
+            }
+            Log::Comment(L"Receiving 100 sub parameters should set the overflow flag");
+            VERIFY_IS_TRUE(mach._subParameterLimitOverflowed);
         }
         mach.ProcessCharacter(L'J');
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
 
-        Log::Comment(L"Receiving 100 sub parameters should lead to removal of last parameter");
-        VERIFY_IS_TRUE(mach._parameters.empty());
-        Log::Comment(L"Receiving 100 sub parameter should set the overflow flag");
-        VERIFY_IS_TRUE(mach._parameterLimitOverflowed);
+        Log::Comment(L"Only MAX_SUBPARAMETER_COUNT (6) sub parameters should be stored for each parameter");
+        VERIFY_ARE_EQUAL(mach._subParameters.size(), 12u);
 
-        Log::Comment(L"Output a sequence with MAX_SUBPARAMETER_COUNT(32) sub parameters");
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
-        mach.ProcessCharacter(AsciiChars::ESC);
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);
-        mach.ProcessCharacter(L'[');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiEntry);
-        mach.ProcessCharacter(L'3');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiParam);
-        for (size_t i = 0; i < MAX_SUBPARAMETER_COUNT; i++)
+        for (size_t nParam = 0; nParam < 2; nParam++)
         {
-            mach.ProcessCharacter(L':');
-            VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiSubParam);
-            mach.ProcessCharacter(L'0' + i % 10);
-            VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiSubParam);
+            for (size_t i = nParam * MAX_SUBPARAMETER_COUNT; i < (nParam + 1) * MAX_SUBPARAMETER_COUNT; i++)
+            {
+                VERIFY_IS_TRUE(mach._subParameters.at(i).has_value());
+                VERIFY_ARE_EQUAL(mach._subParameters.at(i).value(), gsl::narrow_cast<VTInt>(i % 10));
+            }
         }
-        mach.ProcessCharacter(L'J');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
-
-        Log::Comment(L"Only MAX_SUBPARAMETER_COUNT (32) sub parameters should be stored");
-        VERIFY_ARE_EQUAL(mach._subParameters.size(), MAX_SUBPARAMETER_COUNT);
-        for (size_t i = 0; i < MAX_SUBPARAMETER_COUNT; i++)
-        {
-            VERIFY_IS_TRUE(mach._subParameters.at(i).has_value());
-            VERIFY_ARE_EQUAL(mach._subParameters.at(i).value(), gsl::narrow_cast<VTInt>(i % 10));
-        }
+        auto firstRange = mach._subParameterRanges.at(0);
+        auto secondRange = mach._subParameterRanges.at(1);
+        VERIFY_ARE_EQUAL(firstRange.first, 0);
+        VERIFY_ARE_EQUAL(firstRange.second, 6);
+        VERIFY_ARE_EQUAL(secondRange.first, 6);
+        VERIFY_ARE_EQUAL(secondRange.second, 12);
     }
 
     TEST_METHOD(TestLeadingZeroCsiSubParam)

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -457,11 +457,8 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiParam);
         for (size_t i = 0; i < 100; i++)
         {
-            if (i > 0)
-            {
-                mach.ProcessCharacter(L':');
-                VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiSubParam);
-            }
+            mach.ProcessCharacter(L':');
+            VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiSubParam);
             mach.ProcessCharacter(L'0' + i % 10);
             VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiSubParam);
         }

--- a/src/terminal/parser/ut_parser/OutputEngineTest.cpp
+++ b/src/terminal/parser/ut_parser/OutputEngineTest.cpp
@@ -466,7 +466,7 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
 
         Log::Comment(L"Receiving 100 sub parameters should lead to removal of last parameter");
-        VERIFY_IS_FALSE(mach._parameters.at(0).has_value());
+        VERIFY_IS_TRUE(mach._parameters.empty());
         Log::Comment(L"Receiving 100 sub parameter should set the overflow flag");
         VERIFY_IS_TRUE(mach._parameterLimitOverflowed);
 
@@ -532,18 +532,6 @@ class Microsoft::Console::VirtualTerminal::OutputEngineTest final
         auto dispatch = std::make_unique<DummyDispatch>();
         auto engine = std::make_unique<OutputStateMachineEngine>(std::move(dispatch));
         StateMachine mach(std::move(engine));
-
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
-        mach.ProcessCharacter(AsciiChars::ESC);
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);
-        mach.ProcessCharacter(L'[');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiEntry);
-        mach.ProcessCharacter(L':');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiIgnore);
-        mach.ProcessCharacter(L'3');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::CsiIgnore);
-        mach.ProcessCharacter(L'q');
-        VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Ground);
 
         mach.ProcessCharacter(AsciiChars::ESC);
         VERIFY_ARE_EQUAL(mach._state, StateMachine::VTStates::Escape);


### PR DESCRIPTION
Adds support for colon `:` separated sub parameters in parser. Technically, after this PR, nothing should change except, now sub parameters are parsed, stored safely and we don't invalidate the whole sequence when a `:` is received within a parameter substring.

In this PR:
- If sub parameters are detected with a parameter, but the usage is unrecognised, we simply *skip* the parameter in `adaptDispatch`. 
- A separate store for sub parameters is used to avoid too many changes to the codebase.
- We currently allow up to `6` sub parameters for each parameter, extra sub parameters are *ignored*.
- Introduced `VTSubParameters` for easy access to underlying sub parameters.

> **Info**: We don't use sub parameters for any feature yet, this is just the core implementation to support newer usecases.

## Validation Steps Performed
- [x] Use of sub parameters must not have any effect on the output.
- [x] Skip parameters with unexpected set of sub parameters.
- [x] Skip sequences with unexpected set of sub parameters.

References #4321
References #7228
References #15599
References https://github.com/xtermjs/xterm.js/pull/2751
Closes #4321