### PR TITLE
Add more compatibility settings to the Compatibility page

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Compatibility.xaml
@@ -20,7 +20,7 @@
 
     <ScrollViewer ViewChanging="ViewChanging">
         <StackPanel Style="{StaticResource SettingsStackStyle}">
-            <TextBlock x:Uid="Globals_RenderingDisclaimer"
+            <TextBlock x:Uid="Globals_CompatibilityDisclaimer"
                        Style="{StaticResource DisclaimerStyle}" />
 
             <!--  AtlasEngine  -->
@@ -40,6 +40,32 @@
                 <ToggleSwitch IsOn="{x:Bind ViewModel.SoftwareRendering, Mode=TwoWay}"
                               Style="{StaticResource ToggleSwitchInExpanderStyle}" />
             </local:SettingContainer>
+
+            <!--  Environment reloading  -->
+            <local:SettingContainer x:Uid="Globals_ReloadEnvironmentVariables">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.ReloadEnvironmentVariables, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
+
+            <!--  Headless mode  -->
+            <local:SettingContainer x:Uid="Globals_AllowHeadless">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.AllowHeadless, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
+
+            <!--  Isolated Mode mode  -->
+            <local:SettingContainer x:Uid="Globals_IsolatedMode">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.IsolatedMode, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
+
+            <!--  Shell Completions  -->
+            <local:SettingContainer x:Uid="Globals_EnableShellCompletionMenu"
+                                    Visibility="{x:Bind ViewModel.ShellCompletionMenuAvailable}">
+                <ToggleSwitch IsOn="{x:Bind ViewModel.EnableShellCompletionMenu, Mode=TwoWay}"
+                              Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+            </local:SettingContainer>
+
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/src/cascadia/TerminalSettingsEditor/CompatibilityViewModel.cpp
+++ b/src/cascadia/TerminalSettingsEditor/CompatibilityViewModel.cpp
@@ -14,4 +14,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         _settings{ std::move(settings) }
     {
     }
+
+    bool CompatibilityViewModel::ShellCompletionMenuAvailable() const noexcept
+    {
+        return Feature_ShellCompletions::IsEnabled();
+    }
 }

--- a/src/cascadia/TerminalSettingsEditor/CompatibilityViewModel.h
+++ b/src/cascadia/TerminalSettingsEditor/CompatibilityViewModel.h
@@ -12,9 +12,16 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
     {
         explicit CompatibilityViewModel(Model::CascadiaSettings settings) noexcept;
 
+        bool ShellCompletionMenuAvailable() const noexcept;
+
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_settings.ProfileDefaults(), UseAtlasEngine);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_settings.GlobalSettings(), ForceFullRepaintRendering);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(_settings.GlobalSettings(), SoftwareRendering);
+
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_settings.GlobalSettings(), ReloadEnvironmentVariables);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_settings.GlobalSettings(), AllowHeadless);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_settings.GlobalSettings(), IsolatedMode);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(_settings.GlobalSettings(), EnableShellCompletionMenu);
 
     private:
         Model::CascadiaSettings _settings{ nullptr };

--- a/src/cascadia/TerminalSettingsEditor/CompatibilityViewModel.idl
+++ b/src/cascadia/TerminalSettingsEditor/CompatibilityViewModel.idl
@@ -11,8 +11,14 @@ namespace Microsoft.Terminal.Settings.Editor
     {
         CompatibilityViewModel(Microsoft.Terminal.Settings.Model.CascadiaSettings settings);
 
+        Boolean ShellCompletionMenuAvailable { get; };
+
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, UseAtlasEngine);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, ForceFullRepaintRendering);
         PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, SoftwareRendering);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, ReloadEnvironmentVariables);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, AllowHeadless);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, IsolatedMode);
+        PERMANENT_OBSERVABLE_PROJECTED_SETTING(Boolean, EnableShellCompletionMenu);
     }
 }

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -438,6 +438,10 @@
     <value>These settings may be useful for troubleshooting an issue, however they will impact your performance.</value>
     <comment>A disclaimer presented at the top of a page.</comment>
   </data>
