### PR TITLE
Allow skipping artifact publication in all release build jobs

### DIFF
--- a/build/pipelines/templates-v2/job-build-package-wpf.yml
+++ b/build/pipelines/templates-v2/job-build-package-wpf.yml
@@ -21,6 +21,12 @@ parameters:
   - name: jobName
     type: string
     default: PackWPF
+  - name: variables
+    type: object
+    default: {}
+  - name: publishArtifacts
+    type: boolean
+    default: true
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -39,6 +45,9 @@ jobs:
   variables:
     OutputBuildPlatform: AnyCPU
     Terminal.BinDir: $(Build.SourcesDirectory)/bin/$(OutputBuildPlatform)/$(BuildConfiguration)
+    JobOutputDirectory: $(Build.ArtifactStagingDirectory)\nupkg
+    JobOutputArtifactName: wpf-nupkg-$(BuildConfiguration)${{ parameters.artifactStem }}
+    ${{ insert }}: ${{ parameters.variables }}
   steps:
   - checkout: self
     clean: true
@@ -129,6 +138,7 @@ jobs:
         ValidateSignature: true
         Verbosity: 'Verbose'
 
-  - publish: $(Build.ArtifactStagingDirectory)\nupkg
-    artifact: wpf-nupkg-$(BuildConfiguration)${{ parameters.artifactStem }}
-    displayName: Publish nupkg
+  - ${{ if eq(parameters.publishArtifacts, true) }}:
+    - publish: $(JobOutputDirectory)
+      artifact: $(JobOutputArtifactName)
+      displayName: Publish nupkg

--- a/build/pipelines/templates-v2/job-build-project.yml
+++ b/build/pipelines/templates-v2/job-build-project.yml
@@ -57,6 +57,12 @@ parameters:
   - name: beforeBuildSteps
     type: stepList
     default: []
+  - name: variables
+    type: object
+    default: {}
+  - name: publishArtifacts
+    type: boolean
+    default: true
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -84,6 +90,9 @@ jobs:
     # Yup.
     BuildTargetParameter: ' '
     SelectedSigningFragments: ' '
+    JobOutputDirectory: $(Terminal.BinDir)
+    JobOutputArtifactName: build-$(BuildPlatform)-$(BuildConfiguration)${{ parameters.artifactStem }}
+    ${{ insert }}: ${{ parameters.variables }}
   displayName: Build
   timeoutInMinutes: 240
   cancelTimeoutInMinutes: 1
@@ -141,10 +150,17 @@ jobs:
       configuration: $(BuildConfiguration)
       maximumCpuCount: true
 
-  - publish: $(Build.SourcesDirectory)/msbuild.binlog
-    artifact: logs-$(BuildPlatform)-$(BuildConfiguration)${{ parameters.artifactStem }}
-    condition: always()
-    displayName: Publish Build Log
+  - ${{ if eq(parameters.publishArtifacts, true) }}:
+    - publish: $(Build.SourcesDirectory)/msbuild.binlog
+      artifact: logs-$(BuildPlatform)-$(BuildConfiguration)${{ parameters.artifactStem }}
+      condition: always()
+      displayName: Publish Build Log
+  - ${{ else }}:
+    - task: CopyFiles@2
+      displayName: Copy Build Log
+      inputs:
+        contents: $(Build.SourcesDirectory)/msbuild.binlog
+        TargetFolder: $(Terminal.BinDir)
 
   # This saves ~2GiB per architecture. We won't need these later.
   # Removes:
@@ -258,6 +274,7 @@ jobs:
         ValidateSignature: true
         Verbosity: 'Verbose'
 
-  - publish: $(Terminal.BinDir)
-    artifact: build-$(BuildPlatform)-$(BuildConfiguration)${{ parameters.artifactStem }}
-    displayName: Publish All Outputs
+  - ${{ if eq(parameters.publishArtifacts, true) }}:
+    - publish: $(Terminal.BinDir)
+      artifact: $(JobOutputArtifactName)
+      displayName: Publish All Outputs

--- a/build/pipelines/templates-v2/job-merge-msix-into-bundle.yml
+++ b/build/pipelines/templates-v2/job-merge-msix-into-bundle.yml
@@ -23,6 +23,12 @@ parameters:
   - name: jobName
     type: string
     default: Bundle
+  - name: variables
+    type: object
+    default: {}
+  - name: publishArtifacts
+    type: boolean
+    default: true
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -44,6 +50,9 @@ jobs:
       BundleStemName: Microsoft.WindowsTerminalPreview
     ${{ else }}:
       BundleStemName: WindowsTerminalDev
