### PR TITLE
Include our Azure client ID in AzureConnection

### DIFF
--- a/src/cascadia/TerminalConnection/AzureClientID.h
+++ b/src/cascadia/TerminalConnection/AzureClientID.h
@@ -3,4 +3,4 @@
 
 #pragma once
 
-inline constexpr std::wstring_view AzureClientID = L"0";
+inline constexpr std::wstring_view AzureClientID{ L"245e1dee-74ef-4257-a8c8-8208296e1dfd" };


### PR DESCRIPTION
Some folks over in MSAL land told us that client IDs don't need to be kept secret.

This reduces the delta between "public" terminal and "release build" terminal by one more file, leaving only the telemetry header left (which won't be going public for obvious reasons).

This will also make it easier for contributors to test out Azure Cloud Shell changes... and testing out VT without ConPTY interfering[^1].

[^1]: When Dev branding is selected, Azure Cloud Shell has the added perk of being wired directly to TerminalCore rather than going through ConPTY.