+  <data name="Globals_CompatibilityDisclaimer.Text" xml:space="preserve">
+    <value>These settings may be useful for troubleshooting an issue. However, you may experience unexpected behaviors.</value>
+    <comment>A disclaimer presented at the top of a page.</comment>
+  </data>
   <data name="Globals_ShowTitlebar.Header" xml:space="preserve">
     <value>Hide the title bar (requires relaunch)</value>
     <comment>Header for a control to toggle whether the title bar should be shown or not. Changing this setting requires the user to relaunch the app.</comment>
@@ -557,6 +561,38 @@
   <data name="Globals_WordDelimiters.HelpText" xml:space="preserve">
     <value>These symbols will be used when you double-click text in the terminal or activate "Mark mode".</value>
     <comment>A description for what the "word delimiters" setting does. Presented near "Globals_WordDelimiters.Header". "Mark" is used in the sense of "choosing something to interact with."</comment>
+  </data>
+  <data name="Globals_ReloadEnvironmentVariables.Header" xml:space="preserve">
+    <value>Automatically reload environment variables</value>
+    <comment>Header for a control how environment variables are initialized for connections.</comment>
+  </data>
+  <data name="Globals_ReloadEnvironmentVariables.HelpText" xml:space="preserve">
+    <value>When enabled, the Terminal will always generate a fresh environment variable block for new tabs and panes.</value>
+    <comment>A description for what the "reload environment variables" setting does. Presented near "Globals_ReloadEnvironmentVariables.Header".</comment>
+  </data>
+  <data name="Globals_AllowHeadless.Header" xml:space="preserve">
+    <value>Allow the Terminal to keep running without a window</value>
+    <comment>Header for a control that allows the Terminal to run in the background.</comment>
+  </data>
+  <data name="Globals_AllowHeadless.HelpText" xml:space="preserve">
+    <value>When enabled, the Terminal process will continue to run in the background, even after closing the last Terminal window.</value>
+    <comment>A description for what the "Allow the Terminal to keep running without a window" setting does. Presented near "Globals_AllowHeadless.Header".</comment>
+  </data>
+  <data name="Globals_IsolatedMode.Header" xml:space="preserve">
+    <value>Use isolated window processes</value>
+    <comment>Header for a control that enables a mode where windows cannot communicate with each other, for debugging</comment>
+  </data>
+  <data name="Globals_IsolatedMode.HelpText" xml:space="preserve">
+    <value>When enabled, each Terminal window will run in its own process. You won't be able to drag/drop tabs into other windows. Other features may also break unexpectedly.</value>
+    <comment>A description for what the "Use isolated window processes" setting does. Presented near "Globals_IsolatedMode.Header".</comment>
+  </data>
+  <data name="Globals_EnableShellCompletionMenu.Header" xml:space="preserve">
+    <value>Enable experimental shell completions support</value>
+    <comment>Header for a control that enables an experimental new protocol for the Terminal</comment>
+  </data>
+  <data name="Globals_EnableShellCompletionMenu.HelpText" xml:space="preserve">
+    <value>This enables support for an experimental shell completion protocol. This protocol is subject to change in the future.</value>
+    <comment>A description for what the "Enable experimental shell completions support" setting does. Presented near "Globals_EnableShellCompletionMenu.Header".</comment>
   </data>
   <data name="Nav_Appearance.Content" xml:space="preserve">
     <value>Appearance</value>


### PR DESCRIPTION
_⚠️ targets #15665 ⚠️_

## Summary of the Pull Request
Adds some missing settings to the compatibility page. These don't have any controls in the SUI yet, so I chose these. There's plenty of room for more. Lots of these were added in 1.18, just never got a SUI treatment. 

Page looks like this now:

![image](https://github.com/microsoft/terminal/assets/18356694/dfb6a820-7593-44ca-918f-0a71df2009c1)

