### PR TITLE
Don't end the current mark, if we get one of the same kind

### DIFF
--- a/src/cascadia/TerminalCore/TerminalApi.cpp
+++ b/src/cascadia/TerminalCore/TerminalApi.cpp
@@ -341,6 +341,13 @@ void Terminal::MarkCommandStart()
         //
         //We can just do the work below safely.
     }
+    else if (_currentPromptState == PromptState::Command)
+    {
+        // We're already in the command state. We don't want to end the current
+        // mark. We don't want to make a new one. We want to just leave the
+        // current command going.
+        return;
+    }
     else
     {
         // If there was no last mark, or we're in a weird state,
@@ -368,6 +375,13 @@ void Terminal::MarkOutputStart()
         // with.
         //
         //We can just do the work below safely.
+    }
+    else if (_currentPromptState == PromptState::Output)
+    {
+        // We're already in the output state. We don't want to end the current
+        // mark. We don't want to make a new one. We want to just leave the
+        // current output going.
+        return;
     }
     else
     {


### PR DESCRIPTION
If you're already in the "output" state, then an app requesting an "output" mark probably shouldn't end the current mark and start a new one. It should just keep on keepin' on.

The decision to end the previous one was arbitrary in the first place, so let's arbitrarily change it back.

Especially noticable if you hit <kbd>Enter</kbd> during a command, because the auto-mark prompt work will do a CommandEnd, so long-running commands will get broken into multiple marks 🥲
