### PR TITLE
Add support for the VSCode mark sequences*

### DIFF
--- a/src/terminal/adapter/ITermDispatch.hpp
+++ b/src/terminal/adapter/ITermDispatch.hpp
@@ -136,6 +136,7 @@ public:
     virtual bool DoITerm2Action(const std::wstring_view string) = 0;
 
     virtual bool DoFinalTermAction(const std::wstring_view string) = 0;
+    virtual bool DoXtermJsAction(const std::wstring_view string) = 0;
 
     virtual StringHandler DownloadDRCS(const VTInt fontNumber,
                                        const VTParameter startChar,

--- a/src/terminal/adapter/adaptDispatch.cpp
+++ b/src/terminal/adapter/adaptDispatch.cpp
@@ -3729,6 +3729,13 @@ bool AdaptDispatch::DoFinalTermAction(const std::wstring_view string)
     return false;
 }
 
+// We literally only implement the xterm.js sequences that are aliases for the
+// final term ones. Just implement exactly the same.
+bool AdaptDispatch::DoXtermJsAction(const std::wstring_view string)
+{
+    return DoFinalTermAction(string);
+}
+
 // Method Description:
 // - DECDLD - Downloads one or more characters of a dynamically redefinable
 //   character set (DRCS) with a specified pixel pattern. The pixel array is

--- a/src/terminal/adapter/adaptDispatch.hpp
+++ b/src/terminal/adapter/adaptDispatch.hpp
@@ -138,6 +138,7 @@ namespace Microsoft::Console::VirtualTerminal
         bool DoITerm2Action(const std::wstring_view string) override;
 
         bool DoFinalTermAction(const std::wstring_view string) override;
+        bool DoXtermJsAction(const std::wstring_view string) override;
 
         StringHandler DownloadDRCS(const VTInt fontNumber,
                                    const VTParameter startChar,

--- a/src/terminal/parser/OutputStateMachineEngine.cpp
+++ b/src/terminal/parser/OutputStateMachineEngine.cpp
@@ -417,10 +417,11 @@ bool OutputStateMachineEngine::ActionVt52EscDispatch(const VTID id, const VTPara
 bool OutputStateMachineEngine::ActionCsiDispatch(const VTID id, const VTParameters parameters)
 {
     // Bail out if we receive subparameters, but we don't accept them in the sequence.
-    if (parameters.hasSubParams() && !_CanSeqAcceptSubParam(id, parameters)) [[unlikely]]
-    {
-        return false;
-    }
+    if (parameters.hasSubParams() && !_CanSeqAcceptSubParam(id, parameters))
+        [[unlikely]]
+        {
+            return false;
+        }
 
     auto success = false;
 
@@ -866,6 +867,11 @@ bool OutputStateMachineEngine::ActionOscDispatch(const wchar_t /*wch*/,
     case OscActionCodes::FinalTermAction:
     {
         success = _dispatch->DoFinalTermAction(string);
+        break;
+    }
+    case OscActionCodes::XtermJsAction:
+    {
+        success = _dispatch->DoXtermJsAction(string);
         break;
     }
     default:

--- a/src/terminal/parser/OutputStateMachineEngine.hpp
+++ b/src/terminal/parser/OutputStateMachineEngine.hpp
@@ -214,6 +214,7 @@ namespace Microsoft::Console::VirtualTerminal
             ResetBackgroundColor = 111, // Not implemented
             ResetCursorColor = 112,
             FinalTermAction = 133,
+            XtermJsAction = 633,
             ITerm2Action = 1337,
         };
 


### PR DESCRIPTION
_\*that we already support_

VsCode has their own fork of the FTCS marks. Theirs uses `633` as the OSC prefix instead of `133`. This adds support to the Terminal for that format, as an alias for the FTCS marks we already support.

This does not add any of the other sequences we didn't already support.

see: #11000
as complained about in #7434 