### PR TITLE
A small optimization of COOKED_READ_DATA::_erase

### DIFF
--- a/src/host/readDataCooked.hpp
+++ b/src/host/readDataCooked.hpp
@@ -113,7 +113,7 @@ private:
     void _handlePostCharInputLoop(bool isUnicode, size_t& numBytes, ULONG& controlKeyState);
     void _markAsDirty();
     void _flushBuffer();
-    void _erase(til::CoordType distance);
+    void _erase(til::CoordType distance) const;
     til::CoordType _writeChars(const std::wstring_view& text) const;
     til::point _offsetPosition(til::point pos, til::CoordType distance) const;
     void _unwindCursorPosition(til::CoordType distance) const;


### PR DESCRIPTION
This is a small optimization that makes COOKED_READ_DATA erase short
runs of text more quickly. It's not really necessary to do this as
this code is not a hotpath, but I felt like it's neater this way.
It requires no heap allocations even for long runs of text.

## Validation Steps Performed
* Deleting text anywhere in a prompt erases it ✅