### PR TITLE
Dismiss "Failed to reload settings" modals when settings.json is valid

### DIFF
--- a/src/cascadia/TerminalApp/TerminalWindow.cpp
+++ b/src/cascadia/TerminalApp/TerminalWindow.cpp
@@ -783,6 +783,10 @@ namespace winrt::TerminalApp::implementation
             {
                 _ShowLoadWarningsDialog(args.Warnings());
             }
+            else if (args.Result() == S_OK)
+            {
+                DismissDialog();
+            }
             _RefreshThemeRoutine();
         }
     }


### PR DESCRIPTION
Have added a conditional check in `TerminalWindow::UpdateSettings` method

## PR Checklist
- [X] Closes #15987 