### PR TITLE
Fix `enter` to restart the first pane in a split

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -2348,7 +2348,12 @@ namespace winrt::TerminalApp::implementation
         }
 
         _UnZoomIfNeeded();
-        activeTab->SplitPane(*realSplitType, splitSize, newPane);
+        auto [original, _] = activeTab->SplitPane(*realSplitType, splitSize, newPane);
+
+        // When we split the pane, the Pane itself will create a _new_ Pane
+        // instance for the original content. We need to make sure we also
+        // re-add our event handler to that newly created pane.
+        original->RestartTerminalRequested({ get_weak(), &TerminalPage::_restartPaneConnection });
 
         // After GH#6586, the control will no longer focus itself
         // automatically when it's finished being laid out. Manually focus

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1706,6 +1706,11 @@ namespace winrt::TerminalApp::implementation
         hostingTab.TaskbarProgressChanged({ get_weak(), &TerminalPage::_SetTaskbarProgressHandler });
     }
 
+    void TerminalPage::_RegisterPaneEvents(std::shared_ptr<Pane>& pane)
+    {
+        pane->RestartTerminalRequested({ get_weak(), &TerminalPage::_restartPaneConnection });
+    }
+
     // Method Description:
     // - Helper to manually exit "zoom" when certain actions take place.
     //   Anything that modifies the state of the pane tree should probably
@@ -2353,7 +2358,9 @@ namespace winrt::TerminalApp::implementation
         // When we split the pane, the Pane itself will create a _new_ Pane
         // instance for the original content. We need to make sure we also
         // re-add our event handler to that newly created pane.
-        original->RestartTerminalRequested({ get_weak(), &TerminalPage::_restartPaneConnection });
+        //
+        // _MakePane will already call this for the newly created pane.
+        _RegisterPaneEvents(original);
 
         // After GH#6586, the control will no longer focus itself
         // automatically when it's finished being laid out. Manually focus
@@ -3103,7 +3110,7 @@ namespace winrt::TerminalApp::implementation
             original->SetActive();
         }
 
-        resultPane->RestartTerminalRequested({ get_weak(), &TerminalPage::_restartPaneConnection });
+        _RegisterPaneEvents(resultPane);
 
         return resultPane;
     }

--- a/src/cascadia/TerminalApp/TerminalPage.h
+++ b/src/cascadia/TerminalApp/TerminalPage.h
@@ -344,6 +344,7 @@ namespace winrt::TerminalApp::implementation
         void _InitializeTab(winrt::com_ptr<TerminalTab> newTabImpl, uint32_t insertPosition = -1);
         void _RegisterTerminalEvents(Microsoft::Terminal::Control::TermControl term);
         void _RegisterTabEvents(TerminalTab& hostingTab);
+        void _RegisterPaneEvents(std::shared_ptr<Pane>& pane);
 
         void _DismissTabContextMenus();
         void _FocusCurrentTab(const bool focusAlways);

--- a/src/cascadia/TerminalApp/TerminalTab.cpp
+++ b/src/cascadia/TerminalApp/TerminalTab.cpp
@@ -497,9 +497,9 @@ namespace winrt::TerminalApp::implementation
     //         could itself be a parent pane/the root node of a tree of panes
     // Return Value:
     // - <none>
-    void TerminalTab::SplitPane(SplitDirection splitType,
-                                const float splitSize,
-                                std::shared_ptr<Pane> pane)
+    std::pair<std::shared_ptr<Pane>, std::shared_ptr<Pane>> TerminalTab::SplitPane(SplitDirection splitType,
+                                                                                   const float splitSize,
+                                                                                   std::shared_ptr<Pane> pane)
     {
         ASSERT_UI_THREAD();
 
@@ -544,6 +544,8 @@ namespace winrt::TerminalApp::implementation
         // possible that the focus events won't propagate immediately. Updating
         // the focus here will give the same effect though.
         _UpdateActivePane(newPane);
+
+        return { original, newPane };
     }
 
     // Method Description:

--- a/src/cascadia/TerminalApp/TerminalTab.h
+++ b/src/cascadia/TerminalApp/TerminalTab.h
@@ -36,9 +36,9 @@ namespace winrt::TerminalApp::implementation
 
         void AttachColorPicker(winrt::TerminalApp::ColorPickupFlyout& colorPicker);
 
-        void SplitPane(winrt::Microsoft::Terminal::Settings::Model::SplitDirection splitType,
-                       const float splitSize,
-                       std::shared_ptr<Pane> newPane);
+        std::pair<std::shared_ptr<Pane>, std::shared_ptr<Pane>> SplitPane(winrt::Microsoft::Terminal::Settings::Model::SplitDirection splitType,
+                                                                          const float splitSize,
+                                                                          std::shared_ptr<Pane> newPane);
 
         void ToggleSplitOrientation();
         void UpdateIcon(const winrt::hstring iconPath);


### PR DESCRIPTION
I noticed this last week, but forgot to file. If you have a pair of splits, and `exit -1` the first, you can't use `enter` to restart it. 

This PR fixes that. Basically, `TerminalPage` registers it's `_restartPaneConnection` handler when it makes a new `Pane` object. It registers the callback straight to the `Pane`. However, when a `Pane` gets split, it makes a _new_ `Pane` object, and moves the original content into the new pane. `TerminalPage` however, would never hook up its own callback to that newly created pane. 

This fixes that. 