### PR TITLE
Allow closing tabs with middle mouse button when close button is hidden

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -443,7 +443,13 @@ namespace winrt::TerminalApp::implementation
         void _TabDragStarted(const IInspectable& sender, const IInspectable& eventArgs);
         void _TabDragCompleted(const IInspectable& sender, const IInspectable& eventArgs);
 
-        void _OnTabClick(const IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& eventArgs);
+        bool _tabPointerMiddleButtonPressed{ false };
+        bool _tabPointerMiddleButtonExited{ false };
+        void _OnTabPointerPressed(const IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& eventArgs);
+        void _OnTabPointerReleased(const IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& eventArgs);
+        void _OnTabPointerEntered(const IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& eventArgs);
+        void _OnTabPointerExited(const IInspectable& sender, const Windows::UI::Xaml::Input::PointerRoutedEventArgs& eventArgs);
+
         void _OnTabSelectionChanged(const IInspectable& sender, const Windows::UI::Xaml::Controls::SelectionChangedEventArgs& eventArgs);
         void _OnTabItemsChanged(const IInspectable& sender, const Windows::Foundation::Collections::IVectorChangedEventArgs& eventArgs);
         void _OnTabCloseRequested(const IInspectable& sender, const Microsoft::UI::Xaml::Controls::TabViewTabCloseRequestedEventArgs& eventArgs);


### PR DESCRIPTION
## Summary of the Pull Request
This commit fixes the middle mouse button handler. The `PointerReleased` callback is registered, but it is not operational because, on the Release event, the mouse button is no longer pressed. We need to track its state and act accordingly.

Issue was introduced by commit 05e7ea1423ede8ee67c3462fb04538fae5c9f9b2, which changed the event handler from `PointerPressed` to `PointerReleased`, rendering it inoperative. Instead, the default handler is used. The main issue is that when the close button is hidden with the `showCloseButton` option, the default handler no longer closes the tab on middle mouse clicks.

Also made it consistent with the Settings tab, which was never converted to `PointerReleased` and is still handled with a custom handler.

## References and Relevant Issues
Related commit 05e7ea1423ede8ee67c3462fb04538fae5c9f9b2

## Validation Steps Performed
I've been using this commit locally for quite some time, figured out I might as well share it.