### PR TITLE
Fix issues and warnings caused by profiles.schema.json

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -86,12 +86,19 @@
       ]
     },
     "BuiltinSuggestionSource": {
-      "enum": [
-        "commandHistory",
-        "tasks",
-        "all"
-      ],
-      "type": "string"
+      "type": "string",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "enum": [
+            "commandHistory",
+            "tasks",
+            "all"
+          ]
+        }
+      ]
     },
     "SuggestionSource": {
       "default": "all",
@@ -99,15 +106,17 @@
       "$comment": "`tasks` and `local` are sources that would be added by the Tasks feature, as a follow-up",
       "oneOf": [
         {
-          "type": [ "string", "null", "BuiltinSuggestionSource" ]
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/BuiltinSuggestionSource"
         },
         {
           "type": "array",
-          "items": { "type": "BuiltinSuggestionSource" }
-        },
-        {
-          "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "$ref": "#/$defs/BuiltinSuggestionSource"
+          },
+          "uniqueItems": true
         }
       ]
     },
@@ -201,10 +210,6 @@
                 "desktopWallpaper"
               ]
             }
-          ],
-          "type": [
-            "string",
-            "null"
           ]
         },
         "backgroundImageOpacity": {
@@ -270,7 +275,7 @@
           "description": "Use to set a path to a pixel shader to use with the Terminal when unfocused. Overrides `experimental.retroTerminalEffect`. This is an experimental feature, and its continued existence is not guaranteed.",
           "type": "string"
         },
