### PR TITLE
Fix matches of multiple schemas on "colorScheme"

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -1836,11 +1836,7 @@
       "properties": {
         "applicationTheme": {
           "description": "Which UI theme the Terminal should use for controls",
-          "enum": [
-            "light",
-            "dark",
-            "system"
-          ],
+          "enum": [ "light", "dark", "system" ],
           "type": "string"
         },
         "useMica": {
@@ -1871,11 +1867,7 @@
           "type": "string",
           "description": "The name of the theme. This will be displayed in the settings UI.",
           "not": {
-            "enum": [
-              "light",
-              "dark",
-              "system"
-            ]
+            "enum": [ "light", "dark", "system" ]
           }
         },
         "tab": {

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -260,7 +260,8 @@
           "description": "Name of the scheme to use when the app is using dark theme",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
     "FontConfig": {
       "properties": {
@@ -1835,7 +1836,11 @@
       "properties": {
         "applicationTheme": {
           "description": "Which UI theme the Terminal should use for controls",
-          "enum": [ "light", "dark", "system" ],
+          "enum": [
+            "light",
+            "dark",
+            "system"
+          ],
           "type": "string"
         },
         "useMica": {
@@ -1866,7 +1871,11 @@
           "type": "string",
           "description": "The name of the theme. This will be displayed in the settings UI.",
           "not": {
-            "enum": [ "light", "dark", "system" ]
+            "enum": [
+              "light",
+              "dark",
+              "system"
+            ]
           }
         },
         "tab": {


### PR DESCRIPTION
Adds proper `type` for `SchemePair` definition to avoid warnings about matches of multiple schemas.

Same fix as https://github.com/microsoft/terminal/pull/4045

## Validation Steps Performed
- Pointed $schema to local file instead of https://aka.ms/terminal-profiles-schema
- Confirmed warning goes away when using a string
- Confirmed using the light/dark object format still passes validation
- Confirmed values like `"colorScheme": 3` no longer incorrectly pass validation whereas they would before