### PR TITLE
Use a different schema for each branding

### DIFF
--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -1227,6 +1227,15 @@ void CascadiaSettings::WriteSettingsToDisk()
     }
 }
 
+#ifndef NDEBUG
+static [[maybe_unused]] std::string _getDevPathToSchema()
+{
+    std::filesystem::path filePath{ __FILE__ };
+    auto schemaPath = filePath.parent_path().parent_path().parent_path().parent_path() / "doc" / "cascadia" / "profiles.schema.json";
+    return "file:///" + schemaPath.generic_string();
+}
+#endif
+
 // Method Description:
 // - Create a new serialized JsonObject from an instance of this class
 // Arguments:
@@ -1243,7 +1252,9 @@ Json::Value CascadiaSettings::ToJson() const
         "https://aka.ms/terminal-profiles-schema"
 #elif defined(WT_BRANDING_PREVIEW)
         "https://aka.ms/terminal-profiles-schema-preview"
-#else
+#elif !defined(NDEBUG) // DEBUG mode
+        _getDevPathToSchema() // magic schema path that refers to the local source directory
+#else // All other brandings
         "https://raw.githubusercontent.com/microsoft/terminal/main/doc/cascadia/profiles.schema.json"
 #endif
         ;

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -1238,7 +1238,15 @@ Json::Value CascadiaSettings::ToJson() const
     // top-level json object
     auto json{ _globals->ToJson() };
     json["$help"] = "https://aka.ms/terminal-documentation";
-    json["$schema"] = "https://aka.ms/terminal-profiles-schema";
+    json["$schema"] =
+#if defined(WT_BRANDING_RELEASE)
+        "https://aka.ms/terminal-profiles-schema"
+#elif defined(WT_BRANDING_PREVIEW)
+        "https://aka.ms/terminal-profiles-schema-preview"
+#else
+        "https://raw.githubusercontent.com/microsoft/terminal/main/doc/cascadia/profiles.schema.json"
+#endif
+        ;
 
     // "profiles" will always be serialized as an object
     Json::Value profiles{ Json::ValueType::objectValue };


### PR DESCRIPTION
Switch the schema depending on the branding we're being built for

Ever since we started writing the entire settings file out ourselves,
we've had the opportunity to control which schema it uses.

This is a quality-of-life improvement for Preview users, and might make
life easier for Dev users as well.

For Debug builds, it even switches over to a local `file://` path to
the schema in the source directory!

Closes #6601