### PR TITLE
Dismiss flyouts before opening warning dialog when exiting app

### DIFF
--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -1983,6 +1983,11 @@ namespace winrt::TerminalApp::implementation
             _settings.GlobalSettings().ConfirmCloseAllTabs() &&
             !_displayingCloseDialog)
         {
+            if (_newTabButton && _newTabButton.Flyout())
+            {
+                _newTabButton.Flyout().Hide();
+            }
+            _DismissTabContextMenus();
             _displayingCloseDialog = true;
             auto warningResult = co_await _ShowCloseWarningDialog();
             _displayingCloseDialog = false;


### PR DESCRIPTION
Updated the function `TerminalPage::CloseWindow`  to include logic for closing context and flyout menus so that they are dismissed before the warning is displayed.

## PR Checklist
- [X] Closes #16039 
