### PR TITLE
Ensure we are in the foreground when closed with multiple tabs open

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1918,6 +1918,7 @@ namespace winrt::TerminalApp::implementation
             !_displayingCloseDialog)
         {
             _displayingCloseDialog = true;
+            _CloseRequestedWithMultipleTabsHandlers(*this, nullptr);
             auto warningResult = co_await _ShowCloseWarningDialog();
             _displayingCloseDialog = false;
 

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4901,10 +4901,12 @@ namespace winrt::TerminalApp::implementation
         _RemoveTab(*_stashed.draggedTab);
     }
 
+    // Raises the CloseRequestedWithMultipleTabs event so that we can summon the window to the current monitor.
+    // The event args are deferrable so we can wait for them to signal.
     winrt::Windows::Foundation::IAsyncAction TerminalPage::_ClosingWithMultipleTabsOpen()
     {
         auto args = winrt::make_self<CloseRequestedWithMultipleTabsArgs>();
         _CloseRequestedWithMultipleTabsHandlers(*this, *args);
-        co_await winrt::when_all(args->wait_for_deferrals());
+        co_await args->wait_for_deferrals();
     }
 }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4901,14 +4901,10 @@ namespace winrt::TerminalApp::implementation
         _RemoveTab(*_stashed.draggedTab);
     }
 
-    winrt::Windows::Foundation::IAsyncOperation<bool> TerminalPage::_ClosingWithMultipleTabsOpen()
+    winrt::Windows::Foundation::IAsyncAction TerminalPage::_ClosingWithMultipleTabsOpen()
     {
         auto args = winrt::make_self<CloseRequestedWithMultipleTabsArgs>();
-        bool windowSummoned = false;
         _CloseRequestedWithMultipleTabsHandlers(*this, *args);
-        co_await args->wait_for_deferrals();
-        windowSummoned = true;
-
-        co_return windowSummoned;
+        co_await winrt::when_all(args->wait_for_deferrals());
     }
 }

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1918,7 +1918,7 @@ namespace winrt::TerminalApp::implementation
             !_displayingCloseDialog)
         {
             _displayingCloseDialog = true;
-            _CloseRequestedWithMultipleTabsHandlers(*this, nullptr);
+            co_await _ClosingWithMultipleTabsOpen();
             auto warningResult = co_await _ShowCloseWarningDialog();
             _displayingCloseDialog = false;
 
@@ -4899,5 +4899,16 @@ namespace winrt::TerminalApp::implementation
         _MoveContent(std::move(startupActions), windowId, tabIndex, dragPoint);
         // _RemoveTab will make sure to null out the _stashed.draggedTab
         _RemoveTab(*_stashed.draggedTab);
+    }
+
+    winrt::Windows::Foundation::IAsyncOperation<bool> TerminalPage::_ClosingWithMultipleTabsOpen()
+    {
+        auto args = winrt::make_self<CloseRequestedWithMultipleTabsArgs>();
+        bool windowSummoned = false;
+        _CloseRequestedWithMultipleTabsHandlers(*this, *args);
+        co_await args->wait_for_deferrals();
+        windowSummoned = true;
+
+        co_return windowSummoned;
     }
 }

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -11,6 +11,7 @@
 #include "RenameWindowRequestedArgs.g.h"
 #include "RequestMoveContentArgs.g.h"
 #include "RequestReceiveContentArgs.g.h"
+#include "CloseRequestedWithMultipleTabsArgs.g.h"
 #include "Toast.h"
 
 #define DECLARE_ACTION_HANDLER(action) void _Handle##action(const IInspectable& sender, const Microsoft::Terminal::Settings::Model::ActionEventArgs& args);
@@ -87,6 +88,17 @@ namespace winrt::TerminalApp::implementation
             _SourceWindow{ src },
             _TargetWindow{ tgt },
             _TabIndex{ tabIndex } {};
+    };
+
+    struct CloseRequestedWithMultipleTabsArgs : CloseRequestedWithMultipleTabsArgsT<CloseRequestedWithMultipleTabsArgs>,
+        deferrable_event_args<CloseRequestedWithMultipleTabsArgs>
+                                        
+    {
+        WINRT_PROPERTY(bool, Cancel);
+
+    public:
+        CloseRequestedWithMultipleTabsArgs() :
+            _Cancel(false) {}
     };
 
     struct TerminalPage : TerminalPageT<TerminalPage>
