### PR TITLE
Fix CFG on our static-lib-only DLL projects

### DIFF
--- a/src/common.build.pre.props
+++ b/src/common.build.pre.props
@@ -101,6 +101,13 @@
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
     <EnableHybridCRT Condition="'$(EnableHybridCRT)'=='' and '$(ConfigurationSupportsHybridCRT)'=='true'">true</EnableHybridCRT>
     <UseCrtSDKReferenceStaticWarning Condition="'$(EnableHybridCRT)'=='true'">false</UseCrtSDKReferenceStaticWarning>
+    <!--
+      We must set this to True for projects that do not contain any ClCompile entries.
+      The Link task guesses whether to enable CFG based on ClCompile->ControlFlowGuard.
+      Without any ClCompile entries, there's nothing to guess!
+      This impacts our dll projects that only link a lib.
+    -->
+    <LinkControlFlowGuard>true</LinkControlFlowGuard>
   </PropertyGroup>
 
   <ItemDefinitionGroup>


### PR DESCRIPTION
Control Flow Guard requires both linker and compiler flags.

It turns out that the MSVC build rules determine whether to _link_ with CFG based on whether it compiled anything with CFG.

It also turns out that when you don't compile anything (such as in our DLL projects that only consume a static library!), the build rules can't guess whether to link with CFG.

Whoops.
We need to force it.