### PR TITLE
Fix Default Terminal and Color Scheme ComboBoxes cropping at 200% Text Size

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/Appearances.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Appearances.xaml
@@ -59,8 +59,7 @@
                     <ComboBox.ItemTemplate>
                         <DataTemplate x:DataType="local:ColorSchemeViewModel">
                             <Grid Grid.Column="0"
-                                  Height="32"
-                                  Padding="8,8,0,0"
+                                  Padding="8"
                                   VerticalAlignment="Center"
                                   Background="{x:Bind local:Converters.ColorToBrush(BackgroundColor.Color), Mode=OneWay}"
                                   ColumnSpacing="1"

--- a/src/cascadia/TerminalSettingsEditor/Launch.xaml
+++ b/src/cascadia/TerminalSettingsEditor/Launch.xaml
@@ -84,18 +84,18 @@
 
                                     <Grid.ColumnDefinitions>
                                         <!--  icon  -->
-                                        <ColumnDefinition Width="24" />
-                                        <!--  profile name and author  -->
-                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="auto" />
+                                        <!--  terminal name and author  -->
+                                        <ColumnDefinition Width="auto" />
                                         <!--  version  -->
-                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="auto" />
                                     </Grid.ColumnDefinitions>
 
                                     <Grid.RowDefinitions>
-                                        <!--  profile name  -->
-                                        <RowDefinition Height="20" />
+                                        <!--  terminal name  -->
+                                        <RowDefinition Height="auto" />
                                         <!--  author and version  -->
-                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="auto" />
                                     </Grid.RowDefinitions>
 
                                     <IconSourceElement Grid.Row="0"
@@ -109,13 +109,11 @@
                                     <TextBlock Grid.Row="0"
                                                Grid.Column="1"
                                                Grid.ColumnSpan="2"
-                                               Height="20"
                                                AutomationProperties.AccessibilityView="Raw"
                                                Text="{x:Bind Name}" />
 
                                     <TextBlock Grid.Row="1"
                                                Grid.Column="1"
-                                               Height="20"
                                                AutomationProperties.AccessibilityView="Raw"
                                                Style="{ThemeResource SecondaryTextBlockStyle}"
                                                Text="{x:Bind Author}"
@@ -123,7 +121,6 @@
 
                                     <TextBlock Grid.Row="1"
                                                Grid.Column="2"
-                                               Height="20"
                                                AutomationProperties.AccessibilityView="Raw"
                                                Style="{ThemeResource SecondaryTextBlockStyle}"
                                                Text="{x:Bind Version}"


### PR DESCRIPTION
When the OS' "text size" setting gets set to 200% and the display resolution is reduced quite a bit, we get some cropped text in the SUI's Default Terminal ComboBox. Turns out, we have a height set on the items. I went ahead and removed that so we don't crop the text. Everything looks good still!

A similar issue occurs in the Profile > Appearance > Color Scheme ComboBox. I went ahead and fixed that too by removing the height restriction.

Other minor changes:
- fixed the comments
- changed "author and version" row to "auto" instead of "*" (star sizing is great for proportional sizing, so we're not really taking advantage of it)

Closes #15149