### PR TITLE
Set Progress ring color based on the status from the running process

### DIFF
--- a/src/cascadia/TerminalApp/TabHeaderControl.xaml
+++ b/src/cascadia/TerminalApp/TabHeaderControl.xaml
@@ -21,6 +21,7 @@
                           MinWidth="0"
                           MinHeight="0"
                           Margin="3,0,8,0"
+                          Foreground="Red"
                           IsActive="{x:Bind TabStatus.IsProgressRingActive, Mode=OneWay}"
                           IsIndeterminate="{x:Bind TabStatus.IsProgressRingIndeterminate, Mode=OneWay}"
                           Visibility="{x:Bind TabStatus.IsProgressRingActive, Mode=OneWay}"

--- a/src/cascadia/TerminalApp/TabHeaderControl.xaml
+++ b/src/cascadia/TerminalApp/TabHeaderControl.xaml
@@ -21,7 +21,7 @@
                           MinWidth="0"
                           MinHeight="0"
                           Margin="3,0,8,0"
-                          Foreground="Red"
+                          Foreground="{x:Bind TabStatus.ProgressColor, Mode=OneWay}"
                           IsActive="{x:Bind TabStatus.IsProgressRingActive, Mode=OneWay}"
                           IsIndeterminate="{x:Bind TabStatus.IsProgressRingIndeterminate, Mode=OneWay}"
                           Visibility="{x:Bind TabStatus.IsProgressRingActive, Mode=OneWay}"

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -1042,8 +1042,8 @@ namespace winrt::TerminalApp::implementation
                     (taskbarState == 2) ?
                         winrt::Windows::UI::Colors::Red() :
                         ((taskbarState == 4) ?
-                            winrt::Windows::UI::Colors::Orange() :
-                            winrt::Windows::UI::Colors::Green());
+                             winrt::Windows::UI::Colors::Orange() :
+                             winrt::Windows::UI::Colors::Green());
                 _tabStatus.ProgressColor(winrt::Windows::UI::Xaml::Media::SolidColorBrush(color));
             }
             // Hide the tab icon (the progress ring is placed over it)

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -1037,6 +1037,14 @@ namespace winrt::TerminalApp::implementation
 
                 const auto progressValue = gsl::narrow<uint32_t>(state.Progress());
                 _tabStatus.ProgressValue(progressValue);
+
+                const auto color =
+                    (taskbarState == 2) ?
+                        winrt::Windows::UI::Colors::Red() :
+                        ((taskbarState == 4) ?
+                            winrt::Windows::UI::Colors::Orange() :
+                            winrt::Windows::UI::Colors::Green());
+                _tabStatus.ProgressColor(winrt::Windows::UI::Xaml::Media::SolidColorBrush(color));
             }
             // Hide the tab icon (the progress ring is placed over it)
             HideIcon(true);

--- a/src/cascadia/TerminalApp/TerminalTabStatus.h
+++ b/src/cascadia/TerminalApp/TerminalTabStatus.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "TerminalTabStatus.g.h"
+#include <winrt/windows.ui.core.h>
 
 namespace winrt::TerminalApp::implementation
 {
@@ -19,6 +20,7 @@ namespace winrt::TerminalApp::implementation
         WINRT_OBSERVABLE_PROPERTY(bool, IsReadOnlyActive, _PropertyChangedHandlers);
         WINRT_OBSERVABLE_PROPERTY(uint32_t, ProgressValue, _PropertyChangedHandlers);
         WINRT_OBSERVABLE_PROPERTY(bool, IsInputBroadcastActive, _PropertyChangedHandlers);
+        WINRT_OBSERVABLE_PROPERTY(winrt::Windows::UI::Xaml::Media::SolidColorBrush, ProgressColor, _PropertyChangedHandlers, winrt::Windows::UI::Colors::Green());
     };
 }
 

--- a/src/cascadia/TerminalApp/TerminalTabStatus.idl
+++ b/src/cascadia/TerminalApp/TerminalTabStatus.idl
@@ -14,5 +14,6 @@ namespace TerminalApp
         UInt32 ProgressValue { get; set; };
         Boolean IsReadOnlyActive { get; set; };
         Boolean IsInputBroadcastActive { get; set; };
+        Windows.UI.Xaml.Media.SolidColorBrush ProgressColor { get; set; };
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request
Currently Terminal ignores the state flag passed from the VT progress sequence.

### Errors
![image](https://github.com/microsoft/terminal/assets/2091582/fe592957-6180-4778-8b21-b5c4652f35bf)

### Warning
![image](https://github.com/microsoft/terminal/assets/2091582/bdfd156a-907c-4212-8b53-c80ad8cb0a4b)

### Normal
![image](https://github.com/microsoft/terminal/assets/2091582/d3038ebb-0fde-45e9-a783-e107c573bd80)

## References and Relevant Issues
#6700 

## Detailed Description of the Pull Request / Additional comments
This change changes the default color of the progress ring to green. If errors are sent then the color changes to red. If warnings are detected the color changes to orange.

## Validation Steps Performed
Tested end to end with tools that sends status updates.

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
