### PR TITLE
Feat/14909 conn state in tab

### DIFF
--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -1382,15 +1382,15 @@ Profile Pane::GetFocusedProfile()
 }
 
 // Method Description:
-// - Gets the connection state of this pane. If this Pane is not a leaf this will
-//   return NotConnected.
+// - Returns true if the connection state of this pane is closed. If this Pane is not a leaf this will
+//   return false.
 // Arguments:
 // - <none>
 // Return Value:
-// - The connection state of this Pane.
-winrt::Microsoft::Terminal::TerminalConnection::ConnectionState Pane::GetConnectionState() const
+// - true if the connection state of this Pane is closed.
+bool Pane::IsConnectionClosed() const
 {
-    return _connectionState;
+    return _connectionState >= ConnectionState::Closed;
 }
 
 // Method Description:

--- a/src/cascadia/TerminalApp/Pane.cpp
+++ b/src/cascadia/TerminalApp/Pane.cpp
@@ -1382,6 +1382,18 @@ Profile Pane::GetFocusedProfile()
 }
 
 // Method Description:
+// - Gets the connection state of this pane. If this Pane is not a leaf this will
+//   return NotConnected.
+// Arguments:
+// - <none>
+// Return Value:
+// - The connection state of this Pane.
+winrt::Microsoft::Terminal::TerminalConnection::ConnectionState Pane::GetConnectionState() const
+{
+    return _connectionState;
+}
+
+// Method Description:
 // - Returns true if this pane was the last pane to be focused in a tree of panes.
 // Arguments:
 // - <none>

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -75,7 +75,7 @@ public:
     winrt::Microsoft::Terminal::Control::TermControl GetLastFocusedTerminalControl();
     winrt::Microsoft::Terminal::Control::TermControl GetTerminalControl();
     winrt::Microsoft::Terminal::Settings::Model::Profile GetFocusedProfile();
-    winrt::Microsoft::Terminal::TerminalConnection::ConnectionState GetConnectionState() const;
+    bool IsConnectionClosed() const;
 
     // Method Description:
     // - If this is a leaf pane, return its profile.

--- a/src/cascadia/TerminalApp/Pane.h
+++ b/src/cascadia/TerminalApp/Pane.h
@@ -75,6 +75,7 @@ public:
     winrt::Microsoft::Terminal::Control::TermControl GetLastFocusedTerminalControl();
     winrt::Microsoft::Terminal::Control::TermControl GetTerminalControl();
     winrt::Microsoft::Terminal::Settings::Model::Profile GetFocusedProfile();
+    winrt::Microsoft::Terminal::TerminalConnection::ConnectionState GetConnectionState() const;
 
     // Method Description:
     // - If this is a leaf pane, return its profile.

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -840,4 +840,7 @@
     <value>Run as Administrator</value>
     <comment>This text is displayed on context menu for profile entries in add new tab button.</comment>
   </data>
+  <data name="RestartConnectionText" xml:space="preserve">
+    <value>Restart Connection</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -843,4 +843,7 @@
   <data name="RestartConnectionText" xml:space="preserve">
     <value>Restart Connection</value>
   </data>
+  <data name="RestartConnectionToolTip" xml:space="preserve">
+    <value>Restart the active pane connection</value>
+  </data>
 </root>

--- a/src/cascadia/TerminalApp/TabHeaderControl.xaml
+++ b/src/cascadia/TerminalApp/TabHeaderControl.xaml
@@ -43,6 +43,12 @@
                   FontSize="12"
                   Glyph="&#xE72E;"
                   Visibility="{x:Bind TabStatus.IsReadOnlyActive, Mode=OneWay}" />
+        <FontIcon x:Name="HeaderClosedIcon"
+                  Margin="0,0,8,0"
+                  FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                  FontSize="12"
+                  Glyph="&#xEA39;"
+                  Visibility="{x:Bind TabStatus.IsConnectionClosed, Mode=OneWay}" />
         <FontIcon x:Name="HeaderBroadcastIcon"
                   Margin="0,0,8,0"
                   FontFamily="{ThemeResource SymbolThemeFontFamily}"

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4717,9 +4717,12 @@ namespace winrt::TerminalApp::implementation
             makeItem(RS_(L"PaneClose"), L"\xE89F", ActionAndArgs{ ShortcutAction::ClosePane, nullptr });
         }
 
