### PR TITLE
Register some events with performance tags

### DIFF
--- a/src/cascadia/Remoting/Monarch.cpp
+++ b/src/cascadia/Remoting/Monarch.cpp
@@ -119,7 +119,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
             TraceLoggingWrite(g_hRemotingProvider,
                               "Monarch_AddPeasant_Failed",
                               TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                              TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
 
             // We can only get into this try/catch if the peasant died on us. So
             // the return value doesn't _really_ matter. They're not about to
@@ -163,7 +164,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                               "Monarch_handleQuitAll_Failed",
                               TraceLoggingInt64(id, "peasantID", "The ID of the peasant which we could not close"),
                               TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                              TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         };
 
         _forEachPeasant(callback, onError);
@@ -324,7 +326,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                               "Monarch_lookupPeasantIdForName_Failed",
                               TraceLoggingInt64(id, "peasantID", "The ID of the peasant which we could not get the name of"),
                               TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                              TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         };
 
         _forEachPeasant(callback, onError);
@@ -379,7 +382,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
             TraceLoggingWrite(g_hRemotingProvider,
                               "Monarch_HandleActivatePeasant_Failed",
                               TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                              TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         }
     }
 
@@ -510,7 +514,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
             TraceLoggingWrite(g_hRemotingProvider,
                               "Monarch_getMostRecentPeasantID_NoPeasants",
                               TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                              TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
             return 0;
         }
 
@@ -547,7 +552,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                                                      "We thought this peasant was the MRU one, but it was actually already dead."),
                                   TraceLoggingGuid(mruWindowArgs.DesktopID(), "desktopGuid", "The GUID of the desktop the window is on"),
                                   TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                                  TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
                 // We'll go through the loop again. We removed the current one
                 // at positionInList, so the next one in positionInList will be
                 // a new, different peasant.
@@ -624,7 +630,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
             TraceLoggingWrite(g_hRemotingProvider,
                               "Monarch_getMostRecentPeasantID_NotFound",
                               TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                              TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         }
 
         return result;
@@ -757,7 +764,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                                                       "succeeded",
                                                       "true if we successfully dispatched the commandline to the peasant"),
                                   TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                                  TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
                 return *result;
             }
             else if (windowID > 0)
@@ -790,7 +798,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                           "Monarch_ProposeCommandline_NewWindow",
                           TraceLoggingInt64(targetWindow, "targetWindow", "The provided ID"),
                           TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                          TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
 
         // In this case, no usable ID was provided. Return { true, nullopt }
         auto result = winrt::make_self<Remoting::implementation::ProposeCommandlineResult>(true);
@@ -823,7 +832,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                               "Monarch_identifyWindows_Failed",
                               TraceLoggingInt64(id, "peasantID", "The ID of the peasant which we could not identify"),
                               TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                              TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         };
 
         _forEachPeasant(callback, onError);
@@ -875,7 +885,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
             TraceLoggingWrite(g_hRemotingProvider,
                               "Monarch_renameRequested_Failed",
                               TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                              TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         }
     }
 
@@ -947,7 +958,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                                   TraceLoggingUInt64(windowId, "peasantID", "The id of the window we tried to summon"),
                                   TraceLoggingBoolean(args.OnCurrentDesktop(), "OnCurrentDesktop", "true iff the window needs to be on the current virtual desktop"),
                                   TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                                  TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
             }
         }
         catch (...)
@@ -957,7 +969,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                               "Monarch_SummonWindow_Failed",
                               TraceLoggingWideString(searchedForName.c_str(), "searchedForName", "The name of the window we tried to summon"),
                               TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                              TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         }
     }
 
@@ -985,7 +998,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                               "Monarch_identifyWindows_Failed",
                               TraceLoggingInt64(id, "peasantID", "The ID of the peasant which we could not identify"),
                               TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                              TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         };
 
         _forEachPeasant(func, onError);
@@ -1010,7 +1024,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                               "Monarch_DoesQuakeWindowExist_Failed",
                               TraceLoggingInt64(id, "peasantID", "The ID of the peasant which we could not ask for its name"),
                               TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                              TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         };
 
         _forEachPeasant(func, onError);
@@ -1030,7 +1045,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                               "Monarch_SummonAll_Failed",
                               TraceLoggingInt64(id, "peasantID", "The ID of the peasant which we could not summon"),
                               TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                              TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         };
 
         _forEachPeasant(func, onError);
@@ -1053,7 +1069,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                               "Monarch_GetAllWindowLayouts_Failed",
                               TraceLoggingInt64(id, "peasantID", "The ID of the peasant which we could not get a window layout from"),
                               TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                              TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         };
         _forEachPeasant(callback, onError);
 
