### PR TITLE
Add support for ARM64 testing, reintroduce it in CI

### DIFF
--- a/build/pipelines/ci.yml
+++ b/build/pipelines/ci.yml
@@ -95,15 +95,15 @@ stages:
         parameters:
           platform: ARM64
 
-  - ${{ if(eq(parameters.submitHelix, true)) }}:
-    - stage: Helix_x64
-      displayName: Helix x64
-      dependsOn: [Build_x64]
-      condition: and(succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
-      jobs:
-        - template: ./templates/console-ci-helix-job.yml
-          parameters:
-            platform: x64
+            #- ${{ if(eq(parameters.submitHelix, true)) }}:
+            #  - stage: Helix_x64
+            #    displayName: Helix x64
+            #    dependsOn: [Build_x64]
+            #    condition: and(succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
+            #    jobs:
+            #      - template: ./templates/console-ci-helix-job.yml
+            #        parameters:
+            #          platform: x64
 
   - stage: Scripts
     displayName: Code Health Scripts

--- a/build/pipelines/ci.yml
+++ b/build/pipelines/ci.yml
@@ -71,6 +71,7 @@ stages:
       - template: ./templates/test-console-ci.yml
         parameters:
           platform: x64
+
   - stage: Test_x86
     displayName: Test x86
     dependsOn: [Build_x86]
@@ -78,6 +79,15 @@ stages:
       - template: ./templates/test-console-ci.yml
         parameters:
           platform: x86
+
+  - stage: Test_ARM64
+    displayName: Test ARM64
+    dependsOn: [Build_ARM64]
+    condition: not(eq(variables['Build.Reason'], 'PullRequest'))
+    jobs:
+      - template: ./templates/test-console-ci.yml
+        parameters:
+          platform: ARM64
 
   - stage: Helix_x64
     displayName: Helix x64

--- a/build/pipelines/ci.yml
+++ b/build/pipelines/ci.yml
@@ -63,7 +63,6 @@ stages:
   - stage: Build_ARM64
     displayName: Build ARM64
     dependsOn: []
-    condition: not(eq(variables['Build.Reason'], 'PullRequest'))
     jobs:
       - template: ./templates/build-console-ci.yml
         parameters:
@@ -89,7 +88,6 @@ stages:
   - stage: Test_ARM64
     displayName: Test ARM64
     dependsOn: [Build_ARM64]
-    condition: not(eq(variables['Build.Reason'], 'PullRequest'))
     jobs:
       - template: ./templates/test-console-ci.yml
         parameters:

--- a/build/pipelines/ci.yml
+++ b/build/pipelines/ci.yml
@@ -95,7 +95,7 @@ stages:
         parameters:
           platform: ARM64
 
-  - ${{ if(eq(parameters.submitHelix), true) }}:
+  - ${{ if(eq(parameters.submitHelix, true)) }}:
     - stage: Helix_x64
       displayName: Helix x64
       dependsOn: [Build_x64]

--- a/build/pipelines/ci.yml
+++ b/build/pipelines/ci.yml
@@ -95,14 +95,15 @@ stages:
         parameters:
           platform: ARM64
 
-  - stage: Helix_x64
-    displayName: Helix x64
-    dependsOn: [Build_x64]
-    condition: and(eq(true, parameters.submitHelix), succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
-    jobs:
-      - template: ./templates/console-ci-helix-job.yml
-        parameters:
-          platform: x64
+  - ${{ if(eq(parameters.submitHelix), true) }}:
+    - stage: Helix_x64
+      displayName: Helix x64
+      dependsOn: [Build_x64]
+      condition: and(succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
+      jobs:
+        - template: ./templates/console-ci-helix-job.yml
+          parameters:
+            platform: x64
 
   - stage: Scripts
     displayName: Code Health Scripts

--- a/build/pipelines/ci.yml
+++ b/build/pipelines/ci.yml
@@ -98,7 +98,7 @@ stages:
   - stage: Helix_x64
     displayName: Helix x64
     dependsOn: [Build_x64]
-    condition: and(parameters.submitHelix, succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
+    condition: and(parameters['submitHelix'], succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
     jobs:
       - template: ./templates/console-ci-helix-job.yml
         parameters:

--- a/build/pipelines/ci.yml
+++ b/build/pipelines/ci.yml
@@ -98,7 +98,7 @@ stages:
   - stage: Helix_x64
     displayName: Helix x64
     dependsOn: [Build_x64]
-    condition: and(parameters['submitHelix'], succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
+    condition: and(eq(true, parameters.submitHelix), succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
     jobs:
       - template: ./templates/console-ci-helix-job.yml
         parameters:

--- a/build/pipelines/ci.yml
+++ b/build/pipelines/ci.yml
@@ -93,15 +93,15 @@ stages:
         parameters:
           platform: ARM64
 
-            #- ${{ if(eq(parameters.submitHelix, true)) }}:
-            #  - stage: Helix_x64
-            #    displayName: Helix x64
-            #    dependsOn: [Build_x64]
-            #    condition: and(succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
-            #    jobs:
-            #      - template: ./templates/console-ci-helix-job.yml
-            #        parameters:
-            #          platform: x64
+  - ${{ if eq(parameters.submitHelix, true) }}:
+    - stage: Helix_x64
+      displayName: Helix x64
+      dependsOn: [Build_x64]
+      condition: and(succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
+      jobs:
+        - template: ./templates/console-ci-helix-job.yml
+          parameters:
+            platform: x64
 
   - stage: Scripts
     displayName: Code Health Scripts

--- a/build/pipelines/ci.yml
+++ b/build/pipelines/ci.yml
@@ -30,76 +30,33 @@ variables:
 name: 0.0.$(Date:yyMM).$(Date:dd)$(Rev:rr)
 
 parameters:
-  - name: submitHelix
-    displayName: "Submit to Helix for testing"
+  - name: auditMode
+    displayName: "Build in Audit Mode (x64)"
     type: boolean
     default: true
+  - name: runTests
+    displayName: "Run Unit and Feature Tests"
+    type: boolean
+    default: true
+  - name: submitHelix
+    displayName: "Submit to Helix for testing and PGO"
+    type: boolean
+    default: true
+  - name: buildPlatforms
+    type: object
+    default:
+      - x64
+      - x86
+      - arm64
 
 stages:
-  - stage: Audit_x64
-    displayName: Audit Mode
-    dependsOn: []
-    condition: succeeded()
-    jobs:
-      - template: ./templates/build-console-audit-job.yml
-        parameters:
-          platform: x64
-
-  - stage: Build_x64
-    displayName: Build x64
-    dependsOn: []
-    condition: succeeded()
-    jobs:
-      - template: ./templates/build-console-ci.yml
-        parameters:
-          platform: x64
-  - stage: Build_x86
-    displayName: Build x86
-    dependsOn: []
-    jobs:
-      - template: ./templates/build-console-ci.yml
-        parameters:
-          platform: x86
-  - stage: Build_ARM64
-    displayName: Build ARM64
-    dependsOn: []
-    jobs:
-      - template: ./templates/build-console-ci.yml
-        parameters:
-          platform: ARM64
-
-  - stage: Test_x64
-    displayName: Test x64
-    dependsOn: [Build_x64]
-    condition: succeeded()
-    jobs:
-      - template: ./templates/test-console-ci.yml
-        parameters:
-          platform: x64
-
-  - stage: Test_x86
-    displayName: Test x86
-    dependsOn: [Build_x86]
-    jobs:
-      - template: ./templates/test-console-ci.yml
-        parameters:
-          platform: x86
-
-  - stage: Test_ARM64
-    displayName: Test ARM64
-    dependsOn: [Build_ARM64]
-    jobs:
-      - template: ./templates/test-console-ci.yml
-        parameters:
-          platform: ARM64
-
-  - ${{ if eq(parameters.submitHelix, true) }}:
-    - stage: Helix_x64
-      displayName: Helix x64
-      dependsOn: [Build_x64]
-      condition: and(succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
+  - ${{ if eq(parameters.auditMode, true) }}:
+    - stage: Audit_x64
+      displayName: Audit Mode
+      dependsOn: []
+      condition: succeeded()
       jobs:
-        - template: ./templates/console-ci-helix-job.yml
+        - template: ./templates/build-console-audit-job.yml
           parameters:
             platform: x64
 
@@ -110,10 +67,38 @@ stages:
     jobs:
       - template: ./templates/check-formatting.yml
 
+  - ${{ each platform in parameters.buildPlatforms }}:
+    - stage: Build_${{ platform }}
+      displayName: Build ${{ platform }}
+      dependsOn: []
+      condition: succeeded()
+      jobs:
+        - template: ./templates/build-console-ci.yml
+          parameters:
+            platform: ${{ platform }}
+    - ${{ if eq(parameters.runTests, true) }}:
+      - stage: Test_${{ platform }}
+        displayName: Test ${{ platform }}
+        dependsOn:
+          - Build_${{ platform }}
+        condition: succeeded()
+        jobs:
+          - template: ./templates/test-console-ci.yml
+            parameters:
+              platform: ${{ platform }}
 
-  - stage: CodeIndexer
-    displayName: Github CodeNav Indexer
-    dependsOn: [Build_x64]
-    condition: and(succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
-    jobs:
-      - template: ./templates/codenav-indexer.yml
+  - ${{ if and(containsValue(parameters.buildPlatforms, 'x64'), eq(parameters.submitHelix, true), ne(variables['Build.Reason'], 'PullRequest')) }}:
+    - stage: Helix_x64
+      displayName: Helix x64
+      dependsOn: [Build_x64]
+      jobs:
+        - template: ./templates/console-ci-helix-job.yml
+          parameters:
+            platform: x64
+
+  - ${{ if and(containsValue(parameters.buildPlatforms, 'x64'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+    - stage: CodeIndexer
+      displayName: Github CodeNav Indexer
+      dependsOn: [Build_x64]
+      jobs:
+        - template: ./templates/codenav-indexer.yml

--- a/build/pipelines/ci.yml
+++ b/build/pipelines/ci.yml
@@ -29,6 +29,12 @@ variables:
 #     0.0.1904.0900
 name: 0.0.$(Date:yyMM).$(Date:dd)$(Rev:rr)
 
+parameters:
+  - name: submitHelix
+    displayName: "Submit to Helix for testing"
+    type: boolean
+    default: true
+
 stages:
   - stage: Audit_x64
     displayName: Audit Mode
@@ -92,7 +98,7 @@ stages:
   - stage: Helix_x64
     displayName: Helix x64
     dependsOn: [Build_x64]
-    condition: and(succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
+    condition: and(parameters.submitHelix, succeeded(), not(eq(variables['Build.Reason'], 'PullRequest')))
     jobs:
       - template: ./templates/console-ci-helix-job.yml
         parameters:

--- a/build/pipelines/templates/test-console-ci.yml
+++ b/build/pipelines/templates/test-console-ci.yml
@@ -59,14 +59,6 @@ jobs:
         arguments: -MatchPattern '*feature.test*.dll' -Platform '$(RationalizedBuildPlatform)' -Configuration '$(BuildConfiguration)' -LogPath '${{ parameters.testLogPath }}' -Root "$(System.ArtifactsDirectory)\\${{ parameters.artifactName }}\\$(BuildConfiguration)\\$(BuildPlatform)\\test"
       condition: and(succeeded(), ne(variables['PGOBuildMode'], 'Instrument'))
 
-    - task: PowerShell@2
-      displayName: 'Run Local Tests'
-      inputs:
-        targetType: filePath
-        filePath: build\scripts\Run-Tests.ps1
-        arguments: -MatchPattern '*LocalTests*.dll' -Platform '$(RationalizedBuildPlatform)' -Configuration '$(BuildConfiguration)' -LogPath '${{ parameters.testLogPath }}' -Root "$(System.ArtifactsDirectory)\\${{ parameters.artifactName }}\\$(BuildConfiguration)\\$(BuildPlatform)\\test"
-      condition: and(succeeded(), ne(variables['PGOBuildMode'], 'Instrument'))
-
   - task: PowerShell@2
     displayName: 'Convert Test Logs from WTL to xUnit format'
     inputs:

--- a/build/pipelines/templates/test-console-ci.yml
+++ b/build/pipelines/templates/test-console-ci.yml
@@ -50,13 +50,22 @@ jobs:
       arguments: -MatchPattern '*unit.test*.dll' -Platform '$(RationalizedBuildPlatform)' -Configuration '$(BuildConfiguration)' -LogPath '${{ parameters.testLogPath }}' -Root "$(System.ArtifactsDirectory)\\${{ parameters.artifactName }}\\$(BuildConfiguration)\\$(BuildPlatform)\\test"
     condition: and(succeeded(), ne(variables['PGOBuildMode'], 'Instrument'))
 
-  - task: PowerShell@2
-    displayName: 'Run Feature Tests (x64/arm64 only)'
-    inputs:
-      targetType: filePath
-      filePath: build\scripts\Run-Tests.ps1
-      arguments: -MatchPattern '*feature.test*.dll' -Platform '$(RationalizedBuildPlatform)' -Configuration '$(BuildConfiguration)' -LogPath '${{ parameters.testLogPath }}' -Root "$(System.ArtifactsDirectory)\\${{ parameters.artifactName }}\\$(BuildConfiguration)\\$(BuildPlatform)\\test"
-    condition: and(and(succeeded(), ne(variables['PGOBuildMode'], 'Instrument')), ne(variables['BuildPlatform'], 'x86'))
+  - ${{ if or(eq(parameters.platform, 'x64'), eq(parameters.platform, 'arm64')) }}:
+    - task: PowerShell@2
+      displayName: 'Run Feature Tests'
+      inputs:
+        targetType: filePath
+        filePath: build\scripts\Run-Tests.ps1
+        arguments: -MatchPattern '*feature.test*.dll' -Platform '$(RationalizedBuildPlatform)' -Configuration '$(BuildConfiguration)' -LogPath '${{ parameters.testLogPath }}' -Root "$(System.ArtifactsDirectory)\\${{ parameters.artifactName }}\\$(BuildConfiguration)\\$(BuildPlatform)\\test"
+      condition: and(succeeded(), ne(variables['PGOBuildMode'], 'Instrument'))
+
+    - task: PowerShell@2
+      displayName: 'Run Local Tests'
+      inputs:
+        targetType: filePath
+        filePath: build\scripts\Run-Tests.ps1
+        arguments: -MatchPattern '*LocalTests*.dll' -Platform '$(RationalizedBuildPlatform)' -Configuration '$(BuildConfiguration)' -LogPath '${{ parameters.testLogPath }}' -Root "$(System.ArtifactsDirectory)\\${{ parameters.artifactName }}\\$(BuildConfiguration)\\$(BuildPlatform)\\test"
+      condition: and(succeeded(), ne(variables['PGOBuildMode'], 'Instrument'))
 
   - task: PowerShell@2
     displayName: 'Convert Test Logs from WTL to xUnit format'

--- a/build/pipelines/templates/test-console-ci.yml
+++ b/build/pipelines/templates/test-console-ci.yml
@@ -13,16 +13,19 @@ jobs:
     BuildPlatform: ${{ parameters.platform }}
   pool:
     ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: SHINE-OSS-L
+      ${{ if ne(parameters.platform, 'ARM64') }}:
+        name: SHINE-OSS-Testing-x64
+      ${{ else }}:
+        name: SHINE-OSS-Testing-arm64
     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       ${{ if ne(parameters.platform, 'ARM64') }}:
-        name: SHINE-INT-Testing-x64 # Use the default image for this pool...
+        name: SHINE-INT-Testing-x64
       ${{ else }}:
-        name: SHINE-INT-Testing-arm64 # Use the default image for this pool...
+        name: SHINE-INT-Testing-arm64
 
   steps:
   - checkout: self
-    submodules: true
+    submodules: false
     clean: true
     fetchDepth: 1
 
@@ -61,7 +64,7 @@ jobs:
       targetType: filePath
       filePath: build\Helix\ConvertWttLogToXUnit.ps1
       arguments: -WttInputPath '${{ parameters.testLogPath }}' -WttSingleRerunInputPath 'unused.wtl' -WttMultipleRerunInputPath 'unused2.wtl' -XUnitOutputPath 'onBuildMachineResults.xml' -TestNamePrefix '$(BuildConfiguration).$(BuildPlatform)'
-    condition: and(ne(variables['PGOBuildMode'], 'Instrument'),or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86')))
+    condition: ne(variables['PGOBuildMode'], 'Instrument')
 
   - task: PublishTestResults@2
     displayName: 'Upload converted test logs'
@@ -69,13 +72,9 @@ jobs:
     inputs:
       testResultsFormat: 'xUnit' # Options: JUnit, NUnit, VSTest, xUnit, cTest
       testResultsFiles: '**/onBuildMachineResults.xml'
-      #searchFolder: '$(System.DefaultWorkingDirectory)' # Optional
-      #mergeTestResults: false # Optional
-      #failTaskOnFailedTests: false # Optional
       testRunTitle: 'On Build Machine Tests' # Optional
       buildPlatform: $(BuildPlatform) # Optional
       buildConfiguration: $(BuildConfiguration) # Optional
-      #publishRunAttachments: true # Optional
 
   - task: CopyFiles@2
     displayName: 'Copy result logs to Artifacts'

--- a/build/pipelines/templates/test-console-ci.yml
+++ b/build/pipelines/templates/test-console-ci.yml
@@ -15,8 +15,10 @@ jobs:
     ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: SHINE-OSS-L
     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: SHINE-INT-L
-    demands: ImageOverride -equals SHINE-VS17-Latest
+      ${{ if ne(parameters.platform, 'ARM64') }}:
+        name: SHINE-INT-Testing-x64 # Use the default image for this pool...
+      ${{ else }}:
+        name: SHINE-INT-Testing-arm64 # Use the default image for this pool...
 
   steps:
   - checkout: self
@@ -43,15 +45,15 @@ jobs:
       targetType: filePath
       filePath: build\scripts\Run-Tests.ps1
       arguments: -MatchPattern '*unit.test*.dll' -Platform '$(RationalizedBuildPlatform)' -Configuration '$(BuildConfiguration)' -LogPath '${{ parameters.testLogPath }}' -Root "$(System.ArtifactsDirectory)\\${{ parameters.artifactName }}\\$(BuildConfiguration)\\$(BuildPlatform)\\test"
-    condition: and(and(succeeded(), ne(variables['PGOBuildMode'], 'Instrument')), or(eq(variables['BuildPlatform'], 'x64'), eq(variables['BuildPlatform'], 'x86')))
+    condition: and(succeeded(), ne(variables['PGOBuildMode'], 'Instrument'))
 
   - task: PowerShell@2
-    displayName: 'Run Feature Tests (x64 only)'
+    displayName: 'Run Feature Tests (x64/arm64 only)'
     inputs:
       targetType: filePath
       filePath: build\scripts\Run-Tests.ps1
       arguments: -MatchPattern '*feature.test*.dll' -Platform '$(RationalizedBuildPlatform)' -Configuration '$(BuildConfiguration)' -LogPath '${{ parameters.testLogPath }}' -Root "$(System.ArtifactsDirectory)\\${{ parameters.artifactName }}\\$(BuildConfiguration)\\$(BuildPlatform)\\test"
-    condition: and(and(succeeded(), ne(variables['PGOBuildMode'], 'Instrument')), eq(variables['BuildPlatform'], 'x64'))
+    condition: and(and(succeeded(), ne(variables['PGOBuildMode'], 'Instrument')), ne(variables['BuildPlatform'], 'x86'))
 
   - task: PowerShell@2
     displayName: 'Convert Test Logs from WTL to xUnit format'


### PR DESCRIPTION
This pull request introduces the arm64 testing agents and a few build
phases to use them.

In addition to running the ARM64 tests in CI, it makes the following
changes:

- The x64 tests now run on equivalent x64 testing agents
- We now run ARM64 builds (and tests!) on all pull requests
- I've deduplicated a lot of the build and test stages
- New queue-time parameters have been added to control various phases,
  for quick pipeline testing
- A bunch of conditions have been promoted to compile-time checks to
  control the existence of stages and steps more tightly