### PR TITLE
Fix identity of canary appxmanifest

### DIFF
--- a/src/cascadia/CascadiaPackage/Package-Can.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Can.appxmanifest
@@ -7,17 +7,17 @@
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
   xmlns:uap4="http://schemas.microsoft.com/appx/manifest/uap/windows10/4"
+  xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
   xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
   xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4"
   xmlns:desktop5="http://schemas.microsoft.com/appx/manifest/desktop/windows10/5"
   xmlns:desktop6="http://schemas.microsoft.com/appx/manifest/desktop/windows10/6"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   xmlns:virtualization="http://schemas.microsoft.com/appx/manifest/virtualization/windows10"
-  xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
   IgnorableNamespaces="uap mp rescap uap3 desktop6 virtualization">
 
   <Identity
-    Name="WindowsTerminalCan"
+    Name="Microsoft.WindowsTerminalCanary"
     Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
     Version="0.0.1.0" />
 
@@ -72,17 +72,17 @@
             <desktop:ExecutionAlias Alias="wt.exe" />
           </uap3:AppExecutionAlias>
         </uap3:Extension>
+        <uap3:Extension Category="windows.appExtensionHost">
+          <uap3:AppExtensionHost>
+            <uap3:Name>com.microsoft.windows.terminal.settings</uap3:Name>
+          </uap3:AppExtensionHost>
+        </uap3:Extension>
         <uap5:Extension Category="windows.startupTask">
           <uap5:StartupTask
             TaskId="StartTerminalOnLoginTask"
             Enabled="false"
             DisplayName="ms-resource:AppNameCan" />
         </uap5:Extension>
-        <uap3:Extension Category="windows.appExtensionHost">
-              <uap3:AppExtensionHost>
-                <uap3:Name>com.microsoft.windows.terminal.settings</uap3:Name>
-              </uap3:AppExtensionHost>
-        </uap3:Extension>
         <uap3:Extension Category="windows.appExtension">
             <uap3:AppExtension Name="com.microsoft.windows.console.host"
                 Id="OpenConsole-Can"

--- a/src/cascadia/CascadiaPackage/Package-Can.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Can.appxmanifest
@@ -149,4 +149,8 @@
     <rescap:Capability Name="unvirtualizedResources" />
     <rescap:Capability Name="appLicensing" />
   </Capabilities>
+
+  <mp:PhoneIdentity
+    PhoneProductId="348ff861-8d83-47b2-a740-15f8a096dcae"
+    PhonePublisherId="00000000-0000-0000-0000-000000000000" />
 </Package>


### PR DESCRIPTION
This commit fixes the identity of our new canary packages.
Additionally, it slightly reorders one block so that the file is
almost entirely in the same layout as the preview appxmanifest,
allowing for a better direct comparison (with git diff, etc.).