@@ -194,7 +206,7 @@ namespace winrt::TerminalApp::implementation
 
         WINRT_OBSERVABLE_PROPERTY(winrt::Windows::UI::Xaml::Media::Brush, TitlebarBrush, _PropertyChangedHandlers, nullptr);
         WINRT_OBSERVABLE_PROPERTY(winrt::Windows::UI::Xaml::Media::Brush, FrameBrush, _PropertyChangedHandlers, nullptr);
-        TYPED_EVENT(CloseRequestedWithMultipleTabs, IInspectable, IInspectable);
+        TYPED_EVENT(CloseRequestedWithMultipleTabs, winrt::TerminalApp::TerminalPage, winrt::TerminalApp::CloseRequestedWithMultipleTabsArgs);
 
     private:
         friend struct TerminalPageT<TerminalPage>; // for Xaml to bind events
@@ -531,7 +543,7 @@ namespace winrt::TerminalApp::implementation
         void _ContextMenuOpened(const IInspectable& sender, const IInspectable& args);
         void _SelectionMenuOpened(const IInspectable& sender, const IInspectable& args);
         void _PopulateContextMenu(const IInspectable& sender, const bool withSelection);
-
+        winrt::Windows::Foundation::IAsyncOperation<bool> _ClosingWithMultipleTabsOpen();
 #pragma region ActionHandlers
         // These are all defined in AppActionHandlers.cpp
 #define ON_ALL_ACTIONS(action) DECLARE_ACTION_HANDLER(action);

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -543,7 +543,7 @@ namespace winrt::TerminalApp::implementation
         void _ContextMenuOpened(const IInspectable& sender, const IInspectable& args);
         void _SelectionMenuOpened(const IInspectable& sender, const IInspectable& args);
         void _PopulateContextMenu(const IInspectable& sender, const bool withSelection);
-        winrt::Windows::Foundation::IAsyncOperation<bool> _ClosingWithMultipleTabsOpen();
+        winrt::Windows::Foundation::IAsyncAction _ClosingWithMultipleTabsOpen();
 #pragma region ActionHandlers
         // These are all defined in AppActionHandlers.cpp
 #define ON_ALL_ACTIONS(action) DECLARE_ACTION_HANDLER(action);

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -194,6 +194,7 @@ namespace winrt::TerminalApp::implementation
 
         WINRT_OBSERVABLE_PROPERTY(winrt::Windows::UI::Xaml::Media::Brush, TitlebarBrush, _PropertyChangedHandlers, nullptr);
         WINRT_OBSERVABLE_PROPERTY(winrt::Windows::UI::Xaml::Media::Brush, FrameBrush, _PropertyChangedHandlers, nullptr);
+        TYPED_EVENT(CloseRequestedWithMultipleTabs, IInspectable, IInspectable);
 
     private:
         friend struct TerminalPageT<TerminalPage>; // for Xaml to bind events

--- a/src/cascadia/TerminalApp/TerminalPage.idl
+++ b/src/cascadia/TerminalApp/TerminalPage.idl
@@ -56,6 +56,8 @@ namespace TerminalApp
         Boolean IsQuakeWindow();
     };
 
+
+
     [default_interface] runtimeclass TerminalPage : Windows.UI.Xaml.Controls.Page, Windows.UI.Xaml.Data.INotifyPropertyChanged, IDirectKeyListener
     {
         TerminalPage(WindowProperties properties, ContentManager manager);
@@ -103,5 +105,7 @@ namespace TerminalApp
 
         event Windows.Foundation.TypedEventHandler<Object, RequestMoveContentArgs> RequestMoveContent;
         event Windows.Foundation.TypedEventHandler<Object, RequestReceiveContentArgs> RequestReceiveContent;
+        event Windows.Foundation.TypedEventHandler<Object, Object> CloseRequestedWithMultipleTabs;
     }
+
 }

