### PR TITLE
Add support for running profiles from Add tab menu as admin without a keyboard

### DIFF
--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -216,7 +216,7 @@
   </data>
   <data name="SearchWebText" xml:space="preserve">
     <value>Web Search</value>
-  </data>  
+  </data>
   <data name="TabColorChoose" xml:space="preserve">
     <value>Color...</value>
   </data>
@@ -835,5 +835,9 @@
   </data>
   <data name="MoveTabToNewWindowToolTip" xml:space="preserve">
     <value>Moves tab to a new window </value>
+  </data>
+  <data name="RunAsAdminFlyout.Text" xml:space="preserve">
+    <value>Run as Administrator</value>
+    <comment>This text is displayed on context menu for profile entries in add new tab button.</comment>
   </data>
 </root>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1064,9 +1064,7 @@ namespace winrt::TerminalApp::implementation
         // and rely on the base class to show our menu.
         profileMenuItem.ContextRequested([profileMenuItem](auto&&, auto&&) {
             WUX::Controls::Primitives::FlyoutBase::ShowAttachedFlyout(profileMenuItem);
-
         });
-
 
         return profileMenuItem;
     }
@@ -4923,7 +4921,6 @@ namespace winrt::TerminalApp::implementation
         WUX::Controls::MenuFlyout profileMenuItemFlyout{};
         profileMenuItemFlyout.Placement(WUX::Controls::Primitives::FlyoutPlacementMode::BottomEdgeAlignedRight);
 
-
         // Create the menu item and an icon to use in the menu
         WUX::Controls::MenuFlyoutItem runAsAdminItem{};
         WUX::Controls::FontIcon adminShieldIcon{};
@@ -4933,8 +4930,8 @@ namespace winrt::TerminalApp::implementation
 
         runAsAdminItem.Icon(adminShieldIcon);
         runAsAdminItem.Text(RS_(L"RunAsAdminFlyout/Text"));
-        
-        // Click handler for the flyout item       
+
+        // Click handler for the flyout item
         runAsAdminItem.Click([profileIndex, weakThis{ get_weak() }](auto&&, auto&&) {
             if (auto page{ weakThis.get() })
             {

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -530,7 +530,7 @@ namespace winrt::TerminalApp::implementation
         void _ContextMenuOpened(const IInspectable& sender, const IInspectable& args);
         void _SelectionMenuOpened(const IInspectable& sender, const IInspectable& args);
         void _PopulateContextMenu(const IInspectable& sender, const bool withSelection);
-
+        winrt::Windows::UI::Xaml::Controls::MenuFlyout _CreateRunAsAdminFlyout(int profileIndex);
 #pragma region ActionHandlers
         // These are all defined in AppActionHandlers.cpp
 #define ON_ALL_ACTIONS(action) DECLARE_ACTION_HANDLER(action);


### PR DESCRIPTION
## Summary of the Pull Request
Add support for running profiles in the Add Tab drop down as administrator without a keyboard.
## References and Relevant Issues
#14517 
## Detailed Description of the Pull Request / Additional comments
This pull request adds a FlyoutMenu to each Profile entry in the Add New tab drop down. When a profile is right clicked or held for 2 seconds in the case of no mouse input will present a MenuItem to allow the user to click and run the selected profile as administrator
## Validation Steps Performed
- Responds to pointer input events (mouse, pointer, touchpad)
- Adjusts to theme changes.
- Only shows when a profile is selected. Will not show on settings or pallete entries

## PR Checklist
- [x] Closes #14517 
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
