### PR TITLE
build: add a OneBranch Official release pipeline

### DIFF
--- a/build/config/release.gdnbaselines
+++ b/build/config/release.gdnbaselines
@@ -1,0 +1,1127 @@
+{
+  "hydrated": false,
+  "properties": {
+    "helpUri": "https://eng.ms/docs/microsoft-security/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/microsoft-guardian/general/baselines",
+    "hydrationStatus": "This file does not contain identifying data. It is safe to check into your repo. To hydrate this file with identifying data, run `guardian hydrate --help` and follow the guidance."
+  },
+  "version": "1.0.0",
+  "baselines": {
+    "default": {
+      "name": "default",
+      "createdDate": "2023-09-29 19:39:12Z",
+      "lastUpdatedDate": "2023-09-29 19:39:12Z"
+    }
+  },
+  "results": {
+    "b1e592dc96e9286d806682680cffcb44b7ba2f7ea883b022371037689fe2bb5b": {
+      "signature": "b1e592dc96e9286d806682680cffcb44b7ba2f7ea883b022371037689fe2bb5b",
+      "alternativeSignatures": [
+        "25d5f2d86325f3e6666cf720c3b0827c7b5773c42f3770a6e83ab8bc0f716686"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "fd608e2146a69491516290ae3b65d4d094e5f9ba53c6624ff457c3b21f67e433": {
+      "signature": "fd608e2146a69491516290ae3b65d4d094e5f9ba53c6624ff457c3b21f67e433",
+      "alternativeSignatures": [
+        "528526d5f81c7387e9eca88c1dc1e7886bb3189d9c53f7678c63a44a7e78d2b8"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "104eb68a26c9a422f9973b85603046c42bb6894f398e1ebd454d829a386c47cd": {
+      "signature": "104eb68a26c9a422f9973b85603046c42bb6894f398e1ebd454d829a386c47cd",
+      "alternativeSignatures": [
+        "33b75434f899dc72a71c55e6667420b5f3406641eae1a784bad8632fe80eccc6"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "fa8ab295467d81fd138402f12899da84cdf312e2e84712a539e08361b6900651": {
+      "signature": "fa8ab295467d81fd138402f12899da84cdf312e2e84712a539e08361b6900651",
+      "alternativeSignatures": [
+        "b0ef4eae3f158488f99f7705cc93d037d55e8bd39b173c40e25581a35c6889d2"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "2d5cf239e62a256384275134ea1e1180b927f4cd53e51193751b0b5671045be8": {
+      "signature": "2d5cf239e62a256384275134ea1e1180b927f4cd53e51193751b0b5671045be8",
+      "alternativeSignatures": [
+        "bd73f2f051d6525c01db61a4c4a6c3b9a80083da83ed602eae2a70e17286a7ed"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "e88b3902e68d0315f7bef3a24860a7d3d9abd2d960fde06a0c650c6bb569df74": {
+      "signature": "e88b3902e68d0315f7bef3a24860a7d3d9abd2d960fde06a0c650c6bb569df74",
+      "alternativeSignatures": [
+        "143ade735d3d6d19f999555f2ce706f647a64688054b5f19052f99992ab325fd"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "01306239b92e4508b0ab60e025cadc4c974c33c29f1eb28d2b3fdda8d4019e09": {
+      "signature": "01306239b92e4508b0ab60e025cadc4c974c33c29f1eb28d2b3fdda8d4019e09",
+      "alternativeSignatures": [
+        "dca24210a3064ca7069a737f9a88f4a25b1cc1cd4c9e2a095156297246611de5"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "675ea9bd7809b2f210105e9703dffe8e48ee134ab21677e7cc4556bf22782e8d": {
+      "signature": "675ea9bd7809b2f210105e9703dffe8e48ee134ab21677e7cc4556bf22782e8d",
+      "alternativeSignatures": [
+        "7d5287a33645767969627a20e3a65fb2f1bb2db0e79a689b5a804a98f65d01fa"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "6e040bc57aa08165f8af6007e3794149d3a2c0325021e746e9705ada7c05b30c": {
+      "signature": "6e040bc57aa08165f8af6007e3794149d3a2c0325021e746e9705ada7c05b30c",
+      "alternativeSignatures": [
+        "218c0d7d5332113e33632d06eb0f209bac711ac515bd76a0fcfda2a0cbed885d"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "73e85b3af96a27c797fbe9f36f00feccd4118204615b9477da67e5868dd5dfb9": {
+      "signature": "73e85b3af96a27c797fbe9f36f00feccd4118204615b9477da67e5868dd5dfb9",
+      "alternativeSignatures": [
+        "49c44c3dc27233eba172214cb302de4b5c9b2a845e8595e7930fad74805183ac"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "15bd7ecdb19cdd263867db23c12a98029cede5476c89e870b811fce45abb8db4": {
+      "signature": "15bd7ecdb19cdd263867db23c12a98029cede5476c89e870b811fce45abb8db4",
+      "alternativeSignatures": [
+        "2705f7f6c9e83d2a812e264f39878e0e0173a1a5efea16e7206c4d02dc419af8"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "3f7d3360f0b185361b1e67b94c22b2a319b7c2d5aa2c8fd7fc3e4626394cba54": {
+      "signature": "3f7d3360f0b185361b1e67b94c22b2a319b7c2d5aa2c8fd7fc3e4626394cba54",
+      "alternativeSignatures": [
+        "71f05133f86c279daee4f1b85f997955e36857bcc5945dbae71f8bbb91b5df6d"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "3bcb157fd01d81513a15da41b4fc8b2820247331689fef5d0026578d95b85716": {
+      "signature": "3bcb157fd01d81513a15da41b4fc8b2820247331689fef5d0026578d95b85716",
+      "alternativeSignatures": [
+        "67e145d1f3bf6eb205e385884ca6356decffc3cac3e15339cc7ca43441cff99b"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "27ae6a9a7047c5ca98d1dc3a9b0885733875387d475f1426afc4d031b357fc1b": {
+      "signature": "27ae6a9a7047c5ca98d1dc3a9b0885733875387d475f1426afc4d031b357fc1b",
+      "alternativeSignatures": [
+        "b87d72abe37f6144614469221a0ce60e389792843f602805afe149b3ad1dd098"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "bd2aea1d24e36c1dcc128eb87a2c27292ed251d95aedf5f11204647bc68719f8": {
+      "signature": "bd2aea1d24e36c1dcc128eb87a2c27292ed251d95aedf5f11204647bc68719f8",
+      "alternativeSignatures": [
+        "ca29329aae819543d357e86acf0ccce914dbc3a15e0f91016091c3079638ad34"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "b836a6e0d58634003e054c88f3ed615d8e92182ebc78e9dd2168d8126c33e694": {
+      "signature": "b836a6e0d58634003e054c88f3ed615d8e92182ebc78e9dd2168d8126c33e694",
+      "alternativeSignatures": [
+        "850aa5d2e92dac06fc119ed297e84dfde9fdb3f9b116bdb2c83e8d66ea442865"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "e54972bb37d35b3b9c7c764cdf5351f0254ae2b8526465fe03c9ba8a04b06651": {
+      "signature": "e54972bb37d35b3b9c7c764cdf5351f0254ae2b8526465fe03c9ba8a04b06651",
+      "alternativeSignatures": [
+        "9e8723695743edaddfc5b188ec6bde240ddde68516f5c2342bd1c4d2a8c68430"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "3786d03543e25eec1f68beb21a3884953460239c269ba4071baf9fd4f564e763": {
+      "signature": "3786d03543e25eec1f68beb21a3884953460239c269ba4071baf9fd4f564e763",
+      "alternativeSignatures": [
+        "05e0c9bc16b8ade4d40d4e4371864da4ee7d9c8d68b19c3319543dbebea97a39"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "5f7c1c0c1f9290d3afad4bb3a17d5e5d33f2176e18b8ec406df71e8245ec0b7f": {
+      "signature": "5f7c1c0c1f9290d3afad4bb3a17d5e5d33f2176e18b8ec406df71e8245ec0b7f",
+      "alternativeSignatures": [
+        "952d91003467bdf2dbf5e72f56b9c69de52c4abf44cc82c0833ba8d89d9befac"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "605037e76782777be2f16c12c023247671ebad0afea868ed0c4bf939c9ff443a": {
+      "signature": "605037e76782777be2f16c12c023247671ebad0afea868ed0c4bf939c9ff443a",
+      "alternativeSignatures": [
+        "4f77f69716e098fec8214948428cfe9d2c2324d0719250b25e5c084a21d05e69"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "4a173deb8aeab5f4f2463774f117b909dee0168c99bc54b29b1141fca64598bd": {
+      "signature": "4a173deb8aeab5f4f2463774f117b909dee0168c99bc54b29b1141fca64598bd",
+      "alternativeSignatures": [
+        "66526149b57bbdaa8d4e3437a0099a4e3b7818c911b2110fa40d7d0264ce99f6"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "e557e9c4d1c36f69fd4a2310d22bbeadc1dff3dd2404449b8424662bb1c6adc7": {
+      "signature": "e557e9c4d1c36f69fd4a2310d22bbeadc1dff3dd2404449b8424662bb1c6adc7",
+      "alternativeSignatures": [
+        "6b93c58cd83ba89289c12b408c2988dfd54d7936c0920981cf690725155caf7a"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "70eb589101b9b57d2e47f6879348a8b93cd0c2f223e2c20d2289c5e1e8be0b9d": {
+      "signature": "70eb589101b9b57d2e47f6879348a8b93cd0c2f223e2c20d2289c5e1e8be0b9d",
+      "alternativeSignatures": [
+        "e9fe7fc2a31de263521f635058984dd81b4bab9cba174949fc5582fbeef6f693"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "3e5c0b1cad192bf5fa00d6b0f46f4cfaa7251ebaea30177d2d6891890f0dafab": {
+      "signature": "3e5c0b1cad192bf5fa00d6b0f46f4cfaa7251ebaea30177d2d6891890f0dafab",
+      "alternativeSignatures": [
+        "9a1dd0e934ddd3a33f3cf37372052731f5c157c13cac05ef0539815f845db9bf"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "dd3b2ddb278bb70559efcfc10e19c2f3a3bfe805cbbecd6a16dd141433f0b433": {
+      "signature": "dd3b2ddb278bb70559efcfc10e19c2f3a3bfe805cbbecd6a16dd141433f0b433",
+      "alternativeSignatures": [
+        "3fcb3a01715c6d244d26ef49fa4c06f8a92616a9c6465c26c4398c554f7fd67f"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "a635cb613925ab6c9f6b133890169bdf77acee212b6ac8f83cca7253faafaec7": {
+      "signature": "a635cb613925ab6c9f6b133890169bdf77acee212b6ac8f83cca7253faafaec7",
+      "alternativeSignatures": [
+        "2ff5cc7a3bf6cd63862cffc5088690fc824eb1d2f9e42c732fcd1611e9e25bfc"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "4ecdfc33e6267bfeadb1507d5304a9737f3ba0ee3132e6d7bc6f3fd68a47824e": {
+      "signature": "4ecdfc33e6267bfeadb1507d5304a9737f3ba0ee3132e6d7bc6f3fd68a47824e",
+      "alternativeSignatures": [
+        "23dc3273d54a3db12ad729569696b875523201dc13d4cbba9e3642dde17492bb"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "a9b9f171556057eaf197eb19780abfac5df82154f6c06c07240ce73970127df7": {
+      "signature": "a9b9f171556057eaf197eb19780abfac5df82154f6c06c07240ce73970127df7",
+      "alternativeSignatures": [
+        "0a9f4d3a4aa85e918744a5af36851791eb4b2f44fc132560cc56cf5661ba28fb"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "ad9da2b392f1622c6cff4a2b63eadf0da2ff31811dbbf8c9f2b2c4e8d9fefa1f": {
+      "signature": "ad9da2b392f1622c6cff4a2b63eadf0da2ff31811dbbf8c9f2b2c4e8d9fefa1f",
+      "alternativeSignatures": [
+        "b1fafebeb213b04346d56182ce395ccb9a0ad866dc28bda801c222499e550396"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "b8f591f33a84c38402239941484ead425c3e37bfcfd486b9be3a15d2213d9fa3": {
+      "signature": "b8f591f33a84c38402239941484ead425c3e37bfcfd486b9be3a15d2213d9fa3",
+      "alternativeSignatures": [
+        "de56fbe02702da318ea6a113e592b2efee3f942e04e31c5e9300cf6798abea0c"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "37adbb986601cf75f2d1eaebbe6d430a70a0886e60685a880e7d1f2c48f9b125": {
+      "signature": "37adbb986601cf75f2d1eaebbe6d430a70a0886e60685a880e7d1f2c48f9b125",
+      "alternativeSignatures": [
+        "7ebe5c4d5a144a3f356114bf5e062295ee90d5cdc7ca615dc729b7dcba8bed33"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "e0de291c50fb0cae3bdaf75237ac8e3f34acc6a8de18ba589dde4e76352ab849": {
+      "signature": "e0de291c50fb0cae3bdaf75237ac8e3f34acc6a8de18ba589dde4e76352ab849",
+      "alternativeSignatures": [
+        "52c0187472041933b5d850e47cf28ac6a7ef5ba0a6a85bca65af3b3531ddb06a"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "6b163fce31228367e0323768ab0dcc1224f8416cc856ddc03ccc2b8a2cf9a08e": {
+      "signature": "6b163fce31228367e0323768ab0dcc1224f8416cc856ddc03ccc2b8a2cf9a08e",
+      "alternativeSignatures": [
+        "0e6f9f2e1008091bcfbf520d7407c3690564ea5118580fd8cfca965946f53a78"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "25012b8cab7c6dddc276e2c0d7888554e8542dd686891914d2c2e82dfd3f697a": {
+      "signature": "25012b8cab7c6dddc276e2c0d7888554e8542dd686891914d2c2e82dfd3f697a",
+      "alternativeSignatures": [
+        "ea05d52f5ee2b483e83c14216a3e56bc8a4474396b71cbb426ced61242d81919"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "bfc7ac3b82698c138a970968cce2c849ed0e45bb8930d42215f6704659f63762": {
+      "signature": "bfc7ac3b82698c138a970968cce2c849ed0e45bb8930d42215f6704659f63762",
+      "alternativeSignatures": [
+        "c59c7529464c717d1909058d1f4fbc5109881effafab3c67bbbf02ccdffddd4e"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "25582fa1ab3be3a375a0d053304e65b50ebfa590f81a5d957759304ba29e3053": {
+      "signature": "25582fa1ab3be3a375a0d053304e65b50ebfa590f81a5d957759304ba29e3053",
+      "alternativeSignatures": [
+        "e2628baf1e09340a2063cd39c238e541014a65f4433018cc36cd25c5c8c3043d"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "38b73c3711c0c9cd958195f318fd2e6ab1f10cfa94abdfb7505d784ba022cfae": {
+      "signature": "38b73c3711c0c9cd958195f318fd2e6ab1f10cfa94abdfb7505d784ba022cfae",
+      "alternativeSignatures": [
+        "6688a9492755e33e541513bf297d0b4f459f70a43486fd8411749a2caf5cb91c"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "250a0184e9feee525e9a54930f5714965bd2bc29d0fe91c502c560443fa0e10a": {
+      "signature": "250a0184e9feee525e9a54930f5714965bd2bc29d0fe91c502c560443fa0e10a",
+      "alternativeSignatures": [
+        "d7b1083c67959b8f095acd532a10244a0a5afcbc93eefc66be20c19841b2588e"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "2c64c980db98b04a7daeedf4c5d358b8ecaecca81a8e0f70911fd211e06c8e20": {
+      "signature": "2c64c980db98b04a7daeedf4c5d358b8ecaecca81a8e0f70911fd211e06c8e20",
+      "alternativeSignatures": [
+        "7778c4704d515b92d4dc77a9b612c151e6bb9e7cd88e100c7d0419fb150f34e6"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "3bb5f422737103df8f018ec0789d2b7793ce5b1641927d5646e963126e73e1b5": {
+      "signature": "3bb5f422737103df8f018ec0789d2b7793ce5b1641927d5646e963126e73e1b5",
+      "alternativeSignatures": [
+        "225e02e47ea3f999bc43279246ee51b4287e4e2b4b7dac899da91c365d8acd0e"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "6e39bdcfe28e2cb6868a5dcbe12fa712d2a60762bb57fd82734089e19ca85b52": {
+      "signature": "6e39bdcfe28e2cb6868a5dcbe12fa712d2a60762bb57fd82734089e19ca85b52",
+      "alternativeSignatures": [
+        "f6ebab2bea88d78f69c8ae78f4ec641edd0f0796b9ca193260c44cee9d543a18"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "e9a5cff46470c62be3e1db1e43785b71daa88e466c802d4393bf9248a9e6fb56": {
+      "signature": "e9a5cff46470c62be3e1db1e43785b71daa88e466c802d4393bf9248a9e6fb56",
+      "alternativeSignatures": [
+        "3bdabc64cff83a1322f107a97ce6eab6e8cb41b8492643e9a0df3561d0169b95"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "9f19392621589641c13fc5762e36429cc4d38fc04f98297006be89e5ca3e5631": {
+      "signature": "9f19392621589641c13fc5762e36429cc4d38fc04f98297006be89e5ca3e5631",
+      "alternativeSignatures": [
+        "f448a0535740dcb9bddebe7765ea55c819472efdb9cd63761dc156b8af11a260"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "60b306912ae3399a167514dabf495a7f57e0ff17ec9a9491e66cf39c1ecbf60b": {
+      "signature": "60b306912ae3399a167514dabf495a7f57e0ff17ec9a9491e66cf39c1ecbf60b",
+      "alternativeSignatures": [
+        "fbd4d1fe2e8e21ed5fe000fc592ef9fa98ff52f529b849c9ceca12c85c3cf4f3"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "2498be9bbe27f393fad6af89f23cf228fe5c263e38fa3d20d3652b68c356243b": {
+      "signature": "2498be9bbe27f393fad6af89f23cf228fe5c263e38fa3d20d3652b68c356243b",
+      "alternativeSignatures": [
+        "750b9e1ff2f1b443502036d226678bcdda2f22a3879e36b61e3bcec24c0eec3e"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "147fa7e9b0187ab163dfe5049876c838b2b599a8ac2c243226ab4fed8d9e3513": {
+      "signature": "147fa7e9b0187ab163dfe5049876c838b2b599a8ac2c243226ab4fed8d9e3513",
+      "alternativeSignatures": [
+        "5fe9a0ee3ada52e4dbee1aa6f45683a82d14ed812d9d7c1634b786f28fc2ca51"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "a2fe2c57ef4efc03e72dfd1fa653fc9d731b69bda91711f8ab8d46edc3b12667": {
+      "signature": "a2fe2c57ef4efc03e72dfd1fa653fc9d731b69bda91711f8ab8d46edc3b12667",
+      "alternativeSignatures": [
+        "42ab6b70626c246ddea96b060cb7a79248576d19f003c4f4eedf171f4f5992f4"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "e7973a3b90d74d4ff6ee544dee45bb35ac66214a3e92eadecbf8fafccca9abb1": {
+      "signature": "e7973a3b90d74d4ff6ee544dee45bb35ac66214a3e92eadecbf8fafccca9abb1",
+      "alternativeSignatures": [
+        "3359d44d5bbf533487fc65e4a98220af62eef0cc6b883bc35b8286ee1a31ca4f"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "190440674b3fec2fcc77b341a684a9e9100c8dec0911a8c83f19f6ccedcb2b78": {
+      "signature": "190440674b3fec2fcc77b341a684a9e9100c8dec0911a8c83f19f6ccedcb2b78",
+      "alternativeSignatures": [
+        "c7aab0deb9b97032353766e961f4b23bc694e85b8b06709beaddfa2e5743e742"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "4d258afa7d015f4fc96c8866e2e43cb00290526d56394eec3848ed650cec840d": {
+      "signature": "4d258afa7d015f4fc96c8866e2e43cb00290526d56394eec3848ed650cec840d",
+      "alternativeSignatures": [
+        "e23b41b521b849057b8c5ba0594af11fc5ceec59714f3d0ebbeda708511d5803"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "530d02de7ec8a3c9f575cf3770e34665a58b127e01555000e611ee4c5e37e24d": {
+      "signature": "530d02de7ec8a3c9f575cf3770e34665a58b127e01555000e611ee4c5e37e24d",
+      "alternativeSignatures": [
+        "23f217577bcf9d3a6f87c0ac259cf891a80e78f2b77dd58e631816f3183101bd"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "69a35d8bd5d4766e5dc981526229ccc0d27f238b06357bdd8e0469cd35b47d08": {
+      "signature": "69a35d8bd5d4766e5dc981526229ccc0d27f238b06357bdd8e0469cd35b47d08",
+      "alternativeSignatures": [
+        "cab1cab825e5846acc097221236feaf3a06895e648c2ef16a4c285616b714987"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "c78a17b7f8d46b9ddedd34240d76adf92e4f1bf27a978c022e4599fe6a7b150d": {
+      "signature": "c78a17b7f8d46b9ddedd34240d76adf92e4f1bf27a978c022e4599fe6a7b150d",
+      "alternativeSignatures": [
+        "fa75ccd56697c3073a6ef17e2d959ee24b6afc11eabc4bd5dbea1d74ecdb81cb"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "7bd1757994e7f1909ffd25e56393f991d436232150cff2555a97e9b08b347b99": {
+      "signature": "7bd1757994e7f1909ffd25e56393f991d436232150cff2555a97e9b08b347b99",
+      "alternativeSignatures": [
+        "dbdb5c5ebe211b21d9b25e346dfbc58e6b32500258a1efed248e4630216ce57e"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "cef01bb2a477968c8cbc997179d04b90c36febd9cfd21ca973d4a22b3efc4caa": {
+      "signature": "cef01bb2a477968c8cbc997179d04b90c36febd9cfd21ca973d4a22b3efc4caa",
+      "alternativeSignatures": [
+        "9ec52d86604abde8a13124534ec587d3a1686630ea7bb2f736a66963349abdbd"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "11026da7398e29b59d98ffee5ed5317c243407638a77d7a09637ebe2d8bb09f3": {
+      "signature": "11026da7398e29b59d98ffee5ed5317c243407638a77d7a09637ebe2d8bb09f3",
+      "alternativeSignatures": [
+        "a642f1f37cf06c75c2082d720e317481bb7e73249dcda33dba0b5cdd6933926f"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "8f2550b4f39a798d217679c04dd7cb21b72ef63e6f6d63b06aadb1c40d8c2546": {
+      "signature": "8f2550b4f39a798d217679c04dd7cb21b72ef63e6f6d63b06aadb1c40d8c2546",
+      "alternativeSignatures": [
+        "10c95aac8513a0d6cc2c0ef08b51f7f4ac3be4b23ddd90d68d06fc536421acc3"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "022eb0065260832f06f12313f8bf99765488c1db9ff9ef8ecf8a0cbf393e878d": {
+      "signature": "022eb0065260832f06f12313f8bf99765488c1db9ff9ef8ecf8a0cbf393e878d",
+      "alternativeSignatures": [
+        "4801e53b7e46778aa21a8c9a0ec2725e73746fb648e76c9359f6db0f32ac2963"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "36f66ad8b00e978f29a7b1c09c7942247e3b068d131431c3b321190aa7cb2978": {
+      "signature": "36f66ad8b00e978f29a7b1c09c7942247e3b068d131431c3b321190aa7cb2978",
+      "alternativeSignatures": [
+        "7d3ee020a3a1601c49be0c5d687f46858f679ecf6d4150b97ba9ae5abfa742e4"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "c50b78c8370aa9d767f783bddf8c57b2f1dbd749073ccde60b3b210b116b6951": {
+      "signature": "c50b78c8370aa9d767f783bddf8c57b2f1dbd749073ccde60b3b210b116b6951",
+      "alternativeSignatures": [
+        "87568cc368760fe9f38d9fb95e93297d8bb5a83587d20d071f97713443df2e04"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "8e2be08973d6028cf58e152fba8dcd5616b7938591d2292eaf3bb5f80bdcf004": {
+      "signature": "8e2be08973d6028cf58e152fba8dcd5616b7938591d2292eaf3bb5f80bdcf004",
+      "alternativeSignatures": [
+        "d9df5f887062a990099a2cb70e46778aad25304d9758db556040beb4b23a8776"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "be36363b685b28e3ac4457b7a415120cab5a01c14d5c9a19192ef5ebd71c176a": {
+      "signature": "be36363b685b28e3ac4457b7a415120cab5a01c14d5c9a19192ef5ebd71c176a",
+      "alternativeSignatures": [
+        "13779d67c6e5f5eba285b83093a2c9eec2d79b3b36ee86400873191310088255"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "a6e48721d67f94b2876a97fe4b385ee37adc1b345825f751e87d6bd05095bfb9": {
+      "signature": "a6e48721d67f94b2876a97fe4b385ee37adc1b345825f751e87d6bd05095bfb9",
+      "alternativeSignatures": [
+        "f6a5898d9652b23b269283d4bc1a8e95865ee9f7125479ab78087e3dd3b3b12f"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "b1b1aba985591c904b0faf09b54ddc4763890d25e5dcfa2d3ca758165a616970": {
+      "signature": "b1b1aba985591c904b0faf09b54ddc4763890d25e5dcfa2d3ca758165a616970",
+      "alternativeSignatures": [
+        "b7ad084f971c1fae38509e87d50fd4984185ea6915d501d6cc0d1eac8bd93abf"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "078e8e5c43a51876fb09d7fab78a07fe896bbbb74c9507f3b6313ed3fe7586d4": {
+      "signature": "078e8e5c43a51876fb09d7fab78a07fe896bbbb74c9507f3b6313ed3fe7586d4",
+      "alternativeSignatures": [
+        "7046bab04be2bfce75f0a34461871d3dccddab009c2a223a78c08696610c7a55"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "9443465290e747bbefb4435296af78a82a948222097df6559db0d0488f7df81a": {
+      "signature": "9443465290e747bbefb4435296af78a82a948222097df6559db0d0488f7df81a",
+      "alternativeSignatures": [
+        "47a1795431bb9f78383c54fd33cf3427a774ae9802aa994cbd688f81286904bd"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "01a56e39bd6a3652d95b21035efc6d165eb16451f9558d79ff13d297cd345cd9": {
+      "signature": "01a56e39bd6a3652d95b21035efc6d165eb16451f9558d79ff13d297cd345cd9",
+      "alternativeSignatures": [
+        "2169e62964a8fa3bb4ccde41e33232efa8b7ddfb6d5a45688c28318c96ccbe52"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "a9c67896453ec9e7fb742e05ec0a47f13c5c6b7bd3886497afe3c3bb860ef006": {
+      "signature": "a9c67896453ec9e7fb742e05ec0a47f13c5c6b7bd3886497afe3c3bb860ef006",
+      "alternativeSignatures": [
+        "5973211461980400fe2aeea7dafe6079e6f771d799c347a0bcb7c631dc379d5e"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "2689cc88d4721d762e3783920aa7150cd00e4b5f7f15bdd81476dbb56876aa08": {
+      "signature": "2689cc88d4721d762e3783920aa7150cd00e4b5f7f15bdd81476dbb56876aa08",
+      "alternativeSignatures": [
+        "ba41ff939940ab49d1a4b39dfb5fac6108111616c0d7fb87e6f64f1b82cbfbd2"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "64d08c256034d4907fa6655e4914850c945bf1f6db4e14f52a8032eefe8e1245": {
+      "signature": "64d08c256034d4907fa6655e4914850c945bf1f6db4e14f52a8032eefe8e1245",
+      "alternativeSignatures": [
+        "639e5b7c91137d49bd041d7f241bd2403067f445de5058048c4c6c926af226bd"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "689ed96056f498ca67a5a056efa247ee9aea196362e693a0b196e6e9eb2cba0f": {
+      "signature": "689ed96056f498ca67a5a056efa247ee9aea196362e693a0b196e6e9eb2cba0f",
+      "alternativeSignatures": [
+        "9473554d81655d5cf548e8033fc5f34cd42cec8697306b75fc2ec31e8c19b29e"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "f497cbbab92fbbd65c27b122c7ceaf0d181859365ea121a885d32898dec963c6": {
+      "signature": "f497cbbab92fbbd65c27b122c7ceaf0d181859365ea121a885d32898dec963c6",
+      "alternativeSignatures": [
+        "2fe25bb29ed8a90e5dba2e8e899f42713b61d178fd18231d560d4873656fe8a4"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "669b421bcaea46b4f3a2b63097a357920df16b02075d1b86a476f9ee6fc4314a": {
+      "signature": "669b421bcaea46b4f3a2b63097a357920df16b02075d1b86a476f9ee6fc4314a",
+      "alternativeSignatures": [
+        "5647958533f690de004b8f82064ed0fc779fe1206b64a1813f90988481dfb72e"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "8bb84450c75dcbee365ee2b2eb2ff83ef91925afb50d9c96aec845729f3a9be1": {
+      "signature": "8bb84450c75dcbee365ee2b2eb2ff83ef91925afb50d9c96aec845729f3a9be1",
+      "alternativeSignatures": [
+        "85d7ccfcf73dbbc98b78cbd81581f3e81e9bc9a632a589fd79abb6f9cdd3236d"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "9beca9c8ed341ed7dbc682811ca43ec7174d945df99613c85e76e45ad55ac7f3": {
+      "signature": "9beca9c8ed341ed7dbc682811ca43ec7174d945df99613c85e76e45ad55ac7f3",
+      "alternativeSignatures": [
+        "147836cc11afe71d92bdf75ef6d5b1b97ae5f5709d07a9d8c58ef8bce0631a86"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "a0f61b31ca15ee653301086835bfb62889b4f4b537fd703ccfc21df9aa280a59": {
+      "signature": "a0f61b31ca15ee653301086835bfb62889b4f4b537fd703ccfc21df9aa280a59",
+      "alternativeSignatures": [
+        "62828b4278eba310bc7982e5afdac6b0a865bb647f8d3cb078a6391e1a48054f"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "235159b32d9022a9e8bf8e37fd5489bb11ca6f1bf56e8ee8737e63358c3610e5": {
+      "signature": "235159b32d9022a9e8bf8e37fd5489bb11ca6f1bf56e8ee8737e63358c3610e5",
+      "alternativeSignatures": [
+        "ddb5cc4ca95b12e6fcccfd2c5089c798307d3bb664d91e9a87f6efbd1ea78a19"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "48738e93956293a663a2d1f6933bd6856afc4699c22d45da51ca02ffe4781230": {
+      "signature": "48738e93956293a663a2d1f6933bd6856afc4699c22d45da51ca02ffe4781230",
+      "alternativeSignatures": [
+        "e83017371567ceabc524ef3e26a5520be1aac07e75b1f02a173f2eb847fbc3e5"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "6d0c84954b066bde9f165d3e7471f621d824bf0f9d920125f2188196c3e7be99": {
+      "signature": "6d0c84954b066bde9f165d3e7471f621d824bf0f9d920125f2188196c3e7be99",
+      "alternativeSignatures": [
+        "07e93499ac1047ac94bc10474ba57d397bf395f28f8d6e0dd08eeab03f17a539"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "b033555adb13ce0c0ec9e65689e4be5f9856f49f9e201f3dbbb24d430d76ec15": {
+      "signature": "b033555adb13ce0c0ec9e65689e4be5f9856f49f9e201f3dbbb24d430d76ec15",
+      "alternativeSignatures": [
+        "0a59d205aee1fdc5cb027a46c424e4a2da06c5650aadbfdfec77d744278d6b7b"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "c522ca7bfcad2bc36cfb9567a5bbe36395bb3a5969ce411832197ff9ccfd4b32": {
+      "signature": "c522ca7bfcad2bc36cfb9567a5bbe36395bb3a5969ce411832197ff9ccfd4b32",
+      "alternativeSignatures": [
+        "32eb8b00cbe99b945a02337c349a0fb97e1763fa9782469531a6859714a7160f"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "1c58db43c898e119381ecd4a9bb9701f2bbbffd3d0889ca734a905c151b168db": {
+      "signature": "1c58db43c898e119381ecd4a9bb9701f2bbbffd3d0889ca734a905c151b168db",
+      "alternativeSignatures": [
+        "a87bb1c17c23667355c9b8e17f84f37671b65040a3aa7870a7d169165583211e"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "ef7ba70ebe8984da430b1787f439496e14810afd9848a851a3d4cacc37ae7eac": {
+      "signature": "ef7ba70ebe8984da430b1787f439496e14810afd9848a851a3d4cacc37ae7eac",
+      "alternativeSignatures": [
+        "bbff3ea19b6dd5baa7d56928526a38313685c1d81a30c7c2e7c31d7105d8287f"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "5bb44f02281666fb7ef18753b4ed0e08923d741efe0361ab1336c18dd0086111": {
+      "signature": "5bb44f02281666fb7ef18753b4ed0e08923d741efe0361ab1336c18dd0086111",
+      "alternativeSignatures": [
+        "a4f1b29f64aa99073ad3678c41b29ab15bd3af2cbc87ae6b05e6568265734146"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "1621b0375d4c98eb6822a7ae37feccda594bbd0137cba47b721f9f9288929947": {
+      "signature": "1621b0375d4c98eb6822a7ae37feccda594bbd0137cba47b721f9f9288929947",
+      "alternativeSignatures": [
+        "05396ecc761c29e0e0b0a1508c1ed091b213ea18917b9f0ba118c1e7032c51df"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "c566d2437202984d3a9d2682ca810d7c52eb78c7b6236c7b9c82db6f7ba63ac8": {
+      "signature": "c566d2437202984d3a9d2682ca810d7c52eb78c7b6236c7b9c82db6f7ba63ac8",
+      "alternativeSignatures": [
+        "2bcbfb431661bacfa69c2c43c8f09f47444b22353d9e3f7db28f98c7b8126bd6"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "8f8856d0c4f85bb601ea84e7b9da0d5d636573c772951c4e85bf4cf61fef72bc": {
+      "signature": "8f8856d0c4f85bb601ea84e7b9da0d5d636573c772951c4e85bf4cf61fef72bc",
+      "alternativeSignatures": [
+        "769ffcc5ae3360b1017647384c184dc56574e0d9ddd00f4083e1c986e9f616b2"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "b4c31c908facbb22d23b15c3280359184d736901c154d516be16495dbb35ccb0": {
+      "signature": "b4c31c908facbb22d23b15c3280359184d736901c154d516be16495dbb35ccb0",
+      "alternativeSignatures": [
+        "d4603cccc6c303b5f16f1120b15dc74e8bdbef5877922fdcf57f3b29423c027b"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "7e3401dab114451f8ccc26a6ee0ac27639a41cef983b5c7ca7b22f8e03748b53": {
+      "signature": "7e3401dab114451f8ccc26a6ee0ac27639a41cef983b5c7ca7b22f8e03748b53",
+      "alternativeSignatures": [
+        "32964f7bed67a8e77a61cdc1cdedfb55c8800e04f16e9673dbc1c9dda0d2fcf0"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "1599eec39bd8bfe41754c1b87f6d4cf2517107bf55a31fd6f06e57853f0edcb3": {
+      "signature": "1599eec39bd8bfe41754c1b87f6d4cf2517107bf55a31fd6f06e57853f0edcb3",
+      "alternativeSignatures": [
+        "1d0195a64263b4be03267b1ce650ac0ad6b3589f32639ecd3792df0a39134d2a"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "c7e28dfe20e2c60575af07324e9960283b6ab567f4d0877763109330077b535d": {
+      "signature": "c7e28dfe20e2c60575af07324e9960283b6ab567f4d0877763109330077b535d",
+      "alternativeSignatures": [
+        "22da5e4da2ab3befa6aea6c7b562de7057d367a0bf4f05a5791a02c6d7de5886"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "da7db308719d405aa91b08fcda683bc73d9fb73906ad14857b07f1487e2538fb": {
+      "signature": "da7db308719d405aa91b08fcda683bc73d9fb73906ad14857b07f1487e2538fb",
+      "alternativeSignatures": [
+        "e8a05e57577cfff0f0614b0e2ac77ef86185b636ac9a85322decda6d93bb1025"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "406449365cf5b8a747cda6bcb9f698ab04e5f23c76ea26b15ae5f6dd199e200a": {
+      "signature": "406449365cf5b8a747cda6bcb9f698ab04e5f23c76ea26b15ae5f6dd199e200a",
+      "alternativeSignatures": [
+        "ab85af1c9f00c18837eddc1a658df6f16759b57337f0c576979a7ead9ca5aea5"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "2d3985d721950fdc54d6dd67f6da4e2f26da1de752237d6eff2bee79e76e74cf": {
+      "signature": "2d3985d721950fdc54d6dd67f6da4e2f26da1de752237d6eff2bee79e76e74cf",
+      "alternativeSignatures": [
+        "eb8fe28224b13b24a5fd5dab39c73356ab0e958242fefd3468a632b6f1fc8468"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "73a9b54e10ff814734690c8e99319851d3caffb8d7ee02237ccef08057623c57": {
+      "signature": "73a9b54e10ff814734690c8e99319851d3caffb8d7ee02237ccef08057623c57",
+      "alternativeSignatures": [
+        "a8395f556a6edc7f633b06820ab22d4ae275f1e2f0fb9f0389520cba4a3fa038"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "f5e7a576035cfef04eaefb5c3d64e7575c80aea1449c6528d16bd18f19601938": {
+      "signature": "f5e7a576035cfef04eaefb5c3d64e7575c80aea1449c6528d16bd18f19601938",
+      "alternativeSignatures": [
+        "e3bf1d972a8173cd7c9e853facdd28b184614cffc18ce2a47e00114894a9a0f3"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "85150297f02b3d19a5a032b1ec6b083b4bc2eec2643f60cceac18fd07551134e": {
+      "signature": "85150297f02b3d19a5a032b1ec6b083b4bc2eec2643f60cceac18fd07551134e",
+      "alternativeSignatures": [
+        "56a1cb19171420c70451d831140f44f8beace9ee605870a54998170e9b9eea44"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "db5e6cce78b5039be2e56eb828caea7fbc1b2c0ddf2204f3c95e90805f480025": {
+      "signature": "db5e6cce78b5039be2e56eb828caea7fbc1b2c0ddf2204f3c95e90805f480025",
+      "alternativeSignatures": [
+        "38588e5b5cbf9208115ae67488467545f67a83e5ea18d08f65e76318ba2809c1"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "87cbf986f8699bddcd94445159a5772945dd63bb4f55587afaecb5be2846e3cb": {
+      "signature": "87cbf986f8699bddcd94445159a5772945dd63bb4f55587afaecb5be2846e3cb",
+      "alternativeSignatures": [
+        "229e52e7992660959c3cc4581b73623f6807f87a266ecced4af4343f1f8a2c06"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "c3cc891778043c08b6177ace3e90a4af4be52f7936d9df603efcfa77f11df9cf": {
+      "signature": "c3cc891778043c08b6177ace3e90a4af4be52f7936d9df603efcfa77f11df9cf",
+      "alternativeSignatures": [
+        "4d98cab41917051c77b027daaa0ebaad30ae99b738bb3721331ddacb3d13e990"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "dbd00c32ac388db25b7b4095d242411fb192ecc6d471c80d72f6c83bc5790f5d": {
+      "signature": "dbd00c32ac388db25b7b4095d242411fb192ecc6d471c80d72f6c83bc5790f5d",
+      "alternativeSignatures": [
+        "5d3a76ad12be60e1fc117dae08b4e56f70e0e905000e6bac82b7c0d7d47efa12"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "5b68b91f6e33cf24cb0a6b106bad2cccc5f7191510437ce703a42f1fefbb1d13": {
+      "signature": "5b68b91f6e33cf24cb0a6b106bad2cccc5f7191510437ce703a42f1fefbb1d13",
+      "alternativeSignatures": [
+        "cbd85190a9dc566b475d9d0da29ef2890469d545129695dccd33e12b042c7f87"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "48a3d50b09e89367e161fa2e843b605dbf840ac3264623bad804634b9e17f0b1": {
+      "signature": "48a3d50b09e89367e161fa2e843b605dbf840ac3264623bad804634b9e17f0b1",
+      "alternativeSignatures": [
+        "ecf7b4e72800b2f2881b924e7c602984c0101738bfe7d901ef9bf68d54f22acc"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "5b641532bc10265a307b0984e2c1cf7478d345aa73e0b9f52f57de6b6139db0d": {
+      "signature": "5b641532bc10265a307b0984e2c1cf7478d345aa73e0b9f52f57de6b6139db0d",
+      "alternativeSignatures": [
+        "93f72434bf401ab42b1478aae49174f0f231385f2d190646de90b2f321bf0405"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "f5bbdce1f432ce0cc0f8eab2a548e86389c11972a0fd807d5b0218929dc0667f": {
+      "signature": "f5bbdce1f432ce0cc0f8eab2a548e86389c11972a0fd807d5b0218929dc0667f",
+      "alternativeSignatures": [
+        "c0dd620ed7794312e1f535291893133d2983ef6af266bf1261e08f5a40030184"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "b48abf4f4fc439b180232125d632b47c3ca44cde8f518e08d38905578255a76e": {
+      "signature": "b48abf4f4fc439b180232125d632b47c3ca44cde8f518e08d38905578255a76e",
+      "alternativeSignatures": [
+        "8b1d9c30d610788b227bcf7b1a02f715887adb26d9d476705a864bfbd3eec42d"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "5b91412070b80c595c93a131c6423a78aca0eb174e67b49a72f3a28b2f2e04fc": {
+      "signature": "5b91412070b80c595c93a131c6423a78aca0eb174e67b49a72f3a28b2f2e04fc",
+      "alternativeSignatures": [
+        "3b52062806f35937f2372d4497d5679d95e9c28d9cef710ac9f0551b3bf6fa69"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "4e6e328cd795ad8ffa3d409d0e0313ae91f87124a058e5dfe64dfbc93e236f78": {
+      "signature": "4e6e328cd795ad8ffa3d409d0e0313ae91f87124a058e5dfe64dfbc93e236f78",
+      "alternativeSignatures": [
+        "656279220733cb5f45e3ef13a50ae9174c9763f7c24ff163245f6bea398d0794"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "4dd68b37dee025fa0a77ac00e6e85ce7e1ad8add70a2226e10a6423534359a9b": {
+      "signature": "4dd68b37dee025fa0a77ac00e6e85ce7e1ad8add70a2226e10a6423534359a9b",
+      "alternativeSignatures": [
+        "c63dd7cfcff47e1a2f686035319925e8b2d3b0f1ac8db86b39d4b1821ae4797d"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "62a125c376534b19e9083efbad081f32bc294602b7f19a5210ad940e1c450a5f": {
+      "signature": "62a125c376534b19e9083efbad081f32bc294602b7f19a5210ad940e1c450a5f",
+      "alternativeSignatures": [
+        "2b2732249979c5e87cc79cbdec660e2b1c8eba1f93a362e5595ec03cdf1e4951"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    },
+    "f918c167a1a70deba61361fd3138b76fba86387a1f41237efeda8f01d464457e": {
+      "signature": "f918c167a1a70deba61361fd3138b76fba86387a1f41237efeda8f01d464457e",
+      "alternativeSignatures": [
+        "959e93d957e0e5ec521d2f3b9dae02db123812fb8d523d8175329b08694d65d9"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2023-09-29 19:39:12Z"
+    }
+  }
+}

--- a/build/config/tsa.json
+++ b/build/config/tsa.json
@@ -1,0 +1,6 @@
+{
+    "instanceUrl": "https://microsoft.visualstudio.com",
+    "projectName": "OS",
+    "areaPath": "OS\\Windows Client and Services\\ADEPT\\E4D-Engineered for Developers\\SHINE\\Terminal",
+    "notificationAliases": ["condev@microsoft.com", "duhowett@microsoft.com"]
+}

--- a/build/pipelines/ob-nightly.yml
+++ b/build/pipelines/ob-nightly.yml
@@ -1,0 +1,47 @@
+trigger: none
+pr: none
+schedules:
+  - cron: "30 3 * * 2-6" # Run at 03:30 UTC Tuesday through Saturday (After the work day in Pacific, Mon-Fri)
+    displayName: "Nightly Terminal Build"
+    branches:
+      include:
+        - main
+    always: false # only run if there's code changes!
+
+parameters:
+  - name: publishToAzure
+    displayName: "Deploy to **PUBLIC** Azure Storage"
+    type: boolean
+    default: true
+
+name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+
+variables:
+  - template: templates-v2/variables-nuget-package-version.yml
+  - template: templates-v2/variables-onebranch-config.yml
+
+extends:
+  template: templates-v2/pipeline-onebranch-full-release-build.yml
+  parameters:
+    official: true
+    branding: Canary
+    buildTerminal: true
+    pgoBuildMode: Optimize
+    codeSign: true
+    publishSymbolsToPublic: true
+    publishVpackToWindows: false
+    symbolExpiryTime: 15
+    ${{ if eq(true, parameters.publishToAzure) }}:
+      extraPublishJobs:
+        - template: job-deploy-to-azure-storage.yml
+          parameters:
+            pool: { type: windows }
+            dependsOn: [PublishSymbols]
+            storagePublicRootURL: $(AppInstallerRootURL)
+            subscription: $(AzureSubscriptionName)
+            storageAccount: $(AzureStorageAccount)
+            storageContainer: $(AzureStorageContainer)
+            buildConfiguration: Release
+            buildPlatforms: [x64, x86, arm64]
+            environment: production-canary
+

--- a/build/pipelines/ob-release.yml
+++ b/build/pipelines/ob-release.yml
@@ -1,0 +1,81 @@
+trigger: none
+pr: none
+
+# Expose all of these parameters for user configuration.
+parameters:
+  - name: branding
+    displayName: "Branding (Build Type)"
+    type: string
+    default: Release
+    values:
+      - Release
+      - Preview
+      - Canary
+      - Dev
+  - name: buildTerminal
+    displayName: "Build Windows Terminal MSIX"
+    type: boolean
+    default: true
+  - name: buildConPTY
+    displayName: "Build ConPTY NuGet"
+    type: boolean
+    default: false
+  - name: buildWPF
+    displayName: "Build Terminal WPF Control"
+    type: boolean
+    default: false
+  - name: pgoBuildMode
+    displayName: "PGO Build Mode"
+    type: string
+    default: Optimize
+    values:
+      - Optimize
+      - Instrument
+      - None
+  - name: buildConfigurations
+    displayName: "Build Configurations"
+    type: object
+    default:
+      - Release
+  - name: buildPlatforms
+    displayName: "Build Platforms"
+    type: object
+    default:
+      - x64
+      - x86
+      - arm64
+  - name: terminalInternalPackageVersion
+    displayName: "Terminal Internal Package Version"
+    type: string
+    default: '0.0.8'
+
+  - name: publishSymbolsToPublic
+    displayName: "Publish Symbols to MSDL"
+    type: boolean
+    default: true
+  - name: publishVpackToWindows
+    displayName: "Publish VPack to Windows"
+    type: boolean
+    default: false
+
+name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+
+variables:
+  - template: templates-v2/variables-nuget-package-version.yml
+  - template: templates-v2/variables-onebranch-config.yml
+
+extends:
+  template: templates-v2/pipeline-onebranch-full-release-build.yml
+  parameters:
+    official: true
+    branding: ${{ parameters.branding }}
+    buildTerminal: ${{ parameters.buildTerminal }}
+    buildConPTY: ${{ parameters.buildConPTY }}
+    buildWPF: ${{ parameters.buildWPF }}
+    pgoBuildMode: ${{ parameters.pgoBuildMode }}
+    buildConfigurations: ${{ parameters.buildConfigurations }}
+    buildPlatforms: ${{ parameters.buildPlatforms }}
+    codeSign: true
+    terminalInternalPackageVersion: ${{ parameters.terminalInternalPackageVersion }}
+    publishSymbolsToPublic: ${{ parameters.publishSymbolsToPublic }}
+    publishVpackToWindows: ${{ parameters.publishVpackToWindows }}

--- a/build/pipelines/templates-v2/job-build-project.yml
+++ b/build/pipelines/templates-v2/job-build-project.yml
@@ -62,6 +62,9 @@ parameters:
   - name: publishArtifacts
     type: boolean
     default: true
+  - name: removeAllNonSignedFiles
+    type: boolean
+    default: false
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -173,6 +176,7 @@ jobs:
   # - Directories ending in Lib (static lib projects that we fully linked into DLLs which may also contain unnecessary resources)
   # - All LocalTests_ project outputs, as they were subsumed into TestHostApp
   # - All PDB files inside the WindowsTerminal/ output, which do not belong there.
+  # - console.dll, which apparently breaks XFGCheck? lol.
   - pwsh: |-
       $binDir = '$(Terminal.BinDir)'
       $ImportLibs = Get-ChildItem $binDir -Recurse -File -Filter '*.exp' | ForEach-Object { $_.FullName -Replace "exp$","lib" }
@@ -188,6 +192,8 @@ jobs:
       If (-Not [bool]::Parse('${{ parameters.keepAllExpensiveBuildOutputs }}')) {
         $Items += Get-ChildItem '$(Terminal.BinDir)' -Filter '*.pdb' -Recurse
       }
+
+      $Items += Get-ChildItem $binDir -Filter 'console.dll'
 
       $Items | Remove-Item -Recurse -Force -Verbose -ErrorAction:Ignore
     displayName: Clean up static libs and extra symbols
@@ -245,6 +251,14 @@ jobs:
           & "$(MakeAppxPath)" pack /h SHA256 /o /p $PackageFilename /d "$(Terminal.BinDir)/PackageContents"
           Write-Host "##vso[task.setvariable variable=WindowsTerminalPackagePath]${PackageFilename}"
         displayName: Re-pack the new Terminal package after signing
+
+    # Some of our governed pipelines explicitly fail builds that have *any* non-codesigned filed (!)
+    - ${{ if eq(parameters.removeAllNonSignedFiles, true) }}:
+      - pwsh: |-
+          Get-ChildItem "$(Terminal.BinDir)" -Recurse -Include "*.dll","*.exe" |
+            Where-Object { (Get-AuthenticodeSignature $_).Status -Ne "Valid" } |
+            Remove-Item -Verbose -Force
+        displayName: Remove all non-signed output files
 
   - ${{ else }}: # No Signing
     - ${{ if or(parameters.buildTerminal, parameters.buildEverything) }}:

--- a/build/pipelines/templates-v2/job-merge-msix-into-bundle.yml
+++ b/build/pipelines/templates-v2/job-merge-msix-into-bundle.yml
@@ -29,6 +29,9 @@ parameters:
   - name: publishArtifacts
     type: boolean
     default: true
+  - name: afterBuildSteps
+    type: stepList
+    default: []
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -85,7 +88,9 @@ jobs:
       $Components[0] = ([int]$Components[0] + $VersionEpoch)
       $BundleVersion = $Components -Join "."
       New-Item -Type Directory "$(System.ArtifactsDirectory)/bundle"
-      .\build\scripts\Create-AppxBundle.ps1 -InputPath 'bin/' -ProjectName CascadiaPackage -BundleVersion $BundleVersion -OutputPath "$(System.ArtifactsDirectory)\bundle\$(BundleStemName)_$(XES_APPXMANIFESTVERSION)_8wekyb3d8bbwe.msixbundle"
+      $BundlePath = "$(System.ArtifactsDirectory)\bundle\$(BundleStemName)_$(XES_APPXMANIFESTVERSION)_8wekyb3d8bbwe.msixbundle"
+      .\build\scripts\Create-AppxBundle.ps1 -InputPath 'bin/' -ProjectName CascadiaPackage -BundleVersion $BundleVersion -OutputPath $BundlePath
+      Write-Host "##vso[task.setvariable variable=MsixBundlePath]${BundlePath}"
     displayName: Create msixbundle
 
   - ${{ if eq(parameters.codeSign, true) }}:
@@ -138,6 +143,8 @@ jobs:
         OutputPath: 'output.json'
         ValidateSignature: true
         Verbosity: 'Verbose'
+
+  - ${{ parameters.afterBuildSteps }}
 
   - ${{ if eq(parameters.publishArtifacts, true) }}:
     - publish: $(JobOutputDirectory)

--- a/build/pipelines/templates-v2/job-publish-symbols.yml
+++ b/build/pipelines/templates-v2/job-publish-symbols.yml
@@ -17,6 +17,12 @@ parameters:
   - name: symbolExpiryTime
     type: string
     default: 36530 # This is the default from PublishSymbols@2
+  - name: variables
+    type: object
+    default: {}
+  - name: symbolPatGoesInTaskInputs
+    type: boolean
+    default: false
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -27,6 +33,8 @@ jobs:
   ${{ else }}:
     displayName: Publish Symbols Internally
   dependsOn: ${{ parameters.dependsOn }}
+  variables:
+    ${{ insert }}: ${{ parameters.variables }}
   steps:
   - checkout: self
     clean: true
@@ -76,6 +84,8 @@ jobs:
         SymbolsProduct: 'Windows Terminal Converged Symbols'
         SymbolsVersion: '$(XES_APPXMANIFESTVERSION)'
         SymbolExpirationInDays: ${{ parameters.symbolExpiryTime }}
+        ${{ if eq(parameters.symbolPatGoesInTaskInputs, true) }}:
+          Pat: $(ADO_microsoftpublicsymbols_PAT)
         # The ADO task does not support indexing of GitHub sources.
       # There is a bug which causes this task to fail if LIB includes an inaccessible path (even though it does not depend on it).
       # To work around this issue, we just force LIB to be any dir that we know exists.
@@ -83,4 +93,5 @@ jobs:
       env:
         LIB: $(Build.SourcesDirectory)
         ArtifactServices_Symbol_AccountName: microsoftpublicsymbols
-        ArtifactServices_Symbol_PAT: $(ADO_microsoftpublicsymbols_PAT)
+        ${{ if ne(parameters.symbolPatGoesInTaskInputs, true) }}:
+          ArtifactServices_Symbol_PAT: $(ADO_microsoftpublicsymbols_PAT)

--- a/build/pipelines/templates-v2/pipeline-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-full-release-build.yml
@@ -61,28 +61,7 @@ parameters:
       demands: ImageOverride -equals SHINE-VS17-Latest
 
 variables:
-  # If we are building a branch called "release-*", change the NuGet suffix
-  # to "preview". If we don't do that, XES will set the suffix to "release1"
-  # because it truncates the value after the first period.
-  # We also want to disable the suffix entirely if we're Release branded while
-  # on a release branch.
-  # main is special, however. XES ignores main. Since we never produce actual
-  # shipping builds from main, we want to force it to have a beta label as
-  # well.
-  #
-  # In effect:
-  # BRANCH / BRANDING | Release                    | Preview
-  # ------------------|----------------------------|-----------------------------
-  # release-*         | 1.12.20220427              | 1.13.20220427-preview
-  # main              | 1.14.20220427-experimental | 1.14.20220427-experimental
-  # all others        | 1.14.20220427-mybranch     | 1.14.20220427-mybranch
-  ${{ if startsWith(variables['Build.SourceBranchName'], 'release-') }}:
-    ${{ if eq(parameters.branding, 'Release') }}:
-      NoNuGetPackBetaVersion: true
-    ${{ else }}:
-      NuGetPackBetaVersion: preview
-  ${{ elseif eq(variables['Build.SourceBranchName'], 'main') }}:
-    NuGetPackBetaVersion: experimental
+  - template: variables-nuget-package-version.yml
 
 resources:
   repositories:

--- a/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-onebranch-full-release-build.yml
@@ -1,0 +1,256 @@
+parameters:
+  - name: official
+    type: boolean
+    default: false
+  - name: branding
+    type: string
+    default: Release
+    values:
+      - Release
+      - Preview
+      - Canary
+      - Dev
+  - name: buildTerminal
+    type: boolean
+    default: true
+  - name: buildConPTY
+    type: boolean
+    default: false
+  - name: buildWPF
+    type: boolean
+    default: false
+  - name: pgoBuildMode
+    type: string
+    default: Optimize
+    values:
+      - Optimize
+      - Instrument
+      - None
+  - name: buildConfigurations
+    type: object
+    default:
+      - Release
+  - name: buildPlatforms
+    type: object
+    default:
+      - x64
+      - x86
+      - arm64
+  - name: codeSign
+    type: boolean
+    default: true
+  - name: terminalInternalPackageVersion
+    type: string
+    default: '0.0.8'
+
+  - name: publishSymbolsToPublic
+    type: boolean
+    default: true
+  - name: publishVpackToWindows
+    type: boolean
+    default: false
+
+  - name: extraPublishJobs
+    type: object
+    default: []
+
+resources:
+  repositories:
+  - repository: templates
+    type: git
+    name: OneBranch.Pipelines/GovernedTemplates
+    ref: refs/heads/main
+
+extends:
+  ${{ if eq(parameters.official, true) }}:
+    template: v2/Microsoft.Official.yml@templates # https://aka.ms/obpipelines/templates
+  ${{ else }}:
+    template: v2/Microsoft.NonOfficial.yml@templates
+  parameters:
+    featureFlags:
+      WindowsHostVersion: 1ESWindows2022
+    platform:
+      name: 'windows_undocked'
+      product: 'Windows Terminal'
+    cloudvault: # https://aka.ms/obpipelines/cloudvault
+      enabled: false
+    globalSdl: # https://aka.ms/obpipelines/sdl
+      tsa:
+        enabled: true
+        configFile: '$(Build.SourcesDirectory)\build\config\tsa.json'
+      binskim:
+        break: false
+        scanOutputDirectoryOnly: true
+      policheck:
+        break: false
+        severity: Note
+      baseline:
+        baselineFile: '$(Build.SourcesDirectory)\build\config\release.gdnbaselines'
+        suppressionSet: default
+
+    stages:
+      - stage: Build
+        displayName: Build
+        dependsOn: []
+        jobs:
+          - template: ./build/pipelines/templates-v2/job-build-project.yml@self
+            parameters:
+              pool: { type: windows }
+              variables:
+                ob_git_checkout: false # This job checks itself out
+                ob_git_skip_checkout_none: true
+                ob_outputDirectory: $(JobOutputDirectory)
+                ob_artifactBaseName: $(JobOutputArtifactName)
+              publishArtifacts: false # Handled by OneBranch
+              branding: ${{ parameters.branding }}
+              buildTerminal: ${{ parameters.buildTerminal }}
+              buildConPTY: ${{ parameters.buildConPTY }}
+              buildWPF: ${{ parameters.buildWPF }}
+              pgoBuildMode: ${{ parameters.pgoBuildMode }}
+              buildConfigurations: ${{ parameters.buildConfigurations }}
+              buildPlatforms: ${{ parameters.buildPlatforms }}
+              generateSbom: false # this is handled by onebranch
+              removeAllNonSignedFiles: true # appease the overlords
+              codeSign: ${{ parameters.codeSign }}
+              beforeBuildSteps: # Right before we build, lay down the universal package and localizations
+                - task: PkgESSetupBuild@12
+                  displayName: Package ES - Setup Build
+                  inputs:
+                    disableOutputRedirect: true
+
+                - task: UniversalPackages@0
+                  displayName: Download terminal-internal Universal Package
+                  inputs:
+                    feedListDownload: 2b3f8893-a6e8-411f-b197-a9e05576da48
+                    packageListDownload: e82d490c-af86-4733-9dc4-07b772033204
+                    versionListDownload: ${{ parameters.terminalInternalPackageVersion }}
+
+                - template: ./build/pipelines/templates-v2/steps-fetch-and-prepare-localizations.yml@self
+                  parameters:
+                    includePseudoLoc: true
+
+          - ${{ if eq(parameters.buildWPF, true) }}:
+            # Add an Any CPU build flavor for the WPF control bits
+            - template: ./build/pipelines/templates-v2/job-build-project.yml@self
+              parameters:
+                pool: { type: windows }
+                variables:
+                  ob_git_checkout: false # This job checks itself out
+                  ob_git_skip_checkout_none: true
+                  ob_outputDirectory: $(JobOutputDirectory)
+                  ob_artifactBaseName: $(JobOutputArtifactName)
+                publishArtifacts: false # Handled by OneBranch
+                jobName: BuildWPF
+                branding: ${{ parameters.branding }}
+                buildTerminal: false
+                buildWPFDotNetComponents: true
+                buildConfigurations: ${{ parameters.buildConfigurations }}
+                buildPlatforms:
+                  - Any CPU
+                generateSbom: false # this is handled by onebranch
+                removeAllNonSignedFiles: true # appease the overlords
+                codeSign: ${{ parameters.codeSign }}
+                beforeBuildSteps:
+                  - task: PkgESSetupBuild@12
+                    displayName: Package ES - Setup Build
+                    inputs:
+                      disableOutputRedirect: true
+                  # WPF doesn't need the localizations or the universal package, but if it does... put them here.
+
+      - stage: Package
+        displayName: Package
+        dependsOn: [Build]
+        jobs:
+          - ${{ if eq(parameters.buildTerminal, true) }}:
+            - template: ./build/pipelines/templates-v2/job-merge-msix-into-bundle.yml@self
+              parameters:
+                pool: { type: windows }
+                variables:
+                  ob_git_checkout: false # This job checks itself out
+                  ob_git_skip_checkout_none: true
+                  ob_outputDirectory: $(JobOutputDirectory)
+                  ob_artifactBaseName: $(JobOutputArtifactName)
+                  ### This job is also in charge of submitting the vpack to Windows if it's enabled
+                  ob_createvpack_enabled: ${{ and(parameters.buildTerminal, parameters.publishVpackToWindows) }}
+                  ob_updateOSManifest_enabled: ${{ and(parameters.buildTerminal, parameters.publishVpackToWindows) }}
+                  ### If enabled above, these options are in play.
+                  ob_createvpack_packagename: 'WindowsTerminal.app'
+                  ob_createvpack_owneralias: 'conhost@microsoft.com'
+                  ob_createvpack_description: 'VPack for the Windows Terminal Application'
+                  ob_createvpack_targetDestinationDirectory: '$(Destination)'
+                  ob_createvpack_propsFile: false
+                  ob_createvpack_provData: true
+                  ob_createvpack_metadata: '$(Build.SourceVersion)'
+                  ob_createvpack_topLevelRetries: 0
+                  ob_createvpack_failOnStdErr: true
+                  ob_createvpack_taskLogVerbosity: Detailed
+                  ob_createvpack_verbose: true
+                  ob_createvpack_vpackdirectory: '$(JobOutputDirectory)\vpack'
+                  ob_updateOSManifest_gitcheckinConfigPath: '$(Build.SourcesDirectory)\build\config\GitCheckin.json'
+                  # We're skipping the 'fetch' part of the OneBranch rules, but that doesn't mean
+                  # that it doesn't expect to have downloaded a manifest directly to some 'destination'
+                  # folder that it can then update and upload.
+                  # Effectively: it says "destination" but it means "source"
+                  # DH: Don't ask why.
+                  ob_updateOSManifest_destination: $(XES_VPACKMANIFESTDIRECTORY)
+                  ob_updateOSManifest_skipFetch: true
+                publishArtifacts: false # Handled by OneBranch
+                jobName: Bundle
+                branding: ${{ parameters.branding }}
+                buildConfigurations: ${{ parameters.buildConfigurations }}
+                buildPlatforms: ${{ parameters.buildPlatforms }}
+                generateSbom: false # Handled by onebranch
+                codeSign: ${{ parameters.codeSign }}
+                afterBuildSteps:
+                  - pwsh: |-
+                      $d = New-Item "$(JobOutputDirectory)/vpack" -Type Directory
+                      Copy-Item -Verbose -Path "$(MsixBundlePath)" -Destination (Join-Path $d 'Microsoft.WindowsTerminal_8wekyb3d8bbwe.msixbundle')
+                    displayName: Stage msixbundle for vpack
+
+          - ${{ if eq(parameters.buildConPTY, true) }}:
+            - template: ./build/pipelines/templates-v2/job-package-conpty.yml@self
+              parameters:
+                pool: { type: windows }
+                variables:
+                  ob_git_checkout: false # This job checks itself out
+                  ob_git_skip_checkout_none: true
+                  ob_outputDirectory: $(JobOutputDirectory)
+                  ob_artifactBaseName: $(JobOutputArtifactName)
+                publishArtifacts: false # Handled by OneBranch
+                buildConfigurations: ${{ parameters.buildConfigurations }}
+                buildPlatforms: ${{ parameters.buildPlatforms }}
+                generateSbom: false # this is handled by onebranch
+                codeSign: ${{ parameters.codeSign }}
+
+          - ${{ if eq(parameters.buildWPF, true) }}:
+            - template: ./build/pipelines/templates-v2/job-build-package-wpf.yml@self
+              parameters:
+                pool: { type: windows }
+                variables:
+                  ob_git_checkout: false # This job checks itself out
+                  ob_git_skip_checkout_none: true
+                  ob_outputDirectory: $(JobOutputDirectory)
+                  ob_artifactBaseName: $(JobOutputArtifactName)
+                publishArtifacts: false # Handled by OneBranch
+                buildConfigurations: ${{ parameters.buildConfigurations }}
+                buildPlatforms: ${{ parameters.buildPlatforms }}
+                generateSbom: false # this is handled by onebranch
+                codeSign: ${{ parameters.codeSign }}
+
+      - stage: Publish
+        displayName: Publish
+        dependsOn: [Build, Package]
+        jobs:
+          - template: ./build/pipelines/templates-v2/job-publish-symbols.yml@self
+            parameters:
+              pool: { type: windows }
+              includePublicSymbolServer: ${{ parameters.publishSymbolsToPublic }}
+              symbolPatGoesInTaskInputs: true # onebranch tries to muck with the PAT variable, so we need to change how it get the PAT
+              variables:
+                ob_git_checkout: false # This job checks itself out
+                ob_git_skip_checkout_none: true
+                ob_outputDirectory: $(Build.ArtifactStagingDirectory)
+                # Without this, OneBranch will nerf our symbol tasks
+                ob_symbolsPublishing_enabled: true
+
+          - ${{ parameters.extraPublishJobs }}

--- a/build/pipelines/templates-v2/variables-nuget-package-version.yml
+++ b/build/pipelines/templates-v2/variables-nuget-package-version.yml
@@ -1,0 +1,23 @@
+variables:
+  # If we are building a branch called "release-*", change the NuGet suffix
+  # to "preview". If we don't do that, XES will set the suffix to "release1"
+  # because it truncates the value after the first period.
+  # We also want to disable the suffix entirely if we're Release branded while
+  # on a release branch.
+  # main is special, however. XES ignores main. Since we never produce actual
+  # shipping builds from main, we want to force it to have a beta label as
+  # well.
+  #
+  # In effect:
+  # BRANCH / BRANDING | Release                    | Preview
+  # ------------------|----------------------------|-----------------------------
+  # release-*         | 1.12.20220427              | 1.13.20220427-preview
+  # main              | 1.14.20220427-experimental | 1.14.20220427-experimental
+  # all others        | 1.14.20220427-mybranch     | 1.14.20220427-mybranch
+  ${{ if startsWith(variables['Build.SourceBranchName'], 'release-') }}:
+    ${{ if eq(parameters.branding, 'Release') }}:
+      NoNuGetPackBetaVersion: true
+    ${{ else }}:
+      NuGetPackBetaVersion: preview
+  ${{ elseif eq(variables['Build.SourceBranchName'], 'main') }}:
+    NuGetPackBetaVersion: experimental

--- a/build/pipelines/templates-v2/variables-onebranch-config.yml
+++ b/build/pipelines/templates-v2/variables-onebranch-config.yml
@@ -1,0 +1,2 @@
+variables:
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'


### PR DESCRIPTION
This pipeline does everything the existing release pipeline does, except it does it using the OneBranch official templates.

Most of our existing build infrastructure has been reused, with the following changes:

- We are no longer using `job-submit-windows-vpack`, as OneBranch does this for us.
- `job-merge-msix-into-bundle` now supports afterBuildSteps, which we use to stage the msixbundle into the right place for the vpack
- `job-build-project` supports deleting all non-signed files (which the OneBranch post-build validation requires)
- `job-build-project` now deletes `console.dll`, which is unused in any of our builds, because XFGCheck blows up on it for some reason on x86
- `job-publish-symbols` now supports two different types of PAT ingestion
- I have pulled out the NuGet filename variables into a shared variables template

I have also introduced a TSA config (which files bugs on us for binary analysis failures as well as using the word 'sucks' and stuff.)

I have also baselined a number of control flow guard/binary analysis failures.
