### PR TITLE
build: pass branding into the nuget variable template

### DIFF
--- a/build/pipelines/ob-nightly.yml
+++ b/build/pipelines/ob-nightly.yml
@@ -18,6 +18,8 @@ name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 
 variables:
   - template: templates-v2/variables-nuget-package-version.yml
+    parameters:
+      branding: Canary
   - template: templates-v2/variables-onebranch-config.yml
 
 extends:

--- a/build/pipelines/ob-release.yml
+++ b/build/pipelines/ob-release.yml
@@ -62,6 +62,8 @@ name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 
 variables:
   - template: templates-v2/variables-nuget-package-version.yml
+    parameters:
+      branding: ${{ parameters.branding }}
   - template: templates-v2/variables-onebranch-config.yml
 
 extends:

--- a/build/pipelines/templates-v2/pipeline-full-release-build.yml
+++ b/build/pipelines/templates-v2/pipeline-full-release-build.yml
@@ -62,6 +62,8 @@ parameters:
 
 variables:
   - template: variables-nuget-package-version.yml
+    parameters:
+      branding: ${{ parameters.branding }}
 
 resources:
   repositories:

--- a/build/pipelines/templates-v2/variables-nuget-package-version.yml
+++ b/build/pipelines/templates-v2/variables-nuget-package-version.yml
@@ -1,3 +1,7 @@
+parameters:
+  - name: branding
+    type: string
+
 variables:
   # If we are building a branch called "release-*", change the NuGet suffix
   # to "preview". If we don't do that, XES will set the suffix to "release1"


### PR DESCRIPTION
This fixes a cosmetic issue with the version number in the unpackaged builds and NuGet packages.

They were showing up as `-preview`, even when they were stable, because the variable template didn't know about the branding.
