### PR TITLE
ConHost: Ignore WM_[SYS]KEYDOWN/WM_[SYS]KEYUP events with an invalid virtual keycode and a scan code of 0

### DIFF
--- a/src/host/ft_host/Message_KeyPressTests.cpp
+++ b/src/host/ft_host/Message_KeyPressTests.cpp
@@ -112,7 +112,7 @@ class KeyPressTests
             return;
         }
 
-        Log::Comment(L"Testing that key events with invalid virtual keycode and invalid scan code are properly ignored, and not put into the input buffer");
+        Log::Comment(L"Testing that key events with an invalid virtual keycode and an invalid scan code are properly ignored, and not put into the input buffer");
         BOOL successBool;
         auto hwnd = GetConsoleWindow();
         VERIFY_IS_TRUE(!!IsWindow(hwnd));
@@ -125,8 +125,8 @@ class KeyPressTests
         VERIFY_IS_TRUE(!!successBool);
         VERIFY_ARE_EQUAL(events, 0u);
 
-        WPARAM vKey = 0xFF; // invalid keycode
-        BYTE scanCode = 0; // invalid scancode
+        WPARAM vKey = 0xFF;
+        BYTE scanCode = 0;
         WORD repeatCount = 1;
 
         LPARAM lParam = (scanCode << 16) | repeatCount;
@@ -191,6 +191,8 @@ class KeyPressTests
         VERIFY_ARE_EQUAL(events, 1u);
         VERIFY_ARE_EQUAL(inputBuffer[0].EventType, KEY_EVENT);
         VERIFY_ARE_EQUAL(inputBuffer[0].Event.KeyEvent.wRepeatCount, 1, NoThrowString().Format(L"%d", inputBuffer[0].Event.KeyEvent.wRepeatCount));
+        // Scan code should be set to the correct value.
+        VERIFY_ARE_EQUAL(inputBuffer[0].Event.KeyEvent.wVirtualScanCode, VK_LWIN);
         // 'VK_LWIN' is an enhanced key, so the ENHANCED_KEY bit should be set.
         VERIFY_IS_TRUE(inputBuffer[0].Event.KeyEvent.dwControlKeyState & ENHANCED_KEY);
     }
@@ -217,8 +219,8 @@ class KeyPressTests
         VERIFY_IS_TRUE(!!successBool);
         VERIFY_ARE_EQUAL(events, 0u);
 
-        // Send a bunch of 'a' keypresses to the console.
-        WORD repeatCount = 1;
+        // send a bunch of 'a' keypresses to the console.
+        DWORD repeatCount = 1;
         const unsigned int messageSendCount = 1000;
         for (unsigned int i = 0; i < messageSendCount; ++i)
         {

--- a/src/host/ft_host/Message_KeyPressTests.cpp
+++ b/src/host/ft_host/Message_KeyPressTests.cpp
@@ -191,6 +191,8 @@ class KeyPressTests
         VERIFY_ARE_EQUAL(events, 1u);
         VERIFY_ARE_EQUAL(inputBuffer[0].EventType, KEY_EVENT);
         VERIFY_ARE_EQUAL(inputBuffer[0].Event.KeyEvent.wRepeatCount, 1, NoThrowString().Format(L"%d", inputBuffer[0].Event.KeyEvent.wRepeatCount));
+        // 'VK_LWIN' is an enhanced key, so the ENHANCED_KEY bit should be set.
+        VERIFY_IS_TRUE(inputBuffer[0].Event.KeyEvent.dwControlKeyState & ENHANCED_KEY); 
     }
 
     TEST_METHOD(TestCoalesceSameKeyPress)

--- a/src/host/ft_host/Message_KeyPressTests.cpp
+++ b/src/host/ft_host/Message_KeyPressTests.cpp
@@ -192,7 +192,7 @@ class KeyPressTests
         VERIFY_ARE_EQUAL(inputBuffer[0].EventType, KEY_EVENT);
         VERIFY_ARE_EQUAL(inputBuffer[0].Event.KeyEvent.wRepeatCount, 1, NoThrowString().Format(L"%d", inputBuffer[0].Event.KeyEvent.wRepeatCount));
         // 'VK_LWIN' is an enhanced key, so the ENHANCED_KEY bit should be set.
