### PR TITLE
Fix GitHub built-in highlight styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Related repositories include:
 
 ## Installing and running Windows Terminal
 
-> **Note**: Windows Terminal requires Windows 10 2004 (build 19041) or later
+> **Note**\
+> Windows Terminal requires Windows 10 2004 (build 19041) or later
 
 ### Microsoft Store [Recommended]
 
@@ -52,9 +53,10 @@ fails for any reason, you can try the following command at a PowerShell prompt:
 Add-AppxPackage Microsoft.WindowsTerminal_<versionNumber>.msixbundle
 ```
 
-> **Note**: If you install Terminal manually:
+> **Note**\
+> If you install Terminal manually:
 >
-> * You may need to install the [VC++ v14 Desktop Framework Package](https://docs.microsoft.com/troubleshoot/cpp/c-runtime-packages-desktop-bridge#how-to-install-and-update-desktop-framework-packages).  
+> * You may need to install the [VC++ v14 Desktop Framework Package](https://docs.microsoft.com/troubleshoot/cpp/c-runtime-packages-desktop-bridge#how-to-install-and-update-desktop-framework-packages).
 >   This should only be necessary on older builds of Windows 10 and only if you get an error about missing framework packages.
 > * Terminal will not auto-update when new builds are released so you will need
 >   to regularly install the latest Terminal release to receive all the latest
@@ -70,7 +72,8 @@ package:
 winget install --id Microsoft.WindowsTerminal -e
 ```
 
-> **Note** Due to a dependency issue, Terminal's current versions cannot be installed via the Windows Package Manager CLI. To install the stable release 1.17 or later, or the Preview release 1.18 or later, please use an alternative installation method.
+> **Note**\
+> Due to a dependency issue, Terminal's current versions cannot be installed via the Windows Package Manager CLI. To install the stable release 1.17 or later, or the Preview release 1.18 or later, please use an alternative installation method.
 
 #### Via Chocolatey (unofficial)
 
@@ -237,7 +240,8 @@ Cause: You're launching the incorrect solution in Visual Studio.
 Solution: Make sure you're building & deploying the `CascadiaPackage` project in
 Visual Studio.
 
-> **Note**: `OpenConsole.exe` is just a locally-built `conhost.exe`, the classic
+> **Note**\
+> `OpenConsole.exe` is just a locally-built `conhost.exe`, the classic
 > Windows Console that hosts Windows' command-line infrastructure. OpenConsole
 > is used by Windows Terminal to connect to and communicate with command-line
 > applications (via


### PR DESCRIPTION
## Summary of the Pull Request

I updated the note prefix for blockquotes with GitHub latest built-in styles.

## References and Relevant Issues

- https://github.com/orgs/community/discussions/16925

## Detailed Description of the Pull Request / Additional comments

This PR fixed the broken style due to their format change.

## Related former Pull Request

- https://github.com/microsoft/terminal/pull/13615

