### PR TITLE
Attempt fixing repetitive chars in Japanese IME

### DIFF
--- a/src/cascadia/TerminalControl/TSFInputControl.h
+++ b/src/cascadia/TerminalControl/TSFInputControl.h
@@ -58,6 +58,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
         void _textUpdatingHandler(winrt::Windows::UI::Text::Core::CoreTextEditContext sender, const winrt::Windows::UI::Text::Core::CoreTextTextUpdatingEventArgs& args);
         void _formatUpdatingHandler(winrt::Windows::UI::Text::Core::CoreTextEditContext sender, const winrt::Windows::UI::Text::Core::CoreTextFormatUpdatingEventArgs& args);
 
+        std::pair<size_t, size_t> _convertRangeIntoBeginAndLength(winrt::Windows::UI::Text::Core::CoreTextRange range) const noexcept;
         void _SendAndClearText();
         void _RedrawCanvas();
 


### PR DESCRIPTION
Users report in issue #14349 that the Japanese IME may print repetitive
characters since v1.15. The two potential offenders are:
* 2c922e105c6468a8c2469946d44b98390ff94f1d
* ed800dc72de9e51201becf1f752093f4c1b4e155

I don't think either of the two commits themselves is "buggy", but
rather that they make bugs in TSF obvious. This is because backspacing
causes `TermControl::_CharacterHandler` to be called, which will then
call `TSFInputControl().ClearBuffer()`, which _should_ instruct TSF
to flush its entire buffer and reset its state.
That doesn't seem to be happening though.

I think what's happening here is that TSF is either:
* ignoring this request
* getting into a bad state
* running into race conditions due to running out-of-process

2c922e105c6468a8c2469946d44b98390ff94f1d could have triggered the
regression because it drops clamping the signed `range` values from TSF.
I believe at the time I didn't consider it possible that TSF would
actually pass either negative indices or a range where
`StartCaretPosition` is greater than `EndCaretPosition`.

ed800dc72de9e51201becf1f752093f4c1b4e155 could have triggered the
regression because it changed this (simplified):
```cpp
_activeTextStart = min(_activeTextStart, range.StartCaretPosition);
```
into this:
```cpp
_activeTextStart = min(_activeTextStart, _inputBuffer.size());
```

I think the latter is technically more correct, but if TSF is in a bad
state where it didn't properly reset, then this may be off.
(When the buffer contains "foo" and the _activeTextStart is 3 (= end),
then we shouldn't move the start to 0 just because TSF replaced the
entire string with "foobar", since the active part is just "bar".)

Closes #14349

## Validation Steps Performed
* Japanese IME (Full-Width Katakana)
  Typing "saitama" produces "サイタマ" ✅
* Korean IME
  Typing "gksrmf" produces "한글" ✅
* Vietnamese IME
  Typing "xin chaof" produces "xin chào" ✅
* Emoji Picker (Win+.)
  ✅