### PR TITLE
Improve performance of scrollbar marks

### DIFF
--- a/src/cascadia/TerminalControl/ControlCore.cpp
+++ b/src/cascadia/TerminalControl/ControlCore.cpp
@@ -1380,6 +1380,7 @@ namespace winrt::Microsoft::Terminal::Control::implementation
 
     til::color ControlCore::ForegroundColor() const
     {
+        const auto lock = _terminal->LockForReading();
         return _terminal->GetRenderSettings().GetColorAlias(ColorAlias::DefaultForeground);
     }
 

--- a/src/cascadia/TerminalControl/TermControl.xaml
+++ b/src/cascadia/TerminalControl/TermControl.xaml
@@ -1322,28 +1322,14 @@
                        ValueChanged="_ScrollbarChangeHandler"
                        ViewportSize="10" />
 
-            <Grid x:Name="ScrollMarksGrid"
-                  Grid.Column="1"
-                  Width="{StaticResource ScrollBarSize}"
-                  HorizontalAlignment="Right"
-                  VerticalAlignment="Stretch">
-
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-
-                <Border Grid.Row="0"
-                        Height="{StaticResource ScrollBarSize}" />
-                <Canvas x:Name="ScrollBarCanvas"
-                        Grid.Row="1"
-                        Width="{StaticResource ScrollBarSize}"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Stretch" />
-                <Border Grid.Row="2"
-                        Height="{StaticResource ScrollBarSize}" />
-            </Grid>
+            <Image x:Name="ScrollBarCanvas"
+                   Grid.Column="1"
+                   Width="{StaticResource ScrollBarSize}"
+                   HorizontalAlignment="Right"
+                   VerticalAlignment="Stretch"
+                   x:Load="False"
+                   IsHitTestVisible="False"
+                   Visibility="Collapsed" />
 
         </Grid>
 


### PR DESCRIPTION
This replaces the use of a `<Canvas>` with an `<Image>` for drawing
scrollbar marks. Otherwise, WinUI struggles with the up to ~9000 UI
elements as they get dirtied every time the scrollbar moves.
(FWIW 9000 is not a lot and it should not struggle with that.)

The `<Image>` element has the benefit that we can get hold of a CPU-side
bitmap which we can manually draw our marks into and then swap them into
the UI tree. It draws the same 9000 elements, but now WinUI doesn't
struggle anymore because only 1 element gets invalidated every time.

Closes #15955

## Validation Steps Performed
* Fill the buffer with "e"
* Searching for "e" fills the entire thumb range with white ✅
* ...doesn't lag when scrolling around ✅
* ...updates quickly when adding newlines at the end ✅
* Marks sort of align with their scroll position ✅