### PR TITLE
Stage WinAppDriver into its own folder

### DIFF
--- a/src/cascadia/WindowsTerminal_UIATests/Init.cs
+++ b/src/cascadia/WindowsTerminal_UIATests/Init.cs
@@ -22,7 +22,12 @@ namespace Host.Tests.UIA
         public static void SetupAll(TestContext context)
         {
             Log.Comment("Searching for WinAppDriver in the same directory where this test was launched from...");
-            string winAppDriver = Path.Combine(context.TestDeploymentDir, "WinAppDriver.exe");
+            string winAppDriver = Path.Combine(context.TestDeploymentDir, "WinAppDriver", "WinAppDriver.exe");
+
+            if (!File.Exists(winAppDriver))
+            {
+                winAppDriver = Path.Combine(context.TestDeploymentDir, "WinAppDriver.exe");
+            }
 
             Log.Comment($"Attempting to launch WinAppDriver at: {winAppDriver}");
             Log.Comment($"Working directory: {Environment.CurrentDirectory}");

--- a/src/cascadia/WindowsTerminal_UIATests/WindowsTerminal.UIA.Tests.csproj
+++ b/src/cascadia/WindowsTerminal_UIATests/WindowsTerminal.UIA.Tests.csproj
@@ -126,7 +126,7 @@
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy &quot;$(SolutionDir)\dep\WinAppDriver\*&quot; &quot;$(OutDir)\&quot;</PostBuildEvent>
+    <PostBuildEvent>mkdir &quot;$(OutDir)\WinAppDriver&quot; &amp;&amp; copy &quot;$(SolutionDir)\dep\WinAppDriver\*&quot; &quot;$(OutDir)\WinAppDriver\&quot;</PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\..\common.nugetversions.targets" />
 </Project>

--- a/src/cascadia/WindowsTerminal_UIATests/WindowsTerminal.UIA.Tests.csproj
+++ b/src/cascadia/WindowsTerminal_UIATests/WindowsTerminal.UIA.Tests.csproj
@@ -126,7 +126,7 @@
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>mkdir &quot;$(OutDir)\WinAppDriver&quot; &amp;&amp; copy &quot;$(SolutionDir)\dep\WinAppDriver\*&quot; &quot;$(OutDir)\WinAppDriver\&quot;</PostBuildEvent>
+    <PostBuildEvent>mkdir &quot;$(OutDir)\WinAppDriver&quot; 2&gt;nul &amp; copy &quot;$(SolutionDir)\dep\WinAppDriver\*&quot; &quot;$(OutDir)\WinAppDriver\&quot;</PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\..\common.nugetversions.targets" />
 </Project>

--- a/src/host/ft_uia/Host.Tests.UIA.csproj
+++ b/src/host/ft_uia/Host.Tests.UIA.csproj
@@ -149,7 +149,7 @@
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>mkdir &quot;$(OutDir)\WinAppDriver&quot; &amp;&amp; copy &quot;$(SolutionDir)\dep\WinAppDriver\*&quot; &quot;$(OutDir)\WinAppDriver\&quot;</PostBuildEvent>
+    <PostBuildEvent>mkdir &quot;$(OutDir)\WinAppDriver&quot; 2&gt;nul &amp; copy &quot;$(SolutionDir)\dep\WinAppDriver\*&quot; &quot;$(OutDir)\WinAppDriver\&quot;</PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\..\common.nugetversions.targets" />
 </Project>

--- a/src/host/ft_uia/Host.Tests.UIA.csproj
+++ b/src/host/ft_uia/Host.Tests.UIA.csproj
@@ -149,7 +149,7 @@
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy "$(SolutionDir)\dep\WinAppDriver\*" "$(OutDir)\"</PostBuildEvent>
+    <PostBuildEvent>mkdir &quot;$(OutDir)\WinAppDriver&quot; &amp;&amp; copy &quot;$(SolutionDir)\dep\WinAppDriver\*&quot; &quot;$(OutDir)\WinAppDriver\&quot;</PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\..\common.nugetversions.targets" />
 </Project>

--- a/src/host/ft_uia/Init.cs
+++ b/src/host/ft_uia/Init.cs
@@ -28,7 +28,12 @@ namespace Host.Tests.UIA
         public static void SetupAll(TestContext context)
         {
             Log.Comment("Searching for WinAppDriver in the same directory where this test was launched from...");
-            string winAppDriver = Path.Combine(context.TestDeploymentDir, "WinAppDriver.exe");
+            string winAppDriver = Path.Combine(context.TestDeploymentDir, "WinAppDriver", "WinAppDriver.exe");
+
+            if (!File.Exists(winAppDriver))
+            {
+                winAppDriver = Path.Combine(context.TestDeploymentDir, "WinAppDriver.exe");
+            }
 
             Log.Comment($"Attempting to launch WinAppDriver at: {winAppDriver}");
             Log.Comment($"Working directory: {Environment.CurrentDirectory}");


### PR DESCRIPTION
WinAppDriver depends on a bunch of .NET assemblies that collide *big time*. Let's just quarantine it.

I kept the fallback to $TESTDIR\WinAppDriver.exe because there's a chance that the Windows build depends on it.