### PR TITLE
Add winget installation note for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ package:
 winget install --id Microsoft.WindowsTerminal -e
 ```
 
+> **Note** Due to a dependency issue, Terminal's current versions cannot be installed via the Windows Package Manager CLI. To install the stable release 1.17 or later, or the Preview release 1.18 or later, please use an alternative installation method.
+
 #### Via Chocolatey (unofficial)
 
 [Chocolatey](https://chocolatey.org) users can download and install the latest


### PR DESCRIPTION
Adds a note to the ReadMe's installation instructions which describes why current versions of Terminal are unavailable via winget.

## PR Checklist
- [x] Closes #15663 
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