--- a/src/cascadia/TerminalApp/TerminalPage.idl
+++ b/src/cascadia/TerminalApp/TerminalPage.idl
@@ -56,7 +56,11 @@ namespace TerminalApp
         Boolean IsQuakeWindow();
     };
 
-
+    [default_interface] runtimeclass CloseRequestedWithMultipleTabsArgs
+    {
+        Windows.Foundation.Deferral GetDeferral();
+        Boolean Cancel;
+    };
 
     [default_interface] runtimeclass TerminalPage : Windows.UI.Xaml.Controls.Page, Windows.UI.Xaml.Data.INotifyPropertyChanged, IDirectKeyListener
     {
@@ -105,7 +109,7 @@ namespace TerminalApp
 
         event Windows.Foundation.TypedEventHandler<Object, RequestMoveContentArgs> RequestMoveContent;
         event Windows.Foundation.TypedEventHandler<Object, RequestReceiveContentArgs> RequestReceiveContent;
-        event Windows.Foundation.TypedEventHandler<Object, Object> CloseRequestedWithMultipleTabs;
+        event Windows.Foundation.TypedEventHandler<TerminalPage, CloseRequestedWithMultipleTabsArgs> CloseRequestedWithMultipleTabs;
     }
 
 }

--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -185,6 +185,9 @@ namespace winrt::TerminalApp::implementation
             _root->SetInboundListener(true);
         }
 
+        _root->CloseRequestedWithMultipleTabs([weakThis = get_weak()](auto&& sender, auto&&) {
+            weakThis.get()->_CloseRequestedWithMultipleTabsHandlers(sender, nullptr);
+        });
         return _root->Initialize(hwnd);
     }
 

--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -185,8 +185,8 @@ namespace winrt::TerminalApp::implementation
             _root->SetInboundListener(true);
         }
 
-        _root->CloseRequestedWithMultipleTabs([weakThis = get_weak()](auto&& sender, auto&&) {
-            weakThis.get()->_CloseRequestedWithMultipleTabsHandlers(sender, nullptr);
+        _root->CloseRequestedWithMultipleTabs([weakThis = get_weak()](auto&& sender, auto&& args) {
+            weakThis.get()->_CloseRequestedWithMultipleTabsHandlers(sender, args);
         });
         return _root->Initialize(hwnd);
     }

--- a/src/cascadia/TerminalApp/TerminalWindow.h
+++ b/src/cascadia/TerminalApp/TerminalWindow.h
@@ -162,7 +162,7 @@ namespace winrt::TerminalApp::implementation
         void PropertyChanged(winrt::event_token const& token) { _root->PropertyChanged(token); }
 
         TYPED_EVENT(RequestedThemeChanged, winrt::Windows::Foundation::IInspectable, winrt::Microsoft::Terminal::Settings::Model::Theme);
-        TYPED_EVENT(CloseRequestedWithMultipleTabs, winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable);
+        TYPED_EVENT(CloseRequestedWithMultipleTabs, winrt::TerminalApp::TerminalPage, winrt::TerminalApp::CloseRequestedWithMultipleTabsArgs);
 
     private:
         // If you add controls here, but forget to null them either here or in

--- a/src/cascadia/TerminalApp/TerminalWindow.h
+++ b/src/cascadia/TerminalApp/TerminalWindow.h
@@ -162,6 +162,7 @@ namespace winrt::TerminalApp::implementation
         void PropertyChanged(winrt::event_token const& token) { _root->PropertyChanged(token); }
 
         TYPED_EVENT(RequestedThemeChanged, winrt::Windows::Foundation::IInspectable, winrt::Microsoft::Terminal::Settings::Model::Theme);
+        TYPED_EVENT(CloseRequestedWithMultipleTabs, winrt::Windows::Foundation::IInspectable, winrt::Windows::Foundation::IInspectable);
 
     private:
         // If you add controls here, but forget to null them either here or in

--- a/src/cascadia/TerminalApp/TerminalWindow.idl
+++ b/src/cascadia/TerminalApp/TerminalWindow.idl
@@ -38,6 +38,7 @@ namespace TerminalApp
 
     };
 
