### PR TITLE
Update settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,10 @@
 {
-    "C_Cpp.default.browse.databaseFilename": "${workspaceFolder}\\.vscode\\.BROWSE.VC.DB",
-    "C_Cpp.default.browse.path": [
-        "${workspaceFolder}"
-    ],
+    "C_Cpp.default.browse.databaseFilename": "${workspaceFolder}/.vscode/BROWSE.VC.DB",
+    "C_Cpp.default.browse.path": ["${workspaceFolder}"],
     "C_Cpp.loggingLevel": "None",
     "files.associations": {
-        "xstring": "cpp",
         "*.idl": "midl3",
+        "xstring": "cpp",
         "array": "cpp",
         "future": "cpp",
         "istream": "cpp",
@@ -101,11 +99,11 @@
         "latch": "cpp"
     },
     "files.exclude": {
-        "**/bin/**": true,
-        "**/obj/**": true,
-        "**/Generated Files/**": true
+        "**/bin/": true,
+        "**/obj/": true,
+        "**/Generated Files/": true
     },
     "search.exclude": {
-        "**/packages/**": true
+        "**/packages/": true
     }
 }


### PR DESCRIPTION
Removed unnecessary string interpolation for file paths in the "C_Cpp.default.browse.databaseFilename" setting, as VS Code automatically handles workspace folder paths.

Simplified the "C_Cpp.default.browse.path" setting by using an array with a single workspace folder element.

Removed the "xstring" and "array" entries from the "files.associations" section because they were mapped to "cpp" in multiple entries.

Removed the redundant .true from the boolean values in the "files.exclude" and "search.exclude" sections.

## Summary of the Pull Request

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

## PR Checklist
- [ ] Closes #xxx
- [ ] Tests added/passed
- [ ] Documentation updated
   - If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/terminal) and link it here: #xxx
- [ ] Schema updated (if necessary)
