### PR TITLE
About: check PackageManager for updates in addition to Store

### DIFF
--- a/src/cascadia/TerminalApp/pch.h
+++ b/src/cascadia/TerminalApp/pch.h
@@ -49,6 +49,7 @@
 #include <winrt/Windows.Media.h>
 #include <winrt/Windows.Media.Core.h>
 #include <winrt/Windows.Media.Playback.h>
+#include <winrt/Windows.Management.Deployment.h>
 
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.Primitives.h>


### PR DESCRIPTION
With us adding a .appinstaller distribution of Canary, the Store
services update checker has beome insufficient to determine whether
there are package updates.

App Installer supports us checking for updates by using PackageManager
and the Package interfaces.

We'll use those instead of the Store services interface, and bail out
early if the App Installer gives us an answer.
