### PR TITLE
nightly: upload unpackaged to Az as well; force canary to 11+

### DIFF
--- a/build/pipelines/nightly.yml
+++ b/build/pipelines/nightly.yml
@@ -39,5 +39,6 @@ extends:
             storageAccount: $(AzureStorageAccount)
             storageContainer: $(AzureStorageContainer)
             buildConfiguration: Release
+            buildPlatforms: [x64, x86, arm64]
             environment: production-canary
 

--- a/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
+++ b/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
@@ -75,13 +75,13 @@ jobs:
             Get-ChildItem _out -Recur | Select -Expand FullName
           displayName: "Produce AppInstaller for MSIX bundle and de-version ZIP files"
 
-        - task: AzureFileCopy@5
-          displayName: Publish to Storage Account
-          inputs:
-            sourcePath: _out/*
-            Destination: AzureBlob
-            azureSubscription: ${{ parameters.subscription }}
-            storage: ${{ parameters.storageAccount }}
-            ContainerName: ${{ parameters.storageContainer }}
-            AdditionalArgumentsForBlobCopy: "--content-type application/octet-stream"
+#       - task: AzureFileCopy@5
+#         displayName: Publish to Storage Account
+#         inputs:
+#           sourcePath: _out/*
+#           Destination: AzureBlob
+#           azureSubscription: ${{ parameters.subscription }}
+#           storage: ${{ parameters.storageAccount }}
+#           ContainerName: ${{ parameters.storageContainer }}
+#           AdditionalArgumentsForBlobCopy: "--content-type application/octet-stream"
 

--- a/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
+++ b/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
@@ -77,13 +77,13 @@ jobs:
             Get-ChildItem _out -Recur | Select -Expand FullName
           displayName: "Produce AppInstaller for MSIX bundle and de-version ZIP files"
 
-#       - task: AzureFileCopy@5
-#         displayName: Publish to Storage Account
-#         inputs:
-#           sourcePath: _out/*
-#           Destination: AzureBlob
-#           azureSubscription: ${{ parameters.subscription }}
-#           storage: ${{ parameters.storageAccount }}
-#           ContainerName: ${{ parameters.storageContainer }}
-#           AdditionalArgumentsForBlobCopy: "--content-type application/octet-stream"
+        - task: AzureFileCopy@5
+          displayName: Publish to Storage Account
+          inputs:
+            sourcePath: _out/*
+            Destination: AzureBlob
+            azureSubscription: ${{ parameters.subscription }}
+            storage: ${{ parameters.storageAccount }}
+            ContainerName: ${{ parameters.storageContainer }}
+            AdditionalArgumentsForBlobCopy: "--content-type application/octet-stream"
 

--- a/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
+++ b/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
@@ -60,21 +60,24 @@ jobs:
             displayName: Download unpackaged build for ${{ platform }} ${{ parameters.buildConfiguration }}
             inputs:
               artifactName: build-${{ platform }}-${{ parameters.buildConfiguration }}${{ parameters.artifactStem }}
-              downloadPath: '$(Build.SourcesDirectory)/_out'
+              downloadPath: '$(Build.SourcesDirectory)/_unpackaged'
               itemPattern: '**/_unpackaged/*.zip'
 
         - pwsh: |-
             $b = Get-Item _out/*.msixbundle
             ./build/scripts/New-AppInstallerFromTemplateAndBundle.ps1 -BundlePath $b.FullName -AppInstallerTemplatePath ./build/config/template.appinstaller -AppInstallerRoot "${{ parameters.storagePublicRootURL }}" -OutputPath _out/Microsoft.WindowsTerminalCanary.appinstaller
-            $zips = Get-Item _out/*.zip
+          displayName: "Produce AppInstaller for MSIX bundle"
+
+        - pwsh: |-
+            $zips = Get-ChildItem -Recurse -Filter *.zip _unpackaged
             $zips | ForEach-Object {
               $name = $_.Name
               $parts = $name.Split('_')
               $parts[1] = "latest"
               $name = [String]::Join('_', $parts)
-              $_ | Rename-Item -NewName $name
+              $_ | Move-Item -Destination (Join-Path "_out" $name)
             }
-          displayName: "Produce AppInstaller for MSIX bundle and de-version ZIP files"
+          displayName: "Wrangle Unpackaged builds into place, rename"
 
         - task: AzureFileCopy@5
           displayName: Publish to Storage Account

--- a/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
+++ b/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
@@ -74,7 +74,6 @@ jobs:
               $name = [String]::Join('_', $parts)
               $_ | Rename-Item -NewName $name
             }
-            Get-ChildItem _out -Recur | Select -Expand FullName
           displayName: "Produce AppInstaller for MSIX bundle and de-version ZIP files"
 
         - task: AzureFileCopy@5

--- a/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
+++ b/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
@@ -1,6 +1,8 @@
 parameters:
   - name: buildConfiguration
     type: string
+  - name: buildPlatforms
+    type: object
   - name: pool
     type: object
     default: []

--- a/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
+++ b/build/pipelines/templates-v2/job-deploy-to-azure-storage.yml
@@ -53,10 +53,27 @@ jobs:
             downloadPath: '$(Build.SourcesDirectory)/_out'
             itemPattern: '**/*.msixbundle'
 
