### PR TITLE
WIP: POC: bottom tabs (and "future of terminal UX" toughts)

### DIFF
--- a/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
+++ b/src/cascadia/WindowsTerminal/NonClientIslandWindow.cpp
@@ -17,6 +17,9 @@ using namespace ::Microsoft::Console;
 using namespace ::Microsoft::Console::Types;
 
 static constexpr int AutohideTaskbarSize = 2;
+static constexpr bool BottomTabs = true;
+static constexpr auto rowTop = 0;
+static constexpr auto rowBottom = 1;
 
 NonClientIslandWindow::NonClientIslandWindow(const ElementTheme& requestedTheme) noexcept :
     IslandWindow{},
@@ -364,8 +367,9 @@ bool NonClientIslandWindow::Initialize()
     titlebarRow.Height(GridLengthHelper::Auto());
 
     _rootGrid.RowDefinitions().Clear();
-    _rootGrid.RowDefinitions().Append(titlebarRow);
+
     _rootGrid.RowDefinitions().Append(contentRow);
+    _rootGrid.RowDefinitions().InsertAt(BottomTabs ? rowBottom : rowTop, titlebarRow);
 
     // Create our titlebar control
     _titlebar = winrt::TerminalApp::TitlebarControl{ reinterpret_cast<uint64_t>(GetHandle()) };
@@ -376,7 +380,7 @@ bool NonClientIslandWindow::Initialize()
 
     _rootGrid.Children().Append(_titlebar);
 
-    Controls::Grid::SetRow(_titlebar, 0);
+    Controls::Grid::SetRow( _titlebar, BottomTabs ? rowBottom : rowTop);
 
     // GH#3440 - When the titlebar is loaded (officially added to our UI tree),
     // then make sure to update its visual state to reflect if we're in the
@@ -410,7 +414,7 @@ void NonClientIslandWindow::SetContent(winrt::Windows::UI::Xaml::UIElement conte
     const auto fwe = content.try_as<winrt::Windows::UI::Xaml::FrameworkElement>();
     if (fwe)
     {
-        Controls::Grid::SetRow(fwe, 1);
+        Controls::Grid::SetRow(fwe, BottomTabs ? rowTop : rowBottom);
     }
 }
 


### PR DESCRIPTION
## Summary of the Pull Request
Mocking up a switchable 'titlebarRow' and 'contentRow' in `NonClientIslandWindow.cpp`

...it was both **easier than** expected *and* **works better** than expected:

![image](https://github.com/microsoft/terminal/assets/4115323/bb8d5eb2-7ffc-4dd8-ae46-703cea3ee6bd)

## References and Relevant Issues
- microsoft/microsoft-ui-xaml#7032 
- #8888
- #10000
- #11111
- #13392

## Detailed Description of the Pull Request / Additional comments

This is just a **very-very crude POC**, just to see if it's possible in the current implementation to place the tabs at the bottom, and mainly as an attempt to ***induce thought and spark discussion*** about ideas for streamlining UX around the `_quakeMode` window, particularly in relation to the settings panel (also considering the clutter of other terminal windows active at the same time, like elevated ones)

## Checklists, Todos, etc., ... (as food for thought):

- [x] switching the order of the titlebar and the content pane is rather straightforward 
- [x] window is draggable by the bottom titlebar, window controls work, tab drag and drop works between windows  

  however, in it's current form it's far from being complete, both functionality/implementation and usability/design wise

- [ ] **(dependency(?)** microsoft/microsoft-ui-xaml#7032 
- [ ] **(bug)** tab tear-off sometimes places the bottom-titlebar below visible bounds.
- [ ] **(to-do)** setting UI for displaying the tabs on bottom for the Quake Mode window only (maybe for all terminal windows?)
  
- [ ] **(to-discuss)** allow the Settings Pane to pop up/over the Quake Mode window (or All terminal windows) 
in **it's own, possibly centered / default-sized window** (in a *`_settingsMode` window*, so to speak).  
  
  ...as currently the wide + narrow shape of the quake mode window hinders the usability of the settings panel embedded in a tab. (see window shapes in the above screenshot at 1920×1080, also considering keeping the current '1-column' design philosophy of the settings panel (which would lead to many of the options not being very visible at first glance, and would leave a lot of horizontal screen estate wasted)

- [ ] **(to-develop)** unifying the elevated and non-elevated terminal processes into **one window** (using the shield icon per tab)
for example, and if possible, by proxying elevated terminal I/O using named pipes for IPC with a non-elevated monarch?


### Thanks for bearing with me, and kudos for an already immensely useful app!