### PR TITLE
Add Success Message when Correct PowerShell Version is Installed

### DIFF
--- a/tools/CheckPSVersion.ps1
+++ b/tools/CheckPSVersion.ps1
@@ -1,4 +1,7 @@
-if($PSVersionTable.PSVersion.Major -lt 7){
-   Write-Error "Incorrect version of PowerShell installed.`nMake sure you have at least PowerShell Core 7.0.0."
-   Exit 1 
+if ($PSVersionTable.PSVersion.Major -lt 7) {
+    Write-Error "Incorrect version of PowerShell installed.`nMake sure you have at least PowerShell Core 7.0.0."
+    Exit 1
+} else {
+    Write-Output "Correct version of PowerShell installed."
+    Exit 0
 }


### PR DESCRIPTION
## Summary of the Pull Request
Added a success message to be displayed after confirming that the correct PowerShell version is installed.

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments
After implementing the version check in the PowerShell script, a success message is displayed when the correct version is detected. This provides a clear indication to users that their PowerShell version meets the requirements.

## Validation Steps Performed
- [x] Tested the script on systems with different PowerShell versions to ensure the success message appears only when the correct version is installed.
- [x] Manually verified the script behavior after the changes were applied.

## PR Checklist
- [ ] Closes #xxx
- [x] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)