+
     // See IDialogPresenter and TerminalPage's DialogPresenter for more
     // information.
     [default_interface] runtimeclass TerminalWindow : IDirectKeyListener, IDialogPresenter, Windows.UI.Xaml.Data.INotifyPropertyChanged
@@ -144,5 +145,6 @@ namespace TerminalApp
 
         void AttachContent(String content, UInt32 tabIndex);
         void SendContentToOther(RequestReceiveContentArgs args);
+        event Windows.Foundation.TypedEventHandler<Object, Object> CloseRequestedWithMultipleTabs;
     }
 }

--- a/src/cascadia/TerminalApp/TerminalWindow.idl
+++ b/src/cascadia/TerminalApp/TerminalWindow.idl
@@ -145,6 +145,6 @@ namespace TerminalApp
 
         void AttachContent(String content, UInt32 tabIndex);
         void SendContentToOther(RequestReceiveContentArgs args);
-        event Windows.Foundation.TypedEventHandler<Object, Object> CloseRequestedWithMultipleTabs;
+        event Windows.Foundation.TypedEventHandler<TerminalPage, CloseRequestedWithMultipleTabsArgs> CloseRequestedWithMultipleTabs;
     }
 }

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -366,7 +366,7 @@ void AppHost::Initialize()
     _revokers.RequestMoveContent = _windowLogic.RequestMoveContent(winrt::auto_revoke, { this, &AppHost::_handleMoveContent });
     _revokers.RequestReceiveContent = _windowLogic.RequestReceiveContent(winrt::auto_revoke, { this, &AppHost::_handleReceiveContent });
     _revokers.SendContentRequested = _peasant.SendContentRequested(winrt::auto_revoke, { this, &AppHost::_handleSendContent });
-
+    _revokers.CloseRequestedWithMultipleTabs = _windowLogic.CloseRequestedWithMultipleTabs(winrt::auto_revoke, { this, &AppHost::_OnCloseRequestedWithMultipleTabsOpen });
     // Add our GetWindowLayoutRequested handler AFTER the xaml island is
     // started. Our _GetWindowLayoutAsync handler requires us to be able to work
     // on our UI thread, which requires that we have a Dispatcher ready for us