+    JobOutputDirectory: '$(System.ArtifactsDirectory)/bundle'
+    JobOutputArtifactName: appxbundle-$(BuildConfiguration)${{ parameters.artifactStem }}
+    ${{ insert }}: ${{ parameters.variables }}
   dependsOn: ${{ parameters.dependsOn }}
   steps:
   - checkout: self
@@ -128,6 +137,7 @@ jobs:
         ValidateSignature: true
         Verbosity: 'Verbose'
 
-  - publish: '$(System.ArtifactsDirectory)/bundle'
-    artifact: appxbundle-$(BuildConfiguration)${{ parameters.artifactStem }}
-    displayName: Publish msixbundle
+  - ${{ if eq(parameters.publishArtifacts, true) }}:
+    - publish: $(JobOutputDirectory)
+      artifact: $(JobOutputArtifactName)
+      displayName: Publish msixbundle

--- a/build/pipelines/templates-v2/job-package-conpty.yml
+++ b/build/pipelines/templates-v2/job-package-conpty.yml
@@ -21,6 +21,12 @@ parameters:
   - name: jobName
     type: string
     default: PackConPTY
+  - name: variables
+    type: object
+    default: {}
+  - name: publishArtifacts
+    type: boolean
+    default: true
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -36,6 +42,10 @@ jobs:
         ${{ config }}:
           BuildConfiguration: ${{ config }}
   dependsOn: ${{ parameters.dependsOn }}
+  variables:
+    JobOutputDirectory: $(Build.ArtifactStagingDirectory)\nupkg
+    JobOutputArtifactName: conpty-nupkg-$(BuildConfiguration)${{ parameters.artifactStem }}
+    ${{ insert }}: ${{ parameters.variables }}
   steps:
   - checkout: self
     clean: true
@@ -113,6 +123,7 @@ jobs:
         ValidateSignature: true
         Verbosity: 'Verbose'
 
-  - publish: $(Build.ArtifactStagingDirectory)\nupkg
-    artifact: conpty-nupkg-$(BuildConfiguration)${{ parameters.artifactStem }}
-    displayName: Publish nupkg
+  - ${{ if eq(parameters.publishArtifacts, true) }}:
+    - publish: $(JobOutputDirectory)
+      artifact: $(JobOutputArtifactName)
+      displayName: Publish nupkg

--- a/build/pipelines/templates-v2/job-submit-windows-vpack.yml
+++ b/build/pipelines/templates-v2/job-submit-windows-vpack.yml
@@ -13,6 +13,12 @@ parameters:
   - name: artifactStem
     type: string
     default: ''
+  - name: variables
+    type: object
+    default: {}
+  - name: publishArtifacts
+    type: boolean
+    default: true
 
 jobs:
 - job: VPack
@@ -20,6 +26,10 @@ jobs:
     pool: ${{ parameters.pool }}
   displayName: Create and Submit Windows vPack
   dependsOn: ${{ parameters.dependsOn }}
+  variables:
+    JobOutputDirectory: $(XES_VPACKMANIFESTDIRECTORY)
+    JobOutputArtifactName: vpack-manifest${{ parameters.artifactStem }}
+    ${{ insert }}: ${{ parameters.variables }}
   steps:
   - checkout: self
     clean: true
@@ -57,9 +67,10 @@ jobs:
       owner: conhost
       githubToken: $(GitHubTokenForVpackProvenance)
 
-  - publish: $(XES_VPACKMANIFESTDIRECTORY)
-    artifact: vpack-manifest${{ parameters.artifactStem }}
-    displayName: 'Publish VPack Manifest to Drop'
+  - ${{ if eq(parameters.publishArtifacts, true) }}:
+    - publish: $(JobOutputDirectory)
+      artifact: $(JobOutputArtifactName)
+      displayName: 'Publish VPack Manifest to Drop'
 
   - task: PkgESFCIBGit@12
     displayName: 'Submit VPack Manifest to Windows'


### PR DESCRIPTION
The OneBranch build system relies on the *build container host* being able to publish all artifacts all at once. Therefore, our build steps must not publish any artifacts.

I made it configurable so that the impact on existing pipelines was minimal.

For every job that produces artifacts and is part of the release pipeline, I am now exposing two variables that we can pass to OneBranch so that it can locate and name artifacts:
- `JobOutputDirectory`, the output folder for the entire job
- `JobOutputArtifactName`, the name of the artifact produced by the job

I have also added a `variables` parameter to every job, so consuming pipelines can override or insert their own variables.