-        VERIFY_IS_TRUE(inputBuffer[0].Event.KeyEvent.dwControlKeyState & ENHANCED_KEY); 
+        VERIFY_IS_TRUE(inputBuffer[0].Event.KeyEvent.dwControlKeyState & ENHANCED_KEY);
     }
 
     TEST_METHOD(TestCoalesceSameKeyPress)

--- a/src/interactivity/win32/windowio.cpp
+++ b/src/interactivity/win32/windowio.cpp
@@ -172,7 +172,7 @@ void HandleKeyEvent(const HWND hWnd,
     // virtual key code, and invalid scan code. We need to filter such events out,
     // as some applications (e.g. WSL) treat those events as valid key events and
     // translate them to an ascii NULL character. GH#15753
-    if (VirtualScanCode == 0 && !IsCharacterMessage)  // `WM_[SYS][DEAD]CHAR` messages don't have this issue
+    if (VirtualScanCode == 0 && !IsCharacterMessage) // `WM_[SYS][DEAD]CHAR` messages don't have this issue
     {
         // We try to infer the correct scan code from the virtual key code. If the
         // virtual key code is invalid or we couldn't map it to a scan code,

--- a/src/interactivity/win32/windowio.cpp
+++ b/src/interactivity/win32/windowio.cpp
@@ -167,6 +167,14 @@ void HandleKeyEvent(const HWND hWnd,
         // --- END LOAD BEARING CODE ---
     }
 
+    // Certain applications like PowerToys and AutoHotKey, due to their keyboard
+    // remapping feature, send us key events using SendInput() whose values could
+    // be outside of the valid range. We should ignore such KeyEvents. GH#7064
+    if (VirtualKeyCode == 0 || VirtualKeyCode >= 0xff)
+    {
+        return;
+    }
+
     KeyEvent keyEvent{ !!bKeyDown, RepeatCount, VirtualKeyCode, VirtualScanCode, UNICODE_NULL, 0 };
 
     if (Message == WM_CHAR || Message == WM_SYSCHAR || Message == WM_DEADCHAR || Message == WM_SYSDEADCHAR)

--- a/src/interactivity/win32/windowio.cpp
+++ b/src/interactivity/win32/windowio.cpp
@@ -176,16 +176,15 @@ void HandleKeyEvent(const HWND hWnd,
     //   as the virtual key code is valid (0 < vKey < 0xFF).
     if (VirtualScanCode == 0) [[unlikely]]
     {
-        // try to infer scancode from virtual keycode
         auto FullVirtualScanCode = gsl::narrow_cast<WORD>(OneCoreSafeMapVirtualKeyW(VirtualKeyCode, MAPVK_VK_TO_VSC_EX));
         VirtualScanCode = LOBYTE(FullVirtualScanCode);
-        // if we still don't have a scancode, return.
+        // If the virtual key code is invalid, translation fails with LOBYTE(0). (We ignore the enhanced bit because it doesn't affect the scan code.)
         if (VirtualScanCode == 0)
         {
             return;
         }
         // Otherwise, set 'enhanced' bit if necessary and continue.
-        ControlKeyState |= (HIBYTE(FullVirtualScanCode) == 0xE0) && ENHANCED_KEY;
+        ControlKeyState |= (HIBYTE(FullVirtualScanCode) == 0xE0) ? ENHANCED_KEY : 0;
     }
 
     KeyEvent keyEvent{ !!bKeyDown, RepeatCount, VirtualKeyCode, VirtualScanCode, UNICODE_NULL, 0 };


### PR DESCRIPTION
## Summary
Applications like PowerToys, with their keyboard remapping features frequently (i.e whenever a remapped shortcut is triggerred) send `KeyEvent` with out-of-range virtual keycode values (E.g. 0xFF). This is fixed for WT in #7145, we just needed it in our good ol' `conhost`.

After this PR, Key events with an invalid virtual keycode and scancode==0 are ignored, and are not added to the `InputBuffer`. Incase, only virtual keycode is valid but not scancode, we will try to infer the correct scancode using the virtual keycode mapping.

## References and Relevant Issues
#7145 
#7064 

## Validation Steps Performed

- Triggered a remapped shortcut and verified that `showkey -a` doesn't output `^@` unexpectedly.
- Key events with an Invalid virtual Keycode and Scancode == 0 are ignored.
- This PR doesn't include any changes for `WM_[SYS][DEAD]CHAR` messages, they are left unchanged.