-        "useAcrylic":{
+        "useAcrylic": {
           "description": "When set to true, the window will have an acrylic material background when unfocused. When set to false, the window will have a plain, untextured background when unfocused.",
           "type": "boolean"
         }
@@ -645,6 +650,7 @@
           "$ref": "#/$defs/NewTabMenuEntry"
         },
         {
+          "type": "object",
           "properties": {
             "type": {
               "type": "string",
@@ -687,6 +693,7 @@
           "$ref": "#/$defs/NewTabMenuEntry"
         },
         {
+          "type": "object",
           "properties": {
             "type": {
               "type": "string",
@@ -703,6 +710,7 @@
           "$ref": "#/$defs/NewTabMenuEntry"
         },
         {
+          "type": "object",
           "properties": {
             "type": {
               "type": "string",
@@ -724,6 +732,7 @@
           "$ref": "#/$defs/NewTabMenuEntry"
         },
         {
+          "type": "object",
           "properties": {
             "type": {
               "type": "string",
@@ -740,6 +749,7 @@
           "$ref": "#/$defs/NewTabMenuEntry"
         },
         {
+          "type": "object",
           "properties": {
             "type": {
               "type": "string",
@@ -780,6 +790,7 @@
       ]
     },
     "ShortcutAction": {
+      "type": "object",
       "properties": {
         "action": {
           "description": "The action to execute",
@@ -788,8 +799,7 @@
       },
       "required": [
         "action"
-      ],
-      "type": "object"
+      ]
     },
     "AdjustFontSizeAction": {
       "description": "Arguments corresponding to an Adjust Font Size Action",
@@ -798,6 +808,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -822,6 +833,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -863,6 +875,7 @@
           "$ref": "#/$defs/NewTerminalArgs"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -879,6 +892,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -903,6 +917,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -927,6 +942,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -951,6 +967,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -975,6 +992,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -999,6 +1017,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1023,6 +1042,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1050,6 +1070,7 @@
           "$ref": "#/$defs/NewTerminalArgs"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1082,6 +1103,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1119,6 +1141,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1146,6 +1169,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1167,6 +1191,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1188,6 +1213,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1212,6 +1238,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1232,6 +1259,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1252,6 +1280,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1272,6 +1301,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1296,6 +1326,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1324,6 +1355,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1352,6 +1384,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1380,6 +1413,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1404,6 +1438,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1428,6 +1463,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1451,6 +1487,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1476,6 +1513,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1497,6 +1535,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1524,6 +1563,7 @@
           "$ref": "#/$defs/NewTerminalArgs"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1540,6 +1580,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1561,6 +1602,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1582,6 +1624,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1603,6 +1646,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1624,6 +1668,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1646,6 +1691,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1667,6 +1713,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1688,6 +1735,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1739,6 +1787,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1755,6 +1804,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1778,6 +1828,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1806,6 +1857,7 @@
           "$ref": "#/$defs/ShortcutAction"
         },
         {
+          "type": "object",
           "properties": {
             "action": {
               "type": "string",
@@ -1892,7 +1944,11 @@
       "properties": {
         "applicationTheme": {
           "description": "Which UI theme the Terminal should use for controls",
-          "enum": [ "light", "dark", "system" ],
+          "enum": [
+            "light",
+            "dark",
+            "system"
+          ],
           "type": "string"
         },
         "useMica": {
@@ -1923,7 +1979,11 @@
           "type": "string",
           "description": "The name of the theme. This will be displayed in the settings UI.",
           "not": {
-            "enum": [ "light", "dark", "system" ]
+            "enum": [
+              "light",
+              "dark",
+              "system"
+            ]
           }
         },
         "tab": {
@@ -1940,6 +2000,7 @@
     "ThemePair": {
       "additionalProperties": false,
       "description": "A pair of Theme names, to allow the Terminal to switch theme based on the OS theme",
+      "type": "object",
       "properties": {
         "light": {
           "type": "string",
@@ -2121,16 +2182,16 @@
         },
         "name": {
           "description": "The name that will appear in the command palette. If one isn't provided, the terminal will attempt to automatically generate a name.\nIf name is a string, it will be the name of the command.\nIf name is a object, the key property of the object will be used to lookup a localized string resource for the command",
-          "properties": {
-            "key": {
-              "type": "string"
-            }
-          },
           "type": [
             "string",
             "object",
             "null"
-          ]
+          ],
+          "properties": {
+            "key": {
+              "type": "string"
+            }
+          }
         },
         "iterateOn": {
           "type": "string",
@@ -2167,6 +2228,7 @@
     "Globals": {
       "additionalProperties": true,
       "description": "Properties that affect the entire window, regardless of the profile settings.",
+      "type": "object",
       "properties": {
         "alwaysOnTop": {
           "default": false,
@@ -2178,7 +2240,7 @@
           "description": "When set to true, tabs are always displayed. When set to false and \"showTabsInTitlebar\" is set to false, tabs only appear after opening a new tab.",
           "type": "boolean"
         },
-        "compatibility.enableUnfocusedAcrylic":{
+        "compatibility.enableUnfocusedAcrylic": {
           "default": true,
           "description": "When set to true, unfocused windows can have acrylic instead of opaque.",
           "type": "boolean"
@@ -2381,9 +2443,16 @@
         "theme": {
           "default": "dark",
           "description": "Sets the theme of the application. This value should be the name of one of the themes defined in `themes`. The Terminal also includes the themes `dark`, `light`, and `system`.",
-          "oneOf": [
+          "anyOf": [
             {
               "type": "string"
+            },
+            {
+              "enum": [
+                "dark",
+                "light",
+                "system"
+              ]
             },
             {
               "$ref": "#/$defs/ThemePair"
@@ -2494,12 +2563,12 @@
       },
       "required": [
         "defaultProfile"
-      ],
-      "type": "object"
+      ]
     },
     "Profile": {
       "description": "Properties specific to a unique profile.",
       "additionalProperties": false,
+      "type": "object",
       "properties": {
         "acrylicOpacity": {
           "default": 0.5,
@@ -2551,7 +2620,7 @@
         },
         "backgroundImage": {
           "description": "Sets the file location of the image to draw over the window background.",
-          "oneOf": [
+          "anyOf": [
             {
               "type": [
                 "string",
@@ -2563,10 +2632,6 @@
                 "desktopWallpaper"
               ]
             }
-          ],
-          "type": [
-            "string",
-            "null"
           ]
         },
         "backgroundImageAlignment": {
@@ -2903,8 +2968,7 @@
           "description": "When set to true, the window will have an acrylic material background. When set to false, the window will have a plain, untextured background.",
           "type": "boolean"
         }
-      },
-      "type": "object"
+      }
     },
     "ProfileList": {
       "description": "A list of profiles and the properties specific to each.",
@@ -2919,6 +2983,7 @@
     },
     "ProfilesObject": {
       "description": "A list of profiles and default settings that apply to all of them",
+      "type": "object",
       "properties": {
         "list": {
           "$ref": "#/$defs/ProfileList"
@@ -2927,12 +2992,12 @@
           "description": "The default settings that apply to every profile.",
           "$ref": "#/$defs/Profile"
         }
-      },
-      "type": "object"
+      }
     },
     "SchemeList": {
       "description": "Properties are specific to each color scheme. ColorTool is a great tool you can use to create and explore new color schemes. All colors use hex color format.",
       "items": {
+        "type": "object",
         "additionalProperties": false,
         "properties": {
           "name": {
@@ -3021,8 +3086,7 @@
             "$ref": "#/$defs/Color",
             "description": "Sets the color used as ANSI yellow."
           }
-        },
-        "type": "object"
+        }
       },
       "type": "array"
     }
@@ -3032,6 +3096,7 @@
       "$ref": "#/$defs/Globals"
     },
     {
+      "type": "object",
       "additionalItems": true,
       "properties": {
         "profiles": {


### PR DESCRIPTION
This addresses the following issues:
* The JSON Schema spec doesn't actually define whether objects with
  a "properties" key still require `"type": "object"` or not.
  VS Code for instance largely pretends as if it's implied, but when it
  encounters them inside a `oneOf` tree, then it behaves as if it isn't.
  In other words, we need to always set `"type": "object"`.
* Declaring an `oneOf` containing a `"type": "string"` and an `enum`
  doesn't work, because if one of the `enum` cases is given, it results
  in both variants to match, since any `enum` is also a `string`.
  We have to use `anyOf` instead.
* `SuggestionSource` used `"BuiltinSuggestionSource"` inside a `type`
  key which doesn't work. We have to use `$ref` for that.

Closes #13387

## Validation Steps Performed
* VS Code stops complaining ✅
* https://www.jsonschemavalidator.net/ ✅