### PR TITLE
Add missing lock guards on Terminal access

### DIFF
--- a/.github/actions/spelling/allow/apis.txt
+++ b/.github/actions/spelling/allow/apis.txt
@@ -28,6 +28,7 @@ CYICON
 Dacl
 dataobject
 dcomp
+debugbreak
 delayimp
 DERR
 dlldata

--- a/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
+++ b/src/cascadia/PublicTerminalCore/HwndTerminal.hpp
@@ -112,14 +112,13 @@ private:
     HRESULT _CopyTextToSystemClipboard(const TextBuffer::TextAndColor& rows, const bool fAlsoCopyFormatting);
     HRESULT _CopyToSystemClipboard(std::string stringToCopy, LPCWSTR lpszFormat);
     void _PasteTextFromClipboard() noexcept;
-    void _StringPaste(const wchar_t* const pData) noexcept;
 
     const unsigned int _NumberOfClicks(til::point clickPos, std::chrono::steady_clock::time_point clickTime) noexcept;
     HRESULT _StartSelection(LPARAM lParam) noexcept;
     HRESULT _MoveSelection(LPARAM lParam) noexcept;
     IRawElementProviderSimple* _GetUiaProvider() noexcept;
 
-    void _ClearSelection() noexcept;
+    void _ClearSelection();
 
     bool _CanSendVTMouseInput() const noexcept;
     bool _SendMouseEvent(UINT uMsg, WPARAM wParam, LPARAM lParam) noexcept;

--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -83,6 +83,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
         _settings = winrt::make_self<implementation::ControlSettings>(settings, unfocusedAppearance);
         _terminal = std::make_shared<::Microsoft::Terminal::Core::Terminal>();
+        const auto lock = _terminal->LockForWriting();
 
         _setupDispatcherAndCallbacks();
 
@@ -194,7 +195,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             [weakTerminal = std::weak_ptr{ _terminal }]() {
                 if (const auto t = weakTerminal.lock())
                 {
-                    auto lock = t->LockForWriting();
+                    const auto lock = t->LockForWriting();
                     t->UpdatePatternsUnderLock();
                 }
             });
@@ -279,6 +280,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             // Get our current size in rows/cols, and hook them up to
             // this connection too.
             {
+                const auto lock = _terminal->LockForReading();
                 const auto vp = _terminal->GetViewport();
                 const auto width = vp.Width();
                 const auto height = vp.Height();
@@ -315,7 +317,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         _compositionScale = compositionScale;
 
         { // scope for terminalLock
-            auto terminalLock = _terminal->LockForWriting();
+            const auto lock = _terminal->LockForWriting();
 
             if (_initializedTerminal.load(std::memory_order_relaxed))
             {
@@ -424,6 +426,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
         if (_initializedTerminal.load(std::memory_order_relaxed))
         {
+            const auto lock = _terminal->LockForWriting();
             _renderer->EnablePainting();
         }
     }
@@ -486,6 +489,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             _handleControlC();
         }
 
+        const auto lock = _terminal->LockForWriting();
         return _terminal->SendCharEvent(ch, scanCode, modifiers);
     }
 
@@ -514,18 +518,19 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // modifier key. We'll wait for a real keystroke to dismiss the
         // GH #7395 - don't update selection when taking PrintScreen
         // selection.
