### PR TITLE
build: switch the EsrpCodeSigning task to version 3

### DIFF
--- a/build/pipelines/templates-v2/job-build-package-wpf.yml
+++ b/build/pipelines/templates-v2/job-build-package-wpf.yml
@@ -97,7 +97,7 @@ jobs:
       flattenFolders: true
 
   - ${{ if eq(parameters.codeSign, true) }}:
-    - task: EsrpCodeSigning@1
+    - task: EsrpCodeSigning@3
       displayName: Submit *.nupkg to ESRP for code signing
       inputs:
         ConnectedServiceName: 9d6d2960-0793-4d59-943e-78dcb434840a

--- a/build/pipelines/templates-v2/job-build-project.yml
+++ b/build/pipelines/templates-v2/job-build-project.yml
@@ -229,7 +229,7 @@ jobs:
 
     # Code-sign everything we just put together.
     # We run the signing in Terminal.BinDir, because all of the signing batches are relative to the final architecture/configuration output folder.
-    - task: EsrpCodeSigning@1
+    - task: EsrpCodeSigning@3
       displayName: Submit Signing Request
       inputs:
         ConnectedServiceName: 9d6d2960-0793-4d59-943e-78dcb434840a

--- a/build/pipelines/templates-v2/job-merge-msix-into-bundle.yml
+++ b/build/pipelines/templates-v2/job-merge-msix-into-bundle.yml
@@ -89,7 +89,7 @@ jobs:
     displayName: Create msixbundle
 
   - ${{ if eq(parameters.codeSign, true) }}:
-    - task: EsrpCodeSigning@1
+    - task: EsrpCodeSigning@3
       displayName: Submit *.msixbundle to ESRP for code signing
       inputs:
         ConnectedServiceName: 9d6d2960-0793-4d59-943e-78dcb434840a

--- a/build/pipelines/templates-v2/job-package-conpty.yml
+++ b/build/pipelines/templates-v2/job-package-conpty.yml
@@ -82,7 +82,7 @@ jobs:
       versionEnvVar: XES_PACKAGEVERSIONNUMBER
 
   - ${{ if eq(parameters.codeSign, true) }}:
-    - task: EsrpCodeSigning@1
+    - task: EsrpCodeSigning@3
       displayName: Submit *.nupkg to ESRP for code signing
       inputs:
         ConnectedServiceName: 9d6d2960-0793-4d59-943e-78dcb434840a


### PR DESCRIPTION
The version we were using requires .NET 2.1 (wow) which is way out of support.

Task version 3 supports much newer versions.