### PR TITLE
Don't explode if HKCU\Console is write-protected

### DIFF
--- a/src/cascadia/TerminalSettingsModel/DefaultTerminal.cpp
+++ b/src/cascadia/TerminalSettingsModel/DefaultTerminal.cpp
@@ -99,7 +99,9 @@ bool DefaultTerminal::HasCurrent()
 
 void DefaultTerminal::Current(const Model::DefaultTerminal& term)
 {
-    THROW_IF_FAILED(DelegationConfig::s_SetDefaultByPackage(winrt::get_self<DefaultTerminal>(term)->_pkg));
+    // Just log if we fail to write the defterm configuration. It's not worth
+    // exploding over if the regkey is write-protected or something.
+    LOG_IF_FAILED(DelegationConfig::s_SetDefaultByPackage(winrt::get_self<DefaultTerminal>(term)->_pkg));
 
     TraceLoggingWrite(g_hSettingsModelProvider,
                       "DefaultTerminalChanged",


### PR DESCRIPTION
I manually changed the permissions on `HKCU\Console` to deny "Create subkey" to myself. Then confirmed that it explodes before this change, and not after this change.

Closes #15458
