### PR TITLE
release: put the branding and signing status into the build number

### DIFF
--- a/build/pipelines/templates-v2/pipeline-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-full-release-build.yml
@@ -80,6 +80,10 @@ variables:
       NuGetPackBetaVersion: preview
   ${{ elseif eq(variables['Build.SourceBranchName'], 'main') }}:
     NuGetPackBetaVersion: experimental
+  ${{ if eq(parameters.codeSign, true) }}:
+    BuildSlug: ${{ parameters.branding }}
+  ${{ else }}:
+    BuildSlug: ${{ parameters.branding }} Unsigned
 
 resources:
   repositories:
@@ -114,7 +118,7 @@ stages:
                 disableOutputRedirect: true
 
             - pwsh: |-
-                Write-Host "##vso[build.updatebuildnumber]${{ parameters.branding }} $(XES_APPXMANIFESTVERSION)"
+                Write-Host "##vso[build.updatebuildnumber]$(BuildSlug) $(XES_APPXMANIFESTVERSION)"
               displayName: Update Build Number
 
             - task: UniversalPackages@0

--- a/build/pipelines/templates-v2/pipeline-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-full-release-build.yml
@@ -113,6 +113,10 @@ stages:
               inputs:
                 disableOutputRedirect: true
 
+            - pwsh: |-
+                Write-Host "##vso[build.updatebuildnumber]${{ parameters.branding }} $(XES_APPXMANIFESTVERSION)"
+              displayName: Update Build Number
+
             - task: UniversalPackages@0
               displayName: Download terminal-internal Universal Package
               inputs:


### PR DESCRIPTION
<img width="245" alt="image" src="https://github.com/microsoft/terminal/assets/189190/c6249e88-8ee6-4dc1-83db-b032648abf3d">

It will be a lot easier to read if it looks like that.

Currently it looks like this:

<img width="719" alt="image" src="https://github.com/microsoft/terminal/assets/189190/e36285b8-e9e6-457d-a86b-fc514af72221">
