### PR TITLE
Switch away from the WinDev agent pools

### DIFF
--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -340,6 +340,7 @@ jobs:
 
 - ${{ if eq(parameters.buildTerminal, true) }}:
   - job: BundleAndSign
+    pool: { name: SHINE-INT-S }
     displayName: Create and sign AppX/MSIX bundles
     variables:
       ${{ if eq(parameters.branding, 'Release') }}:
@@ -435,6 +436,7 @@ jobs:
 
 - ${{ if eq(parameters.buildConPTY, true) }}:
   - job: PackageAndSignConPTY
+    pool: { name: SHINE-INT-S }
     strategy:
       matrix:
         ${{ each config in parameters.buildConfigurations }}:
@@ -526,6 +528,7 @@ jobs:
 
 - ${{ if eq(parameters.buildWPF, true) }}:
   - job: PackageAndSignWPF
+    pool: { name: SHINE-INT-S }
     strategy:
       matrix:
         ${{ each config in parameters.buildConfigurations }}:
@@ -631,6 +634,7 @@ jobs:
 
 - ${{ if eq(parameters.publishSymbolsToPublic, true) }}:
   - job: PublishSymbols
+    pool: { name: SHINE-INT-S }
     displayName: Publish Symbols
     dependsOn: BundleAndSign
     steps:
@@ -697,6 +701,7 @@ jobs:
 
 - ${{ if eq(parameters.buildTerminalVPack, true) }}:
   - job: VPack
+    pool: { name: SHINE-INT-S }
     displayName: Create Windows vPack
     dependsOn: BundleAndSign
     steps:

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -3,7 +3,7 @@ trigger: none
 pr: none
 
 pool:
-  name: WinDevPool-L
+  name: SHINE-INT-L
   demands: ImageOverride -equals SHINE-VS17-Latest
 
 parameters:

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -4,7 +4,7 @@ pr: none
 
 pool:
   name: WinDevPool-L
-  demands: ImageOverride -equals WinDevVS17-latest
+  demands: ImageOverride -equals SHINE-VS17-Latest
 
 parameters:
   - name: branding

--- a/build/pipelines/release.yml
+++ b/build/pipelines/release.yml
@@ -3,7 +3,7 @@ trigger: none
 pr: none
 
 pool:
-  name: SHINE-INT-L
+  name: SHINE-INT-S # By default, send jobs to the small agent pool.
   demands: ImageOverride -equals SHINE-VS17-Latest
 
 parameters:
@@ -91,6 +91,9 @@ resources:
     ref: main
 jobs:
 - job: Build
+  pool:
+    name: SHINE-INT-L # Run the compilation on the large agent pool, rather than the default small one.
+    demands: ImageOverride -equals SHINE-VS17-Latest
   strategy:
     matrix:
       ${{ each config in parameters.buildConfigurations }}:
@@ -340,7 +343,6 @@ jobs:
 
 - ${{ if eq(parameters.buildTerminal, true) }}:
   - job: BundleAndSign
-    pool: { name: SHINE-INT-S }
     displayName: Create and sign AppX/MSIX bundles
     variables:
       ${{ if eq(parameters.branding, 'Release') }}:
@@ -436,7 +438,6 @@ jobs:
 
 - ${{ if eq(parameters.buildConPTY, true) }}:
   - job: PackageAndSignConPTY
-    pool: { name: SHINE-INT-S }
     strategy:
       matrix:
         ${{ each config in parameters.buildConfigurations }}:
@@ -528,7 +529,6 @@ jobs:
 
 - ${{ if eq(parameters.buildWPF, true) }}:
   - job: PackageAndSignWPF
-    pool: { name: SHINE-INT-S }
     strategy:
       matrix:
         ${{ each config in parameters.buildConfigurations }}:
@@ -634,7 +634,6 @@ jobs:
 
 - ${{ if eq(parameters.publishSymbolsToPublic, true) }}:
   - job: PublishSymbols
-    pool: { name: SHINE-INT-S }
     displayName: Publish Symbols
     dependsOn: BundleAndSign
     steps:
@@ -701,7 +700,6 @@ jobs:
 
 - ${{ if eq(parameters.buildTerminalVPack, true) }}:
   - job: VPack
-    pool: { name: SHINE-INT-S }
     displayName: Create Windows vPack
     dependsOn: BundleAndSign
     steps:

--- a/build/pipelines/templates/build-console-audit-job.yml
+++ b/build/pipelines/templates/build-console-audit-job.yml
@@ -12,7 +12,7 @@ jobs:
     ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: SHINE-OSS-L
     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: WinDevPool-L
+      name: SHINE-INT-L
     demands: ImageOverride -equals SHINE-VS17-Latest
 
   steps:

--- a/build/pipelines/templates/build-console-audit-job.yml
+++ b/build/pipelines/templates/build-console-audit-job.yml
@@ -10,7 +10,7 @@ jobs:
     BuildPlatform: ${{ parameters.platform }}
   pool:
     ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: WinDevPoolOSS-L
+      name: SHINE-OSS-L
     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: WinDevPool-L
     demands: ImageOverride -equals WinDevVS17-latest

--- a/build/pipelines/templates/build-console-audit-job.yml
+++ b/build/pipelines/templates/build-console-audit-job.yml
@@ -13,7 +13,7 @@ jobs:
       name: SHINE-OSS-L
     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: WinDevPool-L
