### PR TITLE
Fix a crash for users without a `tab` theme

### DIFF
--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -176,7 +176,9 @@ namespace winrt::TerminalApp::implementation
         {
             if (!profile.Icon().empty())
             {
-                newTabImpl->UpdateIcon(profile.Icon(), _settings.GlobalSettings().CurrentTheme().Tab().IconStyle());
+                const auto theme = _settings.GlobalSettings().CurrentTheme();
+                const auto iconStyle = (theme && theme.Tab()) ? theme.Tab().IconStyle() : IconStyle::Default;
+                newTabImpl->UpdateIcon(profile.Icon(), iconStyle);
             }
         }
 
@@ -241,7 +243,9 @@ namespace winrt::TerminalApp::implementation
     {
         if (const auto profile = tab.GetFocusedProfile())
         {
-            tab.UpdateIcon(profile.Icon(), _settings.GlobalSettings().CurrentTheme().Tab().IconStyle());
+            const auto theme = _settings.GlobalSettings().CurrentTheme();
+            const auto iconStyle = (theme && theme.Tab()) ? theme.Tab().IconStyle() : IconStyle::Default;
+            tab.UpdateIcon(profile.Icon(), iconStyle);
         }
     }
 


### PR DESCRIPTION
One day into 1.19, and there's a LOT of hits here (**76.25%** of our ~300 crashes). A crash if the Theme doesn't have a `tab` member. 

Regressed in #15948

Closes MSFT:46714723