### PR TITLE
COOKED_READ_DATA: Fix scrolling under ConPTY

### DIFF
--- a/src/cascadia/UnitTests_TerminalCore/ConptyRoundtripTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ConptyRoundtripTests.cpp
@@ -3401,7 +3401,7 @@ void ConptyRoundtripTests::WrapNewLineAtBottomLikeMSYS()
         }
         else if (writingMethod == PrintWithWriteCharsLegacy)
         {
-            WriteCharsLegacy(si, str, true, nullptr);
+            WriteCharsLegacy(si, str, false, nullptr);
         }
     };
 

--- a/src/host/output.cpp
+++ b/src/host/output.cpp
@@ -294,38 +294,6 @@ static void _ScrollScreen(SCREEN_INFORMATION& screenInfo, const Viewport& source
 }
 
 // Routine Description:
-// - This routine is a special-purpose scroll for use by AdjustCursorPosition.
-// Arguments:
-// - screenInfo - reference to screen buffer info.
-// Return Value:
-// - true if we succeeded in scrolling the buffer, otherwise false (if we're out of memory)
-void StreamScrollRegion(SCREEN_INFORMATION& screenInfo)
-{
-    // Rotate the circular buffer around and wipe out the previous final line.
-    auto& buffer = screenInfo.GetTextBuffer();
-    buffer.IncrementCircularBuffer(buffer.GetCurrentAttributes());
-
-    // Trigger a graphical update if we're active.
-    if (screenInfo.IsActiveScreenBuffer())
-    {
-        til::point coordDelta;
-        coordDelta.y = -1;
-
-        auto pNotifier = ServiceLocator::LocateAccessibilityNotifier();
-        if (pNotifier)
-        {
-            // Notify accessibility that a scroll has occurred.
-            pNotifier->NotifyConsoleUpdateScrollEvent(coordDelta.x, coordDelta.y);
-        }
-
-        if (ServiceLocator::LocateGlobals().pRender != nullptr)
-        {
-            ServiceLocator::LocateGlobals().pRender->TriggerScroll(&coordDelta);
-        }
-    }
-}
-
-// Routine Description:
 // - This routine copies ScrollRectangle to DestinationOrigin then fills in ScrollRectangle with Fill.
 // - The scroll region is copied to a third buffer, the scroll region is filled, then the original contents of the scroll region are copied to the destination.
 // Arguments:

--- a/src/host/output.h
+++ b/src/host/output.h
@@ -47,7 +47,5 @@ void ScrollRegion(SCREEN_INFORMATION& screenInfo,
 
 VOID SetConsoleWindowOwner(const HWND hwnd, _Inout_opt_ ConsoleProcessHandle* pProcessData);
 
-void StreamScrollRegion(SCREEN_INFORMATION& screenInfo);
-
 // For handling process handle state, not the window state itself.
 void CloseConsoleProcessState();

--- a/src/host/readDataCooked.hpp
+++ b/src/host/readDataCooked.hpp
@@ -113,10 +113,10 @@ private:
     void _handlePostCharInputLoop(bool isUnicode, size_t& numBytes, ULONG& controlKeyState);
     void _markAsDirty();
     void _flushBuffer();
-    void _erase(til::CoordType distance) const;
-    til::CoordType _writeChars(const std::wstring_view& text) const;
-    til::point _offsetPosition(til::point pos, til::CoordType distance) const;
-    void _unwindCursorPosition(til::CoordType distance) const;
+    void _erase(ptrdiff_t distance) const;
+    ptrdiff_t _writeChars(const std::wstring_view& text) const;
+    til::point _offsetPosition(til::point pos, ptrdiff_t distance) const;
+    void _unwindCursorPosition(ptrdiff_t distance) const;
     void _replaceBuffer(const std::wstring_view& str);
 
     void _popupPush(PopupKind kind);
@@ -140,8 +140,8 @@ private:
 
     std::wstring _buffer;
     size_t _bufferCursor = 0;
-    til::CoordType _distanceCursor;
-    til::CoordType _distanceEnd;
+    ptrdiff_t _distanceCursor = 0;
+    ptrdiff_t _distanceEnd = 0;
     bool _bufferDirty = false;
     bool _insertMode = false;
 


### PR DESCRIPTION
This commit fixes 3 bugs:
* `COOKED_READ_DATA` failed to initialize its `_distanceCursor` and
  `_distanceEnd` members. I took this as an opportunity to make them
  `ptrdiff_t`, to reduce the likelihood of overflows in the future.
* `COOKED_READ_DATA::_writeChars` added `scrollY` to the written
  distance, even though `WriteCharsLegacy` writes a negative value into
  that out parameter. This was fixed by changing `WriteCharsLegacy` to
  write positive values and by adding a debug assertion.
* `StreamScrollRegion` calls `IncrementCircularBuffer` which causes a
  synchronous (!) ConPTY flush to the output pipe (side note: this is
  the primary reason why newlines are so slow in ConPTY).
  Since cooked reads are supposed to behave like a pager and not write
  into the scrollback, we temporarily mark the buffer as inactive
  which prevents `TextBuffer` from snitching about it to VtEngine.

Even after this change, there's still some weird behavior left:
* You cannot move your cursor back beyond (0,0), because this isn't a
  real pager-like implementation. That might be a neat future extension.
* Writing a lot of text and pressing Ctrl+C doesn't properly place the
  cursor and scroll the buffer, unless the cursor is at the end.
  That might also be worth investigating in the future (minor issue).
* When the viewport is full, backspacing more than 1 line of text
  (using Ctrl+Backspace) doesn't erase all of the affected lines,
  because `COOKED_READ_DATA::_erase` uses the same `WriteCharsLegacy`
  function to write whitespace to erase that text. It's only gone
  after typing one more character.
  I've written the code to mostly fix this, but decided against it
  as I considered the problem to be too niche to warrant extra code.

Closes #15899

## Validation Steps Performed
* Generate some text to paste in PowerShell:
  ```pwsh
  "" + (0..512 | % { "word" + $_.ToString().PadLeft(4, "0") })
  ```
* Launch cmd.exe and paste that text
* No flickering ✅
* No writing into the scrollback ✅
* No weird behavior when backspacing ✅