### PR TITLE
Experiment with some conpty windowing fixes

### DIFF
--- a/src/features.xml
+++ b/src/features.xml
@@ -187,4 +187,15 @@
         </alwaysEnabledBrandingTokens>
     </feature>
 
+    <feature>
+        <name>Feature_ConPtyHwndStyles</name>
+        <description>Experiment with different window styles for the conpty window</description>
+        <id>15219</id>
+        <stage>AlwaysDisabled</stage>
+        <alwaysEnabledBrandingTokens>
+            <brandingToken>Dev</brandingToken>
+            <brandingToken>Canary</brandingToken>
+        </alwaysEnabledBrandingTokens>
+    </feature>
+
 </featureStaging>

--- a/src/interactivity/base/InteractivityFactory.cpp
+++ b/src/interactivity/base/InteractivityFactory.cpp
@@ -333,9 +333,16 @@ using namespace Microsoft::Console::Interactivity;
                 //
                 // We're doing WS_MINIMIZEBOX | WS_SYSMENU to get a "minimize
                 // button" for the window, but not the rest of WS_OVERLAPPED, so
-                // that we don't have an actual border, caption, nothing
-                const auto windowStyle = WS_OVERLAPPED | (WS_MINIMIZEBOX | WS_SYSMENU) | WS_POPUP;
-                const auto exStyles = WS_EX_TRANSPARENT | WS_EX_LAYERED | WS_EX_NOACTIVATE;
+                // that we don't have an actual border, caption, nothing.
+                //
+                // (We're using velocity to experimentally try these changes
+                // out, and gather feedback.)
+                const auto windowStyle = Feature_ConPtyHwndStyles::IsEnabled() ?
+                                             WS_OVERLAPPED | (WS_MINIMIZEBOX | WS_SYSMENU) | WS_POPUP :
+                                             WS_OVERLAPPEDWINDOW | WS_POPUP;
+                const auto exStyles = Feature_ConPtyHwndStyles::IsEnabled() ?
+                                          WS_EX_TRANSPARENT | WS_EX_LAYERED | WS_EX_NOACTIVATE :
+                                          WS_EX_TOOLWINDOW | WS_EX_TRANSPARENT | WS_EX_LAYERED | WS_EX_NOACTIVATE;
 
                 // Attempt to create window.
                 hwnd = CreateWindowExW(exStyles,
@@ -399,20 +406,6 @@ using namespace Microsoft::Console::Interactivity;
 
         InteractivityFactory* const pFactory = reinterpret_cast<InteractivityFactory*>(pCreateStruct->lpCreateParams);
         SetWindowLongPtrW(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pFactory));
-
-        WINDOWPLACEMENT place{};
-        place.length = sizeof(WINDOWPLACEMENT);
-        if (GetWindowPlacement(hWnd, &place))
-        {
-            POINT& ptMinMaybe = place.ptMinPosition;
-            auto x = ptMinMaybe.x;
-            auto y = ptMinMaybe.y;
-            auto f = x + y;
-            f;
-            ptMinMaybe.x = ptMinMaybe.y = -32000;
-            place.flags = WPF_SETMINPOSITION;
-            LOG_IF_WIN32_BOOL_FALSE(SetWindowPlacement(hWnd, &place));
-        }
     }
 
     // Dispatch the message to the specific class instance
@@ -466,16 +459,6 @@ using namespace Microsoft::Console::Interactivity;
         }
         break;
     }
-    // case WM_GETMINMAXINFO:
-    // {
-    //     auto lpMinMaxInfo = reinterpret_cast<LPMINMAXINFO>(lParam);
-    //     POINT ptMinMaybe = lpMinMaxInfo->ptReserved;
-    //     auto x = ptMinMaybe.x;
-    //     auto y = ptMinMaybe.y;
-    //     auto f = x + y;
-    //     f;
-    //     break;
-    // }
     // case WM_WINDOWPOSCHANGING:
     //     As long as user32 didn't eat the `ShowWindow` call because the window state requested
     //     matches the existing WS_VISIBLE state of the HWND... we should hear from it in WM_WINDOWPOSCHANGING.
@@ -489,20 +472,6 @@ using namespace Microsoft::Console::Interactivity;
     {
         if (0 == lParam) // Someone explicitly called ShowWindow on us.
         {
-            // WINDOWPLACEMENT place{};
-            // place.length = sizeof(WINDOWPLACEMENT);
-            // if (GetWindowPlacement(hWnd, &place))
-            // {
-            //     POINT& ptMinMaybe = place.ptMinPosition;
-            //     auto x = ptMinMaybe.x;
-            //     auto y = ptMinMaybe.y;
-            //     auto f = x + y;
-            //     f;
-            //     ptMinMaybe.x = ptMinMaybe.y = -32000;
-            //     place.flags = WPF_SETMINPOSITION;
-            //     LOG_IF_WIN32_BOOL_FALSE(SetWindowPlacement(hWnd, &place));
-            // }
-
             _WritePseudoWindowCallback((bool)wParam);
         }
         break;


### PR DESCRIPTION
1. This `break` needs to be there. It's unclear what happens without it. 
2. Experimentally, try different window styles for the conpty window. These are locked to Dev and Canary builds (so we can try them and back them out if they don't work). This might affect
    * #15219 
    * maybe #15536
    * possibly #13388
  