### PR TITLE
Flip bits instead of checking for them

### DIFF
--- a/src/tools/vtapp/Program.cs
+++ b/src/tools/vtapp/Program.cs
@@ -287,15 +287,7 @@ namespace VTApp
 
                             if (Pinvoke.GetConsoleMode(hCon, out mode))
                             {
-                                if ((mode & Pinvoke.ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0)
-                                {
-                                    mode &= ~Pinvoke.ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-                                }
-                                else
-                                {
-                                    mode |= Pinvoke.ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-                                }
-
+                                mode ^= Pinvoke.ENABLE_VIRTUAL_TERMINAL_PROCESSING;
                                 Pinvoke.SetConsoleMode(hCon, mode);
                             }
                             break;
@@ -307,14 +299,7 @@ namespace VTApp
                             int mode;
                             if (Pinvoke.GetConsoleMode(hCon, out mode))
                             {
-                                if ((mode & Pinvoke.ENABLE_VIRTUAL_TERMINAL_INPUT) != 0)
-                                {
-                                    mode &= ~Pinvoke.ENABLE_VIRTUAL_TERMINAL_INPUT;
-                                }
-                                else
-                                {
-                                    mode |= Pinvoke.ENABLE_VIRTUAL_TERMINAL_INPUT;
-                                }
+                                mode ^=  Pinvoke.ENABLE_VIRTUAL_TERMINAL_INPUT;
                                 mode &= ~Pinvoke.ENABLE_PROCESSED_INPUT;
                                 Pinvoke.SetConsoleMode(hCon, mode);
                             }


### PR DESCRIPTION
No need to check for if a bit is set before manually clearing or setting them when xor will do the trick.