### PR TITLE
Build unpackaged Canary distributions in portable mode

### DIFF
--- a/build/pipelines/templates-v2/job-build-project.yml
+++ b/build/pipelines/templates-v2/job-build-project.yml
@@ -89,6 +89,11 @@ jobs:
     # Yup.
     BuildTargetParameter: ' '
     SelectedSigningFragments: ' '
+    # When building the unpackaged distribution, build it in portable mode if it's Canary-branded
+    ${{ if eq(parameters.branding, 'Canary') }}:
+      UnpackagedBuildArguments: -PortableMode
+    ${{ else }}:
+      UnpackagedBuildArguments: ' '
     JobOutputDirectory: $(Terminal.BinDir)
     JobOutputArtifactName: build-$(BuildPlatform)-$(BuildConfiguration)${{ parameters.artifactStem }}
     ${{ insert }}: ${{ parameters.variables }}
@@ -255,7 +260,7 @@ jobs:
     - pwsh: |-
         $XamlAppxPath = (Get-Item "src\cascadia\CascadiaPackage\AppPackages\*\Dependencies\$(BuildPlatform)\Microsoft.UI.Xaml*.appx").FullName
         $outDir = New-Item -Type Directory "$(Terminal.BinDir)/_unpackaged" -ErrorAction:Ignore
-        & .\build\scripts\New-UnpackagedTerminalDistribution.ps1 -TerminalAppX $(WindowsTerminalPackagePath) -XamlAppX $XamlAppxPath -Destination $outDir.FullName
+        & .\build\scripts\New-UnpackagedTerminalDistribution.ps1 $(UnpackagedBuildArguments) -TerminalAppX $(WindowsTerminalPackagePath) -XamlAppX $XamlAppxPath -Destination $outDir.FullName
       displayName: Build Unpackaged Distribution (from MSIX)
       condition: and(succeeded(), ne(variables.WindowsTerminalPackagePath, ''))
 

--- a/build/scripts/New-UnpackagedTerminalDistribution.ps1
+++ b/build/scripts/New-UnpackagedTerminalDistribution.ps1
@@ -25,7 +25,12 @@ Param(
     [Parameter(HelpMessage="Path to makeappx.exe", ParameterSetName='Layout')]
     [ValidateScript({Test-Path $_ -Type Leaf})]
     [string]
-    $MakeAppxPath = "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x64\MakeAppx.exe"
+    $MakeAppxPath = "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x64\MakeAppx.exe",
+
+    [Parameter(HelpMessage="Include the portable mode marker file by default", ParameterSetName='AppX')]
+    [Parameter(HelpMessage="Include the portable mode marker file by default", ParameterSetName='Layout')]
+    [switch]
+    $PortableMode = $PSCmdlet.ParameterSetName -eq 'Layout'
 )
 
 $filesToRemove = @("*.xml", "*.winmd", "Appx*", "Images/*Tile*", "Images/*Logo*") # Remove from Terminal
@@ -127,6 +132,11 @@ $finalTerminalPriFile = Join-Path $terminalAppPath "resources.pri"
 ########
 # Packaging
 ########
+
+$portableModeMarkerFile = Join-Path $terminalAppPath ".portable"
+If ($PortableMode) {
+	"" | Out-File $portableModeMarkerFile
+}
 
 If ($PSCmdlet.ParameterSetName -Eq "AppX") {
 	# We only produce a ZIP when we're combining two AppX directories.


### PR DESCRIPTION
I also added support to the unpackaged distribution script to produce portable mode packages. It is off by default for AppX->ZIP builds and **on** by default for Layout->ZIP builds.

This constitutes a change in behavior.