-        return HasSelection() && ::Microsoft::Terminal::Core::Terminal::IsInputKey(vkey);
+        return _terminal->IsSelectionActive() && ::Microsoft::Terminal::Core::Terminal::IsInputKey(vkey);
     }
 
     bool ControlCore::TryMarkModeKeybinding(const WORD vkey,
                                             const ::Microsoft::Terminal::Core::ControlKeyStates mods)
     {
+        auto lock = _terminal->LockForWriting();
+
         if (_shouldTryUpdateSelection(vkey) && _terminal->SelectionMode() == ::Terminal::SelectionInteractionMode::Mark)
         {
             if (vkey == 'A' && !mods.IsAltPressed() && !mods.IsShiftPressed() && mods.IsCtrlPressed())
             {
                 // Ctrl + A --> Select all
-                auto lock = _terminal->LockForWriting();
                 _terminal->SelectAll();
                 _updateSelectionUI();
                 return true;
@@ -533,7 +538,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             else if (vkey == VK_TAB && !mods.IsAltPressed() && !mods.IsCtrlPressed() && _settings->DetectURLs())
             {
                 // [Shift +] Tab --> next/previous hyperlink
-                auto lock = _terminal->LockForWriting();
                 const auto direction = mods.IsShiftPressed() ? ::Terminal::SearchDirection::Backward : ::Terminal::SearchDirection::Forward;
                 _terminal->SelectHyperlink(direction);
                 _updateSelectionUI();
@@ -542,14 +546,15 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             else if (vkey == VK_RETURN && mods.IsCtrlPressed() && !mods.IsAltPressed() && !mods.IsShiftPressed())
             {
                 // Ctrl + Enter --> Open URL
-                auto lock = _terminal->LockForReading();
                 if (const auto uri = _terminal->GetHyperlinkAtBufferPosition(_terminal->GetSelectionAnchor()); !uri.empty())
                 {
+                    lock.unlock();
                     _OpenHyperlinkHandlers(*this, winrt::make<OpenHyperlinkEventArgs>(winrt::hstring{ uri }));
                 }
                 else
                 {
                     const auto selectedText = _terminal->GetTextBuffer().GetPlainText(_terminal->GetSelectionAnchor(), _terminal->GetSelectionEnd());
+                    lock.unlock();
                     _OpenHyperlinkHandlers(*this, winrt::make<OpenHyperlinkEventArgs>(winrt::hstring{ selectedText }));
                 }
                 return true;
@@ -557,7 +562,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             else if (vkey == VK_RETURN && !mods.IsCtrlPressed() && !mods.IsAltPressed())
             {
                 // [Shift +] Enter --> copy text
-                // Don't lock here! CopySelectionToClipboard already locks for you!
                 CopySelectionToClipboard(mods.IsShiftPressed(), nullptr);
                 _terminal->ClearSelection();
                 _updateSelectionUI();
@@ -572,7 +576,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             else if (const auto updateSlnParams{ _terminal->ConvertKeyEventToUpdateSelectionParams(mods, vkey) })
             {
                 // try to update the selection
-                auto lock = _terminal->LockForWriting();
                 _terminal->UpdateSelection(updateSlnParams->first, updateSlnParams->second, mods);
                 _updateSelectionUI();
                 return true;
@@ -596,6 +599,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                       const ControlKeyStates modifiers,
                                       const bool keyDown)
     {
+        const auto lock = _terminal->LockForWriting();
+
         // Update the selection, if it's present
         // GH#8522, GH#3758 - Only modify the selection on key _down_. If we
         // modify on key up, then there's chance that we'll immediately dismiss
@@ -605,7 +610,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             // try to update the selection
             if (const auto updateSlnParams{ _terminal->ConvertKeyEventToUpdateSelectionParams(modifiers, vkey) })
             {
-                auto lock = _terminal->LockForWriting();
                 _terminal->UpdateSelection(updateSlnParams->first, updateSlnParams->second, modifiers);
                 _updateSelectionUI();
                 return true;
@@ -643,17 +647,18 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                      const short wheelDelta,
                                      const TerminalInput::MouseButtonState state)
     {
+        const auto lock = _terminal->LockForWriting();
         return _terminal->SendMouseEvent(viewportPos, uiButton, states, wheelDelta, state);
     }
 
     void ControlCore::UserScrollViewport(const int viewTop)
     {
-        // Clear the regex pattern tree so the renderer does not try to render them while scrolling
-        _terminal->ClearPatternTree();
-
-        // This is a scroll event that wasn't initiated by the terminal
-        //      itself - it was initiated by the mouse wheel, or the scrollbar.
-        _terminal->UserScrollViewport(viewTop);
+        {
+            // This is a scroll event that wasn't initiated by the terminal
+            //      itself - it was initiated by the mouse wheel, or the scrollbar.
+            const auto lock = _terminal->LockForWriting();
+            _terminal->UserScrollViewport(viewTop);
+        }
 
         const auto shared = _shared.lock_shared();
         if (shared->updatePatternLocations)
@@ -693,6 +698,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // cleartype -> grayscale if the BG is transparent / acrylic.
         if (_renderEngine)
         {
+            const auto lock = _terminal->LockForWriting();
             _renderEngine->EnableTransparentBackground(_isBackgroundTransparent());
             _renderer->NotifyPaintFrame();
         }
@@ -704,7 +710,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void ControlCore::ToggleShaderEffects()
     {
         const auto path = _settings->PixelShaderPath();
-        auto lock = _terminal->LockForWriting();
+        const auto lock = _terminal->LockForWriting();
         // Originally, this action could be used to enable the retro effects
         // even when they're set to `false` in the settings. If the user didn't
         // specify a custom pixel shader, manually enable the legacy retro
@@ -752,7 +758,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         decltype(_terminal->GetHyperlinkIntervalFromViewportPosition({})) newInterval{ std::nullopt };
         if (terminalPosition.has_value())
         {
-            auto lock = _terminal->LockForReading(); // Lock for the duration of our reads.
+            const auto lock = _terminal->LockForReading();
             newId = _terminal->GetHyperlinkIdAtViewportPosition(*terminalPosition);
             newInterval = _terminal->GetHyperlinkIntervalFromViewportPosition(*terminalPosition);
         }
@@ -767,7 +773,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             // wouldn't be able to ask us about the hyperlink text/position
             // without deadlocking us.
             {
-                auto lock = _terminal->LockForWriting();
+                const auto lock = _terminal->LockForWriting();
 
                 _lastHoveredId = newId;
                 _lastHoveredInterval = newInterval;
@@ -782,16 +788,15 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     winrt::hstring ControlCore::GetHyperlink(const Core::Point pos) const
     {
-        // Lock for the duration of our reads.
-        auto lock = _terminal->LockForReading();
+        const auto lock = _terminal->LockForReading();
         return winrt::hstring{ _terminal->GetHyperlinkAtViewportPosition(til::point{ pos }) };
     }
 
     winrt::hstring ControlCore::HoveredUriText() const
     {
-        auto lock = _terminal->LockForReading(); // Lock for the duration of our reads.
         if (_lastHoveredCell.has_value())
         {
+            const auto lock = _terminal->LockForReading();
             auto uri{ _terminal->GetHyperlinkAtViewportPosition(*_lastHoveredCell) };
             uri.resize(std::min<size_t>(1024u, uri.size())); // Truncate for display
             return winrt::hstring{ uri };
@@ -811,7 +816,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
         _settings = winrt::make_self<implementation::ControlSettings>(settings, newAppearance);
 
-        auto lock = _terminal->LockForWriting();
+        const auto lock = _terminal->LockForWriting();
 
         _cellWidth = CSSLengthPercentage::FromString(_settings->CellWidth().c_str());
         _cellHeight = CSSLengthPercentage::FromString(_settings->CellHeight().c_str());
@@ -853,7 +858,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - INVARIANT: This method can only be called if the caller DOES NOT HAVE writing lock on the terminal.
     void ControlCore::ApplyAppearance(const bool& focused)
     {
-        auto lock = _terminal->LockForWriting();
+        const auto lock = _terminal->LockForWriting();
         const auto& newAppearance{ focused ? _settings->FocusedAppearance() : _settings->UnfocusedAppearance() };
         // Update the terminal core with its new Core settings
         _terminal->UpdateAppearance(*newAppearance);
@@ -1081,7 +1086,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         _panelHeight = height;
         _compositionScale = scale;
 
-        auto lock = _terminal->LockForWriting();
+        const auto lock = _terminal->LockForWriting();
         if (scaleChanged)
         {
             // _updateFont relies on the new _compositionScale set above
@@ -1092,7 +1097,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     void ControlCore::SetSelectionAnchor(const til::point position)
     {
-        auto lock = _terminal->LockForWriting();
+        const auto lock = _terminal->LockForWriting();
         _terminal->SetSelectionAnchor(position);
     }
 
@@ -1103,7 +1108,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     //    to throw it all in a struct and pass it along.
     Control::SelectionData ControlCore::SelectionInfo() const
     {
-        auto lock = _terminal->LockForReading();
+        const auto lock = _terminal->LockForReading();
         Control::SelectionData info;
 
         const auto start{ _terminal->SelectionStartForRendering() };
@@ -1126,14 +1131,12 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - position: the point in terminal coordinates (in cells, not pixels)
     void ControlCore::SetEndSelectionPoint(const til::point position)
     {
+        const auto lock = _terminal->LockForWriting();
+
         if (!_terminal->IsSelectionActive())
         {
             return;
         }
-
-        // Have to take the lock because the renderer will not draw correctly if
-        // you move its endpoints while it is generating a frame.
-        auto lock = _terminal->LockForWriting();
 
         til::point terminalPosition{
             std::clamp(position.x, 0, _terminal->GetViewport().Width() - 1),
@@ -1162,6 +1165,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     bool ControlCore::CopySelectionToClipboard(bool singleLine,
                                                const Windows::Foundation::IReference<CopyFormat>& formats)
     {
+        const auto lock = _terminal->LockForWriting();
+
         // no selection --> nothing to copy
         if (!_terminal->IsSelectionActive())
         {
@@ -1211,21 +1216,21 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     void ControlCore::SelectAll()
     {
-        auto lock = _terminal->LockForWriting();
+        const auto lock = _terminal->LockForWriting();
         _terminal->SelectAll();
         _updateSelectionUI();
     }
 
     void ControlCore::ClearSelection()
     {
-        auto lock = _terminal->LockForWriting();
+        const auto lock = _terminal->LockForWriting();
         _terminal->ClearSelection();
         _updateSelectionUI();
     }
 
     bool ControlCore::ToggleBlockSelection()
     {
-        auto lock = _terminal->LockForWriting();
+        const auto lock = _terminal->LockForWriting();
         if (_terminal->IsSelectionActive())
         {
             _terminal->SetBlockSelection(!_terminal->IsBlockSelection());
@@ -1240,7 +1245,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     void ControlCore::ToggleMarkMode()
     {
-        auto lock = _terminal->LockForWriting();
+        const auto lock = _terminal->LockForWriting();
         _terminal->ToggleMarkMode();
         _updateSelectionUI();
     }
@@ -1252,6 +1257,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     bool ControlCore::SwitchSelectionEndpoint()
     {
+        const auto lock = _terminal->LockForWriting();
         if (_terminal->IsSelectionActive())
         {
             _terminal->SwitchSelectionEndpoint();
@@ -1263,6 +1269,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     bool ControlCore::ExpandSelectionToWord()
     {
+        const auto lock = _terminal->LockForWriting();
         if (_terminal->IsSelectionActive())
         {
             _terminal->ExpandSelectionToWord();
@@ -1277,6 +1284,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     //   before sending it over the terminal's connection.
     void ControlCore::PasteText(const winrt::hstring& hstr)
     {
+        const auto lock = _terminal->LockForWriting();
         _terminal->WritePastedText(hstr);
         _terminal->ClearSelection();
         _updateSelectionUI();
@@ -1326,21 +1334,25 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     hstring ControlCore::Title()
     {
+        const auto lock = _terminal->LockForReading();
         return hstring{ _terminal->GetConsoleTitle() };
     }
 
     hstring ControlCore::WorkingDirectory() const
     {
+        const auto lock = _terminal->LockForReading();
         return hstring{ _terminal->GetWorkingDirectory() };
     }
 
     bool ControlCore::BracketedPasteEnabled() const noexcept
     {
+        const auto lock = _terminal->LockForReading();
         return _terminal->IsXtermBracketedPasteModeEnabled();
     }
 
     Windows::Foundation::IReference<winrt::Windows::UI::Color> ControlCore::TabColor() noexcept
     {
+        const auto lock = _terminal->LockForReading();
         auto coreColor = _terminal->GetTabColor();
         return coreColor.has_value() ? Windows::Foundation::IReference<winrt::Windows::UI::Color>{ static_cast<winrt::Windows::UI::Color>(coreColor.value()) } :
                                        nullptr;
@@ -1348,6 +1360,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     til::color ControlCore::BackgroundColor() const
     {
+        const auto lock = _terminal->LockForReading();
         return _terminal->GetRenderSettings().GetColorAlias(ColorAlias::DefaultBackground);
     }
 
@@ -1357,6 +1370,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - The taskbar state of this control
     const size_t ControlCore::TaskbarState() const noexcept
     {
+        const auto lock = _terminal->LockForReading();
         return _terminal->GetTaskbarState();
     }
 
@@ -1366,11 +1380,13 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - The taskbar progress of this control
     const size_t ControlCore::TaskbarProgress() const noexcept
     {
+        const auto lock = _terminal->LockForReading();
         return _terminal->GetTaskbarProgress();
     }
 
     int ControlCore::ScrollOffset()
     {
+        const auto lock = _terminal->LockForReading();
         return _terminal->GetScrollOffset();
     }
 
@@ -1381,6 +1397,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - The height of the terminal in lines of text
     int ControlCore::ViewHeight() const
     {
+        const auto lock = _terminal->LockForReading();
         return _terminal->GetViewport().Height();
     }
 
@@ -1391,6 +1408,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - The height of the terminal in lines of text
     int ControlCore::BufferHeight() const
     {
+        const auto lock = _terminal->LockForReading();
         return _terminal->GetBufferHeight();
     }
 
@@ -1437,12 +1455,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         {
             return;
         }
-
-        // Clear the regex pattern tree so the renderer does not try to render them while scrolling
-        // We're **NOT** taking the lock here unlike _scrollbarChangeHandler because
-        // we are already under lock (since this usually happens as a result of writing).
-        // TODO GH#9617: refine locking around pattern tree
-        _terminal->ClearPatternTree();
 
         // Start the throttled update of our scrollbar.
         auto update{ winrt::make<ScrollPositionChangedArgs>(viewTop,
@@ -1502,6 +1514,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     bool ControlCore::HasSelection() const
     {
+        const auto lock = _terminal->LockForReading();
         return _terminal->IsSelectionActive();
     }
 
@@ -1513,6 +1526,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     Windows::Foundation::Collections::IVector<winrt::hstring> ControlCore::SelectedText(bool trimTrailingWhitespace) const
     {
         // RetrieveSelectedTextFromBuffer will lock while it's reading
+        const auto lock = _terminal->LockForReading();
         const auto internalResult{ _terminal->RetrieveSelectedTextFromBuffer(trimTrailingWhitespace).text };
 
         auto result = winrt::single_threaded_vector<winrt::hstring>();
@@ -1540,7 +1554,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - <none>
     void ControlCore::Search(const winrt::hstring& text, const bool goForward, const bool caseSensitive)
     {
-        auto lock = _terminal->LockForWriting();
+        const auto lock = _terminal->LockForWriting();
 
         if (_searcher.ResetIfStale(*GetRenderData(), text, !goForward, !caseSensitive))
         {
@@ -1635,7 +1649,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     void ControlCore::BlinkAttributeTick()
     {
-        auto lock = _terminal->LockForWriting();
+        const auto lock = _terminal->LockForWriting();
 
         auto& renderSettings = _terminal->GetRenderSettings();
         renderSettings.ToggleBlinkRendition(*_renderer);
@@ -1643,13 +1657,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     void ControlCore::BlinkCursor()
     {
-        if (!_terminal->IsCursorBlinkingAllowed() &&
-            _terminal->IsCursorVisible())
-        {
-            return;
-        }
-        // SetCursorOn will take the write lock for you.
-        _terminal->SetCursorOn(!_terminal->IsCursorOn());
+        const auto lock = _terminal->LockForWriting();
+        _terminal->BlinkCursor();
     }
 
     bool ControlCore::CursorOn() const
@@ -1659,22 +1668,26 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     void ControlCore::CursorOn(const bool isCursorOn)
     {
+        const auto lock = _terminal->LockForWriting();
         _terminal->SetCursorOn(isCursorOn);
     }
 
     void ControlCore::ResumeRendering()
     {
+        const auto lock = _terminal->LockForWriting();
         _renderer->ResetErrorStateAndResume();
     }
 
     bool ControlCore::IsVtMouseModeEnabled() const
     {
-        return _terminal != nullptr && _terminal->IsTrackingMouseInput();
+        const auto lock = _terminal->LockForWriting();
+        return _terminal->IsTrackingMouseInput();
     }
     bool ControlCore::ShouldSendAlternateScroll(const unsigned int uiButton,
                                                 const int32_t delta) const
     {
-        return _terminal != nullptr && _terminal->ShouldSendAlternateScroll(uiButton, delta);
+        const auto lock = _terminal->LockForWriting();
+        return _terminal->ShouldSendAlternateScroll(uiButton, delta);
     }
 
     Core::Point ControlCore::CursorPosition() const
@@ -1685,7 +1698,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             return { 0, 0 };
         }
 
-        auto lock = _terminal->LockForReading();
+        const auto lock = _terminal->LockForReading();
         return _terminal->GetViewportRelativeCursorPosition().to_core_point();
     }
 
@@ -1701,7 +1714,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
                                           const bool isOnOriginalPosition,
                                           bool& selectionNeedsToBeCopied)
     {
-        auto lock = _terminal->LockForWriting();
+        const auto lock = _terminal->LockForWriting();
         // handle ALT key
         _terminal->SetBlockSelection(altEnabled);
 
@@ -1727,14 +1740,14 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         //   the selection (we need to reset selection on double-click or
         //   triple-click, so it captures the word or the line, rather than
         //   extending the selection)
-        if (HasSelection() && (!shiftEnabled || isOnOriginalPosition))
+        if (_terminal->IsSelectionActive() && (!shiftEnabled || isOnOriginalPosition))
         {
             // Reset the selection
             _terminal->ClearSelection();
             selectionNeedsToBeCopied = false; // there's no selection, so there's nothing to update
         }
 
-        if (shiftEnabled && HasSelection())
+        if (shiftEnabled && _terminal->IsSelectionActive())
         {
             // If shift is pressed and there is a selection we extend it using
             // the selection mode (expand the "end" selection point)
@@ -1823,6 +1836,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - Updates the renderer's representation of the selection as well as the selection marker overlay in TermControl
     void ControlCore::_updateSelectionUI()
     {
+        const auto lock = _terminal->LockForWriting();
         _renderer->TriggerSelection();
         // only show the markers if we're doing a keyboard selection or in mark mode
         const bool showMarkers{ _terminal->SelectionMode() >= ::Microsoft::Terminal::Core::Terminal::SelectionInteractionMode::Keyboard };
@@ -1832,10 +1846,12 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     void ControlCore::AttachUiaEngine(::Microsoft::Console::Render::IRenderEngine* const pEngine)
     {
         // _renderer will always exist since it's introduced in the ctor
+        const auto lock = _terminal->LockForWriting();
         _renderer->AddRenderEngine(pEngine);
     }
     void ControlCore::DetachUiaEngine(::Microsoft::Console::Render::IRenderEngine* const pEngine)
     {
+        const auto lock = _terminal->LockForWriting();
         _renderer->RemoveRenderEngine(pEngine);
     }
 
@@ -1863,7 +1879,10 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
         try
         {
-            _terminal->Write(hstr);
+            {
+                const auto lock = _terminal->LockForWriting();
+                _terminal->Write(hstr);
+            }
 
             // Start the throttled update of where our hyperlinks are.
             const auto shared = _shared.lock_shared();
@@ -1904,6 +1923,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
         if (clearType == Control::ClearBufferType::Scrollback || clearType == Control::ClearBufferType::All)
         {
+            const auto lock = _terminal->LockForWriting();
             _terminal->EraseScrollback();
         }
 
@@ -1921,7 +1941,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     hstring ControlCore::ReadEntireBuffer() const
     {
-        auto terminalLock = _terminal->LockForWriting();
+        const auto lock = _terminal->LockForWriting();
 
         const auto& textBuffer = _terminal->GetTextBuffer();
 
@@ -1949,7 +1969,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // Get all of our recent commands. This will only really work if the user has enabled shell integration.
     Control::CommandHistoryContext ControlCore::CommandHistory() const
     {
-        auto terminalLock = _terminal->LockForWriting();
+        const auto lock = _terminal->LockForWriting();
         const auto& textBuffer = _terminal->GetTextBuffer();
 
         std::vector<winrt::hstring> commands;
@@ -2034,6 +2054,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         }
         else
         {
+            const auto lock = _terminal->LockForReading();
             s = _terminal->GetColorScheme();
         }
 
@@ -2057,8 +2078,6 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     // - <none>
     void ControlCore::ColorScheme(const Core::Scheme& scheme)
     {
-        auto l{ _terminal->LockForWriting() };
-
         _settings->FocusedAppearance()->DefaultForeground(scheme.Foreground);
         _settings->FocusedAppearance()->DefaultBackground(scheme.Background);
         _settings->FocusedAppearance()->CursorColor(scheme.CursorColor);
@@ -2081,10 +2100,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         _settings->FocusedAppearance()->SetColorTableEntry(14, scheme.BrightCyan);
         _settings->FocusedAppearance()->SetColorTableEntry(15, scheme.BrightWhite);
 
+        const auto lock = _terminal->LockForWriting();
         _terminal->ApplyScheme(scheme);
-
         _renderEngine->SetSelectionBackground(til::color{ _settings->SelectionBackground() });
-
         _renderer->TriggerRedrawAll(true);
     }
 
@@ -2156,6 +2174,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // focused.
         const auto previous = std::exchange(_isReadOnly, false);
         const auto restore = wil::scope_exit([&]() { _isReadOnly = previous; });
+        const auto lock = _terminal->LockForWriting();
         _terminal->FocusChanged(focused);
     }
 
@@ -2190,7 +2209,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     Windows::Foundation::Collections::IVector<Control::ScrollMark> ControlCore::ScrollMarks() const
     {
-        auto internalMarks{ _terminal->GetScrollMarks() };
+        const auto lock = _terminal->LockForReading();
+        const auto& internalMarks{ _terminal->GetScrollMarks() };
         auto v = winrt::single_threaded_observable_vector<Control::ScrollMark>();
         for (const auto& mark : internalMarks)
         {
@@ -2215,6 +2235,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     void ControlCore::AddMark(const Control::ScrollMark& mark)
     {
+        const auto lock = _terminal->LockForReading();
         ::ScrollMark m{};
 
         if (mark.Color.HasValue)
@@ -2222,7 +2243,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
             m.color = til::color{ mark.Color.Color };
         }
 
-        if (HasSelection())
+        if (_terminal->IsSelectionActive())
         {
             m.start = til::point{ _terminal->GetSelectionAnchor() };
             m.end = til::point{ _terminal->GetSelectionEnd() };
@@ -2236,11 +2257,22 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         // set the start & end to the cursor position.
         _terminal->AddMark(m, m.start, m.end, true);
     }
-    void ControlCore::ClearMark() { _terminal->ClearMark(); }
-    void ControlCore::ClearAllMarks() { _terminal->ClearAllMarks(); }
+
+    void ControlCore::ClearMark()
+    {
+        const auto lock = _terminal->LockForWriting();
+        _terminal->ClearMark();
+    }
+
+    void ControlCore::ClearAllMarks()
+    {
+        const auto lock = _terminal->LockForWriting();
+        _terminal->ClearAllMarks();
+    }
 
     void ControlCore::ScrollToMark(const Control::ScrollToMarkDirection& direction)
     {
+        const auto lock = _terminal->LockForWriting();
         const auto currentOffset = ScrollOffset();
         const auto& marks{ _terminal->GetScrollMarks() };
 
@@ -2347,15 +2379,16 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         const auto bufferSize{ _terminal->GetTextBuffer().GetSize() };
         bufferSize.DecrementInBounds(s.end);
 
-        auto lock = _terminal->LockForWriting();
         _terminal->SelectNewRegion(s.start, s.end);
         _renderer->TriggerSelection();
     }
 
     void ControlCore::SelectCommand(const bool goUp)
     {
-        const til::point start = HasSelection() ? (goUp ? _terminal->GetSelectionAnchor() : _terminal->GetSelectionEnd()) :
-                                                  _terminal->GetTextBuffer().GetCursor().GetPosition();
+        const auto lock = _terminal->LockForWriting();
+
+        const til::point start = _terminal->IsSelectionActive() ? (goUp ? _terminal->GetSelectionAnchor() : _terminal->GetSelectionEnd()) :
+                                                                  _terminal->GetTextBuffer().GetCursor().GetPosition();
 
         std::optional<::ScrollMark> nearest{ std::nullopt };
         const auto& marks{ _terminal->GetScrollMarks() };
@@ -2394,8 +2427,10 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     void ControlCore::SelectOutput(const bool goUp)
     {
-        const til::point start = HasSelection() ? (goUp ? _terminal->GetSelectionAnchor() : _terminal->GetSelectionEnd()) :
-                                                  _terminal->GetTextBuffer().GetCursor().GetPosition();
+        const auto lock = _terminal->LockForWriting();
+
+        const til::point start = _terminal->IsSelectionActive() ? (goUp ? _terminal->GetSelectionAnchor() : _terminal->GetSelectionEnd()) :
+                                                                  _terminal->GetTextBuffer().GetCursor().GetPosition();
 
         std::optional<::ScrollMark> nearest{ std::nullopt };
         const auto& marks{ _terminal->GetScrollMarks() };
@@ -2428,7 +2463,9 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     void ControlCore::ColorSelection(const Control::SelectionColor& fg, const Control::SelectionColor& bg, Core::MatchMode matchMode)
     {
-        if (HasSelection())
+        const auto lock = _terminal->LockForWriting();
+
+        if (_terminal->IsSelectionActive())
         {
             const auto pForeground = winrt::get_self<implementation::SelectionColor>(fg);
             const auto pBackground = winrt::get_self<implementation::SelectionColor>(bg);
@@ -2466,6 +2503,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
     {
         // viewportRelativeCharacterPosition is relative to the current
         // viewport, so adjust for that:
+        const auto lock = _terminal->LockForReading();
         _contextMenuBufferPosition = _terminal->GetViewport().Origin() + viewportRelativeCharacterPosition;
     }
 
@@ -2474,6 +2512,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         bool (*filter)(const ::ScrollMark&),
         til::point_span (*getSpan)(const ::ScrollMark&))
     {
+        const auto lock = _terminal->LockForWriting();
+
         // Do nothing if the caller didn't give us a way to get the span to select for this mark.
         if (!getSpan)
         {
@@ -2520,6 +2560,8 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         const til::point& pos,
         bool (*filter)(const ::ScrollMark&))
     {
+        const auto lock = _terminal->LockForWriting();
+
         // Don't show this if the click was on the selection
         if (_terminal->IsSelectionActive() &&
             _terminal->GetSelectionAnchor() <= pos &&

--- a/src/cascadia/TerminalCore/Terminal.hpp
+++ b/src/cascadia/TerminalCore/Terminal.hpp
@@ -100,8 +100,8 @@ public:
     // WritePastedText comes from our input and goes back to the PTY's input channel
     void WritePastedText(std::wstring_view stringView);
 
-    [[nodiscard]] std::unique_lock<til::recursive_ticket_lock> LockForReading();
-    [[nodiscard]] std::unique_lock<til::recursive_ticket_lock> LockForWriting();
+    [[nodiscard]] std::unique_lock<til::recursive_ticket_lock> LockForReading() const noexcept;
+    [[nodiscard]] std::unique_lock<til::recursive_ticket_lock> LockForWriting() noexcept;
     til::recursive_ticket_lock_suspension SuspendLock() noexcept;
 
     til::CoordType GetBufferHeight() const noexcept;
@@ -109,8 +109,8 @@ public:
     int ViewStartIndex() const noexcept;
     int ViewEndIndex() const noexcept;
 
-    RenderSettings& GetRenderSettings() noexcept { return _renderSettings; };
-    const RenderSettings& GetRenderSettings() const noexcept { return _renderSettings; };
+    RenderSettings& GetRenderSettings() noexcept;
+    const RenderSettings& GetRenderSettings() const noexcept;
 
     const std::vector<ScrollMark>& GetScrollMarks() const noexcept;
     void AddMark(const ScrollMark& mark,
@@ -159,7 +159,7 @@ public:
 #pragma endregion
 
     void ClearMark();
-    void ClearAllMarks() noexcept;
+    void ClearAllMarks();
     til::color GetColorForMark(const ScrollMark& mark) const;
 
 #pragma region ITerminalInput
@@ -230,11 +230,10 @@ public:
     void SetPlayMidiNoteCallback(std::function<void(const int, const int, const std::chrono::microseconds)> pfn) noexcept;
     void CompletionsChangedCallback(std::function<void(std::wstring_view, unsigned int)> pfn) noexcept;
 
-    void SetCursorOn(const bool isOn);
-    bool IsCursorBlinkingAllowed() const noexcept;
+    void BlinkCursor() noexcept;
+    void SetCursorOn(const bool isOn) noexcept;
 
     void UpdatePatternsUnderLock();
-    void ClearPatternTree();
 
     const std::optional<til::color> GetTabColor() const;
 
@@ -403,7 +402,8 @@ private:
     //      Either way, we should make this behavior controlled by a setting.
 
     interval_tree::IntervalTree<til::point, size_t> _patternIntervalTree;
-    void _InvalidatePatternTree(const interval_tree::IntervalTree<til::point, size_t>& tree);
+    void _clearPatternTree();
+    void _InvalidatePatternTree();
     void _InvalidateFromCoords(const til::point start, const til::point end);
 
     // Since virtual keys are non-zero, you assume that this field is empty/invalid if it is.
@@ -432,6 +432,10 @@ private:
     void _StoreKeyEvent(const WORD vkey, const WORD scanCode) noexcept;
     WORD _TakeVirtualKeyFromLastKeyEvent(const WORD scanCode) noexcept;
 
+    void _assertLocked() const noexcept;
+    Console::VirtualTerminal::TerminalInput& _getTerminalInput() noexcept;
+    const Console::VirtualTerminal::TerminalInput& _getTerminalInput() const noexcept;
+
     int _VisibleStartIndex() const noexcept;
     int _VisibleEndIndex() const noexcept;
 
@@ -440,7 +444,7 @@ private:
 
     void _PreserveUserScrollOffset(const int viewportDelta) noexcept;
 
-    void _NotifyScrollEvent() noexcept;
+    void _NotifyScrollEvent();
 
     void _NotifyTerminalCursorPositionChanged() noexcept;
 

--- a/src/cascadia/TerminalCore/terminalrenderdata.cpp
+++ b/src/cascadia/TerminalCore/terminalrenderdata.cpp
@@ -29,11 +29,13 @@ const TextBuffer& Terminal::GetTextBuffer() const noexcept
 
 const FontInfo& Terminal::GetFontInfo() const noexcept
 {
+    _assertLocked();
     return _fontInfo;
 }
 
 void Terminal::SetFontInfo(const FontInfo& fontInfo)
 {
+    _assertLocked();
     _fontInfo = fontInfo;
 }
 
@@ -105,6 +107,8 @@ const std::wstring Microsoft::Terminal::Core::Terminal::GetHyperlinkCustomId(uin
 // - The pattern IDs of the location
 const std::vector<size_t> Terminal::GetPatternId(const til::point location) const
 {
+    _assertLocked();
+
     // Look through our interval tree for this location
     const auto intervals = _patternIntervalTree.findOverlapping({ location.x + 1, location.y }, location);
     if (intervals.size() == 0)
@@ -125,7 +129,7 @@ const std::vector<size_t> Terminal::GetPatternId(const til::point location) cons
 
 std::pair<COLORREF, COLORREF> Terminal::GetAttributeColors(const TextAttribute& attr) const noexcept
 {
-    return _renderSettings.GetAttributeColors(attr);
+    return GetRenderSettings().GetAttributeColors(attr);
 }
 
 std::vector<Microsoft::Console::Types::Viewport> Terminal::GetSelectionRects() noexcept
@@ -185,18 +189,13 @@ void Terminal::SelectNewRegion(const til::point coordStart, const til::point coo
 }
 
 const std::wstring_view Terminal::GetConsoleTitle() const noexcept
-try
 {
+    _assertLocked();
     if (_title.has_value())
     {
-        return _title.value();
+        return *_title;
     }
     return _startingTitle;
-}
-catch (...)
-{
-    LOG_CAUGHT_EXCEPTION();
-    return {};
 }
 
 // Method Description:
@@ -223,5 +222,6 @@ const bool Terminal::IsUiaDataInitialized() const noexcept
     // when a screen reader requests it. However, the terminal might not be fully
     // initialized yet. So we use this to check if any crucial components of
     // UiaData are not yet initialized.
+    _assertLocked();
     return !!_mainBuffer;
 }


### PR DESCRIPTION
`Terminal` is used concurrently by at least 4 threads. The table
below lists the class members and the threads that access them
to the best of my knowledge. Where:
* UI: UI Thread
* BG: Background worker threads (`winrt::resume_background`)
* RD: Render thread
* VT: VT connection thread

|                                    | UI | BG | RD | VT |
|------------------------------------|----|----|----|----|
| `_pfnWriteInput`                   | x  | x  |    | x  |
| `_pfnWarningBell`                  |    |    |    | x  |
| `_pfnTitleChanged`                 |    |    |    | x  |
| `_pfnCopyToClipboard`              |    |    |    | x  |
| `_pfnScrollPositionChanged`        | x  | x  |    | x  |
| `_pfnCursorPositionChanged`        |    |    |    | x  |
| `_pfnTaskbarProgressChanged`       |    |    |    | x  |
| `_pfnShowWindowChanged`            |    |    |    | x  |
| `_pfnPlayMidiNote`                 |    |    |    | x  |
| `_pfnCompletionsChanged`           |    |    |    | x  |
| `_renderSettings`                  | x  |    | x  | x  |
| `_stateMachine`                    | x  |    |    | x  |
| `_terminalInput`                   | x  |    |    | x  |
| `_title`                           | x  |    | x  | x  |
| `_startingTitle`                   | x  |    | x  |    |
| `_startingTabColor`                | x  |    |    |    |
| `_defaultCursorShape`              | x  |    |    | x  |
| `_systemMode`                      |    | x  | x  | x  |
| `_snapOnInput`                     | x  | x  |    |    |
| `_altGrAliasing`                   | x  |    |    |    |
| `_suppressApplicationTitle`        | x  |    |    | x  |
| `_trimBlockSelection`              | x  |    |    |    |
| `_autoMarkPrompts`                 | x  |    |    |    |
| `_taskbarState`                    | x  |    |    | x  |
| `_taskbarProgress`                 | x  |    |    | x  |
| `_workingDirectory`                | x  |    |    | x  |
| `_fontInfo`                        | x  |    | x  |    |
| `_selection`                       | x  | x  | x  | x  |
| `_blockSelection`                  | x  | x  | x  |    |
| `_wordDelimiters`                  | x  | x  |    |    |
| `_multiClickSelectionMode`         | x  | x  | x  |    |
| `_selectionMode`                   | x  | x  | x  |    |
| `_selectionIsTargetingUrl`         | x  | x  | x  |    |
| `_selectionEndpoint`               | x  | x  | x  |    |
| `_anchorInactiveSelectionEndpoint` | x  | x  | x  |    |
| `_mainBuffer`                      | x  | x  | x  | x  |
| `_altBuffer`                       | x  | x  | x  | x  |
| `_mutableViewport`                 | x  |    | x  | x  |
| `_scrollbackLines`                 | x  |    |    |    |
| `_detectURLs`                      | x  |    |    |    |
| `_altBufferSize`                   | x  | x  | x  | x  |
| `_deferredResize`                  | x  |    |    | x  |
| `_scrollOffset`                    | x  | x  | x  | x  |
| `_patternIntervalTree`             | x  | x  | x  | x  |
| `_lastKeyEventCodes`               | x  |    |    |    |
| `_currentPromptState`              | x  |    |    | x  |

Only 7 members are specific to one thread and don't require locking.
All other members require some for of locking to be safe for use.

To address the issue this changeset adds `LockForReading/LockForWriting`
calls everywhere `_terminal` is accessed in `ControlCore/HwndTerminal`.
Additionally, to ensure these issues don't pop up anymore, it adds to
all `Terminal` functions a debug assertion that the lock is being held.

Finally, because this changeset started off rather modest, it contains
changes that I initially made without being aware about the extent of
the issue. It simplifies the access around `_patternIntervalTree` by
making `_InvalidatePatternTree()` directly use that member.
Furthermore, it simplifies `_terminal->SetCursorOn(!IsCursorOn())` to
`BlinkCursor()`, allowing the code to be shared with `HwndTerminal`.

Ideally `Terminal` should not be that much of a class so that we don't
need such coarse locking. Splitting out selection and rendering state
should allow deduplicating code with conhost and use finer locking.

Closes #9617

## Validation Steps Performed
I tried to use as many Windows Terminal features as I could and fixed
every occurrence of `_assertLocked()` failures.