### PR TITLE
Fix a number of minor issues that Clang flagged (again!)

### DIFF
--- a/src/buffer/out/ut_textbuffer/TextBuffer.Unit.Tests.vcxproj
+++ b/src/buffer/out/ut_textbuffer/TextBuffer.Unit.Tests.vcxproj
@@ -14,7 +14,7 @@
     <ClCompile Include="ReflowTests.cpp" />
     <ClCompile Include="TextColorTests.cpp" />
     <ClCompile Include="TextAttributeTests.cpp" />
-    <ClCompile Include="..\precomp.cpp">
+    <ClCompile Include="precomp.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
   </ItemGroup>
@@ -30,7 +30,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\precomp.h" />
+    <ClInclude Include="precomp.h" />
   </ItemGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
+++ b/src/cascadia/TerminalSettingsModel/ActionAndArgs.cpp
@@ -459,7 +459,7 @@ namespace winrt::Microsoft::Terminal::Settings::Model::implementation
         auto data = winrt::to_string(content);
 
         std::string errs;
-        std::unique_ptr<Json::CharReader> reader{ Json::CharReaderBuilder::CharReaderBuilder().newCharReader() };
+        std::unique_ptr<Json::CharReader> reader{ Json::CharReaderBuilder{}.newCharReader() };
         Json::Value root;
         if (!reader->parse(data.data(), data.data() + data.size(), &root, &errs))
         {

--- a/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
+++ b/src/cascadia/TerminalSettingsModel/CascadiaSettingsSerialization.cpp
@@ -1228,7 +1228,7 @@ void CascadiaSettings::WriteSettingsToDisk()
 }
 
 #ifndef NDEBUG
-static [[maybe_unused]] std::string _getDevPathToSchema()
+[[maybe_unused]] static std::string _getDevPathToSchema()
 {
     std::filesystem::path filePath{ __FILE__ };
     auto schemaPath = filePath.parent_path().parent_path().parent_path().parent_path() / "doc" / "cascadia" / "profiles.schema.json";

--- a/src/interactivity/win32/windowproc.cpp
+++ b/src/interactivity/win32/windowproc.cpp
@@ -735,7 +735,7 @@ using namespace Microsoft::Console::Types;
         }
         break;
     }
-#endif DBG
+#endif // DBG
 
     case EVENT_CONSOLE_CARET:
     case EVENT_CONSOLE_UPDATE_REGION:

--- a/src/renderer/atlas/BackendD3D.h
+++ b/src/renderer/atlas/BackendD3D.h
@@ -218,7 +218,7 @@ namespace Microsoft::Console::Render::Atlas
         void _drawText(RenderingPayload& p);
         ATLAS_ATTR_COLD void _drawTextOverlapSplit(const RenderingPayload& p, u16 y);
         ATLAS_ATTR_COLD static void _initializeFontFaceEntry(AtlasFontFaceEntryInner& fontFaceEntry);
-        ATLAS_ATTR_COLD [[nodiscard]] bool _drawGlyph(const RenderingPayload& p, const AtlasFontFaceEntryInner& fontFaceEntry, AtlasGlyphEntry& glyphEntry);
+        [[nodiscard]] ATLAS_ATTR_COLD bool _drawGlyph(const RenderingPayload& p, const AtlasFontFaceEntryInner& fontFaceEntry, AtlasGlyphEntry& glyphEntry);
         bool _drawSoftFontGlyph(const RenderingPayload& p, const AtlasFontFaceEntryInner& fontFaceEntry, AtlasGlyphEntry& glyphEntry);
         void _drawGlyphPrepareRetry(const RenderingPayload& p);
         void _splitDoubleHeightGlyph(const RenderingPayload& p, const AtlasFontFaceEntryInner& fontFaceEntry, AtlasGlyphEntry& glyphEntry);

--- a/src/renderer/vt/tracing.cpp
+++ b/src/renderer/vt/tracing.cpp
@@ -18,14 +18,14 @@ RenderTracing::RenderTracing()
 {
 #ifndef UNIT_TESTING
     TraceLoggingRegister(g_hConsoleVtRendererTraceProvider);
-#endif UNIT_TESTING
+#endif // UNIT_TESTING
 }
 
 RenderTracing::~RenderTracing()
 {
 #ifndef UNIT_TESTING
     TraceLoggingUnregister(g_hConsoleVtRendererTraceProvider);
-#endif UNIT_TESTING
+#endif // UNIT_TESTING
 }
 
 // Function Description:
