### PR TITLE
Clean up WriteConsoleInputA conversion

### DIFF
--- a/src/host/directio.cpp
+++ b/src/host/directio.cpp
@@ -220,7 +220,7 @@ try
         }
     }
 
-    auto result = IInputEvent::Create(std::span{events.data(), events.size()});
+    auto result = IInputEvent::Create(std::span{ events.data(), events.size() });
     return _WriteConsoleInputWImplHelper(context, result, written, append);
 }
 CATCH_RETURN();

--- a/src/host/directio.cpp
+++ b/src/host/directio.cpp
@@ -153,12 +153,15 @@ try
     const auto& gci = ServiceLocator::LocateGlobals().getConsoleInformation();
     til::small_vector<INPUT_RECORD, 16> events;
 
+    auto it = buffer.begin();
+    const auto end = buffer.end();
+
     // Check out the loop below. When a previous call ended on a leading DBCS we store it for
     // the next call to WriteConsoleInputAImpl to join it with the now available trailing DBCS.
     if (context.IsWritePartialByteSequenceAvailable())
     {
         auto lead = context.FetchWritePartialByteSequence(false)->ToInputRecord();
-        const auto& trail = buffer.front();
+        const auto& trail = *it;
 
         if (trail.EventType == KEY_EVENT)
         {
@@ -174,10 +177,12 @@ try
                 lead.Event.KeyEvent.uChar.UnicodeChar = wide[i];
                 events.push_back(lead);
             }
+
+            ++it;
         }
     }
 
-    for (auto it = buffer.begin(), end = buffer.end(); it != end; ++it)
+    for (; it != end; ++it)
     {
         if (it->EventType != KEY_EVENT)
         {

--- a/src/host/ft_host/CJK_DbcsTests.cpp
+++ b/src/host/ft_host/CJK_DbcsTests.cpp
@@ -2,9 +2,11 @@
 // Licensed under the MIT license.
 
 #include "precomp.h"
+
 #include <io.h>
 #include <fcntl.h>
-#include <iostream>
+
+#include "../../types/inc/IInputEvent.hpp"
 
 #define JAPANESE_CP 932u
 
@@ -115,6 +117,7 @@ class DbcsTests
     // This test must come before ones that launch another process as launching another process can tamper with the codepage
     // in ways that this test is not expecting.
     TEST_METHOD(TestMultibyteInputRetrieval);
+    TEST_METHOD(TestMultibyteInputCoalescing);
 
     BEGIN_TEST_METHOD(TestDbcsWriteRead)
         TEST_METHOD_PROPERTY(L"Data:fUseTrueTypeFont", L"{true, false}")
@@ -1904,6 +1907,34 @@ void DbcsTests::TestMultibyteInputRetrieval()
     }
 
     FlushConsoleInputBuffer(hIn);
+}
+
+// This test ensures that two separate WriteConsoleInputA with trailing/leading DBCS are joined (coalesced) into a single wide character.
+void DbcsTests::TestMultibyteInputCoalescing()
+{
+    SetConsoleCP(932);
+
+    const auto in = GetStdHandle(STD_INPUT_HANDLE);
+    FlushConsoleInputBuffer(in);
+
+    DWORD count;
+    {
+        const auto record = KeyEvent{ true, 1, 123, 456, 0x82, 789 }.ToInputRecord();
+        VERIFY_WIN32_BOOL_SUCCEEDED(WriteConsoleInputA(in, &record, 1, &count));
+    }
+    {
+        const auto record = KeyEvent{ true, 1, 234, 567, 0xA2, 890 }.ToInputRecord();
+        VERIFY_WIN32_BOOL_SUCCEEDED(WriteConsoleInputA(in, &record, 1, &count));
+    }
+
+    // Asking for 2 records and asserting we only got 1 ensures
+    // that we receive the exact number of expected records.
+    INPUT_RECORD actual[2];
+    VERIFY_WIN32_BOOL_SUCCEEDED(ReadConsoleInputW(in, &actual[0], 2, &count));
+    VERIFY_ARE_EQUAL(1u, count);
+
+    const auto expected = KeyEvent{ true, 1, 123, 456, L'い', 789 }.ToInputRecord();
+    VERIFY_ARE_EQUAL(expected, actual[0]);
 }
 
 void DbcsTests::TestDbcsOneByOne()


### PR DESCRIPTION
This commit inlines `EventsToUnicode` into `WriteConsoleInputAImpl`
because soon we'll not use deques for events anymore and so the old
code won't work. It cleans up the implementation because I intend to
move all this code directly into `InputBuffer` to have a better and
tighter control over how text gets converted. UTF-8 input for instance
requires the storage of up to 3 input events and this code is not fit
to handle that. It's also unmaintainable because our input handling
code shouldn't be spread over a dozen files either. 😄

## Validation Steps Performed
* Unit and feature tests are ✅