### PR TITLE
Added background to CommandKeyChord

### DIFF
--- a/src/cascadia/TerminalApp/CommandPalette.xaml
+++ b/src/cascadia/TerminalApp/CommandPalette.xaml
@@ -75,6 +75,7 @@
                             HorizontalAlignment="Right"
                             VerticalAlignment="Center"
                             AutomationProperties.AccessibilityView="Raw"
+                            Background="{ThemeResource FlyoutPresenterBackground}"
                             Style="{ThemeResource KeyChordBorderStyle}"
                             Visibility="{x:Bind Item.KeyChordText, Mode=OneWay, Converter={StaticResource CommandKeyChordVisibilityConverter}}">
 


### PR DESCRIPTION
## Summary of the Pull Request

Adds a background to key chord border in the CommandPalette Screen. This prevents certain accent colors from rendering the KeyChords unreadable.

Before (where the text is unreadble);
![image](https://github.com/microsoft/terminal/assets/33658638/370fa7c7-f42e-48b3-af54-6fe7d5f89c73)

After (from this PR):
![image](https://github.com/microsoft/terminal/assets/33658638/5ce8601a-80f2-4efe-9270-9dd7209cdfff)

See #15228 for more details