@@ -79,7 +79,7 @@ void RenderTracing::TraceStringFill(const size_t n, const char c) const
 #else
     UNREFERENCED_PARAMETER(n);
     UNREFERENCED_PARAMETER(c);
-#endif UNIT_TESTING
+#endif // UNIT_TESTING
 }
 void RenderTracing::TraceString(const std::string_view& instr) const
 {
@@ -96,7 +96,7 @@ void RenderTracing::TraceString(const std::string_view& instr) const
     }
 #else
     UNREFERENCED_PARAMETER(instr);
-#endif UNIT_TESTING
+#endif // UNIT_TESTING
 }
 
 void RenderTracing::TraceInvalidate(const til::rect& invalidRect) const
@@ -114,7 +114,7 @@ void RenderTracing::TraceInvalidate(const til::rect& invalidRect) const
     }
 #else
     UNREFERENCED_PARAMETER(invalidRect);
-#endif UNIT_TESTING
+#endif // UNIT_TESTING
 }
 
 void RenderTracing::TraceInvalidateAll(const til::rect& viewport) const
@@ -132,7 +132,7 @@ void RenderTracing::TraceInvalidateAll(const til::rect& viewport) const
     }
 #else
     UNREFERENCED_PARAMETER(viewport);
-#endif UNIT_TESTING
+#endif // UNIT_TESTING
 }
 
 void RenderTracing::TraceTriggerCircling(const bool newFrame) const
@@ -145,7 +145,7 @@ void RenderTracing::TraceTriggerCircling(const bool newFrame) const
                       TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 #else
     UNREFERENCED_PARAMETER(newFrame);
-#endif UNIT_TESTING
+#endif // UNIT_TESTING
 }
 
 void RenderTracing::TraceInvalidateScroll(const til::point scroll) const
@@ -215,7 +215,7 @@ void RenderTracing::TraceStartPaint(const bool quickReturn,
     UNREFERENCED_PARAMETER(scrollDelt);
     UNREFERENCED_PARAMETER(cursorMoved);
     UNREFERENCED_PARAMETER(wrappedRow);
-#endif UNIT_TESTING
+#endif // UNIT_TESTING
 }
 
 void RenderTracing::TraceEndPaint() const
@@ -226,7 +226,7 @@ void RenderTracing::TraceEndPaint() const
                       TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
                       TraceLoggingKeyword(TIL_KEYWORD_TRACE));
 #else
-#endif UNIT_TESTING
+#endif // UNIT_TESTING
 }
 
 void RenderTracing::TraceLastText(const til::point lastTextPos) const
@@ -244,7 +244,7 @@ void RenderTracing::TraceLastText(const til::point lastTextPos) const
     }
 #else
     UNREFERENCED_PARAMETER(lastTextPos);
-#endif UNIT_TESTING
+#endif // UNIT_TESTING
 }
 
 void RenderTracing::TraceScrollFrame(const til::point scrollDeltaPos) const
@@ -262,7 +262,7 @@ void RenderTracing::TraceScrollFrame(const til::point scrollDeltaPos) const
     }
 #else
     UNREFERENCED_PARAMETER(scrollDeltaPos);
-#endif UNIT_TESTING
+#endif // UNIT_TESTING
 }
 
 void RenderTracing::TraceMoveCursor(const til::point lastTextPos, const til::point cursor) const
@@ -286,7 +286,7 @@ void RenderTracing::TraceMoveCursor(const til::point lastTextPos, const til::poi
 #else
     UNREFERENCED_PARAMETER(lastTextPos);
     UNREFERENCED_PARAMETER(cursor);
-#endif UNIT_TESTING
+#endif // UNIT_TESTING
 }
 
 void RenderTracing::TraceWrapped() const
@@ -302,7 +302,7 @@ void RenderTracing::TraceWrapped() const
                           TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 #else
-#endif UNIT_TESTING
+#endif // UNIT_TESTING
 }
 
 void RenderTracing::TraceSetWrapped(const til::CoordType wrappedRow) const
