### PR TITLE
Canary: add the appLicensing capability

### DIFF
--- a/src/cascadia/CascadiaPackage/Package-Can.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Can.appxmanifest
@@ -147,5 +147,6 @@
     <Capability Name="internetClient" />
     <rescap:Capability Name="runFullTrust" />
     <rescap:Capability Name="unvirtualizedResources" />
+    <rescap:Capability Name="appLicensing" />
   </Capabilities>
 </Package>


### PR DESCRIPTION
This should allow the package to be installed without AppXSvc consulting the store or the licensing service.

It's free and open-source. It shouldn't need a license to run.
