### PR TITLE
Use `weak_ptr`s for `AppHost` for coroutines

### DIFF
--- a/src/cascadia/WindowsTerminal/AppHost.h
+++ b/src/cascadia/WindowsTerminal/AppHost.h
@@ -6,7 +6,7 @@
 #include "NotificationIcon.h"
 #include <ThrottledFunc.h>
 
-class AppHost
+class AppHost : public std::enable_shared_from_this<AppHost>
 {
 public:
     AppHost(const winrt::TerminalApp::AppLogic& logic,

--- a/src/cascadia/WindowsTerminal/WindowThread.cpp
+++ b/src/cascadia/WindowsTerminal/WindowThread.cpp
@@ -24,7 +24,7 @@ void WindowThread::CreateHost()
     assert(_warmWindow == nullptr);
 
     // Start the AppHost HERE, on the actual thread we want XAML to run on
-    _host = std::make_unique<::AppHost>(_appLogic,
+    _host = std::make_shared<::AppHost>(_appLogic,
                                         _args,
                                         _manager,
                                         _peasant);
@@ -164,7 +164,7 @@ void WindowThread::Microwave(
     _peasant = std::move(peasant);
     _args = std::move(args);
 
-    _host = std::make_unique<::AppHost>(_appLogic,
+    _host = std::make_shared<::AppHost>(_appLogic,
                                         _args,
                                         _manager,
                                         _peasant,

--- a/src/cascadia/WindowsTerminal/WindowThread.h
+++ b/src/cascadia/WindowsTerminal/WindowThread.h
@@ -35,7 +35,11 @@ private:
     winrt::Microsoft::Terminal::Remoting::WindowRequestedArgs _args{ nullptr };
     winrt::Microsoft::Terminal::Remoting::WindowManager _manager{ nullptr };
 
-    std::unique_ptr<::AppHost> _host{ nullptr };
+    // This is a "shared_ptr", but it should be treated as a unique, owning ptr.
+    // It's shared, because there are edge cases in refrigeration where internal
+    // co_awaits inside AppHost might resume after we've dtor'd it, and there's
+    // no other way for us to let the AppHost know it has passed on.
+    std::shared_ptr<::AppHost> _host{ nullptr };
     winrt::event_token _UpdateSettingsRequestedToken;
 
     std::unique_ptr<::IslandWindow> _warmWindow{ nullptr };


### PR DESCRIPTION
See MSFT:46763065. Looks like we're in the middle of being `Refrigerate`d, we're pumping messages, and as we pump messages, we get to a `co_await` in `AppHost::_WindowInitializedHandler`. When we resume, we just try to use `this` like everything's fine but OH NO, IT'S NOT.

To fix this, I'm
* Adding `enable_shared_from_this` to `AppHost`
* Holding the `AppHost` in a shared_ptr in WindowThread
  - though, this is a singular owning `shared_ptr`. This is probably ripe for other footguns, but there's little we can do about this.
* whenever we `co_await` in `AppHost`, make sure we grab a weak ref first, and check it on the other side.

This is another "squint and yep that's a bug" fix, that I haven't been able to verify locally. This is
[allegedly](https://media.tenor.com/VQi3bktwLdIAAAAC/allegedly-supposedly.gif) about 10% of our 1.19 crashes after 3 days.

Closes #16061