@@ -1492,4 +1492,17 @@ void AppHost::_handleSendContent(const winrt::Windows::Foundation::IInspectable&
 void AppHost::_requestUpdateSettings()
 {
     _UpdateSettingsRequestedHandlers();
+}
+
+// page -> window -> us
+// The TerminalWindow was asked to close with multiple tabs open. Ensure that we are in the foreground
+void AppHost::_OnCloseRequestedWithMultipleTabsOpen(const winrt::Windows::Foundation::IInspectable&, const winrt::Windows::Foundation::IInspectable&)
+{
+    Remoting::SummonWindowBehavior args;
+    args.DropdownDuration(0);
+    args.MoveToCurrentDesktop(false);
+    args.ToMonitor(Remoting::MonitorBehavior::ToCurrent);
+    args.ToggleVisibility(false);
+
+    _window->SummonWindow(args);
 }

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -1503,8 +1503,8 @@ void AppHost::_OnCloseRequestedWithMultipleTabsOpen(const winrt::TerminalApp::Te
     summonWindowBehaviorArgs.MoveToCurrentDesktop(false);
     summonWindowBehaviorArgs.ToMonitor(Remoting::MonitorBehavior::ToCurrent);
     summonWindowBehaviorArgs.ToggleVisibility(false);
-
+    auto deferral = args.GetDeferral();
     _window->SummonWindow(summonWindowBehaviorArgs);
+    deferral.Complete();
 
-    args.GetDeferral().Complete();
 }

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -1501,10 +1501,9 @@ void AppHost::_OnCloseRequestedWithMultipleTabsOpen(const winrt::TerminalApp::Te
     Remoting::SummonWindowBehavior summonWindowBehaviorArgs;
     summonWindowBehaviorArgs.DropdownDuration(0);
     summonWindowBehaviorArgs.MoveToCurrentDesktop(false);
-    summonWindowBehaviorArgs.ToMonitor(Remoting::MonitorBehavior::ToCurrent);
+    summonWindowBehaviorArgs.ToMonitor(Remoting::MonitorBehavior::InPlace);
     summonWindowBehaviorArgs.ToggleVisibility(false);
     auto deferral = args.GetDeferral();
     _window->SummonWindow(summonWindowBehaviorArgs);
     deferral.Complete();
-
 }

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -1496,13 +1496,15 @@ void AppHost::_requestUpdateSettings()
 
 // page -> window -> us
 // The TerminalWindow was asked to close with multiple tabs open. Ensure that we are in the foreground
-void AppHost::_OnCloseRequestedWithMultipleTabsOpen(const winrt::Windows::Foundation::IInspectable&, const winrt::Windows::Foundation::IInspectable&)
+void AppHost::_OnCloseRequestedWithMultipleTabsOpen(const winrt::TerminalApp::TerminalPage&, const winrt::TerminalApp::CloseRequestedWithMultipleTabsArgs& args)
 {
-    Remoting::SummonWindowBehavior args;
-    args.DropdownDuration(0);
-    args.MoveToCurrentDesktop(false);
-    args.ToMonitor(Remoting::MonitorBehavior::ToCurrent);
-    args.ToggleVisibility(false);
+    Remoting::SummonWindowBehavior summonWindowBehaviorArgs;
+    summonWindowBehaviorArgs.DropdownDuration(0);
+    summonWindowBehaviorArgs.MoveToCurrentDesktop(false);
+    summonWindowBehaviorArgs.ToMonitor(Remoting::MonitorBehavior::ToCurrent);
+    summonWindowBehaviorArgs.ToggleVisibility(false);
 
-    _window->SummonWindow(args);
+    _window->SummonWindow(summonWindowBehaviorArgs);
+
+    args.GetDeferral().Complete();
 }

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -1500,6 +1500,9 @@ void AppHost::_requestUpdateSettings()
 // The TerminalWindow was asked to close with multiple tabs open. Ensure that we are in the foreground
 void AppHost::_OnCloseRequestedWithMultipleTabsOpen(const winrt::TerminalApp::TerminalPage&, const winrt::TerminalApp::CloseRequestedWithMultipleTabsArgs& args)
 {
+
+    Remoting::SummonWindowSelectionArgs selectionArgs;
+    
     Remoting::SummonWindowBehavior summonWindowBehaviorArgs;
     summonWindowBehaviorArgs.DropdownDuration(0);
     summonWindowBehaviorArgs.MoveToCurrentDesktop(false);
@@ -1508,13 +1511,15 @@ void AppHost::_OnCloseRequestedWithMultipleTabsOpen(const winrt::TerminalApp::Te
     
     // We need to wait to signal our event args until the Window has been summoned. So lets grab a deferral here.
     // If we dont wait the Confirmation dialog will dismiss during the movement of the window.
-    auto deferral = args.GetDeferral();
 
     // This code will run after the window has moved to signal our deferral as complete and then clean up the event_token.
-    _WindowMovedToken = _window->WindowMoved([deferral, this]() {
+    /*_WindowMovedToken = _window->WindowMoved([deferral, this]() {
         deferral.Complete();
         _window->WindowMoved(_WindowMovedToken);
-    });
+    });*/
 
-    _window->SummonWindow(summonWindowBehaviorArgs);
+    //_window->SummonWindow(summonWindowBehaviorArgs);
+    selectionArgs.SummonBehavior(summonWindowBehaviorArgs);
+    _windowManager.SummonWindow(selectionArgs);
+    args.GetDeferral().Complete();
 }

--- a/src/cascadia/WindowsTerminal/AppHost.cpp
+++ b/src/cascadia/WindowsTerminal/AppHost.cpp
@@ -1500,9 +1500,6 @@ void AppHost::_requestUpdateSettings()
 // The TerminalWindow was asked to close with multiple tabs open. Ensure that we are in the foreground
 void AppHost::_OnCloseRequestedWithMultipleTabsOpen(const winrt::TerminalApp::TerminalPage&, const winrt::TerminalApp::CloseRequestedWithMultipleTabsArgs& args)
 {
-
-    Remoting::SummonWindowSelectionArgs selectionArgs;
-    
     Remoting::SummonWindowBehavior summonWindowBehaviorArgs;
     summonWindowBehaviorArgs.DropdownDuration(0);
     summonWindowBehaviorArgs.MoveToCurrentDesktop(false);
@@ -1511,15 +1508,13 @@ void AppHost::_OnCloseRequestedWithMultipleTabsOpen(const winrt::TerminalApp::Te
     
     // We need to wait to signal our event args until the Window has been summoned. So lets grab a deferral here.
     // If we dont wait the Confirmation dialog will dismiss during the movement of the window.
+    auto deferral = args.GetDeferral();
 
     // This code will run after the window has moved to signal our deferral as complete and then clean up the event_token.
-    /*_WindowMovedToken = _window->WindowMoved([deferral, this]() {
+    _WindowMovedToken = _window->WindowMoved([deferral, this]() {
         deferral.Complete();
         _window->WindowMoved(_WindowMovedToken);
-    });*/
+    });
 
-    //_window->SummonWindow(summonWindowBehaviorArgs);
-    selectionArgs.SummonBehavior(summonWindowBehaviorArgs);
-    _windowManager.SummonWindow(selectionArgs);
-    args.GetDeferral().Complete();
+    _window->SummonWindow(summonWindowBehaviorArgs);
 }

--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -157,6 +157,7 @@ private:
     void _startFrameTimer();
     void _stopFrameTimer();
     void _updateFrameColor(const winrt::Windows::Foundation::IInspectable&, const winrt::Windows::Foundation::IInspectable&);
+    void _OnCloseRequestedWithMultipleTabsOpen(const winrt::Windows::Foundation::IInspectable&, const winrt::Windows::Foundation::IInspectable&);
 
     winrt::event_token _GetWindowLayoutRequestedToken;
     winrt::event_token _frameTimerToken;
@@ -201,5 +202,6 @@ private:
 
         winrt::Microsoft::Terminal::Remoting::WindowManager::QuitAllRequested_revoker QuitAllRequested;
         winrt::Microsoft::Terminal::Remoting::Peasant::SendContentRequested_revoker SendContentRequested;
+        winrt::TerminalApp::TerminalWindow::CloseRequestedWithMultipleTabs_revoker CloseRequestedWithMultipleTabs;
     } _revokers{};
 };

--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -161,6 +161,7 @@ private:
 
     winrt::event_token _GetWindowLayoutRequestedToken;
     winrt::event_token _frameTimerToken;
+    winrt::event_token _WindowMovedToken;
 
     // Helper struct. By putting these all into one struct, we can revoke them
     // all at once, by assigning _revokers to a fresh Revokers instance. That'll

--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -157,7 +157,7 @@ private:
     void _startFrameTimer();
     void _stopFrameTimer();
     void _updateFrameColor(const winrt::Windows::Foundation::IInspectable&, const winrt::Windows::Foundation::IInspectable&);
-    void _OnCloseRequestedWithMultipleTabsOpen(const winrt::Windows::Foundation::IInspectable&, const winrt::Windows::Foundation::IInspectable&);
+    void _OnCloseRequestedWithMultipleTabsOpen(const winrt::TerminalApp::TerminalPage&, const winrt::TerminalApp::CloseRequestedWithMultipleTabsArgs&);
 
     winrt::event_token _GetWindowLayoutRequestedToken;
     winrt::event_token _frameTimerToken;


### PR DESCRIPTION
## Summary of the Pull Request
- Adds an event to the `TerminalPage` and `TerminalWindow` that can be raised when the terminal is closed with multiple tabs opened. This event can be handled in the `AppHost` by summoning the window.
## References and Relevant Issues
#12605 
## Detailed Description of the Pull Request / Additional comments
I initially implemented this as a `WINRT_CALLBACK` but it kind of stuck out in the host layer so I decided to switch it to a `TypedEvent`. This will also allow for information passing if so desired in the future.

## Validation Steps Performed
Validated that the window is brought to the foreground when multiple tabs are open so that the Confirm dialog is seen. Window is not summoned if only a single tab is open.

## PR Checklist
- [ ] Closes #12605 
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
