### PR TITLE
Add Auto Prop Name to 'Delete Color Scheme' button

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/EditColorScheme.cpp
+++ b/src/cascadia/TerminalSettingsEditor/EditColorScheme.cpp
@@ -35,6 +35,7 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         Automation::AutomationProperties::SetName(RenameAcceptButton(), RS_(L"RenameAccept/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
         Automation::AutomationProperties::SetName(RenameCancelButton(), RS_(L"RenameCancel/[using:Windows.UI.Xaml.Controls]ToolTipService/ToolTip"));
         Automation::AutomationProperties::SetName(SetAsDefaultButton(), RS_(L"ColorScheme_SetAsDefault/Header"));
+        Automation::AutomationProperties::SetName(DeleteButton(), RS_(L"ColorScheme_DeleteButton/Text"));
     }
 
     void EditColorScheme::OnNavigatedTo(const NavigationEventArgs& e)


### PR DESCRIPTION
Since the "delete color scheme" button is filled with an icon and a Text Box, the text is not automatically exposed as the autoProp.Name for the button. We have to do it manually just like we do for "delete profile".

Validated manually using accessibility insights

Closes #15984