### PR TITLE
Add UIA element grouping to SettingsContainer

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/SettingContainerStyle.xaml
+++ b/src/cascadia/TerminalSettingsEditor/SettingContainerStyle.xaml
@@ -106,7 +106,8 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:SettingContainer">
-                    <Grid Style="{StaticResource NonExpanderGrid}">
+                    <Grid Style="{StaticResource NonExpanderGrid}"
+                          AutomationProperties.Name="{TemplateBinding Header}">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />

--- a/src/cascadia/TerminalSettingsEditor/SettingContainerStyle.xaml
+++ b/src/cascadia/TerminalSettingsEditor/SettingContainerStyle.xaml
@@ -106,8 +106,8 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:SettingContainer">
-                    <Grid Style="{StaticResource NonExpanderGrid}"
-                          AutomationProperties.Name="{TemplateBinding Header}">
+                    <Grid AutomationProperties.Name="{TemplateBinding Header}"
+                          Style="{StaticResource NonExpanderGrid}">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />


### PR DESCRIPTION
Adds an `AutomationProperty.Name` to the main grid in the `SettingContainer`. Doing so makes it so that the group of elements is considered a "group \<header\>".

Now, when navigating with a screen reader, when you enter the group of elements, the "group \<header\>" will be presented. Thus, if the user navigates to the "reset" button, it'll be prefaced with a "group \<header\>" announcement first. If the user navigates to it from the other direction (the setting control), this announcement isn't made, but the user already has an understanding of what group of settings they're in, which is standard practice.

Closes #15158 