-    demands: ImageOverride -equals WinDevVS17-latest
+    demands: ImageOverride -equals SHINE-VS17-Latest
 
   steps:
   - checkout: self

--- a/build/pipelines/templates/build-console-ci.yml
+++ b/build/pipelines/templates/build-console-ci.yml
@@ -14,7 +14,7 @@ jobs:
     EnableRichCodeNavigation: true
   pool:
     ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: WinDevPoolOSS-L
+      name: SHINE-OSS-L
     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: WinDevPool-L
     demands: ImageOverride -equals WinDevVS17-latest

--- a/build/pipelines/templates/build-console-ci.yml
+++ b/build/pipelines/templates/build-console-ci.yml
@@ -16,7 +16,7 @@ jobs:
     ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: SHINE-OSS-L
     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: WinDevPool-L
+      name: SHINE-INT-L
     demands: ImageOverride -equals SHINE-VS17-Latest
 
   steps:

--- a/build/pipelines/templates/build-console-ci.yml
+++ b/build/pipelines/templates/build-console-ci.yml
@@ -17,7 +17,7 @@ jobs:
       name: SHINE-OSS-L
     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: WinDevPool-L
-    demands: ImageOverride -equals WinDevVS17-latest
+    demands: ImageOverride -equals SHINE-VS17-Latest
 
   steps:
   - template: build-console-steps.yml

--- a/build/pipelines/templates/build-console-fuzzing.yml
+++ b/build/pipelines/templates/build-console-fuzzing.yml
@@ -11,7 +11,7 @@ jobs:
     BuildPlatform: ${{ parameters.platform }}
   pool:
     ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: WinDevPoolOSS-L
+      name: SHINE-OSS-L
     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: WinDevPool-L
     demands: ImageOverride -equals WinDevVS17-latest

--- a/build/pipelines/templates/build-console-fuzzing.yml
+++ b/build/pipelines/templates/build-console-fuzzing.yml
@@ -13,7 +13,7 @@ jobs:
     ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: SHINE-OSS-L
     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: WinDevPool-L
+      name: SHINE-INT-L
     demands: ImageOverride -equals SHINE-VS17-Latest
 
   steps:

--- a/build/pipelines/templates/build-console-fuzzing.yml
+++ b/build/pipelines/templates/build-console-fuzzing.yml
@@ -14,7 +14,7 @@ jobs:
       name: SHINE-OSS-L
     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: WinDevPool-L
-    demands: ImageOverride -equals WinDevVS17-latest
+    demands: ImageOverride -equals SHINE-VS17-Latest
 
   steps:
   - checkout: self

--- a/build/pipelines/templates/build-console-pgo.yml
+++ b/build/pipelines/templates/build-console-pgo.yml
@@ -16,7 +16,7 @@ jobs:
     ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: SHINE-OSS-L
     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: WinDevPool-L
+      name: SHINE-INT-L
     demands: ImageOverride -equals SHINE-VS17-Latest
 
   steps:

--- a/build/pipelines/templates/build-console-pgo.yml
+++ b/build/pipelines/templates/build-console-pgo.yml
@@ -14,7 +14,7 @@ jobs:
     PGOBuildMode: 'Instrument'
   pool:
     ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: WinDevPoolOSS-L
+      name: SHINE-OSS-L
     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: WinDevPool-L
     demands: ImageOverride -equals WinDevVS17-latest

--- a/build/pipelines/templates/build-console-pgo.yml
+++ b/build/pipelines/templates/build-console-pgo.yml
@@ -17,7 +17,7 @@ jobs:
       name: SHINE-OSS-L
     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: WinDevPool-L
-    demands: ImageOverride -equals WinDevVS17-latest
+    demands: ImageOverride -equals SHINE-VS17-Latest
 
   steps:
   - template: build-console-steps.yml

--- a/build/pipelines/templates/test-console-ci.yml
+++ b/build/pipelines/templates/test-console-ci.yml
@@ -13,7 +13,7 @@ jobs:
     BuildPlatform: ${{ parameters.platform }}
   pool:
     ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: WinDevPoolOSS-L
+      name: SHINE-OSS-L
     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: WinDevPool-L
     demands: ImageOverride -equals WinDevVS17-latest

--- a/build/pipelines/templates/test-console-ci.yml
+++ b/build/pipelines/templates/test-console-ci.yml
@@ -15,7 +15,7 @@ jobs:
     ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: SHINE-OSS-L
     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: WinDevPool-L
+      name: SHINE-INT-L
     demands: ImageOverride -equals SHINE-VS17-Latest
 
   steps:

--- a/build/pipelines/templates/test-console-ci.yml
+++ b/build/pipelines/templates/test-console-ci.yml
@@ -16,7 +16,7 @@ jobs:
       name: SHINE-OSS-L
     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: WinDevPool-L
-    demands: ImageOverride -equals WinDevVS17-latest
+    demands: ImageOverride -equals SHINE-VS17-Latest
 
   steps:
   - checkout: self


### PR DESCRIPTION
Using our own pools like this gives us a lot of freedom in the tooling that's installed, the OS versions it targets, and when we take on Visual Studio updates.

As part of this effort, I've also stood up a "small" agent pool. At the time of this PR, that pool is using D2ads-v5 SKU VMs (2 vcore 8 GiB) versus the "large" agent pool's D8as-v5 (8 vcore 32 GiB). Smaller build tasks have been moved over to the small pool. Compilation's the hard part, so it gets to stay on the large pool.