-        if (const auto& control{ _GetActiveControl() }; control.ConnectionState() >= ConnectionState::Closed)
+        if (const auto pane{ _GetFocusedTabImpl()->GetActivePane() })
         {
-            makeItem(RS_(L"RestartConnectionText"), L"\xE72C", ActionAndArgs{ ShortcutAction::RestartConnection, nullptr });
+            if (pane->IsConnectionClosed())
+            {
+                makeItem(RS_(L"RestartConnectionText"), L"\xE72C", ActionAndArgs{ ShortcutAction::RestartConnection, nullptr });
+            }
         }
 
         if (withSelection)

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -4664,8 +4664,7 @@ namespace winrt::TerminalApp::implementation
                                             const bool withSelection)
     {
         // withSelection can be used to add actions that only appear if there's
-        // selected text, like "search the web". In this initial draft, it's not
-        // actually augmented by the TerminalPage, so it's left commented out.
+        // selected text, like "search the web"
 
         const auto& menu{ sender.try_as<MUX::Controls::CommandBarFlyout>() };
         if (!menu)
@@ -4716,6 +4715,11 @@ namespace winrt::TerminalApp::implementation
         if (_GetFocusedTabImpl()->GetLeafPaneCount() > 1)
         {
             makeItem(RS_(L"PaneClose"), L"\xE89F", ActionAndArgs{ ShortcutAction::ClosePane, nullptr });
+        }
+
+        if (const auto& control{ _GetActiveControl() }; control.ConnectionState() >= ConnectionState::Closed)
+        {
+            makeItem(RS_(L"RestartConnectionText"), L"\xE72C", ActionAndArgs{ ShortcutAction::RestartConnection, nullptr });
         }
 
         if (withSelection)

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -1078,7 +1078,7 @@ namespace winrt::TerminalApp::implementation
         if (_rootPane)
         {
             const bool isClosed = _rootPane->WalkTree([&](const auto& p) {
-                return p->GetConnectionState() >= ConnectionState::Closed;
+                return p->IsConnectionClosed();
             });
 
             _tabStatus.IsConnectionClosed(isClosed);
@@ -1086,8 +1086,9 @@ namespace winrt::TerminalApp::implementation
 
         if (_activePane)
         {
-            const bool isClosed = _activePane->GetConnectionState() >= ConnectionState::Closed;
-            _restartConnectionMenuItem.Visibility(isClosed ? WUX::Visibility::Visible : WUX::Visibility::Collapsed);
+            _restartConnectionMenuItem.Visibility(_activePane->IsConnectionClosed() ?
+                                                      WUX::Visibility::Visible :
+                                                      WUX::Visibility::Collapsed);
         }
     }
 

--- a/src/cascadia/TerminalApp/TerminalTab.h
+++ b/src/cascadia/TerminalApp/TerminalTab.h
@@ -116,6 +116,7 @@ namespace winrt::TerminalApp::implementation
         std::shared_ptr<Pane> _zoomedPane{ nullptr };
 
         Windows::UI::Xaml::Controls::MenuFlyoutItem _closePaneMenuItem;
+        Windows::UI::Xaml::Controls::MenuFlyoutItem _restartConnectionMenuItem;
 
         winrt::hstring _lastIconPath{};
         std::optional<winrt::Windows::UI::Color> _runtimeTabColor{};
@@ -155,8 +156,6 @@ namespace winrt::TerminalApp::implementation
         bool _inRename{ false };
         winrt::Windows::UI::Xaml::Controls::TextBox::LayoutUpdated_revoker _tabRenameBoxLayoutUpdatedRevoker;
 
-        winrt::TerminalApp::ShortcutActionDispatch _dispatch;
-
         void _Setup();
 
         std::optional<Windows::UI::Xaml::DispatcherTimer> _bellIndicatorTimer;
@@ -182,6 +181,7 @@ namespace winrt::TerminalApp::implementation
         void _UpdateProgressState();
 
         void _UpdateConnectionClosedState();
+        void _RestartActivePaneConnection();
 
         void _DuplicateTab();
 

--- a/src/cascadia/TerminalApp/TerminalTab.h
+++ b/src/cascadia/TerminalApp/TerminalTab.h
@@ -132,6 +132,7 @@ namespace winrt::TerminalApp::implementation
             winrt::event_token titleToken;
             winrt::event_token colorToken;
             winrt::event_token taskbarToken;
+            winrt::event_token stateToken;
             winrt::event_token readOnlyToken;
             winrt::event_token focusToken;
 
@@ -179,6 +180,8 @@ namespace winrt::TerminalApp::implementation
         void _RecalculateAndApplyReadOnly();
 
         void _UpdateProgressState();
+
+        void _UpdateConnectionClosedState();
 
         void _DuplicateTab();
 

--- a/src/cascadia/TerminalApp/TerminalTabStatus.h
+++ b/src/cascadia/TerminalApp/TerminalTabStatus.h
@@ -12,6 +12,7 @@ namespace winrt::TerminalApp::implementation
         TerminalTabStatus() = default;
 
         WINRT_CALLBACK(PropertyChanged, Windows::UI::Xaml::Data::PropertyChangedEventHandler);
+        WINRT_OBSERVABLE_PROPERTY(bool, IsConnectionClosed, _PropertyChangedHandlers);
         WINRT_OBSERVABLE_PROPERTY(bool, IsPaneZoomed, _PropertyChangedHandlers);
         WINRT_OBSERVABLE_PROPERTY(bool, IsProgressRingActive, _PropertyChangedHandlers);
         WINRT_OBSERVABLE_PROPERTY(bool, IsProgressRingIndeterminate, _PropertyChangedHandlers);

--- a/src/cascadia/TerminalApp/TerminalTabStatus.idl
+++ b/src/cascadia/TerminalApp/TerminalTabStatus.idl
@@ -7,6 +7,7 @@ namespace TerminalApp
     {
         TerminalTabStatus();
 
+        Boolean IsConnectionClosed { get; set; };
         Boolean IsPaneZoomed { get; set; };
         Boolean IsProgressRingActive { get; set; };
         Boolean IsProgressRingIndeterminate { get; set; };


### PR DESCRIPTION
## Summary of the Pull Request
When a connection is Closed, show an indicator in the respective tab.
When the active pane's connection is Closed, show a "Restart Connection" action in the right-click context menu and in the tab context menu.

## Validation Steps Performed
- Force close a connection, check the indicator is shown in the tab.
- Right-click on pane shows the Restart Connection action if its connection is closed
- Right-click on tab shows the Restart Connection action if the active pane's connection is closed
- Indicator is cleared after connection is restarted (no panes in closed state)

## PR Checklist
- [x] Closes #14909 
- [ ] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)