@@ -318,7 +318,7 @@ void RenderTracing::TraceSetWrapped(const til::CoordType wrappedRow) const
     }
 #else
     UNREFERENCED_PARAMETER(wrappedRow);
-#endif UNIT_TESTING
+#endif // UNIT_TESTING
 }
 
 void RenderTracing::TraceClearWrapped() const
@@ -334,7 +334,7 @@ void RenderTracing::TraceClearWrapped() const
                           TraceLoggingKeyword(TIL_KEYWORD_TRACE));
     }
 #else
-#endif UNIT_TESTING
+#endif // UNIT_TESTING
 }
 
 void RenderTracing::TracePaintCursor(const til::point coordCursor) const
@@ -352,5 +352,5 @@ void RenderTracing::TracePaintCursor(const til::point coordCursor) const
     }
 #else
     UNREFERENCED_PARAMETER(coordCursor);
-#endif UNIT_TESTING
+#endif // UNIT_TESTING
 }

--- a/src/terminal/input/terminalInput.hpp
+++ b/src/terminal/input/terminalInput.hpp
@@ -18,8 +18,8 @@ namespace Microsoft::Console::VirtualTerminal
             bool isRightButtonDown;
         };
 
-        static [[nodiscard]] OutputType MakeUnhandled() noexcept;
-        static [[nodiscard]] OutputType MakeOutput(const std::wstring_view& str);
+        [[nodiscard]] static OutputType MakeUnhandled() noexcept;
+        [[nodiscard]] static OutputType MakeOutput(const std::wstring_view& str);
         [[nodiscard]] OutputType HandleKey(const INPUT_RECORD& pInEvent);
         [[nodiscard]] OutputType HandleFocus(bool focused) const;
         [[nodiscard]] OutputType HandleMouse(til::point position, unsigned int button, short modifierKeyState, short delta, MouseButtonState state);
@@ -74,9 +74,9 @@ namespace Microsoft::Console::VirtualTerminal
         bool _forceDisableWin32InputMode{ false };
 
         [[nodiscard]] OutputType _makeCharOutput(wchar_t ch);
-        static [[nodiscard]] OutputType _makeEscapedOutput(wchar_t wch);
-        static [[nodiscard]] OutputType _makeWin32Output(const KEY_EVENT_RECORD& key);
-        static [[nodiscard]] OutputType _searchWithModifier(const KEY_EVENT_RECORD& keyEvent);
+        [[nodiscard]] static OutputType _makeEscapedOutput(wchar_t wch);
+        [[nodiscard]] static OutputType _makeWin32Output(const KEY_EVENT_RECORD& key);
+        [[nodiscard]] static OutputType _searchWithModifier(const KEY_EVENT_RECORD& keyEvent);
 
 #pragma region MouseInputState Management
         // These methods are defined in mouseInputState.cpp
@@ -92,9 +92,9 @@ namespace Microsoft::Console::VirtualTerminal
 #pragma endregion
 
 #pragma region MouseInput
-        static [[nodiscard]] OutputType _GenerateDefaultSequence(til::point position, unsigned int button, bool isHover, short modifierKeyState, short delta);
-        static [[nodiscard]] OutputType _GenerateUtf8Sequence(til::point position, unsigned int button, bool isHover, short modifierKeyState, short delta);
-        static [[nodiscard]] OutputType _GenerateSGRSequence(til::point position, unsigned int button, bool isDown, bool isHover, short modifierKeyState, short delta);
+        [[nodiscard]] static OutputType _GenerateDefaultSequence(til::point position, unsigned int button, bool isHover, short modifierKeyState, short delta);
+        [[nodiscard]] static OutputType _GenerateUtf8Sequence(til::point position, unsigned int button, bool isHover, short modifierKeyState, short delta);
+        [[nodiscard]] static OutputType _GenerateSGRSequence(til::point position, unsigned int button, bool isDown, bool isHover, short modifierKeyState, short delta);
 
         [[nodiscard]] OutputType _makeAlternateScrollOutput(short delta) const;
 


### PR DESCRIPTION
* `[[nodiscard]]` and `[[maybe_unused]]` must come before `virtual` and `static` qualifiers
* We were calling the jsoncpp constructors directly (again) as functions (again)
* Some of our preprocessor `#endif` lines were quite messed up (`-Winvalid-token`)
* One of our test projects was using somebody else's `precomp.h`

Related to #14871