### PR TITLE
Fix horizontal scrolling bugs in AtlasEngine/DxEngine

### DIFF
--- a/src/renderer/atlas/AtlasEngine.api.cpp
+++ b/src/renderer/atlas/AtlasEngine.api.cpp
@@ -119,7 +119,7 @@ constexpr HRESULT vec2_narrow(U x, U y, vec2<T>& out) noexcept
         if (delta < 0)
         {
             _api.invalidatedRows.start = gsl::narrow_cast<u16>(clamp<int>(_api.invalidatedRows.start + delta, u16min, u16max));
-            _api.invalidatedRows.end = _api.s->cellCount.y;
+            _api.invalidatedRows.end = _api.s->viewportCellCount.y;
         }
         else
         {
@@ -182,17 +182,29 @@ constexpr HRESULT vec2_narrow(U x, U y, vec2<T>& out) noexcept
 }
 
 [[nodiscard]] HRESULT AtlasEngine::UpdateViewport(const til::inclusive_rect& srNewViewport) noexcept
+try
 {
-    const u16x2 cellCount{
-        gsl::narrow_cast<u16>(std::max(1, srNewViewport.right - srNewViewport.left + 1)),
-        gsl::narrow_cast<u16>(std::max(1, srNewViewport.bottom - srNewViewport.top + 1)),
+    const u16x2 viewportCellCount{
+        gsl::narrow<u16>(std::max(1, srNewViewport.right - srNewViewport.left + 1)),
+        gsl::narrow<u16>(std::max(1, srNewViewport.bottom - srNewViewport.top + 1)),
     };
-    if (_api.s->cellCount != cellCount)
+    const u16x2 viewportOffset{
+        gsl::narrow<u16>(srNewViewport.left),
+        gsl::narrow<u16>(srNewViewport.top),
+    };
+
+    if (_api.s->viewportCellCount != viewportCellCount)
     {
-        _api.s.write()->cellCount = cellCount;
+        _api.s.write()->viewportCellCount = viewportCellCount;
     }
+    if (_api.s->viewportOffset != viewportOffset)
+    {
+        _api.s.write()->viewportOffset = viewportOffset;
+    }
+
     return S_OK;
 }
+CATCH_RETURN()
 
 [[nodiscard]] HRESULT AtlasEngine::GetProposedFont(const FontInfoDesired& fontInfoDesired, _Out_ FontInfo& fontInfo, const int dpi) noexcept
 try

--- a/src/renderer/atlas/AtlasEngine.r.cpp
+++ b/src/renderer/atlas/AtlasEngine.r.cpp
@@ -463,7 +463,10 @@ void AtlasEngine::_present()
             {
                 const auto offsetInPx = _p.scrollOffset * _p.s->font->cellSize.y;
                 const auto width = _p.s->targetSize.x;
-                const auto height = _p.s->cellCount.y * _p.s->font->cellSize.y;
+                // We don't use targetSize.y here, because "height" refers to the bottom coordinate of the last text row
+                // in the buffer. We then add the "offsetInPx" (which is negative when scrolling text upwards) and thus
+                // end up with a "bottom" value that is the bottom of the last row of text that we haven't invalidated.
+                const auto height = _p.s->viewportCellCount.y * _p.s->font->cellSize.y;
                 const auto top = std::max(0, offsetInPx);
                 const auto bottom = height + std::min(0, offsetInPx);
 

--- a/src/renderer/atlas/BackendD2D.cpp
+++ b/src/renderer/atlas/BackendD2D.cpp
@@ -68,7 +68,7 @@ void BackendD2D::_handleSettingsUpdate(const RenderingPayload& p)
     const auto renderTargetChanged = !_renderTarget;
     const auto fontChanged = _fontGeneration != p.s->font.generation();
     const auto cursorChanged = _cursorGeneration != p.s->cursor.generation();
-    const auto cellCountChanged = _cellCount != p.s->cellCount;
+    const auto cellCountChanged = _viewportCellCount != p.s->viewportCellCount;
 
     if (renderTargetChanged)
     {
@@ -120,8 +120,8 @@ void BackendD2D::_handleSettingsUpdate(const RenderingPayload& p)
             .dpiY = static_cast<f32>(p.s->font->dpi),
         };
         const D2D1_SIZE_U size{
-            p.s->cellCount.x,
-            p.s->cellCount.y,
+            p.s->viewportCellCount.x,
+            p.s->viewportCellCount.y,
         };
         const D2D1_MATRIX_3X2_F transform{
             .m11 = static_cast<f32>(p.s->font->cellSize.x),
@@ -145,7 +145,7 @@ void BackendD2D::_handleSettingsUpdate(const RenderingPayload& p)
     _generation = p.s.generation();
     _fontGeneration = p.s->font.generation();
     _cursorGeneration = p.s->cursor.generation();
-    _cellCount = p.s->cellCount;
+    _viewportCellCount = p.s->viewportCellCount;
 }
 
 void BackendD2D::_drawBackground(const RenderingPayload& p) noexcept

--- a/src/renderer/atlas/BackendD2D.h
+++ b/src/renderer/atlas/BackendD2D.h
@@ -53,7 +53,7 @@ namespace Microsoft::Console::Render::Atlas
         til::generation_t _generation;
         til::generation_t _fontGeneration;
         til::generation_t _cursorGeneration;
-        u16x2 _cellCount{};
+        u16x2 _viewportCellCount{};
 
 #if ATLAS_DEBUG_SHOW_DIRTY
         i32r _presentRects[9]{};

--- a/src/renderer/atlas/BackendD3D.h
+++ b/src/renderer/atlas/BackendD3D.h
@@ -37,8 +37,8 @@ namespace Microsoft::Console::Render::Atlas
         struct alignas(16) PSConstBuffer
         {
             alignas(sizeof(f32x4)) f32x4 backgroundColor;
-            alignas(sizeof(f32x2)) f32x2 cellSize;
-            alignas(sizeof(f32x2)) f32x2 cellCount;
+            alignas(sizeof(f32x2)) f32x2 backgroundCellSize;
+            alignas(sizeof(f32x2)) f32x2 backgroundCellCount;
             alignas(sizeof(f32x4)) f32 gammaRatios[4]{};
             alignas(sizeof(f32)) f32 enhancedContrast = 0;
             alignas(sizeof(f32)) f32 underlineWidth = 0;
@@ -281,7 +281,7 @@ namespace Microsoft::Console::Render::Atlas
         til::generation_t _fontGeneration;
         til::generation_t _miscGeneration;
         u16x2 _targetSize{};
-        u16x2 _cellCount{};
+        u16x2 _viewportCellCount{};
         ShadingType _textShadingType = ShadingType::Default;
 
         // An empty-box cursor spanning a wide glyph that has different

--- a/src/renderer/atlas/common.h
+++ b/src/renderer/atlas/common.h
@@ -387,8 +387,12 @@ namespace Microsoft::Console::Render::Atlas
         til::generational<FontSettings> font;
         til::generational<CursorSettings> cursor;
         til::generational<MiscellaneousSettings> misc;
+        // Size of the viewport / swap chain in pixel.
         u16x2 targetSize{ 1, 1 };
-        u16x2 cellCount{ 1, 1 };
+        // Size of the portion of the text buffer that we're drawing on the screen.
+        u16x2 viewportCellCount{ 1, 1 };
+        // The position of the viewport inside the text buffer (in cells).
+        u16x2 viewportOffset{ 0, 0 };
     };
 
     using GenerationalSettings = til::generational<Settings>;
@@ -545,7 +549,7 @@ namespace Microsoft::Console::Render::Atlas
         void MarkAllAsDirty() noexcept
         {
             dirtyRectInPx = { 0, 0, s->targetSize.x, s->targetSize.y };
-            invalidatedRows = { 0, s->cellCount.y };
+            invalidatedRows = { 0, s->viewportCellCount.y };
             scrollOffset = 0;
         }
     };

--- a/src/renderer/atlas/shader_ps.hlsl
+++ b/src/renderer/atlas/shader_ps.hlsl
@@ -7,8 +7,8 @@
 cbuffer ConstBuffer : register(b0)
 {
     float4 backgroundColor;
-    float2 cellSize;
-    float2 cellCount;
+    float2 backgroundCellSize;
+    float2 backgroundCellCount;
     float4 gammaRatios;
     float enhancedContrast;
     float underlineWidth;
@@ -34,8 +34,8 @@ Output main(PSData data) : SV_Target
     {
     case SHADING_TYPE_TEXT_BACKGROUND:
     {
-        const float2 cell = data.position.xy / cellSize;
-        color = all(cell < cellCount) ? background[cell] : backgroundColor;
+        const float2 cell = data.position.xy / backgroundCellSize;
+        color = all(cell < backgroundCellCount) ? background[cell] : backgroundColor;
         weights = float4(1, 1, 1, 1);
         break;
     }

--- a/src/renderer/dx/CustomTextRenderer.cpp
+++ b/src/renderer/dx/CustomTextRenderer.cpp
@@ -509,7 +509,7 @@ CATCH_RETURN()
     clipRect.top = origin.y + drawingContext->topClipOffset;
     clipRect.bottom = origin.y + drawingContext->cellSize.height - drawingContext->bottomClipOffset;
     clipRect.left = 0;
-    clipRect.right = drawingContext->targetSize.width;
+    clipRect.right = FLT_MAX;
 
     // If we already have a clip rectangle, check if it different than the previous one.
     if (_clipRect.has_value())

--- a/tools/ConsoleTypes.natvis
+++ b/tools/ConsoleTypes.natvis
@@ -146,11 +146,18 @@
         <DisplayString Condition="_occupied">{glyphIndex}</DisplayString>
     </Type>
 
-    <Type Name="Microsoft::Console::Render::Atlas::BackendD3D::AtlasFontFaceEntry">
-        <DisplayString Condition="!_occupied">(empty)</DisplayString>
-        <DisplayString Condition="_occupied">{(void*)fontFace.m_ptr}, {lineRendition}</DisplayString>
+    <Type Name="Microsoft::Console::Render::Atlas::BackendD3D::AtlasFontFaceEntryInner">
+        <DisplayString>{(void*)fontFace.m_ptr}, {lineRendition}</DisplayString>
         <Expand>
             <ExpandedItem>glyphs</ExpandedItem>
+        </Expand>
+    </Type>
+
+    <Type Name="Microsoft::Console::Render::Atlas::BackendD3D::AtlasFontFaceEntry">
+        <DisplayString Condition="!inner._Mypair._Myval2">(empty)</DisplayString>
+        <DisplayString Condition="inner._Mypair._Myval2">{*inner._Mypair._Myval2}</DisplayString>
+        <Expand>
+            <ExpandedItem>*inner._Mypair._Myval2</ExpandedItem>
         </Expand>
     </Type>
 </AutoVisualizer>


### PR DESCRIPTION
This commit fixes a number of issues around horizontal scrolling.
DxEngine only had one bug, where the clip rect would cause any content
outside of the actual viewport to be invisible. AtlasEngine had more
bugs, mostly around the conversion from textbuffer-relative coordinates
to viewport-relative coordinates, since AtlasEngine stores things like
the cursor position, attributes, etc., relative to the viewport.

It also renames `cellCount` to `viewportCellCount`, because I realized
that it might have to deal with a `textBufferCellCount` or similar in
the future. I hope that the new name is more descriptive of what it
refers to.

This is in preparation for #1860

## Validation Steps Performed
* Patch `RenderingTests` to run in the main (and not alt) buffer
* Horizontal scrolling of line renditions and attributes works ✅
* Selection retains its position (mostly) ✅