### PR TITLE
Fix C# warnings during a clean build

### DIFF
--- a/src/cascadia/WpfTerminalControl/TerminalContainer.cs
+++ b/src/cascadia/WpfTerminalControl/TerminalContainer.cs
@@ -113,23 +113,24 @@ namespace Microsoft.Terminal.Wpf
                 {
                     this.connection.TerminalOutput -= this.Connection_TerminalOutput;
                 }
-                this.Connection_TerminalOutput(this, new TerminalOutputEventArgs("\x001bc\x1b]104\x1b\\")); //reset console/clear screen - https://github.com/microsoft/terminal/pull/15062#issuecomment-1505654110
+
+                this.Connection_TerminalOutput(this, new TerminalOutputEventArgs("\x001bc\x1b]104\x1b\\")); // reset console/clear screen - https://github.com/microsoft/terminal/pull/15062#issuecomment-1505654110
                 var wasNull = this.connection == null;
                 this.connection = value;
                 if (this.connection != null)
                 {
                     if (wasNull)
                     {
-                         this.Connection_TerminalOutput(this, new TerminalOutputEventArgs("\x1b[?25h")); //show cursor
+                        this.Connection_TerminalOutput(this, new TerminalOutputEventArgs("\x1b[?25h")); // show cursor
                     }
+
                     this.connection.TerminalOutput += this.Connection_TerminalOutput;
                     this.connection.Start();
                 }
                 else
                 {
-                    this.Connection_TerminalOutput(this, new TerminalOutputEventArgs("\x1b[?25l")); //hide cursor
+                    this.Connection_TerminalOutput(this, new TerminalOutputEventArgs("\x1b[?25l")); // hide cursor
                 }
-                    
             }
         }
 


### PR DESCRIPTION
#### Fix warnings due to formatting during a clean build

Seems like the compiler cares about them more than our formatter. Possibly introduced in https://github.com/microsoft/terminal/pull/15062

## Validation Steps Performed
- Tests passed