+        - ${{ each platform in parameters.buildPlatforms }}:
+          - task: DownloadPipelineArtifact@2
+            displayName: Download unpackaged build for ${{ platform }} ${{ parameters.buildConfiguration }}
+            inputs:
+              artifactName: build-${{ platform }}-${{ parameters.buildConfiguration }}${{ parameters.artifactStem }}
+              downloadPath: '$(Build.SourcesDirectory)/_out'
+              itemPattern: '**/_unpackaged/*.zip'
+
         - pwsh: |-
             $b = Get-Item _out/*.msixbundle
             ./build/scripts/New-AppInstallerFromTemplateAndBundle.ps1 -BundlePath $b.FullName -AppInstallerTemplatePath ./build/config/template.appinstaller -AppInstallerRoot "${{ parameters.storagePublicRootURL }}" -OutputPath _out/Microsoft.WindowsTerminalCanary.appinstaller
-          displayName: "Produce AppInstaller for MSIX bundle"
+            $zips = Get-Item _out/*.zip
+            $zips | ForEach-Object {
+              $name = $_.Name
+              $parts = $name.Split('_')
+              $parts[1] = "latest"
+              $name = [String]::Join('_', $parts)
+              $_ | Rename-Item -NewName $name
+            }
+            Get-ChildItem _out -Recur | Select -Expand FullName
+          displayName: "Produce AppInstaller for MSIX bundle and de-version ZIP files"
 
         - task: AzureFileCopy@5
           displayName: Publish to Storage Account

--- a/src/cascadia/CascadiaPackage/Package-Can.appxmanifest
+++ b/src/cascadia/CascadiaPackage/Package-Can.appxmanifest
@@ -36,7 +36,8 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.22621.0" />
+    <!-- rescap:appLicensing only works on 22000+. Until that's fixed, MinVersion will not let people install it on Windows 10... -->
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.22000.0" MaxVersionTested="10.0.22621.0" />
   </Dependencies>
 
   <Resources>


### PR DESCRIPTION
Unfortunately, the appLicensing restricted capability we used to make Canary installable without the store only works on Windows 11. Because of that, we have to restrict the app package to Windows 11 and above.

I'd rather not leave Windows 10 users out in the cold, so this pull request also publishes Canary builds to the public storage bucket with the name `Microsoft.WindowsTerminalCanary_latest_x64.zip` (etc.)

The version number will be kept inside the archive. It remains to be seen whether that is a good idea!

When combined with #16048, Canary builds from Azure will automatically run in portable mode!