@@ -1069,7 +1086,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                           "Monarch_MoveContent_Requested",
                           TraceLoggingWideString(window.c_str(), "window", "The name of the window we tried to move to"),
                           TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                          TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
 
         uint64_t windowId = _lookupPeasantIdForName(window);
         if (windowId == 0)
@@ -1081,7 +1099,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                 TraceLoggingWrite(g_hRemotingProvider,
                                   "Monarch_MoveContent_FailedToParseId",
                                   TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                                  TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
             }
             else
             {
@@ -1128,7 +1147,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                           TraceLoggingUInt64(args.SourceWindow(), "source", "The window which started the drag"),
                           TraceLoggingUInt64(args.TargetWindow(), "target", "The window which was the target of the drop"),
                           TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                          TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
 
         if (auto senderPeasant{ _getPeasant(args.SourceWindow()) })
         {
@@ -1148,7 +1168,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
             TraceLoggingWrite(g_hRemotingProvider,
                               "Monarch_SendContent_NoWindow",
                               TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                              TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         }
     }
 }

--- a/src/cascadia/Remoting/WindowManager.cpp
+++ b/src/cascadia/Remoting/WindowManager.cpp
@@ -198,7 +198,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                     TraceLoggingWrite(g_hRemotingProvider,
                                       "WindowManager_IntentionallyIsolated",
                                       TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                                      TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                                      TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
                 }
 
                 if (!_monarch)
@@ -213,7 +214,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                     TraceLoggingWrite(g_hRemotingProvider,
                                       "WindowManager_FailedToCoCreate",
                                       TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                                      TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                                      TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
                 }
                 _createCallbacks();
 
@@ -290,7 +292,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                                   "WindowManager_proposeToMonarch_unexpectedExceptionFromKing",
                                   TraceLoggingInt32(attempts, "attempts", "How many times we've tried"),
                                   TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                                  TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                                  TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
                 LOG_CAUGHT_EXCEPTION();
                 attempts++;
 
@@ -305,7 +308,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                     TraceLoggingWrite(g_hRemotingProvider,
                                       "WindowManager_TooManyAttempts_NullMonarchIsolateMode",
                                       TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                                      TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                                      TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
 
                     // Set the monarch to null, so that we'll create a new one
                     // (or just generally check if we need to even make a window
@@ -328,7 +332,8 @@ namespace winrt::Microsoft::Terminal::Remoting::implementation
                     TraceLoggingWrite(g_hRemotingProvider,
                                       "WindowManager_proposeToMonarch_tryAgain",
                                       TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                                      TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                                      TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                                      TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
                 }
             }
         }

--- a/src/cascadia/WindowsTerminal/IslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/IslandWindow.cpp
@@ -749,7 +749,8 @@ long IslandWindow::_calculateTotalSize(const bool isWidth, const long clientSize
             "EndSession",
             TraceLoggingDescription("Emitted when the OS has sent a WM_ENDSESSION"),
             TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-            TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+            TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+            TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
 
         _AutomaticShutdownRequestedHandlers();
         return true;

--- a/src/cascadia/WindowsTerminal/WindowEmperor.cpp
+++ b/src/cascadia/WindowsTerminal/WindowEmperor.cpp
@@ -380,7 +380,8 @@ winrt::Windows::Foundation::IAsyncAction WindowEmperor::_saveWindowLayouts()
                               "AppHost_SaveWindowLayouts_Failed",
                               TraceLoggingDescription("An error occurred when collecting or writing window state"),
                               TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                              TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                              TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                              TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
         }
     }
 
@@ -406,7 +407,8 @@ winrt::fire_and_forget WindowEmperor::_saveWindowLayoutsRepeat()
                           "AppHost_requestGetLayout",
                           TraceLoggingDescription("Logged when triggering a throttled write of the window state"),
                           TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
-                          TraceLoggingKeyword(TIL_KEYWORD_TRACE));
+                          TraceLoggingKeyword(TIL_KEYWORD_TRACE),
+                          TelemetryPrivacyDataTag(PDT_ProductAndServicePerformance));
 
         _getWindowLayoutThrottler.value()();
     }


### PR DESCRIPTION
Some of the data privacy tags are wrong. I've updated them to be "PDT_ProductAndServicePerformance" since they are reporting an event that the system did, not the user.

## References
- https://www.osgwiki.com/wiki/DataES_NGP_Export#.22It_looks_like_the_datatype_on_my_telemetry_event_is_incorrect._How_do_I_fix_it.3F.22
- https://www.osgwiki.com/wiki/Privacy_Data_Type_-_Tagging_in_Code
- https://microsoft.visualstudio.com/OSGData/_git/client.pipelines/pullrequest/9257394?path=/SigX/DEL/DataES/Common/Resources/EventMetadata.json
